### PR TITLE
Ensure Preferences are consistent with code

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -1806,7 +1806,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
         // On newer Androids, ignore this setting, which should be hidden in the prefs anyway.
         mDisableClipboard = "0".equals(prefs.getString(PreferenceKeys.Dictionary));
         // mDeckFilename = preferences.getString("deckFilename", "");
-        mPrefFullscreenReview = Integer.parseInt(prefs.getString(PreferenceKeys.FullscreenMode));
+        mPrefFullscreenReview = prefs.getIntFromStr(PreferenceKeys.FullscreenMode);
         mRelativeButtonSize = prefs.getInt(PreferenceKeys.AnswerButtonSide);
         mSpeakText = prefs.getBoolean(PreferenceKeys.Tts);
         mPrefUseTimer = prefs.getBoolean(PreferenceKeys.TimeoutAnswer);
@@ -1819,15 +1819,15 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
         mGesturesEnabled = AnkiDroidApp.initiateGestures(prefs);
         mLinkOverridesTouchGesture = prefs.getBoolean(PreferenceKeys.LinkOverridesTouchGesture);
         if (mGesturesEnabled) {
-            mGestureSwipeUp = Integer.parseInt(prefs.getString(PreferenceKeys.GestureSwipeUp));
-            mGestureSwipeDown = Integer.parseInt(prefs.getString(PreferenceKeys.GestureSwipeDown));
-            mGestureSwipeLeft = Integer.parseInt(prefs.getString(PreferenceKeys.GestureSwipeLeft));
-            mGestureSwipeRight = Integer.parseInt(prefs.getString(PreferenceKeys.GestureSwipeRight));
-            mGestureDoubleTap = Integer.parseInt(prefs.getString(PreferenceKeys.GestureDoubleTap));
+            mGestureSwipeUp = prefs.getIntFromStr(PreferenceKeys.GestureSwipeUp);
+            mGestureSwipeDown = prefs.getIntFromStr(PreferenceKeys.GestureSwipeDown);
+            mGestureSwipeLeft = prefs.getIntFromStr(PreferenceKeys.GestureSwipeLeft);
+            mGestureSwipeRight = prefs.getIntFromStr(PreferenceKeys.GestureSwipeRight);
+            mGestureDoubleTap = prefs.getIntFromStr(PreferenceKeys.GestureDoubleTap);
             mGestureTapProcessor.init(preferences);
-            mGestureLongclick = Integer.parseInt(prefs.getString(PreferenceKeys.GestureLongClick));
-            mGestureVolumeUp = Integer.parseInt(prefs.getString(PreferenceKeys.GestureVolumeUp));
-            mGestureVolumeDown = Integer.parseInt(prefs.getString(PreferenceKeys.GestureVolumeDown));
+            mGestureLongclick = prefs.getIntFromStr(PreferenceKeys.GestureLongClick);
+            mGestureVolumeUp = prefs.getIntFromStr(PreferenceKeys.GestureVolumeUp);
+            mGestureVolumeDown = prefs.getIntFromStr(PreferenceKeys.GestureVolumeDown);
         }
 
         if (prefs.getBoolean(PreferenceKeys.KeepScreenOn)) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -1879,7 +1879,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
     private void recreateWebView() {
         if (mCardWebView == null) {
             mCardWebView = createWebView();
-            WebViewDebugging.initializeDebugging(AnkiDroidApp.getSharedPrefs(this));
+            WebViewDebugging.initializeDebugging(Prefs.fromContext(this));
             mCardFrame.addView(mCardWebView);
             mGestureDetectorImpl.onWebViewCreated(mCardWebView);
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -1816,7 +1816,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
         mDoubleScrolling = prefs.getBoolean(PreferenceKeys.DoubleScrolling);
         mPrefShowTopbar = prefs.getBoolean(PreferenceKeys.ShowTopBar);
 
-        mGesturesEnabled = AnkiDroidApp.initiateGestures(preferences);
+        mGesturesEnabled = AnkiDroidApp.initiateGestures(prefs);
         mLinkOverridesTouchGesture = prefs.getBoolean(PreferenceKeys.LinkOverridesTouchGesture);
         if (mGesturesEnabled) {
             mGestureSwipeUp = Integer.parseInt(prefs.getString(PreferenceKeys.GestureSwipeUp));

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -118,6 +118,8 @@ import com.ichi2.libanki.Sound;
 import com.ichi2.libanki.Utils;
 import com.ichi2.libanki.template.MathJax;
 import com.ichi2.libanki.template.TemplateFilters;
+import com.ichi2.preferences.PreferenceKeys;
+import com.ichi2.preferences.Prefs;
 import com.ichi2.themes.HtmlColors;
 import com.ichi2.themes.Themes;
 import com.ichi2.utils.AdaptionUtil;
@@ -1583,10 +1585,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
         initControls();
 
         // Position answer buttons
-        String answerButtonsPosition = AnkiDroidApp.getSharedPrefs(this).getString(
-                getString(R.string.answer_buttons_position_preference),
-                "bottom"
-        );
+        String answerButtonsPosition = Prefs.getString(this, PreferenceKeys.AnswerButtonPosition);
         LinearLayout answerArea = findViewById(R.id.bottom_area_layout);
         RelativeLayout.LayoutParams answerAreaParams = (RelativeLayout.LayoutParams) answerArea.getLayoutParams();
         RelativeLayout.LayoutParams cardContainerParams = (RelativeLayout.LayoutParams) mCardContainer.getLayoutParams();
@@ -1800,36 +1799,38 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
     protected SharedPreferences restorePreferences() {
         SharedPreferences preferences = AnkiDroidApp.getSharedPrefs(getBaseContext());
 
-        mUseInputTag = preferences.getBoolean("useInputTag", false);
-        mDoNotUseCodeFormatting = preferences.getBoolean("noCodeFormatting", false);
+        Prefs prefs = new Prefs(preferences);
+
+        mUseInputTag = prefs.getBoolean(PreferenceKeys.UseInputTag);
+        mDoNotUseCodeFormatting = prefs.getBoolean(PreferenceKeys.NoCodeFormatting);
         // On newer Androids, ignore this setting, which should be hidden in the prefs anyway.
-        mDisableClipboard = "0".equals(preferences.getString("dictionary", "0"));
+        mDisableClipboard = "0".equals(prefs.getString(PreferenceKeys.Dictionary));
         // mDeckFilename = preferences.getString("deckFilename", "");
-        mPrefFullscreenReview = Integer.parseInt(preferences.getString("fullscreenMode", "0"));
-        mRelativeButtonSize = preferences.getInt("answerButtonSize", 100);
-        mSpeakText = preferences.getBoolean("tts", false);
-        mPrefUseTimer = preferences.getBoolean("timeoutAnswer", false);
-        mPrefWaitAnswerSecond = preferences.getInt("timeoutAnswerSeconds", 20);
-        mPrefWaitQuestionSecond = preferences.getInt("timeoutQuestionSeconds", 60);
-        mScrollingButtons = preferences.getBoolean("scrolling_buttons", false);
-        mDoubleScrolling = preferences.getBoolean("double_scrolling", false);
-        mPrefShowTopbar = preferences.getBoolean("showTopbar", true);
+        mPrefFullscreenReview = Integer.parseInt(prefs.getString(PreferenceKeys.FullscreenMode));
+        mRelativeButtonSize = prefs.getInt(PreferenceKeys.AnswerButtonSide);
+        mSpeakText = prefs.getBoolean(PreferenceKeys.Tts);
+        mPrefUseTimer = prefs.getBoolean(PreferenceKeys.TimeoutAnswer);
+        mPrefWaitAnswerSecond = prefs.getInt(PreferenceKeys.TimeoutAnswerSeconds);
+        mPrefWaitQuestionSecond = prefs.getInt(PreferenceKeys.TimeoutQuestionSeconds);
+        mScrollingButtons = prefs.getBoolean(PreferenceKeys.ScrollingButtons);
+        mDoubleScrolling = prefs.getBoolean(PreferenceKeys.DoubleScrolling);
+        mPrefShowTopbar = prefs.getBoolean(PreferenceKeys.ShowTopBar);
 
         mGesturesEnabled = AnkiDroidApp.initiateGestures(preferences);
-        mLinkOverridesTouchGesture = preferences.getBoolean("linkOverridesTouchGesture", false);
+        mLinkOverridesTouchGesture = prefs.getBoolean(PreferenceKeys.LinkOverridesTouchGesture);
         if (mGesturesEnabled) {
-            mGestureSwipeUp = Integer.parseInt(preferences.getString("gestureSwipeUp", "9"));
-            mGestureSwipeDown = Integer.parseInt(preferences.getString("gestureSwipeDown", "0"));
-            mGestureSwipeLeft = Integer.parseInt(preferences.getString("gestureSwipeLeft", "8"));
-            mGestureSwipeRight = Integer.parseInt(preferences.getString("gestureSwipeRight", "17"));
-            mGestureDoubleTap = Integer.parseInt(preferences.getString("gestureDoubleTap", "7"));
+            mGestureSwipeUp = Integer.parseInt(prefs.getString(PreferenceKeys.GestureSwipeUp));
+            mGestureSwipeDown = Integer.parseInt(prefs.getString(PreferenceKeys.GestureSwipeDown));
+            mGestureSwipeLeft = Integer.parseInt(prefs.getString(PreferenceKeys.GestureSwipeLeft));
+            mGestureSwipeRight = Integer.parseInt(prefs.getString(PreferenceKeys.GestureSwipeRight));
+            mGestureDoubleTap = Integer.parseInt(prefs.getString(PreferenceKeys.GestureDoubleTap));
             mGestureTapProcessor.init(preferences);
-            mGestureLongclick = Integer.parseInt(preferences.getString("gestureLongclick", "11"));
-            mGestureVolumeUp = Integer.parseInt(preferences.getString("gestureVolumeUp", "0"));
-            mGestureVolumeDown = Integer.parseInt(preferences.getString("gestureVolumeDown", "0"));
+            mGestureLongclick = Integer.parseInt(prefs.getString(PreferenceKeys.GestureLongClick));
+            mGestureVolumeUp = Integer.parseInt(prefs.getString(PreferenceKeys.GestureVolumeUp));
+            mGestureVolumeDown = Integer.parseInt(prefs.getString(PreferenceKeys.GestureVolumeDown));
         }
 
-        if (preferences.getBoolean("keepScreenOn", false)) {
+        if (prefs.getBoolean(PreferenceKeys.KeepScreenOn)) {
             this.getWindow().addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
         }
 
@@ -2253,7 +2254,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
         mCardContent = mCardTemplate.render(content, style, cardClass);
         Timber.d("base url = %s", mBaseUrl);
 
-        if (AnkiDroidApp.getSharedPrefs(this).getBoolean("html_javascript_debugging", false)) {
+        if (Prefs.getBoolean(this, PreferenceKeys.HtmlJavascriptDebugging)) {
             try {
                 try (FileOutputStream f = new FileOutputStream(new File(CollectionHelper.getCurrentAnkiDroidDirectory(this),
                         "card.html"))) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiActivity.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiActivity.java
@@ -44,6 +44,8 @@ import com.ichi2.compat.customtabs.CustomTabActivityHelper;
 import com.ichi2.compat.customtabs.CustomTabsFallback;
 import com.ichi2.compat.customtabs.CustomTabsHelper;
 import com.ichi2.libanki.Collection;
+import com.ichi2.preferences.PreferenceKeys;
+import com.ichi2.preferences.Prefs;
 import com.ichi2.themes.Themes;
 import com.ichi2.utils.AdaptionUtil;
 import com.ichi2.utils.AndroidUiUtils;
@@ -158,8 +160,7 @@ public class AnkiActivity extends AppCompatActivity implements SimpleMessageDial
 
 
     public boolean animationDisabled() {
-        SharedPreferences preferences = AnkiDroidApp.getSharedPrefs(this);
-        return preferences.getBoolean("safeDisplay", false);
+        return Prefs.fromContext(this).getBoolean(PreferenceKeys.SafeDisplay);
     }
 
 
@@ -490,9 +491,9 @@ public class AnkiActivity extends AppCompatActivity implements SimpleMessageDial
 
 
     public void showSimpleNotification(String title, String message, NotificationChannels.Channel channel) {
-        SharedPreferences prefs = AnkiDroidApp.getSharedPrefs(this);
+        SharedPreferences preferences = AnkiDroidApp.getSharedPrefs(this);
         // Show a notification unless all notifications have been totally disabled
-        if (Integer.parseInt(prefs.getString("minimumCardsDueForNotification", "0")) <= Preferences.PENDING_NOTIFICATIONS_ONLY) {
+        if (Integer.parseInt(preferences.getString("minimumCardsDueForNotification", "0")) <= Preferences.PENDING_NOTIFICATIONS_ONLY) {
             // Use the title as the ticker unless the title is simply "AnkiDroid"
             String ticker = title;
             if (title.equals(getResources().getString(R.string.app_name))) {
@@ -508,11 +509,13 @@ public class AnkiActivity extends AppCompatActivity implements SimpleMessageDial
                     .setStyle(new NotificationCompat.BigTextStyle().bigText(message))
                     .setVisibility(NotificationCompat.VISIBILITY_PUBLIC)
                     .setTicker(ticker);
+
+            Prefs prefs = new Prefs(preferences);
             // Enable vibrate and blink if set in preferences
-            if (prefs.getBoolean("widgetVibrate", false)) {
+            if (prefs.getBoolean(PreferenceKeys.WidgetVibrate)) {
                 builder.setVibrate(new long[] { 1000, 1000, 1000});
             }
-            if (prefs.getBoolean("widgetBlink", false)) {
+            if (prefs.getBoolean(PreferenceKeys.WidgetBlink)) {
                 builder.setLights(Color.BLUE, 1000, 1000);
             }
             // Creates an explicit intent for an Activity in your app

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.java
@@ -447,7 +447,7 @@ public class AnkiDroidApp extends Application {
             } else {
                 preferences = getSharedPrefs(remoteContext);
             }
-            Configuration langConfig = getLanguageConfig(remoteContext.getResources().getConfiguration(), preferences);
+            Configuration langConfig = getLanguageConfig(remoteContext.getResources().getConfiguration(), new Prefs(preferences));
             return remoteContext.createConfigurationContext(langConfig);
         } catch (Exception e) {
             Timber.e(e, "failed to update context with new language");
@@ -465,9 +465,9 @@ public class AnkiDroidApp extends Application {
      */
     @SuppressWarnings("deprecation")
     @NonNull
-    private static Configuration getLanguageConfig(@NonNull Configuration remoteConfig, @NonNull SharedPreferences prefs) {
+    private static Configuration getLanguageConfig(@NonNull Configuration remoteConfig, @NonNull Prefs prefs) {
         Configuration newConfig = new Configuration(remoteConfig);
-        Locale newLocale = LanguageUtil.getLocale(prefs.getString(Preferences.LANGUAGE, ""), prefs);
+        Locale newLocale = LanguageUtil.getLocale(prefs.getString(PreferenceKeys.Language), prefs);
         Timber.d("AnkiDroidApp::getLanguageConfig - setting locale to %s", newLocale);
         //API level >=24
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.java
@@ -47,6 +47,8 @@ import com.ichi2.anki.exception.StorageAccessException;
 import com.ichi2.anki.services.BootService;
 import com.ichi2.anki.services.NotificationService;
 import com.ichi2.compat.CompatHelper;
+import com.ichi2.preferences.PreferenceKeys;
+import com.ichi2.preferences.Prefs;
 import com.ichi2.utils.AdaptionUtil;
 import com.ichi2.utils.ExceptionUtil;
 import com.ichi2.utils.LanguageUtil;
@@ -489,10 +491,10 @@ public class AnkiDroidApp extends Application {
     }
 
 
-    public static boolean initiateGestures(SharedPreferences preferences) {
-        boolean enabled = preferences.getBoolean("gestures", false);
+    public static boolean initiateGestures(Prefs preferences) {
+        boolean enabled = preferences.getBoolean(PreferenceKeys.Gestures);
         if (enabled) {
-            int sensitivity = preferences.getInt("swipeSensitivity", 100);
+            int sensitivity = preferences.getInt(PreferenceKeys.SwipeSensitivity);
             if (sensitivity != 100) {
                 float sens = 100.0f/sensitivity;
                 sSwipeMinDistance = (int) (DEFAULT_SWIPE_MIN_DISTANCE * sens + 0.5f);

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiFont.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiFont.java
@@ -9,6 +9,8 @@ import android.graphics.Typeface;
 import android.widget.Toast;
 
 import com.ichi2.libanki.Utils;
+import com.ichi2.preferences.PreferenceKeys;
+import com.ichi2.preferences.Prefs;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -96,7 +98,7 @@ public class AnkiFont {
         // determine if override font or default font
         SharedPreferences preferences = AnkiDroidApp.getSharedPrefs(ctx);
         String defaultFont = preferences.getString("defaultFont", "");
-        boolean overrideFont = "1".equals(preferences.getString("overrideFontBehavior", "0"));
+        boolean overrideFont = "1".equals(Prefs.getString(preferences, PreferenceKeys.OverrideFontBehavior));
         if (defaultFont.equalsIgnoreCase(name)) {
             if (overrideFont) {
                 createdFont.setAsOverride();

--- a/AnkiDroid/src/main/java/com/ichi2/anki/BackupManager.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/BackupManager.java
@@ -23,6 +23,8 @@ import com.ichi2.compat.CompatHelper;
 import com.ichi2.libanki.Collection;
 import com.ichi2.libanki.Utils;
 import com.ichi2.libanki.utils.Time;
+import com.ichi2.preferences.PreferenceKeys;
+import com.ichi2.preferences.Prefs;
 import com.ichi2.utils.FileUtil;
 
 import java.io.BufferedOutputStream;
@@ -98,7 +100,7 @@ public class BackupManager {
     @SuppressWarnings("PMD.NPathComplexity")
     private static boolean performBackupInBackground(final String colPath, int interval, boolean force, @NonNull Time time) {
         SharedPreferences prefs = AnkiDroidApp.getSharedPrefs(AnkiDroidApp.getInstance().getBaseContext());
-        if (prefs.getInt("backupMax", 8) == 0 && !force) {
+        if (Prefs.getInt(prefs, PreferenceKeys.BackupMax) == 0 && !force) {
             Timber.w("backups are disabled");
             return false;
         }
@@ -177,8 +179,8 @@ public class BackupManager {
                     CompatHelper.getCompat().copyFile(colPath, zos);
                     zos.close();
                     // Delete old backup files if needed
-                    SharedPreferences prefs = AnkiDroidApp.getSharedPrefs(AnkiDroidApp.getInstance().getBaseContext());
-                    deleteDeckBackups(colPath, prefs.getInt("backupMax", 8));
+                    Prefs prefs = Prefs.fromContext(AnkiDroidApp.getInstance().getBaseContext());
+                    deleteDeckBackups(colPath,  prefs.getInt(PreferenceKeys.BackupMax));
                     // set timestamp of file in order to avoid creating a new backup unless its changed
                     if (!backupFile.setLastModified(colFile.lastModified())) {
                         Timber.w("performBackupInBackground() setLastModified() failed on file %s", backupFilename);

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -78,6 +78,8 @@ import com.ichi2.libanki.Consts;
 import com.ichi2.libanki.Decks;
 import com.ichi2.libanki.Utils;
 import com.ichi2.libanki.Deck;
+import com.ichi2.preferences.PreferenceKeys;
+import com.ichi2.preferences.Prefs;
 import com.ichi2.themes.Themes;
 import com.ichi2.upgrade.Upgrade;
 import com.ichi2.utils.BooleanGetter;
@@ -172,7 +174,6 @@ public class CardBrowser extends NavigationDrawerActivity implements
     private static final int ADD_NOTE = 1;
     private static final int PREVIEW_CARDS = 2;
 
-    private static final int DEFAULT_FONT_SIZE_RATIO = 100;
     // Should match order of R.array.card_browser_order_labels
     public static final int CARD_ORDER_NONE = 0;
     private static final String[] fSortTypes = new String[] {
@@ -531,7 +532,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
         Timber.d("onCollectionLoaded()");
         registerExternalStorageListener();
 
-        SharedPreferences preferences = AnkiDroidApp.getSharedPrefs(getBaseContext());
+        Prefs preferences = Prefs.fromContext(getBaseContext());
 
         // Load reference to action bar title
         mActionBarTitle = findViewById(R.id.toolbar_title);
@@ -566,7 +567,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
                 break;
             }
         }
-        if (mOrder == 1 && preferences.getBoolean("cardBrowserNoSorting", false)) {
+        if (mOrder == 1 && preferences.getBoolean(PreferenceKeys.CardBrowserNoSorting)) {
             mOrder = 0;
         }
         //This upgrade should already have been done during
@@ -583,7 +584,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
                 R.array.browser_column1_headings, android.R.layout.simple_spinner_item);
         column1Adapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
         cardsColumn1Spinner.setAdapter(column1Adapter);
-        mColumn1Index = AnkiDroidApp.getSharedPrefs(getBaseContext()).getInt("cardBrowserColumn1", 0);
+        mColumn1Index = preferences.getInt(PreferenceKeys.CardBrowserColumn1);
         cardsColumn1Spinner.setOnItemSelectedListener(new OnItemSelectedListener() {
             @Override
             public void onItemSelected(AdapterView<?> parent, View view, int pos, long id) {
@@ -604,7 +605,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
             }
         });
         // Load default value for column2 selection
-        mColumn2Index = AnkiDroidApp.getSharedPrefs(getBaseContext()).getInt("cardBrowserColumn2", 0);
+        mColumn2Index = preferences.getInt(PreferenceKeys.CardBrowserColumn2);
         // Setup the column 2 heading as a spinner so that users can easily change the column type
         Spinner cardsColumn2Spinner = findViewById(R.id.browser_column2_spinner);
         ArrayAdapter<CharSequence> column2Adapter = ArrayAdapter.createFromResource(this,
@@ -632,8 +633,8 @@ public class CardBrowser extends NavigationDrawerActivity implements
             }
         });
         // get the font and font size from the preferences
-        int sflRelativeFontSize = preferences.getInt("relativeCardBrowserFontSize", DEFAULT_FONT_SIZE_RATIO);
-        String sflCustomFont = preferences.getString("browserEditorFont", "");
+        int sflRelativeFontSize = preferences.getInt(PreferenceKeys.RelativeCardBrowserFontSize);
+        String sflCustomFont = preferences.getString(PreferenceKeys.BrowserEditorFont);
         Column[] columnsContent = {COLUMN1_KEYS[mColumn1Index], COLUMN2_KEYS[mColumn2Index]};
         // make a new list adapter mapping the data in mCards to column1 and column2 of R.layout.card_item_browser
         mCardsAdapter = new MultiColumnListAdapter(
@@ -1726,7 +1727,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
 
     @CheckResult
     private static String formatQA(String text, Context context) {
-        boolean showFilenames = AnkiDroidApp.getSharedPrefs(context).getBoolean("card_browser_show_media_filenames", false);
+        boolean showFilenames = Prefs.fromContext(context).getBoolean(PreferenceKeys.CardBrowserShowMediaFilenames);
         return formatQAInternal(text, showFilenames);
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/FieldEditText.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/FieldEditText.java
@@ -4,7 +4,6 @@ package com.ichi2.anki;
 import android.content.ClipDescription;
 import android.content.ClipboardManager;
 import android.content.Context;
-import android.content.SharedPreferences;
 import android.graphics.drawable.Drawable;
 import android.net.Uri;
 import android.os.Build;
@@ -17,21 +16,21 @@ import android.view.inputmethod.EditorInfo;
 import android.view.inputmethod.InputConnection;
 import android.widget.EditText;
 
-import java.util.Locale;
-
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-import androidx.annotation.RequiresApi;
-
-import androidx.core.view.inputmethod.EditorInfoCompat;
-import androidx.core.view.inputmethod.InputConnectionCompat;
-import timber.log.Timber;
-
+import com.ichi2.preferences.PreferenceKeys;
+import com.ichi2.preferences.Prefs;
 import com.ichi2.themes.Themes;
 import com.ichi2.ui.FixedEditText;
 import com.ichi2.utils.ClipboardUtil;
 
+import java.util.Locale;
 import java.util.Objects;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.annotation.RequiresApi;
+import androidx.core.view.inputmethod.EditorInfoCompat;
+import androidx.core.view.inputmethod.InputConnectionCompat;
+import timber.log.Timber;
 
 import static android.view.inputmethod.EditorInfo.IME_FLAG_NO_EXTRACT_UI;
 import static com.ichi2.utils.ClipboardUtil.IMAGE_MIME_TYPES;
@@ -78,8 +77,8 @@ public class FieldEditText extends FixedEditText {
 
     private boolean shouldDisableExtendedTextUi() {
         try {
-            SharedPreferences sp = AnkiDroidApp.getSharedPrefs(this.getContext());
-            return sp.getBoolean("disableExtendedTextUi", false);
+            Prefs prefs = Prefs.fromContext(getContext());
+            return prefs.getBoolean(PreferenceKeys.DisableExtendedTextUi);
         } catch (Exception e) {
             Timber.e(e, "Failed to get extended UI preference");
             return false;

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Lookup.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Lookup.java
@@ -11,6 +11,8 @@ import android.view.View;
 import com.afollestad.materialdialogs.MaterialDialog;
 
 import com.ichi2.libanki.Utils;
+import com.ichi2.preferences.PreferenceKeys;
+import com.ichi2.preferences.Prefs;
 
 import timber.log.Timber;
 
@@ -19,7 +21,7 @@ public class Lookup {
     /**
      * Searches
      */
-    private static final int DICTIONARY_NONE = 0;    // use no dictionary
+    public static final int DICTIONARY_NONE = 0;    // use no dictionary
     private static final int DICTIONARY_AEDICT = 1;  // Japanese dictionary
     private static final int DICTIONARY_EIJIRO_WEB = 2; // japanese web dictionary
     private static final int DICTIONARY_LEO_WEB = 3; // German web dictionary for English, French, Spanish, Italian,
@@ -39,8 +41,8 @@ public class Lookup {
 
     public static boolean initialize(Context context) {
         mContext = context;
-        SharedPreferences preferences = AnkiDroidApp.getSharedPrefs(AnkiDroidApp.getInstance().getBaseContext());
-        mDictionary = Integer.parseInt(preferences.getString("dictionary", Integer.toString(DICTIONARY_NONE)));
+        Prefs preferences = Prefs.fromContext(AnkiDroidApp.getInstance().getBaseContext());
+        mDictionary = Integer.parseInt(preferences.getString(PreferenceKeys.Dictionary));
         switch (mDictionary) {
             case DICTIONARY_AEDICT:
                 mDictionaryAction = "sk.baka.aedict.action.ACTION_SEARCH_EDICT";

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Lookup.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Lookup.java
@@ -4,9 +4,7 @@ package com.ichi2.anki;
 import android.content.ComponentName;
 import android.content.Context;
 import android.content.Intent;
-import android.content.SharedPreferences;
 import android.net.Uri;
-import android.view.View;
 
 import com.afollestad.materialdialogs.MaterialDialog;
 
@@ -42,7 +40,7 @@ public class Lookup {
     public static boolean initialize(Context context) {
         mContext = context;
         Prefs preferences = Prefs.fromContext(AnkiDroidApp.getInstance().getBaseContext());
-        mDictionary = Integer.parseInt(preferences.getString(PreferenceKeys.Dictionary));
+        mDictionary = preferences.getIntFromStr(PreferenceKeys.Dictionary);
         switch (mDictionary) {
             case DICTIONARY_AEDICT:
                 mDictionaryAction = "sk.baka.aedict.action.ACTION_SEARCH_EDICT";

--- a/AnkiDroid/src/main/java/com/ichi2/anki/MyAccount.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/MyAccount.java
@@ -35,6 +35,8 @@ import com.google.android.material.textfield.TextInputLayout;
 import com.ichi2.anki.web.HostNumFactory;
 import com.ichi2.async.Connection;
 import com.ichi2.async.Connection.Payload;
+import com.ichi2.preferences.PreferenceKeys;
+import com.ichi2.preferences.Prefs;
 import com.ichi2.themes.StyledProgressDialog;
 import com.ichi2.ui.TextInputEditField;
 import com.ichi2.utils.AdaptionUtil;
@@ -65,7 +67,7 @@ public class MyAccount extends AnkiActivity {
     private void switchToState(int newState) {
         switch (newState) {
             case STATE_LOGGED_IN:
-                String username = AnkiDroidApp.getSharedPrefs(getBaseContext()).getString("username", "");
+                String username = Prefs.getString(getBaseContext(), PreferenceKeys.Username);
                 mUsernameLoggedIn.setText(username);
                 mToolbar = mLoggedIntoMyAccountView.findViewById(R.id.toolbar);
                 if (mToolbar!= null) {
@@ -105,7 +107,7 @@ public class MyAccount extends AnkiActivity {
         initAllContentViews();
 
         SharedPreferences preferences = AnkiDroidApp.getSharedPrefs(getBaseContext());
-        if (preferences.getString("hkey", "").length() > 0) {
+        if (Prefs.getString(preferences, PreferenceKeys.HKey).length() > 0) {
             switchToState(STATE_LOGGED_IN);
         } else {
             switchToState(STATE_LOG_IN);

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NavigationDrawerActivity.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NavigationDrawerActivity.java
@@ -37,6 +37,8 @@ import android.view.MenuItem;
 import android.view.View;
 
 import com.ichi2.anki.dialogs.HelpDialog;
+import com.ichi2.preferences.PreferenceKeys;
+import com.ichi2.preferences.Prefs;
 import com.ichi2.themes.Themes;
 import androidx.drawerlayout.widget.ClosableDrawerLayout;
 
@@ -65,7 +67,7 @@ public abstract class NavigationDrawerActivity extends AnkiActivity implements N
     public static final int REQUEST_PREFERENCES_UPDATE = 100;
     public static final int REQUEST_BROWSE_CARDS = 101;
     public static final int REQUEST_STATISTICS = 102;
-    private static final String NIGHT_MODE_PREFERENCE = "invertedColors";
+    public static final String NIGHT_MODE_PREFERENCE = "invertedColors";
 
     /**
      * runnable that will be executed after the drawer has been closed.
@@ -98,7 +100,7 @@ public abstract class NavigationDrawerActivity extends AnkiActivity implements N
         final SharedPreferences preferences = getPreferences();
         View actionLayout = mNavigationView.getMenu().findItem(R.id.nav_night_mode).getActionView();
         mNightModeSwitch = actionLayout.findViewById(R.id.switch_compat);
-        mNightModeSwitch.setChecked(preferences.getBoolean(NIGHT_MODE_PREFERENCE, false));
+        mNightModeSwitch.setChecked(Prefs.getBoolean(preferences, PreferenceKeys.InvertedColors));
         mNightModeSwitch.setOnCheckedChangeListener((buttonView, isChecked) -> applyNightMode(isChecked));
         // ActionBarDrawerToggle ties together the the proper interactions
         // between the sliding drawer and the action bar app icon
@@ -232,14 +234,14 @@ public abstract class NavigationDrawerActivity extends AnkiActivity implements N
 
     @Override
     protected void onActivityResult(int requestCode, int resultCode, Intent data) {
-        final SharedPreferences preferences = getPreferences();
+        final Prefs preferences = new Prefs(getPreferences());
         Timber.i("Handling Activity Result: %d. Result: %d", requestCode, resultCode);
         NotificationChannels.setup(getApplicationContext());
         // Restart the activity on preference change
         if (requestCode == REQUEST_PREFERENCES_UPDATE) {
             if (mOldColPath != null && CollectionHelper.getCurrentAnkiDroidDirectory(this).equals(mOldColPath)) {
                 // collection path hasn't been changed so just restart the current activity
-                if ((this instanceof Reviewer) && preferences.getBoolean("tts", false)) {
+                if ((this instanceof Reviewer) && preferences.getBoolean(PreferenceKeys.Tts)) {
                     // Workaround to kick user back to StudyOptions after opening settings from Reviewer
                     // because onDestroy() of old Activity interferes with TTS in new Activity
                     finishWithoutAnimation();

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -25,7 +25,6 @@ import android.content.ClipboardManager;
 import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
-import android.content.SharedPreferences;
 import android.content.res.Resources;
 import android.graphics.Typeface;
 import android.graphics.drawable.Drawable;
@@ -92,13 +91,14 @@ import com.ichi2.async.TaskManager;
 import com.ichi2.compat.CompatHelper;
 import com.ichi2.libanki.Card;
 import com.ichi2.libanki.Collection;
-import com.ichi2.libanki.Consts;
 import com.ichi2.libanki.Models;
 import com.ichi2.libanki.Model;
 import com.ichi2.libanki.Note;
 import com.ichi2.libanki.Note.ClozeUtils;
 import com.ichi2.libanki.Utils;
 import com.ichi2.libanki.Deck;
+import com.ichi2.preferences.PreferenceKeys;
+import com.ichi2.preferences.Prefs;
 import com.ichi2.themes.StyledProgressDialog;
 import com.ichi2.themes.Themes;
 import com.ichi2.anki.widgets.PopupMenuWithIcons;
@@ -1097,18 +1097,18 @@ public class NoteEditor extends AnkiActivity {
         }
 
         menu.findItem(R.id.action_show_toolbar).setChecked(!shouldHideToolbar());
-        menu.findItem(R.id.action_capitalize).setChecked(AnkiDroidApp.getSharedPrefs(this).getBoolean("note_editor_capitalize", true));
+        menu.findItem(R.id.action_capitalize).setChecked(Prefs.getBoolean(this, PreferenceKeys.NoteEditorCapitalize));
 
         return super.onCreateOptionsMenu(menu);
     }
 
 
     protected static boolean shouldReplaceNewlines() {
-        return AnkiDroidApp.getSharedPrefs(AnkiDroidApp.getInstance()).getBoolean("noteEditorNewlineReplace", true);
+        return Prefs.getBoolean(AnkiDroidApp.getInstance(), PreferenceKeys.NoteEditorNewlineReplace);
     }
 
     protected static boolean shouldHideToolbar() {
-        return !AnkiDroidApp.getSharedPrefs(AnkiDroidApp.getInstance()).getBoolean("noteEditorShowToolbar", true);
+        return !Prefs.getBoolean(AnkiDroidApp.getInstance(), PreferenceKeys.NoteEditorShowToolbar);
     }
 
     @Override
@@ -1475,8 +1475,8 @@ public class NoteEditor extends AnkiActivity {
 
         // Use custom font if selected from preferences
         Typeface mCustomTypeface = null;
-        SharedPreferences preferences = AnkiDroidApp.getSharedPrefs(getBaseContext());
-        String customFont = preferences.getString("browserEditorFont", "");
+        Prefs prefs = new Prefs(AnkiDroidApp.getSharedPrefs(getBaseContext()));
+        String customFont = prefs.getString(PreferenceKeys.BrowserEditorFont);
         if (!"".equals(customFont)) {
             mCustomTypeface = AnkiFont.getTypeface(this, customFont);
         }
@@ -1515,11 +1515,12 @@ public class NoteEditor extends AnkiActivity {
             edit_line_view.setHintLocale(getHintLocaleForField(edit_line_view.getName()));
             initFieldEditText(newTextbox, i, !editModelMode);
             mEditFields.add(newTextbox);
-            SharedPreferences prefs = AnkiDroidApp.getSharedPrefs(this);
-            if (prefs.getInt("note_editor_font_size", -1) > 0) {
-                newTextbox.setTextSize(prefs.getInt("note_editor_font_size", -1));
+
+            int noteEditorFontSize = prefs.getInt(PreferenceKeys.NoteEditorFontSize);
+            if (noteEditorFontSize > 0) {
+                newTextbox.setTextSize(noteEditorFontSize);
             }
-            newTextbox.setCapitalize(prefs.getBoolean("note_editor_capitalize", true));
+            newTextbox.setCapitalize(prefs.getBoolean(PreferenceKeys.NoteEditorCapitalize));
 
             ImageButton mediaButton = edit_line_view.getMediaButton();
             // Load icons from attributes

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
@@ -55,6 +55,8 @@ import com.ichi2.compat.CompatHelper;
 import com.ichi2.libanki.Collection;
 import com.ichi2.libanki.Utils;
 import com.ichi2.preferences.NumberRangePreference;
+import com.ichi2.preferences.PreferenceKeys;
+import com.ichi2.preferences.Prefs;
 import com.ichi2.themes.Themes;
 import com.ichi2.ui.AppCompatPreferenceActivity;
 import com.ichi2.ui.ConfirmationPreference;
@@ -687,7 +689,7 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
                     break;
                 }
                 case AnkiDroidApp.FEEDBACK_REPORT_KEY: {
-                    String value = prefs.getString(AnkiDroidApp.FEEDBACK_REPORT_KEY, "");
+                    String value = Prefs.getString(prefs, PreferenceKeys.FeedbackReportKey);
                     AnkiDroidApp.getInstance().setAcraReportingMode(value);
                     // If the user changed error reporting, make sure future reports have a chance to post
                     AnkiDroidApp.deleteACRALimiterData(this);
@@ -696,8 +698,8 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
                     break;
                 }
                 case "syncAccount": {
-                    SharedPreferences preferences = AnkiDroidApp.getSharedPrefs(getBaseContext());
-                    String username = preferences.getString("username", "");
+                    Prefs preferences = Prefs.fromContext(getBaseContext());
+                    String username = preferences.getString(PreferenceKeys.Username);
                     android.preference.Preference syncAccount = screen.findPreference("syncAccount");
                     if (syncAccount != null) {
                         if (TextUtils.isEmpty(username)) {
@@ -790,7 +792,7 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
 
 
     private void updateGestureCornerTouch(android.preference.PreferenceScreen screen) {
-        boolean gestureCornerTouch = AnkiDroidApp.getSharedPrefs(this).getBoolean("gestureCornerTouch", false);
+        boolean gestureCornerTouch = Prefs.fromContext(this).getBoolean(PreferenceKeys.GestureCornerTouch);
         if (gestureCornerTouch) {
             screen.findPreference("gestureTapTop").setTitle(R.string.gestures_corner_tap_top_center);
             screen.findPreference("gestureTapLeft").setTitle(R.string.gestures_corner_tap_middle_left);
@@ -836,7 +838,7 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
                 }
                 break;
             case "advanced_statistics_link":
-                if (!AnkiDroidApp.getSharedPrefs(this).getBoolean("advanced_statistics_enabled", false)) {
+                if (!Prefs.fromContext(this).getBoolean(PreferenceKeys.AdvancedStatisticsEnabled)) {
                     pref.setSummary(R.string.disabled);
                 } else {
                     pref.setSummary(R.string.enabled);

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.java
@@ -1202,9 +1202,8 @@ public class Reviewer extends AbstractFlashcardViewer {
 
 
     private void disableDrawerSwipeOnConflicts() {
-        SharedPreferences preferences = AnkiDroidApp.getSharedPrefs(getBaseContext());
-        Prefs prefs = new Prefs(preferences);
-        boolean gesturesEnabled = AnkiDroidApp.initiateGestures(preferences);
+        Prefs prefs = Prefs.fromContext(getBaseContext());
+        boolean gesturesEnabled = AnkiDroidApp.initiateGestures(prefs);
         if (gesturesEnabled) {
             int gestureSwipeUp = Integer.parseInt(prefs.getString(PreferenceKeys.GestureSwipeUp));
             int gestureSwipeDown = Integer.parseInt(prefs.getString(PreferenceKeys.GestureSwipeDown));

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.java
@@ -911,7 +911,7 @@ public class Reviewer extends AbstractFlashcardViewer {
         mPrefHideDueCount = prefs.getBoolean(PreferenceKeys.HideDueCount);
         mPrefShowETA = prefs.getBoolean(PreferenceKeys.ShowEta);
         this.mProcessor.setup();
-        mPrefFullscreenReview = Integer.parseInt(prefs.getString(PreferenceKeys.FullscreenMode)) > 0;
+        mPrefFullscreenReview = prefs.getIntFromStr(PreferenceKeys.FullscreenMode) > 0;
         mActionButtons.setup(preferences);
         return preferences;
     }
@@ -1097,7 +1097,7 @@ public class Reviewer extends AbstractFlashcardViewer {
         );
         // Show / hide the Action bar together with the status bar
         SharedPreferences prefs = AnkiDroidApp.getSharedPrefs(a);
-        final int fullscreenMode = Integer.parseInt(Prefs.getString(prefs, PreferenceKeys.FullscreenMode));
+        final int fullscreenMode = new Prefs(prefs).getIntFromStr(PreferenceKeys.FullscreenMode);
         a.getWindow().setStatusBarColor(Themes.getColorFromAttr(a, R.attr.colorPrimaryDark));
         View decorView = a.getWindow().getDecorView();
         decorView.setOnSystemUiVisibilityChangeListener
@@ -1205,9 +1205,9 @@ public class Reviewer extends AbstractFlashcardViewer {
         Prefs prefs = Prefs.fromContext(getBaseContext());
         boolean gesturesEnabled = AnkiDroidApp.initiateGestures(prefs);
         if (gesturesEnabled) {
-            int gestureSwipeUp = Integer.parseInt(prefs.getString(PreferenceKeys.GestureSwipeUp));
-            int gestureSwipeDown = Integer.parseInt(prefs.getString(PreferenceKeys.GestureSwipeDown));
-            int gestureSwipeRight = Integer.parseInt(prefs.getString(PreferenceKeys.GestureSwipeRight));
+            int gestureSwipeUp = prefs.getIntFromStr(PreferenceKeys.GestureSwipeUp);
+            int gestureSwipeDown = prefs.getIntFromStr(PreferenceKeys.GestureSwipeDown);
+            int gestureSwipeRight = prefs.getIntFromStr(PreferenceKeys.GestureSwipeRight);
             if (gestureSwipeUp != COMMAND_NOTHING ||
                     gestureSwipeDown != COMMAND_NOTHING ||
                     gestureSwipeRight != COMMAND_NOTHING) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.java
@@ -34,7 +34,6 @@ import android.os.Handler;
 import android.os.Message;
 import android.text.SpannableString;
 import android.text.style.UnderlineSpan;
-import android.util.Pair;
 import android.view.KeyEvent;
 import android.view.Menu;
 import android.view.MenuItem;
@@ -71,9 +70,7 @@ import com.ichi2.anki.reviewer.ReviewerUi;
 import com.ichi2.anki.workarounds.FirefoxSnackbarWorkaround;
 import com.ichi2.anki.reviewer.ActionButtons;
 import com.ichi2.async.CollectionTask;
-import com.ichi2.async.TaskListener;
 import com.ichi2.async.TaskManager;
-import com.ichi2.compat.CompatHelper;
 import com.ichi2.libanki.Card;
 import com.ichi2.libanki.Collection;
 import com.ichi2.libanki.Collection.DismissType;
@@ -81,6 +78,8 @@ import com.ichi2.libanki.Consts;
 import com.ichi2.libanki.Decks;
 import com.ichi2.libanki.Utils;
 import com.ichi2.libanki.sched.Counts;
+import com.ichi2.preferences.PreferenceKeys;
+import com.ichi2.preferences.Prefs;
 import com.ichi2.themes.Themes;
 import com.ichi2.utils.AndroidUiUtils;
 import com.ichi2.utils.FunctionalInterfaces.Consumer;
@@ -908,10 +907,11 @@ public class Reviewer extends AbstractFlashcardViewer {
     @Override
     protected SharedPreferences restorePreferences() {
         SharedPreferences preferences = super.restorePreferences();
-        mPrefHideDueCount = preferences.getBoolean("hideDueCount", false);
-        mPrefShowETA = preferences.getBoolean("showETA", true);
+        Prefs prefs = new Prefs(preferences);
+        mPrefHideDueCount = prefs.getBoolean(PreferenceKeys.HideDueCount);
+        mPrefShowETA = prefs.getBoolean(PreferenceKeys.ShowEta);
         this.mProcessor.setup();
-        mPrefFullscreenReview = Integer.parseInt(preferences.getString("fullscreenMode", "0")) > 0;
+        mPrefFullscreenReview = Integer.parseInt(prefs.getString(PreferenceKeys.FullscreenMode)) > 0;
         mActionButtons.setup(preferences);
         return preferences;
     }
@@ -1097,7 +1097,7 @@ public class Reviewer extends AbstractFlashcardViewer {
         );
         // Show / hide the Action bar together with the status bar
         SharedPreferences prefs = AnkiDroidApp.getSharedPrefs(a);
-        final int fullscreenMode = Integer.parseInt(prefs.getString("fullscreenMode", "0"));
+        final int fullscreenMode = Integer.parseInt(Prefs.getString(prefs, PreferenceKeys.FullscreenMode));
         a.getWindow().setStatusBarColor(Themes.getColorFromAttr(a, R.attr.colorPrimaryDark));
         View decorView = a.getWindow().getDecorView();
         decorView.setOnSystemUiVisibilityChangeListener
@@ -1203,11 +1203,12 @@ public class Reviewer extends AbstractFlashcardViewer {
 
     private void disableDrawerSwipeOnConflicts() {
         SharedPreferences preferences = AnkiDroidApp.getSharedPrefs(getBaseContext());
+        Prefs prefs = new Prefs(preferences);
         boolean gesturesEnabled = AnkiDroidApp.initiateGestures(preferences);
         if (gesturesEnabled) {
-            int gestureSwipeUp = Integer.parseInt(preferences.getString("gestureSwipeUp", "9"));
-            int gestureSwipeDown = Integer.parseInt(preferences.getString("gestureSwipeDown", "0"));
-            int gestureSwipeRight = Integer.parseInt(preferences.getString("gestureSwipeRight", "17"));
+            int gestureSwipeUp = Integer.parseInt(prefs.getString(PreferenceKeys.GestureSwipeUp));
+            int gestureSwipeDown = Integer.parseInt(prefs.getString(PreferenceKeys.GestureSwipeDown));
+            int gestureSwipeRight = Integer.parseInt(prefs.getString(PreferenceKeys.GestureSwipeRight));
             if (gestureSwipeUp != COMMAND_NOTHING ||
                     gestureSwipeDown != COMMAND_NOTHING ||
                     gestureSwipeRight != COMMAND_NOTHING) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Whiteboard.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Whiteboard.java
@@ -45,6 +45,8 @@ import android.widget.LinearLayout;
 
 import com.ichi2.libanki.utils.Time;
 import com.ichi2.libanki.utils.TimeUtils;
+import com.ichi2.preferences.PreferenceKeys;
+import com.ichi2.preferences.Prefs;
 
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -110,7 +112,7 @@ public class Whiteboard extends View {
         mPaint.setStyle(Paint.Style.STROKE);
         mPaint.setStrokeJoin(Paint.Join.ROUND);
         mPaint.setStrokeCap(Paint.Cap.ROUND);
-        int wbStrokeWidth = AnkiDroidApp.getSharedPrefs(cardViewer).getInt("whiteBoardStrokeWidth", 6);
+        int wbStrokeWidth = Prefs.getInt(cardViewer, PreferenceKeys.WhiteBoardStrokeWidth);
         mPaint.setStrokeWidth((float) wbStrokeWidth);
         createBitmap();
         mPath = new Path();

--- a/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/CardAppearance.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/CardAppearance.java
@@ -4,6 +4,8 @@ import android.content.SharedPreferences;
 
 import com.ichi2.anki.reviewer.ReviewerCustomFonts;
 import com.ichi2.libanki.Card;
+import com.ichi2.preferences.PreferenceKeys;
+import com.ichi2.preferences.Prefs;
 import com.ichi2.themes.Themes;
 
 import androidx.annotation.CheckResult;
@@ -52,15 +54,16 @@ public class CardAppearance {
     }
 
     public static CardAppearance create(ReviewerCustomFonts customFonts, SharedPreferences preferences) {
-        int cardZoom = preferences.getInt("cardZoom", 100);
-        int imageZoom = preferences.getInt("imageZoom", 100);
+        Prefs prefs = new Prefs(preferences);
+        int cardZoom = prefs.getInt(PreferenceKeys.CardZoom);
+        int imageZoom = prefs.getInt(PreferenceKeys.ImageZoom);
         boolean nightMode = isInNightMode(preferences);
-        boolean centerVertically = preferences.getBoolean("centerVertically", false);
+        boolean centerVertically = prefs.getBoolean(PreferenceKeys.CenterVertically);
         return new CardAppearance(customFonts, cardZoom, imageZoom, nightMode, centerVertically);
     }
 
     public static boolean isInNightMode(SharedPreferences sharedPrefs) {
-        return sharedPrefs.getBoolean("invertedColors", false);
+        return Prefs.getBoolean(sharedPrefs, PreferenceKeys.InvertedColors);
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/GestureTapProcessor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/GestureTapProcessor.java
@@ -48,18 +48,18 @@ public class GestureTapProcessor {
 
     public void init(SharedPreferences preferences) {
         Prefs prefs = new Prefs(preferences);
-        mGestureTapLeft = Integer.parseInt(prefs.getString(PreferenceKeys.GestureTapLeft));
-        mGestureTapRight = Integer.parseInt(prefs.getString(PreferenceKeys.GestureTapRight));
-        mGestureTapTop = Integer.parseInt(prefs.getString(PreferenceKeys.GestureTapTop));
-        mGestureTapBottom = Integer.parseInt(prefs.getString(PreferenceKeys.GestureTapBottom));
+        mGestureTapLeft = prefs.getIntFromStr(PreferenceKeys.GestureTapLeft);
+        mGestureTapRight = prefs.getIntFromStr(PreferenceKeys.GestureTapRight);
+        mGestureTapTop = prefs.getIntFromStr(PreferenceKeys.GestureTapTop);
+        mGestureTapBottom = prefs.getIntFromStr(PreferenceKeys.GestureTapBottom);
 
         mUseCornerTouch = prefs.getBoolean(PreferenceKeys.GestureCornerTouch);
         if (mUseCornerTouch) {
-            mGestureTapTopLeft = Integer.parseInt(prefs.getString(PreferenceKeys.GestureTapTopLeft));
-            mGestureTapTopRight = Integer.parseInt(prefs.getString(PreferenceKeys.GestureTapTopRight));
-            mGestureTapCenter = Integer.parseInt(prefs.getString(PreferenceKeys.GestureTapCenter));
-            mGestureTapBottomLeft = Integer.parseInt(prefs.getString(PreferenceKeys.GestureTapBottomLeft));
-            mGestureTapBottomRight = Integer.parseInt(prefs.getString(PreferenceKeys.GestureTapBottomRight));
+            mGestureTapTopLeft = prefs.getIntFromStr(PreferenceKeys.GestureTapTopLeft);
+            mGestureTapTopRight = prefs.getIntFromStr(PreferenceKeys.GestureTapTopRight);
+            mGestureTapCenter = prefs.getIntFromStr(PreferenceKeys.GestureTapCenter);
+            mGestureTapBottomLeft = prefs.getIntFromStr(PreferenceKeys.GestureTapBottomLeft);
+            mGestureTapBottomRight = prefs.getIntFromStr(PreferenceKeys.GestureTapBottomRight);
         }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/GestureTapProcessor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/GestureTapProcessor.java
@@ -18,6 +18,9 @@ package com.ichi2.anki.cardviewer;
 
 import android.content.SharedPreferences;
 
+import com.ichi2.preferences.PreferenceKeys;
+import com.ichi2.preferences.Prefs;
+
 import static com.ichi2.anki.cardviewer.ViewerCommand.COMMAND_NOTHING;
 
 public class GestureTapProcessor {
@@ -44,18 +47,19 @@ public class GestureTapProcessor {
 
 
     public void init(SharedPreferences preferences) {
-        mGestureTapLeft = Integer.parseInt(preferences.getString("gestureTapLeft", "3"));
-        mGestureTapRight = Integer.parseInt(preferences.getString("gestureTapRight", "6"));
-        mGestureTapTop = Integer.parseInt(preferences.getString("gestureTapTop", "12"));
-        mGestureTapBottom = Integer.parseInt(preferences.getString("gestureTapBottom", "2"));
+        Prefs prefs = new Prefs(preferences);
+        mGestureTapLeft = Integer.parseInt(prefs.getString(PreferenceKeys.GestureTapLeft));
+        mGestureTapRight = Integer.parseInt(prefs.getString(PreferenceKeys.GestureTapRight));
+        mGestureTapTop = Integer.parseInt(prefs.getString(PreferenceKeys.GestureTapTop));
+        mGestureTapBottom = Integer.parseInt(prefs.getString(PreferenceKeys.GestureTapBottom));
 
-        mUseCornerTouch = preferences.getBoolean("gestureCornerTouch", false);
+        mUseCornerTouch = prefs.getBoolean(PreferenceKeys.GestureCornerTouch);
         if (mUseCornerTouch) {
-            mGestureTapTopLeft = Integer.parseInt(preferences.getString("gestureTapTopLeft", "0"));
-            mGestureTapTopRight = Integer.parseInt(preferences.getString("gestureTapTopRight", "0"));
-            mGestureTapCenter = Integer.parseInt(preferences.getString("gestureTapCenter", "0"));
-            mGestureTapBottomLeft = Integer.parseInt(preferences.getString("gestureTapBottomLeft", "0"));
-            mGestureTapBottomRight = Integer.parseInt(preferences.getString("gestureTapBottomRight", "0"));
+            mGestureTapTopLeft = Integer.parseInt(prefs.getString(PreferenceKeys.GestureTapTopLeft));
+            mGestureTapTopRight = Integer.parseInt(prefs.getString(PreferenceKeys.GestureTapTopRight));
+            mGestureTapCenter = Integer.parseInt(prefs.getString(PreferenceKeys.GestureTapCenter));
+            mGestureTapBottomLeft = Integer.parseInt(prefs.getString(PreferenceKeys.GestureTapBottomLeft));
+            mGestureTapBottomRight = Integer.parseInt(prefs.getString(PreferenceKeys.GestureTapBottomRight));
         }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/contextmenu/AnkiCardContextMenu.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/contextmenu/AnkiCardContextMenu.java
@@ -18,6 +18,8 @@ package com.ichi2.anki.contextmenu;
 
 import android.content.Context;
 
+import com.ichi2.preferences.PreferenceKeys;
+
 import androidx.annotation.NonNull;
 
 public class AnkiCardContextMenu extends SystemContextMenu {
@@ -41,14 +43,9 @@ public class AnkiCardContextMenu extends SystemContextMenu {
         return "com.ichi2.anki.AnkiCardContextMenuAction";
     }
 
-    @Override
-    protected boolean getDefaultEnabledStatus() {
-        return true;
-    }
-
     @NonNull
     @Override
-    protected String getPreferenceKey() {
-        return ANKI_CARD_CONTEXT_MENU_PREF_KEY;
+    protected PreferenceKeys.PreferenceKey<Boolean> getPreferenceKey() {
+        return PreferenceKeys.AnkiCardContextMenu;
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/contextmenu/CardBrowserContextMenu.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/contextmenu/CardBrowserContextMenu.java
@@ -18,6 +18,8 @@ package com.ichi2.anki.contextmenu;
 
 import android.content.Context;
 
+import com.ichi2.preferences.PreferenceKeys;
+
 import androidx.annotation.NonNull;
 
 public class CardBrowserContextMenu extends SystemContextMenu {
@@ -40,14 +42,9 @@ public class CardBrowserContextMenu extends SystemContextMenu {
         return "com.ichi2.anki.CardBrowserContextMenuAction";
     }
 
-    @Override
-    protected boolean getDefaultEnabledStatus() {
-        return false;
-    }
-
     @NonNull
     @Override
-    protected String getPreferenceKey() {
-        return CARD_BROWSER_CONTEXT_MENU_PREF_KEY;
+    protected PreferenceKeys.PreferenceKey<Boolean> getPreferenceKey() {
+        return PreferenceKeys.CardBrowserContextMenu;
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/contextmenu/SystemContextMenu.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/contextmenu/SystemContextMenu.java
@@ -20,7 +20,8 @@ import android.content.ComponentName;
 import android.content.Context;
 import android.content.pm.PackageManager;
 
-import com.ichi2.anki.AnkiDroidApp;
+import com.ichi2.preferences.PreferenceKeys;
+import com.ichi2.preferences.Prefs;
 
 import androidx.annotation.CheckResult;
 import androidx.annotation.NonNull;
@@ -33,9 +34,8 @@ import static android.content.pm.PackageManager.DONT_KILL_APP;
 
 public abstract class SystemContextMenu {
 
-    protected abstract boolean getDefaultEnabledStatus();
     @NonNull
-    protected abstract String getPreferenceKey();
+    protected abstract PreferenceKeys.PreferenceKey<Boolean> getPreferenceKey();
     /** We use an activity alias as the name so we can disable the context menu without disabling the activity */
     @NonNull
     protected abstract String getActivityName();
@@ -68,7 +68,7 @@ public abstract class SystemContextMenu {
     }
 
     protected boolean getPreferenceStatus() {
-        return AnkiDroidApp.getSharedPrefs(mContext).getBoolean(getPreferenceKey(), getDefaultEnabledStatus());
+        return Prefs.fromContext(mContext).getBoolean(getPreferenceKey());
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DialogHandler.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DialogHandler.java
@@ -15,6 +15,8 @@ import com.ichi2.anki.R;
 import com.ichi2.async.Connection;
 import com.ichi2.libanki.Collection;
 import com.ichi2.anki.analytics.UsageAnalytics;
+import com.ichi2.preferences.PreferenceKeys;
+import com.ichi2.preferences.Prefs;
 
 import java.lang.ref.WeakReference;
 import java.util.ArrayList;
@@ -114,11 +116,11 @@ public class DialogHandler extends Handler {
             dialog.setArgs(msgData.getString("message"));
             (mActivity.get()).showDialogFragment(dialog);
         } else if (msg.what == MSG_DO_SYNC) {
-            SharedPreferences preferences = AnkiDroidApp.getSharedPrefs(mActivity.get());
+            Prefs preferences = new Prefs(AnkiDroidApp.getSharedPrefs(mActivity.get()));
             Resources res = mActivity.get().getResources();
             Collection col = mActivity.get().getCol();
-            String hkey = preferences.getString("hkey", "");
-            long millisecondsSinceLastSync = col.getTime().intTimeMS() - preferences.getLong("lastSyncTime", 0);
+            String hkey = preferences.getString(PreferenceKeys.HKey);
+            long millisecondsSinceLastSync = col.getTime().intTimeMS() - preferences.getLong(PreferenceKeys.LastSyncTime);
             boolean limited = millisecondsSinceLastSync < INTENT_SYNC_MIN_INTERVAL;
             if (!limited && hkey.length() > 0 && Connection.isOnline()) {
                 ((DeckPicker) mActivity.get()).sync();

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/ActionButtonStatus.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/ActionButtonStatus.java
@@ -6,6 +6,8 @@ import android.view.Menu;
 import android.view.MenuItem;
 
 import com.ichi2.anki.R;
+import com.ichi2.preferences.PreferenceKeys;
+import com.ichi2.preferences.Prefs;
 import com.ichi2.themes.Themes;
 
 import java.util.HashMap;
@@ -45,31 +47,33 @@ public class ActionButtonStatus {
 
     public void setup(SharedPreferences preferences) {
         // NOTE: the default values below should be in sync with preferences_custom_buttons.xml and reviewer.xml
-        setupButton(preferences, R.id.action_undo, "customButtonUndo", SHOW_AS_ACTION_ALWAYS);
-        setupButton(preferences, R.id.action_schedule, "customButtonScheduleCard", SHOW_AS_ACTION_NEVER);
-        setupButton(preferences, R.id.action_flag, "customButtonFlag", SHOW_AS_ACTION_ALWAYS);
-        setupButton(preferences, R.id.action_tag, "customButtonTags", SHOW_AS_ACTION_NEVER);
-        setupButton(preferences, R.id.action_edit, "customButtonEditCard", SHOW_AS_ACTION_IF_ROOM);
-        setupButton(preferences, R.id.action_add_note_reviewer, "customButtonAddCard", MENU_DISABLED);
-        setupButton(preferences, R.id.action_replay, "customButtonReplay", SHOW_AS_ACTION_IF_ROOM);
-        setupButton(preferences, R.id.action_card_info, "customButtonCardInfo", MENU_DISABLED);
-        setupButton(preferences, R.id.action_clear_whiteboard, "customButtonClearWhiteboard", SHOW_AS_ACTION_IF_ROOM);
-        setupButton(preferences, R.id.action_hide_whiteboard, "customButtonShowHideWhiteboard", SHOW_AS_ACTION_ALWAYS);
-        setupButton(preferences, R.id.action_select_tts, "customButtonSelectTts", SHOW_AS_ACTION_NEVER);
-        setupButton(preferences, R.id.action_open_deck_options, "customButtonDeckOptions", SHOW_AS_ACTION_NEVER);
-        setupButton(preferences, R.id.action_bury, "customButtonBury", SHOW_AS_ACTION_NEVER);
-        setupButton(preferences, R.id.action_suspend, "customButtonSuspend", SHOW_AS_ACTION_NEVER);
-        setupButton(preferences, R.id.action_mark_card, "customButtonMarkCard", SHOW_AS_ACTION_IF_ROOM);
-        setupButton(preferences, R.id.action_delete, "customButtonDelete", SHOW_AS_ACTION_NEVER);
-        setupButton(preferences, R.id.action_toggle_mic_tool_bar, "customButtonToggleMicToolBar", SHOW_AS_ACTION_NEVER);
-        setupButton(preferences, R.id.action_toggle_whiteboard, "customButtonEnableWhiteboard", SHOW_AS_ACTION_NEVER);
-        setupButton(preferences, R.id.action_save_whiteboard, "customButtonSaveWhiteboard", SHOW_AS_ACTION_NEVER);
-        setupButton(preferences, R.id.action_change_whiteboard_pen_color, "customButtonWhiteboardPenColor", SHOW_AS_ACTION_IF_ROOM);
+        // TODO: Link this to test for #5346
+        Prefs prefs = new Prefs(preferences);
+        setupButton(prefs, R.id.action_undo, PreferenceKeys.CustomButtonUndo);
+        setupButton(prefs, R.id.action_schedule, PreferenceKeys.CustomButtonScheduleCard);
+        setupButton(prefs, R.id.action_flag, PreferenceKeys.CustomButtonFlag);
+        setupButton(prefs, R.id.action_tag, PreferenceKeys.CustomButtonTags);
+        setupButton(prefs, R.id.action_edit, PreferenceKeys.CustomButtonEditCard);
+        setupButton(prefs, R.id.action_add_note_reviewer, PreferenceKeys.CustomButtonAddCard);
+        setupButton(prefs, R.id.action_replay, PreferenceKeys.CustomButtonReplay);
+        setupButton(prefs, R.id.action_card_info, PreferenceKeys.CustomButtonCardInfo);
+        setupButton(prefs, R.id.action_clear_whiteboard, PreferenceKeys.CustomButtonClearWhiteboard);
+        setupButton(prefs, R.id.action_hide_whiteboard, PreferenceKeys.CustomButtonShowHideWhiteboard);
+        setupButton(prefs, R.id.action_select_tts, PreferenceKeys.CustomButtonSelectTts);
+        setupButton(prefs, R.id.action_open_deck_options, PreferenceKeys.CustomButtonDeckOptions);
+        setupButton(prefs, R.id.action_bury, PreferenceKeys.CustomButtonBury);
+        setupButton(prefs, R.id.action_suspend, PreferenceKeys.CustomButtonSuspend);
+        setupButton(prefs, R.id.action_mark_card, PreferenceKeys.CustomButtonMarkCard);
+        setupButton(prefs, R.id.action_delete, PreferenceKeys.CustomButtonDelete);
+        setupButton(prefs, R.id.action_toggle_mic_tool_bar, PreferenceKeys.CustomButtonToggleMicToolBar);
+        setupButton(prefs, R.id.action_toggle_whiteboard, PreferenceKeys.CustomButtonEnableWhiteboard);
+        setupButton(prefs, R.id.action_save_whiteboard, PreferenceKeys.CustomButtonSaveWhiteboard);
+        setupButton(prefs, R.id.action_change_whiteboard_pen_color, PreferenceKeys.CustomButtonWhiteboardPenColor);
     }
 
 
-    private void setupButton(SharedPreferences preferences, @IdRes int resourceId, String preferenceName, int showAsActionType) {
-        mCustomButtons.put(resourceId, Integer.parseInt(preferences.getString(preferenceName, Integer.toString(showAsActionType))));
+    private void setupButton(Prefs preferences, @IdRes int resourceId, PreferenceKeys.CustomButtonPreferenceKey key) {
+        mCustomButtons.put(resourceId, Integer.parseInt(preferences.getString(key)));
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/ActionButtonStatus.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/ActionButtonStatus.java
@@ -72,8 +72,8 @@ public class ActionButtonStatus {
     }
 
 
-    private void setupButton(Prefs preferences, @IdRes int resourceId, PreferenceKeys.CustomButtonPreferenceKey key) {
-        mCustomButtons.put(resourceId, Integer.parseInt(preferences.getString(key)));
+    private void setupButton(Prefs preferences, @IdRes int resourceId, PreferenceKeys.StringAsIntKey key) {
+        mCustomButtons.put(resourceId, preferences.getIntFromStr(key));
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/ReviewerCustomFonts.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/ReviewerCustomFonts.java
@@ -23,6 +23,8 @@ import android.text.TextUtils;
 import com.ichi2.anki.AnkiDroidApp;
 import com.ichi2.anki.AnkiFont;
 import com.ichi2.libanki.Utils;
+import com.ichi2.preferences.PreferenceKeys;
+import com.ichi2.preferences.Prefs;
 
 import java.util.HashMap;
 import java.util.List;
@@ -115,7 +117,7 @@ public class ReviewerCustomFonts {
         if (mOverrideFontStyle == null) {
             SharedPreferences preferences = AnkiDroidApp.getSharedPrefs(context);
             AnkiFont defaultFont = customFontsMap.get(preferences.getString("defaultFont", null));
-            boolean overrideFont = "1".equals(preferences.getString("overrideFontBehavior", "0"));
+            boolean overrideFont = "1".equals(Prefs.getString(preferences, PreferenceKeys.OverrideFontBehavior));
             if (defaultFont != null && overrideFont) {
                 mOverrideFontStyle = "BODY, .card, * { " + defaultFont.getCSS(true) + " }\n";
             } else {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/services/BootService.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/services/BootService.java
@@ -15,6 +15,8 @@ import com.ichi2.anki.UIUtils;
 import com.ichi2.libanki.Collection;
 import com.ichi2.libanki.DeckConfig;
 import com.ichi2.libanki.utils.Time;
+import com.ichi2.preferences.PreferenceKeys;
+import com.ichi2.preferences.Prefs;
 import com.ichi2.utils.Permissions;
 
 import com.ichi2.utils.JSONObject;
@@ -129,7 +131,7 @@ public class BootService extends BroadcastReceiver {
         }
 
         final Calendar calendar = time.calendar();
-        calendar.set(Calendar.HOUR_OF_DAY, sp.getInt("dayOffset", 0));
+        calendar.set(Calendar.HOUR_OF_DAY, Prefs.getInt(sp, PreferenceKeys.DayOffset));
         calendar.set(Calendar.MINUTE, 0);
         calendar.set(Calendar.SECOND, 0);
         final PendingIntent notificationIntent =

--- a/AnkiDroid/src/main/java/com/ichi2/anki/services/NotificationService.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/services/NotificationService.java
@@ -29,6 +29,8 @@ import com.ichi2.anki.DeckPicker;
 import com.ichi2.anki.NotificationChannels;
 import com.ichi2.anki.Preferences;
 import com.ichi2.anki.R;
+import com.ichi2.preferences.PreferenceKeys;
+import com.ichi2.preferences.Prefs;
 import com.ichi2.widget.WidgetStatus;
 
 import timber.log.Timber;
@@ -63,11 +65,12 @@ public class NotificationService extends BroadcastReceiver {
                     .setColor(ContextCompat.getColor(context, R.color.material_light_blue_700))
                     .setContentTitle(cardsDueText)
                     .setTicker(cardsDueText);
+            Prefs prefs = new Prefs(preferences);
             // Enable vibrate and blink if set in preferences
-            if (preferences.getBoolean("widgetVibrate", false)) {
+            if (prefs.getBoolean(PreferenceKeys.WidgetVibrate)) {
                 builder.setVibrate(new long[] { 1000, 1000, 1000});
             }
-            if (preferences.getBoolean("widgetBlink", false)) {
+            if (prefs.getBoolean(PreferenceKeys.WidgetBlink)) {
                 builder.setLights(Color.BLUE, 1000, 1000);
             }
             // Creates an explicit intent for an Activity in your app

--- a/AnkiDroid/src/main/java/com/ichi2/anki/web/CustomSyncServer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/web/CustomSyncServer.java
@@ -19,6 +19,9 @@ package com.ichi2.anki.web;
 import android.content.Context;
 import android.content.SharedPreferences;
 
+import com.ichi2.preferences.PreferenceKeys;
+import com.ichi2.preferences.Prefs;
+
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import timber.log.Timber;
@@ -43,7 +46,7 @@ public class CustomSyncServer {
     }
 
     public static boolean isEnabled(@NonNull SharedPreferences userPreferences) {
-        return userPreferences.getBoolean(PREFERENCE_ENABLE_CUSTOM_SYNC_SERVER, false);
+        return Prefs.getBoolean(userPreferences, PreferenceKeys.EnableCustomSyncServer);
     }
 
     public static void handleSyncServerPreferenceChange(Context context) {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/hooks/ChessFilter.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/hooks/ChessFilter.java
@@ -17,10 +17,10 @@
 package com.ichi2.libanki.hooks;
 
 
-
 import android.content.Context;
 
-import com.ichi2.anki.AnkiDroidApp;
+import com.ichi2.preferences.PreferenceKeys;
+import com.ichi2.preferences.Prefs;
 
 import java.util.Locale;
 import java.util.regex.Matcher;
@@ -63,7 +63,7 @@ public class ChessFilter {
     		"})('%s', %b)";
 
     public static String fenToChessboard(String text, Context context) {
-        if (!AnkiDroidApp.getSharedPrefs(context).getBoolean("convertFenText", false)) {
+        if (!Prefs.fromContext(context).getBoolean(PreferenceKeys.ConvertFenText)) {
             return text;
         }
         boolean showBlack = false;

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/stats/AdvancedStatistics.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/stats/AdvancedStatistics.java
@@ -18,10 +18,8 @@
 package com.ichi2.libanki.stats;
 
 import android.content.Context;
-import android.content.SharedPreferences;
 import android.database.Cursor;
 
-import com.ichi2.anki.AnkiDroidApp;
 import com.ichi2.anki.CollectionHelper;
 import com.ichi2.anki.R;
 import com.ichi2.anki.stats.StatsMetaInfo;
@@ -31,6 +29,8 @@ import com.ichi2.libanki.DB;
 import com.ichi2.libanki.Decks;
 import com.ichi2.libanki.DeckConfig;
 import com.ichi2.libanki.utils.Time;
+import com.ichi2.preferences.PreferenceKeys;
+import com.ichi2.preferences.Prefs;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -163,7 +163,7 @@ public class AdvancedStatistics {
      */
     public StatsMetaInfo calculateDueAsMetaInfo(StatsMetaInfo metaInfo, Stats.AxisType type, Context context, String dids) {
 
-        if (!AnkiDroidApp.getSharedPrefs(context).getBoolean("advanced_statistics_enabled", false)) {
+        if (!Prefs.fromContext(context).getBoolean(PreferenceKeys.AdvancedStatisticsEnabled)) {
             return metaInfo;
         }
         //To indicate that we calculated the statistics so that Stats.java knows that it shouldn't display the standard Forecast chart.
@@ -1010,14 +1010,14 @@ public class AdvancedStatistics {
         private final Collection mCol;
 
         public Settings(Context context) {
-            SharedPreferences prefs = AnkiDroidApp.getSharedPrefs(context);
+            Prefs prefs = Prefs.fromContext(context);
             mCol = CollectionHelper.getInstance().getCol(context);
 
-            computeNDays = prefs.getInt("advanced_forecast_stats_compute_n_days", 0);
-            int computePrecision = prefs.getInt("advanced_forecast_stats_compute_precision", 90);
+            computeNDays = prefs.getInt(PreferenceKeys.AdvancedForecastStatsComputeNDays);
+            int computePrecision = prefs.getInt(PreferenceKeys.AdvancedForecastStatsComputePrecision);
             computeMaxError = (100-computePrecision)/100.0;
 
-            simulateNIterations = prefs.getInt("advanced_forecast_stats_mc_n_iterations", 1);
+            simulateNIterations = prefs.getInt(PreferenceKeys.AdvancedForecastStatsMcNIterations);
 
             Timber.d("computeNDays: %s", computeNDays);
             Timber.d("computeMaxError: %s", computeMaxError);

--- a/AnkiDroid/src/main/java/com/ichi2/preferences/PreferenceKeys.java
+++ b/AnkiDroid/src/main/java/com/ichi2/preferences/PreferenceKeys.java
@@ -40,172 +40,172 @@ import static com.ichi2.anki.web.CustomSyncServer.PREFERENCE_ENABLE_CUSTOM_SYNC_
  * Tested via PreferenceTest.preferenceDefaultsAreNotChangedWhenOpeningPreferences
  * */
 public class PreferenceKeys {
-    public static PreferenceKey<Boolean> UseInputTag = new PreferenceKey<>("useInputTag", false);
-    public static PreferenceKey<Boolean> NoCodeFormatting = new PreferenceKey<>("noCodeFormatting", false);
-    public static StringAsIntKey Dictionary = new StringAsIntKey("dictionary", Integer.toString(Lookup.DICTIONARY_NONE));
-    public static StringAsIntKey FullscreenMode = new StringAsIntKey("fullscreenMode", "0");
-    public static PreferenceKey<Integer> AnswerButtonSide = new PreferenceKey<>("answerButtonSize", 100);
-    public static PreferenceKey<Boolean> Tts = new PreferenceKey<>("tts", false);
-    public static PreferenceKey<Boolean> TimeoutAnswer = new PreferenceKey<>("timeoutAnswer", false);
-    public static PreferenceKey<Integer> TimeoutAnswerSeconds = new PreferenceKey<>("timeoutAnswerSeconds", 20);
-    public static PreferenceKey<Integer> TimeoutQuestionSeconds = new PreferenceKey<>("timeoutQuestionSeconds", 60);
-    public static PreferenceKey<Boolean> ScrollingButtons = new PreferenceKey<>("scrolling_buttons", false);
-    public static PreferenceKey<Boolean> DoubleScrolling = new PreferenceKey<>("double_scrolling", false);
-    public static PreferenceKey<Boolean> ShowTopBar = new PreferenceKey<>("showTopbar", true);
-    public static PreferenceKey<Boolean> LinkOverridesTouchGesture = new PreferenceKey<>("linkOverridesTouchGesture", false);
+    public static final PreferenceKey<Boolean> UseInputTag = new PreferenceKey<>("useInputTag", false);
+    public static final PreferenceKey<Boolean> NoCodeFormatting = new PreferenceKey<>("noCodeFormatting", false);
+    public static final StringAsIntKey Dictionary = new StringAsIntKey("dictionary", Integer.toString(Lookup.DICTIONARY_NONE));
+    public static final StringAsIntKey FullscreenMode = new StringAsIntKey("fullscreenMode", "0");
+    public static final PreferenceKey<Integer> AnswerButtonSide = new PreferenceKey<>("answerButtonSize", 100);
+    public static final PreferenceKey<Boolean> Tts = new PreferenceKey<>("tts", false);
+    public static final PreferenceKey<Boolean> TimeoutAnswer = new PreferenceKey<>("timeoutAnswer", false);
+    public static final PreferenceKey<Integer> TimeoutAnswerSeconds = new PreferenceKey<>("timeoutAnswerSeconds", 20);
+    public static final PreferenceKey<Integer> TimeoutQuestionSeconds = new PreferenceKey<>("timeoutQuestionSeconds", 60);
+    public static final PreferenceKey<Boolean> ScrollingButtons = new PreferenceKey<>("scrolling_buttons", false);
+    public static final PreferenceKey<Boolean> DoubleScrolling = new PreferenceKey<>("double_scrolling", false);
+    public static final PreferenceKey<Boolean> ShowTopBar = new PreferenceKey<>("showTopbar", true);
+    public static final PreferenceKey<Boolean> LinkOverridesTouchGesture = new PreferenceKey<>("linkOverridesTouchGesture", false);
 
-    public static PreferenceKey<Boolean> Gestures = new PreferenceKey<>("gestures", false);
-    public static PreferenceKey<Integer> SwipeSensitivity = new PreferenceKey<>( "swipeSensitivity", 100);
-    public static StringAsIntKey GestureSwipeUp = new StringAsIntKey("gestureSwipeUp", "9");
-    public static StringAsIntKey GestureSwipeDown = new StringAsIntKey("gestureSwipeDown", "0");
-    public static StringAsIntKey GestureSwipeLeft = new StringAsIntKey("gestureSwipeLeft", "8");
-    public static StringAsIntKey GestureSwipeRight = new StringAsIntKey("gestureSwipeRight", "17");
-    public static StringAsIntKey GestureDoubleTap = new StringAsIntKey("gestureDoubleTap", "7");
-    public static StringAsIntKey GestureLongClick = new StringAsIntKey("gestureLongclick", "11");  /* This appears to be unused */
-    public static StringAsIntKey GestureVolumeUp = new StringAsIntKey("gestureVolumeUp", "0");
-    public static StringAsIntKey GestureVolumeDown = new StringAsIntKey("gestureVolumeDown", "0");
+    public static final PreferenceKey<Boolean> Gestures = new PreferenceKey<>("gestures", false);
+    public static final PreferenceKey<Integer> SwipeSensitivity = new PreferenceKey<>( "swipeSensitivity", 100);
+    public static final StringAsIntKey GestureSwipeUp = new StringAsIntKey("gestureSwipeUp", "9");
+    public static final StringAsIntKey GestureSwipeDown = new StringAsIntKey("gestureSwipeDown", "0");
+    public static final StringAsIntKey GestureSwipeLeft = new StringAsIntKey("gestureSwipeLeft", "8");
+    public static final StringAsIntKey GestureSwipeRight = new StringAsIntKey("gestureSwipeRight", "17");
+    public static final StringAsIntKey GestureDoubleTap = new StringAsIntKey("gestureDoubleTap", "7");
+    public static final StringAsIntKey GestureLongClick = new StringAsIntKey("gestureLongclick", "11");  /* This appears to be unused */
+    public static final StringAsIntKey GestureVolumeUp = new StringAsIntKey("gestureVolumeUp", "0");
+    public static final StringAsIntKey GestureVolumeDown = new StringAsIntKey("gestureVolumeDown", "0");
 
-    public static PreferenceKey<Boolean> KeepScreenOn = new PreferenceKey<>("keepScreenOn", false);
-    public static PreferenceKey<Boolean> HtmlJavascriptDebugging = new PreferenceKey<>("html_javascript_debugging", false);
-    public static PreferenceKey<String> AnswerButtonPosition = new PreferenceKey<>("answerButtonPosition", "bottom"); // This exists in constants.xml - remove?
+    public static final PreferenceKey<Boolean> KeepScreenOn = new PreferenceKey<>("keepScreenOn", false);
+    public static final PreferenceKey<Boolean> HtmlJavascriptDebugging = new PreferenceKey<>("html_javascript_debugging", false);
+    public static final PreferenceKey<String> AnswerButtonPosition = new PreferenceKey<>("answerButtonPosition", "bottom"); // This exists in constants.xml - remove?
 
     // card appearance
-    public static PreferenceKey<Integer> CardZoom = new PreferenceKey<>("cardZoom", 100);
-    public static PreferenceKey<Integer> ImageZoom = new PreferenceKey<>("imageZoom", 100);
-    public static PreferenceKey<Boolean> CenterVertically = new PreferenceKey<>("centerVertically", false);
-    public static PreferenceKey<Boolean> InvertedColors = new PreferenceKey<>(NIGHT_MODE_PREFERENCE, false);
+    public static final PreferenceKey<Integer> CardZoom = new PreferenceKey<>("cardZoom", 100);
+    public static final PreferenceKey<Integer> ImageZoom = new PreferenceKey<>("imageZoom", 100);
+    public static final PreferenceKey<Boolean> CenterVertically = new PreferenceKey<>("centerVertically", false);
+    public static final PreferenceKey<Boolean> InvertedColors = new PreferenceKey<>(NIGHT_MODE_PREFERENCE, false);
 
     // Whiteboard
-    public static PreferenceKey<Integer> WhiteBoardStrokeWidth = new PreferenceKey<>("whiteBoardStrokeWidth", 6);
+    public static final PreferenceKey<Integer> WhiteBoardStrokeWidth = new PreferenceKey<>("whiteBoardStrokeWidth", 6);
 
     // MyAccount
-    public static PreferenceKey<String> Username = new PreferenceKey<>("username", "");
-    public static PreferenceKey<String> HKey = new PreferenceKey<>("hkey", "");
+    public static final PreferenceKey<String> Username = new PreferenceKey<>("username", "");
+    public static final PreferenceKey<String> HKey = new PreferenceKey<>("hkey", "");
 
     // DialogHandler
-    public static PreferenceKey<Long> LastSyncTime = new PreferenceKey<>("lastSyncTime", 0L);
+    public static final PreferenceKey<Long> LastSyncTime = new PreferenceKey<>("lastSyncTime", 0L);
 
     // Note Editor
-    public static PreferenceKey<Boolean> NoteEditorCapitalize = new PreferenceKey<>("note_editor_capitalize", true);
-    public static PreferenceKey<Boolean> NoteEditorNewlineReplace = new PreferenceKey<>("noteEditorNewlineReplace", true);
-    public static PreferenceKey<Boolean> NoteEditorShowToolbar = new PreferenceKey<>("noteEditorShowToolbar", true);
-    public static PreferenceKey<String> BrowserEditorFont = new PreferenceKey<>("browserEditorFont", ""); // and card browser
-    public static PreferenceKey<Integer> NoteEditorFontSize = new PreferenceKey<>("note_editor_font_size", -1);
+    public static final PreferenceKey<Boolean> NoteEditorCapitalize = new PreferenceKey<>("note_editor_capitalize", true);
+    public static final PreferenceKey<Boolean> NoteEditorNewlineReplace = new PreferenceKey<>("noteEditorNewlineReplace", true);
+    public static final PreferenceKey<Boolean> NoteEditorShowToolbar = new PreferenceKey<>("noteEditorShowToolbar", true);
+    public static final PreferenceKey<String> BrowserEditorFont = new PreferenceKey<>("browserEditorFont", ""); // and card browser
+    public static final PreferenceKey<Integer> NoteEditorFontSize = new PreferenceKey<>("note_editor_font_size", -1);
 
-    public static PreferenceKey<Boolean> DisableExtendedTextUi = new PreferenceKey<>("disableExtendedTextUi", false);
+    public static final PreferenceKey<Boolean> DisableExtendedTextUi = new PreferenceKey<>("disableExtendedTextUi", false);
 
     // Reviewer
-    public static PreferenceKey<Boolean> HideDueCount = new PreferenceKey<>("hideDueCount", false);
-    public static PreferenceKey<Boolean> ShowEta = new PreferenceKey<>("showETA", true);
+    public static final PreferenceKey<Boolean> HideDueCount = new PreferenceKey<>("hideDueCount", false);
+    public static final PreferenceKey<Boolean> ShowEta = new PreferenceKey<>("showETA", true);
 
     // Widget
-    public static PreferenceKey<Boolean> WidgetSmallEnabled = new PreferenceKey<>("widgetSmallEnabled", false);
+    public static final PreferenceKey<Boolean> WidgetSmallEnabled = new PreferenceKey<>("widgetSmallEnabled", false);
     // TODO: minimumCardsDueForNotification - currently ambiguous default
 
     // SyncStatus
-    public static PreferenceKey<Boolean> ShowSyncStatusBadge = new PreferenceKey<>("showSyncStatusBadge", true);
-    public static PreferenceKey<Boolean> ChangesSinceLastSync = new PreferenceKey<>("changesSinceLastSync", false);
+    public static final PreferenceKey<Boolean> ShowSyncStatusBadge = new PreferenceKey<>("showSyncStatusBadge", true);
+    public static final PreferenceKey<Boolean> ChangesSinceLastSync = new PreferenceKey<>("changesSinceLastSync", false);
 
 
     // Themes
-    public static StringAsIntKey NightTheme = new StringAsIntKey("nightTheme", "0");
-    public static StringAsIntKey DayTheme = new StringAsIntKey("dayTheme", "0");
+    public static final StringAsIntKey NightTheme = new StringAsIntKey("nightTheme", "0");
+    public static final StringAsIntKey DayTheme = new StringAsIntKey("dayTheme", "0");
 
     // ReviewerCustomFonts
     // TODO: null or "" in code
     // public static NullablePreferenceKey<String> DefaultFont = new NullablePreferenceKey<>("defaultFont", null);
-    public static PreferenceKey<String> OverrideFontBehavior = new PreferenceKey<>("overrideFontBehavior", "0");
+    public static final PreferenceKey<String> OverrideFontBehavior = new PreferenceKey<>("overrideFontBehavior", "0");
 
     // GestureTapProcessor
-    public static StringAsIntKey GestureTapLeft = new StringAsIntKey("gestureTapLeft", "3");
-    public static StringAsIntKey GestureTapRight = new StringAsIntKey("gestureTapRight", "6");
-    public static StringAsIntKey GestureTapTop = new StringAsIntKey("gestureTapTop", "12");
-    public static StringAsIntKey GestureTapBottom = new StringAsIntKey("gestureTapBottom", "2");
-    public static PreferenceKey<Boolean> GestureCornerTouch = new PreferenceKey<>("gestureCornerTouch", false);
-    public static StringAsIntKey GestureTapTopLeft = new StringAsIntKey("gestureTapTopLeft", "0");
-    public static StringAsIntKey GestureTapTopRight = new StringAsIntKey("gestureTapTopRight", "0");
-    public static StringAsIntKey GestureTapCenter = new StringAsIntKey("gestureTapCenter", "0");
-    public static StringAsIntKey GestureTapBottomLeft = new StringAsIntKey("gestureTapBottomLeft", "0");
-    public static StringAsIntKey GestureTapBottomRight = new StringAsIntKey("gestureTapBottomRight", "0");
+    public static final StringAsIntKey GestureTapLeft = new StringAsIntKey("gestureTapLeft", "3");
+    public static final StringAsIntKey GestureTapRight = new StringAsIntKey("gestureTapRight", "6");
+    public static final StringAsIntKey GestureTapTop = new StringAsIntKey("gestureTapTop", "12");
+    public static final StringAsIntKey GestureTapBottom = new StringAsIntKey("gestureTapBottom", "2");
+    public static final PreferenceKey<Boolean> GestureCornerTouch = new PreferenceKey<>("gestureCornerTouch", false);
+    public static final StringAsIntKey GestureTapTopLeft = new StringAsIntKey("gestureTapTopLeft", "0");
+    public static final StringAsIntKey GestureTapTopRight = new StringAsIntKey("gestureTapTopRight", "0");
+    public static final StringAsIntKey GestureTapCenter = new StringAsIntKey("gestureTapCenter", "0");
+    public static final StringAsIntKey GestureTapBottomLeft = new StringAsIntKey("gestureTapBottomLeft", "0");
+    public static final StringAsIntKey GestureTapBottomRight = new StringAsIntKey("gestureTapBottomRight", "0");
 
     // ActionButtonStatus
-    public static CustomButtonPreferenceKey CustomButtonUndo = new CustomButtonPreferenceKey("customButtonUndo", SHOW_AS_ACTION_ALWAYS);
-    public static CustomButtonPreferenceKey CustomButtonScheduleCard = new CustomButtonPreferenceKey("customButtonScheduleCard", SHOW_AS_ACTION_NEVER);
-    public static CustomButtonPreferenceKey CustomButtonFlag = new CustomButtonPreferenceKey("customButtonFlag", SHOW_AS_ACTION_ALWAYS);
-    public static CustomButtonPreferenceKey CustomButtonTags = new CustomButtonPreferenceKey("customButtonTags", SHOW_AS_ACTION_NEVER);
-    public static CustomButtonPreferenceKey CustomButtonEditCard = new CustomButtonPreferenceKey("customButtonEditCard", SHOW_AS_ACTION_IF_ROOM);
-    public static CustomButtonPreferenceKey CustomButtonAddCard = new CustomButtonPreferenceKey("customButtonAddCard", MENU_DISABLED);
-    public static CustomButtonPreferenceKey CustomButtonReplay = new CustomButtonPreferenceKey("customButtonReplay", SHOW_AS_ACTION_IF_ROOM);
-    public static CustomButtonPreferenceKey CustomButtonCardInfo = new CustomButtonPreferenceKey("customButtonCardInfo", MENU_DISABLED);
-    public static CustomButtonPreferenceKey CustomButtonClearWhiteboard = new CustomButtonPreferenceKey("customButtonClearWhiteboard", SHOW_AS_ACTION_IF_ROOM);
-    public static CustomButtonPreferenceKey CustomButtonShowHideWhiteboard = new CustomButtonPreferenceKey("customButtonShowHideWhiteboard", SHOW_AS_ACTION_ALWAYS);
-    public static CustomButtonPreferenceKey CustomButtonSelectTts = new CustomButtonPreferenceKey("customButtonSelectTts", SHOW_AS_ACTION_NEVER);
-    public static CustomButtonPreferenceKey CustomButtonDeckOptions = new CustomButtonPreferenceKey("customButtonDeckOptions", SHOW_AS_ACTION_NEVER);
-    public static CustomButtonPreferenceKey CustomButtonBury = new CustomButtonPreferenceKey("customButtonBury", SHOW_AS_ACTION_NEVER);
-    public static CustomButtonPreferenceKey CustomButtonSuspend = new CustomButtonPreferenceKey("customButtonSuspend", SHOW_AS_ACTION_NEVER);
-    public static CustomButtonPreferenceKey CustomButtonMarkCard = new CustomButtonPreferenceKey("customButtonMarkCard", SHOW_AS_ACTION_IF_ROOM);
-    public static CustomButtonPreferenceKey CustomButtonDelete = new CustomButtonPreferenceKey("customButtonDelete", SHOW_AS_ACTION_NEVER);
-    public static CustomButtonPreferenceKey CustomButtonToggleMicToolBar = new CustomButtonPreferenceKey("customButtonToggleMicToolBar", SHOW_AS_ACTION_NEVER);
-    public static CustomButtonPreferenceKey CustomButtonEnableWhiteboard = new CustomButtonPreferenceKey("customButtonEnableWhiteboard", SHOW_AS_ACTION_NEVER);
-    public static CustomButtonPreferenceKey CustomButtonSaveWhiteboard = new CustomButtonPreferenceKey("customButtonSaveWhiteboard", SHOW_AS_ACTION_NEVER);
-    public static CustomButtonPreferenceKey CustomButtonWhiteboardPenColor = new CustomButtonPreferenceKey("customButtonWhiteboardPenColor", SHOW_AS_ACTION_IF_ROOM);
+    public static final CustomButtonPreferenceKey CustomButtonUndo = new CustomButtonPreferenceKey("customButtonUndo", SHOW_AS_ACTION_ALWAYS);
+    public static final CustomButtonPreferenceKey CustomButtonScheduleCard = new CustomButtonPreferenceKey("customButtonScheduleCard", SHOW_AS_ACTION_NEVER);
+    public static final CustomButtonPreferenceKey CustomButtonFlag = new CustomButtonPreferenceKey("customButtonFlag", SHOW_AS_ACTION_ALWAYS);
+    public static final CustomButtonPreferenceKey CustomButtonTags = new CustomButtonPreferenceKey("customButtonTags", SHOW_AS_ACTION_NEVER);
+    public static final CustomButtonPreferenceKey CustomButtonEditCard = new CustomButtonPreferenceKey("customButtonEditCard", SHOW_AS_ACTION_IF_ROOM);
+    public static final CustomButtonPreferenceKey CustomButtonAddCard = new CustomButtonPreferenceKey("customButtonAddCard", MENU_DISABLED);
+    public static final CustomButtonPreferenceKey CustomButtonReplay = new CustomButtonPreferenceKey("customButtonReplay", SHOW_AS_ACTION_IF_ROOM);
+    public static final CustomButtonPreferenceKey CustomButtonCardInfo = new CustomButtonPreferenceKey("customButtonCardInfo", MENU_DISABLED);
+    public static final CustomButtonPreferenceKey CustomButtonClearWhiteboard = new CustomButtonPreferenceKey("customButtonClearWhiteboard", SHOW_AS_ACTION_IF_ROOM);
+    public static final CustomButtonPreferenceKey CustomButtonShowHideWhiteboard = new CustomButtonPreferenceKey("customButtonShowHideWhiteboard", SHOW_AS_ACTION_ALWAYS);
+    public static final CustomButtonPreferenceKey CustomButtonSelectTts = new CustomButtonPreferenceKey("customButtonSelectTts", SHOW_AS_ACTION_NEVER);
+    public static final CustomButtonPreferenceKey CustomButtonDeckOptions = new CustomButtonPreferenceKey("customButtonDeckOptions", SHOW_AS_ACTION_NEVER);
+    public static final CustomButtonPreferenceKey CustomButtonBury = new CustomButtonPreferenceKey("customButtonBury", SHOW_AS_ACTION_NEVER);
+    public static final CustomButtonPreferenceKey CustomButtonSuspend = new CustomButtonPreferenceKey("customButtonSuspend", SHOW_AS_ACTION_NEVER);
+    public static final CustomButtonPreferenceKey CustomButtonMarkCard = new CustomButtonPreferenceKey("customButtonMarkCard", SHOW_AS_ACTION_IF_ROOM);
+    public static final CustomButtonPreferenceKey CustomButtonDelete = new CustomButtonPreferenceKey("customButtonDelete", SHOW_AS_ACTION_NEVER);
+    public static final CustomButtonPreferenceKey CustomButtonToggleMicToolBar = new CustomButtonPreferenceKey("customButtonToggleMicToolBar", SHOW_AS_ACTION_NEVER);
+    public static final CustomButtonPreferenceKey CustomButtonEnableWhiteboard = new CustomButtonPreferenceKey("customButtonEnableWhiteboard", SHOW_AS_ACTION_NEVER);
+    public static final CustomButtonPreferenceKey CustomButtonSaveWhiteboard = new CustomButtonPreferenceKey("customButtonSaveWhiteboard", SHOW_AS_ACTION_NEVER);
+    public static final CustomButtonPreferenceKey CustomButtonWhiteboardPenColor = new CustomButtonPreferenceKey("customButtonWhiteboardPenColor", SHOW_AS_ACTION_IF_ROOM);
 
     // Advanced Statistics
-    public static PreferenceKey<Boolean> AdvancedStatisticsEnabled = new PreferenceKey<>("advanced_statistics_enabled", false);
-    public static PreferenceKey<Integer> AdvancedForecastStatsMcNIterations = new PreferenceKey<>("advanced_forecast_stats_mc_n_iterations", 1);
-    public static PreferenceKey<Integer> AdvancedForecastStatsComputeNDays = new PreferenceKey<>("advanced_forecast_stats_compute_n_days", 0);
-    public static PreferenceKey<Integer> AdvancedForecastStatsComputePrecision = new PreferenceKey<>("advanced_forecast_stats_compute_precision", 90);
+    public static final PreferenceKey<Boolean> AdvancedStatisticsEnabled = new PreferenceKey<>("advanced_statistics_enabled", false);
+    public static final PreferenceKey<Integer> AdvancedForecastStatsMcNIterations = new PreferenceKey<>("advanced_forecast_stats_mc_n_iterations", 1);
+    public static final PreferenceKey<Integer> AdvancedForecastStatsComputeNDays = new PreferenceKey<>("advanced_forecast_stats_compute_n_days", 0);
+    public static final PreferenceKey<Integer> AdvancedForecastStatsComputePrecision = new PreferenceKey<>("advanced_forecast_stats_compute_precision", 90);
 
     // ACRA
     // Note: defaulted to "" in Preferences, but should never have been hit
-    public static PreferenceKey<String> FeedbackReportKey = new PreferenceKey<>(AnkiDroidApp.FEEDBACK_REPORT_KEY, FEEDBACK_REPORT_ASK);
+    public static final PreferenceKey<String> FeedbackReportKey = new PreferenceKey<>(AnkiDroidApp.FEEDBACK_REPORT_KEY, FEEDBACK_REPORT_ASK);
 
     // DeckPicker - Sync
-    public static PreferenceKey<Boolean> AutomaticSyncMode = new PreferenceKey<>("automaticSyncMode", false);
-    public static PreferenceKey<Boolean> SyncFetchesMedia = new PreferenceKey<>("syncFetchesMedia", true);
+    public static final PreferenceKey<Boolean> AutomaticSyncMode = new PreferenceKey<>("automaticSyncMode", false);
+    public static final PreferenceKey<Boolean> SyncFetchesMedia = new PreferenceKey<>("syncFetchesMedia", true);
 
     // DeckPicker
-    public static PreferenceKey<Boolean> NoSpaceLeft = new PreferenceKey<>("noSpaceLeft", false);
-    public static PreferenceKey<String> LastVersion = new PreferenceKey<>("lastVersion", "");
-    public static PreferenceKey<Boolean> DeckPickerBackground = new PreferenceKey<>("deckPickerBackground", false);
+    public static final PreferenceKey<Boolean> NoSpaceLeft = new PreferenceKey<>("noSpaceLeft", false);
+    public static final PreferenceKey<String> LastVersion = new PreferenceKey<>("lastVersion", "");
+    public static final PreferenceKey<Boolean> DeckPickerBackground = new PreferenceKey<>("deckPickerBackground", false);
 
     // Card Browser
-    public static PreferenceKey<Boolean> CardBrowserNoSorting = new PreferenceKey<>("cardBrowserNoSorting", false);
-    public static PreferenceKey<Integer> CardBrowserColumn1 = new PreferenceKey<>("cardBrowserColumn1", 0);
-    public static PreferenceKey<Integer> CardBrowserColumn2 = new PreferenceKey<>("cardBrowserColumn2", 0);
-    public static PreferenceKey<Integer> RelativeCardBrowserFontSize = new PreferenceKey<>("relativeCardBrowserFontSize", 100);
-    public static PreferenceKey<Boolean> CardBrowserShowMediaFilenames = new PreferenceKey<>("card_browser_show_media_filenames", false);
+    public static final PreferenceKey<Boolean> CardBrowserNoSorting = new PreferenceKey<>("cardBrowserNoSorting", false);
+    public static final PreferenceKey<Integer> CardBrowserColumn1 = new PreferenceKey<>("cardBrowserColumn1", 0);
+    public static final PreferenceKey<Integer> CardBrowserColumn2 = new PreferenceKey<>("cardBrowserColumn2", 0);
+    public static final PreferenceKey<Integer> RelativeCardBrowserFontSize = new PreferenceKey<>("relativeCardBrowserFontSize", 100);
+    public static final PreferenceKey<Boolean> CardBrowserShowMediaFilenames = new PreferenceKey<>("card_browser_show_media_filenames", false);
 
     // Notifications
-    public static PreferenceKey<Boolean> WidgetVibrate = new PreferenceKey<>("widgetVibrate", false);
-    public static PreferenceKey<Boolean> WidgetBlink = new PreferenceKey<>("widgetBlink", false);
+    public static final PreferenceKey<Boolean> WidgetVibrate = new PreferenceKey<>("widgetVibrate", false);
+    public static final PreferenceKey<Boolean> WidgetBlink = new PreferenceKey<>("widgetBlink", false);
 
     // Animations
-    public static PreferenceKey<Boolean> SafeDisplay = new PreferenceKey<>("safeDisplay", false);
+    public static final PreferenceKey<Boolean> SafeDisplay = new PreferenceKey<>("safeDisplay", false);
 
     // Chess
-    public static PreferenceKey<Boolean> ConvertFenText = new PreferenceKey<>("convertFenText", false);
+    public static final PreferenceKey<Boolean> ConvertFenText = new PreferenceKey<>("convertFenText", false);
 
     // Context Menus
-    public static PreferenceKey<Boolean> CardBrowserContextMenu = new PreferenceKey<>(CARD_BROWSER_CONTEXT_MENU_PREF_KEY, false);
-    public static PreferenceKey<Boolean> AnkiCardContextMenu = new PreferenceKey<>(ANKI_CARD_CONTEXT_MENU_PREF_KEY, true);
+    public static final PreferenceKey<Boolean> CardBrowserContextMenu = new PreferenceKey<>(CARD_BROWSER_CONTEXT_MENU_PREF_KEY, false);
+    public static final PreferenceKey<Boolean> AnkiCardContextMenu = new PreferenceKey<>(ANKI_CARD_CONTEXT_MENU_PREF_KEY, true);
 
     // Custom Sync Server
-    public static PreferenceKey<Boolean> EnableCustomSyncServer = new PreferenceKey<>(PREFERENCE_ENABLE_CUSTOM_SYNC_SERVER, false);
+    public static final PreferenceKey<Boolean> EnableCustomSyncServer = new PreferenceKey<>(PREFERENCE_ENABLE_CUSTOM_SYNC_SERVER, false);
     // TODO: variable defaults (null/empty): syncBaseUrl, syncMediaUrl
 
     // BootService
-    public static PreferenceKey<Integer> DayOffset = new PreferenceKey<>("dayOffset", 0);
-    public static PreferenceKey<String> Language = new PreferenceKey<>(Preferences.LANGUAGE, "");
+    public static final PreferenceKey<Integer> DayOffset = new PreferenceKey<>("dayOffset", 0);
+    public static final PreferenceKey<String> Language = new PreferenceKey<>(Preferences.LANGUAGE, "");
 
     // Backups
-    public static PreferenceKey<Integer> BackupMax = new PreferenceKey<>("backupMax", 8);
+    public static final PreferenceKey<Integer> BackupMax = new PreferenceKey<>("backupMax", 8);
 
 
 
     public static class PreferenceKey<T> {
-        public String key;
-        public T defaultValue;
+        public final String key;
+        public final T defaultValue;
 
         public PreferenceKey(String key, T value) {
             this.key = key;

--- a/AnkiDroid/src/main/java/com/ichi2/preferences/PreferenceKeys.java
+++ b/AnkiDroid/src/main/java/com/ichi2/preferences/PreferenceKeys.java
@@ -193,6 +193,8 @@ public class PreferenceKeys {
     public static PreferenceKey<Boolean> EnableCustomSyncServer = new PreferenceKey<>(PREFERENCE_ENABLE_CUSTOM_SYNC_SERVER, false);
     // TODO: variable defaults (null/empty): syncBaseUrl, syncMediaUrl
 
+    // BootService
+    public static PreferenceKey<Integer> DayOffset = new PreferenceKey<>("dayOffset", 0);
 
     public static class PreferenceKey<T> {
         public String key;

--- a/AnkiDroid/src/main/java/com/ichi2/preferences/PreferenceKeys.java
+++ b/AnkiDroid/src/main/java/com/ichi2/preferences/PreferenceKeys.java
@@ -25,6 +25,8 @@ import java.lang.annotation.RetentionPolicy;
 import androidx.annotation.IntDef;
 
 import static com.ichi2.anki.AnkiDroidApp.FEEDBACK_REPORT_ASK;
+import static com.ichi2.anki.contextmenu.AnkiCardContextMenu.ANKI_CARD_CONTEXT_MENU_PREF_KEY;
+import static com.ichi2.anki.contextmenu.CardBrowserContextMenu.CARD_BROWSER_CONTEXT_MENU_PREF_KEY;
 import static com.ichi2.anki.reviewer.ActionButtonStatus.MENU_DISABLED;
 import static com.ichi2.anki.reviewer.ActionButtonStatus.SHOW_AS_ACTION_ALWAYS;
 import static com.ichi2.anki.reviewer.ActionButtonStatus.SHOW_AS_ACTION_IF_ROOM;
@@ -176,6 +178,10 @@ public class PreferenceKeys {
 
     // Chess
     public static PreferenceKey<Boolean> ConvertFenText = new PreferenceKey<>("convertFenText", false);
+
+    // Context Menus
+    public static PreferenceKey<Boolean> CardBrowserContextMenu = new PreferenceKey<>(CARD_BROWSER_CONTEXT_MENU_PREF_KEY, false);
+    public static PreferenceKey<Boolean> AnkiCardContextMenu = new PreferenceKey<>(ANKI_CARD_CONTEXT_MENU_PREF_KEY, true);
 
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/preferences/PreferenceKeys.java
+++ b/AnkiDroid/src/main/java/com/ichi2/preferences/PreferenceKeys.java
@@ -48,6 +48,12 @@ public class PreferenceKeys {
     public static PreferenceKey<Boolean> HtmlJavascriptDebugging = new PreferenceKey<>("html_javascript_debugging", false);
     public static PreferenceKey<String> AnswerButtonPosition = new PreferenceKey<>("answerButtonPosition", "bottom"); // This exists in constants.xml - remove?
 
+    // card appearance
+    public static PreferenceKey<Integer> CardZoom = new PreferenceKey<>("cardZoom", 100);
+    public static PreferenceKey<Integer> ImageZoom = new PreferenceKey<>("imageZoom", 100);
+    public static PreferenceKey<Boolean> CenterVertically = new PreferenceKey<>("centerVertically", false);
+    public static PreferenceKey<Boolean> InvertedColors = new PreferenceKey<>("invertedColors", false);
+
 
     public static class PreferenceKey<T> {
         public String key;

--- a/AnkiDroid/src/main/java/com/ichi2/preferences/PreferenceKeys.java
+++ b/AnkiDroid/src/main/java/com/ichi2/preferences/PreferenceKeys.java
@@ -40,7 +40,7 @@ public class PreferenceKeys {
     public static PreferenceKey<String> GestureSwipeLeft = new PreferenceKey<>("gestureSwipeLeft", "8");
     public static PreferenceKey<String> GestureSwipeRight = new PreferenceKey<>("gestureSwipeRight", "17");
     public static PreferenceKey<String> GestureDoubleTap = new PreferenceKey<>("gestureDoubleTap", "7");
-    public static PreferenceKey<String> GestureLongClick = new PreferenceKey<>("gestureLongclick", "11");
+    public static PreferenceKey<String> GestureLongClick = new PreferenceKey<>("gestureLongclick", "11");  /* This appears to be unused */
     public static PreferenceKey<String> GestureVolumeUp = new PreferenceKey<>("gestureVolumeUp", "0");
     public static PreferenceKey<String> GestureVolumeDown = new PreferenceKey<>("gestureVolumeDown", "0");
 
@@ -53,6 +53,10 @@ public class PreferenceKeys {
     public static PreferenceKey<Integer> ImageZoom = new PreferenceKey<>("imageZoom", 100);
     public static PreferenceKey<Boolean> CenterVertically = new PreferenceKey<>("centerVertically", false);
     public static PreferenceKey<Boolean> InvertedColors = new PreferenceKey<>("invertedColors", false);
+
+    // Whiteboard
+    public static PreferenceKey<Integer> WhiteBoardStrokeWidth = new PreferenceKey<>("whiteBoardStrokeWidth", 6);
+
 
 
     public static class PreferenceKey<T> {

--- a/AnkiDroid/src/main/java/com/ichi2/preferences/PreferenceKeys.java
+++ b/AnkiDroid/src/main/java/com/ichi2/preferences/PreferenceKeys.java
@@ -37,7 +37,7 @@ import static com.ichi2.anki.web.CustomSyncServer.PREFERENCE_ENABLE_CUSTOM_SYNC_
 
 /**
  * Keys to ensure consistency between XML and code defaults
- * TODO: No tests have been run on this yet
+ * Tested via PreferenceTest.preferenceDefaultsAreNotChangedWhenOpeningPreferences
  * */
 public class PreferenceKeys {
     public static PreferenceKey<Boolean> UseInputTag = new PreferenceKey<>("useInputTag", false);

--- a/AnkiDroid/src/main/java/com/ichi2/preferences/PreferenceKeys.java
+++ b/AnkiDroid/src/main/java/com/ichi2/preferences/PreferenceKeys.java
@@ -57,6 +57,10 @@ public class PreferenceKeys {
     // Whiteboard
     public static PreferenceKey<Integer> WhiteBoardStrokeWidth = new PreferenceKey<>("whiteBoardStrokeWidth", 6);
 
+    // MyAccount
+    public static PreferenceKey<String> Username = new PreferenceKey<>("username", "");
+    public static PreferenceKey<String> HKey = new PreferenceKey<>("hkey", "");
+
 
 
     public static class PreferenceKey<T> {

--- a/AnkiDroid/src/main/java/com/ichi2/preferences/PreferenceKeys.java
+++ b/AnkiDroid/src/main/java/com/ichi2/preferences/PreferenceKeys.java
@@ -42,8 +42,8 @@ import static com.ichi2.anki.web.CustomSyncServer.PREFERENCE_ENABLE_CUSTOM_SYNC_
 public class PreferenceKeys {
     public static PreferenceKey<Boolean> UseInputTag = new PreferenceKey<>("useInputTag", false);
     public static PreferenceKey<Boolean> NoCodeFormatting = new PreferenceKey<>("noCodeFormatting", false);
-    public static PreferenceKey<String> Dictionary = new PreferenceKey<>("dictionary", Integer.toString(Lookup.DICTIONARY_NONE));
-    public static PreferenceKey<String> FullscreenMode = new PreferenceKey<>("fullscreenMode", "0");
+    public static StringAsIntKey Dictionary = new StringAsIntKey("dictionary", Integer.toString(Lookup.DICTIONARY_NONE));
+    public static StringAsIntKey FullscreenMode = new StringAsIntKey("fullscreenMode", "0");
     public static PreferenceKey<Integer> AnswerButtonSide = new PreferenceKey<>("answerButtonSize", 100);
     public static PreferenceKey<Boolean> Tts = new PreferenceKey<>("tts", false);
     public static PreferenceKey<Boolean> TimeoutAnswer = new PreferenceKey<>("timeoutAnswer", false);
@@ -56,14 +56,14 @@ public class PreferenceKeys {
 
     public static PreferenceKey<Boolean> Gestures = new PreferenceKey<>("gestures", false);
     public static PreferenceKey<Integer> SwipeSensitivity = new PreferenceKey<>( "swipeSensitivity", 100);
-    public static PreferenceKey<String> GestureSwipeUp = new PreferenceKey<>("gestureSwipeUp", "9");
-    public static PreferenceKey<String> GestureSwipeDown = new PreferenceKey<>("gestureSwipeDown", "0");
-    public static PreferenceKey<String> GestureSwipeLeft = new PreferenceKey<>("gestureSwipeLeft", "8");
-    public static PreferenceKey<String> GestureSwipeRight = new PreferenceKey<>("gestureSwipeRight", "17");
-    public static PreferenceKey<String> GestureDoubleTap = new PreferenceKey<>("gestureDoubleTap", "7");
-    public static PreferenceKey<String> GestureLongClick = new PreferenceKey<>("gestureLongclick", "11");  /* This appears to be unused */
-    public static PreferenceKey<String> GestureVolumeUp = new PreferenceKey<>("gestureVolumeUp", "0");
-    public static PreferenceKey<String> GestureVolumeDown = new PreferenceKey<>("gestureVolumeDown", "0");
+    public static StringAsIntKey GestureSwipeUp = new StringAsIntKey("gestureSwipeUp", "9");
+    public static StringAsIntKey GestureSwipeDown = new StringAsIntKey("gestureSwipeDown", "0");
+    public static StringAsIntKey GestureSwipeLeft = new StringAsIntKey("gestureSwipeLeft", "8");
+    public static StringAsIntKey GestureSwipeRight = new StringAsIntKey("gestureSwipeRight", "17");
+    public static StringAsIntKey GestureDoubleTap = new StringAsIntKey("gestureDoubleTap", "7");
+    public static StringAsIntKey GestureLongClick = new StringAsIntKey("gestureLongclick", "11");  /* This appears to be unused */
+    public static StringAsIntKey GestureVolumeUp = new StringAsIntKey("gestureVolumeUp", "0");
+    public static StringAsIntKey GestureVolumeDown = new StringAsIntKey("gestureVolumeDown", "0");
 
     public static PreferenceKey<Boolean> KeepScreenOn = new PreferenceKey<>("keepScreenOn", false);
     public static PreferenceKey<Boolean> HtmlJavascriptDebugging = new PreferenceKey<>("html_javascript_debugging", false);
@@ -108,8 +108,8 @@ public class PreferenceKeys {
 
 
     // Themes
-    public static PreferenceKey<String> NightTheme = new PreferenceKey<>("nightTheme", "0");
-    public static PreferenceKey<String> DayTheme = new PreferenceKey<>("dayTheme", "0");
+    public static StringAsIntKey NightTheme = new StringAsIntKey("nightTheme", "0");
+    public static StringAsIntKey DayTheme = new StringAsIntKey("dayTheme", "0");
 
     // ReviewerCustomFonts
     // TODO: null or "" in code
@@ -117,16 +117,16 @@ public class PreferenceKeys {
     public static PreferenceKey<String> OverrideFontBehavior = new PreferenceKey<>("overrideFontBehavior", "0");
 
     // GestureTapProcessor
-    public static PreferenceKey<String> GestureTapLeft = new PreferenceKey<>("gestureTapLeft", "3");
-    public static PreferenceKey<String> GestureTapRight = new PreferenceKey<>("gestureTapRight", "6");
-    public static PreferenceKey<String> GestureTapTop = new PreferenceKey<>("gestureTapTop", "12");
-    public static PreferenceKey<String> GestureTapBottom = new PreferenceKey<>("gestureTapBottom", "2");
+    public static StringAsIntKey GestureTapLeft = new StringAsIntKey("gestureTapLeft", "3");
+    public static StringAsIntKey GestureTapRight = new StringAsIntKey("gestureTapRight", "6");
+    public static StringAsIntKey GestureTapTop = new StringAsIntKey("gestureTapTop", "12");
+    public static StringAsIntKey GestureTapBottom = new StringAsIntKey("gestureTapBottom", "2");
     public static PreferenceKey<Boolean> GestureCornerTouch = new PreferenceKey<>("gestureCornerTouch", false);
-    public static PreferenceKey<String> GestureTapTopLeft = new PreferenceKey<>("gestureTapTopLeft", "0");
-    public static PreferenceKey<String> GestureTapTopRight = new PreferenceKey<>("gestureTapTopRight", "0");
-    public static PreferenceKey<String> GestureTapCenter = new PreferenceKey<>("gestureTapCenter", "0");
-    public static PreferenceKey<String> GestureTapBottomLeft = new PreferenceKey<>("gestureTapBottomLeft", "0");
-    public static PreferenceKey<String> GestureTapBottomRight = new PreferenceKey<>("gestureTapBottomRight", "0");
+    public static StringAsIntKey GestureTapTopLeft = new StringAsIntKey("gestureTapTopLeft", "0");
+    public static StringAsIntKey GestureTapTopRight = new StringAsIntKey("gestureTapTopRight", "0");
+    public static StringAsIntKey GestureTapCenter = new StringAsIntKey("gestureTapCenter", "0");
+    public static StringAsIntKey GestureTapBottomLeft = new StringAsIntKey("gestureTapBottomLeft", "0");
+    public static StringAsIntKey GestureTapBottomRight = new StringAsIntKey("gestureTapBottomRight", "0");
 
     // ActionButtonStatus
     public static CustomButtonPreferenceKey CustomButtonUndo = new CustomButtonPreferenceKey("customButtonUndo", SHOW_AS_ACTION_ALWAYS);
@@ -213,8 +213,14 @@ public class PreferenceKeys {
         }
     }
 
+    /** A value stored as a string, but uses as an int */
+    public static class StringAsIntKey extends PreferenceKey<String> {
+        public StringAsIntKey(String key, String value) {
+            super(key, value);
+        }
+    }
 
-    public static class CustomButtonPreferenceKey extends PreferenceKey<String> {
+    public static class CustomButtonPreferenceKey extends StringAsIntKey {
         public CustomButtonPreferenceKey(String key, @CustomButtonDef int value) {
             super(key, Integer.toString(value));
         }

--- a/AnkiDroid/src/main/java/com/ichi2/preferences/PreferenceKeys.java
+++ b/AnkiDroid/src/main/java/com/ichi2/preferences/PreferenceKeys.java
@@ -16,8 +16,6 @@
 
 package com.ichi2.preferences;
 
-import android.content.SharedPreferences;
-
 import com.ichi2.anki.AnkiDroidApp;
 import com.ichi2.anki.Lookup;
 
@@ -84,7 +82,7 @@ public class PreferenceKeys {
     public static PreferenceKey<Boolean> NoteEditorCapitalize = new PreferenceKey<>("note_editor_capitalize", true);
     public static PreferenceKey<Boolean> NoteEditorNewlineReplace = new PreferenceKey<>("noteEditorNewlineReplace", true);
     public static PreferenceKey<Boolean> NoteEditorShowToolbar = new PreferenceKey<>("noteEditorShowToolbar", true);
-    public static PreferenceKey<String> BrowserEditorFont = new PreferenceKey<>("browserEditorFont", "");
+    public static PreferenceKey<String> BrowserEditorFont = new PreferenceKey<>("browserEditorFont", ""); // and card browser
     public static PreferenceKey<Integer> NoteEditorFontSize = new PreferenceKey<>("note_editor_font_size", -1);
 
     // Reviewer
@@ -158,6 +156,14 @@ public class PreferenceKeys {
     public static PreferenceKey<Boolean> NoSpaceLeft = new PreferenceKey<>("noSpaceLeft", false);
     public static PreferenceKey<String> LastVersion = new PreferenceKey<>("lastVersion", "");
     public static PreferenceKey<Boolean> DeckPickerBackground = new PreferenceKey<>("deckPickerBackground", false);
+
+    // Card Browser
+    public static PreferenceKey<Boolean> CardBrowserNoSorting = new PreferenceKey<>("cardBrowserNoSorting", false);
+    public static PreferenceKey<Integer> CardBrowserColumn1 = new PreferenceKey<>("cardBrowserColumn1", 0);
+    public static PreferenceKey<Integer> CardBrowserColumn2 = new PreferenceKey<>("cardBrowserColumn2", 0);
+    public static PreferenceKey<Integer> RelativeCardBrowserFontSize = new PreferenceKey<>("relativeCardBrowserFontSize", 100);
+    public static PreferenceKey<Boolean> CardBrowserShowMediaFilenames = new PreferenceKey<>("card_browser_show_media_filenames", false);
+
 
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/preferences/PreferenceKeys.java
+++ b/AnkiDroid/src/main/java/com/ichi2/preferences/PreferenceKeys.java
@@ -25,6 +25,7 @@ import java.lang.annotation.RetentionPolicy;
 import androidx.annotation.IntDef;
 
 import static com.ichi2.anki.AnkiDroidApp.FEEDBACK_REPORT_ASK;
+import static com.ichi2.anki.NavigationDrawerActivity.NIGHT_MODE_PREFERENCE;
 import static com.ichi2.anki.contextmenu.AnkiCardContextMenu.ANKI_CARD_CONTEXT_MENU_PREF_KEY;
 import static com.ichi2.anki.contextmenu.CardBrowserContextMenu.CARD_BROWSER_CONTEXT_MENU_PREF_KEY;
 import static com.ichi2.anki.reviewer.ActionButtonStatus.MENU_DISABLED;
@@ -71,7 +72,7 @@ public class PreferenceKeys {
     public static PreferenceKey<Integer> CardZoom = new PreferenceKey<>("cardZoom", 100);
     public static PreferenceKey<Integer> ImageZoom = new PreferenceKey<>("imageZoom", 100);
     public static PreferenceKey<Boolean> CenterVertically = new PreferenceKey<>("centerVertically", false);
-    public static PreferenceKey<Boolean> InvertedColors = new PreferenceKey<>("invertedColors", false);
+    public static PreferenceKey<Boolean> InvertedColors = new PreferenceKey<>(NIGHT_MODE_PREFERENCE, false);
 
     // Whiteboard
     public static PreferenceKey<Integer> WhiteBoardStrokeWidth = new PreferenceKey<>("whiteBoardStrokeWidth", 6);

--- a/AnkiDroid/src/main/java/com/ichi2/preferences/PreferenceKeys.java
+++ b/AnkiDroid/src/main/java/com/ichi2/preferences/PreferenceKeys.java
@@ -71,6 +71,10 @@ public class PreferenceKeys {
     public static PreferenceKey<String> BrowserEditorFont = new PreferenceKey<>("browserEditorFont", "");
     public static PreferenceKey<Integer> NoteEditorFontSize = new PreferenceKey<>("note_editor_font_size", -1);
 
+    // Reviewer
+    public static PreferenceKey<Boolean> HideDueCount = new PreferenceKey<>("hideDueCount", false);
+    public static PreferenceKey<Boolean> ShowEta = new PreferenceKey<>("showETA", true);
+
 
 
     public static class PreferenceKey<T> {

--- a/AnkiDroid/src/main/java/com/ichi2/preferences/PreferenceKeys.java
+++ b/AnkiDroid/src/main/java/com/ichi2/preferences/PreferenceKeys.java
@@ -16,6 +16,7 @@
 
 package com.ichi2.preferences;
 
+import com.ichi2.anki.AnkiDroidApp;
 import com.ichi2.anki.Lookup;
 
 import java.lang.annotation.Retention;
@@ -23,6 +24,7 @@ import java.lang.annotation.RetentionPolicy;
 
 import androidx.annotation.IntDef;
 
+import static com.ichi2.anki.AnkiDroidApp.FEEDBACK_REPORT_ASK;
 import static com.ichi2.anki.reviewer.ActionButtonStatus.MENU_DISABLED;
 import static com.ichi2.anki.reviewer.ActionButtonStatus.SHOW_AS_ACTION_ALWAYS;
 import static com.ichi2.anki.reviewer.ActionButtonStatus.SHOW_AS_ACTION_IF_ROOM;
@@ -138,6 +140,15 @@ public class PreferenceKeys {
     public static CustomButtonPreferenceKey CustomButtonEnableWhiteboard = new CustomButtonPreferenceKey("customButtonEnableWhiteboard", SHOW_AS_ACTION_NEVER);
     public static CustomButtonPreferenceKey CustomButtonSaveWhiteboard = new CustomButtonPreferenceKey("customButtonSaveWhiteboard", SHOW_AS_ACTION_NEVER);
     public static CustomButtonPreferenceKey CustomButtonWhiteboardPenColor = new CustomButtonPreferenceKey("customButtonWhiteboardPenColor", SHOW_AS_ACTION_IF_ROOM);
+
+    // Preferences
+    public static PreferenceKey<Boolean> AdvancedStatisticsEnabled = new PreferenceKey<>("advanced_statistics_enabled", false);
+
+    // ACRA
+    // Note: defaulted to "" in Preferences, but should never have been hit
+    public static PreferenceKey<String> FeedbackReportKey = new PreferenceKey<>(AnkiDroidApp.FEEDBACK_REPORT_KEY, FEEDBACK_REPORT_ASK);
+
+
 
     public static class PreferenceKey<T> {
         public String key;

--- a/AnkiDroid/src/main/java/com/ichi2/preferences/PreferenceKeys.java
+++ b/AnkiDroid/src/main/java/com/ichi2/preferences/PreferenceKeys.java
@@ -79,6 +79,10 @@ public class PreferenceKeys {
     public static PreferenceKey<Boolean> WidgetSmallEnabled = new PreferenceKey<>("widgetSmallEnabled", false);
     // TODO: minimumCardsDueForNotification - currently ambiguous default
 
+    // SyncStatus
+    public static PreferenceKey<Boolean> ShowSyncStatusBadge = new PreferenceKey<>("showSyncStatusBadge", true);
+    public static PreferenceKey<Boolean> ChangesSinceLastSync = new PreferenceKey<>("changesSinceLastSync", false);
+
 
 
     public static class PreferenceKey<T> {

--- a/AnkiDroid/src/main/java/com/ichi2/preferences/PreferenceKeys.java
+++ b/AnkiDroid/src/main/java/com/ichi2/preferences/PreferenceKeys.java
@@ -198,6 +198,9 @@ public class PreferenceKeys {
     public static PreferenceKey<Integer> DayOffset = new PreferenceKey<>("dayOffset", 0);
     public static PreferenceKey<String> Language = new PreferenceKey<>(Preferences.LANGUAGE, "");
 
+    // Backups
+    public static PreferenceKey<Integer> BackupMax = new PreferenceKey<>("backupMax", 8);
+
 
 
     public static class PreferenceKey<T> {

--- a/AnkiDroid/src/main/java/com/ichi2/preferences/PreferenceKeys.java
+++ b/AnkiDroid/src/main/java/com/ichi2/preferences/PreferenceKeys.java
@@ -64,6 +64,13 @@ public class PreferenceKeys {
     // DialogHandler
     public static PreferenceKey<Long> LastSyncTime = new PreferenceKey<>("lastSyncTime", 0L);
 
+    // Note Editor
+    public static PreferenceKey<Boolean> NoteEditorCapitalize = new PreferenceKey<>("note_editor_capitalize", true);
+    public static PreferenceKey<Boolean> NoteEditorNewlineReplace = new PreferenceKey<>("noteEditorNewlineReplace", true);
+    public static PreferenceKey<Boolean> NoteEditorShowToolbar = new PreferenceKey<>("noteEditorShowToolbar", true);
+    public static PreferenceKey<String> BrowserEditorFont = new PreferenceKey<>("browserEditorFont", "");
+    public static PreferenceKey<Integer> NoteEditorFontSize = new PreferenceKey<>("note_editor_font_size", -1);
+
 
 
     public static class PreferenceKey<T> {

--- a/AnkiDroid/src/main/java/com/ichi2/preferences/PreferenceKeys.java
+++ b/AnkiDroid/src/main/java/com/ichi2/preferences/PreferenceKeys.java
@@ -75,6 +75,10 @@ public class PreferenceKeys {
     public static PreferenceKey<Boolean> HideDueCount = new PreferenceKey<>("hideDueCount", false);
     public static PreferenceKey<Boolean> ShowEta = new PreferenceKey<>("showETA", true);
 
+    // Widget
+    public static PreferenceKey<Boolean> WidgetSmallEnabled = new PreferenceKey<>("widgetSmallEnabled", false);
+    // TODO: minimumCardsDueForNotification - currently ambiguous default
+
 
 
     public static class PreferenceKey<T> {

--- a/AnkiDroid/src/main/java/com/ichi2/preferences/PreferenceKeys.java
+++ b/AnkiDroid/src/main/java/com/ichi2/preferences/PreferenceKeys.java
@@ -88,6 +88,11 @@ public class PreferenceKeys {
     public static PreferenceKey<String> NightTheme = new PreferenceKey<>("nightTheme", "0");
     public static PreferenceKey<String> DayTheme = new PreferenceKey<>("dayTheme", "0");
 
+    // ReviewerCustomFonts
+    // TODO: null or "" in code
+    // public static NullablePreferenceKey<String> DefaultFont = new NullablePreferenceKey<>("defaultFont", null);
+    public static PreferenceKey<String> OverrideFontBehavior = new PreferenceKey<>("overrideFontBehavior", "0");
+
 
 
     public static class PreferenceKey<T> {

--- a/AnkiDroid/src/main/java/com/ichi2/preferences/PreferenceKeys.java
+++ b/AnkiDroid/src/main/java/com/ichi2/preferences/PreferenceKeys.java
@@ -16,6 +16,16 @@
 
 package com.ichi2.preferences;
 
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+import androidx.annotation.IntDef;
+
+import static com.ichi2.anki.reviewer.ActionButtonStatus.MENU_DISABLED;
+import static com.ichi2.anki.reviewer.ActionButtonStatus.SHOW_AS_ACTION_ALWAYS;
+import static com.ichi2.anki.reviewer.ActionButtonStatus.SHOW_AS_ACTION_IF_ROOM;
+import static com.ichi2.anki.reviewer.ActionButtonStatus.SHOW_AS_ACTION_NEVER;
+
 /**
  * Keys to ensure consistency between XML and code defaults
  * TODO: No tests have been run on this yet
@@ -105,6 +115,28 @@ public class PreferenceKeys {
     public static PreferenceKey<String> GestureTapBottomLeft = new PreferenceKey<>("gestureTapBottomLeft", "0");
     public static PreferenceKey<String> GestureTapBottomRight = new PreferenceKey<>("gestureTapBottomRight", "0");
 
+    // ActionButtonStatus
+    public static CustomButtonPreferenceKey CustomButtonUndo = new CustomButtonPreferenceKey("customButtonUndo", SHOW_AS_ACTION_ALWAYS);
+    public static CustomButtonPreferenceKey CustomButtonScheduleCard = new CustomButtonPreferenceKey("customButtonScheduleCard", SHOW_AS_ACTION_NEVER);
+    public static CustomButtonPreferenceKey CustomButtonFlag = new CustomButtonPreferenceKey("customButtonFlag", SHOW_AS_ACTION_ALWAYS);
+    public static CustomButtonPreferenceKey CustomButtonTags = new CustomButtonPreferenceKey("customButtonTags", SHOW_AS_ACTION_NEVER);
+    public static CustomButtonPreferenceKey CustomButtonEditCard = new CustomButtonPreferenceKey("customButtonEditCard", SHOW_AS_ACTION_IF_ROOM);
+    public static CustomButtonPreferenceKey CustomButtonAddCard = new CustomButtonPreferenceKey("customButtonAddCard", MENU_DISABLED);
+    public static CustomButtonPreferenceKey CustomButtonReplay = new CustomButtonPreferenceKey("customButtonReplay", SHOW_AS_ACTION_IF_ROOM);
+    public static CustomButtonPreferenceKey CustomButtonCardInfo = new CustomButtonPreferenceKey("customButtonCardInfo", MENU_DISABLED);
+    public static CustomButtonPreferenceKey CustomButtonClearWhiteboard = new CustomButtonPreferenceKey("customButtonClearWhiteboard", SHOW_AS_ACTION_IF_ROOM);
+    public static CustomButtonPreferenceKey CustomButtonShowHideWhiteboard = new CustomButtonPreferenceKey("customButtonShowHideWhiteboard", SHOW_AS_ACTION_ALWAYS);
+    public static CustomButtonPreferenceKey CustomButtonSelectTts = new CustomButtonPreferenceKey("customButtonSelectTts", SHOW_AS_ACTION_NEVER);
+    public static CustomButtonPreferenceKey CustomButtonDeckOptions = new CustomButtonPreferenceKey("customButtonDeckOptions", SHOW_AS_ACTION_NEVER);
+    public static CustomButtonPreferenceKey CustomButtonBury = new CustomButtonPreferenceKey("customButtonBury", SHOW_AS_ACTION_NEVER);
+    public static CustomButtonPreferenceKey CustomButtonSuspend = new CustomButtonPreferenceKey("customButtonSuspend", SHOW_AS_ACTION_NEVER);
+    public static CustomButtonPreferenceKey CustomButtonMarkCard = new CustomButtonPreferenceKey("customButtonMarkCard", SHOW_AS_ACTION_IF_ROOM);
+    public static CustomButtonPreferenceKey CustomButtonDelete = new CustomButtonPreferenceKey("customButtonDelete", SHOW_AS_ACTION_NEVER);
+    public static CustomButtonPreferenceKey CustomButtonToggleMicToolBar = new CustomButtonPreferenceKey("customButtonToggleMicToolBar", SHOW_AS_ACTION_NEVER);
+    public static CustomButtonPreferenceKey CustomButtonEnableWhiteboard = new CustomButtonPreferenceKey("customButtonEnableWhiteboard", SHOW_AS_ACTION_NEVER);
+    public static CustomButtonPreferenceKey CustomButtonSaveWhiteboard = new CustomButtonPreferenceKey("customButtonSaveWhiteboard", SHOW_AS_ACTION_NEVER);
+    public static CustomButtonPreferenceKey CustomButtonWhiteboardPenColor = new CustomButtonPreferenceKey("customButtonWhiteboardPenColor", SHOW_AS_ACTION_IF_ROOM);
+
     public static class PreferenceKey<T> {
         public String key;
         public T defaultValue;
@@ -113,5 +145,17 @@ public class PreferenceKeys {
             this.key = key;
             this.defaultValue = value;
         }
+    }
+
+
+    public static class CustomButtonPreferenceKey extends PreferenceKey<String> {
+        public CustomButtonPreferenceKey(String key, @CustomButtonDef int value) {
+            super(key, Integer.toString(value));
+        }
+
+
+        @Retention(RetentionPolicy.SOURCE)
+        @IntDef({SHOW_AS_ACTION_NEVER, SHOW_AS_ACTION_IF_ROOM, SHOW_AS_ACTION_ALWAYS, MENU_DISABLED })
+        public @interface CustomButtonDef {}
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/preferences/PreferenceKeys.java
+++ b/AnkiDroid/src/main/java/com/ichi2/preferences/PreferenceKeys.java
@@ -52,6 +52,8 @@ public class PreferenceKeys {
     public static PreferenceKey<Boolean> ShowTopBar = new PreferenceKey<>("showTopbar", true);
     public static PreferenceKey<Boolean> LinkOverridesTouchGesture = new PreferenceKey<>("linkOverridesTouchGesture", false);
 
+    public static PreferenceKey<Boolean> Gestures = new PreferenceKey<>("gestures", false);
+    public static PreferenceKey<Integer> SwipeSensitivity = new PreferenceKey<>( "swipeSensitivity", 100);
     public static PreferenceKey<String> GestureSwipeUp = new PreferenceKey<>("gestureSwipeUp", "9");
     public static PreferenceKey<String> GestureSwipeDown = new PreferenceKey<>("gestureSwipeDown", "0");
     public static PreferenceKey<String> GestureSwipeLeft = new PreferenceKey<>("gestureSwipeLeft", "8");

--- a/AnkiDroid/src/main/java/com/ichi2/preferences/PreferenceKeys.java
+++ b/AnkiDroid/src/main/java/com/ichi2/preferences/PreferenceKeys.java
@@ -31,6 +31,7 @@ import static com.ichi2.anki.reviewer.ActionButtonStatus.MENU_DISABLED;
 import static com.ichi2.anki.reviewer.ActionButtonStatus.SHOW_AS_ACTION_ALWAYS;
 import static com.ichi2.anki.reviewer.ActionButtonStatus.SHOW_AS_ACTION_IF_ROOM;
 import static com.ichi2.anki.reviewer.ActionButtonStatus.SHOW_AS_ACTION_NEVER;
+import static com.ichi2.anki.web.CustomSyncServer.PREFERENCE_ENABLE_CUSTOM_SYNC_SERVER;
 
 /**
  * Keys to ensure consistency between XML and code defaults
@@ -183,6 +184,9 @@ public class PreferenceKeys {
     public static PreferenceKey<Boolean> CardBrowserContextMenu = new PreferenceKey<>(CARD_BROWSER_CONTEXT_MENU_PREF_KEY, false);
     public static PreferenceKey<Boolean> AnkiCardContextMenu = new PreferenceKey<>(ANKI_CARD_CONTEXT_MENU_PREF_KEY, true);
 
+    // Custom Sync Server
+    public static PreferenceKey<Boolean> EnableCustomSyncServer = new PreferenceKey<>(PREFERENCE_ENABLE_CUSTOM_SYNC_SERVER, false);
+    // TODO: variable defaults (null/empty): syncBaseUrl, syncMediaUrl
 
 
     public static class PreferenceKey<T> {

--- a/AnkiDroid/src/main/java/com/ichi2/preferences/PreferenceKeys.java
+++ b/AnkiDroid/src/main/java/com/ichi2/preferences/PreferenceKeys.java
@@ -164,6 +164,12 @@ public class PreferenceKeys {
     public static PreferenceKey<Integer> RelativeCardBrowserFontSize = new PreferenceKey<>("relativeCardBrowserFontSize", 100);
     public static PreferenceKey<Boolean> CardBrowserShowMediaFilenames = new PreferenceKey<>("card_browser_show_media_filenames", false);
 
+    // Notifications
+    public static PreferenceKey<Boolean> WidgetVibrate = new PreferenceKey<>("widgetVibrate", false);
+    public static PreferenceKey<Boolean> WidgetBlink = new PreferenceKey<>("widgetBlink", false);
+
+    // Animations
+    public static PreferenceKey<Boolean> SafeDisplay = new PreferenceKey<>("safeDisplay", false);
 
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/preferences/PreferenceKeys.java
+++ b/AnkiDroid/src/main/java/com/ichi2/preferences/PreferenceKeys.java
@@ -90,6 +90,8 @@ public class PreferenceKeys {
     public static PreferenceKey<String> BrowserEditorFont = new PreferenceKey<>("browserEditorFont", ""); // and card browser
     public static PreferenceKey<Integer> NoteEditorFontSize = new PreferenceKey<>("note_editor_font_size", -1);
 
+    public static PreferenceKey<Boolean> DisableExtendedTextUi = new PreferenceKey<>("disableExtendedTextUi", false);
+
     // Reviewer
     public static PreferenceKey<Boolean> HideDueCount = new PreferenceKey<>("hideDueCount", false);
     public static PreferenceKey<Boolean> ShowEta = new PreferenceKey<>("showETA", true);

--- a/AnkiDroid/src/main/java/com/ichi2/preferences/PreferenceKeys.java
+++ b/AnkiDroid/src/main/java/com/ichi2/preferences/PreferenceKeys.java
@@ -174,6 +174,9 @@ public class PreferenceKeys {
     // Animations
     public static PreferenceKey<Boolean> SafeDisplay = new PreferenceKey<>("safeDisplay", false);
 
+    // Chess
+    public static PreferenceKey<Boolean> ConvertFenText = new PreferenceKey<>("convertFenText", false);
+
 
 
     public static class PreferenceKey<T> {

--- a/AnkiDroid/src/main/java/com/ichi2/preferences/PreferenceKeys.java
+++ b/AnkiDroid/src/main/java/com/ichi2/preferences/PreferenceKeys.java
@@ -16,6 +16,8 @@
 
 package com.ichi2.preferences;
 
+import com.ichi2.anki.Lookup;
+
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 
@@ -33,7 +35,7 @@ import static com.ichi2.anki.reviewer.ActionButtonStatus.SHOW_AS_ACTION_NEVER;
 public class PreferenceKeys {
     public static PreferenceKey<Boolean> UseInputTag = new PreferenceKey<>("useInputTag", false);
     public static PreferenceKey<Boolean> NoCodeFormatting = new PreferenceKey<>("noCodeFormatting", false);
-    public static PreferenceKey<String> Dictionary = new PreferenceKey<>("dictionary", "0");
+    public static PreferenceKey<String> Dictionary = new PreferenceKey<>("dictionary", Integer.toString(Lookup.DICTIONARY_NONE));
     public static PreferenceKey<String> FullscreenMode = new PreferenceKey<>("fullscreenMode", "0");
     public static PreferenceKey<Integer> AnswerButtonSide = new PreferenceKey<>("answerButtonSize", 100);
     public static PreferenceKey<Boolean> Tts = new PreferenceKey<>("tts", false);

--- a/AnkiDroid/src/main/java/com/ichi2/preferences/PreferenceKeys.java
+++ b/AnkiDroid/src/main/java/com/ichi2/preferences/PreferenceKeys.java
@@ -18,6 +18,7 @@ package com.ichi2.preferences;
 
 import com.ichi2.anki.AnkiDroidApp;
 import com.ichi2.anki.Lookup;
+import com.ichi2.anki.Preferences;
 
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -195,6 +196,9 @@ public class PreferenceKeys {
 
     // BootService
     public static PreferenceKey<Integer> DayOffset = new PreferenceKey<>("dayOffset", 0);
+    public static PreferenceKey<String> Language = new PreferenceKey<>(Preferences.LANGUAGE, "");
+
+
 
     public static class PreferenceKey<T> {
         public String key;

--- a/AnkiDroid/src/main/java/com/ichi2/preferences/PreferenceKeys.java
+++ b/AnkiDroid/src/main/java/com/ichi2/preferences/PreferenceKeys.java
@@ -1,0 +1,61 @@
+/*
+ *  Copyright (c) 2021 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.preferences;
+
+/**
+ * Keys to ensure consistency between XML and code defaults
+ * TODO: No tests have been run on this yet
+ * */
+public class PreferenceKeys {
+    public static PreferenceKey<Boolean> UseInputTag = new PreferenceKey<>("useInputTag", false);
+    public static PreferenceKey<Boolean> NoCodeFormatting = new PreferenceKey<>("noCodeFormatting", false);
+    public static PreferenceKey<String> Dictionary = new PreferenceKey<>("dictionary", "0");
+    public static PreferenceKey<String> FullscreenMode = new PreferenceKey<>("fullscreenMode", "0");
+    public static PreferenceKey<Integer> AnswerButtonSide = new PreferenceKey<>("answerButtonSize", 100);
+    public static PreferenceKey<Boolean> Tts = new PreferenceKey<>("tts", false);
+    public static PreferenceKey<Boolean> TimeoutAnswer = new PreferenceKey<>("timeoutAnswer", false);
+    public static PreferenceKey<Integer> TimeoutAnswerSeconds = new PreferenceKey<>("timeoutAnswerSeconds", 20);
+    public static PreferenceKey<Integer> TimeoutQuestionSeconds = new PreferenceKey<>("timeoutQuestionSeconds", 60);
+    public static PreferenceKey<Boolean> ScrollingButtons = new PreferenceKey<>("scrolling_buttons", false);
+    public static PreferenceKey<Boolean> DoubleScrolling = new PreferenceKey<>("double_scrolling", false);
+    public static PreferenceKey<Boolean> ShowTopBar = new PreferenceKey<>("showTopbar", true);
+    public static PreferenceKey<Boolean> LinkOverridesTouchGesture = new PreferenceKey<>("linkOverridesTouchGesture", false);
+
+    public static PreferenceKey<String> GestureSwipeUp = new PreferenceKey<>("gestureSwipeUp", "9");
+    public static PreferenceKey<String> GestureSwipeDown = new PreferenceKey<>("gestureSwipeDown", "0");
+    public static PreferenceKey<String> GestureSwipeLeft = new PreferenceKey<>("gestureSwipeLeft", "8");
+    public static PreferenceKey<String> GestureSwipeRight = new PreferenceKey<>("gestureSwipeRight", "17");
+    public static PreferenceKey<String> GestureDoubleTap = new PreferenceKey<>("gestureDoubleTap", "7");
+    public static PreferenceKey<String> GestureLongClick = new PreferenceKey<>("gestureLongclick", "11");
+    public static PreferenceKey<String> GestureVolumeUp = new PreferenceKey<>("gestureVolumeUp", "0");
+    public static PreferenceKey<String> GestureVolumeDown = new PreferenceKey<>("gestureVolumeDown", "0");
+
+    public static PreferenceKey<Boolean> KeepScreenOn = new PreferenceKey<>("keepScreenOn", false);
+    public static PreferenceKey<Boolean> HtmlJavascriptDebugging = new PreferenceKey<>("html_javascript_debugging", false);
+    public static PreferenceKey<String> AnswerButtonPosition = new PreferenceKey<>("answerButtonPosition", "bottom"); // This exists in constants.xml - remove?
+
+
+    public static class PreferenceKey<T> {
+        public String key;
+        public T defaultValue;
+
+        public PreferenceKey(String key, T value) {
+            this.key = key;
+            this.defaultValue = value;
+        }
+    }
+}

--- a/AnkiDroid/src/main/java/com/ichi2/preferences/PreferenceKeys.java
+++ b/AnkiDroid/src/main/java/com/ichi2/preferences/PreferenceKeys.java
@@ -61,6 +61,9 @@ public class PreferenceKeys {
     public static PreferenceKey<String> Username = new PreferenceKey<>("username", "");
     public static PreferenceKey<String> HKey = new PreferenceKey<>("hkey", "");
 
+    // DialogHandler
+    public static PreferenceKey<Long> LastSyncTime = new PreferenceKey<>("lastSyncTime", 0L);
+
 
 
     public static class PreferenceKey<T> {

--- a/AnkiDroid/src/main/java/com/ichi2/preferences/PreferenceKeys.java
+++ b/AnkiDroid/src/main/java/com/ichi2/preferences/PreferenceKeys.java
@@ -84,6 +84,11 @@ public class PreferenceKeys {
     public static PreferenceKey<Boolean> ChangesSinceLastSync = new PreferenceKey<>("changesSinceLastSync", false);
 
 
+    // Themes
+    public static PreferenceKey<String> NightTheme = new PreferenceKey<>("nightTheme", "0");
+    public static PreferenceKey<String> DayTheme = new PreferenceKey<>("dayTheme", "0");
+
+
 
     public static class PreferenceKey<T> {
         public String key;

--- a/AnkiDroid/src/main/java/com/ichi2/preferences/PreferenceKeys.java
+++ b/AnkiDroid/src/main/java/com/ichi2/preferences/PreferenceKeys.java
@@ -93,7 +93,17 @@ public class PreferenceKeys {
     // public static NullablePreferenceKey<String> DefaultFont = new NullablePreferenceKey<>("defaultFont", null);
     public static PreferenceKey<String> OverrideFontBehavior = new PreferenceKey<>("overrideFontBehavior", "0");
 
-
+    // GestureTapProcessor
+    public static PreferenceKey<String> GestureTapLeft = new PreferenceKey<>("gestureTapLeft", "3");
+    public static PreferenceKey<String> GestureTapRight = new PreferenceKey<>("gestureTapRight", "6");
+    public static PreferenceKey<String> GestureTapTop = new PreferenceKey<>("gestureTapTop", "12");
+    public static PreferenceKey<String> GestureTapBottom = new PreferenceKey<>("gestureTapBottom", "2");
+    public static PreferenceKey<Boolean> GestureCornerTouch = new PreferenceKey<>("gestureCornerTouch", false);
+    public static PreferenceKey<String> GestureTapTopLeft = new PreferenceKey<>("gestureTapTopLeft", "0");
+    public static PreferenceKey<String> GestureTapTopRight = new PreferenceKey<>("gestureTapTopRight", "0");
+    public static PreferenceKey<String> GestureTapCenter = new PreferenceKey<>("gestureTapCenter", "0");
+    public static PreferenceKey<String> GestureTapBottomLeft = new PreferenceKey<>("gestureTapBottomLeft", "0");
+    public static PreferenceKey<String> GestureTapBottomRight = new PreferenceKey<>("gestureTapBottomRight", "0");
 
     public static class PreferenceKey<T> {
         public String key;

--- a/AnkiDroid/src/main/java/com/ichi2/preferences/PreferenceKeys.java
+++ b/AnkiDroid/src/main/java/com/ichi2/preferences/PreferenceKeys.java
@@ -16,6 +16,8 @@
 
 package com.ichi2.preferences;
 
+import android.content.SharedPreferences;
+
 import com.ichi2.anki.AnkiDroidApp;
 import com.ichi2.anki.Lookup;
 
@@ -147,6 +149,15 @@ public class PreferenceKeys {
     // ACRA
     // Note: defaulted to "" in Preferences, but should never have been hit
     public static PreferenceKey<String> FeedbackReportKey = new PreferenceKey<>(AnkiDroidApp.FEEDBACK_REPORT_KEY, FEEDBACK_REPORT_ASK);
+
+    // DeckPicker - Sync
+    public static PreferenceKey<Boolean> AutomaticSyncMode = new PreferenceKey<>("automaticSyncMode", false);
+    public static PreferenceKey<Boolean> SyncFetchesMedia = new PreferenceKey<>("syncFetchesMedia", true);
+
+    // DeckPicker
+    public static PreferenceKey<Boolean> NoSpaceLeft = new PreferenceKey<>("noSpaceLeft", false);
+    public static PreferenceKey<String> LastVersion = new PreferenceKey<>("lastVersion", "");
+    public static PreferenceKey<Boolean> DeckPickerBackground = new PreferenceKey<>("deckPickerBackground", false);
 
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/preferences/PreferenceKeys.java
+++ b/AnkiDroid/src/main/java/com/ichi2/preferences/PreferenceKeys.java
@@ -141,8 +141,11 @@ public class PreferenceKeys {
     public static CustomButtonPreferenceKey CustomButtonSaveWhiteboard = new CustomButtonPreferenceKey("customButtonSaveWhiteboard", SHOW_AS_ACTION_NEVER);
     public static CustomButtonPreferenceKey CustomButtonWhiteboardPenColor = new CustomButtonPreferenceKey("customButtonWhiteboardPenColor", SHOW_AS_ACTION_IF_ROOM);
 
-    // Preferences
+    // Advanced Statistics
     public static PreferenceKey<Boolean> AdvancedStatisticsEnabled = new PreferenceKey<>("advanced_statistics_enabled", false);
+    public static PreferenceKey<Integer> AdvancedForecastStatsMcNIterations = new PreferenceKey<>("advanced_forecast_stats_mc_n_iterations", 1);
+    public static PreferenceKey<Integer> AdvancedForecastStatsComputeNDays = new PreferenceKey<>("advanced_forecast_stats_compute_n_days", 0);
+    public static PreferenceKey<Integer> AdvancedForecastStatsComputePrecision = new PreferenceKey<>("advanced_forecast_stats_compute_precision", 90);
 
     // ACRA
     // Note: defaulted to "" in Preferences, but should never have been hit

--- a/AnkiDroid/src/main/java/com/ichi2/preferences/Prefs.java
+++ b/AnkiDroid/src/main/java/com/ichi2/preferences/Prefs.java
@@ -1,0 +1,67 @@
+/*
+ *  Copyright (c) 2021 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.preferences;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+
+import com.ichi2.anki.AnkiDroidApp;
+
+public class Prefs {
+
+    private final SharedPreferences mPreferences;
+
+    public Prefs(SharedPreferences preferences) {
+        mPreferences = preferences;
+    }
+
+    public boolean getBoolean(PreferenceKeys.PreferenceKey<Boolean> key) {
+        return mPreferences.getBoolean(key.key, key.defaultValue);
+    }
+
+    public int getInt(PreferenceKeys.PreferenceKey<Integer> key) {
+        return mPreferences.getInt(key.key, key.defaultValue);
+    }
+
+    public String getString(PreferenceKeys.PreferenceKey<String> key) {
+        return mPreferences.getString(key.key, key.defaultValue);
+    }
+
+    public static boolean getBoolean(Context context, PreferenceKeys.PreferenceKey<Boolean> key) {
+        return new Prefs(AnkiDroidApp.getSharedPrefs(context)).getBoolean(key);
+    }
+
+    public static int getInt(Context context, PreferenceKeys.PreferenceKey<Integer> key) {
+        return new Prefs(AnkiDroidApp.getSharedPrefs(context)).getInt(key);
+    }
+
+    public static String getString(Context context, PreferenceKeys.PreferenceKey<String> key) {
+        return new Prefs(AnkiDroidApp.getSharedPrefs(context)).getString(key);
+    }
+
+    public static boolean getBoolean(SharedPreferences preferences, PreferenceKeys.PreferenceKey<Boolean> key) {
+        return new Prefs(preferences).getBoolean(key);
+    }
+
+    public static int getInt(SharedPreferences preferences, PreferenceKeys.PreferenceKey<Integer> key) {
+        return new Prefs(preferences).getInt(key);
+    }
+
+    public static String getString(SharedPreferences preferences, PreferenceKeys.PreferenceKey<String> key) {
+        return new Prefs(preferences).getString(key);
+    }
+}

--- a/AnkiDroid/src/main/java/com/ichi2/preferences/Prefs.java
+++ b/AnkiDroid/src/main/java/com/ichi2/preferences/Prefs.java
@@ -41,6 +41,10 @@ public class Prefs {
         return mPreferences.getString(key.key, key.defaultValue);
     }
 
+    public long getLong(PreferenceKeys.PreferenceKey<Long> key) {
+        return mPreferences.getLong(key.key, key.defaultValue);
+    }
+
     public static boolean getBoolean(Context context, PreferenceKeys.PreferenceKey<Boolean> key) {
         return new Prefs(AnkiDroidApp.getSharedPrefs(context)).getBoolean(key);
     }
@@ -53,6 +57,10 @@ public class Prefs {
         return new Prefs(AnkiDroidApp.getSharedPrefs(context)).getString(key);
     }
 
+    public static long getLong(Context context, PreferenceKeys.PreferenceKey<Long> key) {
+        return new Prefs(AnkiDroidApp.getSharedPrefs(context)).getLong(key);
+    }
+
     public static boolean getBoolean(SharedPreferences preferences, PreferenceKeys.PreferenceKey<Boolean> key) {
         return new Prefs(preferences).getBoolean(key);
     }
@@ -63,5 +71,8 @@ public class Prefs {
 
     public static String getString(SharedPreferences preferences, PreferenceKeys.PreferenceKey<String> key) {
         return new Prefs(preferences).getString(key);
+    }
+    public static long getLong(SharedPreferences preferences, PreferenceKeys.PreferenceKey<Long> key) {
+        return new Prefs(preferences).getLong(key);
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/preferences/Prefs.java
+++ b/AnkiDroid/src/main/java/com/ichi2/preferences/Prefs.java
@@ -32,6 +32,12 @@ public class Prefs {
         mPreferences = preferences;
     }
 
+
+    public static Prefs fromContext(Context context) {
+        return new Prefs(AnkiDroidApp.getSharedPrefs(context));
+    }
+
+
     public boolean getBoolean(PreferenceKeys.PreferenceKey<Boolean> key) {
         return mPreferences.getBoolean(key.key, key.defaultValue);
     }

--- a/AnkiDroid/src/main/java/com/ichi2/preferences/Prefs.java
+++ b/AnkiDroid/src/main/java/com/ichi2/preferences/Prefs.java
@@ -24,6 +24,7 @@ import com.ichi2.anki.AnkiDroidApp;
 public class Prefs {
 
     // TODO: StringSet - ensure that it does not accept and return a mutable class.
+    // COULD_BE_BETTER: Consider improving this pattern via method: "Integer.parseInt(preferences.getString())"
 
     private final SharedPreferences mPreferences;
 

--- a/AnkiDroid/src/main/java/com/ichi2/preferences/Prefs.java
+++ b/AnkiDroid/src/main/java/com/ichi2/preferences/Prefs.java
@@ -23,6 +23,8 @@ import com.ichi2.anki.AnkiDroidApp;
 
 public class Prefs {
 
+    // TODO: StringSet - ensure that it does not accept and return a mutable class.
+
     private final SharedPreferences mPreferences;
 
     public Prefs(SharedPreferences preferences) {

--- a/AnkiDroid/src/main/java/com/ichi2/preferences/Prefs.java
+++ b/AnkiDroid/src/main/java/com/ichi2/preferences/Prefs.java
@@ -24,7 +24,6 @@ import com.ichi2.anki.AnkiDroidApp;
 public class Prefs {
 
     // TODO: StringSet - ensure that it does not accept and return a mutable class.
-    // COULD_BE_BETTER: Consider improving this pattern via method: "Integer.parseInt(preferences.getString())"
 
     private final SharedPreferences mPreferences;
 
@@ -52,6 +51,11 @@ public class Prefs {
 
     public long getLong(PreferenceKeys.PreferenceKey<Long> key) {
         return mPreferences.getLong(key.key, key.defaultValue);
+    }
+
+    /** Converts a string-based key to an integer */
+    public int getIntFromStr(PreferenceKeys.StringAsIntKey key) {
+        return Integer.parseInt(getString(key));
     }
 
     public static boolean getBoolean(Context context, PreferenceKeys.PreferenceKey<Boolean> key) {

--- a/AnkiDroid/src/main/java/com/ichi2/themes/Themes.java
+++ b/AnkiDroid/src/main/java/com/ichi2/themes/Themes.java
@@ -43,7 +43,7 @@ public class Themes {
     public static void setTheme(Context context) {
         Prefs prefs = Prefs.fromContext(context.getApplicationContext());
         if (prefs.getBoolean(PreferenceKeys.InvertedColors)) {
-            int theme = Integer.parseInt(prefs.getString(PreferenceKeys.NightTheme));
+            int theme = prefs.getIntFromStr(PreferenceKeys.NightTheme);
             switch (theme) {
                 case THEME_NIGHT_DARK:
                     context.setTheme(R.style.Theme_Dark_Compat);
@@ -53,7 +53,7 @@ public class Themes {
                     break;
             }
         } else {
-            int theme = Integer.parseInt(prefs.getString(PreferenceKeys.DayTheme));
+            int theme = prefs.getIntFromStr(PreferenceKeys.DayTheme);
             switch (theme) {
                 case THEME_DAY_LIGHT:
                     context.setTheme(R.style.Theme_Light_Compat);
@@ -68,7 +68,7 @@ public class Themes {
     public static void setThemeLegacy(Context context) {
         Prefs prefs = Prefs.fromContext(context.getApplicationContext());
         if (prefs.getBoolean(PreferenceKeys.InvertedColors)) {
-            int theme = Integer.parseInt(prefs.getString(PreferenceKeys.NightTheme));
+            int theme = prefs.getIntFromStr(PreferenceKeys.NightTheme);
             switch (theme) {
                 case THEME_NIGHT_DARK:
                     context.setTheme(R.style.LegacyActionBarDark);
@@ -78,7 +78,7 @@ public class Themes {
                     break;
             }
         } else {
-            int theme = Integer.parseInt(prefs.getString(PreferenceKeys.DayTheme));
+            int theme = prefs.getIntFromStr(PreferenceKeys.DayTheme);
             switch (theme) {
                 case THEME_DAY_LIGHT:
                     context.setTheme(R.style.LegacyActionBarLight);
@@ -127,9 +127,9 @@ public class Themes {
     public static int getCurrentTheme(Context context) {
         Prefs prefs = Prefs.fromContext(context);
         if (prefs.getBoolean(PreferenceKeys.InvertedColors)) {
-            return Integer.parseInt(prefs.getString(PreferenceKeys.NightTheme));
+            return prefs.getIntFromStr(PreferenceKeys.NightTheme);
         } else {
-            return Integer.parseInt(prefs.getString(PreferenceKeys.DayTheme));
+            return prefs.getIntFromStr(PreferenceKeys.DayTheme);
         }
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/themes/Themes.java
+++ b/AnkiDroid/src/main/java/com/ichi2/themes/Themes.java
@@ -19,12 +19,13 @@ package com.ichi2.themes;
 
 
 import android.content.Context;
-import android.content.SharedPreferences;
 import android.content.res.TypedArray;
-import androidx.core.content.ContextCompat;
 
-import com.ichi2.anki.AnkiDroidApp;
 import com.ichi2.anki.R;
+import com.ichi2.preferences.PreferenceKeys;
+import com.ichi2.preferences.Prefs;
+
+import androidx.core.content.ContextCompat;
 
 public class Themes {
     public final static int ALPHA_ICON_ENABLED_LIGHT = 255; // 100%
@@ -40,9 +41,9 @@ public class Themes {
 
 
     public static void setTheme(Context context) {
-        SharedPreferences prefs = AnkiDroidApp.getSharedPrefs(context.getApplicationContext());
-        if (prefs.getBoolean("invertedColors", false)) {
-            int theme = Integer.parseInt(prefs.getString("nightTheme", "0"));
+        Prefs prefs = Prefs.fromContext(context.getApplicationContext());
+        if (prefs.getBoolean(PreferenceKeys.InvertedColors)) {
+            int theme = Integer.parseInt(prefs.getString(PreferenceKeys.NightTheme));
             switch (theme) {
                 case THEME_NIGHT_DARK:
                     context.setTheme(R.style.Theme_Dark_Compat);
@@ -52,7 +53,7 @@ public class Themes {
                     break;
             }
         } else {
-            int theme = Integer.parseInt(prefs.getString("dayTheme", "0"));
+            int theme = Integer.parseInt(prefs.getString(PreferenceKeys.DayTheme));
             switch (theme) {
                 case THEME_DAY_LIGHT:
                     context.setTheme(R.style.Theme_Light_Compat);
@@ -65,9 +66,9 @@ public class Themes {
     }
 
     public static void setThemeLegacy(Context context) {
-        SharedPreferences prefs = AnkiDroidApp.getSharedPrefs(context.getApplicationContext());
-        if (prefs.getBoolean("invertedColors", false)) {
-            int theme = Integer.parseInt(prefs.getString("nightTheme", "0"));
+        Prefs prefs = Prefs.fromContext(context.getApplicationContext());
+        if (prefs.getBoolean(PreferenceKeys.InvertedColors)) {
+            int theme = Integer.parseInt(prefs.getString(PreferenceKeys.NightTheme));
             switch (theme) {
                 case THEME_NIGHT_DARK:
                     context.setTheme(R.style.LegacyActionBarDark);
@@ -77,7 +78,7 @@ public class Themes {
                     break;
             }
         } else {
-            int theme = Integer.parseInt(prefs.getString("dayTheme", "0"));
+            int theme = Integer.parseInt(prefs.getString(PreferenceKeys.DayTheme));
             switch (theme) {
                 case THEME_DAY_LIGHT:
                     context.setTheme(R.style.LegacyActionBarLight);
@@ -124,11 +125,11 @@ public class Themes {
      * whether we are in day mode or night mode.
      */
     public static int getCurrentTheme(Context context) {
-        SharedPreferences prefs = AnkiDroidApp.getSharedPrefs(context);
-        if (prefs.getBoolean("invertedColors", false)) {
-            return Integer.parseInt(prefs.getString("nightTheme", "0"));
+        Prefs prefs = Prefs.fromContext(context);
+        if (prefs.getBoolean(PreferenceKeys.InvertedColors)) {
+            return Integer.parseInt(prefs.getString(PreferenceKeys.NightTheme));
         } else {
-            return Integer.parseInt(prefs.getString("dayTheme", "0"));
+            return Integer.parseInt(prefs.getString(PreferenceKeys.DayTheme));
         }
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/utils/LanguageUtil.java
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/LanguageUtil.java
@@ -16,12 +16,12 @@
 
 package com.ichi2.utils;
 
-import android.content.SharedPreferences;
 import android.content.res.Resources;
 import android.text.TextUtils;
 
 import com.ichi2.anki.AnkiDroidApp;
-import com.ichi2.anki.Preferences;
+import com.ichi2.preferences.PreferenceKeys;
+import com.ichi2.preferences.Prefs;
 
 import java.text.DateFormat;
 import java.util.Date;
@@ -65,8 +65,7 @@ public class LanguageUtil {
      */
     @NonNull
     public static Locale getLocale(@Nullable String localeCode) {
-        SharedPreferences prefs = AnkiDroidApp.getSharedPrefs(AnkiDroidApp.getInstance().getBaseContext());
-        return getLocale(localeCode, prefs);
+        return getLocale(localeCode, Prefs.fromContext(AnkiDroidApp.getInstance().getBaseContext()));
     }
 
     /**
@@ -76,11 +75,11 @@ public class LanguageUtil {
      * @return The {@link Locale} for the given code
      */
     @NonNull
-    public static Locale getLocale(@Nullable String localeCode, @NonNull SharedPreferences prefs) {
+    public static Locale getLocale(@Nullable String localeCode, @NonNull Prefs prefs) {
         Locale locale;
         if (localeCode == null || TextUtils.isEmpty(localeCode)) {
 
-            localeCode = prefs.getString(Preferences.LANGUAGE, "");
+            localeCode = prefs.getString(PreferenceKeys.Language);
             // If no code provided use the app language.
         }
         if (TextUtils.isEmpty(localeCode)) {

--- a/AnkiDroid/src/main/java/com/ichi2/utils/SyncStatus.java
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/SyncStatus.java
@@ -20,6 +20,8 @@ import android.content.SharedPreferences;
 
 import com.ichi2.anki.AnkiDroidApp;
 import com.ichi2.libanki.Collection;
+import com.ichi2.preferences.PreferenceKeys;
+import com.ichi2.preferences.Prefs;
 import com.ichi2.utils.FunctionalInterfaces.Supplier;
 
 import androidx.annotation.NonNull;
@@ -72,21 +74,21 @@ public enum SyncStatus {
 
 
     private static boolean isDisabled() {
-        SharedPreferences preferences = AnkiDroidApp.getSharedPrefs(AnkiDroidApp.getInstance());
-        return !preferences.getBoolean("showSyncStatusBadge", true);
+        Prefs preferences = Prefs.fromContext(AnkiDroidApp.getInstance());
+        return !preferences.getBoolean(PreferenceKeys.ShowSyncStatusBadge);
     }
 
 
     private static boolean isLoggedIn() {
-        SharedPreferences preferences = AnkiDroidApp.getSharedPrefs(AnkiDroidApp.getInstance());
-        String hkey = preferences.getString("hkey", "");
+        Prefs preferences = Prefs.fromContext(AnkiDroidApp.getInstance());
+        String hkey = preferences.getString(PreferenceKeys.HKey);
         return hkey != null && hkey.length() != 0;
     }
 
 
     /** Whether data has been changed - to be converted to Rust */
     public static boolean hasDatabaseChanges() {
-        return AnkiDroidApp.getSharedPrefs(AnkiDroidApp.getInstance()).getBoolean("changesSinceLastSync", false);
+        return Prefs.fromContext(AnkiDroidApp.getInstance()).getBoolean(PreferenceKeys.ChangesSinceLastSync);
     }
 
     /** To be converted to Rust */

--- a/AnkiDroid/src/main/java/com/ichi2/utils/WebViewDebugging.java
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/WebViewDebugging.java
@@ -1,8 +1,10 @@
 package com.ichi2.utils;
 
-import android.content.SharedPreferences;
 import android.os.Build;
 import android.webkit.WebView;
+
+import com.ichi2.preferences.PreferenceKeys;
+import com.ichi2.preferences.Prefs;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.RequiresApi;
@@ -13,7 +15,7 @@ public class WebViewDebugging {
     private static boolean sHasSetDataDirectory = false;
 
     @UiThread
-    public static void initializeDebugging(SharedPreferences sharedPrefs) {
+    public static void initializeDebugging(Prefs prefs) {
         // DEFECT: We might be able to cache this value: check what happens on WebView Renderer crash
         // On your desktop use chrome://inspect to connect to emulator WebViews
         // Beware: Crash in AnkiDroidApp.onCreate() with:
@@ -22,7 +24,7 @@ public class WebViewDebugging {
         is not supported. https://crbug.com/558377 : Lock owner com.ichi2.anki:acra at
         org.chromium.android_webview.AwDataDirLock.a(PG:26)
          */
-        boolean enableDebugging = sharedPrefs.getBoolean("html_javascript_debugging", false);
+        boolean enableDebugging = prefs.getBoolean(PreferenceKeys.HtmlJavascriptDebugging);
         WebView.setWebContentsDebuggingEnabled(enableDebugging);
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/widget/WidgetStatus.java
+++ b/AnkiDroid/src/main/java/com/ichi2/widget/WidgetStatus.java
@@ -30,6 +30,8 @@ import com.ichi2.async.BaseAsyncTask;
 import com.ichi2.libanki.Collection;
 import com.ichi2.libanki.sched.Counts;
 import com.ichi2.libanki.sched.DeckDueTreeNode;
+import com.ichi2.preferences.PreferenceKeys;
+import com.ichi2.preferences.Prefs;
 
 import java.util.List;
 
@@ -57,7 +59,7 @@ public final class WidgetStatus {
      */
     public static void update(Context context) {
         SharedPreferences preferences = AnkiDroidApp.getSharedPrefs(context);
-        sSmallWidgetEnabled = preferences.getBoolean("widgetSmallEnabled", false);
+        sSmallWidgetEnabled = Prefs.getBoolean(preferences, PreferenceKeys.WidgetSmallEnabled);
         boolean notificationEnabled = Integer.parseInt(preferences.getString("minimumCardsDueForNotification", "1000001")) < 1000000;
         boolean canExecuteTask = ((sUpdateDeckStatusAsyncTask == null) || (sUpdateDeckStatusAsyncTask.getStatus() == AsyncTask.Status.FINISHED));
         if ((sSmallWidgetEnabled || notificationEnabled) && canExecuteTask) {

--- a/AnkiDroid/src/main/res/xml/preference_headers.xml
+++ b/AnkiDroid/src/main/res/xml/preference_headers.xml
@@ -15,8 +15,6 @@
 ~ this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
 
-<!-- If adding a new screen, please update PreferencesTest -->
-
 <preference-headers xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     tools:ignore="UnusedAttribute">

--- a/AnkiDroid/src/main/res/xml/preference_headers.xml
+++ b/AnkiDroid/src/main/res/xml/preference_headers.xml
@@ -15,6 +15,7 @@
 ~ this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
 
+<!-- If adding a new screen, please update PreferencesTest -->
 
 <preference-headers xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"

--- a/AnkiDroid/src/test/java/com/ichi2/anki/PreferencesTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/PreferencesTest.java
@@ -20,6 +20,7 @@ import android.content.SharedPreferences;
 
 import com.ichi2.preferences.PreferenceKeys;
 import com.ichi2.preferences.Prefs;
+import com.ichi2.testutils.ResourceUtils;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -31,6 +32,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import androidx.annotation.XmlRes;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -113,14 +115,10 @@ public class PreferencesTest extends RobolectricTest {
 
     @SuppressWarnings( {"deprecation", "RedundantSuppression"})
     private void setAllDefaultPreferences() {
-        android.preference.PreferenceManager.setDefaultValues(getTargetContext(), R.xml.preferences_advanced, true);
-        android.preference.PreferenceManager.setDefaultValues(getTargetContext(), R.xml.preferences_appearance, true);
-        android.preference.PreferenceManager.setDefaultValues(getTargetContext(), R.xml.preferences_custom_buttons, true);
-        android.preference.PreferenceManager.setDefaultValues(getTargetContext(), R.xml.preferences_custom_sync_server, true);
-        android.preference.PreferenceManager.setDefaultValues(getTargetContext(), R.xml.preferences_advanced_statistics, true);
-        android.preference.PreferenceManager.setDefaultValues(getTargetContext(), R.xml.preferences_general, true);
-        android.preference.PreferenceManager.setDefaultValues(getTargetContext(), R.xml.preferences_gestures, true);
-        android.preference.PreferenceManager.setDefaultValues(getTargetContext(), R.xml.preferences_reviewing, true);
+
+        for (@XmlRes int resource : ResourceUtils.getPreferenceXml()) {
+            android.preference.PreferenceManager.setDefaultValues(getTargetContext(), resource, true);
+        }
     }
 
     private static boolean isPublicStaticField(Field f) {

--- a/AnkiDroid/src/test/java/com/ichi2/anki/PreferencesTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/PreferencesTest.java
@@ -1,0 +1,131 @@
+/*
+ *  Copyright (c) 2021 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki;
+
+import android.content.SharedPreferences;
+
+import com.ichi2.preferences.PreferenceKeys;
+import com.ichi2.preferences.Prefs;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.core.Is.is;
+
+@RunWith(AndroidJUnit4.class)
+public class PreferencesTest extends RobolectricTest {
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void preferenceDefaultsAreNotChangedWhenOpeningPreferences() throws IllegalAccessException {
+        // 5346
+        setAllDefaultPreferences();
+
+        Field[] fields = PreferenceKeys.class.getDeclaredFields();
+
+        List<Field> staticFields = Arrays.stream(fields)
+                .filter(PreferencesTest::isPublicStaticField)
+                .collect(Collectors.toList());
+        assertThat(staticFields.isEmpty(), is(false));
+
+        Prefs prefs = new Prefs(getSharedPrefs());
+
+        HashSet<String> errors = new HashSet<>();
+
+        for (Field f : staticFields) {
+            PreferenceKeys.PreferenceKey<?> k = (PreferenceKeys.PreferenceKey<?>) f.get(null);
+
+            assertThat(k, notNullValue());
+
+            try {
+                switch (k.defaultValue.getClass().getSimpleName()) {
+                    case "Boolean":
+                        assertThat(k.key, prefs.getBoolean((PreferenceKeys.PreferenceKey<Boolean>) k), is(k.defaultValue));
+                        break;
+                    case "Integer":
+                        assertThat(k.key, prefs.getInt((PreferenceKeys.PreferenceKey<Integer>) k), is(k.defaultValue));
+                        break;
+                    case "Long":
+                        assertThat(k.key, prefs.getLong((PreferenceKeys.PreferenceKey<Long>) k), is(k.defaultValue));
+                        break;
+                    case "String":
+                        assertThat(k.key, prefs.getString((PreferenceKeys.PreferenceKey<String>) k), is(k.defaultValue));
+                        break;
+                    default: throw new IllegalStateException("Not supported: " + k.defaultValue.getClass().getSimpleName());
+                }
+            } catch (AssertionError e) {
+                errors.add(e.getMessage().replace('\n', ' ') + "\n");
+            }
+        }
+
+        assertThat(errors, empty());
+    }
+
+    @Test
+    public void testSettingPreferencesChangesData() {
+        // Ensures that opening settings would set the wrong default
+        boolean syncFetchesMedia = getSharedPrefs().getBoolean(PreferenceKeys.DoubleScrolling.key, !PreferenceKeys.DoubleScrolling.defaultValue);
+
+        assertThat("A value should not be set", syncFetchesMedia, not(is(PreferenceKeys.DoubleScrolling.defaultValue)));
+
+        setAllDefaultPreferences();
+
+        boolean newPrefValue = getSharedPrefs().getBoolean(PreferenceKeys.DoubleScrolling.key, !PreferenceKeys.DoubleScrolling.defaultValue);
+
+        assertThat(
+                "Value should be set and is the default",
+                newPrefValue,
+                is(PreferenceKeys.DoubleScrolling.defaultValue));
+    }
+
+
+    protected SharedPreferences getSharedPrefs() {
+        return AnkiDroidApp.getSharedPrefs(getTargetContext());
+    }
+
+
+    @SuppressWarnings( {"deprecation", "RedundantSuppression"})
+    private void setAllDefaultPreferences() {
+        android.preference.PreferenceManager.setDefaultValues(getTargetContext(), R.xml.preferences_advanced, true);
+        android.preference.PreferenceManager.setDefaultValues(getTargetContext(), R.xml.preferences_appearance, true);
+        android.preference.PreferenceManager.setDefaultValues(getTargetContext(), R.xml.preferences_custom_buttons, true);
+        android.preference.PreferenceManager.setDefaultValues(getTargetContext(), R.xml.preferences_custom_sync_server, true);
+        android.preference.PreferenceManager.setDefaultValues(getTargetContext(), R.xml.preferences_advanced_statistics, true);
+        android.preference.PreferenceManager.setDefaultValues(getTargetContext(), R.xml.preferences_general, true);
+        android.preference.PreferenceManager.setDefaultValues(getTargetContext(), R.xml.preferences_gestures, true);
+        android.preference.PreferenceManager.setDefaultValues(getTargetContext(), R.xml.preferences_reviewing, true);
+    }
+
+    private static boolean isPublicStaticField(Field f) {
+        int modifiers = f.getModifiers();
+        // Unit tests on CI have a private static transient field
+        return Modifier.isStatic(modifiers) && Modifier.isPublic(modifiers);
+    }
+}

--- a/AnkiDroid/src/test/java/com/ichi2/testutils/ResourceUtils.java
+++ b/AnkiDroid/src/test/java/com/ichi2/testutils/ResourceUtils.java
@@ -1,0 +1,89 @@
+/*
+ *  Copyright (c) 2021 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not
+see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.testutils;
+
+import com.ichi2.anki.R;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class ResourceUtils {
+
+    private static final HashMap<Integer, XmlType> xmlValues = new HashMap<>();
+
+    static {
+        xmlValues.put(R.xml.preferences_advanced, XmlType.PreferencesWithSettings);
+        xmlValues.put(R.xml.preferences_appearance, XmlType.PreferencesWithSettings);
+        xmlValues.put(R.xml.preferences_custom_buttons, XmlType.PreferencesWithSettings);
+        xmlValues.put(R.xml.preferences_custom_sync_server, XmlType.PreferencesWithSettings);
+        xmlValues.put(R.xml.preferences_advanced_statistics, XmlType.PreferencesWithSettings);
+        xmlValues.put(R.xml.preferences_general, XmlType.PreferencesWithSettings);
+        xmlValues.put(R.xml.preferences_gestures, XmlType.PreferencesWithSettings);
+        xmlValues.put(R.xml.preferences_reviewing, XmlType.PreferencesWithSettings);
+
+        // slightly different as it's a category page with no current preferences
+        xmlValues.put(R.xml.preference_headers, XmlType.Unclassified);
+
+        xmlValues.put(R.xml.deck_options, XmlType.DeckOptionsHack);
+        xmlValues.put(R.xml.cram_deck_options, XmlType.DeckOptionsHack);
+
+
+        xmlValues.put(R.xml.widget_provider_add_note, XmlType.Widget);
+        xmlValues.put(R.xml.widget_provider_small, XmlType.Widget);
+
+        xmlValues.put(R.xml.standalone_badge_offset, XmlType.Badge);
+        xmlValues.put(R.xml.standalone_badge_gravity_top_start, XmlType.Badge);
+        xmlValues.put(R.xml.standalone_badge_gravity_bottom_start, XmlType.Badge);
+        xmlValues.put(R.xml.standalone_badge_gravity_bottom_end, XmlType.Badge);
+        xmlValues.put(R.xml.standalone_badge, XmlType.Badge);
+
+
+        xmlValues.put(R.xml.image_share_filepaths, XmlType.Paths);
+        xmlValues.put(R.xml.filepaths, XmlType.Paths);
+
+
+        xmlValues.put(R.xml.network_security_config, XmlType.NetSecurityConfig);
+
+    }
+
+    public static Collection<Integer> getPreferenceXml() {
+        return xmlValues.entrySet().stream()
+                .filter(x -> x.getValue() == XmlType.PreferencesWithSettings)
+                .map(Map.Entry::getKey)
+                .collect(Collectors.toList());
+    }
+
+    private enum XmlType {
+        PreferencesWithSettings,
+        DeckOptionsHack,
+        Widget,
+        Badge,
+        Paths,
+        NetSecurityConfig,
+        Unclassified
+    }
+
+
+
+    public static Set<Integer> getAllKnownXml() {
+        return xmlValues.keySet();
+    }
+}

--- a/AnkiDroid/src/test/java/com/ichi2/testutils/ResourceUtilsTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/testutils/ResourceUtilsTest.java
@@ -1,0 +1,56 @@
+/*
+ *  Copyright (c) 2021 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.testutils;
+
+import com.ichi2.anki.R;
+
+import org.jetbrains.annotations.NotNull;
+import org.junit.Test;
+
+import java.lang.reflect.Field;
+import java.util.Collection;
+import java.util.HashMap;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
+
+public class ResourceUtilsTest {
+    @Test
+    public void allFilesAreCategorised() throws IllegalAccessException {
+        // This exists to ensure a user cannot add a Preference screen and forget to add it in PreferencesTest
+        HashMap<Integer, String> allXml = getFieldValues(R.xml.class);
+
+        Collection<Integer> knownXml = ResourceUtils.getAllKnownXml();
+
+        for (Integer key : knownXml) {
+            allXml.remove(key);
+        }
+
+        assertThat("Some XML files are not classified in ResourceUtils", allXml.values(), empty());
+    }
+
+    @NotNull
+    private static <T> HashMap<Integer, String> getFieldValues(@SuppressWarnings("SameParameterValue") Class<T> clazz) throws IllegalAccessException {
+        Field[] badFields = clazz.getFields();
+        HashMap<Integer, String> resFields = new HashMap<>();
+        for (Field f : badFields) {
+            resFields.put((Integer) f.get(clazz), f.getName());
+        }
+        return resFields;
+    }
+
+}


### PR DESCRIPTION
## Purpose / Description
Preferences in the `.xml` occasionally had their values differ from the code. This adds a framework to ensure it won't happen again

## Fixes
Fixes #5346 

## Approach
* Define each used preference as a constant (get only)
* Create accessor class
* Reflect & use unit test to ensure values are unchanged
* Ensure that all xml files are used in the above test

## How Has This Been Tested?

Not tested on device

Failing unit test to discuss

## Learning (optional, can help others)
Wanted to do this for a while. 

Should have dealt with this sooner, I've added a few preferences, and this made it slower process.


## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)