### PR TITLE
TEST: fix flaky test: collectionIsVersion11AfterOpen

### DIFF
--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/RustTest.java
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/RustTest.java
@@ -33,9 +33,11 @@ import static org.hamcrest.Matchers.is;
 
 public class RustTest extends InstrumentedTest {
 
-    /** Ensure that the database can't be locked */
+    /** Ensure that the database isn't be locked
+     * This happened before the database code was converted to use the Rust backend.
+      */
     @Rule
-    public Timeout timeout = new Timeout(3, TimeUnit.SECONDS);
+    public Timeout timeout = new Timeout(30, TimeUnit.SECONDS);
 
     @Test
     public void collectionIsVersion11AfterOpen() throws BackendException, IOException {


### PR DESCRIPTION
The timeout was too low, we just want to ensure that this test doesn't block

It did originally before the backend was converted to use Rust for DB access

Fixes #8067 