### PR TITLE
AbstractFlashcardViewer: Fix "Restricted API" error

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -937,7 +937,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
                         response.setResponseHeaders(headers);
                         return response;
                     } catch (Exception e) {
-                        Timber.e(e, "Error trying to open path in asset loader");
+                        Timber.w(e, "Error trying to open path in asset loader");
                     }
 
                     return null;

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -921,27 +921,24 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
         mViewerUrl = mBaseUrl + "__viewer__.html";
 
         mAssetLoader = new WebViewAssetLoader.Builder()
-            .addPathHandler("/", new WebViewAssetLoader.PathHandler() {
-                @Override
-                public WebResourceResponse handle(String path) {
-                    try {
-                        File file = new File(mediaDir, path);
-                        FileInputStream is = new FileInputStream(file);
+            .addPathHandler("/", path -> {
+                try {
+                    File file = new File(mediaDir, path);
+                    FileInputStream is = new FileInputStream(file);
 
-                        String mimeType = AssetHelper.guessMimeType(path);
+                    String mimeType = AssetHelper.guessMimeType(path);
 
-                        HashMap<String, String> headers = new HashMap<String, String>();
-                        headers.put("Access-Control-Allow-Origin", "*");
+                    HashMap<String, String> headers = new HashMap<>();
+                    headers.put("Access-Control-Allow-Origin", "*");
 
-                        WebResourceResponse response = new WebResourceResponse(mimeType, null, is);
-                        response.setResponseHeaders(headers);
-                        return response;
-                    } catch (Exception e) {
-                        Timber.w(e, "Error trying to open path in asset loader");
-                    }
-
-                    return null;
+                    WebResourceResponse response = new WebResourceResponse(mimeType, null, is);
+                    response.setResponseHeaders(headers);
+                    return response;
+                } catch (Exception e) {
+                    Timber.w(e, "Error trying to open path in asset loader");
                 }
+
+                return null;
             })
             .build();
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -50,7 +50,6 @@ import androidx.annotation.VisibleForTesting;
 import androidx.coordinatorlayout.widget.CoordinatorLayout;
 import androidx.core.content.ContextCompat;
 import androidx.appcompat.app.ActionBar;
-import androidx.webkit.internal.AssetHelper;
 import androidx.webkit.WebViewAssetLoader;
 
 import android.text.TextUtils;
@@ -122,6 +121,7 @@ import com.ichi2.themes.HtmlColors;
 import com.ichi2.themes.Themes;
 import com.ichi2.utils.AdaptionUtil;
 import com.ichi2.utils.AndroidUiUtils;
+import com.ichi2.utils.AssetHelper;
 import com.ichi2.utils.ClipboardUtil;
 import com.ichi2.utils.BooleanGetter;
 import com.ichi2.utils.CardGetter;

--- a/AnkiDroid/src/main/java/com/ichi2/utils/AssetHelper.java
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/AssetHelper.java
@@ -1,0 +1,60 @@
+/*
+ *  Copyright (c) 2021 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  This file incorporates work covered by the following copyright and
+ *  permission notice:
+ *
+ *     Copyright 2019 The Android Open Source Project
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ *     https://android.googlesource.com/platform/frameworks/support/+/refs/heads/androidx-main/webkit/webkit/src/main/java/androidx/webkit/internal/AssetHelper.java#195
+ *     at commit 1931e06ac0424ff5c7bbc2df34c658b9e95e11f6
+ */
+
+package com.ichi2.utils;
+
+import java.net.URLConnection;
+
+import androidx.annotation.NonNull;
+
+/** Clone of RestrictedApi functionality */
+public class AssetHelper {
+
+    /**
+     * Use {@link URLConnection#guessContentTypeFromName} to guess MIME type or return the
+     * "text/plain" if it can't guess.
+     *
+     * Copy of {@link androidx.webkit.internal.AssetHelper#guessMimeType(String)}
+     *
+     * @param path path of the file to guess its MIME type.
+     * @return MIME type guessed from file extension or "text/plain".
+     */
+    @NonNull
+    public static String guessMimeType(String path) {
+        String mimeType = URLConnection.guessContentTypeFromName(path);
+        return mimeType == null ? "text/plain" : mimeType;
+    }
+}


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
Android Studio showed `androidx.webkit.internal.AssetHelper#guessMimeType` was restricted.

## Fixes
Fixes #8065

## Approach
Reimplement the functionality, add copyright warning

## How Has This Been Tested?
* ⚠️ Untested - please propose test case

## Learning

https://android.googlesource.com/platform/frameworks/support/+/refs/heads/androidx-main/webkit/webkit/src/main/java/androidx/webkit/internal/AssetHelper.java#195

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)