### PR TITLE
Timber all exceptions catched not re-thrown

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -1860,6 +1860,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
             throw new RuntimeException(e);
         } catch (NullPointerException npe) {
             // NPE on collection only happens if the Collection is broken, follow AnkiActivity example
+            Timber.w(npe);
             Intent deckPicker = new Intent(this, DeckPicker.class);
             deckPicker.putExtra("collectionLoadError", true); // don't currently do anything with this
             deckPicker.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_NEW_TASK);
@@ -2327,6 +2328,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
                     mMissingImageHandler.processMissingSound(file, this::displayCouldNotFindMediaSnackbar);
                 }
             } catch (Exception e) {
+                Timber.w(e);
                 return false;
             }
 
@@ -3939,6 +3941,7 @@ see card.js for available functions
                 }
 
             } catch (JSONException j) {
+                Timber.w(j);
                 UIUtils.showThemedToast(AbstractFlashcardViewer.this, getString(R.string.invalid_json_data, j.getLocalizedMessage()), false);
             }
             return apiStatusJson;

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiActivity.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiActivity.java
@@ -238,6 +238,7 @@ public class AnkiActivity extends AppCompatActivity implements SimpleMessageDial
         try {
             super.startActivityForResult(intent, requestCode);
         } catch (ActivityNotFoundException e) {
+            Timber.w(e);
             UIUtils.showSimpleSnackbar(this, R.string.activity_start_failed,true);
         }
     }
@@ -468,6 +469,7 @@ public class AnkiActivity extends AppCompatActivity implements SimpleMessageDial
         try {
             showDialogFragment(newFragment);
         } catch (IllegalStateException e) {
+            Timber.w(e);
             // Store a persistent message to SharedPreferences instructing AnkiDroid to show dialog
             DialogHandler.storeMessage(newFragment.getDialogHandlerMessage());
             // Show a basic notification to the user in the notification bar in the meantime

--- a/AnkiDroid/src/main/java/com/ichi2/anki/BackupManager.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/BackupManager.java
@@ -121,6 +121,7 @@ public class BackupManager {
                 lastBackupDate = df.parse(deckBackups[len].getName().replaceAll(
                         "^.*-(\\d{4}-\\d{2}-\\d{2}-\\d{2}-\\d{2}).colpkg$", "$1"));
             } catch (ParseException e) {
+                Timber.w(e);
                 lastBackupDate = null;
             }
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.java
@@ -736,6 +736,7 @@ public class CardTemplateEditor extends AnkiActivity implements DeckSelectionDia
                 mTemplateEditor.getCol().modSchema();
                 deleteTemplate(tmpl, model);
             } catch (ConfirmModSchemaException e) {
+                e.log();
                 ConfirmationDialog d = new ConfirmationDialog();
                 d.setArgs(getResources().getString(R.string.full_sync_confirmation));
                 Runnable confirm = () -> {
@@ -787,6 +788,7 @@ public class CardTemplateEditor extends AnkiActivity implements DeckSelectionDia
                 Timber.d("addNewTemplateWithCheck() called and no CMSE?");
                 addNewTemplate(model);
             } catch (ConfirmModSchemaException e) {
+                e.log();
                 ConfirmationDialog d = new ConfirmationDialog();
                 d.setArgs(getResources().getString(R.string.full_sync_confirmation));
                 Runnable confirm = () -> {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CollectionHelper.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CollectionHelper.java
@@ -137,6 +137,7 @@ public class CollectionHelper {
         try {
             return getCol(context).getTime();
         } catch (Exception e) {
+            Timber.w(e);
             return new SystemTime();
         }
     }
@@ -151,6 +152,7 @@ public class CollectionHelper {
         try {
             return getCol(context);
         } catch (Exception e) {
+            Timber.w(e);
             AnkiDroidApp.sendExceptionReport(e, "CollectionHelper.getColSafe");
             return null;
         }
@@ -220,6 +222,7 @@ public class CollectionHelper {
             initializeAnkiDroidDirectory(getCurrentAnkiDroidDirectory(context));
             return true;
         } catch (StorageAccessException e) {
+            Timber.w(e);
             return false;
         }
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckOptions.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckOptions.java
@@ -339,6 +339,7 @@ public class DeckOptions extends AppCompatPreferenceActivity implements OnShared
                                     try {
                                         remConf();
                                     } catch (ConfirmModSchemaException e) {
+                                        e.log();
                                         // Libanki determined that a full sync will be required, so confirm with the user before proceeding
                                         // TODO : Use ConfirmationDialog DialogFragment -- not compatible with PreferenceActivity
                                         new MaterialDialog.Builder(DeckOptions.this)
@@ -681,6 +682,7 @@ public class DeckOptions extends AppCompatPreferenceActivity implements OnShared
                 try {
                     title = title.replace("XXX", mDeck.getString("name"));
                 } catch (JSONException e) {
+                    Timber.w(e);
                     title = title.replace("XXX", "???");
                 }
             }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -284,6 +284,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
             }
         } catch (Exception e) {
             // Maybe later don't report if collectionIsOpen is false?
+            Timber.w(e);
             String info = deckId + " colOpen:" + collectionIsOpen;
             AnkiDroidApp.sendExceptionReport(e, "deckPicker::onDeckClick", info);
             displayFailedToOpenDeck(deckId);
@@ -1148,6 +1149,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
                 getCol().modSchema();
             } catch (ConfirmModSchemaException e) {
                 Timber.w("Forcing full sync");
+                e.log();
                 // If libanki determines it's necessary to confirm the full sync then show a confirmation dialog
                 // We have to show the dialog via the DialogHandler since this method is called via an async task
                 Resources res = getResources();
@@ -1338,10 +1340,12 @@ public class DeckPicker extends NavigationDrawerActivity implements
         try {
             previous = preferences.getLong(UPGRADE_VERSION_KEY, current);
         } catch (ClassCastException e) {
+            Timber.w(e);
             try {
                 // set 20900203 to default value, as it's the latest version that stores integer in shared prefs
                 previous = preferences.getInt(UPGRADE_VERSION_KEY, 20900203);
             } catch (ClassCastException cce) {
+                Timber.w(cce);
                 // Previous versions stored this as a string.
                 String s = preferences.getString(UPGRADE_VERSION_KEY, "");
                 // The last version of AnkiDroid that stored this as a string was 2.0.2.
@@ -1389,6 +1393,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
                 boolean old = preferences.getBoolean("fullscreenReview", false);
                 preferences.edit().putString("fullscreenMode", old ? "1": "0").apply();
             } catch (ClassCastException e) {
+                Timber.w(e);
                 // TODO:  can remove this catch as it was only here to fix an error in the betas
                 preferences.edit().remove("fullscreenMode").apply();
             }
@@ -2153,7 +2158,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
         try {
             uri = FileProvider.getUriForFile(DeckPicker.this, "com.ichi2.anki.apkgfileprovider", attachment);
         } catch (IllegalArgumentException e) {
-            Timber.e("Could not generate a valid URI for the apkg file");
+            Timber.w(e, "Could not generate a valid URI for the apkg file");
             UIUtils.showThemedToast(this, getResources().getString(R.string.apk_share_error), false);
             return;
         }
@@ -2596,6 +2601,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
                 UIUtils.showThemedToast(this, getString(R.string.create_shortcut_failed), false);
             }
         } catch (Exception e) {
+            Timber.w(e);
             UIUtils.showThemedToast(this, getString(R.string.create_shortcut_error, e.getLocalizedMessage()), false);
         }
     }
@@ -2627,6 +2633,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
                         try {
                             col.getDecks().rename(col.getDecks().get(did), newName);
                         } catch (DeckRenameException e) {
+                            Timber.w(e);
                             // We get a localized string from libanki to explain the error
                             UIUtils.showThemedToast(DeckPicker.this, e.getLocalizedMessage(res), false);
                         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/FieldEditText.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/FieldEditText.java
@@ -147,6 +147,7 @@ public class FieldEditText extends FixedEditText {
                 InputConnectionCompat.commitContent(inputConnection, editorInfo, contentInfo, flags, opts);
                 return true;
             } catch (Exception e) {
+                Timber.w(e);
                 AnkiDroidApp.sendExceptionReport(e, "NoteEditor::onImage");
                 return false;
             }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/FilteredDeckOptions.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/FilteredDeckOptions.java
@@ -376,6 +376,7 @@ public class FilteredDeckOptions extends AppCompatPreferenceActivity implements 
             try {
                 title = title.replace("XXX", mDeck.getString("name"));
             } catch (JSONException e) {
+                Timber.w(e);
                 title = title.replace("XXX", "???");
             }
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ModelBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ModelBrowser.java
@@ -423,6 +423,7 @@ public class ModelBrowser extends AnkiActivity {
                 d.setCancel(cancel);
                 ModelBrowser.this.showDialogFragment(d);
             } catch (ConfirmModSchemaException e) {
+                e.log();
                 ConfirmationDialog c = new ConfirmationDialog();
                 c.setArgs(getResources().getString(R.string.full_sync_confirmation));
                 c.setConfirm(confirm);

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ModelFieldEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ModelFieldEditor.java
@@ -219,6 +219,7 @@ public class ModelFieldEditor extends AnkiActivity implements LocaleSelectionDia
                         mCol.modSchema();
                         TaskManager.launchCollectionTask(new CollectionTask.AddField(mMod, fieldName), listener);
                     } catch (ConfirmModSchemaException e) {
+                        e.log();
 
                         //Create dialogue to for schema change
                         ConfirmationDialog c = new ConfirmationDialog();
@@ -265,6 +266,7 @@ public class ModelFieldEditor extends AnkiActivity implements LocaleSelectionDia
                 d.setCancel(mConfirmDialogCancel);
                 showDialogFragment(d);
             } catch (ConfirmModSchemaException e) {
+                e.log();
                 ConfirmationDialog c = new ConfirmationDialog();
                 c.setConfirm(confirm);
                 c.setCancel(mConfirmDialogCancel);
@@ -301,6 +303,7 @@ public class ModelFieldEditor extends AnkiActivity implements LocaleSelectionDia
                     try {
                         renameField();
                     } catch (ConfirmModSchemaException e) {
+                        e.log();
 
                         // Handler mod schema confirmation
                         ConfirmationDialog c = new ConfirmationDialog();
@@ -310,6 +313,7 @@ public class ModelFieldEditor extends AnkiActivity implements LocaleSelectionDia
                             try {
                                 renameField();
                             } catch (ConfirmModSchemaException e1) {
+                                e1.log();
                                 //This should never be thrown
                             }
                             dismissContextMenu();
@@ -342,6 +346,7 @@ public class ModelFieldEditor extends AnkiActivity implements LocaleSelectionDia
                         try {
                             pos = Integer.parseInt(newPosition);
                         } catch (NumberFormatException n) {
+                            Timber.w(n);
                             UIUtils.showThemedToast(this, getResources().getString(R.string.toast_out_of_range), true);
                             return;
                         }
@@ -355,6 +360,7 @@ public class ModelFieldEditor extends AnkiActivity implements LocaleSelectionDia
                                 mCol.modSchema();
                                 TaskManager.launchCollectionTask(new CollectionTask.RepositionField(mMod,mNoteFields.getJSONObject(mCurrentPos), pos - 1));
                             } catch (ConfirmModSchemaException e) {
+                                e.log();
 
                                 // Handle mod schema confirmation
                                 ConfirmationDialog c = new ConfirmationDialog();
@@ -429,6 +435,7 @@ public class ModelFieldEditor extends AnkiActivity implements LocaleSelectionDia
             mCol.modSchema();
             TaskManager.launchCollectionTask(new CollectionTask.ChangeSortField(mMod, mCurrentPos), listener);
         } catch (ConfirmModSchemaException e) {
+            e.log();
             // Handler mMod schema confirmation
             ConfirmationDialog c = new ConfirmationDialog();
             c.setArgs(getResources().getString(R.string.full_sync_confirmation));

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -1047,6 +1047,7 @@ public class NoteEditor extends AnkiActivity {
         try {
             changeNoteType(oldModel, newModel);
         } catch (ConfirmModSchemaException e) {
+            e.log();
             // Libanki has determined we should ask the user to confirm first
             ConfirmationDialog dialog = new ConfirmationDialog();
             dialog.setArgs(res.getString(R.string.full_sync_confirmation));

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
@@ -507,6 +507,7 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
                 UIUtils.showThemedToast(this, getString(R.string.no_image_selected), false);
             }
         } catch (OutOfMemoryError | Exception e) {
+            Timber.w(e);
             UIUtils.showThemedToast(this, getString(R.string.error_selecting_image, e.getLocalizedMessage()), false);
         }
     }
@@ -521,6 +522,7 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
                 Intent openThirdPartyAppsIntent = new Intent(Intent.ACTION_VIEW, Uri.parse(githubThirdPartyAppsUrl));
                 super.startActivity(openThirdPartyAppsIntent);
             } catch (ActivityNotFoundException e) {
+                Timber.w(e);
                 //We use a different message here. We have limited space in the snackbar
                 String error = getString(R.string.activity_start_failed_load_url, githubThirdPartyAppsUrl);
                 UIUtils.showSimpleSnackbar(this, error, false);
@@ -886,6 +888,7 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
                 return;
             }
         } catch (NullPointerException e) {
+            Timber.w(e);
             value = "";
         }
         // Get summary text
@@ -917,6 +920,7 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
             Double.parseDouble(value);
             return replaceString(str, value);
         } catch (NumberFormatException e){
+            Timber.w(e);
             return value;
         }
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ReadText.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ReadText.java
@@ -135,7 +135,7 @@ public class ReadText {
             try {
                 builder.build().show();
             } catch (WindowManager.BadTokenException e) {
-                Timber.w("Activity invalidated before TTS language dialog could display");
+                Timber.w(e,"Activity invalidated before TTS language dialog could display");
             }
         }, delay);
     }
@@ -331,7 +331,7 @@ public class ReadText {
                     Timber.v("ReadText.buildAvailableLanguages() :: %s  not available (error code %d)", loc.getDisplayName(), retCode);
                 }
             } catch (IllegalArgumentException e) {
-                Timber.e("Error checking if language %s available", loc.getDisplayName());
+                Timber.w(e, "Error checking if language %s available", loc.getDisplayName());
             }
         }
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.java
@@ -367,6 +367,7 @@ public class Reviewer extends AbstractFlashcardViewer {
                     String savedWhiteboardFileName = mWhiteboard.saveWhiteboard(getCol().getTime());
                     UIUtils.showThemedToast(Reviewer.this, getString(R.string.white_board_image_saved, savedWhiteboardFileName), true);
                 } catch (Exception e) {
+                    Timber.w(e);
                     UIUtils.showThemedToast(Reviewer.this, getString(R.string.white_board_image_save_failed, e.getLocalizedMessage()), true);
                 }
             }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/analytics/UsageAnalytics.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/analytics/UsageAnalytics.java
@@ -320,6 +320,7 @@ public class UsageAnalytics {
                 display.getSize(size);
                 this.screenResolution(size.x + "x" + size.y);
             } catch (RuntimeException e) {
+                Timber.w(e);
                 // nothing much to do here, it means we couldn't get WindowManager
             }
 
@@ -341,6 +342,7 @@ public class UsageAnalytics {
                     this.userAgent(System.getProperty("http.agent"));
                 }
             } catch (RuntimeException e) {
+                Timber.w(e);
                 // Catch RuntimeException as WebView initialization blows up in unpredictable ways
                 // but analytics should never be a show-stopper
                 this.userAgent(System.getProperty("http.agent"));

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/CustomStudyDialog.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/CustomStudyDialog.java
@@ -214,6 +214,7 @@ public class CustomStudyDialog extends AnalyticsDialogFragment {
                     try {
                         n = Integer.parseInt(mEditText.getText().toString());
                     } catch (Exception ignored) {
+                        Timber.w(ignored);
                         // This should never happen because we disable positive button for non-parsable inputs
                         return;
                     }
@@ -283,6 +284,7 @@ public class CustomStudyDialog extends AnalyticsDialogFragment {
                     Integer.parseInt(mEditText.getText().toString());
                     dialog.getActionButton(DialogAction.POSITIVE).setEnabled(true);
                 } catch (Exception ignored) {
+                    Timber.w(ignored);
                     dialog.getActionButton(DialogAction.POSITIVE).setEnabled(false);
                 }
             }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ImportDialog.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ImportDialog.java
@@ -137,7 +137,7 @@ public class ImportDialog extends AsyncDialogFragment {
         try {
             return URLDecoder.decode(name, "UTF-8");
         } catch (Exception e) {
-            Timber.w("Failed to convert filename to displayable string");
+            Timber.w(e,"Failed to convert filename to displayable string");
             return name;
         }
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/exception/ConfirmModSchemaException.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/exception/ConfirmModSchemaException.java
@@ -1,6 +1,8 @@
 
 package com.ichi2.anki.exception;
 
+import timber.log.Timber;
+
 public class ConfirmModSchemaException extends Exception {
 
     /**
@@ -10,5 +12,13 @@ public class ConfirmModSchemaException extends Exception {
 
 
     public ConfirmModSchemaException() {
+    }
+
+
+    /**
+     * Add the current exception to log.
+     */
+    public void log() {
+        Timber.v(this);
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/AudioView.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/AudioView.java
@@ -392,6 +392,7 @@ public class AudioView extends LinearLayout {
                             mRecorder.start();
                             highSampling = true;
                         } catch (Exception e) {
+                            Timber.w(e);
                             // in all cases, fall back to low sampling
                         }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/activity/LoadPronounciationActivity.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/activity/LoadPronounciationActivity.java
@@ -45,6 +45,8 @@ import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.util.Locale;
 
+import timber.log.Timber;
+
 /**
  * Activity to load pronunciation files from Beolingus.
  * <p>
@@ -155,6 +157,7 @@ public class LoadPronounciationActivity extends Activity implements OnCancelList
             // post.setStopper(PRONUNC_STOPPER);
             mPostTranslation.execute();
         } catch (Exception e) {
+            Timber.w(e);
             progressDialog.dismiss();
             showToast(gtxt(R.string.multimedia_editor_something_wrong));
         }
@@ -287,6 +290,7 @@ public class LoadPronounciationActivity extends Activity implements OnCancelList
                 mPostPronunciation.setAddress(mPronunciationAddress);
                 mPostPronunciation.execute();
             } catch (Exception e) {
+                Timber.w(e);
                 progressDialog.dismiss();
                 showToast(gtxt(R.string.multimedia_editor_something_wrong));
             }
@@ -315,6 +319,7 @@ public class LoadPronounciationActivity extends Activity implements OnCancelList
                 mDownloadMp3Task.setAddress(mMp3Address);
                 mDownloadMp3Task.execute();
             } catch (Exception e) {
+                Timber.w(e);
                 progressDialog.dismiss();
                 showToast(gtxt(R.string.multimedia_editor_something_wrong));
             }
@@ -386,6 +391,7 @@ public class LoadPronounciationActivity extends Activity implements OnCancelList
         try {
             query = URLEncoder.encode(mSource, "utf-8");
         } catch (UnsupportedEncodingException e) {
+            Timber.w(e);
             query = mSource.replace(" ", "%20");
         }
 
@@ -427,6 +433,7 @@ public class LoadPronounciationActivity extends Activity implements OnCancelList
                     progressDialog.dismiss();
             }
         } catch (Exception e) {
+            Timber.w(e);
             // nothing is done intentionally
         }
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/activity/TranslationActivity.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/activity/TranslationActivity.java
@@ -28,6 +28,8 @@ import android.os.Bundle;
 
 import androidx.annotation.NonNull;
 import androidx.fragment.app.FragmentActivity;
+import timber.log.Timber;
+
 import android.view.Menu;
 import android.widget.ArrayAdapter;
 import android.widget.Button;
@@ -112,6 +114,7 @@ public class TranslationActivity extends FragmentActivity implements DialogInter
         try {
             mSource = getIntent().getExtras().getString(EXTRA_SOURCE);
         } catch (Exception e) {
+            Timber.w(e);
             mSource = "";
         }
 
@@ -217,6 +220,7 @@ public class TranslationActivity extends FragmentActivity implements DialogInter
             mTranslationLoadPost = new BackgroundPost();
             mTranslationLoadPost.execute();
         } catch (Exception e) {
+            Timber.w(e);
             progressDialog.dismiss();
             showToast(getText(R.string.multimedia_editor_something_wrong));
         }
@@ -238,6 +242,7 @@ public class TranslationActivity extends FragmentActivity implements DialogInter
         try {
             query = URLEncoder.encode(mSource, "utf-8");
         } catch (UnsupportedEncodingException e) {
+            Timber.w(e);
             query = mSource.replace(" ", "%20");
         }
 
@@ -426,6 +431,7 @@ public class TranslationActivity extends FragmentActivity implements DialogInter
                     progressDialog.dismiss();
             }
         } catch (Exception e) {
+            Timber.w(e);
             // nothing is done intentionally
         }
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicAudioClipFieldController.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicAudioClipFieldController.java
@@ -117,6 +117,7 @@ public class BasicAudioClipFieldController extends FieldControllerBase implement
                     Timber.i("Audio clip name does not have extension, using second half of mime type");
                     audioClipFullNameParts = new String[] {audioClipFullName, cursor.getString(2).split("/")[1]};
                 } catch (Exception e) {
+                    Timber.w(e);
                     // This code is difficult to stabilize - it is not clear how to handle files with no extension
                     // and apparently we may fail to get MIME_TYPE information - in that case we will gather information
                     // about what people are experiencing in the real world and decide later, but without crashing at least

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicImageFieldController.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicImageFieldController.java
@@ -460,6 +460,7 @@ public class BasicImageFieldController extends FieldControllerBase implements IF
             Timber.d("internalizeUri successful. Returning internalFile.");
             return returnFile;
         } catch (Exception e) {
+            Timber.w(e);
             showSomethingWentWrong();
             return null;
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicTextFieldController.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicTextFieldController.java
@@ -44,6 +44,8 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 
+import timber.log.Timber;
+
 /**
  * One of the most powerful controllers - creates UI and works with the field of textual type.
  * <p>
@@ -266,6 +268,7 @@ public class BasicTextFieldController extends FieldControllerBase implements IFi
                 String translation = data.getExtras().get(TranslationActivity.EXTRA_TRANSLATION).toString();
                 mEditText.setText(translation);
             } catch (Exception e) {
+                Timber.w(e);
                 showToast(gtxt(R.string.multimedia_editor_something_wrong));
             }
         } else if (requestCode == REQUEST_CODE_PRONOUNCIATION && resultCode == Activity.RESULT_OK) {
@@ -283,6 +286,7 @@ public class BasicTextFieldController extends FieldControllerBase implements IFi
                 af.setHasTemporaryMedia(true);
                 mActivity.handleFieldChanged(af);
             } catch (Exception e) {
+                Timber.w(e);
                 showToast(gtxt(R.string.multimedia_editor_pron_pronunciation_failed));
             }
         } else if (requestCode == REQUEST_CODE_TRANSLATE_COLORDICT && resultCode == Activity.RESULT_OK) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/ImageField.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/ImageField.java
@@ -30,6 +30,7 @@ import java.io.File;
 import androidx.annotation.CheckResult;
 import androidx.annotation.NonNull;
 import androidx.annotation.VisibleForTesting;
+import timber.log.Timber;
 
 /**
  * Field with an image.
@@ -184,6 +185,7 @@ public class ImageField extends FieldBase implements IField {
             }
             return image.attr("src");
         } catch (Exception e) {
+            Timber.w(e);
             return "";
         }
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/noteeditor/CustomToolbarButton.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/noteeditor/CustomToolbarButton.java
@@ -25,6 +25,7 @@ import java.util.Set;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import timber.log.Timber;
 
 import static com.ichi2.libanki.Consts.FIELD_SEPARATOR;
 
@@ -59,6 +60,7 @@ public class CustomToolbarButton {
         try {
             index = Integer.parseInt(fields[0]);
         } catch (Exception e) {
+            Timber.w(e);
             return null;
         }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/noteeditor/Toolbar.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/noteeditor/Toolbar.java
@@ -122,6 +122,7 @@ public class Toolbar extends FrameLayout {
         try {
             c = (char) event.getUnicodeChar(0);
         } catch (Exception e) {
+            Timber.w(e);
             return false;
         }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/provider/CardContentProvider.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/provider/CardContentProvider.java
@@ -762,7 +762,7 @@ public class CardContentProvider extends ContentProvider {
                     long deckId = Long.parseLong(deckIdStr);
                     return bulkInsertNotes(values, deckId);
                 } catch (NumberFormatException e) {
-                    Timber.d("Invalid %s: %s", FlashCardsContract.Note.DECK_ID_QUERY_PARAM, deckIdStr);
+                    Timber.d(e,"Invalid %s: %s", FlashCardsContract.Note.DECK_ID_QUERY_PARAM, deckIdStr);
                 }
             }
             // deckId not specified, so default to #super implementation (as in spec version 1)
@@ -1434,7 +1434,7 @@ public class CardContentProvider extends ContentProvider {
             try {
                 id = Long.parseLong(uri.getPathSegments().get(1));
             } catch (NumberFormatException e) {
-                throw new IllegalArgumentException("Model ID must be either numeric or the String CURRENT_MODEL_ID");
+                throw new IllegalArgumentException("Model ID must be either numeric or the String CURRENT_MODEL_ID", e);
             }
         }
         return id;
@@ -1478,6 +1478,7 @@ public class CardContentProvider extends ContentProvider {
              }
              return !Arrays.asList(callingPi.requestedPermissions).contains(READ_WRITE_PERMISSION);
         } catch (PackageManager.NameNotFoundException e) {
+            Timber.w(e);
             return false;
         }
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/services/BootService.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/services/BootService.java
@@ -67,8 +67,10 @@ public class BootService extends BroadcastReceiver {
         try {
             runnable.run();
         } catch (SecurityException ex) {
+            Timber.w(ex);
             error = R.string.boot_service_too_many_notifications;
         } catch (Exception e) {
+            Timber.w(e);
             error = R.string.boot_service_failed_to_schedule_notifications;
         }
         if (error != null) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/services/ReminderService.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/services/ReminderService.java
@@ -80,7 +80,7 @@ public class ReminderService extends BroadcastReceiver {
             colHelper = CollectionHelper.getInstance();
             col = colHelper.getCol(context);
         } catch (Throwable t) {
-            Timber.w("onReceive - unexpectedly unable to get collection. Returning.");
+            Timber.w(t,"onReceive - unexpectedly unable to get collection. Returning.");
             return;
         }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/web/HttpFetcher.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/web/HttpFetcher.java
@@ -150,6 +150,7 @@ public class HttpFetcher {
             return file.getAbsolutePath();
 
         } catch (Exception e) {
+            Timber.w(e);
             return "FAILED " + e.getMessage();
         } finally {
             if (response != null && response.body() != null) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/web/PreferenceBackedHostNum.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/web/PreferenceBackedHostNum.java
@@ -75,6 +75,7 @@ public class PreferenceBackedHostNum extends HostNum {
         try {
             return Integer.parseInt(hostNum);
         } catch (Exception e) {
+            Timber.w(e);
             return getDefaultHostNum();
         }
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/widgets/PopupMenuWithIcons.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/widgets/PopupMenuWithIcons.java
@@ -4,6 +4,8 @@ import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import android.content.Context;
 import androidx.appcompat.widget.PopupMenu;
+import timber.log.Timber;
+
 import android.view.View;
 
 /**
@@ -28,7 +30,9 @@ public class PopupMenuWithIcons extends PopupMenu {
                         break;
                     }
                 }
-            } catch (Exception ignored) {}
+            } catch (Exception ignored) {
+                Timber.w(ignored);
+            }
         }
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
@@ -1320,6 +1320,7 @@ public class CollectionTask<ProgressListener, ProgressBackground extends Progres
             try {
                 imp.run();
             } catch (ImportExportException e) {
+                Timber.w(e);
                 return new Triple(null, true, e.getMessage());
             }
             return new Triple<>(imp, false, null);
@@ -1385,6 +1386,7 @@ public class CollectionTask<ProgressListener, ProgressBackground extends Progres
                 try {
                     tmpCol.close();
                 } catch (Exception e2) {
+                    Timber.w(e2);
                     // do nothing
                 }
                 AnkiDroidApp.sendExceptionReport(e, "doInBackgroundImportReplace - open col");
@@ -1405,6 +1407,7 @@ public class CollectionTask<ProgressListener, ProgressBackground extends Progres
                 CollectionHelper.getInstance().lockCollection();
                 BackupManager.performBackupInBackground(colPath, true, time);
             } catch (Exception e) {
+                Timber.w(e);
             }
             // overwrite collection
             File f = new File(colFile);
@@ -1559,6 +1562,7 @@ public class CollectionTask<ProgressListener, ProgressBackground extends Progres
                 col.save();
                 return true;
             } catch (JSONException e) {
+                Timber.w(e);
                 return false;
             }
         }
@@ -1608,6 +1612,7 @@ public class CollectionTask<ProgressListener, ProgressBackground extends Progres
                 col.save();
                 return true;
             } catch (JSONException e) {
+                Timber.w(e);
                 return false;
             }
         }
@@ -1640,6 +1645,7 @@ public class CollectionTask<ProgressListener, ProgressBackground extends Progres
                 }
                 return true;
             } catch (JSONException e) {
+                Timber.w(e);
                 return false;
             }
         }
@@ -1657,6 +1663,7 @@ public class CollectionTask<ProgressListener, ProgressBackground extends Progres
             try {
                 col.getMedia().rebuildIfInvalid();
             } catch (IOException e) {
+                Timber.w(e);
                 return new PairWithBoolean<>(false, null);
             }
             // A media check on AnkiDroid will also update the media db
@@ -1804,6 +1811,7 @@ public class CollectionTask<ProgressListener, ProgressBackground extends Progres
                 col.getModels().rem(col.getModels().get(modID));
                 col.save();
             } catch (ConfirmModSchemaException e) {
+                e.log();
                 Timber.e("doInBackGroundDeleteModel :: ConfirmModSchemaException");
                 return false;
             }
@@ -1834,6 +1842,7 @@ public class CollectionTask<ProgressListener, ProgressBackground extends Progres
                 col.save();
             } catch (ConfirmModSchemaException e) {
                 //Should never be reached
+                e.log();
                 return false;
             }
             return true;
@@ -1863,6 +1872,7 @@ public class CollectionTask<ProgressListener, ProgressBackground extends Progres
                 col.getModels().moveField(model, field, index);
                 col.save();
             } catch (ConfirmModSchemaException e) {
+                e.log();
                 //Should never be reached
                 return false;
             }

--- a/AnkiDroid/src/main/java/com/ichi2/async/Connection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/Connection.java
@@ -227,11 +227,13 @@ public class Connection extends BaseAsyncTask<Connection.Payload, Object, Connec
         try {
             ret = server.hostKey(username, password);
         } catch (UnknownHttpResponseException e) {
+            Timber.w(e);
             data.success = false;
             data.resultType = ERROR;
             data.result = new Object[]{e.getResponseCode(), e.getMessage() };
             return data;
         } catch (Exception e2) {
+            Timber.w(e2);
             // Ask user to report all bugs which aren't timeout errors
             if (!timeoutOccurred(e2)) {
                 AnkiDroidApp.sendExceptionReport(e2, "doInBackgroundLogin");
@@ -252,6 +254,7 @@ public class Connection extends BaseAsyncTask<Connection.Payload, Object, Connec
                     hostkey = response.getString("key");
                     valid = (hostkey != null) && (hostkey.length() > 0);
                 } catch (JSONException e) {
+                    Timber.w(e);
                     valid = false;
                 } catch (IllegalStateException | IOException | NullPointerException e) {
                     throw new RuntimeException(e);
@@ -426,12 +429,14 @@ public class Connection extends BaseAsyncTask<Connection.Payload, Object, Connec
                     default:
                     }
                 } catch (OutOfMemoryError e) {
+                    Timber.w(e);
                     AnkiDroidApp.sendExceptionReport(e, "doInBackgroundSync-fullSync");
                     data.success = false;
                     data.resultType = OUT_OF_MEMORY_ERROR;
                     data.result = new Object[0];
                     return data;
                 } catch (RuntimeException e) {
+                    Timber.w(e);
                     if (timeoutOccurred(e)) {
                         data.resultType = CONNECTION_ERROR;
                     } else if (USER_ABORTED_SYNC.toString().equals(e.getMessage())) {
@@ -479,6 +484,7 @@ public class Connection extends BaseAsyncTask<Connection.Payload, Object, Connec
                         }
                     }
                 } catch (RuntimeException e) {
+                    Timber.w(e);
                     if (timeoutOccurred(e)) {
                         data.resultType = CONNECTION_ERROR;
                         data.result = new Object[]{e};

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/AnkiPackageExporter.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/AnkiPackageExporter.java
@@ -471,6 +471,7 @@ public final class AnkiPackageExporter extends AnkiExporter {
             try {
                 runtime.exec(deleteCmd);
             } catch (IOException ignored) {
+                Timber.w(ignored);
             }
         }
         return media;

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
@@ -462,6 +462,7 @@ public class Collection {
                     DB.safeEndInTransaction(db);
                 }
             } catch (RuntimeException e) {
+                Timber.w(e);
                 AnkiDroidApp.sendExceptionReport(e, "closeDB");
             }
             if (!mServer) {
@@ -581,6 +582,7 @@ public class Collection {
         try {
             id = mConf.getInt(type);
         } catch (JSONException e) {
+            Timber.w(e);
             id = 1;
         }
         mConf.put(type, id + 1);
@@ -895,6 +897,7 @@ public class Collection {
                                 did = ndid;
                             }
                         } catch (JSONException e) {
+                            Timber.w(e);
                             // do nothing
                         }
                         if (getDecks().isDyn(did)) {
@@ -1177,6 +1180,7 @@ public class Collection {
             try {
                 html = ParsedNode.parse_inner(format).render(fields, "q".equals(type), getContext());
             } catch (TemplateError er) {
+                Timber.w(er);
                 html = er.message(getContext());
             }
             html = ChessFilter.fenToChessboard(html, getContext());
@@ -1467,7 +1471,7 @@ public class Collection {
             }
             mDb.getDatabase().setTransactionSuccessful();
         } catch (SQLiteDatabaseLockedException ex) {
-            Timber.e("doInBackgroundCheckDatabase - Database locked");
+            Timber.w(ex,"doInBackgroundCheckDatabase - Database locked");
             return result.markAsLocked();
         } catch (RuntimeException e) {
             Timber.e(e, "doInBackgroundCheckDatabase - RuntimeException on marking card");
@@ -1740,7 +1744,7 @@ public class Collection {
                     fixCount++;
                 }
             } catch (NoSuchDeckException e) {
-                Timber.e("Unable to find dynamic deck %d", id);
+                Timber.w(e, "Unable to find dynamic deck %d", id);
             }
         }
         if (fixCount > 0) {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/DeckConfig.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/DeckConfig.java
@@ -19,6 +19,7 @@ package com.ichi2.libanki;
 import com.ichi2.utils.JSONObject;
 
 import androidx.annotation.Nullable;
+import timber.log.Timber;
 
 public class DeckConfig extends JSONObject{
     public DeckConfig(JSONObject json) {
@@ -35,9 +36,11 @@ public class DeckConfig extends JSONObject{
             //#6089 - Anki 2.1.24 changed this to a bool, reverted in 2.1.25.
             return config.getInt("timer") != 0;
         } catch (Exception e) {
+            Timber.w(e);
             try {
                 return config.getBoolean("timer");
             } catch (Exception ex) {
+                Timber.w(ex);
                 return null;
             }
         }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Finder.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Finder.java
@@ -125,6 +125,7 @@ public class Finder {
             }
         } catch (SQLException e) {
             // invalid grouping
+            Timber.w(e);
             return new ArrayList<>(0);
         }
         if (rev) {
@@ -154,6 +155,7 @@ public class Finder {
                 res.add(cur.getLong(0));
             }
         } catch (SQLException e) {
+            Timber.w(e);
             // invalid grouping
             return new ArrayList<>(0);
         }
@@ -531,6 +533,7 @@ public class Finder {
         try {
             days = Integer.parseInt(r[0]);
         } catch (NumberFormatException e) {
+            Timber.w(e);
             return null;
         }
         days = Math.min(days, 31);
@@ -552,6 +555,7 @@ public class Finder {
         try {
             days = Integer.parseInt(val);
         } catch (NumberFormatException e) {
+            Timber.w(e);
             return null;
         }
         long cutoff = (mCol.getSched().getDayCutoff() - SECONDS_PER_DAY * days) * 1000;
@@ -578,6 +582,7 @@ public class Finder {
                 val = Integer.parseInt(sval);
             }
         } catch (NumberFormatException e) {
+            Timber.w(e);
             return null;
         }
         // is prop valid?
@@ -706,6 +711,7 @@ public class Finder {
         try {
             num = Integer.parseInt(val) - 1;
         } catch (NumberFormatException e) {
+            Timber.w(e);
             num = null;
         }
         if (num != null) {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Media.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Media.java
@@ -514,6 +514,7 @@ public class Media {
         try {
             findChanges();
         } catch (SQLException ignored) {
+            Timber.w(ignored);
             _deleteDB();
         }
         List<List<String>> result = new ArrayList<>(3);
@@ -895,6 +896,7 @@ public class Media {
                         meta.put(new JSONArray().put(normname).put(Integer.toString(c)));
                         sz += file.length();
                     } catch (FileNotFoundException e) {
+                        Timber.w(e);
                         // A file has been marked as added but no longer exists in the media directory.
                         // Skip over it and mark it as removed in the db.
                         removeFile(fname);

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Model.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Model.java
@@ -31,6 +31,7 @@ import java.util.List;
 import java.util.Set;
 
 import androidx.annotation.CheckResult;
+import timber.log.Timber;
 
 /**
  * Represents a note type, a.k.a. Model.
@@ -102,6 +103,7 @@ public class Model extends JSONObject {
             try {
                 node = ParsedNode.parse_inner(format_question);
             } catch (TemplateError er) {
+                Timber.w(er);
             }
             nodes.add(node);
         }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/importer/Anki2Importer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/importer/Anki2Importer.java
@@ -177,6 +177,7 @@ public class Anki2Importer extends Importer {
         try {
             mDst.getDb().execute("vacuum");
         } catch (Exception e) {
+            Timber.w(e);
             // This is actually not fatal but can fail since vacuum takes so much space
             // Allow the import to succeed but recommend the user run check database
             mLog.add(getRes().getString(R.string.import_succeeded_but_check_database, e.getLocalizedMessage()));
@@ -185,6 +186,7 @@ public class Anki2Importer extends Importer {
         try {
             mDst.getDb().execute("analyze");
         } catch (Exception e) {
+            Timber.w(e);
             // This is actually not fatal but can fail
             // Allow the import to succeed but recommend the user run check database
             mLog.add(getRes().getString(R.string.import_succeeded_but_check_database, e.getLocalizedMessage()));
@@ -715,6 +717,7 @@ public class Anki2Importer extends Importer {
         try {
             return new BufferedInputStream(new FileInputStream(path), MEDIAPICKLIMIT * 2);
         } catch (IOException e) {
+            Timber.w(e);
             return null;
         }
     }
@@ -859,6 +862,7 @@ public class Anki2Importer extends Importer {
             System.arraycopy(baos.toByteArray(), 0, result, 0, Math.min(baos.size(), MEDIAPICKLIMIT));
             return result;
         } catch (IOException e) {
+            Timber.w(e);
             return null;
         }
     }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/importer/AnkiPackageImporter.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/importer/AnkiPackageImporter.java
@@ -63,6 +63,7 @@ public class AnkiPackageImporter extends Anki2Importer {
                 try {
                     mZip = new ZipFile(new File(mFile));
                 } catch (FileNotFoundException fileNotFound) {
+                    Timber.w(fileNotFound);
                     // The cache can be cleared between copying the file in and importing. This is temporary
                     if (fileNotFound.getMessage().contains("ENOENT")) {
                         mLog.add(getRes().getString(R.string.import_log_file_cache_cleared));

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/importer/TextImporter.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/importer/TextImporter.java
@@ -163,9 +163,11 @@ public class TextImporter extends NoteImporter {
                 String join = getLinesFromFile(10);
                 dialect = sniffer.sniff(join, mPatterns.toCharArray());
             } catch (Exception e) {
+                Timber.w(e);
                 try {
                     dialect = sniffer.sniff(getFirstFileLine().orElse(""), mPatterns.toCharArray());
                 } catch (Exception ex) {
+                    Timber.w(ex);
                     // pass
                 }
             }
@@ -178,6 +180,7 @@ public class TextImporter extends NoteImporter {
             try {
                 reader = CsvReader.fromDialect(data, dialect);
             } catch (Exception e) {
+                Timber.w(e);
                 err();
             }
         } else {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
@@ -1305,6 +1305,7 @@ public class SchedV2 extends AbstractSched {
             try {
                 delay = delays.getDouble(len - left);
             } catch (JSONException e) {
+                Timber.w(e);
                 if (conf.getJSONArray("delays").length() > 0) {
                     delay = conf.getJSONArray("delays").getDouble(0);
                 } else {
@@ -1457,6 +1458,7 @@ public class SchedV2 extends AbstractSched {
             mCol.getDb().execute("INSERT INTO revlog VALUES (?,?,?,?,?,?,?,?,?)",
                     getTime().intTimeMS(), id, usn, ease, ivl, lastIvl, factor, timeTaken, type);
         } catch (SQLiteConstraintException e) {
+            Timber.w(e);
             try {
                 Thread.sleep(10);
             } catch (InterruptedException e1) {
@@ -2253,6 +2255,7 @@ public class SchedV2 extends AbstractSched {
                     _current_timezone_offset(),
                     _rolloverHour());
         } catch (BackendNotSupportedException e) {
+            Timber.w(e);
             return null;
         }
     }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sync/MediaSyncer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sync/MediaSyncer.java
@@ -94,6 +94,7 @@ public class MediaSyncer {
                 try {
                     mCol.getMedia().findChanges();
                 } catch (SQLException ignored) {
+                    Timber.w(ignored);
                     return new Pair<>(CORRUPT, null);
                 }
             }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sync/RemoteServer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sync/RemoteServer.java
@@ -31,6 +31,7 @@ import java.util.HashMap;
 import java.util.Locale;
 
 import okhttp3.Response;
+import timber.log.Timber;
 
 @SuppressWarnings({"PMD.AvoidThrowingRawExceptionTypes","PMD.MethodNamingConventions"})
 public class RemoteServer extends HttpSyncer {
@@ -49,6 +50,7 @@ public class RemoteServer extends HttpSyncer {
             credentials.put("p", pw);
             return super.req("hostKey", HttpSyncer.getInputStream(Utils.jsonToString(credentials)));
         } catch (JSONException e) {
+            Timber.w(e);
             return null;
         }
     }
@@ -121,6 +123,7 @@ public class RemoteServer extends HttpSyncer {
         try {
             return Long.parseLong(s);
         } catch (NumberFormatException e) {
+            Timber.w(e);
             return 0;
         }
     }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sync/Syncer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sync/Syncer.java
@@ -230,6 +230,7 @@ public class Syncer {
                 try {
                     mergeChanges(lchg, rchg);
                 } catch (UnexpectedSchemaChange e) {
+                    Timber.w(e);
                     mRemoteServer.abort();
                     _forceFullSync();
                 }
@@ -286,9 +287,11 @@ public class Syncer {
             throw new RuntimeException(e);
         } catch (OutOfMemoryError e) {
             AnkiDroidApp.sendExceptionReport(e, "Syncer-sync");
+            Timber.w(e);
             return new Pair<>( OUT_OF_MEMORY_ERROR , null);
         } catch (IOException e) {
             AnkiDroidApp.sendExceptionReport(e, "Syncer-sync");
+            Timber.w(e);
             return new Pair<>( IO_EXCEPTION , null);
         }
         return new Pair<>( SUCCESS , null);
@@ -930,6 +933,7 @@ public class Syncer {
             try {
                 mRemoteServer.abort();
             } catch (UnknownHttpResponseException ignored) {
+                Timber.w(ignored);
             }
             throw new RuntimeException(USER_ABORTED_SYNC.toString());
         }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sync/UnifiedTrustManager.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sync/UnifiedTrustManager.java
@@ -27,6 +27,8 @@ import javax.net.ssl.TrustManager;
 import javax.net.ssl.TrustManagerFactory;
 import javax.net.ssl.X509TrustManager;
 
+import timber.log.Timber;
+
 // https://stackoverflow.com/questions/27562666/programmatically-add-a-certificate-authority-while-keeping-android-system-ssl-ce
 // Changes:
 // We try the local manager first.
@@ -58,6 +60,7 @@ class UnifiedTrustManager implements X509TrustManager {
         try {
             localTrustManager.checkServerTrusted(chain, authType);
         } catch (CertificateException ce) {
+            Timber.w(ce);
             defaultTrustManager.checkServerTrusted(chain, authType);
         }
     }
@@ -66,6 +69,7 @@ class UnifiedTrustManager implements X509TrustManager {
         try {
             localTrustManager.checkClientTrusted(chain, authType);
         } catch (CertificateException ce) {
+            Timber.w(ce);
             defaultTrustManager.checkClientTrusted(chain, authType);
         }
     }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/template/ParsedNode.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/template/ParsedNode.java
@@ -21,6 +21,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.VisibleForTesting;
 import okhttp3.internal.Util;
+import timber.log.Timber;
 
 /**
  * Represents a template, allow to check in linear time which card is empty/render card.
@@ -146,6 +147,7 @@ public abstract class ParsedNode {
             render_into(fields, Utils.nonEmptyFields(fields), builder);
             return builder.toString();
         } catch (TemplateError er) {
+            Timber.w(er);
             String side = (question)? context.getString(R.string.card_template_editor_front): context.getString(R.string.card_template_editor_back);
             String explanation = context.getString(R.string.has_a_problem, side, er.message(context));
             String more_explanation = "<a href=\""+ TEMPLATE_ERROR_LINK+"\">" + context.getString(R.string.more_information) + "</a>";

--- a/AnkiDroid/src/main/java/com/ichi2/preferences/NumberRangePreference.java
+++ b/AnkiDroid/src/main/java/com/ichi2/preferences/NumberRangePreference.java
@@ -24,6 +24,8 @@ import android.util.AttributeSet;
 
 import com.ichi2.anki.AnkiDroidApp;
 
+import timber.log.Timber;
+
 @SuppressWarnings("deprecation") // TODO Tracked in https://github.com/ankidroid/Anki-Android/issues/5019
 public class NumberRangePreference extends android.preference.EditTextPreference {
 
@@ -97,6 +99,7 @@ public class NumberRangePreference extends android.preference.EditTextPreference
             try {
                 return getValidatedRangeFromInt(Integer.parseInt(input));
             } catch (NumberFormatException e) {
+                Timber.w(e);
                 return mMin;
             }
         }

--- a/AnkiDroid/src/main/java/com/ichi2/preferences/StepsPreference.java
+++ b/AnkiDroid/src/main/java/com/ichi2/preferences/StepsPreference.java
@@ -28,6 +28,8 @@ import com.ichi2.anki.UIUtils;
 import com.ichi2.utils.JSONArray;
 import com.ichi2.utils.JSONException;
 
+import timber.log.Timber;
+
 @SuppressWarnings("deprecation") // TODO Tracked in https://github.com/ankidroid/Anki-Android/issues/5019
 public class StepsPreference extends android.preference.EditTextPreference {
 
@@ -148,6 +150,7 @@ public class StepsPreference extends android.preference.EditTextPreference {
             }
         } catch (NumberFormatException | JSONException e) {
             // Can't serialize float. Value likely too big/small.
+            Timber.w(e);
             return null;
         }
         return stepsAr;

--- a/AnkiDroid/src/main/java/com/ichi2/themes/HtmlColors.java
+++ b/AnkiDroid/src/main/java/com/ichi2/themes/HtmlColors.java
@@ -6,6 +6,8 @@ import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import timber.log.Timber;
+
 public class HtmlColors {
     private static final Pattern fHtmlColorPattern = Pattern.compile(
             "((?:color|background)\\s*[=:]\\s*\"?)((?:[a-z]+|#[0-9a-f]+|rgb\\([0-9]+,\\s*[0-9],+\\s*[0-9]+\\)))([\";\\s])", Pattern.CASE_INSENSITIVE);
@@ -68,6 +70,7 @@ public class HtmlColors {
                     }
                 }
             } catch (NumberFormatException e) {
+                Timber.w(e);
                 // shouldn't happen but ignore anyway
             }
             m1.appendReplacement(sb, m1.group(1) + color + m1.group(3));

--- a/AnkiDroid/src/main/java/com/ichi2/upgrade/Upgrade.java
+++ b/AnkiDroid/src/main/java/com/ichi2/upgrade/Upgrade.java
@@ -6,6 +6,8 @@ import com.ichi2.libanki.Collection;
 import com.ichi2.utils.JSONException;
 import com.ichi2.utils.JSONObject;
 
+import timber.log.Timber;
+
 public class Upgrade {
 
     public static boolean upgradeJSONIfNecessary(Collection col, JSONObject conf, String name, boolean defaultValue) {
@@ -13,10 +15,12 @@ public class Upgrade {
         try {
             val = conf.getBoolean(name);
         } catch (JSONException e) {
+            Timber.w(e);
             // workaround to repair wrong values from older libanki versions
             try {
                 conf.put(name, val);
             } catch (JSONException e1) {
+                Timber.w(e1);
                 // do nothing
             }
             col.save();

--- a/AnkiDroid/src/main/java/com/ichi2/utils/AdaptionUtil.java
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/AdaptionUtil.java
@@ -34,6 +34,8 @@ import com.ichi2.anki.AnkiDroidApp;
 import java.util.List;
 import java.util.Locale;
 
+import timber.log.Timber;
+
 public class AdaptionUtil {
     private static boolean sHasRunRestrictedLearningDeviceCheck = false;
     private static boolean sIsRestrictedLearningDevice = false;
@@ -57,6 +59,7 @@ public class AdaptionUtil {
                     ActivityManager.isUserAMonkey() ||
                             isRunningUnderFirebaseTestLab();
         } catch (Exception e) {
+            Timber.w(e);
             return false;
         }
     }
@@ -66,6 +69,7 @@ public class AdaptionUtil {
         try {
             return isRunningUnderFirebaseTestLab(AnkiDroidApp.getInstance().getContentResolver());
         } catch (Exception e) {
+            Timber.w(e);
             return false;
         }
     }
@@ -118,6 +122,7 @@ public class AdaptionUtil {
                 return (info != null) && (info.applicationInfo != null) &&
                         ((info.applicationInfo.flags & ApplicationInfo.FLAG_SYSTEM) != 0);
             } catch (PackageManager.NameNotFoundException e) {
+                Timber.w(e);
                 return false;
             }
         } else {

--- a/AnkiDroid/src/main/java/com/ichi2/utils/ExifUtil.java
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/ExifUtil.java
@@ -24,6 +24,7 @@ import android.graphics.Matrix;
 
 import androidx.annotation.NonNull;
 import androidx.exifinterface.media.ExifInterface;
+import timber.log.Timber;
 
 import java.io.File;
 
@@ -50,6 +51,7 @@ public class ExifUtil {
             bmp = Bitmap.createBitmap(bmp, 0, 0, bmp.getWidth(), bmp.getHeight(), mat, true);
             return bmp;
         } catch (Exception e) {
+            Timber.w(e);
             return bmp;
         }
     }

--- a/AnkiDroid/src/main/java/com/ichi2/utils/IntentUtil.java
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/IntentUtil.java
@@ -24,12 +24,15 @@ import com.ichi2.anki.AnkiActivity;
 import com.ichi2.anki.R;
 import com.ichi2.anki.UIUtils;
 
+import timber.log.Timber;
+
 public class IntentUtil {
     public static boolean canOpenIntent(Context context, Intent intent) {
         try {
             final PackageManager packageManager = context.getPackageManager();
             return intent.resolveActivity(packageManager) != null;
         } catch (Exception e) {
+            Timber.w(e);
             return false;
         }
     }
@@ -43,6 +46,7 @@ public class IntentUtil {
                 UIUtils.showThemedToast(activity, errorMsg, true);
             }
         } catch (Exception e) {
+            Timber.w(e);
             final String errorMsg = activity.getString(R.string.feedback_no_suitable_app_found);
             UIUtils.showThemedToast(activity, errorMsg, true);
         }

--- a/AnkiDroid/src/main/java/com/ichi2/utils/SyncStatus.java
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/SyncStatus.java
@@ -23,6 +23,7 @@ import com.ichi2.libanki.Collection;
 import com.ichi2.utils.FunctionalInterfaces.Supplier;
 
 import androidx.annotation.NonNull;
+import timber.log.Timber;
 
 public enum SyncStatus {
     INCONCLUSIVE,
@@ -42,6 +43,7 @@ public enum SyncStatus {
         try {
             col = getCol.get();
         } catch (Exception e) {
+            Timber.w(e);
             return SyncStatus.INCONCLUSIVE;
         }
 

--- a/AnkiDroid/src/main/java/com/wildplot/android/parsing/AtomTypes/NumberAtom.java
+++ b/AnkiDroid/src/main/java/com/wildplot/android/parsing/AtomTypes/NumberAtom.java
@@ -19,6 +19,8 @@ import com.wildplot.android.parsing.Atom;
 import com.wildplot.android.parsing.ExpressionFormatException;
 import com.wildplot.android.parsing.TreeElement;
 
+import timber.log.Timber;
+
 public class NumberAtom implements TreeElement {
 
     private Atom.AtomType atomType = Atom.AtomType.NUMBER;
@@ -29,6 +31,7 @@ public class NumberAtom implements TreeElement {
         try {
             this.value = Double.parseDouble(factorString);
         } catch (NumberFormatException e) {
+            Timber.w(e);
             atomType = Atom.AtomType.INVALID;
         }
 


### PR DESCRIPTION
I currently have an exception which is not printed. Instead, it shows an error message in ankidroid, but that does not help me to debug.
I realize that even if it's great for the user, it seems always nice to timber exceptions for people actually reading at logs.

Exception: I didn't add timbers to com.ichi2.anki.api since it's another package

