### PR TITLE
curDeck is saved as a long.

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
@@ -984,7 +984,7 @@ public class Decks {
         String name = mDecks.get(did).getString("name");
 
         // current deck
-        mCol.getConf().put("curDeck", Long.toString(did));
+        mCol.getConf().put("curDeck", did);
         // and active decks (current + all children)
         TreeMap<String, Long> actv = children(did); // Note: TreeMap is already sorted
         actv.put(name, did);

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/DecksTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/DecksTest.java
@@ -226,4 +226,14 @@ public class DecksTest extends RobolectricTest {
      }
      */
 
+    @Test
+    public void curDeckIsLong() {
+        // Regression for #8092
+        Collection col = getCol();
+        Decks decks = col.getDecks();
+        long id = decks.id("test");
+        decks.select(id);
+        assertThat("curDeck should be saved as a long. A deck id.", col.getConf().get("curDeck") instanceof Long);
+    }
+
 }


### PR DESCRIPTION
Fixed #8092. Thanks @dae. This was the case since 2014, no idea why, and why it started to be a bug
1fbf16e693e6c8787cb00f6a8b00e88f1f76be46


I suggest pushing it to a stable version quickly, since it was creating problem. The problem seems to be because Anki does not accept string anymore and not because of an ankidroid change, but that's still a problem