### PR TITLE
Remove "create subdeck" for filtered deck

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckPickerContextMenu.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckPickerContextMenu.java
@@ -119,15 +119,18 @@ public class DeckPickerContextMenu extends AnalyticsDialogFragment {
     int[] getListIds() {
         Collection col = CollectionHelper.getInstance().getCol(getContext());
         long did = getArguments().getLong("did");
+        boolean dyn = col.getDecks().isDyn(did);
         ArrayList<Integer> itemIds = new ArrayList<>(9);
-        if (col.getDecks().isDyn(did)) {
+        if (dyn) {
             itemIds.add(CONTEXT_MENU_CUSTOM_STUDY_REBUILD);
             itemIds.add(CONTEXT_MENU_CUSTOM_STUDY_EMPTY);
         }
         itemIds.add(CONTEXT_MENU_RENAME_DECK);
-        itemIds.add(CONTEXT_MENU_CREATE_SUBDECK);
+        if (!dyn) {
+            itemIds.add(CONTEXT_MENU_CREATE_SUBDECK);
+        }
         itemIds.add(CONTEXT_MENU_DECK_OPTIONS);
-        if (!col.getDecks().isDyn(did)) {
+        if (!dyn) {
             itemIds.add(CONTEXT_MENU_CUSTOM_STUDY);
         }
         itemIds.add(CONTEXT_MENU_DELETE_DECK);


### PR DESCRIPTION
Partial correction of #8095. When you long press on a filtered deck, it won't offer to create a subdeck.
It does not stop to create one at all, but at least there is not invite.