### PR TITLE
No filtered has child

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -670,7 +670,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
 
     private void createNewDeck(String deckName) {
         Timber.i("DeckPicker:: Creating new deck...");
-        getCol().getDecks().id(deckName, true);
+        getCol().getDecks().id(deckName);
         updateDeckList();
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -104,6 +104,7 @@ import com.ichi2.anki.dialogs.MediaCheckDialog;
 import com.ichi2.anki.dialogs.SyncErrorDialog;
 import com.ichi2.anki.exception.ConfirmModSchemaException;
 import com.ichi2.anki.exception.DeckRenameException;
+import com.ichi2.anki.exception.FilteredAncestor;
 import com.ichi2.anki.receiver.SdCardReceiver;
 import com.ichi2.anki.stats.AnkiStatsTaskHandler;
 import com.ichi2.anki.web.HostNumFactory;
@@ -646,7 +647,10 @@ public class DeckPicker extends NavigationDrawerActivity implements
                     .onPositive((dialog, which) -> {
                         String deckName = mDialogEditText.getText().toString();
                         if (Decks.isValidDeckName(deckName)) {
-                            createNewDeck(deckName);
+                            boolean creation_succeed = createNewDeck(deckName);
+                            if (!creation_succeed) {
+                                return;
+                            }
                         } else {
                             Timber.i("configureFloatingActionsMenu::addDeckButton::onPositiveListener - Not creating invalid deck name '%s'", deckName);
                             UIUtils.showThemedToast(this, getString(R.string.invalid_deck_name), false);
@@ -668,10 +672,21 @@ public class DeckPicker extends NavigationDrawerActivity implements
     }
 
 
-    private void createNewDeck(String deckName) {
+    /**
+     * It can fail if an ancestor is a filtered deck.
+     * @param deckName Create a deck with this name.
+     * @return Whether creation succeeded.
+     */
+    private boolean createNewDeck(String deckName) {
         Timber.i("DeckPicker:: Creating new deck...");
-        getCol().getDecks().id(deckName);
+        try {
+            getCol().getDecks().id(deckName);
+        } catch (FilteredAncestor filteredAncestor) {
+            UIUtils.showThemedToast(this, getString(R.string.decks_rename_filtered_nosubdecks), false);
+            return false;
+        }
         updateDeckList();
+        return true;
     }
 
 
@@ -823,7 +838,12 @@ public class DeckPicker extends NavigationDrawerActivity implements
                             return;
                         }
                         Timber.i("DeckPicker:: Creating filtered deck...");
-                        getCol().getDecks().newDyn(filteredDeckName);
+                        try {
+                            getCol().getDecks().newDyn(filteredDeckName);
+                        } catch (FilteredAncestor filteredAncestor) {
+                            UIUtils.showThemedToast(this, getString(R.string.decks_rename_filtered_nosubdecks), false);
+                            return;
+                        }
                         openStudyOptions(true);
                     })
                     .show();
@@ -2911,7 +2931,10 @@ public class DeckPicker extends NavigationDrawerActivity implements
                     String textValue = mDialogEditText.getText().toString();
                     String newName = getCol().getDecks().getSubdeckName(did, textValue);
                     if (Decks.isValidDeckName(newName)) {
-                        createNewDeck(newName);
+                        boolean creation_succeed = createNewDeck(newName);
+                        if (!creation_succeed) {
+                            return;
+                        }
                     } else {
                         Timber.i("createSubDeckDialog - not creating invalid subdeck name '%s'", newName);
                         UIUtils.showThemedToast(this, getString(R.string.invalid_deck_name), false);

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/CustomStudyDialog.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/CustomStudyDialog.java
@@ -43,6 +43,7 @@ import com.ichi2.anki.R;
 import com.ichi2.anki.Reviewer;
 import com.ichi2.anki.UIUtils;
 import com.ichi2.anki.analytics.AnalyticsDialogFragment;
+import com.ichi2.anki.exception.FilteredAncestor;
 import com.ichi2.async.CollectionTask;
 import com.ichi2.async.TaskListener;
 import com.ichi2.async.TaskListenerWithContext;
@@ -449,8 +450,12 @@ public class CustomStudyDialog extends AnalyticsDialogFragment {
             }
         } else {
             Timber.i("Creating Dynamic Deck '%s' for custom study", customStudyDeck);
-            long customStudyDid = decks.newDyn(customStudyDeck);
-            dyn = decks.get(customStudyDid);
+            try {
+                dyn = decks.get(decks.newDyn(customStudyDeck));
+            } catch (FilteredAncestor filteredAncestor) {
+                UIUtils.showThemedToast(getActivity(), getString(R.string.decks_rename_filtered_nosubdecks), true);
+                return;
+            }
         }
         if (!dyn.has("terms")) {
             //#5959 - temp code to diagnose why terms doesn't exist.

--- a/AnkiDroid/src/main/java/com/ichi2/anki/exception/FilteredAncestor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/exception/FilteredAncestor.java
@@ -1,0 +1,13 @@
+package com.ichi2.anki.exception;
+
+public class FilteredAncestor extends Exception {
+    private final String mFilteredAncestorName;
+    public FilteredAncestor(String filteredAncestorName) {
+        this.mFilteredAncestorName = filteredAncestorName;
+    }
+
+    public String getFilteredAncestorName() {
+        return mFilteredAncestorName;
+    }
+
+}

--- a/AnkiDroid/src/main/java/com/ichi2/anki/provider/CardContentProvider.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/provider/CardContentProvider.java
@@ -1026,7 +1026,7 @@ public class CardContentProvider extends ContentProvider {
             case DECKS:
                 // Insert new deck with specified name
                 String deckName = values.getAsString(FlashCardsContract.Deck.DECK_NAME);
-                did = col.getDecks().id(deckName, false);
+                did = col.getDecks().id_dont_create(deckName);
                 if (did != null) {
                     throw new IllegalArgumentException("Deck name already exists: " + deckName);
                 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/provider/CardContentProvider.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/provider/CardContentProvider.java
@@ -44,6 +44,7 @@ import com.ichi2.anki.FlashCardsContract;
 import com.ichi2.anki.FlashCardsContract.CardTemplate;
 import com.ichi2.anki.R;
 import com.ichi2.anki.exception.ConfirmModSchemaException;
+import com.ichi2.anki.exception.FilteredAncestor;
 import com.ichi2.compat.CompatHelper;
 import com.ichi2.libanki.Consts;
 import com.ichi2.libanki.Decks;
@@ -1033,7 +1034,11 @@ public class CardContentProvider extends ContentProvider {
                 if (!Decks.isValidDeckName(deckName)) {
                     throw new IllegalArgumentException("Invalid deck name '" + deckName + "'");
                 }
-                did = col.getDecks().id(deckName);
+                try {
+                    did = col.getDecks().id(deckName);
+                } catch (FilteredAncestor filteredSubdeck) {
+                    throw new IllegalArgumentException("Deck " + deckName + " has filtered ancestor " + filteredSubdeck.getFilteredAncestorName());
+                }
                 Deck deck = col.getDecks().get(did);
                 if (deck != null) {
                     try {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/provider/CardContentProvider.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/provider/CardContentProvider.java
@@ -1033,7 +1033,7 @@ public class CardContentProvider extends ContentProvider {
                 if (!Decks.isValidDeckName(deckName)) {
                     throw new IllegalArgumentException("Invalid deck name '" + deckName + "'");
                 }
-                did = col.getDecks().id(deckName, true);
+                did = col.getDecks().id(deckName);
                 Deck deck = col.getDecks().get(did);
                 if (deck != null) {
                     try {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
@@ -1579,7 +1579,7 @@ public class Collection {
 
         //we use a ! prefix to keep it at the top of the deck list
         String recoveredDeckName = "! " + mContext.getString(R.string.check_integrity_recovered_deck_name);
-        Long nextDeckId = getDecks().id(recoveredDeckName , true);
+        Long nextDeckId = getDecks().id(recoveredDeckName);
 
         if (nextDeckId == null) {
             throw new IllegalStateException("Unable to create deck");

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
@@ -1579,7 +1579,8 @@ public class Collection {
 
         //we use a ! prefix to keep it at the top of the deck list
         String recoveredDeckName = "! " + mContext.getString(R.string.check_integrity_recovered_deck_name);
-        Long nextDeckId = getDecks().id(recoveredDeckName);
+        Long nextDeckId = getDecks().id_safe(recoveredDeckName);
+        // Still a risk of failure if recoveredDeckName is the name of a filtered deck
 
         if (nextDeckId == null) {
             throw new IllegalStateException("Unable to create deck");

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
@@ -328,14 +328,18 @@ public class Decks {
         return id(name, true, type);
     }
 
+    private String usable_name(String name) {
+        name = strip(name);
+        name = name.replace("\"", "");
+        name = Normalizer.normalize(name, Normalizer.Form.NFC);
+        return name;
+    }
 
     /**
      * Add a deck with NAME. Reuse deck if already exists. Return id as int.
      */
     public Long id(String name, boolean create, String type) {
-        name = strip(name);
-        name = name.replace("\"", "");
-        name = Normalizer.normalize(name, Normalizer.Form.NFC);
+        name = usable_name(name);
         Deck deck = byName(name);
         if (deck != null) {
             return deck.getLong("id");

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
@@ -347,6 +347,17 @@ public class Decks {
             // not top level; ensure all parents exist
             name = _ensureParents(name);
         }
+        return id_create_name_valid(name, type);
+    }
+
+
+    /**
+     * @param name A name, assuming it's not a deck name, all ancestors exists and are not filtered
+     * @param type The json encoding of the deck, except for name and id
+     * @return the deck's id
+     */
+    private Long id_create_name_valid(String name, String type) {
+        Long id;
         Deck g = new Deck(type);
         g.put("name", name);
         do {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
@@ -314,18 +314,17 @@ public class Decks {
      * ***********************************************************
      */
 
+    public Long id_dont_create(String name) {
+        name = usable_name(name);
+        Deck deck = byName(name);
+        if (deck != null) {
+            return deck.getLong("id");
+        }
+        return null;
+    }
+
     public Long id(String name) {
-        return id(name, true);
-    }
-
-
-    public Long id(String name, boolean create) {
-        return id(name, create, defaultDeck);
-    }
-
-
-    public Long id(String name, String type) {
-        return id(name, type);
+        return id(name, defaultDeck);
     }
 
     private String usable_name(String name) {
@@ -338,20 +337,16 @@ public class Decks {
     /**
      * Add a deck with NAME. Reuse deck if already exists. Return id as int.
      */
-    public Long id(String name, boolean create, String type) {
+    public Long id(String name, String type) {
         name = usable_name(name);
-        Deck deck = byName(name);
-        if (deck != null) {
-            return deck.getLong("id");
-        }
-        if (!create) {
-            return null;
+        Long id = id_dont_create(name);
+        if (id != null) {
+            return id;
         }
         if (name.contains("::")) {
             // not top level; ensure all parents exist
             name = _ensureParents(name);
         }
-        long id;
         Deck g = new Deck(type);
         g.put("name", name);
         do {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
@@ -325,7 +325,7 @@ public class Decks {
 
 
     public Long id(String name, String type) {
-        return id(name, true, type);
+        return id(name, type);
     }
 
     private String usable_name(String name) {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Finder.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Finder.java
@@ -670,10 +670,10 @@ public class Finder {
             ids = dids(mCol.getDecks().selected());
         } else if (!val.contains("*")) {
             // single deck
-            ids = dids(mCol.getDecks().id(val, false));
+            ids = dids(mCol.getDecks().id_dont_create(val));
         } else {
             // wildcard
-            ids = dids(mCol.getDecks().id(val, false));
+            ids = dids(mCol.getDecks().id_dont_create(val));
             if (ids == null) {
                 ids = new ArrayList<>();
                 val = val.replace("*", ".*");

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/importer/Anki2Importer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/importer/Anki2Importer.java
@@ -147,7 +147,7 @@ public class Anki2Importer extends Importer {
             mDst.getMedia().getDb().getDatabase().beginTransaction();
 
             if (!TextUtils.isEmpty(mDeckPrefix)) {
-                long id = mDst.getDecks().id(mDeckPrefix);
+                long id = mDst.getDecks().id_safe(mDeckPrefix);
                 mDst.getDecks().select(id);
             }
             Timber.i("Preparing Import");
@@ -470,11 +470,11 @@ public class Anki2Importer extends Importer {
                 head += "::";
             }
             head += parent;
-            long idInSrc = mSrc.getDecks().id(head);
+            long idInSrc = mSrc.getDecks().id_safe(head);
             _did(idInSrc);
         }
         // create in local
-        long newid = mDst.getDecks().id(name);
+        long newid = mDst.getDecks().id_safe(name);
         // pull conf over
         if (g.has("conf") && g.getLong("conf") != 1) {
             DeckConfig conf = mSrc.getDecks().getConf(g.getLong("conf"));

--- a/AnkiDroid/src/test/java/com/ichi2/anki/RobolectricTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/RobolectricTest.java
@@ -24,6 +24,7 @@ import com.afollestad.materialdialogs.MaterialDialog;
 import com.ichi2.anki.dialogs.DialogHandler;
 import com.ichi2.anki.dialogs.utils.FragmentTestActivity;
 import com.ichi2.anki.exception.ConfirmModSchemaException;
+import com.ichi2.anki.exception.FilteredAncestor;
 import com.ichi2.async.CollectionTask;
 import com.ichi2.async.TaskListener;
 import com.ichi2.async.TaskManager;
@@ -348,11 +349,19 @@ public class RobolectricTest {
     }
 
     protected long addDeck(String deckName) {
-        return getCol().getDecks().id(deckName);
+        try {
+            return getCol().getDecks().id(deckName);
+        } catch (FilteredAncestor filteredAncestor) {
+            throw new RuntimeException(filteredAncestor);
+        }
     }
 
     protected long addDynamicDeck(String name) {
-        return getCol().getDecks().newDyn(name);
+        try {
+            return getCol().getDecks().newDyn(name);
+        } catch (FilteredAncestor filteredAncestor) {
+            throw new RuntimeException(filteredAncestor);
+        }
     }
 
     protected void ensureCollectionLoadIsSynchronous() {

--- a/AnkiDroid/src/test/java/com/ichi2/anki/RobolectricTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/RobolectricTest.java
@@ -348,7 +348,7 @@ public class RobolectricTest {
     }
 
     protected long addDeck(String deckName) {
-        return getCol().getDecks().id(deckName, true);
+        return getCol().getDecks().id(deckName);
     }
 
     protected long addDynamicDeck(String name) {

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/DecksTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/DecksTest.java
@@ -120,6 +120,11 @@ public class DecksTest extends RobolectricTest {
         Note n = col.newNote();
         n.setItem("Front", "abc");
         col.addNote(n);
+
+        assertEquals(decks.id_dont_create("new deck").longValue(), parentId);
+        assertEquals(decks.id_dont_create("  New Deck  ").longValue(), parentId);
+        assertNull(decks.id_dont_create("Not existing deck"));
+        assertNotNull(decks.id_dont_create("new deck::not either"));
     }
 
 

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/DecksTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/DecksTest.java
@@ -275,10 +275,32 @@ public class DecksTest extends RobolectricTest {
         Decks decks = col.getDecks();
         addDeck("test");
         String subsubdeck_name = decks._ensureParents("  tESt :: sub :: subdeck");
-        assertEquals(subsubdeck_name, "test::sub:: subdeck");// Only parents are renamed, not the last deck.
+        assertEquals("test::sub:: subdeck", subsubdeck_name);// Only parents are renamed, not the last deck.
         assertNotNull(decks.byName("test::sub"));
         assertNull(decks.byName("test::sub:: subdeck"));
         assertNull(decks.byName("  test :: sub :: subdeck"));
         assertNull(decks.byName("  test :: sub "));
     }
+
+    @Test
+    public void testEnsureParentsNotFiltered() {
+        Collection col = getCol();
+        Decks decks = col.getDecks();
+        addDeck("test");
+        String subsubdeck_name = decks._ensureParentsNotFiltered("  tESt :: sub :: subdeck");
+        assertEquals("test::sub:: subdeck", subsubdeck_name);// Only parents are renamed, not the last deck.
+        assertNotNull(decks.byName("test::sub"));
+        assertNull(decks.byName("test::sub:: subdeck"));
+        assertNull(decks.byName("  test :: sub :: subdeck"));
+        assertNull(decks.byName("  test :: sub "));
+
+        decks.newDyn("filtered");
+        String filtered_subdeck_name = decks._ensureParentsNotFiltered("filtered:: sub :: subdeck");
+        assertEquals("filtered'::sub:: subdeck", filtered_subdeck_name);// Only parents are renamed, not the last deck.
+        assertNotNull(decks.byName("filtered'::sub"));
+        assertNotNull(decks.byName("filtered'"));
+        assertNull(decks.byName("filtered::sub:: subdeck"));
+        assertNull(decks.byName("filtered::sub"));
+    }
+
 }

--- a/AnkiDroid/src/test/java/com/ichi2/testutils/libanki/FilteredDeckUtil.java
+++ b/AnkiDroid/src/test/java/com/ichi2/testutils/libanki/FilteredDeckUtil.java
@@ -16,12 +16,18 @@
 
 package com.ichi2.testutils.libanki;
 
+import com.ichi2.anki.exception.FilteredAncestor;
 import com.ichi2.libanki.Collection;
 import com.ichi2.libanki.DeckConfig;
 
 public class FilteredDeckUtil {
     public static long createFilteredDeck(Collection col, String name, String search) {
-        long filteredDid = col.getDecks().newDyn(name);
+        long filteredDid = 0;
+        try {
+            filteredDid = col.getDecks().newDyn(name);
+        } catch (FilteredAncestor filteredAncestor) {
+            throw new RuntimeException(filteredAncestor);
+        }
 
         DeckConfig conf = col.getDecks().confForDid(filteredDid);
 


### PR DESCRIPTION
This fixes #8095. However, I strongly consider merging #8101 to #8106 first, since they are all contained here.

Essentially, there are two versions of id and _ensureParents, one which always succeed, up to renaming ancestors; it's useful for imports and checking deck collection, since failing is not allowed, and one version which throws an exception. This exception is then dealt with on UI or in content provider. There are tests ensuring it works as expected.

I also splitted some function, so that the part which does not have to throw exception do not have to be duplicated.