### PR TITLE
Read JSON file from collection.media using JS API

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -54,7 +54,6 @@ import androidx.webkit.internal.AssetHelper;
 import androidx.webkit.WebViewAssetLoader;
 
 import android.text.TextUtils;
-import android.util.Log;
 import android.util.Pair;
 import android.util.TypedValue;
 import android.view.GestureDetector;
@@ -4053,7 +4052,6 @@ see card.js for available functions
         public String ankiReadJson(String jsonFileName) {
 
             String currentAnkiDroidDirectory = CollectionHelper.getCurrentAnkiDroidDirectory(getBaseContext());
-            Log.i("path::", currentAnkiDroidDirectory);
 
             File collectionMedia = new File(currentAnkiDroidDirectory, "collection.media");
             File readFile = new File(collectionMedia, jsonFileName);

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -138,7 +138,6 @@ import com.ichi2.utils.WebViewDebugging;
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.FileInputStream;
-import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
@@ -218,7 +217,6 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
     private static final int ankiJsErrorCodeDefault = 0;
     private static final int ankiJsErrorCodeMarkCard = 1;
     private static final int ankiJsErrorCodeFlagCard = 2;
-    private Context mContext;
 
     /**
      * Broadcast that informs us when the sd card is about to be unmounted
@@ -892,8 +890,6 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
         initNavigationDrawer(mainView);
 
         mShortAnimDuration = getResources().getInteger(android.R.integer.config_shortAnimTime);
-
-        mContext = this;
     }
 
     protected int getContentViewAttr(int fullscreenMode) {


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
In Anki the json file can be loaded using ```/some.json``` because Anki uses localhost for reviewing, so file can be accessed using
```
$.getJSON("data.json", function(json) {
    console.log(json); 
});
```
But in case of AnkiDroid the reviewer html are shown using ```file:///```, so loading json leads to following error.
```
Access to XMLHttpRequest at 'file:///storage/emulated/0/AnkiDroid/collection.media/data.json' from origin 'null' has been 
blocked by CORS policy: Cross origin requests are only supported for protocol schemes: http, data, chrome, chrome-untrusted, 
https.
```

So, in this PR, JS API used to read file and pass to webview using ```JavascriptInterface``` 

## Fixes
Fixes #7943

## Approach
1. Check for file exists in ```collection.media``` folder
2. if exists then read json as text file and pass contents in json as string to reviewer webview
(Here parsing of json not done because not required. The content of json is used by deck templates and it is up to JavaScript how data can be used. JavaScript ```JSON.stringify``` and ```JSON.parse``` can be used parse json data from strings.)

## How Has This Been Tested?
1. Paste ```json``` files inside ```collection.media``` folder in AnkiDroid
2. Read that json file using
```
AnkiDroidJS.ankiReadJson( jsonFileName );
```

E.g.
Reading ```的.json``` inside collection.media
```
var jsonData = AnkiDroidJS.ankiReadJson("的.json");
console.log(jsonData);
```
![demo 61](https://user-images.githubusercontent.com/12841290/107988237-85b2bf00-700a-11eb-93d2-f92d2c984079.png)

## Learning (optional, can help others)
https://developer.android.com/reference/android/webkit/JavascriptInterface

## Checklist
_Please, go through these checks before submitting the PR._

- [ x ] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [ x ] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ x ] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [ x ] You have commented your code, particularly in hard-to-understand areas
- [ x ] You have performed a self-review of your own code
- [ x ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)