### PR TITLE
Ensure that latex's alt text work with appendReplacement

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/LaTeX.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/LaTeX.java
@@ -60,9 +60,14 @@ public class LaTeX {
      * NOTE: _imgLink produces an alphanumeric filename so there is no need to escape the replacement string.
      */
     public static String mungeQA(String html, Collection col, Model model) {
+        return mungeQA(html, col.getMedia(), model);
+    }
+
+    // It's only goal is to allow testing with a different media manager.
+    @VisibleForTesting
+    public static String mungeQA(String html, Media m, Model model) {
         StringBuffer sb = new StringBuffer();
         Matcher matcher = sStandardPattern.matcher(html);
-        Media m = col.getMedia();
         while (matcher.find()) {
             matcher.appendReplacement(sb, _imgLink(matcher.group(1), model, m));
         }
@@ -101,7 +106,7 @@ public class LaTeX {
 
         String fname = "latex-" + Utils.checksum(txt) + "." + ext;
         if (m.have(fname)) {
-            return "<img class=latex alt=\"" + HtmlUtils.escape(latex) + "\" src=\"" + fname + "\">";
+            return Matcher.quoteReplacement("<img class=latex alt=\"" + HtmlUtils.escape(latex) + "\" src=\"" + fname + "\">");
         } else {
             return Matcher.quoteReplacement(latex);
         }

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/LaTeXTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/LaTeXTest.java
@@ -3,6 +3,7 @@ package com.ichi2.libanki;
 import com.ichi2.anki.RobolectricTest;
 
 import org.hamcrest.CoreMatchers;
+import org.hamcrest.Matchers;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -36,7 +37,28 @@ public class LaTeXTest extends RobolectricTest {
         Collection col = getCol();
         Media m = new MockMedia(col);
         Model model = col.getModels().byName("Basic");
+        // The hashing function should never change, as it would broke link. So hard coding the expected hash value is valid
+        // Test with media access
         assertThat(LaTeX._imgLink("$\\sqrt[3]{2} + \\text{\"var\"}$", model, m),
-                CoreMatchers.containsString("<img class=latex alt=\"$\\sqrt[3]{2} + \\text{&quot;var&quot;}$\" src="));
+                Matchers.is("<img class=latex alt=\"\\$\\\\sqrt[3]{2} + \\\\text{&quot;var&quot;}\\$\" src=\"latex-dd84e5d506179a137f7924d0960609a8c89d491e.png\">"));
+
+        // Test without access to media
+        assertThat(LaTeX._imgLink("$\\sqrt[3]{2} + \\text{\"var\"}$", model, col.getMedia()),
+                Matchers.is("\\$\\\\sqrt[3]{2} + \\\\text{\"var\"}\\$"));
+    }
+
+    @Test
+    public void  mungeQATest() {
+        Collection col = getCol();
+        Media m = new MockMedia(col);
+        Model model = col.getModels().byName("Basic");
+
+        // Test with media access
+        assertThat(LaTeX.mungeQA("[$]\\sqrt[3]{2} + \\text{\"var\"}[/$]", m, model),
+                Matchers.is("<img class=latex alt=\"$\\sqrt[3]{2} + \\text{&quot;var&quot;}$\" src=\"latex-dd84e5d506179a137f7924d0960609a8c89d491e.png\">"));
+
+        // Test without access to media
+        assertThat(LaTeX.mungeQA("[$]\\sqrt[3]{2} + \\text{\"var\"}[/$]", col, model),
+                Matchers.is("$\\sqrt[3]{2} + \\text{\"var\"}$"));
     }
 }


### PR DESCRIPTION
This corrects #8121.

The problem was introduced when I added alt text to LaTeX's image. I didn't properly escape the alt text. I escaped it for html but not for the method appendReplacement. This methods considers that $i corresponds to the ith group matched by the regexp, which breaks everything as soon as a LaTeX element starts with a number or an opening curly braces.

I put priority high, because it's a bug introduced since last stable, and I'd consider it to be blocking.

regression tests added with it