### PR TITLE
port parent limit change from desktop

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
@@ -1546,17 +1546,7 @@ public class SchedV2 extends AbstractSched {
             lim--;
         }
 
-        if (parentLimit != null) {
-            return Math.min(parentLimit, lim);
-        } else if (!d.getString("name").contains("::")) {
-            return lim;
-        } else {
-            for (@NonNull Deck parent : mCol.getDecks().parents(did)) {
-                // pass in dummy parentLimit so we don't do parent lookup again
-                lim = Math.min(lim, _deckRevLimitSingle(parent, lim, considerCurrentCard));
-            }
-            return lim;
-        }
+        return lim;
     }
 
 

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/sched/SchedV2Test.java
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/sched/SchedV2Test.java
@@ -782,21 +782,21 @@ public class SchedV2Test extends RobolectricTest {
         // (('parent', 1514457677462, 5, 0, 0, (('child', 1514457677463, 5, 0, 0, ()),)))
         assertEquals("parent", tree.getFullDeckName());
         assertEquals(5, tree.getRevCount());  // paren, tree.review_count)t
-        assertEquals(5, tree.getChildren().get(0).getRevCount());
+        assertEquals(10, tree.getChildren().get(0).getRevCount());
 
         // .counts() should match
         col.getDecks().select(child.getLong("id"));
         col.reset();
-        assertEquals(new Counts(0, 0, 5), col.getSched().counts());
+        assertEquals(new Counts(0, 0, 10), col.getSched().counts());
 
         // answering a card in the child should decrement parent count
         Card c = getCard();
         col.getSched().answerCard(c, 3);
-        assertEquals(new Counts(0, 0, 4), col.getSched().counts());
+        assertEquals(new Counts(0, 0, 9), col.getSched().counts());
 
         tree = col.getSched().deckDueTree().get(1);
         assertEquals(4, tree.getRevCount());
-        assertEquals(4, tree.getChildren().get(0).getRevCount());
+        assertEquals(9, tree.getChildren().get(0).getRevCount());
     }
 
 


### PR DESCRIPTION
Hi guys,

The upcoming desktop version tweaks the v2 scheduler to not cap the selected deck by its parents. This should not cause any problems when syncing between older/new clients, but if users have a parent limit set to a smaller value than a child, their deck list and counts during review may differ between clients, which could be confusing.

Ports https://github.com/ankitects/anki/commit/5f9792392a953271eee21004e3a49b591999b9a7
