### PR TITLE
De-flake some unit tests

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
@@ -3108,7 +3108,7 @@ public class SchedV2 extends AbstractSched {
     protected void _sortIntoLrn(long due, long id) {
         if (!mLrnQueue.isFilled()) {
             // We don't want to add an element to the queue if it's not yet assumed to have its normal content.
-            // Adding anything is useless while the queue awaits beeing filled
+            // Adding anything is useless while the queue awaits being filled
             return;
         }
         ListIterator<LrnCard> i = mLrnQueue.listIterator();

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/sched/SchedV2Test.java
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/sched/SchedV2Test.java
@@ -1238,13 +1238,17 @@ public class SchedV2Test extends RobolectricTest {
         // ordinals should arrive in order
         AbstractSched sched = col.getSched();
         Card c = sched.getCard();
+        advanceRobolectricLooperWithSleep();
         sched.answerCard(c, sched.answerButtons(c) - 1); // not upstream. But we are not expecting multiple getCard without review
         assertEquals(0, c.getOrd());
         c = sched.getCard();
+        advanceRobolectricLooperWithSleep();
         sched.answerCard(c, sched.answerButtons(c) - 1); // not upstream. But we are not expecting multiple getCard without review
         assertEquals(1, c.getOrd());
         c = sched.getCard();
+        advanceRobolectricLooperWithSleep();
         sched.answerCard(c, sched.answerButtons(c) - 1); // not upstream. But we are not expecting multiple getCard without review
+        advanceRobolectricLooperWithSleep();
         assertEquals(2, c.getOrd());
     }
 

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/sched/SchedV2Test.java
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/sched/SchedV2Test.java
@@ -1740,6 +1740,7 @@ public class SchedV2Test extends RobolectricTest {
         deck.put("resched", false);
         sched.rebuildDyn(did);
         col.reset();
+        advanceRobolectricLooper();
         Card card;
         for(int i = 0; i < 3; i++) {
             card = sched.getCard();


### PR DESCRIPTION
## Pull Request template

## Purpose / Description

These unit tests were failing semi-reproducibly locally for me:

SchedV2Test::test_ordcycleV2
SchedV2Test::regression_test_preview

## Fixes

One of them was noted here https://github.com/ankidroid/Anki-Android/pull/8086#issuecomment-775191775

Neither was formally logged

## Approach

Call the robolectric looper to advance

## How Has This Been Tested?

Just like soylent green, it's made of tests

## Learning (optional, can help others)

I learned that gradle really does not want to re-run tests over and over without any changes - you have to force it, so my reproduction run was like:

`./gradlew clean jacocoUnitTestReport --rerun-tasks`

## Checklist


- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)