### PR TITLE
Forward-port to new style of getting ABI splits for release APK versioning

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -1,6 +1,3 @@
-import com.android.ddmlib.DdmPreferences
-import com.android.build.OutputFile
-
 plugins {
  // Gradle plugin portal 
  id 'com.github.triplet.play' version '3.0.0'
@@ -117,23 +114,27 @@ android {
     }
     // applicationVariants are e.g. debug, release
     applicationVariants.all { variant ->
-        // purge debug sounds from react-native-background-geolocation-android
+
+        // We want the same version stream for all ABIs in debug but for release we can split them
         if (variant.buildType.name == 'release') {
-            // We want the same version stream for all ABIs in debug but for release we can split them
             variant.outputs.each { output ->
+
                 // For each separate APK per architecture, set a unique version code as described here:
                 // https://developer.android.com/studio/build/configure-apk-splits.html
                 def versionCodes = ["armeabi-v7a": 1, "x86": 2, "arm64-v8a": 3, "x86_64": 4]
-                def abi = output.getFilter(OutputFile.ABI)
-                if (abi != null) {  // null for the universal-debug, universal-release variants
-                    //  From: https://developer.android.com/studio/publish/versioning#appversioning
-                    //  "Warning: The greatest value Google Play allows for versionCode is 2100000000"
-                    //  AnkiDroid versionCodes have a budget 8 digits (through AnkiDroid 9)
-                    //  This style does ABI version code ranges with the 9th digit as 0-4.
-                    //  This consumes ~20% of the version range space, w/50 years of versioning at our major-version pace
-                    output.versionCodeOverride =
-                            // ex:  321200106 = 3 * 100000000 + 21200106
-                            versionCodes.get(abi) * 100000000 + defaultConfig.versionCode
+                def outputFile = output.outputFile
+                if (outputFile != null && outputFile.name.endsWith('.apk')) {
+                    def abi = output.getFilter("ABI")
+                    if (abi != null) {  // null for the universal-debug, universal-release variants
+                        //  From: https://developer.android.com/studio/publish/versioning#appversioning
+                        //  "Warning: The greatest value Google Play allows for versionCode is 2100000000"
+                        //  AnkiDroid versionCodes have a budget 8 digits (through AnkiDroid 9)
+                        //  This style does ABI version code ranges with the 9th digit as 0-4.
+                        //  This consumes ~20% of the version range space, w/50 years of versioning at our major-version pace
+                        output.versionCodeOverride =
+                                // ex:  321200106 = 3 * 100000000 + 21200106
+                                versionCodes.get(abi) * 100000000 + defaultConfig.versionCode
+                    }
                 }
             }
         }


### PR DESCRIPTION

## Pull Request template

## Purpose / Description

Gradle deprecated old way of getting ABI split info, use the new way

## Fixes

No issue logged

## Approach

I carefully inspected (by executing the build script) the object tree available to me on the variant outputs, and what properties they had, along with the source code

https://android.googlesource.com/platform/tools/base/+/master/build-system/gradle-core/src/main/groovy/com/android/build/gradle/api/ApkOutputFile.java#146

And settled on this style to get the ABI in use, and then index into the version shift array for version code override

## How Has This Been Tested?

I was able to successfully generate expected different version codes for each of the APK files resulting from the ABI splits, verifiable via apkanalyzer manifest version-code <apk file> (assuming you have apkanalyzer tool installed)


## Learning (optional, can help others)

Google updates documentation slowly some times? The official document still directs people to use the symbols they deprecated.

## Checklist

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)