### PR TITLE
Add layout hints to reviewer buttons in reviewer layout

### DIFF
--- a/AnkiDroid/src/main/res/layout/reviewer.xml
+++ b/AnkiDroid/src/main/res/layout/reviewer.xml
@@ -44,7 +44,11 @@
                 android:layout_centerHorizontal="true"
                 android:layout_above="@+id/bottom_area_layout"/>
 
-            <include layout="@layout/reviewer_answer_buttons" />
+            <include layout="@layout/reviewer_answer_buttons"
+                android:layout_alignParentBottom="true"
+                android:translationZ="1dp"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"/>
         </RelativeLayout>
     </androidx.coordinatorlayout.widget.CoordinatorLayout>
     <!-- Left navigation drawer -->


### PR DESCRIPTION

## Pull Request template

## Purpose / Description

The layout buttons are flickering and disappearing in Android 8/8.1

They don't contain any layout hints, so I added a bunch in the hope it will fix the issue

## Fixes
Fixes #7369

## Approach

- I added some basic hints to align bottom and set a width / height
- I added one advanced hint to set Z axis 1dp higher than other elements


## How Has This Been Tested?

I was not able to reproduce the original problem, but, I don't see any regressions with these changes either.
I tested in API19 (to make sure the API21+ translationZ attribute did not cause a problem)
I tested in API26/27 (Android 8/8.1) and did not see the problem but did see correct behavior in normal reviewing, in full screen reviewing with buttons hidden (they were hidden), and in full screen when you drag down from top (the buttons came back)

## Learning (optional, can help others)

I got nothing, this is sort of a shot in the dark. Hopefully it works.

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)