### PR TITLE
Issue7369/reviewer buttons clean

### DIFF
--- a/AnkiDroid/src/main/res/layout-v26/navigation_drawer.xml
+++ b/AnkiDroid/src/main/res/layout-v26/navigation_drawer.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.google.android.material.navigation.NavigationView
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/navdrawer_items_container"
+    style="@style/NavDrawer"
+    android:layout_width="wrap_content"
+    android:layerType="software"
+    android:layout_height="match_parent"
+    android:layout_gravity="start"
+    app:headerLayout="@layout/navdrawer_header"
+    app:itemIconTint="?attr/navDrawerItemColor"
+    app:itemTextColor="?attr/navDrawerItemColor"
+    app:itemBackground="?attr/navDrawerItemBackgroundColor"
+    app:menu="@menu/navigation_drawer" />

--- a/AnkiDroid/src/main/res/layout-v26/reviewer.xml
+++ b/AnkiDroid/src/main/res/layout-v26/reviewer.xml
@@ -1,0 +1,59 @@
+<androidx.drawerlayout.widget.ClosableDrawerLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/drawer_layout"
+    android:layout_width="fill_parent"
+    android:layout_height="fill_parent"
+    android:layerType="software"
+    android:fitsSystemWindows="true">
+    <!-- First child of DrawerLayout assumed to be main content, others are drawers.
+     We use a Coordinator layout as root View for main content as it allows snackbars
+     to be swiped off screen. Other behaviors can also be added in the future if necessary -->
+    <androidx.coordinatorlayout.widget.CoordinatorLayout
+        android:id="@+id/root_layout"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layerType="software"
+        android:focusableInTouchMode="true" >
+        <!-- Bring in each component from separate files as we have fullscreen versions of reviewer -->
+        <RelativeLayout
+            android:id="@+id/front_frame"
+            android:layerType="software"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent">
+            <include layout="@layout/toolbar"/>
+
+            <include
+                layout="@layout/reviewer_topbar"
+                android:layout_width="match_parent"
+                android:layerType="software"
+                android:layout_height="wrap_content"
+                android:layout_below="@id/toolbar" />
+
+            <include
+                layout="@layout/reviewer_mic_tool_bar"
+                android:layerType="software"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_below="@id/top_bar" />
+
+            <include
+                layout="@layout/reviewer_flashcard"
+                android:layout_width="match_parent"
+                android:layerType="software"
+                android:layout_height="match_parent"
+                android:layout_below="@id/mic_tool_bar_layer" />
+
+            <include
+                layout="@layout/reviewer_whiteboard_pen_color"
+                android:layout_width="wrap_content"
+                android:layerType="software"
+                android:layout_height="wrap_content"
+                android:layout_centerHorizontal="true"
+                android:layout_above="@+id/bottom_area_layout"/>
+
+            <include layout="@layout/reviewer_answer_buttons" />
+        </RelativeLayout>
+    </androidx.coordinatorlayout.widget.CoordinatorLayout>
+    <!-- Left navigation drawer -->
+    <include layout="@layout/navigation_drawer" />
+</androidx.drawerlayout.widget.ClosableDrawerLayout>

--- a/AnkiDroid/src/main/res/layout-v26/reviewer_answer_buttons.xml
+++ b/AnkiDroid/src/main/res/layout-v26/reviewer_answer_buttons.xml
@@ -1,0 +1,206 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout android:id="@+id/bottom_area_layout"
+    android:layout_width="fill_parent"
+    android:layout_height="wrap_content"
+    android:layerType="software"
+    android:orientation="vertical"
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <!-- "Type in the answer" bar -->
+    <com.ichi2.ui.FixedEditText
+        android:id="@+id/answer_field"
+        android:layerType="software"
+        android:layout_width="fill_parent"
+        android:layout_height="wrap_content"
+        android:hint="@string/type_answer_hint"
+        android:imeOptions="actionDone"
+        android:inputType="text|textNoSuggestions" />
+    <!--
+         Looks like setting android:imeActionLabel confuses the
+         original AOSP soft keyboard, so don't.
+    -->
+
+    <FrameLayout
+        android:id="@+id/preview_buttons_layout"
+        android:layerType="software"
+        android:layout_width="match_parent"
+        android:layout_height="48dp"
+        android:orientation="horizontal"
+        android:background="?attr/hardButtonRef"
+        android:visibility="gone"
+        tools:visibility="visible">
+
+        <com.ichi2.ui.FixedTextView
+            android:id="@+id/preview_flip_flashcard"
+            android:layout_width="wrap_content"
+            android:layerType="software"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            android:textColor="?attr/answerButtonTextColor"
+            android:text="@string/show_answer"
+            style="@style/FooterButton" />
+
+        <ImageView
+            android:id="@+id/preview_previous_flashcard"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="start|center_vertical"
+            android:padding="12dp"
+            android:focusable="true"
+            android:background="?attr/hardButtonRef"
+            android:layerType="software"
+            app:srcCompat="@drawable/ic_baseline_chevron_left_24"
+            app:tint="?attr/hardButtonTextColor" />
+
+        <ImageView
+            android:id="@+id/preview_next_flashcard"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="end|center_vertical"
+            android:padding="12dp"
+            android:layerType="software"
+            android:focusable="true"
+            android:background="?attr/hardButtonRef"
+            app:srcCompat="@drawable/ic_baseline_chevron_right_24"
+            app:tint="?attr/hardButtonTextColor" />
+    </FrameLayout>
+
+    <FrameLayout
+        android:id="@+id/answer_options_layout"
+        android:layout_width="fill_parent"
+        android:layerType="software"
+        android:layout_height="fill_parent">
+
+        <LinearLayout
+            android:id="@+id/ease_buttons"
+            android:layout_width="fill_parent"
+            android:layout_height="fill_parent"
+            android:layerType="software"
+            android:visibility="gone"
+            android:focusable="false"
+            android:orientation="horizontal">
+
+            <LinearLayout
+                style="@style/FooterButton"
+                android:background="?attr/againButtonRef"
+                android:id="@+id/flashcard_layout_ease1"
+                android:nextFocusRight="@id/flashcard_layout_ease2"
+                android:layerType="software"
+                android:layout_width="0dip"
+                android:layout_height="@dimen/touch_target"
+                android:layout_weight="1"
+                android:orientation="vertical">
+
+                <com.ichi2.ui.FixedTextView
+                    android:id="@+id/nextTime1"
+                    android:layerType="software"
+                    style="@style/AgainButtonTimeStyle"
+                    tools:text="&lt; 10 min" />
+
+                <com.ichi2.ui.FixedTextView
+                    android:id="@+id/ease1"
+                    android:layerType="software"
+                    android:text="@string/ease_button_again"
+                    style="@style/AgainButtonEaseStyle"/>
+            </LinearLayout>
+
+            <LinearLayout
+                style="@style/FooterButton"
+                android:background="?attr/hardButtonRef"
+                android:layerType="software"
+                android:id="@+id/flashcard_layout_ease2"
+                android:nextFocusRight="@id/flashcard_layout_ease3"
+                android:nextFocusLeft="@id/flashcard_layout_ease1"
+                android:layout_width="0dip"
+                android:layout_height="@dimen/touch_target"
+                android:layout_weight="1"
+                android:orientation="vertical">
+
+                <com.ichi2.ui.FixedTextView
+                    android:id="@+id/nextTime2"
+                    style="@style/HardButtonTimeStyle"
+                    android:layerType="software"
+                    tools:text="2 d" />
+
+                <com.ichi2.ui.FixedTextView
+                    android:id="@+id/ease2"
+                    android:layerType="software"
+                    android:text="@string/ease_button_hard"
+                    style="@style/HardButtonEaseStyle" />
+            </LinearLayout>
+
+            <LinearLayout
+                style="@style/FooterButton"
+                android:background="?attr/goodButtonRef"
+                android:layerType="software"
+                android:id="@+id/flashcard_layout_ease3"
+                android:nextFocusRight="@id/flashcard_layout_ease4"
+                android:nextFocusLeft="@id/flashcard_layout_ease2"
+                android:layout_width="0dip"
+                android:layout_height="@dimen/touch_target"
+                android:layout_weight="1"
+                android:orientation="vertical">
+
+                <com.ichi2.ui.FixedTextView
+                    android:id="@+id/nextTime3"
+                    android:layerType="software"
+                    style="@style/GoodButtonTimeStyle"
+                    tools:text="3 d" />
+
+                <com.ichi2.ui.FixedTextView
+                    android:id="@+id/ease3"
+                    android:layerType="software"
+                    android:text="@string/ease_button_good"
+                    style="@style/GoodButtonEaseStyle"/>
+            </LinearLayout>
+
+            <LinearLayout
+                style="@style/FooterButton"
+                android:background="?attr/easyButtonRef"
+                android:layerType="software"
+                android:id="@+id/flashcard_layout_ease4"
+                android:nextFocusLeft="@id/flashcard_layout_ease3"
+                android:layout_width="0dip"
+                android:layout_height="@dimen/touch_target"
+                android:layout_weight="1"
+                android:orientation="vertical">
+
+                <com.ichi2.ui.FixedTextView
+                    android:id="@+id/nextTime4"
+                    android:layerType="software"
+                    style="@style/EasyButtonTimeStyle"
+                    tools:text="4 d" />
+
+                <com.ichi2.ui.FixedTextView
+                    android:id="@+id/ease4"
+                    android:layerType="software"
+                    android:text="@string/ease_button_easy"
+                    style="@style/EasyButtonEaseStyle" />
+            </LinearLayout>
+        </LinearLayout>
+
+        <LinearLayout
+            android:id="@+id/flashcard_layout_flip"
+            android:layerType="software"
+            android:layout_width="fill_parent"
+            android:layout_height="@dimen/touch_target"
+            android:orientation="vertical"
+            android:focusable="true"
+            tools:visibility="gone">
+
+            <Button
+                style="@style/FooterButton"
+                android:duplicateParentState="true"
+                android:background="?attr/hardButtonRef"
+                android:id="@+id/flip_card"
+                android:layerType="software"
+                android:layout_width="fill_parent"
+                android:layout_height="fill_parent"
+                android:clickable="false"
+                android:text="@string/show_answer"
+                android:textColor="?attr/answerButtonTextColor" />
+        </LinearLayout>
+    </FrameLayout>
+</LinearLayout>

--- a/AnkiDroid/src/main/res/layout-v26/reviewer_flashcard.xml
+++ b/AnkiDroid/src/main/res/layout-v26/reviewer_flashcard.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+~ Copyright (c) 2009 Andrew <andrewdubya@gmail>
+~ Copyright (c) 2009 Nicolas Raoul <nicolas.raoul@gmail.com>
+~ Copyright (c) 2009 Edu Zamora <edu.zasu@gmail.com>
+~ Copyright (c) 2009 Jordi Chacon <jordi.chacon@gmail.com>
+~ Copyright (c) 2010 Norbert Nagold <norbert.nagold@gmail.com>
+~ Copyright (c) 2014 Roland Sieker <ospalh@gmail.com>
+~ Copyright (c) 2016 Timothy Rae <perceptualchaos2@gmail.com>
+~
+~ This program is free software; you can redistribute it and/or modify it under
+~ the terms of the GNU General Public License as published by the Free Software
+~ Foundation; either version 3 of the License, or (at your option) any later
+~ version.
+~
+~ This program is distributed in the hope that it will be useful, but WITHOUT ANY
+~ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+~ PARTICULAR PURPOSE. See the GNU General Public License for more details.
+~
+~ You should have received a copy of the GNU General Public License along with
+~ this program.  If not, see <http://www.gnu.org/licenses/>.
+-->
+
+<FrameLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_gravity="center"
+    android:layerType="software"
+    android:id="@+id/flashcard_frame"
+    android:layout_width="fill_parent"
+    android:layout_height="fill_parent"
+    android:layout_margin="0dip">
+
+    <FrameLayout
+        android:layout_gravity="center"
+        android:layerType="software"
+        android:id="@+id/flashcard"
+        android:layout_width="fill_parent"
+        android:layout_height="fill_parent" />
+    <FrameLayout
+        android:layout_gravity="center"
+        android:id="@+id/touch_layer"
+        android:layerType="software"
+        android:layout_width="fill_parent"
+        android:layout_height="fill_parent"
+        android:layout_margin="0dip"
+        android:longClickable="true" />
+    <FrameLayout
+        android:layout_gravity="center"
+        android:id="@+id/whiteboard"
+        android:layerType="software"
+        android:layout_margin="0dip"
+        android:layout_width="fill_parent"
+        android:layout_height="fill_parent" />
+    <ImageView
+        android:id="@+id/lookup_button"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layerType="software"
+        android:layout_gravity="right"
+        android:clickable="true"
+        android:padding="5dip"
+        android:src="@drawable/ic_lookup"
+        android:visibility="gone"
+        android:contentDescription="@string/lookup_button_content" />
+</FrameLayout>

--- a/AnkiDroid/src/main/res/layout-v26/reviewer_mic_tool_bar.xml
+++ b/AnkiDroid/src/main/res/layout-v26/reviewer_mic_tool_bar.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/mic_tool_bar_layer"
+    android:layout_width="match_parent"
+    android:layerType="software"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"/>

--- a/AnkiDroid/src/main/res/layout-v26/reviewer_topbar.xml
+++ b/AnkiDroid/src/main/res/layout-v26/reviewer_topbar.xml
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/top_bar"
+        android:layout_width="fill_parent"
+        android:layout_height="wrap_content"
+        android:paddingLeft="9dp"
+        android:paddingRight="10dp"
+        android:layerType="software"
+        android:paddingTop="2dp"
+        android:paddingBottom="3dp"
+        android:gravity="center_vertical"
+        android:background="?attr/topBarColor">
+        <com.ichi2.ui.FixedTextView
+            android:id="@+id/new_number"
+            android:layerType="software"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text=""
+            android:textColor="?attr/newCountColor"
+            android:textSize="14sp" />
+        <com.ichi2.ui.FixedTextView
+            android:id="@+id/learn_number"
+            android:layerType="software"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_toRightOf="@+id/new_number"
+            android:paddingLeft="8dp"
+            android:text=""
+            android:textColor="?attr/learnCountColor"
+            android:textSize="14sp" />
+
+        <com.ichi2.ui.FixedTextView
+            android:id="@+id/review_number"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layerType="software"
+            android:layout_toRightOf="@+id/learn_number"
+            android:paddingLeft="8dp"
+            android:text=""
+            android:textColor="?attr/reviewCountColor"
+            android:textSize="14sp" />
+
+        <com.ichi2.ui.FixedTextView
+            android:id="@+id/choosen_answer"
+            android:layerType="software"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textAlignment="center"
+            android:layout_centerHorizontal="true"
+            android:minEms="4"
+            android:gravity="center"
+            android:text=""
+            android:textSize="14sp" />
+
+
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layerType="software"
+        android:layout_toLeftOf="@+id/card_time"
+        android:layout_alignTop="@+id/card_time"
+        android:layout_alignBottom="@+id/card_time"
+        android:layout_toRightOf="@+id/choosen_answer"
+        android:gravity="center" >
+
+        <ImageView
+            android:id="@+id/flag_icon"
+            android:layout_width="wrap_content"
+            android:layerType="software"
+            android:layout_height="wrap_content"
+            android:visibility="invisible"
+            android:layout_gravity="center"
+            />
+        <ImageView
+            android:id="@+id/mark_icon"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layerType="software"
+            android:visibility="invisible"
+            android:layout_gravity="center"
+            />
+        </LinearLayout>
+        <Chronometer
+            android:id="@+id/card_time"
+            android:layerType="software"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_alignParentRight="true"
+            android:gravity="end"
+            android:textSize="14sp"
+            android:visibility="invisible" />
+</RelativeLayout>

--- a/AnkiDroid/src/main/res/layout-v26/toolbar.xml
+++ b/AnkiDroid/src/main/res/layout-v26/toolbar.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<merge xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <androidx.appcompat.widget.Toolbar
+        android:id="@+id/toolbar"
+        android:layout_width="fill_parent"
+        android:layout_height="wrap_content"
+        android:layerType="software"
+        android:layout_alignParentTop="true"
+        android:background="?attr/colorPrimary"
+        android:minHeight="?attr/actionBarSize"
+        android:theme="@style/ActionBarStyle"
+        app:navigationContentDescription="@string/abc_action_bar_up_description"
+        app:navigationIcon="?attr/homeAsUpIndicator">
+
+        <com.ichi2.ui.FixedTextView
+            android:id="@+id/toolbar_title"
+            android:layerType="software"
+            android:layout_width="wrap_content"
+            android:layout_height="match_parent"
+            android:textColor="@color/white"
+            android:textSize="20sp"
+            android:visibility="gone" />
+
+        <Spinner
+            android:id="@+id/toolbar_spinner"
+            android:layout_width="match_parent"
+            android:layerType="software"
+            android:layout_height="wrap_content"
+            android:background="?attr/selectableItemBackground"
+            android:visibility="gone"
+            app:popupTheme="@style/ActionBar.Popup" />
+    </androidx.appcompat.widget.Toolbar>
+</merge>

--- a/AnkiDroid/src/main/res/layout-v28/navigation_drawer.xml
+++ b/AnkiDroid/src/main/res/layout-v28/navigation_drawer.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.google.android.material.navigation.NavigationView
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/navdrawer_items_container"
+    style="@style/NavDrawer"
+    android:layout_width="wrap_content"
+    android:layout_height="match_parent"
+    android:layout_gravity="start"
+    app:headerLayout="@layout/navdrawer_header"
+    app:itemIconTint="?attr/navDrawerItemColor"
+    app:itemTextColor="?attr/navDrawerItemColor"
+    app:itemBackground="?attr/navDrawerItemBackgroundColor"
+    app:menu="@menu/navigation_drawer" />

--- a/AnkiDroid/src/main/res/layout-v28/reviewer.xml
+++ b/AnkiDroid/src/main/res/layout-v28/reviewer.xml
@@ -1,0 +1,52 @@
+<androidx.drawerlayout.widget.ClosableDrawerLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/drawer_layout"
+    android:layout_width="fill_parent"
+    android:layout_height="fill_parent"
+    android:fitsSystemWindows="true">
+    <!-- First child of DrawerLayout assumed to be main content, others are drawers.
+     We use a Coordinator layout as root View for main content as it allows snackbars
+     to be swiped off screen. Other behaviors can also be added in the future if necessary -->
+    <androidx.coordinatorlayout.widget.CoordinatorLayout
+        android:id="@+id/root_layout"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:focusableInTouchMode="true" >
+        <!-- Bring in each component from separate files as we have fullscreen versions of reviewer -->
+        <RelativeLayout
+            android:id="@+id/front_frame"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent">
+            <include layout="@layout/toolbar"/>
+
+            <include
+                layout="@layout/reviewer_topbar"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_below="@id/toolbar" />
+
+            <include
+                layout="@layout/reviewer_mic_tool_bar"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_below="@id/top_bar" />
+
+            <include
+                layout="@layout/reviewer_flashcard"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:layout_below="@id/mic_tool_bar_layer" />
+
+            <include
+                layout="@layout/reviewer_whiteboard_pen_color"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_centerHorizontal="true"
+                android:layout_above="@+id/bottom_area_layout"/>
+
+            <include layout="@layout/reviewer_answer_buttons" />
+        </RelativeLayout>
+    </androidx.coordinatorlayout.widget.CoordinatorLayout>
+    <!-- Left navigation drawer -->
+    <include layout="@layout/navigation_drawer" />
+</androidx.drawerlayout.widget.ClosableDrawerLayout>

--- a/AnkiDroid/src/main/res/layout-v28/reviewer_answer_buttons.xml
+++ b/AnkiDroid/src/main/res/layout-v28/reviewer_answer_buttons.xml
@@ -1,0 +1,184 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout android:id="@+id/bottom_area_layout"
+    android:layout_width="fill_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <!-- "Type in the answer" bar -->
+    <com.ichi2.ui.FixedEditText
+        android:id="@+id/answer_field"
+        android:layout_width="fill_parent"
+        android:layout_height="wrap_content"
+        android:hint="@string/type_answer_hint"
+        android:imeOptions="actionDone"
+        android:inputType="text|textNoSuggestions" />
+    <!--
+         Looks like setting android:imeActionLabel confuses the
+         original AOSP soft keyboard, so don't.
+    -->
+
+    <FrameLayout
+        android:id="@+id/preview_buttons_layout"
+        android:layout_width="match_parent"
+        android:layout_height="48dp"
+        android:orientation="horizontal"
+        android:background="?attr/hardButtonRef"
+        android:visibility="gone"
+        tools:visibility="visible">
+
+        <com.ichi2.ui.FixedTextView
+            android:id="@+id/preview_flip_flashcard"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            android:textColor="?attr/answerButtonTextColor"
+            android:text="@string/show_answer"
+            style="@style/FooterButton" />
+
+        <ImageView
+            android:id="@+id/preview_previous_flashcard"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="start|center_vertical"
+            android:padding="12dp"
+            android:focusable="true"
+            android:background="?attr/hardButtonRef"
+            app:srcCompat="@drawable/ic_baseline_chevron_left_24"
+            app:tint="?attr/hardButtonTextColor" />
+
+        <ImageView
+            android:id="@+id/preview_next_flashcard"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="end|center_vertical"
+            android:padding="12dp"
+            android:focusable="true"
+            android:background="?attr/hardButtonRef"
+            app:srcCompat="@drawable/ic_baseline_chevron_right_24"
+            app:tint="?attr/hardButtonTextColor" />
+    </FrameLayout>
+
+    <FrameLayout
+        android:id="@+id/answer_options_layout"
+        android:layout_width="fill_parent"
+        android:layout_height="fill_parent">
+
+        <LinearLayout
+            android:id="@+id/ease_buttons"
+            android:layout_width="fill_parent"
+            android:layout_height="fill_parent"
+            android:visibility="gone"
+            android:focusable="false"
+            android:orientation="horizontal">
+
+            <LinearLayout
+                style="@style/FooterButton"
+                android:background="?attr/againButtonRef"
+                android:id="@+id/flashcard_layout_ease1"
+                android:nextFocusRight="@id/flashcard_layout_ease2"
+                android:layout_width="0dip"
+                android:layout_height="@dimen/touch_target"
+                android:layout_weight="1"
+                android:orientation="vertical">
+
+                <com.ichi2.ui.FixedTextView
+                    android:id="@+id/nextTime1"
+                    style="@style/AgainButtonTimeStyle"
+                    tools:text="&lt; 10 min" />
+
+                <com.ichi2.ui.FixedTextView
+                    android:id="@+id/ease1"
+                    android:text="@string/ease_button_again"
+                    style="@style/AgainButtonEaseStyle"/>
+            </LinearLayout>
+
+            <LinearLayout
+                style="@style/FooterButton"
+                android:background="?attr/hardButtonRef"
+                android:id="@+id/flashcard_layout_ease2"
+                android:nextFocusRight="@id/flashcard_layout_ease3"
+                android:nextFocusLeft="@id/flashcard_layout_ease1"
+                android:layout_width="0dip"
+                android:layout_height="@dimen/touch_target"
+                android:layout_weight="1"
+                android:orientation="vertical">
+
+                <com.ichi2.ui.FixedTextView
+                    android:id="@+id/nextTime2"
+                    style="@style/HardButtonTimeStyle"
+                    tools:text="2 d" />
+
+                <com.ichi2.ui.FixedTextView
+                    android:id="@+id/ease2"
+                    android:text="@string/ease_button_hard"
+                    style="@style/HardButtonEaseStyle" />
+            </LinearLayout>
+
+            <LinearLayout
+                style="@style/FooterButton"
+                android:background="?attr/goodButtonRef"
+                android:id="@+id/flashcard_layout_ease3"
+                android:nextFocusRight="@id/flashcard_layout_ease4"
+                android:nextFocusLeft="@id/flashcard_layout_ease2"
+                android:layout_width="0dip"
+                android:layout_height="@dimen/touch_target"
+                android:layout_weight="1"
+                android:orientation="vertical">
+
+                <com.ichi2.ui.FixedTextView
+                    android:id="@+id/nextTime3"
+                    style="@style/GoodButtonTimeStyle"
+                    tools:text="3 d" />
+
+                <com.ichi2.ui.FixedTextView
+                    android:id="@+id/ease3"
+                    android:text="@string/ease_button_good"
+                    style="@style/GoodButtonEaseStyle"/>
+            </LinearLayout>
+
+            <LinearLayout
+                style="@style/FooterButton"
+                android:background="?attr/easyButtonRef"
+                android:id="@+id/flashcard_layout_ease4"
+                android:nextFocusLeft="@id/flashcard_layout_ease3"
+                android:layout_width="0dip"
+                android:layout_height="@dimen/touch_target"
+                android:layout_weight="1"
+                android:orientation="vertical">
+
+                <com.ichi2.ui.FixedTextView
+                    android:id="@+id/nextTime4"
+                    style="@style/EasyButtonTimeStyle"
+                    tools:text="4 d" />
+
+                <com.ichi2.ui.FixedTextView
+                    android:id="@+id/ease4"
+                    android:text="@string/ease_button_easy"
+                    style="@style/EasyButtonEaseStyle" />
+            </LinearLayout>
+        </LinearLayout>
+
+        <LinearLayout
+            android:id="@+id/flashcard_layout_flip"
+            android:layout_width="fill_parent"
+            android:layout_height="@dimen/touch_target"
+            android:orientation="vertical"
+            android:focusable="true"
+            tools:visibility="gone">
+
+            <Button
+                style="@style/FooterButton"
+                android:duplicateParentState="true"
+                android:background="?attr/hardButtonRef"
+                android:id="@+id/flip_card"
+                android:layout_width="fill_parent"
+                android:layout_height="fill_parent"
+                android:clickable="false"
+                android:text="@string/show_answer"
+                android:textColor="?attr/answerButtonTextColor" />
+        </LinearLayout>
+    </FrameLayout>
+</LinearLayout>

--- a/AnkiDroid/src/main/res/layout-v28/reviewer_flashcard.xml
+++ b/AnkiDroid/src/main/res/layout-v28/reviewer_flashcard.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+~ Copyright (c) 2009 Andrew <andrewdubya@gmail>
+~ Copyright (c) 2009 Nicolas Raoul <nicolas.raoul@gmail.com>
+~ Copyright (c) 2009 Edu Zamora <edu.zasu@gmail.com>
+~ Copyright (c) 2009 Jordi Chacon <jordi.chacon@gmail.com>
+~ Copyright (c) 2010 Norbert Nagold <norbert.nagold@gmail.com>
+~ Copyright (c) 2014 Roland Sieker <ospalh@gmail.com>
+~ Copyright (c) 2016 Timothy Rae <perceptualchaos2@gmail.com>
+~
+~ This program is free software; you can redistribute it and/or modify it under
+~ the terms of the GNU General Public License as published by the Free Software
+~ Foundation; either version 3 of the License, or (at your option) any later
+~ version.
+~
+~ This program is distributed in the hope that it will be useful, but WITHOUT ANY
+~ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+~ PARTICULAR PURPOSE. See the GNU General Public License for more details.
+~
+~ You should have received a copy of the GNU General Public License along with
+~ this program.  If not, see <http://www.gnu.org/licenses/>.
+-->
+
+<FrameLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_gravity="center"
+    android:id="@+id/flashcard_frame"
+    android:layout_width="fill_parent"
+    android:layout_height="fill_parent"
+    android:layout_margin="0dip">
+
+    <FrameLayout
+        android:layout_gravity="center"
+        android:id="@+id/flashcard"
+        android:layout_width="fill_parent"
+        android:layout_height="fill_parent" />
+    <FrameLayout
+        android:layout_gravity="center"
+        android:id="@+id/touch_layer"
+        android:layout_width="fill_parent"
+        android:layout_height="fill_parent"
+        android:layout_margin="0dip"
+        android:longClickable="true" />
+    <FrameLayout
+        android:layout_gravity="center"
+        android:id="@+id/whiteboard"
+        android:layout_margin="0dip"
+        android:layout_width="fill_parent"
+        android:layout_height="fill_parent" />
+    <ImageView
+        android:id="@+id/lookup_button"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="right"
+        android:clickable="true"
+        android:padding="5dip"
+        android:src="@drawable/ic_lookup"
+        android:visibility="gone"
+        android:contentDescription="@string/lookup_button_content" />
+</FrameLayout>

--- a/AnkiDroid/src/main/res/layout-v28/reviewer_mic_tool_bar.xml
+++ b/AnkiDroid/src/main/res/layout-v28/reviewer_mic_tool_bar.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/mic_tool_bar_layer"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"/>

--- a/AnkiDroid/src/main/res/layout-v28/reviewer_topbar.xml
+++ b/AnkiDroid/src/main/res/layout-v28/reviewer_topbar.xml
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/top_bar"
+        android:layout_width="fill_parent"
+        android:layout_height="wrap_content"
+        android:paddingLeft="9dp"
+        android:paddingRight="10dp"
+        android:paddingTop="2dp"
+        android:paddingBottom="3dp"
+        android:gravity="center_vertical"
+        android:background="?attr/topBarColor">
+        <com.ichi2.ui.FixedTextView
+            android:id="@+id/new_number"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text=""
+            android:textColor="?attr/newCountColor"
+            android:textSize="14sp" />
+        <com.ichi2.ui.FixedTextView
+            android:id="@+id/learn_number"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_toRightOf="@+id/new_number"
+            android:paddingLeft="8dp"
+            android:text=""
+            android:textColor="?attr/learnCountColor"
+            android:textSize="14sp" />
+
+        <com.ichi2.ui.FixedTextView
+            android:id="@+id/review_number"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_toRightOf="@+id/learn_number"
+            android:paddingLeft="8dp"
+            android:text=""
+            android:textColor="?attr/reviewCountColor"
+            android:textSize="14sp" />
+
+        <com.ichi2.ui.FixedTextView
+            android:id="@+id/choosen_answer"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textAlignment="center"
+            android:layout_centerHorizontal="true"
+            android:minEms="4"
+            android:gravity="center"
+            android:text=""
+            android:textSize="14sp" />
+
+
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_toLeftOf="@+id/card_time"
+        android:layout_alignTop="@+id/card_time"
+        android:layout_alignBottom="@+id/card_time"
+        android:layout_toRightOf="@+id/choosen_answer"
+        android:gravity="center" >
+
+        <ImageView
+            android:id="@+id/flag_icon"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:visibility="invisible"
+            android:layout_gravity="center"
+            />
+        <ImageView
+            android:id="@+id/mark_icon"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:visibility="invisible"
+            android:layout_gravity="center"
+            />
+        </LinearLayout>
+        <Chronometer
+            android:id="@+id/card_time"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_alignParentRight="true"
+            android:gravity="end"
+            android:textSize="14sp"
+            android:visibility="invisible" />
+</RelativeLayout>

--- a/AnkiDroid/src/main/res/layout-v28/toolbar.xml
+++ b/AnkiDroid/src/main/res/layout-v28/toolbar.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<merge xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <androidx.appcompat.widget.Toolbar
+        android:id="@+id/toolbar"
+        android:layout_width="fill_parent"
+        android:layout_height="wrap_content"
+        android:layout_alignParentTop="true"
+        android:background="?attr/colorPrimary"
+        android:minHeight="?attr/actionBarSize"
+        android:theme="@style/ActionBarStyle"
+        app:navigationContentDescription="@string/abc_action_bar_up_description"
+        app:navigationIcon="?attr/homeAsUpIndicator">
+
+        <com.ichi2.ui.FixedTextView
+            android:id="@+id/toolbar_title"
+            android:layout_width="wrap_content"
+            android:layout_height="match_parent"
+            android:textColor="@color/white"
+            android:textSize="20sp"
+            android:visibility="gone" />
+
+        <Spinner
+            android:id="@+id/toolbar_spinner"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:background="?attr/selectableItemBackground"
+            android:visibility="gone"
+            app:popupTheme="@style/ActionBar.Popup" />
+    </androidx.appcompat.widget.Toolbar>
+</merge>

--- a/AnkiDroid/src/main/res/layout/reviewer.xml
+++ b/AnkiDroid/src/main/res/layout/reviewer.xml
@@ -44,11 +44,7 @@
                 android:layout_centerHorizontal="true"
                 android:layout_above="@+id/bottom_area_layout"/>
 
-            <include layout="@layout/reviewer_answer_buttons"
-                android:layout_alignParentBottom="true"
-                android:translationZ="1dp"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"/>
+            <include layout="@layout/reviewer_answer_buttons" />
         </RelativeLayout>
     </androidx.coordinatorlayout.widget.CoordinatorLayout>
     <!-- Left navigation drawer -->


### PR DESCRIPTION
## Pull Request template

## Purpose / Description

Reviewer buttons are not appearing for some people on Android 8/8.1

I am completely unable to reproduce it on emulators, so my hunch is that it is a hardware render change in the OS or the WebView.

There is confirmation that turning the reviewer views to software render mode is a valid workaround for at least one tester

## Fixes

Fixes #7369 on release-2.14 branch

## Approach

This change is a change of all related views to software render, using the Android layout API overlay system to focus them to only API26 and API27 by copying the original files into layout-v26 with the software render change, and copying the original unaltered files into layout-v28 so it goes back to hardware.

I am not thrilled with this change so I am not proposing it for main branch - I would rather maintain one layout and programmatically toggle software render on just the views we need to toggle, but that requires a lot more time and dedicated testing effort vs a confirmation from a tester that this large-scale change does work.

## How Has This Been Tested?

Using parallel releases from my fork, in collaboration with testers on the linked issue

## Learning (optional, can help others)

https://stackoverflow.com/questions/18448862/android-text-disappears-frequently-in-webview-when-layer-type-software-is-set
https://stackoverflow.com/questions/26325725/how-to-use-layertype-value-being-set-differently-inside-the-resources
https://stackoverflow.com/questions/57465334/android-webview-with-layer-type-software-not-showing-html5-canvas-content
https://developer.android.com/guide/topics/graphics/hardware-accel#controlling

## Checklist

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)