### PR TITLE
Release TextToSpeech with a Context

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -1016,7 +1016,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
         }
         Timber.d("onDestroy()");
         if (mSpeakText) {
-            ReadText.releaseTts();
+            ReadText.releaseTts(this);
         }
         if (mUnmountReceiver != null) {
             unregisterReceiver(mUnmountReceiver);

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ReadText.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ReadText.java
@@ -337,8 +337,14 @@ public class ReadText {
     }
 
 
-    public static void releaseTts() {
-        if (mTts != null) {
+    /**
+     * Request that TextToSpeech is stopped and shutdown after it it no longer being used
+     * by the context that initialized it.
+     * No-op if the current instance of TextToSpeech was initialized by another Context
+     * @param context The context used during {@link #initializeTts(Context, ReadTextListener)}
+     */
+    public static void releaseTts(Context context) {
+        if (mTts != null && mReviewer.get() == context) {
             mTts.stop();
             mTts.shutdown();
         }
@@ -370,5 +376,11 @@ public class ReadText {
     @Nullable
     public static String getTextToSpeak() {
         return mTextToSpeak;
+    }
+
+    @VisibleForTesting(otherwise = VisibleForTesting.NONE)
+    @Nullable
+    public static TextToSpeech getTextToSpeech() {
+        return mTts;
     }
 }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/ReadTextTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/ReadTextTest.java
@@ -16,6 +16,8 @@
 
 package com.ichi2.anki;
 
+import android.content.Context;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -28,6 +30,7 @@ import static com.ichi2.libanki.Sound.SoundSide.QUESTION;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.Mockito.mock;
+import static org.robolectric.Shadows.shadowOf;
 
 @RunWith(AndroidJUnit4.class)
 public class ReadTextTest extends RobolectricTest{
@@ -113,6 +116,28 @@ public class ReadTextTest extends RobolectricTest{
         assertThat(MetaDB.getLanguage(getTargetContext(), 2, 1, QUESTION), is("English"));
     }
 
+    @Test
+    public void testIsTextToSpeechReleased_sameContext() {
+        Context context = getTargetContext();
+        initializeTextToSpeech(context);
+        ReadText.releaseTts(context);
+        assertThat(isTextToSpeechShutdown(), is(true));
+    }
+
+    @Test
+    public void testIsTextToSpeechReleased_differentContext() {
+        initializeTextToSpeech(getTargetContext());
+        ReadText.releaseTts(null);
+        assertThat(isTextToSpeechShutdown(), is(false));
+    }
+
+    private boolean isTextToSpeechShutdown() {
+        return shadowOf(ReadText.getTextToSpeech()).isShutdown();
+    }
+
+    private void initializeTextToSpeech(Context context) {
+        ReadText.initializeTts(context, mock(AbstractFlashcardViewer.ReadTextListener.class));
+    }
 
     protected void storeLanguage(int i, String french) {
         MetaDB.storeLanguage(getTargetContext(), i, 1, QUESTION, french);


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
TextToSpeech was being released (shutdown) incorrectly due to a race condition.
When AbstractFlashcardViewer is recreated (Ex: through changing themes), the newly created activity initialized a new TextToSpeech. 
The old activity then releases that same TextToSpeech instance from onDestroy()
TextToSpeech will not work until it is re-initialized.

## Fixes
Fixes #8084

https://user-images.githubusercontent.com/16379504/110561114-1fa2ee80-8115-11eb-9a4b-db9f48ae2677.mp4

## Approach
When TextToSpeech is initialized, a Context is passed in and stored.
That Context is always 'paired' with a single instance of TextToSpeech.
Because the caller that initialized the instance wants to make sure it cleans up when it's done, it attempts to release it.
The instance is stored in a static private field in a different class, so the caller cannot tell what the state of that instance is.
To prevent a caller from releasing an instance of TextToSpeech that was initialized by another caller, the same Context must be passed it to verify if the instance belongs to it or not.

This has some caveats though. For instance, right now the only context used is AbstractFlashcardViewer, but if you were to start passing in a shared context like the application context, this problem would re-occur.

Because of the overall structure of ReadText and its connections, it was hard to find a solution that didn't involve a massive amount of time and code changes.

## How Has This Been Tested?

1. Enable TTS
2. Go to Study
3. Change theme from hamburger menu (switch on/off night mode)
4. Choose 'Replay audio' from dots menu

The audio should play after both step 3 (when the card is first shown) and step 4.

Tested on an emulator with API 29.

## Learning (optional, can help others)
https://developer.android.com/reference/android/speech/tts/TextToSpeech
http://robolectric.org/javadoc/4.0/org/robolectric/shadows/ShadowTextToSpeech.html



Text to speech is shared through all applications. Maybe it's possible that the current usage here could be changed from a (pseudo) per-activity usage to something more like a singleton? The initialization takes quite a long time to run, and it's likely that when used once, it will be used quite often throughout the session, so a different setup and destroy system could run perform better.

When re-initializing TextToSpeech inside ReadText, it's directly overriding the old reference without calling `shutdown()` on it beforehand. I'm wondering how much of an effect this has...


## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)