### PR TITLE
Export selected cards from CardBrowser

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/ActivityExportingDelegate.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ActivityExportingDelegate.java
@@ -49,7 +49,7 @@ public class ActivityExportingDelegate <A extends AnkiActivity & ExportCompleteD
     }
 
 
-    public void exportApkg(String filename, Long did, boolean includeSched, boolean includeMedia) {
+    public void exportApkg(String filename, Long did, List<Long> cardIds, boolean includeSched, boolean includeMedia) {
         File exportDir = new File(mActivity.getExternalCacheDir(), "export");
         exportDir.mkdirs();
         File exportPath;
@@ -60,6 +60,11 @@ public class ActivityExportingDelegate <A extends AnkiActivity & ExportCompleteD
         } else if (!includeSched) {
             // full export without scheduling is assumed to be shared with someone else -- use "All Decks.apkg"
             exportPath = new File(exportDir, "All Decks" + timeStampSuffix + ".apkg");
+        } else if (did != null && cardIds == null) {
+            // filename not explicitly specified, but a deck has been specified so use deck name
+            exportPath = new File(exportDir, getCol().getDecks().get(did).getString("name").replaceAll("\\W+", "_") + timeStampSuffix + ".apkg");
+        } else if (did == null && cardIds != null) {
+            exportPath = new File(exportDir, "Selected Cards" + timeStampSuffix + ".apkg");
         } else {
             // full collection export -- use "collection.colpkg"
             File colPath = new File(getCol().getPath());
@@ -67,7 +72,7 @@ public class ActivityExportingDelegate <A extends AnkiActivity & ExportCompleteD
             exportPath = new File(exportDir, newFileName);
         }
         final ExportListener exportListener = new ExportListener(mActivity);
-        TaskManager.launchCollectionTask(new CollectionTask.ExportApkg(exportPath.getPath(), did, includeSched, includeMedia), exportListener);
+        TaskManager.launchCollectionTask(new CollectionTask.ExportApkg(exportPath.getPath(), did, cardIds, includeSched, includeMedia), exportListener);
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ActivityExportingDelegate.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ActivityExportingDelegate.java
@@ -1,0 +1,204 @@
+package com.ichi2.anki;
+
+
+import android.content.Intent;
+import android.net.Uri;
+import android.os.ParcelFileDescriptor;
+import android.util.Pair;
+
+import com.afollestad.materialdialogs.MaterialDialog;
+import com.ichi2.anki.dialogs.ExportCompleteDialog;
+import com.ichi2.anki.dialogs.ExportCompleteDialog.ExportCompleteDialogListener;
+import com.ichi2.async.CollectionTask;
+import com.ichi2.async.TaskListenerWithContext;
+import com.ichi2.async.TaskManager;
+import com.ichi2.compat.CompatHelper;
+import com.ichi2.libanki.Collection;
+import com.ichi2.libanki.utils.TimeUtils;
+import com.ichi2.themes.StyledProgressDialog;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.util.List;
+
+import androidx.annotation.NonNull;
+import androidx.core.app.ShareCompat;
+import androidx.core.content.FileProvider;
+import timber.log.Timber;
+
+/**
+ * A delegate class used in any {@link AnkiActivity} where the exporting feature is required.
+ * <p>
+ * The calling activity must implement {@link ExportCompleteDialogListener} and can then forward any call the the exporting delegate
+ */
+public class ActivityExportingDelegate <A extends AnkiActivity & ExportCompleteDialogListener> {
+
+    private final A mActivity;
+    private final int mPickExportFileCallbackCode;
+
+    private String mExportFileName;
+
+
+    /**
+     * @param activity the calling activity (must implement {@link ExportCompleteDialogListener})
+     * @param mPickExportFileCallbackCode the code that will be used on onActivityResult
+     */
+    public ActivityExportingDelegate(A activity, int mPickExportFileCallbackCode) {
+        mActivity = activity;
+        this.mPickExportFileCallbackCode = mPickExportFileCallbackCode;
+    }
+
+
+    public void exportApkg(String filename, Long did, boolean includeSched, boolean includeMedia) {
+        File exportDir = new File(mActivity.getExternalCacheDir(), "export");
+        exportDir.mkdirs();
+        File exportPath;
+        String timeStampSuffix = "-" + TimeUtils.getTimestamp(getCol().getTime());
+        if (filename != null) {
+            // filename has been explicitly specified
+            exportPath = new File(exportDir, filename);
+        } else if (!includeSched) {
+            // full export without scheduling is assumed to be shared with someone else -- use "All Decks.apkg"
+            exportPath = new File(exportDir, "All Decks" + timeStampSuffix + ".apkg");
+        } else {
+            // full collection export -- use "collection.colpkg"
+            File colPath = new File(getCol().getPath());
+            String newFileName = colPath.getName().replace(".anki2", timeStampSuffix + ".colpkg");
+            exportPath = new File(exportDir, newFileName);
+        }
+        final ExportListener exportListener = new ExportListener(mActivity);
+        TaskManager.launchCollectionTask(new CollectionTask.ExportApkg(exportPath.getPath(), did, includeSched, includeMedia), exportListener);
+    }
+
+
+    public void emailFile(String path) {
+        // Make sure the file actually exists
+        File attachment = new File(path);
+        if (!attachment.exists()) {
+            Timber.e("Specified apkg file %s does not exist", path);
+            UIUtils.showThemedToast(mActivity, mActivity.getResources().getString(R.string.apk_share_error), false);
+            return;
+        }
+        // Get a URI for the file to be shared via the FileProvider API
+        Uri uri;
+        try {
+            uri = FileProvider.getUriForFile(mActivity, "com.ichi2.anki.apkgfileprovider", attachment);
+        } catch (IllegalArgumentException e) {
+            Timber.e("Could not generate a valid URI for the apkg file");
+            UIUtils.showThemedToast(mActivity, mActivity.getResources().getString(R.string.apk_share_error), false);
+            return;
+        }
+        Intent shareIntent = new ShareCompat.IntentBuilder(mActivity)
+                .setType("application/apkg")
+                .setStream(uri)
+                .setSubject(mActivity.getString(R.string.export_email_subject, attachment.getName()))
+                .setHtmlText(mActivity.getString(R.string.export_email_text))
+                .getIntent();
+        if (shareIntent.resolveActivity(mActivity.getPackageManager()) != null) {
+            mActivity.startActivityWithoutAnimation(shareIntent);
+        } else {
+            // Try to save it?
+            UIUtils.showSimpleSnackbar(mActivity, R.string.export_send_no_handlers, false);
+            saveExportFile(path);
+        }
+    }
+
+
+    public void saveExportFile(String path) {
+        // Make sure the file actually exists
+        File attachment = new File(path);
+        if (!attachment.exists()) {
+            Timber.e("saveExportFile() Specified apkg file %s does not exist", path);
+            UIUtils.showSimpleSnackbar(mActivity, R.string.export_save_apkg_unsuccessful, false);
+            return;
+        }
+
+        // Send the user to the standard Android file picker via Intent
+        mExportFileName = path;
+        Intent saveIntent = new Intent(Intent.ACTION_CREATE_DOCUMENT);
+        saveIntent.addCategory(Intent.CATEGORY_OPENABLE);
+        saveIntent.setType("application/apkg");
+        saveIntent.putExtra(Intent.EXTRA_TITLE, attachment.getName());
+        saveIntent.putExtra("android.content.extra.SHOW_ADVANCED", true);
+        saveIntent.putExtra("android.content.extra.FANCY", true);
+        saveIntent.putExtra("android.content.extra.SHOW_FILESIZE", true);
+        mActivity.startActivityForResultWithoutAnimation(saveIntent, mPickExportFileCallbackCode);
+    }
+
+
+    public boolean exportToProvider(Intent intent, boolean deleteAfterExport) {
+        if ((intent == null) || (intent.getData() == null)) {
+            Timber.e("exportToProvider() provided with insufficient intent data %s", intent);
+            return false;
+        }
+        Uri uri = intent.getData();
+        Timber.d("Exporting from file to ContentProvider URI: %s/%s", mExportFileName, uri.toString());
+        FileOutputStream fileOutputStream;
+        ParcelFileDescriptor pfd;
+        try {
+            pfd = mActivity.getContentResolver().openFileDescriptor(uri, "w");
+
+            if (pfd != null) {
+                fileOutputStream = new FileOutputStream(pfd.getFileDescriptor());
+                CompatHelper.getCompat().copyFile(mExportFileName, fileOutputStream);
+                fileOutputStream.close();
+                pfd.close();
+            } else {
+                Timber.w("exportToProvider() failed - ContentProvider returned null file descriptor for %s", uri);
+                return false;
+            }
+            if (deleteAfterExport && !new File(mExportFileName).delete()) {
+                Timber.w("Failed to delete temporary export file %s", mExportFileName);
+            }
+        } catch (Exception e) {
+            Timber.e(e, "Unable to export file to Uri: %s/%s", mExportFileName, uri.toString());
+            return false;
+        }
+        return true;
+    }
+
+
+    private Collection getCol() {
+        return CollectionHelper.getInstance().getCol(mActivity);
+    }
+
+
+    private static class ExportListener extends TaskListenerWithContext<AnkiActivity, Void, Pair<Boolean, String>> {
+        private MaterialDialog mProgressDialog;
+
+
+        public ExportListener(AnkiActivity activity) {
+            super(activity);
+        }
+
+
+        @Override
+        public void actualOnPreExecute(@NonNull AnkiActivity activity) {
+            mProgressDialog = StyledProgressDialog.show(activity, "",
+                    activity.getResources().getString(R.string.export_in_progress), false);
+        }
+
+
+        @Override
+        public void actualOnPostExecute(@NonNull AnkiActivity activity, Pair<Boolean, String> result) {
+            if (mProgressDialog != null && mProgressDialog.isShowing()) {
+                mProgressDialog.dismiss();
+            }
+
+            // If boolean and string are both set, we are signalling an error message
+            // instead of a successful result.
+            if (result.first && result.second != null) {
+                Timber.w("Export Failed: %s", result.second);
+                activity.showSimpleMessageDialog(result.second);
+            } else {
+                Timber.i("Export successful");
+                String exportPath = result.second;
+                if (exportPath != null) {
+                    activity.showAsyncDialogFragment(ExportCompleteDialog.newInstance(exportPath));
+                } else {
+                    UIUtils.showThemedToast(activity, activity.getResources().getString(R.string.export_unsuccessful), true);
+                }
+            }
+        }
+    }
+}

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -95,7 +95,7 @@ import com.ichi2.anki.dialogs.DeckPickerAnalyticsOptInDialog;
 import com.ichi2.anki.dialogs.DeckPickerBackupNoSpaceLeftDialog;
 import com.ichi2.anki.dialogs.DeckPickerConfirmDeleteDeckDialog;
 import com.ichi2.anki.dialogs.DeckPickerContextMenu;
-import com.ichi2.anki.dialogs.DeckPickerExportCompleteDialog;
+import com.ichi2.anki.dialogs.ExportCompleteDialog;
 import com.ichi2.anki.dialogs.DeckPickerNoSpaceLeftDialog;
 import com.ichi2.anki.dialogs.DialogHandler;
 import com.ichi2.anki.dialogs.ExportDialog;
@@ -124,7 +124,6 @@ import com.ichi2.libanki.Models;
 import com.ichi2.libanki.Utils;
 import com.ichi2.libanki.importer.AnkiPackageImporter;
 import com.ichi2.libanki.sched.AbstractDeckTreeNode;
-import com.ichi2.libanki.sched.DeckTreeNode;
 import com.ichi2.libanki.sync.CustomSyncServerUrlException;
 import com.ichi2.libanki.sync.Syncer;
 import com.ichi2.libanki.utils.TimeUtils;
@@ -145,7 +144,6 @@ import com.ichi2.utils.JSONException;
 
 import java.io.File;
 import java.io.FileOutputStream;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
@@ -162,7 +160,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
         StudyOptionsListener, SyncErrorDialog.SyncErrorDialogListener, ImportDialog.ImportDialogListener,
         MediaCheckDialog.MediaCheckDialogListener, ExportDialog.ExportDialogListener,
         ActivityCompat.OnRequestPermissionsResultCallback, CustomStudyDialog.CustomStudyListener,
-        DeckPickerExportCompleteDialog.DeckPickerExportCompleteDialogListener {
+        ExportCompleteDialog.ExportCompleteDialogListener {
 
 
     /**
@@ -423,7 +421,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
                 Timber.i("Export successful");
                 String exportPath = result.second;
                 if (exportPath != null) {
-                    deckPicker.showAsyncDialogFragment(DeckPickerExportCompleteDialog.newInstance(exportPath));
+                    deckPicker.showAsyncDialogFragment(ExportCompleteDialog.newInstance(exportPath));
                 } else {
                     UIUtils.showThemedToast(deckPicker, deckPicker.getResources().getString(R.string.export_unsuccessful), true);
                 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -161,7 +161,8 @@ import static com.ichi2.anim.ActivityTransitionAnimation.Direction.*;
 public class DeckPicker extends NavigationDrawerActivity implements
         StudyOptionsListener, SyncErrorDialog.SyncErrorDialogListener, ImportDialog.ImportDialogListener,
         MediaCheckDialog.MediaCheckDialogListener, ExportDialog.ExportDialogListener,
-        ActivityCompat.OnRequestPermissionsResultCallback, CustomStudyDialog.CustomStudyListener {
+        ActivityCompat.OnRequestPermissionsResultCallback, CustomStudyDialog.CustomStudyListener,
+        DeckPickerExportCompleteDialog.DeckPickerExportCompleteDialogListener {
 
 
     /**

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -2093,8 +2093,8 @@ public class DeckPicker extends NavigationDrawerActivity implements
 
 
     @Override
-    public void exportApkg(String filename, Long did, boolean includeSched, boolean includeMedia) {
-        mExportingDelegate.exportApkg(filename,did,includeSched,includeMedia);
+    public void exportApkg(String filename, Long did, List<Long> cids, boolean includeSched, boolean includeMedia) {
+        mExportingDelegate.exportApkg(filename, did, cids, includeSched, includeMedia);
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckPickerExportCompleteDialog.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckPickerExportCompleteDialog.java
@@ -13,7 +13,16 @@ import java.io.File;
 import androidx.annotation.NonNull;
 
 public class DeckPickerExportCompleteDialog extends AsyncDialogFragment {
-    
+
+    public interface DeckPickerExportCompleteDialogListener {
+        void dismissAllDialogFragments();
+
+        void emailFile(String path);
+
+        void saveExportFile(String exportPath);
+    }
+
+
     public static DeckPickerExportCompleteDialog newInstance(String exportPath) {
         DeckPickerExportCompleteDialog f = new DeckPickerExportCompleteDialog();
         Bundle args = new Bundle();
@@ -35,15 +44,15 @@ public class DeckPickerExportCompleteDialog extends AsyncDialogFragment {
                 .positiveText(R.string.export_send_button)
                 .negativeText(R.string.export_save_button)
                 .onPositive((dialog, which) -> {
-                    ((DeckPicker) getActivity()).dismissAllDialogFragments();
-                    ((DeckPicker) getActivity()).emailFile(exportPath);
+                    ((DeckPickerExportCompleteDialogListener) getActivity()).dismissAllDialogFragments();
+                    ((DeckPickerExportCompleteDialogListener) getActivity()).emailFile(exportPath);
                 })
                 .onNegative((dialog, which) -> {
-                    ((DeckPicker) getActivity()).dismissAllDialogFragments();
-                    ((DeckPicker) getActivity()).saveExportFile(exportPath);
+                    ((DeckPickerExportCompleteDialogListener) getActivity()).dismissAllDialogFragments();
+                    ((DeckPickerExportCompleteDialogListener) getActivity()).saveExportFile(exportPath);
                 })
                 .neutralText(R.string.dialog_cancel)
-                .onNeutral((dialog, which) -> ((DeckPicker) getActivity()).dismissAllDialogFragments());
+                .onNeutral((dialog, which) -> ((DeckPickerExportCompleteDialogListener) getActivity()).dismissAllDialogFragments());
         return dialogBuilder.show();
     }
     

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DialogHandler.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DialogHandler.java
@@ -88,7 +88,7 @@ public class DialogHandler extends Handler {
             ((DeckPicker) mActivity.get()).showSyncErrorDialog(id, message);
         } else if (msg.what == MSG_SHOW_EXPORT_COMPLETE_DIALOG) {
             // Export complete
-            AsyncDialogFragment f = DeckPickerExportCompleteDialog.newInstance(msgData.getString("exportPath"));
+            AsyncDialogFragment f = ExportCompleteDialog.newInstance(msgData.getString("exportPath"));
             mActivity.get().showAsyncDialogFragment(f);
         } else if (msg.what == MSG_SHOW_MEDIA_CHECK_COMPLETE_DIALOG) {            
             // Media check results

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ExportCompleteDialog.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ExportCompleteDialog.java
@@ -5,16 +5,15 @@ import android.os.Bundle;
 import android.os.Message;
 
 import com.afollestad.materialdialogs.MaterialDialog;
-import com.ichi2.anki.DeckPicker;
 import com.ichi2.anki.R;
 
 import java.io.File;
 
 import androidx.annotation.NonNull;
 
-public class DeckPickerExportCompleteDialog extends AsyncDialogFragment {
+public class ExportCompleteDialog extends AsyncDialogFragment {
 
-    public interface DeckPickerExportCompleteDialogListener {
+    public interface ExportCompleteDialogListener {
         void dismissAllDialogFragments();
 
         void emailFile(String path);
@@ -23,8 +22,8 @@ public class DeckPickerExportCompleteDialog extends AsyncDialogFragment {
     }
 
 
-    public static DeckPickerExportCompleteDialog newInstance(String exportPath) {
-        DeckPickerExportCompleteDialog f = new DeckPickerExportCompleteDialog();
+    public static ExportCompleteDialog newInstance(String exportPath) {
+        ExportCompleteDialog f = new ExportCompleteDialog();
         Bundle args = new Bundle();
         args.putString("exportPath", exportPath);
         f.setArguments(args);
@@ -44,15 +43,15 @@ public class DeckPickerExportCompleteDialog extends AsyncDialogFragment {
                 .positiveText(R.string.export_send_button)
                 .negativeText(R.string.export_save_button)
                 .onPositive((dialog, which) -> {
-                    ((DeckPickerExportCompleteDialogListener) getActivity()).dismissAllDialogFragments();
-                    ((DeckPickerExportCompleteDialogListener) getActivity()).emailFile(exportPath);
+                    ((ExportCompleteDialogListener) getActivity()).dismissAllDialogFragments();
+                    ((ExportCompleteDialogListener) getActivity()).emailFile(exportPath);
                 })
                 .onNegative((dialog, which) -> {
-                    ((DeckPickerExportCompleteDialogListener) getActivity()).dismissAllDialogFragments();
-                    ((DeckPickerExportCompleteDialogListener) getActivity()).saveExportFile(exportPath);
+                    ((ExportCompleteDialogListener) getActivity()).dismissAllDialogFragments();
+                    ((ExportCompleteDialogListener) getActivity()).saveExportFile(exportPath);
                 })
                 .neutralText(R.string.dialog_cancel)
-                .onNeutral((dialog, which) -> ((DeckPickerExportCompleteDialogListener) getActivity()).dismissAllDialogFragments());
+                .onNeutral((dialog, which) -> ((ExportCompleteDialogListener) getActivity()).dismissAllDialogFragments());
         return dialogBuilder.show();
     }
     

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ExportDialog.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ExportDialog.java
@@ -83,8 +83,7 @@ public class ExportDialog extends AnalyticsDialogFragment {
         super.onCreate(savedInstanceState);
         Resources res = getResources();
         final Long did = BundleUtils.getNullableLong(getArguments(), "did");
-        final long[] _cids = getArguments().getLongArray("cids");
-        final List<Long> cids = _cids == null ? null : Utils.primitiveArray2List(_cids);
+        final List<Long> cids = BundleUtils.getNullableLongList(getArguments(), "cids");
         Integer[] checked;
         if (did != null) {
             mIncludeSched = false;

--- a/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
@@ -1477,13 +1477,15 @@ public class CollectionTask<ProgressListener, ProgressBackground extends Progres
     public static class ExportApkg extends Task<Void, Pair<Boolean, String>> {
         private final String apkgPath;
         private final Long did;
+        private final List<Long> cardIds;
         private final Boolean includeSched;
         private final Boolean includeMedia;
 
 
-        public ExportApkg(String apkgPath, Long did, Boolean includeSched, Boolean includeMedia) {
+        public ExportApkg(String apkgPath, Long did, List<Long> cardIds, Boolean includeSched, Boolean includeMedia) {
             this.apkgPath = apkgPath;
             this.did = did;
+            this.cardIds = cardIds;
             this.includeSched = includeSched;
             this.includeMedia = includeMedia;
         }
@@ -1493,7 +1495,12 @@ public class CollectionTask<ProgressListener, ProgressBackground extends Progres
             Timber.d("doInBackgroundExportApkg");
 
             try {
-                AnkiPackageExporter exporter = new AnkiPackageExporter(col, did, includeSched, includeMedia);
+                AnkiPackageExporter exporter;
+                if (cardIds != null) {
+                    exporter = new AnkiPackageExporter(col, cardIds, includeSched, includeMedia);
+                } else {
+                    exporter = new AnkiPackageExporter(col, did, includeSched, includeMedia);
+                }
                 exporter.exportInto(apkgPath, col.getContext());
             } catch (FileNotFoundException e) {
                 Timber.e(e, "FileNotFoundException in doInBackgroundExportApkg");

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Utils.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Utils.java
@@ -463,6 +463,21 @@ public class Utils {
         return ar;
     }
 
+
+    /**
+     * Converts an array of primitive long to {@link java.util.List<Long>}
+     * @param arr input array
+     * @return output list
+     */
+    @NonNull
+    public static List<Long> primitiveArray2List(@NonNull long[] arr) {
+        final List<Long> list = new ArrayList<Long>(arr.length);
+        for (int i = 0; i < arr.length; i++) {
+            list.add(i, arr[i]);
+        }
+        return list;
+    }
+
     public static Long[] list2ObjectArray(List<Long> list) {
         return list.toArray(new Long[0]);
     }

--- a/AnkiDroid/src/main/java/com/ichi2/utils/BundleUtils.java
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/BundleUtils.java
@@ -2,6 +2,10 @@ package com.ichi2.utils;
 
 import android.os.Bundle;
 
+import com.ichi2.libanki.Utils;
+
+import java.util.List;
+
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
@@ -26,6 +30,23 @@ public class BundleUtils {
             return null;
         }
         return bundle.getLong(key);
+    }
+
+
+    /**
+     * Retrieves a {@link List<Long>} value from a {@link Bundle} using a key, returns null if not found
+     *
+     * @param bundle the bundle to look into
+     *               can be null to support nullable bundles like {@link Fragment#getArguments()}
+     * @param key the key to use
+     * @return the long list, or null if not found
+     */
+    @Nullable
+    public static List<Long> getNullableLongList(@Nullable Bundle bundle, @NonNull String key) {
+        if (bundle == null || !bundle.containsKey(key)) {
+            return null;
+        }
+        return Utils.primitiveArray2List(bundle.getLongArray(key));
     }
 
 }

--- a/AnkiDroid/src/main/res/menu/card_browser_multiselect.xml
+++ b/AnkiDroid/src/main/res/menu/card_browser_multiselect.xml
@@ -72,6 +72,10 @@
         android:title="@string/card_editor_reschedule_card"/>
 
     <item
+        android:id="@+id/action_export_cards"
+        android:title="@string/card_editor_export_card"/>
+
+    <item
         android:id="@+id/action_reset_cards_progress"
         android:title="@string/card_editor_reset_card"/>
 

--- a/AnkiDroid/src/main/res/values/02-strings.xml
+++ b/AnkiDroid/src/main/res/values/02-strings.xml
@@ -125,6 +125,7 @@
     <string name="card_editor_reposition_card">Reposition</string>
     <string name="card_editor_reset_card">Reset progress</string>
     <string name="card_editor_reschedule_card" comment="Action to reschedule a card">Reschedule</string>
+    <string name="card_editor_export_card" comment="Action to export selected cards">Export cards</string>
     <string name="card_editor_preview_card" comment="Button offering to preview some card(s)">Preview</string>
     <string name="error_insufficient_memory">Operation not possible due to insufficient memory on your device</string>
     <string name="rename" comment="Confirm that the renaming action should be processed.">Rename</string>
@@ -171,6 +172,7 @@
     <string name="export_include_media">Include media</string>
     <string name="confirm_apkg_export">Export collection as Anki package?</string>
     <string name="confirm_apkg_export_deck">Export “%s” as apkg file?</string>
+    <string name="confirm_apkg_export_selected_cards">Export selected cards as apkg file?</string>
     <string name="export_in_progress">Exporting Anki package file…</string>
     <string name="export_successful_title">Send Anki package?</string>
     <string name="export_send_button">Send</string>

--- a/AnkiDroid/src/test/java/com/ichi2/utils/BundleUtilsTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/utils/BundleUtilsTest.java
@@ -2,11 +2,15 @@ package com.ichi2.utils;
 
 import android.os.Bundle;
 
+import com.ichi2.libanki.Utils;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.stubbing.Answer;
 import org.robolectric.RobolectricTestRunner;
 
+import java.util.Arrays;
+import java.util.List;
 import java.util.Random;
 
 import static org.junit.Assert.assertEquals;
@@ -52,6 +56,48 @@ public class BundleUtilsTest {
         Long val = BundleUtils.getNullableLong(b, KEY);
 
         verify(b).getLong(eq(KEY));
+
+        assertEquals(expected, val);
+    }
+
+
+    @Test
+    public void test_GetNullableLongList_NullBundle_ReturnsNull() {
+        List<Long> val = BundleUtils.getNullableLongList(null, KEY);
+        assertNull(val);
+    }
+
+
+    @Test
+    public void test_GetNullableLongList_NotFound_ReturnsNull() {
+        final Bundle b = mock(Bundle.class);
+
+        when(b.containsKey(anyString())).thenReturn(false);
+
+        List<Long> val = BundleUtils.getNullableLongList(b, KEY);
+
+        verify(b, times(0)).getLongArray(eq(KEY));
+
+        assertNull(val);
+    }
+
+
+    @Test
+    public void test_GetNullableLongList_Found_ReturnIt() {
+        final List<Long> expected = Arrays.asList(
+                new Random().nextLong(),
+                new Random().nextLong(),
+                new Random().nextLong()
+        );
+        final Bundle b = mock(Bundle.class);
+
+        when(b.containsKey(anyString())).thenReturn(true);
+
+        when(b.getLongArray(anyString())).thenReturn(Utils.toPrimitive(expected));
+
+        List<Long> val = BundleUtils.getNullableLongList(b, KEY);
+
+        verify(b).getLongArray(eq(KEY));
 
         assertEquals(expected, val);
     }


### PR DESCRIPTION
Export individual cards from CardBrowser

## Pull Request template

## Purpose / Description

> Following upstream, I believe it would be nice to be able to select card(s) in the deck browser and have an option to export them. It would be especially useful to share buggy card for debugging or to share a card type with an example without needing to share a whole deck or create it



## Fixes
Fixes #8045 

<img src="https://user-images.githubusercontent.com/6633545/110561577-9a3d2f80-8150-11eb-9415-160136c31cbe.png" width="25%"><img src="https://user-images.githubusercontent.com/6633545/110561582-9c06f300-8150-11eb-825c-1c79d09947f0.png" width="25%">

## Approach
I have extracted all the needed logic for exporting cards and moved it to its own class ``ExportHelper``. This class will delegate all actions from any activity that wish to implement exporting.

I also needed to change the ankilib to make it a colse as the pylib one

## How Has This Been Tested?

- [x] Export normal deck
- [x] Export collection
- [x] Export individual cards from card browser

## Learning (optional, can help others)
_Describe the research stage_

_Links to blog posts, patterns, libraries or addons used to solve this problem_

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)