### PR TITLE
feat: Warn when loading external http content

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -132,6 +132,7 @@ import com.ichi2.utils.FunctionalInterfaces.Function;
 import com.ichi2.utils.JSONArray;
 import com.ichi2.utils.JSONException;
 import com.ichi2.utils.JSONObject;
+import com.ichi2.utils.MaxExecFunction;
 import com.ichi2.utils.WebViewDebugging;
 
 import java.io.ByteArrayInputStream;
@@ -3305,6 +3306,12 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
             if (isLoadedFromProtocolRelativeUrl(url)) {
                 mMissingImageHandler.processInefficientImage(AbstractFlashcardViewer.this::displayMediaUpgradeRequiredSnackbar);
             }
+
+            if (isLoadedFromHttpUrl(url)) {
+                //shouldInterceptRequest is not running on the UI thread.
+                AbstractFlashcardViewer.this.runOnUiThread(() -> mDisplayMediaLoadedFromHttpWarningSnackbar.execOnceForReference(mCurrentCard));
+            }
+
             return null;
         }
 
@@ -3312,14 +3319,15 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
         @Override
         @TargetApi(Build.VERSION_CODES.N)
         public WebResourceResponse shouldInterceptRequest(WebView view, WebResourceRequest request) {
-            WebResourceResponse result = mLoader.shouldInterceptRequest(request.getUrl());
+            Uri url = request.getUrl();
+            WebResourceResponse result = mLoader.shouldInterceptRequest(url);
 
             if (result != null) {
                 return result;
             }
 
             if (!AdaptionUtil.hasWebBrowser(getBaseContext())) {
-                String scheme = request.getUrl().getScheme().trim();
+                String scheme = url.getScheme().trim();
                 if ("http".equalsIgnoreCase(scheme) || "https".equalsIgnoreCase(scheme)) {
                     String response = getResources().getString(R.string.no_outgoing_link_in_cardbrowser);
                     return new WebResourceResponse("text/html", "utf-8", new ByteArrayInputStream(response.getBytes()));
@@ -3330,7 +3338,20 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
                 mMissingImageHandler.processInefficientImage(AbstractFlashcardViewer.this::displayMediaUpgradeRequiredSnackbar);
             }
 
+            if (isLoadedFromHttpUrl(url)) {
+                //shouldInterceptRequest is not running on the UI thread.
+                AbstractFlashcardViewer.this.runOnUiThread(() -> mDisplayMediaLoadedFromHttpWarningSnackbar.execOnceForReference(mCurrentCard));
+            }
+
             return null;
+        }
+
+        protected boolean isLoadedFromHttpUrl(String url) {
+            return url.trim().toLowerCase().startsWith("http");
+        }
+
+        protected boolean isLoadedFromHttpUrl(Uri uri) {
+            return uri.getScheme().equalsIgnoreCase("http");
         }
 
         protected boolean isLoadedFromProtocolRelativeUrl(String url) {
@@ -3677,6 +3698,10 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
         }
     }
 
+    private final MaxExecFunction mDisplayMediaLoadedFromHttpWarningSnackbar = new MaxExecFunction(3, () -> {
+        OnClickListener onClickListener = (v) -> openUrl(Uri.parse(getString(R.string.link_faq_external_http_content)));
+        showSnackbar(getString(R.string.cannot_load_http_resource), R.string.help, onClickListener);
+    });
 
     private void displayCouldNotFindMediaSnackbar(String filename) {
         OnClickListener onClickListener = (v) -> openUrl(Uri.parse(getString(R.string.link_faq_missing_media)));

--- a/AnkiDroid/src/main/java/com/ichi2/utils/MaxExecFunction.java
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/MaxExecFunction.java
@@ -1,0 +1,67 @@
+/*
+ Copyright (c) 2021 Tarek Mohamed <tarekkma@gmail.com>
+
+ This program is free software; you can redistribute it and/or modify it under
+ the terms of the GNU General Public License as published by the Free Software
+ Foundation; either version 3 of the License, or (at your option) any later
+ version.
+
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License along with
+ this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.utils;
+
+import java.lang.ref.WeakReference;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+/**
+ * A utility class that can put a limit on how much a function gets called.
+ * It can also be used to only fire a function only once for a given reference, respecting the max execution number
+ */
+public class MaxExecFunction {
+
+    private final Runnable mFunc;
+    private final int mMaxNumberOfExecutions;
+    private int mCurrentNumberOfExecutions = 0;
+    @Nullable
+    private WeakReference<Object> mLastExecutionReference;
+
+
+    public MaxExecFunction(int maxNumberOfExecutions, @NonNull Runnable func) {
+        this.mFunc = func;
+        this.mMaxNumberOfExecutions = maxNumberOfExecutions;
+    }
+
+
+    /**
+     * Execute the function, if the max number of max execution hasn't been reached
+     */
+    public void exec() {
+        if (mCurrentNumberOfExecutions >= mMaxNumberOfExecutions) {
+            return;
+        }
+        mCurrentNumberOfExecutions++;
+        mFunc.run();
+    }
+
+
+    /**
+     * Execute the faction, if it didn't get called for the same reference before and the number execution hasn't been reached
+     *
+     * @param ref the reference
+     */
+    public void execOnceForReference(Object ref) {
+        if (mLastExecutionReference != null && mLastExecutionReference.get() == ref) {
+            return;
+        }
+        mLastExecutionReference = new WeakReference<>(ref);
+        exec();
+    }
+}

--- a/AnkiDroid/src/main/res/values/02-strings.xml
+++ b/AnkiDroid/src/main/res/values/02-strings.xml
@@ -323,6 +323,7 @@
     <!-- Card Viewer -->
     <string name="card_viewer_could_not_find_image">Card Content Error: Failed to load ‘%s’</string>
     <string name="card_viewer_media_relative_protocol">Card Content Error: Media update required</string>
+    <string name="cannot_load_http_resource">Loading http resources is no longer supported</string>
 
     <!-- Deck Picker -->
     <string name="deck_picker_failed_deck_load">Failed to load deck ‘%s’</string>

--- a/AnkiDroid/src/main/res/values/constants.xml
+++ b/AnkiDroid/src/main/res/values/constants.xml
@@ -190,6 +190,7 @@
     <string name="link_faq_tts">https://github.com/ankidroid/Anki-Android/wiki/FAQ#tts--text-to-speech-is-not-speaking</string>
     <string name="link_faq_missing_media" tools:ignore="Typos">https://github.com/ankidroid/Anki-Android/wiki/FAQ#why-doesnt-my-sound-or-image-work-on-ankidroid</string>
     <string name="link_faq_invalid_protocol_relative">https://github.com/ankidroid/Anki-Android/wiki/FAQ#why-do-my-images-need-a-protocol</string>
+    <string name="link_faq_external_http_content">https://github.com/ankidroid/Anki-Android/wiki/FAQ#external-content</string>
     <string name="shared_decks_url">https://ankiweb.net/shared/decks/</string>
     <string name="repair_deck">https://docs.ankiweb.net/#/files?id=corrupt-collections</string>
     <string name="resetpw_url">http://ankiweb.net/account/resetpw</string>

--- a/AnkiDroid/src/test/java/com/ichi2/utils/MaxExecFunctionTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/utils/MaxExecFunctionTest.java
@@ -1,0 +1,77 @@
+/*
+ *  Copyright (c) 2021 Tarek Mohamed <tarekkma@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.utils;
+
+import junit.framework.TestCase;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+
+import static org.mockito.Mockito.*;
+
+@RunWith(AndroidJUnit4.class)
+public class MaxExecFunctionTest extends TestCase {
+
+    private Runnable function;
+
+    @Before
+    public void before(){
+        function = mock(Runnable.class);
+    }
+
+    @Test
+    public void doNotExceedMaxExecs(){
+        final MaxExecFunction m = new MaxExecFunction(3,function);
+
+        for (int i = 0; i < 50; i++) {
+            m.exec();
+        }
+
+        verify(function,times(3)).run();
+    }
+
+    @Test
+    public void onlyOnceForAReference(){
+        final Object ref = new Object();
+        final MaxExecFunction m = new MaxExecFunction(3,function);
+
+        for (int i = 0; i < 50; i++) {
+            m.execOnceForReference(ref);
+        }
+
+        verify(function,times(1)).run();
+    }
+
+
+    @Test
+    public void doNotExceedMaxExecsWithMultipleReferences(){
+        final MaxExecFunction m = new MaxExecFunction(3,function);
+
+        for (int i = 0; i < 10; i++) {
+            final Object ref = new Object();
+            for (int j = 0; j < 10; j++) {
+                m.execOnceForReference(ref);
+            }
+        }
+
+        verify(function,times(3)).run();
+    }
+
+}


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
When the user tries to load an external file/image using the unsecure HTTP protocol will result in ``net::err_CLEARTEXT_NOT_PERMITTED`` and the file/image will not load for the user without any explanation.
see: #7231

<img src="https://user-images.githubusercontent.com/6633545/110771582-54bd5700-8263-11eb-83b1-34ec581e255a.png" width="25%">

## Fixes
Fixes #7741

## Approach
Since we are using a custom ``WebViewClient`` we have the ability to intercept requests that the web view is making. So checking whither the URL scheme is HTTP or not becomes easy.

2 new string were added, one for the snackbar message, and another constant link for the [FQA#external-content](https://github.com/ankidroid/Anki-Android/wiki/FAQ#external-content).

## How Has This Been Tested?

Tested manually by trying to load a card with an HTTP image

## Learning (optional, can help others)
Reading the docs of ``WebViewClient.shouldOverrideUrlLoading``. And realizing it won't be running on the Main/UI thread.

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)