### PR TITLE
Speed up randomizeCards and orderCards

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
@@ -2788,13 +2788,13 @@ public class SchedV2 extends AbstractSched {
 
 
     public void randomizeCards(long did) {
-        List<Long> cids = mCol.getDb().queryLongList("select id from cards where did = ?", did);
+        List<Long> cids = mCol.getDb().queryLongList("select id from cards where type = " + Consts.CARD_TYPE_NEW + " and did = ?", did);
         sortCards(cids, 1, 1, true, false);
     }
 
 
     public void orderCards(long did) {
-        List<Long> cids = mCol.getDb().queryLongList("SELECT id FROM cards WHERE did = ? ORDER BY nid", did);
+        List<Long> cids = mCol.getDb().queryLongList("SELECT id FROM cards WHERE type = " + Consts.CARD_TYPE_NEW + " AND did = ? ORDER BY nid", did);
         sortCards(cids, 1, 1, false, false);
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
@@ -2773,7 +2773,7 @@ public class SchedV2 extends AbstractSched {
                 int shiftby = high - low + 1;
                 mCol.getDb().execute(
                         "UPDATE cards SET mod = ?, usn = ?, due = due + ?"
-                                + " WHERE id NOT IN " + scids + " AND due >= ? AND queue = " + Consts.QUEUE_TYPE_NEW,
+                                + " WHERE id NOT IN " + scids + " AND due >= ? AND type = " + Consts.CARD_TYPE_NEW,
                         now, mCol.usn(), shiftby, low);
             }
         }


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
This makes shuffling your deck (that is, switching deck-ordering between random and in-order-added) faster.

## Fixes
Fixes #8172.

## Approach
The existing code passes in lots of cards that the subsequent UPDATEs filter out. We can go faster by doing more of this filtering in the initial query.

Stuff I worry about:

1. This isn't consistent with the [desktop implementation](https://github.com/ankitects/anki/blob/a0c47243b648a42f0f1a4a2c10c8b8495a0cfee6/rslib/src/scheduler/new.rs#L165)
2. Maybe I'm missing an important distinction between cards.type = ${CARD_TYPE_NEW} and cards.queue = ${QUEUE_TYPE_NEW}, and it's not safe to assume new cards are in the new queue or vice versa?
3. Maybe I'm missing something else, and we really _do_ need to pass non-new cards into `sortCards` here?

## How Has This Been Tested?
I copied my sqlite3 database off my phone to an emulator (Pixel 2 API 30), opened my main deck, and changed the sort order for new cards.

I ran `gradlew jacocoUnitTestReport` and `SchedV2Test.test_filt_keep_lrn_state` is failing for me. I _think_ that's environmental (it also fails on `master` on my machine), but someone who understands the functionality this test covers should take a look and make sure I didn't break it.

## Learning (optional, can help others)
To find out where this happens: `git grep 'in order added'` to find `new_order_labels`, `git grep 'new_order_labels'` to find `DeckOptions.java`. From there, I saw `commit`, `CollectionTask.reorder`, and `DeckOptions.resortConf`.

To see how it got that way, I looked around with `git log --pretty=fuller -p --follow -- $(git ls-files | grep SchedV2.java)` for a while and found 72fb782662e3d9231dff389325706d4939b931cf.

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [ ] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)

(Caveats: there are no UI changes. I didn't add any comments because I thought the change was relatively self-explanatory - let me know if that's wrong.)