### PR TITLE
Highlight default selection in pickers

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -160,7 +160,7 @@ public class NoteEditor extends AnkiActivity {
     // kill sCardBrowserCard and AbstractFlashcardViewer.getEditorCard()
 
 
-//    public static final String SOURCE_LANGUAGE = "SOURCE_LANGUAGE";
+    //    public static final String SOURCE_LANGUAGE = "SOURCE_LANGUAGE";
 //    public static final String TARGET_LANGUAGE = "TARGET_LANGUAGE";
     public static final String SOURCE_TEXT = "SOURCE_TEXT";
     public static final String TARGET_TEXT = "TARGET_TEXT";
@@ -734,7 +734,7 @@ public class NoteEditor extends AnkiActivity {
             case KeyEvent.KEYCODE_D:
                 //null check in case Spinner is moved into options menu in the future
                 if (event.isCtrlPressed() && (mNoteDeckSpinner != null)) {
-                        mNoteDeckSpinner.performClick();
+                    mNoteDeckSpinner.performClick();
                 }
                 break;
 
@@ -746,7 +746,7 @@ public class NoteEditor extends AnkiActivity {
 
             case KeyEvent.KEYCODE_N:
                 if (event.isCtrlPressed() && (mNoteTypeSpinner != null)) {
-                        mNoteTypeSpinner.performClick();
+                    mNoteTypeSpinner.performClick();
                 }
                 break;
 
@@ -1258,7 +1258,7 @@ public class NoteEditor extends AnkiActivity {
 
     private void closeCardEditorWithCheck() {
         if (hasUnsavedChanges()) {
-           showDiscardChangesDialog();
+            showDiscardChangesDialog();
         } else {
             closeNoteEditor();
         }
@@ -1397,27 +1397,27 @@ public class NoteEditor extends AnkiActivity {
                 break;
             }
             case REQUEST_TEMPLATE_EDIT: {
-                    // Model can change regardless of exit type - update ourselves and CardBrowser
-                    mReloadRequired = true;
-                    mEditorNote.reloadModel();
-                    if (mCurrentEditedCard == null || !mEditorNote.cids().contains(mCurrentEditedCard.getId())) {
-                        if (!mAddNote) {
-                            /* This can occur, for example, if the
-                             * card type was deleted or if the note
-                             * type was changed without moving this
-                             * card to another type. */
-                            Timber.d("onActivityResult() template edit return - current card is gone, close note editor");
-                            UIUtils.showThemedToast(this, getString(R.string.template_for_current_card_deleted), false);
-                            closeNoteEditor();
-                        } else {
-                            Timber.d("onActivityResult() template edit return, in add mode, just re-display");
-                        }
+                // Model can change regardless of exit type - update ourselves and CardBrowser
+                mReloadRequired = true;
+                mEditorNote.reloadModel();
+                if (mCurrentEditedCard == null || !mEditorNote.cids().contains(mCurrentEditedCard.getId())) {
+                    if (!mAddNote) {
+                        /* This can occur, for example, if the
+                         * card type was deleted or if the note
+                         * type was changed without moving this
+                         * card to another type. */
+                        Timber.d("onActivityResult() template edit return - current card is gone, close note editor");
+                        UIUtils.showThemedToast(this, getString(R.string.template_for_current_card_deleted), false);
+                        closeNoteEditor();
                     } else {
-                        Timber.d("onActivityResult() template edit return - current card exists");
-                        // reload current card - the template ordinals are possibly different post-edit
-                        mCurrentEditedCard = getCol().getCard(mCurrentEditedCard.getId());
-                        updateCards(mEditorNote.model());
+                        Timber.d("onActivityResult() template edit return, in add mode, just re-display");
                     }
+                } else {
+                    Timber.d("onActivityResult() template edit return - current card exists");
+                    // reload current card - the template ordinals are possibly different post-edit
+                    mCurrentEditedCard = getCol().getCard(mCurrentEditedCard.getId());
+                    updateCards(mEditorNote.model());
+                }
                 break;
             }
         }
@@ -2074,7 +2074,7 @@ public class NoteEditor extends AnkiActivity {
             String name = tmpls.getJSONObject(i).optString("name");
             // If more than one card, and we have an existing card, underline existing card
             if (!mAddNote && tmpls.length() > 1 && model == mEditorNote.model() && mCurrentEditedCard != null &&
-                mCurrentEditedCard.template().optString("name").equals(name)) {
+                    mCurrentEditedCard.template().optString("name").equals(name)) {
                 name = "<u>" + name + "</u>";
             }
             cardsList.append(name);
@@ -2402,8 +2402,6 @@ public class NoteEditor extends AnkiActivity {
         editText.setText(newText);
         new EditFieldTextWatcher(i).afterTextChanged(editText.getText());
     }
-
-
 
     @VisibleForTesting
     long getDeckId() {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -570,7 +570,7 @@ public class NoteEditor extends AnkiActivity {
                 // If this item is selected item
                 if(position == mNoteTypeSpinner.getSelectedItemPosition()){
                     // Set spinner selected popup item's text color
-                    tv.setBackgroundColor(Color.GRAY);
+                    tv.setBackgroundColor(Color.LTGRAY);
                 }
 
                 // Return the modified view
@@ -612,13 +612,16 @@ public class NoteEditor extends AnkiActivity {
         ArrayAdapter<String> noteDeckAdapter = new ArrayAdapter<String>(this, android.R.layout.simple_spinner_item, deckNames){
             @Override
             public View getDropDownView(int position, View convertView, ViewGroup parent){
+
+                mCurrentDid = mAllDeckIds.get(position);
+
                 // Cast the drop down items (popup items) as text view
                 TextView tv = (TextView) super.getDropDownView(position,convertView,parent);
 
                 // If this item is selected
                 if(position == mNoteDeckSpinner.getSelectedItemPosition()){
                     // Set spinner selected popup item's text color
-                    tv.setBackgroundColor(Color.GRAY);
+                    tv.setBackgroundColor(Color.LTGRAY);
                 }
 
                 // Return the modified view
@@ -627,19 +630,6 @@ public class NoteEditor extends AnkiActivity {
         };
         mNoteDeckSpinner.setAdapter(noteDeckAdapter);
         noteDeckAdapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
-        mNoteDeckSpinner.setOnItemSelectedListener(new OnItemSelectedListener() {
-            @Override
-            public void onItemSelected(AdapterView<?> parent, View view, int pos, long id) {
-                // Timber.i("NoteEditor:: onItemSelected() fired on mNoteDeckSpinner with pos = %d", pos);
-                mCurrentDid = mAllDeckIds.get(pos);
-            }
-
-            @Override
-            public void onNothingSelected(AdapterView<?> parent) {
-                // Do Nothing
-            }
-        });
-
         mCurrentDid = intent.getLongExtra(EXTRA_DID, mCurrentDid);
 
         setDid(mEditorNote);

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -567,10 +567,10 @@ public class NoteEditor extends AnkiActivity {
                 // Cast the drop down items (popup items) as text view
                 TextView tv = (TextView) super.getDropDownView(position,convertView,parent);
 
-                // If this item is selected item
+                // If this item is selected
                 if(position == mNoteTypeSpinner.getSelectedItemPosition()){
-                    // Set spinner selected popup item's text color
                     tv.setBackgroundColor(Color.LTGRAY);
+                    tv.setTextColor(Color.BLACK);
                 }
 
                 // Return the modified view
@@ -620,8 +620,8 @@ public class NoteEditor extends AnkiActivity {
 
                 // If this item is selected
                 if(position == mNoteDeckSpinner.getSelectedItemPosition()){
-                    // Set spinner selected popup item's text color
                     tv.setBackgroundColor(Color.LTGRAY);
+                    tv.setTextColor(Color.BLACK);
                 }
 
                 // Return the modified view

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -27,6 +27,7 @@ import android.content.Intent;
 import android.content.IntentFilter;
 import android.content.SharedPreferences;
 import android.content.res.Resources;
+import android.graphics.Color;
 import android.graphics.Typeface;
 import android.graphics.drawable.Drawable;
 import android.net.Uri;
@@ -52,6 +53,7 @@ import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.MenuItem;
 import android.view.View;
+import android.view.ViewGroup;
 import android.view.ViewGroup.MarginLayoutParams;
 import android.view.WindowManager;
 import android.view.inputmethod.InputMethodManager;
@@ -559,7 +561,22 @@ public class NoteEditor extends AnkiActivity {
             mAllModelIds.add(m.getLong("id"));
         }
 
-        ArrayAdapter<String> noteTypeAdapter = new ArrayAdapter<>(this, android.R.layout.simple_spinner_item, modelNames);
+        ArrayAdapter<String> noteTypeAdapter = new ArrayAdapter<String>(this, android.R.layout.simple_spinner_item, modelNames){
+            @Override
+            public View getDropDownView(int position, View convertView, ViewGroup parent){
+                // Cast the drop down items (popup items) as text view
+                TextView tv = (TextView) super.getDropDownView(position,convertView,parent);
+
+                // If this item is selected item
+                if(position == mNoteTypeSpinner.getSelectedItemPosition()){
+                    // Set spinner selected popup item's text color
+                    tv.setBackgroundColor(Color.GRAY);
+                }
+
+                // Return the modified view
+                return tv;
+            }
+        };
         mNoteTypeSpinner.setAdapter(noteTypeAdapter);
         noteTypeAdapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
 
@@ -592,7 +609,22 @@ public class NoteEditor extends AnkiActivity {
             mAllDeckIds.add(thisDid);
         }
 
-        ArrayAdapter<String> noteDeckAdapter = new ArrayAdapter<>(this, android.R.layout.simple_spinner_item, deckNames);
+        ArrayAdapter<String> noteDeckAdapter = new ArrayAdapter<String>(this, android.R.layout.simple_spinner_item, deckNames){
+            @Override
+            public View getDropDownView(int position, View convertView, ViewGroup parent){
+                // Cast the drop down items (popup items) as text view
+                TextView tv = (TextView) super.getDropDownView(position,convertView,parent);
+
+                // If this item is selected
+                if(position == mNoteDeckSpinner.getSelectedItemPosition()){
+                    // Set spinner selected popup item's text color
+                    tv.setBackgroundColor(Color.GRAY);
+                }
+
+                // Return the modified view
+                return tv;
+            }
+        };
         mNoteDeckSpinner.setAdapter(noteDeckAdapter);
         noteDeckAdapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
         mNoteDeckSpinner.setOnItemSelectedListener(new OnItemSelectedListener() {

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <p align="center">
 <img src="docs/graphics/logos/banner_readme.png"/>
-</p>
 
+<p>
 <a href="https://github.com/ankidroid/Anki-Android/releases"><img src="https://img.shields.io/github/v/release/ankidroid/Anki-Android" alt="release"/></a>
 <a href="https://travis-ci.org/github/ankidroid/Anki-Android"><img src="https://img.shields.io/travis/ankidroid/Anki-Android" alt="build"/></a>
 <a href="https://opencollective.com/ankidroid"><img src="https://img.shields.io/opencollective/all/ankidroid" alt="Open Collective backers and sponsors"/></a>

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <p align="center">
 <img src="docs/graphics/logos/banner_readme.png"/>
+</p>
 
-<p>
 <a href="https://github.com/ankidroid/Anki-Android/releases"><img src="https://img.shields.io/github/v/release/ankidroid/Anki-Android" alt="release"/></a>
 <a href="https://travis-ci.org/github/ankidroid/Anki-Android"><img src="https://img.shields.io/travis/ankidroid/Anki-Android" alt="build"/></a>
 <a href="https://opencollective.com/ankidroid"><img src="https://img.shields.io/opencollective/all/ankidroid" alt="Open Collective backers and sponsors"/></a>


### PR DESCRIPTION
## Purpose / Description
Highlight default selection in the pickers of note editor.


## Fixes
Issue #7931

## Approach
`Before change` When the user was in note editor, there is a selector to change the type of note or card's deck, It was not highlighted.
`After change` Now, when the user selects something in this section, the background of the selected one will be highlighted by default to "light gray" color and the text color itself will be "black".

## How Has This Been Tested?
Manual Testing; by interacting with the app
With device: Xiaomi redmi note 4 

edit: Tested by [Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&utm_source=www.apk4fun.com)

**Screenshots of last commit**
<div align="center">
<pre>
   <img alt="" width="30%" src="https://user-images.githubusercontent.com/48657780/111163716-0501c700-85a6-11eb-9bb5-7e86cffa7fff.jpeg">   <img alt="" width="30%" src="https://user-images.githubusercontent.com/48657780/111163722-0632f400-85a6-11eb-8327-8d4dd1a08489.jpeg">   <img alt="" width="30%" src="https://user-images.githubusercontent.com/48657780/111166210-8fe3c100-85a8-11eb-8be1-5558bf1858a0.jpeg"> 
     
</pre>
</div>

## Checklist

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)