### PR TITLE
Fixes #8164 Changed custom tabs theme with respect to app theme

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiActivity.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiActivity.java
@@ -377,7 +377,7 @@ public class AnkiActivity extends AppCompatActivity implements SimpleMessageDial
             return;
         }
 
-        int toolbarColor=Themes.getColorFromAttr(this,R.attr.customTabToolbarColor);
+        int toolbarColor = Themes.getColorFromAttr(this, R.attr.customTabToolbarColor);
         int navBarColor=Themes.getColorFromAttr(this,R.attr.customTabNavBarColor);
 
         CustomTabColorSchemeParams colorSchemeParams =
@@ -635,4 +635,3 @@ public class AnkiActivity extends AppCompatActivity implements SimpleMessageDial
         return true;
     }
 }
-

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiActivity.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiActivity.java
@@ -378,7 +378,7 @@ public class AnkiActivity extends AppCompatActivity implements SimpleMessageDial
         }
 
         int toolbarColor = Themes.getColorFromAttr(this, R.attr.customTabToolbarColor);
-        int navBarColor=Themes.getColorFromAttr(this,R.attr.customTabNavBarColor);
+        int navBarColor = Themes.getColorFromAttr(this, R.attr.customTabNavBarColor);
 
         CustomTabColorSchemeParams colorSchemeParams =
                 new CustomTabColorSchemeParams.Builder()

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiActivity.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiActivity.java
@@ -49,8 +49,6 @@ import com.ichi2.themes.Themes;
 import com.ichi2.utils.AdaptionUtil;
 import com.ichi2.utils.AndroidUiUtils;
 
-import java.lang.reflect.Method;
-
 import timber.log.Timber;
 
 import static androidx.browser.customtabs.CustomTabsIntent.COLOR_SCHEME_DARK;
@@ -70,9 +68,6 @@ public class AnkiActivity extends AppCompatActivity implements SimpleMessageDial
 
     // custom tabs
     private CustomTabActivityHelper mCustomTabActivityHelper;
-
-    // colors for custom tabs
-    int navBarColor, toolBarColor;
 
     public AnkiActivity() {
         super();
@@ -374,38 +369,6 @@ public class AnkiActivity extends AppCompatActivity implements SimpleMessageDial
         }
     }
 
-
-    /**
-     * This method will fetch the colors like colorPrimary and colorPrimaryDark, for setting them in CustomTabsIntent.
-     * This is used for changing toolbar and nav bar color in custom tabs with respect to the theme of app.
-     * Here, the current theme (from styles.xml) is fetched using reflection as it is private.
-     */
-    private void fetchThemeColors() {
-        int currentTheme = 0;
-        try {
-            Method m = Class.forName(Context.class.getName()).getMethod("getThemeResId");
-            m.setAccessible(true);
-            currentTheme = (Integer) m.invoke(this);
-        } catch (Exception e) {
-            System.out.println("currentTheme exception "+currentTheme+ e.getCause()+e.getMessage());
-        }
-
-        if (getResources().getResourceName(currentTheme).equals("com.ichi2.anki:style/Theme_Dark_Compat")) {
-            navBarColor = ContextCompat.getColor(this, R.color.material_grey_800);
-            toolBarColor = ContextCompat.getColor(this, R.color.material_grey_800);
-        } else if (getResources().getResourceName(currentTheme).equals("com.ichi2.anki:style/Theme_Plain_Compat")) {
-            navBarColor = ContextCompat.getColor(this, R.color.material_grey_500);
-            toolBarColor = ContextCompat.getColor(this, R.color.material_grey_600);
-        } else if (getResources().getResourceName(currentTheme).equals("com.ichi2.anki:style/Theme_Black_Compat")) {
-            navBarColor = toolBarColor = ContextCompat.getColor(this, R.color.black);
-        } else {
-            // if thrown exception this will prevent the app from crashing and will be set as default.
-            navBarColor = ContextCompat.getColor(this, R.color.material_light_blue_500);
-            toolBarColor = ContextCompat.getColor(this, R.color.material_light_blue_700);
-        }
-
-    }
-
     public void openUrl(Uri url) {
         //DEFECT: We might want a custom view for the toast, given i8n may make the text too long for some OSes to
         //display the toast
@@ -414,11 +377,12 @@ public class AnkiActivity extends AppCompatActivity implements SimpleMessageDial
             return;
         }
 
-        fetchThemeColors();
+        int toolbarColor=Themes.getColorFromAttr(this,R.attr.customTabToolbarColor);
+        int navBarColor=Themes.getColorFromAttr(this,R.attr.customTabNavBarColor);
 
         CustomTabColorSchemeParams colorSchemeParams =
                 new CustomTabColorSchemeParams.Builder()
-                        .setToolbarColor(toolBarColor)
+                        .setToolbarColor(toolbarColor)
                         .setNavigationBarColor(navBarColor)
                         .build();
 

--- a/AnkiDroid/src/main/res/drawable/ic_back_arrow_custom_tab.xml
+++ b/AnkiDroid/src/main/res/drawable/ic_back_arrow_custom_tab.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:tint="#FFFFFF"
+    android:viewportHeight="24"
+    android:viewportWidth="24">
+    <path
+        android:fillColor="@color/white"
+        android:pathData="M20,11H7.83l5.59,-5.59L12,4l-8,8 8,8 1.41,-1.41L7.83,13H20v-2z" />
+</vector>

--- a/AnkiDroid/src/main/res/values/attrs.xml
+++ b/AnkiDroid/src/main/res/values/attrs.xml
@@ -112,4 +112,7 @@
     <attr name="fab_labelsTextColor" format="color"/>
     <attr name="fab_background" format="color"/>
     <attr name="fab_item_background" format="reference"/>
+    <!--Custom Tabs colors-->
+    <attr name="customTabToolbarColor" format="color"/>
+    <attr name="customTabNavBarColor" format="color"/>
 </resources>

--- a/AnkiDroid/src/main/res/values/theme_black.xml
+++ b/AnkiDroid/src/main/res/values/theme_black.xml
@@ -100,6 +100,9 @@
         <item name="android:listPreferredItemHeight">56dip</item>
         <item name="md_dark_theme">true</item>
         <item name="md_background_color">@color/theme_black_primary_light</item>
+        <!--Custom Tabs colors-->
+        <item name="customTabToolbarColor">#000000</item>
+        <item name="customTabNavBarColor">#070707</item>
     </style>
 
     <!-- Preferences screens -->

--- a/AnkiDroid/src/main/res/values/theme_dark.xml
+++ b/AnkiDroid/src/main/res/values/theme_dark.xml
@@ -108,6 +108,9 @@
         <!-- Dialog styles -->
         <item name="android:listPreferredItemHeight">56dip</item>
         <item name="md_dark_theme">true</item>
+        <!--Custom Tabs colors-->
+        <item name="customTabToolbarColor">#3d3d3d</item>
+        <item name="customTabNavBarColor">@color/material_grey_800</item>
     </style>
 
     <!-- Preferences screens -->

--- a/AnkiDroid/src/main/res/values/theme_light.xml
+++ b/AnkiDroid/src/main/res/values/theme_light.xml
@@ -122,6 +122,9 @@ APIs. It's visible when there aren't enough decks to fill the screen.
         <!-- Dialog styles -->
         <item name="android:listPreferredItemHeight">56dip</item>
         <item name="md_dark_theme">false</item>
+        <!--Custom Tabs colors-->
+        <item name="customTabToolbarColor">@color/material_light_blue_700</item>
+        <item name="customTabNavBarColor">@color/material_light_blue_500</item>
     </style>
 
     <!-- Preferences screens -->

--- a/AnkiDroid/src/main/res/values/theme_plain.xml
+++ b/AnkiDroid/src/main/res/values/theme_plain.xml
@@ -39,6 +39,9 @@
         <item name="fab_normal">@color/theme_plain_accent</item>
         <item name="fab_pressed">#c8607d8b</item> <!-- 55 less opacity than fab_normal -->
         <item name="fab_background">@color/theme_plain_primary_dark</item>
+        <!--Custom Tabs colors-->
+        <item name="customTabToolbarColor">@color/material_grey_600</item>
+        <item name="customTabNavBarColor">@color/material_grey_500</item>
     </style>
 
     <!-- Preferences screens -->


### PR DESCRIPTION
## Purpose / Description
The app was not changing the theme of custom tabs with respect to the theme of the app (it was always blue colored theme). In this PR, that issue is fixed. The change is somewhat broader than mentioned in issue as all the themes (light, plain, dark, black) are considered.
After fixing, the output of all 4 themes is in below image.

![img](https://user-images.githubusercontent.com/65870389/110910463-61ab7a80-8337-11eb-95b4-17f98ccbc6f6.png)

## Fixes
Fixes #8164 

## Approach
Firstly, I used reflection to get the current theme value in `int` format (if the reflection throws exception then we will switch to the light mode irrespective of app theme). Then, I had made some changes in `CustomTabsIntent`.

## How Has This Been Tested?
Tested this on real device (Redmi Note 7S and Android SDK 29).

## Learning (optional, can help others)
Anyone interested in how custom tabs work can look here at the official [link.](https://developer.android.com/reference/androidx/browser/customtabs/CustomTabsIntent.Builder)

## Checklist

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)