### PR TITLE
Fixes #6535 ChangeLogs theme with respect to app theme

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/Info.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Info.java
@@ -18,17 +18,19 @@
 
 package com.ichi2.anki;
 
+import android.annotation.SuppressLint;
 import android.content.ClipData;
 import android.content.Context;
 import android.content.res.Resources;
+import android.content.res.TypedArray;
 import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
-import android.util.TypedValue;
 import android.view.KeyEvent;
 import android.view.View;
 import android.webkit.WebChromeClient;
 import android.webkit.WebView;
+import android.webkit.WebViewClient;
 import android.widget.Button;
 
 import com.ichi2.utils.IntentUtil;
@@ -52,6 +54,7 @@ public class Info extends AnkiActivity {
     public static final int TYPE_NEW_VERSION = 2;
 
 
+    @SuppressLint("SetJavaScriptEnabled")
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         if (showedActivityFailedScreen(savedInstanceState)) {
@@ -94,16 +97,16 @@ public class Info extends AnkiActivity {
         }
 
         StringBuilder sb = new StringBuilder();
+
+        // Apply Theme colors
+        TypedArray typedArray = getTheme().obtainStyledAttributes(new int[] {android.R.attr.colorBackground, android.R.attr.textColor});
+        int backgroundColor = typedArray.getColor(0, -1);
+        String textColor = String.format("#%06X", (0xFFFFFF & typedArray.getColor(1, -1))); // Color to hex string
+        webView.setBackgroundColor(backgroundColor);
+
         switch (mType) {
             case TYPE_ABOUT: {
                 String[] content = res.getStringArray(R.array.about_content);
-
-                // Apply theme colours.
-                TypedValue typedValue = new TypedValue();
-                getTheme().resolveAttribute(android.R.attr.colorBackground, typedValue, true);
-                webView.setBackgroundColor(typedValue.data);
-                getTheme().resolveAttribute(android.R.attr.textColor, typedValue, true);
-                String textColor = String.format("#%06X", (0xFFFFFF & typedValue.data)); // Color to hex string
                 sb.append("<html><style>body {color:").append(textColor).append(";}</style>");
 
                 sb.append("<body text=\"#000000\" link=\"#E37068\" alink=\"#E37068\" vlink=\"#E37068\">");
@@ -134,9 +137,28 @@ public class Info extends AnkiActivity {
                 Button continueButton = (findViewById(R.id.right_button));
                 continueButton.setText(res.getString(R.string.dialog_continue));
                 continueButton.setOnClickListener((arg) -> close());
+                String background = String.format("#%06X", (0xFFFFFF & backgroundColor));
                 webView.loadUrl("file:///android_asset/changelog.html");
-                break;
+                webView.getSettings().setJavaScriptEnabled(true);
+
+                webView.setWebViewClient(new WebViewClient() {
+                    @Override
+                    public void onPageFinished(WebView view, String url) {
+
+                        /* The order of below javascript code must not change (this order works both in debug and release mode)
+                         *  or else it will break in any one mode.
+                         */
+                        webView.loadUrl(
+                                "javascript:document.body.style.setProperty(\"color\", \"" + textColor + "\");"
+                                        + "x=document.getElementsByTagName(\"a\"); for(i=0;i<x.length;i++){x[i].style.color=\"#E37068\";}"
+                                        + "document.getElementsByTagName(\"h1\")[0].style.color=\"" + textColor + "\";"
+                                        + "x=document.getElementsByTagName(\"h2\"); for(i=0;i<x.length;i++){x[i].style.color=\"#E37068\";}"
+                                        + "document.body.style.setProperty(\"background\", \"" + background + "\");"
+                        );
+                    }
+                });
             }
+            break;
             default:
                 finishWithoutAnimation();
                 break;


### PR DESCRIPTION
## Purpose / Description
Change log was always in light mode even when the app is in night mode both in release and debug build.
Also, just reformatted 2-3 lines `(ctrl+alt+L)` .
**Point to note is to test whether this will work in release mode I copied the changelog from the app ( live on playstore). This is to make sure that changelogs does not break in release builds.**

Attaching Screenshot for better refrence.
![img](https://user-images.githubusercontent.com/65870389/111028923-dfe34c00-841f-11eb-9b00-cd66c30b5d33.png)


## Fixes
Fixes #6535 

## Approach
Used **javascript** to make changes in the colors of `webView` (textColor, backgroundColor and link colors).

## How Has This Been Tested?
Tested on real device (Redmi Note 7S and API 29).

## Learning (optional, can help others)
This PR can help you to learn the usage and implementation of javascript in webView for changing themes (day/night mode).

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)