### PR TITLE
Remove codecov

### DIFF
--- a/.github/workflows/tests_unit.yml
+++ b/.github/workflows/tests_unit.yml
@@ -72,12 +72,3 @@ jobs:
 
       - name: Run Unit Tests
         run: ./gradlew jacocoUnitTestReport
-
-      - name: Submit Coverage
-        # This can fail on timeouts etc, wrap with retry
-        uses: nick-invision/retry@v2
-        with:
-          timeout_minutes: 10
-          retry_wait_seconds: 60
-          max_attempts: 3
-          command: curl https://codecov.io/bash -o codecov.sh && bash ./codecov.sh 


### PR DESCRIPTION
Currently, it seems only negative to me.
It adds far too much comment, making the code read really hard. Indeed, when there is an empty line, it is not shown as an erroneous line, so it put a new comment after each empty line

Furthermore, it shows as broken commit while we are actually accepting it. Making it hard to check when there is really worry, as with unit test, and when it's only a covering problem, which currently is not something we work on.
