### PR TITLE
Added increment/decrement buttons for "New cards/day" preference

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/preferences/IncrementerNumberRangePreference.java
+++ b/AnkiDroid/src/main/java/com/ichi2/preferences/IncrementerNumberRangePreference.java
@@ -69,6 +69,7 @@ public class IncrementerNumberRangePreference extends NumberRangePreference {
     protected void onDialogClosed(boolean positiveResult) {
         super.onDialogClosed(positiveResult);
 
+        // Need to remove Views explicitly otherwise the app crashes when the setting is accessed again
         // Remove mEditText, mIncrementButton, mDecrementButton before removing mLinearLayout
         mLinearLayout.removeAllViews();
         ViewGroup parent = (ViewGroup) mLinearLayout.getParent();

--- a/AnkiDroid/src/main/java/com/ichi2/preferences/IncrementerNumberRangePreference.java
+++ b/AnkiDroid/src/main/java/com/ichi2/preferences/IncrementerNumberRangePreference.java
@@ -97,7 +97,5 @@ public class IncrementerNumberRangePreference extends NumberRangePreference {
         mLinearLayout.removeAllViews();
         ViewGroup parent = (ViewGroup) mLinearLayout.getParent();
         parent.removeView(mLinearLayout);
-
-        notifyChanged();
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/preferences/IncrementerNumberRangePreference.java
+++ b/AnkiDroid/src/main/java/com/ichi2/preferences/IncrementerNumberRangePreference.java
@@ -18,6 +18,7 @@ package com.ichi2.preferences;
 
 import android.content.Context;
 import android.util.AttributeSet;
+import android.view.Gravity;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.Button;
@@ -79,8 +80,19 @@ public class IncrementerNumberRangePreference extends NumberRangePreference {
     }
 
 
-    @Override // TODO: Edit layout style to fill entire width
+    @Override
     protected View onCreateDialogView() {
+        // Make mEditText fill all available space
+        mLinearLayout.setOrientation(LinearLayout.HORIZONTAL);
+        LinearLayout.LayoutParams params = new LinearLayout.LayoutParams(
+                LinearLayout.LayoutParams.MATCH_PARENT,
+                LinearLayout.LayoutParams.WRAP_CONTENT,
+                1.0f
+        );
+        mEditText.setLayoutParams(params);
+        // Centre text inside mEditText
+        mEditText.setGravity(Gravity.CENTER_HORIZONTAL);
+
         mLinearLayout.addView(mIncrementButton);
         mLinearLayout.addView(mEditText);
         mLinearLayout.addView(mDecrementButton);

--- a/AnkiDroid/src/main/java/com/ichi2/preferences/IncrementerNumberRangePreference.java
+++ b/AnkiDroid/src/main/java/com/ichi2/preferences/IncrementerNumberRangePreference.java
@@ -85,31 +85,31 @@ public class IncrementerNumberRangePreference extends NumberRangePreference {
      * Sets {@link #mEditText} width and gravity.
      */
     private void initialize() {
-        mIncrementButton.setText("+");
-        mDecrementButton.setText("-");
-
+        // Layout parameters for mEditText
+        LinearLayout.LayoutParams editTextParams = new LinearLayout.LayoutParams(
+                LinearLayout.LayoutParams.MATCH_PARENT,
+                LinearLayout.LayoutParams.WRAP_CONTENT,
+                3.0f
+        );
+        // Layout parameters for mIncrementButton and mDecrementButton
         LinearLayout.LayoutParams buttonParams = new LinearLayout.LayoutParams(
                 LinearLayout.LayoutParams.WRAP_CONTENT,
                 LinearLayout.LayoutParams.WRAP_CONTENT,
                 1.0f
         );
 
+        mEditText.setLayoutParams(editTextParams);
+        // Centre text inside mEditText
+        mEditText.setGravity(Gravity.CENTER_HORIZONTAL);
+
+        mIncrementButton.setText("+");
+        mDecrementButton.setText("-");
         mIncrementButton.setLayoutParams(buttonParams);
         mDecrementButton.setLayoutParams(buttonParams);
-
         mIncrementButton.setOnClickListener(view -> updateEditText(true));
         mDecrementButton.setOnClickListener(view -> updateEditText(false));
 
-        // Make mEditText fill all available space
         mLinearLayout.setOrientation(LinearLayout.HORIZONTAL);
-        LinearLayout.LayoutParams params = new LinearLayout.LayoutParams(
-                LinearLayout.LayoutParams.MATCH_PARENT,
-                LinearLayout.LayoutParams.WRAP_CONTENT,
-                3.0f
-        );
-        mEditText.setLayoutParams(params);
-        // Centre text inside mEditText
-        mEditText.setGravity(Gravity.CENTER_HORIZONTAL);
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/preferences/IncrementerNumberRangePreference.java
+++ b/AnkiDroid/src/main/java/com/ichi2/preferences/IncrementerNumberRangePreference.java
@@ -1,0 +1,95 @@
+/****************************************************************************************
+ * Copyright (c) 2021 Tushar Bhatt <tbhatt312@gmail.com>                                *
+ *                                                                                      *
+ * This program is free software; you can redistribute it and/or modify it under        *
+ * the terms of the GNU General Public License as published by the Free Software        *
+ * Foundation; either version 3 of the License, or (at your option) any later           *
+ * version.                                                                             *
+ *                                                                                      *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *                                                                                      *
+ * You should have received a copy of the GNU General Public License along with         *
+ * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ ****************************************************************************************/
+
+package com.ichi2.preferences;
+
+import android.content.Context;
+import android.util.AttributeSet;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.Button;
+import android.widget.EditText;
+import android.widget.LinearLayout;
+import android.widget.TextView;
+
+
+@SuppressWarnings("deprecation") // TODO Tracked in https://github.com/ankidroid/Anki-Android/issues/5019
+public class IncrementerNumberRangePreference extends NumberRangePreference {
+
+    private final LinearLayout mLinearLayout = new LinearLayout(getContext());
+    private final EditText mEditText = getEditText();
+    private final Button mIncrementButton = new Button(getContext());
+    private final Button mDecrementButton = new Button(getContext());
+
+
+    public IncrementerNumberRangePreference(Context context, AttributeSet attrs, int defStyle) {
+        super(context, attrs, defStyle);
+        initialize();
+    }
+
+
+    public IncrementerNumberRangePreference(Context context, AttributeSet attrs) {
+        super(context, attrs);
+        initialize();
+    }
+
+
+    public IncrementerNumberRangePreference(Context context) {
+        super(context);
+        initialize();
+    }
+
+
+    private void initialize() {
+        mIncrementButton.setText("+");
+        mDecrementButton.setText("-");
+
+        mIncrementButton.setOnClickListener(view -> {
+            int value = Integer.parseInt(String.valueOf(mEditText.getText()));
+            value = IncrementerNumberRangePreference.super.getValidatedRangeFromInt(value + 1);
+            mEditText.setText(String.valueOf(value));
+        });
+
+        mDecrementButton.setOnClickListener(view -> {
+            int value = Integer.parseInt(String.valueOf(mEditText.getText()));
+            value = IncrementerNumberRangePreference.super.getValidatedRangeFromInt(value - 1);
+            mEditText.setText(String.valueOf(value));
+        });
+    }
+
+
+    @Override // TODO: Edit layout style to will entire width
+    protected View onCreateDialogView() {
+        mLinearLayout.addView(mIncrementButton);
+        mLinearLayout.addView(mEditText);
+        mLinearLayout.addView(mDecrementButton);
+
+        return mLinearLayout;
+    }
+
+
+    //persist values and disassemble views
+    @Override
+    protected void onDialogClosed(boolean positiveResult) {
+        super.onDialogClosed(positiveResult);
+
+        mLinearLayout.removeAllViews();
+        ViewGroup parent = (ViewGroup) mLinearLayout.getParent();
+        parent.removeView(mLinearLayout);
+
+        notifyChanged();
+    }
+}

--- a/AnkiDroid/src/main/java/com/ichi2/preferences/IncrementerNumberRangePreference.java
+++ b/AnkiDroid/src/main/java/com/ichi2/preferences/IncrementerNumberRangePreference.java
@@ -88,6 +88,15 @@ public class IncrementerNumberRangePreference extends NumberRangePreference {
         mIncrementButton.setText("+");
         mDecrementButton.setText("-");
 
+        LinearLayout.LayoutParams buttonParams = new LinearLayout.LayoutParams(
+                LinearLayout.LayoutParams.WRAP_CONTENT,
+                LinearLayout.LayoutParams.WRAP_CONTENT,
+                1.0f
+        );
+
+        mIncrementButton.setLayoutParams(buttonParams);
+        mDecrementButton.setLayoutParams(buttonParams);
+
         mIncrementButton.setOnClickListener(view -> updateEditText(true));
         mDecrementButton.setOnClickListener(view -> updateEditText(false));
 
@@ -96,7 +105,7 @@ public class IncrementerNumberRangePreference extends NumberRangePreference {
         LinearLayout.LayoutParams params = new LinearLayout.LayoutParams(
                 LinearLayout.LayoutParams.MATCH_PARENT,
                 LinearLayout.LayoutParams.WRAP_CONTENT,
-                1.0f
+                3.0f
         );
         mEditText.setLayoutParams(params);
         // Centre text inside mEditText

--- a/AnkiDroid/src/main/java/com/ichi2/preferences/IncrementerNumberRangePreference.java
+++ b/AnkiDroid/src/main/java/com/ichi2/preferences/IncrementerNumberRangePreference.java
@@ -25,6 +25,8 @@ import android.widget.Button;
 import android.widget.EditText;
 import android.widget.LinearLayout;
 
+import com.ichi2.anki.R;
+
 
 @SuppressWarnings("deprecation") // TODO Tracked in https://github.com/ankidroid/Anki-Android/issues/5019
 public class IncrementerNumberRangePreference extends NumberRangePreference {
@@ -102,8 +104,8 @@ public class IncrementerNumberRangePreference extends NumberRangePreference {
         // Centre text inside mEditText
         mEditText.setGravity(Gravity.CENTER_HORIZONTAL);
 
-        mIncrementButton.setText("+");
-        mDecrementButton.setText("-");
+        mIncrementButton.setText(R.string.plus_sign);
+        mDecrementButton.setText(R.string.minus_sign);
         mIncrementButton.setLayoutParams(buttonParams);
         mDecrementButton.setLayoutParams(buttonParams);
         mIncrementButton.setOnClickListener(view -> updateEditText(true));

--- a/AnkiDroid/src/main/java/com/ichi2/preferences/IncrementerNumberRangePreference.java
+++ b/AnkiDroid/src/main/java/com/ichi2/preferences/IncrementerNumberRangePreference.java
@@ -55,17 +55,6 @@ public class IncrementerNumberRangePreference extends NumberRangePreference {
 
     @Override
     protected View onCreateDialogView() {
-        // Make mEditText fill all available space
-        mLinearLayout.setOrientation(LinearLayout.HORIZONTAL);
-        LinearLayout.LayoutParams params = new LinearLayout.LayoutParams(
-                LinearLayout.LayoutParams.MATCH_PARENT,
-                LinearLayout.LayoutParams.WRAP_CONTENT,
-                1.0f
-        );
-        mEditText.setLayoutParams(params);
-        // Centre text inside mEditText
-        mEditText.setGravity(Gravity.CENTER_HORIZONTAL);
-
         mLinearLayout.addView(mIncrementButton);
         mLinearLayout.addView(mEditText);
         mLinearLayout.addView(mDecrementButton);
@@ -90,6 +79,10 @@ public class IncrementerNumberRangePreference extends NumberRangePreference {
      * <p>
      * Sets appropriate Text and OnClickListener to {@link #mIncrementButton} and {@link #mDecrementButton}
      * respectively.
+     * <p>
+     * Sets orientation for {@link #mLinearLayout}.
+     * <p>
+     * Sets {@link #mEditText} width and gravity.
      */
     private void initialize() {
         mIncrementButton.setText("+");
@@ -97,6 +90,17 @@ public class IncrementerNumberRangePreference extends NumberRangePreference {
 
         mIncrementButton.setOnClickListener(view -> updateEditText(true));
         mDecrementButton.setOnClickListener(view -> updateEditText(false));
+
+        // Make mEditText fill all available space
+        mLinearLayout.setOrientation(LinearLayout.HORIZONTAL);
+        LinearLayout.LayoutParams params = new LinearLayout.LayoutParams(
+                LinearLayout.LayoutParams.MATCH_PARENT,
+                LinearLayout.LayoutParams.WRAP_CONTENT,
+                1.0f
+        );
+        mEditText.setLayoutParams(params);
+        // Centre text inside mEditText
+        mEditText.setGravity(Gravity.CENTER_HORIZONTAL);
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/preferences/IncrementerNumberRangePreference.java
+++ b/AnkiDroid/src/main/java/com/ichi2/preferences/IncrementerNumberRangePreference.java
@@ -30,7 +30,7 @@ import android.widget.TextView;
 public class IncrementerNumberRangePreference extends NumberRangePreference {
 
     private final LinearLayout mLinearLayout = new LinearLayout(getContext());
-    private final EditText mEditText = getEditText();
+    private final EditText mEditText = getEditText(); // Get default EditText from parent
     private final Button mIncrementButton = new Button(getContext());
     private final Button mDecrementButton = new Button(getContext());
 
@@ -53,25 +53,33 @@ public class IncrementerNumberRangePreference extends NumberRangePreference {
     }
 
 
+    /**
+     * Performs initial configurations which are common for all constructors.
+     * <p>
+     * Sets appropriate Text and OnClickListener to {@link #mIncrementButton} and {@link #mDecrementButton}
+     * respectively.
+     */
     private void initialize() {
         mIncrementButton.setText("+");
         mDecrementButton.setText("-");
 
         mIncrementButton.setOnClickListener(view -> {
             int value = Integer.parseInt(String.valueOf(mEditText.getText()));
+            // Check (value + 1) is in range
             value = IncrementerNumberRangePreference.super.getValidatedRangeFromInt(value + 1);
             mEditText.setText(String.valueOf(value));
         });
 
         mDecrementButton.setOnClickListener(view -> {
             int value = Integer.parseInt(String.valueOf(mEditText.getText()));
+            // Check (value - 1) is in range
             value = IncrementerNumberRangePreference.super.getValidatedRangeFromInt(value - 1);
             mEditText.setText(String.valueOf(value));
         });
     }
 
 
-    @Override // TODO: Edit layout style to will entire width
+    @Override // TODO: Edit layout style to fill entire width
     protected View onCreateDialogView() {
         mLinearLayout.addView(mIncrementButton);
         mLinearLayout.addView(mEditText);
@@ -81,11 +89,11 @@ public class IncrementerNumberRangePreference extends NumberRangePreference {
     }
 
 
-    //persist values and disassemble views
     @Override
     protected void onDialogClosed(boolean positiveResult) {
         super.onDialogClosed(positiveResult);
 
+        // Remove mEditText, mIncrementButton, mDecrementButton before removing mLinearLayout
         mLinearLayout.removeAllViews();
         ViewGroup parent = (ViewGroup) mLinearLayout.getParent();
         parent.removeView(mLinearLayout);

--- a/AnkiDroid/src/main/java/com/ichi2/preferences/IncrementerNumberRangePreference.java
+++ b/AnkiDroid/src/main/java/com/ichi2/preferences/IncrementerNumberRangePreference.java
@@ -24,7 +24,6 @@ import android.view.ViewGroup;
 import android.widget.Button;
 import android.widget.EditText;
 import android.widget.LinearLayout;
-import android.widget.TextView;
 
 
 @SuppressWarnings("deprecation") // TODO Tracked in https://github.com/ankidroid/Anki-Android/issues/5019
@@ -51,32 +50,6 @@ public class IncrementerNumberRangePreference extends NumberRangePreference {
     public IncrementerNumberRangePreference(Context context) {
         super(context);
         initialize();
-    }
-
-
-    /**
-     * Performs initial configurations which are common for all constructors.
-     * <p>
-     * Sets appropriate Text and OnClickListener to {@link #mIncrementButton} and {@link #mDecrementButton}
-     * respectively.
-     */
-    private void initialize() {
-        mIncrementButton.setText("+");
-        mDecrementButton.setText("-");
-
-        mIncrementButton.setOnClickListener(view -> {
-            int value = Integer.parseInt(String.valueOf(mEditText.getText()));
-            // Check (value + 1) is in range
-            value = IncrementerNumberRangePreference.super.getValidatedRangeFromInt(value + 1);
-            mEditText.setText(String.valueOf(value));
-        });
-
-        mDecrementButton.setOnClickListener(view -> {
-            int value = Integer.parseInt(String.valueOf(mEditText.getText()));
-            // Check (value - 1) is in range
-            value = IncrementerNumberRangePreference.super.getValidatedRangeFromInt(value - 1);
-            mEditText.setText(String.valueOf(value));
-        });
     }
 
 
@@ -109,5 +82,34 @@ public class IncrementerNumberRangePreference extends NumberRangePreference {
         mLinearLayout.removeAllViews();
         ViewGroup parent = (ViewGroup) mLinearLayout.getParent();
         parent.removeView(mLinearLayout);
+    }
+
+
+    /**
+     * Performs initial configurations which are common for all constructors.
+     * <p>
+     * Sets appropriate Text and OnClickListener to {@link #mIncrementButton} and {@link #mDecrementButton}
+     * respectively.
+     */
+    private void initialize() {
+        mIncrementButton.setText("+");
+        mDecrementButton.setText("-");
+
+        mIncrementButton.setOnClickListener(view -> updateEditText(true));
+        mDecrementButton.setOnClickListener(view -> updateEditText(false));
+    }
+
+
+    /**
+     * Increments/Decrements the value of {@link #mEditText} by 1 based on the parameter value.
+     *
+     * @param isIncrement Indicator for whether to increase or decrease the value.
+     */
+    private void updateEditText(boolean isIncrement) {
+        int value = Integer.parseInt(mEditText.getText().toString());
+        value = isIncrement ? value + 1 : value - 1;
+        // Make sure value is within range
+        value = super.getValidatedRangeFromInt(value);
+        mEditText.setText(String.valueOf(value));
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/preferences/NumberRangePreference.java
+++ b/AnkiDroid/src/main/java/com/ichi2/preferences/NumberRangePreference.java
@@ -109,7 +109,7 @@ public class NumberRangePreference extends android.preference.EditTextPreference
      * @param input Integer to validate.
      * @return The input value within acceptable range.
      */
-    private int getValidatedRangeFromInt(int input) {
+    protected int getValidatedRangeFromInt(int input) {
         if (input < mMin) {
             input = mMin;
         } else if (input > mMax) {

--- a/AnkiDroid/src/main/res/values/02-strings.xml
+++ b/AnkiDroid/src/main/res/values/02-strings.xml
@@ -363,4 +363,9 @@
     <string name="create_shortcut_failed" comment="home screen == launcher">Your home screen does not allow AnkiDroid to add shortcuts</string>
     <string name="create_shortcut_error">Error adding shortcut: %s</string>
     <string name="note_editor_capitalize" comment="This is for a switch with a checkbox - on: enabled">Capitalize sentences</string>
+
+
+    <!-- Symbols used as Button text in IncrementNumberRangePreference -->
+    <string name="plus_sign" comment="Label for increment button in IncrementerNumberRangePreference">+</string>
+    <string name="minus_sign" comment="Label for increment button in IncrementerNumberRangePreference">-</string>
 </resources>

--- a/AnkiDroid/src/main/res/values/02-strings.xml
+++ b/AnkiDroid/src/main/res/values/02-strings.xml
@@ -367,5 +367,5 @@
 
     <!-- Symbols used as Button text in IncrementNumberRangePreference -->
     <string name="plus_sign" comment="Label for increment button in IncrementerNumberRangePreference">+</string>
-    <string name="minus_sign" comment="Label for increment button in IncrementerNumberRangePreference">-</string>
+    <string name="minus_sign" comment="Label for decrement button in IncrementerNumberRangePreference">-</string>
 </resources>

--- a/AnkiDroid/src/main/res/xml/deck_options.xml
+++ b/AnkiDroid/src/main/res/xml/deck_options.xml
@@ -75,8 +75,7 @@
                 android:key="newOrder"
                 android:summary=""
                 android:title="@string/deck_conf_order" />
-
-            <com.ichi2.preferences.NumberRangePreference
+            <com.ichi2.preferences.IncrementerNumberRangePreference
                 android:key="newPerDay"
                 android:title="@string/deck_conf_new_cards_day"
                 app:max="9999"


### PR DESCRIPTION
## Added increment/decrement buttons for "New cards/day" preference

## Purpose / Description
Feature request was made to add + and - buttons to "New cards/day" preference in Deck options. This PR implements that feature.

## Fixes
Fixes #8024 

## Approach
Created a new class `com.ichi2.preferences.IncrementerNumberRangePreference` which extends `com.ichi2.preferences.NumberRangePreference` and adds two buttons to the preference, one for increment and one for decrement. This class can be used for other numerical preferences as well.

## How Has This Been Tested?

Emulated on API 29, Android 10.0. Worked as expected.

## Output

![output](https://user-images.githubusercontent.com/21220253/111055787-612df380-849f-11eb-8f57-d5cdb3d948d0.png)

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)