### PR TITLE
JS API to know if answer is displaying or question

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -4024,7 +4024,7 @@ see card.js for available functions
         }
 
         @JavascriptInterface
-        public boolean ankiIsDisplayAnswer() { return isDisplayingAnswer(); };
+        public boolean ankiIsDisplayingAnswer() { return isDisplayingAnswer(); };
 
         @JavascriptInterface
         public boolean ankiIsActiveNetworkMetered() {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -4024,6 +4024,9 @@ see card.js for available functions
         }
 
         @JavascriptInterface
+        public boolean ankiIsDisplayAnswer() { return isDisplayingAnswer(); };
+
+        @JavascriptInterface
         public boolean ankiIsActiveNetworkMetered() {
             try {
                 ConnectivityManager cm = (ConnectivityManager) AnkiDroidApp.getInstance().getApplicationContext()


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
_Describe the problem or feature and motivation_

It will be easier to know when question is displaying and answer using js api. I am implementing addon sometime card content only need to added to front side and some time to back side. So, there are no api to know the side of card.

## Fixes
Fixes _Link to the issues._

## Approach
1. Using ```JavascriptInterface```
2. Using ```AbstractFlashcardViewer::isDisplayingAnswer()```

## How Has This Been Tested?
1. Tested on Nexus 5 emulator
2. Add following to front/back side of card template to know if card currently displaying answer
```js
console.log(AnkiDroidJS.ankiIsDisplayingAnswer());
```
Return value: ```true``` or ```false```

## Learning (optional, can help others)
https://developer.android.com/reference/android/webkit/JavascriptInterface

## Checklist
_Please, go through these checks before submitting the PR._

- [ x ] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [ x ] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ x ] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [ x ] You have commented your code, particularly in hard-to-understand areas
- [ x ] You have performed a self-review of your own code
- [ x ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ x ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
