### PR TITLE
Fixes #7526 Added icons to Multimedia menu in Note Editor

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -1626,7 +1626,7 @@ public class NoteEditor extends AnkiActivity {
             } else {
                 // Otherwise we make a popup menu allowing the user to choose between audio/image/text field
                 // TODO: Update the icons for dark material theme, then can set 3rd argument to true
-                PopupMenuWithIcons popup = new PopupMenuWithIcons(NoteEditor.this, v, false);
+                PopupMenuWithIcons popup = new PopupMenuWithIcons(NoteEditor.this, v, true);
                 MenuInflater inflater = popup.getMenuInflater();
                 inflater.inflate(R.menu.popupmenu_multimedia_options, popup.getMenu());
                 popup.setOnMenuItemClickListener(item -> {

--- a/AnkiDroid/src/main/res/drawable/ic_popup_menu_item_audio.xml
+++ b/AnkiDroid/src/main/res/drawable/ic_popup_menu_item_audio.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M12,3v9.28c-0.47,-0.17 -0.97,-0.28 -1.5,-0.28C8.01,12 6,14.01 6,16.5S8.01,21 10.5,21c2.31,0 4.2,-1.75 4.45,-4H15V6h4V3h-7z"/>
+</vector>

--- a/AnkiDroid/src/main/res/drawable/ic_popup_menu_item_clear.xml
+++ b/AnkiDroid/src/main/res/drawable/ic_popup_menu_item_clear.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M19,6.41L17.59,5 12,10.59 6.41,5 5,6.41 10.59,12 5,17.59 6.41,19 12,13.41 17.59,19 19,17.59 13.41,12z"/>
+</vector>

--- a/AnkiDroid/src/main/res/drawable/ic_popup_menu_item_editor.xml
+++ b/AnkiDroid/src/main/res/drawable/ic_popup_menu_item_editor.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M3,17.25V21h3.75L17.81,9.94l-3.75,-3.75L3,17.25zM20.71,7.04c0.39,-0.39 0.39,-1.02 0,-1.41l-2.34,-2.34c-0.39,-0.39 -1.02,-0.39 -1.41,0l-1.83,1.83 3.75,3.75 1.83,-1.83z"/>
+</vector>

--- a/AnkiDroid/src/main/res/drawable/ic_popup_menu_item_image.xml
+++ b/AnkiDroid/src/main/res/drawable/ic_popup_menu_item_image.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M21,19V5c0,-1.1 -0.9,-2 -2,-2H5c-1.1,0 -2,0.9 -2,2v14c0,1.1 0.9,2 2,2h14c1.1,0 2,-0.9 2,-2zM8.5,13.5l2.5,3.01L14.5,12l4.5,6H5l3.5,-4.5z"/>
+</vector>

--- a/AnkiDroid/src/main/res/drawable/ic_popup_menu_item_record.xml
+++ b/AnkiDroid/src/main/res/drawable/ic_popup_menu_item_record.xml
@@ -1,0 +1,13 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:tint="?attr/colorControlNormal"
+    android:viewportHeight="24"
+    android:viewportWidth="24">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M9,9m-4,0a4,4 0,1 1,8 0a4,4 0,1 1,-8 0" />
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M9,15c-2.67,0 -8,1.34 -8,4v2h16v-2c0,-2.66 -5.33,-4 -8,-4zM16.76,5.36l-1.68,1.69c0.84,1.18 0.84,2.71 0,3.89l1.68,1.69c2.02,-2.02 2.02,-5.07 0,-7.27zM20.07,2l-1.63,1.63c2.77,3.02 2.77,7.56 0,10.74L20.07,16c3.9,-3.89 3.91,-9.95 0,-14z" />
+</vector>

--- a/AnkiDroid/src/main/res/menu/popupmenu_multimedia_options.xml
+++ b/AnkiDroid/src/main/res/menu/popupmenu_multimedia_options.xml
@@ -1,23 +1,41 @@
 <?xml version="1.0" encoding="utf-8"?>
-<menu xmlns:android="http://schemas.android.com/apk/res/android" >
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
 
-    <group android:id="@+id/menu_multimedia_group"
-        android:title="@string/multimedia_editor_attach_media" >
+    <group
+        android:id="@+id/menu_multimedia_group"
+        android:title="@string/multimedia_editor_attach_media">
         <item
             android:id="@+id/menu_multimedia_photo"
-            android:title="@string/multimedia_editor_popup_image"/>
+            android:icon="@drawable/ic_popup_menu_item_image"
+            android:title="@string/multimedia_editor_popup_image"
+            app:showAsAction="always"
+            tools:ignore="AlwaysShowAction" />
         <item
             android:id="@+id/menu_multimedia_audio_clip"
-            android:title="@string/multimedia_editor_popup_audio_clip"/>
+            android:icon="@drawable/ic_popup_menu_item_audio"
+            android:title="@string/multimedia_editor_popup_audio_clip"
+            app:showAsAction="always"
+            tools:ignore="AlwaysShowAction" />
         <item
             android:id="@+id/menu_multimedia_audio"
-            android:title="@string/multimedia_editor_popup_audio"/>
+            android:icon="@drawable/ic_popup_menu_item_record"
+            android:title="@string/multimedia_editor_popup_audio"
+            app:showAsAction="always"
+            tools:ignore="AlwaysShowAction" />
         <item
             android:id="@+id/menu_multimedia_text"
-            android:title="@string/multimedia_editor_popup_text"/>
+            android:icon="@drawable/ic_popup_menu_item_editor"
+            android:title="@string/multimedia_editor_popup_text"
+            app:showAsAction="always"
+            tools:ignore="AlwaysShowAction" />
         <item
             android:id="@+id/menu_multimedia_clear_field"
-            android:title="@string/multimedia_editor_popup_clear_field"/>
+            android:icon="@drawable/ic_popup_menu_item_clear"
+            android:title="@string/multimedia_editor_popup_clear_field"
+            app:showAsAction="always"
+            tools:ignore="AlwaysShowAction" />
     </group>
 
 </menu>

--- a/AnkiDroid/src/main/res/menu/popupmenu_multimedia_options.xml
+++ b/AnkiDroid/src/main/res/menu/popupmenu_multimedia_options.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<menu xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools">
+<menu xmlns:android="http://schemas.android.com/apk/res/android">
 
     <group
         android:id="@+id/menu_multimedia_group"
@@ -9,33 +7,23 @@
         <item
             android:id="@+id/menu_multimedia_photo"
             android:icon="@drawable/ic_popup_menu_item_image"
-            android:title="@string/multimedia_editor_popup_image"
-            app:showAsAction="always"
-            tools:ignore="AlwaysShowAction" />
+            android:title="@string/multimedia_editor_popup_image" />
         <item
             android:id="@+id/menu_multimedia_audio_clip"
             android:icon="@drawable/ic_popup_menu_item_audio"
-            android:title="@string/multimedia_editor_popup_audio_clip"
-            app:showAsAction="always"
-            tools:ignore="AlwaysShowAction" />
+            android:title="@string/multimedia_editor_popup_audio_clip" />
         <item
             android:id="@+id/menu_multimedia_audio"
             android:icon="@drawable/ic_popup_menu_item_record"
-            android:title="@string/multimedia_editor_popup_audio"
-            app:showAsAction="always"
-            tools:ignore="AlwaysShowAction" />
+            android:title="@string/multimedia_editor_popup_audio" />
         <item
             android:id="@+id/menu_multimedia_text"
             android:icon="@drawable/ic_popup_menu_item_editor"
-            android:title="@string/multimedia_editor_popup_text"
-            app:showAsAction="always"
-            tools:ignore="AlwaysShowAction" />
+            android:title="@string/multimedia_editor_popup_text" />
         <item
             android:id="@+id/menu_multimedia_clear_field"
             android:icon="@drawable/ic_popup_menu_item_clear"
-            android:title="@string/multimedia_editor_popup_clear_field"
-            app:showAsAction="always"
-            tools:ignore="AlwaysShowAction" />
+            android:title="@string/multimedia_editor_popup_clear_field" />
     </group>
 
 </menu>


### PR DESCRIPTION
## Purpose / Description
Added icons to Multimedia menu in Note Editor. (working for all the themes)

## Fixes
Fixes #7526 

## Approach
Added new vector icons and then used them in Popup Multimedia Menu.
**After the change the menu now looks like this.**

![img](https://user-images.githubusercontent.com/65870389/111075218-ebf90780-850c-11eb-9b60-42b7dccebe28.png)


## How Has This Been Tested?
Tested on real device (Redmi Note 7S , API 29) and on emulator also (Pixel 3a , API 21).

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [x] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
