### PR TITLE
Added View Cards List option in deck's context menu

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -2570,6 +2570,16 @@ public class DeckPicker extends NavigationDrawerActivity implements
         }
     }
 
+    /** Callback to open card browser for currently selected deck */
+    public void openCardBrowser() {
+        openCardBrowser(mContextMenuDid);
+    }
+    public void openCardBrowser(long did) {
+        Intent i = new Intent(DeckPicker.this, CardBrowser.class);
+        i.putExtra("did", mContextMenuDid);
+        startActivityWithAnimation(i, FADE);
+    }
+
 
     // Callback to show export dialog for currently selected deck
     public void showContextMenuExportDialog() {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckPickerContextMenu.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckPickerContextMenu.java
@@ -53,6 +53,7 @@ public class DeckPickerContextMenu extends AnalyticsDialogFragment {
     private static final int CONTEXT_MENU_CUSTOM_STUDY_EMPTY = 7;
     private static final int CONTEXT_MENU_CREATE_SUBDECK = 8;
     private static final int CONTEXT_MENU_CREATE_SHORTCUT = 9;
+    private static final int CONTEXT_MENU_CARD_BROWSER = 10;
     @Retention(SOURCE)
     @IntDef( {CONTEXT_MENU_RENAME_DECK,
             CONTEXT_MENU_DECK_OPTIONS,
@@ -64,6 +65,7 @@ public class DeckPickerContextMenu extends AnalyticsDialogFragment {
             CONTEXT_MENU_CUSTOM_STUDY_EMPTY,
             CONTEXT_MENU_CREATE_SUBDECK,
             CONTEXT_MENU_CREATE_SHORTCUT,
+            CONTEXT_MENU_CARD_BROWSER,
     })
     public @interface DECK_PICKER_CONTEXT_MENU {}
 
@@ -101,6 +103,7 @@ public class DeckPickerContextMenu extends AnalyticsDialogFragment {
         keyValueMap.put(CONTEXT_MENU_RENAME_DECK, res.getString(R.string.rename_deck));
         keyValueMap.put(CONTEXT_MENU_DECK_OPTIONS, res.getString(R.string.menu__deck_options));
         keyValueMap.put(CONTEXT_MENU_CUSTOM_STUDY, res.getString(R.string.custom_study));
+        keyValueMap.put(CONTEXT_MENU_CARD_BROWSER, res.getString(R.string.browse_cards));
         keyValueMap.put(CONTEXT_MENU_DELETE_DECK, res.getString(R.string.contextmenu_deckpicker_delete_deck));
         keyValueMap.put(CONTEXT_MENU_EXPORT_DECK, res.getString(R.string.export_deck));
         keyValueMap.put(CONTEXT_MENU_UNBURY, res.getString(R.string.unbury));
@@ -120,7 +123,7 @@ public class DeckPickerContextMenu extends AnalyticsDialogFragment {
         Collection col = CollectionHelper.getInstance().getCol(getContext());
         long did = getArguments().getLong("did");
         boolean dyn = col.getDecks().isDyn(did);
-        ArrayList<Integer> itemIds = new ArrayList<>(9);
+        ArrayList<Integer> itemIds = new ArrayList<>(10);
         if (dyn) {
             itemIds.add(CONTEXT_MENU_CUSTOM_STUDY_REBUILD);
             itemIds.add(CONTEXT_MENU_CUSTOM_STUDY_EMPTY);
@@ -133,6 +136,7 @@ public class DeckPickerContextMenu extends AnalyticsDialogFragment {
         if (!dyn) {
             itemIds.add(CONTEXT_MENU_CUSTOM_STUDY);
         }
+        itemIds.add(CONTEXT_MENU_CARD_BROWSER);
         itemIds.add(CONTEXT_MENU_DELETE_DECK);
         itemIds.add(CONTEXT_MENU_EXPORT_DECK);
         if (col.getSched().haveBuried(did)) {
@@ -203,6 +207,12 @@ public class DeckPickerContextMenu extends AnalyticsDialogFragment {
             case CONTEXT_MENU_CREATE_SUBDECK: {
                 Timber.i("Create Subdeck selected");
                 ((DeckPicker) getActivity()).createSubdeckDialog();
+                break;
+            }
+            case CONTEXT_MENU_CARD_BROWSER: {
+                Timber.i(("Browse cards selected"));
+                ((DeckPicker) getActivity()).openCardBrowser();
+                ((AnkiActivity) getActivity()).dismissAllDialogFragments();
                 break;
             }
         }

--- a/AnkiDroid/src/main/res/values/01-core.xml
+++ b/AnkiDroid/src/main/res/values/01-core.xml
@@ -78,6 +78,7 @@
     <string name="undo_action_change_deck_multi">change decks</string>
     <string name="move_all_to_deck">Move all to deck</string>
     <string name="unbury">Unbury</string>
+    <string name="browse_cards">Browse cards</string>
     <string name="rename_deck">Rename deck</string>
     <string name="create_shortcut">Create shortcut</string>
     <string name="menu_add" comment="A generic add button - Main Deck Picker and card templates. Please inform us if you need more specific strings">Add</string>


### PR DESCRIPTION
## Added View Cards List option in deck's context menu

## Purpose / Description
A feature request was made to add a view cards list option to the selected deck's context menu. This PR implements the feature.

## Fixes
Fixes #8187 

## Approach
Created a new function `openCardBrowser` in DeckPicker.java which calls back the card browser for the selected deck by creating an Intent. Added a new Variable `CONTEXT_MENU_VIEW_CARDS_LIST` that adds View Cards List option to Material Dialog and calls the function `openCardBrowser`.

## How Has This Been Tested?

Emulated on API 30, Android 10.0 and tested on Xiaomi Redmi Note 7 Pro Physical Device. Worked as expected.

## Checklist
_Please, go through these checks before submitting the PR._

* [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
* [x] You have a descriptive commit message with a short title (first line, max 50 chars).
* [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
* [x] You have commented your code, particularly in hard-to-understand areas
* [x] You have performed a self-review of your own code
* [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
* [x] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
