### PR TITLE
Readme: Fix Contributors Image

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Join Us On
 
 Thanks to these awesome contributors who keep this project going
 
-<a href="https://github.com/ankidroid/Anki-Android/graphs/contributors"><img src="https://opencollective.com/jest/contributors.svg?width=890&button=false" /></a>
+<a href="https://github.com/ankidroid/Anki-Android/graphs/contributors"><img src="https://opencollective.com/ankidroid/contributors.svg?width=890&button=false" /></a>
 
 ### [Sponsors](https://opencollective.com/ankidroid#sponsor)
 <a href="https://opencollective.com/ankidroid/sponsor/0/website" target="_blank"><img src="https://opencollective.com/ankidroid/sponsor/0/avatar.svg"></a>


### PR DESCRIPTION
Previously pointed to jest

Before: https://github.com/ankidroid/Anki-Android/tree/947976d93aa02b05d523796c30daa0feff60915b#github-contributors

Now: https://github.com/david-allison-1/Anki-Android/tree/fix-readme#github-contributors

It's still an interesting order... We've surely had a lot more new contributors after me. Gotta be doing some filtering?

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [x] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
