### PR TITLE
Add check on back button to close DeckPicker

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -1089,7 +1089,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
                     finishWithAnimation();
                     return;
                 } else {
-                    Toast.makeText(this, "Press back again to exit", Toast.LENGTH_SHORT).show();
+                    Toast.makeText(this, "Press back again to close the app", Toast.LENGTH_SHORT).show();
                 }
                 mBackPressedTime = System.currentTimeMillis();
             }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -214,6 +214,8 @@ public class DeckPicker extends NavigationDrawerActivity implements
 
     private long mContextMenuDid;
 
+    private long mBackPressedTime;
+
     private EditText mDialogEditText;
 
     // flag asking user to do a full sync which is used in upgrade path
@@ -1082,8 +1084,14 @@ public class DeckPicker extends NavigationDrawerActivity implements
             if (mActionsMenu != null && mActionsMenu.isExpanded()) {
                 mActionsMenu.collapse();
             } else {
-                automaticSync();
-                finishWithAnimation();
+                if (mBackPressedTime + 2000 > System.currentTimeMillis()) {
+                    automaticSync();
+                    finishWithAnimation();
+                    return;
+                } else {
+                    Toast.makeText(this, "Press back again to exit", Toast.LENGTH_SHORT).show();
+                }
+                mBackPressedTime = System.currentTimeMillis();
             }
         }
     }


### PR DESCRIPTION
## Back button check to close the app

## Purpose / Description
_Added the feature to check the back button press to close `DeckPickerActivity` it doesn't kill the process it just closes the Activity keeps the process running then it can be killed by system as per pattern in android programing_

## Fixes
Fixes #8226

## Approach
_How does this change address the problem?_
It check if the back button is pressed then it shows toast telling that `Press back again to close the app` if the user presses the back button within 200ms the it closes the app but doesn't kill the process it solve the issue of accidentally closing the app on back press

## How Has This Been Tested?
This has been tested on physical device running on android 10 (API 29)

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [ ] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
