### PR TITLE
Added condition to display error if preview is selected in NoteEditor and first field is empty

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -1215,9 +1215,9 @@ public class NoteEditor extends AnkiActivity {
     @VisibleForTesting
     void performPreview() {
         //show error if first textfield is empty
-        if(TextUtils.isEmpty(getCurrentFieldText(0))){
+        if (TextUtils.isEmpty(getCurrentFieldText(0))) {
             UIUtils.showThemedToast(this, getResources().getString(R.string.note_editor_no_first_field), false);
-        }else {
+        } else {
             Intent previewer = new Intent(NoteEditor.this, CardTemplatePreviewer.class);
 
             if (mCurrentEditedCard != null) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -1214,19 +1214,24 @@ public class NoteEditor extends AnkiActivity {
 
     @VisibleForTesting
     void performPreview() {
-        Intent previewer = new Intent(NoteEditor.this, CardTemplatePreviewer.class);
+        //show error if first textfield is empty
+        if(TextUtils.isEmpty(getCurrentFieldText(0))){
+            UIUtils.showThemedToast(this, getResources().getString(R.string.note_editor_no_first_field), false);
+        }else {
+            Intent previewer = new Intent(NoteEditor.this, CardTemplatePreviewer.class);
 
-        if (mCurrentEditedCard != null) {
-            previewer.putExtra("ordinal", mCurrentEditedCard.getOrd());
+            if (mCurrentEditedCard != null) {
+                previewer.putExtra("ordinal", mCurrentEditedCard.getOrd());
+            }
+            previewer.putExtra(TemporaryModel.INTENT_MODEL_FILENAME, TemporaryModel.saveTempModel(this, mEditorNote.model()));
+
+            // Send the previewer all our current editing information
+            Bundle noteEditorBundle = new Bundle();
+            addInstanceStateToBundle(noteEditorBundle);
+            noteEditorBundle.putBundle("editFields", getFieldsAsBundleForPreview());
+            previewer.putExtra("noteEditorBundle", noteEditorBundle);
+            startActivityForResultWithoutAnimation(previewer, REQUEST_PREVIEW);
         }
-        previewer.putExtra(TemporaryModel.INTENT_MODEL_FILENAME, TemporaryModel.saveTempModel(this, mEditorNote.model()));
-
-        // Send the previewer all our current editing information
-        Bundle noteEditorBundle = new Bundle();
-        addInstanceStateToBundle(noteEditorBundle);
-        noteEditorBundle.putBundle("editFields", getFieldsAsBundleForPreview());
-        previewer.putExtra("noteEditorBundle", noteEditorBundle);
-        startActivityForResultWithoutAnimation(previewer, REQUEST_PREVIEW);
     }
 
 


### PR DESCRIPTION
## Purpose / Description
I thought it was better to toast an error when preview is selected without adding a first field as you can't save the note without the first field either so what's the point of previewing it. I would like to get feedback if this is correct thing to do.

## Approach
toast string "The first field is empty" if preview is pressed with empty first field.

## How Has This Been Tested?
It successfully toasts error "The first field is empty" when preview is clicked
`Before-------------------------------------------------------------------------------------------------------------After`

<p float="left">
  <img src="https://i.imgur.com/7GVKejh.jpeg" width="400" />
  <img src="https://i.imgur.com/YVIp5pC.jpg" width="400" /> 
</p>

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [x] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
