### PR TITLE
Notification can now take to reviewer Activity if review was in progress before.

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.java
@@ -68,6 +68,7 @@ import com.ichi2.anki.multimediacard.AudioView;
 import com.ichi2.anki.dialogs.RescheduleDialog;
 import com.ichi2.anki.reviewer.PeripheralKeymap;
 import com.ichi2.anki.reviewer.ReviewerUi;
+import com.ichi2.anki.services.NotificationService;
 import com.ichi2.anki.workarounds.FirefoxSnackbarWorkaround;
 import com.ichi2.anki.reviewer.ActionButtons;
 import com.ichi2.async.CollectionTask;
@@ -162,6 +163,7 @@ public class Reviewer extends AbstractFlashcardViewer {
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
+
         if (showedActivityFailedScreen(savedInstanceState)) {
             return;
         }
@@ -273,6 +275,22 @@ public class Reviewer extends AbstractFlashcardViewer {
     @Override
     protected void onCollectionLoaded(Collection col) {
         super.onCollectionLoaded(col);
+
+        //This checks if the control came here through Notification tap.
+        if (getIntent().getExtras() != null) {
+            if (getIntent().getExtras().containsKey(NotificationService.THROUGH_NOTIFICATION)) {
+                /*  It verifies if there are pending cards to review
+                    if there are pending cards, then this Activity will resume the pending Review
+                    else the control will go to the DeckPicker Activity to show the Deck List
+                */
+                if (col.getSched().count() == 0) {
+                    startActivityWithoutAnimation(new Intent(this, DeckPicker.class));
+                    finishWithoutAnimation();
+                    return;
+                }
+            }
+        }
+
         // Load the first card and start reviewing. Uses the answer card
         // task to load a card, but since we send null
         // as the card to answer, no card will be answered.


### PR DESCRIPTION
## Purpose / Description 
Currently, tapping the notification opens Deck List instead of Review page when pending reviews are present. 
This PR contains the code which will allow user to go to Review page instead of deck list page by tapping the notification when a review is already in progress. 
If no review is in progress the deck list page will open. 

## Fixes #3593 


## Approach 

1. Added a check in NotificationService.java => onReceive function which checks if there are pending card to review and decides the intent of Notification click based on this. 

2. Step 1 happens while the Notification onReceive method gets triggered and this can contain the lagging data as well. 

For example when this onReceive is triggered there may be pending cards to review and based on the logic it decides to open Review page on tapping the notification but there are cases where the user taps the notification after completing the deck also in this case the Review page will open and there will be no card to review. 

For this case added a check in Review activity where it checks if the Review Activity is open through Notification and verifies if there are pending cards or not, if there are no pending cards then it opens Deck List page instead. 

## How Has This Been Tested? 
This has been tested by me manually going through each of the following scenario: 

1. When user is reviewing a deck => Goes out of the app and there are pending cards to review. Notification appears and on tapping the notification the user is resumed to the Review page to continue the review process. 

2. When user is reviewing a deck => Completes the Deck Review => app closes automatically as the review is complete. Notification appears and on tapping the notification the deck list is opened. 

3. There are no review in progress but there are decks to review. Notification appears and on tapping the notification the deck list is opened. 

## Checklist _Please, go through these checks before submitting the PR._ 
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read) 
- [x] You have a descriptive commit message with a short title (first line, max 50 chars). - 
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) - 
- [x] You have commented your code, particularly in hard-to-understand areas 
- [x] You have performed a self-review of your own code 
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings) 
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner] (https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)