### PR TITLE
fix card scroll conflict

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -64,6 +64,7 @@ import android.view.MotionEvent;
 import android.view.View;
 import android.view.View.OnClickListener;
 import android.view.ViewGroup;
+import android.view.ViewParent;
 import android.view.WindowManager;
 import android.view.inputmethod.EditorInfo;
 import android.view.inputmethod.InputMethodManager;
@@ -88,6 +89,7 @@ import android.widget.RelativeLayout;
 import android.widget.TextView;
 
 import com.afollestad.materialdialogs.MaterialDialog;
+import com.drakeet.drawer.FullDraggableContainer;
 import com.google.android.material.snackbar.Snackbar;
 import com.ichi2.anim.ViewAnimation;
 import com.ichi2.anki.cardviewer.GestureTapProcessor;
@@ -2898,6 +2900,43 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
                 scrollHandler.removeCallbacks(scrollYRunnable);
                 scrollHandler.postDelayed(scrollYRunnable, 300);
             }
+        }
+
+        @Override
+        public boolean onTouchEvent(MotionEvent event) {
+            if (event.getAction() == MotionEvent.ACTION_DOWN) {
+                ViewParent scrollParent = findScrollParent(this);
+                if (scrollParent != null) {
+                    scrollParent.requestDisallowInterceptTouchEvent(true);
+                }
+            }
+            return super.onTouchEvent(event);
+        }
+
+
+        @Override
+        protected void onOverScrolled(int scrollX, int scrollY, boolean clampedX, boolean clampedY) {
+            if (clampedX) {
+                ViewParent scrollParent = findScrollParent(this);
+                if (scrollParent != null) {
+                    scrollParent.requestDisallowInterceptTouchEvent(false);
+                }
+            }
+            super.onOverScrolled(scrollX, scrollY, clampedX, clampedY);
+        }
+
+
+        private ViewParent findScrollParent(View current) {
+            ViewParent parent = current.getParent();
+            if (parent == null) {
+                return null;
+            }
+            if (parent instanceof FullDraggableContainer) {
+                return parent;
+            } else if (parent instanceof View) {
+                return findScrollParent((View) parent);
+            }
+            return null;
         }
 
         private final Handler scrollHandler = new Handler();


### PR DESCRIPTION
https://github.com/ankidroid/Anki-Android/issues/8235

## Pull Request template

## Purpose / Description
fix webView scroll conflict with FullDraggableContainer

## Fixes
Fixes #8235

## Approach
Respond to internal webview swipe first,If the internal slide of the webview is finished, the external slide is responded to, the key to solving the problem lies in the WebView.onOverScrolled method

## How Has This Been Tested?

working well on my pixel phone

## Learning (optional, can help others)
_Describe the research stage_

_Links to blog posts, patterns, libraries or addons used to solve this problem_

## Checklist
_Please, go through these checks before submitting the PR._

- [ ] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [ ] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [ ] You have commented your code, particularly in hard-to-understand areas
- [ ] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
