### PR TITLE
Progress Dialog of NoteEditor Extra Space Remove 

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -273,7 +273,7 @@ public class NoteEditor extends AnkiActivity {
         public void actualOnPreExecute(@NonNull NoteEditor noteEditor) {
             Resources res = noteEditor.getResources();
             noteEditor.mProgressDialog = StyledProgressDialog
-                    .show(noteEditor, "", res.getString(R.string.saving_facts), false);
+                    .show(noteEditor, null, res.getString(R.string.saving_facts), false);
         }
 
         @Override


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
Solves the bug of extra space

Before:
![Screenshot_1615822428](https://user-images.githubusercontent.com/61244704/111403765-acd9da80-86f5-11eb-9baa-3b32fdb1c85b.png)

After:
![Screenshot_1615946584](https://user-images.githubusercontent.com/61244704/111403787-b6634280-86f5-11eb-8dae-994cdfe13ec8.png)

## Fixes
"" in progress dialog changed to null
fixes bug ankidroid#8252


## How Has This Been Tested?

Tested on Emulator: Pixel 3a API R

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [x] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
