### PR TITLE
Add test to ensure Utils.stripHTML behave the same as the upstream

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Utils.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Utils.java
@@ -107,9 +107,10 @@ public class Utils {
     private Utils() { }
 
     // Regex pattern used in removing tags from text before diff
+    private static final Pattern commentPattern = Pattern.compile("(?s)<!--.*?-->");
     private static final Pattern stylePattern = Pattern.compile("(?si)<style.*?>.*?</style>");
     private static final Pattern scriptPattern = Pattern.compile("(?si)<script.*?>.*?</script>");
-    private static final Pattern tagPattern = Pattern.compile("<.*?>");
+    private static final Pattern tagPattern = Pattern.compile("(?s)<.*?>");
     private static final Pattern imgPattern = Pattern.compile("(?i)<img[^>]+src=[\"']?([^\"'>]+)[\"']?[^>]*>");
     private static final Pattern soundPattern = Pattern.compile("(?i)\\[sound:([^]]+)]");
     private static final Pattern htmlEntitiesPattern = Pattern.compile("&#?\\w+;");
@@ -296,6 +297,7 @@ public class Utils {
      * @return The text without the aforementioned tags.
      */
     public static String stripHTML(String s) {
+        s = commentPattern.matcher(s).replaceAll("");
         s = stripHTMLScriptAndStyleTags(s);
         Matcher htmlMatcher = tagPattern.matcher(s);
         s = htmlMatcher.replaceAll("");

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/UtilsTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/UtilsTest.java
@@ -25,9 +25,11 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URL;
 import java.nio.file.Paths;
+import java.util.Arrays;
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
@@ -39,6 +41,7 @@ import org.junit.runner.RunWith;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
 import static com.ichi2.libanki.Utils.nonEmptyFields;
+import static org.junit.Assert.assertEquals;
 
 
 @RunWith(AndroidJUnit4.class)
@@ -115,5 +118,40 @@ public class UtilsTest {
         m.put("bar", " plop  ");
         s.add("bar");
         Assert.assertEquals(s, nonEmptyFields(m));
+    }
+
+
+    @Test
+    public void test_stripHTML_will_remove_tags() {
+        final List<String> strings = Arrays.asList(
+                "<>",
+                "<1>",
+                "<asdasd>",
+                "<\n>",
+                "<\\qwq>",
+                "<aa\nsd\nas\n?\n>"
+        );
+
+        for (String s : strings) {
+            assertEquals(s.replace("\n","\\n") + " should be removed.",
+                    "", Utils.stripHTML(s));
+        }
+    }
+
+    @Test
+    public void test_stripHTML_will_remove_comments() {
+        final List<String> strings = Arrays.asList(
+                "<!---->",
+                "<!--dd-->",
+                "<!--asd asd asd-->",
+                "<!--\n-->",
+                "<!--\nsd-->",
+                "<!--lkl\nklk\n-->"
+        );
+
+        for (String s : strings) {
+            assertEquals(s.replace("\n","\\n") + " should be removed.",
+                    "", Utils.stripHTML(s));
+        }
     }
 }


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
While working on #8248 I found an inconsistency between the pylib code and ankilib code. When dealing with tags. Also pylib code removes comments and ankilib currently lacks this.

## Approach
I have also added a test to the pylib util code
https://github.com/TarekkMA/anki/blob/698f7745f3/pylib/tests/test_utils.py#L3-L14

## How Has This Been Tested?
Using tests :)

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [x] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
