### PR TITLE
Render manual and support page HTML / include in app

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -240,6 +240,7 @@ dependencies {
 
     // == Rust conversion (from Anki-Android-Backend on GitHub) ==
     String backendVersion = "0.1.2" // We want both testing and implementation on the same version
+
     // build with ./gradlew rsdroid:assembleRelease
     // In my experience, using `files()` currently requires a reindex operation, which is slow.
     // implementation files("C:\\GitHub\\Rust-Test\\rsdroid\\build\\outputs\\aar\\rsdroid-release.aar")

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.java
@@ -212,6 +212,9 @@ public class AnkiDroidApp extends Application {
     }
 
 
+
+
+
     /**
      * Get the ACRA ConfigurationBuilder - use this followed by setting it to modify the config
      * @return ConfigurationBuilder for the current ACRA config
@@ -603,6 +606,7 @@ public class AnkiDroidApp extends Application {
             return getAppResources().getString(R.string.link_manual);
         }
     }
+
 
     /**
      * Check whether l is the currently set language code

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/HelpDialog.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/HelpDialog.java
@@ -16,10 +16,14 @@
 
 package com.ichi2.anki.dialogs;
 
+import android.annotation.SuppressLint;
 import android.content.Context;
+import android.content.res.AssetManager;
 import android.net.Uri;
 import android.os.Parcel;
 import android.os.Parcelable;
+import android.util.Log;
+import android.webkit.WebView;
 
 import com.ichi2.anki.AnkiActivity;
 import com.ichi2.anki.AnkiDroidApp;
@@ -28,6 +32,9 @@ import com.ichi2.anki.dialogs.RecursivePictureMenu.Item;
 import com.ichi2.anki.dialogs.RecursivePictureMenu.ItemHeader;
 import com.ichi2.utils.IntentUtil;
 
+import java.io.BufferedReader;
+import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -35,24 +42,52 @@ import java.util.Arrays;
 import androidx.annotation.DrawableRes;
 import androidx.annotation.StringRes;
 import androidx.fragment.app.DialogFragment;
+import timber.log.Timber;
 
 public class HelpDialog {
+
+
+    private static final String TAG ="Hello" ;
+
 
     private static void openManual(AnkiActivity ankiActivity) {
         ankiActivity.openUrl(Uri.parse(AnkiDroidApp.getManualUrl()));
     }
 
+    @SuppressLint("SetJavaScriptEnabled")
     private static void openFeedback(AnkiActivity ankiActivity) {
-        ankiActivity.openUrl(Uri.parse(AnkiDroidApp.getFeedbackUrl()));
+        WebView view = new WebView(ankiActivity);
+        view.getSettings().setJavaScriptEnabled(true);
+        view.loadUrl("file:///assets/AnkiDroidSupport.html");
+        ankiActivity.setContentView(view);
+
+        try {
+
+            AssetManager assetManager = ankiActivity.getAssets();
+            InputStream stream = assetManager.open("AnkiDroidSupport.html");
+            BufferedReader r = new BufferedReader(new InputStreamReader(stream));
+            StringBuilder total = new StringBuilder();
+            String line;
+            while ((line = r.readLine()) != null) {
+                total.append(line).append("\n");
+            }
+            view.loadDataWithBaseURL(null, total.toString(), "text/html", "UTF-8", null);
+        } catch (Exception xxx) {
+            Timber.e(xxx, "Load assets/AnkiDroidSupport.html");
+        }
+
     }
+
+
 
     public static DialogFragment createInstance(Context context) {
 
         RateAppItem rateAppItem = new RateAppItem(R.string.help_item_support_rate_ankidroid, R.drawable.ic_star_black_24);
+
         Item[] allItems = {
                 new ItemHeader(R.string.help_title_using_ankidroid, R.drawable.ic_manual_black_24dp,
                         new FunctionItem(R.string.help_item_ankidroid_manual, R.drawable.ic_manual_black_24dp, HelpDialog::openManual),
-                        new LinkItem(R.string.help_item_anki_manual, R.drawable.ic_manual_black_24dp, R.string.link_anki_manual),
+                        new FunctionItem(R.string.help_item_anki_manual, R.drawable.ic_manual_black_24dp,HelpDialog::openAnkiManual),
                         new LinkItem(R.string.help_item_ankidroid_faq, R.drawable.ic_help_black_24dp, R.string.link_ankidroid_faq)
                 ),
                 new ItemHeader(R.string.help_title_get_help, R.drawable.ic_help_black_24dp,
@@ -85,6 +120,32 @@ public class HelpDialog {
 
         return RecursivePictureMenu.createInstance(itemList, R.string.help);
     }
+
+
+    @SuppressLint("SetJavaScriptEnabled")
+    private static void openAnkiManual(AnkiActivity ankiActivity) {
+        WebView view = new WebView(ankiActivity);
+        view.getSettings().setJavaScriptEnabled(true);
+        view.loadUrl("file:///assets/AnkiManual.html");
+        ankiActivity.setContentView(view);
+
+        try {
+
+            AssetManager assetManager = ankiActivity.getAssets();
+            InputStream stream = assetManager.open("AnkiManual.html");
+            BufferedReader r = new BufferedReader(new InputStreamReader(stream));
+            StringBuilder total = new StringBuilder();
+            String line;
+            while ((line = r.readLine()) != null) {
+                total.append(line).append("\n");
+            }
+            view.loadDataWithBaseURL(null, total.toString(), "text/html", "UTF-8", null);
+        } catch (Exception xxx) {
+            Timber.e(xxx, "Load assets/AnkiManual.html");
+        }
+
+    }
+
 
     public static class RateAppItem extends Item implements Parcelable {
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/HelpDialog.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/HelpDialog.java
@@ -17,6 +17,7 @@
 package com.ichi2.anki.dialogs;
 
 import android.annotation.SuppressLint;
+import android.app.Dialog;
 import android.content.Context;
 import android.content.res.AssetManager;
 import android.net.Uri;
@@ -47,7 +48,7 @@ import timber.log.Timber;
 public class HelpDialog {
 
 
-    private static final String TAG ="Hello" ;
+
 
 
     private static void openManual(AnkiActivity ankiActivity) {
@@ -75,6 +76,8 @@ public class HelpDialog {
         } catch (Exception xxx) {
             Timber.e(xxx, "Load assets/AnkiDroidSupport.html");
         }
+        ankiActivity.dismissAllDialogFragments();
+
 
     }
 
@@ -122,6 +125,7 @@ public class HelpDialog {
     }
 
 
+
     @SuppressLint("SetJavaScriptEnabled")
     private static void openAnkiManual(AnkiActivity ankiActivity) {
         WebView view = new WebView(ankiActivity);
@@ -143,6 +147,9 @@ public class HelpDialog {
         } catch (Exception xxx) {
             Timber.e(xxx, "Load assets/AnkiManual.html");
         }
+        ankiActivity.dismissAllDialogFragments();
+
+
 
     }
 

--- a/tools/chromeos/release.sh
+++ b/tools/chromeos/release.sh
@@ -53,5 +53,6 @@ done
 echo "`jq 'del(.file_handlers.any.types) | .file_handlers.any.extensions = ["apkg"]' cws/unpacked/manifest.json`" > cws/unpacked/manifest.json
 
 # Prepare release package
+# shellcheck disable=SC2164
 cd cws/unpacked
 zip -q -r -o ../../cws/release.zip *


### PR DESCRIPTION
## The manual and help instructions can now be loaded offline 
Issue #6829 resolved
The support and manual webpages have been added in the offline mode


## Fixes
#6829 


_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [x] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
