### PR TITLE
Fixes #7910 Select many option in Card browser

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -658,7 +658,6 @@ public class CardBrowser extends NavigationDrawerActivity implements
                 CheckBox cb = view.findViewById(R.id.card_checkbox);
                 cb.toggle();
                 onCheck(position, view);
-                mLastSelectedPosition = position;
             } else {
                 // load up the card selected on the list
                 long clickedCardId = getCards().get(position).getId();

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -658,6 +658,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
                 CheckBox cb = view.findViewById(R.id.card_checkbox);
                 cb.toggle();
                 onCheck(position, view);
+                mLastSelectedPosition = position;
             } else {
                 // load up the card selected on the list
                 long clickedCardId = getCards().get(position).getId();
@@ -666,16 +667,28 @@ public class CardBrowser extends NavigationDrawerActivity implements
             }
         });
         mCardsListView.setOnItemLongClickListener((adapterView, view, position, id) -> {
-            mLastSelectedPosition = position;
-            saveScrollingState(position);
-            loadMultiSelectMode();
+            if (mInMultiSelectMode) {
+                for (int i = Math.min(mLastSelectedPosition, position); i <= Math.max(mLastSelectedPosition, position); i++) {
+                    // getting the view of particular view and then checking whether it's already checked or not
+                    View childView = mCardsListView.getChildAt(i);
+                    CheckBox cb = childView.findViewById(R.id.card_checkbox);
+                    if (!cb.isChecked()) {
+                        cb.toggle();
+                        onCheck(i, childView);
+                    }
+                }
+            } else {
+                mLastSelectedPosition = position;
+                saveScrollingState(position);
+                loadMultiSelectMode();
 
-            // click on whole cell triggers select
-            CheckBox cb = view.findViewById(R.id.card_checkbox);
-            cb.toggle();
-            onCheck(position, view);
-            recenterListView(view);
-            mCardsAdapter.notifyDataSetChanged();
+                // click on whole cell triggers select
+                CheckBox cb = view.findViewById(R.id.card_checkbox);
+                cb.toggle();
+                onCheck(position, view);
+                recenterListView(view);
+                mCardsAdapter.notifyDataSetChanged();
+            }
             return true;
         });
 


### PR DESCRIPTION
## Purpose / Description
Currently, we do not support drag to select many but it's alternative as suggested and approved here https://github.com/ankidroid/Anki-Android/issues/7910#issuecomment-768767950 is added.

## Fixes
Fixes #7910 

## Approach
If in multi select mode then added a loop to select all the items between current selected and the one long pressed. 
Attaching the screen recording...


https://user-images.githubusercontent.com/65870389/111865788-0f013c80-898f-11eb-89de-dae23dc65f34.mp4


## How Has This Been Tested?
Tested on real device (Redmi Note 7S and API29)

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [x] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
