### PR TITLE
Added save/cancel buttons to deck options

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckOptions.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckOptions.java
@@ -327,7 +327,6 @@ public class DeckOptions extends AppCompatPreferenceActivity implements OnShared
                                 break;
                             case "desc":
                                 mDeckCopy.put("desc", value);
-                                mCol.getDecks().save(mDeckCopy);
                                 break;
                             case "newSteps":
                                 mOptionsCopy.getJSONObject("new").put("delays", StepsPreference.convertToJSON((String) value));
@@ -473,16 +472,6 @@ public class DeckOptions extends AppCompatPreferenceActivity implements OnShared
                     }
                 } catch (JSONException e) {
                     throw new RuntimeException(e);
-                }
-
-                // save conf
-                try {
-                    mCol.getDecks().save(mOptionsCopy);
-                } catch (RuntimeException e) {
-                    Timber.e(e, "DeckOptions - RuntimeException on saving conf");
-                    AnkiDroidApp.sendExceptionReport(e, "DeckOptionsSaveConf");
-                    setResult(DeckPicker.RESULT_DB_ERROR);
-                    finish();
                 }
 
                 // make sure we refresh the parent cached values

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckOptions.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckOptions.java
@@ -568,7 +568,7 @@ public class DeckOptions extends AppCompatPreferenceActivity implements OnShared
                                             .neutralText(getResources().getString(R.string.dialog_cancel))
                                             .onPositive((dialog, which) -> {
                                                 // Save changes before loading new group
-                                                // writeChanges();
+                                                writeChanges();
                                                 TaskManager.launchCollectionTask(
                                                         new CollectionTask.ConfChange(originalDeck, newOptions),
                                                         confChangeHandler()
@@ -984,14 +984,36 @@ public class DeckOptions extends AppCompatPreferenceActivity implements OnShared
         return super.onKeyDown(keyCode, event);
     }
 
+
+    /**
+     * Writes changes to database based on the value of {@link #mPreferenceChanged} and {@link #mSaveChanges}.
+     * After changes are saved/discarded, the activity is finished.
+     */
     private void closeWithResult() {
         if (mPreferenceChanged) {
-            setResult(RESULT_OK);
+            if (mSaveChanges) {
+                // Preferences are changed and should be saved
+                mPref.writeChanges();
+                setResult(RESULT_OK);
+                finish();
+                ActivityTransitionAnimation.slide(this, FADE);
+            } else {
+                // Preferences are changed but back key is pressed (ask for confirmation)
+                DiscardChangesDialog
+                        .getDefault(this)
+                        .onPositive((dialog, which) -> {
+                            setResult(RESULT_CANCELED);
+                            finish();
+                            ActivityTransitionAnimation.slide(this, FADE);
+                        })
+                        .show();
+            }
         } else {
+            // Preferences are not changed
             setResult(RESULT_CANCELED);
+            finish();
+            ActivityTransitionAnimation.slide(this, FADE);
         }
-        finish();
-        ActivityTransitionAnimation.slide(this, FADE);
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckOptions.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckOptions.java
@@ -132,6 +132,16 @@ public class DeckOptions extends AppCompatPreferenceActivity implements OnShared
         private final Map<String, String> mSummaries = new HashMap<>();
         private MaterialDialog mProgressDialog;
         private final List<OnSharedPreferenceChangeListener> listeners = new LinkedList<>();
+        /*
+         * Post-save settings
+         * Some of the preferences require additional configurations after saving them.
+         * Reminder enable: Enable reminder based on preference
+         * Reminder time: Set reminder time based on preference
+         *
+         * Boolean variables are used to keep track of these preferences inside Editor.commit().
+         */
+        private boolean mUpdateReminderEnabled = false;
+        private boolean mUpdateReminderTime = false;
 
 
         private DeckPreferenceHack() {
@@ -449,27 +459,8 @@ public class DeckOptions extends AppCompatPreferenceActivity implements OnShared
                                 }
 
                                 mOptionsCopy.put("reminder", reminder);
-
-                                final AlarmManager alarmManager = (AlarmManager) getSystemService(ALARM_SERVICE);
-                                final PendingIntent reminderIntent = PendingIntent.getBroadcast(
-                                        getApplicationContext(),
-                                        (int) mOptionsCopy.getLong("id"),
-                                        new Intent(getApplicationContext(), ReminderService.class).putExtra
-                                                (ReminderService.EXTRA_DECK_OPTION_ID, mOptionsCopy.getLong("id")),
-                                        0
-                                );
-
-                                alarmManager.cancel(reminderIntent);
-                                if ((Boolean) value) {
-                                    final Calendar calendar = reminderToCalendar(mCol.getTime(), reminder);
-
-                                    alarmManager.setRepeating(
-                                            AlarmManager.RTC_WAKEUP,
-                                            calendar.getTimeInMillis(),
-                                            AlarmManager.INTERVAL_DAY,
-                                            reminderIntent
-                                    );
-                                }
+                                mUpdateReminderEnabled = true; // Alarm will be modified after changes are saved
+                                mUpdateReminderTime = (Boolean) value; // New alarm will be set if reminder is enabled
                                 break;
                             }
                             case "reminderTime": {
@@ -480,26 +471,7 @@ public class DeckOptions extends AppCompatPreferenceActivity implements OnShared
                                         .put(TimePreference.parseMinutes((String) value)));
 
                                 mOptionsCopy.put("reminder", reminder);
-
-                                final AlarmManager alarmManager = (AlarmManager) getSystemService(ALARM_SERVICE);
-                                final PendingIntent reminderIntent = PendingIntent.getBroadcast(
-                                        getApplicationContext(),
-                                        (int) mOptionsCopy.getLong("id"),
-                                        new Intent(getApplicationContext(), ReminderService.class).putExtra
-                                                (ReminderService.EXTRA_DECK_OPTION_ID, mOptionsCopy.getLong("id")),
-                                        0
-                                );
-
-                                alarmManager.cancel(reminderIntent);
-
-                                final Calendar calendar = reminderToCalendar(mCol.getTime(), reminder);
-
-                                alarmManager.setRepeating(
-                                        AlarmManager.RTC_WAKEUP,
-                                        calendar.getTimeInMillis(),
-                                        AlarmManager.INTERVAL_DAY,
-                                        reminderIntent
-                                );
+                                mUpdateReminderTime = true; // Alarm will be modified after changes are saved
                                 break;
                             }
                             default:

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckOptions.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckOptions.java
@@ -32,6 +32,7 @@ import android.os.Bundle;
 import android.text.TextUtils;
 
 import android.view.KeyEvent;
+import android.view.Menu;
 import android.view.MenuItem;
 
 import com.afollestad.materialdialogs.MaterialDialog;
@@ -89,6 +90,11 @@ public class DeckOptions extends AppCompatPreferenceActivity implements OnShared
     private boolean mPreferenceChanged = false;
     private BroadcastReceiver mUnmountReceiver = null;
     private DeckPreferenceHack mPref;
+    /**
+     * Indicator for whether to save the preference changes or not.
+     * Set to true when save button is clicked.
+     */
+    private boolean mSaveChanges = false;
 
 
     /**
@@ -922,12 +928,24 @@ public class DeckOptions extends AppCompatPreferenceActivity implements OnShared
 
     }
 
+
+    @Override
+    public boolean onCreateOptionsMenu(Menu menu) {
+        getMenuInflater().inflate(R.menu.deck_options, menu);
+        return super.onCreateOptionsMenu(menu);
+    }
+
+
     @Override
     @SuppressWarnings("deprecation") // TODO Tracked in https://github.com/ankidroid/Anki-Android/issues/5019
     public boolean onOptionsItemSelected(MenuItem item) {
         if (item.getItemId() == android.R.id.home) {
             closeWithResult();
             return true;
+        } else if (item.getItemId() == R.id.action_save) {
+            Timber.d("DeckOptions - onOptionsItemSelected() save changes");
+            mSaveChanges = true;
+            closeWithResult();
         }
         return false;
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckOptions.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckOptions.java
@@ -222,6 +222,196 @@ public class DeckOptions extends AppCompatPreferenceActivity implements OnShared
         }
 
 
+        /**
+         * Writes the changes made to {@link #mOptionsCopy} and {@link #mDeckCopy} to actual options and deck data.
+         * After writing the changes, they're committed to the database.
+         */
+        public void writeChanges() {
+            // Create references to actual options and deck data
+            DeckConfig options = getOptionsReference();
+            Deck deck = getDeckReference();
+
+            Object changedValue;
+            // For every change in the copy of options/deck, write them to actual options/deck respectively
+            for (String key : mChanges) {
+                switch (key) {
+                    // New cards
+                    case "newSteps":
+                        changedValue = mOptionsCopy.getJSONObject("new").get("delays");
+                        options.getJSONObject("new").put("delays", changedValue);
+                        break;
+                    case "newOrder":
+                        changedValue = mOptionsCopy.getJSONObject("new").get("order");
+                        options.getJSONObject("new").put("order", changedValue);
+                        TaskManager.launchCollectionTask(
+                                new CollectionTask.Reorder(mOptionsCopy),
+                                new ConfChangeHandler(mPref) // Cannot call Editor.confChangeHandler() in this context
+                        );
+                        break;
+                    case "newPerDay":
+                        changedValue = mOptionsCopy.getJSONObject("new").get("perDay");
+                        options.getJSONObject("new").put("perDay", changedValue);
+                        break;
+                    case "newGradIvl":
+                    case "newEasy":
+                        changedValue = mOptionsCopy.getJSONObject("new").get("ints");
+                        options.getJSONObject("new").put("ints", changedValue);
+                        break;
+                    case "newFactor":
+                        changedValue = mOptionsCopy.getJSONObject("new").get("initialFactor");
+                        options.getJSONObject("new").put("initialFactor", changedValue);
+                        break;
+                    case "newBury":
+                        changedValue = mOptionsCopy.getJSONObject("new").get("bury");
+                        options.getJSONObject("new").put("bury", changedValue);
+                        break;
+
+                    // Reviews
+                    case "revPerDay":
+                        changedValue = mOptionsCopy.getJSONObject("rev").get("perDay");
+                        options.getJSONObject("rev").put("perDay", changedValue);
+                        break;
+                    case "easyBonus":
+                        changedValue = mOptionsCopy.getJSONObject("rev").get("ease4");
+                        options.getJSONObject("rev").put("ease4", changedValue);
+                        break;
+                    case "hardFactor":
+                        changedValue = mOptionsCopy.getJSONObject("rev").get("hardFactor");
+                        options.getJSONObject("rev").put("hardFactor", changedValue);
+                        break;
+                    case "revIvlFct":
+                        changedValue = mOptionsCopy.getJSONObject("rev").get("ivlFct");
+                        options.getJSONObject("rev").put("ivlFct", changedValue);
+                        break;
+                    case "revMaxIvl":
+                        changedValue = mOptionsCopy.getJSONObject("rev").get("maxIvl");
+                        options.getJSONObject("rev").put("maxIvl", changedValue);
+                        break;
+                    case "revBury":
+                        changedValue = mOptionsCopy.getJSONObject("rev").get("bury");
+                        options.getJSONObject("rev").put("bury", changedValue);
+                        break;
+                    case "revUseGeneralTimeoutSettings":
+                        changedValue = mOptionsCopy.getJSONObject("rev").get("useGeneralTimeoutSettings");
+                        options.getJSONObject("rev").put("useGeneralTimeoutSettings", changedValue);
+                        break;
+                    case "revTimeoutAnswer":
+                        changedValue = mOptionsCopy.getJSONObject("rev").get("timeoutAnswer");
+                        options.getJSONObject("rev").put("timeoutAnswer", changedValue);
+                        break;
+                    case "revTimeoutAnswerSeconds":
+                        changedValue = mOptionsCopy.getJSONObject("rev").get("timeoutAnswerSeconds");
+                        options.getJSONObject("rev").put("timeoutAnswerSeconds", changedValue);
+                        break;
+                    case "revTimeoutQuestionSeconds":
+                        changedValue = mOptionsCopy.getJSONObject("rev").get("timeoutQuestionSeconds");
+                        options.getJSONObject("rev").put("timeoutQuestionSeconds", changedValue);
+                        break;
+
+                    // Lapses
+                    case "lapSteps":
+                        changedValue = mOptionsCopy.getJSONObject("lapse").get("delays");
+                        options.getJSONObject("lapse").put("delays", changedValue);
+                        break;
+                    case "lapNewIvl":
+                        changedValue = mOptionsCopy.getJSONObject("lapse").get("mult");
+                        options.getJSONObject("lapse").put("mult", changedValue);
+                        break;
+                    case "lapMinIvl":
+                        changedValue = mOptionsCopy.getJSONObject("lapse").get("minInt");
+                        options.getJSONObject("lapse").put("minInt", changedValue);
+                        break;
+                    case "lapLeechThres":
+                        changedValue = mOptionsCopy.getJSONObject("lapse").get("leechFails");
+                        options.getJSONObject("lapse").put("leechFails", changedValue);
+                        break;
+                    case "lapLeechAct":
+                        changedValue = mOptionsCopy.getJSONObject("lapse").get("leechAction");
+                        options.getJSONObject("lapse").put("leechAction", changedValue);
+                        break;
+
+                    // General
+                    case "maxAnswerTime":
+                        changedValue = mOptionsCopy.get("maxTaken");
+                        options.put("maxTaken", changedValue);
+                        break;
+                    case "showAnswerTimer":
+                        changedValue = mOptionsCopy.get("timer");
+                        options.put("timer", changedValue);
+                        break;
+                    case "autoPlayAudio":
+                        changedValue = mOptionsCopy.get("autoplay");
+                        options.put("autoplay", changedValue);
+                        break;
+                    case "replayQuestion":
+                        changedValue = mOptionsCopy.get("replayq");
+                        options.put("replayq", changedValue);
+                        break;
+
+                    // Reminders
+                    case "reminderEnabled":
+                    case "reminderTime":
+                        changedValue = mOptionsCopy.get("reminder");
+                        options.put("reminder", changedValue);
+                        break;
+
+                    // Deck Description
+                    case "desc":
+                        changedValue = mDeckCopy.get("desc");
+                        deck.put("desc", changedValue);
+                        break;
+
+                    // Unknown key
+                    default:
+                        Timber.w("Unknown key type: %s", key);
+                        break;
+                }
+            }
+
+            // This section is placed outside of switch-case because it's common for "reminderEnabled" and "reminderTime"
+            // This way we avoid redundant execution
+            if (mUpdateReminderEnabled || mUpdateReminderTime) {
+                // Update reminder settings (key: reminderEnabled, reminderTime)
+                final AlarmManager alarmManager = (AlarmManager) getSystemService(ALARM_SERVICE);
+                final PendingIntent reminderIntent = PendingIntent.getBroadcast(
+                        getApplicationContext(),
+                        (int) mOptionsCopy.getLong("id"),
+                        new Intent(getApplicationContext(), ReminderService.class).putExtra
+                                (ReminderService.EXTRA_DECK_OPTION_ID, mOptionsCopy.getLong("id")),
+                        0
+                );
+                alarmManager.cancel(reminderIntent);
+
+                if (mUpdateReminderTime) {
+                    // Set reminder if enabled (key: reminderTime)
+                    final JSONObject reminder = mOptionsCopy.getJSONObject("reminder");
+                    final Calendar calendar = reminderToCalendar(mCol.getTime(), reminder);
+                    alarmManager.setRepeating(
+                            AlarmManager.RTC_WAKEUP,
+                            calendar.getTimeInMillis(),
+                            AlarmManager.INTERVAL_DAY,
+                            reminderIntent
+                    );
+                }
+            }
+
+            try {
+                // Write new changes to DB
+                mCol.getDecks().save(deck);
+                mCol.getDecks().save(options);
+            } catch (RuntimeException e) {
+                // Couldn't write to DB, exit Deck Options activity
+                Timber.e(e, "DeckOptions - RuntimeException on saving conf");
+                AnkiDroidApp.sendExceptionReport(e, "DeckOptionsSaveConf");
+                setResult(DeckPicker.RESULT_DB_ERROR);
+                finish();
+            }
+
+            // All changes are saved; clear set
+            mChanges.clear();
+        }
+
+
         private boolean parseTimerValue(DeckConfig options) {
             return DeckConfig.parseTimerOpt(options, true);
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckOptions.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckOptions.java
@@ -88,6 +88,43 @@ public class DeckOptions extends AppCompatPreferenceActivity implements OnShared
     private BroadcastReceiver mUnmountReceiver = null;
     private DeckPreferenceHack mPref;
 
+
+    /**
+     * Returns a reference to the deck data.
+     * Uses {@link #mCol} to get deck data and if it's uninitialized, {@link NullPointerException} is thrown.
+     *
+     * @return Reference to deck data
+     */
+    private Deck getDeckReference() throws NullPointerException {
+        if (mCol == null) {
+            throw new NullPointerException("Collection object is not initialized");
+        }
+        Bundle extras = getIntent().getExtras();
+        if (extras != null && extras.containsKey("did")) {
+            return mCol.getDecks().get(extras.getLong("did"));
+        } else {
+            return mCol.getDecks().current();
+        }
+    }
+
+
+    /**
+     * Returns a reference to the options data.
+     * Uses {@link #mCol} and {@link #mDeck} to get options data and if they are uninitialized,
+     * {@link NullPointerException} is thrown.
+     *
+     * @return Reference to actual deck options
+     */
+    private DeckConfig getOptionsReference() throws NullPointerException {
+        if (mCol == null) {
+            throw new NullPointerException("Collection object is not initialized");
+        } else if (mDeck == null) {
+            throw new NullPointerException("Deck object is not initialized");
+        }
+        return mCol.getDecks().confForDid(mDeck.getLong("id"));
+    }
+
+
     public class DeckPreferenceHack implements SharedPreferences {
 
         private final Map<String, String> mValues = new HashMap<>(30); // At most as many as in cacheValues

--- a/AnkiDroid/src/main/res/menu/deck_options.xml
+++ b/AnkiDroid/src/main/res/menu/deck_options.xml
@@ -1,0 +1,10 @@
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:ankidroid="http://schemas.android.com/apk/res-auto">
+
+    <item
+        android:id="@+id/action_save"
+        android:icon="@drawable/ic_done_white_24dp"
+        android:title="@string/save"
+        ankidroid:showAsAction="always"/>
+
+</menu>

--- a/AnkiDroid/src/main/res/values/03-dialogs.xml
+++ b/AnkiDroid/src/main/res/values/03-dialogs.xml
@@ -184,6 +184,8 @@
 
     <!-- Deck Options -->
     <string name="deck_options_corrupt">Failed to process deck options: %s</string>
+    <string name="deck_options_group_changes">Do you want to save changes for \'%s\'?</string>
+    <string name="discard" comment="Option to discard any changes made">Discard</string>
 
     <!-- Database Errors-->
     <string name="database_locked_title">Database Locked</string>

--- a/AnkiDroid/src/main/res/values/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values/10-preferences.xml
@@ -242,6 +242,7 @@
     <string name="deck_conf_replayq_summ">When answer shown, replay both question and answer audio</string>
     <string name="deck_conf_manage">Group management</string>
     <string name="deck_conf_manage_summ">Add and change options groups</string>
+    <string name="deck_conf_group_notice">Modifying these settings will save your current changes</string>
     <string name="deck_conf_current_group">Current group</string>
     <string name="deck_conf_rename" comment="Menu entry to rename a deck">Rename</string>
     <string name="deck_conf_reset">Restore defaults</string>

--- a/AnkiDroid/src/main/res/xml/deck_options.xml
+++ b/AnkiDroid/src/main/res/xml/deck_options.xml
@@ -25,6 +25,10 @@
         <PreferenceScreen android:title="@string/deck_conf_manage"
             android:summary="@string/deck_conf_manage_summ" >
             <Preference
+                android:key="groupNotice"
+                android:summary="@string/deck_conf_group_notice" />
+
+            <Preference
                 android:enabled="false"
                 android:key="currentConf"
                 android:title="@string/deck_conf_current_group" />


### PR DESCRIPTION
## Purpose / Description
Providing user Save and Cancel buttons to explicitly decide whether to save changes in deck options or discard them. Originally, some changes were not saved until the user went back to the deck screen. In addition to that, some of the changes may be partially committed if the app is closed immediately after changing a setting.

## Fixes
Fixes #8180 

## Approach
Added a 'Save' button which triggers a database write. This eliminates any ambiguity on the user's end. In addition, a 'Cancel' button is also added to undo all temporary changes. Pressing the back key after making changes or changing options group opens a confirmation dialog.
Changing settings in Group Management immediately save all other changes made by the user. A note is added to inform the user of the same.

## How Has This Been Tested?
Emulated on API 29, Android 10.0. Worked as expected.

## UI Changes
| Deck options screen | Confirmation on back key press |
|:-------------------------:|:-------------------------:|
| ![main-screen](https://user-images.githubusercontent.com/21220253/111863341-1588b780-8981-11eb-9b73-bae4c5799610.png) | ![back-key-confirm](https://user-images.githubusercontent.com/21220253/111863391-508aeb00-8981-11eb-9330-4954cee7f648.PNG) |

| Confirmation on changing Options Group | Added note in Group Management screen |
|:-------------------------:|:-------------------------:|
| ![options-group-change](https://user-images.githubusercontent.com/21220253/111863411-68fb0580-8981-11eb-87fd-0ab1ffb0377f.PNG) | ![group-management-screen](https://user-images.githubusercontent.com/21220253/111863414-744e3100-8981-11eb-99a8-0bba6816d25b.PNG) |


## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [x] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
