### PR TITLE
Fixes #8272: Removed white space for no title in a StyledProgressDialog dialouge popup

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckOptions.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckOptions.java
@@ -616,7 +616,7 @@ public class DeckOptions extends AppCompatPreferenceActivity implements OnShared
         @Override
         public void actualOnPreExecute(@NonNull DeckPreferenceHack deckPreferenceHack) {
             Resources res = deckPreferenceHack.getDeckOptions().getResources();
-            deckPreferenceHack.mProgressDialog = StyledProgressDialog.show(deckPreferenceHack.getDeckOptions(), "",
+            deckPreferenceHack.mProgressDialog = StyledProgressDialog.show(deckPreferenceHack.getDeckOptions(), null,
                     res.getString(R.string.reordering_cards), false);
         }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -401,7 +401,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
 
         @Override
         public void actualOnPreExecute(@NonNull DeckPicker deckPicker) {
-            deckPicker.mProgressDialog = StyledProgressDialog.show(deckPicker, "",
+            deckPicker.mProgressDialog = StyledProgressDialog.show(deckPicker, null,
                     deckPicker.getResources().getString(R.string.export_in_progress), false);
         }
 
@@ -1568,7 +1568,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
 
         @Override
         public void actualOnPreExecute(@NonNull DeckPicker deckPicker) {
-            deckPicker.mProgressDialog = StyledProgressDialog.show(deckPicker, "",
+            deckPicker.mProgressDialog = StyledProgressDialog.show(deckPicker, null,
                     deckPicker.getResources().getString(R.string.backup_repair_deck_progress), false);
         }
 
@@ -1627,7 +1627,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
 
         @Override
         public void actualOnPreExecute(@NonNull DeckPicker deckPicker) {
-            deckPicker.mProgressDialog = StyledProgressDialog.show(deckPicker, "",
+            deckPicker.mProgressDialog = StyledProgressDialog.show(deckPicker, null,
                     deckPicker.getResources().getString(R.string.check_media_message), false);
         }
 
@@ -1661,7 +1661,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
 
         @Override
         public void actualOnPreExecute(@NonNull DeckPicker deckPicker) {
-            deckPicker.mProgressDialog = StyledProgressDialog.show(deckPicker, "",
+            deckPicker.mProgressDialog = StyledProgressDialog.show(deckPicker, null,
                     deckPicker.getResources().getString(R.string.delete_media_message), false);
         }
 
@@ -2719,7 +2719,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
 
         @Override
         public void actualOnPreExecute(@NonNull DeckPicker deckPicker) {
-            deckPicker.mProgressDialog = StyledProgressDialog.show(deckPicker, "",
+            deckPicker.mProgressDialog = StyledProgressDialog.show(deckPicker, null,
                     deckPicker.getResources().getString(R.string.delete_deck), false);
             if (did == deckPicker.getCol().getDecks().current().optLong("id")) {
                 removingCurrent = true;

--- a/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsFragment.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsFragment.java
@@ -341,13 +341,13 @@ public class StudyOptionsFragment extends Fragment implements Toolbar.OnMenuItem
             return true;
         } else if (itemId == R.id.action_rebuild) {
             Timber.i("StudyOptionsFragment:: rebuild cram deck button pressed");
-            mProgressDialog = StyledProgressDialog.show(getActivity(), "",
+            mProgressDialog = StyledProgressDialog.show(getActivity(), null,
                     getResources().getString(R.string.rebuild_filtered_deck), true);
             TaskManager.launchCollectionTask(new CollectionTask.RebuildCram(), getCollectionTaskListener(true));
             return true;
         } else if (itemId == R.id.action_empty) {
             Timber.i("StudyOptionsFragment:: empty cram deck button pressed");
-            mProgressDialog = StyledProgressDialog.show(getActivity(), "",
+            mProgressDialog = StyledProgressDialog.show(getActivity(), null,
                     getResources().getString(R.string.empty_filtered_deck), false);
             TaskManager.launchCollectionTask(new CollectionTask.EmptyCram(), getCollectionTaskListener(true));
             return true;
@@ -463,7 +463,7 @@ public class StudyOptionsFragment extends Fragment implements Toolbar.OnMenuItem
                 if (deck.isDyn() && deck.has("empty")) {
                     deck.remove("empty");
                 }
-                    mProgressDialog = StyledProgressDialog.show(getActivity(), "",
+                    mProgressDialog = StyledProgressDialog.show(getActivity(), null,
                             getResources().getString(R.string.rebuild_filtered_deck), true);
                     TaskManager.launchCollectionTask(new CollectionTask.RebuildCram(), getCollectionTaskListener(true));
             } else {

--- a/AnkiDroid/src/main/java/com/ichi2/themes/StyledProgressDialog.java
+++ b/AnkiDroid/src/main/java/com/ichi2/themes/StyledProgressDialog.java
@@ -60,7 +60,7 @@ public class StyledProgressDialog extends Dialog {
 
     public static MaterialDialog show(Context context, CharSequence title, CharSequence message,
             boolean cancelable, DialogInterface.OnCancelListener cancelListener) {
-        if (title.equals("")) {
+        if ("".equals(title)) {
             title = null;
             Timber.w("Invalid title was provided. Using null");
         }

--- a/AnkiDroid/src/main/java/com/ichi2/themes/StyledProgressDialog.java
+++ b/AnkiDroid/src/main/java/com/ichi2/themes/StyledProgressDialog.java
@@ -62,7 +62,7 @@ public class StyledProgressDialog extends Dialog {
             boolean cancelable, DialogInterface.OnCancelListener cancelListener) {
         if ("".equals(title)) {
             title = null;
-            Timber.w("Invalid title was provided. Using null");
+            Timber.d("Invalid title was provided. Using null");
         }
         return new MaterialDialog.Builder(context)
                 .title(title)

--- a/AnkiDroid/src/main/java/com/ichi2/themes/StyledProgressDialog.java
+++ b/AnkiDroid/src/main/java/com/ichi2/themes/StyledProgressDialog.java
@@ -60,6 +60,10 @@ public class StyledProgressDialog extends Dialog {
 
     public static MaterialDialog show(Context context, CharSequence title, CharSequence message,
             boolean cancelable, DialogInterface.OnCancelListener cancelListener) {
+        if (title.equals("")) {
+            title = null;
+            Timber.w("Invalid title was provided. Using null");
+        }
         return new MaterialDialog.Builder(context)
                 .title(title)
                 .content(message)


### PR DESCRIPTION
## Purpose / Description
Removing white space for no title in a StyledProgressDialog dialouge popup

## Fixes
Fixes https://github.com/ankidroid/Anki-Android/issues/8272

## Approach
I looked over every method using `StyledProgressDialog`  with title being "" and replaced with null

## How Has This Been Tested?
<p float="left">
  <img src="https://i.imgur.com/K0X1tuW.jpeg" width="400" />
</p>

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [x] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
