### PR TITLE
Highlight default selection in pickers 

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -613,8 +613,6 @@ public class NoteEditor extends AnkiActivity {
             @Override
             public View getDropDownView(int position, View convertView, ViewGroup parent){
 
-                mCurrentDid = mAllDeckIds.get(position);
-
                 // Cast the drop down items (popup items) as text view
                 TextView tv = (TextView) super.getDropDownView(position, convertView, parent);
 
@@ -630,6 +628,19 @@ public class NoteEditor extends AnkiActivity {
         };
         mNoteDeckSpinner.setAdapter(noteDeckAdapter);
         noteDeckAdapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
+        mNoteDeckSpinner.setOnItemSelectedListener(new OnItemSelectedListener() {
+
+            @Override
+            public void onItemSelected(AdapterView<?> parent, View view, int pos, long id) {
+                // Timber.i("NoteEditor:: onItemSelected() fired on mNoteDeckSpinner with pos = %d", pos);
+                mCurrentDid = mAllDeckIds.get(pos);
+            }
+
+            @Override
+            public void onNothingSelected(AdapterView<?> parent) {
+                // Do Nothing
+            }
+        });
 
         mCurrentDid = intent.getLongExtra(EXTRA_DID, mCurrentDid);
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -561,14 +561,14 @@ public class NoteEditor extends AnkiActivity {
             mAllModelIds.add(m.getLong("id"));
         }
 
-        ArrayAdapter<String> noteTypeAdapter = new ArrayAdapter<String>(this, android.R.layout.simple_spinner_item, modelNames){
+        ArrayAdapter<String> noteTypeAdapter = new ArrayAdapter<String>(this, android.R.layout.simple_spinner_item, modelNames) {
             @Override
-            public View getDropDownView(int position, View convertView, ViewGroup parent){
+            public View getDropDownView(int position, View convertView, ViewGroup parent) {
                 // Cast the drop down items (popup items) as text view
-                TextView tv = (TextView) super.getDropDownView(position,convertView,parent);
+                TextView tv = (TextView) super.getDropDownView(position, convertView, parent);
 
                 // If this item is selected
-                if(position == mNoteTypeSpinner.getSelectedItemPosition()){
+                if (position == mNoteTypeSpinner.getSelectedItemPosition()) {
                     tv.setBackgroundColor(Color.LTGRAY);
                     tv.setTextColor(Color.BLACK);
                 }
@@ -609,17 +609,17 @@ public class NoteEditor extends AnkiActivity {
             mAllDeckIds.add(thisDid);
         }
 
-        ArrayAdapter<String> noteDeckAdapter = new ArrayAdapter<String>(this, android.R.layout.simple_spinner_item, deckNames){
+        ArrayAdapter<String> noteDeckAdapter = new ArrayAdapter<String>(this, android.R.layout.simple_spinner_item, deckNames) {
             @Override
             public View getDropDownView(int position, View convertView, ViewGroup parent){
 
                 mCurrentDid = mAllDeckIds.get(position);
 
                 // Cast the drop down items (popup items) as text view
-                TextView tv = (TextView) super.getDropDownView(position,convertView,parent);
+                TextView tv = (TextView) super.getDropDownView(position, convertView, parent);
 
                 // If this item is selected
-                if(position == mNoteDeckSpinner.getSelectedItemPosition()){
+                if (position == mNoteDeckSpinner.getSelectedItemPosition()) {
                     tv.setBackgroundColor(Color.LTGRAY);
                     tv.setTextColor(Color.BLACK);
                 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -611,7 +611,7 @@ public class NoteEditor extends AnkiActivity {
 
         ArrayAdapter<String> noteDeckAdapter = new ArrayAdapter<String>(this, android.R.layout.simple_spinner_item, deckNames) {
             @Override
-            public View getDropDownView(int position, View convertView, ViewGroup parent){
+            public View getDropDownView(int position, View convertView, ViewGroup parent) {
 
                 // Cast the drop down items (popup items) as text view
                 TextView tv = (TextView) super.getDropDownView(position, convertView, parent);
@@ -2505,4 +2505,3 @@ public class NoteEditor extends AnkiActivity {
         }
     }
 }
-

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -569,8 +569,8 @@ public class NoteEditor extends AnkiActivity {
 
                 // If this item is selected
                 if (position == mNoteTypeSpinner.getSelectedItemPosition()) {
-                    tv.setBackgroundColor(Color.LTGRAY);
-                    tv.setTextColor(Color.BLACK);
+                    tv.setBackgroundColor(ContextCompat.getColor(NoteEditor.this, R.color.note_editor_selected_item_background));
+                    tv.setTextColor(ContextCompat.getColor(NoteEditor.this, R.color.note_editor_selected_item_text));
                 }
 
                 // Return the modified view
@@ -620,8 +620,8 @@ public class NoteEditor extends AnkiActivity {
 
                 // If this item is selected
                 if (position == mNoteDeckSpinner.getSelectedItemPosition()) {
-                    tv.setBackgroundColor(Color.LTGRAY);
-                    tv.setTextColor(Color.BLACK);
+                    tv.setBackgroundColor(ContextCompat.getColor(NoteEditor.this, R.color.note_editor_selected_item_background));
+                    tv.setTextColor(ContextCompat.getColor(NoteEditor.this, R.color.note_editor_selected_item_text));
                 }
 
                 // Return the modified view
@@ -2494,3 +2494,4 @@ public class NoteEditor extends AnkiActivity {
         }
     }
 }
+

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -27,6 +27,7 @@ import android.content.Intent;
 import android.content.IntentFilter;
 import android.content.SharedPreferences;
 import android.content.res.Resources;
+import android.graphics.Color;
 import android.graphics.Typeface;
 import android.graphics.drawable.Drawable;
 import android.net.Uri;
@@ -52,6 +53,7 @@ import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.MenuItem;
 import android.view.View;
+import android.view.ViewGroup;
 import android.view.ViewGroup.MarginLayoutParams;
 import android.view.WindowManager;
 import android.view.inputmethod.InputMethodManager;
@@ -559,7 +561,22 @@ public class NoteEditor extends AnkiActivity {
             mAllModelIds.add(m.getLong("id"));
         }
 
-        ArrayAdapter<String> noteTypeAdapter = new ArrayAdapter<>(this, android.R.layout.simple_spinner_item, modelNames);
+        ArrayAdapter<String> noteTypeAdapter = new ArrayAdapter<String>(this, android.R.layout.simple_spinner_item, modelNames){
+            @Override
+            public View getDropDownView(int position, View convertView, ViewGroup parent){
+                // Cast the drop down items (popup items) as text view
+                TextView tv = (TextView) super.getDropDownView(position,convertView,parent);
+
+                // If this item is selected
+                if(position == mNoteTypeSpinner.getSelectedItemPosition()){
+                    tv.setBackgroundColor(Color.LTGRAY);
+                    tv.setTextColor(Color.BLACK);
+                }
+
+                // Return the modified view
+                return tv;
+            }
+        };
         mNoteTypeSpinner.setAdapter(noteTypeAdapter);
         noteTypeAdapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
 
@@ -592,21 +609,27 @@ public class NoteEditor extends AnkiActivity {
             mAllDeckIds.add(thisDid);
         }
 
-        ArrayAdapter<String> noteDeckAdapter = new ArrayAdapter<>(this, android.R.layout.simple_spinner_item, deckNames);
+        ArrayAdapter<String> noteDeckAdapter = new ArrayAdapter<String>(this, android.R.layout.simple_spinner_item, deckNames){
+            @Override
+            public View getDropDownView(int position, View convertView, ViewGroup parent){
+
+                mCurrentDid = mAllDeckIds.get(position);
+
+                // Cast the drop down items (popup items) as text view
+                TextView tv = (TextView) super.getDropDownView(position,convertView,parent);
+
+                // If this item is selected
+                if(position == mNoteDeckSpinner.getSelectedItemPosition()){
+                    tv.setBackgroundColor(Color.LTGRAY);
+                    tv.setTextColor(Color.BLACK);
+                }
+
+                // Return the modified view
+                return tv;
+            }
+        };
         mNoteDeckSpinner.setAdapter(noteDeckAdapter);
         noteDeckAdapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
-        mNoteDeckSpinner.setOnItemSelectedListener(new OnItemSelectedListener() {
-            @Override
-            public void onItemSelected(AdapterView<?> parent, View view, int pos, long id) {
-                // Timber.i("NoteEditor:: onItemSelected() fired on mNoteDeckSpinner with pos = %d", pos);
-                mCurrentDid = mAllDeckIds.get(pos);
-            }
-
-            @Override
-            public void onNothingSelected(AdapterView<?> parent) {
-                // Do Nothing
-            }
-        });
 
         mCurrentDid = intent.getLongExtra(EXTRA_DID, mCurrentDid);
 

--- a/AnkiDroid/src/main/res/values/colors.xml
+++ b/AnkiDroid/src/main/res/values/colors.xml
@@ -102,6 +102,9 @@
 
     <color name="material_theme_grey">#303030</color>
 
+    <color name="note_editor_selected_item_background">#D1D0CE</color>
+    <color name="note_editor_selected_item_text">#000000</color>
+
     <color name="flag_red">#ff0000</color>
     <color name="flag_orange">#FF9800</color>
     <color name="flag_green">#00ff00</color>
@@ -110,3 +113,4 @@
     <color name="badge_error">#f45000</color>
     <color name="badge_warning">#ff5e13</color>
 </resources>
+


### PR DESCRIPTION
## Purpose / Description
Fixes  #7931

Highlight default selection in the pickers of note editor.
Related PRs: https://github.com/ankidroid/Anki-Android/pull/8171 and https://github.com/ankidroid/Anki-Android/pull/8174

## Approach
`Before change` When the user was in note editor, there is a selector to change the type of note or card's deck, It was not highlighted.
`After change` Now, when the user selects something in this section, the background of the selected one will be highlighted by default to "light gray" color and the text color itself will be "black".

## How Has This Been Tested?
Tested by [Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&utm_source=www.apk4fun.com).

**Screenshots**
<div align="center">
<pre>
   <img alt="" width="30%" src="https://user-images.githubusercontent.com/48657780/111163716-0501c700-85a6-11eb-9bb5-7e86cffa7fff.jpeg">   <img alt="" width="30%" src="https://user-images.githubusercontent.com/48657780/111163722-0632f400-85a6-11eb-8327-8d4dd1a08489.jpeg">   <img alt="" width="30%" src="https://user-images.githubusercontent.com/48657780/111166210-8fe3c100-85a8-11eb-8be1-5558bf1858a0.jpeg"> 
     
</pre>
</div>

## Checklist

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)