### PR TITLE
Explicit dependency on androidx.fragment/androidx.activity, bump versions

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -221,10 +221,12 @@ dependencies {
     annotationProcessor "com.google.auto.service:auto-service:1.0-rc7"
 
     implementation fileTree(dir: 'libs', include: ['*.jar'])
+    implementation 'androidx.activity:activity:1.2.1'
     implementation 'androidx.annotation:annotation:1.1.0'
     implementation 'androidx.appcompat:appcompat:1.2.0'
     implementation 'androidx.browser:browser:1.3.0'
     implementation 'androidx.exifinterface:exifinterface:1.3.2'
+    implementation 'androidx.fragment:fragment:1.3.1'
     implementation 'androidx.localbroadcastmanager:localbroadcastmanager:1.0.0'
     implementation "androidx.preference:preference:1.1.1"
     implementation 'androidx.recyclerview:recyclerview:1.1.0'
@@ -281,10 +283,7 @@ dependencies {
     testImplementation 'androidx.test:core:1.3.0'
     testImplementation 'androidx.test.ext:junit:1.1.2'
     // debugImplementation required vs testImplementation: https://issuetracker.google.com/issues/128612536
-    debugImplementation("androidx.fragment:fragment-testing:1.2.5") {
-        // monitor dep constrained to 1.2 by fragment-testing, 1.3+ is needed: https://github.com/android/android-test/issues/481
-        exclude group:'androidx.test', module:'monitor'
-    }
+    debugImplementation 'androidx.fragment:fragment-testing:1.3.1'
 
     // May need a resolution strategy for support libs to our versions
     androidTestImplementation 'com.azimolabs.conditionwatcher:conditionwatcher:0.2'

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.java
@@ -521,6 +521,7 @@ public class CardTemplateEditor extends AnkiActivity implements DeckSelectionDia
         }
 
 
+        @SuppressWarnings("deprecation") // Tracked as https://github.com/ankidroid/Anki-Android/issues/8293
         private void performPreview() {
             Collection col = mTemplateEditor.getCol();
             TemporaryModel tempModel = mTemplateEditor.getTempModel();
@@ -575,6 +576,7 @@ public class CardTemplateEditor extends AnkiActivity implements DeckSelectionDia
         }
 
 
+        @SuppressWarnings("deprecation") // Tracked as https://github.com/ankidroid/Anki-Android/issues/8293
         private void launchCardBrowserAppearance(JSONObject currentTemplate) {
             Context context = AnkiDroidApp.getInstance().getBaseContext();
             if (context == null) {
@@ -627,6 +629,7 @@ public class CardTemplateEditor extends AnkiActivity implements DeckSelectionDia
         }
 
 
+        @SuppressWarnings("deprecation") // Tracked as https://github.com/ankidroid/Anki-Android/issues/8293
         @Override
         public void onActivityResult(int requestCode, int resultCode, @Nullable Intent data) {
             super.onActivityResult(requestCode, resultCode, data);

--- a/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsFragment.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsFragment.java
@@ -158,6 +158,7 @@ public class StudyOptionsFragment extends Fragment implements Toolbar.OnMenuItem
      *                      deck has no options associated with it yet and should use a default
      *                      set of values.
      */
+    @SuppressWarnings("deprecation") // Tracked as https://github.com/ankidroid/Anki-Android/issues/8293
     private void openFilteredDeckOptions(boolean defaultConfig) {
         Intent i = new Intent(getActivity(), FilteredDeckOptions.class);
         i.putExtra("defaultConfig", defaultConfig);
@@ -241,6 +242,7 @@ public class StudyOptionsFragment extends Fragment implements Toolbar.OnMenuItem
     }
 
 
+    @SuppressWarnings("deprecation") // Tracked as https://github.com/ankidroid/Anki-Android/issues/8293
     private void openReviewer() {
         Intent reviewer = new Intent(getActivity(), Reviewer.class);
         if (mFragmented) {
@@ -312,6 +314,7 @@ public class StudyOptionsFragment extends Fragment implements Toolbar.OnMenuItem
         }
     };
 
+    @SuppressWarnings("deprecation") // Tracked as https://github.com/ankidroid/Anki-Android/issues/8293
     @Override
     public boolean onMenuItemClick(MenuItem item) {
         int itemId = item.getItemId();
@@ -434,6 +437,7 @@ public class StudyOptionsFragment extends Fragment implements Toolbar.OnMenuItem
     }
 
 
+    @SuppressWarnings("deprecation") // Tracked as https://github.com/ankidroid/Anki-Android/issues/8293
     @Override
     public void onActivityResult(int requestCode, int resultCode, Intent intent) {
         super.onActivityResult(requestCode, resultCode, intent);

--- a/AnkiDroid/src/test/java/com/ichi2/anki/AbstractFlashcardViewerCommandTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/AbstractFlashcardViewerCommandTest.java
@@ -22,6 +22,9 @@ import com.ichi2.anki.reviewer.CardMarker.FlagDef;
 import com.ichi2.libanki.Card;
 
 import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import androidx.test.ext.junit.runners.AndroidJUnit4;
 
 import static com.ichi2.anki.reviewer.CardMarker.FLAG_BLUE;
 import static com.ichi2.anki.reviewer.CardMarker.FLAG_GREEN;
@@ -35,7 +38,8 @@ import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class AbstractFlashcardViewerCommandTest {
+@RunWith(AndroidJUnit4.class)
+public class AbstractFlashcardViewerCommandTest extends RobolectricTest {
 
     @Test
     public void doubleTapSetsNone() {

--- a/AnkiDroid/src/test/java/com/ichi2/anki/AbstractFlashcardViewerKeyboardInputTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/AbstractFlashcardViewerKeyboardInputTest.java
@@ -19,12 +19,15 @@ package com.ichi2.anki;
 import android.view.KeyEvent;
 
 import org.junit.Test;
+import org.junit.runner.RunWith;
 
+import androidx.test.ext.junit.runners.AndroidJUnit4;
 import timber.log.Timber;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 
-public class AbstractFlashcardViewerKeyboardInputTest {
+@RunWith(AndroidJUnit4.class)
+public class AbstractFlashcardViewerKeyboardInputTest extends RobolectricTest {
 
     @Test
     public void spaceShowsAnswer() {

--- a/AnkiDroid/src/test/java/com/ichi2/anki/ReviewerKeyboardInputTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/ReviewerKeyboardInputTest.java
@@ -23,9 +23,11 @@ import com.ichi2.libanki.Card;
 import com.ichi2.libanki.Collection;
 
 import org.junit.Test;
+import org.junit.runner.RunWith;
 
 import androidx.annotation.CheckResult;
 import androidx.annotation.NonNull;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
 import timber.log.Timber;
 
 import static android.view.KeyEvent.*;
@@ -40,7 +42,8 @@ import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class ReviewerKeyboardInputTest {
+@RunWith(AndroidJUnit4.class)
+public class ReviewerKeyboardInputTest extends RobolectricTest {
 
     @Test
     public void whenDisplayingQuestionTyping1DoesNothing() {


### PR DESCRIPTION

## Pull Request template

## Purpose / Description

Previously the dependency was implicit, this makes it obvious now and puts the
version under our control

Fragment 1.3.x brings in new APIs and causes deprecation warnings as noted here:
https://github.com/ankidroid/Anki-Android/issues/8293

Ignore the deprecation from now, forward-port tests to use robolectric where needed
for looper / lifecycle management in new Fragment version
_Describe the problem or feature and motivation_

## Fixes
Related #8293 - deprecation tracking issue

## Approach
- adds explicit dependency on the fragment and activity libraries in use
- adds a deprecation tracker issue and notes in the code for forward-porting work
- alters some tests that were implicitly using fragments to run under robolectric so that the Looper is mocked (new fragment library touches it, causing errors without robolectric)

## How Has This Been Tested?

Only CI and a quick click-through of the affected fragments on an emulator. Seems to work?

## Learning (optional, can help others)

As noted in #8293 (where it is more useful since that issue will live on)

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [x] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
