### PR TITLE
Unwanted else-if with browserDeckidFromDeckPicker and REQUEST_BROWSE_CARDS in DeckPicker removed.

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -908,14 +908,6 @@ public class DeckPicker extends NavigationDrawerActivity implements
                 CollectionTask.waitForAllToFinish(4);
                 sync();
             }
-        } else if (requestCode == REQUEST_BROWSE_CARDS) {
-            // Store the selected deck after opening browser
-            if (intent != null && intent.getBooleanExtra("allDecksSelected", false)) {
-                AnkiDroidApp.getSharedPrefs(this).edit().putLong("browserDeckIdFromDeckPicker", Decks.NOT_FOUND_DECK_ID).apply();
-            } else {
-                long selectedDeck = getCol().getDecks().selected();
-                AnkiDroidApp.getSharedPrefs(this).edit().putLong("browserDeckIdFromDeckPicker", selectedDeck).apply();
-            }
         } else if (requestCode == REQUEST_PATH_UPDATE) {
             // The collection path was inaccessible on startup so just close the activity and let user restart
             finishWithoutAnimation();


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
fixed #8266.Remove unwanted code with browserDeckidFromDeckPicker

REQUEST_BROWSE_CARDS and browserDeckIdFromDeckPicker removed as the animations that were introduced have been deprecated and no longer used

## Fixes
Fixes _Link to the issues._

fixed #8266

## Approach
_How does this change address the problem

REQUEST_BROWSE_CARDS and browserDeckIdFromDeckPicker removed as the animations that were introduced have been deprecated and no longer used

## How Has This Been Tested?

Runs on my device,Samsung SM-013F
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration (SDK version(s), emulator or physical, etc)

## Learning (optional, can help others)
_Describe the research stage_

_Links to blog posts, patterns, libraries or addons used to solve this problem_

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
