### PR TITLE
NF: MockTime takes date parameter

### DIFF
--- a/AnkiDroid/src/test/java/com/ichi2/anki/RobolectricTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/RobolectricTest.java
@@ -244,10 +244,10 @@ public class RobolectricTest {
     * Each time time is checked, it advance by 10 ms. Not enough to create any change visible to user, but ensure
      * we don't get two equal time.*/
     protected Collection getCol() {
-        // 2020/08/07, 07:00:00. Normally not near day cutoff.
-        MockTime time = new MockTime(1596783600000L, 10);
+        MockTime time = new MockTime(2020, 7, 7, 7, 0, 0, 10);
         return CollectionHelper.getInstance().getCol(getTargetContext(), time);
     }
+
 
     protected MockTime getCollectionTime() {
         return (MockTime) getCol().getTime();

--- a/AnkiDroid/src/test/java/com/ichi2/testutils/MockTime.java
+++ b/AnkiDroid/src/test/java/com/ichi2/testutils/MockTime.java
@@ -18,6 +18,9 @@ package com.ichi2.testutils;
 
 import com.ichi2.libanki.utils.Time;
 
+import java.util.Calendar;
+import java.util.TimeZone;
+
 public class MockTime extends Time {
 
     /** Number of miliseconds between each call. */
@@ -34,6 +37,23 @@ public class MockTime extends Time {
     public MockTime(long time, int step) {
         this.mTime = time;
         this.mStep = step;
+    }
+
+    /** A clock at time Time, each call advance by step ms.*/
+    public MockTime(int year, int month, int date, int hourOfDay, int minute,
+                    int second) {
+        this(year, month, date, hourOfDay, minute, second, 0);
+    }
+
+    /** create a mock time whose initial value is this date. Month is 0-based, in order to stay close to calendar. MS are 0.*/
+    public MockTime(int year, int month, int date, int hourOfDay, int minute,
+                    int second, int step) {
+        Calendar cal = Calendar.getInstance();
+        cal.setTimeZone(TimeZone.getTimeZone("GMT"));
+        cal.clear();
+        cal.set(year, month, date, hourOfDay, minute, second);
+        mTime = cal.getTimeInMillis();
+        mStep = step;
     }
 
     /** Time in milisecond since epoch. */

--- a/AnkiDroid/src/test/java/com/ichi2/testutils/MockTimeTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/testutils/MockTimeTest.java
@@ -1,0 +1,15 @@
+package com.ichi2.testutils;
+
+import com.ichi2.testutils.MockTime;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+public class MockTimeTest {
+    @Test
+    public void DateTest() {
+        MockTime time = new MockTime(2020, 7, 7, 7, 0, 0, 0);
+        Assert.assertEquals(1596783600000L, time.intTimeMS());
+    }
+}


### PR DESCRIPTION
Instead of using time stamp, I suggest using calendar parameters to create MockTime. It will be easier to debug. I can tell it since I'm having a lot of problem creating regression test for a problem related to time right now.