### PR TITLE
NF: resetCounts keeps cancelListener

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
@@ -224,7 +224,7 @@ public class SchedV2 extends AbstractSched {
 
     @Override
     public void resetCounts(@NonNull CancelListener cancelListener) {
-        resetCounts(true);
+        resetCounts(cancelListener,true);
     }
 
     public void resetCounts(boolean checkCutoff) {


### PR DESCRIPTION
CancelListener should be used to cancel work if required. It should be passed instead of being set to null