### PR TITLE
Remove allow_empty from card projection

### DIFF
--- a/api/src/main/java/com/ichi2/anki/FlashCardsContract.java
+++ b/api/src/main/java/com/ichi2/anki/FlashCardsContract.java
@@ -312,7 +312,6 @@ public class FlashCardsContract {
                 Note._ID,
                 Note.GUID,
                 Note.MID,
-                Note.ALLOW_EMPTY,
                 Note.MOD,
                 Note.USN,
                 Note.TAGS,


### PR DESCRIPTION
No idea:
1. why it was not detected by tests (they were passing when merged)
2. I added them here, were they clearly have nothing to do

Fixes #8311


