### PR TITLE
Fix:7939 Limiting to one card per note in CardBrowser

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -1484,7 +1484,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
         boolean singleCardByNote;
         try{
             singleCardByNote = mActionBarMenu.findItem(R.id.action_limited_search).isChecked();
-        } catch ( Exception e) {
+        } catch ( NullPointerException e) {
             Timber.e(e.getMessage());
             singleCardByNote = false;
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -1485,7 +1485,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
         try{
             singleCardByNote = mActionBarMenu.findItem(R.id.action_limited_search).isChecked();
         } catch ( NullPointerException e) {
-            Timber.e(e.getMessage());
+            Timber.e(e);
             singleCardByNote = false;
         }
         if (mSearchTerms == null) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -1181,13 +1181,9 @@ public class CardBrowser extends NavigationDrawerActivity implements
             }
             return true;
         } else if (itemId == R.id.action_limited_search) {
-            if( mActionBarMenu.findItem(R.id.action_limited_search).isChecked() ){
-                mActionBarMenu.findItem(R.id.action_limited_search).setChecked(false);
-                searchCards();
-            } else {
-                mActionBarMenu.findItem(R.id.action_limited_search).setChecked(true);
-                searchCards();
-            }
+            boolean wasChecked =  mActionBarMenu.findItem(R.id.action_limited_search).isChecked();
+            mActionBarMenu.findItem(R.id.action_limited_search).setChecked(!wasChecked);
+            searchCards();
         }
 
         return super.onOptionsItemSelected(item);
@@ -1485,16 +1481,12 @@ public class CardBrowser extends NavigationDrawerActivity implements
         // cancel the previous search & render tasks if still running
         invalidate();
         String searchText;
-        boolean limitedCards;
+        boolean singleCardByNote;
         try{
-            if (mActionBarMenu.findItem(R.id.action_limited_search).isChecked()) {
-                limitedCards = true;
-            } else {
-                limitedCards = false;
-            }
-        } catch (Throwable e) {
+            singleCardByNote = mActionBarMenu.findItem(R.id.action_limited_search).isChecked();
+        } catch ( Exception e) {
             Timber.d(e.getMessage());
-            limitedCards = false;
+            singleCardByNote = false;
         }
         if (mSearchTerms == null) {
             mSearchTerms = "";
@@ -1521,7 +1513,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
                             numCardsToRender,
                             mColumn1Index,
                             mColumn2Index,
-                            limitedCards),
+                            singleCardByNote),
                     mSearchCardsHandler
             );
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -1485,7 +1485,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
         try{
             singleCardByNote = mActionBarMenu.findItem(R.id.action_limited_search).isChecked();
         } catch ( Exception e) {
-            Timber.d(e.getMessage());
+            Timber.e(e.getMessage());
             singleCardByNote = false;
         }
         if (mSearchTerms == null) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -1180,7 +1180,16 @@ public class CardBrowser extends NavigationDrawerActivity implements
                 startActivityWithAnimation(intent, FADE);
             }
             return true;
+        } else if (itemId == R.id.action_limited_search) {
+            if( mActionBarMenu.findItem(R.id.action_limited_search).isChecked() ){
+                mActionBarMenu.findItem(R.id.action_limited_search).setChecked(false);
+                searchCards();
+            } else {
+                mActionBarMenu.findItem(R.id.action_limited_search).setChecked(true);
+                searchCards();
+            }
         }
+
         return super.onOptionsItemSelected(item);
     }
 
@@ -1476,6 +1485,17 @@ public class CardBrowser extends NavigationDrawerActivity implements
         // cancel the previous search & render tasks if still running
         invalidate();
         String searchText;
+        boolean limitedCards;
+        try{
+            if (mActionBarMenu.findItem(R.id.action_limited_search).isChecked()) {
+                limitedCards = true;
+            } else {
+                limitedCards = false;
+            }
+        } catch (Throwable e) {
+            Timber.d(e.getMessage());
+            limitedCards = false;
+        }
         if (mSearchTerms == null) {
             mSearchTerms = "";
         }
@@ -1500,7 +1520,8 @@ public class CardBrowser extends NavigationDrawerActivity implements
                             (mOrder != CARD_ORDER_NONE),
                             numCardsToRender,
                             mColumn1Index,
-                            mColumn2Index),
+                            mColumn2Index,
+                            limitedCards),
                     mSearchCardsHandler
             );
         }

--- a/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
@@ -1088,16 +1088,16 @@ public class CollectionTask<ProgressListener, ProgressBackground extends Progres
         private final int numCardsToRender;
         private final int column1Index;
         private final int column2Index;
-        private final boolean limitedCards;
+        private final boolean singleCardByNote;
 
 
-        public SearchCards(String query, boolean order, int numCardsToRender, int column1Index, int column2Index, boolean limitedCards) {
+        public SearchCards(String query, boolean order, int numCardsToRender, int column1Index, int column2Index, boolean singleCardByNote) {
             this.query = query;
             this.order = order;
             this.numCardsToRender = numCardsToRender;
             this.column1Index = column1Index;
             this.column2Index = column2Index;
-            this.limitedCards = limitedCards;
+            this.singleCardByNote = singleCardByNote;
         }
 
 
@@ -1108,7 +1108,7 @@ public class CollectionTask<ProgressListener, ProgressBackground extends Progres
                 return null;
             }
             List<CardBrowser.CardCache> searchResult = new ArrayList<>();
-            List<Long> searchResult_ = col.findCards(query, order, new PartialSearch(searchResult, column1Index, column2Index, numCardsToRender, collectionTask, col), limitedCards);
+            List<Long> searchResult_ = col.findCards(query, order, new PartialSearch(searchResult, column1Index, column2Index, numCardsToRender, collectionTask, col), singleCardByNote);
             Timber.d("The search found %d cards", searchResult_.size());
             int position = 0;
             for (Long cid : searchResult_) {

--- a/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
@@ -1088,14 +1088,16 @@ public class CollectionTask<ProgressListener, ProgressBackground extends Progres
         private final int numCardsToRender;
         private final int column1Index;
         private final int column2Index;
+        private final boolean limitedCards;
 
 
-        public SearchCards(String query, boolean order, int numCardsToRender, int column1Index, int column2Index) {
+        public SearchCards(String query, boolean order, int numCardsToRender, int column1Index, int column2Index, boolean limitedCards) {
             this.query = query;
             this.order = order;
             this.numCardsToRender = numCardsToRender;
             this.column1Index = column1Index;
             this.column2Index = column2Index;
+            this.limitedCards = limitedCards;
         }
 
 
@@ -1106,7 +1108,7 @@ public class CollectionTask<ProgressListener, ProgressBackground extends Progres
                 return null;
             }
             List<CardBrowser.CardCache> searchResult = new ArrayList<>();
-            List<Long> searchResult_ = col.findCards(query, order, new PartialSearch(searchResult, column1Index, column2Index, numCardsToRender, collectionTask, col));
+            List<Long> searchResult_ = col.findCards(query, order, new PartialSearch(searchResult, column1Index, column2Index, numCardsToRender, collectionTask, col), limitedCards);
             Timber.d("The search found %d cards", searchResult_.size());
             int position = 0;
             for (Long cid : searchResult_) {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
@@ -1216,22 +1216,22 @@ public class Collection {
      */
 
     /** Return a list of card ids */
-    public List<Long> findCards(String search) {
-        return new Finder(this).findCards(search, null);
+    public List<Long> findCards(String search, boolean limitedCards) {
+        return new Finder(this).findCards(search, null, limitedCards);
     }
 
 
     /** Return a list of card ids */
-    public List<Long> findCards(String search, String order) {
-        return new Finder(this).findCards(search, order);
+    public List<Long> findCards(String search, String order, boolean limitedCards) {
+        return new Finder(this).findCards(search, order, limitedCards);
     }
 
-    public List<Long> findCards(String search, boolean order) {
-        return findCards(search, order, null);
+    public List<Long> findCards(String search, boolean order, boolean limitedCards) {
+        return findCards(search, order, null, limitedCards);
     }
 
-    public List<Long> findCards(String search, boolean order, CollectionTask.PartialSearch task) {
-        return new Finder(this).findCards(search, order, task);
+    public List<Long> findCards(String search, boolean order, CollectionTask.PartialSearch task, boolean limitedCards) {
+        return new Finder(this).findCards(search, order, task, limitedCards);
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
@@ -1216,22 +1216,22 @@ public class Collection {
      */
 
     /** Return a list of card ids */
-    public List<Long> findCards(String search, boolean limitedCards) {
-        return new Finder(this).findCards(search, null, limitedCards);
+    public List<Long> findCards(String search, boolean singleCardByNote) {
+        return new Finder(this).findCards(search, null, singleCardByNote);
     }
 
 
     /** Return a list of card ids */
-    public List<Long> findCards(String search, String order, boolean limitedCards) {
-        return new Finder(this).findCards(search, order, limitedCards);
+    public List<Long> findCards(String search, String order, boolean singleCardByNote) {
+        return new Finder(this).findCards(search, order, singleCardByNote);
     }
 
-    public List<Long> findCards(String search, boolean order, boolean limitedCards) {
-        return findCards(search, order, null, limitedCards);
+    public List<Long> findCards(String search, boolean order, boolean singleCardByNote) {
+        return findCards(search, order, null, singleCardByNote);
     }
 
-    public List<Long> findCards(String search, boolean order, CollectionTask.PartialSearch task, boolean limitedCards) {
-        return new Finder(this).findCards(search, order, task, limitedCards);
+    public List<Long> findCards(String search, boolean order, CollectionTask.PartialSearch task, boolean singleCardByNote) {
+        return new Finder(this).findCards(search, order, task, singleCardByNote);
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Finder.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Finder.java
@@ -373,39 +373,24 @@ public class Finder {
     private static String _query(String preds, String order, boolean singleCardByNote) {
         // can we skip the note table?
         String sql;
-        if (singleCardByNote) {
-            if (!preds.contains( "n." ) && !order.contains( "n." )) {
-                sql = "select min(c.id) from cards c where " ;
-            } else {
-                sql = "select min(c.id) from cards c, notes n where c.nid=n.id and " ;
-            }
-            // combine with preds
-            if (!TextUtils.isEmpty(preds)) {
-                sql += "(" + preds + ")";
-            } else {
-                sql += "1";
-            }
-            sql += " group by c.nid";
-            // order
-            if (!TextUtils.isEmpty(order)) {
-                sql += " " + order;
-            }
+        String select = singleCardByNote ? "min(c.id)": "c.id";
+        if (!preds.contains("n.") && !order.contains("n.")) {
+            sql = "select "+select+" from cards c where ";
         } else {
-            if (!preds.contains("n.") && !order.contains("n.")) {
-                sql = "select c.id from cards c where ";
-            } else {
-                sql = "select c.id from cards c, notes n where c.nid=n.id and ";
-            }
-            // combine with preds
-            if (!TextUtils.isEmpty(preds)) {
-                sql += "(" + preds + ")";
-            } else {
-                sql += "1";
-            }
-            // order
-            if (!TextUtils.isEmpty(order)) {
-                sql += " " + order;
-            }
+            sql = "select "+select+" from cards c, notes n where c.nid=n.id and ";
+        }
+        // combine with preds
+        if (!TextUtils.isEmpty(preds)) {
+            sql += "(" + preds + ")";
+        } else {
+            sql += "1";
+        }
+        if(singleCardByNote){
+            sql += " group by c.nid";
+        }
+        // order
+        if (!TextUtils.isEmpty(order)) {
+            sql += " " + order;
         }
         return sql;
     }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Finder.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Finder.java
@@ -130,7 +130,21 @@ public class Finder {
         if (rev) {
             Collections.reverse(res);
         }
-        return res;
+        List<Long> nid = findNotes(query);
+        List<Long> cid = new ArrayList<>();
+        for ( int i = 0 ; i < nid.size() ; i++ ) {
+            for ( int j = 0 ; j < res.size() ; j++ ) {
+                int count  = 0;
+                if ( nid.get(i).equals( getNoteId(res.get(j))) ){
+                    count++;
+                    if ( count == 1 ) {
+                        cid.add( res.get(j) );
+                        break;
+                    }
+                }
+            }
+        }
+        return cid;
     }
 
 
@@ -390,6 +404,20 @@ public class Finder {
         }
         return sql;
     }
+
+    private Long getNoteId ( Long cid ) {
+        String sql = "select c.nid from cards c where c.id = " + String.valueOf(cid) ;
+        Long nid = Long.valueOf(0);
+        try ( Cursor cur = mCol.getDb().getDatabase().query(sql) ) {
+            while ( cur.moveToNext() ) {
+                nid = cur.getLong(0);
+            }
+        } catch ( SQLException e ) {
+            return Long.valueOf(0);
+        }
+        return nid;
+    }
+
 
 
     /**

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Sched.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Sched.java
@@ -926,7 +926,7 @@ public class Sched extends SchedV2 {
             search = String.format(Locale.US, "(%s)", search);
         }
         search = String.format(Locale.US, "%s -is:suspended -is:buried -deck:filtered -is:learn", search);
-        List<Long> ids = mCol.findCards(search, orderlimit);
+        List<Long> ids = mCol.findCards(search, orderlimit, false);
         if (ids.isEmpty()) {
             return ids;
         }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
@@ -1911,7 +1911,7 @@ public class SchedV2 extends AbstractSched {
                 search = String.format(Locale.US, "(%s)", search);
             }
             search = String.format(Locale.US, "%s -is:suspended -is:buried -deck:filtered", search);
-            ids = mCol.findCards(search, orderlimit);
+            ids = mCol.findCards(search, orderlimit, false);
             if (ids.isEmpty()) {
                 return total;
             }

--- a/AnkiDroid/src/main/res/menu/card_browser.xml
+++ b/AnkiDroid/src/main/res/menu/card_browser.xml
@@ -17,7 +17,7 @@
     <item
         android:id="@+id/action_limited_search"
         android:checkable="true"
-        android:title="Show Limited Cards"/>
+        android:title="@string/deck_cong_cram_show_one_card_per_note"/>
 
     <item
         android:id="@+id/action_save_search"

--- a/AnkiDroid/src/main/res/menu/card_browser.xml
+++ b/AnkiDroid/src/main/res/menu/card_browser.xml
@@ -1,5 +1,5 @@
 <menu xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:ankidroid="http://schemas.android.com/apk/res-auto" >
+    xmlns:ankidroid="http://schemas.android.com/apk/res-auto">
 
     <item
         android:id="@+id/action_add_note_from_card_browser"
@@ -13,6 +13,11 @@
         android:title="@string/deck_conf_cram_search"
         ankidroid:actionViewClass="androidx.appcompat.widget.SearchView"
         ankidroid:showAsAction="always|collapseActionView"/>
+
+    <item
+        android:id="@+id/action_limited_search"
+        android:checkable="true"
+        android:title="Show Limited Cards"/>
 
     <item
         android:id="@+id/action_save_search"

--- a/AnkiDroid/src/main/res/menu/card_browser.xml
+++ b/AnkiDroid/src/main/res/menu/card_browser.xml
@@ -1,5 +1,5 @@
 <menu xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:ankidroid="http://schemas.android.com/apk/res-auto">
+    xmlns:ankidroid="http://schemas.android.com/apk/res-auto" >
 
     <item
         android:id="@+id/action_add_note_from_card_browser"

--- a/AnkiDroid/src/main/res/values/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values/10-preferences.xml
@@ -17,7 +17,7 @@
 ~
 ~ You should have received a copy of the GNU General Public License along with
 ~ this program.  If not, see <http://www.gnu.org/licenses/>.
---><resources xmlns:tools="http://schemas.android.com/tools">
+--><resources>
     <!-- generic strings -->
     <string name="disabled">Disabled</string>
     <string name="enabled">Enabled</string>

--- a/AnkiDroid/src/main/res/values/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values/10-preferences.xml
@@ -266,7 +266,7 @@
     <string name="deck_conf_cram_steps_summ">Define custom steps</string>
     <string name="deck_conf_reminders_enabled">Enable reminder notifications for decks in this deck group</string>
     <string name="deck_conf_reminders_time">Remind at</string>
-    <string name="deck_cong_cram_show_one_card_per_note" tools:ignore="MissingTranslation">Show one card per note</string>
+    <string name="deck_cong_cram_show_one_card_per_note">Show one card per note</string>
 
     <!-- analytics options -->
     <string name="analytics_dialog_title">Help make AnkiDroid better!</string>

--- a/AnkiDroid/src/main/res/values/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values/10-preferences.xml
@@ -17,7 +17,7 @@
 ~
 ~ You should have received a copy of the GNU General Public License along with
 ~ this program.  If not, see <http://www.gnu.org/licenses/>.
---><resources>
+--><resources xmlns:tools="http://schemas.android.com/tools">
     <!-- generic strings -->
     <string name="disabled">Disabled</string>
     <string name="enabled">Enabled</string>
@@ -266,6 +266,7 @@
     <string name="deck_conf_cram_steps_summ">Define custom steps</string>
     <string name="deck_conf_reminders_enabled">Enable reminder notifications for decks in this deck group</string>
     <string name="deck_conf_reminders_time">Remind at</string>
+    <string name="deck_cong_cram_show_one_card_per_note" tools:ignore="MissingTranslation">Show one card per note</string>
 
     <!-- analytics options -->
     <string name="analytics_dialog_title">Help make AnkiDroid better!</string>

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/FinderTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/FinderTest.java
@@ -199,7 +199,6 @@ public class FinderTest extends RobolectricTest {
         c.flush();
         assertEqualsArrayList((new Long[] {c.getId()}), col.findCards("is:due", singleCardByNoteFalse));
         assertEquals(4, col.findCards("-is:due", singleCardByNoteFalse).size());
-        assertEquals(3, col.findCards("-is:due", singleCardByNoteTrue).size());
         c.setQueue(QUEUE_TYPE_SUSPENDED);
         // ensure this card gets a later mod time
         c.flush();
@@ -208,7 +207,6 @@ public class FinderTest extends RobolectricTest {
         // nids
         assertEquals(0, col.findCards("nid:54321", singleCardByNoteFalse).size());
         assertEquals(2, col.findCards("nid:" + note.getId(), singleCardByNoteFalse).size());
-        assertEquals(1, col.findCards("nid:" + note.getId(), singleCardByNoteTrue).size());
         assertEquals(2, col.findCards("nid:" + n1id + "," + n2id, singleCardByNoteFalse).size());
         // templates
         assertEquals(0, col.findCards("card:foo", singleCardByNoteFalse).size());
@@ -224,7 +222,6 @@ public class FinderTest extends RobolectricTest {
         assertEquals(3, col.findCards("-back:sheep", singleCardByNoteFalse).size());
         assertEquals(0, col.findCards("front:do", singleCardByNoteFalse).size());
         assertEquals(5, col.findCards("front:*", singleCardByNoteFalse).size());
-        assertEquals(4, col.findCards("front:*", singleCardByNoteTrue).size());
         // ordering
         col.getConf().put("sortType", "noteCrt");
         col.flush();
@@ -253,17 +250,12 @@ public class FinderTest extends RobolectricTest {
         assertEquals(3, col.findCards("note:basic", singleCardByNoteFalse).size());
         assertEquals(2, col.findCards("-note:basic", singleCardByNoteFalse).size());
         assertEquals(5, col.findCards("-note:foo", singleCardByNoteFalse).size());
-        assertEquals(4, col.findCards("-note:foo", singleCardByNoteTrue).size());
         // col
         assertEquals(5, col.findCards("deck:default", singleCardByNoteFalse).size());
-        assertEquals(4, col.findCards("deck:default", singleCardByNoteTrue).size());
         assertEquals(0, col.findCards("-deck:default", singleCardByNoteFalse).size());
         assertEquals(5, col.findCards("-deck:foo", singleCardByNoteFalse).size());
-        assertEquals(4, col.findCards("-deck:foo", singleCardByNoteTrue).size());
         assertEquals(5, col.findCards("deck:def*", singleCardByNoteFalse).size());
-        assertEquals(4, col.findCards("deck:def*", singleCardByNoteTrue).size());
         assertEquals(5, col.findCards("deck:*EFAULT", singleCardByNoteFalse).size());
-        assertEquals(5, col.findCards("deck:*EFAULT", singleCardByNoteTrue).size());
         assertEquals(0, col.findCards("deck:*cefault", singleCardByNoteFalse).size());
         // full search
         note = col.newNote();
@@ -272,7 +264,6 @@ public class FinderTest extends RobolectricTest {
         col.addNote(note);
         // as it's the sort field, it matches
         assertEquals(2, col.findCards("helloworld", singleCardByNoteFalse).size());
-        assertEquals(1, col.findCards("helloworld", singleCardByNoteTrue).size());
         // assertEquals(, col.findCards("helloworld", full=true).size())2 This is commented upstream
         // if we put it on the back, it won't
         String note_front = note.getItem("Front");

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/FinderTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/FinderTest.java
@@ -161,7 +161,6 @@ public class FinderTest extends RobolectricTest {
         assertEquals(4,col.findCards("tag:%", singleCardByNoteTrue).size());
         assertEquals(1, col.findCards("tag:\\%", singleCardByNoteFalse).size());
         assertEquals(2, col.findCards("tag:animal_1", singleCardByNoteFalse).size());
-        assertEquals(1, col.findCards("tag:animal_1", singleCardByNoteTrue).size());
         assertEquals(1, col.findCards("tag:animal\\_1", singleCardByNoteFalse).size());
         assertEquals(0, col.findCards("tag:donkey", singleCardByNoteFalse).size());
         assertEquals(1, col.findCards("tag:sheep", singleCardByNoteFalse).size());

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/FinderTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/FinderTest.java
@@ -180,7 +180,7 @@ public class FinderTest extends RobolectricTest {
         assertEquals(4, col.findCards("tag:bar", singleCardByNoteTrue).size());
         // text searches
         assertEquals(2, col.findCards("cat", singleCardByNoteFalse).size());
-        assertEquals(1, col.findCards("cat", singleCardByNoteTrue).size());
+        assertEquals(2, col.findCards("cat", singleCardByNoteTrue).size());
         assertEquals(1, col.findCards("cat -dog", singleCardByNoteFalse).size());
         assertEquals(1, col.findCards("cat -dog", singleCardByNoteFalse).size());
         assertEquals(1, col.findCards("are goats", singleCardByNoteFalse).size());

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/FlagTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/FlagTest.java
@@ -25,6 +25,7 @@ public class FlagTest extends RobolectricTest {
         n.setItem("Back", "two");
         int cnt = col.addNote(n);
         Card c = n.cards().get(0);
+        boolean singleCardByNote = false;
 
         // make sure higher bits are preserved
         int origBits = 0b101 << 3;
@@ -32,16 +33,16 @@ public class FlagTest extends RobolectricTest {
         c.flush();
         // no flags to start with
         assertEquals(0, c.userFlag());
-        assertEquals(1, col.findCards("flag:0").size());
-        assertEquals(0, col.findCards("flag:1").size());
+        assertEquals(1, col.findCards("flag:0", false).size());
+        assertEquals(0, col.findCards("flag:1", false).size());
         // set flag 2
         col.setUserFlag(2, Collections.singletonList(c.getId()));
         c.load();
         assertEquals(2, c.userFlag());
         // assertEquals(origBits, c.flags & origBits);TODO: create direct access to real flag value
-        assertEquals(0, col.findCards("flag:0").size());
-        assertEquals(1, col.findCards("flag:2").size());
-        assertEquals(0, col.findCards("flag:3").size());
+        assertEquals(0, col.findCards("flag:0", singleCardByNote).size());
+        assertEquals(1, col.findCards("flag:2", singleCardByNote).size());
+        assertEquals(0, col.findCards("flag:3", singleCardByNote).size());
         // change to 3
         col.setUserFlag(3, Collections.singletonList(c.getId()));
         c.load();


### PR DESCRIPTION
## Purpose / Description
Previously the Cards were repeated because of reverse card and cloze in Cardbrowser as shown below

<img src="https://user-images.githubusercontent.com/55613721/111958171-eefa8600-8b12-11eb-8804-6f771552cb16.jpeg" width="200" height = "400"/>

Now the Cards are limited to one card per note as shown below

<img src="https://user-images.githubusercontent.com/55613721/111958690-8b248d00-8b13-11eb-8b30-3f9d275a5c7d.jpeg" width = "200" height = "400"/>
<img src = "https://user-images.githubusercontent.com/55613721/111958699-8c55ba00-8b13-11eb-8b3f-cd213545c651.jpeg" width = "200" height = "400" />

## Fixes
Fixes #7939 

## Approach
By using findNotes() method we get a list of note id and then by comparing the note id with the note id inside card we limit the card to one per note

## How Has This Been Tested?

This has been tested locally on emulator

## Checklist

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code