### PR TITLE
Implemented Search Deck Feature In Add Note Activity

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -215,7 +215,6 @@ public class NoteEditor extends AnkiActivity implements DeckSelectionDialog.Deck
     private LinearLayout mFieldsLayoutContainer;
 
     private Spinner mNoteDeckSpinner;
-    private LinearLayout mNoteDeckLayout;
     
     private TextView mTagsButton;
     private TextView mCardsButton;
@@ -606,7 +605,6 @@ public class NoteEditor extends AnkiActivity implements DeckSelectionDialog.Deck
         }
 
         mNoteDeckSpinner = findViewById(R.id.note_deck_spinner);
-        mNoteDeckLayout = findViewById(R.id.note_deck_layout);
 
         ArrayAdapter<String> noteDeckAdapter = new ArrayAdapter<>(this, android.R.layout.simple_spinner_item, mAllDeckNames);
         mNoteDeckSpinner.setAdapter(noteDeckAdapter);

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -744,6 +744,12 @@ public class NoteEditor extends AnkiActivity implements DeckSelectionDialog.Deck
                 }
                 break;
 
+            case KeyEvent.KEYCODE_D:
+                if (event.isCtrlPressed() && (mDeckEditorCardsButton != null)) {
+                    displayDeckOverrideDialog(getCol());
+                }
+                break;
+
             case KeyEvent.KEYCODE_L:
                 if (event.isCtrlPressed()) {
                     showCardTemplateEditor();

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -264,7 +264,7 @@ public class NoteEditor extends AnkiActivity implements DeckSelectionDialog.Deck
     public void onDeckSelected(@Nullable DeckSelectionDialog.SelectableDeck deck) {
         if (deck != null) {
             mDeckEditorCardsText.setText(deck.getName());
-            mCurrentDid=deck.getDeckId();
+            mCurrentDid = deck.getDeckId();
         }
     }
 
@@ -585,8 +585,8 @@ public class NoteEditor extends AnkiActivity implements DeckSelectionDialog.Deck
             deckTextView.setText(R.string.CardEditorCardDeck);
         }
 
-        mDeckEditorCardsButton = findViewById(R.id.DeckEditorCardsButton);
-        mDeckEditorCardsText = findViewById(R.id.DeckEditorCardsText);
+        mDeckEditorCardsButton = findViewById(R.id.deck_editor_cards_button);
+        mDeckEditorCardsText = findViewById(R.id.deck_editor_cards_text);
 
         ArrayList<Deck> decks = getCol().getDecks().all();
         Collections.sort(decks, DeckComparator.instance);
@@ -712,7 +712,7 @@ public class NoteEditor extends AnkiActivity implements DeckSelectionDialog.Deck
     private void displayDeckOverrideDialog(Collection col) {
         FunctionalInterfaces.Filter<Deck> nonDynamic = (d) -> !Decks.isDynamic(d);
         List<DeckSelectionDialog.SelectableDeck> decks = DeckSelectionDialog.SelectableDeck.fromCollection(col, nonDynamic);
-        DeckSelectionDialog dialog = DeckSelectionDialog.newInstance("Deck Search", "", decks);
+        DeckSelectionDialog dialog = DeckSelectionDialog.newInstance("Deck Search", null, decks);
         AnkiActivity.showDialogFragment(NoteEditor.this, dialog);
     }
 
@@ -1505,7 +1505,7 @@ public class NoteEditor extends AnkiActivity implements DeckSelectionDialog.Deck
 
             if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
                 if (i == 0) {
-                    findViewById(R.id.DeckEditorCardsButton).setNextFocusForwardId(newTextbox.getId());
+                    findViewById(R.id.deck_editor_cards_button).setNextFocusForwardId(newTextbox.getId());
                 }
                 if (previous != null) {
                     previous.getLastViewInTabOrder().setNextFocusForwardId(newTextbox.getId());

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckSelectionDialog.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckSelectionDialog.java
@@ -59,7 +59,7 @@ public class DeckSelectionDialog extends AnalyticsDialogFragment {
      * A dialog which handles selecting a deck
      */
     @NonNull
-    public static DeckSelectionDialog newInstance(@NonNull String title, @NonNull String summaryMessage, @NonNull List<SelectableDeck> decks) {
+    public static DeckSelectionDialog newInstance(@NonNull String title, @Nullable String summaryMessage, @NonNull List<SelectableDeck> decks) {
         DeckSelectionDialog f = new DeckSelectionDialog();
         Bundle args = new Bundle();
         args.putString("summaryMessage", summaryMessage);
@@ -88,7 +88,12 @@ public class DeckSelectionDialog extends AnalyticsDialogFragment {
 
         Bundle arguments = requireArguments();
 
-        summary.setText(getSummaryMessage(arguments));
+        if (getSummaryMessage(arguments) == null) {
+            summary.setVisibility(View.GONE);
+        } else {
+            summary.setVisibility(View.VISIBLE);
+            summary.setText(getSummaryMessage(arguments));
+        }
 
         RecyclerView recyclerView = dialogView.findViewById(R.id.deck_picker_dialog_list);
         recyclerView.requestFocus();
@@ -108,7 +113,6 @@ public class DeckSelectionDialog extends AnalyticsDialogFragment {
 
         MaterialDialog.Builder builder = new MaterialDialog.Builder(requireActivity())
                 .neutralText(R.string.dialog_cancel)
-                .negativeText(R.string.restore_default)
                 .customView(dialogView, false)
                 .onNegative((dialog, which) -> onDeckSelected(null))
                 .onNeutral((dialog, which) -> { });
@@ -118,9 +122,9 @@ public class DeckSelectionDialog extends AnalyticsDialogFragment {
     }
 
 
-    @NonNull
+    @Nullable
     private String getSummaryMessage(Bundle arguments) {
-        return Objects.requireNonNull(arguments.getString("summaryMessage"));
+        return arguments.getString("summaryMessage");
     }
 
 

--- a/AnkiDroid/src/main/res/layout/note_editor.xml
+++ b/AnkiDroid/src/main/res/layout/note_editor.xml
@@ -68,11 +68,30 @@
                         android:gravity="left|center_vertical"
                         android:textStyle="bold"
                         android:text="@string/CardEditorNoteDeck" />
-                    <Spinner
-                        android:id="@+id/note_deck_spinner"
+                    <LinearLayout
                         android:layout_width="fill_parent"
-                        android:layout_height="@dimen/touch_target"
-                        app:popupTheme="@style/ActionBar.Popup"/>
+                        android:layout_height="wrap_content"
+                        android:orientation="vertical" >
+                        <LinearLayout
+                            android:id="@+id/DeckEditorCardsButton"
+                            style="?android:attr/buttonStyleSmall"
+                            android:layout_width="fill_parent"
+                            android:layout_height="wrap_content"
+                            android:layout_gravity="center"
+                            android:gravity="center" >
+
+                            <com.ichi2.ui.FixedTextView
+                                android:id="@+id/DeckEditorCardsText"
+                                android:layout_width="fill_parent"
+                                android:layout_height="wrap_content"
+                                android:layout_gravity="center"
+                                android:layout_marginLeft="5dip"
+                                android:layout_marginRight="5dip"
+                                android:clickable="false"
+                                tools:text="Card 1"
+                                android:gravity="left|center_vertical" />
+                        </LinearLayout>
+                    </LinearLayout>
                 </LinearLayout>
 
                 <!-- Front/Back/Attach views added in NoteEditor.populateEditFields(..) -->

--- a/AnkiDroid/src/main/res/layout/note_editor.xml
+++ b/AnkiDroid/src/main/res/layout/note_editor.xml
@@ -45,17 +45,11 @@
                         android:gravity="left|center_vertical"
                         android:textStyle="bold"
                         android:text="@string/CardEditorModel" />
-                    <LinearLayout
+                    <Spinner
+                        android:id="@+id/note_type_spinner"
                         android:layout_width="fill_parent"
                         android:layout_height="@dimen/touch_target"
-                        style="?android:attr/buttonStyleSmall"
-                        android:orientation="vertical" >
-                        <Spinner
-                            android:id="@+id/note_type_spinner"
-                            android:layout_width="fill_parent"
-                            android:layout_height="wrap_content"
-                            app:popupTheme="@style/ActionBar.Popup" />
-                    </LinearLayout>
+                        app:popupTheme="@style/ActionBar.Popup"/>
                 </LinearLayout>
 
                 <!-- Deck selector -->
@@ -74,30 +68,11 @@
                         android:gravity="left|center_vertical"
                         android:textStyle="bold"
                         android:text="@string/CardEditorNoteDeck" />
-                    <LinearLayout
+                    <Spinner
+                        android:id="@+id/note_deck_spinner"
                         android:layout_width="fill_parent"
-                        android:layout_height="wrap_content"
-                        android:orientation="vertical" >
-                        <LinearLayout
-                            android:id="@+id/deck_editor_cards_button"
-                            style="?android:attr/buttonStyleSmall"
-                            android:layout_width="fill_parent"
-                            android:layout_height="wrap_content"
-                            android:layout_gravity="center"
-                            android:gravity="center" >
-                            <com.ichi2.ui.FixedTextView
-                                android:id="@+id/deck_editor_cards_text"
-                                android:layout_width="fill_parent"
-                                android:layout_height="wrap_content"
-                                android:layout_gravity="center"
-                                android:layout_marginStart="5dip"
-                                android:layout_marginEnd="5dip"
-                                android:clickable="false"
-                                android:textColor="@color/black"
-                                tools:text="Card 1"
-                                android:gravity="left|center_vertical" />
-                        </LinearLayout>
-                    </LinearLayout>
+                        android:layout_height="@dimen/touch_target"
+                        app:popupTheme="@style/ActionBar.Popup"/>
                 </LinearLayout>
 
                 <!-- Front/Back/Attach views added in NoteEditor.populateEditFields(..) -->

--- a/AnkiDroid/src/main/res/layout/note_editor.xml
+++ b/AnkiDroid/src/main/res/layout/note_editor.xml
@@ -45,11 +45,17 @@
                         android:gravity="left|center_vertical"
                         android:textStyle="bold"
                         android:text="@string/CardEditorModel" />
-                    <Spinner
-                        android:id="@+id/note_type_spinner"
+                    <LinearLayout
                         android:layout_width="fill_parent"
                         android:layout_height="@dimen/touch_target"
-                        app:popupTheme="@style/ActionBar.Popup"/>
+                        style="?android:attr/buttonStyleSmall"
+                        android:orientation="vertical" >
+                        <Spinner
+                            android:id="@+id/note_type_spinner"
+                            android:layout_width="fill_parent"
+                            android:layout_height="wrap_content"
+                            app:popupTheme="@style/ActionBar.Popup" />
+                    </LinearLayout>
                 </LinearLayout>
 
                 <!-- Deck selector -->
@@ -73,21 +79,21 @@
                         android:layout_height="wrap_content"
                         android:orientation="vertical" >
                         <LinearLayout
-                            android:id="@+id/DeckEditorCardsButton"
+                            android:id="@+id/deck_editor_cards_button"
                             style="?android:attr/buttonStyleSmall"
                             android:layout_width="fill_parent"
                             android:layout_height="wrap_content"
                             android:layout_gravity="center"
                             android:gravity="center" >
-
                             <com.ichi2.ui.FixedTextView
-                                android:id="@+id/DeckEditorCardsText"
+                                android:id="@+id/deck_editor_cards_text"
                                 android:layout_width="fill_parent"
                                 android:layout_height="wrap_content"
                                 android:layout_gravity="center"
-                                android:layout_marginLeft="5dip"
-                                android:layout_marginRight="5dip"
+                                android:layout_marginStart="5dip"
+                                android:layout_marginEnd="5dip"
                                 android:clickable="false"
+                                android:textColor="@color/black"
                                 tools:text="Card 1"
                                 android:gravity="left|center_vertical" />
                         </LinearLayout>


### PR DESCRIPTION
Fixes #8276

## Need
With Current Spinner in add note activity user can select any deck , but
->If number of decks is very big it will be hard for user to search particular deck in spinner .
->Anki-desktop do have search decks feature.

## Work done till now:
1 Used `DeckSelectionDialog` class to implement search dialog.

## Output
<img src="https://user-images.githubusercontent.com/52353967/111996504-174ca980-8b40-11eb-9e30-81b9548f7960.gif" width="250" height="500" />
