### PR TITLE
HACK: Fix startup crash due to broken WebView

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/analytics/UsageAnalytics.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/analytics/UsageAnalytics.java
@@ -291,6 +291,10 @@ public class UsageAnalytics {
 
 
     protected static boolean canGetDefaultUserAgent() {
+        // FIXME: Hack to fix #8319 - broken 'Android System WebView' update
+        return false;
+/*
+
         // #5502 - getDefaultUserAgent starts a WebView. We can't have two WebViews with the same data directory.
         // But ACRA starts an :acra process which does not terminate when AnkiDroid is restarted. https://crbug.com/558377
 
@@ -301,6 +305,7 @@ public class UsageAnalytics {
 
         // If we have a custom data directory, then the crash will not occur.
         return WebViewDebugging.hasSetDataDirectory();
+*/
     }
 
 


### PR DESCRIPTION
**Needs Review - Unsure if this is the approach we want to take**

## Pull Request template

## Purpose / Description
`WebSettings.getDefaultUserAgent(context)` hard crashes the app. Note: diagnosed myself via debugger as the first crash, app worked fine after removal.

Known issue with WebView. Many issues in news about this.

Possible problematic version 89.0.4389.90 (code 438909033)
But, this was updated days ago, so there may be another cause and it didn't feel safe to block a version without knowing for sure that it's the only one causing issues.

## Fixes
Fixes #8319

## Approach
Don't call `WebSettings.getDefaultUserAgent(context)` - this disables some level of granularity for analytics

## How Has This Been Tested?

* App no longer crashed during initial testing
* ⚠️ I've now reinstalled the WebView and can't repro a crash at all

## Learning (optional, can help others)
https://9to5google.com/2021/03/22/android-apps-crashing-webview/

Crash cause was diagnosed myself

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [x] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
