### PR TITLE
Fix #8229 [Bug] {{cloze:Text}} ignores repeated words and just check first of them

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -149,6 +149,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Set;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReadWriteLock;
@@ -822,16 +823,16 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
      *
      * @param txt The field text with the clozes
      * @param idx The index of the cloze to use
-     * @return A string with a comma-separeted list of unique cloze strings with the correct index.
+     * @return If the cloze strings are the same, return a single cloze string, otherwise, return
+     *         a string with a comma-separeted list of strings with the correct index.
      */
-
-    private String contentForCloze(String txt, int idx) {
+    @VisibleForTesting
+    protected String contentForCloze(String txt, int idx) {
         @SuppressWarnings("RegExpRedundantEscape") // In Android, } should be escaped
         Pattern re = Pattern.compile("\\{\\{c" + idx + "::(.+?)\\}\\}");
         Matcher m = re.matcher(txt);
-        Set<String> matches = new LinkedHashSet<>(); // Size can't be known in advance
-        // LinkedHashSet: make entries appear only once, like Anki desktop (see also issue #2208), and keep the order
-        // they appear in.
+        List<String> matches = new ArrayList<>();
+
         String groupOne;
         int colonColonIndex = -1;
         while (m.find()) {
@@ -843,15 +844,15 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
             }
             matches.add(groupOne);
         }
-        // Now do what the pythonic ", ".join(matches) does in a tricky way
-        String prefix = "";
-        StringBuilder resultBuilder = new StringBuilder();
-        for (String match : matches) {
-            resultBuilder.append(prefix);
-            resultBuilder.append(match);
-            prefix = ", ";
+
+        Set<String> uniqMatches = new HashSet<>(matches); // Allow to check whether there are distinct strings
+
+        // Make it consistent with the Desktop version (see issue #8229)
+        if (uniqMatches.size() == 1) {
+            return matches.get(0);
+        } else {
+            return TextUtils.join(", ", matches);
         }
-        return resultBuilder.toString();
     }
 
     private final Handler mTimerHandler = new Handler();

--- a/AnkiDroid/src/test/java/com/ichi2/anki/AbstractFlashcardViewerTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/AbstractFlashcardViewerTest.java
@@ -372,6 +372,19 @@ public class AbstractFlashcardViewerTest extends RobolectricTest {
     }
 
 
+    @Test
+    public void testClozeWithRepeatedWords() {
+        // 8229
+        NonAbstractFlashcardViewer nafv = getViewer();
+
+        String cloze1 = "This is {{c1::test}} which is containing {{c1::test}} word twice";
+        assertEquals("test", nafv.contentForCloze(cloze1, 1));
+
+        String cloze2 = "This is {{c1::test}} which is containing {{c1::test}} word twice {{c1::test2}}";
+        assertEquals("test, test, test2", nafv.contentForCloze(cloze2, 1));
+    }
+
+
     private NonAbstractFlashcardViewer getViewer() {
         Note n = getCol().newNote();
         n.setField(0, "a");


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
Fix #8229 [Bug] {{cloze:Text}} ignores repeated words and just check first of them

## Fixes
Fixes  #[8229](https://github.com/ankidroid/Anki-Android/issues/8229)

## Approach
In the original file, the project uses `set<String>` to save the correct answer to use for {{type::cloze::NN}} fields (refer to the `private String contentForCloze(String txt, int idx) ` function in AbstractFlashcardViewer.java). In this case, {{cloze:Text}} ignores repeated words because there cannot be duplicate elements in a set. While in the Desktop version, close is handled by:
```python
# https://github.com/ankitects/anki/blob/main/qt/aqt/reviewer.py
# lines 500-516
def _contentForCloze(self, txt: str, idx: int) -> str:
    matches = re.findall(r"\{\{c%s::(.+?)\}\}" % idx, txt, re.DOTALL)
    if not matches:
        return None

    def noHint(txt: str) -> str:
        if "::" in txt:
            return txt.split("::")[0]
        return txt

    matches = [noHint(txt) for txt in matches]
    uniqMatches = set(matches)
    if len(uniqMatches) == 1:
        txt = matches[0]
    else:
        txt = ", ".join(matches)
    return txt
```
Therefore, I use `ArrayList<String>` to make it consistent with the Desktop version. Unit test has been added.


## How Has This Been Tested?

working well on my pixel phone

## Learning (optional, can help others)
_Describe the research stage_

_Links to blog posts, patterns, libraries or addons used to solve this problem_

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
