### PR TITLE
Fixes #7013 Fixed deprecated NetworkInfo

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/async/Connection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/Connection.java
@@ -23,7 +23,6 @@ import android.content.Context;
 import android.net.ConnectivityManager;
 import android.net.Network;
 import android.net.NetworkCapabilities;
-import android.net.NetworkInfo;
 import android.os.AsyncTask;
 import android.os.Build;
 import android.os.PowerManager;
@@ -50,7 +49,6 @@ import com.ichi2.utils.JSONObject;
 import java.io.IOException;
 
 import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 import okhttp3.Response;
 import timber.log.Timber;
 
@@ -560,7 +558,7 @@ public class Connection extends BaseAsyncTask<Connection.Payload, Object, Connec
         super.publishProgress(id, up, down);
     }
 
-
+    @SuppressWarnings("deprecation")
     public static boolean isOnline() {
         if (sAllowSyncOnNoConnection) {
             return true;
@@ -569,7 +567,7 @@ public class Connection extends BaseAsyncTask<Connection.Payload, Object, Connec
                 .getSystemService(Context.CONNECTIVITY_SERVICE);
 
         /* NetworkInfo is deprecated in API 29 so we have to check separately for higher API Levels */
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M && cm != null) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q && cm != null) {
             Network network = cm.getActiveNetwork();
             if (network == null) {
                 return false;
@@ -578,7 +576,7 @@ public class Connection extends BaseAsyncTask<Connection.Payload, Object, Connec
             return networkCapabilities != null && (networkCapabilities.hasTransport(NetworkCapabilities.TRANSPORT_WIFI)
                     || networkCapabilities.hasTransport(NetworkCapabilities.TRANSPORT_CELLULAR));
         } else if (cm != null) {
-            NetworkInfo networkInfo = cm.getActiveNetworkInfo();
+            android.net.NetworkInfo networkInfo = cm.getActiveNetworkInfo();
             return networkInfo != null && networkInfo.isConnected();
         }
         return false;

--- a/AnkiDroid/src/main/java/com/ichi2/async/Connection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/Connection.java
@@ -565,21 +565,27 @@ public class Connection extends BaseAsyncTask<Connection.Payload, Object, Connec
         }
         ConnectivityManager cm = (ConnectivityManager) AnkiDroidApp.getInstance().getApplicationContext()
                 .getSystemService(Context.CONNECTIVITY_SERVICE);
-
+        if (cm == null) {
+            return false;
+        }
         /* NetworkInfo is deprecated in API 29 so we have to check separately for higher API Levels */
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q && cm != null) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
             Network network = cm.getActiveNetwork();
             if (network == null) {
                 return false;
             }
             NetworkCapabilities networkCapabilities = cm.getNetworkCapabilities(network);
-            return networkCapabilities != null && (networkCapabilities.hasTransport(NetworkCapabilities.TRANSPORT_WIFI)
-                    || networkCapabilities.hasTransport(NetworkCapabilities.TRANSPORT_CELLULAR));
-        } else if (cm != null) {
+            if (networkCapabilities == null) {
+                return false;
+            }
+            boolean isInternetSuspended = !networkCapabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_NOT_SUSPENDED);
+            return networkCapabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
+                    && networkCapabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_VALIDATED)
+                    && !isInternetSuspended;
+        } else {
             android.net.NetworkInfo networkInfo = cm.getActiveNetworkInfo();
             return networkInfo != null && networkInfo.isConnected();
         }
-        return false;
     }
 
 


### PR DESCRIPTION
## Purpose / Description
Fixed the deprecated NetworkInfo as it was deprecated.

## Fixes
Fixes #7013

## Approach
By using different methods in APIs greater than or equal to 23.

## How Has This Been Tested?

## Checklist

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [x] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
