### PR TITLE
Fixes #4759 'Custom study: Don't show "increase new card limit" when no new cards'

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/CustomStudyDialog.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/CustomStudyDialog.java
@@ -69,20 +69,14 @@ public class CustomStudyDialog extends AnalyticsDialogFragment {
     public static final int CONTEXT_MENU_LIMITS = 1;
     public static final int CONTEXT_MENU_EMPTY_SCHEDULE = 2;
     // Standard custom study options to show in the context menu
-    @VisibleForTesting
-    static final int CUSTOM_STUDY_NEW = 100;
-    @VisibleForTesting
-    static final int CUSTOM_STUDY_REV = 101;
-    @VisibleForTesting
-    static final int CUSTOM_STUDY_FORGOT = 102;
+    private static final int CUSTOM_STUDY_NEW = 100;
+    private static final int CUSTOM_STUDY_REV = 101;
+    private static final int CUSTOM_STUDY_FORGOT = 102;
     @VisibleForTesting
     static final int CUSTOM_STUDY_AHEAD = 103;
-    @VisibleForTesting
-    static final int CUSTOM_STUDY_RANDOM = 104;
-    @VisibleForTesting
-    static final int CUSTOM_STUDY_PREVIEW = 105;
-    @VisibleForTesting
-    static final int CUSTOM_STUDY_TAGS = 106;
+    private static final int CUSTOM_STUDY_RANDOM = 104;
+    private static final int CUSTOM_STUDY_PREVIEW = 105;
+    private static final int CUSTOM_STUDY_TAGS = 106;
     // Special items to put in the context menu
     private static final int DECK_OPTIONS = 107;
     private static final int MORE_OPTIONS = 108;

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/CustomStudyDialog.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/CustomStudyDialog.java
@@ -368,6 +368,7 @@ public class CustomStudyDialog extends AnalyticsDialogFragment {
                 }
                 break;
             case CONTEXT_MENU_LIMITS:
+                // Special custom study options to show when the daily study limit has been reached
                 dialogOptions.remove(Integer.valueOf(CUSTOM_STUDY_FORGOT));
                 dialogOptions.remove(Integer.valueOf(CUSTOM_STUDY_AHEAD));
                 dialogOptions.remove(Integer.valueOf(CUSTOM_STUDY_RANDOM));

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/CustomStudyDialog.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/CustomStudyDialog.java
@@ -342,60 +342,42 @@ public class CustomStudyDialog extends AnalyticsDialogFragment {
      */
     private int[] getListIds(int dialogId) {
         Collection col = getAnkiActivity().getCol();
-
-        ArrayList<Integer> dialogOptions= new ArrayList<Integer>(){
-            {
-                add(CUSTOM_STUDY_NEW);
-                add(CUSTOM_STUDY_REV);
-                add(CUSTOM_STUDY_FORGOT);
-                add(CUSTOM_STUDY_AHEAD);
-                add(CUSTOM_STUDY_RANDOM);
-                add(CUSTOM_STUDY_PREVIEW);
-                add(CUSTOM_STUDY_TAGS);
-                add(DECK_OPTIONS);
-                add(MORE_OPTIONS);
-            }
-        };
-
         switch (dialogId) {
             case CONTEXT_MENU_STANDARD:
                 // Standard context menu
-                dialogOptions.remove(Integer.valueOf(DECK_OPTIONS));
-                dialogOptions.remove(Integer.valueOf(MORE_OPTIONS));
+                ArrayList<Integer> dialogOptions = new ArrayList<Integer>(){{
+                    add(CUSTOM_STUDY_NEW);
+                    add(CUSTOM_STUDY_REV);
+                    add(CUSTOM_STUDY_FORGOT);
+                    add(CUSTOM_STUDY_AHEAD);
+                    add(CUSTOM_STUDY_RANDOM);
+                    add(CUSTOM_STUDY_PREVIEW);
+                    add(CUSTOM_STUDY_TAGS);
+                }};
                 if (col.getSched().newCount() == 0) {
                     // If no new cards we wont show CUSTOM_STUDY_NEW
                     dialogOptions.remove(Integer.valueOf(CUSTOM_STUDY_NEW));
                 }
-                break;
+                return ContextMenuHelper.integerListToArray(dialogOptions);
             case CONTEXT_MENU_LIMITS:
                 // Special custom study options to show when the daily study limit has been reached
-                dialogOptions.remove(Integer.valueOf(CUSTOM_STUDY_FORGOT));
-                dialogOptions.remove(Integer.valueOf(CUSTOM_STUDY_AHEAD));
-                dialogOptions.remove(Integer.valueOf(CUSTOM_STUDY_RANDOM));
-                dialogOptions.remove(Integer.valueOf(CUSTOM_STUDY_PREVIEW));
-                dialogOptions.remove(Integer.valueOf(CUSTOM_STUDY_TAGS));
-                if (!col.getSched().newDue()) {
-                    dialogOptions.remove(Integer.valueOf(CUSTOM_STUDY_NEW));
-                } else if(!col.getSched().revDue()) {
-                    dialogOptions.remove(Integer.valueOf(CUSTOM_STUDY_REV));
+                if (col.getSched().newDue() && col.getSched().revDue()) {
+                    return new int[] {CUSTOM_STUDY_NEW, CUSTOM_STUDY_REV, DECK_OPTIONS, MORE_OPTIONS};
+                } else {
+                    if (col.getSched().newDue()) {
+                        return new int[]{CUSTOM_STUDY_NEW, DECK_OPTIONS, MORE_OPTIONS};
+                    } else {
+                        return new int[]{CUSTOM_STUDY_REV, DECK_OPTIONS, MORE_OPTIONS};
+                    }
                 }
-                break;
             case CONTEXT_MENU_EMPTY_SCHEDULE:
                 // Special custom study options to show when extending the daily study limits is not applicable
-                dialogOptions.remove(Integer.valueOf(CUSTOM_STUDY_NEW));
-                dialogOptions.remove(Integer.valueOf(CUSTOM_STUDY_REV));
-                dialogOptions.remove(Integer.valueOf(MORE_OPTIONS));
-                break;
+                return new int[] {CUSTOM_STUDY_FORGOT, CUSTOM_STUDY_AHEAD, CUSTOM_STUDY_RANDOM,
+                        CUSTOM_STUDY_PREVIEW, CUSTOM_STUDY_TAGS, DECK_OPTIONS};
             default:
-                dialogOptions.clear();
                 break;
         }
-        int [] list = new int[dialogOptions.size()];
-        for (int i=0; i< dialogOptions.size(); i++) {
-            list[i] = dialogOptions.get(i);
-        }
-
-        return list;
+        return null;
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/CustomStudyDialog.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/CustomStudyDialog.java
@@ -351,15 +351,14 @@ public class CustomStudyDialog extends AnalyticsDialogFragment {
         switch (dialogId) {
             case CONTEXT_MENU_STANDARD:
                 // Standard context menu
-                ArrayList<Integer> dialogOptions = new ArrayList<Integer>(){{
-                    add(CUSTOM_STUDY_NEW);
-                    add(CUSTOM_STUDY_REV);
-                    add(CUSTOM_STUDY_FORGOT);
-                    add(CUSTOM_STUDY_AHEAD);
-                    add(CUSTOM_STUDY_RANDOM);
-                    add(CUSTOM_STUDY_PREVIEW);
-                    add(CUSTOM_STUDY_TAGS);
-                }};
+                ArrayList<Integer> dialogOptions = new ArrayList<Integer>();
+                dialogOptions.add(CUSTOM_STUDY_NEW);
+                dialogOptions.add(CUSTOM_STUDY_REV);
+                dialogOptions.add(CUSTOM_STUDY_FORGOT);
+                dialogOptions.add(CUSTOM_STUDY_AHEAD);
+                dialogOptions.add(CUSTOM_STUDY_RANDOM);
+                dialogOptions.add(CUSTOM_STUDY_PREVIEW);
+                dialogOptions.add(CUSTOM_STUDY_TAGS);
                 if (col.getSched().newCount() == 0) {
                     // If no new cards we wont show CUSTOM_STUDY_NEW
                     dialogOptions.remove(Integer.valueOf(CUSTOM_STUDY_NEW));

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/CustomStudyDialog.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/CustomStudyDialog.java
@@ -69,14 +69,20 @@ public class CustomStudyDialog extends AnalyticsDialogFragment {
     public static final int CONTEXT_MENU_LIMITS = 1;
     public static final int CONTEXT_MENU_EMPTY_SCHEDULE = 2;
     // Standard custom study options to show in the context menu
-    private static final int CUSTOM_STUDY_NEW = 100;
-    private static final int CUSTOM_STUDY_REV = 101;
-    private static final int CUSTOM_STUDY_FORGOT = 102;
+    @VisibleForTesting
+    static final int CUSTOM_STUDY_NEW = 100;
+    @VisibleForTesting
+    static final int CUSTOM_STUDY_REV = 101;
+    @VisibleForTesting
+    static final int CUSTOM_STUDY_FORGOT = 102;
     @VisibleForTesting
     static final int CUSTOM_STUDY_AHEAD = 103;
-    private static final int CUSTOM_STUDY_RANDOM = 104;
-    private static final int CUSTOM_STUDY_PREVIEW = 105;
-    private static final int CUSTOM_STUDY_TAGS = 106;
+    @VisibleForTesting
+    static final int CUSTOM_STUDY_RANDOM = 104;
+    @VisibleForTesting
+    static final int CUSTOM_STUDY_PREVIEW = 105;
+    @VisibleForTesting
+    static final int CUSTOM_STUDY_TAGS = 106;
     // Special items to put in the context menu
     private static final int DECK_OPTIONS = 107;
     private static final int MORE_OPTIONS = 108;

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/CustomStudyDialog.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/CustomStudyDialog.java
@@ -27,6 +27,7 @@ import timber.log.Timber;
 import android.text.Editable;
 import android.text.TextUtils;
 import android.text.TextWatcher;
+import android.util.Log;
 import android.view.View;
 import android.view.WindowManager;
 import android.view.inputmethod.EditorInfo;
@@ -345,6 +346,10 @@ public class CustomStudyDialog extends AnalyticsDialogFragment {
         switch (dialogId) {
             case CONTEXT_MENU_STANDARD:
                 // Standard context menu
+                if (col.getSched().newCount()==0) {
+                    return new int[] {CUSTOM_STUDY_REV, CUSTOM_STUDY_FORGOT, CUSTOM_STUDY_AHEAD,
+                            CUSTOM_STUDY_RANDOM, CUSTOM_STUDY_PREVIEW, CUSTOM_STUDY_TAGS};
+                }
                 return new int[] {CUSTOM_STUDY_NEW, CUSTOM_STUDY_REV, CUSTOM_STUDY_FORGOT, CUSTOM_STUDY_AHEAD,
                         CUSTOM_STUDY_RANDOM, CUSTOM_STUDY_PREVIEW, CUSTOM_STUDY_TAGS};
             case CONTEXT_MENU_LIMITS:

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/CustomStudyDialog.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/CustomStudyDialog.java
@@ -27,7 +27,6 @@ import timber.log.Timber;
 import android.text.Editable;
 import android.text.TextUtils;
 import android.text.TextWatcher;
-import android.util.Log;
 import android.view.View;
 import android.view.WindowManager;
 import android.view.inputmethod.EditorInfo;
@@ -347,6 +346,7 @@ public class CustomStudyDialog extends AnalyticsDialogFragment {
             case CONTEXT_MENU_STANDARD:
                 // Standard context menu
                 if (col.getSched().newCount()==0) {
+                    // If no new cards we wont show CUSTOM_STUDY_NEW
                     return new int[] {CUSTOM_STUDY_REV, CUSTOM_STUDY_FORGOT, CUSTOM_STUDY_AHEAD,
                             CUSTOM_STUDY_RANDOM, CUSTOM_STUDY_PREVIEW, CUSTOM_STUDY_TAGS};
                 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/CustomStudyDialog.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/CustomStudyDialog.java
@@ -342,35 +342,59 @@ public class CustomStudyDialog extends AnalyticsDialogFragment {
      */
     private int[] getListIds(int dialogId) {
         Collection col = getAnkiActivity().getCol();
+
+        ArrayList<Integer> dialogOptions= new ArrayList<Integer>(){
+            {
+                add(CUSTOM_STUDY_NEW);
+                add(CUSTOM_STUDY_REV);
+                add(CUSTOM_STUDY_FORGOT);
+                add(CUSTOM_STUDY_AHEAD);
+                add(CUSTOM_STUDY_RANDOM);
+                add(CUSTOM_STUDY_PREVIEW);
+                add(CUSTOM_STUDY_TAGS);
+                add(DECK_OPTIONS);
+                add(MORE_OPTIONS);
+            }
+        };
+
         switch (dialogId) {
             case CONTEXT_MENU_STANDARD:
                 // Standard context menu
-                if (col.getSched().newCount()==0) {
+                dialogOptions.remove(Integer.valueOf(DECK_OPTIONS));
+                dialogOptions.remove(Integer.valueOf(MORE_OPTIONS));
+                if (col.getSched().newCount() == 0) {
                     // If no new cards we wont show CUSTOM_STUDY_NEW
-                    return new int[] {CUSTOM_STUDY_REV, CUSTOM_STUDY_FORGOT, CUSTOM_STUDY_AHEAD,
-                            CUSTOM_STUDY_RANDOM, CUSTOM_STUDY_PREVIEW, CUSTOM_STUDY_TAGS};
+                    dialogOptions.remove(Integer.valueOf(CUSTOM_STUDY_NEW));
                 }
-                return new int[] {CUSTOM_STUDY_NEW, CUSTOM_STUDY_REV, CUSTOM_STUDY_FORGOT, CUSTOM_STUDY_AHEAD,
-                        CUSTOM_STUDY_RANDOM, CUSTOM_STUDY_PREVIEW, CUSTOM_STUDY_TAGS};
+                break;
             case CONTEXT_MENU_LIMITS:
-                // Special custom study options to show when the daily study limit has been reached
-                if (col.getSched().newDue() && col.getSched().revDue()) {
-                    return new int[] {CUSTOM_STUDY_NEW, CUSTOM_STUDY_REV, DECK_OPTIONS, MORE_OPTIONS};
-                } else {
-                    if (col.getSched().newDue()) {
-                        return new int[]{CUSTOM_STUDY_NEW, DECK_OPTIONS, MORE_OPTIONS};
-                    } else {
-                        return new int[]{CUSTOM_STUDY_REV, DECK_OPTIONS, MORE_OPTIONS};
-                    }
+                dialogOptions.remove(Integer.valueOf(CUSTOM_STUDY_FORGOT));
+                dialogOptions.remove(Integer.valueOf(CUSTOM_STUDY_AHEAD));
+                dialogOptions.remove(Integer.valueOf(CUSTOM_STUDY_RANDOM));
+                dialogOptions.remove(Integer.valueOf(CUSTOM_STUDY_PREVIEW));
+                dialogOptions.remove(Integer.valueOf(CUSTOM_STUDY_TAGS));
+                if (!col.getSched().newDue()) {
+                    dialogOptions.remove(Integer.valueOf(CUSTOM_STUDY_NEW));
+                } else if(!col.getSched().revDue()) {
+                    dialogOptions.remove(Integer.valueOf(CUSTOM_STUDY_REV));
                 }
+                break;
             case CONTEXT_MENU_EMPTY_SCHEDULE:
                 // Special custom study options to show when extending the daily study limits is not applicable
-                return new int[] {CUSTOM_STUDY_FORGOT, CUSTOM_STUDY_AHEAD, CUSTOM_STUDY_RANDOM,
-                        CUSTOM_STUDY_PREVIEW, CUSTOM_STUDY_TAGS, DECK_OPTIONS};
+                dialogOptions.remove(Integer.valueOf(CUSTOM_STUDY_NEW));
+                dialogOptions.remove(Integer.valueOf(CUSTOM_STUDY_REV));
+                dialogOptions.remove(Integer.valueOf(MORE_OPTIONS));
+                break;
             default:
+                dialogOptions.clear();
                 break;
         }
-        return null;
+        int [] list = new int[dialogOptions.size()];
+        for (int i=0; i< dialogOptions.size(); i++) {
+            list[i] = dialogOptions.get(i);
+        }
+
+        return list;
     }
 
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/CustomStudyDialogTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/CustomStudyDialogTest.java
@@ -27,6 +27,7 @@ import com.ichi2.anki.dialogs.CustomStudyDialog.CustomStudyListener;
 import com.ichi2.libanki.Deck;
 import com.ichi2.utils.JSONObject;
 
+import org.hamcrest.Matchers;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -68,6 +69,22 @@ public class CustomStudyDialogTest extends RobolectricTest {
 
         String expected = "{\"newToday\":[0,0],\"revToday\":[0,0],\"lrnToday\":[0,0],\"timeToday\":[0,0],\"collapsed\":false,\"dyn\":1,\"desc\":\"\",\"usn\":-1,\"delays\":null,\"separate\":true,\"terms\":[[\"deck:\\\"Default\\\" prop:due<=1\",99999,6]],\"resched\":true,\"return\":true}";
         assertThat(customStudy.toString(), is(expected));
+    }
+    
+    
+    @Test 
+    public void increaseNewCardLimitRegressionTest(){
+        // #8338 - Regression Test
+        CustomStudyDialog standard = CustomStudyDialog.newInstance(CustomStudyDialog.CONTEXT_MENU_STANDARD,2);
+
+        FragmentScenario<CustomStudyDialogForTesting> scenarioStandard = getDialogScenario(standard);
+
+        scenarioStandard.onFragment(f ->{
+            MaterialDialog dialog = (MaterialDialog)f.getDialog();
+            assertThat(dialog,notNullValue());
+            assertThat(dialog.getItems(), Matchers.not(Matchers.hasItem("Modify today’s new card limit")));
+        });
+
     }
 
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/CustomStudyDialogTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/CustomStudyDialogTest.java
@@ -91,7 +91,6 @@ public class CustomStudyDialogTest extends RobolectricTest {
             assertThat(dialog,notNullValue());
             assertThat(dialog.getItems(), Matchers.not(Matchers.hasItem(getResourceString(R.string.custom_study_increase_new_limit))));
         });
-
     }
 
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/CustomStudyDialogTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/CustomStudyDialogTest.java
@@ -74,7 +74,6 @@ public class CustomStudyDialogTest extends RobolectricTest {
     }
 
 
-
     @Test
     @Config(qualifiers = "en")
     public void increaseNewCardLimitRegressionTest(){

--- a/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/CustomStudyDialogTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/CustomStudyDialogTest.java
@@ -86,7 +86,7 @@ public class CustomStudyDialogTest extends RobolectricTest {
 
         scenarioStandard.moveToState(Lifecycle.State.STARTED);
 
-        scenarioStandard.onFragment(f ->{
+        scenarioStandard.onFragment(f -> {
             MaterialDialog dialog = (MaterialDialog)f.getDialog();
             assertThat(dialog,notNullValue());
             assertThat(dialog.getItems(), Matchers.not(Matchers.hasItem(getResourceString(R.string.custom_study_increase_new_limit))));

--- a/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/CustomStudyDialogTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/CustomStudyDialogTest.java
@@ -82,6 +82,8 @@ public class CustomStudyDialogTest extends RobolectricTest {
 
         FragmentScenario<CustomStudyDialogForTesting> scenarioStandard = getDialogScenario(standard);
 
+        scenarioStandard.moveToState(Lifecycle.State.STARTED);
+
         scenarioStandard.onFragment(f ->{
             MaterialDialog dialog = (MaterialDialog)f.getDialog();
             assertThat(dialog,notNullValue());

--- a/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/CustomStudyDialogTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/CustomStudyDialogTest.java
@@ -80,7 +80,7 @@ public class CustomStudyDialogTest extends RobolectricTest {
     @Config(qualifiers = "en")
     public void increaseNewCardLimitRegressionTest(){
         // #8338 - Regression Test
-        CustomStudyDialog standard = CustomStudyDialog.newInstance(CustomStudyDialog.CONTEXT_MENU_STANDARD,1);
+        CustomStudyDialog standard = CustomStudyDialog.newInstance(CustomStudyDialog.CONTEXT_MENU_STANDARD, 1);
 
         FragmentScenario<CustomStudyDialogForTesting> scenarioStandard = getDialogScenario(standard);
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/CustomStudyDialogTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/CustomStudyDialogTest.java
@@ -29,6 +29,7 @@ import com.ichi2.libanki.Deck;
 import com.ichi2.utils.JSONObject;
 
 import org.hamcrest.Matchers;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.annotation.Config;
@@ -75,6 +76,7 @@ public class CustomStudyDialogTest extends RobolectricTest {
 
 
     @Test
+    @Ignore("#8406")
     @Config(qualifiers = "en")
     public void increaseNewCardLimitRegressionTest(){
         // #8338 - Regression Test

--- a/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/CustomStudyDialogTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/CustomStudyDialogTest.java
@@ -22,6 +22,7 @@ import com.afollestad.materialdialogs.DialogAction;
 import com.afollestad.materialdialogs.MaterialDialog;
 import com.ichi2.anki.AnkiActivity;
 import com.ichi2.anki.CardTemplateBrowserAppearanceEditor;
+import com.ichi2.anki.R;
 import com.ichi2.anki.RobolectricTest;
 import com.ichi2.anki.dialogs.CustomStudyDialog.CustomStudyListener;
 import com.ichi2.libanki.Deck;
@@ -30,6 +31,7 @@ import com.ichi2.utils.JSONObject;
 import org.hamcrest.Matchers;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.robolectric.annotation.Config;
 
 import androidx.annotation.NonNull;
 import androidx.fragment.app.testing.FragmentScenario;
@@ -70,9 +72,11 @@ public class CustomStudyDialogTest extends RobolectricTest {
         String expected = "{\"newToday\":[0,0],\"revToday\":[0,0],\"lrnToday\":[0,0],\"timeToday\":[0,0],\"collapsed\":false,\"dyn\":1,\"desc\":\"\",\"usn\":-1,\"delays\":null,\"separate\":true,\"terms\":[[\"deck:\\\"Default\\\" prop:due<=1\",99999,6]],\"resched\":true,\"return\":true}";
         assertThat(customStudy.toString(), is(expected));
     }
-    
-    
-    @Test 
+
+
+
+    @Test
+    @Config(qualifiers = "en")
     public void increaseNewCardLimitRegressionTest(){
         // #8338 - Regression Test
         CustomStudyDialog standard = CustomStudyDialog.newInstance(CustomStudyDialog.CONTEXT_MENU_STANDARD,2);
@@ -82,7 +86,7 @@ public class CustomStudyDialogTest extends RobolectricTest {
         scenarioStandard.onFragment(f ->{
             MaterialDialog dialog = (MaterialDialog)f.getDialog();
             assertThat(dialog,notNullValue());
-            assertThat(dialog.getItems(), Matchers.not(Matchers.hasItem("Modify today’s new card limit")));
+            assertThat(dialog.getItems(), Matchers.not(Matchers.hasItem(getResourceString(R.string.custom_study_increase_new_limit))));
         });
 
     }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/CustomStudyDialogTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/CustomStudyDialogTest.java
@@ -78,7 +78,7 @@ public class CustomStudyDialogTest extends RobolectricTest {
     @Config(qualifiers = "en")
     public void increaseNewCardLimitRegressionTest(){
         // #8338 - Regression Test
-        CustomStudyDialog standard = CustomStudyDialog.newInstance(CustomStudyDialog.CONTEXT_MENU_STANDARD,2);
+        CustomStudyDialog standard = CustomStudyDialog.newInstance(CustomStudyDialog.CONTEXT_MENU_STANDARD,1);
 
         FragmentScenario<CustomStudyDialogForTesting> scenarioStandard = getDialogScenario(standard);
 


### PR DESCRIPTION
## Purpose / Description
Removed increase new card limit when no new cards

## Fixes
Fixes #4759

## Approach
Added a condition check to check if there are no new cards.

## How Has This Been Tested?

Tested on Nokia 6.1+ (physical) , android 10 stock version.


## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
