### PR TITLE
Fixes #7983 Remaining time wrongly displayed as "0s" when falling und…

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Utils.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Utils.java
@@ -195,6 +195,9 @@ public class Utils {
         Resources res = context.getResources();
         if (time_s < TIME_HOUR_LONG) {
             time_x = (int) Math.round(time_s / TIME_MINUTE);
+            if(time_x == 0) {
+                time_x++;
+            }
             return res.getQuantityString(R.plurals.reviewer_window_title, time_x, time_x);
             //It used to be minutes only. So the word "minutes" is not
             //explicitly written in the ressource name.

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Utils.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Utils.java
@@ -195,7 +195,7 @@ public class Utils {
         Resources res = context.getResources();
         if (time_s < TIME_HOUR_LONG) {
             time_x = (int) Math.round(time_s / TIME_MINUTE);
-            if(time_x == 0) {
+            if (time_x == 0) {
                 time_x++;
             }
             return res.getQuantityString(R.plurals.reviewer_window_title, time_x, time_x);

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Utils.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Utils.java
@@ -194,10 +194,8 @@ public class Utils {
         int remaining; // Time in the unit smaller than x
         Resources res = context.getResources();
         if (time_s < TIME_HOUR_LONG) {
-            time_x = (int) Math.round(time_s / TIME_MINUTE);
-            if (time_x == 0) {
-                time_x++;
-            }
+            // get time remaining, but never less than 1
+            time_x = Math.max((int) Math.round(time_s / TIME_MINUTE), 1);
             return res.getQuantityString(R.plurals.reviewer_window_title, time_x, time_x);
             //It used to be minutes only. So the word "minutes" is not
             //explicitly written in the ressource name.


### PR DESCRIPTION
Added an if check which clamps the remaining time to 1 minute in case it goes under it.

## Purpose / Description
Intends to fix the wrong time (0 minute) displayed when the remaining time is under a minute.

![Screenshot_20210326-170251](https://user-images.githubusercontent.com/80831951/112626449-399f3980-8e56-11eb-9551-80e013594be5.png)



## Fixes
Fixes #7983 

After Fix
![Screenshot_20210326-170731](https://user-images.githubusercontent.com/80831951/112626625-779c5d80-8e56-11eb-9955-d1198b0a4e6d.png)


## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [x] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
