### PR TITLE
Use text from browser search bar as first field when adding new note added 

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -1335,7 +1335,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
         if (did != null && did > 0) {
             intent.putExtra(NoteEditor.EXTRA_DID, (long) did);
         }
-        intent.putExtra("SEARCH",mSearchTerms);
+        intent.putExtra(NoteEditor.TEXT_FROM_SEARCH_VIEW, mSearchTerms);
         return intent;
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -1335,6 +1335,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
         if (did != null && did > 0) {
             intent.putExtra(NoteEditor.EXTRA_DID, (long) did);
         }
+        intent.putExtra("SEARCH",mSearchTerms);
         return intent;
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -1335,7 +1335,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
         if (did != null && did > 0) {
             intent.putExtra(NoteEditor.EXTRA_DID, (long) did);
         }
-        intent.putExtra(NoteEditor.TEXT_FROM_SEARCH_VIEW, mSearchTerms);
+        intent.putExtra(NoteEditor.EXTRA_TEXT_FROM_SEARCH_VIEW, mSearchTerms);
         return intent;
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -232,7 +232,7 @@ public class NoteEditor extends AnkiActivity {
 
     /* indicates if a new note is added or a card is edited */
     private boolean mAddNote;
-
+    private String search_item_query;
     private boolean mAedictIntent;
 
     /* indicates which activity called Note Editor */
@@ -642,7 +642,7 @@ public class NoteEditor extends AnkiActivity {
         });
 
         mCurrentDid = intent.getLongExtra(EXTRA_DID, mCurrentDid);
-
+        search_item_query=intent.getStringExtra("SEARCH");
         setDid(mEditorNote);
 
         setNote(mEditorNote, FieldChangeType.onActivityCreation(shouldReplaceNewlines()));
@@ -697,6 +697,7 @@ public class NoteEditor extends AnkiActivity {
 
         //set focus to FieldEditText 'first' on startup like Anki desktop
         if (mEditFields != null && !mEditFields.isEmpty()) {
+            mEditFields.getFirst().setText(search_item_query);
             mEditFields.getFirst().requestFocus();
         }
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -171,7 +171,7 @@ public class NoteEditor extends AnkiActivity {
     public static final String EXTRA_TAGS = "TAGS";
     public static final String EXTRA_ID = "ID";
     public static final String EXTRA_DID = "DECK_ID";
-
+    public static final String TEXT_FROM_SEARCH_VIEW= "";
     private static final String ACTION_CREATE_FLASHCARD = "org.openintents.action.CREATE_FLASHCARD";
     private static final String ACTION_CREATE_FLASHCARD_SEND = "android.intent.action.SEND";
 
@@ -227,12 +227,11 @@ public class NoteEditor extends AnkiActivity {
     private ArrayList<Long> mAllModelIds;
     private Map<Integer, Integer> mModelChangeFieldMap;
     private HashMap<Integer, Integer> mModelChangeCardMap;
-
+    private String mGetTextFromSearchView;
     private ArrayList<Integer> mCustomViewIds = new ArrayList<>();
 
     /* indicates if a new note is added or a card is edited */
     private boolean mAddNote;
-    private String search_item_query;
     private boolean mAedictIntent;
 
     /* indicates which activity called Note Editor */
@@ -642,7 +641,7 @@ public class NoteEditor extends AnkiActivity {
         });
 
         mCurrentDid = intent.getLongExtra(EXTRA_DID, mCurrentDid);
-        search_item_query=intent.getStringExtra("SEARCH");
+        mGetTextFromSearchView = intent.getStringExtra(TEXT_FROM_SEARCH_VIEW);
         setDid(mEditorNote);
 
         setNote(mEditorNote, FieldChangeType.onActivityCreation(shouldReplaceNewlines()));
@@ -697,7 +696,7 @@ public class NoteEditor extends AnkiActivity {
 
         //set focus to FieldEditText 'first' on startup like Anki desktop
         if (mEditFields != null && !mEditFields.isEmpty()) {
-            mEditFields.getFirst().setText(search_item_query);
+            mEditFields.getFirst().setText(mGetTextFromSearchView);
             mEditFields.getFirst().requestFocus();
         }
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -172,7 +172,7 @@ public class NoteEditor extends AnkiActivity implements
     public static final String EXTRA_TAGS = "TAGS";
     public static final String EXTRA_ID = "ID";
     public static final String EXTRA_DID = "DECK_ID";
-    public static final String TEXT_FROM_SEARCH_VIEW= "SEARCH";
+    public static final String EXTRA_TEXT_FROM_SEARCH_VIEW = "SEARCH";
     private static final String ACTION_CREATE_FLASHCARD = "org.openintents.action.CREATE_FLASHCARD";
     private static final String ACTION_CREATE_FLASHCARD_SEND = "android.intent.action.SEND";
 
@@ -642,7 +642,7 @@ public class NoteEditor extends AnkiActivity implements
         });
 
         mCurrentDid = intent.getLongExtra(EXTRA_DID, mCurrentDid);
-        mGetTextFromSearchView = intent.getStringExtra(TEXT_FROM_SEARCH_VIEW);
+        mGetTextFromSearchView = intent.getStringExtra(EXTRA_TEXT_FROM_SEARCH_VIEW);
         setDid(mEditorNote);
 
         setNote(mEditorNote, FieldChangeType.onActivityCreation(shouldReplaceNewlines()));
@@ -697,7 +697,10 @@ public class NoteEditor extends AnkiActivity implements
 
         //set focus to FieldEditText 'first' on startup like Anki desktop
         if (mEditFields != null && !mEditFields.isEmpty()) {
-            mEditFields.getFirst().setText(mGetTextFromSearchView);
+            //won't set Text in the first field if the value is empty or null
+            if(mGetTextFromSearchView!=null && !mGetTextFromSearchView.isEmpty()) {
+                mEditFields.getFirst().setText(mGetTextFromSearchView);
+            }
             mEditFields.getFirst().requestFocus();
         }
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -697,8 +697,8 @@ public class NoteEditor extends AnkiActivity implements
 
         //set focus to FieldEditText 'first' on startup like Anki desktop
         if (mEditFields != null && !mEditFields.isEmpty()) {
-            //won't set Text in the first field if the value is empty or null
-            if(mGetTextFromSearchView!=null && !mGetTextFromSearchView.isEmpty()) {
+            // EXTRA_TEXT_FROM_SEARCH_VIEW takes priority over other intent inputs
+            if (mGetTextFromSearchView != null && !mGetTextFromSearchView.isEmpty()) {
                 mEditFields.getFirst().setText(mGetTextFromSearchView);
             }
             mEditFields.getFirst().requestFocus();

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -172,7 +172,7 @@ public class NoteEditor extends AnkiActivity implements
     public static final String EXTRA_TAGS = "TAGS";
     public static final String EXTRA_ID = "ID";
     public static final String EXTRA_DID = "DECK_ID";
-    public static final String TEXT_FROM_SEARCH_VIEW= "";
+    public static final String TEXT_FROM_SEARCH_VIEW= "SEARCH";
     private static final String ACTION_CREATE_FLASHCARD = "org.openintents.action.CREATE_FLASHCARD";
     private static final String ACTION_CREATE_FLASHCARD_SEND = "android.intent.action.SEND";
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -228,7 +228,6 @@ public class NoteEditor extends AnkiActivity implements
     private ArrayList<Long> mAllModelIds;
     private Map<Integer, Integer> mModelChangeFieldMap;
     private HashMap<Integer, Integer> mModelChangeCardMap;
-    private String mGetTextFromSearchView;
     private ArrayList<Integer> mCustomViewIds = new ArrayList<>();
 
     /* indicates if a new note is added or a card is edited */
@@ -642,7 +641,7 @@ public class NoteEditor extends AnkiActivity implements
         });
 
         mCurrentDid = intent.getLongExtra(EXTRA_DID, mCurrentDid);
-        mGetTextFromSearchView = intent.getStringExtra(EXTRA_TEXT_FROM_SEARCH_VIEW);
+        String mGetTextFromSearchView = intent.getStringExtra(EXTRA_TEXT_FROM_SEARCH_VIEW);
         setDid(mEditorNote);
 
         setNote(mEditorNote, FieldChangeType.onActivityCreation(shouldReplaceNewlines()));


### PR DESCRIPTION
## Purpose / Description
The purpose to not rewrite the text typed in SearchView of Card Browser activity and directly use it when clicking on Add note (overflow menu) if there is no such card present.

## Fixes
Use text from browser search bar as the first field when adding a new note #4925

## Approach
The approach was to first send the text from the CardBrowser activity on Add Note item click that was done using intent.putExtra and then setting it in first edit field when the focus was being set to it.

## How Has This Been Tested?
Tested on a physical device (Android -9)

## Screenshots


https://user-images.githubusercontent.com/46752548/112643128-08c8ff80-8e6a-11eb-8ec9-46eec1e7c7aa.mp4

## Checklist
_Please, go through these checks before submitting the PR._

- [x]  You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x]  You have a descriptive commit message with a short title (first line, max 50 chars).
- [x]  Your code follows the style of the project (e.g. never omit braces in if statements)
- [x]  You have commented on your code, particularly in hard-to-understand areas
- [x]  You have performed a self-review of your own code




