### PR TITLE
Fixes #8169 'Card Browser becomes empty on toggling night mode"

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -1474,7 +1474,6 @@ public class CardBrowser extends NavigationDrawerActivity implements
     }
 
     private void invalidate() {
-        TaskManager.cancelAllTasks(CollectionTask.SearchCards.class);
         TaskManager.cancelAllTasks(CollectionTask.RenderBrowserQA.class);
         TaskManager.cancelAllTasks(CollectionTask.CheckCardSelection.class);
         mCards.clear();
@@ -1489,6 +1488,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
 
     private void searchCards() {
         // cancel the previous search & render tasks if still running
+        TaskManager.cancelAllTasks(CollectionTask.SearchCards.class);
         invalidate();
         String searchText;
         if (mSearchTerms == null) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -511,7 +511,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
 
         // Saves the present Night Mode Preference on activity start.
         isDarkModeAtStart=AnkiDroidApp.getSharedPrefs(getApplicationContext())
-                .getBoolean(NIGHT_MODE_PREFERENCE,false);
+                .getBoolean(NIGHT_MODE_PREFERENCE, false);
 
         if (showedActivityFailedScreen(savedInstanceState)) {
             return;

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -146,7 +146,8 @@ public class CardBrowser extends NavigationDrawerActivity implements
     private String mSearchTerms;
     private String mRestrictOnDeck;
     private int mCurrentFlag;
-
+    private static final String NIGHT_MODE_PREFERENCE = "invertedColors";
+    private boolean isDarkModeAtStart;
     private MenuItem mSearchItem;
     private MenuItem mSaveSearchItem;
     private MenuItem mMySearchesItem;
@@ -507,6 +508,11 @@ public class CardBrowser extends NavigationDrawerActivity implements
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
+
+        // Saves the present Night Mode Preference on activity start.
+        isDarkModeAtStart=AnkiDroidApp.getSharedPrefs(getApplicationContext())
+                .getBoolean(NIGHT_MODE_PREFERENCE,false);
+
         if (showedActivityFailedScreen(savedInstanceState)) {
             return;
         }
@@ -820,7 +826,14 @@ public class CardBrowser extends NavigationDrawerActivity implements
     @Override
     protected void onDestroy() {
         Timber.d("onDestroy()");
-        invalidate();
+        if(isDarkModeAtStart == AnkiDroidApp.getSharedPrefs(getApplicationContext())
+                        .getBoolean(NIGHT_MODE_PREFERENCE,false)) {
+
+            // We don't want to invalidate on just theme change.
+            // as it cancels all the running tasks and the card browser is left empty.
+
+            invalidate();
+        }
         super.onDestroy();
         if (mUnmountReceiver != null) {
             unregisterReceiver(mUnmountReceiver);
@@ -1474,6 +1487,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
     }
 
     private void invalidate() {
+        TaskManager.cancelAllTasks(CollectionTask.SearchCards.class);
         TaskManager.cancelAllTasks(CollectionTask.RenderBrowserQA.class);
         TaskManager.cancelAllTasks(CollectionTask.CheckCardSelection.class);
         mCards.clear();
@@ -1488,7 +1502,6 @@ public class CardBrowser extends NavigationDrawerActivity implements
 
     private void searchCards() {
         // cancel the previous search & render tasks if still running
-        TaskManager.cancelAllTasks(CollectionTask.SearchCards.class);
         invalidate();
         String searchText;
         if (mSearchTerms == null) {


### PR DESCRIPTION
## Fixes
Fixes #8169

## Approach
On a very exhaustive investigation, I found out that onDestroy is calling the search task to end, so when the search task is going on and the query is long enough the end search is called before it can finish and return the ouput , which results in empty card browser (The reason why we can see this clearly on all deck as the query is long ).
Moved the search cancelling statement to the start of next search to handle the error. 

## How Has This Been Tested?

Tested on Nokia 6.1 + , android 10 , sotck.

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
