### PR TITLE
Fixed #8347 adding the password/email icon to the left hand side of the boxes.

### DIFF
--- a/AnkiDroid/src/main/res/drawable/ic_baseline_lock_24.xml
+++ b/AnkiDroid/src/main/res/drawable/ic_baseline_lock_24.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="@android:color/holo_blue_dark">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M18,8h-1L17,6c0,-2.76 -2.24,-5 -5,-5S7,3.24 7,6v2L6,8c-1.1,0 -2,0.9 -2,2v10c0,1.1 0.9,2 2,2h12c1.1,0 2,-0.9 2,-2L20,10c0,-1.1 -0.9,-2 -2,-2zM12,17c-1.1,0 -2,-0.9 -2,-2s0.9,-2 2,-2 2,0.9 2,2 -0.9,2 -2,2zM15.1,8L8.9,8L8.9,6c0,-1.71 1.39,-3.1 3.1,-3.1 1.71,0 3.1,1.39 3.1,3.1v2z"/>
+</vector>

--- a/AnkiDroid/src/main/res/layout/my_account.xml
+++ b/AnkiDroid/src/main/res/layout/my_account.xml
@@ -58,6 +58,9 @@
                         android:id="@+id/username"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
+                        android:drawableStart="@drawable/ic_email_black_24dp"
+                        android:drawableLeft="@drawable/ic_email_black_24dp"
+                        android:drawablePadding="8dp"
                         android:inputType="textNoSuggestions|textEmailAddress"
                         android:layout_margin="@dimen/content_vertical_padding"/>
                 </com.google.android.material.textfield.TextInputLayout>
@@ -73,6 +76,9 @@
                         android:id="@+id/password"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
+                        android:drawableStart="@drawable/ic_baseline_lock_24"
+                        android:drawableLeft="@drawable/ic_baseline_lock_24"
+                        android:drawablePadding="8dp"
                         android:inputType="textPassword"
                         android:layout_margin="@dimen/content_vertical_padding"
                         android:paddingRight="40dp"/>


### PR DESCRIPTION
## Adding the password/email icon to the left hand side of the boxes.

## Purpose / Description
At login UI , password /email icon is missing so I adding the password/email icon to the left hand side of the EditText boxs.

## Fixes
fixes #8347 

## Approach
1  Added email icon at email EditText box
2  Added  password icon at password EditText box

## How Has This Been Tested?

Tested this UI with different sizes of devices.

## Outputs :-
### Login UI in Night Mode  
<img src="https://user-images.githubusercontent.com/72181295/112718053-9104de80-8f16-11eb-9309-e461bb1b04da.jpeg" width="200" height="400">    <img src="https://user-images.githubusercontent.com/72181295/112718050-906c4800-8f16-11eb-9c6a-2f5cf4a358b4.jpeg" width="200" height="400">    <img src="https://user-images.githubusercontent.com/72181295/112718048-8ea28480-8f16-11eb-90e3-4e9970696159.jpeg" width="200" height="400">   
### Login UI in Light Mode
<img src="https://user-images.githubusercontent.com/72181295/112718106-db865b00-8f16-11eb-9cb9-afb9222fd0bb.jpeg" width="200" height="400">    <img src="https://user-images.githubusercontent.com/72181295/112718105-db865b00-8f16-11eb-893a-18525c4cb30a.jpeg" width="200" height="400">    <img src="https://user-images.githubusercontent.com/72181295/112718104-d9bc9780-8f16-11eb-9b4d-33a2352f94c9.jpeg" width="200" height="400"> 

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [x] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
