### PR TITLE
coverage: disable noisy annotations on PRs

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,6 +1,11 @@
 # the comments are too noisy to be useful
 comment: false
 
+# disable noisy inline-annotations ("Added line [LineNum] was not covered by tests") on PRs (#8296)
+# https://docs.codecov.io/docs/github-checks-beta
+github_checks:
+  annotations: false
+
 coverage:
   range: "36...100"
   status:


### PR DESCRIPTION
## Purpose / Description
Most PRs had annotations added on each branch which did not have coverage

This added more noise to the PR, and was not helpful, as we aren't yet going for 100% coverage, it made reviews harder, and probably alienated new contributors



## Fixes
Fixes #8296

## Approach
Disable the annotations

## How Has This Been Tested?
Untested - let's test in PROD. Looks similar to other files on GitHub

## Learning (optional, can help others)
https://docs.codecov.io/docs/github-checks-beta

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [x] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
