### PR TITLE
added lint rules to check for copyright header in .java files

### DIFF
--- a/lint-rules/src/main/java/com/ichi2/anki/lint/IssueRegistry.java
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/IssueRegistry.java
@@ -2,6 +2,7 @@ package com.ichi2.anki.lint;
 
 import com.android.tools.lint.detector.api.ApiKt;
 import com.android.tools.lint.detector.api.Issue;
+import com.ichi2.anki.lint.rules.CopyrightHeaderChecker;
 import com.ichi2.anki.lint.rules.DirectCalendarInstanceUsage;
 import com.ichi2.anki.lint.rules.DirectSystemTimeInstantiation;
 import com.ichi2.anki.lint.rules.DirectSystemCurrentTimeMillisUsage;
@@ -22,6 +23,7 @@ public class IssueRegistry extends com.android.tools.lint.client.api.IssueRegist
     @Override
     public List<Issue> getIssues() {
         List<Issue> issues = new ArrayList<>();
+        issues.add(CopyrightHeaderChecker.ISSUE);
         issues.add(DirectCalendarInstanceUsage.ISSUE);
         issues.add(DirectSystemCurrentTimeMillisUsage.ISSUE);
         issues.add(DirectDateInstantiation.ISSUE);

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/rules/CopyrightHeaderChecker.java
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/CopyrightHeaderChecker.java
@@ -52,7 +52,7 @@ public class CopyrightHeaderChecker extends Detector implements SourceCodeScanne
             ID,
             DESCRIPTION,
             EXPLANATION,
-            Constants.ANKI_TIME_CATEGORY,
+            Constants.ANKI_CODE_STYLE_CATEGORY,
             Constants.ANKI_TIME_PRIORITY,
             Constants.ANKI_TIME_SEVERITY,
             implementation

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/rules/CopyrightHeaderChecker.java
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/CopyrightHeaderChecker.java
@@ -40,9 +40,13 @@ public class CopyrightHeaderChecker extends Detector implements SourceCodeScanne
     static final String ID = "CopyrightHeaderChecker";
     @VisibleForTesting
     static final String DESCRIPTION = "Add Copyright Header in each file";
-    private static final String EXPLANATION = "All files in AnkiDroid must contain  Copyright Header. " +
-            "The copyright header can be set in Settings - Editor - Copyright - Copyright Profiles - Add Profile - AnkiDroid. " +
-            "Search in Settings for 'Copyright'";
+    private static final String EXPLANATION = "All files in AnkiDroid must contain a " +
+            "GPLv3-compatible copyright header" +
+            "The copyright header can be set in " +
+            "Settings - Editor - Copyright - Copyright Profiles - Add Profile - AnkiDroid. " +
+            "Search in Settings for 'Copyright'" +
+            "Add Licence Notice given in this page " +
+            "https://www.gnu.org/licenses/gpl-faq.en.html#GPLIncompatibleLibs";
     private static final Implementation implementation = new Implementation(CopyrightHeaderChecker.class, Scope.JAVA_FILE_SCOPE);
     public static final Issue ISSUE = Issue.create(
             ID,
@@ -68,10 +72,8 @@ public class CopyrightHeaderChecker extends Detector implements SourceCodeScanne
 
     @Override
     public void afterCheckFile(@NotNull Context context) {
-        String source = context.getContents().toString();
+        CharSequence source = context.getContents();
         Pattern pattern = Pattern.compile("/*\n" +
-                " *  Copyright (c) $today.year David Allison <davidallisongithub@gmail.com>\n" +
-                " *\n" +
                 " *  This program is free software; you can redistribute it and/or modify it under\n" +
                 " *  the terms of the GNU General Public License as published by the Free Software\n" +
                 " *  Foundation; either version 3 of the License, or (at your option) any later\n" +

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/rules/CopyrightHeaderChecker.java
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/CopyrightHeaderChecker.java
@@ -1,0 +1,100 @@
+/*
+ *  Copyright (c) 2021 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.lint.rules;
+
+import com.android.tools.lint.detector.api.Context;
+import com.android.tools.lint.detector.api.Detector;
+import com.android.tools.lint.detector.api.Implementation;
+import com.android.tools.lint.detector.api.Issue;
+import com.android.tools.lint.detector.api.Scope;
+import com.android.tools.lint.detector.api.SourceCodeScanner;
+import com.google.common.annotations.VisibleForTesting;
+import com.ichi2.anki.lint.utils.Constants;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.jetbrains.uast.UClass;
+import org.jetbrains.uast.UElement;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class CopyrightHeaderChecker extends Detector implements SourceCodeScanner {
+    @VisibleForTesting
+    static final String ID = "CopyrightHeaderChecker";
+    @VisibleForTesting
+    static final String DESCRIPTION = "Add Copyright Header in each file";
+    private static final String EXPLANATION = "All files in AnkiDroid must contain  Copyright Header. " +
+            "The copyright header can be set in Settings - Editor - Copyright - Copyright Profiles - Add Profile - AnkiDroid. " +
+            "Search in Settings for 'Copyright'";
+    private static final Implementation implementation = new Implementation(CopyrightHeaderChecker.class, Scope.JAVA_FILE_SCOPE);
+    public static final Issue ISSUE = Issue.create(
+            ID,
+            DESCRIPTION,
+            EXPLANATION,
+            Constants.ANKI_TIME_CATEGORY,
+            Constants.ANKI_TIME_PRIORITY,
+            Constants.ANKI_TIME_SEVERITY,
+            implementation
+    );
+
+    public CopyrightHeaderChecker() {
+
+    }
+
+
+    @Nullable
+    @Override
+    public List<Class<? extends UElement>> getApplicableUastTypes() {
+        return Collections.singletonList(UClass.class);
+    }
+
+
+    @Override
+    public void afterCheckFile(@NotNull Context context) {
+        String source = context.getContents().toString();
+        Pattern pattern = Pattern.compile("/*\n" +
+                " *  Copyright (c) $today.year David Allison <davidallisongithub@gmail.com>\n" +
+                " *\n" +
+                " *  This program is free software; you can redistribute it and/or modify it under\n" +
+                " *  the terms of the GNU General Public License as published by the Free Software\n" +
+                " *  Foundation; either version 3 of the License, or (at your option) any later\n" +
+                " *  version.\n" +
+                " *\n" +
+                " *  This program is distributed in the hope that it will be useful, but WITHOUT ANY\n" +
+                " *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A\n" +
+                " *  PARTICULAR PURPOSE. See the GNU General Public License for more details.\n" +
+                " *\n" +
+                " *  You should have received a copy of the GNU General Public License along with\n" +
+                " *  this program.  If not, see <http://www.gnu.org/licenses/>.\n" +
+                " */");
+        Matcher matcher = pattern.matcher(source);
+        boolean found = false;
+        if (matcher.find()) {
+            found = true;
+        }
+        if (!found) {
+            context.report(
+                    ISSUE,
+                    null,
+                    DESCRIPTION
+            );
+        }
+    }
+}

--- a/lint-rules/src/test/java/com/ichi2/anki/lint/rules/CopyrightHeaderCheckerTest.java
+++ b/lint-rules/src/test/java/com/ichi2/anki/lint/rules/CopyrightHeaderCheckerTest.java
@@ -1,0 +1,62 @@
+/*
+ *  Copyright (c) 2021 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.lint.rules;
+
+import org.intellij.lang.annotations.Language;
+import org.junit.Test;
+
+import static com.android.tools.lint.checks.infrastructure.TestFile.JavaTestFile.create;
+import static com.android.tools.lint.checks.infrastructure.TestLintTask.lint;
+import static org.junit.Assert.assertTrue;
+
+public class CopyrightHeaderCheckerTest {
+
+    @Language("JAVA")
+    private final String mCopyrightHeader = "/*\n" +
+            " *  Copyright (c) $today.year David Allison <davidallisongithub@gmail.com>\n" +
+            " *\n" +
+            " *  This program is free software; you can redistribute it and/or modify it under\n" +
+            " *  the terms of the GNU General Public License as published by the Free Software\n" +
+            " *  Foundation; either version 3 of the License, or (at your option) any later\n" +
+            " *  version.\n" +
+            " *\n" +
+            " *  This program is distributed in the hope that it will be useful, but WITHOUT ANY\n" +
+            " *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A\n" +
+            " *  PARTICULAR PURPOSE. See the GNU General Public License for more details.\n" +
+            " *\n" +
+            " *  You should have received a copy of the GNU General Public License along with\n" +
+            " *  this program.  If not, see <http://www.gnu.org/licenses/>.\n" +
+            " */";
+
+
+
+
+    @Test
+    public void showsErrorForNoCopyrightHeader() {
+        lint()
+                .allowMissingSdk()
+                .allowCompilationErrors()
+                .files(create(mCopyrightHeader))
+                .issues(CopyrightHeaderChecker.ISSUE)
+                .run()
+                .expectErrorCount(1)
+                .check(output -> {
+                    assertTrue(output.contains(CopyrightHeaderChecker.ID));
+                    assertTrue(output.contains(CopyrightHeaderChecker.DESCRIPTION));
+                });
+    }
+}

--- a/lint-rules/src/test/java/com/ichi2/anki/lint/rules/CopyrightHeaderCheckerTest.java
+++ b/lint-rules/src/test/java/com/ichi2/anki/lint/rules/CopyrightHeaderCheckerTest.java
@@ -27,8 +27,6 @@ public class CopyrightHeaderCheckerTest {
 
     @Language("JAVA")
     private final String mCopyrightHeader = "/*\n" +
-            " *  Copyright (c) $today.year David Allison <davidallisongithub@gmail.com>\n" +
-            " *\n" +
             " *  This program is free software; you can redistribute it and/or modify it under\n" +
             " *  the terms of the GNU General Public License as published by the Free Software\n" +
             " *  Foundation; either version 3 of the License, or (at your option) any later\n" +
@@ -46,7 +44,7 @@ public class CopyrightHeaderCheckerTest {
 
 
     @Test
-    public void showsErrorForNoCopyrightHeader() {
+    public void fileWithCopyrightHeaderPasses() {
         lint()
                 .allowMissingSdk()
                 .allowCompilationErrors()


### PR DESCRIPTION
## Pull Request template
added a lint rule which will check that all files have copyright header and if not will explain contributer how to do so
## Fixes
Fixes #8211 

## Approach
Feed `Copyright Header` in `Pattern`
`Matcher` will tell if that pattern is found
Reference use : https://github.com/vanniktech/lint-rules/blob/master/lint-rules-android-lint/src/main/java/com/vanniktech/lintrules/android/InvalidSingleLineCommentDetector.kt
## How Has This Been Tested?

CI should tell

## Learning (optional, can help others)
https://github.com/vanniktech/lint-rules
## Checklist

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)