### PR TITLE
Bump appcompat to 1.3.0-rc01.

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -223,7 +223,7 @@ dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation 'androidx.activity:activity:1.2.1'
     implementation 'androidx.annotation:annotation:1.1.0'
-    implementation 'androidx.appcompat:appcompat:1.2.0'
+    implementation 'androidx.appcompat:appcompat:1.3.0-rc01'
     implementation 'androidx.browser:browser:1.3.0'
     implementation 'androidx.exifinterface:exifinterface:1.3.2'
     implementation 'androidx.fragment:fragment:1.3.1'

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -960,6 +960,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
 
 
     public void onRequestPermissionsResult (int requestCode, @NonNull String[] permissions, @NonNull int[] grantResults) {
+        super.onRequestPermissionsResult(requestCode, permissions, grantResults);
         if (requestCode == REQUEST_STORAGE_PERMISSION && permissions.length == 1) {
             if (grantResults[0] == PackageManager.PERMISSION_GRANTED) {
                 invalidateOptionsMenu();
@@ -2162,7 +2163,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
             UIUtils.showThemedToast(this, getResources().getString(R.string.apk_share_error), false);
             return;
         }
-        Intent shareIntent = ShareCompat.IntentBuilder.from(DeckPicker.this)
+        Intent shareIntent = new ShareCompat.IntentBuilder(DeckPicker.this)
                 .setType("application/apkg")
                 .setStream(uri)
                 .setSubject(getString(R.string.export_email_subject, attachment.getName()))


### PR DESCRIPTION
## Purpose / Description

This should fix the issue related to menu items with icons in RTL locales (https://issuetracker.google.com/issues/146100178).

The new version of `appcompat` did deprecate `startActivityForResult/onActvityResult`, so a suppress warning annotation was added.


## Fixes
Issues specified in https://github.com/ankidroid/Anki-Android/pull/8261#pullrequestreview-622598680
And related to https://github.com/ankidroid/Anki-Android/issues/8259

## How Has This Been Tested?

Manual testing

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [x] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
