### PR TITLE
Enable java 8 library desugaring

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -154,6 +154,7 @@ android {
         preDexLibraries = preDexEnabled && !ciBuild
     }
     compileOptions {
+        coreLibraryDesugaringEnabled true
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
@@ -214,6 +215,7 @@ dependencies {
         resolutionStrategy {
             force 'org.jetbrains:annotations:20.1.0'
         }
+    coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:1.0.4'
     }
 
     compileOnly 'org.jetbrains:annotations:20.1.0'

--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -215,9 +215,9 @@ dependencies {
         resolutionStrategy {
             force 'org.jetbrains:annotations:20.1.0'
         }
-        coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:1.0.9'
     }
 
+    coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:1.0.9'
     compileOnly 'org.jetbrains:annotations:20.1.0'
     compileOnly "com.google.auto.service:auto-service-annotations:1.0-rc7"
     annotationProcessor "com.google.auto.service:auto-service:1.0-rc7"

--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -154,7 +154,7 @@ android {
         preDexLibraries = preDexEnabled && !ciBuild
     }
     compileOptions {
-        coreLibraryDesugaringEnabled true
+        coreLibraryDesugaringEnabled true // Enabling desugaring.
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
@@ -215,7 +215,7 @@ dependencies {
         resolutionStrategy {
             force 'org.jetbrains:annotations:20.1.0'
         }
-        coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:1.0.9'
+        coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:1.0.9' // Setting the version of core desugaring library.
 //    coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:1.0.4'
     }
 

--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -215,8 +215,7 @@ dependencies {
         resolutionStrategy {
             force 'org.jetbrains:annotations:20.1.0'
         }
-        coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:1.0.9' // Setting the version of core desugaring library.
-//    coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:1.0.4'
+        coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:1.0.9'
     }
 
     compileOnly 'org.jetbrains:annotations:20.1.0'

--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -215,7 +215,8 @@ dependencies {
         resolutionStrategy {
             force 'org.jetbrains:annotations:20.1.0'
         }
-    coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:1.0.4'
+        coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:1.0.9'
+//    coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:1.0.4'
     }
 
     compileOnly 'org.jetbrains:annotations:20.1.0'

--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -154,7 +154,7 @@ android {
         preDexLibraries = preDexEnabled && !ciBuild
     }
     compileOptions {
-        coreLibraryDesugaringEnabled true // Enabling desugaring.
+        coreLibraryDesugaringEnabled true
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/CardAppearance.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/CardAppearance.java
@@ -5,6 +5,7 @@ import android.content.SharedPreferences;
 import com.ichi2.anki.reviewer.ReviewerCustomFonts;
 import com.ichi2.libanki.Card;
 import com.ichi2.themes.Themes;
+//import java.time.*; This line was added to test the build and run on API 22.
 
 import androidx.annotation.CheckResult;
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/CardAppearance.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/CardAppearance.java
@@ -5,7 +5,6 @@ import android.content.SharedPreferences;
 import com.ichi2.anki.reviewer.ReviewerCustomFonts;
 import com.ichi2.libanki.Card;
 import com.ichi2.themes.Themes;
-//import java.time.*; This line was added to test the build and run on API 22.
 
 import androidx.annotation.CheckResult;
 


### PR DESCRIPTION
## Purpose / Description
This pull request aims to enable java 8 library desugaring.

## Fixes
Fixes [#7052 ](https://github.com/ankidroid/Anki-Android/issues/7052)

## Approach
The change enables core library desugaring for java 8 libraries.

## How Has This Been Tested?

The changes have been tested on API 22 by adding `import java.time.*`. It is one of the libraries supported by d8 desugaring.  

## Learning (optional, can help others)
I explored desugaring and dex compiler, d8 in Android Studio.
I referred to the following:
https://jakewharton.com/d8-library-desugaring/
https://blog.stylingandroid.com/d8-desugaring/
https://github.com/ankidroid/Anki-Android/issues/7052

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
