### PR TITLE
readme: add newline between licences

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,5 +134,5 @@ Our Awesome Team of Contributors
 
 License
 -------
-[GPL-3.0 License](https://github.com/ankidroid/Anki-Android/blob/master/COPYING)
+[GPL-3.0 License](https://github.com/ankidroid/Anki-Android/blob/master/COPYING)  
 [AGPL-3.0 Licence](https://github.com/ankitects/anki/blob/master/LICENSE) for some part of the back-end


### PR DESCRIPTION
Adds a newline between GPL and AGPL

Before: https://github.com/ankidroid/Anki-Android/tree/2d67ba15e7760aeabc790befecf05bc04e18feae#license
After: https://github.com/david-allison-1/Anki-Android/tree/readme-newline#license