### PR TITLE
Issue with day and night switch

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/NavigationDrawerActivity.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NavigationDrawerActivity.java
@@ -191,7 +191,11 @@ public abstract class NavigationDrawerActivity extends AnkiActivity implements N
         final SharedPreferences preferences = getPreferences();
         Timber.i("Night mode was %s", setToNightMode ? "enabled" : "disabled");
         preferences.edit().putBoolean(NIGHT_MODE_PREFERENCE, setToNightMode).apply();
-        restartActivityInvalidateBackstack(NavigationDrawerActivity.this);
+        //restartActivityInvalidateBackstack(NavigationDrawerActivity.this);
+        if(setToNightMode)
+            AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_YES);
+        else
+            AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_NO);
     }
 
     @Override


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
The app is getting restarted when switching between day and night mode

## Fixes
#8351

## Approach
When switching to the dashboard it remains at the same activity, the splash screen is not displayed.

## How Has This Been Tested?

It is reproducible on every mobile. You can test it simply by switching in day and night mode.

## Learning (optional, can help others)
You can see a different way of switching between night and day mode.

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented on your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [x] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
