### PR TITLE
Improve documentation: activityHandlesRestoreBackup

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiActivity.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiActivity.java
@@ -605,7 +605,7 @@ public class AnkiActivity extends AppCompatActivity implements SimpleMessageDial
     }
 
     protected boolean showedActivityFailedScreen(Bundle savedInstanceState) {
-        if (!AnkiDroidApp.isInitialized()) {
+        if (!AnkiDroidApp.isUninitialized()) {
             return false;
         }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.java
@@ -200,7 +200,7 @@ public class AnkiDroidApp extends Application {
     }
 
 
-    public static boolean isInitialized() {
+    public static boolean isUninitialized() {
         return sInstance == null;
     }
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/ActivityStartupUnderBackupTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/ActivityStartupUnderBackupTest.java
@@ -17,6 +17,7 @@
 package com.ichi2.anki;
 
 import android.app.Activity;
+import android.os.Bundle;
 
 import com.ichi2.anki.multimediacard.activity.LoadPronounciationActivity;
 import com.ichi2.anki.multimediacard.activity.TranslationActivity;
@@ -67,10 +68,12 @@ public class ActivityStartupUnderBackupTest extends RobolectricTest {
     }
 
 
+    /**
+     * Tests that each activity can handle {@link AnkiDroidApp#getInstance()} returning null
+     * This happens during a backup, for details, see {@link AnkiActivity#showedActivityFailedScreen(Bundle)}
+     */
     @Test
     public void activityHandlesRestoreBackup() {
-        // See: showActivityFailedScreen
-
         AnkiDroidApp.simulateRestoreFromBackup();
         ActivityController<? extends Activity> controller = mLauncher.build(getTargetContext()).create();
 


### PR DESCRIPTION
## Purpose / Description
User mentioned that the failure was confusing: it'll occur again, and this needs to be correct to stop crashes, so I've improved the documentation


## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [x] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
