### PR TITLE
Fixes #4699 "Type in Answer" auto focus for answer field.

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -81,7 +81,6 @@ import android.webkit.WebView.HitTestResult;
 import android.webkit.WebViewClient;
 import android.widget.Button;
 import android.widget.Chronometer;
-import android.widget.EditText;
 import android.widget.FrameLayout;
 import android.widget.ImageView;
 import android.widget.LinearLayout;
@@ -1760,7 +1759,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
         // This does not handle mUseInputTag (the WebView contains an input field with a typable answer).
         // In this case, the user can use touch to focus the field if necessary.
         if (typeAnswer()) {
-            mAnswerField.focus();
+            mAnswerField.focusWithKeyboard();
         } else {
             mFlipCardLayout.requestFocus();
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -121,6 +121,7 @@ import com.ichi2.libanki.template.MathJax;
 import com.ichi2.libanki.template.TemplateFilters;
 import com.ichi2.themes.HtmlColors;
 import com.ichi2.themes.Themes;
+import com.ichi2.ui.FixedEditText;
 import com.ichi2.utils.AdaptionUtil;
 import com.ichi2.utils.AndroidUiUtils;
 import com.ichi2.utils.AssetHelper;
@@ -289,7 +290,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
     protected TextView mNext2;
     protected TextView mNext3;
     protected TextView mNext4;
-    protected EditText mAnswerField;
+    protected FixedEditText mAnswerField;
     protected TextView mEase1;
     protected TextView mEase2;
     protected TextView mEase3;
@@ -1759,12 +1760,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
         // This does not handle mUseInputTag (the WebView contains an input field with a typable answer).
         // In this case, the user can use touch to focus the field if necessary.
         if (typeAnswer()) {
-            // Required on some devices to show soft keyboard (Android 10 in my case): https://stackoverflow.com/a/7784904
-            mAnswerField.postDelayed(() -> {
-                mAnswerField.requestFocus();
-                InputMethodManager imm = (InputMethodManager) this.getSystemService(Context.INPUT_METHOD_SERVICE);
-                imm.showSoftInput(mAnswerField, InputMethodManager.SHOW_IMPLICIT);
-            }, 200);
+            mAnswerField.focus();
         } else {
             mFlipCardLayout.requestFocus();
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -1759,7 +1759,12 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
         // This does not handle mUseInputTag (the WebView contains an input field with a typable answer).
         // In this case, the user can use touch to focus the field if necessary.
         if (typeAnswer()) {
-            mAnswerField.requestFocus();
+            // Required on some devices to show soft keyboard (Android 10 in my case): https://stackoverflow.com/a/7784904
+            mAnswerField.postDelayed(() -> {
+                mAnswerField.requestFocus();
+                InputMethodManager imm = (InputMethodManager) this.getSystemService(Context.INPUT_METHOD_SERVICE);
+                imm.showSoftInput(mAnswerField, InputMethodManager.SHOW_IMPLICIT);
+            }, 200);
         } else {
             mFlipCardLayout.requestFocus();
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -298,13 +298,7 @@ public class NoteEditor extends AnkiActivity implements
                 mIntent = new Intent();
                 mIntent.putExtra(EXTRA_ID, noteEditor.getIntent().getStringExtra(EXTRA_ID));
             } else if (!noteEditor.mEditFields.isEmpty()) {
-                FieldEditText firstEditField = noteEditor.mEditFields.getFirst();
-                // Required on my Android 9 Phone to show keyboard: https://stackoverflow.com/a/7784904
-                firstEditField.postDelayed(() -> {
-                    firstEditField.requestFocus();
-                    InputMethodManager imm = (InputMethodManager) noteEditor.getSystemService(Context.INPUT_METHOD_SERVICE);
-                    imm.showSoftInput(firstEditField, InputMethodManager.SHOW_IMPLICIT);
-                }, 200);
+                noteEditor.mEditFields.getFirst().focus();
             }
             if (!mCloseAfter && (noteEditor.mProgressDialog != null) && noteEditor.mProgressDialog.isShowing()) {
                 try {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -27,7 +27,6 @@ import android.content.Intent;
 import android.content.IntentFilter;
 import android.content.SharedPreferences;
 import android.content.res.Resources;
-import android.graphics.Color;
 import android.graphics.Typeface;
 import android.graphics.drawable.Drawable;
 import android.net.Uri;
@@ -56,7 +55,6 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.view.ViewGroup.MarginLayoutParams;
 import android.view.WindowManager;
-import android.view.inputmethod.InputMethodManager;
 import android.widget.AdapterView;
 import android.widget.AdapterView.OnItemSelectedListener;
 import android.widget.ArrayAdapter;
@@ -298,7 +296,7 @@ public class NoteEditor extends AnkiActivity implements
                 mIntent = new Intent();
                 mIntent.putExtra(EXTRA_ID, noteEditor.getIntent().getStringExtra(EXTRA_ID));
             } else if (!noteEditor.mEditFields.isEmpty()) {
-                noteEditor.mEditFields.getFirst().focus();
+                noteEditor.mEditFields.getFirst().focusWithKeyboard();
             }
             if (!mCloseAfter && (noteEditor.mProgressDialog != null) && noteEditor.mProgressDialog.isShowing()) {
                 try {

--- a/AnkiDroid/src/main/java/com/ichi2/ui/FixedEditText.java
+++ b/AnkiDroid/src/main/java/com/ichi2/ui/FixedEditText.java
@@ -137,6 +137,9 @@ public class FixedEditText extends AppCompatEditText {
         }
     }
 
+    /*
+     * Focuses the edit text and opens the soft keyboard.
+     */
     public void focus(){
         this.postDelayed(() -> {
             this.requestFocus();

--- a/AnkiDroid/src/main/java/com/ichi2/ui/FixedEditText.java
+++ b/AnkiDroid/src/main/java/com/ichi2/ui/FixedEditText.java
@@ -42,6 +42,7 @@ import android.content.Context;
 import android.graphics.Canvas;
 import android.util.AttributeSet;
 import android.view.MotionEvent;
+import android.view.inputmethod.InputMethodManager;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -134,5 +135,13 @@ public class FixedEditText extends AppCompatEditText {
             Timber.w(ex);
             return false;
         }
+    }
+
+    public void focus(){
+        this.postDelayed(() -> {
+            this.requestFocus();
+            InputMethodManager imm = (InputMethodManager) getContext().getSystemService(Context.INPUT_METHOD_SERVICE);
+            imm.showSoftInput(this, InputMethodManager.SHOW_IMPLICIT);
+        }, 200);
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/ui/FixedEditText.java
+++ b/AnkiDroid/src/main/java/com/ichi2/ui/FixedEditText.java
@@ -137,10 +137,12 @@ public class FixedEditText extends AppCompatEditText {
         }
     }
 
-    /*
+
+    /**
      * Focuses the edit text and opens the soft keyboard.
      */
-    public void focus(){
+    public void focusWithKeyboard() {
+        //  Required on some Android 9,10 devices to show keyboard: https://stackoverflow.com/a/7784904
         this.postDelayed(() -> {
             this.requestFocus();
             InputMethodManager imm = (InputMethodManager) getContext().getSystemService(Context.INPUT_METHOD_SERVICE);


### PR DESCRIPTION
## Purpose / Description
Auto Focus on answer field in "type in answer" cards.

## Fixes
Fixes #4699

## Approach
Added code to open soft keyboard on focus .


## How Has This Been Tested?

Tested on Nokia 6.1+ android 10 stock.

## Learning (optional, can help others)

[Stack overflow](https://stackoverflow.com/questions/5105354/how-to-show-soft-keyboard-when-edittext-is-focused/7784904#7784904)

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
