### PR TITLE
search deck in NoteEditor

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.java
@@ -559,7 +559,7 @@ public class CardTemplateEditor extends AnkiActivity implements DeckSelectionDia
             FunctionalInterfaces.Filter<Deck> nonDynamic = (d) -> !Decks.isDynamic(d);
             List<SelectableDeck> decks = SelectableDeck.fromCollection(col, nonDynamic);
             String title = getString(R.string.card_template_editor_deck_override);
-            DeckSelectionDialog dialog = DeckSelectionDialog.newInstance(title, explanation, decks);
+            DeckSelectionDialog dialog = DeckSelectionDialog.newInstance(title, explanation, true, decks);
             AnkiActivity.showDialogFragment(activity, dialog);
         }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -271,7 +271,7 @@ public class NoteEditor extends AnkiActivity implements
     private void displayDeckOverrideDialog(Collection col) {
         FunctionalInterfaces.Filter<Deck> nonDynamic = (d) -> !Decks.isDynamic(d);
         List<DeckSelectionDialog.SelectableDeck> decks = DeckSelectionDialog.SelectableDeck.fromCollection(col, nonDynamic);
-        DeckSelectionDialog dialog = DeckSelectionDialog.newInstance("Deck Search", null, decks);
+        DeckSelectionDialog dialog = DeckSelectionDialog.newInstance("Deck Search", null, false, decks);
         AnkiActivity.showDialogFragment(NoteEditor.this, dialog);
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -271,7 +271,7 @@ public class NoteEditor extends AnkiActivity implements
     private void displayDeckOverrideDialog(Collection col) {
         FunctionalInterfaces.Filter<Deck> nonDynamic = (d) -> !Decks.isDynamic(d);
         List<DeckSelectionDialog.SelectableDeck> decks = DeckSelectionDialog.SelectableDeck.fromCollection(col, nonDynamic);
-        DeckSelectionDialog dialog = DeckSelectionDialog.newInstance("Deck Search", null, false, decks);
+        DeckSelectionDialog dialog = DeckSelectionDialog.newInstance(getString(R.string.search_deck), null, false, decks);
         AnkiActivity.showDialogFragment(NoteEditor.this, dialog);
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckSelectionDialog.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckSelectionDialog.java
@@ -114,9 +114,8 @@ public class DeckSelectionDialog extends AnalyticsDialogFragment {
 
         MaterialDialog.Builder builder = new MaterialDialog.Builder(requireActivity())
                 .neutralText(R.string.dialog_cancel)
-                .customView(dialogView, false)
-                .onNeutral((dialog, which) -> {
-                });
+                .customView(dialogView, false);
+
         if (arguments.getBoolean("keepRestoreDefaultButton")) {
             builder = builder.negativeText(R.string.restore_default).onNegative((dialog, which) -> onDeckSelected(null));
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckSelectionDialog.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckSelectionDialog.java
@@ -117,7 +117,7 @@ public class DeckSelectionDialog extends AnalyticsDialogFragment {
                 .customView(dialogView, false)
                 .onNegative((dialog, which) -> onDeckSelected(null))
                 .onNeutral((dialog, which) -> {
-                });;
+                });
         if (arguments.getBoolean("keepRestoreDefaultButton")) {
             builder = builder.negativeText(R.string.restore_default).onNegative((dialog, which) -> onDeckSelected(null));
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckSelectionDialog.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckSelectionDialog.java
@@ -112,23 +112,16 @@ public class DeckSelectionDialog extends AnalyticsDialogFragment {
 
         adjustToolbar(dialogView, adapter);
 
-        MaterialDialog.Builder builder;
+        MaterialDialog.Builder builder = new MaterialDialog.Builder(requireActivity())
+                .neutralText(R.string.dialog_cancel)
+                .customView(dialogView, false)
+                .onNegative((dialog, which) -> onDeckSelected(null))
+                .onNeutral((dialog, which) -> {
+                });;
         if (arguments.getBoolean("keepRestoreDefaultButton")) {
-            builder = new MaterialDialog.Builder(requireActivity())
-                    .neutralText(R.string.dialog_cancel)
-                    .negativeText(R.string.restore_default)
-                    .customView(dialogView, false)
-                    .onNegative((dialog, which) -> onDeckSelected(null))
-                    .onNeutral((dialog, which) -> {
-                    });
-        } else {
-            builder = new MaterialDialog.Builder(requireActivity())
-                    .neutralText(R.string.dialog_cancel)
-                    .customView(dialogView, false)
-                    .onNegative((dialog, which) -> onDeckSelected(null))
-                    .onNeutral((dialog, which) -> {
-                    });
+            builder = builder.negativeText(R.string.restore_default).onNegative((dialog, which) -> onDeckSelected(null));
         }
+
         mDialog = builder.build();
         return mDialog;
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckSelectionDialog.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckSelectionDialog.java
@@ -115,7 +115,6 @@ public class DeckSelectionDialog extends AnalyticsDialogFragment {
         MaterialDialog.Builder builder = new MaterialDialog.Builder(requireActivity())
                 .neutralText(R.string.dialog_cancel)
                 .customView(dialogView, false)
-                .onNegative((dialog, which) -> onDeckSelected(null))
                 .onNeutral((dialog, which) -> {
                 });
         if (arguments.getBoolean("keepRestoreDefaultButton")) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckSelectionDialog.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckSelectionDialog.java
@@ -59,11 +59,12 @@ public class DeckSelectionDialog extends AnalyticsDialogFragment {
      * A dialog which handles selecting a deck
      */
     @NonNull
-    public static DeckSelectionDialog newInstance(@NonNull String title, @Nullable String summaryMessage, @NonNull List<SelectableDeck> decks) {
+    public static DeckSelectionDialog newInstance(@NonNull String title, @Nullable String summaryMessage, @NonNull boolean keepRestoreDefaultButton, @NonNull List<SelectableDeck> decks) {
         DeckSelectionDialog f = new DeckSelectionDialog();
         Bundle args = new Bundle();
         args.putString("summaryMessage", summaryMessage);
         args.putString("title", title);
+        args.putBoolean("keepRestoreDefaultButton", keepRestoreDefaultButton);
         args.putParcelableArrayList("deckNames", new ArrayList<>(decks));
         f.setArguments(args);
         return f;
@@ -111,12 +112,23 @@ public class DeckSelectionDialog extends AnalyticsDialogFragment {
 
         adjustToolbar(dialogView, adapter);
 
-        MaterialDialog.Builder builder = new MaterialDialog.Builder(requireActivity())
-                .neutralText(R.string.dialog_cancel)
-                .customView(dialogView, false)
-                .onNegative((dialog, which) -> onDeckSelected(null))
-                .onNeutral((dialog, which) -> { });
-
+        MaterialDialog.Builder builder;
+        if (arguments.getBoolean("keepRestoreDefaultButton")) {
+            builder = new MaterialDialog.Builder(requireActivity())
+                    .neutralText(R.string.dialog_cancel)
+                    .negativeText(R.string.restore_default)
+                    .customView(dialogView, false)
+                    .onNegative((dialog, which) -> onDeckSelected(null))
+                    .onNeutral((dialog, which) -> {
+                    });
+        } else {
+            builder = new MaterialDialog.Builder(requireActivity())
+                    .neutralText(R.string.dialog_cancel)
+                    .customView(dialogView, false)
+                    .onNegative((dialog, which) -> onDeckSelected(null))
+                    .onNeutral((dialog, which) -> {
+                    });
+        }
         mDialog = builder.build();
         return mDialog;
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckSelectionDialog.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckSelectionDialog.java
@@ -59,7 +59,7 @@ public class DeckSelectionDialog extends AnalyticsDialogFragment {
      * A dialog which handles selecting a deck
      */
     @NonNull
-    public static DeckSelectionDialog newInstance(@NonNull String title, @NonNull String summaryMessage, @NonNull List<SelectableDeck> decks) {
+    public static DeckSelectionDialog newInstance(@NonNull String title, @Nullable String summaryMessage, @NonNull List<SelectableDeck> decks) {
         DeckSelectionDialog f = new DeckSelectionDialog();
         Bundle args = new Bundle();
         args.putString("summaryMessage", summaryMessage);
@@ -88,7 +88,12 @@ public class DeckSelectionDialog extends AnalyticsDialogFragment {
 
         Bundle arguments = requireArguments();
 
-        summary.setText(getSummaryMessage(arguments));
+        if (getSummaryMessage(arguments) == null) {
+            summary.setVisibility(View.GONE);
+        } else {
+            summary.setVisibility(View.VISIBLE);
+            summary.setText(getSummaryMessage(arguments));
+        }
 
         RecyclerView recyclerView = dialogView.findViewById(R.id.deck_picker_dialog_list);
         recyclerView.requestFocus();
@@ -108,7 +113,6 @@ public class DeckSelectionDialog extends AnalyticsDialogFragment {
 
         MaterialDialog.Builder builder = new MaterialDialog.Builder(requireActivity())
                 .neutralText(R.string.dialog_cancel)
-                .negativeText(R.string.restore_default)
                 .customView(dialogView, false)
                 .onNegative((dialog, which) -> onDeckSelected(null))
                 .onNeutral((dialog, which) -> { });
@@ -118,9 +122,9 @@ public class DeckSelectionDialog extends AnalyticsDialogFragment {
     }
 
 
-    @NonNull
+    @Nullable
     private String getSummaryMessage(Bundle arguments) {
-        return Objects.requireNonNull(arguments.getString("summaryMessage"));
+        return arguments.getString("summaryMessage");
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckSelectionDialog.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckSelectionDialog.java
@@ -112,16 +112,23 @@ public class DeckSelectionDialog extends AnalyticsDialogFragment {
 
         adjustToolbar(dialogView, adapter);
 
-        MaterialDialog.Builder builder = new MaterialDialog.Builder(requireActivity())
-                .neutralText(R.string.dialog_cancel)
-                .customView(dialogView, false)
-                .onNegative((dialog, which) -> onDeckSelected(null))
-                .onNeutral((dialog, which) -> {
-                });;
+        MaterialDialog.Builder builder;
         if (arguments.getBoolean("keepRestoreDefaultButton")) {
-            builder = builder.negativeText(R.string.restore_default).onNegative((dialog, which) -> onDeckSelected(null));
+            builder = new MaterialDialog.Builder(requireActivity())
+                    .neutralText(R.string.dialog_cancel)
+                    .negativeText(R.string.restore_default)
+                    .customView(dialogView, false)
+                    .onNegative((dialog, which) -> onDeckSelected(null))
+                    .onNeutral((dialog, which) -> {
+                    });
+        } else {
+            builder = new MaterialDialog.Builder(requireActivity())
+                    .neutralText(R.string.dialog_cancel)
+                    .customView(dialogView, false)
+                    .onNegative((dialog, which) -> onDeckSelected(null))
+                    .onNeutral((dialog, which) -> {
+                    });
         }
-
         mDialog = builder.build();
         return mDialog;
     }

--- a/AnkiDroid/src/main/res/values/01-core.xml
+++ b/AnkiDroid/src/main/res/values/01-core.xml
@@ -138,6 +138,7 @@
     <string name="custom_study_deck_name">Custom study session</string>
     <string name="custom_study_deck_exists">Rename the existing custom study deck first</string>
     <string name="empty_deck">This deck is empty</string>
+    <string name="search_deck">Deck Search</string>
     <string name="empty_deck_add_note">Add card</string>
     <string name="invalid_deck_name">Invalid deck name</string>
     <string name="studyoptions_empty">This deck is empty. Press the + button to add new content.</string>


### PR DESCRIPTION
Fixes #8276

## Need
With Current Spinner in add note activity user can select any deck , but
->If number of decks is very big it will be hard for user to search particular deck in spinner .
->Anki-desktop do have search decks feature.

## Work done till now:
1 Used `DeckSelectionDialog` class to implement search dialog.

## Output
<img src="https://user-images.githubusercontent.com/52353967/112660724-c14b6f00-8e7b-11eb-991d-28b1d27257d6.jpg" width="250" height="500" />----<img src="https://user-images.githubusercontent.com/52353967/112660726-c27c9c00-8e7b-11eb-855f-c767854e3af5.jpg" width="250" height="500" />
