### PR TITLE
Number of hours after which a backup new backup is created is changed…

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -209,6 +209,8 @@ apply from: "./jacoco.gradle"
 apply from: "../lint.gradle"
 
 dependencies {
+    implementation 'androidx.coordinatorlayout:coordinatorlayout:1.1.0'
+
     // Can possibly remove if upstream PR merges https://github.com/JakeWharton/timber/pull/398
     configurations.all {
         resolutionStrategy {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/BackupManager.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/BackupManager.java
@@ -53,7 +53,7 @@ public class BackupManager {
 
 
     /** Number of hours after which a backup new backup is created */
-    private static final int BACKUP_INTERVAL = 5;
+    private static final int BACKUP_INTERVAL = 24;
 
 
     /* Prevent class from being instantiated */

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 <p align="center">
 <img src="docs/graphics/logos/banner_readme.png"/>
 </p>
-
 <a href="https://github.com/ankidroid/Anki-Android/releases"><img src="https://img.shields.io/github/v/release/ankidroid/Anki-Android" alt="release"/></a>
 <a href="https://travis-ci.org/github/ankidroid/Anki-Android"><img src="https://img.shields.io/travis/ankidroid/Anki-Android" alt="build"/></a>
 <a href="https://opencollective.com/ankidroid"><img src="https://img.shields.io/opencollective/all/ankidroid" alt="Open Collective backers and sponsors"/></a>


### PR DESCRIPTION
… from 5 to 24.  24 hours is an ideal time frame, 5 hour is too early and will be more frequent.

## Pull Request template

## Purpose / Description
I think 5 hours of frequency for back up is too much.. It should be 24 hours ideally.

## Fixes
Fixes _Link to the issues._

## Approach
_How does this change address the problem?_

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration (SDK version(s), emulator or physical, etc)

## Learning (optional, can help others)
_Describe the research stage_

_Links to blog posts, patterns, libraries or addons used to solve this problem_

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
