### PR TITLE
Fixes #4312: All Undo actions carried out from DeckPicker open the Reviewer

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -1427,10 +1427,10 @@ public class DeckPicker extends NavigationDrawerActivity implements
 
 
         @Override
-        public void actualOnPostExecute(@NonNull DeckPicker deckPicker, BooleanGetter voi) {
+        public void actualOnPostExecute(@NonNull DeckPicker deckPicker, BooleanGetter success) {
             deckPicker.hideProgressBar();
             Timber.i("Undo completed");
-            if ((voi.getBoolean()) && (mUndoneCard != null)) {
+            if ((success.getBoolean()) && (mUndoneCard != null)) {
                 Timber.i("Review undone - opening reviewer.");
                 deckPicker.openReviewer();
             }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -143,6 +143,8 @@ import com.ichi2.widget.WidgetStatus;
 
 import com.ichi2.utils.JSONException;
 
+import org.jetbrains.annotations.NotNull;
+
 import java.io.File;
 import java.io.FileOutputStream;
 import java.util.List;
@@ -1395,15 +1397,14 @@ public class DeckPicker extends NavigationDrawerActivity implements
         }
     }
 
-    private UndoTaskListener undoTaskListener(boolean isReview) {
-        return new UndoTaskListener(isReview, this);
+    private UndoTaskListener undoTaskListener() {
+        return new UndoTaskListener(this);
     }
     private static class UndoTaskListener extends TaskListenerWithContext<DeckPicker, Card, BooleanGetter> {
-        private final boolean mIsreview;
+        Card mUndoneCard;
 
-        public UndoTaskListener(boolean isReview, DeckPicker deckPicker) {
+        public UndoTaskListener(DeckPicker deckPicker) {
             super(deckPicker);
-            this.mIsreview = isReview;
         }
 
 
@@ -1420,10 +1421,16 @@ public class DeckPicker extends NavigationDrawerActivity implements
 
 
         @Override
+        public void actualOnProgressUpdate(@NonNull @NotNull DeckPicker deckPicker, Card value) {
+            mUndoneCard = value;
+        }
+
+
+        @Override
         public void actualOnPostExecute(@NonNull DeckPicker deckPicker, BooleanGetter voi) {
             deckPicker.hideProgressBar();
             Timber.i("Undo completed");
-            if (mIsreview) {
+            if ((voi.getBoolean()) && (mUndoneCard != null)) {
                 Timber.i("Review undone - opening reviewer.");
                 deckPicker.openReviewer();
             }
@@ -1431,9 +1438,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
     }
     private void undo() {
         Timber.i("undo()");
-        String undoReviewString = getResources().getString(R.string.undo_action_review);
-        final boolean isReview = undoReviewString.equals(getCol().undoName(getResources()));
-        TaskManager.launchCollectionTask(new CollectionTask.Undo(), undoTaskListener(isReview));
+        TaskManager.launchCollectionTask(new CollectionTask.Undo(), undoTaskListener());
     }
 
 


### PR DESCRIPTION
## Purpose / Description
Undoing Bury Card on the last card of the deck does not navigate to the Reviewer and update the left, blue number

## Fixes
Fixes #4312 

## Behavior
After clicking on 'Undo Bury Card', the study screen with the card is displayed again, just as it is done when the last card is answered and then you chose "Undo bury card" - the expected behavior described in #4312. In addition, the leftmost blue number is updated immediately for both the suspend and bury action.

## Approach
Similar approach to that used for 'Undo Last Review'. Calls ```deckPicker.updateDeckList()``` in DeckPicker.java to update the blue number. 

## How Has This Been Tested?
* Tested on SAMSUNG SM-A805F API 29 (Physical Device)
* Pixel 3a XL API 27 (Emulator)

## Checklist

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code

No UI changes
