### PR TITLE
Ensures forbidden symbols are removed from new field names

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/ModelFieldEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ModelFieldEditor.java
@@ -226,9 +226,7 @@ public class ModelFieldEditor extends AnkiActivity implements LocaleSelectionDia
                         c.setArgs(getResources().getString(R.string.full_sync_confirmation));
                         Runnable confirm = () -> {
                             mCol.modSchemaNoCheck();
-                            String fieldName1 = mFieldNameInput.getText().toString()
-                                    .replaceAll("[\\n\\r]", "");
-                            TaskManager.launchCollectionTask(new CollectionTask.AddField(mMod, fieldName1), listener);
+                            TaskManager.launchCollectionTask(new CollectionTask.AddField(mMod, fieldName), listener);
                             dismissContextMenu();
                         };
 


### PR DESCRIPTION
Fixes #8388.

The same string `fieldName` should be used independently of whether there is an exception thrown
