### PR TITLE
fix: ACRA Crash Dialog - Can't enter additional information

### DIFF
--- a/AnkiDroid/src/main/res/layout/feedback.xml
+++ b/AnkiDroid/src/main/res/layout/feedback.xml
@@ -14,7 +14,7 @@
         android:layout_width="fill_parent"
         android:layout_height="wrap_content" >
 
-        <com.ichi2.ui.FixedEditText
+        <EditText
             android:id="@+id/etFeedbackText"
             android:layout_width="fill_parent"
             android:layout_height="wrap_content"


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
Issue is due to  com.ichi2.ui.FixedEditText replace it with Editext
## Fixes
#8380 

## How Has This Been Tested
Android Device:Redmi y3(api-29)

## Screenshot
![Screenshot_2021-03-30-14-02-11-828_com ichi2 anki](https://user-images.githubusercontent.com/65972015/112959037-a8370c80-9160-11eb-80e2-c100a7870326.jpg)


## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [x] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
