### PR TITLE
Toolbar nightmode support

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -2010,7 +2010,7 @@ public class NoteEditor extends AnkiActivity implements
 
         // Let the user add more buttons (always at the end).
         // Sets the add custom tag icon color.
-        final Drawable drawable = ResourcesCompat.getDrawable(getResources(),R.drawable.ic_add_toolbar_icon,null);
+        final Drawable drawable = ResourcesCompat.getDrawable(getResources(), R.drawable.ic_add_toolbar_icon, null);
         drawable.setTint(Themes.getColorFromAttr(NoteEditor.this, R.attr.toolbarIconColor));
         mToolbar.insertItem(0, drawable, this::displayAddToolbarDialog);
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -131,6 +131,7 @@ import java.util.Map;
 import java.util.Set;
 
 import androidx.core.content.ContextCompat;
+import androidx.core.content.res.ResourcesCompat;
 import androidx.core.text.HtmlCompat;
 import androidx.fragment.app.DialogFragment;
 import timber.log.Timber;
@@ -2009,7 +2010,7 @@ public class NoteEditor extends AnkiActivity implements
 
         // Let the user add more buttons (always at the end).
         // Sets the add custom tag icon color.
-        Drawable drawable = getResources().getDrawable(R.drawable.ic_add_toolbar_icon, getTheme());
+        final Drawable drawable = ResourcesCompat.getDrawable(getResources(),R.drawable.ic_add_toolbar_icon,null);
         drawable.setTint(Themes.getColorFromAttr(NoteEditor.this, R.attr.toolbarIconColor));
         mToolbar.insertItem(0, drawable, this::displayAddToolbarDialog);
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -27,7 +27,6 @@ import android.content.Intent;
 import android.content.IntentFilter;
 import android.content.SharedPreferences;
 import android.content.res.Resources;
-import android.graphics.Color;
 import android.graphics.Typeface;
 import android.graphics.drawable.Drawable;
 import android.net.Uri;
@@ -132,7 +131,6 @@ import java.util.Map;
 import java.util.Set;
 
 import androidx.core.content.ContextCompat;
-import androidx.core.graphics.drawable.DrawableCompat;
 import androidx.core.text.HtmlCompat;
 import androidx.fragment.app.DialogFragment;
 import timber.log.Timber;

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -27,6 +27,7 @@ import android.content.Intent;
 import android.content.IntentFilter;
 import android.content.SharedPreferences;
 import android.content.res.Resources;
+import android.graphics.Color;
 import android.graphics.Typeface;
 import android.graphics.drawable.Drawable;
 import android.net.Uri;
@@ -131,6 +132,7 @@ import java.util.Map;
 import java.util.Set;
 
 import androidx.core.content.ContextCompat;
+import androidx.core.graphics.drawable.DrawableCompat;
 import androidx.core.text.HtmlCompat;
 import androidx.fragment.app.DialogFragment;
 import timber.log.Timber;
@@ -473,6 +475,10 @@ public class NoteEditor extends AnkiActivity implements
             }
             modifyCurrentSelection(formatter, (FieldEditText) currentFocus);
         });
+
+        // Sets the background and icon color of toolbar respectively.
+        mToolbar.setBackgroundColor(Themes.getColorFromAttr(NoteEditor.this, R.attr.toolbarBackgroundColor));
+        mToolbar.setIconColor(Themes.getColorFromAttr(NoteEditor.this, R.attr.toolbarIconColor));
 
         enableToolbar(mainView);
 
@@ -1790,7 +1796,7 @@ public class NoteEditor extends AnkiActivity implements
 
         // Sets the background color of disabled EditText.
         if (!enabled) {
-            editText.setBackgroundColor(Themes.getColorFromAttr(NoteEditor.this,R.attr.editTextBackgroundColor));
+            editText.setBackgroundColor(Themes.getColorFromAttr(NoteEditor.this, R.attr.editTextBackgroundColor));
         }
         editText.setEnabled(enabled);
     }
@@ -2004,7 +2010,10 @@ public class NoteEditor extends AnkiActivity implements
         }
 
         // Let the user add more buttons (always at the end).
-        mToolbar.insertItem(0, R.drawable.ic_add_toolbar_icon, this::displayAddToolbarDialog);
+        // Sets the add custom tag icon color.
+        Drawable drawable = getResources().getDrawable(R.drawable.ic_add_toolbar_icon, getTheme());
+        drawable.setTint(Themes.getColorFromAttr(NoteEditor.this, R.attr.toolbarIconColor));
+        mToolbar.insertItem(0, drawable, this::displayAddToolbarDialog);
     }
 
     @NonNull

--- a/AnkiDroid/src/main/java/com/ichi2/anki/noteeditor/Toolbar.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/noteeditor/Toolbar.java
@@ -45,6 +45,7 @@ import com.ichi2.utils.ViewGroupUtils;
 import java.util.ArrayList;
 import java.util.List;
 
+import androidx.annotation.ColorInt;
 import androidx.annotation.DrawableRes;
 import androidx.annotation.IdRes;
 import androidx.annotation.NonNull;
@@ -305,6 +306,14 @@ public class Toolbar extends FrameLayout {
         }
 
         mFormatCallback.performFormat(formatter);
+    }
+
+    public void setIconColor(@ColorInt int color) {
+        for (int i = 0; i < this.mToolbar.getChildCount(); i++) {
+            AppCompatImageButton button = (AppCompatImageButton) this.mToolbar.getChildAt(i);
+            button.setColorFilter(color);
+        }
+        mStringPaint.setColor(color);
     }
 
 

--- a/AnkiDroid/src/main/res/layout/note_editor.xml
+++ b/AnkiDroid/src/main/res/layout/note_editor.xml
@@ -140,7 +140,6 @@
     </LinearLayout>
 
     <com.ichi2.anki.noteeditor.Toolbar
-        android:background="#D6D7D7"
         android:layout_gravity="bottom"
         android:id="@+id/editor_toolbar"
         android:layout_width="match_parent"

--- a/AnkiDroid/src/main/res/values/attrs.xml
+++ b/AnkiDroid/src/main/res/values/attrs.xml
@@ -100,6 +100,8 @@
     <!-- Note editor colors -->
     <attr name="duplicateColor" format="color"/>
     <attr name="editTextBackgroundColor" format="color"/>
+    <attr name="toolbarBackgroundColor" format="color"/>
+    <attr name="toolbarIconColor" format="color"/>
     <!-- Images -->
     <attr name="navDrawerImage" format="integer"/>
     <attr name="attachFileImage" format="integer"/>

--- a/AnkiDroid/src/main/res/values/theme_black.xml
+++ b/AnkiDroid/src/main/res/values/theme_black.xml
@@ -90,6 +90,8 @@
         <item name="duplicateColor">#855</item>
         <!-- Note editor colors -->
         <item name="editTextBackgroundColor">#EE5C5C5C</item>
+        <item name="toolbarBackgroundColor">#616161</item>
+        <item name="toolbarIconColor">@color/white</item>
         <!-- FAB -->
         <item name="fab_normal">#ff303030</item>
         <item name="fab_pressed">#c8303030</item> <!-- 55 less opacity than fab_normal -->

--- a/AnkiDroid/src/main/res/values/theme_dark.xml
+++ b/AnkiDroid/src/main/res/values/theme_dark.xml
@@ -93,6 +93,8 @@
         <!-- Note editor colors -->
         <item name="duplicateColor">#855</item>
         <item name="editTextBackgroundColor">#EE5C5C5C</item>
+        <item name="toolbarBackgroundColor">#616161</item>
+        <item name="toolbarIconColor">@color/white</item>
         <!-- FAB -->
         <item name="fab_normal">@color/material_light_blue_700</item>
         <item name="fab_pressed">@color/material_light_blue_900</item>

--- a/AnkiDroid/src/main/res/values/theme_light.xml
+++ b/AnkiDroid/src/main/res/values/theme_light.xml
@@ -107,6 +107,8 @@ APIs. It's visible when there aren't enough decks to fill the screen.
         <!-- Note editor colors -->
         <item name="duplicateColor">#fcc</item>
         <item name="editTextBackgroundColor">#EBCCCCCC</item>
+        <item name="toolbarBackgroundColor">#D6D7D7</item>
+        <item name="toolbarIconColor">@color/black</item>
         <!-- FAB -->
         <item name="fab_normal">@color/material_light_blue_700</item>
         <item name="fab_pressed">@color/material_light_blue_900</item>

--- a/AnkiDroid/src/main/res/values/theme_plain.xml
+++ b/AnkiDroid/src/main/res/values/theme_plain.xml
@@ -37,6 +37,8 @@
         <item name="cardBrowserDivider">?attr/dividerHorizontal</item>
         <!-- Note editor colors -->
         <item name="editTextBackgroundColor">#EBCCCCCC</item>
+        <item name="toolbarBackgroundColor">#D6D7D7</item>
+        <item name="toolbarIconColor">@color/black</item>
         <!-- FAB -->
         <item name="fab_normal">@color/theme_plain_accent</item>
         <item name="fab_pressed">#c8607d8b</item> <!-- 55 less opacity than fab_normal -->


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
Added toolbar support for night mode.

## Fixes
Fixes #7832

## Approach
_How does this change address the problem?_

- I changed the toolbar background color to light grey or dark grey depending on the theme.
- I have created a method that changes the icon color to white or black depending on the theme.
- I have changed the Tint of the existing add custom tag icon depending on the theme.

## How Has This Been Tested?

Tested on Samsung Galaxy M51, android 11 (Samsung One UI 3.1)

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [x] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
