### PR TITLE
Lookup button enabled/disabled depending on Lookup Dictionary preference 

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -23,6 +23,7 @@ package com.ichi2.anki;
 
 import android.annotation.SuppressLint;
 import android.annotation.TargetApi;
+import android.app.Application;
 import android.content.ActivityNotFoundException;
 import android.content.BroadcastReceiver;
 import android.content.ClipData;
@@ -87,6 +88,7 @@ import android.widget.ImageView;
 import android.widget.LinearLayout;
 import android.widget.RelativeLayout;
 import android.widget.TextView;
+import android.widget.Toast;
 
 import com.afollestad.materialdialogs.MaterialDialog;
 import com.drakeet.drawer.FullDraggableContainer;
@@ -1339,12 +1341,17 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
             Timber.d("Clipboard has text = %b", clipboardHasText());
             lookUp();
         } else {
-            selectAndCopyText();
+
+            UIUtils.showThemedToast(AbstractFlashcardViewer.this, "Clipboard is empty" , false);
+
+//            selectAndCopyText();
         }
     }
 
 
     private void lookUp() {
+
+
         mLookUpIcon.setVisibility(View.GONE);
         mIsSelecting = false;
         if (Lookup.lookUp(clipboardGetText().toString())) {
@@ -2574,6 +2581,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
             processCardAction(shiftPressEvent::dispatch);
             shiftPressEvent.isShiftPressed();
             mIsSelecting = true;
+
         } catch (Exception e) {
             throw new AssertionError(e);
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -23,7 +23,6 @@ package com.ichi2.anki;
 
 import android.annotation.SuppressLint;
 import android.annotation.TargetApi;
-import android.app.Application;
 import android.content.ActivityNotFoundException;
 import android.content.BroadcastReceiver;
 import android.content.ClipData;
@@ -88,7 +87,7 @@ import android.widget.ImageView;
 import android.widget.LinearLayout;
 import android.widget.RelativeLayout;
 import android.widget.TextView;
-import android.widget.Toast;
+
 
 import com.afollestad.materialdialogs.MaterialDialog;
 import com.drakeet.drawer.FullDraggableContainer;
@@ -1341,17 +1340,12 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
             Timber.d("Clipboard has text = %b", clipboardHasText());
             lookUp();
         } else {
-
             UIUtils.showThemedToast(AbstractFlashcardViewer.this, "Clipboard is empty" , false);
-
-//            selectAndCopyText();
         }
     }
 
 
     private void lookUp() {
-
-
         mLookUpIcon.setVisibility(View.GONE);
         mIsSelecting = false;
         if (Lookup.lookUp(clipboardGetText().toString())) {
@@ -2581,7 +2575,6 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
             processCardAction(shiftPressEvent::dispatch);
             shiftPressEvent.isShiftPressed();
             mIsSelecting = true;
-
         } catch (Exception e) {
             throw new AssertionError(e);
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Lookup.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Lookup.java
@@ -6,7 +6,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.net.Uri;
-import android.widget.Toast;
+
 
 import com.afollestad.materialdialogs.MaterialDialog;
 import com.ichi2.anki.analytics.UsageAnalytics;
@@ -71,13 +71,11 @@ public class Lookup {
                 break;
         }
         Timber.v("Is intent available = %b", mIsDictionaryAvailable);
-
         return mIsDictionaryAvailable;
     }
 
 
     public static boolean lookUp(String text) {
-        Timber.d("Dictionary optioooon:"+String.valueOf(mIsDictionaryAvailable));
         if (!mIsDictionaryAvailable) {
             return false;
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Lookup.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Lookup.java
@@ -6,6 +6,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.net.Uri;
+import android.widget.Toast;
 
 import com.afollestad.materialdialogs.MaterialDialog;
 import com.ichi2.anki.analytics.UsageAnalytics;
@@ -70,11 +71,13 @@ public class Lookup {
                 break;
         }
         Timber.v("Is intent available = %b", mIsDictionaryAvailable);
+
         return mIsDictionaryAvailable;
     }
 
 
     public static boolean lookUp(String text) {
+        Timber.d("Dictionary optioooon:"+String.valueOf(mIsDictionaryAvailable));
         if (!mIsDictionaryAvailable) {
             return false;
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.java
@@ -1186,9 +1186,6 @@ public class Reviewer extends AbstractFlashcardViewer {
         mWhiteboard.setEnabled(true);
     }
 
-
-
-
     // Show or hide the whiteboard
     private void setWhiteboardVisibility(boolean state) {
         mShowWhiteboard = state;

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.java
@@ -1186,6 +1186,9 @@ public class Reviewer extends AbstractFlashcardViewer {
         mWhiteboard.setEnabled(true);
     }
 
+
+
+
     // Show or hide the whiteboard
     private void setWhiteboardVisibility(boolean state) {
         mShowWhiteboard = state;

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/ActionButtonStatus.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/ActionButtonStatus.java
@@ -66,10 +66,13 @@ public class ActionButtonStatus {
         setupButton(preferences, R.id.action_toggle_whiteboard, "customButtonEnableWhiteboard", SHOW_AS_ACTION_NEVER);
         setupButton(preferences, R.id.action_save_whiteboard, "customButtonSaveWhiteboard", SHOW_AS_ACTION_NEVER);
         setupButton(preferences, R.id.action_change_whiteboard_pen_color, "customButtonWhiteboardPenColor", SHOW_AS_ACTION_IF_ROOM);
-        if(Lookup.isAvailable())
+        if(Lookup.isAvailable()){  //checks if Lookup Dictionary preference is enabled
             setupButton(preferences, R.id.action_search_dictionary, "customButtonSearchDictionary",SHOW_AS_ACTION_IF_ROOM);
-        else
+        }
+        else{
             setupButton(preferences, R.id.action_search_dictionary, "customButtonSearchDictionary",MENU_DISABLED);
+        }
+
     }
 
 
@@ -136,6 +139,4 @@ public class ActionButtonStatus {
     public boolean whiteboardPenColorIsDisabled() {
         return mCustomButtons.get(R.id.action_change_whiteboard_pen_color) == MENU_DISABLED;
     }
-
-
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/ActionButtonStatus.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/ActionButtonStatus.java
@@ -5,6 +5,7 @@ import android.graphics.drawable.Drawable;
 import android.view.Menu;
 import android.view.MenuItem;
 
+import com.ichi2.anki.Lookup;
 import com.ichi2.anki.R;
 import com.ichi2.themes.Themes;
 
@@ -65,6 +66,10 @@ public class ActionButtonStatus {
         setupButton(preferences, R.id.action_toggle_whiteboard, "customButtonEnableWhiteboard", SHOW_AS_ACTION_NEVER);
         setupButton(preferences, R.id.action_save_whiteboard, "customButtonSaveWhiteboard", SHOW_AS_ACTION_NEVER);
         setupButton(preferences, R.id.action_change_whiteboard_pen_color, "customButtonWhiteboardPenColor", SHOW_AS_ACTION_IF_ROOM);
+        if(Lookup.isAvailable())
+            setupButton(preferences, R.id.action_search_dictionary, "customButtonSearchDictionary",SHOW_AS_ACTION_IF_ROOM);
+        else
+            setupButton(preferences, R.id.action_search_dictionary, "customButtonSearchDictionary",MENU_DISABLED);
     }
 
 
@@ -131,4 +136,6 @@ public class ActionButtonStatus {
     public boolean whiteboardPenColorIsDisabled() {
         return mCustomButtons.get(R.id.action_change_whiteboard_pen_color) == MENU_DISABLED;
     }
+
+
 }

--- a/AnkiDroid/src/main/res/menu/reviewer.xml
+++ b/AnkiDroid/src/main/res/menu/reviewer.xml
@@ -118,7 +118,7 @@
     <item
         android:id="@+id/action_search_dictionary"
         android:title="@string/menu_select"
-        android:visible="false"/>
+        />
     <item
         android:id="@+id/action_open_deck_options"
         android:title="@string/menu__deck_options" />

--- a/AnkiDroid/src/main/res/xml/preferences_custom_buttons.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_custom_buttons.xml
@@ -102,6 +102,12 @@ TODO: Add a unit test
             android:entryValues="@array/custom_button_values"
             android:key="customButtonToggleMicToolBar"
             android:title="@string/menu_toggle_mic_tool_bar" />
+        <ListPreference
+            android:defaultValue="0"
+            android:entries="@array/custom_button_labels"
+            android:entryValues="@array/custom_button_values"
+            android:key="customButtonSearchDictionary"
+            android:title="@string/menu_select" />
     </PreferenceCategory>
     <PreferenceCategory android:title="@string/menu_dismiss_note" >
         <ListPreference


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
Made the select text Action Button visible/invisible depending on the Look Up dictionary preference and made the button display a toast if no text was selected.

## Fixes
Fixes #7679

## Checklist
_Please, go through these checks before submitting the PR._

- [ x ] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [ x ] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ x ] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [ x ] You have commented your code, particularly in hard-to-understand areas
- [ x ] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
