### PR TITLE
Fixes #8287 Fail CI if Analytics string constants are changed

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/analytics/AnalyticsConstant.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/analytics/AnalyticsConstant.java
@@ -1,0 +1,29 @@
+/*
+ Copyright (c) 2021 Mrudul Tora <mrudultora@gmail.com>
+ This program is free software; you can redistribute it and/or modify it under
+ the terms of the GNU General Public License as published by the Free Software
+ Foundation; either version 3 of the License, or (at your option) any later
+ version.
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ You should have received a copy of the GNU General Public License along with
+ this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.analytics;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * This marker annotation is used for annotating string constants used in Analytics.
+ */
+
+@Target(ElementType.FIELD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface AnalyticsConstant {
+
+}

--- a/AnkiDroid/src/main/java/com/ichi2/anki/analytics/UsageAnalytics.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/analytics/UsageAnalytics.java
@@ -358,6 +358,7 @@ public class UsageAnalytics {
     }
 
 
+
     public static class Category {
         public static final String SYNC = "Sync";
         public static final String LINK_CLICKED = "LinkClicked";

--- a/AnkiDroid/src/main/java/com/ichi2/anki/analytics/UsageAnalytics.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/analytics/UsageAnalytics.java
@@ -366,6 +366,7 @@ public class UsageAnalytics {
     /**
      * These Strings must not be changed as they are used for analytic comparisons between AnkiDroid versions.
      * If a new string is added here then the respective changes must also be made in AnalyticsConstantsTest.java
+     * All the constant strings added here must be annotated with @AnalyticsConstant.
      */
     public static class Actions {
         /* Analytics actions used in Help Dialog*/

--- a/AnkiDroid/src/main/java/com/ichi2/anki/analytics/UsageAnalytics.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/analytics/UsageAnalytics.java
@@ -358,7 +358,6 @@ public class UsageAnalytics {
     }
 
 
-
     public static class Category {
         public static final String SYNC = "Sync";
         public static final String LINK_CLICKED = "LinkClicked";
@@ -366,38 +365,67 @@ public class UsageAnalytics {
 
     /**
      * These Strings must not be changed as they are used for analytic comparisons between AnkiDroid versions.
+     * If a new string is added here then the respective changes must also be made in AnalyticsConstantsTest.java
      */
     public static class Actions {
         /* Analytics actions used in Help Dialog*/
+        @AnalyticsConstant
         public static final String OPENED_HELPDIALOG = "Opened HelpDialogBox";
+        @AnalyticsConstant
         public static final String OPENED_USING_ANKIDROID = "Opened Using AnkiDroid";
+        @AnalyticsConstant
         public static final String OPENED_GET_HELP = "Opened Get Help";
+        @AnalyticsConstant
         public static final String OPENED_SUPPORT_ANKIDROID = "Opened Support AnkiDroid";
+        @AnalyticsConstant
         public static final String OPENED_COMMUNITY = "Opened Community";
+        @AnalyticsConstant
         public static final String OPENED_ANKIDROID_MANUAL = "Opened AnkiDroid Manual";
+        @AnalyticsConstant
         public static final String OPENED_ANKI_MANUAL = "Opened Anki Manual";
+        @AnalyticsConstant
         public static final String OPENED_ANKIDROID_FAQ = "Opened AnkiDroid FAQ";
+        @AnalyticsConstant
         public static final String OPENED_MAILING_LIST = "Opened Mailing List";
+        @AnalyticsConstant
         public static final String OPENED_REPORT_BUG = "Opened Report a Bug";
+        @AnalyticsConstant
         public static final String OPENED_DONATE = "Opened Donate";
+        @AnalyticsConstant
         public static final String OPENED_TRANSLATE = "Opened Translate";
+        @AnalyticsConstant
         public static final String OPENED_DEVELOP = "Opened Develop";
+        @AnalyticsConstant
         public static final String OPENED_RATE = "Opened Rate";
+        @AnalyticsConstant
         public static final String OPENED_OTHER = "Opened Other";
+        @AnalyticsConstant
         public static final String OPENED_SEND_FEEDBACK = "Opened Send Feedback";
+        @AnalyticsConstant
         public static final String OPENED_ANKI_FORUMS = "Opened Anki Forums";
+        @AnalyticsConstant
         public static final String OPENED_REDDIT = "Opened Reddit";
+        @AnalyticsConstant
         public static final String OPENED_DISCORD = "Opened Discord";
+        @AnalyticsConstant
         public static final String OPENED_FACEBOOK = "Opened Facebook";
+        @AnalyticsConstant
         public static final String OPENED_TWITTER = "Opened Twitter";
+        @AnalyticsConstant
         public static final String EXCEPTION_REPORT = "Exception Report";
 
         /* Analytics actions used in Lookup Dictionary */
+        @AnalyticsConstant
         public static final String AEDICT = "aedict";
+        @AnalyticsConstant
         public static final String LEO = "leo";
+        @AnalyticsConstant
         public static final String COLORDICT = "colordict";
+        @AnalyticsConstant
         public static final String FORA = "fora";
+        @AnalyticsConstant
         public static final String NCIKU = "nciku";
+        @AnalyticsConstant
         public static final String EIJIRO = "eijiro";
     }
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/analytics/AnalyticsConstantsTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/analytics/AnalyticsConstantsTest.java
@@ -31,7 +31,7 @@ public class AnalyticsConstantsTest {
 
     @RunWith(Parameterized.class)
     public static class AnalyticsConstantsFieldValuesTest {
-        private String analyticsString;
+        private final String analyticsString;
 
 
         public AnalyticsConstantsFieldValuesTest(String analyticsString) {
@@ -105,7 +105,14 @@ public class AnalyticsConstantsTest {
 
         @Test
         public void fieldSizeEqualsListOfConstantFields() {
-            assertEquals("Add the new constant here also in the list listOfConstantFields", listOfConstantFields.size(), getFieldSize());
+            if (getFieldSize() > listOfConstantFields.size()) {
+                assertEquals("Add the new constant here also in the list listOfConstantFields", listOfConstantFields.size(), getFieldSize());
+            } else if (getFieldSize() < listOfConstantFields.size()) {
+                assertEquals("Remove the constant from the list listOfConstantFields", listOfConstantFields.size(), getFieldSize());
+            } else {
+                assertEquals(listOfConstantFields.size(), getFieldSize());
+            }
+
         }
 
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/analytics/AnalyticsConstantsTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/analytics/AnalyticsConstantsTest.java
@@ -86,7 +86,7 @@ public class AnalyticsConstantsTest {
          */
         @Test
         public void checkAnalyticsString() {
-            assertEquals("There is no such string in Actions class, thus returning null. Re-check if you renamed any string in the analytics string constants of Actions class or AnalyticsConstantsTest.listOfConstantFields. If so, revert them as those string constants must not change as they are compared in analytics.",
+            assertEquals("Re-check if you renamed any string in the analytics string constants of Actions class or AnalyticsConstantsTest.listOfConstantFields. If so, revert them as those string constants must not change as they are compared in analytics.",
                     analyticsString, getStringFromReflection(analyticsString));
         }
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/analytics/AnalyticsConstantsTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/analytics/AnalyticsConstantsTest.java
@@ -1,0 +1,78 @@
+/*
+ Copyright (c) 2021 Mrudul Tora <mrudultora@gmail.com>
+ This program is free software; you can redistribute it and/or modify it under
+ the terms of the GNU General Public License as published by the Free Software
+ Foundation; either version 3 of the License, or (at your option) any later
+ version.
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ You should have received a copy of the GNU General Public License along with
+ this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.analytics;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class AnalyticsConstantsTest {
+    private final List<String> listOfConstantFields = new ArrayList<>();
+
+
+    @Before
+    public void addAnalyticsConstants() {
+        listOfConstantFields.add("Opened HelpDialogBox");
+        listOfConstantFields.add("Opened Using AnkiDroid");
+        listOfConstantFields.add("Opened Get Help");
+        listOfConstantFields.add("Opened Support AnkiDroid");
+        listOfConstantFields.add("Opened Community");
+        listOfConstantFields.add("Opened AnkiDroid Manual");
+        listOfConstantFields.add("Opened Anki Manual");
+        listOfConstantFields.add("Opened AnkiDroid FAQ");
+        listOfConstantFields.add("Opened Mailing List");
+        listOfConstantFields.add("Opened Report a Bug");
+        listOfConstantFields.add("Opened Donate");
+        listOfConstantFields.add("Opened Translate");
+        listOfConstantFields.add("Opened Develop");
+        listOfConstantFields.add("Opened Rate");
+        listOfConstantFields.add("Opened Other");
+        listOfConstantFields.add("Opened Send Feedback");
+        listOfConstantFields.add("Opened Anki Forums");
+        listOfConstantFields.add("Opened Reddit");
+        listOfConstantFields.add("Opened Discord");
+        listOfConstantFields.add("Opened Facebook");
+        listOfConstantFields.add("Opened Twitter");
+        listOfConstantFields.add("Exception Report");
+        listOfConstantFields.add("aedict");
+        listOfConstantFields.add("leo");
+        listOfConstantFields.add("colordict");
+        listOfConstantFields.add("fora");
+        listOfConstantFields.add("nciku");
+        listOfConstantFields.add("eijiro");
+    }
+
+
+    @Test
+    public void checkAnalyticsString() {
+        UsageAnalytics.Actions actions = new UsageAnalytics.Actions();
+        Field[] field;
+        field = actions.getClass().getDeclaredFields();
+        for (int i = 0; i < field.length; i++) {
+            if (field[i].isAnnotationPresent(AnalyticsConstant.class)) {
+                try {
+                    assertThat(field[i].get(actions), is(listOfConstantFields.get(i)));
+                } catch (IllegalAccessException e) {
+                    e.printStackTrace();
+                }
+            }
+        }
+    }
+}

--- a/AnkiDroid/src/test/java/com/ichi2/anki/analytics/AnalyticsConstantsTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/analytics/AnalyticsConstantsTest.java
@@ -24,6 +24,11 @@ import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 
+/**
+ * This class contains two nested classes and is using the concept of Enclosed runner that internally works as a Suite.
+ * The first inner class is a Parameterized class and will run according to the size of test case, while the second
+ * inner class is non-parameterized and will run only once.
+ */
 @RunWith(Enclosed.class)
 public class AnalyticsConstantsTest {
     private static final List<String> listOfConstantFields = new ArrayList<>();
@@ -73,6 +78,11 @@ public class AnalyticsConstantsTest {
         }
 
 
+        /**
+         * The message here means that the string being checked cannot be found in Actions class.
+         * If encountered with this message, re-check the list present here and constants in Actions class, to resolve
+         * the test failure.
+         */
         @Test
         public void checkAnalyticsString() {
             assertEquals("There is no such string in Actions class, thus returning null.", analyticsString, getStringFromReflection(analyticsString));
@@ -84,11 +94,11 @@ public class AnalyticsConstantsTest {
             UsageAnalytics.Actions actions = new UsageAnalytics.Actions();
             Field[] field;
             field = actions.getClass().getDeclaredFields();
-            for (int i = 0; i < field.length; i++) {
-                if (field[i].isAnnotationPresent(AnalyticsConstant.class)) {
+            for (Field value : field) {
+                if (value.isAnnotationPresent(AnalyticsConstant.class)) {
                     try {
-                        if (field[i].get(actions).equals(analyticsStringToBeChecked)) {
-                            reflectedString = (String) field[i].get(actions);
+                        if (value.get(actions).equals(analyticsStringToBeChecked)) {
+                            reflectedString = (String) value.get(actions);
                         }
                     } catch (IllegalAccessException e) {
                         throw new RuntimeException();
@@ -117,7 +127,7 @@ public class AnalyticsConstantsTest {
 
 
         /**
-         * This method is used to get th size of fields in Actions Class.
+         * This method is used to get the size of fields in Actions Class.
          * Because whenever a new constant is added in Actions Class but not added to the list present in this
          * class (listOfConstantFields) the test must fail.
          */

--- a/AnkiDroid/src/test/java/com/ichi2/anki/analytics/AnalyticsConstantsTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/analytics/AnalyticsConstantsTest.java
@@ -13,66 +13,112 @@
 
 package com.ichi2.anki.analytics;
 
-import org.junit.Before;
 import org.junit.Test;
+import org.junit.experimental.runners.Enclosed;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
 import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertEquals;
 
+@RunWith(Enclosed.class)
 public class AnalyticsConstantsTest {
-    private final List<String> listOfConstantFields = new ArrayList<>();
+    private static final List<String> listOfConstantFields = new ArrayList<>();
 
 
-    @Before
-    public void addAnalyticsConstants() {
-        listOfConstantFields.add("Opened HelpDialogBox");
-        listOfConstantFields.add("Opened Using AnkiDroid");
-        listOfConstantFields.add("Opened Get Help");
-        listOfConstantFields.add("Opened Support AnkiDroid");
-        listOfConstantFields.add("Opened Community");
-        listOfConstantFields.add("Opened AnkiDroid Manual");
-        listOfConstantFields.add("Opened Anki Manual");
-        listOfConstantFields.add("Opened AnkiDroid FAQ");
-        listOfConstantFields.add("Opened Mailing List");
-        listOfConstantFields.add("Opened Report a Bug");
-        listOfConstantFields.add("Opened Donate");
-        listOfConstantFields.add("Opened Translate");
-        listOfConstantFields.add("Opened Develop");
-        listOfConstantFields.add("Opened Rate");
-        listOfConstantFields.add("Opened Other");
-        listOfConstantFields.add("Opened Send Feedback");
-        listOfConstantFields.add("Opened Anki Forums");
-        listOfConstantFields.add("Opened Reddit");
-        listOfConstantFields.add("Opened Discord");
-        listOfConstantFields.add("Opened Facebook");
-        listOfConstantFields.add("Opened Twitter");
-        listOfConstantFields.add("Exception Report");
-        listOfConstantFields.add("aedict");
-        listOfConstantFields.add("leo");
-        listOfConstantFields.add("colordict");
-        listOfConstantFields.add("fora");
-        listOfConstantFields.add("nciku");
-        listOfConstantFields.add("eijiro");
+    @RunWith(Parameterized.class)
+    public static class AnalyticsConstantsFieldValuesTest {
+        private String analyticsString;
+
+
+        public AnalyticsConstantsFieldValuesTest(String analyticsString) {
+            this.analyticsString = analyticsString;
+        }
+
+
+        @Parameterized.Parameters
+        public static List<String> addAnalyticsConstants() {
+            listOfConstantFields.add("Opened HelpDialogBox");
+            listOfConstantFields.add("Opened Using AnkiDroid");
+            listOfConstantFields.add("Opened Get Help");
+            listOfConstantFields.add("Opened Support AnkiDroid");
+            listOfConstantFields.add("Opened Community");
+            listOfConstantFields.add("Opened AnkiDroid Manual");
+            listOfConstantFields.add("Opened Anki Manual");
+            listOfConstantFields.add("Opened AnkiDroid FAQ");
+            listOfConstantFields.add("Opened Mailing List");
+            listOfConstantFields.add("Opened Report a Bug");
+            listOfConstantFields.add("Opened Donate");
+            listOfConstantFields.add("Opened Translate");
+            listOfConstantFields.add("Opened Develop");
+            listOfConstantFields.add("Opened Rate");
+            listOfConstantFields.add("Opened Other");
+            listOfConstantFields.add("Opened Send Feedback");
+            listOfConstantFields.add("Opened Anki Forums");
+            listOfConstantFields.add("Opened Reddit");
+            listOfConstantFields.add("Opened Discord");
+            listOfConstantFields.add("Opened Facebook");
+            listOfConstantFields.add("Opened Twitter");
+            listOfConstantFields.add("Exception Report");
+            listOfConstantFields.add("aedict");
+            listOfConstantFields.add("leo");
+            listOfConstantFields.add("colordict");
+            listOfConstantFields.add("fora");
+            listOfConstantFields.add("nciku");
+            listOfConstantFields.add("eijiro");
+            return listOfConstantFields;
+        }
+
+
+        @Test
+        public void checkAnalyticsString() {
+            assertEquals("There is no such string in Actions class, thus returning null.", analyticsString, getStringFromReflection(analyticsString));
+        }
+
+
+        public String getStringFromReflection(String analyticsStringToBeChecked) {
+            String reflectedString = null;
+            UsageAnalytics.Actions actions = new UsageAnalytics.Actions();
+            Field[] field;
+            field = actions.getClass().getDeclaredFields();
+            for (int i = 0; i < field.length; i++) {
+                if (field[i].isAnnotationPresent(AnalyticsConstant.class)) {
+                    try {
+                        if (field[i].get(actions).equals(analyticsStringToBeChecked)) {
+                            reflectedString = (String) field[i].get(actions);
+                        }
+                    } catch (IllegalAccessException e) {
+                        throw new RuntimeException();
+                    }
+                }
+            }
+            return reflectedString;
+        }
+
     }
 
 
-    @Test
-    public void checkAnalyticsString() {
-        UsageAnalytics.Actions actions = new UsageAnalytics.Actions();
-        Field[] field;
-        field = actions.getClass().getDeclaredFields();
-        for (int i = 0; i < field.length; i++) {
-            if (field[i].isAnnotationPresent(AnalyticsConstant.class)) {
-                try {
-                    assertThat(field[i].get(actions), is(listOfConstantFields.get(i)));
-                } catch (IllegalAccessException e) {
-                    e.printStackTrace();
-                }
-            }
+    public static class AnalyticsConstantsFieldLengthTest {
+
+        @Test
+        public void fieldSizeEqualsListOfConstantFields() {
+            assertEquals("Add the new constant here also in the list listOfConstantFields", listOfConstantFields.size(), getFieldSize());
+        }
+
+
+        /**
+         * This method is used to get th size of fields in Actions Class.
+         * Because whenever a new constant is added in Actions Class but not added to the list present in this
+         * class (listOfConstantFields) the test must fail.
+         */
+        public static int getFieldSize() {
+            UsageAnalytics.Actions actions = new UsageAnalytics.Actions();
+            Field[] field;
+            field = actions.getClass().getDeclaredFields();
+            return field.length;
         }
     }
 }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/analytics/AnalyticsConstantsTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/analytics/AnalyticsConstantsTest.java
@@ -86,7 +86,8 @@ public class AnalyticsConstantsTest {
          */
         @Test
         public void checkAnalyticsString() {
-            assertEquals("There is no such string in Actions class, thus returning null.", analyticsString, getStringFromReflection(analyticsString));
+            assertEquals("There is no such string in Actions class, thus returning null. Re-check if you renamed any string in the analytics string constants of Actions class or AnalyticsConstantsTest.listOfConstantFields. If so, revert them as those string constants must not change as they are compared in analytics.",
+                    analyticsString, getStringFromReflection(analyticsString));
         }
 
 
@@ -117,9 +118,11 @@ public class AnalyticsConstantsTest {
         @Test
         public void fieldSizeEqualsListOfConstantFields() {
             if (getFieldSize() > listOfConstantFields.size()) {
-                assertEquals("Add the new constant here also in the list listOfConstantFields", listOfConstantFields.size(), getFieldSize());
+                assertEquals("Add the newly added analytics constant to AnalyticsConstantsTest.listOfConstantFields. NOTE: Constants should not be renamed as we cannot compare these in analytics.",
+                        listOfConstantFields.size(), getFieldSize());
             } else if (getFieldSize() < listOfConstantFields.size()) {
-                assertEquals("Remove the constant from the list listOfConstantFields", listOfConstantFields.size(), getFieldSize());
+                assertEquals("If a constant is removed, it should be removed from AnalyticsConstantsTest.listOfConstantFields. NOTE: Constants should not be renamed as we cannot compare these in analytics.",
+                        listOfConstantFields.size(), getFieldSize());
             } else {
                 assertEquals(listOfConstantFields.size(), getFieldSize());
             }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/analytics/AnalyticsConstantsTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/analytics/AnalyticsConstantsTest.java
@@ -20,6 +20,7 @@ import org.junit.runners.Parameterized;
 
 import java.lang.reflect.Field;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
@@ -131,11 +132,10 @@ public class AnalyticsConstantsTest {
          * Because whenever a new constant is added in Actions Class but not added to the list present in this
          * class (listOfConstantFields) the test must fail.
          */
-        public static int getFieldSize() {
-            UsageAnalytics.Actions actions = new UsageAnalytics.Actions();
-            Field[] field;
-            field = actions.getClass().getDeclaredFields();
-            return field.length;
+        public static long getFieldSize() {
+            return Arrays.stream(UsageAnalytics.Actions.class.getDeclaredFields())
+                    .filter(x -> x.isAnnotationPresent(AnalyticsConstant.class))
+                    .count();
         }
     }
 }


### PR DESCRIPTION
## Purpose / Description
Strings used in analytics must not change. So, CI must be failed if changes are made to those.

## Fixes
Fixes #8287 

## Approach
Added a custom annotation `@AnalyticsConstant` and fetched the fields via reflection and checked them with hardcoded fields in the unit test.

## How Has This Been Tested?
Ran the test in Android Studio.

## Learning (optional, can help others)
• Working with Annotations.
• Working with Java Reflection.
• If anyone wants to learn about Parameterized test then this PR would be helpful.

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [x] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
