### PR TITLE
NF: Remove DismissType

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -148,7 +148,6 @@ import java.net.URLDecoder;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.locks.Lock;
@@ -1387,7 +1386,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
                 .onPositive((dialog, which) -> {
                     Timber.i("AbstractFlashcardViewer:: OK button pressed to delete note %d", mCurrentCard.getNid());
                     mSoundPlayer.stopSounds();
-                    dismiss(Collection.DismissType.DELETE_NOTE);
+                    dismiss(new CollectionTask.DeleteNote(mCurrentCard));
                 })
                 .build().show();
     }
@@ -2635,16 +2634,16 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
                 lookUpOrSelectText();
                 return true;
             case COMMAND_BURY_CARD:
-                dismiss(Collection.DismissType.BURY_CARD);
+                dismiss(new CollectionTask.BuryCard(mCurrentCard));
                 return true;
             case COMMAND_BURY_NOTE:
-                dismiss(Collection.DismissType.BURY_NOTE);
+                dismiss(new CollectionTask.BuryNote(mCurrentCard));
                 return true;
             case COMMAND_SUSPEND_CARD:
-                dismiss(Collection.DismissType.SUSPEND_CARD);
+                dismiss(new CollectionTask.SuspendCard(mCurrentCard));
                 return true;
             case COMMAND_SUSPEND_NOTE:
-                dismiss(Collection.DismissType.SUSPEND_NOTE);
+                dismiss(new CollectionTask.SuspendNote(mCurrentCard));
                 return true;
             case COMMAND_DELETE:
                 showDeleteNoteDialog();
@@ -3277,9 +3276,9 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
             } */
     }
 
-    protected void dismiss(Collection.DismissType type) {
+    protected void dismiss(CollectionTask.DismissNote dismiss) {
         blockControls(false);
-        TaskManager.launchCollectionTask(new CollectionTask.DismissNote(mCurrentCard, type), mDismissCardHandler);
+        TaskManager.launchCollectionTask(dismiss, mDismissCardHandler);
     }
 
     /** Signals from a WebView represent actions with no parameters */

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.java
@@ -342,13 +342,13 @@ public class Reviewer extends AbstractFlashcardViewer {
             Timber.i("Reviewer:: Bury button pressed");
             if (!MenuItemCompat.getActionProvider(item).hasSubMenu()) {
                 Timber.d("Bury card due to no submenu");
-                dismiss(DismissType.BURY_CARD);
+                dismiss(new CollectionTask.BuryCard(mCurrentCard));
             }
         } else if (itemId == R.id.action_suspend) {
             Timber.i("Reviewer:: Suspend button pressed");
             if (!MenuItemCompat.getActionProvider(item).hasSubMenu()) {
                 Timber.d("Suspend card due to no submenu");
-                dismiss(DismissType.SUSPEND_CARD);
+                dismiss(new CollectionTask.SuspendCard(mCurrentCard));
             }
         } else if (itemId == R.id.action_delete) {
             Timber.i("Reviewer:: Delete note button pressed");
@@ -1306,10 +1306,10 @@ public class Reviewer extends AbstractFlashcardViewer {
         public boolean onMenuItemClick(MenuItem item) {
             int itemId = item.getItemId();
             if (itemId == R.id.action_suspend_card) {
-                dismiss(DismissType.SUSPEND_CARD);
+                dismiss(new CollectionTask.SuspendCard(mCurrentCard));
                 return true;
             } else if (itemId == R.id.action_suspend_note) {
-                dismiss(DismissType.SUSPEND_NOTE);
+                dismiss(new CollectionTask.SuspendNote(mCurrentCard));
                 return true;
             }
             return false;
@@ -1354,10 +1354,10 @@ public class Reviewer extends AbstractFlashcardViewer {
         public boolean onMenuItemClick(MenuItem item) {
             int itemId = item.getItemId();
             if (itemId == R.id.action_bury_card) {
-                dismiss(DismissType.BURY_CARD);
+                dismiss(new CollectionTask.BuryCard(mCurrentCard));
                 return true;
             } else if (itemId == R.id.action_bury_note) {
-                dismiss(DismissType.BURY_NOTE);
+                dismiss(new CollectionTask.BuryNote(mCurrentCard));
                 return true;
             }
             return false;

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.java
@@ -76,7 +76,6 @@ import com.ichi2.async.TaskManager;
 import com.ichi2.compat.CompatHelper;
 import com.ichi2.libanki.Card;
 import com.ichi2.libanki.Collection;
-import com.ichi2.libanki.Collection.DismissType;
 import com.ichi2.libanki.Consts;
 import com.ichi2.libanki.Decks;
 import com.ichi2.libanki.Utils;

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
@@ -1384,16 +1384,27 @@ public class Collection {
         }
     }
 
+    private static class UndoReview extends Undoable {
+        private final boolean mWasLeech;
+        @NonNull private final Card mClonedCard;
+        public UndoReview(boolean wasLeech, @NonNull Card clonedCard) {
+            super(REVIEW);
+            mClonedCard = clonedCard;
+            mWasLeech = wasLeech;
+        }
+
+        @NonNull
+        @Override
+        public Card undo(@NonNull Collection col) {
+            col.getSched().undoReview(mClonedCard, mWasLeech);
+            return mClonedCard;
+        }
+    }
+
     public void markReview(Card card) {
         boolean wasLeech = card.note().hasTag("leech");
         Card clonedCard = card.clone();
-        Undoable undoableReview = new Undoable(REVIEW) {
-            public @Nullable Card undo(@NonNull Collection col) {
-                col.getSched().undoReview(clonedCard, wasLeech);
-                return clonedCard;
-            }
-        };
-        markUndo(undoableReview);
+        markUndo(new UndoReview(wasLeech, clonedCard));
     }
 
     /**

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
@@ -87,7 +87,6 @@ import androidx.sqlite.db.SupportSQLiteStatement;
 import timber.log.Timber;
 
 import static com.ichi2.async.CancelListener.isCancelled;
-import static com.ichi2.libanki.Collection.DismissType.REVIEW;
 import static com.ichi2.libanki.Consts.DECK_DYN;
 
 // Anki maintains a cache of used tags so it can quickly present a list of tags
@@ -154,39 +153,6 @@ public class Collection {
             // other config
             "'curModel': null, " + "'nextPos': 1, " + "'sortType': \"noteFld\", "
             + "'sortBackwards': False, 'addToCur': True }"; // add new to currently selected deck?
-
-    public enum DismissType {
-        REVIEW(R.string.undo_action_review),
-        BURY_CARD(R.string.menu_bury_card),
-        BURY_NOTE(R.string.menu_bury_note),
-        SUSPEND_CARD(R.string.menu_suspend_card),
-        SUSPEND_CARD_MULTI(R.string.menu_suspend_card),
-        UNSUSPEND_CARD_MULTI(R.string.card_browser_unsuspend_card),
-        SUSPEND_NOTE(R.string.menu_suspend_note),
-        DELETE_NOTE(R.string.menu_delete_note),
-        DELETE_NOTE_MULTI(R.string.card_browser_delete_card),
-        CHANGE_DECK_MULTI(R.string.undo_action_change_deck_multi),
-        MARK_NOTE_MULTI(R.string.card_browser_mark_card),
-        UNMARK_NOTE_MULTI(R.string.card_browser_unmark_card),
-        FLAG(R.string.menu_flag),
-        REPOSITION_CARDS(R.string.card_editor_reposition_card),
-        RESCHEDULE_CARDS(R.string.card_editor_reschedule_card),
-        RESET_CARDS(R.string.card_editor_reset_card);
-
-        @StringRes
-        private final int mUndoNameId;
-
-        DismissType(int undoNameId) {
-            this.mUndoNameId = undoNameId;
-        }
-
-        private Locale getLocale(Resources resources) {
-            return LanguageUtil.getLocaleCompat(resources);
-        }
-        public String getString(Resources res) {
-            return res.getString(mUndoNameId).toLowerCase(getLocale(res));
-        }
-    }
 
     private static final int UNDO_SIZE_MAX = 20;
 
@@ -1351,16 +1317,16 @@ public class Collection {
 
     /** Undo menu item name, or "" if undo unavailable. */
     @VisibleForTesting
-    public @Nullable DismissType undoType() {
+    public @Nullable Undoable undoType() {
         if (mUndo.size() > 0) {
-            return mUndo.getLast().getDismissType();
+            return mUndo.getLast();
         }
         return null;
     }
     public String undoName(Resources res) {
-        DismissType type = undoType();
+        Undoable type = undoType();
         if (type != null) {
-            return type.getString(res);
+            return type.name(res);
         }
         return "";
     }
@@ -1372,23 +1338,24 @@ public class Collection {
 
     public @Nullable Card undo() {
         Undoable lastUndo = mUndo.removeLast();
-        Timber.d("undo() of type %s", lastUndo.getDismissType());
+        Timber.d("undo() of type %s", lastUndo.getClass());
         return lastUndo.undo(this);
     }
 
     public void markUndo(@NonNull Undoable undo) {
-        Timber.d("markUndo() of type %s", undo.getDismissType());
+        Timber.d("markUndo() of type %s", undo.getClass());
         mUndo.add(undo);
         while (mUndo.size() > UNDO_SIZE_MAX) {
             mUndo.removeFirst();
         }
     }
 
-    private static class UndoReview extends Undoable {
+    @VisibleForTesting
+    public static class UndoReview extends Undoable {
         private final boolean mWasLeech;
         @NonNull private final Card mClonedCard;
         public UndoReview(boolean wasLeech, @NonNull Card clonedCard) {
-            super(REVIEW);
+            super(R.string.undo_action_review);
             mClonedCard = clonedCard;
             mWasLeech = wasLeech;
         }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Undoable.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Undoable.java
@@ -2,30 +2,31 @@ package com.ichi2.libanki;
 
 import android.content.res.Resources;
 
-import com.ichi2.libanki.Collection.DismissType;
+import com.ichi2.utils.LanguageUtil;
 
 import java.util.List;
+import java.util.Locale;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.annotation.StringRes;
 import timber.log.Timber;
 
 public abstract class Undoable {
-    private final DismissType mDt;
+    @StringRes public final int mUndoNameId;
 
     /**
      * For all descendants, we assume that a card/note/object passed as argument is never going to be changed again.
      * It's the caller reponsability to clone the object if necessary.*/
-    public Undoable(DismissType dt) {
-        mDt = dt;
+    public Undoable(@StringRes int undoNameId) {
+        mUndoNameId = undoNameId;
     }
 
+    private Locale getLocale(Resources resources) {
+        return LanguageUtil.getLocaleCompat(resources);
+    }
     public String name(Resources res) {
-        return mDt.getString(res);
-    }
-
-    public DismissType getDismissType() {
-        return mDt;
+        return res.getString(mUndoNameId).toLowerCase(getLocale(res));
     }
 
     /**
@@ -34,13 +35,13 @@ public abstract class Undoable {
      * Returned positive integers are card id. Those ids is the card that was discarded and that may be sent back to the reviewer.*/
     public abstract @Nullable Card undo(@NonNull Collection col);
 
-    public static @NonNull Undoable revertToProvidedState (DismissType dt, Card card){
+    public static @NonNull Undoable revertToProvidedState (@StringRes int undoNameId, Card card){
         Note note = card.note();
         List<Card> cards = note.cards();
-        return new Undoable(dt) {
+        return new Undoable(undoNameId) {
             public @Nullable
             Card undo(@NonNull Collection col) {
-                Timber.i("Undo: %s", dt);
+                Timber.i("Undo: %d", undoNameId);
                 for (Card cc : cards) {
                     cc.flush(false);
                 }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/ReviewerKeyboardInputTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/ReviewerKeyboardInputTest.java
@@ -19,6 +19,7 @@ package com.ichi2.anki;
 import android.view.KeyEvent;
 
 import com.ichi2.anki.reviewer.ReviewerUi;
+import com.ichi2.async.CollectionTask;
 import com.ichi2.libanki.Card;
 import com.ichi2.libanki.Collection;
 
@@ -271,7 +272,7 @@ public class ReviewerKeyboardInputTest extends RobolectricTest {
         private int mAnswerButtonCount = 4;
         private boolean mEditedCard;
         private boolean mMarkedCard;
-        private Collection.DismissType mDismissType;
+        private CollectionTask.DismissNote mDismissType;
         private boolean mUndoCalled;
         private boolean mReplayAudioCalled;
         private ControlBlock mControlsAreBlocked = ControlBlock.UNBLOCKED;
@@ -454,12 +455,12 @@ public class ReviewerKeyboardInputTest extends RobolectricTest {
         }
 
         public boolean getSuspendNoteCalled() {
-            return mDismissType == Collection.DismissType.SUSPEND_NOTE;
+            return mDismissType instanceof CollectionTask.SuspendNote;
         }
 
 
         public boolean getBuryNoteCalled() {
-            return mDismissType == Collection.DismissType.BURY_NOTE;
+            return mDismissType instanceof CollectionTask.BuryNote;
         }
 
 
@@ -473,8 +474,8 @@ public class ReviewerKeyboardInputTest extends RobolectricTest {
         }
 
         @Override
-        protected void dismiss(Collection.DismissType type) {
-            this.mDismissType = type;
+        protected void dismiss(CollectionTask.DismissNote dismiss) {
+            this.mDismissType = dismiss;
         }
 
         @Override
@@ -489,7 +490,7 @@ public class ReviewerKeyboardInputTest extends RobolectricTest {
 
 
         public boolean getSuspendCardCalled() {
-            return mDismissType == Collection.DismissType.SUSPEND_CARD;
+            return mDismissType instanceof CollectionTask.SuspendCard;
         }
 
 

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/UndoTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/UndoTest.java
@@ -12,6 +12,8 @@ import androidx.test.ext.junit.runners.AndroidJUnit4;
 import static com.ichi2.libanki.Consts.COUNT_REMAINING;
 import static com.ichi2.libanki.Consts.QUEUE_TYPE_LRN;
 import static com.ichi2.libanki.Consts.QUEUE_TYPE_NEW;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
@@ -120,7 +122,7 @@ public class UndoTest extends RobolectricTest {
         // performing a normal op will clear the review queue
         c = col.getSched().getCard();
         col.getSched().answerCard(c, 3);
-        assertEquals(Collection.DismissType.REVIEW, col.undoType());
+        assertThat(col.undoType(), is(instanceOf(Collection.UndoReview.class)));
         col.save("foo");
         // Upstream, "save" can be undone. This test fails here because it's not the case in AnkiDroid
         assumeThat(col.undoName(getTargetContext().getResources()), is("foo"));


### PR DESCRIPTION
The DismissType was extremely redundant. It was only used in switch/case. Those switch where not even exhaustive, they accepted only some specific dismiss types. I believe that we are far better without them, directly instantiating Undo and DismissTasks.
 
Actually, I thought I already removed it when I redid background tasks, so I was surprised to see them appearing in another PR.

As usual, the goal is to make code simpler to follow and hopefully debug. Instead of using an element of an enum, and then finding where it is used, you can directly read the undo function or the task function