### PR TITLE
NF: factorize Undoable::name

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
@@ -182,7 +182,7 @@ public class Collection {
             return LanguageUtil.getLocaleCompat(resources);
         }
         public String getString(Resources res) {
-            return res.getString(mUndoNameId).toLowerCase(getLocale(res));
+            return res.getString(mUndoNameId);
         }
     }
 
@@ -1349,16 +1349,16 @@ public class Collection {
 
     /** Undo menu item name, or "" if undo unavailable. */
     @VisibleForTesting
-    public @Nullable DismissType undoType() {
+    public @Nullable Undoable undoType() {
         if (mUndo.size() > 0) {
-            return mUndo.getLast().getDismissType();
+            return mUndo.getLast();
         }
         return null;
     }
     public String undoName(Resources res) {
-        DismissType type = undoType();
+        Undoable type = undoType();
         if (type != null) {
-            return type.getString(res);
+            return type.name(res);
         }
         return "";
     }

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/UndoTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/UndoTest.java
@@ -120,7 +120,7 @@ public class UndoTest extends RobolectricTest {
         // performing a normal op will clear the review queue
         c = col.getSched().getCard();
         col.getSched().answerCard(c, 3);
-        assertEquals(Collection.DismissType.REVIEW, col.undoType());
+        assertEquals(Collection.DismissType.REVIEW, col.undoType().getDismissType());
         col.save("foo");
         // Upstream, "save" can be undone. This test fails here because it's not the case in AnkiDroid
         assumeThat(col.undoName(getTargetContext().getResources()), is("foo"));


### PR DESCRIPTION
undoType was only used:
* in test to check whether a value is null
* to get the name

Undo::name was never used. It is now similar to what is already existing. It allow for the "name" function to really be
contained in undo and ensure that the remaining of the code don't have to deal with the id.


Otherwise, if this is not merged, we may just want to remove the unused method `name` from Undoable