### PR TITLE
Make launcher icon red in debug mode

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -84,6 +84,9 @@ android {
                 testCoverageEnabled true
             }
 
+            // make the icon red if in debug mode
+            resValue 'color', 'anki_foreground_icon_color_0', "#FFFF0000"
+            resValue 'color', 'anki_foreground_icon_color_1', "#FFFF0000"
         }
         release {
             minifyEnabled true
@@ -91,6 +94,8 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
             signingConfig signingConfigs.release
             buildConfigField "String", "ACRA_URL", '"https://ankidroid.org/acra/report"'
+            resValue 'color', 'anki_foreground_icon_color_0', "#FF29B6F6"
+            resValue 'color', 'anki_foreground_icon_color_1', "#FF0288D1"
         }
     }
 

--- a/AnkiDroid/src/main/res/drawable-v24/ic_launcher_foreground.xml
+++ b/AnkiDroid/src/main/res/drawable-v24/ic_launcher_foreground.xml
@@ -18,8 +18,8 @@
             android:endY="140.15863"
             android:endX="164.13487"
             android:type="linear">
-          <item android:offset="0" android:color="#FF29B6F6"/>
-          <item android:offset="1" android:color="#FF0288D1"/>
+          <item android:offset="0" android:color="@color/anki_foreground_icon_color_0"/>
+          <item android:offset="1" android:color="@color/anki_foreground_icon_color_1"/>
         </gradient>
       </aapt:attr>
     </path>


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
I was struggling to tell the icons apart in my quick launch as the app name was truncated

## Fixes
None - I do recall an issue for this but can't find it

## Approach
Extract properties to manifest and use `resValue`

## How Has This Been Tested?
![image](https://user-images.githubusercontent.com/62114487/113249664-fc540500-92b6-11eb-9a92-448b8edbfa6f.png)

This also affects the resource if not using a rounded icon

## Learning
`resValue`, mostly trial and error, docs are bad: https://developer.android.com/studio/build/gradle-tips#share-custom-fields-and-resource-values-with-your-app-code

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [x] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)