### PR TITLE
Don't show Full Sync From Server if user does not have AnkiWeb Account

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -777,7 +777,8 @@ public class DeckPicker extends NavigationDrawerActivity implements
             case NO_ACCOUNT:
             case FULL_SYNC:
                 if (syncStatus == SyncStatus.NO_ACCOUNT) {
-                    syncMenu.setTitle(R.string.sync_menu_title_no_account);
+                    syncMenu.setVisible(false);
+                    // syncMenu.setTitle(R.string.sync_menu_title_no_account);
                 } else if (syncStatus == SyncStatus.FULL_SYNC) {
                     syncMenu.setTitle(R.string.sync_menu_title_full_sync);
                 }

--- a/AnkiDroid/src/main/java/com/ichi2/ui/FixedTextView.java
+++ b/AnkiDroid/src/main/java/com/ichi2/ui/FixedTextView.java
@@ -61,9 +61,7 @@ public class FixedTextView extends AppCompatTextView {
         super(context, attrs);
     }
 
-    public FixedTextView(@NonNull Context context, @Nullable AttributeSet attrs, int defStyleAttr) {
-        super(context, attrs, defStyleAttr);
-    }
+    public FixedTextView(@NonNull Context context, @Nullable AttributeSet attrs, int defStyleAttr){ super(context, attrs, defStyleAttr); }
 
     @Override
     protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {

--- a/AnkiDroid/src/main/res/menu/deck_picker.xml
+++ b/AnkiDroid/src/main/res/menu/deck_picker.xml
@@ -15,6 +15,7 @@
         android:icon="@drawable/ic_sync_white_24dp"
         android:title="@string/button_sync"
         ankidroid:showAsAction="always"/>
+
     <item
         android:id="@+id/action_undo"
         android:icon="@drawable/ic_undo_white_24dp"
@@ -22,6 +23,7 @@
         ankidroid:actionProviderClass="com.ichi2.ui.RtlCompliantActionProvider"
         ankidroid:showAsAction="never"
         android:visible="false"/>
+
     <item
         android:id="@+id/action_new_filtered_deck"
         android:enabled="false"

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 <p align="center">
 <img src="docs/graphics/logos/banner_readme.png"/>
 </p>
-
 <a href="https://github.com/ankidroid/Anki-Android/releases"><img src="https://img.shields.io/github/v/release/ankidroid/Anki-Android" alt="release"/></a>
 <a href="https://github.com/ankidroid/Anki-Android/actions"><img src="https://img.shields.io/github/checks-status/ankidroid/Anki-Android/master?label=build" alt="build"/></a>
 <a href="https://opencollective.com/ankidroid"><img src="https://img.shields.io/opencollective/all/ankidroid" alt="Open Collective backers and sponsors"/></a>


### PR DESCRIPTION
## Pull Request template

## Purpose
I want to work upon this, the Database error for not show sync from server.

## Fixes
I just hide the option of FULL SYNC for unregistered users.

## Approach
This will affect simply hide the icon, and if icon not visible, then it is also not clickable,

## Checklist

- [*] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [*] You have a descriptive commit message with a short title (first line, max 50 chars).
- [*] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [*] You have commented your code, particularly in hard-to-understand areas
- [*] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
