### PR TITLE
Fixes #8151 Build flavors for Amazon Appstore and Google Playstore

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -66,7 +66,7 @@ jobs:
           timeout_minutes: 10
           retry_wait_seconds: 60
           max_attempts: 3
-          command: ./gradlew :AnkiDroid:compileReleaseJavaWithJavac compileLint lint-rules:compileTestJava
+          command: ./gradlew :AnkiDroid:compilePlayReleaseJavaWithJavac compileLint lint-rules:compileTestJava
 
       - name: Run Lint Release
         run: ./gradlew lintRelease

--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -100,6 +100,21 @@ android {
     }
 
     /**
+     * Product Flavors are used for Amazon App Store and Google Play Store.
+     * This is because we cannot use Camera Permissions in Amazon App Store (for FireTv etc...)
+     * Therefore, different AndroidManifest for Camera Permissions is used in Amazon flavor.
+     */
+    flavorDimensions "appStore"
+    productFlavors {
+        play {
+            dimension "appStore"
+        }
+        amazon {
+            dimension "appStore"
+        }
+    }
+
+    /**
      * Set this to true to create five separate APKs instead of one:
      *   - 2 APKs that only work on ARM/ARM64 devices
      *   - 2 APKs that only works on x86/x86_64 devices

--- a/AnkiDroid/jacoco.gradle
+++ b/AnkiDroid/jacoco.gradle
@@ -60,7 +60,7 @@ tasks.withType(Test) {
 }
 
 // Our merge report task
-task jacocoTestReport(type: JacocoReport, dependsOn: ['testDebugUnitTest', 'connectedDebugAndroidTest']) {
+task jacocoTestReport(type: JacocoReport, dependsOn: ['testPlayDebugUnitTest', 'connectedPlayDebugAndroidTest']) {
     def htmlOutDir = layout.buildDirectory.dir("reports/jacoco/$name/html").get().asFile
 
     doLast {
@@ -85,7 +85,7 @@ task jacocoTestReport(type: JacocoReport, dependsOn: ['testDebugUnitTest', 'conn
 }
 
 // A unit-test only report task
-task jacocoUnitTestReport(type: JacocoReport, dependsOn: ['testDebugUnitTest']) {
+task jacocoUnitTestReport(type: JacocoReport, dependsOn: ['testPlayDebugUnitTest']) {
     def htmlOutDir = layout.buildDirectory.dir("reports/jacoco/$name/html").get().asFile
 
     doLast {
@@ -110,7 +110,7 @@ task jacocoUnitTestReport(type: JacocoReport, dependsOn: ['testDebugUnitTest']) 
 }
 
 // A connected android tests only report task
-task jacocoAndroidTestReport(type: JacocoReport, dependsOn: ['connectedDebugAndroidTest']) {
+task jacocoAndroidTestReport(type: JacocoReport, dependsOn: ['connectedPlayDebugAndroidTest']) {
     def htmlOutDir = layout.buildDirectory.dir("reports/jacoco/$name/html").get().asFile
 
     doLast {

--- a/AnkiDroid/src/amazon/AndroidManifest.xml
+++ b/AnkiDroid/src/amazon/AndroidManifest.xml
@@ -1,0 +1,10 @@
+<manifest package="com.ichi2.anki"
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:installLocation="auto">
+
+    <!-- This camera permission will be removed in the merged manifest due to node removal -->
+    <uses-permission
+        android:name="android.permission.CAMERA"
+        tools:node="remove" />
+</manifest> 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -1685,7 +1685,7 @@ public class NoteEditor extends AnkiActivity implements
                 inflater.inflate(R.menu.popupmenu_multimedia_options, popup.getMenu());
 
                 /* To check whether Camera Permission is asked in AndroidManifest.xml */
-                if (CheckCameraPermission.isPermissionAvailableInManifest(this)) {
+                if (!CheckCameraPermission.manifestContainsPermission(this)) {
                     MenuItem item = popup.getMenu().findItem(R.id.menu_multimedia_photo);
                     item.setVisible(false);
                 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -105,6 +105,7 @@ import com.ichi2.themes.StyledProgressDialog;
 import com.ichi2.themes.Themes;
 import com.ichi2.anki.widgets.PopupMenuWithIcons;
 import com.ichi2.utils.AdaptionUtil;
+import com.ichi2.utils.CheckCameraPermission;
 import com.ichi2.utils.ContentResolverUtil;
 import com.ichi2.utils.DeckComparator;
 import com.ichi2.utils.FileUtil;
@@ -1682,6 +1683,13 @@ public class NoteEditor extends AnkiActivity implements
                 PopupMenuWithIcons popup = new PopupMenuWithIcons(NoteEditor.this, v, true);
                 MenuInflater inflater = popup.getMenuInflater();
                 inflater.inflate(R.menu.popupmenu_multimedia_options, popup.getMenu());
+
+                /* To check whether Camera Permission is asked in AndroidManifest.xml */
+                if (CheckCameraPermission.isPermissionAvailableInManifest(this)) {
+                    MenuItem item = popup.getMenu().findItem(R.id.menu_multimedia_photo);
+                    item.setVisible(false);
+                }
+
                 popup.setOnMenuItemClickListener(item -> {
 
                     int itemId = item.getItemId();

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/activity/MultimediaEditFieldActivity.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/activity/MultimediaEditFieldActivity.java
@@ -218,7 +218,7 @@ public class MultimediaEditFieldActivity extends AnkiActivity
         menu.findItem(R.id.multimedia_edit_field_to_image).setVisible(mField.getType() != EFieldType.IMAGE);
 
         /* To check whether Camera Permission is asked in AndroidManifest.xml */
-        if (CheckCameraPermission.isPermissionAvailableInManifest(this)) {
+        if (!CheckCameraPermission.manifestContainsPermission(this)) {
             menu.findItem(R.id.multimedia_edit_field_to_image).setVisible(false);
         }
         return true;

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/activity/MultimediaEditFieldActivity.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/activity/MultimediaEditFieldActivity.java
@@ -47,6 +47,7 @@ import com.ichi2.anki.multimediacard.fields.IField;
 import com.ichi2.anki.multimediacard.fields.IFieldController;
 import com.ichi2.anki.multimediacard.fields.ImageField;
 import com.ichi2.anki.multimediacard.fields.TextField;
+import com.ichi2.utils.CheckCameraPermission;
 import com.ichi2.utils.Permissions;
 
 import java.io.File;
@@ -215,6 +216,11 @@ public class MultimediaEditFieldActivity extends AnkiActivity
         menu.findItem(R.id.multimedia_edit_field_to_audio).setVisible(mField.getType() != EFieldType.AUDIO_RECORDING);
         menu.findItem(R.id.multimedia_edit_field_to_audio_clip).setVisible(mField.getType() != EFieldType.AUDIO_CLIP);
         menu.findItem(R.id.multimedia_edit_field_to_image).setVisible(mField.getType() != EFieldType.IMAGE);
+
+        /* To check whether Camera Permission is asked in AndroidManifest.xml */
+        if (CheckCameraPermission.isPermissionAvailableInManifest(this)) {
+            menu.findItem(R.id.multimedia_edit_field_to_image).setVisible(false);
+        }
         return true;
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/utils/CheckCameraPermission.java
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/CheckCameraPermission.java
@@ -1,0 +1,42 @@
+/***************************************************************************************
+ *                                                                                      *
+ * Copyright (c) 2021 Mrudul Tora <mrudultora@gmail.com>                                *
+ *                                                                                      *
+ * This program is free software; you can redistribute it and/or modify it under        *
+ * the terms of the GNU General Public License as published by the Free Software        *
+ * Foundation; either version 3 of the License, or (at your option) any later           *
+ * version.                                                                             *
+ *                                                                                      *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *                                                                                      *
+ * You should have received a copy of the GNU General Public License along with         *
+ * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ ****************************************************************************************/
+
+package com.ichi2.utils;
+
+import android.content.Context;
+import android.content.pm.PackageManager;
+
+import java.util.Arrays;
+
+import timber.log.Timber;
+
+public class CheckCameraPermission {
+
+    public static boolean isPermissionAvailableInManifest(Context context) {
+        try {
+            String[] requestedPermissions = context.getPackageManager()
+                    .getPackageInfo(context.getPackageName(), PackageManager.GET_PERMISSIONS)
+                    .requestedPermissions;
+            if (Arrays.toString(requestedPermissions).contains("android.permission.CAMERA")) {
+                return false;
+            }
+        } catch (Exception e) {
+            Timber.w(e);
+        }
+        return true;
+    }
+}

--- a/AnkiDroid/src/main/java/com/ichi2/utils/CheckCameraPermission.java
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/CheckCameraPermission.java
@@ -26,17 +26,17 @@ import timber.log.Timber;
 
 public class CheckCameraPermission {
 
-    public static boolean isPermissionAvailableInManifest(Context context) {
+    public static boolean manifestContainsPermission(Context context) {
         try {
             String[] requestedPermissions = context.getPackageManager()
                     .getPackageInfo(context.getPackageName(), PackageManager.GET_PERMISSIONS)
                     .requestedPermissions;
             if (Arrays.toString(requestedPermissions).contains("android.permission.CAMERA")) {
-                return false;
+                return true;
             }
         } catch (Exception e) {
             Timber.w(e);
         }
-        return true;
+        return false;
     }
 }

--- a/tools/parallel-package-release.sh
+++ b/tools/parallel-package-release.sh
@@ -35,8 +35,8 @@ for BUILD in $BUILDNAMES; do
     git clean -f
     LCBUILD=`tr '[:upper:]' '[:lower:]' <<< $BUILD`
     ./tools/parallel-package-name.sh com.ichi2.anki.$LCBUILD AnkiDroid.$BUILD
-    ./gradlew assembleRelease -Duniversal-apk=true
-    cp AnkiDroid/build/outputs/apk/release/AnkiDroid-universal-release.apk ./AnkiDroid-$TAG.parallel.$BUILD.apk
+    ./gradlew assemblePlayRelease -Duniversal-apk=true
+    cp AnkiDroid/build/outputs/apk/play/release/AnkiDroid-play-universal-release.apk ./AnkiDroid-$TAG.parallel.$BUILD.apk
 done
 git reset --hard
 git clean -f

--- a/tools/release.sh
+++ b/tools/release.sh
@@ -99,7 +99,7 @@ fi
 
 # Build signed APK using Gradle and publish to Play
 # Configuration for pushing to Play specified in build.gradle 'play' task
-if ! ./gradlew publishReleaseApk
+if ! ./gradlew publishPlayReleaseApk
 then
   # APK contains problems, abort release
   git checkout -- $GRADLEFILE # Revert version change
@@ -107,7 +107,7 @@ then
 fi
 
 # Now build the universal release also
-if ! ./gradlew assembleRelease -Duniversal-apk=true
+if ! ./gradlew assemblePlayRelease -Duniversal-apk=true
 then
   # APK contains problems, abort release
   git checkout -- $GRADLEFILE # Revert version change
@@ -117,7 +117,7 @@ fi
 # Copy universal APK to cwd
 ABIS='universal arm64-v8a x86 x86_64 armeabi-v7a'
 for ABI in $ABIS; do
-  cp AnkiDroid/build/outputs/apk/release/AnkiDroid-"$ABI"-release.apk AnkiDroid-"$VERSION"-"$ABI".apk
+  cp AnkiDroid/build/outputs/apk/play/release/AnkiDroid-play-"$ABI"-release.apk AnkiDroid-"$VERSION"-"$ABI".apk
 done
 
 


### PR DESCRIPTION
## Purpose / Description
Different flavors added for Amazon App store and Google Play store (we cannot use default here). And, I tried to hide the camera related options in amazon flavor.

## Fixes
Fixes #8151

## Approach
Added the flavors in gradle. Created a class to get all the permissions to find out whether camera permission is present in manifest or not. If not present. hide the camera related options from menu's.
4 Build variants are generated now (amazonDebug, amazonRelease, playDebug, playRelease)

![img](https://user-images.githubusercontent.com/65870389/111910471-80bcb180-8a87-11eb-926c-c0cdeb485519.png)

## How Has This Been Tested?
Tested on real device (Redmi Note 7S and API 29).

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [x] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
