### PR TITLE
Minor refactorings and SQL window size calculation fixed

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
@@ -358,7 +358,6 @@ public class Collection {
         int pos = 1;
         StringBuilder buf = new StringBuilder();
 
-        // code refactoring done to remove unnecessary break statements
         while (true) {
             try (Cursor cursor = mDb.query("SELECT substr(" + columnName + ", ?, ?) FROM col",
                     Integer.toString(pos), Integer.toString(getChunk()))) {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
@@ -366,7 +366,7 @@ public class Collection {
                 }
                 String res = cursor.getString(0);
                 if (res.length() == 0) {
-                    break;
+                      break;
                 }
                 buf.append(res);
                 if (res.length() < getChunk()) {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
@@ -367,15 +367,16 @@ public class Collection {
                 }
                 String res = cursor.getString(0);
                 if (res.length() == 0) {
-                    return buf.toString();
+                    break;
                 }
                 buf.append(res);
                 if (res.length() < getChunk()) {
-                    return buf.toString();
+                    break;
                 }
                 pos += getChunk();
             }
         }
+        return buf.toString();
     }
 
     /**

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
@@ -332,7 +332,7 @@ public class Collection {
         SupportSQLiteDatabase db = mDb.getDatabase();
         String db_name = (db instanceof DatabaseChangeDecorator) ? ((DatabaseChangeDecorator) db).getWrapped().getClass().getName() : null;
 
-        if (db_name != null && "io.requery.android.database.sqlite.SQLiteDatabase".equals(db_name)) {
+        if ("io.requery.android.database.sqlite.SQLiteDatabase".equals(db_name)) {
             try {
                 Field cursorWindowSize = io.requery.android.database.CursorWindow.class.getDeclaredField("sDefaultCursorWindowSize");
                 cursorWindowSize.setAccessible(true);


### PR DESCRIPTION
## Purpose
The method `getChunk()` in Collection.java, returned zero as SQL window size if the object `db` is an instance of `DatabaseChangeDecorator`. This had to be changed to the default SQL window size. 

## Fixes
Fixes #8421 

## Approach
In the condition faced in the issue, it should return the value which is calculated considering the default SQL window size. This is because the condition that `db_name` equals to "io.requery.android.database.sqlite.SQLiteDatabase"  will not be satisfied as `db_name` doesn't exist. 

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
