### PR TITLE
Ignore Invalid field naming lint for wildplot

### DIFF
--- a/AnkiDroid/src/main/java/com/wildplot/android/parsing/Atom.java
+++ b/AnkiDroid/src/main/java/com/wildplot/android/parsing/Atom.java
@@ -15,8 +15,17 @@
  ****************************************************************************************/
 package com.wildplot.android.parsing;
 
-import com.wildplot.android.parsing.AtomTypes.*;
+import android.annotation.SuppressLint;
 
+import com.wildplot.android.parsing.AtomTypes.FunctionXAtom;
+import com.wildplot.android.parsing.AtomTypes.FunctionXYAtom;
+import com.wildplot.android.parsing.AtomTypes.MathFunctionAtom;
+import com.wildplot.android.parsing.AtomTypes.NumberAtom;
+import com.wildplot.android.parsing.AtomTypes.VariableAtom;
+import com.wildplot.android.parsing.AtomTypes.XVariableAtom;
+import com.wildplot.android.parsing.AtomTypes.YVariableAtom;
+
+@SuppressLint("FieldNamingPatternDetector")
 public class Atom implements TreeElement {
     private final TopLevelParser parser;
 

--- a/AnkiDroid/src/main/java/com/wildplot/android/parsing/AtomTypes/FunctionXAtom.java
+++ b/AnkiDroid/src/main/java/com/wildplot/android/parsing/AtomTypes/FunctionXAtom.java
@@ -15,10 +15,17 @@
  ****************************************************************************************/
 package com.wildplot.android.parsing.AtomTypes;
 
-import com.wildplot.android.parsing.*;
+import android.annotation.SuppressLint;
+
+import com.wildplot.android.parsing.Atom;
+import com.wildplot.android.parsing.Expression;
+import com.wildplot.android.parsing.ExpressionFormatException;
+import com.wildplot.android.parsing.TopLevelParser;
+import com.wildplot.android.parsing.TreeElement;
 
 import java.util.regex.Pattern;
 
+@SuppressLint("FieldNamingPatternDetector")
 public class FunctionXAtom implements TreeElement {
     private Atom.AtomType atomType = Atom.AtomType.FUNCTION_X;
     private final TopLevelParser parser;

--- a/AnkiDroid/src/main/java/com/wildplot/android/parsing/AtomTypes/FunctionXYAtom.java
+++ b/AnkiDroid/src/main/java/com/wildplot/android/parsing/AtomTypes/FunctionXYAtom.java
@@ -16,13 +16,20 @@
 
 package com.wildplot.android.parsing.AtomTypes;
 
-import com.wildplot.android.parsing.*;
+import android.annotation.SuppressLint;
+
+import com.wildplot.android.parsing.Atom;
+import com.wildplot.android.parsing.Expression;
+import com.wildplot.android.parsing.ExpressionFormatException;
+import com.wildplot.android.parsing.TopLevelParser;
+import com.wildplot.android.parsing.TreeElement;
 
 import java.util.regex.Pattern;
 
 /**
  * @author Michael Goldbach
  */
+@SuppressLint("FieldNamingPatternDetector")
 public class FunctionXYAtom implements TreeElement {
 
     private Atom.AtomType atomType = Atom.AtomType.FUNCTION_X;

--- a/AnkiDroid/src/main/java/com/wildplot/android/parsing/AtomTypes/MathFunctionAtom.java
+++ b/AnkiDroid/src/main/java/com/wildplot/android/parsing/AtomTypes/MathFunctionAtom.java
@@ -15,12 +15,15 @@
  ****************************************************************************************/
 package com.wildplot.android.parsing.AtomTypes;
 
+import android.annotation.SuppressLint;
+
 import com.wildplot.android.parsing.Expression;
 import com.wildplot.android.parsing.ExpressionFormatException;
 import com.wildplot.android.parsing.TopLevelParser;
 import com.wildplot.android.parsing.TreeElement;
 
 
+@SuppressLint("FieldNamingPatternDetector")
 public class MathFunctionAtom implements TreeElement {
 
     private final TopLevelParser parser;

--- a/AnkiDroid/src/main/java/com/wildplot/android/parsing/AtomTypes/NumberAtom.java
+++ b/AnkiDroid/src/main/java/com/wildplot/android/parsing/AtomTypes/NumberAtom.java
@@ -15,12 +15,15 @@
  ****************************************************************************************/
 package com.wildplot.android.parsing.AtomTypes;
 
+import android.annotation.SuppressLint;
+
 import com.wildplot.android.parsing.Atom;
 import com.wildplot.android.parsing.ExpressionFormatException;
 import com.wildplot.android.parsing.TreeElement;
 
 import timber.log.Timber;
 
+@SuppressLint("FieldNamingPatternDetector")
 public class NumberAtom implements TreeElement {
 
     private Atom.AtomType atomType = Atom.AtomType.NUMBER;

--- a/AnkiDroid/src/main/java/com/wildplot/android/parsing/AtomTypes/VariableAtom.java
+++ b/AnkiDroid/src/main/java/com/wildplot/android/parsing/AtomTypes/VariableAtom.java
@@ -15,6 +15,8 @@
  ****************************************************************************************/
 package com.wildplot.android.parsing.AtomTypes;
 
+import android.annotation.SuppressLint;
+
 import com.wildplot.android.parsing.Atom;
 import com.wildplot.android.parsing.ExpressionFormatException;
 import com.wildplot.android.parsing.TopLevelParser;
@@ -23,6 +25,7 @@ import com.wildplot.android.parsing.TreeElement;
 import java.util.regex.Pattern;
 
 
+@SuppressLint("FieldNamingPatternDetector")
 public class VariableAtom implements TreeElement {
 
     private Atom.AtomType atomType = Atom.AtomType.NUMBER;

--- a/AnkiDroid/src/main/java/com/wildplot/android/parsing/AtomTypes/XVariableAtom.java
+++ b/AnkiDroid/src/main/java/com/wildplot/android/parsing/AtomTypes/XVariableAtom.java
@@ -15,11 +15,14 @@
  ****************************************************************************************/
 package com.wildplot.android.parsing.AtomTypes;
 
+import android.annotation.SuppressLint;
+
 import com.wildplot.android.parsing.Atom;
 import com.wildplot.android.parsing.ExpressionFormatException;
 import com.wildplot.android.parsing.TopLevelParser;
 import com.wildplot.android.parsing.TreeElement;
 
+@SuppressLint("FieldNamingPatternDetector")
 public class XVariableAtom implements TreeElement {
 
     private final Atom.AtomType atomType = Atom.AtomType.VARIABLE;

--- a/AnkiDroid/src/main/java/com/wildplot/android/parsing/AtomTypes/YVariableAtom.java
+++ b/AnkiDroid/src/main/java/com/wildplot/android/parsing/AtomTypes/YVariableAtom.java
@@ -15,11 +15,14 @@
  ****************************************************************************************/
 package com.wildplot.android.parsing.AtomTypes;
 
+import android.annotation.SuppressLint;
+
 import com.wildplot.android.parsing.Atom;
 import com.wildplot.android.parsing.ExpressionFormatException;
 import com.wildplot.android.parsing.TopLevelParser;
 import com.wildplot.android.parsing.TreeElement;
 
+@SuppressLint("FieldNamingPatternDetector")
 public class YVariableAtom implements TreeElement {
 
     private final Atom.AtomType atomType = Atom.AtomType.VARIABLE;

--- a/AnkiDroid/src/main/java/com/wildplot/android/parsing/Expression.java
+++ b/AnkiDroid/src/main/java/com/wildplot/android/parsing/Expression.java
@@ -16,6 +16,9 @@
 package com.wildplot.android.parsing;
 
 
+import android.annotation.SuppressLint;
+
+@SuppressLint("FieldNamingPatternDetector")
 public class Expression implements TreeElement {
     private final TopLevelParser parser;
 

--- a/AnkiDroid/src/main/java/com/wildplot/android/parsing/Factor.java
+++ b/AnkiDroid/src/main/java/com/wildplot/android/parsing/Factor.java
@@ -16,6 +16,9 @@
 package com.wildplot.android.parsing;
 
 
+import android.annotation.SuppressLint;
+
+@SuppressLint("FieldNamingPatternDetector")
 public class Factor implements TreeElement {
     private final TopLevelParser parser;
 

--- a/AnkiDroid/src/main/java/com/wildplot/android/parsing/Pow.java
+++ b/AnkiDroid/src/main/java/com/wildplot/android/parsing/Pow.java
@@ -16,6 +16,9 @@
 package com.wildplot.android.parsing;
 
 
+import android.annotation.SuppressLint;
+
+@SuppressLint("FieldNamingPatternDetector")
 public class Pow implements TreeElement {
     private final TopLevelParser parser;
 

--- a/AnkiDroid/src/main/java/com/wildplot/android/parsing/Term.java
+++ b/AnkiDroid/src/main/java/com/wildplot/android/parsing/Term.java
@@ -16,6 +16,9 @@
 package com.wildplot.android.parsing;
 
 
+import android.annotation.SuppressLint;
+
+@SuppressLint("FieldNamingPatternDetector")
 public class Term implements TreeElement {
     private final TopLevelParser parser;
 

--- a/AnkiDroid/src/main/java/com/wildplot/android/parsing/TopLevelParser.java
+++ b/AnkiDroid/src/main/java/com/wildplot/android/parsing/TopLevelParser.java
@@ -15,12 +15,15 @@
  ****************************************************************************************/
 package com.wildplot.android.parsing;
 
+import android.annotation.SuppressLint;
+
 import com.wildplot.android.rendering.interfaces.Function2D;
 import com.wildplot.android.rendering.interfaces.Function3D;
 
 import java.util.HashMap;
 import java.util.regex.Pattern;
 
+@SuppressLint("FieldNamingPatternDetector")
 public class TopLevelParser implements Function2D, Function3D, Cloneable {
     private final HashMap<String, TopLevelParser> parserRegister;
     private final HashMap<String, Double> varMap = new HashMap<>(2); // Number form initVarMap

--- a/AnkiDroid/src/main/java/com/wildplot/android/rendering/BarGraph.java
+++ b/AnkiDroid/src/main/java/com/wildplot/android/rendering/BarGraph.java
@@ -15,6 +15,8 @@
  ****************************************************************************************/
 package com.wildplot.android.rendering;
 
+import android.annotation.SuppressLint;
+
 import com.wildplot.android.rendering.graphics.wrapper.ColorWrap;
 import com.wildplot.android.rendering.graphics.wrapper.GraphicsWrap;
 import com.wildplot.android.rendering.graphics.wrapper.RectangleWrap;
@@ -25,6 +27,7 @@ import com.wildplot.android.rendering.interfaces.Legendable;
 /**
  * BarGraph uses a point matrix or a function to render bar graphs on PlotSheet object
  */
+@SuppressLint("FieldNamingPatternDetector")
 public class BarGraph implements Drawable, Legendable {
 
     private String mName = "";

--- a/AnkiDroid/src/main/java/com/wildplot/android/rendering/DrawableContainer.java
+++ b/AnkiDroid/src/main/java/com/wildplot/android/rendering/DrawableContainer.java
@@ -15,12 +15,15 @@
  ****************************************************************************************/
 package com.wildplot.android.rendering;
 
+import android.annotation.SuppressLint;
+
 import com.wildplot.android.rendering.graphics.wrapper.GraphicsWrap;
 import com.wildplot.android.rendering.interfaces.Drawable;
 
 import java.util.Vector;
 
 
+@SuppressLint("FieldNamingPatternDetector")
 public class DrawableContainer implements Drawable {
 
     private final Vector<Drawable> drawableVector = new Vector<>();

--- a/AnkiDroid/src/main/java/com/wildplot/android/rendering/LegendDrawable.java
+++ b/AnkiDroid/src/main/java/com/wildplot/android/rendering/LegendDrawable.java
@@ -15,12 +15,15 @@
  ****************************************************************************************/
 package com.wildplot.android.rendering;
 
+import android.annotation.SuppressLint;
+
 import com.wildplot.android.rendering.graphics.wrapper.ColorWrap;
 import com.wildplot.android.rendering.graphics.wrapper.GraphicsWrap;
 import com.wildplot.android.rendering.interfaces.Drawable;
 import com.wildplot.android.rendering.interfaces.Legendable;
 
 
+@SuppressLint("FieldNamingPatternDetector")
 public class LegendDrawable implements Drawable, Legendable {
 
     private String mName = "";

--- a/AnkiDroid/src/main/java/com/wildplot/android/rendering/Lines.java
+++ b/AnkiDroid/src/main/java/com/wildplot/android/rendering/Lines.java
@@ -15,7 +15,13 @@
  ****************************************************************************************/
 package com.wildplot.android.rendering;
 
-import com.wildplot.android.rendering.graphics.wrapper.*;
+import android.annotation.SuppressLint;
+
+import com.wildplot.android.rendering.graphics.wrapper.BasicStrokeWrap;
+import com.wildplot.android.rendering.graphics.wrapper.ColorWrap;
+import com.wildplot.android.rendering.graphics.wrapper.GraphicsWrap;
+import com.wildplot.android.rendering.graphics.wrapper.RectangleWrap;
+import com.wildplot.android.rendering.graphics.wrapper.StrokeWrap;
 import com.wildplot.android.rendering.interfaces.Drawable;
 import com.wildplot.android.rendering.interfaces.Legendable;
 
@@ -24,6 +30,7 @@ import com.wildplot.android.rendering.interfaces.Legendable;
  * The LinesPoints objects draw points from a data array and connect them with lines on.
  * These LinesPoints are drawn onto a PlotSheet object
  */
+@SuppressLint("FieldNamingPatternDetector")
 public class Lines implements Drawable, Legendable {
 
     private boolean mHasShadow = false;

--- a/AnkiDroid/src/main/java/com/wildplot/android/rendering/MultiScreenPart.java
+++ b/AnkiDroid/src/main/java/com/wildplot/android/rendering/MultiScreenPart.java
@@ -15,6 +15,8 @@
  ****************************************************************************************/
 package com.wildplot.android.rendering;
 
+import android.annotation.SuppressLint;
+
 import com.wildplot.android.rendering.interfaces.Drawable;
 
 import java.util.Vector;
@@ -23,6 +25,7 @@ import java.util.Vector;
  * This class is used to store informations for a certain plot in a multi-plot sheet.
  * The informations are the drawables for this plotsheet and the x and y limitations
  */
+@SuppressLint("FieldNamingPatternDetector")
 public class MultiScreenPart {
     private final double[] xRange;
     private final double[] yRange;

--- a/AnkiDroid/src/main/java/com/wildplot/android/rendering/PieChart.java
+++ b/AnkiDroid/src/main/java/com/wildplot/android/rendering/PieChart.java
@@ -15,6 +15,8 @@
  ****************************************************************************************/
 package com.wildplot.android.rendering;
 
+import android.annotation.SuppressLint;
+
 import com.wildplot.android.rendering.graphics.wrapper.ColorWrap;
 import com.wildplot.android.rendering.graphics.wrapper.FontMetricsWrap;
 import com.wildplot.android.rendering.graphics.wrapper.GraphicsWrap;
@@ -24,6 +26,7 @@ import com.wildplot.android.rendering.interfaces.Legendable;
 
 import androidx.annotation.NonNull;
 
+@SuppressLint("FieldNamingPatternDetector")
 public class PieChart implements Drawable, Legendable {
     // First sector starts at 12 o'clock.
     private static final float FIRST_SECTOR_OFFSET = -90;

--- a/AnkiDroid/src/main/java/com/wildplot/android/rendering/PlotSheet.java
+++ b/AnkiDroid/src/main/java/com/wildplot/android/rendering/PlotSheet.java
@@ -16,9 +16,13 @@
 package com.wildplot.android.rendering;
 
 
+import android.annotation.SuppressLint;
 import android.graphics.Typeface;
 
-import com.wildplot.android.rendering.graphics.wrapper.*;
+import com.wildplot.android.rendering.graphics.wrapper.ColorWrap;
+import com.wildplot.android.rendering.graphics.wrapper.FontMetricsWrap;
+import com.wildplot.android.rendering.graphics.wrapper.GraphicsWrap;
+import com.wildplot.android.rendering.graphics.wrapper.RectangleWrap;
 import com.wildplot.android.rendering.interfaces.Drawable;
 import com.wildplot.android.rendering.interfaces.Legendable;
 
@@ -35,6 +39,7 @@ import timber.log.Timber;
  * This is a sheet that is used to plot mathematical functions including coordinate systems and optional extras like
  * legends and descriptors. Additionally all conversions from image to plot coordinates are done here
  */
+@SuppressLint("FieldNamingPatternDetector")
 public class PlotSheet implements Drawable {
 
     protected Typeface typeface = Typeface.DEFAULT;

--- a/AnkiDroid/src/main/java/com/wildplot/android/rendering/XAxis.java
+++ b/AnkiDroid/src/main/java/com/wildplot/android/rendering/XAxis.java
@@ -16,6 +16,8 @@
 package com.wildplot.android.rendering;
 
 
+import android.annotation.SuppressLint;
+
 import com.wildplot.android.rendering.graphics.wrapper.FontMetricsWrap;
 import com.wildplot.android.rendering.graphics.wrapper.GraphicsWrap;
 import com.wildplot.android.rendering.graphics.wrapper.RectangleWrap;
@@ -26,6 +28,7 @@ import java.text.DecimalFormat;
 /**
  * This Class represents a Drawable x-axis
  */
+@SuppressLint("FieldNamingPatternDetector")
 public class XAxis implements Drawable {
 
     private boolean isIntegerNumbering = false;

--- a/AnkiDroid/src/main/java/com/wildplot/android/rendering/XGrid.java
+++ b/AnkiDroid/src/main/java/com/wildplot/android/rendering/XGrid.java
@@ -15,6 +15,8 @@
  ****************************************************************************************/
 package com.wildplot.android.rendering;
 
+import android.annotation.SuppressLint;
+
 import com.wildplot.android.rendering.graphics.wrapper.ColorWrap;
 import com.wildplot.android.rendering.graphics.wrapper.GraphicsWrap;
 import com.wildplot.android.rendering.graphics.wrapper.RectangleWrap;
@@ -24,6 +26,7 @@ import com.wildplot.android.rendering.interfaces.Drawable;
 /**
  * This class represents grid lines parallel to the x-axis
  */
+@SuppressLint("FieldNamingPatternDetector")
 public class XGrid implements Drawable {
 
     /**

--- a/AnkiDroid/src/main/java/com/wildplot/android/rendering/YAxis.java
+++ b/AnkiDroid/src/main/java/com/wildplot/android/rendering/YAxis.java
@@ -15,6 +15,8 @@
  ****************************************************************************************/
 package com.wildplot.android.rendering;
 
+import android.annotation.SuppressLint;
+
 import com.wildplot.android.rendering.graphics.wrapper.FontMetricsWrap;
 import com.wildplot.android.rendering.graphics.wrapper.GraphicsWrap;
 import com.wildplot.android.rendering.graphics.wrapper.RectangleWrap;
@@ -25,6 +27,7 @@ import java.text.DecimalFormat;
 /**
  * This Class represents a Drawable x-axis
  */
+@SuppressLint("FieldNamingPatternDetector")
 public class YAxis implements Drawable {
 
     private boolean mHasNumbersRotated = false;

--- a/AnkiDroid/src/main/java/com/wildplot/android/rendering/YGrid.java
+++ b/AnkiDroid/src/main/java/com/wildplot/android/rendering/YGrid.java
@@ -15,6 +15,8 @@
  ****************************************************************************************/
 package com.wildplot.android.rendering;
 
+import android.annotation.SuppressLint;
+
 import com.wildplot.android.rendering.graphics.wrapper.ColorWrap;
 import com.wildplot.android.rendering.graphics.wrapper.GraphicsWrap;
 import com.wildplot.android.rendering.graphics.wrapper.RectangleWrap;
@@ -24,6 +26,7 @@ import com.wildplot.android.rendering.interfaces.Drawable;
 /**
  * This class represents grid lines parallel to the y-axis
  */
+@SuppressLint("FieldNamingPatternDetector")
 public class YGrid implements Drawable {
 
     /**

--- a/AnkiDroid/src/main/java/com/wildplot/android/rendering/graphics/wrapper/ColorWrap.java
+++ b/AnkiDroid/src/main/java/com/wildplot/android/rendering/graphics/wrapper/ColorWrap.java
@@ -15,6 +15,9 @@
  ****************************************************************************************/
 package com.wildplot.android.rendering.graphics.wrapper;
 
+import android.annotation.SuppressLint;
+
+@SuppressLint("FieldNamingPatternDetector")
 public class ColorWrap {
     //android.graphics.Color
     private final int colorValue;

--- a/AnkiDroid/src/main/java/com/wildplot/android/rendering/graphics/wrapper/FontMetricsWrap.java
+++ b/AnkiDroid/src/main/java/com/wildplot/android/rendering/graphics/wrapper/FontMetricsWrap.java
@@ -15,6 +15,9 @@
  ****************************************************************************************/
 package com.wildplot.android.rendering.graphics.wrapper;
 
+import android.annotation.SuppressLint;
+
+@SuppressLint("FieldNamingPatternDetector")
 public class FontMetricsWrap {
     private final GraphicsWrap g;
 

--- a/AnkiDroid/src/main/java/com/wildplot/android/rendering/graphics/wrapper/GraphicsWrap.java
+++ b/AnkiDroid/src/main/java/com/wildplot/android/rendering/graphics/wrapper/GraphicsWrap.java
@@ -15,6 +15,7 @@
  ****************************************************************************************/
 package com.wildplot.android.rendering.graphics.wrapper;
 
+import android.annotation.SuppressLint;
 import android.graphics.Canvas;
 import android.graphics.Paint;
 import android.graphics.Paint.Style;
@@ -26,6 +27,7 @@ import android.graphics.Typeface;
  *
  * @author Michael Goldbach
  */
+@SuppressLint("FieldNamingPatternDetector")
 public class GraphicsWrap {
     private final Canvas canvas;
     private final Paint paint;

--- a/AnkiDroid/src/main/java/com/wildplot/android/rendering/graphics/wrapper/StrokeWrap.java
+++ b/AnkiDroid/src/main/java/com/wildplot/android/rendering/graphics/wrapper/StrokeWrap.java
@@ -15,6 +15,9 @@
  ****************************************************************************************/
 package com.wildplot.android.rendering.graphics.wrapper;
 
+import android.annotation.SuppressLint;
+
+@SuppressLint("FieldNamingPatternDetector")
 public class StrokeWrap {
     private final float strokeSize;
 


### PR DESCRIPTION
It's not worth worrying about the m variable prefix as we're not
going to edit external library code

Fixes 138/384 lint warnings

## Fixes
Related: #8387

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [x] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
