### PR TITLE
Implement Create New Deck Function In Add Note Activity

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPickerFloatingActionMenu.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPickerFloatingActionMenu.java
@@ -23,6 +23,7 @@ import android.widget.EditText;
 import android.widget.LinearLayout;
 
 import com.google.android.material.floatingactionbutton.FloatingActionButton;
+import com.ichi2.anki.dialogs.CreateDeckDialog;
 import com.ichi2.libanki.Decks;
 import com.ichi2.ui.FixedEditText;
 
@@ -76,25 +77,11 @@ public class DeckPickerFloatingActionMenu {
         mAddDeckButton.setOnClickListener(addDeckButtonView -> {
             if (mIsFABOpen) {
                 closeFloatingActionMenu();
-                EditText mDialogEditText = new FixedEditText(mDeckPicker);
-                mDialogEditText.setSingleLine(true);
-                new MaterialEditTextDialog.Builder(mDeckPicker, mDialogEditText)
-                        .title(R.string.new_deck)
-                        .positiveText(R.string.dialog_ok)
-                        .onPositive((dialog, which) -> {
-                            String deckName = mDialogEditText.getText().toString();
-                            if (Decks.isValidDeckName(deckName)) {
-                                boolean creation_succeed = deckPicker.createNewDeck(deckName);
-                                if (!creation_succeed) {
-                                    return;
-                                }
-                            } else {
-                                Timber.d("configureFloatingActionsMenu::addDeckButton::onPositiveListener - Not creating invalid deck name '%s'", deckName);
-                                UIUtils.showThemedToast(mDeckPicker, mDeckPicker.getString(R.string.invalid_deck_name), false);
-                            }
-                        })
-                        .negativeText(R.string.dialog_cancel)
-                        .show();
+                CreateDeckDialog createDeckDialog = new CreateDeckDialog(mDeckPicker, R.string.new_deck, CreateDeckDialog.DeckDialogType.DECK, null);
+                createDeckDialog.setOnNewDeckCreated((i) -> {
+                    deckPicker.updateDeckList();
+                });
+                createDeckDialog.showDialog();
             }
         });
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -264,6 +264,7 @@ public class NoteEditor extends AnkiActivity implements
     public void onDeckSelected(@Nullable DeckSelectionDialog.SelectableDeck deck) {
         if (deck != null) {
             mCurrentDid = deck.getDeckId();
+            initializeNoteDeckSpinner();
             mNoteDeckSpinner.setSelection(mAllDeckIds.indexOf(deck.getDeckId()), false);
         }
     }
@@ -605,46 +606,7 @@ public class NoteEditor extends AnkiActivity implements
             deckTextView.setText(R.string.CardEditorCardDeck);
         }
         mNoteDeckSpinner = findViewById(R.id.note_deck_spinner);
-
-        List<Deck> decks = getCol().getDecks().all();
-        Collections.sort(decks, DeckComparator.INSTANCE);
-        final ArrayList<String> deckNames = new ArrayList<>(decks.size());
-        mAllDeckIds = new ArrayList<>(decks.size());
-        for (Deck d : decks) {
-            // add current deck and all other non-filtered decks to deck list
-            long thisDid = d.getLong("id");
-            String currentName = d.getString("name");
-            String lineContent = null;
-            if (d.isStd()) {
-                lineContent = currentName ;
-            } else if (!mAddNote && mCurrentEditedCard != null && mCurrentEditedCard.getDid() == thisDid) {
-                lineContent = getApplicationContext().getString(R.string.current_and_default_deck, currentName, col.getDecks().name(mCurrentEditedCard.getODid()));
-            } else {
-                continue;
-            }
-            deckNames.add(lineContent);
-            mAllDeckIds.add(thisDid);
-        }
-
-        ArrayAdapter<String> noteDeckAdapter = new ArrayAdapter<String>(this, android.R.layout.simple_spinner_item, deckNames) {
-            @Override
-            public View getDropDownView(int position, View convertView, ViewGroup parent) {
-
-                // Cast the drop down items (popup items) as text view
-                TextView tv = (TextView) super.getDropDownView(position, convertView, parent);
-
-                // If this item is selected
-                if (position == mNoteDeckSpinner.getSelectedItemPosition()) {
-                    tv.setBackgroundColor(ContextCompat.getColor(NoteEditor.this, R.color.note_editor_selected_item_background));
-                    tv.setTextColor(ContextCompat.getColor(NoteEditor.this, R.color.note_editor_selected_item_text));
-                }
-
-                // Return the modified view
-                return tv;
-            }
-        };
-        mNoteDeckSpinner.setAdapter(noteDeckAdapter);
-        noteDeckAdapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
+        initializeNoteDeckSpinner();
         mNoteDeckSpinner.setOnTouchListener(new View.OnTouchListener() {
 
                 public boolean onTouch(View view, MotionEvent motionEvent) {
@@ -717,6 +679,48 @@ public class NoteEditor extends AnkiActivity implements
             }
             mEditFields.getFirst().requestFocus();
         }
+    }
+
+    public void initializeNoteDeckSpinner() {
+        List<Deck> decks = getCol().getDecks().all();
+        Collections.sort(decks, DeckComparator.INSTANCE);
+        final ArrayList<String> deckNames = new ArrayList<>(decks.size());
+        mAllDeckIds = new ArrayList<>(decks.size());
+        for (Deck d : decks) {
+            // add current deck and all other non-filtered decks to deck list
+            long thisDid = d.getLong("id");
+            String currentName = d.getString("name");
+            String lineContent = null;
+            if (d.isStd()) {
+                lineContent = currentName ;
+            } else if (!mAddNote && mCurrentEditedCard != null && mCurrentEditedCard.getDid() == thisDid) {
+                lineContent = getApplicationContext().getString(R.string.current_and_default_deck, currentName, getCol().getDecks().name(mCurrentEditedCard.getODid()));
+            } else {
+                continue;
+            }
+            deckNames.add(lineContent);
+            mAllDeckIds.add(thisDid);
+        }
+
+        ArrayAdapter<String> noteDeckAdapter = new ArrayAdapter<String>(this, android.R.layout.simple_spinner_item, deckNames) {
+            @Override
+            public View getDropDownView(int position, View convertView, ViewGroup parent) {
+
+                // Cast the drop down items (popup items) as text view
+                TextView tv = (TextView) super.getDropDownView(position, convertView, parent);
+
+                // If this item is selected
+                if (position == mNoteDeckSpinner.getSelectedItemPosition()) {
+                    tv.setBackgroundColor(ContextCompat.getColor(NoteEditor.this, R.color.note_editor_selected_item_background));
+                    tv.setTextColor(ContextCompat.getColor(NoteEditor.this, R.color.note_editor_selected_item_text));
+                }
+
+                // Return the modified view
+                return tv;
+            }
+        };
+        mNoteDeckSpinner.setAdapter(noteDeckAdapter);
+        noteDeckAdapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/CreateDeckDialog.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/CreateDeckDialog.java
@@ -137,7 +137,7 @@ public class CreateDeckDialog {
     private boolean createNewDeck(@NonNull String deckName) {
         try {
             // create normal deck or sub deck
-            Timber.i("DeckPicker:: Creating new deck...");
+            Timber.i("CreateDeckDialog::createNewDeck");
             long newDeckId = mAnkiActivity.getCol().getDecks().id(deckName);
             mOnNewDeckCreated.accept(newDeckId);
         } catch (FilteredAncestor filteredAncestor) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/CreateDeckDialog.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/CreateDeckDialog.java
@@ -32,6 +32,7 @@ import com.ichi2.ui.FixedEditText;
 import java.util.List;
 import java.util.Locale;
 import java.util.function.Consumer;
+import java.util.stream.Collectors;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -73,15 +74,14 @@ public class CreateDeckDialog {
     }
 
     public void showFilteredDeckDialog() {
-        Timber.i("DeckPicker:: New filtered deck button pressed");
+        Timber.i("CreateDeckDialog::showFilteredDeckDialog");
         List<String> names = mAnkiActivity.getCol().getDecks().allNames();
         int n = 1;
-        String name = String.format(Locale.getDefault(), "%s %d", mContext.getResources().getString(R.string.filtered_deck_name), n);
-        while (names.contains(name)) {
+        String namePrefix = mContext.getResources().getString(R.string.filtered_deck_name) + " ";
+        while (names.contains(namePrefix + n)) {
             n++;
-            name = String.format(Locale.getDefault(), "%s %d", mContext.getResources().getString(R.string.filtered_deck_name), n);
         }
-        mDialogEditText.setText(name);
+        mDialogEditText.setText(namePrefix + n);
 
         showDialog();
     }
@@ -115,7 +115,7 @@ public class CreateDeckDialog {
         if (Decks.isValidDeckName(deckName)) {
             createNewDeck(deckName);
         } else {
-            Timber.d("configureFloatingActionsMenu::addDeckButton::onPositiveListener - Not creating invalid deck name '%s'", deckName);
+            Timber.d("CreateDeckDialog::createDeck - Not creating invalid deck name '%s'", deckName);
             UIUtils.showThemedToast(mContext, mContext.getString(R.string.invalid_deck_name), false);
         }
         closeDialog();
@@ -124,7 +124,7 @@ public class CreateDeckDialog {
     public boolean createFilteredDeck(@NonNull String deckName) {
         try {
             // create filtered deck
-            Timber.i("DeckPicker:: Creating filtered deck...");
+            Timber.i("CreateDeckDialog::createFilteredDeck...");
             long newDeckId = mAnkiActivity.getCol().getDecks().newDyn(deckName);
             mOnNewDeckCreated.accept(newDeckId);
         } catch (FilteredAncestor filteredAncestor) {
@@ -175,7 +175,7 @@ public class CreateDeckDialog {
     public void renameDeck(String newDeckName) {
         String newName = newDeckName.replaceAll("\"", "");
         if (!Decks.isValidDeckName(newName)) {
-            Timber.i("renameDeckDialog not renaming deck to invalid name '%s'", newName);
+            Timber.i("CreateDeckDialog::renameDeck not renaming deck to invalid name '%s'", newName);
             UIUtils.showThemedToast(mContext, mContext.getString(R.string.invalid_deck_name), false);
         } else if (!newName.equals(mPreviousDeckName)) {
             try {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/CreateDeckDialog.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/CreateDeckDialog.java
@@ -1,0 +1,199 @@
+/****************************************************************************************
+ * Copyright (c) 2021 Akshay Jadhav <jadhavakshay0701@gmail.com>                        *
+ *                                                                                      *
+ * This program is free software; you can redistribute it and/or modify it under        *
+ * the terms of the GNU General Public License as published by the Free Software        *
+ * Foundation; either version 3 of the License, or (at your option) any later           *
+ * version.                                                                             *
+ *                                                                                      *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *                                                                                      *
+ * You should have received a copy of the GNU General Public License along with         *
+ * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ ****************************************************************************************/
+
+package com.ichi2.anki.dialogs;
+
+import android.content.Context;
+import android.widget.EditText;
+
+import com.afollestad.materialdialogs.MaterialDialog;
+import com.ichi2.anki.AnkiActivity;
+import com.ichi2.anki.R;
+import com.ichi2.anki.UIUtils;
+import com.ichi2.anki.exception.DeckRenameException;
+import com.ichi2.anki.exception.FilteredAncestor;
+import com.ichi2.libanki.Collection;
+import com.ichi2.libanki.Decks;
+import com.ichi2.ui.FixedEditText;
+
+import java.util.List;
+import java.util.Locale;
+import java.util.function.Consumer;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import timber.log.Timber;
+
+public class CreateDeckDialog {
+
+    private final EditText mDialogEditText;
+    private final MaterialDialog.Builder mBuilder;
+    private final Context mContext;
+    private final int mTitle;
+    private final AnkiActivity mAnkiActivity;
+    private final Long mParentId;
+    private String mPreviousDeckName;
+    private final DeckDialogType mDeckDialogType;
+    public Consumer<Long> mOnNewDeckCreated;
+
+    public enum DeckDialogType
+    {
+        FILTERED_DECK,
+        DECK,
+        SUB_DECK,
+        RENAME_DECK
+    }
+
+    public CreateDeckDialog(@NonNull Context context, @NonNull int title, @NonNull DeckDialogType deckDialogType, @Nullable Long parentId) {
+        this.mContext = context;
+        this.mTitle = title;
+        this.mParentId = parentId;
+        this.mDeckDialogType = deckDialogType;
+        this.mDialogEditText = new FixedEditText(context);
+        mAnkiActivity = new AnkiActivity();
+        mBuilder = new MaterialDialog.Builder(context);
+    }
+
+    public void setDeckName(@NonNull String deckName) {
+        mPreviousDeckName = deckName;
+        mDialogEditText.setText(deckName);
+    }
+
+    public void showFilteredDeckDialog() {
+        Timber.i("DeckPicker:: New filtered deck button pressed");
+        List<String> names = mAnkiActivity.getCol().getDecks().allNames();
+        int n = 1;
+        String name = String.format(Locale.getDefault(), "%s %d", mContext.getResources().getString(R.string.filtered_deck_name), n);
+        while (names.contains(name)) {
+            n++;
+            name = String.format(Locale.getDefault(), "%s %d", mContext.getResources().getString(R.string.filtered_deck_name), n);
+        }
+        mDialogEditText.setText(name);
+
+        showDialog();
+    }
+
+    public String getDeckName() {
+        return mDialogEditText.getText().toString();
+    }
+
+    public MaterialDialog showDialog() {
+        mDialogEditText.setSingleLine(true);
+        mDialogEditText.setId(R.id.action_edit);
+
+        return mBuilder.title(mTitle)
+                .positiveText(R.string.dialog_ok)
+                .customView(mDialogEditText, true)
+                .negativeText(R.string.dialog_cancel)
+                .onPositive((dialog, which) -> onPositiveButtonClicked())
+                .show();
+    }
+
+    public void closeDialog() {
+        mBuilder.build().dismiss();
+    }
+
+    public void createSubDeck(@NonNull long did, @Nullable String deckName) {
+        String deckNameWithParentName = mAnkiActivity.getCol().getDecks().getSubdeckName(did, deckName);
+        createDeck(deckNameWithParentName);
+    }
+
+    public void createDeck(@NonNull String deckName) {
+        if (Decks.isValidDeckName(deckName)) {
+            createNewDeck(deckName);
+        } else {
+            Timber.d("configureFloatingActionsMenu::addDeckButton::onPositiveListener - Not creating invalid deck name '%s'", deckName);
+            UIUtils.showThemedToast(mContext, mContext.getString(R.string.invalid_deck_name), false);
+        }
+        closeDialog();
+    }
+
+    public boolean createFilteredDeck(@NonNull String deckName) {
+        try {
+            // create filtered deck
+            Timber.i("DeckPicker:: Creating filtered deck...");
+            long newDeckId = mAnkiActivity.getCol().getDecks().newDyn(deckName);
+            mOnNewDeckCreated.accept(newDeckId);
+        } catch (FilteredAncestor filteredAncestor) {
+            UIUtils.showThemedToast(mContext, mContext.getString(R.string.decks_rename_filtered_nosubdecks), false);
+            return false;
+        }
+        return true;
+    }
+
+    private boolean createNewDeck(@NonNull String deckName) {
+        try {
+            // create normal deck or sub deck
+            Timber.i("DeckPicker:: Creating new deck...");
+            long newDeckId = mAnkiActivity.getCol().getDecks().id(deckName);
+            mOnNewDeckCreated.accept(newDeckId);
+        } catch (FilteredAncestor filteredAncestor) {
+            Timber.w(filteredAncestor);
+            return false;
+        }
+        return true;
+    }
+
+    private void onPositiveButtonClicked() {
+        if (!getDeckName().isEmpty()) {
+            switch (mDeckDialogType) {
+                case DECK: {
+                    // create deck
+                    createDeck(getDeckName());
+                    break;
+                }
+                case RENAME_DECK: {
+                    renameDeck(getDeckName());
+                    break;
+                }
+                case SUB_DECK: {
+                    // create sub deck
+                    createSubDeck(mParentId, getDeckName());
+                    break;
+                }
+                case FILTERED_DECK: {
+                    // create filtered deck
+                    createFilteredDeck(getDeckName());
+                }
+            }
+        }
+    }
+
+    public void renameDeck(String newDeckName) {
+        String newName = newDeckName.replaceAll("\"", "");
+        if (!Decks.isValidDeckName(newName)) {
+            Timber.i("renameDeckDialog not renaming deck to invalid name '%s'", newName);
+            UIUtils.showThemedToast(mContext, mContext.getString(R.string.invalid_deck_name), false);
+        } else if (!newName.equals(mPreviousDeckName)) {
+            try {
+                Collection col = mAnkiActivity.getCol();
+                Long deckId = col.getDecks().id(mPreviousDeckName);
+                col.getDecks().rename(col.getDecks().get(deckId), newName);
+                mOnNewDeckCreated.accept(deckId);
+            } catch (DeckRenameException e) {
+                Timber.w(e);
+                // We get a localized string from libanki to explain the error
+                UIUtils.showThemedToast(mContext, e.getLocalizedMessage(mContext.getResources()), false);
+            } catch (FilteredAncestor filteredAncestor) {
+                Timber.w(filteredAncestor);
+            }
+        }
+    }
+
+    public void setOnNewDeckCreated(Consumer<Long> c) {
+        this.mOnNewDeckCreated = c;
+    }
+}

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckSelectionDialog.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckSelectionDialog.java
@@ -29,8 +29,11 @@ import android.widget.Filterable;
 import android.widget.TextView;
 
 import com.afollestad.materialdialogs.MaterialDialog;
+import com.ichi2.anki.AnkiActivity;
 import com.ichi2.anki.R;
+import com.ichi2.anki.UIUtils;
 import com.ichi2.anki.analytics.AnalyticsDialogFragment;
+import com.ichi2.anki.exception.FilteredAncestor;
 import com.ichi2.libanki.Collection;
 import com.ichi2.libanki.Deck;
 import com.ichi2.utils.FunctionalInterfaces;
@@ -49,6 +52,7 @@ import androidx.appcompat.widget.Toolbar;
 import androidx.recyclerview.widget.DividerItemDecoration;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
+import timber.log.Timber;
 
 public class DeckSelectionDialog extends AnalyticsDialogFragment {
 
@@ -166,6 +170,52 @@ public class DeckSelectionDialog extends AnalyticsDialogFragment {
                 return true;
             }
         });
+
+        MenuItem addDecks = mToolbar.getMenu().findItem(R.id.deck_picker_dialog_action_add_deck);
+        addDecks.setOnMenuItemClickListener(menuItem -> {
+            // creating new deck without any parent deck
+            showDeckDialog();
+            return true;
+        });
+    }
+
+    private void showSubDeckDialog(String parentDeckPath) {
+        try {
+            // create subdeck
+            Long parentId = requireAnkiActivity().getCol().getDecks().id(parentDeckPath);
+            CreateDeckDialog createDeckDialog = new CreateDeckDialog(requireActivity(), R.string.create_subdeck, CreateDeckDialog.DeckDialogType.SUB_DECK, parentId);
+            createDeckDialog.setOnNewDeckCreated((id) -> {
+                // a sub deck was created
+                selectDeckWithDeckName(requireAnkiActivity().getCol().getDecks().name(id));
+            });
+            createDeckDialog.showDialog();
+        } catch (FilteredAncestor filteredAncestor) {
+            Timber.w(filteredAncestor);
+        }
+    }
+
+    private void showDeckDialog() {
+        CreateDeckDialog createDeckDialog =  new CreateDeckDialog(requireActivity(), R.string.new_deck, CreateDeckDialog.DeckDialogType.DECK, null);
+        createDeckDialog.setOnNewDeckCreated((id) -> {
+            // a deck was created
+            selectDeckWithDeckName(requireAnkiActivity().getCol().getDecks().name(id));
+        });
+        createDeckDialog.showDialog();
+    }
+
+    @NonNull
+    protected AnkiActivity requireAnkiActivity() {
+        return (AnkiActivity) requireActivity();
+    }
+
+    private void selectDeckWithDeckName(@NonNull String deckName) {
+        try {
+            Long id = requireAnkiActivity().getCol().getDecks().id(deckName);
+            SelectableDeck dec = new SelectableDeck(id, deckName);
+            selectDeckAndClose(dec);
+        } catch (FilteredAncestor filteredAncestor) {
+            UIUtils.showThemedToast(requireActivity(), getString(R.string.decks_rename_filtered_nosubdecks), false);
+        }
     }
 
 
@@ -192,6 +242,15 @@ public class DeckSelectionDialog extends AnalyticsDialogFragment {
                 mDeckTextView.setOnClickListener(view -> {
                     String deckName = ctv.getText().toString();
                     selectDeckByNameAndClose(deckName);
+                });
+
+                mDeckTextView.setOnLongClickListener(new View.OnLongClickListener() {
+                    @Override
+                    public boolean onLongClick(View view) {
+                        // creating sub deck with parent deck path
+                        showSubDeckDialog(ctv.getText().toString());
+                        return true;
+                    }
                 });
             }
 

--- a/AnkiDroid/src/main/res/menu/deck_picker_dialog_menu.xml
+++ b/AnkiDroid/src/main/res/menu/deck_picker_dialog_menu.xml
@@ -23,4 +23,9 @@
         android:title="@string/deck_picker_dialog_filter_decks"
         ankidroid:actionViewClass="androidx.appcompat.widget.SearchView"
         ankidroid:showAsAction="always|collapseActionView"/>
+    <item
+        android:id="@+id/deck_picker_dialog_action_add_deck"
+        android:icon="@drawable/ic_add_white"
+        android:title="@string/menu_add"
+        ankidroid:showAsAction="always" />
 </menu>

--- a/AnkiDroid/src/main/res/values/01-core.xml
+++ b/AnkiDroid/src/main/res/values/01-core.xml
@@ -107,7 +107,6 @@
     <string name="menu_unmark_note">Unmark note</string>
     <string name="menu_toggle_mic_tool_bar">Check pronunciation</string>
     <string name="new_deck">Create deck</string>
-    <string name="create" comment="Button to create a filtered deck">Create</string>
     <string name="new_dynamic_deck">Create filtered deck</string>
     <string name="night_mode">Night mode</string>
     <string name="directory_inaccessible">AnkiDroid directory is inaccessible</string>

--- a/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/CreateDeckDialogTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/CreateDeckDialogTest.java
@@ -54,7 +54,7 @@ public class CreateDeckDialogTest extends RobolectricTest {
             CreateDeckDialog createDeckDialog = new CreateDeckDialog(activity, R.string.new_deck, CreateDeckDialog.DeckDialogType.FILTERED_DECK, null);
             AtomicReference<Boolean> isCreated = new AtomicReference<>(false);
             String deckName = "filteredDeck";
-            shadowOf(getMainLooper()).idle();
+            advanceRobolectricLooper();
 
             createDeckDialog.setOnNewDeckCreated((id) -> {
                 // a deck was created
@@ -80,7 +80,7 @@ public class CreateDeckDialogTest extends RobolectricTest {
             CreateDeckDialog createDeckDialog = new CreateDeckDialog(activity, R.string.new_deck, CreateDeckDialog.DeckDialogType.SUB_DECK, deckParentId);
             AtomicReference<Boolean> isCreated = new AtomicReference<>(false);
             String deckName = "filteredDeck";
-            shadowOf(getMainLooper()).idle();
+            advanceRobolectricLooper();
 
             createDeckDialog.setOnNewDeckCreated((id) -> {
                 try {
@@ -104,7 +104,7 @@ public class CreateDeckDialogTest extends RobolectricTest {
             CreateDeckDialog createDeckDialog = new CreateDeckDialog(activity, R.string.new_deck, CreateDeckDialog.DeckDialogType.DECK, null);
             AtomicReference<Boolean> isCreated = new AtomicReference<>(false);
             String deckName = "Deck Name";
-            shadowOf(getMainLooper()).idle();
+            advanceRobolectricLooper();
 
             createDeckDialog.setOnNewDeckCreated((id) -> {
                 // a deck was created
@@ -127,7 +127,7 @@ public class CreateDeckDialogTest extends RobolectricTest {
             CreateDeckDialog createDeckDialog = new CreateDeckDialog(activity, R.string.new_deck, CreateDeckDialog.DeckDialogType.RENAME_DECK, null);
             createDeckDialog.setDeckName(deckName);
             AtomicReference<Boolean> isCreated = new AtomicReference<>(false);
-            shadowOf(getMainLooper()).idle();
+            advanceRobolectricLooper();
 
             createDeckDialog.setOnNewDeckCreated((id) -> {
                 // a deck name was renamed

--- a/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/CreateDeckDialogTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/CreateDeckDialogTest.java
@@ -1,0 +1,144 @@
+/****************************************************************************************
+ * Copyright (c) 2021 Akshay Jadhav <jadhavakshay0701@gmail.com>                        *
+ *                                                                                      *
+ * This program is free software; you can redistribute it and/or modify it under        *
+ * the terms of the GNU General Public License as published by the Free Software        *
+ * Foundation; either version 3 of the License, or (at your option) any later           *
+ * version.                                                                             *
+ *                                                                                      *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *                                                                                      *
+ * You should have received a copy of the GNU General Public License along with         *
+ * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ ****************************************************************************************/
+
+package com.ichi2.anki.dialogs;
+
+import com.ichi2.anki.AnkiActivity;
+import com.ichi2.anki.DeckPicker;
+import com.ichi2.anki.R;
+import com.ichi2.anki.RobolectricTest;
+import com.ichi2.anki.exception.FilteredAncestor;
+import com.ichi2.libanki.Decks;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+
+import java.util.concurrent.atomic.AtomicReference;
+import androidx.lifecycle.Lifecycle;
+import androidx.test.core.app.ActivityScenario;
+import static android.os.Looper.getMainLooper;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.robolectric.Shadows.shadowOf;
+
+@RunWith(RobolectricTestRunner.class)
+public class CreateDeckDialogTest extends RobolectricTest {
+
+    private ActivityScenario<DeckPicker> mActivityScenario;
+
+    @Override
+    public void setUp() {
+        super.setUp();
+        ensureCollectionLoadIsSynchronous();
+        mActivityScenario = ActivityScenario.launch(DeckPicker.class);
+        mActivityScenario.moveToState(Lifecycle.State.STARTED);
+    }
+
+    @Test
+    public void testCreateFilteredDeckFunction() {
+        mActivityScenario.onActivity(activity -> {
+            CreateDeckDialog createDeckDialog = new CreateDeckDialog(activity, R.string.new_deck, CreateDeckDialog.DeckDialogType.FILTERED_DECK, null);
+            AtomicReference<Boolean> isCreated = new AtomicReference<>(false);
+            String deckName = "filteredDeck";
+            shadowOf(getMainLooper()).idle();
+
+            createDeckDialog.setOnNewDeckCreated((id) -> {
+                // a deck was created
+                try {
+                    isCreated.set(true);
+                    final Decks decks = activity.getCol().getDecks();
+                    assertThat(id, is(decks.id(deckName)));
+                } catch (FilteredAncestor filteredAncestor) {
+                    throw new RuntimeException(filteredAncestor);
+                }
+            });
+
+            createDeckDialog.createFilteredDeck(deckName);
+            assertThat(isCreated.get(), is(true));
+        });
+    }
+
+    @Test
+    public void testCreateSubDeckFunction() throws FilteredAncestor {
+        Long deckParentId = new AnkiActivity().getCol().getDecks().id("Deck Name");
+
+        mActivityScenario.onActivity(activity -> {
+            CreateDeckDialog createDeckDialog = new CreateDeckDialog(activity, R.string.new_deck, CreateDeckDialog.DeckDialogType.SUB_DECK, deckParentId);
+            AtomicReference<Boolean> isCreated = new AtomicReference<>(false);
+            String deckName = "filteredDeck";
+            shadowOf(getMainLooper()).idle();
+
+            createDeckDialog.setOnNewDeckCreated((id) -> {
+                try {
+                    isCreated.set(true);
+                    final Decks decks = activity.getCol().getDecks();
+                    String deckNameWithParentName = decks.getSubdeckName(deckParentId, deckName);
+                    assertThat(id, is(decks.id(deckNameWithParentName)));
+                } catch (FilteredAncestor filteredAncestor) {
+                    throw new RuntimeException(filteredAncestor);
+                }
+            });
+
+            createDeckDialog.createSubDeck(deckParentId, deckName);
+            assertThat(isCreated.get(), is(true));
+        });
+    }
+
+    @Test
+    public void testCreateDeckFunction() {
+        mActivityScenario.onActivity(activity -> {
+            CreateDeckDialog createDeckDialog = new CreateDeckDialog(activity, R.string.new_deck, CreateDeckDialog.DeckDialogType.DECK, null);
+            AtomicReference<Boolean> isCreated = new AtomicReference<>(false);
+            String deckName = "Deck Name";
+            shadowOf(getMainLooper()).idle();
+
+            createDeckDialog.setOnNewDeckCreated((id) -> {
+                // a deck was created
+                isCreated.set(true);
+                final Decks decks = activity.getCol().getDecks();
+                assertThat(id, is(decks.byName(deckName).getLong("id")));
+            });
+
+            createDeckDialog.createDeck(deckName);
+            assertThat(isCreated.get(), is(true));
+        });
+    }
+
+    @Test
+    public void testRenameDeckFunction() {
+        String deckName = "Deck Name";
+        String deckNewName = "New Deck Name";
+        mActivityScenario.onActivity(activity -> {
+
+            CreateDeckDialog createDeckDialog = new CreateDeckDialog(activity, R.string.new_deck, CreateDeckDialog.DeckDialogType.RENAME_DECK, null);
+            createDeckDialog.setDeckName(deckName);
+            AtomicReference<Boolean> isCreated = new AtomicReference<>(false);
+            shadowOf(getMainLooper()).idle();
+
+            createDeckDialog.setOnNewDeckCreated((id) -> {
+                // a deck name was renamed
+                isCreated.set(true);
+                final Decks decks = activity.getCol().getDecks();
+                assertThat(deckNewName, is(decks.name(id)));
+            });
+
+            createDeckDialog.renameDeck(deckNewName);
+            assertThat(isCreated.get(), is(true));
+        });
+    }
+
+} 


### PR DESCRIPTION
## Problem
With Current Spinner in add note activity user can select any deck , but
1 if user don't found particular deck in list then user have to go back to main activity to create that deck and then user have to create note and select that particular deck , it is lengthy process.

## Solution
We can implement add new create deck function at top left corner of `DeckSelectionDialog` box,so that if any user don't found deck , then user can directly create new deck from there without aborting whole process to create new deck.

## Fixes
Fixes #8275 

# work done 

- [✔️ ] Extracted Add Deck Dialog from DeckPicker class to separate CreateDeckDialog class,

- [✔️] Added add deck function to DeckSelection class in NoteEditor activity,

- [✔️] Removed Unused Resource `R.string.create`


## Output 
<img src="https://user-images.githubusercontent.com/52353967/112320127-bb675980-8cd4-11eb-8eec-cfc9e42fb61c.gif" width="250" height="500" />------<img src="https://user-images.githubusercontent.com/52353967/112320120-ba362c80-8cd4-11eb-8714-bcd9666f5c24.gif" width="250" height="500" />
1 Add Deck Video
2 Add Sub Deck Video
