### PR TITLE
fix :Deck ordering differs from Anki Desktop

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractDeckTreeComparator.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractDeckTreeComparator.java
@@ -1,0 +1,24 @@
+package com.ichi2.anki;
+
+import com.ichi2.libanki.sched.AbstractDeckTreeNode;
+
+import java.util.Comparator;
+
+public class AbstractDeckTreeComparator implements Comparator<AbstractDeckTreeNode<?>> {
+
+
+        @Override
+        public int compare(AbstractDeckTreeNode<?> o1, AbstractDeckTreeNode<?> o2) {
+            int minDepth = Math.min(o1.getDepth(), o2.getDepth()) + 1;
+            String [] mNameComponentsO1 =o1.getmNameComponents();
+            String [] mNameComponetsO2 =o2.getmNameComponents();
+            // Consider each subdeck name in the ordering
+            for (int i = 0; i < minDepth; i++) {
+                int result = mNameComponentsO1[i].compareToIgnoreCase(mNameComponetsO2[i]);
+                return result;
+            }
+            return Integer.compare(o1.getDepth(), o2.getDepth());
+        }
+    }
+
+

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractDeckTreeComparator.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractDeckTreeComparator.java
@@ -9,15 +9,17 @@ public class AbstractDeckTreeComparator implements Comparator<AbstractDeckTreeNo
 
         @Override
         public int compare(AbstractDeckTreeNode<?> o1, AbstractDeckTreeNode<?> o2) {
-            int minDepth = Math.min(o1.getDepth(), o2.getDepth()) + 1;
             String[] mNameComponentsO1 = o1.getmNameComponents();
             String[] mNameComponetsO2 = o2.getmNameComponents();
+            int minDepth = Math.min(mNameComponentsO1.length, mNameComponetsO2.length);
             // Consider each subdeck name in the ordering
             for (int i = 0; i < minDepth; i++) {
                 int result = mNameComponentsO1[i].compareToIgnoreCase(mNameComponetsO2[i]);
-                return result;
+                if (result != 0) {
+                    return result;
+                }
             }
-            return Integer.compare(o1.getDepth(), o2.getDepth());
+            return Integer.compare(mNameComponentsO1.length, mNameComponetsO2.length);
         }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractDeckTreeComparator.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractDeckTreeComparator.java
@@ -10,8 +10,8 @@ public class AbstractDeckTreeComparator implements Comparator<AbstractDeckTreeNo
         @Override
         public int compare(AbstractDeckTreeNode<?> o1, AbstractDeckTreeNode<?> o2) {
             int minDepth = Math.min(o1.getDepth(), o2.getDepth()) + 1;
-            String [] mNameComponentsO1 =o1.getmNameComponents();
-            String [] mNameComponetsO2 =o2.getmNameComponents();
+            String[] mNameComponentsO1 = o1.getmNameComponents();
+            String[] mNameComponetsO2 = o2.getmNameComponents();
             // Consider each subdeck name in the ordering
             for (int i = 0; i < minDepth; i++) {
                 int result = mNameComponentsO1[i].compareToIgnoreCase(mNameComponetsO2[i]);

--- a/AnkiDroid/src/main/java/com/ichi2/anki/widgets/DeckAdapter.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/widgets/DeckAdapter.java
@@ -38,6 +38,7 @@ import android.widget.LinearLayout;
 import android.widget.RelativeLayout;
 import android.widget.TextView;
 
+import com.ichi2.anki.AbstractDeckTreeComparator;
 import com.ichi2.anki.R;
 import com.ichi2.compat.CompatHelper;
 import com.ichi2.libanki.Collection;
@@ -48,6 +49,7 @@ import com.ichi2.utils.FilterResultsUtils;
 import com.ichi2.libanki.sched.Counts;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 
@@ -281,6 +283,7 @@ public class DeckAdapter<T extends AbstractDeckTreeNode<T>> extends RecyclerView
 
     @Override
     public int getItemCount() {
+        Collections.sort(mCurrentDeckList, new AbstractDeckTreeComparator());
         return mCurrentDeckList.size();
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/AbstractDeckTreeNode.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/AbstractDeckTreeNode.java
@@ -193,4 +193,9 @@ public abstract class AbstractDeckTreeNode<T extends AbstractDeckTreeNode<T>> im
 
 
     public abstract T withChildren(List<T> children);
+
+    public String[] getmNameComponents() {
+        return mNameComponents;
+    }
+
 }


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
_Describe the problem or feature and motivation_

## Fixes
Fixes #8397 



## Approach
Add an class -AbstractDeckTreeComparator which sort the mCurrentDeckList in DeckAdapter 
mCurrentDeckList is list of item for Recycler view 
## How Has This Been Tested?
Android Device:Redmiy3
API :29

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [x] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
