### PR TITLE
chore: remove pre-API21 workaround for language icon in prefs

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
@@ -197,25 +197,6 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
                     mCategory.removePreference(mCheckBoxPref_Vibrate);
                     mCategory.removePreference(mCheckBoxPref_Blink);
                 }
-                try {
-                    // This works on an API 19 emulator
-                    // use icon= once we're past API 21
-                    // ----
-                    // android.content.res.Resources$NotFoundException: File res/drawable/ic_language_black_24dp.xml
-                    // from drawable resource ID #0x7f0800d7. If the resource you are trying to use is a vector
-                    // resource, you may be referencing it in an unsupported way.
-                    // See AppCompatDelegate.setCompatVectorFromResourcesEnabled() for more info.
-                    Drawable languageIcon = VectorDrawableCompat.create(
-                            getResources(),
-                            R.drawable.ic_language_black_24dp,
-                            getTheme());
-
-                    screen.findPreference("language").setIcon(languageIcon);
-                } catch (Exception e) {
-                    Timber.w(e, "Failed to set language icon");
-                }
-
-
                 // Build languages
                 initializeLanguageDialog(screen);
                 break;

--- a/AnkiDroid/src/main/res/xml/preferences_general.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_general.xml
@@ -59,6 +59,7 @@
         <ListPreference
             android:defaultValue="@string/empty_string"
             android:key="language"
+            android:icon="@drawable/ic_language_black_24dp"
             android:title="@string/language" />
         <CheckBoxPreference
             android:defaultValue="false"


### PR DESCRIPTION

## Pull Request template

## Purpose / Description

the prefs screen can handle SVG drawables directly in API21+

## Fixes

Nothing logged, was just a comment in an area was working in, and the time has come

## Approach

Remove the Compat API usage, set the drawable directly

## How Has This Been Tested?

Checked day and night mode in API21 and API30 emulator on the general settings preference screen, all good

This was a nice workaround to use the SVG on lower APIs from @david-allison-1 - David you should check it

## Learning (optional, can help others)

It's hard to notice all the old API workarounds in one go when bumping minSdkVersion! Possibly could use some sort of clear marking, like an annotation plus lint check or something

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
