### PR TITLE
Add Hardware render toggle for Reviewer

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -1876,7 +1876,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
         recreateWebView();
     }
 
-    private void recreateWebView() {
+    protected void recreateWebView() {
         if (mCardWebView == null) {
             mCardWebView = createWebView();
             WebViewDebugging.initializeDebugging(AnkiDroidApp.getSharedPrefs(this));

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -37,6 +37,7 @@ import android.database.SQLException;
 import android.graphics.PixelFormat;
 import android.graphics.drawable.Drawable;
 import android.net.Uri;
+import android.os.Build;
 import android.os.Bundle;
 import android.os.Message;
 import android.os.ParcelFileDescriptor;
@@ -1138,6 +1139,17 @@ public class DeckPicker extends NavigationDrawerActivity implements
 
 
     private void showStartupScreensAndDialogs(SharedPreferences preferences, int skip) {
+
+        // For Android 8/8.1 we want to use software rendering by default or the Reviewer UI is broken #7369
+        if (CompatHelper.getSdkVersion() == Build.VERSION_CODES.O ||
+                CompatHelper.getSdkVersion() == Build.VERSION_CODES.O_MR1) {
+                if (!preferences.contains("softwareRender")) {
+                    Timber.i("Android 8/8.1 detected with no render preference. Turning on software render.");
+                    preferences.edit().putBoolean("softwareRender", true).apply();
+                } else {
+                    Timber.i("Android 8/8.1 detected, software render preference already exists.");
+                }
+        }
 
         if (!BackupManager.enoughDiscSpace(CollectionHelper.getCurrentAnkiDroidDirectory(this))) {
             Timber.i("Not enough space to do backup");

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Info.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Info.java
@@ -35,6 +35,7 @@ import android.widget.Button;
 
 import com.ichi2.utils.IntentUtil;
 import com.ichi2.utils.VersionUtils;
+import com.ichi2.utils.ViewGroupUtils;
 
 import org.acra.util.Installation;
 
@@ -103,6 +104,8 @@ public class Info extends AnkiActivity {
         int backgroundColor = typedArray.getColor(0, -1);
         String textColor = String.format("#%06X", (0xFFFFFF & typedArray.getColor(1, -1))); // Color to hex string
         webView.setBackgroundColor(backgroundColor);
+
+        ViewGroupUtils.setRenderWorkaround(this);
 
         switch (mType) {
             case TYPE_ABOUT: {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.java
@@ -34,7 +34,6 @@ import android.os.Handler;
 import android.os.Message;
 import android.text.SpannableString;
 import android.text.style.UnderlineSpan;
-import android.util.Pair;
 import android.view.KeyEvent;
 import android.view.Menu;
 import android.view.MenuItem;
@@ -71,9 +70,7 @@ import com.ichi2.anki.reviewer.ReviewerUi;
 import com.ichi2.anki.workarounds.FirefoxSnackbarWorkaround;
 import com.ichi2.anki.reviewer.ActionButtons;
 import com.ichi2.async.CollectionTask;
-import com.ichi2.async.TaskListener;
 import com.ichi2.async.TaskManager;
-import com.ichi2.compat.CompatHelper;
 import com.ichi2.libanki.Card;
 import com.ichi2.libanki.Collection;
 import com.ichi2.libanki.Consts;
@@ -85,6 +82,7 @@ import com.ichi2.utils.AndroidUiUtils;
 import com.ichi2.utils.FunctionalInterfaces.Consumer;
 import com.ichi2.utils.PairWithBoolean;
 import com.ichi2.utils.Permissions;
+import com.ichi2.utils.ViewGroupUtils;
 import com.ichi2.widget.WidgetStatus;
 
 import java.lang.ref.WeakReference;
@@ -208,6 +206,12 @@ public class Reviewer extends AbstractFlashcardViewer {
     }
 
     @Override
+    protected void recreateWebView() {
+        super.recreateWebView();
+        ViewGroupUtils.setRenderWorkaround(this);
+    }
+
+    @Override
     protected boolean shouldDisplayMark() {
         boolean markValue = super.shouldDisplayMark();
         if (!markValue) {
@@ -296,6 +300,8 @@ public class Reviewer extends AbstractFlashcardViewer {
         if (mPrefFullscreenReview) {
             setFullScreen(this);
         }
+
+        ViewGroupUtils.setRenderWorkaround(this);
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/utils/ViewGroupUtils.java
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/ViewGroupUtils.java
@@ -16,13 +16,17 @@
 
 package com.ichi2.utils;
 
+import android.app.Activity;
 import android.view.View;
 import android.view.ViewGroup;
+
+import com.ichi2.anki.AnkiDroidApp;
 
 import java.util.ArrayList;
 import java.util.List;
 
 import androidx.annotation.NonNull;
+import timber.log.Timber;
 
 public class ViewGroupUtils {
     @NonNull
@@ -46,5 +50,33 @@ public class ViewGroupUtils {
             }
         }
         return views;
+    }
+
+    public static void setRenderWorkaround(Activity activity) {
+        if (AnkiDroidApp.getSharedPrefs(activity).getBoolean("softwareRender", false)) {
+            Timber.i("ViewGroupUtils::setRenderWorkaround - software render requested, altering Views...");
+            ViewGroupUtils.setContentViewLayerTypeSoftware(activity);
+        } else {
+            Timber.i("ViewGroupUtils::setRenderWorkaround - using default / hardware rendering");
+        }
+    }
+
+    /**
+     * Gets all the Views for the given Activity's ContentView, and sets their layerType
+     * to the given layerType
+     *
+     * @param activity Activity containing the View hierarchy to alter
+     */
+    private static void setContentViewLayerTypeSoftware(@NonNull Activity activity) {
+        ViewGroup rootViewGroup =
+                (ViewGroup) ((ViewGroup) activity.findViewById(android.R.id.content))
+                        .getChildAt(0);
+        List<View> allViews = getAllChildrenRecursive(rootViewGroup);
+        allViews.add(rootViewGroup);
+        for (View v : allViews) {
+            Timber.d("ViewGroupUtils::setContentViewLayerTypeSoftware for view %s",
+                    v.getId());
+            v.setLayerType(View.LAYER_TYPE_SOFTWARE, null);
+        }
     }
 }

--- a/AnkiDroid/src/main/res/values/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values/10-preferences.xml
@@ -133,6 +133,8 @@
     <string name="timeout_answer_seconds_summ" comment="The time to wait (in seconds) in the reviewer before automatically showing the next question or answer">XXX s</string>
     <string name="timeout_question_seconds">Time to show next question</string>
     <string name="select_locale_title">Select language</string>
+    <string name="software_render">Disable card hardware render</string>
+    <string name="software_render_summ">Hardware render is faster but may have problems, specifically on Android 8/8.1. If you cannot see parts of the card review user interface, try this setting.</string>
     <string name="safe_display">Safe display mode</string>
     <string name="safe_display_summ">Disable all animations and use safer method for drawing cards. E-ink devices may require this.</string>
     <string name="disable_extended_text_ui">Disable Single-Field Edit Mode</string>

--- a/AnkiDroid/src/main/res/xml/preferences_advanced.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_advanced.xml
@@ -54,6 +54,11 @@
             android:title="@string/pref_cat_workarounds" >
             <CheckBoxPreference
                 android:defaultValue="false"
+                android:key="softwareRender"
+                android:summary="@string/software_render_summ"
+                android:title="@string/software_render" />
+            <CheckBoxPreference
+                android:defaultValue="false"
                 android:key="safeDisplay"
                 android:summary="@string/safe_display_summ"
                 android:title="@string/safe_display" />


### PR DESCRIPTION
## Pull Request template

## Purpose / Description

Android 8/8.1 had something terrible happen in an update, which caused the entire Reviewer UI to disappear #7369 

In order to stop the user outcry of a totally broken app I implemented a quick Layout XML based switch to software render for Android 8/8.1 in #8154 

This caused a separate user outcry because some users then had terrible scroll performance or similar with the software rendering.

Since it's clear we can't make the correct choice for all users, we need to expose the tradeoff / choice to the users as a preference, but with a safe (if low performance) default of software render for Android 8

## Fixes
Fixes #8160 

## Approach
- add a new advanced preference "softwareRender"
- on startup, if we are Android 8/8.1 and there is no entry for "softwareRender" set, set it to true
- if "softwareRender" is true, in Reviewer get the view tree for the content view and set it to software render

## How Has This Been Tested?

Tested on an emulator both Android 8/8.1 and 10, the diagnostics in the log were as expected

Note that I was never able to trigger this issue myself, however these users were able to test:

- Users with Reviewer UI broken: @jbuschtoens @josemlucero @terryneal2 @terrywallwork
- Users with poor scroll performance: @KidaYuushi @Arx724 @Kayminet

Once this is released in an alpha, if anyone from each set of those users could confirm that the reviewer is working for them, or that if they turn hardware render back on they have good performance, then we have a successful fix

## Learning (optional, can help others)

- It is hard to dynamically get the root content view but stackoverflow has the answer...
- not being in control of the WebView is irritating but I certainly don't want to implement a modern web browser, so here we are

## Checklist

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
