### PR TITLE
Set focus on 'Create deck' name field by default

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPickerFloatingActionMenu.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPickerFloatingActionMenu.java
@@ -100,6 +100,7 @@ public class DeckPickerFloatingActionMenu {
                         .negativeText(R.string.dialog_cancel)
                         .show();
 
+                // Open keyboard when dialog shows
                 Objects.requireNonNull(materialDialog.getWindow()).setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_ALWAYS_VISIBLE);
             }
         });

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPickerFloatingActionMenu.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPickerFloatingActionMenu.java
@@ -19,6 +19,7 @@ package com.ichi2.anki;
 import android.animation.Animator;
 import android.content.SharedPreferences;
 import android.view.View;
+import android.view.WindowManager;
 import android.widget.EditText;
 import android.widget.LinearLayout;
 
@@ -26,6 +27,8 @@ import com.afollestad.materialdialogs.MaterialDialog;
 import com.google.android.material.floatingactionbutton.FloatingActionButton;
 import com.ichi2.libanki.Decks;
 import com.ichi2.ui.FixedEditText;
+
+import java.util.Objects;
 
 import timber.log.Timber;
 
@@ -77,7 +80,8 @@ public class DeckPickerFloatingActionMenu {
                 closeFloatingActionMenu();
                 EditText mDialogEditText = new FixedEditText(mDeckPicker);
                 mDialogEditText.setSingleLine(true);
-                new MaterialDialog.Builder(mDeckPicker)
+                mDialogEditText.requestFocus();
+                MaterialDialog materialDialog = new MaterialDialog.Builder(mDeckPicker)
                         .title(R.string.new_deck)
                         .positiveText(R.string.dialog_ok)
                         .customView(mDialogEditText, true)
@@ -95,6 +99,8 @@ public class DeckPickerFloatingActionMenu {
                         })
                         .negativeText(R.string.dialog_cancel)
                         .show();
+
+                Objects.requireNonNull(materialDialog.getWindow()).setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_ALWAYS_VISIBLE);
             }
         });
 


### PR DESCRIPTION
## Purpose / Description
Add functionality to auto-focus on the `FixedEditText` field of the dialog when `Create deck` option is selected from `DeckPickerFloatingActionMenu`.

## Fixes
Fixes #8462 

## Approach
Called `requestFocus()` method on the `FixedEditText` to get focus on that and used `setSoftInputMode()` to bring up the keyboard. 

## How Has This Been Tested?

Verified that the field is getting focused when the dialog is being opened and the keyboard is being displayed.

## Checklist

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
