### PR TITLE
NF: Add BackupManagerTestUtilities

### DIFF
--- a/AnkiDroid/src/test/java/com/ichi2/anki/BackupManagerIntegrationTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/BackupManagerIntegrationTest.java
@@ -18,11 +18,11 @@ package com.ichi2.anki;
 
 import com.ichi2.async.CollectionTask;
 import com.ichi2.testutils.AnkiAssert;
+import com.ichi2.testutils.BackupManagerTestUtilities;
 
 import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.robolectric.shadows.ShadowStatFs;
 
 import java.io.File;
 
@@ -51,12 +51,16 @@ public class BackupManagerIntegrationTest extends RobolectricTest {
 
 
     private String createBackup() {
-        int blockCount = 100000;
-        ShadowStatFs.registerStats(new File(getCol().getPath()).getParentFile().getPath(), blockCount, blockCount, blockCount);
+        try {
+            BackupManagerTestUtilities.setupSpaceForBackup(getTargetContext());
 
-        assertThat("Backup should work", BackupManager.performBackupInBackground(getCol().getPath(), getCol().getTime()), is(true));
+            assertThat("Backup should work", BackupManager.performBackupInBackground(getCol().getPath(), getCol().getTime()), is(true));
 
-        return spinUntilBackupExists(1000);
+            return spinUntilBackupExists(1000);
+        } finally {
+            BackupManagerTestUtilities.reset();
+        }
+
     }
 
 

--- a/AnkiDroid/src/test/java/com/ichi2/testutils/BackupManagerTestUtilities.java
+++ b/AnkiDroid/src/test/java/com/ichi2/testutils/BackupManagerTestUtilities.java
@@ -1,0 +1,44 @@
+/*
+ *  Copyright (c) 2021 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.testutils;
+
+import android.content.Context;
+
+import com.ichi2.anki.BackupManager;
+import com.ichi2.anki.CollectionHelper;
+
+import org.robolectric.shadows.ShadowStatFs;
+
+import java.io.File;
+
+import static org.junit.Assert.assertTrue;
+
+public class BackupManagerTestUtilities {
+    public static void setupSpaceForBackup(Context context) {
+        String currentAnkiDroidDirectory = CollectionHelper.getCurrentAnkiDroidDirectory(context);
+
+        String path = new File(currentAnkiDroidDirectory).getParentFile().getPath();
+        ShadowStatFs.registerStats(path, 100, 20, 10000);
+
+        assertTrue(BackupManager.enoughDiscSpace(currentAnkiDroidDirectory));
+    }
+
+
+    public static void reset() {
+        ShadowStatFs.reset();
+    }
+}


### PR DESCRIPTION
## Purpose / Description
This would have been useful for testing the DeckPicker, but I picked a
different strategy. It's still a useful abstraction, even though the
calling test is currently ignored.

## Fixes
N/A

## How Has This Been Tested?

Manually in a unit test which won't make it into the codebase

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [x] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)