### PR TITLE
Fix "AnkiDroid database problem" if database is locked 

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.java
@@ -193,6 +193,9 @@ public class AnkiDroidApp extends Application {
     @Nullable
     private Throwable mWebViewError;
 
+    /** HACK: Whether an exception report has been thrown - TODO: Rewrite an ACRA Listener to do this */
+    @VisibleForTesting
+    public static boolean sSentExceptionReportHack;
 
     @NonNull
     public static InputStream getResourceAsStream(@NonNull String name) {
@@ -408,6 +411,8 @@ public class AnkiDroidApp extends Application {
 
     public static void sendExceptionReport(Throwable e, String origin, @Nullable String additionalInfo, boolean onlyIfSilent) {
         UsageAnalytics.sendAnalyticsException(e, false);
+
+        sSentExceptionReportHack = true;
 
         if (onlyIfSilent) {
             String reportMode = getSharedPrefs(getInstance().getApplicationContext()).getString(AnkiDroidApp.FEEDBACK_REPORT_KEY, FEEDBACK_REPORT_ASK);

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CollectionHelper.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CollectionHelper.java
@@ -33,6 +33,8 @@ import com.ichi2.libanki.utils.Time;
 import com.ichi2.preferences.PreferenceExtensions;
 import com.ichi2.utils.FileUtil;
 
+import net.ankiweb.rsdroid.BackendException;
+
 import java.io.File;
 import java.io.IOException;
 
@@ -151,6 +153,9 @@ public class CollectionHelper {
     public synchronized Collection getColSafe(Context context) {
         try {
             return getCol(context);
+        } catch (BackendException.BackendDbException.BackendDbLockedException e) {
+            Timber.w(e);
+            return null;
         } catch (Exception e) {
             Timber.w(e);
             AnkiDroidApp.sendExceptionReport(e, "CollectionHelper.getColSafe");

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -556,6 +556,10 @@ public class DeckPicker extends NavigationDrawerActivity implements
                 Timber.i("Displaying database versioning");
                 showDatabaseErrorDialog(DatabaseErrorDialog.INCOMPATIBLE_DB_VERSION);
                 break;
+            case DATABASE_LOCKED:
+                Timber.i("Displaying database locked error");
+                showDatabaseErrorDialog(DatabaseErrorDialog.DIALOG_DB_LOCKED);
+                break;
             case DB_ERROR:
             default:
                 Timber.i("Displaying database error");

--- a/AnkiDroid/src/main/java/com/ichi2/anki/InitialActivity.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/InitialActivity.java
@@ -1,0 +1,61 @@
+/*
+ *  Copyright (c) 2021 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki;
+
+import android.content.Context;
+
+import androidx.annotation.CheckResult;
+import androidx.annotation.NonNull;
+import timber.log.Timber;
+
+/** Utilities for launching the first activity (currently the DeckPicker) */
+public class InitialActivity {
+
+    private InitialActivity() {
+
+    }
+
+    @NonNull
+    @CheckResult
+    public static StartupFailure getStartupFailureType(Context context) {
+        if (!AnkiDroidApp.isSdCardMounted()) {
+            return StartupFailure.SD_CARD_NOT_MOUNTED;
+        } else if (!CollectionHelper.isCurrentAnkiDroidDirAccessible(context)) {
+            return StartupFailure.DIRECTORY_NOT_ACCESSIBLE;
+        } else if (isFutureAnkiDroidVersion(context)) {
+            return StartupFailure.FUTURE_ANKIDROID_VERSION;
+        } else {
+            return StartupFailure.DB_ERROR;
+        }
+    }
+
+    private static boolean isFutureAnkiDroidVersion(Context context) {
+        try {
+            return CollectionHelper.isFutureAnkiDroidVersion(context);
+        } catch (Exception e) {
+            Timber.w(e, "Could not determine if future AnkiDroid version - assuming not");
+            return false;
+        }
+    }
+
+    public enum StartupFailure {
+        SD_CARD_NOT_MOUNTED,
+        DIRECTORY_NOT_ACCESSIBLE,
+        FUTURE_ANKIDROID_VERSION,
+        DB_ERROR,
+    }
+}

--- a/AnkiDroid/src/main/java/com/ichi2/anki/InitialActivity.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/InitialActivity.java
@@ -18,6 +18,8 @@ package com.ichi2.anki;
 
 import android.content.Context;
 
+import net.ankiweb.rsdroid.BackendException;
+
 import androidx.annotation.CheckResult;
 import androidx.annotation.NonNull;
 import timber.log.Timber;
@@ -39,6 +41,13 @@ public class InitialActivity {
         } else if (isFutureAnkiDroidVersion(context)) {
             return StartupFailure.FUTURE_ANKIDROID_VERSION;
         } else {
+            try {
+                CollectionHelper.getInstance().getCol(context);
+            } catch (BackendException.BackendDbException.BackendDbLockedException e) {
+                return StartupFailure.DATABASE_LOCKED;
+            } catch (Exception ignored) {
+
+            }
             return StartupFailure.DB_ERROR;
         }
     }
@@ -57,5 +66,6 @@ public class InitialActivity {
         DIRECTORY_NOT_ACCESSIBLE,
         FUTURE_ANKIDROID_VERSION,
         DB_ERROR,
+        DATABASE_LOCKED,
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DatabaseErrorDialog.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DatabaseErrorDialog.java
@@ -41,7 +41,7 @@ public class DatabaseErrorDialog extends AsyncDialogFragment {
     public static final int DIALOG_FULL_SYNC_FROM_SERVER = 8;
     /** If the database is locked, all we can do is reset the app */
     public static final int DIALOG_DB_LOCKED = 9;
-    /** If the datbase is at a version higher than what we can currently handle */
+    /** If the database is at a version higher than what we can currently handle */
     public static final int INCOMPATIBLE_DB_VERSION = 10;
 
     // public flag which lets us distinguish between inaccessible and corrupt database

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/backend/DroidBackendFactory.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/backend/DroidBackendFactory.java
@@ -23,11 +23,16 @@ import net.ankiweb.rsdroid.BackendFactory;
 import net.ankiweb.rsdroid.RustBackendFailedException;
 import net.ankiweb.rsdroid.RustCleanup;
 
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.annotation.VisibleForTesting;
 import timber.log.Timber;
 
 /** Responsible for selection of either the Rust or Java-based backend */
 public class DroidBackendFactory {
+
+    private static DroidBackend sBackendForTesting;
+
 
     /** Intentionally private - use {@link DroidBackendFactory#getInstance(boolean)}} */
     private DroidBackendFactory() {
@@ -38,8 +43,12 @@ public class DroidBackendFactory {
      * Obtains an instance of a {@link DroidBackend}.
      * Each call to this method will generate a separate instance which can handle a new Anki collection
      */
+    @NonNull
     @RustCleanup("Change back to a constant SYNC_VER")
     public static DroidBackend getInstance(boolean useBackend) {
+        if (sBackendForTesting != null) {
+            return sBackendForTesting;
+        }
 
         BackendFactory backendFactory = null;
         if (useBackend) {
@@ -63,5 +72,10 @@ public class DroidBackendFactory {
         } else {
             return new RustDroidBackend(backendFactory);
         }
+    }
+
+    @VisibleForTesting
+    public static void setOverride(DroidBackend backend) {
+        sBackendForTesting = backend;
     }
 }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/DeckPickerTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/DeckPickerTest.java
@@ -209,6 +209,7 @@ public class DeckPickerTest extends RobolectricTest {
 
     @Test
     public void databaseLockedWithPermissionIntegrationTest() {
+        AnkiDroidApp.sSentExceptionReportHack = false;
         try {
             BackendEmulatingOpenConflict.enable();
             InitialActivityTest.setupForDatabaseConflict();
@@ -216,6 +217,8 @@ public class DeckPickerTest extends RobolectricTest {
             DeckPickerEx d = super.startActivityNormallyOpenCollectionWithIntent(DeckPickerEx.class, new Intent());
 
             assertThat("A specific dialog for a conflict should be shown", d.mDatabaseErrorDialog, is(DatabaseErrorDialog.DIALOG_DB_LOCKED));
+
+            assertThat("No exception reports should be thrown", AnkiDroidApp.sSentExceptionReportHack, is(false));
         } finally {
             BackendEmulatingOpenConflict.disable();
             InitialActivityTest.setupForDefault();

--- a/AnkiDroid/src/test/java/com/ichi2/anki/InitialActivityTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/InitialActivityTest.java
@@ -1,0 +1,70 @@
+/*
+ *  Copyright (c) 2021 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki;
+
+import android.app.Application;
+
+import com.ichi2.testutils.BackendEmulatingOpenConflict;
+import com.ichi2.testutils.EmptyApplication;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.Shadows;
+import org.robolectric.annotation.Config;
+import org.robolectric.shadows.ShadowApplication;
+import org.robolectric.shadows.ShadowEnvironment;
+
+import androidx.test.core.app.ApplicationProvider;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+@RunWith(AndroidJUnit4.class)
+@Config(application = EmptyApplication.class) // no point in Application init if we don't use it
+public class InitialActivityTest extends RobolectricTest {
+    @Before
+    @Override
+    public void setUp() {
+        super.setUp();
+        BackendEmulatingOpenConflict.enable();
+    }
+
+    @After
+    @Override
+    public void tearDown() {
+        super.tearDown();
+        BackendEmulatingOpenConflict.disable();
+    }
+
+    @Test
+    public void testInitialActivityResult() {
+        setupForDatabaseConflict();
+
+        InitialActivity.StartupFailure f = InitialActivity.getStartupFailureType(getTargetContext());
+
+        assertThat("A conflict should be returned", f, is(InitialActivity.StartupFailure.DATABASE_LOCKED));
+    }
+
+    public static void setupForDatabaseConflict() {
+        ShadowApplication app = Shadows.shadowOf((Application) ApplicationProvider.getApplicationContext());
+        app.grantPermissions(android.Manifest.permission.WRITE_EXTERNAL_STORAGE, android.Manifest.permission.READ_EXTERNAL_STORAGE);
+        ShadowEnvironment.setExternalStorageState("mounted");
+    }
+}

--- a/AnkiDroid/src/test/java/com/ichi2/anki/InitialActivityTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/InitialActivityTest.java
@@ -55,16 +55,26 @@ public class InitialActivityTest extends RobolectricTest {
 
     @Test
     public void testInitialActivityResult() {
-        setupForDatabaseConflict();
+        try {
+            setupForDatabaseConflict();
 
-        InitialActivity.StartupFailure f = InitialActivity.getStartupFailureType(getTargetContext());
+            InitialActivity.StartupFailure f = InitialActivity.getStartupFailureType(getTargetContext());
 
-        assertThat("A conflict should be returned", f, is(InitialActivity.StartupFailure.DATABASE_LOCKED));
+            assertThat("A conflict should be returned", f, is(InitialActivity.StartupFailure.DATABASE_LOCKED));
+        } finally {
+            setupForDefault();
+        }
     }
 
     public static void setupForDatabaseConflict() {
         ShadowApplication app = Shadows.shadowOf((Application) ApplicationProvider.getApplicationContext());
         app.grantPermissions(android.Manifest.permission.WRITE_EXTERNAL_STORAGE, android.Manifest.permission.READ_EXTERNAL_STORAGE);
         ShadowEnvironment.setExternalStorageState("mounted");
+    }
+
+    public static void setupForDefault() {
+        ShadowApplication app = Shadows.shadowOf((Application) ApplicationProvider.getApplicationContext());
+        app.denyPermissions(android.Manifest.permission.WRITE_EXTERNAL_STORAGE, android.Manifest.permission.READ_EXTERNAL_STORAGE);
+        ShadowEnvironment.setExternalStorageState("removed");
     }
 }

--- a/AnkiDroid/src/test/java/com/ichi2/testutils/BackendEmulatingOpenConflict.java
+++ b/AnkiDroid/src/test/java/com/ichi2/testutils/BackendEmulatingOpenConflict.java
@@ -1,0 +1,60 @@
+/*
+ *  Copyright (c) 2021 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.testutils;
+
+import com.ichi2.libanki.DB;
+import com.ichi2.libanki.backend.DroidBackendFactory;
+import com.ichi2.libanki.backend.RustDroidBackend;
+
+import net.ankiweb.rsdroid.BackendException;
+import net.ankiweb.rsdroid.BackendFactory;
+import net.ankiweb.rsdroid.RustBackendFailedException;
+
+import BackendProto.Backend;
+
+import static org.mockito.Mockito.mock;
+
+/** Test helper:
+ * causes getCol to emulate an exception caused by having another AnkiDroid instance open on the same collection
+ */
+public class BackendEmulatingOpenConflict extends RustDroidBackend {
+
+    public BackendEmulatingOpenConflict(BackendFactory mBackend) {
+        super(mBackend);
+    }
+
+
+    public static void enable() {
+        try {
+            DroidBackendFactory.setOverride(new BackendEmulatingOpenConflict(BackendFactory.createInstance()));
+        } catch (RustBackendFailedException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+
+    public static void disable() {
+        DroidBackendFactory.setOverride(null);
+    }
+
+
+    @Override
+    public DB openCollectionDatabase(String path) {
+        Backend.BackendError error = mock(Backend.BackendError.class);
+        throw new BackendException.BackendDbException.BackendDbLockedException(error);
+    }
+}

--- a/AnkiDroid/src/test/java/com/ichi2/testutils/BackendEmulatingOpenConflictTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/testutils/BackendEmulatingOpenConflictTest.java
@@ -1,0 +1,55 @@
+/*
+ *  Copyright (c) 2021 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.testutils;
+
+import com.ichi2.anki.CollectionHelper;
+import com.ichi2.anki.RobolectricTest;
+
+import net.ankiweb.rsdroid.BackendException.BackendDbException.BackendDbLockedException;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+
+import static org.junit.Assert.assertThrows;
+
+@RunWith(AndroidJUnit4.class)
+public class BackendEmulatingOpenConflictTest extends RobolectricTest {
+
+    @Before
+    @Override
+    public void setUp() {
+        super.setUp();
+        BackendEmulatingOpenConflict.enable();
+    }
+
+    @After
+    @Override
+    public void tearDown() {
+        super.tearDown();
+        BackendEmulatingOpenConflict.disable();
+    }
+
+    @Test
+    public void assumeMocksAreValid() {
+        assertThrows(BackendDbLockedException.class, () -> CollectionHelper.getInstance().getCol(super.getTargetContext()));
+    }
+
+}


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
Due to the Rust DB code, we now lock the database, if two Anki clients are using the same

On startup, we didn't differentiate between DB locked and DB corrupt, which I expect would confuse users, and likely lead some to delete their databases.

## Fixes
Fixes #8075 

## Approach
* Detect the specific exception (now possible)
* If the exception is thrown, use the "locked" dialog that I added ages ago for check datbase.


## How Has This Been Tested?

Unit tests, and on my device

* Both from a "no permission" and "normal" scenario
* Also a janky unit test to ensure that no ACRA errors are raised

![image](https://user-images.githubusercontent.com/62114487/113531038-9d94d100-95bf-11eb-9e47-9811b3d4bda7.png)


## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [x] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
