### PR TITLE
Tags Dialog split into atomic commit

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/TagsDialog.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/TagsDialog.java
@@ -61,6 +61,11 @@ public class TagsDialog extends AnalyticsDialogFragment {
         public TagsList(@NonNull ArrayList<String> allTags, @NonNull TreeSet<String> currentTags) {
             mCurrentTags = currentTags;
             mAllTags = allTags;
+            for (String tag : mCurrentTags) {
+                if (!allTags.contains(tag)) {
+                    allTags.add(tag);
+                }
+            }
         }
 
 
@@ -248,15 +253,8 @@ public class TagsDialog extends AnalyticsDialogFragment {
         TreeSet<String> currentTags = new TreeSet<>(String.CASE_INSENSITIVE_ORDER);
         currentTags.addAll(requireArguments().getStringArrayList(CHECKED_TAGS_KEY));
 
-        ArrayList<String> allTags = requireArguments().getStringArrayList(ALL_TAGS_KEY);
 
-        for (String tag : currentTags) {
-            if (!allTags.contains(tag)) {
-                allTags.add(tag);
-            }
-        }
-
-        mTags = new TagsList(allTags, currentTags);
+        mTags = new TagsList(requireArguments().getStringArrayList(ALL_TAGS_KEY), currentTags);
 
         setCancelable(true);
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/TagsDialog.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/TagsDialog.java
@@ -31,6 +31,7 @@ import com.ichi2.utils.FilterResultsUtils;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
 import java.util.TreeSet;
@@ -44,7 +45,7 @@ public class TagsDialog extends AnalyticsDialogFragment {
     /**
      * A container class that keeps track of tags and their status
      */
-    public static class TagsList {
+    public static class TagsList implements Iterable<String> {
         private TreeSet<String> mCurrentTags;
         private List<String> mAllTags;
 
@@ -133,6 +134,13 @@ public class TagsDialog extends AnalyticsDialogFragment {
                 //priority for checked items.
                 return lhs_checked == rhs_checked ? lhs.compareToIgnoreCase(rhs) : lhs_checked ? -1 : 1;
             });
+        }
+
+
+        @NonNull
+        @Override
+        public Iterator<String> iterator() {
+            return mAllTags.iterator();
         }
     }
 
@@ -450,7 +458,7 @@ public class TagsDialog extends AnalyticsDialogFragment {
                     mFilteredTags.addAll(mTags.mAllTags);
                 } else {
                     final String filterPattern = constraint.toString().toLowerCase(Locale.getDefault()).trim();
-                    for (String tag : mTags.mAllTags) {
+                    for (String tag : mTags) {
                         if (tag.toLowerCase(Locale.getDefault()).contains(filterPattern)) {
                             mFilteredTags.add(tag);
                         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/TagsDialog.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/TagsDialog.java
@@ -294,18 +294,12 @@ public class TagsDialog extends AnalyticsDialogFragment {
         MenuItem checkAllItem = mToolbar.getMenu().findItem(R.id.tags_dialog_action_select_all);
         checkAllItem.setOnMenuItemClickListener(menuItem -> {
             boolean changed = false;
-            if (mTags.mCurrentTags.containsAll(mTagsArrayAdapter.mTagsList)) {
-                mTags.mCurrentTags.removeAll(mTagsArrayAdapter.mTagsList);
+            if (mTags.mAllTags.size() == mTags.mCurrentTags.size()) {
+                mTags.mCurrentTags.clear();
                 changed = true;
             } else {
-                for (String tag : mTagsArrayAdapter.mTagsList) {
-                    if (!mTags.isChecked(tag)) {
-                        mTags.check(tag);
-                        changed = true;
-                    }
-                }
+                changed = mTags.mCurrentTags.addAll(mTags.mAllTags);
             }
-
             if (changed) {
                 mTagsArrayAdapter.notifyDataSetChanged();
             }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/TagsDialog.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/TagsDialog.java
@@ -97,6 +97,22 @@ public class TagsDialog extends AnalyticsDialogFragment {
         public boolean uncheck(String tag) {
             return mCurrentTags.remove(tag);
         }
+
+
+        /**
+         * Toggle the status if all tags,
+         * if all tags are checked, then uncheck them
+         * otherwise uncheck all tags
+         *
+         * @return true if this tag list changed as a result of the call
+         */
+        public boolean toggleAllCheckedStatuses() {
+            if (mAllTags.size() == mCurrentTags.size()) {
+                mCurrentTags.clear();
+                return true;
+            }
+            return mCurrentTags.addAll(mAllTags);
+        }
     }
 
 
@@ -293,14 +309,7 @@ public class TagsDialog extends AnalyticsDialogFragment {
 
         MenuItem checkAllItem = mToolbar.getMenu().findItem(R.id.tags_dialog_action_select_all);
         checkAllItem.setOnMenuItemClickListener(menuItem -> {
-            boolean changed = false;
-            if (mTags.mAllTags.size() == mTags.mCurrentTags.size()) {
-                mTags.mCurrentTags.clear();
-                changed = true;
-            } else {
-                changed = mTags.mCurrentTags.addAll(mTags.mAllTags);
-            }
-            if (changed) {
+            if (mTags.toggleAllCheckedStatuses()) {
                 mTagsArrayAdapter.notifyDataSetChanged();
             }
             return true;

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/TagsDialog.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/TagsDialog.java
@@ -71,6 +71,32 @@ public class TagsDialog extends AnalyticsDialogFragment {
         public boolean isChecked(String tag) {
             return mCurrentTags.contains(tag);
         }
+
+
+        /**
+         * Mark a tag as checked tag
+         *
+         * @param tag the tag to be checked (case-insensitive)
+         * @return true if the tag changed its check status
+         *         false if the tag was already checked or not in the list
+         */
+        public boolean check(String tag) {
+            if (!mAllTags.contains(tag)) {
+                return false;
+            }
+            return mCurrentTags.add(tag);
+        }
+
+        /**
+         * Mark a tag as unchecked tag
+         *
+         * @param tag the tag to be checked (case-insensitive)
+         * @return true if the tag changed its check status
+         *         false if the tag was already unchecked or not in the list
+         */
+        public boolean uncheck(String tag) {
+            return mCurrentTags.remove(tag);
+        }
     }
 
 
@@ -274,7 +300,7 @@ public class TagsDialog extends AnalyticsDialogFragment {
             } else {
                 for (String tag : mTagsArrayAdapter.mTagsList) {
                     if (!mTags.isChecked(tag)) {
-                        mTags.mCurrentTags.add(tag);
+                        mTags.check(tag);
                         changed = true;
                     }
                 }
@@ -320,7 +346,7 @@ public class TagsDialog extends AnalyticsDialogFragment {
             } else {
                 feedbackText = getString(R.string.tag_editor_add_feedback_existing, tag);
             }
-            mTags.mCurrentTags.add(tag);
+            mTags.check(tag);
             mTagsArrayAdapter.notifyDataSetChanged();
             // Show a snackbar to let the user know the tag was added successfully
             UIUtils.showSnackbar(getActivity(), feedbackText, false, -1, null,
@@ -365,9 +391,9 @@ public class TagsDialog extends AnalyticsDialogFragment {
                 ctv.toggle();
                 String tag = ctv.getText().toString();
                 if (ctv.isChecked() && !mTags.isChecked(tag)) {
-                    mTags.mCurrentTags.add(tag);
+                    mTags.check(tag);
                 } else if (!ctv.isChecked()) {
-                    mTags.mCurrentTags.remove(tag);
+                    mTags.uncheck(tag);
                 }
             });
             return vh;

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/TagsDialog.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/TagsDialog.java
@@ -47,6 +47,30 @@ public class TagsDialog extends AnalyticsDialogFragment {
     public static class TagsList {
         private TreeSet<String> mCurrentTags;
         private List<String> mAllTags;
+
+
+        /**
+         * Return true if a tag is checked given its index in the list
+         *
+         * @param index index of the tag to check
+         * @return whether the tag is checked or not
+         * @throws IndexOutOfBoundsException if the index is out of range
+         *                                   (<tt>index &lt; 0 || index &gt;= size()</tt>)
+         */
+        public boolean isChecked(int index) {
+            return isChecked(mAllTags.get(index));
+        }
+
+
+        /**
+         * Return true if a tag is checked
+         *
+         * @param tag the tag to check (case-insensitive)
+         * @return whether the tag is checked or not
+         */
+        public boolean isChecked(String tag) {
+            return mCurrentTags.contains(tag);
+        }
     }
 
 
@@ -249,7 +273,7 @@ public class TagsDialog extends AnalyticsDialogFragment {
                 changed = true;
             } else {
                 for (String tag : mTagsArrayAdapter.mTagsList) {
-                    if (!mTags.mCurrentTags.contains(tag)) {
+                    if (!mTags.isChecked(tag)) {
                         mTags.mCurrentTags.add(tag);
                         changed = true;
                     }
@@ -322,8 +346,8 @@ public class TagsDialog extends AnalyticsDialogFragment {
 
         public void sortData() {
             Collections.sort(mTagsList, (lhs, rhs) -> {
-                boolean lhs_checked = mTags.mCurrentTags.contains(lhs);
-                boolean rhs_checked = mTags.mCurrentTags.contains(rhs);
+                boolean lhs_checked = mTags.isChecked(lhs);
+                boolean rhs_checked = mTags.isChecked(rhs);
                 //priority for checked items.
                 return lhs_checked == rhs_checked ? lhs.compareToIgnoreCase(rhs) : lhs_checked ? -1 : 1;
             });
@@ -340,7 +364,7 @@ public class TagsDialog extends AnalyticsDialogFragment {
                 CheckedTextView ctv = (CheckedTextView) view;
                 ctv.toggle();
                 String tag = ctv.getText().toString();
-                if (ctv.isChecked() && !mTags.mCurrentTags.contains(tag)) {
+                if (ctv.isChecked() && !mTags.isChecked(tag)) {
                     mTags.mCurrentTags.add(tag);
                 } else if (!ctv.isChecked()) {
                     mTags.mCurrentTags.remove(tag);
@@ -353,7 +377,7 @@ public class TagsDialog extends AnalyticsDialogFragment {
         public void onBindViewHolder(@NonNull ViewHolder holder, int position) {
             String tag = mTagsList.get(position);
             holder.mTagItemCheckedTextView.setText(tag);
-            holder.mTagItemCheckedTextView.setChecked(mTags.mCurrentTags.contains(tag));
+            holder.mTagItemCheckedTextView.setChecked(mTags.isChecked(tag));
         }
 
         @Override

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/TagsDialog.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/TagsDialog.java
@@ -28,6 +28,7 @@ import com.ichi2.anki.R;
 import com.ichi2.anki.UIUtils;
 import com.ichi2.anki.analytics.AnalyticsDialogFragment;
 import com.ichi2.utils.FilterResultsUtils;
+import com.ichi2.utils.UniqueArrayList;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -60,13 +61,8 @@ public class TagsDialog extends AnalyticsDialogFragment {
          */
         public TagsList(@NonNull ArrayList<String> allTags, @NonNull List<String> currentTags) {
             mCurrentTags = new TreeSet<>(String.CASE_INSENSITIVE_ORDER);
-            currentTags.addAll(currentTags);
-            mAllTags = allTags;
-            for (String tag : mCurrentTags) {
-                if (!allTags.contains(tag)) {
-                    allTags.add(tag);
-                }
-            }
+            mCurrentTags.addAll(currentTags);
+            mAllTags = UniqueArrayList.from(allTags);
         }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/TagsDialog.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/TagsDialog.java
@@ -113,6 +113,14 @@ public class TagsDialog extends AnalyticsDialogFragment {
             }
             return mCurrentTags.addAll(mAllTags);
         }
+
+
+        /**
+         * @return true if there is no tags in the list
+         */
+        public boolean isEmpty() {
+            return mAllTags.isEmpty();
+        }
     }
 
 
@@ -214,7 +222,7 @@ public class TagsDialog extends AnalyticsDialogFragment {
         mTagsListRecyclerView.setAdapter(mTagsArrayAdapter);
 
         mNoTagsTextView = tagsDialogView.findViewById(R.id.tags_dialog_no_tags_textview);
-        if (mTags.mAllTags.isEmpty()) {
+        if (mTags.isEmpty()) {
             mNoTagsTextView.setVisibility(View.VISIBLE);
         }
         RadioGroup mOptionsGroup = tagsDialogView.findViewById(R.id.tags_dialog_options_radiogroup);

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/TagsDialog.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/TagsDialog.java
@@ -121,6 +121,19 @@ public class TagsDialog extends AnalyticsDialogFragment {
         public boolean isEmpty() {
             return mAllTags.isEmpty();
         }
+
+
+        /**
+         * Sort the tag list alphabetically ignoring the case, with priority for checked tags
+         */
+        public void sort() {
+            Collections.sort(mAllTags, (lhs, rhs) -> {
+                boolean lhs_checked = isChecked(lhs);
+                boolean rhs_checked = isChecked(rhs);
+                //priority for checked items.
+                return lhs_checked == rhs_checked ? lhs.compareToIgnoreCase(rhs) : lhs_checked ? -1 : 1;
+            });
+        }
     }
 
 
@@ -382,12 +395,7 @@ public class TagsDialog extends AnalyticsDialogFragment {
         }
 
         public void sortData() {
-            Collections.sort(mTagsList, (lhs, rhs) -> {
-                boolean lhs_checked = mTags.isChecked(lhs);
-                boolean rhs_checked = mTags.isChecked(rhs);
-                //priority for checked items.
-                return lhs_checked == rhs_checked ? lhs.compareToIgnoreCase(rhs) : lhs_checked ? -1 : 1;
-            });
+            mTags.sort();
         }
 
         @NonNull

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/TagsDialog.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/TagsDialog.java
@@ -41,6 +41,14 @@ public class TagsDialog extends AnalyticsDialogFragment {
     }
 
 
+    /**
+     * A container class that keeps track of tags and their status
+     */
+    public static class TagsList {
+        private TreeSet<String> mCurrentTags;
+        private List<String> mAllTags;
+    }
+
 
     /**
      * Enum that define all possible types of TagsDialog
@@ -65,8 +73,7 @@ public class TagsDialog extends AnalyticsDialogFragment {
     private static final String ALL_TAGS_KEY = "all_tags";
 
     private DialogType mType;
-    private TreeSet<String> mCurrentTags;
-    private List<String> mAllTags;
+    private TagsList mTags = new TagsList();
 
     private String mPositiveText;
     private String mDialogTitle;
@@ -110,14 +117,14 @@ public class TagsDialog extends AnalyticsDialogFragment {
 
         mType = DialogType.values()[requireArguments().getInt(DIALOG_TYPE_KEY)];
 
-        mCurrentTags = new TreeSet<>(String.CASE_INSENSITIVE_ORDER);
-        mCurrentTags.addAll(requireArguments().getStringArrayList(CHECKED_TAGS_KEY));
+        mTags.mCurrentTags = new TreeSet<>(String.CASE_INSENSITIVE_ORDER);
+        mTags.mCurrentTags.addAll(requireArguments().getStringArrayList(CHECKED_TAGS_KEY));
 
-        mAllTags = requireArguments().getStringArrayList(ALL_TAGS_KEY);
+        mTags.mAllTags = requireArguments().getStringArrayList(ALL_TAGS_KEY);
 
-        for (String tag : mCurrentTags) {
-            if (!mAllTags.contains(tag)) {
-                mAllTags.add(tag);
+        for (String tag : mTags.mCurrentTags) {
+            if (!mTags.mAllTags.contains(tag)) {
+                mTags.mAllTags.add(tag);
             }
         }
 
@@ -141,7 +148,7 @@ public class TagsDialog extends AnalyticsDialogFragment {
         mTagsListRecyclerView.setAdapter(mTagsArrayAdapter);
 
         mNoTagsTextView = tagsDialogView.findViewById(R.id.tags_dialog_no_tags_textview);
-        if (mAllTags.isEmpty()) {
+        if (mTags.mAllTags.isEmpty()) {
             mNoTagsTextView.setVisibility(View.VISIBLE);
         }
         RadioGroup mOptionsGroup = tagsDialogView.findViewById(R.id.tags_dialog_options_radiogroup);
@@ -169,7 +176,7 @@ public class TagsDialog extends AnalyticsDialogFragment {
                 .negativeText(R.string.dialog_cancel)
                 .customView(tagsDialogView, false)
                 .onPositive((dialog, which) -> ((TagsDialogListener)requireActivity())
-                        .onSelectedTags(new ArrayList<>(mCurrentTags), mSelectedOption));
+                        .onSelectedTags(new ArrayList<>(mTags.mCurrentTags), mSelectedOption));
         mDialog = builder.build();
 
         mDialog.getWindow().setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_ADJUST_RESIZE);
@@ -237,13 +244,13 @@ public class TagsDialog extends AnalyticsDialogFragment {
         MenuItem checkAllItem = mToolbar.getMenu().findItem(R.id.tags_dialog_action_select_all);
         checkAllItem.setOnMenuItemClickListener(menuItem -> {
             boolean changed = false;
-            if (mCurrentTags.containsAll(mTagsArrayAdapter.mTagsList)) {
-                mCurrentTags.removeAll(mTagsArrayAdapter.mTagsList);
+            if (mTags.mCurrentTags.containsAll(mTagsArrayAdapter.mTagsList)) {
+                mTags.mCurrentTags.removeAll(mTagsArrayAdapter.mTagsList);
                 changed = true;
             } else {
                 for (String tag : mTagsArrayAdapter.mTagsList) {
-                    if (!mCurrentTags.contains(tag)) {
-                        mCurrentTags.add(tag);
+                    if (!mTags.mCurrentTags.contains(tag)) {
+                        mTags.mCurrentTags.add(tag);
                         changed = true;
                     }
                 }
@@ -278,8 +285,8 @@ public class TagsDialog extends AnalyticsDialogFragment {
     public void addTag(String tag) {
         if (!TextUtils.isEmpty(tag)) {
             String feedbackText;
-            if (!mAllTags.contains(tag)) {
-                mAllTags.add(tag);
+            if (!mTags.mAllTags.contains(tag)) {
+                mTags.mAllTags.add(tag);
                 if (mNoTagsTextView.getVisibility() == View.VISIBLE) {
                     mNoTagsTextView.setVisibility(View.GONE);
                 }
@@ -289,7 +296,7 @@ public class TagsDialog extends AnalyticsDialogFragment {
             } else {
                 feedbackText = getString(R.string.tag_editor_add_feedback_existing, tag);
             }
-            mCurrentTags.add(tag);
+            mTags.mCurrentTags.add(tag);
             mTagsArrayAdapter.notifyDataSetChanged();
             // Show a snackbar to let the user know the tag was added successfully
             UIUtils.showSnackbar(getActivity(), feedbackText, false, -1, null,
@@ -309,14 +316,14 @@ public class TagsDialog extends AnalyticsDialogFragment {
         public final List<String> mTagsList;
 
         public  TagsArrayAdapter() {
-            mTagsList = new ArrayList<>(mAllTags);
+            mTagsList = new ArrayList<>(mTags.mAllTags);
             sortData();
         }
 
         public void sortData() {
             Collections.sort(mTagsList, (lhs, rhs) -> {
-                boolean lhs_checked = mCurrentTags.contains(lhs);
-                boolean rhs_checked = mCurrentTags.contains(rhs);
+                boolean lhs_checked = mTags.mCurrentTags.contains(lhs);
+                boolean rhs_checked = mTags.mCurrentTags.contains(rhs);
                 //priority for checked items.
                 return lhs_checked == rhs_checked ? lhs.compareToIgnoreCase(rhs) : lhs_checked ? -1 : 1;
             });
@@ -333,10 +340,10 @@ public class TagsDialog extends AnalyticsDialogFragment {
                 CheckedTextView ctv = (CheckedTextView) view;
                 ctv.toggle();
                 String tag = ctv.getText().toString();
-                if (ctv.isChecked() && !mCurrentTags.contains(tag)) {
-                    mCurrentTags.add(tag);
+                if (ctv.isChecked() && !mTags.mCurrentTags.contains(tag)) {
+                    mTags.mCurrentTags.add(tag);
                 } else if (!ctv.isChecked()) {
-                    mCurrentTags.remove(tag);
+                    mTags.mCurrentTags.remove(tag);
                 }
             });
             return vh;
@@ -346,7 +353,7 @@ public class TagsDialog extends AnalyticsDialogFragment {
         public void onBindViewHolder(@NonNull ViewHolder holder, int position) {
             String tag = mTagsList.get(position);
             holder.mTagItemCheckedTextView.setText(tag);
-            holder.mTagItemCheckedTextView.setChecked(mCurrentTags.contains(tag));
+            holder.mTagItemCheckedTextView.setChecked(mTags.mCurrentTags.contains(tag));
         }
 
         @Override
@@ -371,10 +378,10 @@ public class TagsDialog extends AnalyticsDialogFragment {
             protected FilterResults performFiltering(CharSequence constraint) {
                 mFilteredTags.clear();
                 if (constraint.length() == 0) {
-                    mFilteredTags.addAll(mAllTags);
+                    mFilteredTags.addAll(mTags.mAllTags);
                 } else {
                     final String filterPattern = constraint.toString().toLowerCase(Locale.getDefault()).trim();
-                    for (String tag : mAllTags) {
+                    for (String tag : mTags.mAllTags) {
                         if (tag.toLowerCase(Locale.getDefault()).contains(filterPattern)) {
                             mFilteredTags.add(tag);
                         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/TagsDialog.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/TagsDialog.java
@@ -46,8 +46,22 @@ public class TagsDialog extends AnalyticsDialogFragment {
      * A container class that keeps track of tags and their status
      */
     public static class TagsList implements Iterable<String> {
-        private TreeSet<String> mCurrentTags;
-        private List<String> mAllTags;
+        private final @NonNull TreeSet<String> mCurrentTags;
+        private final @NonNull List<String> mAllTags;
+
+
+        /**
+         * Construct a new {@link TagsList}
+         *
+         * @param allTags A list of all tags possible
+         *                any duplicates will be ignored
+         * @param currentTags A list of checked tags
+         *                any duplicates will be ignored
+         */
+        public TagsList(@NonNull ArrayList<String> allTags, @NonNull TreeSet<String> currentTags) {
+            mCurrentTags = currentTags;
+            mAllTags = allTags;
+        }
 
 
         /**
@@ -187,7 +201,7 @@ public class TagsDialog extends AnalyticsDialogFragment {
     private static final String ALL_TAGS_KEY = "all_tags";
 
     private DialogType mType;
-    private TagsList mTags = new TagsList();
+    private TagsList mTags;
 
     private String mPositiveText;
     private String mDialogTitle;
@@ -231,16 +245,18 @@ public class TagsDialog extends AnalyticsDialogFragment {
 
         mType = DialogType.values()[requireArguments().getInt(DIALOG_TYPE_KEY)];
 
-        mTags.mCurrentTags = new TreeSet<>(String.CASE_INSENSITIVE_ORDER);
-        mTags.mCurrentTags.addAll(requireArguments().getStringArrayList(CHECKED_TAGS_KEY));
+        TreeSet<String> currentTags = new TreeSet<>(String.CASE_INSENSITIVE_ORDER);
+        currentTags.addAll(requireArguments().getStringArrayList(CHECKED_TAGS_KEY));
 
-        mTags.mAllTags = requireArguments().getStringArrayList(ALL_TAGS_KEY);
+        ArrayList<String> allTags = requireArguments().getStringArrayList(ALL_TAGS_KEY);
 
-        for (String tag : mTags.mCurrentTags) {
-            if (!mTags.mAllTags.contains(tag)) {
-                mTags.mAllTags.add(tag);
+        for (String tag : currentTags) {
+            if (!allTags.contains(tag)) {
+                allTags.add(tag);
             }
         }
+
+        mTags = new TagsList(allTags, currentTags);
 
         setCancelable(true);
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/TagsDialog.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/TagsDialog.java
@@ -75,6 +75,17 @@ public class TagsDialog extends AnalyticsDialogFragment {
 
 
         /**
+         * Adds a tag to the list if it is not already present.
+         *
+         * @param tag  the tag to add
+         * @return true if tag was added (new tag)
+         */
+        public boolean add(String tag) {
+            return mAllTags.add(tag);
+        }
+
+
+        /**
          * Mark a tag as checked tag
          *
          * @param tag the tag to be checked (case-insensitive)
@@ -367,8 +378,7 @@ public class TagsDialog extends AnalyticsDialogFragment {
     public void addTag(String tag) {
         if (!TextUtils.isEmpty(tag)) {
             String feedbackText;
-            if (!mTags.mAllTags.contains(tag)) {
-                mTags.mAllTags.add(tag);
+            if (mTags.add(tag)) {
                 if (mNoTagsTextView.getVisibility() == View.VISIBLE) {
                     mNoTagsTextView.setVisibility(View.GONE);
                 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/TagsDialog.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/TagsDialog.java
@@ -136,6 +136,14 @@ public class TagsDialog extends AnalyticsDialogFragment {
 
 
         /**
+         * @return return all checked tags as an List
+         */
+        public List<String> getCheckedTagList() {
+            return new ArrayList<>(mCurrentTags);
+        }
+
+
+        /**
          * Sort the tag list alphabetically ignoring the case, with priority for checked tags
          */
         public void sort() {
@@ -282,7 +290,7 @@ public class TagsDialog extends AnalyticsDialogFragment {
                 .negativeText(R.string.dialog_cancel)
                 .customView(tagsDialogView, false)
                 .onPositive((dialog, which) -> ((TagsDialogListener)requireActivity())
-                        .onSelectedTags(new ArrayList<>(mTags.mCurrentTags), mSelectedOption));
+                        .onSelectedTags(mTags.getCheckedTagList(), mSelectedOption));
         mDialog = builder.build();
 
         mDialog.getWindow().setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_ADJUST_RESIZE);

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/TagsDialog.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/TagsDialog.java
@@ -58,8 +58,9 @@ public class TagsDialog extends AnalyticsDialogFragment {
          * @param currentTags A list of checked tags
          *                any duplicates will be ignored
          */
-        public TagsList(@NonNull ArrayList<String> allTags, @NonNull TreeSet<String> currentTags) {
-            mCurrentTags = currentTags;
+        public TagsList(@NonNull ArrayList<String> allTags, @NonNull List<String> currentTags) {
+            mCurrentTags = new TreeSet<>(String.CASE_INSENSITIVE_ORDER);
+            currentTags.addAll(currentTags);
             mAllTags = allTags;
             for (String tag : mCurrentTags) {
                 if (!allTags.contains(tag)) {
@@ -250,11 +251,10 @@ public class TagsDialog extends AnalyticsDialogFragment {
 
         mType = DialogType.values()[requireArguments().getInt(DIALOG_TYPE_KEY)];
 
-        TreeSet<String> currentTags = new TreeSet<>(String.CASE_INSENSITIVE_ORDER);
-        currentTags.addAll(requireArguments().getStringArrayList(CHECKED_TAGS_KEY));
 
-
-        mTags = new TagsList(requireArguments().getStringArrayList(ALL_TAGS_KEY), currentTags);
+        mTags = new TagsList(
+                    requireArguments().getStringArrayList(ALL_TAGS_KEY),
+                    requireArguments().getStringArrayList(CHECKED_TAGS_KEY));
 
         setCancelable(true);
     }


### PR DESCRIPTION
I tried to review #8322 and still have problem checking the first commit 9f5a60421a8d948f3c2fa7f76c5d51fd79f20d32 of @TarekkMA, so I decided to split it into commits as atomic as I could.

As you can see, I had to stop at some point. Indeed, I could not understand why the last commit was correct. Why ` && !mTags.isChecked(tag)` was removed in a test. Why TagsArrayAdapter do not have to copy anymore the list of elements (as far as I can tell, it means change in the adapter gets immediately reflected into the other one, which was not the case before). So I'd like to understand or to get your help trying to really atomize it.

Concerning af49114, I don't know either why it work, but it seems to be consistent with your PR