### PR TITLE
[Modified]: Action buttons for cards changed to OnTouch.

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -438,31 +438,42 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
         }
     };
 
-    private final View.OnClickListener mSelectEaseHandler = new View.OnClickListener() {
+    private final View.OnTouchListener mSelectEaseHandler = new View.OnTouchListener() {
+        Card mPrevCard;
         @Override
-        public void onClick(View view) {
-            // Ignore what is most likely an accidental double-tap.
-            if (SystemClock.elapsedRealtime() - mLastClickTime < DOUBLE_TAP_IGNORE_THRESHOLD) {
-                return;
+        public boolean onTouch(View view, MotionEvent event) {
+            if (event.getAction() == MotionEvent.ACTION_DOWN) {
+                // Save card when button pressed
+                mPrevCard = mCurrentCard;
+                return true;
             }
-            mLastClickTime = SystemClock.elapsedRealtime();
-            mTimeoutHandler.removeCallbacks(mShowQuestionTask);
-            int id = view.getId();
-            if (id == R.id.flashcard_layout_ease1) {
-                Timber.i("AbstractFlashcardViewer:: EASE_1 pressed");
-                answerCard(Consts.BUTTON_ONE);
-            } else if (id == R.id.flashcard_layout_ease2) {
-                Timber.i("AbstractFlashcardViewer:: EASE_2 pressed");
-                answerCard(Consts.BUTTON_TWO);
-            } else if (id == R.id.flashcard_layout_ease3) {
-                Timber.i("AbstractFlashcardViewer:: EASE_3 pressed");
-                answerCard(Consts.BUTTON_THREE);
-            } else if (id == R.id.flashcard_layout_ease4) {
-                Timber.i("AbstractFlashcardViewer:: EASE_4 pressed");
-                answerCard(Consts.BUTTON_FOUR);
-            } else {
-                mCurrentEase = 0;
+            // Perform intended action only if the button has been pressed for current card
+            if (event.getAction() == MotionEvent.ACTION_UP && mPrevCard == mCurrentCard) {
+                // Ignore what is most likely an accidental double-tap.
+                if (SystemClock.elapsedRealtime() - mLastClickTime < DOUBLE_TAP_IGNORE_THRESHOLD) {
+                    return false;
+                }
+                mLastClickTime = SystemClock.elapsedRealtime();
+                mTimeoutHandler.removeCallbacks(mShowQuestionTask);
+                int id = view.getId();
+                if (id == R.id.flashcard_layout_ease1) {
+                    Timber.i("AbstractFlashcardViewer:: EASE_1 pressed");
+                    answerCard(Consts.BUTTON_ONE);
+                } else if (id == R.id.flashcard_layout_ease2) {
+                    Timber.i("AbstractFlashcardViewer:: EASE_2 pressed");
+                    answerCard(Consts.BUTTON_TWO);
+                } else if (id == R.id.flashcard_layout_ease3) {
+                    Timber.i("AbstractFlashcardViewer:: EASE_3 pressed");
+                    answerCard(Consts.BUTTON_THREE);
+                } else if (id == R.id.flashcard_layout_ease4) {
+                    Timber.i("AbstractFlashcardViewer:: EASE_4 pressed");
+                    answerCard(Consts.BUTTON_FOUR);
+                } else {
+                    mCurrentEase = 0;
+                }
+                return true;
             }
+            return false;
         }
     };
 
@@ -1516,19 +1527,19 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
 
         mEase1 = findViewById(R.id.ease1);
         mEase1Layout = findViewById(R.id.flashcard_layout_ease1);
-        mEase1Layout.setOnClickListener(mSelectEaseHandler);
+        mEase1Layout.setOnTouchListener(mSelectEaseHandler);
 
         mEase2 = findViewById(R.id.ease2);
         mEase2Layout = findViewById(R.id.flashcard_layout_ease2);
-        mEase2Layout.setOnClickListener(mSelectEaseHandler);
+        mEase2Layout.setOnTouchListener(mSelectEaseHandler);
 
         mEase3 = findViewById(R.id.ease3);
         mEase3Layout = findViewById(R.id.flashcard_layout_ease3);
-        mEase3Layout.setOnClickListener(mSelectEaseHandler);
+        mEase3Layout.setOnTouchListener(mSelectEaseHandler);
 
         mEase4 = findViewById(R.id.ease4);
         mEase4Layout = findViewById(R.id.flashcard_layout_ease4);
-        mEase4Layout.setOnClickListener(mSelectEaseHandler);
+        mEase4Layout.setOnTouchListener(mSelectEaseHandler);
 
         mNext1 = findViewById(R.id.nextTime1);
         mNext2 = findViewById(R.id.nextTime2);


### PR DESCRIPTION
## Purpose / Description
If a card auto-advances right as you were answering you can get a weird skip effect, where the card you were trying to answer for is failed, the next card senses that you were holding one of the 4 buttons and since you were just lifting your finger as the next card comes in, it is marked with that answer, and moves to the next card.

## Fixes
Fixes #4631 

## Approach
A new function has been created with `OnTouch` listener and `ACTION_DOWN` has been used to save the current instance of card. It will ensure that the options which are chosen for a particular card, the changes will be reflected for that card itself. In the `OnClick` listener the saved card will be compared to the current card, if same only then the required actions are performed.

## How Has This Been Tested?
The work has been tested on physical device (Xiaomi redmi note5 pro).
Steps to test:

1. Ensure your cards auto-advance
2. Hold down on an answer without lifting your finger
3. The card auto advances
4. The action/due date of the card chosen will be applicable for the card on which it was chosen for.


## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code