### PR TITLE
Replace timebox notice with a popup

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -648,7 +648,14 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
                 int nMins = elapsed.first / 60;
                 String mins = res.getQuantityString(R.plurals.in_minutes, nMins, nMins);
                 String timeboxMessage = res.getQuantityString(R.plurals.timebox_reached, nCards, nCards, mins);
-                UIUtils.showThemedToast(AbstractFlashcardViewer.this, timeboxMessage, true);
+                new MaterialDialog.Builder(AbstractFlashcardViewer.this)
+                        .title(res.getString(R.string.timebox_reached_title))
+                        .content(timeboxMessage)
+                        .positiveText(R.string.dialog_finish)
+                        .negativeText(R.string.dialog_continue)
+                        .cancelable(true)
+                        .onPositive((materialDialog, dialogAction) -> finishWithAnimation(RIGHT))
+                        .show();
                 getCol().startTimebox();
             }
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -654,7 +654,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
                         .positiveText(R.string.dialog_continue)
                         .negativeText(R.string.close)
                         .cancelable(true)
-                        .onNegative((materialDialog, dialogAction) -> finishWithAnimation(RIGHT))
+                        .onNegative((materialDialog, dialogAction) -> finishWithAnimation(END))
                         .onPositive((materialDialog, dialogAction) -> getCol().startTimebox())
                         .cancelListener(materialDialog -> getCol().startTimebox())
                         .show();

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -648,13 +648,15 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
                 int nMins = elapsed.first / 60;
                 String mins = res.getQuantityString(R.plurals.in_minutes, nMins, nMins);
                 String timeboxMessage = res.getQuantityString(R.plurals.timebox_reached, nCards, nCards, mins);
+                // Restarting Timebox in .onPositive is not necessary,
+                // because the following line will restart it (along with restarting after cancelling the dialog box)
                 new MaterialDialog.Builder(AbstractFlashcardViewer.this)
                         .title(res.getString(R.string.timebox_reached_title))
                         .content(timeboxMessage)
-                        .positiveText(R.string.dialog_finish)
-                        .negativeText(R.string.dialog_continue)
+                        .positiveText(R.string.dialog_continue)
+                        .negativeText(R.string.dialog_close)
                         .cancelable(true)
-                        .onPositive((materialDialog, dialogAction) -> finishWithAnimation(RIGHT))
+                        .onNegative((materialDialog, dialogAction) -> finishWithAnimation(RIGHT))
                         .show();
                 getCol().startTimebox();
             }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -648,17 +648,16 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
                 int nMins = elapsed.first / 60;
                 String mins = res.getQuantityString(R.plurals.in_minutes, nMins, nMins);
                 String timeboxMessage = res.getQuantityString(R.plurals.timebox_reached, nCards, nCards, mins);
-                // Restarting Timebox in .onPositive is not necessary,
-                // because the following line will restart it (along with restarting after cancelling the dialog box)
                 new MaterialDialog.Builder(AbstractFlashcardViewer.this)
                         .title(res.getString(R.string.timebox_reached_title))
                         .content(timeboxMessage)
                         .positiveText(R.string.dialog_continue)
-                        .negativeText(R.string.dialog_close)
+                        .negativeText(R.string.close)
                         .cancelable(true)
                         .onNegative((materialDialog, dialogAction) -> finishWithAnimation(RIGHT))
+                        .onPositive((materialDialog, dialogAction) -> getCol().startTimebox())
+                        .cancelListener(materialDialog -> getCol().startTimebox())
                         .show();
-                getCol().startTimebox();
             }
         }
 

--- a/AnkiDroid/src/main/res/values/02-strings.xml
+++ b/AnkiDroid/src/main/res/values/02-strings.xml
@@ -110,6 +110,7 @@
     <string name="field_remapping">%1$s (from “%2$s”)</string>
     <string name="confirm_map_cards_to_nothing">Any cards mapped to nothing will be deleted. If a note has no remaining cards, it will be lost. Are you sure you want to continue?</string>
 
+    <string name="timebox_reached_title">Timebox reached</string>
     <plurals name="timebox_reached">
         <item quantity="one">%1$d card studied in %2$s</item>
         <item quantity="other">%1$d cards studied in %2$s</item>

--- a/AnkiDroid/src/main/res/values/03-dialogs.xml
+++ b/AnkiDroid/src/main/res/values/03-dialogs.xml
@@ -107,6 +107,7 @@
     <string name="dialog_ok">OK</string>
     <string name="dialog_no">No</string>
     <string name="dialog_continue">Continue</string>
+    <string name="dialog_finish">Finish</string>
     <string name="dialog_positive_create" comment="Create a new collection, probably erasing the previous one, may be necessary in case of error.">Create</string>
     <string name="dialog_positive_delete">Delete</string>
     <!-- Currently unsued, should be useful in the future -->

--- a/AnkiDroid/src/main/res/values/03-dialogs.xml
+++ b/AnkiDroid/src/main/res/values/03-dialogs.xml
@@ -107,7 +107,7 @@
     <string name="dialog_ok">OK</string>
     <string name="dialog_no">No</string>
     <string name="dialog_continue">Continue</string>
-    <string name="dialog_finish">Finish</string>
+    <string name="dialog_close">Close</string>
     <string name="dialog_positive_create" comment="Create a new collection, probably erasing the previous one, may be necessary in case of error.">Create</string>
     <string name="dialog_positive_delete">Delete</string>
     <!-- Currently unsued, should be useful in the future -->

--- a/AnkiDroid/src/main/res/values/03-dialogs.xml
+++ b/AnkiDroid/src/main/res/values/03-dialogs.xml
@@ -107,7 +107,6 @@
     <string name="dialog_ok">OK</string>
     <string name="dialog_no">No</string>
     <string name="dialog_continue">Continue</string>
-    <string name="dialog_close">Close</string>
     <string name="dialog_positive_create" comment="Create a new collection, probably erasing the previous one, may be necessary in case of error.">Create</string>
     <string name="dialog_positive_delete">Delete</string>
     <!-- Currently unsued, should be useful in the future -->


### PR DESCRIPTION
## Purpose / Description
Replaces the timebox notice with a dialog popup.

## Fixes
Fixes #8081.

## Approach
Replace the themed toast with a material dialog.

## How Has This Been Tested?

I set the time box limit to 1 minute in preference, then opened up any deck, wait for 1 minute and answer. The dialog box shows up as expected.

## Checklist

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [x] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
