### PR TITLE
Fix #8466: Update card colour when a flag is selected

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -1020,7 +1020,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
         return checkedCardCount() >= getCardCount(); //must handle 0.
     }
 
-
+    @VisibleForTesting
     public void flagTask (int flag) {
         TaskManager.launchCollectionTask(
                 new CollectionTask.Flag(getSelectedCardIds(), flag),

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -1025,6 +1025,12 @@ public class CardBrowser extends NavigationDrawerActivity implements
         TaskManager.launchCollectionTask(
                 new CollectionTask.Flag(getSelectedCardIds(), flag),
                 flagCardHandler());
+
+        for (CardCache card: getCards()) {
+            if (getSelectedCardIds().contains(card.getCard().getId())) {
+                card.getCard().setUserFlag(flag);
+            }
+        }
     }
 
     /** Updates flag icon color and cards shown with given color */

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -1021,7 +1021,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
     }
 
 
-    private void flagTask (int flag) {
+    public void flagTask (int flag) {
         TaskManager.launchCollectionTask(
                 new CollectionTask.Flag(getSelectedCardIds(), flag),
                 flagCardHandler());

--- a/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.java
@@ -527,6 +527,17 @@ public class CardBrowserTest extends RobolectricTest {
         assertThat("Results should only be from the selected deck", cardBrowser.getCardCount(), is(1));
     }
 
+    @Test
+    public void checkIfFlagSelectionUpdatesSelectedCard() {
+        CardBrowser b = getBrowserWithNotes(1);
+        b.checkCardsAtPositions(0);
+
+        Card card = getCheckedCard(b).getCard();
+        b.flagTask(1);
+
+        assertThat(card.userFlag(), is(1));
+    }
+
     protected void assertUndoDoesNotContain(CardBrowser browser, @StringRes int resId) {
         ShadowActivity shadowActivity = shadowOf(browser);
         MenuItem item = shadowActivity.getOptionsMenu().findItem(R.id.action_undo);

--- a/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.java
@@ -533,6 +533,7 @@ public class CardBrowserTest extends RobolectricTest {
         b.checkCardsAtPositions(0);
 
         Card card = getCheckedCard(b).getCard();
+
         b.flagTask(1);
 
         assertThat(card.userFlag(), is(1));

--- a/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.java
@@ -536,7 +536,7 @@ public class CardBrowserTest extends RobolectricTest {
 
         b.flagTask(1);
 
-        assertThat(card.userFlag(), is(1));
+        assertThat("Card colour should get updated when a flag is selected", card.userFlag(), is(1));
     }
 
     protected void assertUndoDoesNotContain(CardBrowser browser, @StringRes int resId) {


### PR DESCRIPTION
## Purpose / Description

Card colour needs to be updated when a flag is selected for that card.

## Fixes

Fixes #8466 

## Approach

Added functionality to iterate through the cards and set the selected flag for the selected cards.

## How Has This Been Tested?

Verified that the functionality is working.

## Checklist

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
