### PR TITLE
NF: Refactor CustomStudyDialog to use FragmentFactory

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -102,6 +102,7 @@ import com.ichi2.anki.dialogs.ExportDialog;
 import com.ichi2.anki.dialogs.ImportDialog;
 import com.ichi2.anki.dialogs.MediaCheckDialog;
 import com.ichi2.anki.dialogs.SyncErrorDialog;
+import com.ichi2.anki.dialogs.customstudy.CustomStudyDialogFactory;
 import com.ichi2.anki.exception.ConfirmModSchemaException;
 import com.ichi2.anki.exception.DeckRenameException;
 import com.ichi2.anki.exception.FilteredAncestor;
@@ -250,6 +251,8 @@ public class DeckPicker extends NavigationDrawerActivity implements
     private boolean mClosedWelcomeMessage;
 
     private SearchView mToolbarSearchView;
+
+    private CustomStudyDialogFactory mCustomStudyDialogFactory;
 
     // ----------------------------------------------------------------------------
     // LISTENERS
@@ -446,6 +449,8 @@ public class DeckPicker extends NavigationDrawerActivity implements
         if (showedActivityFailedScreen(savedInstanceState)) {
             return;
         }
+
+        mCustomStudyDialogFactory = new CustomStudyDialogFactory(this::getCol, this).attachToActivity(this);
 
         SharedPreferences preferences = AnkiDroidApp.getSharedPrefs(getBaseContext());
 
@@ -2302,7 +2307,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
         } else if (getCol().getSched().newDue() || getCol().getSched().revDue()) {
             // If there are no cards to review because of the daily study limit then give "Study more" option
             UIUtils.showSnackbar(this, R.string.studyoptions_limit_reached, false, R.string.study_more, v -> {
-                CustomStudyDialog d = CustomStudyDialog.newInstance(
+                CustomStudyDialog d = mCustomStudyDialogFactory.newCustomStudyDialog().withArguments(
                         CustomStudyDialog.CONTEXT_MENU_LIMITS,
                         getCol().getDecks().selected(), true);
                 showDialogFragment(d);
@@ -2333,7 +2338,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
         } else {
             // Otherwise say there are no cards scheduled to study, and give option to do custom study
             UIUtils.showSnackbar(this, R.string.studyoptions_empty_schedule, false, R.string.custom_study, v -> {
-                CustomStudyDialog d = CustomStudyDialog.newInstance(
+                CustomStudyDialog d = mCustomStudyDialogFactory.newCustomStudyDialog().withArguments(
                         CustomStudyDialog.CONTEXT_MENU_EMPTY_SCHEDULE,
                         getCol().getDecks().selected(), true);
                 showDialogFragment(d);

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -89,7 +89,7 @@ import com.ichi2.anki.StudyOptionsFragment.StudyOptionsListener;
 import com.ichi2.anki.analytics.UsageAnalytics;
 import com.ichi2.anki.dialogs.AsyncDialogFragment;
 import com.ichi2.anki.dialogs.ConfirmationDialog;
-import com.ichi2.anki.dialogs.CustomStudyDialog;
+import com.ichi2.anki.dialogs.customstudy.CustomStudyDialog;
 import com.ichi2.anki.dialogs.DatabaseErrorDialog;
 import com.ichi2.anki.dialogs.DeckPickerAnalyticsOptInDialog;
 import com.ichi2.anki.dialogs.DeckPickerBackupNoSpaceLeftDialog;

--- a/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsActivity.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsActivity.java
@@ -23,6 +23,7 @@ import android.view.View;
 
 import com.ichi2.anki.StudyOptionsFragment.StudyOptionsListener;
 import com.ichi2.anki.dialogs.customstudy.CustomStudyDialog;
+import com.ichi2.anki.dialogs.customstudy.CustomStudyDialogFactory;
 import com.ichi2.widget.WidgetStatus;
 
 import timber.log.Timber;
@@ -38,6 +39,8 @@ public class StudyOptionsActivity extends NavigationDrawerActivity implements St
         if (showedActivityFailedScreen(savedInstanceState)) {
             return;
         }
+        CustomStudyDialogFactory customStudyDialogFactory = new CustomStudyDialogFactory(this::getCol, this);
+        customStudyDialogFactory.attachToActivity(this);
         super.onCreate(savedInstanceState);
         // The empty frame layout is a workaround for fragments not showing when they are added
         // to android.R.id.content when an action bar is used in Android 2.1 (and potentially

--- a/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsActivity.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsActivity.java
@@ -21,9 +21,8 @@ import android.os.Bundle;
 import android.view.MenuItem;
 import android.view.View;
 
-import com.ichi2.anim.ActivityTransitionAnimation;
 import com.ichi2.anki.StudyOptionsFragment.StudyOptionsListener;
-import com.ichi2.anki.dialogs.CustomStudyDialog;
+import com.ichi2.anki.dialogs.customstudy.CustomStudyDialog;
 import com.ichi2.widget.WidgetStatus;
 
 import timber.log.Timber;

--- a/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsFragment.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsFragment.java
@@ -55,6 +55,7 @@ import com.ichi2.themes.StyledProgressDialog;
 import com.ichi2.utils.BooleanGetter;
 import com.ichi2.utils.HtmlUtils;
 
+import androidx.fragment.app.FragmentFactory;
 import timber.log.Timber;
 
 import static com.ichi2.anim.ActivityTransitionAnimation.Direction.*;
@@ -288,9 +289,11 @@ public class StudyOptionsFragment extends Fragment implements Toolbar.OnMenuItem
      * Show the context menu for the custom study options
      */
     private void showCustomStudyContextMenu() {
-        CustomStudyDialog d = CustomStudyDialog.newInstance(CustomStudyDialog.CONTEXT_MENU_STANDARD,
-                getCol().getDecks().selected());
-        ((AnkiActivity)getActivity()).showDialogFragment(d);
+        final AnkiActivity ankiActivity = ((AnkiActivity) requireActivity());
+        final FragmentFactory fragmentFactory = ankiActivity.getSupportFragmentManager().getFragmentFactory();
+        CustomStudyDialog d = (CustomStudyDialog) fragmentFactory.instantiate(ankiActivity.getClassLoader(), CustomStudyDialog.class.getName());
+        d.withArguments(CustomStudyDialog.CONTEXT_MENU_STANDARD, getCol().getDecks().selected());
+        ankiActivity.showDialogFragment(d);
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsFragment.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsFragment.java
@@ -53,6 +53,7 @@ import com.ichi2.libanki.Utils;
 import com.ichi2.libanki.Deck;
 import com.ichi2.themes.StyledProgressDialog;
 import com.ichi2.utils.BooleanGetter;
+import com.ichi2.utils.FragmentFactoryUtils;
 import com.ichi2.utils.HtmlUtils;
 
 import androidx.fragment.app.FragmentFactory;
@@ -290,8 +291,7 @@ public class StudyOptionsFragment extends Fragment implements Toolbar.OnMenuItem
      */
     private void showCustomStudyContextMenu() {
         final AnkiActivity ankiActivity = ((AnkiActivity) requireActivity());
-        final FragmentFactory fragmentFactory = ankiActivity.getSupportFragmentManager().getFragmentFactory();
-        CustomStudyDialog d = (CustomStudyDialog) fragmentFactory.instantiate(ankiActivity.getClassLoader(), CustomStudyDialog.class.getName());
+        CustomStudyDialog d = FragmentFactoryUtils.instantiate(ankiActivity, CustomStudyDialog.class);
         d.withArguments(CustomStudyDialog.CONTEXT_MENU_STANDARD, getCol().getDecks().selected());
         ankiActivity.showDialogFragment(d);
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsFragment.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsFragment.java
@@ -41,7 +41,7 @@ import android.widget.TextView;
 
 import com.afollestad.materialdialogs.MaterialDialog;
 import com.ichi2.anim.ActivityTransitionAnimation;
-import com.ichi2.anki.dialogs.CustomStudyDialog;
+import com.ichi2.anki.dialogs.customstudy.CustomStudyDialog;
 import com.ichi2.async.CollectionTask;
 import com.ichi2.async.TaskListener;
 import com.ichi2.async.TaskManager;
@@ -54,7 +54,6 @@ import com.ichi2.libanki.Deck;
 import com.ichi2.themes.StyledProgressDialog;
 import com.ichi2.utils.BooleanGetter;
 import com.ichi2.utils.HtmlUtils;
-import com.ichi2.utils.UiUtil;
 
 import timber.log.Timber;
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckPickerContextMenu.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckPickerContextMenu.java
@@ -17,7 +17,6 @@ package com.ichi2.anki.dialogs;
 
 import android.app.Dialog;
 import android.content.res.Resources;
-import android.os.Build;
 import android.os.Bundle;
 
 import com.afollestad.materialdialogs.MaterialDialog;
@@ -27,6 +26,7 @@ import com.ichi2.anki.DeckPicker;
 import com.ichi2.anki.R;
 import com.ichi2.anki.StudyOptionsFragment;
 import com.ichi2.anki.analytics.AnalyticsDialogFragment;
+import com.ichi2.anki.dialogs.customstudy.CustomStudyDialog;
 import com.ichi2.libanki.Collection;
 
 import java.lang.annotation.Retention;

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckPickerContextMenu.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckPickerContextMenu.java
@@ -35,6 +35,7 @@ import java.util.HashMap;
 
 import androidx.annotation.IntDef;
 import androidx.annotation.NonNull;
+import androidx.fragment.app.FragmentFactory;
 import timber.log.Timber;
 
 import static java.lang.annotation.RetentionPolicy.SOURCE;
@@ -160,9 +161,12 @@ public class DeckPickerContextMenu extends AnalyticsDialogFragment {
             case CONTEXT_MENU_CUSTOM_STUDY: {
                 Timber.i("Custom study option selected");
                 long did = getArguments().getLong("did");
-                CustomStudyDialog d = CustomStudyDialog.newInstance(
-                        CustomStudyDialog.CONTEXT_MENU_STANDARD, did);
-                ((AnkiActivity) getActivity()).showDialogFragment(d);
+
+                final AnkiActivity ankiActivity = ((AnkiActivity) requireActivity());
+                final FragmentFactory fragmentFactory = ankiActivity.getSupportFragmentManager().getFragmentFactory();
+                CustomStudyDialog d = (CustomStudyDialog) fragmentFactory.instantiate(ankiActivity.getClassLoader(), CustomStudyDialog.class.getName());
+                d.withArguments(CustomStudyDialog.CONTEXT_MENU_STANDARD, did);
+                ankiActivity.showDialogFragment(d);
                 break;
             }
             case CONTEXT_MENU_CREATE_SHORTCUT:

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckPickerContextMenu.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckPickerContextMenu.java
@@ -28,6 +28,7 @@ import com.ichi2.anki.StudyOptionsFragment;
 import com.ichi2.anki.analytics.AnalyticsDialogFragment;
 import com.ichi2.anki.dialogs.customstudy.CustomStudyDialog;
 import com.ichi2.libanki.Collection;
+import com.ichi2.utils.FragmentFactoryUtils;
 
 import java.lang.annotation.Retention;
 import java.util.ArrayList;
@@ -163,8 +164,7 @@ public class DeckPickerContextMenu extends AnalyticsDialogFragment {
                 long did = getArguments().getLong("did");
 
                 final AnkiActivity ankiActivity = ((AnkiActivity) requireActivity());
-                final FragmentFactory fragmentFactory = ankiActivity.getSupportFragmentManager().getFragmentFactory();
-                CustomStudyDialog d = (CustomStudyDialog) fragmentFactory.instantiate(ankiActivity.getClassLoader(), CustomStudyDialog.class.getName());
+                CustomStudyDialog d = FragmentFactoryUtils.instantiate(ankiActivity, CustomStudyDialog.class);
                 d.withArguments(CustomStudyDialog.CONTEXT_MENU_STANDARD, did);
                 ankiActivity.showDialogFragment(d);
                 break;

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/customstudy/CreateCustomStudySessionListener.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/customstudy/CreateCustomStudySessionListener.java
@@ -1,0 +1,35 @@
+package com.ichi2.anki.dialogs.customstudy;
+
+import com.ichi2.anki.StudyOptionsFragment;
+import com.ichi2.anki.dialogs.customstudy.CustomStudyDialog.CustomStudyListener;
+import com.ichi2.async.TaskListenerWithContext;
+
+import androidx.annotation.NonNull;
+
+import static com.ichi2.anki.dialogs.customstudy.CreateCustomStudySessionListener.*;
+
+class CreateCustomStudySessionListener extends TaskListenerWithContext<Callback, Void, StudyOptionsFragment.DeckStudyData> {
+
+    public interface Callback {
+        void hideProgressBar();
+        void onCreateCustomStudySession();
+        void showProgressBar();
+    }
+
+    public CreateCustomStudySessionListener(Callback callback) {
+        super(callback);
+    }
+
+
+    @Override
+    public void actualOnPreExecute(@NonNull Callback callback) {
+        callback.showProgressBar();
+    }
+
+
+    @Override
+    public void actualOnPostExecute(@NonNull Callback callback, StudyOptionsFragment.DeckStudyData v) {
+        callback.hideProgressBar();
+        callback.onCreateCustomStudySession();
+    }
+}

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/customstudy/CustomStudyDialog.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/customstudy/CustomStudyDialog.java
@@ -362,7 +362,7 @@ public class CustomStudyDialog extends AnalyticsDialogFragment implements
         switch (dialogId) {
             case CONTEXT_MENU_STANDARD:
                 // Standard context menu
-                ArrayList<Integer> dialogOptions = new ArrayList<Integer>();
+                ArrayList<Integer> dialogOptions = new ArrayList<>();
                 dialogOptions.add(CUSTOM_STUDY_NEW);
                 dialogOptions.add(CUSTOM_STUDY_REV);
                 dialogOptions.add(CUSTOM_STUDY_FORGOT);

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/customstudy/CustomStudyDialog.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/customstudy/CustomStudyDialog.java
@@ -75,13 +75,24 @@ public class CustomStudyDialog extends AnalyticsDialogFragment implements
     private static final int CUSTOM_STUDY_REV = 101;
     private static final int CUSTOM_STUDY_FORGOT = 102;
     @VisibleForTesting
-    static final int CUSTOM_STUDY_AHEAD = 103;
+    public static final int CUSTOM_STUDY_AHEAD = 103;
     private static final int CUSTOM_STUDY_RANDOM = 104;
     private static final int CUSTOM_STUDY_PREVIEW = 105;
     private static final int CUSTOM_STUDY_TAGS = 106;
     // Special items to put in the context menu
     private static final int DECK_OPTIONS = 107;
     private static final int MORE_OPTIONS = 108;
+
+
+    private final CustomStudyListener mCustomStudyListener;
+    private final Collection mCollection;
+
+
+    public CustomStudyDialog(Collection collection, CustomStudyListener customStudyListener) {
+        this.mCollection = collection;
+        this.mCustomStudyListener = customStudyListener;
+    }
+
 
     public interface CustomStudyListener extends CreateCustomStudySessionListener.Callback {
         void onExtendStudyLimits();
@@ -90,34 +101,22 @@ public class CustomStudyDialog extends AnalyticsDialogFragment implements
         void startActivityForResultWithoutAnimation(Intent intent, int requestCode);
     }
 
-    /**
-     * Instance factories
-     */
-    public static CustomStudyDialog newInstance(int id, long did) {
-        return newInstance(id, did, false);
+
+    public CustomStudyDialog withArguments(int id, long did) {
+        return withArguments(id, did, false);
     }
 
-    public static CustomStudyDialog newInstance(int id, long did, boolean jumpToReviewer) {
-        CustomStudyDialog f = new CustomStudyDialog();
-        Bundle args = new Bundle();
+
+    public CustomStudyDialog withArguments(int id, long did, boolean jumpToReviewer) {
+        Bundle args = this.getArguments();
+        if (args == null) {
+            args = new Bundle();
+        }
         args.putInt("id", id);
         args.putLong("did", did);
         args.putBoolean("jumpToReviewer", jumpToReviewer);
-        f.setArguments(args);
-        return f;
-    }
-
-
-    private CustomStudyListener mCustomStudyListener;
-    private Collection mCollection;
-
-
-    @Override
-    public void onAttach(@NonNull Context context) {
-        super.onAttach(context);
-        AnkiActivity ankiActivity = (AnkiActivity) requireActivity();
-        mCustomStudyListener = (CustomStudyListener) ankiActivity;
-        mCollection = ankiActivity.getCol();
+        this.setArguments(args);
+        return this;
     }
 
 
@@ -158,8 +157,12 @@ public class CustomStudyDialog extends AnalyticsDialogFragment implements
                         }
                         case MORE_OPTIONS: {
                             // User asked to see all custom study options
-                            CustomStudyDialog d = CustomStudyDialog.newInstance(CONTEXT_MENU_STANDARD,
-                                    requireArguments().getLong("did"), jumpToReviewer);
+                            final CustomStudyDialog d = new CustomStudyDialog(mCollection, mCustomStudyListener)
+                                    .withArguments(
+                                            CONTEXT_MENU_STANDARD,
+                                            requireArguments().getLong("did"),
+                                            jumpToReviewer
+                                    );
                             mCustomStudyListener.showDialogFragment(d);
                             break;
                         }
@@ -178,8 +181,12 @@ public class CustomStudyDialog extends AnalyticsDialogFragment implements
                         }
                         default: {
                             // User asked for a standard custom study option
-                            CustomStudyDialog d = CustomStudyDialog.newInstance(view.getId(),
-                                    requireArguments().getLong("did"), jumpToReviewer);
+                            final CustomStudyDialog d = new CustomStudyDialog(mCollection, mCustomStudyListener)
+                                    .withArguments(
+                                            view.getId(),
+                                            requireArguments().getLong("did"),
+                                            jumpToReviewer
+                                    );
                             mCustomStudyListener.showDialogFragment(d);
                         }
                     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/customstudy/CustomStudyDialog.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/customstudy/CustomStudyDialog.java
@@ -115,7 +115,7 @@ public class CustomStudyDialog extends AnalyticsDialogFragment implements
     @Override
     public void onAttach(@NonNull Context context) {
         super.onAttach(context);
-        AnkiActivity ankiActivity = requireAnkiActivity();
+        AnkiActivity ankiActivity = (AnkiActivity) requireActivity();
         mCustomStudyListener = (CustomStudyListener) ankiActivity;
         mCollection = ankiActivity.getCol();
     }
@@ -148,11 +148,10 @@ public class CustomStudyDialog extends AnalyticsDialogFragment implements
                 .itemsIds(listIds)
                 .items(ContextMenuHelper.getValuesFromKeys(getKeyValueMap(), listIds))
                 .itemsCallback((materialDialog, view, which, charSequence) -> {
-                    AnkiActivity activity = requireAnkiActivity();
                     switch (view.getId()) {
                         case DECK_OPTIONS: {
                             // User asked to permanently change the deck options
-                            Intent i = new Intent(activity, DeckOptions.class);
+                            Intent i = new Intent(requireContext(), DeckOptions.class);
                             i.putExtra("did", requireArguments().getLong("did"));
                             requireActivity().startActivity(i);
                             break;
@@ -458,7 +457,6 @@ public class CustomStudyDialog extends AnalyticsDialogFragment implements
      */
     private void createCustomStudySession(JSONArray delays, Object[] terms, Boolean resched) {
         Deck dyn;
-        final AnkiActivity activity = requireAnkiActivity();
         long did = requireArguments().getLong("did");
         Decks decks = mCollection.getDecks();
         String deckToStudyName = decks.get(did).getString("name");
@@ -517,20 +515,13 @@ public class CustomStudyDialog extends AnalyticsDialogFragment implements
     }
 
     private void onLimitsExtended(boolean jumpToReviewer) {
-        AnkiActivity activity = requireAnkiActivity();
         if (jumpToReviewer) {
-            mCustomStudyListener.startActivityForResultWithoutAnimation(new Intent(activity, Reviewer.class), AnkiActivity.REQUEST_REVIEW);
+            mCustomStudyListener.startActivityForResultWithoutAnimation(new Intent(requireContext(), Reviewer.class), AnkiActivity.REQUEST_REVIEW);
         } else {
             mCustomStudyListener.onExtendStudyLimits();
         }
         mCustomStudyListener.dismissAllDialogFragments();
     }
-
-    @NonNull
-    protected AnkiActivity requireAnkiActivity() {
-        return (AnkiActivity) requireActivity();
-    }
-
 
     private CreateCustomStudySessionListener createCustomStudySessionListener(){
         return new CreateCustomStudySessionListener(mCustomStudyListener);

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/customstudy/CustomStudyDialog.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/customstudy/CustomStudyDialog.java
@@ -226,8 +226,8 @@ public class CustomStudyDialog extends AnalyticsDialogFragment implements
                     int n;
                     try {
                         n = Integer.parseInt(mEditText.getText().toString());
-                    } catch (Exception ignored) {
-                        Timber.w(ignored);
+                    } catch (Exception e) {
+                        Timber.w(e);
                         // This should never happen because we disable positive button for non-parsable inputs
                         return;
                     }
@@ -296,8 +296,8 @@ public class CustomStudyDialog extends AnalyticsDialogFragment implements
                 try {
                     Integer.parseInt(mEditText.getText().toString());
                     dialog.getActionButton(DialogAction.POSITIVE).setEnabled(true);
-                } catch (Exception ignored) {
-                    Timber.w(ignored);
+                } catch (Exception e) {
+                    Timber.w(e);
                     dialog.getActionButton(DialogAction.POSITIVE).setEnabled(false);
                 }
             }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/customstudy/CustomStudyDialog.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/customstudy/CustomStudyDialog.java
@@ -473,7 +473,7 @@ public class CustomStudyDialog extends AnalyticsDialogFragment implements
             Timber.i("Found deck: '%s'", customStudyDeck);
             if (cur.isStd()) {
                 Timber.w("Deck: '%s' was non-dynamic", customStudyDeck);
-                UIUtils.showThemedToast(requireActivity(), getString(R.string.custom_study_deck_exists), true);
+                UIUtils.showThemedToast(requireContext(), getString(R.string.custom_study_deck_exists), true);
                 return;
             } else {
                 Timber.i("Emptying dynamic deck '%s' for custom study", customStudyDeck);

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/customstudy/CustomStudyDialog.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/customstudy/CustomStudyDialog.java
@@ -42,14 +42,12 @@ import com.ichi2.anki.CollectionHelper;
 import com.ichi2.anki.DeckOptions;
 import com.ichi2.anki.R;
 import com.ichi2.anki.Reviewer;
-import com.ichi2.anki.StudyOptionsFragment;
 import com.ichi2.anki.UIUtils;
 import com.ichi2.anki.analytics.AnalyticsDialogFragment;
 import com.ichi2.anki.dialogs.ContextMenuHelper;
 import com.ichi2.anki.dialogs.TagsDialog;
 import com.ichi2.anki.exception.FilteredAncestor;
 import com.ichi2.async.CollectionTask;
-import com.ichi2.async.TaskListenerWithContext;
 import com.ichi2.async.TaskManager;
 import com.ichi2.libanki.Collection;
 import com.ichi2.libanki.Consts;
@@ -84,8 +82,7 @@ public class CustomStudyDialog extends AnalyticsDialogFragment implements
     private static final int DECK_OPTIONS = 107;
     private static final int MORE_OPTIONS = 108;
 
-    public interface CustomStudyListener {
-        void onCreateCustomStudySession();
+    public interface CustomStudyListener extends CreateCustomStudySessionListener.Callback {
         void onExtendStudyLimits();
     }
 
@@ -522,24 +519,6 @@ public class CustomStudyDialog extends AnalyticsDialogFragment implements
 
 
     private CreateCustomStudySessionListener createCustomStudySessionListener(){
-        return new CreateCustomStudySessionListener(requireAnkiActivity());
-    }
-    private static class CreateCustomStudySessionListener extends TaskListenerWithContext<AnkiActivity, Void, StudyOptionsFragment.DeckStudyData> {
-        public CreateCustomStudySessionListener(AnkiActivity activity) {
-            super(activity);
-        }
-
-
-        @Override
-        public void actualOnPreExecute(@NonNull AnkiActivity activity) {
-            activity.showProgressBar();
-        }
-
-
-        @Override
-        public void actualOnPostExecute(@NonNull AnkiActivity activity, StudyOptionsFragment.DeckStudyData v) {
-            activity.hideProgressBar();
-            ((CustomStudyListener) activity).onCreateCustomStudySession();
-        }
+        return new CreateCustomStudySessionListener((CustomStudyListener) requireAnkiActivity());
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/customstudy/CustomStudyDialog.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/customstudy/CustomStudyDialog.java
@@ -13,7 +13,7 @@
  * You should have received a copy of the GNU General Public License along with         *
  * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
  ****************************************************************************************/
-package com.ichi2.anki.dialogs;
+package com.ichi2.anki.dialogs.customstudy;
 
 import android.annotation.SuppressLint;
 import android.app.Dialog;
@@ -45,9 +45,10 @@ import com.ichi2.anki.Reviewer;
 import com.ichi2.anki.StudyOptionsFragment;
 import com.ichi2.anki.UIUtils;
 import com.ichi2.anki.analytics.AnalyticsDialogFragment;
+import com.ichi2.anki.dialogs.ContextMenuHelper;
+import com.ichi2.anki.dialogs.TagsDialog;
 import com.ichi2.anki.exception.FilteredAncestor;
 import com.ichi2.async.CollectionTask;
-import com.ichi2.async.TaskListener;
 import com.ichi2.async.TaskListenerWithContext;
 import com.ichi2.async.TaskManager;
 import com.ichi2.libanki.Collection;

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/customstudy/CustomStudyDialogFactory.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/customstudy/CustomStudyDialogFactory.java
@@ -1,0 +1,35 @@
+package com.ichi2.anki.dialogs.customstudy;
+
+import com.ichi2.anki.dialogs.customstudy.CustomStudyDialog.CustomStudyListener;
+import com.ichi2.libanki.Collection;
+import com.ichi2.utils.ExtendedFragmentFactory;
+import com.ichi2.utils.FunctionalInterfaces.Supplier;
+
+import androidx.annotation.NonNull;
+import androidx.fragment.app.Fragment;
+
+public class CustomStudyDialogFactory extends ExtendedFragmentFactory {
+
+    final Supplier<Collection> mCollectionSupplier;
+    final CustomStudyListener mCustomStudyListener;
+
+    public CustomStudyDialogFactory(Supplier<Collection> mCollectionSupplier, CustomStudyListener mCustomStudyListener) {
+        this.mCollectionSupplier = mCollectionSupplier;
+        this.mCustomStudyListener = mCustomStudyListener;
+    }
+
+    @NonNull
+    @Override
+    public Fragment instantiate(@NonNull ClassLoader classLoader, @NonNull String className) {
+        Class<? extends Fragment> cls = loadFragmentClass(classLoader, className);
+        if (cls == CustomStudyDialog.class) {
+            return newCustomStudyDialog();
+        }
+        return super.instantiate(classLoader, className);
+    }
+
+    @NonNull
+    public CustomStudyDialog newCustomStudyDialog() {
+        return new CustomStudyDialog(mCollectionSupplier.get(), mCustomStudyListener);
+    }
+}

--- a/AnkiDroid/src/main/java/com/ichi2/utils/FragmentFactoryUtils.java
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/FragmentFactoryUtils.java
@@ -1,0 +1,32 @@
+/*
+ Copyright (c) 2021 Tarek Mohamed <tarekkma@gmail.com>
+
+ This program is free software; you can redistribute it and/or modify it under
+ the terms of the GNU General Public License as published by the Free Software
+ Foundation; either version 3 of the License, or (at your option) any later
+ version.
+
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License along with
+ this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.ichi2.utils;
+
+import androidx.fragment.app.Fragment;
+import androidx.fragment.app.FragmentActivity;
+import androidx.fragment.app.FragmentFactory;
+
+public class FragmentFactoryUtils {
+
+    /**
+     * A convenience util method that instantiate a fragment using the passed activity {@link FragmentFactory}
+     */
+    public static <F extends Fragment> F instantiate(FragmentActivity activity, Class<F> cls) {
+        final FragmentFactory factory = activity.getSupportFragmentManager().getFragmentFactory();
+        return (F) factory.instantiate(activity.getClassLoader(), cls.getName());
+    }
+
+}

--- a/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/CustomStudyDialogTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/CustomStudyDialogTest.java
@@ -129,8 +129,9 @@ public class CustomStudyDialogTest extends RobolectricTest {
         }
 
 
+        @NonNull
         @Override
-        protected AnkiActivity getAnkiActivity() {
+        protected AnkiActivity requireAnkiActivity() {
             return mAnkiActivity;
         }
     }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/CustomStudyDialogTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/CustomStudyDialogTest.java
@@ -31,7 +31,6 @@ import com.ichi2.libanki.sched.AbstractSched;
 
 import org.hamcrest.Matchers;
 import org.junit.After;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
@@ -104,13 +103,17 @@ public class CustomStudyDialogTest extends RobolectricTest {
 
 
     @Test
-    @Ignore("ERROR") //java.lang.UnsupportedOperationException: Failed to resolve attribute at index 13: TypedValue{t=0x2/d=0x7f040340 a=-1}
     @Config(qualifiers = "en")
     public void increaseNewCardLimitRegressionTest(){
         // #8338 - Regression Test
         Bundle args = new CustomStudyDialog(whatever(), whatever())
                 .withArguments(CustomStudyDialog.CONTEXT_MENU_STANDARD, 1)
                 .getArguments();
+
+        // we are using mock collection for the CustomStudyDialog but still other parts of the code
+        // access a real collection, so we must ensure that collection is loaded first
+        // so we don't get net/ankiweb/rsdroid/BackendException$BackendDbException$BackendDbLockedException
+        ensureCollectionLoadIsSynchronous();
 
         Collection mockCollection = mock(Collection.class, Mockito.RETURNS_DEEP_STUBS);
         AbstractSched mockSched = mock(AbstractSched.class);
@@ -119,7 +122,7 @@ public class CustomStudyDialogTest extends RobolectricTest {
 
 
         CustomStudyDialogFactory factory = new CustomStudyDialogFactory(() -> mockCollection, mockListener);
-        FragmentScenario<CustomStudyDialog> scenario = FragmentScenario.launch(CustomStudyDialog.class, args, factory);
+        FragmentScenario<CustomStudyDialog> scenario = FragmentScenario.launch(CustomStudyDialog.class, args, R.style.Theme_AppCompat, factory);
 
         scenario.moveToState(Lifecycle.State.STARTED);
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/CustomStudyDialogTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/CustomStudyDialogTest.java
@@ -24,9 +24,9 @@ import com.ichi2.anki.AnkiActivity;
 import com.ichi2.anki.CardTemplateBrowserAppearanceEditor;
 import com.ichi2.anki.R;
 import com.ichi2.anki.RobolectricTest;
-import com.ichi2.anki.dialogs.CustomStudyDialog.CustomStudyListener;
+import com.ichi2.anki.dialogs.customstudy.CustomStudyDialog;
+import com.ichi2.anki.dialogs.customstudy.CustomStudyDialog.CustomStudyListener;
 import com.ichi2.libanki.Deck;
-import com.ichi2.utils.JSONObject;
 
 import org.hamcrest.Matchers;
 import org.junit.Ignore;
@@ -39,7 +39,6 @@ import androidx.fragment.app.testing.FragmentScenario;
 import androidx.lifecycle.Lifecycle;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
-import static com.ichi2.libanki.Consts.DECK_DYN;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.core.IsNull.notNullValue;

--- a/AnkiDroid/src/test/java/com/ichi2/utils/FragmentFactoryUtilsTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/utils/FragmentFactoryUtilsTest.java
@@ -1,0 +1,54 @@
+/*
+ Copyright (c) 2021 Tarek Mohamed <tarekkma@gmail.com>
+
+ This program is free software; you can redistribute it and/or modify it under
+ the terms of the GNU General Public License as published by the Free Software
+ Foundation; either version 3 of the License, or (at your option) any later
+ version.
+
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License along with
+ this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.ichi2.utils;
+
+import org.junit.Test;
+
+import androidx.fragment.app.Fragment;
+import androidx.fragment.app.FragmentActivity;
+import androidx.fragment.app.FragmentFactory;
+import androidx.fragment.app.FragmentManager;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+public class FragmentFactoryUtilsTest {
+
+
+    private static class TestFragment extends Fragment {}
+
+    @Test
+    public void test_instantiate() {
+        FragmentActivity activity = mock(FragmentActivity.class);
+        FragmentManager manager = mock(FragmentManager.class);
+        FragmentFactory factory = mock(FragmentFactory.class);
+        ClassLoader classLoader = mock(ClassLoader.class);
+
+        TestFragment testFragment = new TestFragment();
+
+        when(activity.getSupportFragmentManager()).thenReturn(manager);
+        when(activity.getClassLoader()).thenReturn(classLoader);
+
+        when(manager.getFragmentFactory()).thenReturn(factory);
+        when(factory.instantiate(classLoader, testFragment.getClass().getName()))
+                .thenReturn(testFragment);
+
+
+        Fragment result = FragmentFactoryUtils.instantiate(activity, TestFragment.class);
+        assertEquals(testFragment, result);
+        verify(factory, times(1)).instantiate(classLoader, testFragment.getClass().getName());
+    }
+}


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
Clean `CustomStudyDialog` and refactored to use `FragmentFactory`
All commits should be NF

## Fixes
Fixes #8406

## Approach
using `FragmentFactory`

## How Has This Been Tested?

~~**TESTS ARE DISABLED FOR `CustomStudyDialog`** I will enable them once I understand them 😅  I have to search about the fragment testing and how these tests are written~~

EDIT:
~~I have migrated `learnAheadCardsRegressionTest` to use the new FragmentFactory, but `increaseNewCardLimitRegressionTest` have some strange exceptions. I have to dig deeper to see what's wrong.~~

EDIT 2: FIXED 🥳 


## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
