### PR TITLE
fix: Not allowed to increase new cards

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/CustomStudyDialog.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/CustomStudyDialog.java
@@ -358,7 +358,7 @@ public class CustomStudyDialog extends AnalyticsDialogFragment implements
                 dialogOptions.add(CUSTOM_STUDY_RANDOM);
                 dialogOptions.add(CUSTOM_STUDY_PREVIEW);
                 dialogOptions.add(CUSTOM_STUDY_TAGS);
-                if (col.getSched().newCount() == 0) {
+                if (col.getSched().totalNewForCurrentDeck() == 0) {
                     // If no new cards we wont show CUSTOM_STUDY_NEW
                     dialogOptions.remove(Integer.valueOf(CUSTOM_STUDY_NEW));
                 }


### PR DESCRIPTION

## Fixes
Fixes #8481

## Approach
`newCount()` is the currently displayed "new count", not the total

## How Has This Been Tested?

Quick manual test on my phone. Automated tests are blocked on this dialog currently.

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [x] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
