### PR TITLE
Add preference: Focus ‘type in answer’

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -385,6 +385,9 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
     /** Handle providing help for "Image Not Found" */
     private static final MissingImageHandler mMissingImageHandler = new MissingImageHandler();
 
+    /** Preference: Whether the user wants to focus "type in answer" */
+    private boolean mFocusTypeAnswer;
+
     // ----------------------------------------------------------------------------
     // LISTENERS
     // ----------------------------------------------------------------------------
@@ -1757,7 +1760,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
     private void focusAnswerCompletionField() {
         // This does not handle mUseInputTag (the WebView contains an input field with a typable answer).
         // In this case, the user can use touch to focus the field if necessary.
-        if (typeAnswer()) {
+        if (typeAnswer() && mFocusTypeAnswer) {
             mAnswerField.focusWithKeyboard();
         } else {
             mFlipCardLayout.requestFocus();
@@ -1814,6 +1817,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
         mScrollingButtons = preferences.getBoolean("scrolling_buttons", false);
         mDoubleScrolling = preferences.getBoolean("double_scrolling", false);
         mPrefShowTopbar = preferences.getBoolean("showTopbar", true);
+        mFocusTypeAnswer = preferences.getBoolean("autoFocusTypeInAnswer", false);
 
         mGesturesEnabled = AnkiDroidApp.initiateGestures(preferences);
         mLinkOverridesTouchGesture = preferences.getBoolean("linkOverridesTouchGesture", false);

--- a/AnkiDroid/src/main/res/values/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values/10-preferences.xml
@@ -280,6 +280,9 @@
 
     <string name="no_code_formatting">Simple typed answer formatting</string>
     <string name="no_code_formatting_summ">Fixes ‘􏿾’ appearing in typed answer results</string>
+    
+    <string name="type_in_answer_focus">Focus ‘type in answer’</string>
+    <string name="type_in_answer_focus_summ">Automatically focus the ‘type in answer’ field in the reviewer</string>
 
     <!-- Open Changelog-->
     <string name="open_changelog">Open Changelog</string>

--- a/AnkiDroid/src/main/res/xml/preferences_advanced.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_advanced.xml
@@ -65,6 +65,7 @@
             <CheckBoxPreference
                 android:defaultValue="false"
                 android:key="useInputTag"
+                android:disableDependentsState="true"
                 android:summary="@string/use_input_tag_summ"
                 android:title="@string/use_input_tag" />
             <!-- Workaround for #5533 -->
@@ -86,6 +87,17 @@
                 android:key="noCodeFormatting"
                 android:summary="@string/no_code_formatting_summ"
                 android:title="@string/no_code_formatting" />
+            <!-- #8424 - allow users to decide if they want to focus the EditText
+                Note: this functionality is already disabled if useInputTag is enabled
+                UseInputTag: has had `disableDependentsState` set, so this is disabled
+                if useInputTag is true
+             -->
+            <CheckBoxPreference
+                android:defaultValue="false"
+                android:key="autoFocusTypeInAnswer"
+                android:summary="@string/type_in_answer_focus_summ"
+                android:dependency="useInputTag"
+                android:title="@string/type_in_answer_focus" />
         </PreferenceCategory>
         <PreferenceCategory
             android:key="category_plugins"


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
Some users only use the 'type in answer' function occasionally (for example: checking spelling)

When we added the 'always focus type in answer' functionality, this was not a good preference for them, as the keyboard uses a lot of space.

## Fixes
Fixes #8424

## Approach
Now, we add in a preference: "Focus ‘type in answer’".

We default this to false, as to not change user expectations

This preference does not make sense if the 'Type answer into the card'
feature is set, so disable it if we use an <input> box.

## How Has This Been Tested?

On my phone: 

* Preference is disabled if "type into card" is enabled
* Default is with no keyboard
* Otherwise, keyboard appears

## Learning (optional, can help others)
https://stackoverflow.com/questions/3591901/how-to-do-opposite-of-of-preference-attribute-androiddependency

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [x] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

![image](https://user-images.githubusercontent.com/62114487/113726561-3d4f7d80-96ec-11eb-9301-02ac804afe21.png)