### PR TITLE
Add unit test for TextCardExporter

### DIFF
--- a/AnkiDroid/src/test/java/com/ichi2/libanki/TextCardExporterTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/TextCardExporterTest.java
@@ -46,27 +46,32 @@ public class TextCardExporterTest extends RobolectricTest {
 
 
     @Test
-    public void textExportTestCard() throws IOException {
-        Path tempExportDir = Files.createTempDirectory("AnkiDroid-test_export_textnote");
+    public void testExportTextCardWithHTML() throws IOException {
+        Path tempExportDir = Files.createTempDirectory("AnkiDroid-test_export_textcard");
         File exportedFile = new File(tempExportDir.toFile(), "export.txt");
 
-        // With HTML
-        TextCardExporter exporterWithHTML = new TextCardExporter(col, true);
-        exporterWithHTML.doExport(exportedFile.getAbsolutePath());
-        String contentWithHTML = new String(Files.readAllBytes(Paths.get(exportedFile.getAbsolutePath())));
-        String expectedWithHTML = "";
-        // Optionally we can choose to strip styling from contentWithHTML
-        expectedWithHTML += String.format(Locale.US, "<style>%s</style>", noteList.get(0).model().getString("css"));
-        expectedWithHTML += "foo\tbar<br>\n";
-        expectedWithHTML += String.format(Locale.US, "<style>%s</style>", noteList.get(1).model().getString("css"));
-        expectedWithHTML += "baz\tqux\n";
-        assertEquals(expectedWithHTML, contentWithHTML);
+        TextCardExporter exporter = new TextCardExporter(col, true);
+        exporter.doExport(exportedFile.getAbsolutePath());
+        String content = new String(Files.readAllBytes(Paths.get(exportedFile.getAbsolutePath())));
+        String expected = "";
+        // Alternatively we can choose to strip styling from content, instead of adding styling to expected
+        expected += String.format(Locale.US, "<style>%s</style>", noteList.get(0).model().getString("css"));
+        expected += "foo\tbar<br>\n";
+        expected += String.format(Locale.US, "<style>%s</style>", noteList.get(1).model().getString("css"));
+        expected += "baz\tqux\n";
+        assertEquals(expected, content);
+    }
 
-        // Without HTML
-        TextCardExporter exporterWithoutHTML = new TextCardExporter(col, false);
-        exporterWithoutHTML.doExport(exportedFile.getAbsolutePath());
-        String contentWithoutHTML = new String(Files.readAllBytes(Paths.get(exportedFile.getAbsolutePath())));
-        String expectedWithoutHTML = "foo\tbar\nbaz\tqux\n";
-        assertEquals(expectedWithoutHTML, contentWithoutHTML);
+
+    @Test
+    public void testExportTextCardWithoutHTML() throws IOException {
+        Path tempExportDir = Files.createTempDirectory("AnkiDroid-test_export_textcard");
+        File exportedFile = new File(tempExportDir.toFile(), "export.txt");
+
+        TextCardExporter exporter = new TextCardExporter(col, false);
+        exporter.doExport(exportedFile.getAbsolutePath());
+        String content = new String(Files.readAllBytes(Paths.get(exportedFile.getAbsolutePath())));
+        String expected = "foo\tbar\nbaz\tqux\n";
+        assertEquals(expected, content);
     }
 }

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/TextCardExporterTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/TextCardExporterTest.java
@@ -1,3 +1,16 @@
+/*
+ Copyright (c) 2021 Trung Dang <bill081001@gmail.com>
+ This program is free software; you can redistribute it and/or modify it under
+ the terms of the GNU General Public License as published by the Free Software
+ Foundation; either version 3 of the License, or (at your option) any later
+ version.
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ You should have received a copy of the GNU General Public License along with
+ this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package com.ichi2.libanki;
 
 import com.ichi2.anki.RobolectricTest;

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/TextCardExporterTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/TextCardExporterTest.java
@@ -1,0 +1,72 @@
+package com.ichi2.libanki;
+
+import com.ichi2.anki.RobolectricTest;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(AndroidJUnit4.class)
+public class TextCardExporterTest extends RobolectricTest {
+    private Collection col;
+    private List<Note> noteList = new ArrayList<Note>();
+
+
+    @Before
+    public void setUp() {
+        super.setUp();
+        col = getCol();
+        Note note = col.newNote();
+        note.setItem("Front", "foo");
+        note.setItem("Back", "bar<br>");
+        note.setTagsFromStr("tag, tag2");
+        col.addNote(note);
+        noteList.add(note);
+        // with a different col
+        note = col.newNote();
+        note.setItem("Front", "baz");
+        note.setItem("Back", "qux");
+        note.model().put("did", addDeck("new col"));
+        col.addNote(note);
+        noteList.add(note);
+    }
+
+
+    @Test
+    public void textExportTestCard() throws IOException {
+        Path tempExportDir = Files.createTempDirectory("AnkiDroid-test_export_textnote");
+        File exportedFile = new File(tempExportDir.toFile(), "export.txt");
+
+        // With HTML
+        TextCardExporter exporterWithHTML = new TextCardExporter(col, true);
+        exporterWithHTML.doExport(exportedFile.getAbsolutePath());
+        String contentWithHTML = new String(Files.readAllBytes(Paths.get(exportedFile.getAbsolutePath())));
+        String expectedWithHTML = "";
+        // Optionally we can choose to strip styling from contentWithHTML
+        expectedWithHTML += String.format(Locale.US, "<style>%s</style>", noteList.get(0).model().getString("css"));
+        expectedWithHTML += "foo\tbar<br>\n";
+        expectedWithHTML += String.format(Locale.US, "<style>%s</style>", noteList.get(1).model().getString("css"));
+        expectedWithHTML += "baz\tqux\n";
+        assertEquals(expectedWithHTML, contentWithHTML);
+
+        // Without HTML
+        TextCardExporter exporterWithoutHTML = new TextCardExporter(col, false);
+        exporterWithoutHTML.doExport(exportedFile.getAbsolutePath());
+        String contentWithoutHTML = new String(Files.readAllBytes(Paths.get(exportedFile.getAbsolutePath())));
+        String expectedWithoutHTML = "foo\tbar\nbaz\tqux\n";
+        assertEquals(expectedWithoutHTML, contentWithoutHTML);
+    }
+}

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/TextCardExporterTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/TextCardExporterTest.java
@@ -35,7 +35,7 @@ public class TextCardExporterTest extends RobolectricTest {
         note.setTagsFromStr("tag, tag2");
         col.addNote(note);
         noteList.add(note);
-        // with a different col
+        // with a different note
         note = col.newNote();
         note.setItem("Front", "baz");
         note.setItem("Back", "qux");


### PR DESCRIPTION
## Purpose / Description
Add unit test for TextCardExporter.
It is noteworthy that upstream does not have such a test.

## Approach
Comparing outputs of TextCardExporter with expected outputs.

## How Has This Been Tested?
Passed the unit test locally.

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code

## Additional
I saw there's an ExportingTest.java within the same folder, which looks like it's trying to copy upstream's exporting tests, but the current state has separate tests for different Exporters.
