### PR TITLE
Flip +/- buttons in IncrementerNumberRangePreference

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/preferences/IncrementerNumberRangePreference.java
+++ b/AnkiDroid/src/main/java/com/ichi2/preferences/IncrementerNumberRangePreference.java
@@ -57,9 +57,9 @@ public class IncrementerNumberRangePreference extends NumberRangePreference {
 
     @Override
     protected View onCreateDialogView() {
-        mLinearLayout.addView(mIncrementButton);
-        mLinearLayout.addView(mEditText);
         mLinearLayout.addView(mDecrementButton);
+        mLinearLayout.addView(mEditText);
+        mLinearLayout.addView(mIncrementButton);
 
         return mLinearLayout;
     }


### PR DESCRIPTION
## Purpose / Description
Follow-up to the discussion in #8191. For input stepper elements it's more natural for the minus button to be on the left and the plus button on the right, similar to how the number line works. This is also recommended in these guidelines:
https://www.nngroup.com/articles/input-steppers/
https://material.io/components/sliders#anatomy

## Approach
Flips the +/- buttons.

## How Has This Been Tested?

Tested in the emulator. 
<details>
  <summary>Before</summary>
  
  ![before](https://user-images.githubusercontent.com/5216613/113850213-83fbb100-979a-11eb-8752-8c2a5316a654.png)
</details>
<details>
  <summary>After</summary>
  
  ![after](https://user-images.githubusercontent.com/5216613/113848878-35014c00-9799-11eb-9aaf-db5937070cc1.png)
</details>
<details>
  <summary>For RTL languages, the buttons are still correctly switched.</summary>
  
  ![RTL](https://user-images.githubusercontent.com/5216613/113848886-3894d300-9799-11eb-8898-5276883cb184.png)
</details>



## Learning (optional, can help others)
I looked for relevant UI guidelines (linked above).

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
