### PR TITLE
Get deck name using JS API

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -4099,6 +4099,11 @@ see card.js for available functions
         public boolean ankiIsDisplayingAnswer() { return isDisplayingAnswer(); };
 
         @JavascriptInterface
+        public String ankiGetDeckName() {
+            return Decks.basename(getCol().getDecks().get(mCurrentCard.getDid()).getString("name"));
+        }
+
+        @JavascriptInterface
         public boolean ankiIsActiveNetworkMetered() {
             try {
                 ConnectivityManager cm = (ConnectivityManager) AnkiDroidApp.getInstance().getApplicationContext()

--- a/AnkiDroid/src/test/java/com/ichi2/anki/ReviewerTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/ReviewerTest.java
@@ -246,6 +246,27 @@ public class ReviewerTest extends RobolectricTest {
         assertThat(reviewer.getSupportActionBar().getTitle(), is("B"));
     }
 
+    @Test
+    public void jsAnkiGetDeckName() {
+        Collection col = getCol();
+        Models models = col.getModels();
+        Decks decks = col.getDecks();
+
+        Long didAb = addDeck("A::B");
+        Model basic = models.byName(AnkiDroidApp.getAppResources().getString(R.string.basic_model_name));
+        basic.put("did", didAb);
+        addNoteUsingBasicModel("foo", "bar");
+
+        Long didA = addDeck("A");
+        decks.select(didA);
+
+        Reviewer reviewer = startReviewer();
+        JavaScriptFunction javaScriptFunction = reviewer.javaScriptFunction();
+
+        waitForAsyncTasksToComplete();
+        assertThat(javaScriptFunction.ankiGetDeckName(), is("B"));
+    }
+
     private void toggleWhiteboard(ReviewerForMenuItems reviewer) {
         reviewer.toggleWhiteboard();
 


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
It helps in getting deck name when custom card layout used/designed. The `{{Deck}}` or `{{Subdeck}}` not working when added from js-addons `index.js`. So, it will easier to add deck name to reviewer using JS API.

## Fixes
Fixes _Link to the issues._

## Approach
It is implemented using existing JavascriptInterface

## How Has This Been Tested?
Tested on emulator

Add following to front/back side of card in `script` tag
```
console.log(AnkiDroidJS.ankiGetDeckName());
```

## Learning (optional, can help others)
https://developer.android.com/reference/android/webkit/JavascriptInterface

## Checklist
_Please, go through these checks before submitting the PR._

- [ x ] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [ x ] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ x ] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [ x ] You have commented your code, particularly in hard-to-understand areas
- [ x ] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
