### PR TITLE
Dependency updates 20210407

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -224,8 +224,8 @@ dependencies {
 
     coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:1.1.5'
     compileOnly 'org.jetbrains:annotations:20.1.0'
-    compileOnly "com.google.auto.service:auto-service-annotations:1.0-rc7"
-    annotationProcessor "com.google.auto.service:auto-service:1.0-rc7"
+    compileOnly "com.google.auto.service:auto-service-annotations:1.0"
+    annotationProcessor "com.google.auto.service:auto-service:1.0"
 
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation 'androidx.activity:activity:1.2.2'

--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -252,7 +252,7 @@ dependencies {
     // build with ./gradlew rsdroid:assembleRelease
     // In my experience, using `files()` currently requires a reindex operation, which is slow.
     // implementation files("C:\\GitHub\\Rust-Test\\rsdroid\\build\\outputs\\aar\\rsdroid-release.aar")
-    implementation 'com.google.protobuf:protobuf-java:3.15.6' // This is required when loading from a file
+    implementation 'com.google.protobuf:protobuf-java:3.15.7' // This is required when loading from a file
     implementation "io.github.david-allison-1:anki-android-backend:$backendVersion"
     // build with ./gradlew rsdroid-testing:assembleRelease
     // RobolectricTest.java: replace RustBackendLoader.init(); with RustBackendLoader.loadRsdroid(path);

--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -222,7 +222,7 @@ dependencies {
         }
     }
 
-    coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:1.0.9'
+    coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:1.1.5'
     compileOnly 'org.jetbrains:annotations:20.1.0'
     compileOnly "com.google.auto.service:auto-service-annotations:1.0-rc7"
     annotationProcessor "com.google.auto.service:auto-service:1.0-rc7"


### PR DESCRIPTION

Standard dependency update PR

- turns out the desugaring PR #8361 was using an old dep, thanks dependabot for noticing - verified the new dep will work for us (it had a requirement for a medium-high D8 version but we are already using a D8 that is newer)
- google autoservice libs **finally** went 1.0, so no more rc there :fireworks: 