### PR TITLE
Fix "Check Pronunciation" Keyboard Shortcut usage

### DIFF
--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/reviewer/PeripheralKeymapTest.java
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/reviewer/PeripheralKeymapTest.java
@@ -45,6 +45,7 @@ public class PeripheralKeymapTest {
         PeripheralKeymap peripheralKeymap = new PeripheralKeymap(MockReviewerUi.displayingAnswer(), processed::add);
         peripheralKeymap.setup();
 
+        peripheralKeymap.onKeyDown(KeyEvent.KEYCODE_NUMPAD_1, getNumpadEvent(KeyEvent.KEYCODE_NUMPAD_1));
         peripheralKeymap.onKeyUp(KeyEvent.KEYCODE_NUMPAD_1, getNumpadEvent(KeyEvent.KEYCODE_NUMPAD_1));
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.java
@@ -63,6 +63,8 @@ import androidx.vectordrawable.graphics.drawable.VectorDrawableCompat;
 
 import com.ichi2.anki.cardviewer.CardAppearance;
 import com.ichi2.anki.dialogs.ConfirmationDialog;
+import com.ichi2.anki.multimediacard.AudioPlayer;
+import com.ichi2.anki.multimediacard.AudioRecorder;
 import com.ichi2.anki.multimediacard.AudioView;
 import com.ichi2.anki.dialogs.RescheduleDialog;
 import com.ichi2.anki.reviewer.PeripheralKeymap;
@@ -466,7 +468,8 @@ public class Reviewer extends AbstractFlashcardViewer {
      * @return Whether the mic toolbar is usable
      */
     @SuppressWarnings("BooleanMethodIsAlwaysInverted")
-    private boolean openMicToolbar() {
+    @VisibleForTesting
+    public boolean openMicToolbar() {
         if (mMicToolBar == null || mMicToolBar.getVisibility() != View.VISIBLE) {
             openOrToggleMicToolbar();
         }
@@ -1273,6 +1276,10 @@ public class Reviewer extends AbstractFlashcardViewer {
         return mWhiteboard;
     }
 
+    @VisibleForTesting(otherwise = VisibleForTesting.NONE)
+    public AudioView getAudioView() {
+        return mMicToolBar;
+    }
 
     /**
      * Inner class which implements the submenu for the Suspend button

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/AudioPlayer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/AudioPlayer.java
@@ -1,0 +1,94 @@
+/*
+ *  Copyright (c) 2013 Bibek Shrestha <bibekshrestha@gmail.com>
+ *  Copyright (c) 2013 Zaur Molotnikov <qutorial@gmail.com>
+ *  Copyright (c) 2013 Nicolas Raoul <nicolas.raoul@gmail.com>
+ *  Copyright (c) 2013 Flavio Lerda <flerda@gmail.com>
+ *  Copyright (c) 2021 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.multimediacard;
+
+import android.media.MediaPlayer;
+
+import java.io.IOException;
+
+import androidx.annotation.Nullable;
+import timber.log.Timber;
+
+public class AudioPlayer {
+
+    private MediaPlayer mPlayer;
+    @Nullable private Runnable mOnStoppingListener;
+    @Nullable private Runnable mOnStoppedListener;
+
+
+    public void play(String audioPath) throws IOException {
+        mPlayer = new MediaPlayer();
+        mPlayer.setDataSource(audioPath);
+        mPlayer.setOnCompletionListener(mp -> {
+            onStopping();
+            mPlayer.stop();
+            onStopped();
+        });
+        mPlayer.prepare();
+        mPlayer.start();
+    }
+
+
+    private void onStopped() {
+        if (mOnStoppedListener == null) {
+            return;
+        }
+        mOnStoppedListener.run();
+    }
+
+
+    private void onStopping() {
+        if (mOnStoppingListener == null) {
+            return;
+        }
+        mOnStoppingListener.run();
+    }
+
+
+    public void start() {
+        mPlayer.start();
+    }
+
+
+    public void stop() {
+        try {
+            mPlayer.prepare();
+            mPlayer.seekTo(0);
+        } catch (Exception e) {
+            Timber.e(e);
+        }
+    }
+
+
+    public void pause() {
+        mPlayer.pause();
+    }
+
+
+    public void setOnStoppingListener(Runnable listener) {
+        this.mOnStoppingListener = listener;
+    }
+
+
+    public void setOnStoppedListener(Runnable listener) {
+        this.mOnStoppedListener = listener;
+    }
+}

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/AudioRecorder.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/AudioRecorder.java
@@ -1,0 +1,103 @@
+/*
+ *  Copyright (c) 2013 Bibek Shrestha <bibekshrestha@gmail.com>
+ *  Copyright (c) 2013 Zaur Molotnikov <qutorial@gmail.com>
+ *  Copyright (c) 2013 Nicolas Raoul <nicolas.raoul@gmail.com>
+ *  Copyright (c) 2013 Flavio Lerda <flerda@gmail.com>
+ *  Copyright (c) 2021 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.multimediacard;
+
+import android.media.MediaRecorder;
+
+import java.io.IOException;
+
+import androidx.annotation.Nullable;
+import timber.log.Timber;
+
+public class AudioRecorder {
+
+    @Nullable
+    private MediaRecorder mRecorder = null;
+
+    @Nullable
+    private Runnable mOnRecordingInitialized;
+
+
+    private MediaRecorder initMediaRecorder(String audioPath) {
+        MediaRecorder mr = new MediaRecorder();
+        mr.setAudioSource(MediaRecorder.AudioSource.MIC);
+        mr.setOutputFormat(MediaRecorder.OutputFormat.THREE_GPP);
+        onRecordingInitialized();
+        mr.setOutputFile(audioPath); // audioPath could change
+        return mr;
+    }
+
+
+    private void onRecordingInitialized() {
+        if (mOnRecordingInitialized != null) {
+            mOnRecordingInitialized.run();
+        }
+    }
+
+    public void startRecording(String audioPath) throws IOException {
+        boolean highSampling = false;
+        try {
+            // try high quality AAC @ 44.1kHz / 192kbps first
+            // can throw IllegalArgumentException if codec isn't supported
+            mRecorder = initMediaRecorder(audioPath);
+            mRecorder.setAudioEncoder(MediaRecorder.AudioEncoder.AAC);
+            mRecorder.setAudioChannels(2);
+            mRecorder.setAudioSamplingRate(44100);
+            mRecorder.setAudioEncodingBitRate(192000);
+            // this can also throw IOException if output path is invalid
+            mRecorder.prepare();
+            mRecorder.start();
+            highSampling = true;
+        } catch (Exception e) {
+            Timber.w(e);
+            // in all cases, fall back to low sampling
+        }
+
+        if (!highSampling) {
+            // if we are here, either the codec didn't work or output file was invalid
+            // fall back on default
+            mRecorder = initMediaRecorder(audioPath);
+            mRecorder.setAudioEncoder(MediaRecorder.AudioEncoder.AMR_NB);
+
+            mRecorder.prepare();
+            mRecorder.start();
+        }
+    }
+
+
+    public void stopRecording() {
+        if (mRecorder != null) {
+            mRecorder.stop();
+        }
+    }
+
+
+    public void setOnRecordingInitializedHandler(Runnable onRecordingInitialized) {
+        this.mOnRecordingInitialized = onRecordingInitialized;
+    }
+
+
+    public void release() {
+        if (mRecorder != null) {
+            mRecorder.release();
+        }
+    }
+}

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/AudioView.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/AudioView.java
@@ -1,21 +1,21 @@
-/****************************************************************************************
- * Copyright (c) 2013 Bibek Shrestha <bibekshrestha@gmail.com>                          *
- * Copyright (c) 2013 Zaur Molotnikov <qutorial@gmail.com>                              *
- * Copyright (c) 2013 Nicolas Raoul <nicolas.raoul@gmail.com>                           *
- * Copyright (c) 2013 Flavio Lerda <flerda@gmail.com>                                   *
- *                                                                                      *
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU General Public License as published by the Free Software        *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
- *                                                                                      *
- * You should have received a copy of the GNU General Public License along with         *
- * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
- ****************************************************************************************/
+/*
+ *  Copyright (c) 2013 Bibek Shrestha <bibekshrestha@gmail.com>
+ *  Copyright (c) 2013 Zaur Molotnikov <qutorial@gmail.com>
+ *  Copyright (c) 2013 Nicolas Raoul <nicolas.raoul@gmail.com>
+ *  Copyright (c) 2013 Flavio Lerda <flerda@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 
 package com.ichi2.anki.multimediacard;
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/AudioView.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/AudioView.java
@@ -216,15 +216,38 @@ public class AudioView extends LinearLayout {
         mAudioRecorder.release();
     }
 
+    /** Stops playing and records */
     public void toggleRecord() {
+        stopPlaying();
+
         if (mRecord != null) {
             mRecord.callOnClick();
         }
     }
 
+
+    /** Stops recording and presses the play button */
     public void togglePlay() {
+        // cancelling recording is done via pressing the record button again
+        stopRecording();
+
         if (mPlayPause != null) {
             mPlayPause.callOnClick();
+        }
+    }
+
+    /** If recording is occurring, stop it */
+    private void stopRecording() {
+        if (mStatus == Status.RECORDING && mRecord != null) {
+            mRecord.callOnClick();
+        }
+    }
+
+    /** If playing, stop it */
+    protected void stopPlaying() {
+        // The stop button only applies to the player, and does nothing if no action is needed
+        if (mStop != null) {
+            mStop.callOnClick();
         }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/AudioView.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/AudioView.java
@@ -49,8 +49,8 @@ public class AudioView extends LinearLayout {
     protected StopButton mStop = null;
     protected RecordButton mRecord = null;
 
-    private final AudioRecorder mAudioRecorder = new AudioRecorder();
-    private final AudioPlayer mPlayer = new AudioPlayer();
+    private AudioRecorder mAudioRecorder = new AudioRecorder();
+    private AudioPlayer mPlayer = new AudioPlayer();
 
     private OnRecordingFinishEventListener mOnRecordingFinishEventListener = null;
 
@@ -421,5 +421,23 @@ public class AudioView extends LinearLayout {
 
     public interface OnRecordingFinishEventListener {
         void onRecordingFinish(View v);
+    }
+
+
+    @VisibleForTesting(otherwise = VisibleForTesting.NONE)
+    public void setRecorder(@NonNull AudioRecorder recorder) {
+        this.mAudioRecorder = recorder;
+    }
+
+
+    @VisibleForTesting(otherwise = VisibleForTesting.NONE)
+    public void setPlayer(@NonNull AudioPlayer player) {
+        this.mPlayer = player;
+    }
+
+
+    @VisibleForTesting(otherwise = VisibleForTesting.NONE)
+    public Status getStatus() {
+        return mStatus;
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/AudioView.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/AudioView.java
@@ -45,8 +45,8 @@ import timber.log.Timber;
 public class AudioView extends LinearLayout {
     protected final String mAudioPath;
 
-    protected PlayPauseButton mPlayPause = null;
-    protected StopButton mStop = null;
+    protected PlayPauseButton mPlayPause;
+    protected StopButton mStop;
     protected RecordButton mRecord = null;
 
     private AudioRecorder mAudioRecorder = new AudioRecorder();

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/PeripheralKeymap.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/PeripheralKeymap.java
@@ -57,12 +57,7 @@ public class PeripheralKeymap {
     }
 
 
-    @SuppressWarnings( {"unused", "RedundantSuppression"})
     public boolean onKeyDown(int keyCode, KeyEvent event) {
-        return false;
-    }
-
-    public boolean onKeyUp(int keyCode, KeyEvent event) {
         if (!mHasSetup) {
             return false;
         }
@@ -71,6 +66,11 @@ public class PeripheralKeymap {
         } else {
             return mQuestionKeyMap.onKeyUp(keyCode, event);
         }
+    }
+
+    @SuppressWarnings( {"unused", "RedundantSuppression"})
+    public boolean onKeyUp(int keyCode, KeyEvent event) {
+        return false;
     }
 
     private static class KeyMap {

--- a/AnkiDroid/src/test/java/com/ichi2/anki/reviewer/KeyboardShortcutIntegrationTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/reviewer/KeyboardShortcutIntegrationTest.java
@@ -1,0 +1,231 @@
+/*
+ *  Copyright (c) 2021 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.reviewer;
+
+import android.Manifest;
+import android.app.Application;
+import android.content.Intent;
+import android.view.KeyEvent;
+
+import com.ichi2.anki.Reviewer;
+import com.ichi2.anki.RobolectricTest;
+import com.ichi2.anki.multimediacard.AudioPlayer;
+import com.ichi2.anki.multimediacard.AudioRecorder;
+import com.ichi2.anki.multimediacard.AudioView;
+
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.Shadows;
+
+import java.io.IOException;
+
+import androidx.test.core.app.ApplicationProvider;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+@RunWith(AndroidJUnit4.class)
+public class KeyboardShortcutIntegrationTest extends RobolectricTest {
+
+    private Reviewer reviewer;
+
+
+    @Before
+    @Override
+    public void setUp() {
+        super.setUp();
+        addNoteUsingBasicModel("Hello", "World");
+        Shadows.shadowOf((Application) ApplicationProvider.getApplicationContext()).grantPermissions(Manifest.permission.RECORD_AUDIO);
+        reviewer = super.startActivityNormallyOpenCollectionWithIntent(Reviewer.class, new Intent());
+        waitForAsyncTasksToComplete();
+    }
+
+
+    /**
+     * Press "Shift + V"
+     * Release "Shift", then release "V"
+     *
+     * Expected: Recording is triggered
+     * #7780
+     */
+    @Test
+    @Ignore("7780")
+    public void testActionsOccurOnKeyDown() throws IOException {
+        AudioRecorder recorder = setupRecorderMock();
+
+        pressShiftAndVThenRelease();
+
+        verify(recorder, times(1)).startRecording(anyString());
+        verifyNoMoreInteractions(recorder);
+    }
+
+    /**
+     * Press "Shift + V"
+     * While recording press "V"
+     *
+     * Expected: Current state is stopped and the desired state is triggered
+     * #7780
+     */
+    @Test
+    @Ignore("7780")
+    public void playingWhileRecordingStopsRecordingAndStartsPlaying() throws IOException {
+        AudioPlayer player = setupPlayerMock();
+        AudioRecorder recorder = setupRecorderMock();
+
+        pressShiftAndVThenRelease();
+
+        verify(recorder, times(1)).startRecording(anyString());
+        verifyNoMoreInteractions(recorder, player);
+        assertStatus(AudioView.Status.RECORDING);
+
+        // now we're set up and recording, pressing V should move us to playing
+
+        pressVThenRelease();
+
+        verify(recorder, times(1)).stopRecording();
+        verify(player, times(1)).play(anyString());
+        verifyNoMoreInteractions(recorder, player);
+        assertStatus(AudioView.Status.PLAYING);
+    }
+
+
+    /**
+     * Press " V"
+     * While playing press "Shift + V"
+     *
+     * Expected: Current state is stopped and the desired state is triggered
+     * #7780
+     */
+    @Test
+    @Ignore("7780")
+    public void recordingWhilePlayingStopsPlayingAndStartsRecording() throws IOException {
+        Shadows.shadowOf((Application) ApplicationProvider.getApplicationContext()).grantPermissions(Manifest.permission.RECORD_AUDIO);
+
+        AudioPlayer player = setupPlayerMock();
+        AudioRecorder recorder = setupRecorderMock();
+
+        // We don't need anything recorded as the mock doesn't mind
+        pressVThenRelease();
+
+        verify(player, times(1)).play(anyString());
+        verifyNoMoreInteractions(recorder, player);
+        assertStatus(AudioView.Status.PLAYING);
+
+        // now we're set up and recording, pressing Shift + V should move us to recording
+        pressShiftAndVThenRelease();
+
+        verify(player, times(1)).stop();
+        verify(recorder, times(1)).startRecording(anyString());
+        verifyNoMoreInteractions(recorder, player);
+        assertStatus(AudioView.Status.RECORDING);
+
+    }
+
+
+    protected void assertStatus(AudioView.Status recording) {
+        assertThat(reviewer.getAudioView().getStatus(), is(recording));
+    }
+
+
+    protected AudioPlayer setupPlayerMock() {
+        assertThat(reviewer.openMicToolbar(), is(true));
+        AudioPlayer player = mock(AudioPlayer.class);
+        reviewer.getAudioView().setPlayer(player);
+        return player;
+    }
+
+
+    protected AudioRecorder setupRecorderMock() {
+        assertThat(reviewer.openMicToolbar(), is(true));
+        AudioRecorder recorder = mock(AudioRecorder.class);
+        reviewer.getAudioView().setRecorder(recorder);
+        return recorder;
+    }
+
+
+    private void pressVThenRelease() {
+        depressVKey();
+        releaseVKey();
+    }
+
+
+    protected void pressShiftAndVThenRelease() {
+        depressShiftKey();
+        depressVKeyWithShiftHeld();
+        releaseShiftKey();
+        releaseVKey();
+    }
+
+
+    private void releaseVKey() {
+        KeyEvent mock = mock(KeyEvent.class);
+        when(mock.getKeyCode()).thenReturn(KeyEvent.KEYCODE_V);
+        when(mock.getUnicodeChar()).thenReturn((int) 'v');
+        when(mock.getUnicodeChar(anyInt())).thenReturn((int) 'v');
+        reviewer.onKeyUp(KeyEvent.KEYCODE_V, mock);
+    }
+
+
+    private void releaseShiftKey() {
+        KeyEvent mock = mock(KeyEvent.class);
+        when(mock.getKeyCode()).thenReturn(KeyEvent.KEYCODE_SHIFT_LEFT);
+        reviewer.onKeyUp(KeyEvent.KEYCODE_SHIFT_LEFT, mock);
+    }
+
+    private void depressVKey() {
+        KeyEvent mock = mock(KeyEvent.class);
+        when(mock.getKeyCode()).thenReturn(KeyEvent.KEYCODE_V);
+        when(mock.getUnicodeChar()).thenReturn((int) 'v');
+        when(mock.getUnicodeChar(anyInt())).thenReturn((int) 'v');
+        reviewer.onKeyDown(KeyEvent.KEYCODE_V, mock);
+    }
+
+    private void depressVKeyWithShiftHeld() {
+        KeyEvent mock = mock(KeyEvent.class);
+        when(mock.isShiftPressed()).thenReturn(true);
+        when(mock.getKeyCode()).thenReturn(KeyEvent.KEYCODE_V);
+        reviewer.onKeyDown(KeyEvent.KEYCODE_V, mock);
+    }
+
+
+    private void depressShiftKey() {
+
+        KeyEvent mock = mock(KeyEvent.class);
+        when(mock.getAction()).thenReturn(0);
+        when(mock.getDeviceId()).thenReturn(9);
+        when(mock.getDownTime()).thenReturn(35660208L);
+        when(mock.getEventTime()).thenReturn(35660208L);
+        when(mock.getFlags()).thenReturn(8);
+        when(mock.getKeyCode()).thenReturn(KeyEvent.KEYCODE_SHIFT_LEFT);
+        when(mock.getMetaState()).thenReturn(65);
+        when(mock.getScanCode()).thenReturn(42);
+        when(mock.getSource()).thenReturn(257);
+        when(mock.getRepeatCount()).thenReturn(0);
+
+        reviewer.onKeyDown(KeyEvent.KEYCODE_SHIFT_LEFT, mock);
+    }
+}

--- a/AnkiDroid/src/test/java/com/ichi2/anki/reviewer/KeyboardShortcutIntegrationTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/reviewer/KeyboardShortcutIntegrationTest.java
@@ -28,7 +28,6 @@ import com.ichi2.anki.multimediacard.AudioRecorder;
 import com.ichi2.anki.multimediacard.AudioView;
 
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.Shadows;
@@ -90,7 +89,6 @@ public class KeyboardShortcutIntegrationTest extends RobolectricTest {
      * #7780
      */
     @Test
-    @Ignore("7780")
     public void playingWhileRecordingStopsRecordingAndStartsPlaying() throws IOException {
         AudioPlayer player = setupPlayerMock();
         AudioRecorder recorder = setupRecorderMock();
@@ -120,7 +118,6 @@ public class KeyboardShortcutIntegrationTest extends RobolectricTest {
      * #7780
      */
     @Test
-    @Ignore("7780")
     public void recordingWhilePlayingStopsPlayingAndStartsRecording() throws IOException {
         Shadows.shadowOf((Application) ApplicationProvider.getApplicationContext()).grantPermissions(Manifest.permission.RECORD_AUDIO);
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/reviewer/KeyboardShortcutIntegrationTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/reviewer/KeyboardShortcutIntegrationTest.java
@@ -73,7 +73,6 @@ public class KeyboardShortcutIntegrationTest extends RobolectricTest {
      * #7780
      */
     @Test
-    @Ignore("7780")
     public void testActionsOccurOnKeyDown() throws IOException {
         AudioRecorder recorder = setupRecorderMock();
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/reviewer/PeripheralKeymapTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/reviewer/PeripheralKeymapTest.java
@@ -45,7 +45,7 @@ public class PeripheralKeymapTest {
 
         assertThat((char) event.getUnicodeChar(), is('\0'));
         assertThat((char) event.getUnicodeChar(0), is('1'));
-        peripheralKeymap.onKeyUp(8, event);
+        peripheralKeymap.onKeyDown(8, event);
 
         assertThat(processed, hasSize(1));
         assertThat(processed.get(0), is(ViewerCommand.COMMAND_TOGGLE_FLAG_RED));


### PR DESCRIPTION
## Purpose / Description
I added keyboard shortcuts to "Check Pronunciation", but they had a few issues:

* (long time) - shortcuts were on keyUp, not keyDown, this meant Shift + V did the wrong thing if `Shift` was released before `V`
* Pressing the "record" shortcut did work if playing
* Pressing the "play" shortcut did not work if recording

## Fixes
Fixes #7780 

## Approach
* ⚠️ Shortcuts are now on KeyDown - may need `AbstractFlashcardViewer`/`Reviewer` auditing
* Record stops "Play"
* Play stops "Record"

Also: 

* Abstracted out dependencies from `AudioView` and did end-to-end tests

## How Has This Been Tested?

Unit tested and tested on my phone with keyboard

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [x] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
