### PR TITLE
fix crash: NullPointerException while syncing

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CollectionHelper.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CollectionHelper.java
@@ -400,4 +400,8 @@ public class CollectionHelper {
         }
     }
 
+    @VisibleForTesting(otherwise = VisibleForTesting.NONE)
+    public void setColForTests(Collection col) {
+        this.mCollection = col;
+    }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/services/ReminderService.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/services/ReminderService.java
@@ -169,9 +169,9 @@ public class ReminderService extends BroadcastReceiver {
             return null;
         }
 
-        List<DeckDueTreeNode> dues = col.getSched().deckDueTree();
-        List<DeckDueTreeNode> decks = new ArrayList<>(dues.size());
         try {
+            List<DeckDueTreeNode> dues = col.getSched().deckDueTree();
+            List<DeckDueTreeNode> decks = new ArrayList<>(dues.size());
             // This loop over top level deck only. No notification will ever occur for subdecks.
             for (DeckDueTreeNode node : dues) {
                 JSONObject deck = col.getDecks().get(node.getDid(), false);


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
ReminderService was refactored in a commit which moved `deckDueTree` outside a try..catch

https://github.com/ankidroid/Anki-Android/commit/5128cc2c756ce1434367eb58807650581f26c661#diff-eab9b1b76312c13e47b4f32c7297da450ce522c4f6d15c79e55a8a8a5c51364fR172

This caused a crash

## Fixes
Fixes #8264

## Approach
We put it back into the try, and add a test to simulate a thrown exception when accessing the collection.

We explicitly test getSched() to target this call

Add in a helper method to CollectionHelper to allow us to simulate
getDb() failures due to closing the collection while syncing

## How Has This Been Tested?

⚠️ Unit tested only

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
