### PR TITLE
NF: Adding a reset to default button for setting default directory path

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
@@ -332,8 +332,8 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
                         builder.setMessage(R.string.dialog_collection_path_not_dir)
                                 .setPositiveButton(R.string.dialog_ok, (dialog, which) -> dialog.dismiss())
                                 .setNegativeButton(R.string.reset_custom_buttons, (dialog, which) -> {
-                                        CollectionHelper.getDefaultAnkiDroidDirectory();
-                                        collectionPathPreference.setText("/sdcard/AnkiDroid");
+                                        String defaultDirectory = CollectionHelper.getDefaultAnkiDroidDirectory();
+                                        collectionPathPreference.setText(defaultDirectory);
                                     });
                         builder.show();
                         return false;

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
@@ -335,7 +335,7 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
                                         dialog.dismiss();
                                     }
                                 })
-                                .setNegativeButton(R.string.dialog_reset_to_default, new DialogInterface.OnClickListener() {
+                                .setNegativeButton(R.string.reset_custom_buttons, new DialogInterface.OnClickListener() {
                                     public void onClick(DialogInterface dialog, int id) {
                                         try {
                                             CollectionHelper.initializeAnkiDroidDirectory("/sdcard/AnkiDroid");

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
@@ -328,14 +328,13 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
                         return true;
                     } catch (StorageAccessException e) {
                         Timber.e(e, "Could not initialize directory: %s", newPath);
-                        AlertDialog.Builder builder = new AlertDialog.Builder(Preferences.this);
-                        builder.setMessage(R.string.dialog_collection_path_not_dir)
-                                .setPositiveButton(R.string.dialog_ok, (dialog, which) -> dialog.dismiss())
-                                .setNegativeButton(R.string.reset_custom_buttons, (dialog, which) -> {
-                                        String defaultDirectory = CollectionHelper.getDefaultAnkiDroidDirectory();
-                                        collectionPathPreference.setText(defaultDirectory);
-                                    });
-                        builder.show();
+                        MaterialDialog materialDialog = new MaterialDialog.Builder(Preferences.this)
+                                .title(R.string.dialog_collection_path_not_dir)
+                                .positiveText(R.string.dialog_ok)
+                                .negativeText(R.string.reset_custom_buttons)
+                                .onPositive((dialog, which) -> dialog.dismiss())
+                                .onNegative((dialog, which) -> collectionPathPreference.setText(CollectionHelper.getDefaultAnkiDroidDirectory()))
+                                .show();
                         return false;
                     }
                 });

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
@@ -330,22 +330,12 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
                         Timber.e(e, "Could not initialize directory: %s", newPath);
                         AlertDialog.Builder builder = new AlertDialog.Builder(Preferences.this);
                         builder.setMessage(R.string.dialog_collection_path_not_dir)
-                                .setPositiveButton(R.string.dialog_ok, new DialogInterface.OnClickListener() {
-                                    public void onClick(DialogInterface dialog, int id) {
-                                        dialog.dismiss();
-                                    }
-                                })
-                                .setNegativeButton(R.string.reset_custom_buttons, new DialogInterface.OnClickListener() {
-                                    public void onClick(DialogInterface dialog, int id) {
-                                        try {
-                                            CollectionHelper.initializeAnkiDroidDirectory("/sdcard/AnkiDroid");
-                                            collectionPathPreference.setText("/sdcard/AnkiDroid");
-                                        } catch (StorageAccessException storageAccessException) {
-                                            storageAccessException.printStackTrace();
-                                        }
-                                    }
-                                });
-                        builder.create().show();
+                                .setPositiveButton(R.string.dialog_ok, (dialog, which) -> dialog.dismiss())
+                                .setNegativeButton(R.string.reset_custom_buttons, (dialog, which) -> {
+                                        CollectionHelper.getDefaultAnkiDroidDirectory();
+                                        collectionPathPreference.setText("/sdcard/AnkiDroid");
+                                    });
+                        builder.show();
                         return false;
                     }
                 });

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
@@ -26,6 +26,7 @@ import android.app.PendingIntent;
 import android.content.ActivityNotFoundException;
 import android.content.ComponentName;
 import android.content.Context;
+import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.content.SharedPreferences.OnSharedPreferenceChangeListener;
@@ -327,7 +328,24 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
                         return true;
                     } catch (StorageAccessException e) {
                         Timber.e(e, "Could not initialize directory: %s", newPath);
-                        Toast.makeText(getApplicationContext(), R.string.dialog_collection_path_not_dir, Toast.LENGTH_LONG).show();
+                        AlertDialog.Builder builder = new AlertDialog.Builder(Preferences.this);
+                        builder.setMessage(R.string.dialog_collection_path_not_dir)
+                                .setPositiveButton(R.string.dialog_ok, new DialogInterface.OnClickListener() {
+                                    public void onClick(DialogInterface dialog, int id) {
+                                        dialog.dismiss();
+                                    }
+                                })
+                                .setNegativeButton(R.string.dialog_reset_to_default, new DialogInterface.OnClickListener() {
+                                    public void onClick(DialogInterface dialog, int id) {
+                                        try {
+                                            CollectionHelper.initializeAnkiDroidDirectory("/sdcard/AnkiDroid");
+                                            collectionPathPreference.setText("/sdcard/AnkiDroid");
+                                        } catch (StorageAccessException storageAccessException) {
+                                            storageAccessException.printStackTrace();
+                                        }
+                                    }
+                                });
+                        builder.create().show();
                         return false;
                     }
                 });

--- a/AnkiDroid/src/main/res/values/03-dialogs.xml
+++ b/AnkiDroid/src/main/res/values/03-dialogs.xml
@@ -120,7 +120,6 @@
 
     <string name="lookup_button_content">Look up</string>
     <string name="dialog_collection_path_not_dir">The path specified wasn’t a valid directory</string>
-    <string name="dialog_reset_to_default">Reset to default</string>
 
     <!-- Media checking -->
     <string name="check_media_title">Check media?</string>

--- a/AnkiDroid/src/main/res/values/03-dialogs.xml
+++ b/AnkiDroid/src/main/res/values/03-dialogs.xml
@@ -120,6 +120,7 @@
 
     <string name="lookup_button_content">Look up</string>
     <string name="dialog_collection_path_not_dir">The path specified wasn’t a valid directory</string>
+    <string name="dialog_reset_to_default">Reset to default</string>
 
     <!-- Media checking -->
     <string name="check_media_title">Check media?</string>


### PR DESCRIPTION
## Purpose / Description
If a user enters incorrect Directory path then a dialog appears with an option to reset the path to default

<img src="https://user-images.githubusercontent.com/55613721/114007723-32792200-987f-11eb-925b-2ab8681886de.png" width="400" height="800"/>

## Fixes
Fixes #8013 

## How Has This Been Tested?
This has been tested on a Real Device 

## Checklist

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
