### PR TITLE
Improve dialog usage by setting default focus on EditText

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -131,7 +131,6 @@ import com.ichi2.themes.StyledProgressDialog;
 import com.ichi2.ui.BadgeDrawableBuilder;
 import com.ichi2.ui.FixedEditText;
 import com.ichi2.utils.AdaptionUtil;
-import com.ichi2.utils.AndroidUiUtils;
 import com.ichi2.utils.BooleanGetter;
 import com.ichi2.utils.ImportUtils;
 import com.ichi2.utils.PairWithBoolean;
@@ -148,7 +147,6 @@ import java.io.FileOutputStream;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
-import java.util.Objects;
 import java.util.TreeMap;
 
 import timber.log.Timber;
@@ -2612,7 +2610,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
         final String currentName = getCol().getDecks().name(did);
         mDialogEditText.setText(currentName);
         mDialogEditText.setSelection(mDialogEditText.getText().length());
-        MaterialDialog materialDialog = new MaterialDialog.Builder(DeckPicker.this)
+        new MaterialEditTextDialog.Builder(DeckPicker.this, mDialogEditText)
                 .title(res.getString(R.string.rename_deck))
                 .customView(mDialogEditText, true)
                 .positiveText(R.string.rename)
@@ -2641,9 +2639,6 @@ public class DeckPicker extends NavigationDrawerActivity implements
                 })
                 .onNegative((dialog, which) -> dismissAllDialogFragments())
                 .show();
-
-        // Open keyboard when dialog shows
-        AndroidUiUtils.setFocusAndOpenKeyboard(mDialogEditText, Objects.requireNonNull(materialDialog.getWindow()));
     }
 
 
@@ -2918,7 +2913,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
         mDialogEditText = new FixedEditText(this);
         mDialogEditText.setSingleLine();
         mDialogEditText.setSelection(mDialogEditText.getText().length());
-        MaterialDialog materialDialog = new MaterialDialog.Builder(DeckPicker.this)
+        new MaterialEditTextDialog.Builder(DeckPicker.this, mDialogEditText)
                 .title(R.string.create_subdeck)
                 .customView(mDialogEditText, true)
                 .positiveText(R.string.dialog_ok)
@@ -2944,9 +2939,6 @@ public class DeckPicker extends NavigationDrawerActivity implements
                 })
                 .onNegative((dialog, which) -> dismissAllDialogFragments())
                 .show();
-
-        // Open keyboard when dialog shows
-        AndroidUiUtils.setFocusAndOpenKeyboard(mDialogEditText, Objects.requireNonNull(materialDialog.getWindow()));
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -131,6 +131,7 @@ import com.ichi2.themes.StyledProgressDialog;
 import com.ichi2.ui.BadgeDrawableBuilder;
 import com.ichi2.ui.FixedEditText;
 import com.ichi2.utils.AdaptionUtil;
+import com.ichi2.utils.AndroidUiUtils;
 import com.ichi2.utils.BooleanGetter;
 import com.ichi2.utils.ImportUtils;
 import com.ichi2.utils.PairWithBoolean;
@@ -147,6 +148,7 @@ import java.io.FileOutputStream;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
+import java.util.Objects;
 import java.util.TreeMap;
 
 import timber.log.Timber;
@@ -2610,7 +2612,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
         final String currentName = getCol().getDecks().name(did);
         mDialogEditText.setText(currentName);
         mDialogEditText.setSelection(mDialogEditText.getText().length());
-        new MaterialDialog.Builder(DeckPicker.this)
+        MaterialDialog materialDialog = new MaterialDialog.Builder(DeckPicker.this)
                 .title(res.getString(R.string.rename_deck))
                 .customView(mDialogEditText, true)
                 .positiveText(R.string.rename)
@@ -2638,7 +2640,10 @@ public class DeckPicker extends NavigationDrawerActivity implements
                     }
                 })
                 .onNegative((dialog, which) -> dismissAllDialogFragments())
-                .build().show();
+                .show();
+
+        // Open keyboard when dialog shows
+        AndroidUiUtils.setFocusAndOpenKeyboard(mDialogEditText, Objects.requireNonNull(materialDialog.getWindow()));
     }
 
 
@@ -2913,7 +2918,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
         mDialogEditText = new FixedEditText(this);
         mDialogEditText.setSingleLine();
         mDialogEditText.setSelection(mDialogEditText.getText().length());
-        new MaterialDialog.Builder(DeckPicker.this)
+        MaterialDialog materialDialog = new MaterialDialog.Builder(DeckPicker.this)
                 .title(R.string.create_subdeck)
                 .customView(mDialogEditText, true)
                 .positiveText(R.string.dialog_ok)
@@ -2938,7 +2943,10 @@ public class DeckPicker extends NavigationDrawerActivity implements
                     }
                 })
                 .onNegative((dialog, which) -> dismissAllDialogFragments())
-                .build().show();
+                .show();
+
+        // Open keyboard when dialog shows
+        AndroidUiUtils.setFocusAndOpenKeyboard(mDialogEditText, Objects.requireNonNull(materialDialog.getWindow()));
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -2612,7 +2612,6 @@ public class DeckPicker extends NavigationDrawerActivity implements
         mDialogEditText.setSelection(mDialogEditText.getText().length());
         new MaterialEditTextDialog.Builder(DeckPicker.this, mDialogEditText)
                 .title(res.getString(R.string.rename_deck))
-                .customView(mDialogEditText, true)
                 .positiveText(R.string.rename)
                 .negativeText(R.string.dialog_cancel)
                 .onPositive((dialog, which) -> {
@@ -2915,7 +2914,6 @@ public class DeckPicker extends NavigationDrawerActivity implements
         mDialogEditText.setSelection(mDialogEditText.getText().length());
         new MaterialEditTextDialog.Builder(DeckPicker.this, mDialogEditText)
                 .title(R.string.create_subdeck)
-                .customView(mDialogEditText, true)
                 .positiveText(R.string.dialog_ok)
                 .negativeText(R.string.dialog_cancel)
                 .onPositive((dialog, which) -> {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPickerFloatingActionMenu.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPickerFloatingActionMenu.java
@@ -19,7 +19,6 @@ package com.ichi2.anki;
 import android.animation.Animator;
 import android.content.SharedPreferences;
 import android.view.View;
-import android.view.WindowManager;
 import android.widget.EditText;
 import android.widget.LinearLayout;
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPickerFloatingActionMenu.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPickerFloatingActionMenu.java
@@ -22,13 +22,9 @@ import android.view.View;
 import android.widget.EditText;
 import android.widget.LinearLayout;
 
-import com.afollestad.materialdialogs.MaterialDialog;
 import com.google.android.material.floatingactionbutton.FloatingActionButton;
 import com.ichi2.libanki.Decks;
 import com.ichi2.ui.FixedEditText;
-import com.ichi2.utils.AndroidUiUtils;
-
-import java.util.Objects;
 
 import timber.log.Timber;
 
@@ -82,7 +78,7 @@ public class DeckPickerFloatingActionMenu {
                 closeFloatingActionMenu();
                 EditText mDialogEditText = new FixedEditText(mDeckPicker);
                 mDialogEditText.setSingleLine(true);
-                MaterialDialog materialDialog = new MaterialDialog.Builder(mDeckPicker)
+                new MaterialEditTextDialog.Builder(mDeckPicker, mDialogEditText)
                         .title(R.string.new_deck)
                         .positiveText(R.string.dialog_ok)
                         .customView(mDialogEditText, true)
@@ -100,9 +96,6 @@ public class DeckPickerFloatingActionMenu {
                         })
                         .negativeText(R.string.dialog_cancel)
                         .show();
-
-                // Open keyboard when dialog shows
-                AndroidUiUtils.setFocusAndOpenKeyboard(mDialogEditText, Objects.requireNonNull(materialDialog.getWindow()));
             }
         });
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPickerFloatingActionMenu.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPickerFloatingActionMenu.java
@@ -27,6 +27,7 @@ import com.afollestad.materialdialogs.MaterialDialog;
 import com.google.android.material.floatingactionbutton.FloatingActionButton;
 import com.ichi2.libanki.Decks;
 import com.ichi2.ui.FixedEditText;
+import com.ichi2.utils.AndroidUiUtils;
 
 import java.util.Objects;
 
@@ -82,7 +83,6 @@ public class DeckPickerFloatingActionMenu {
                 closeFloatingActionMenu();
                 EditText mDialogEditText = new FixedEditText(mDeckPicker);
                 mDialogEditText.setSingleLine(true);
-                mDialogEditText.requestFocus();
                 MaterialDialog materialDialog = new MaterialDialog.Builder(mDeckPicker)
                         .title(R.string.new_deck)
                         .positiveText(R.string.dialog_ok)
@@ -103,7 +103,7 @@ public class DeckPickerFloatingActionMenu {
                         .show();
 
                 // Open keyboard when dialog shows
-                Objects.requireNonNull(materialDialog.getWindow()).setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_ALWAYS_VISIBLE);
+                AndroidUiUtils.setFocusAndOpenKeyboard(mDialogEditText, Objects.requireNonNull(materialDialog.getWindow()));
             }
         });
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPickerFloatingActionMenu.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPickerFloatingActionMenu.java
@@ -81,7 +81,6 @@ public class DeckPickerFloatingActionMenu {
                 new MaterialEditTextDialog.Builder(mDeckPicker, mDialogEditText)
                         .title(R.string.new_deck)
                         .positiveText(R.string.dialog_ok)
-                        .customView(mDialogEditText, true)
                         .onPositive((dialog, which) -> {
                             String deckName = mDialogEditText.getText().toString();
                             if (Decks.isValidDeckName(deckName)) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/MaterialEditTextDialog.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/MaterialEditTextDialog.java
@@ -1,0 +1,42 @@
+package com.ichi2.anki;
+
+import android.content.Context;
+import android.widget.EditText;
+
+import com.afollestad.materialdialogs.MaterialDialog;
+import com.ichi2.utils.AndroidUiUtils;
+
+import java.util.Objects;
+
+import androidx.annotation.NonNull;
+
+public class MaterialEditTextDialog extends MaterialDialog {
+    protected MaterialEditTextDialog(Builder builder) {
+        super(builder);
+    }
+
+    public static class Builder extends MaterialDialog.Builder {
+
+        public EditText editText;
+
+        public Builder(@NonNull Context context, EditText editText) {
+            super(context);
+            this.editText = editText;
+        }
+
+        @Override
+        public MaterialDialog show() {
+            MaterialDialog materialDialog = super.show();
+            displayKeyboard(editText, materialDialog);
+
+            return materialDialog;
+        }
+
+        /**
+         * Open keyboard when dialog shows.
+         */
+        public void displayKeyboard(EditText editText, MaterialDialog materialDialog) {
+            AndroidUiUtils.setFocusAndOpenKeyboard(editText, Objects.requireNonNull(materialDialog.getWindow()));
+        }
+    }
+}

--- a/AnkiDroid/src/main/java/com/ichi2/anki/MaterialEditTextDialog.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/MaterialEditTextDialog.java
@@ -26,12 +26,11 @@ public class MaterialEditTextDialog extends MaterialDialog {
 
         @Override
         public MaterialDialog show() {
+            customView(editText, true);
             MaterialDialog materialDialog = super.show();
             displayKeyboard(editText, materialDialog);
-
             return materialDialog;
         }
-
 
         /**
          * Method to display keyboard when dialog shows.

--- a/AnkiDroid/src/main/java/com/ichi2/anki/MaterialEditTextDialog.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/MaterialEditTextDialog.java
@@ -1,3 +1,20 @@
+/****************************************************************************************
+ *                                                                                      *
+ * Copyright (c) 2021 Shridhar Goel <shridhar.goel@gmail.com>                           *
+ *                                                                                      *
+ * This program is free software; you can redistribute it and/or modify it under        *
+ * the terms of the GNU General Public License as published by the Free Software        *
+ * Foundation; either version 3 of the License, or (at your option) any later           *
+ * version.                                                                             *
+ *                                                                                      *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *                                                                                      *
+ * You should have received a copy of the GNU General Public License along with         *
+ * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ ****************************************************************************************/
+
 package com.ichi2.anki;
 
 import android.content.Context;

--- a/AnkiDroid/src/main/java/com/ichi2/anki/MaterialEditTextDialog.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/MaterialEditTextDialog.java
@@ -32,8 +32,11 @@ public class MaterialEditTextDialog extends MaterialDialog {
             return materialDialog;
         }
 
+
         /**
-         * Open keyboard when dialog shows.
+         * Method to display keyboard when dialog shows.
+         * @param editText EditText present in the dialog.
+         * @param materialDialog Dialog which contains the EditText and needs the keyboard to be displayed.
          */
         public void displayKeyboard(EditText editText, MaterialDialog materialDialog) {
             AndroidUiUtils.setFocusAndOpenKeyboard(editText, Objects.requireNonNull(materialDialog.getWindow()));


### PR DESCRIPTION
## Purpose / Description
Improve dialog usage by setting default focus on EditText

## Fixes
Fixes #8464 

## Approach
Used utility function for focusing on EditText and opening keyboard when dialog is opened for 'Create deck', 'Rename deck' and 'Create subdeck'.

## How Has This Been Tested?

Verified that the functionality is working.

## Checklist

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
