### PR TITLE
Add lint rule: PrintStackTraceUsage

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -965,7 +965,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
             String data = Utils.convertStreamToString(getAssets().open("card_template.html"));
             mCardTemplate = new CardTemplate(data);
         } catch (IOException e) {
-            e.printStackTrace();
+            Timber.w(e);
         }
 
         // Initialize text-to-speech. This is an asynchronous operation.
@@ -3615,7 +3615,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
             try {
                 startActivityWithoutAnimation(intent);
             } catch (ActivityNotFoundException e) {
-                e.printStackTrace(); // Don't crash if the intent is not handled
+                Timber.w(e); // Don't crash if the intent is not handled
             }
             return true;
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/BackupManager.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/BackupManager.java
@@ -186,7 +186,7 @@ public class BackupManager {
                     }
                     Timber.i("Backup created succesfully");
                 } catch (IOException e) {
-                    e.printStackTrace();
+                    Timber.w(e);
                 }
             }
         };

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -1317,7 +1317,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
             try {
                 arrayAdapter.add(deck.getString("name"));
             } catch (JSONException e) {
-                e.printStackTrace();
+                Timber.w(e);
             }
         }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DatabaseErrorDialog.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DatabaseErrorDialog.java
@@ -76,7 +76,7 @@ public class DatabaseErrorDialog extends AsyncDialogFragment {
         try {
             sqliteInstalled = Runtime.getRuntime().exec("sqlite3 --version").waitFor() == 0;
         } catch (IOException | InterruptedException e) {
-            e.printStackTrace();
+            Timber.w(e);
         }
 
         switch (mType) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/provider/CardContentProvider.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/provider/CardContentProvider.java
@@ -356,7 +356,7 @@ public class CardContentProvider extends ContentProvider {
                                 }
                             }
                         } catch (NumberFormatException nfe) {
-                            nfe.printStackTrace();
+                            Timber.w(nfe);
                         }
                     }
                 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/NoteService.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/NoteService.java
@@ -67,7 +67,7 @@ public class NoteService {
             }
         } catch (JSONException e) {
             // TODO Auto-generated catch block
-            e.printStackTrace();
+            Timber.w(e);
         }
         return null;
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/stats/AnkiStatsTaskHandler.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/stats/AnkiStatsTaskHandler.java
@@ -172,7 +172,7 @@ public class AnkiStatsTaskHandler {
                 try {
                     mWebView.loadData(URLEncoder.encode(html, "UTF-8").replaceAll("\\+", " "), "text/html; charset=utf-8", "utf-8");
                 } catch (UnsupportedEncodingException e) {
-                    e.printStackTrace();
+                    Timber.w(e);
                 }
                 mProgressBar.setVisibility(View.GONE);
                 int backgroundColor = Themes.getColorFromAttr(mWebView.getContext(), android.R.attr.colorBackground);

--- a/AnkiDroid/src/main/java/com/ichi2/async/Connection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/Connection.java
@@ -103,7 +103,7 @@ public class Connection extends BaseAsyncTask<Connection.Payload, Object, Connec
                 sInstance.get();
             }
         } catch (Exception e) {
-            e.printStackTrace();
+            Timber.w(e);
         }
 
         sInstance = new Connection();

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/AnkiPackageExporter.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/AnkiPackageExporter.java
@@ -495,7 +495,7 @@ public final class AnkiPackageExporter extends AnkiExporter {
                 media.put(Integer.toString(c), file.getName());
                 c++;
             } catch (JSONException e) {
-                e.printStackTrace();
+                Timber.w(e);
             }
         }
         return media;
@@ -608,7 +608,7 @@ class ZipFile {
         try {
             mZos.close();
         } catch (IOException e) {
-            e.printStackTrace();
+            Timber.w(e);
         }
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Utils.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Utils.java
@@ -568,7 +568,6 @@ public class Utils {
                 throw new RuntimeException(e);
             } catch (UnsupportedEncodingException e) {
                 Timber.e(e, "Utils.checksum :: UnsupportedEncodingException");
-                e.printStackTrace();
             }
             BigInteger biginteger = new BigInteger(1, digest);
             result = biginteger.toString(16);
@@ -679,7 +678,7 @@ public class Utils {
             rd.close();
             contentOfMyInputStream = sb.toString();
         } catch (Exception e) {
-            e.printStackTrace();
+            Timber.w(e);
         }
 
         return contentOfMyInputStream;
@@ -803,7 +802,7 @@ public class Utils {
                     try {
                         Thread.sleep(200);
                     } catch (InterruptedException e1) {
-                        e1.printStackTrace();
+                        Timber.w(e1);
                     }
                 }
             }

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/IssueRegistry.java
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/IssueRegistry.java
@@ -10,6 +10,7 @@ import com.ichi2.anki.lint.rules.DirectGregorianInstantiation;
 import com.ichi2.anki.lint.rules.DuplicateCrowdInStrings;
 import com.ichi2.anki.lint.rules.DuplicateTextInPreferencesXml;
 import com.ichi2.anki.lint.rules.InconsistentAnnotationUsage;
+import com.ichi2.anki.lint.rules.PrintStackTraceUsage;
 
 import org.jetbrains.annotations.NotNull;
 
@@ -29,6 +30,7 @@ public class IssueRegistry extends com.android.tools.lint.client.api.IssueRegist
         issues.add(InconsistentAnnotationUsage.ISSUE);
         issues.add(DuplicateTextInPreferencesXml.ISSUE);
         issues.add(DuplicateCrowdInStrings.ISSUE);
+        issues.add(PrintStackTraceUsage.ISSUE);
         return issues;
     }
 

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/rules/PrintStackTraceUsage.java
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/PrintStackTraceUsage.java
@@ -1,0 +1,92 @@
+/*
+ *  Copyright (c) 2021 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.lint.rules;
+
+import com.android.tools.lint.client.api.JavaEvaluator;
+import com.android.tools.lint.detector.api.Detector;
+import com.android.tools.lint.detector.api.Implementation;
+import com.android.tools.lint.detector.api.Issue;
+import com.android.tools.lint.detector.api.JavaContext;
+import com.android.tools.lint.detector.api.LintFix;
+import com.android.tools.lint.detector.api.Scope;
+import com.android.tools.lint.detector.api.SourceCodeScanner;
+import com.google.common.annotations.VisibleForTesting;
+import com.ichi2.anki.lint.utils.Constants;
+import com.intellij.psi.PsiMethod;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.jetbrains.uast.UCallExpression;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class PrintStackTraceUsage extends Detector implements SourceCodeScanner {
+
+    @VisibleForTesting
+    static final String ID = "PrintStackTraceUsage";
+    @VisibleForTesting
+    static final String DESCRIPTION = "Use Timber to log exceptions (typically Timber.w if non-fatal)";
+    private static final String EXPLANATION = "AnkiDroid exclusively uses Timber for logging exceptions. See: https://github.com/ankidroid/Anki-Android/wiki/Code-style#logging";
+    private static final Implementation implementation = new Implementation(PrintStackTraceUsage.class, Scope.JAVA_FILE_SCOPE);
+    public static final Issue ISSUE = Issue.create(
+            ID,
+            DESCRIPTION,
+            EXPLANATION,
+            Constants.ANKI_CODE_STYLE_CATEGORY,
+            Constants.ANKI_CODE_STYLE_PRIORITY,
+            Constants.ANKI_CODE_STYLE_SEVERITY,
+            implementation
+    );
+
+    @Nullable
+    @Override
+    public List<String> getApplicableMethodNames() {
+        List<String> forbiddenMethods = new ArrayList<>();
+        forbiddenMethods.add("printStackTrace");
+        return forbiddenMethods;
+    }
+
+
+    @Override
+    public void visitMethodCall(@NotNull JavaContext context, @NotNull UCallExpression node, @NotNull PsiMethod method) {
+        super.visitMethodCall(context, node, method);
+        JavaEvaluator evaluator = context.getEvaluator();
+
+        // if we have arguments, we're not writing to stdout, so it's an OK call
+        boolean hasArguments = node.getValueArgumentCount() != 0;
+        if (hasArguments || !evaluator.isMemberInSubClassOf(method, "java.lang.Throwable", false)) {
+            return;
+        }
+
+        LintFix fix = LintFix.create()
+                .replace()
+                .select(node.asSourceString())
+                // We don't need a semicolon here
+                .with("Timber.w(" + node.getReceiver().asSourceString() + ")")
+                .autoFix()
+                .build();
+
+        context.report(
+                ISSUE,
+                context.getCallLocation(node, true, true),
+                DESCRIPTION,
+                fix
+        );
+    }
+
+}

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/utils/Constants.java
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/utils/Constants.java
@@ -43,4 +43,20 @@ public class Constants {
      */
     public static final Severity ANKI_CROWDIN_SEVERITY = Severity.FATAL;
 
+    /**
+     * A special {@link Category} which groups the Lint issues related to Code Style as a
+     * sub category for {@link Category#COMPLIANCE}.
+     */
+    public static final Category ANKI_CODE_STYLE_CATEGORY = create(Category.COMPLIANCE, "CodeStyle", 10);
+
+    /**
+     * The priority for the Lint issues used by rules related to Code Style.
+     */
+    public static final int ANKI_CODE_STYLE_PRIORITY = 10;
+
+    /**
+     * The severity for the Lint issues used by rules related to Code Style.
+     */
+    public static final Severity ANKI_CODE_STYLE_SEVERITY = Severity.FATAL;
+
 }

--- a/lint-rules/src/test/java/com/ichi2/anki/lint/rules/PrintStackTraceUsageTest.java
+++ b/lint-rules/src/test/java/com/ichi2/anki/lint/rules/PrintStackTraceUsageTest.java
@@ -1,0 +1,79 @@
+/*
+ *  Copyright (c) 2021 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.lint.rules;
+
+import org.intellij.lang.annotations.Language;
+import org.junit.Test;
+
+import static com.android.tools.lint.checks.infrastructure.TestFile.JavaTestFile.create;
+import static com.android.tools.lint.checks.infrastructure.TestLintTask.lint;
+import static org.junit.Assert.assertTrue;
+
+public class PrintStackTraceUsageTest {
+
+    @Language("JAVA")
+    private static final String printStackTraceUsage =
+            "import java.io.IOException;          \n" +
+            "public class Test {                  \n" +
+            "    public Test() {                  \n" +
+            "        try {                        \n" +
+            "        } catch (IOException ex) {   \n" +
+            "            ex.printStackTrace();    \n" +
+            "        }                            \n" +
+            "    }                                \n" +
+            "}";
+
+    @Language("JAVA")
+    private static final String printStackTraceWithMethodArgument =
+            "import java.io.IOException;                            \n" +
+            "import java.io.PrintWriter;                            \n" +
+            "public class Test {                                    \n" +
+            "    public Test() {                                    \n" +
+            "        try {                                          \n" +
+            "        } catch (IOException ex) {                     \n" +
+            "            ex.printStackTrace(new PrintWriter(sw));   \n" +
+            "        }                                              \n" +
+            "    }                                                  \n" +
+            "}";
+
+
+
+    @Test
+    public void showsErrorForUsageWithNoParam() {
+        lint()
+                .allowMissingSdk()
+                .files(create(printStackTraceUsage))
+                .issues(PrintStackTraceUsage.ISSUE)
+                .run()
+                .expectErrorCount(1)
+                .check(output -> {
+                    assertTrue(output.contains(PrintStackTraceUsage.ID));
+                });
+    }
+
+    @Test
+    public void noErrorIfParamUsage() {
+        // .check() is not required for the code to execute
+        // If we have a parameter, we're not writing to stdout, so it's OK
+        lint()
+                .allowMissingSdk()
+                .files(create(printStackTraceWithMethodArgument))
+                .issues(PrintStackTraceUsage.ISSUE)
+                .run()
+                .expectErrorCount(0);
+    }
+}


### PR DESCRIPTION
## Purpose / Description

For the "Use Timber for logging" code style rule: Use lint instead of enforcing it manually

**Welcoming**
If we're not nitting the code, it's more welcoming to new contributors, and they should want to contribute more

**Onboarding**
Shows one of our code style rules in a discoverable manner

**Feedback loop**
This reduces the feedback loop for a developer, automated feedback is much faster than manual

**Saves time**
Saves a reviewer's time picking up on a nitpick

**Automated enforcement**
Nothing slips through code reviews

## Approach

Add a lint check. This also includes AnkiDroid's first "Auto-fix" lint rule

## How Has This Been Tested?

Lint only

![image](https://user-images.githubusercontent.com/62114487/114045111-b03d2d80-987f-11eb-9fa2-b2ce9b127a8d.png)
![image](https://user-images.githubusercontent.com/62114487/114045094-ad423d00-987f-11eb-89f8-027fcdd896b8.png)

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
