### PR TITLE
SchedV2: Fix "Start of Day" not being set

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
@@ -567,8 +567,7 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
                             ((android.preference.ListPreference)pref).setValueIndex(conf.getInt("newSpread"));
                             break;
                         case "dayOffset":
-                            Calendar calendar = col.crtGregorianCalendar();
-                            ((SeekBarPreference)pref).setValue(calendar.get(Calendar.HOUR_OF_DAY));
+                            ((SeekBarPreference)pref).setValue(getDayOffset(col));
                             break;
                         case "newTimezoneHandling":
                             android.preference.CheckBoxPreference checkBox = (android.preference.CheckBoxPreference) pref;
@@ -596,6 +595,21 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
         mOriginalSumarries.put(pref.getKey(), (s != null) ? s.toString() : "");
         // Update summary
         updateSummary(pref);
+    }
+
+    @VisibleForTesting
+    public static int getDayOffset(Collection col) {
+        Calendar calendar = col.crtGregorianCalendar();
+        return calendar.get(Calendar.HOUR_OF_DAY);
+    }
+
+    @VisibleForTesting
+    public void setDayOffset(int hours) {
+        Calendar date = getCol().crtGregorianCalendar();
+        date.set(Calendar.HOUR_OF_DAY, hours);
+        getCol().setCrt(date.getTimeInMillis() / 1000);
+        getCol().setMod();
+        BootService.scheduleNotification(getCol().getTime(), this);
     }
 
 
@@ -655,12 +669,7 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
                     getCol().setMod();
                     break;
                 case "dayOffset": {
-                    int hours = ((SeekBarPreference) pref).getValue();
-                    Calendar date = getCol().crtGregorianCalendar();
-                    date.set(Calendar.HOUR_OF_DAY, hours);
-                    getCol().setCrt(date.getTimeInMillis() / 1000);
-                    getCol().setMod();
-                    BootService.scheduleNotification(getCol().getTime(), this);
+                    setDayOffset(((SeekBarPreference) pref).getValue());
                     break;
                 }
                 case "minimumCardsDueForNotification": {
@@ -1042,5 +1051,10 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
         public void onSharedPreferenceChanged(SharedPreferences sharedPreferences, String key) {
             ((Preferences) getActivity()).updatePreference(sharedPreferences, key, this);
         }
+    }
+
+    @VisibleForTesting(otherwise = VisibleForTesting.NONE)
+    public void attachBaseContext(Context context) {
+        super.attachBaseContext(context);
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
@@ -598,7 +598,6 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
     }
 
     /** Returns the hour that the collection rolls over to the next day */
-    @VisibleForTesting
     public static int getDayOffset(Collection col) {
         switch (col.schedVer()) {
             default:

--- a/AnkiDroid/src/main/java/com/ichi2/anki/services/BootService.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/services/BootService.java
@@ -148,8 +148,7 @@ public class BootService extends BroadcastReceiver {
     protected static int getRolloverHourOfDay(Context context) {
         // TODO; We might want to use the BootService retry code here when called from preferences.
 
-        // TODO: This is a historic value, might be better as the default 4 is used elsewhere for rollover
-        int defValue = 0;
+        int defValue = 4;
 
         try {
             Collection col = CollectionHelper.getInstance().getCol(context);

--- a/AnkiDroid/src/main/java/com/ichi2/anki/services/BootService.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/services/BootService.java
@@ -131,7 +131,7 @@ public class BootService extends BroadcastReceiver {
         }
 
         final Calendar calendar = time.calendar();
-        calendar.set(Calendar.HOUR_OF_DAY, sp.getInt("dayOffset", 0));
+        calendar.set(Calendar.HOUR_OF_DAY, getRolloverHourOfDay(context));
         calendar.set(Calendar.MINUTE, 0);
         calendar.set(Calendar.SECOND, 0);
         final PendingIntent notificationIntent =
@@ -142,5 +142,28 @@ public class BootService extends BroadcastReceiver {
                 AlarmManager.INTERVAL_DAY,
                 notificationIntent
         );
+    }
+
+    /** Returns the hour of day when rollover to the next day occurs */
+    protected static int getRolloverHourOfDay(Context context) {
+        // TODO; We might want to use the BootService retry code here when called from preferences.
+
+        // TODO: This is a historic value, might be better as the default 4 is used elsewhere for rollover
+        int defValue = 0;
+
+        try {
+            Collection col = CollectionHelper.getInstance().getCol(context);
+            switch (col.schedVer()) {
+                default:
+                case 1:
+                    SharedPreferences sp = AnkiDroidApp.getSharedPrefs(context);
+                    return sp.getInt("dayOffset", defValue);
+                case 2:
+                    return col.getConf().optInt("rollover", defValue);
+            }
+        } catch (Exception e) {
+            Timber.w(e);
+            return defValue;
+        }
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/stats/Stats.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/stats/Stats.java
@@ -23,6 +23,7 @@ import android.text.TextUtils;
 import android.util.Pair;
 
 import com.ichi2.anki.AnkiDroidApp;
+import com.ichi2.anki.Preferences;
 import com.ichi2.anki.R;
 import com.ichi2.anki.stats.OverviewStatsBuilder;
 import com.ichi2.anki.stats.OverviewStatsBuilder.OverviewStats.AnswerButtonsOverview;
@@ -865,13 +866,7 @@ public class Stats {
         if (lim.length() > 0) {
             lim = " and " + lim;
         }
-        int rolloverHour;
-        if (mCol.schedVer() == 1) {
-            Calendar sd = mCol.crtGregorianCalendar();
-            rolloverHour = sd.get(Calendar.HOUR_OF_DAY);
-        } else {
-            rolloverHour = mCol.getConf().optInt("rollover", 4);
-        }
+        int rolloverHour = Preferences.getDayOffset(mCol);
         int pd = _periodDays();
         if (pd > 0) {
             lim += " and id > " + ((mCol.getSched().getDayCutoff() -  (SECONDS_PER_DAY * pd)) * 1000);

--- a/AnkiDroid/src/test/java/com/ichi2/anki/PreferencesTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/PreferencesTest.java
@@ -1,0 +1,48 @@
+/*
+ *  Copyright (c) 2021 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import androidx.annotation.NonNull;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+@RunWith(AndroidJUnit4.class)
+public class PreferencesTest extends RobolectricTest {
+
+    @Test
+    public void testDayOffsetExhaustive() {
+        Preferences preferences = getInstance();
+        for (int i = 0; i < 24; i++) {
+            preferences.setDayOffset(i);
+            assertThat(Preferences.getDayOffset(getCol()), is(i));
+        }
+    }
+
+
+    @NonNull
+    protected Preferences getInstance() {
+        Preferences preferences = new Preferences();
+        preferences.attachBaseContext(getTargetContext());
+        return preferences;
+    }
+
+}

--- a/AnkiDroid/src/test/java/com/ichi2/anki/PreferencesTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/PreferencesTest.java
@@ -16,6 +16,8 @@
 
 package com.ichi2.anki;
 
+import com.ichi2.anki.exception.ConfirmModSchemaException;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -37,6 +39,28 @@ public class PreferencesTest extends RobolectricTest {
         }
     }
 
+    @Test
+    public void testDayOffsetExhaustiveV2() throws ConfirmModSchemaException {
+        getCol().changeSchedulerVer(2);
+        Preferences preferences = getInstance();
+        for (int i = 0; i < 24; i++) {
+            preferences.setDayOffset(i);
+            assertThat(Preferences.getDayOffset(getCol()), is(i));
+        }
+    }
+
+    @Test
+    public void setDayOffsetSetsConfig() throws ConfirmModSchemaException {
+        getCol().changeSchedulerVer(2);
+        Preferences preferences = getInstance();
+
+        int offset = Preferences.getDayOffset(getCol());
+        assertThat("Default offset should be 4", offset, is(4));
+
+        preferences.setDayOffset(2);
+
+        assertThat("rollover config should be set to new value", getCol().getConf().optInt("rollover", 4), is(2));
+    }
 
     @NonNull
     protected Preferences getInstance() {


### PR DESCRIPTION
## Purpose / Description
SchedV2 introduced the concept of a "rollover" time. We did read this in SchedV2, but we did not set it in the settings.

We now set this value

⚠️ This also changes the Notification Service: We now default a new day to 4AM instead of Midnight for a notification if:
* there is an error loading the "start of new day"
* "start of new day" was not explicitly set

I chose this because the preference would use the "starts of new day" value if it was set.

## Fixes
Fixes #6203 

## Approach

* set "rollover" if the scheduler is v2
* Use "rollover" in the BootService if sched v2 is set

Replicating the logic in: https://github.com/ankitects/anki/commit/b17a0552d061af360e35e1cda48b2d228c94b66e

## How Has This Been Tested?

⚠️ This is a change which is hard to test
* minimally tested manually to ensure that it doesn't crash
* some unit tests, 
 
I don't feel these guarantee correctness. A thorough review, or further test plan would help put my mind at ease

## Learning (optional, can help others)

https://github.com/ankitects/anki/commit/b17a0552d061af360e35e1cda48b2d228c94b66e - Anki commit that we replicate

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
