### PR TITLE
confForDid: use default on invalid configuration

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
@@ -801,6 +801,10 @@ public class Decks {
         assert deck != null;
         if (deck.has("conf")) {
             DeckConfig conf = getConf(deck.getLong("conf"));
+            if (conf == null) {
+                // fall back on default
+                conf = getConf(1L);
+            }
             conf.put("dyn", DECK_STD);
             return conf;
         }

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/DecksTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/DecksTest.java
@@ -319,4 +319,17 @@ public class DecksTest extends RobolectricTest {
         assertNull(decks.byName("filtered::sub"));
     }
 
+    @Test
+    public void confForDidReturnsDefaultIfNotFound() {
+        // https://github.com/ankitects/anki/commit/94d369db18c2a6ac3b0614498d8abcc7db538633
+        Decks decks = getCol().getDecks();
+
+        Deck d = decks.all().get(0);
+        d.put("conf", 12L);
+        decks.save();
+
+        DeckConfig config = decks.confForDid(d.getLong("id"));
+
+        assertThat("If a config is not found, return the default", config.getLong("id"), is(1L));
+    }
 }


### PR DESCRIPTION
From Anki commit https://github.com/ankitects/anki/commit/94d369db18c2a6ac3b0614498d8abcc7db538633

## Purpose / Description

I'm tackling converting `Decks.java` to handle the V16 schema. I've ported the decks class, and now I'm looking to consolidate our code (which has been optimised) and the new Python code which calls the backend.

The more code that I make identical to the "new" python, the less code that needs to go into the commit.

## How Has This Been Tested?

Unit tested

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
