### PR TITLE
Revert

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
@@ -404,25 +404,6 @@ public class CollectionTask<ProgressListener, ProgressBackground extends Progres
     }
 
 
-
-    private static class UndoSuspendCard extends UndoAction {
-        private final Card mSuspendedCard;
-
-
-        public UndoSuspendCard(Card suspendedCard) {
-            super(R.string.menu_suspend_card);
-            this.mSuspendedCard = suspendedCard;
-        }
-
-
-        public @Nullable Card undo(@NonNull Collection col) {
-            Timber.i("UNDO: Suspend Card %d", mSuspendedCard.getId());
-            mSuspendedCard.flush(false);
-            return mSuspendedCard;
-        }
-    }
-
-
     private static class UndoDeleteNote extends UndoAction {
         private final Note mNote;
         private final ArrayList<Card> mAllCs;
@@ -537,7 +518,7 @@ public class CollectionTask<ProgressListener, ProgressBackground extends Progres
         protected void actualTask(Collection col) {
             // collect undo information
             Card suspendedCard = mCard.clone();
-            col.markUndo(new UndoSuspendCard(suspendedCard));
+            col.markUndo(revertCardToProvidedState(R.string.menu_suspend_card, suspendedCard));
             // suspend card
             if (mCard.getQueue() == Consts.QUEUE_TYPE_SUSPENDED) {
                 col.getSched().unsuspendCards(new long[] {mCard.getId()});

--- a/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
@@ -508,7 +508,7 @@ public class CollectionTask<ProgressListener, ProgressBackground extends Progres
         @Override
         protected void actualTask(Collection col) {
             // collect undo information
-            col.markUndo(revertToProvidedState(R.string.menu_bury_card, mCard));
+            col.markUndo(revertNoteToProvidedState(R.string.menu_bury_card, mCard));
             // then bury
             col.getSched().buryCards(new long[] {mCard.getId()});
         }
@@ -522,7 +522,7 @@ public class CollectionTask<ProgressListener, ProgressBackground extends Progres
         @Override
         protected void actualTask(Collection col) {
             // collect undo information
-            col.markUndo(revertToProvidedState(R.string.menu_bury_note, mCard));
+            col.markUndo(revertNoteToProvidedState(R.string.menu_bury_note, mCard));
             // then bury
             col.getSched().buryNote(mCard.note().getId());
         }
@@ -560,7 +560,7 @@ public class CollectionTask<ProgressListener, ProgressBackground extends Progres
             for (int i = 0; i < cards.size(); i++) {
                 cids[i] = cards.get(i).getId();
             }
-            col.markUndo(revertToProvidedState(R.string.menu_suspend_note, mCard));
+            col.markUndo(revertNoteToProvidedState(R.string.menu_suspend_note, mCard));
             // suspend note
             col.getSched().suspendCards(cids);
         }

--- a/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
@@ -489,7 +489,7 @@ public class CollectionTask<ProgressListener, ProgressBackground extends Progres
         @Override
         protected void actualTask(Collection col) {
             // collect undo information
-            col.markUndo(revertNoteToProvidedState(R.string.menu_bury_card, mCard));
+            col.markUndo(revertCardToProvidedState(R.string.menu_bury_card, mCard));
             // then bury
             col.getSched().buryCards(new long[] {mCard.getId()});
         }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/UndoAction.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/UndoAction.java
@@ -42,8 +42,18 @@ public abstract class UndoAction {
      * @return An UndoAction which, if executed, put back the `card` in the state given here
      */
     public static @NonNull UndoAction revertNoteToProvidedState(@StringRes int undoNameId, Card card){
-        Note note = card.note();
-        List<Card> cards = note.cards();
+        return revertToProvidedState(undoNameId, card, card.note().cards());
+    }
+
+
+    /**
+     * Create an UndoAction that set back `card` and its siblings to the current states.
+     * @param undoNameId The id of the string representing an action that could be undone
+     * @param card the card currently in the reviewer
+     * @param cards The cards that must be reverted
+     * @return An UndoAction which, if executed, put back the `card` in the state given here
+     */
+    private static @NonNull UndoAction revertToProvidedState(@StringRes int undoNameId, Card card, List<Card> cards){
         return new UndoAction(undoNameId) {
             public @Nullable
             Card undo(@NonNull Collection col) {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/UndoAction.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/UndoAction.java
@@ -2,8 +2,12 @@ package com.ichi2.libanki;
 
 import android.content.res.Resources;
 
+import com.ichi2.utils.ArrayUtil;
 import com.ichi2.utils.LanguageUtil;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
 
@@ -45,6 +49,16 @@ public abstract class UndoAction {
         return revertToProvidedState(undoNameId, card, card.note().cards());
     }
 
+    /**
+     * Create an UndoAction that set back `card` and its siblings to the current states.
+     * @param undoNameId The id of the string representing an action that could be undone
+     * @param card the card currently in the reviewer
+     * @return An UndoAction which, if executed, put back the `card` in the state given here
+     */
+    public static @NonNull UndoAction revertCardToProvidedState(@StringRes int undoNameId, Card card){
+        return revertToProvidedState(undoNameId, card, Arrays.asList(card.clone()));
+    }
+
 
     /**
      * Create an UndoAction that set back `card` and its siblings to the current states.
@@ -53,7 +67,7 @@ public abstract class UndoAction {
      * @param cards The cards that must be reverted
      * @return An UndoAction which, if executed, put back the `card` in the state given here
      */
-    private static @NonNull UndoAction revertToProvidedState(@StringRes int undoNameId, Card card, List<Card> cards){
+    private static @NonNull UndoAction revertToProvidedState(@StringRes int undoNameId, Card card, Iterable<Card> cards){
         return new UndoAction(undoNameId) {
             public @Nullable
             Card undo(@NonNull Collection col) {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/UndoAction.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/UndoAction.java
@@ -35,7 +35,13 @@ public abstract class UndoAction {
      * Returned positive integers are card id. Those ids is the card that was discarded and that may be sent back to the reviewer.*/
     public abstract @Nullable Card undo(@NonNull Collection col);
 
-    public static @NonNull UndoAction revertToProvidedState (@StringRes int undoNameId, Card card){
+    /**
+     * Create an UndoAction that set back `card` and its siblings to the current states.
+     * @param undoNameId The id of the string representing an action that could be undone
+     * @param card the card currently in the reviewer
+     * @return An UndoAction which, if executed, put back the `card` in the state given here
+     */
+    public static @NonNull UndoAction revertNoteToProvidedState(@StringRes int undoNameId, Card card){
         Note note = card.note();
         List<Card> cards = note.cards();
         return new UndoAction(undoNameId) {


### PR DESCRIPTION
the name `revertToProvidedState` was misleading, as it took a card and revert a whole note. Splitting and having a method for class and one for note makes far more sens