### PR TITLE
Display Order of Card Browser corrected

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -267,6 +267,8 @@ public class CardBrowser extends NavigationDrawerActivity implements
             mCards.reverse();
             updateList();
         }
+        // To update the collection
+        getCol().flush();
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -241,7 +241,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
                 return true;
             };
 
-
+    @VisibleForTesting(otherwise = VisibleForTesting.PROTECTED)
     protected void changeCardOrder(int which) {
         if (which != mOrder) {
             mOrder = which;
@@ -268,7 +268,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
             updateList();
         }
         // To update the collection
-        getCol().flush();
+        getCol().getDb().setMod(true);
     }
 
 


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
Before, there was a bug - when we close the app after changing the display order in Card Browser, and then reopen it again, it was getting set to the default value, it was not getting saved in the DB. Adding just one command ie getCol().flush() solved this issue.

## Fixes
Issue #4199 

## Approach
Just added `getCol().flush()` in `CardBrowser.java` in the function `changeCardOrder()`. This saves the updated `sortType` field in the database.

## How Has This Been Tested?
1. From the homepage, go to Card Browser.
2. Go to Change Display Order from Options.
3. Select any order.
4. Close the app and remove it from Android History.
5. Reopen the app and go to Card Browser again.
6. The order selected will be seen.

## Learning (optional, can help others)
Just find out where the error is originating either by using debugging statements (`Timber`) or anything and then keep using `Ctrl + left mouse click` on the functions nearby to get to the root of the problem.

## Checklist

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
(https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
