### PR TITLE
Added unit test for DeckPicker with No Permissions

### DIFF
--- a/AnkiDroid/src/test/java/com/ichi2/anki/DeckPickerTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/DeckPickerTest.java
@@ -265,8 +265,7 @@ public class DeckPickerTest extends RobolectricTest {
     public void deckPickerNotCrashOnNoPermissionTest() {
         Application application = ApplicationProvider.getApplicationContext();
         ShadowApplication app = shadowOf(application);
-        app.denyPermissions(Manifest.permission.READ_EXTERNAL_STORAGE);
-        app.denyPermissions(Manifest.permission.WRITE_EXTERNAL_STORAGE);
+        app.denyPermissions(Manifest.permission.READ_EXTERNAL_STORAGE, Manifest.permission.WRITE_EXTERNAL_STORAGE);
 
         try (ActivityScenario<DeckPicker> scenario = ActivityScenario.launch(DeckPicker.class)) {
             scenario.onActivity(deckPicker -> {

--- a/AnkiDroid/src/test/java/com/ichi2/anki/DeckPickerTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/DeckPickerTest.java
@@ -1,13 +1,16 @@
 package com.ichi2.anki;
 
 import android.Manifest;
+import android.app.Activity;
 import android.app.Application;
+import android.app.Instrumentation;
 import android.content.ComponentName;
 import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.content.SharedPreferences.Editor;
 import android.content.pm.PackageManager;
+import android.view.Menu;
 
 import com.ichi2.anki.dialogs.DatabaseErrorDialog;
 import com.ichi2.libanki.Collection;
@@ -25,9 +28,11 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 
+import androidx.appcompat.widget.Toolbar;
 import androidx.test.core.app.ActivityScenario;
 import androidx.test.core.app.ApplicationProvider;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
+import timber.log.Timber;
 
 import static com.ichi2.anki.DeckPicker.UPGRADE_VERSION_KEY;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -35,6 +40,7 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -264,15 +270,12 @@ public class DeckPickerTest extends RobolectricTest {
 
         try (ActivityScenario<DeckPicker> scenario = ActivityScenario.launch(DeckPicker.class)) {
             scenario.onActivity(deckPicker -> {
-                ShadowActivity shadowActivity = shadowOf(deckPicker);
-                Intent outputIntent = shadowActivity.getNextStartedActivity();
-                ComponentName component = outputIntent.getComponent();
-
-                assertThat(component, notNullValue());
-                ComponentName componentName = Objects.requireNonNull(component);
-
-                assertThat("Deck Picker currently handles permissions, so should be called", componentName.getClassName(), is("com.ichi2.anki.DeckPicker"));
+                Toolbar toolbar = deckPicker.findViewById(R.id.toolbar);
+                deckPicker.onCreateOptionsMenu(toolbar.getMenu());
+                assertThat("Deck was added", getCol().getDecks().count(), is(1));
+                assertThat("Not visible",toolbar.getMenu().findItem(R.id.deck_picker_action_filter).isVisible(),is(false));
             });
+
         }
 
     }


### PR DESCRIPTION
## Purpose / Description
Automated testing such that developers can't accidentally make changes which cause AnkiDroid to crash if it doesn't have storage permission.

## Fixes
Fixes #7849 

## Approach
Create an instance of the app using shadow and remove file access permissions both read and write. Then create and instance of `deckPicker` class and run it, expected result should be that it again calls `deckPicker` class as it will ask user to grant permission.

## How Has This Been Tested?
It is a unit test.

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code