### PR TITLE
Refactor TagsDialog to use FactoryFragment

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -95,6 +95,7 @@ import com.ichi2.anki.cardviewer.GestureTapProcessor;
 import com.ichi2.anki.cardviewer.MissingImageHandler;
 import com.ichi2.anki.dialogs.tags.TagsDialog;
 import com.ichi2.anki.dialogs.tags.TagsDialogFactory;
+import com.ichi2.anki.dialogs.tags.TagsDialogListener;
 import com.ichi2.anki.multimediacard.AudioView;
 import com.ichi2.anki.cardviewer.CardAppearance;
 import com.ichi2.anki.receiver.SdCardReceiver;
@@ -168,7 +169,7 @@ import com.github.zafarkhaja.semver.Version;
 import static com.ichi2.anim.ActivityTransitionAnimation.Direction.*;
 
 @SuppressWarnings({"PMD.AvoidThrowingRawExceptionTypes","PMD.FieldDeclarationsShouldBeAtStartOfClass"})
-public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity implements ReviewerUi, CommandProcessor, TagsDialog.TagsDialogListener {
+public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity implements ReviewerUi, CommandProcessor, TagsDialogListener {
 
     /**
      * Result codes that are returned when this activity finishes.

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -94,6 +94,7 @@ import com.ichi2.anim.ViewAnimation;
 import com.ichi2.anki.cardviewer.GestureTapProcessor;
 import com.ichi2.anki.cardviewer.MissingImageHandler;
 import com.ichi2.anki.dialogs.tags.TagsDialog;
+import com.ichi2.anki.dialogs.tags.TagsDialogFactory;
 import com.ichi2.anki.multimediacard.AudioView;
 import com.ichi2.anki.cardviewer.CardAppearance;
 import com.ichi2.anki.receiver.SdCardReceiver;
@@ -223,6 +224,8 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
      * Broadcast that informs us when the sd card is about to be unmounted
      */
     private BroadcastReceiver mUnmountReceiver = null;
+
+    private TagsDialogFactory mTagsDialogFactory;
 
     /**
      * Variables to hold preferences
@@ -945,6 +948,9 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
         Timber.d("onCreate()");
         SharedPreferences preferences = restorePreferences();
         mCardAppearance = CardAppearance.create(new ReviewerCustomFonts(this.getBaseContext()), preferences);
+
+        mTagsDialogFactory = new TagsDialogFactory(this).attachToActivity(this);
+
         super.onCreate(savedInstanceState);
         setContentView(getContentViewAttr(mPrefFullscreenReview));
 
@@ -3947,7 +3953,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
     protected void showTagsDialog() {
         ArrayList<String> tags = new ArrayList<>(getCol().getTags().all());
         ArrayList<String> selTags = new ArrayList<>(mCurrentCard.note().getTags());
-        TagsDialog dialog = TagsDialog.newInstance(TagsDialog.DialogType.ADD_TAG, selTags, tags);
+        TagsDialog dialog = mTagsDialogFactory.newTagsDialog().withArguments(TagsDialog.DialogType.ADD_TAG, selTags, tags);
         showDialogFragment(dialog);
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -68,6 +68,7 @@ import com.ichi2.anki.dialogs.RescheduleDialog;
 import com.ichi2.anki.dialogs.SimpleMessageDialog;
 import com.ichi2.anki.dialogs.tags.TagsDialog;
 import com.ichi2.anki.dialogs.tags.TagsDialogFactory;
+import com.ichi2.anki.dialogs.tags.TagsDialogListener;
 import com.ichi2.anki.receiver.SdCardReceiver;
 import com.ichi2.anki.widgets.DeckDropDownAdapter;
 import com.ichi2.async.CollectionTask;
@@ -114,7 +115,7 @@ import static com.ichi2.libanki.stats.Stats.SECONDS_PER_DAY;
 import static com.ichi2.anim.ActivityTransitionAnimation.Direction.*;
 
 public class CardBrowser extends NavigationDrawerActivity implements
-        DeckDropDownAdapter.SubtitleListener, TagsDialog.TagsDialogListener {
+        DeckDropDownAdapter.SubtitleListener, TagsDialogListener {
 
     enum Column {
         QUESTION,

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -67,6 +67,7 @@ import com.ichi2.anki.dialogs.IntegerDialog;
 import com.ichi2.anki.dialogs.RescheduleDialog;
 import com.ichi2.anki.dialogs.SimpleMessageDialog;
 import com.ichi2.anki.dialogs.tags.TagsDialog;
+import com.ichi2.anki.dialogs.tags.TagsDialogFactory;
 import com.ichi2.anki.receiver.SdCardReceiver;
 import com.ichi2.anki.widgets.DeckDropDownAdapter;
 import com.ichi2.async.CollectionTask;
@@ -148,6 +149,8 @@ public class CardBrowser extends NavigationDrawerActivity implements
     private String mSearchTerms;
     private String mRestrictOnDeck;
     private int mCurrentFlag;
+
+    private TagsDialogFactory mTagsDialogFactory;
 
     private MenuItem mSearchItem;
     private MenuItem mSaveSearchItem;
@@ -568,6 +571,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
         if (showedActivityFailedScreen(savedInstanceState)) {
             return;
         }
+        mTagsDialogFactory = new TagsDialogFactory(this).attachToActivity(this);
         super.onCreate(savedInstanceState);
         Timber.d("onCreate()");
         if (wasLoadedFromExternalTextActionItem() && !Permissions.hasStorageAccessPermission(this)) {
@@ -1420,7 +1424,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
     }
 
     private void showTagsDialog() {
-        TagsDialog dialog = TagsDialog.newInstance(
+        TagsDialog dialog = mTagsDialogFactory.newTagsDialog().withArguments(
                 TagsDialog.DialogType.FILTER_BY_TAG, new ArrayList<>(0), new ArrayList<>(getCol().getTags().all()));
         showDialogFragment(dialog);
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -72,6 +72,7 @@ import com.ichi2.anki.dialogs.DiscardChangesDialog;
 import com.ichi2.anki.dialogs.IntegerDialog;
 import com.ichi2.anki.dialogs.LocaleSelectionDialog;
 import com.ichi2.anki.dialogs.tags.TagsDialog;
+import com.ichi2.anki.dialogs.tags.TagsDialogFactory;
 import com.ichi2.anki.exception.ConfirmModSchemaException;
 import com.ichi2.anki.multimediacard.IMultimediaEditableNote;
 import com.ichi2.anki.multimediacard.activity.MultimediaEditFieldActivity;
@@ -217,6 +218,8 @@ public class NoteEditor extends AnkiActivity implements
     private BroadcastReceiver mUnmountReceiver = null;
 
     private LinearLayout mFieldsLayoutContainer;
+
+    private TagsDialogFactory mTagsDialogFactory;
 
     private TextView mTagsButton;
     private TextView mCardsButton;
@@ -407,6 +410,9 @@ public class NoteEditor extends AnkiActivity implements
             return;
         }
         Timber.d("onCreate()");
+
+        mTagsDialogFactory = new TagsDialogFactory(this).attachToActivity(this);
+
         super.onCreate(savedInstanceState);
         mFieldState.setInstanceState(savedInstanceState);
         setContentView(R.layout.note_editor);
@@ -1379,7 +1385,7 @@ public class NoteEditor extends AnkiActivity implements
         }
         ArrayList<String> tags = new ArrayList<>(getCol().getTags().all());
         ArrayList<String> selTags = new ArrayList<>(mSelectedTags);
-        TagsDialog dialog = TagsDialog.newInstance(TagsDialog.DialogType.ADD_TAG, selTags, tags);
+        TagsDialog dialog = mTagsDialogFactory.newTagsDialog().withArguments(TagsDialog.DialogType.ADD_TAG, selTags, tags);
         showDialogFragment(dialog);
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -73,6 +73,7 @@ import com.ichi2.anki.dialogs.IntegerDialog;
 import com.ichi2.anki.dialogs.LocaleSelectionDialog;
 import com.ichi2.anki.dialogs.tags.TagsDialog;
 import com.ichi2.anki.dialogs.tags.TagsDialogFactory;
+import com.ichi2.anki.dialogs.tags.TagsDialogListener;
 import com.ichi2.anki.exception.ConfirmModSchemaException;
 import com.ichi2.anki.multimediacard.IMultimediaEditableNote;
 import com.ichi2.anki.multimediacard.activity.MultimediaEditFieldActivity;
@@ -156,7 +157,7 @@ import static com.ichi2.libanki.Models.NOT_FOUND_NOTE_TYPE;
  */
 public class NoteEditor extends AnkiActivity implements
         DeckSelectionDialog.DeckSelectionListener,
-        TagsDialog.TagsDialogListener {
+        TagsDialogListener {
     // DA 2020-04-13 - Refactoring Plans once tested:
     // * There is a difference in functionality depending on whether we are editing
     // * Extract mAddNote and mCurrentEditedCard into inner class. Gate mCurrentEditedCard on edit state.

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/customstudy/CustomStudyDialog.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/customstudy/CustomStudyDialog.java
@@ -25,7 +25,6 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.VisibleForTesting;
 import androidx.fragment.app.DialogFragment;
-import androidx.fragment.app.FragmentResultListener;
 import timber.log.Timber;
 
 import android.text.Editable;
@@ -48,7 +47,6 @@ import com.ichi2.anki.UIUtils;
 import com.ichi2.anki.analytics.AnalyticsDialogFragment;
 import com.ichi2.anki.dialogs.ContextMenuHelper;
 import com.ichi2.anki.dialogs.tags.TagsDialog;
-import com.ichi2.anki.dialogs.tags.TagsDialogFactory;
 import com.ichi2.anki.dialogs.tags.TagsDialogListener;
 import com.ichi2.anki.exception.FilteredAncestor;
 import com.ichi2.async.CollectionTask;
@@ -126,12 +124,7 @@ public class CustomStudyDialog extends AnalyticsDialogFragment implements
     @Override
     public void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        getParentFragmentManager().setFragmentResultListener(TagsDialog.FRAGMENT_RESULT_ON_SELECTED_TAGS_KEY, this,
-                (requestKey, bundle) -> {
-                    final List<String> selectedTags = bundle.getStringArrayList(TagsDialog.FRAGMENT_RESULT_ON_SELECTED_TAGS__TAGS);
-                    final int option = bundle.getInt(TagsDialog.FRAGMENT_RESULT_ON_SELECTED_TAGS__OPTION);
-                    onSelectedTags(selectedTags, option);
-                });
+        registerFragmentResultReceiver(this);
     }
 
 
@@ -350,6 +343,7 @@ public class CustomStudyDialog extends AnalyticsDialogFragment implements
      * Gathers the final selection of tags and type of cards,
      * Generates the search screen for the custom study deck.
      */
+    @Override
     public void onSelectedTags(List<String> selectedTags, int option) {
         StringBuilder sb = new StringBuilder();
         switch (option) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/customstudy/CustomStudyDialog.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/customstudy/CustomStudyDialog.java
@@ -46,6 +46,7 @@ import com.ichi2.anki.UIUtils;
 import com.ichi2.anki.analytics.AnalyticsDialogFragment;
 import com.ichi2.anki.dialogs.ContextMenuHelper;
 import com.ichi2.anki.dialogs.tags.TagsDialog;
+import com.ichi2.anki.dialogs.tags.TagsDialogFactory;
 import com.ichi2.anki.exception.FilteredAncestor;
 import com.ichi2.async.CollectionTask;
 import com.ichi2.async.TaskManager;
@@ -119,6 +120,13 @@ public class CustomStudyDialog extends AnalyticsDialogFragment implements
     }
 
 
+    TagsDialog newTagsDialog() {
+        // This can only work with configChanges set in AndroidManifest.xml
+        // this is a temp solution until using FragmentResultApi
+        return new TagsDialog(this);
+    }
+
+
     @NonNull
     @Override
     public Dialog onCreateDialog(Bundle savedInstanceState) {
@@ -172,7 +180,7 @@ public class CustomStudyDialog extends AnalyticsDialogFragment implements
                              * of that Dialog.
                              */
                             long currentDeck = requireArguments().getLong("did");
-                            TagsDialog dialogFragment = TagsDialog.newInstance(
+                            TagsDialog dialogFragment = newTagsDialog().withArguments(
                                     TagsDialog.DialogType.CUSTOM_STUDY_TAGS, new ArrayList<>(),
                                     new ArrayList<>(mCollection.getTags().byDeck(currentDeck, true)));
                             mCustomStudyListener.showDialogFragment(dialogFragment);

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/customstudy/CustomStudyDialog.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/customstudy/CustomStudyDialog.java
@@ -47,6 +47,7 @@ import com.ichi2.anki.analytics.AnalyticsDialogFragment;
 import com.ichi2.anki.dialogs.ContextMenuHelper;
 import com.ichi2.anki.dialogs.tags.TagsDialog;
 import com.ichi2.anki.dialogs.tags.TagsDialogFactory;
+import com.ichi2.anki.dialogs.tags.TagsDialogListener;
 import com.ichi2.anki.exception.FilteredAncestor;
 import com.ichi2.async.CollectionTask;
 import com.ichi2.async.TaskManager;
@@ -65,7 +66,7 @@ import java.util.Locale;
 
 
 public class CustomStudyDialog extends AnalyticsDialogFragment implements
-        TagsDialog.TagsDialogListener {
+        TagsDialogListener {
     // Different configurations for the context menu
     public static final int CONTEXT_MENU_STANDARD = 0;
     public static final int CONTEXT_MENU_LIMITS = 1;

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/tags/TagsDialog.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/tags/TagsDialog.java
@@ -74,34 +74,31 @@ public class TagsDialog extends AnalyticsDialogFragment {
 
     private MaterialDialog mDialog;
 
-    private TagsDialogListener mListener;
+    private final TagsDialogListener mListener;
+
+    public TagsDialog(TagsDialogListener listener) {
+        mListener = listener;
+    }
 
     /**
-     * Initializes an instance of {@link TagsDialog} using passed parameters
-     *
      * @param type the type of dialog @see {@link DialogType}
      * @param checkedTags tags of the note
      * @param allTags all possible tags in the collection
      * @return Initialized instance of {@link TagsDialog}
      */
     @NonNull
-    public static TagsDialog newInstance(@NonNull DialogType type, @NonNull List<String> checkedTags, @NonNull List<String> allTags) {
-        TagsDialog t = new TagsDialog();
+    public TagsDialog withArguments(@NonNull DialogType type, @NonNull List<String> checkedTags, @NonNull List<String> allTags) {
+        Bundle args = this.getArguments();
+        if (args == null) {
+            args = new Bundle();
+        }
 
-        Bundle args = new Bundle();
         args.putInt(DIALOG_TYPE_KEY, type.ordinal());
         args.putStringArrayList(CHECKED_TAGS_KEY, new ArrayList<>(checkedTags));
         args.putStringArrayList(ALL_TAGS_KEY, new ArrayList<>(allTags));
-        t.setArguments(args);
+        setArguments(args);
 
-        return t;
-    }
-
-
-    @Override
-    public void onAttach(@NonNull Context context) {
-        super.onAttach(context);
-        mListener = (TagsDialogListener) requireActivity();
+        return this;
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/tags/TagsDialog.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/tags/TagsDialog.java
@@ -21,20 +21,16 @@ import com.ichi2.anki.analytics.AnalyticsDialogFragment;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import androidx.appcompat.widget.SearchView;
 import androidx.appcompat.widget.Toolbar;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 
-public class TagsDialog extends AnalyticsDialogFragment implements TagsDialogListener {
-
-    public static final String FRAGMENT_RESULT_ON_SELECTED_TAGS_KEY = "FRAGMENT_RESULT_ON_SELECTED_TAGS_KEY";
-    public static final String FRAGMENT_RESULT_ON_SELECTED_TAGS__TAGS = "TAGS";
-    public static final String FRAGMENT_RESULT_ON_SELECTED_TAGS__OPTION = "OPTION";
-
-
+public class TagsDialog extends AnalyticsDialogFragment {
 
     /**
      * Enum that define all possible types of TagsDialog
@@ -74,7 +70,7 @@ public class TagsDialog extends AnalyticsDialogFragment implements TagsDialogLis
 
     private MaterialDialog mDialog;
 
-    @NonNull
+    @Nullable
     private final TagsDialogListener mListener;
 
 
@@ -92,7 +88,7 @@ public class TagsDialog extends AnalyticsDialogFragment implements TagsDialogLis
      * @see <a href="https://developer.android.com/guide/fragments/communicate#fragment-result">Fragment Result API</a>
      */
     public TagsDialog() {
-        mListener = this;
+        mListener = null;
     }
 
     /**
@@ -132,6 +128,10 @@ public class TagsDialog extends AnalyticsDialogFragment implements TagsDialogLis
         setCancelable(true);
     }
 
+    @NonNull
+    private TagsDialogListener getTagsDialogListener() {
+        return mListener != null ? mListener : TagsDialogListener.createFragmentResultSender(getParentFragmentManager());
+    }
 
     @NonNull
     @Override
@@ -175,22 +175,12 @@ public class TagsDialog extends AnalyticsDialogFragment implements TagsDialogLis
                 .positiveText(mPositiveText)
                 .negativeText(R.string.dialog_cancel)
                 .customView(tagsDialogView, false)
-                .onPositive((dialog, which) -> mListener.onSelectedTags(mTags.copyOfCheckedTagList(), mSelectedOption));
+                .onPositive((dialog, which) -> getTagsDialogListener().onSelectedTags(mTags.copyOfCheckedTagList(), mSelectedOption));
         mDialog = builder.build();
 
         mDialog.getWindow().setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_ADJUST_RESIZE);
         return mDialog;
     }
-
-
-    @Override
-    public void onSelectedTags(List<String> selectedTags, int option) {
-        final Bundle bundle = new Bundle();
-        bundle.putStringArrayList(FRAGMENT_RESULT_ON_SELECTED_TAGS__TAGS, new ArrayList<>(selectedTags));
-        bundle.putInt(FRAGMENT_RESULT_ON_SELECTED_TAGS__OPTION, option);
-        getParentFragmentManager().setFragmentResult(FRAGMENT_RESULT_ON_SELECTED_TAGS_KEY, bundle);
-    }
-
 
     private void adjustToolbar(View tagsDialogView) {
         Toolbar mToolbar = tagsDialogView.findViewById(R.id.tags_dialog_toolbar);

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/tags/TagsDialog.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/tags/TagsDialog.java
@@ -2,6 +2,7 @@ package com.ichi2.anki.dialogs.tags;
 
 import android.annotation.SuppressLint;
 import android.app.Dialog;
+import android.content.Context;
 import android.os.Bundle;
 import android.text.InputFilter;
 import android.text.InputType;
@@ -73,6 +74,8 @@ public class TagsDialog extends AnalyticsDialogFragment {
 
     private MaterialDialog mDialog;
 
+    private TagsDialogListener mListener;
+
     /**
      * Initializes an instance of {@link TagsDialog} using passed parameters
      *
@@ -92,6 +95,13 @@ public class TagsDialog extends AnalyticsDialogFragment {
         t.setArguments(args);
 
         return t;
+    }
+
+
+    @Override
+    public void onAttach(@NonNull Context context) {
+        super.onAttach(context);
+        mListener = (TagsDialogListener) requireActivity();
     }
 
 
@@ -153,8 +163,7 @@ public class TagsDialog extends AnalyticsDialogFragment {
                 .positiveText(mPositiveText)
                 .negativeText(R.string.dialog_cancel)
                 .customView(tagsDialogView, false)
-                .onPositive((dialog, which) -> ((TagsDialogListener)requireActivity())
-                        .onSelectedTags(mTags.copyOfCheckedTagList(), mSelectedOption));
+                .onPositive((dialog, which) -> mListener.onSelectedTags(mTags.copyOfCheckedTagList(), mSelectedOption));
         mDialog = builder.build();
 
         mDialog.getWindow().setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_ADJUST_RESIZE);

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/tags/TagsDialog.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/tags/TagsDialog.java
@@ -28,7 +28,12 @@ import androidx.appcompat.widget.Toolbar;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 
-public class TagsDialog extends AnalyticsDialogFragment {
+public class TagsDialog extends AnalyticsDialogFragment implements TagsDialogListener {
+
+    public static final String FRAGMENT_RESULT_ON_SELECTED_TAGS_KEY = "FRAGMENT_RESULT_ON_SELECTED_TAGS_KEY";
+    public static final String FRAGMENT_RESULT_ON_SELECTED_TAGS__TAGS = "TAGS";
+    public static final String FRAGMENT_RESULT_ON_SELECTED_TAGS__OPTION = "OPTION";
+
 
 
     /**
@@ -69,10 +74,25 @@ public class TagsDialog extends AnalyticsDialogFragment {
 
     private MaterialDialog mDialog;
 
+    @NonNull
     private final TagsDialogListener mListener;
 
-    public TagsDialog(TagsDialogListener listener) {
+
+    /**
+     * Constructs a new {@link TagsDialog} that will communicate the results using the provided listener.
+     */
+    public TagsDialog(@NonNull TagsDialogListener listener) {
         mListener = listener;
+    }
+
+
+    /**
+     * Constructs a new {@link TagsDialog} that will communicate the results using Fragment Result API.
+     *
+     * @see <a href="https://developer.android.com/guide/fragments/communicate#fragment-result">Fragment Result API</a>
+     */
+    public TagsDialog() {
+        mListener = this;
     }
 
     /**
@@ -161,6 +181,16 @@ public class TagsDialog extends AnalyticsDialogFragment {
         mDialog.getWindow().setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_ADJUST_RESIZE);
         return mDialog;
     }
+
+
+    @Override
+    public void onSelectedTags(List<String> selectedTags, int option) {
+        final Bundle bundle = new Bundle();
+        bundle.putStringArrayList(FRAGMENT_RESULT_ON_SELECTED_TAGS__TAGS, new ArrayList<>(selectedTags));
+        bundle.putInt(FRAGMENT_RESULT_ON_SELECTED_TAGS__OPTION, option);
+        getParentFragmentManager().setFragmentResult(FRAGMENT_RESULT_ON_SELECTED_TAGS_KEY, bundle);
+    }
+
 
     private void adjustToolbar(View tagsDialogView) {
         Toolbar mToolbar = tagsDialogView.findViewById(R.id.tags_dialog_toolbar);

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/tags/TagsDialog.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/tags/TagsDialog.java
@@ -2,7 +2,6 @@ package com.ichi2.anki.dialogs.tags;
 
 import android.annotation.SuppressLint;
 import android.app.Dialog;
-import android.content.Context;
 import android.os.Bundle;
 import android.text.InputFilter;
 import android.text.InputType;
@@ -30,10 +29,6 @@ import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 
 public class TagsDialog extends AnalyticsDialogFragment {
-    public interface TagsDialogListener {
-        void onSelectedTags(List<String> selectedTags, int option);
-    }
-
 
 
     /**

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/tags/TagsDialogFactory.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/tags/TagsDialogFactory.java
@@ -1,0 +1,48 @@
+/*
+ Copyright (c) 2021 Tarek Mohamed <tarekkma@gmail.com>
+
+ This program is free software; you can redistribute it and/or modify it under
+ the terms of the GNU General Public License as published by the Free Software
+ Foundation; either version 3 of the License, or (at your option) any later
+ version.
+
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License along with
+ this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.ichi2.anki.dialogs.tags;
+
+import com.ichi2.anki.dialogs.tags.TagsDialog.TagsDialogListener;
+import com.ichi2.utils.ExtendedFragmentFactory;
+
+import androidx.annotation.NonNull;
+import androidx.fragment.app.Fragment;
+
+public class TagsDialogFactory extends ExtendedFragmentFactory {
+
+    final TagsDialogListener mListener;
+
+
+    public TagsDialogFactory(TagsDialogListener listener) {
+        this.mListener = listener;
+    }
+
+
+    @NonNull
+    @Override
+    public Fragment instantiate(@NonNull ClassLoader classLoader, @NonNull String className) {
+        Class<? extends Fragment> cls = loadFragmentClass(classLoader, className);
+        if (cls == TagsDialog.class) {
+            return newTagsDialog();
+        }
+        return super.instantiate(classLoader, className);
+    }
+
+
+    public TagsDialog newTagsDialog() {
+        return new TagsDialog(mListener);
+    }
+}

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/tags/TagsDialogFactory.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/tags/TagsDialogFactory.java
@@ -15,7 +15,7 @@
  */
 package com.ichi2.anki.dialogs.tags;
 
-import com.ichi2.anki.dialogs.tags.TagsDialog.TagsDialogListener;
+import com.ichi2.anki.dialogs.tags.TagsDialogListener;
 import com.ichi2.utils.ExtendedFragmentFactory;
 
 import androidx.annotation.NonNull;

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/tags/TagsDialogListener.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/tags/TagsDialogListener.java
@@ -1,0 +1,22 @@
+/*
+ Copyright (c) 2021 Tarek Mohamed Abdalla <tarekkma@gmail.com>
+
+ This program is free software; you can redistribute it and/or modify it under
+ the terms of the GNU General Public License as published by the Free Software
+ Foundation; either version 3 of the License, or (at your option) any later
+ version.
+
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License along with
+ this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.ichi2.anki.dialogs.tags;
+
+import java.util.List;
+
+public interface TagsDialogListener {
+    void onSelectedTags(List<String> selectedTags, int option);
+}

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/tags/TagsDialogListener.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/tags/TagsDialogListener.java
@@ -15,8 +15,43 @@
  */
 package com.ichi2.anki.dialogs.tags;
 
+import android.os.Bundle;
+
+import java.util.ArrayList;
 import java.util.List;
 
+import androidx.fragment.app.Fragment;
+import androidx.fragment.app.FragmentManager;
+
 public interface TagsDialogListener {
+
+    String ON_SELECTED_TAGS_KEY = "ON_SELECTED_TAGS_KEY";
+    String ON_SELECTED_TAGS__TAGS = "TAGS";
+    String ON_SELECTED_TAGS__OPTION = "OPTION";
+
     void onSelectedTags(List<String> selectedTags, int option);
+
+
+    default <F extends Fragment & TagsDialogListener> void registerFragmentResultReceiver(F fragment) {
+        fragment.getParentFragmentManager().setFragmentResultListener(
+                ON_SELECTED_TAGS_KEY, fragment,
+                (requestKey, bundle) -> {
+                    final List<String> selectedTags = bundle.getStringArrayList(ON_SELECTED_TAGS__TAGS);
+                    final int option = bundle.getInt(ON_SELECTED_TAGS__OPTION);
+                    fragment.onSelectedTags(selectedTags, option);
+                }
+        );
+    }
+
+    static TagsDialogListener createFragmentResultSender(FragmentManager fragmentManager) {
+        return new TagsDialogListener() {
+            @Override
+            public void onSelectedTags(List<String> selectedTags, int option) {
+                final Bundle bundle = new Bundle();
+                bundle.putStringArrayList(ON_SELECTED_TAGS__TAGS, new ArrayList<>(selectedTags));
+                bundle.putInt(ON_SELECTED_TAGS__OPTION, option);
+                fragmentManager.setFragmentResult(ON_SELECTED_TAGS_KEY, bundle);
+            }
+        };
+    }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/utils/ExtendedFragmentFactory.java
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/ExtendedFragmentFactory.java
@@ -75,9 +75,16 @@ public abstract class ExtendedFragmentFactory extends FragmentFactory {
      * and updating the activity with the extended factory
      */
     public <F extends ExtendedFragmentFactory> F attachToActivity(@NonNull AppCompatActivity activity) {
-        final FragmentManager fm = activity.getSupportFragmentManager();
-        mBaseFactory = fm.getFragmentFactory();
-        fm.setFragmentFactory(this);
+        return (F) attachToFragmentManager(activity.getSupportFragmentManager());
+    }
+
+    /**
+     * Attaches the factory to a fragment manager by setting the current fragment factory as the base factory
+     * and updating the fragment manager with the extended factory
+     */
+    public <F extends ExtendedFragmentFactory> F attachToFragmentManager(@NonNull FragmentManager fragmentManager) {
+        mBaseFactory = fragmentManager.getFragmentFactory();
+        fragmentManager.setFragmentFactory(this);
         return (F) this;
     }
 }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/CustomStudyDialogTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/CustomStudyDialogTest.java
@@ -28,6 +28,7 @@ import com.ichi2.anki.dialogs.customstudy.CustomStudyDialogFactory;
 import com.ichi2.libanki.Collection;
 import com.ichi2.libanki.Deck;
 import com.ichi2.libanki.sched.AbstractSched;
+import com.ichi2.testutils.ParametersUtils;
 
 import org.hamcrest.Matchers;
 import org.junit.After;
@@ -40,6 +41,7 @@ import androidx.fragment.app.testing.FragmentScenario;
 import androidx.lifecycle.Lifecycle;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
+import static com.ichi2.testutils.ParametersUtils.whatever;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.core.IsNull.notNullValue;
@@ -65,10 +67,6 @@ public class CustomStudyDialogTest extends RobolectricTest {
         reset(mockListener);
     }
 
-
-    private static <T> T whatever() {
-        return null;
-    }
 
     @Test
     public void learnAheadCardsRegressionTest() {

--- a/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/tags/TagsDialogTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/tags/TagsDialogTest.java
@@ -1,0 +1,154 @@
+/*
+ Copyright (c) 2021 Tarek Mohamed <tarekkma@gmail.com>
+
+ This program is free software; you can redistribute it and/or modify it under
+ the terms of the GNU General Public License as published by the Free Software
+ Foundation; either version 3 of the License, or (at your option) any later
+ version.
+
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License along with
+ this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.ichi2.anki.dialogs.tags;
+
+import android.os.Bundle;
+import android.view.View;
+import android.widget.RadioGroup;
+
+import com.afollestad.materialdialogs.DialogAction;
+import com.afollestad.materialdialogs.MaterialDialog;
+import com.ichi2.anki.R;
+import com.ichi2.anki.dialogs.tags.TagsDialog.DialogType;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import androidx.fragment.app.testing.FragmentScenario;
+import androidx.lifecycle.Lifecycle;
+import androidx.lifecycle.LifecycleOwner;
+import androidx.lifecycle.LifecycleRegistry;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+
+import static com.ichi2.testutils.ParametersUtils.whatever;
+import static com.ichi2.utils.ListUtil.assertListEquals;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.IsNull.notNullValue;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(AndroidJUnit4.class)
+public class TagsDialogTest {
+
+
+    private static LifecycleOwner mockLifecycleOwner() {
+        LifecycleOwner owner = mock(LifecycleOwner.class);
+        LifecycleRegistry lifecycle = new LifecycleRegistry(owner);
+        lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_RESUME);
+        when(owner.getLifecycle()).thenReturn(lifecycle);
+        return owner;
+    }
+
+
+    @Test
+    public void testTagsDialogCustomStudyOptionInterface() {
+
+        final DialogType type = DialogType.CUSTOM_STUDY_TAGS;
+        final List<String> allTags = Arrays.asList("1", "2", "3", "4");
+
+        Bundle args = new TagsDialog(whatever())
+                .withArguments(type, new ArrayList<>(), allTags)
+                .getArguments();
+
+
+        final TagsDialogListener mockListener = mock(TagsDialogListener.class);
+
+
+        TagsDialogFactory factory = new TagsDialogFactory(mockListener);
+        FragmentScenario<TagsDialog> scenario = FragmentScenario.launch(TagsDialog.class, args, R.style.Theme_AppCompat, factory);
+
+        scenario.moveToState(Lifecycle.State.STARTED);
+
+        scenario.onFragment((f) -> {
+            MaterialDialog dialog = (MaterialDialog) f.getDialog();
+            assertThat(dialog, notNullValue());
+
+            final View body = dialog.getCustomView();
+            final RadioGroup mOptionsGroup  = body.findViewById(R.id.tags_dialog_options_radiogroup);
+
+            assertEquals(mOptionsGroup.getVisibility(), View.VISIBLE);
+
+            final int expectedOption = 1;
+
+            mOptionsGroup.getChildAt(expectedOption).performClick();
+
+            dialog.getActionButton(DialogAction.POSITIVE).callOnClick();
+
+            verify(mockListener, times(1)).onSelectedTags(new ArrayList<>(), expectedOption);
+        });
+    }
+
+
+    @Test
+    public void testTagsDialogCustomStudyOptionFragmentAPI() {
+
+        final DialogType type = DialogType.CUSTOM_STUDY_TAGS;
+        final List<String> allTags = Arrays.asList("1", "2", "3", "4");
+
+        Bundle args = new TagsDialog(whatever())
+                .withArguments(type, new ArrayList<>(), allTags)
+                .getArguments();
+
+
+
+        FragmentScenario<TagsDialog> scenario = FragmentScenario.launch(TagsDialog.class, args, R.style.Theme_AppCompat);
+
+        scenario.moveToState(Lifecycle.State.STARTED);
+
+        scenario.onFragment((f) -> {
+            MaterialDialog dialog = (MaterialDialog) f.getDialog();
+            assertThat(dialog, notNullValue());
+
+
+
+
+            AtomicReference<List<String>> returnedList = new AtomicReference<>();
+            AtomicInteger returnedOption = new AtomicInteger();
+
+            f.getParentFragmentManager().setFragmentResultListener(TagsDialog.FRAGMENT_RESULT_ON_SELECTED_TAGS_KEY, mockLifecycleOwner(),
+                    (requestKey, bundle) -> {
+                        returnedList.set(bundle.getStringArrayList(TagsDialog.FRAGMENT_RESULT_ON_SELECTED_TAGS__TAGS));
+                        returnedOption.set(bundle.getInt(TagsDialog.FRAGMENT_RESULT_ON_SELECTED_TAGS__OPTION));
+                    });
+
+
+
+            final View body = dialog.getCustomView();
+            final RadioGroup mOptionsGroup  = body.findViewById(R.id.tags_dialog_options_radiogroup);
+
+            assertEquals(mOptionsGroup.getVisibility(), View.VISIBLE);
+
+            final int expectedOption = 2;
+
+            mOptionsGroup.getChildAt(expectedOption).performClick();
+
+            dialog.getActionButton(DialogAction.POSITIVE).callOnClick();
+
+            assertListEquals(new ArrayList<>(), returnedList.get());
+            assertEquals(expectedOption, returnedOption.get());
+        });
+    }
+
+}

--- a/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/tags/TagsDialogTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/tags/TagsDialogTest.java
@@ -39,6 +39,7 @@ import androidx.lifecycle.LifecycleOwner;
 import androidx.lifecycle.LifecycleRegistry;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
+import static com.ichi2.anki.dialogs.tags.TagsDialogListener.*;
 import static com.ichi2.testutils.ParametersUtils.whatever;
 import static com.ichi2.utils.ListUtil.assertListEquals;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -127,10 +128,10 @@ public class TagsDialogTest {
             AtomicReference<List<String>> returnedList = new AtomicReference<>();
             AtomicInteger returnedOption = new AtomicInteger();
 
-            f.getParentFragmentManager().setFragmentResultListener(TagsDialog.FRAGMENT_RESULT_ON_SELECTED_TAGS_KEY, mockLifecycleOwner(),
+            f.getParentFragmentManager().setFragmentResultListener(ON_SELECTED_TAGS_KEY, mockLifecycleOwner(),
                     (requestKey, bundle) -> {
-                        returnedList.set(bundle.getStringArrayList(TagsDialog.FRAGMENT_RESULT_ON_SELECTED_TAGS__TAGS));
-                        returnedOption.set(bundle.getInt(TagsDialog.FRAGMENT_RESULT_ON_SELECTED_TAGS__OPTION));
+                        returnedList.set(bundle.getStringArrayList(ON_SELECTED_TAGS__TAGS));
+                        returnedOption.set(bundle.getInt(ON_SELECTED_TAGS__OPTION));
                     });
 
 

--- a/AnkiDroid/src/test/java/com/ichi2/testutils/ParametersUtils.java
+++ b/AnkiDroid/src/test/java/com/ichi2/testutils/ParametersUtils.java
@@ -1,0 +1,26 @@
+/*
+ Copyright (c) 2021 Tarek Mohamed <tarekkma@gmail.com>
+
+ This program is free software; you can redistribute it and/or modify it under
+ the terms of the GNU General Public License as published by the Free Software
+ Foundation; either version 3 of the License, or (at your option) any later
+ version.
+
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License along with
+ this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.testutils;
+
+public class ParametersUtils {
+    /**
+     * Used to satisfy a parameter with a null in a declarative way
+     */
+    public static <T> T whatever() {
+        return null;
+    }
+}


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
#8341 introduced a bug in CustomStudyDialog, it removed the setter for the listener (which is great, since we can't rely on it to be there after a configuration change) but it assumed the fact that getActivity() would return an activity that does implement the interface.

In the case of `CustomStudyDialog`, the interface was implemented on the dialog, not on its hosing activity `StudyOptionsActivity`.

## Fixes
Fixes #8487

## Approach
By using `ExtendedFragmentFactory`, it was an easy task.


## How Has This Been Tested?

Manually + Unit Tests

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
