### PR TITLE
Fixing gestures with answer buttons not working

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -441,7 +441,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
 
     // Event handler for eases (answer buttons)
     class SelectEaseHandler implements View.OnClickListener, View.OnTouchListener {
-        private final int CLICK_ACTION_THRESHOLD = 200;
+        private static final int CLICK_ACTION_THRESHOLD = 200;
 
         private Card mPrevCard = null;
         private boolean mHasBeenTouched = false;

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -456,6 +456,10 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
                 // Save states when button pressed
                 mPrevCard = mCurrentCard;
                 mHasBeenTouched = true;
+                // We will need to check if a touch is followed by a click
+                // Since onTouch always come before onClick, we should check if
+                // the touch is going to be a click by storing the start coordinates
+                // and comparing with the end coordinates of the touch
                 mTouchX = event.getRawX();
                 mTouchY = event.getRawY();
             } else if (event.getAction() == MotionEvent.ACTION_UP) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -1664,7 +1664,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
             displayCardAnswer();
             return;
         }
-        performClickWithVisualFeedback(cardOrdinal);
+        answerCard(cardOrdinal);
     }
 
 
@@ -2809,33 +2809,8 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
         if (!sDisplayAnswer) {
             return false;
         }
-        performClickWithVisualFeedback(ease);
+        answerCard(ease);
         return true;
-    }
-
-
-    protected void performClickWithVisualFeedback(int ease) {
-        // Delay could potentially be lower - testing with 20 left a visible "click"
-        switch (ease) {
-            case EASE_1:
-                performClickWithVisualFeedback(mEase1Layout);
-                break;
-            case EASE_2:
-                performClickWithVisualFeedback(mEase2Layout);
-                break;
-            case EASE_3:
-                performClickWithVisualFeedback(mEase3Layout);
-                break;
-            case EASE_4:
-                performClickWithVisualFeedback(mEase4Layout);
-                break;
-        }
-    }
-
-
-    private void performClickWithVisualFeedback(LinearLayout easeLayout) {
-        easeLayout.requestFocus();
-        easeLayout.postDelayed(easeLayout::performClick, 20);
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -429,10 +429,10 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
         public void onClick(View view) {
             Timber.i("AbstractFlashcardViewer:: Show answer button pressed");
             // Ignore what is most likely an accidental double-tap.
-            if (SystemClock.elapsedRealtime() - mLastClickTime < DOUBLE_TAP_IGNORE_THRESHOLD) {
+            if (getElapsedRealTime() - mLastClickTime < DOUBLE_TAP_IGNORE_THRESHOLD) {
                 return;
             }
-            mLastClickTime = SystemClock.elapsedRealtime();
+            mLastClickTime = getElapsedRealTime();
             mTimeoutHandler.removeCallbacks(mShowAnswerTask);
             displayCardAnswer();
         }
@@ -479,6 +479,12 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
             return false;
         }
     };
+
+    @VisibleForTesting
+    protected long getElapsedRealTime() {
+        return SystemClock.elapsedRealtime();
+    }
+
 
     private final View.OnTouchListener mGestureListener = new View.OnTouchListener() {
         @Override
@@ -1317,9 +1323,9 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
             mCurrentCard.resumeTimer();
             // Then update and resume the UI timer. Set the base time as if the timer had started
             // timeTaken() seconds ago.
-            mCardTimer.setBase(SystemClock.elapsedRealtime() - mCurrentCard.timeTaken());
+            mCardTimer.setBase(getElapsedRealTime() - mCurrentCard.timeTaken());
             // Don't start the timer if we have already reached the time limit or it will tick over
-            if ((SystemClock.elapsedRealtime() - mCardTimer.getBase()) < mCurrentCard.timeLimit()) {
+            if ((getElapsedRealTime() - mCardTimer.getBase()) < mCurrentCard.timeLimit()) {
                 mCardTimer.start();
             }
         }
@@ -2001,14 +2007,14 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
         getTheme().resolveAttribute(android.R.attr.textColor, typedValue, true);
         mCardTimer.setTextColor(typedValue.data);
 
-        mCardTimer.setBase(SystemClock.elapsedRealtime());
+        mCardTimer.setBase(getElapsedRealTime());
         mCardTimer.start();
 
         // Stop and highlight the timer if it reaches the time limit.
         getTheme().resolveAttribute(R.attr.maxTimerColor, typedValue, true);
         final int limit = mCurrentCard.timeLimit();
         mCardTimer.setOnChronometerTickListener(chronometer -> {
-            long elapsed = SystemClock.elapsedRealtime() - chronometer.getBase();
+            long elapsed = getElapsedRealTime() - chronometer.getBase();
             if (elapsed >= limit) {
                 chronometer.setTextColor(typedValue.data);
                 chronometer.stop();

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -2821,18 +2821,21 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
         switch (ease) {
             case EASE_1:
                 displayVisualFeedback(mEase1Layout);
+                answerCard(ease);
                 break;
             case EASE_2:
                 displayVisualFeedback(mEase2Layout);
+                answerCard(ease);
                 break;
             case EASE_3:
                 displayVisualFeedback(mEase3Layout);
+                answerCard(ease);
                 break;
             case EASE_4:
                 displayVisualFeedback(mEase4Layout);
+                answerCard(ease);
                 break;
         }
-        answerCard(ease);
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -445,6 +445,8 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
             if (event.getAction() == MotionEvent.ACTION_DOWN) {
                 // Save card when button pressed
                 mPrevCard = mCurrentCard;
+                // Animate the button
+                view.setPressed(true);
                 return true;
             }
             // Perform intended action only if the button has been pressed for current card
@@ -453,6 +455,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
                 if (SystemClock.elapsedRealtime() - mLastClickTime < DOUBLE_TAP_IGNORE_THRESHOLD) {
                     return false;
                 }
+                view.setPressed(false);
                 mLastClickTime = SystemClock.elapsedRealtime();
                 mTimeoutHandler.removeCallbacks(mShowQuestionTask);
                 int id = view.getId();
@@ -1664,7 +1667,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
             displayCardAnswer();
             return;
         }
-        answerCard(cardOrdinal);
+        answerCardWithVisualFeedback(cardOrdinal);
     }
 
 
@@ -2809,8 +2812,33 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
         if (!sDisplayAnswer) {
             return false;
         }
-        answerCard(ease);
+        answerCardWithVisualFeedback(ease);
         return true;
+    }
+
+    protected void answerCardWithVisualFeedback(int ease) {
+        // Delay could potentially be lower - testing with 20 left a visible "click"
+        switch (ease) {
+            case EASE_1:
+                displayVisualFeedback(mEase1Layout);
+                break;
+            case EASE_2:
+                displayVisualFeedback(mEase2Layout);
+                break;
+            case EASE_3:
+                displayVisualFeedback(mEase3Layout);
+                break;
+            case EASE_4:
+                displayVisualFeedback(mEase4Layout);
+                break;
+        }
+        answerCard(ease);
+    }
+
+
+    private void displayVisualFeedback(LinearLayout easeLayout) {
+        easeLayout.setPressed(true);
+        easeLayout.postDelayed(() -> easeLayout.setPressed(false), 20);
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -441,6 +441,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
 
     // Event handler for eases (answer buttons)
     class SelectEaseHandler implements View.OnClickListener, View.OnTouchListener {
+        // maximum screen distance from initial touch where we will consider a click related to the touch
         private static final int CLICK_ACTION_THRESHOLD = 200;
 
         private Card mPrevCard = null;

--- a/AnkiDroid/src/test/java/com/ichi2/anki/AbstractFlashcardViewerTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/AbstractFlashcardViewerTest.java
@@ -11,7 +11,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
 import org.robolectric.android.controller.ActivityController;
-import org.robolectric.shadows.ShadowLooper;
 
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
@@ -415,8 +414,6 @@ public class AbstractFlashcardViewerTest extends RobolectricTest {
         assertThat("Displaying answer", viewer.isDisplayingAnswer(), is(true));
 
         viewer.executeCommand(ViewerCommand.COMMAND_FLIP_OR_ANSWER_BETTER_THAN_RECOMMENDED);
-
-        ShadowLooper.runUiThreadTasksIncludingDelayedTasks();
 
         assertThat(viewer.mAnswered, notNullValue());
     }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/AbstractFlashcardViewerTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/AbstractFlashcardViewerTest.java
@@ -3,6 +3,7 @@ package com.ichi2.anki;
 import android.app.Activity;
 import android.content.Intent;
 
+import com.ichi2.anki.cardviewer.ViewerCommand;
 import com.ichi2.libanki.Note;
 import com.ichi2.testutils.AnkiAssert;
 
@@ -10,6 +11,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
 import org.robolectric.android.controller.ActivityController;
+import org.robolectric.shadows.ShadowLooper;
 
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
@@ -22,17 +24,20 @@ import static com.ichi2.anki.AbstractFlashcardViewer.WebViewSignalParserUtils.SH
 import static com.ichi2.anki.AbstractFlashcardViewer.WebViewSignalParserUtils.SIGNAL_NOOP;
 import static com.ichi2.anki.AbstractFlashcardViewer.WebViewSignalParserUtils.TYPE_FOCUS;
 import static com.ichi2.anki.AbstractFlashcardViewer.WebViewSignalParserUtils.getSignalFromUrl;
-
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.Assert.assertEquals;
 
 @RunWith(AndroidJUnit4.class)
 public class AbstractFlashcardViewerTest extends RobolectricTest {
 
     public static class NonAbstractFlashcardViewer extends AbstractFlashcardViewer {
+        public Integer mAnswered;
+        private int lastTime = 0;
+
         @Override
         protected void setTitle() {
         }
@@ -41,6 +46,20 @@ public class AbstractFlashcardViewerTest extends RobolectricTest {
         @Override
         protected void performReload() {
             // intentionally blank
+        }
+
+
+        @Override
+        protected void answerCard(int ease) {
+            super.answerCard(ease);
+            this.mAnswered = ease;
+        }
+
+
+        @Override
+        protected long getElapsedRealTime() {
+            lastTime += DOUBLE_TAP_IGNORE_THRESHOLD;
+            return lastTime;
         }
 
 
@@ -384,6 +403,23 @@ public class AbstractFlashcardViewerTest extends RobolectricTest {
         assertEquals("test, test, test2", nafv.contentForCloze(cloze2, 1));
     }
 
+    @Test
+    public void testCommandPerformsAnswerCard() {
+        // Regression for #8527/#8572
+        // Note: Couldn't get a spy working, so overriding the method
+        NonAbstractFlashcardViewer viewer = getViewer();
+
+        assertThat("Displaying question", viewer.isDisplayingAnswer(), is(false));
+        viewer.executeCommand(ViewerCommand.COMMAND_FLIP_OR_ANSWER_BETTER_THAN_RECOMMENDED);
+
+        assertThat("Displaying answer", viewer.isDisplayingAnswer(), is(true));
+
+        viewer.executeCommand(ViewerCommand.COMMAND_FLIP_OR_ANSWER_BETTER_THAN_RECOMMENDED);
+
+        ShadowLooper.runUiThreadTasksIncludingDelayedTasks();
+
+        assertThat(viewer.mAnswered, notNullValue());
+    }
 
     private NonAbstractFlashcardViewer getViewer() {
         Note n = getCol().newNote();

--- a/AnkiDroid/src/test/java/com/ichi2/anki/ReviewerKeyboardInputTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/ReviewerKeyboardInputTest.java
@@ -517,10 +517,5 @@ public class ReviewerKeyboardInputTest extends RobolectricTest {
         public boolean hasBeenAnswered() {
             return mAnswered != null;
         }
-
-        @Override
-        protected void performClickWithVisualFeedback(int ease) {
-            answerCard(ease);
-        }
     }
 }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/ReviewerKeyboardInputTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/ReviewerKeyboardInputTest.java
@@ -519,7 +519,7 @@ public class ReviewerKeyboardInputTest extends RobolectricTest {
         }
 
         @Override
-        protected void answerCardWithVisualFeedback(int ease) {
+        protected void performClickWithVisualFeedback(int ease) {
             answerCard(ease);
         }
     }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/ReviewerKeyboardInputTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/ReviewerKeyboardInputTest.java
@@ -517,5 +517,10 @@ public class ReviewerKeyboardInputTest extends RobolectricTest {
         public boolean hasBeenAnswered() {
             return mAnswered != null;
         }
+
+        @Override
+        protected void answerCardWithVisualFeedback(int ease) {
+            answerCard(ease);
+        }
     }
 }


### PR DESCRIPTION
## Purpose / Description
Fixing gestures with answer buttons not working on the latest alpha release.

## Fixes
Fixes #8527 
Fixes #8572.

## Approach
Completely removing the usage of `performClickWithAction`, opting to `answerCard`, since only touching actions on buttons are registered now.

## How Has This Been Tested?

Tested on my physical device.

## Checklist

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
