### PR TITLE
Decks: refactor restoreToDefault for Rust

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
@@ -882,11 +882,11 @@ public class Decks {
 
     public void restoreToDefault(DeckConfig conf) {
         int oldOrder = conf.getJSONObject("new").getInt("order");
-        DeckConfig _new = new DeckConfig(DEFAULT_CONF);
+        DeckConfig _new = mCol.getBackend().new_deck_config_legacy();
         _new.put("id", conf.getLong("id"));
         _new.put("name", conf.getString("name"));
-        mDconf.put(_new.getLong("id"), _new);
-        save(_new);
+
+        updateConf(_new);
         // if it was previously randomized, resort
         if (oldOrder == 0) {
             mCol.getSched().resortConf(_new);

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
@@ -885,7 +885,7 @@ public class Decks {
         DeckConfig _new = new DeckConfig(DEFAULT_CONF);
         _new.put("id", conf.getLong("id"));
         _new.put("name", conf.getString("name"));
-        mDconf.put(conf.getLong("id"), _new);
+        mDconf.put(_new.getLong("id"), _new);
         save(_new);
         // if it was previously randomized, resort
         if (oldOrder == 0) {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/backend/DroidBackend.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/backend/DroidBackend.java
@@ -17,8 +17,12 @@
 package com.ichi2.libanki.backend;
 
 import com.ichi2.libanki.DB;
+import com.ichi2.libanki.DeckConfig;
+import com.ichi2.libanki.Decks;
 import com.ichi2.libanki.backend.exception.BackendNotSupportedException;
 import com.ichi2.libanki.backend.model.SchedTimingToday;
+
+import net.ankiweb.rsdroid.RustV1Cleanup;
 
 import androidx.annotation.VisibleForTesting;
 
@@ -59,4 +63,9 @@ public interface DroidBackend {
      * @return minutes west of UTC in the local timezone
      */
     int local_minutes_west(long timestampSeconds) throws BackendNotSupportedException;
+
+    @RustV1Cleanup("backend.newDeckConfigLegacy")
+    default DeckConfig new_deck_config_legacy() {
+        return new DeckConfig(Decks.DEFAULT_CONF);
+    }
 }


### PR DESCRIPTION
The more methods that we make equivalent to the python at the commit of `anki` that we're using, the more seamless that the conversion is.

https://github.com/ankitects/anki/commit/004cc2b5f8260c31b2177b4e544f1554e08f7a33

https://github.com/ankidroid/Anki-Android/blob/d7057d3c979086f2c5712156ac6c564a57cda9cd/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java#L817-L820

## How Has This Been Tested?

Untested

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
