### PR TITLE
Lint: Disallow direct usages of Toast#makeText

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiFont.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiFont.java
@@ -6,8 +6,6 @@ import android.content.SharedPreferences;
 import android.content.res.Resources;
 import android.graphics.Typeface;
 
-import android.widget.Toast;
-
 import com.ichi2.libanki.Utils;
 
 import java.io.File;
@@ -158,8 +156,7 @@ public class AnkiFont {
                 // Show warning toast
                 String name = new File(path).getName();
                 Resources res = AnkiDroidApp.getAppResources();
-                Toast toast = Toast.makeText(ctx, res.getString(R.string.corrupt_font, name), Toast.LENGTH_LONG);
-                toast.show();
+                UIUtils.showThemedToast(ctx, res.getString(R.string.corrupt_font, name), false);
                 // Don't warn again in this session
                 corruptFonts.add(path);
             }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -80,7 +80,6 @@ import android.widget.Filterable;
 import android.widget.LinearLayout;
 import android.widget.RelativeLayout;
 import android.widget.TextView;
-import android.widget.Toast;
 
 import com.afollestad.materialdialogs.MaterialDialog;
 import com.ichi2.anki.CollectionHelper.CollectionIntegrityStorageCheck;
@@ -566,7 +565,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
                 Timber.i("AnkiDroid directory inaccessible");
                 Intent i = Preferences.getPreferenceSubscreenIntent(this, "com.ichi2.anki.prefs.advanced");
                 startActivityForResultWithoutAnimation(i, REQUEST_PATH_UPDATE);
-                Toast.makeText(this, R.string.directory_inaccessible, Toast.LENGTH_LONG).show();
+                UIUtils.showThemedToast(this, R.string.directory_inaccessible, false);
                 break;
             case FUTURE_ANKIDROID_VERSION:
                 Timber.i("Displaying database versioning");
@@ -945,7 +944,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
                 handleStartup(colIsOpen());
             } else {
                 // User denied access to file storage  so show error toast and display "App Info"
-                Toast.makeText(this, R.string.startup_no_storage_permission, Toast.LENGTH_LONG).show();
+                UIUtils.showThemedToast(this, R.string.startup_no_storage_permission, false);
                 finishWithoutAnimation();
                 // Open the Android settings page for our app so that the user can grant the missing permission
                 Intent intent = new Intent();

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ModelBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ModelBrowser.java
@@ -35,7 +35,6 @@ import android.widget.EditText;
 import android.widget.ListView;
 import android.widget.Spinner;
 import android.widget.TextView;
-import android.widget.Toast;
 
 import com.afollestad.materialdialogs.MaterialDialog;
 import com.ichi2.anki.dialogs.ConfirmationDialog;
@@ -541,9 +540,7 @@ public class ModelBrowser extends AnkiActivity {
 
 
     private void showToast(CharSequence text) {
-        int duration = Toast.LENGTH_SHORT;
-        Toast toast = Toast.makeText(this, text, duration);
-        toast.show();
+        UIUtils.showThemedToast(this, text, true);
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
@@ -26,7 +26,6 @@ import android.app.PendingIntent;
 import android.content.ActivityNotFoundException;
 import android.content.ComponentName;
 import android.content.Context;
-import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.content.SharedPreferences.OnSharedPreferenceChangeListener;
@@ -39,7 +38,6 @@ import android.text.TextUtils;
 import android.view.MenuItem;
 import android.view.WindowManager.BadTokenException;
 import android.webkit.URLUtil;
-import android.widget.Toast;
 
 import com.afollestad.materialdialogs.MaterialDialog;
 import com.ichi2.anim.ActivityTransitionAnimation;
@@ -210,8 +208,8 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
                     if (prefs.getBoolean("gestures", false) || !"2".equals(newValue)) {
                         return true;
                     } else {
-                        Toast.makeText(getApplicationContext(),
-                                R.string.full_screen_error_gestures, Toast.LENGTH_LONG).show();
+                        UIUtils.showThemedToast(getApplicationContext(),
+                                R.string.full_screen_error_gestures, false);
                         return false;
                     }
                 });
@@ -393,12 +391,12 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
                 fullSyncPreference.setDialogTitle(R.string.force_full_sync_title);
                 fullSyncPreference.setOkHandler(() -> {
                     if (getCol() == null) {
-                        Toast.makeText(getApplicationContext(), R.string.directory_inaccessible, Toast.LENGTH_LONG).show();
+                        UIUtils.showThemedToast(getApplicationContext(), R.string.directory_inaccessible, false);
                         return;
                     }
                     getCol().modSchemaNoCheck();
                     getCol().setMod();
-                    Toast.makeText(getApplicationContext(), android.R.string.ok, Toast.LENGTH_SHORT).show();
+                    UIUtils.showThemedToast(getApplicationContext(), android.R.string.ok, true);
                 });
                 // Workaround preferences
                 removeUnnecessaryAdvancedPrefs(screen);

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ReadText.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ReadText.java
@@ -25,7 +25,6 @@ import android.speech.tts.TextToSpeech;
 import android.speech.tts.UtteranceProgressListener;
 
 import android.view.WindowManager;
-import android.widget.Toast;
 
 import com.afollestad.materialdialogs.MaterialDialog;
 import com.google.android.material.snackbar.Snackbar;
@@ -59,8 +58,8 @@ public class ReadText {
     public static void speak(String text, String loc, int queueMode) {
         int result = mTts.setLanguage(localeFromStringIgnoringScriptAndExtensions(loc));
         if (result == TextToSpeech.LANG_MISSING_DATA || result == TextToSpeech.LANG_NOT_SUPPORTED) {
-            Toast.makeText(mReviewer.get(), mReviewer.get().getString(R.string.no_tts_available_message)
-                    + " (" + loc + ")", Toast.LENGTH_LONG).show();
+            UIUtils.showThemedToast(mReviewer.get(), mReviewer.get().getString(R.string.no_tts_available_message)
+                    + " (" + loc + ")", false);
             Timber.e("Error loading locale %s", loc);
         } else {
             if (mTts.isSpeaking() && queueMode == TextToSpeech.QUEUE_FLUSH) {
@@ -213,8 +212,8 @@ public class ReadText {
         if (!originalLocaleCode.isEmpty()) {
             // (after notifying them first that no TTS voice was found for the locale
             // they originally requested)
-            Toast.makeText(mReviewer.get(), mReviewer.get().getString(R.string.no_tts_available_message)
-                    + " (" + originalLocaleCode + ")", Toast.LENGTH_LONG).show();
+            UIUtils.showThemedToast(mReviewer.get(), mReviewer.get().getString(R.string.no_tts_available_message)
+                    + " (" + originalLocaleCode + ")", false);
         }
         selectTts(mTextToSpeak, mDid, mOrd, mQuestionAnswer);
     }
@@ -277,7 +276,7 @@ public class ReadText {
                     Timber.d("TTS initialized and available languages found");
                     ((AbstractFlashcardViewer) mReviewer.get()).ttsInitialized();
                 } else {
-                    Toast.makeText(mReviewer.get(), mReviewer.get().getString(R.string.no_tts_available_message), Toast.LENGTH_LONG).show();
+                    UIUtils.showThemedToast(mReviewer.get(), mReviewer.get().getString(R.string.no_tts_available_message), false);
                     Timber.w("TTS initialized but no available languages found");
                 }
                 mTts.setOnUtteranceProgressListener(new UtteranceProgressListener() {
@@ -303,12 +302,12 @@ public class ReadText {
                     }
                 });
             } else {
-                Toast.makeText(mReviewer.get(), mReviewer.get().getString(R.string.no_tts_available_message), Toast.LENGTH_LONG).show();
+                UIUtils.showThemedToast(mReviewer.get(), mReviewer.get().getString(R.string.no_tts_available_message), false);
                 Timber.w("TTS not successfully initialized");
             }
         });
         // Show toast that it's getting initialized, as it can take a while before the sound plays the first time
-        Toast.makeText(context, context.getString(R.string.initializing_tts), Toast.LENGTH_LONG).show();
+        UIUtils.showThemedToast(context, context.getString(R.string.initializing_tts), false);
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/UIUtils.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/UIUtils.java
@@ -7,6 +7,7 @@ import android.graphics.Color;
 import com.google.android.material.snackbar.Snackbar;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.StringRes;
 import androidx.core.content.ContextCompat;
 import android.view.View;
 import android.widget.TextView;
@@ -25,6 +26,12 @@ public class UIUtils {
 
     public static void showThemedToast(Context context, String text, boolean shortLength) {
         Toast.makeText(context, text, shortLength ? Toast.LENGTH_SHORT : Toast.LENGTH_LONG).show();
+    }
+    public static void showThemedToast(Context context, CharSequence text, boolean shortLength) {
+        UIUtils.showThemedToast(context, text.toString(), shortLength);
+    }
+    public static void showThemedToast(Context context, @StringRes int textResource, boolean shortLength) {
+        Toast.makeText(context, textResource, shortLength ? Toast.LENGTH_SHORT : Toast.LENGTH_LONG).show();
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/activity/LoadPronounciationActivity.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/activity/LoadPronounciationActivity.java
@@ -31,9 +31,9 @@ import android.widget.ArrayAdapter;
 import android.widget.Button;
 import android.widget.LinearLayout;
 import android.widget.Spinner;
-import android.widget.Toast;
 
 import com.ichi2.anki.R;
+import com.ichi2.anki.UIUtils;
 import com.ichi2.anki.multimediacard.beolingus.parsing.BeolingusParser;
 import com.ichi2.anki.multimediacard.language.LanguageListerBeolingus;
 import com.ichi2.anki.runtimetools.TaskOperations;
@@ -402,16 +402,12 @@ public class LoadPronounciationActivity extends Activity implements OnCancelList
 
 
     private void showToast(CharSequence text) {
-        int duration = Toast.LENGTH_SHORT;
-        Toast toast = Toast.makeText(this, text, duration);
-        toast.show();
+        UIUtils.showThemedToast(this, text, true);
     }
 
 
     private void showToastLong(CharSequence text) {
-        int duration = Toast.LENGTH_LONG;
-        Toast toast = Toast.makeText(this, text, duration);
-        toast.show();
+        UIUtils.showThemedToast(this, text, false);
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/activity/TranslationActivity.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/activity/TranslationActivity.java
@@ -36,11 +36,11 @@ import android.widget.Button;
 import android.widget.LinearLayout;
 import android.widget.Spinner;
 import android.widget.TextView;
-import android.widget.Toast;
 
 import com.google.gson.Gson;
 import com.ichi2.anki.AnkiDroidApp;
 import com.ichi2.anki.R;
+import com.ichi2.anki.UIUtils;
 import com.ichi2.anki.multimediacard.glosbe.json.Meaning;
 import com.ichi2.anki.multimediacard.glosbe.json.Phrase;
 import com.ichi2.anki.multimediacard.glosbe.json.Response;
@@ -259,9 +259,7 @@ public class TranslationActivity extends FragmentActivity implements DialogInter
 
 
     private void showToastLong(CharSequence text) {
-        int duration = Toast.LENGTH_LONG;
-        Toast toast = Toast.makeText(this, text, duration);
-        toast.show();
+        UIUtils.showThemedToast(this, text, false);
     }
 
 
@@ -384,9 +382,7 @@ public class TranslationActivity extends FragmentActivity implements DialogInter
 
 
     private void showToast(CharSequence text) {
-        int duration = Toast.LENGTH_SHORT;
-        Toast toast = Toast.makeText(this, text, duration);
-        toast.show();
+        UIUtils.showThemedToast(this, text, true);
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicTextFieldController.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicTextFieldController.java
@@ -30,9 +30,9 @@ import android.widget.EditText;
 import android.widget.LinearLayout;
 import android.widget.LinearLayout.LayoutParams;
 import android.widget.TextView;
-import android.widget.Toast;
 
 import com.ichi2.anki.R;
+import com.ichi2.anki.UIUtils;
 import com.ichi2.anki.multimediacard.activity.LoadPronounciationActivity;
 import com.ichi2.anki.multimediacard.activity.PickStringDialogFragment;
 import com.ichi2.anki.multimediacard.activity.TranslationActivity;
@@ -334,9 +334,7 @@ public class BasicTextFieldController extends FieldControllerBase implements IFi
      * @param text A short cut to show a toast
      */
     private void showToast(CharSequence text) {
-        int duration = Toast.LENGTH_SHORT;
-        Toast toast = Toast.makeText(mActivity, text, duration);
-        toast.show();
+        UIUtils.showThemedToast(mActivity, text, true);
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/AbstractSched.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/AbstractSched.java
@@ -4,10 +4,9 @@ import android.app.Activity;
 import android.content.Context;
 import android.content.res.Resources;
 import android.util.Pair;
-import android.widget.Toast;
-
 
 import com.ichi2.anki.R;
+import com.ichi2.anki.UIUtils;
 import com.ichi2.async.CancelListener;
 import com.ichi2.libanki.Card;
 import com.ichi2.libanki.Consts;
@@ -484,7 +483,7 @@ public abstract class AbstractSched {
             } else {
                 leechMessage = res.getString(R.string.leech_notification);
             }
-            activity.runOnUiThread(() -> Toast.makeText(activity, leechMessage, Toast.LENGTH_SHORT).show());
+            activity.runOnUiThread(() -> UIUtils.showThemedToast(activity, leechMessage, true));
 
         } else {
             Timber.w("LeechHook :: could not show leech toast as activity was null");

--- a/AnkiDroid/src/main/java/com/ichi2/preferences/CustomDialogPreference.java
+++ b/AnkiDroid/src/main/java/com/ichi2/preferences/CustomDialogPreference.java
@@ -20,11 +20,11 @@ import android.content.Context;
 import android.content.DialogInterface;
 import android.content.SharedPreferences.Editor;
 import android.util.AttributeSet;
-import android.widget.Toast;
 
 import com.ichi2.anki.AnkiDroidApp;
 import com.ichi2.anki.MetaDB;
 import com.ichi2.anki.R;
+import com.ichi2.anki.UIUtils;
 
 @SuppressWarnings("deprecation") // TODO Tracked in https://github.com/ankidroid/Anki-Android/issues/5019
 public class CustomDialogPreference extends android.preference.DialogPreference implements DialogInterface.OnClickListener {
@@ -57,9 +57,7 @@ public class CustomDialogPreference extends android.preference.DialogPreference 
             } else {
                 // Main Preferences :: Reset Languages
                 if (MetaDB.resetLanguages(mContext)) {
-                    Toast successReport = Toast.makeText(this.getContext(),
-                            AnkiDroidApp.getAppResources().getString(R.string.reset_confirmation), Toast.LENGTH_SHORT);
-                    successReport.show();
+                    UIUtils.showThemedToast(this.getContext(), AnkiDroidApp.getAppResources().getString(R.string.reset_confirmation), true);
                 }
             }
         }

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/IssueRegistry.java
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/IssueRegistry.java
@@ -7,6 +7,7 @@ import com.ichi2.anki.lint.rules.DirectSystemTimeInstantiation;
 import com.ichi2.anki.lint.rules.DirectSystemCurrentTimeMillisUsage;
 import com.ichi2.anki.lint.rules.DirectDateInstantiation;
 import com.ichi2.anki.lint.rules.DirectGregorianInstantiation;
+import com.ichi2.anki.lint.rules.DirectToastMakeTextUsage;
 import com.ichi2.anki.lint.rules.DuplicateCrowdInStrings;
 import com.ichi2.anki.lint.rules.DuplicateTextInPreferencesXml;
 import com.ichi2.anki.lint.rules.InconsistentAnnotationUsage;
@@ -27,6 +28,7 @@ public class IssueRegistry extends com.android.tools.lint.client.api.IssueRegist
         issues.add(DirectDateInstantiation.ISSUE);
         issues.add(DirectGregorianInstantiation.ISSUE);
         issues.add(DirectSystemTimeInstantiation.ISSUE);
+        issues.add(DirectToastMakeTextUsage.ISSUE);
         issues.add(InconsistentAnnotationUsage.ISSUE);
         issues.add(DuplicateTextInPreferencesXml.ISSUE);
         issues.add(DuplicateCrowdInStrings.ISSUE);

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/IssueRegistry.java
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/IssueRegistry.java
@@ -22,16 +22,17 @@ public class IssueRegistry extends com.android.tools.lint.client.api.IssueRegist
     @NotNull
     @Override
     public List<Issue> getIssues() {
+        // Keep this list lexicographically ordered.
         List<Issue> issues = new ArrayList<>();
         issues.add(DirectCalendarInstanceUsage.ISSUE);
-        issues.add(DirectSystemCurrentTimeMillisUsage.ISSUE);
         issues.add(DirectDateInstantiation.ISSUE);
         issues.add(DirectGregorianInstantiation.ISSUE);
+        issues.add(DirectSystemCurrentTimeMillisUsage.ISSUE);
         issues.add(DirectSystemTimeInstantiation.ISSUE);
         issues.add(DirectToastMakeTextUsage.ISSUE);
-        issues.add(InconsistentAnnotationUsage.ISSUE);
-        issues.add(DuplicateTextInPreferencesXml.ISSUE);
         issues.add(DuplicateCrowdInStrings.ISSUE);
+        issues.add(DuplicateTextInPreferencesXml.ISSUE);
+        issues.add(InconsistentAnnotationUsage.ISSUE);
         issues.add(PrintStackTraceUsage.ISSUE);
         return issues;
     }

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/rules/DirectToastMakeTextUsage.java
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/DirectToastMakeTextUsage.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2021 Nicola Dardanis <nicdard@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.lint.rules;
+
+import com.android.tools.lint.client.api.JavaEvaluator;
+import com.android.tools.lint.detector.api.Detector;
+import com.android.tools.lint.detector.api.Implementation;
+import com.android.tools.lint.detector.api.Issue;
+import com.android.tools.lint.detector.api.JavaContext;
+import com.android.tools.lint.detector.api.Scope;
+import com.android.tools.lint.detector.api.SourceCodeScanner;
+import com.google.common.annotations.VisibleForTesting;
+import com.ichi2.anki.lint.utils.Constants;
+import com.ichi2.anki.lint.utils.LintUtils;
+import com.intellij.psi.PsiMethod;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.jetbrains.uast.UCallExpression;
+import org.jetbrains.uast.UClass;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * This custom Lint rules will raise an error if a developer uses the {android.widget.Toast#makeText(...)} method instead
+ * of using the method provided by the UIUtils class {com.ichi2.anki.UIUtils#showThemedToast(...)}.
+ */
+public class DirectToastMakeTextUsage extends Detector implements SourceCodeScanner {
+
+    @VisibleForTesting
+    static final String ID = "DirectToastMakeTextUsage";
+    @VisibleForTesting
+    static final String DESCRIPTION = "Use UIUtils.showThemedToast instead of Toast.makeText";
+    private static final String EXPLANATION = "To improve code consistency within the codebase you should use UIUtils.showThemedToast in place" +
+            " of the library Toast.makeText(...).show(). This ensures also that the toast is actually displayed after being created";
+    private static final Implementation implementation = new Implementation(DirectToastMakeTextUsage.class, Scope.JAVA_FILE_SCOPE);
+    public static final Issue ISSUE = Issue.create(
+            ID,
+            DESCRIPTION,
+            EXPLANATION,
+            Constants.ANKI_CODE_STYLE_CATEGORY,
+            Constants.ANKI_CODE_STYLE_PRIORITY,
+            Constants.ANKI_CODE_STYLE_SEVERITY,
+            implementation
+    );
+
+    public DirectToastMakeTextUsage() {
+
+    }
+
+    @Nullable
+    @Override
+    public List<String> getApplicableMethodNames() {
+        List<String> forbiddenToastMethods = new ArrayList<>();
+        forbiddenToastMethods.add("makeText");
+        return forbiddenToastMethods;
+    }
+
+
+    @Override
+    public void visitMethodCall(@NotNull JavaContext context, @NotNull UCallExpression node, @NotNull PsiMethod method) {
+        super.visitMethodCall(context, node, method);
+        JavaEvaluator evaluator = context.getEvaluator();
+        List<UClass> foundClasses = context.getUastFile().getClasses();
+        if (!LintUtils.isAnAllowedClass(foundClasses, "UIUtils") && evaluator.isMemberInClass(method, "android.widget.Toast")) {
+            context.report(
+                    ISSUE,
+                    node,
+                    context.getCallLocation(node, true, true),
+                    DESCRIPTION
+            );
+        }
+    }
+
+}

--- a/lint-rules/src/test/java/com/ichi2/anki/lint/rules/DirectToastMakeTextUsageTest.java
+++ b/lint-rules/src/test/java/com/ichi2/anki/lint/rules/DirectToastMakeTextUsageTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2021 Nicola Dardanis <nicdard@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.lint.rules;
+
+import org.intellij.lang.annotations.Language;
+import org.junit.Test;
+
+import static com.android.tools.lint.checks.infrastructure.TestFile.JavaTestFile.create;
+import static com.android.tools.lint.checks.infrastructure.TestLintTask.lint;
+import static org.junit.Assert.assertTrue;
+
+public class DirectToastMakeTextUsageTest {
+
+    @Language("JAVA")
+    private final String stubToast = "                                      \n" +
+            "package android.widget;                                        \n" +
+            "public class Toast {                                           \n" +
+            "                                                               \n" +
+            "    public static Toast makeText(Context context,              \n" +
+            "                                String text,                   \n" +
+            "                                int duration) {                \n" +
+            "         // Stub                                               \n" +
+            "    }                                                          \n" +
+            "}                                                              \n";
+
+    @Language("JAVA")
+    private final String javaFileToBeTested = "                             \n" +
+            "package com.ichi2.anki.lint.rules;                             \n" +
+            "                                                               \n" +
+            "import android.widget.Toast;                                   \n" +
+            "                                                               \n" +
+            "public class TestJavaClass {                                   \n" +
+            "                                                               \n" +
+            "    public static void main(String[] args) {                   \n" +
+            "        Toast.makeText();                                      \n" +
+            "    }                                                          \n" +
+            "}                                                              \n";
+
+    @Language("JAVA")
+    private final String javaFileWithUIUtils = "                            \n" +
+            "package com.ichi2.anki.lint.rules;                             \n" +
+            "                                                               \n" +
+            "import android.widget.Toast;                                   \n" +
+            "                                                               \n" +
+            "public class UIUtils {                                         \n" +
+            "                                                               \n" +
+            "    public static void main(String[] args) {                   \n" +
+            "        Toast.makeText();                                      \n" +
+            "    }                                                          \n" +
+            "}                                                              \n";
+
+
+    @Test
+    public void showsErrorsForInvalidUsage() {
+        lint()
+                .allowMissingSdk()
+                .allowCompilationErrors()
+                .files(create(stubToast), create(javaFileToBeTested))
+                .issues(DirectToastMakeTextUsage.ISSUE)
+                .run()
+                .expectErrorCount(1)
+                .check(output -> {
+                    assertTrue(output.contains(DirectToastMakeTextUsage.ID));
+                    assertTrue(output.contains(DirectToastMakeTextUsage.DESCRIPTION));
+                });
+    }
+
+    @Test
+    public void allowsUsageForUIUtils() {
+        lint()
+                .allowMissingSdk()
+                .allowCompilationErrors()
+                .files(create(stubToast), create(javaFileWithUIUtils))
+                .issues(DirectToastMakeTextUsage.ISSUE)
+                .run()
+                .expectClean();
+    }
+}


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
Spare code review time and make the codebase cleaner by suggesting people to use `UIUtils.showThemedToast` instead of the `Toast.makeText`.

## Fixes
Fixes https://github.com/ankidroid/Anki-Android/issues/8576

## Approach
Implement a custom lint rule.

## How Has This Been Tested?
Unit tests are provided together with the implementation. Also,the lint report has been generated and the IDE provides visual feedback on the working rule.

## Learning (optional, can help others)
https://developer.android.com/studio/write/lint
https://proandroiddev.com/implementing-your-first-android-lint-rule-6e572383b292
https://proandroiddev.com/testing-your-first-android-lint-rule-bb78c1f2d2bd

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
