### PR TITLE
Added test to ensure deepClone() returns a new instance

### DIFF
--- a/AnkiDroid/src/test/java/com/ichi2/utils/JSONObjectTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/utils/JSONObjectTest.java
@@ -152,6 +152,17 @@ public class JSONObjectTest {
         Assert.assertEquals(removeQuotes(correctJsonObjectNestedWithArray.toString()), jsonObjectSubType.toString());
     }
 
+
+    /**
+     * Tests that the a new copy is returned instead of a reference to the original.
+     */
+    @Test
+    public void deepCloneReferenceTest() {
+        JSONObject clone = correctJsonObjectBasic.deepClone();
+        // Both objects should point to different memory address
+        Assert.assertNotEquals(clone, correctJsonObjectBasic);
+    }
+
     @Test
     public void fromMapTest() {
         JSONObject fromMapJsonObject = JSONObject.fromMap(booleanMap);


### PR DESCRIPTION
## Purpose / Description
Added a test to check whether a new object is returned by the `deepClone()` method of `JSONObject` class. The test fails if the clone and original object point to the same memory location.

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
