### PR TITLE
Don't persist Anki logo in background on startup

### DIFF
--- a/AnkiDroid/src/main/res/layout/homescreen.xml
+++ b/AnkiDroid/src/main/res/layout/homescreen.xml
@@ -3,6 +3,7 @@
                                            android:id="@+id/drawer_layout"
                                            android:layout_width="match_parent"
                                            android:layout_height="match_parent"
+                                           android:background="?android:attr/colorBackground"
                                            android:fitsSystemWindows="true">
     <com.drakeet.drawer.FullDraggableContainer
         android:layout_width="match_parent"


### PR DESCRIPTION
## Purpose / Description
On Samsung devices, when AnkiDroid is launched for the first time, the splash screen with the AnkiDroid logo doesn't disappear and stays in the background of DeckPicker

## Fixes
Fixes #8227 

## Approach
For homescreen.xml, copy the xlarge version's android:background attribute placement to the normal version (as an attribute of the root, ClosableDrawerLayout View)

## How Has This Been Tested?
Tested on:
- Samsung Galaxy A80 API 30 (Physical Device) - Solves the issue
- Pixel 4 API 27 (Emulator) - Doesn't change previous, correct behavior

I would love to have any contributors with Samsung devices confirm that this solves the issue!

## Checklist

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
