### PR TITLE
Fixes #8598: Pop DeckPicker from back stack on return via Navigation Drawer

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/NavigationDrawerActivity.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NavigationDrawerActivity.java
@@ -299,7 +299,8 @@ public abstract class NavigationDrawerActivity extends AnkiActivity implements N
             if (itemId == R.id.nav_decks) {
                 Timber.i("Navigating to decks");
                 Intent deckPicker = new Intent(NavigationDrawerActivity.this, DeckPicker.class);
-                deckPicker.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_NEW_TASK);    // opening DeckPicker should clear back history
+                // opening DeckPicker should use the instance on the back stack & clear back history
+                deckPicker.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_SINGLE_TOP);
                 startActivityWithAnimation(deckPicker, END);
             } else if (itemId == R.id.nav_browser) {
                 Timber.i("Navigating to card browser");


### PR DESCRIPTION
## Purpose / Description
DeckPicker would restart upon returning to it from Card Browser/Statistics via the Navigation Drawer

## Fixes
Fixes #8598 

## Approach
Use the following flags while launching the DeckPicker intent from NavigationDrawerActivity
- Intent.FLAG_ACTIVITY_CLEAR_TOP: Finishes activities above DeckPicker in the back stack
- Intent.FLAG_ACTIVITY_SINGLE_TOP: Doesn't relaunch DeckPicker if it's at the top of the back stack

Previously, FLAG_ACTIVITY_NEW_TASK was used which made a new Task on the back stack and forced the target activity of the Intent to be launched. This approach is only suitable for 'launcher' behavior, like that of IntentHandler.

## How Has This Been Tested?
Tested on:
- Samsung Galaxy A80 API 30 (Physical Device)
- Pixel 4 API 27 (Emulator)
- Pixel XL API 21 (Emulator)


## Checklist

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
