### PR TITLE
Attempt to de-flake "regression_test_preview" with sleeps

### DIFF
--- a/AnkiDroid/src/test/java/com/ichi2/libanki/sched/SchedV2Test.java
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/sched/SchedV2Test.java
@@ -1744,16 +1744,18 @@ public class SchedV2Test extends RobolectricTest {
         deck.put("resched", false);
         sched.rebuildDyn(did);
         col.reset();
-        advanceRobolectricLooper();
         Card card;
         for(int i = 0; i < 3; i++) {
+            advanceRobolectricLooperWithSleep();
             card = sched.getCard();
             assertNotNull(card);
             sched.answerCard(card, Consts.BUTTON_ONE);
         }
+        advanceRobolectricLooperWithSleep();
         assertEquals(1, sched.lrnCount());
         card = sched.getCard();
         assertEquals(1, sched.counts(card).getLrn());
+        advanceRobolectricLooperWithSleep();
         sched.answerCard(card, Consts.BUTTON_ONE);
         assertDoesNotThrow(col::undo);
     }


### PR DESCRIPTION
## Pull Request template

## Purpose / Description

Hard to reproduce this one locally but hopefully this helps, it is our top flake I think in unit test runs

## Fixes
Related #8064 

## Approach

Just add sleeps to the method as it does things likely asynchronous

## How Has This Been Tested?

This one was a little frustrating. It shows up in CI as noted in related issue and I see it locally *sometimes* but after adding the sleeps I never saw it again either on this branch with these sleeps or (when I attempted to negative test it) when I switched back to main branch and tried to reproduce again.

So results are very inconclusive, however adding sleeps can't really hurt.

## Learning (optional, can help others)

Tests and asynchronous things are not delicious together like peanut butter and chocolate.

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
