### PR TITLE
fix: Open DeckPicker if collection path changes

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/NavigationDrawerActivity.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NavigationDrawerActivity.java
@@ -53,8 +53,6 @@ public abstract class NavigationDrawerActivity extends AnkiActivity implements N
     protected CharSequence mTitle;
     protected Boolean mFragmented = false;
     private boolean mNavButtonGoesBack = false;
-    // Other members
-    private String mOldColPath;
     private int mOldTheme;
     // Navigation drawer list item entries
     private DrawerLayout mDrawerLayout;
@@ -237,22 +235,16 @@ public abstract class NavigationDrawerActivity extends AnkiActivity implements N
         NotificationChannels.setup(getApplicationContext());
         // Restart the activity on preference change
         if (requestCode == REQUEST_PREFERENCES_UPDATE) {
-            if (mOldColPath != null && CollectionHelper.getCurrentAnkiDroidDirectory(this).equals(mOldColPath)) {
-                // collection path hasn't been changed so just restart the current activity
-                if ((this instanceof Reviewer) && preferences.getBoolean("tts", false)) {
-                    // Workaround to kick user back to StudyOptions after opening settings from Reviewer
-                    // because onDestroy() of old Activity interferes with TTS in new Activity
-                    finishWithoutAnimation();
-                } else if (mOldTheme != Themes.getCurrentTheme(getApplicationContext())) {
-                    // The current theme was changed, so need to reload the stack with the new theme
-                    restartActivityInvalidateBackstack(this);
-                } else {
-                    restartActivity();
-                }
-            } else {
-                // collection path has changed so kick the user back to the DeckPicker
-                CollectionHelper.getInstance().closeCollection(true, "Preference Modification: collection path changed");
+            // collection path hasn't been changed so just restart the current activity
+            if ((this instanceof Reviewer) && preferences.getBoolean("tts", false)) {
+                // Workaround to kick user back to StudyOptions after opening settings from Reviewer
+                // because onDestroy() of old Activity interferes with TTS in new Activity
+                finishWithoutAnimation();
+            } else if (mOldTheme != Themes.getCurrentTheme(getApplicationContext())) {
+                // The current theme was changed, so need to reload the stack with the new theme
                 restartActivityInvalidateBackstack(this);
+            } else {
+                restartActivity();
             }
         } else {
             super.onActivityResult(requestCode, resultCode, data);
@@ -313,7 +305,6 @@ public abstract class NavigationDrawerActivity extends AnkiActivity implements N
                 mNightModeSwitch.performClick();
             } else if (itemId == R.id.nav_settings) {
                 Timber.i("Navigating to settings");
-                mOldColPath = CollectionHelper.getCurrentAnkiDroidDirectory(NavigationDrawerActivity.this);
                 // Remember the theme we started with so we can restart the Activity if it changes
                 mOldTheme = Themes.getCurrentTheme(getApplicationContext());
                 startActivityForResultWithAnimation(new Intent(NavigationDrawerActivity.this, Preferences.class), REQUEST_PREFERENCES_UPDATE, FADE);

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
@@ -26,7 +26,6 @@ import android.app.PendingIntent;
 import android.content.ActivityNotFoundException;
 import android.content.ComponentName;
 import android.content.Context;
-import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.content.SharedPreferences.OnSharedPreferenceChangeListener;
@@ -116,6 +115,8 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
     private android.preference.CheckBoxPreference mBackgroundImage;
     private static long fileLength;
 
+    /** The collection path when Preferences was opened  */
+    private String mOldCollectionPath = null;
 
     // ----------------------------------------------------------------------------
     // Overridden methods
@@ -129,6 +130,9 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
         getSupportActionBar().setHomeButtonEnabled(true);
         getSupportActionBar().setDisplayHomeAsUpEnabled(true);
         setTitle(getResources().getText(R.string.preferences_title));
+
+        // onRestoreInstanceState takes priority, this is only set on init.
+        mOldCollectionPath = CollectionHelper.getCollectionPath(this);
     }
 
     private Collection getCol() {
@@ -163,6 +167,40 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
         }
         return false;
     }
+
+    @Override
+    public void onBackPressed() {
+        // If the collection path has changed, we want to move back to the deck picker immediately
+        // This performs the move when back is pressed on the "Advanced" screen
+        if (!Utils.equals(CollectionHelper.getCollectionPath(this), mOldCollectionPath)) {
+            restartWithNewDeckPicker();
+        } else {
+            super.onBackPressed();
+        }
+    }
+
+
+    protected void restartWithNewDeckPicker() {
+        // PERF: DB access on foreground thread
+        CollectionHelper.getInstance().closeCollection(true, "Preference Modification: collection path changed");
+        Intent deckPicker = new Intent(this, DeckPicker.class);
+        deckPicker.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_NEW_TASK);
+        startActivity(deckPicker);
+    }
+
+
+    @Override
+    protected void onSaveInstanceState(Bundle outState) {
+        super.onSaveInstanceState(outState);
+        outState.putString("mOldCollectionPath", mOldCollectionPath);
+    }
+
+    @Override
+    protected void onRestoreInstanceState(Bundle state) {
+        super.onRestoreInstanceState(state);
+        mOldCollectionPath = state.getString("mOldCollectionPath");
+    }
+
 
     @Override
     public void onSharedPreferenceChanged(SharedPreferences sharedPreferences, String key) {


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
Before this change, we performed this check on `onActivityResult`.

This was bad, as we had :
* onCreate -> startCollectionLoading -> onCollectionLoaded
* onActivityResult -> closeCollection -> crash

There was also a bug that `mOldColPath` was not saved via `onSaveInstanceState`, this meant "Don't Keep Activities" would cause accessing the preferences to always reopen the collection

## Fixes
Fixes #8422

## Approach
Instead, open the Deck Picker immediately after the "advanced" Window has been closed, if the collection path has changed

## How Has This Been Tested?

On-device testing with "Don't keep Activities"

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
