### PR TITLE
Bump recyclerview to 1.2.0, forward-port deprecated APIs

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -236,7 +236,7 @@ dependencies {
     implementation 'androidx.fragment:fragment:1.3.2'
     implementation 'androidx.localbroadcastmanager:localbroadcastmanager:1.0.0'
     implementation "androidx.preference:preference:1.1.1"
-    implementation 'androidx.recyclerview:recyclerview:1.1.0'
+    implementation 'androidx.recyclerview:recyclerview:1.2.0'
     implementation 'androidx.sqlite:sqlite-framework:2.1.0'
     implementation 'androidx.swiperefreshlayout:swiperefreshlayout:1.1.0'
     implementation 'androidx.viewpager2:viewpager2:1.0.0'

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckSelectionDialog.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckSelectionDialog.java
@@ -98,7 +98,6 @@ public class DeckSelectionDialog extends AnalyticsDialogFragment {
 
         RecyclerView recyclerView = dialogView.findViewById(R.id.deck_picker_dialog_list);
         recyclerView.requestFocus();
-        recyclerView.setHasFixedSize(true);
 
         RecyclerView.LayoutManager deckLayoutManager = new LinearLayoutManager(requireActivity());
         recyclerView.setLayoutManager(deckLayoutManager);

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/LocaleSelectionDialog.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/LocaleSelectionDialog.java
@@ -133,7 +133,6 @@ public class LocaleSelectionDialog extends AnalyticsDialogFragment {
     private void setupRecyclerView(@NonNull Activity activity, @NonNull View tagsDialogView, LocaleListAdapter adapter) {
         RecyclerView recyclerView = tagsDialogView.findViewById(R.id.locale_dialog_selection_list);
         recyclerView.requestFocus();
-        recyclerView.setHasFixedSize(true);
         RecyclerView.LayoutManager layoutManager = new LinearLayoutManager(activity);
         recyclerView.setLayoutManager(layoutManager);
         recyclerView.setAdapter(adapter);

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/TagsDialog.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/TagsDialog.java
@@ -132,7 +132,6 @@ public class TagsDialog extends AnalyticsDialogFragment {
         View tagsDialogView = LayoutInflater.from(getActivity()).inflate(R.layout.tags_dialog, null, false);
         mTagsListRecyclerView = tagsDialogView.findViewById(R.id.tags_dialog_tags_list);
         mTagsListRecyclerView.requestFocus();
-        mTagsListRecyclerView.setHasFixedSize(true);
 
         RecyclerView.LayoutManager tagsListLayout = new LinearLayoutManager(getActivity());
         mTagsListRecyclerView.setLayoutManager(tagsListLayout);

--- a/AnkiDroid/src/main/java/com/ichi2/ui/ButtonItemAdapter.java
+++ b/AnkiDroid/src/main/java/com/ichi2/ui/ButtonItemAdapter.java
@@ -93,7 +93,7 @@ public class ButtonItemAdapter extends RecyclerView.Adapter<ButtonItemAdapter.Bu
         private final ImageButton mButton;
         private final ButtonItemAdapter mAdapter;
 
-        ButtonVH(View itemView, ButtonItemAdapter adapter) {
+        private ButtonVH(View itemView, ButtonItemAdapter adapter) {
             super(itemView);
             mTitle = itemView.findViewById(R.id.card_browser_my_search_name_textview);
             mButton = itemView.findViewById(R.id.card_browser_my_search_remove_button);
@@ -109,10 +109,10 @@ public class ButtonItemAdapter extends RecyclerView.Adapter<ButtonItemAdapter.Bu
                 return;
             }
             if (view instanceof ImageButton) {
-                mAdapter.mButtonCallback.onButtonClicked(mItems.get(getAdapterPosition()));
+                mAdapter.mButtonCallback.onButtonClicked(mItems.get(getBindingAdapterPosition()));
             }
             else {
-                mAdapter.mItemCallback.onItemClicked(mItems.get(getAdapterPosition()));
+                mAdapter.mItemCallback.onItemClicked(mItems.get(getBindingAdapterPosition()));
             }
         }
     }


### PR DESCRIPTION

## Pull Request template

## Purpose / Description

Previous `getAdapterPosition()` API was split to be non-ambiguous

## Approach

`getBindingAdapterPosition()` seems like the correct option to use between
the two new APIs, as the listener appears to be viewed from the adapter context,
not the RecyclerView context (where `getAbsoluteAdapterPosition()` would be correct)

## How Has This Been Tested?

Local `./gradlew jacocoTestReport` plus the API usage was all in card browser saved searches dialog so I made a couple of saved searches then I made sure when I selected them for use or for delete that the correct search was used (or deleted)

## Learning (optional, can help others)

The war against bitrot can be won. Also dependabot really helps in that war.

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
