### PR TITLE
Fix DeckPicker crashing showing "analytics opt in"

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -452,10 +452,10 @@ public class DeckPicker extends NavigationDrawerActivity implements
 
         //we need to restore here, as we need it before super.onCreate() is called.
         restoreWelcomeMessage(savedInstanceState);
-        handleStartup();
 
         // Then set theme and content view
         super.onCreate(savedInstanceState);
+        handleStartup();
         setContentView(R.layout.homescreen);
         View mainView = findViewById(android.R.id.content);
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -1187,7 +1187,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
             Timber.i("AnkiDroid is being updated and a collection already exists.");
             // The user might appreciate us now, see if they will help us get better?
             if (!preferences.contains(UsageAnalytics.ANALYTICS_OPTIN_KEY)) {
-                showDialogFragment(DeckPickerAnalyticsOptInDialog.newInstance());
+                displayAnalyticsOptInDialog();
             }
 
             // For upgrades, we check if we are upgrading
@@ -1324,6 +1324,12 @@ public class DeckPicker extends NavigationDrawerActivity implements
             onFinishedStartup();
         }
     }
+
+    @VisibleForTesting
+    protected void displayAnalyticsOptInDialog() {
+        showDialogFragment(DeckPickerAnalyticsOptInDialog.newInstance());
+    }
+
 
     protected long getPreviousVersion(SharedPreferences preferences, long current) {
         long previous;

--- a/AnkiDroid/src/test/java/com/ichi2/anki/DeckPickerTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/DeckPickerTest.java
@@ -13,7 +13,6 @@ import com.ichi2.libanki.sched.AbstractSched;
 import com.ichi2.testutils.BackendEmulatingOpenConflict;
 import com.ichi2.testutils.BackupManagerTestUtilities;
 
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
@@ -249,7 +248,6 @@ public class DeckPickerTest extends RobolectricTest {
     }
 
     @Test
-    @Ignore("8610")
     public void deckPickerOpensWithHelpMakeAnkiDroidBetterDialog() {
         // Refactor: It would be much better to use a spy - see if we can get this into Robolecteic
         try {

--- a/AnkiDroid/src/test/java/com/ichi2/anki/InitialActivityTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/InitialActivityTest.java
@@ -67,14 +67,25 @@ public class InitialActivityTest extends RobolectricTest {
     }
 
     public static void setupForDatabaseConflict() {
-        ShadowApplication app = Shadows.shadowOf((Application) ApplicationProvider.getApplicationContext());
-        app.grantPermissions(android.Manifest.permission.WRITE_EXTERNAL_STORAGE, android.Manifest.permission.READ_EXTERNAL_STORAGE);
+        grantWritePermissions();
         ShadowEnvironment.setExternalStorageState("mounted");
     }
 
+
+
     public static void setupForDefault() {
+        revokeWritePermissions();
+        ShadowEnvironment.setExternalStorageState("removed");
+    }
+
+
+    protected static void grantWritePermissions() {
+        ShadowApplication app = Shadows.shadowOf((Application) ApplicationProvider.getApplicationContext());
+        app.grantPermissions(android.Manifest.permission.WRITE_EXTERNAL_STORAGE, android.Manifest.permission.READ_EXTERNAL_STORAGE);
+    }
+
+    protected static void revokeWritePermissions() {
         ShadowApplication app = Shadows.shadowOf((Application) ApplicationProvider.getApplicationContext());
         app.denyPermissions(android.Manifest.permission.WRITE_EXTERNAL_STORAGE, android.Manifest.permission.READ_EXTERNAL_STORAGE);
-        ShadowEnvironment.setExternalStorageState("removed");
     }
 }


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
Deck Picker crashed on open

## Fixes
Fixes #8610

## Approach
Move the call after `onCreate`, add test

## How Has This Been Tested?
Regression test: tested DeckPicker open with both permissions and no permissions

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
