### PR TITLE
feat: Enable jacoco reports to be opened

### DIFF
--- a/AnkiDroid/jacoco.gradle
+++ b/AnkiDroid/jacoco.gradle
@@ -56,10 +56,16 @@ tasks.withType(Test) {
 }
 
 // Our merge report task
-task jacocoTestReport(type: JacocoReport, dependsOn: ['jacocoAndroidTestReport', 'jacocoUnitTestReport']) {
+task jacocoTestReport(type: JacocoReport, dependsOn: ['testDebugUnitTest', 'connectedDebugAndroidTest']) {
+    def htmlOutDir = layout.buildDirectory.dir("reports/jacoco/$name/html").get().asFile
+
+    doLast {
+        openReport htmlOutDir
+    }
 
     reports {
         xml.enabled = true
+        html.destination htmlOutDir
     }
 
     def fileFilter = ['**/R.class', '**/R$*.class', '**/BuildConfig.*', '**/Manifest*.*', '**/*Test*.*', 'android/**/*.*']
@@ -99,7 +105,7 @@ task jacocoUnitTestReport(type: JacocoReport, dependsOn: ['testDebugUnitTest']) 
     ])
 }
 
-// Our merge report task
+// A connected android tests only report task
 task jacocoAndroidTestReport(type: JacocoReport, dependsOn: ['connectedDebugAndroidTest']) {
     def htmlOutDir = layout.buildDirectory.dir("reports/jacoco/$name/html").get().asFile
 

--- a/AnkiDroid/jacoco.gradle
+++ b/AnkiDroid/jacoco.gradle
@@ -1,3 +1,5 @@
+import groovy.transform.*
+
 apply plugin: 'jacoco'
 
 jacoco {
@@ -8,6 +10,43 @@ jacoco {
 android {
     jacoco {
         version = "0.8.5"
+    }
+}
+
+@Memoized
+Properties getLocalProperties() {
+    final propertiesFile = project.rootProject.file("local.properties")
+
+    final properties = new Properties()
+
+    if (propertiesFile.exists()) {
+        properties.load(propertiesFile.newDataInputStream())
+    }
+
+    return properties
+}
+
+def openReport(htmlOutDir) {
+    final reportPath = "$htmlOutDir/index.html"
+
+    println "HTML Report: $reportPath"
+
+    if (!project.hasProperty("open-report")) {
+        println "to open the report automatically in your default browser add '-Popen-report' cli argument"
+        return
+    }
+
+    def os = org.gradle.internal.os.OperatingSystem.current()
+    if (os.isWindows()) {
+        exec { commandLine 'cmd', '/c', "start $reportPath" }
+    } else if (os.isMacOsX()) {
+        exec { commandLine 'open', "$reportPath" }
+    } else if (os.isLinux()) {
+        if (localProperties.containsKey("linux-html-cmd")) {
+            exec { commandLine properties.get("linux-html-cmd"), "$reportPath" }
+        } else {
+            println "'linux-html-cmd' property could not be found in 'local.properties'"
+        }
     }
 }
 
@@ -37,9 +76,15 @@ task jacocoTestReport(type: JacocoReport, dependsOn: ['jacocoAndroidTestReport',
 
 // A unit-test only report task
 task jacocoUnitTestReport(type: JacocoReport, dependsOn: ['testDebugUnitTest']) {
+    def htmlOutDir = layout.buildDirectory.dir("reports/jacoco/$name/html").get().asFile
+
+    doLast {
+        openReport htmlOutDir
+    }
 
     reports {
         xml.enabled = true
+        html.destination htmlOutDir
     }
 
     def fileFilter = ['**/R.class', '**/R$*.class', '**/BuildConfig.*', '**/Manifest*.*', '**/*Test*.*', 'android/**/*.*']
@@ -56,9 +101,15 @@ task jacocoUnitTestReport(type: JacocoReport, dependsOn: ['testDebugUnitTest']) 
 
 // Our merge report task
 task jacocoAndroidTestReport(type: JacocoReport, dependsOn: ['connectedDebugAndroidTest']) {
+    def htmlOutDir = layout.buildDirectory.dir("reports/jacoco/$name/html").get().asFile
+
+    doLast {
+        openReport htmlOutDir
+    }
 
     reports {
         xml.enabled = true
+        html.destination htmlOutDir
     }
 
     def fileFilter = ['**/R.class', '**/R$*.class', '**/BuildConfig.*', '**/Manifest*.*', '**/*Test*.*', 'android/**/*.*']

--- a/AnkiDroid/jacoco.gradle
+++ b/AnkiDroid/jacoco.gradle
@@ -42,10 +42,14 @@ def openReport(htmlOutDir) {
     } else if (os.isMacOsX()) {
         exec { commandLine 'open', "$reportPath" }
     } else if (os.isLinux()) {
-        if (localProperties.containsKey("linux-html-cmd")) {
-            exec { commandLine properties.get("linux-html-cmd"), "$reportPath" }
-        } else {
-            println "'linux-html-cmd' property could not be found in 'local.properties'"
+        try {
+            exec { commandLine 'xdg-open', "$reportPath" }
+        } catch (Exception ignored) {
+            if (localProperties.containsKey("linux-html-cmd")) {
+                exec { commandLine properties.get("linux-html-cmd"), "$reportPath" }
+            } else {
+                println "'linux-html-cmd' property could not be found in 'local.properties'"
+            }
         }
     }
 }


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
+ Enables jacoco reports to be opened automatically after a successful task.
+ Print the report `index.html` location

**NOTE:** for Linux users `linux-html-cmd` proproty must be defined in `local.properties` file.

`open-report` argument flag must be provided for this feature to work:
```
./gradlew jacocoAndroidTestReport -Popen-report
```

## Fixes
Fixes #8240

## How Has This Been Tested?

Manually on macOS

## Checklist

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
