### PR TITLE
Fix: 7173 Returning Locale.getDefault

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/utils/LanguageUtil.java
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/LanguageUtil.java
@@ -98,7 +98,6 @@ public class LanguageUtil {
             }
         } else {
             locale = Locale.getDefault();
-
         }
         return locale;
     }

--- a/AnkiDroid/src/main/java/com/ichi2/utils/LanguageUtil.java
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/LanguageUtil.java
@@ -94,10 +94,11 @@ public class LanguageUtil {
                 locale = new Locale(localeParts[0], localeParts[1]);
             } catch (ArrayIndexOutOfBoundsException e) {
                 Timber.w(e, "LanguageUtil::getLocale variant split fail, using code '%s' raw.", localeCode);
-                locale = new Locale(localeCode);
+                locale = Locale.getDefault();
             }
         } else {
-            locale = new Locale(localeCode);
+            locale = Locale.getDefault();
+
         }
         return locale;
     }


### PR DESCRIPTION
## Purpose / Description
Returning Locale.getDefault()

## Fixes
Fixes #7173 

## How Has This Been Tested?

This has been tested on a Real device

## Checklist

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code