### PR TITLE
Lint: Lint rule for use of UIUtils.showSnackbar instead of Snackbar.make

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -3815,15 +3815,16 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
         View parentLayout = findViewById(android.R.id.content);
         String snackbarMsg = getString(R.string.api_version_developer_contact, mCardSuppliedDeveloperContact, errorMsg);
 
-        Snackbar snackbar = Snackbar.make(parentLayout, snackbarMsg, Snackbar.LENGTH_LONG);
-        View snackbarView = snackbar.getView();
-        TextView snackTextView = snackbarView.findViewById(com.google.android.material.R.id.snackbar_text);
-        snackTextView.setTextColor(Color.WHITE);
-        snackTextView.setMaxLines(3);
 
-        snackbar.setActionTextColor(Color.MAGENTA)
-                .setAction(getString(R.string.reviewer_invalid_api_version_visit_documentation), view -> openUrl(Uri.parse("https://github.com/ankidroid/Anki-Android/wiki")));
-
+        Snackbar snackbar = UIUtils.showSnackbar(this,
+                snackbarMsg,
+                false,
+                R.string.reviewer_invalid_api_version_visit_documentation,
+                view -> openUrl(Uri.parse("https://github.com/ankidroid/Anki-Android/wiki")),
+                parentLayout,
+                null);
+        TextView snackbarTextView=snackbar.getView().findViewById(com.google.android.material.R.id.snackbar_text);
+        snackbarTextView.setMaxLines(3);
         snackbar.show();
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -3823,7 +3823,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
                 view -> openUrl(Uri.parse("https://github.com/ankidroid/Anki-Android/wiki")),
                 parentLayout,
                 null);
-        TextView snackbarTextView=snackbar.getView().findViewById(com.google.android.material.R.id.snackbar_text);
+        TextView snackbarTextView = snackbar.getView().findViewById(com.google.android.material.R.id.snackbar_text);
         snackbarTextView.setMaxLines(3);
         snackbar.show();
     }

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/IssueRegistry.java
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/IssueRegistry.java
@@ -4,6 +4,7 @@ import com.android.tools.lint.detector.api.ApiKt;
 import com.android.tools.lint.detector.api.Issue;
 import com.ichi2.anki.lint.rules.ConstantFieldDetector;
 import com.ichi2.anki.lint.rules.DirectCalendarInstanceUsage;
+import com.ichi2.anki.lint.rules.DirectSnackbarMakeUsage;
 import com.ichi2.anki.lint.rules.DirectSystemTimeInstantiation;
 import com.ichi2.anki.lint.rules.DirectSystemCurrentTimeMillisUsage;
 import com.ichi2.anki.lint.rules.DirectDateInstantiation;
@@ -29,6 +30,7 @@ public class IssueRegistry extends com.android.tools.lint.client.api.IssueRegist
         issues.add(DirectCalendarInstanceUsage.ISSUE);
         issues.add(DirectDateInstantiation.ISSUE);
         issues.add(DirectGregorianInstantiation.ISSUE);
+        issues.add(DirectSnackbarMakeUsage.ISSUE);
         issues.add(DirectSystemCurrentTimeMillisUsage.ISSUE);
         issues.add(DirectSystemTimeInstantiation.ISSUE);
         issues.add(DirectToastMakeTextUsage.ISSUE);

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/rules/DirectSnackbarMakeUsage.java
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/DirectSnackbarMakeUsage.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2021 Mrudul Tora <mrudultora@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.lint.rules;
+
+import com.android.tools.lint.client.api.JavaEvaluator;
+import com.android.tools.lint.detector.api.Detector;
+import com.android.tools.lint.detector.api.Implementation;
+import com.android.tools.lint.detector.api.Issue;
+import com.android.tools.lint.detector.api.JavaContext;
+import com.android.tools.lint.detector.api.Scope;
+import com.android.tools.lint.detector.api.SourceCodeScanner;
+import com.google.common.annotations.VisibleForTesting;
+import com.ichi2.anki.lint.utils.Constants;
+import com.ichi2.anki.lint.utils.LintUtils;
+import com.intellij.psi.PsiMethod;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.jetbrains.uast.UCallExpression;
+import org.jetbrains.uast.UClass;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * This custom Lint rules will raise an error if a developer uses the {com.google.android.material.snackbar.Snackbar#make(...)} method
+ * instead of using the method provided by the UIUtils class {com.ichi2.anki.UIUtils#showSimpleSnackbar(...)}
+ * or {com.ichi2.anki.UIUtils#showSnackbar(...)}.
+ */
+public class DirectSnackbarMakeUsage extends Detector implements SourceCodeScanner {
+
+    @VisibleForTesting
+    static final String ID = "DirectSnackbarMakeUsage";
+
+    @VisibleForTesting
+    static final String DESCRIPTION = "Use UIUtils.showSimpleSnackbar or UIUtils.showSnackbar instead of Snackbar.make";
+
+    private static final String EXPLANATION = "To improve code consistency within the codebase you should use UIUtils.showSimpleSnackbar or UIUtils.showSnackbar " +
+            "in place of the library Snackbar.make(...).show()";
+
+    private static final Implementation implementation = new Implementation(DirectSnackbarMakeUsage.class, Scope.JAVA_FILE_SCOPE);
+
+    public static final Issue ISSUE = Issue.create(
+            ID,
+            DESCRIPTION,
+            EXPLANATION,
+            Constants.ANKI_CODE_STYLE_CATEGORY,
+            Constants.ANKI_CODE_STYLE_PRIORITY,
+            Constants.ANKI_CODE_STYLE_SEVERITY,
+            implementation
+    );
+
+
+    public DirectSnackbarMakeUsage() {
+
+    }
+
+
+    @Nullable
+    @Override
+    public List<String> getApplicableMethodNames() {
+        List<String> forbiddenMethods = new ArrayList<>();
+        forbiddenMethods.add("make");
+        return forbiddenMethods;
+    }
+
+
+    @Override
+    public void visitMethodCall(@NotNull JavaContext context, @NotNull UCallExpression node, @NotNull PsiMethod method) {
+        super.visitMethodCall(context, node, method);
+        JavaEvaluator evaluator = context.getEvaluator();
+        List<UClass> foundClasses = context.getUastFile().getClasses();
+        if (!LintUtils.isAnAllowedClass(foundClasses, "UIUtils")
+                && evaluator.isMemberInClass(method, "com.google.android.material.snackbar.Snackbar")) {
+            context.report(
+                    ISSUE,
+                    node,
+                    context.getCallLocation(node, true, true),
+                    DESCRIPTION
+            );
+        }
+    }
+
+}

--- a/lint-rules/src/test/java/com/ichi2/anki/lint/rules/DirectSnackbarMakeUsageTest.java
+++ b/lint-rules/src/test/java/com/ichi2/anki/lint/rules/DirectSnackbarMakeUsageTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2021 Mrudul Tora <mrudultora@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.lint.rules;
+
+import org.intellij.lang.annotations.Language;
+import org.junit.Test;
+
+import static com.android.tools.lint.checks.infrastructure.TestFile.JavaTestFile.create;
+import static com.android.tools.lint.checks.infrastructure.TestLintTask.lint;
+import static org.junit.Assert.assertTrue;
+
+public class DirectSnackbarMakeUsageTest {
+    @Language("JAVA")
+    private final String stubSnackbar = "                                      \n" +
+            "package com.google.android.material.snackbar;                     \n" +
+            "public class Snackbar {                                           \n" +
+            "                                                                  \n" +
+            "    public static Snackbar make(View view,                        \n" +
+            "                                CharSequence text,                \n" +
+            "                                int duration) {                   \n" +
+            "         // Stub                                                  \n" +
+            "    }                                                             \n" +
+            "}                                                                 \n";
+
+    @Language("JAVA")
+    private final String javaFileToBeTested = "                             \n" +
+            "package com.ichi2.anki.lint.rules;                             \n" +
+            "                                                               \n" +
+            "import com.google.android.material.snackbar.Snackbar;          \n" +
+            "                                                               \n" +
+            "public class TestJavaClass {                                   \n" +
+            "                                                               \n" +
+            "    public static void main(String[] args) {                   \n" +
+            "        Snackbar snackbar = Snackbar.make();                   \n" +
+            "        snackbar.show();                                       \n" +
+            "    }                                                          \n" +
+            "}                                                              \n";
+
+    @Language("JAVA")
+    private final String javaFileWithUIUtils = "                            \n" +
+            "package com.ichi2.anki.lint.rules;                             \n" +
+            "                                                               \n" +
+            "import com.google.android.material.snackbar.Snackbar;          \n" +
+            "                                                               \n" +
+            "public class UIUtils {                                         \n" +
+            "                                                               \n" +
+            "    public static void main(String[] args) {                   \n" +
+            "        Snackbar snackbar = Snackbar.make();                   \n" +
+            "        snackbar.show();                                       \n" +
+            "    }                                                          \n" +
+            "}                                                              \n";
+
+
+    @Test
+    public void showsErrorsForInvalidUsage() {
+        lint()
+                .allowMissingSdk()
+                .allowCompilationErrors()
+                .files(create(stubSnackbar), create(javaFileToBeTested))
+                .issues(DirectSnackbarMakeUsage.ISSUE)
+                .run()
+                .expectErrorCount(1)
+                .check(output -> {
+                    assertTrue(output.contains(DirectSnackbarMakeUsage.ID));
+                    assertTrue(output.contains(DirectSnackbarMakeUsage.DESCRIPTION));
+                });
+    }
+
+
+    @Test
+    public void allowsUsageForUIUtils() {
+        lint()
+                .allowMissingSdk()
+                .allowCompilationErrors()
+                .files(create(stubSnackbar), create(javaFileWithUIUtils))
+                .issues(DirectSnackbarMakeUsage.ISSUE)
+                .run()
+                .expectClean();
+    }
+}


### PR DESCRIPTION
## Purpose / Description
The methods to use Snackbars must be from UIUtils class rather than using them directly (Snackbar.make(...)).

## Fixes
None

## Approach
Added a lint rule to check this. And, removed the currently used Snackbar.make(....).

![Untitled](https://user-images.githubusercontent.com/65870389/114904060-12c09b80-9e35-11eb-9b5e-a8428b7443e9.png)

# Screenshots
![img](https://user-images.githubusercontent.com/65870389/114921756-8c15b980-9e48-11eb-8378-a1600d6f5f31.jpg)

This screenshot is fix for the existing lint errors (related to this PR).

## How Has This Been Tested?
Unit tests passing and `gradlew lintRelease` successful.

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [x] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
