### PR TITLE
Repair a crash on tablet

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/stats/AnkiStatsTaskHandler.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/stats/AnkiStatsTaskHandler.java
@@ -233,15 +233,16 @@ public class AnkiStatsTaskHandler {
             sLock.lock();
             try {
                 Collection collection = params[0].first;
+
+                TextView textView = params[0].second;
+                mTextView = new WeakReference<>(textView);
+
                 if (!mIsRunning || collection == null || collection.getDb() == null) {
                     Timber.d("Quitting DeckPreviewStatistics before execution");
                     return null;
                 } else {
                     Timber.d("Starting DeckPreviewStatistics");
                 }
-
-                TextView textView = params[0].second;
-                mTextView = new WeakReference<>(textView);
 
                 //eventually put this in Stats (in desktop it is not though)
                 int cards;

--- a/AnkiDroid/src/main/java/com/ichi2/anki/stats/AnkiStatsTaskHandler.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/stats/AnkiStatsTaskHandler.java
@@ -220,11 +220,10 @@ public class AnkiStatsTaskHandler {
     private static class DeckPreviewStatistics extends AsyncTask<Pair<Collection, TextView>, Void, String> {
         private WeakReference<TextView> mTextView;
 
-        private boolean mIsRunning = false;
+        private boolean mIsRunning = true;
 
         public DeckPreviewStatistics() {
             super();
-            mIsRunning = true;
         }
 
         @Override


### PR DESCRIPTION
ensure that mTextView is not null

After installing a new version of ankidroid from master and syncing, I got the message

```
    java.lang.NullPointerException: Attempt to invoke virtual method 'java.lang.Object java.lang.ref.WeakReference.get()' on a null object reference
        at com.ichi2.anki.stats.AnkiStatsTaskHandler$DeckPreviewStatistics.onPostExecute(AnkiStatsTaskHandler.java:275)
        at com.ichi2.anki.stats.AnkiStatsTaskHandler$DeckPreviewStatistics.onPostExecute(AnkiStatsTaskHandler.java:220)
        at android.os.AsyncTask.finish(AsyncTask.java:755)
        at android.os.AsyncTask.access$900(AsyncTask.java:192)
        at android.os.AsyncTask$InternalHandler.handleMessage(AsyncTask.java:772)
        at android.os.Handler.dispatchMessage(Handler.java:107)
        at android.os.Looper.loop(Looper.java:237)
        at android.app.ActivityThread.main(ActivityThread.java:8107)
        at java.lang.reflect.Method.invoke(Native Method)
        at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:496)
        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1100)
```

I suspect that it is because collection or the db is empty (normal after a sync. )


This solves it by ensuring that the value is set before it is returned