### PR TITLE
Clear ACRA on cancel, use ACRA data for rate limit

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/analytics/AnkiDroidCrashReportDialog.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/analytics/AnkiDroidCrashReportDialog.java
@@ -116,6 +116,11 @@ public class AnkiDroidCrashReportDialog extends CrashReportDialog implements Dia
             // Send the crash report
             mHelper.sendCrash(mUserComment.getText().toString(), "");
         } else {
+            // If the user got to the dialog, they were not limited.
+            // The limiter persists it's limit info *before* the user cancels.
+            // Therefore, on cancel, purge limits to make sure the user may actually send in future.
+            // Better to maybe send to many reports than definitely too few.
+            AnkiDroidApp.deleteACRALimiterData(this);
             mHelper.cancelReports();
         }
 


### PR DESCRIPTION
## Pull Request template

## Purpose / Description

If the user canceled, they should not be limited in the future

## Fixes
Fixes #8379
Supercedes #8432

## Approach
- the limiter should have the best source of info for rate limiting, not an internal static timestamp thing
- the limiter stores report timestamps when generated, not approved though, so clear on cancel
- I snuck in some access limitation changes to de-lint AndroidStudio in the area

Currently doing something distasteful in order to access the limiter data but it I have positive confirmation from upstream that the next version of ACRA allows it with no reflection:

https://github.com/ACRA/acra/issues/843#issuecomment-820784697

```java
long mostRecentTimestamp = LimiterData.load(this).getReportMetadata().stream()
    .filter(report -> report.getExceptionClass().equals(UserSubmittedException.class.getName()))
    .mapToLong(report -> report.getTimestamp().getTimeInMillis())
    .max().orElse(-1);
```

I will file a separate issue to update to ACRA 5.8.0 with that information and a pointer to this code to remove the reflection

## How Has This Been Tested?

Oh, so much clicking and log watching on an API30 emulator

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
