### PR TITLE
Dependency updates 20210415

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -33,15 +33,18 @@ jobs:
     timeout-minutes: 15
     runs-on: ubuntu-latest
     steps:
-      - uses: styfle/cancel-workflow-action@0.8.0
+      - uses: styfle/cancel-workflow-action@0.9.0
+        with:
+          all_but_latest: true
 
       - uses: actions/checkout@v2
         with:
           fetch-depth: 1
 
       - name: Configure JDK 1.11
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v2
         with:
+          distribution: "adopt"
           java-version: "11" # ubuntu-latest is about to default to 11, force it everywhere
 
       - name: Verify JDK11

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,8 +18,9 @@ jobs:
           key: gradle-${{ hashFiles('**/*.gradle*') }}-v1
 
       - name: Configure JDK 1.11
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v2
         with:
+          distribution: "adopt"
           java-version: "11" # ubuntu-latest is about to default to 11, force it everywhere
 
       - name: Verify JDK11
@@ -47,7 +48,7 @@ jobs:
           git remote set-url origin git@github.com:$GITHUB_REPOSITORY
         shell: bash
 
-      - uses: webfactory/ssh-agent@v0.4.1
+      - uses: webfactory/ssh-agent@v0.5.2
         with:
           ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
 

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/stale@v1
+    - uses: actions/stale@v3
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         stale-issue-message: 'Hello 👋, this issue has been opened for more than 2 months with no activity on it. If the issue is still here, please keep in mind that we need community support and help to fix it! Just comment something like _still searching for solutions_ and if you found one, please open a pull request! You have 7 days until this gets closed automatically'

--- a/.github/workflows/tests_emulator.yml
+++ b/.github/workflows/tests_emulator.yml
@@ -36,7 +36,9 @@ jobs:
       EMULATOR_COMMAND: "-avd TestingAVD -noaudio -gpu swiftshader_indirect -camera-back none -no-snapshot -no-window -no-boot-anim -nojni -memory 2048 -timezone 'Europe/London' -cores 2"
       EMULATOR_EXECUTABLE: qemu-system-x86_64-headless
     steps:
-      - uses: styfle/cancel-workflow-action@0.8.0
+      - uses: styfle/cancel-workflow-action@0.9.0
+        with:
+          all_but_latest: true
 
       - uses: actions/checkout@v2
         with:
@@ -49,8 +51,9 @@ jobs:
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*') }}-v1
 
       - name: Configure JDK 1.11
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v2
         with:
+          distribution: "adopt"
           java-version: "11" # ubuntu-latest is about to default to 11, force it everywhere
 
       - name: Verify JDK11

--- a/.github/workflows/tests_unit.yml
+++ b/.github/workflows/tests_unit.yml
@@ -35,15 +35,18 @@ jobs:
     #env:
     #  CODACY_TOKEN: ${{ secrets.CODACY_TOKEN }}
     steps:
-      - uses: styfle/cancel-workflow-action@0.8.0
+      - uses: styfle/cancel-workflow-action@0.9.0
+        with:
+          all_but_latest: true
 
       - uses: actions/checkout@v2
         with:
           fetch-depth: 50
 
       - name: Configure JDK 1.11
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v2
         with:
+          distribution: "adopt"
           java-version: "11" # ubuntu-latest is about to default to 11, force it everywhere
 
       - name: Verify JDK11

--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -252,7 +252,7 @@ dependencies {
     // build with ./gradlew rsdroid:assembleRelease
     // In my experience, using `files()` currently requires a reindex operation, which is slow.
     // implementation files("C:\\GitHub\\Rust-Test\\rsdroid\\build\\outputs\\aar\\rsdroid-release.aar")
-    implementation 'com.google.protobuf:protobuf-java:3.15.7' // This is required when loading from a file
+    implementation 'com.google.protobuf:protobuf-java:3.15.8' // This is required when loading from a file
     implementation "io.github.david-allison-1:anki-android-backend:$backendVersion"
     // build with ./gradlew rsdroid-testing:assembleRelease
     // RobolectricTest.java: replace RustBackendLoader.init(); with RustBackendLoader.loadRsdroid(path);

--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -260,10 +260,10 @@ dependencies {
     testImplementation "io.github.david-allison-1:anki-android-backend-testing:$backendVersion"
 
     // May need a resolution strategy for support libs to our versions
-    implementation'ch.acra:acra-http:5.5.1'
-    implementation'ch.acra:acra-dialog:5.5.1'
-    implementation'ch.acra:acra-toast:5.5.1'
-    implementation'ch.acra:acra-limiter:5.5.1'
+    implementation'ch.acra:acra-http:5.7.0'
+    implementation'ch.acra:acra-dialog:5.7.0'
+    implementation'ch.acra:acra-toast:5.7.0'
+    implementation'ch.acra:acra-limiter:5.7.0'
 
     implementation 'io.requery:sqlite-android:3.34.1'
     implementation 'com.afollestad.material-dialogs:core:0.9.6.0'


### PR DESCRIPTION

Standard dependency updates PR - each commit has notes

ACRA was tested by me locally (as part of #8629 I checked 5.7.0) and the workflow changes can't be verified until we see them run here...