### PR TITLE
WIP Java16 support - not working yet / proof-of-concept

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -1,6 +1,6 @@
 plugins {
  // Gradle plugin portal 
- id 'com.github.triplet.play' version '3.5.0-agp7.0'
+ id 'com.github.triplet.play' version '3.6.0'
 }
 
 apply plugin: 'com.android.application'

--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -140,7 +140,7 @@ android {
 
         // We want the same version stream for all ABIs in debug but for release we can split them
         if (variant.buildType.name == 'release') {
-            variant.outputs.each { output ->
+            variant.outputs.all { output ->
 
                 // For each separate APK per architecture, set a unique version code as described here:
                 // https://developer.android.com/studio/build/configure-apk-splits.html

--- a/build.gradle
+++ b/build.gradle
@@ -35,11 +35,11 @@ allprojects {
 ext {
 
     jvmVersion = Jvm.current().javaVersion.majorVersion
-    if (jvmVersion != "11" && jvmVersion != "14") {
+    if (jvmVersion != "11" && jvmVersion != "14" && jvmVersion != "16") {
         println "\n\n\n"
         println "**************************************************************************************************************"
         println "\n\n\n"
-        println "ERROR: AnkiDroid builds with JVM 11 and 14"
+        println "ERROR: AnkiDroid builds with JVM version 11, 14, or 16."
         println "  Incompatible major version detected: '" + jvmVersion + "'"
         println "\n\n\n"
         println "**************************************************************************************************************"


### PR DESCRIPTION
## Pull Request template

## Purpose / Description

Support JDK16 for development

## Fixes
Fixes #8434 

## Approach

- update google play publisher plugin to 3.7.0 (just released, works with our new android gradle plugin 7.0 only)
- clean up JDK compatibility message
- clean up usage of variants in gradle file to match current recommended syntax

## How Has This Been Tested?

On linux with JDK11 (this should cover most developers)

On macOS 

```bash
brew install adoptopenjdk16
export JAVA_HOME=$(/usr/libexec/java_home -v16)
export PATH=$JAVA_HOME/bin:$PATH
./gradlew clean jacocoTestReport
```

## Learning (optional, can help others)

Bleeding edge is bleeding.

## Checklist
_Please, go through these checks before submitting the PR._

- [ ] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [ ] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [ ] You have commented your code, particularly in hard-to-understand areas
- [ ] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
