### PR TITLE
Feat: Use androidx activity result api in AnkiActivity

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anim/ActivityTransitionAnimation.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anim/ActivityTransitionAnimation.java
@@ -37,7 +37,8 @@ public class ActivityTransitionAnimation {
         case NONE:
             activity.overridePendingTransition(R.anim.none, R.anim.none);
             break;
-        default: //DOWN:
+        case DOWN:
+        default:
             // this is the default animation, we shouldn't try to override it
         }
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anim/ActivityTransitionAnimation.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anim/ActivityTransitionAnimation.java
@@ -6,6 +6,8 @@ import android.content.Context;
 import android.util.LayoutDirection;
 import com.ichi2.anki.R;
 
+import androidx.core.app.ActivityOptionsCompat;
+
 public class ActivityTransitionAnimation {
     public static void slide(Activity activity, Direction direction) {
         switch (direction) {
@@ -37,6 +39,32 @@ public class ActivityTransitionAnimation {
             break;
         default: //DOWN:
             // this is the default animation, we shouldn't try to override it
+        }
+    }
+
+
+    public static ActivityOptionsCompat getAnimationOptions(Activity activity, Direction direction) {
+        switch (direction) {
+            case START:
+                return isRightToLeft(activity)
+                    ? ActivityOptionsCompat.makeCustomAnimation(activity, R.anim.slide_right_in, R.anim.slide_right_out)
+                    : ActivityOptionsCompat.makeCustomAnimation(activity, R.anim.slide_left_in, R.anim.slide_left_out);
+            case END:
+                return isRightToLeft(activity)
+                    ? ActivityOptionsCompat.makeCustomAnimation(activity, R.anim.slide_left_in, R.anim.slide_left_out)
+                    : ActivityOptionsCompat.makeCustomAnimation(activity, R.anim.slide_right_in, R.anim.slide_right_out);
+            case FADE:
+                return ActivityOptionsCompat.makeCustomAnimation(activity, R.anim.fade_out, R.anim.fade_in);
+            case UP:
+                return ActivityOptionsCompat.makeCustomAnimation(activity, R.anim.slide_up_in, R.anim.slide_up_out);
+            case DIALOG_EXIT:
+                return ActivityOptionsCompat.makeCustomAnimation(activity, R.anim.none, R.anim.dialog_exit);
+            case NONE:
+                return ActivityOptionsCompat.makeCustomAnimation(activity, R.anim.none, R.anim.none);
+            case DOWN:
+            default:
+                // this is the default animation, we shouldn't try to override it
+                return ActivityOptionsCompat.makeBasic();
         }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiActivity.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiActivity.java
@@ -14,6 +14,7 @@ import android.media.AudioManager;
 import android.net.Uri;
 import android.os.Bundle;
 
+import androidx.activity.result.ActivityResultLauncher;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatDelegate;
 import androidx.appcompat.widget.Toolbar;
@@ -255,6 +256,28 @@ public class AnkiActivity extends AppCompatActivity implements SimpleMessageDial
         enableIntentAnimation(intent);
         startActivityForResult(intent, requestCode);
         enableActivityAnimation(animation);
+    }
+
+
+    public void launchActivityForResult(Intent intent, ActivityResultLauncher<Intent> launcher, Direction animation) {
+        try {
+            launcher.launch(intent, ActivityTransitionAnimation.getAnimationOptions(this, animation));
+        } catch (ActivityNotFoundException e) {
+            Timber.w(e);
+            UIUtils.showSimpleSnackbar(this, R.string.activity_start_failed, true);
+        }
+    }
+
+
+    public void launchActivityForResultWithoutAnimation(Intent intent, ActivityResultLauncher<Intent> launcher) {
+        disableIntentAnimation(intent);
+        launchActivityForResult(intent, launcher, NONE);
+    }
+
+
+    public void launchActivityForResultWithAnimation(Intent intent, ActivityResultLauncher<Intent> launcher, Direction animation) {
+        enableIntentAnimation(intent);
+        launchActivityForResult(intent, launcher, animation);
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -1306,7 +1306,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
 
     protected void onPreview() {
         Intent previewer = getPreviewIntent();
-        mOnPreviewCardsActivityResult.launch(previewer);
+        this.launchActivityForResultWithoutAnimation(previewer, mOnPreviewCardsActivityResult);
     }
 
 


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
The old method of passing information to / starting / receiving results from one Activity to/from another Activity is deprecated in general, here we start refactoring the code to use the new androidx.activity APIs for such communication

## Fixes
Fixes (only partially) https://github.com/ankidroid/Anki-Android/issues/8602


## Approach
Each `startActivityForResult` and corresponding case in `onActivityResult` is refactored to use the new API.
This PR introduce complementary methods for those to start an activity in `AnkiActivity` to instead "launch" it through an `ActivityResultLauncher`, configuring it with the right transitions and animations. This base methods are then used in `CardBrowser` to manage the communication with other Activities from which a result is expected.
In order to be sure that the style looks good before moving to the others, I just refactored the code in `CardBrowser` to give an example. I will cleanup `AnkiActivity` as soon as all communications will be ported to the new APIs.

## How Has This Been Tested?
On emulators: API 30 and API 25.

## Learning (optional, can help others)
https://developer.android.com/training/basics/intents/result

## Checklist

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
