### PR TITLE
Fix: Duplicate cards shown in Card Browser

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
@@ -1058,7 +1058,7 @@ public class CollectionTask<ProgressListener, ProgressBackground extends Progres
         private final Collection mCol;
 
         public PartialSearch(List<CardBrowser.CardCache> cards, int columnIndex1, int columnIndex2, int numCardsToRender, ProgressSenderAndCancelListener<List<CardBrowser.CardCache>> collectionTask, Collection col) {
-            mCards = cards;
+            mCards = new ArrayList<>(cards);
             mColumn1Index = columnIndex1;
             mColumn2Index = columnIndex2;
             mNumCardsToRender = numCardsToRender;
@@ -1113,7 +1113,7 @@ public class CollectionTask<ProgressListener, ProgressBackground extends Progres
                         return;
                     }
                     mRes.add(value);
-                    if (mRes.size() > getNumCardsToRender()) {
+                    if (mRes.size() >= getNumCardsToRender()) {
                         PartialSearch.this.doProgress(mRes);
                         mSendProgress = false;
                     }

--- a/AnkiDroid/src/test/java/com/ichi2/async/AbstractCollectionTaskTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/async/AbstractCollectionTaskTest.java
@@ -38,4 +38,10 @@ public abstract class AbstractCollectionTaskTest extends RobolectricTest {
             throw new RuntimeException(e);
         }
     }
+
+    protected <Progress, Result> void waitForTask(CollectionTask.Task<Progress, Result> task, TaskListener<Progress, Result> listener) {
+        TaskManager.launchCollectionTask(task, listener);
+
+        waitForAsyncTasksToComplete();
+    }
 }

--- a/AnkiDroid/src/test/java/com/ichi2/async/CollectionTaskSearchCardsTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/async/CollectionTaskSearchCardsTest.java
@@ -1,0 +1,63 @@
+/*
+ *  Copyright (c) 2021 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.async;
+
+import com.ichi2.anki.CardBrowser;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+
+import java.util.List;
+
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@RunWith(AndroidJUnit4.class)
+public class CollectionTaskSearchCardsTest extends AbstractCollectionTaskTest {
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void searchCardsNumberOfResultCount() {
+        addNoteUsingBasicModel("Hello", "World");
+        addNoteUsingBasicModel("One", "Two");
+
+        int cardsToRender = 1;
+        int numberOfCards = 2;
+
+        CollectionTask.SearchCards task = new CollectionTask.SearchCards("", false, cardsToRender, 0, 0);
+        TaskListener<List<CardBrowser.CardCache>, List<CardBrowser.CardCache>> listener = mock(TaskListener.class);
+
+        waitForTask(task, listener);
+
+        verify(listener, times(1)).onPreExecute();
+
+        ArgumentCaptor<List<CardBrowser.CardCache>> argumentCaptor = ArgumentCaptor.forClass(List.class);
+        verify(listener, times(1)).onProgressUpdate(argumentCaptor.capture());
+        assertThat("OnProgress sends the provided number of cards to render", argumentCaptor.getValue().size(), is(cardsToRender));
+
+        ArgumentCaptor<List<CardBrowser.CardCache>> argumentCaptor2 = ArgumentCaptor.forClass(List.class);
+        verify(listener, times(1)).onPostExecute(argumentCaptor2.capture());
+        assertThat("All cards should be provided on Post Execute", argumentCaptor2.getValue().size(), is(numberOfCards));
+
+    }
+}


### PR DESCRIPTION
## Purpose / Description
Main issue: we weren't duplicating the list, leading to prefetched cards bring added twice

The other issue was an off-by-one error in the count of cards to pre render. This didn't matter too much, but we returned one more than was requested

## Fixes
Fixes #8547

## Approach
Clone the list, and use the correct comparison

## How Has This Been Tested?

Unit tested and tested on-device

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
