### PR TITLE
Card Browser, NoteEditor And Statistics : Improve "Search Deck" UX 

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -765,13 +765,13 @@ public class CardBrowser extends NavigationDrawerActivity implements
 
     private void selectDeckAndSave(long deckId) {
         mDeckSpinnerSelection.selectDeckById(deckId);
-        if (deckId == ALL_DECKS_ID){
+        if (deckId == ALL_DECKS_ID) {
             mRestrictOnDeck = "";
-            saveLastDeckId(ALL_DECKS_ID);
         } else {
             String deckName = getCol().getDecks().name(deckId);
             mRestrictOnDeck = "deck:\"" + deckName + "\" ";
         }
+        saveLastDeckId(deckId);
         searchCards();
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -37,7 +37,6 @@ import com.google.android.material.snackbar.Snackbar;
 
 import androidx.annotation.Nullable;
 import androidx.annotation.VisibleForTesting;
-import androidx.appcompat.app.ActionBar;
 import androidx.appcompat.widget.SearchView;
 import android.text.TextUtils;
 import android.util.Pair;
@@ -127,7 +126,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
             return;
         }
         long deckId = deck.getDeckId();
-        mDeckSpinnerSelection.inizatizeActionBarDeckSpinner();
+        mDeckSpinnerSelection.initializeActionBarDeckSpinner();
         selectDeckAndSave(deckId);
     }
 
@@ -751,7 +750,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
 
         long deckId = getCol().getDecks().selected();
         mDeckSpinnerSelection = new DeckSpinnerSelection(CardBrowser.this, R.id.toolbar_spinner, false);
-        mDeckSpinnerSelection.inizatizeActionBarDeckSpinner();
+        mDeckSpinnerSelection.initializeActionBarDeckSpinner();
         selectDeckAndSave(deckId);
 
         // If a valid value for last deck exists then use it, otherwise use libanki selected deck

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -749,7 +749,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
         getWindow().setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_ALWAYS_HIDDEN);
 
         long deckId = getCol().getDecks().selected();
-        mDeckSpinnerSelection = new DeckSpinnerSelection(CardBrowser.this, R.id.toolbar_spinner, false);
+        mDeckSpinnerSelection = new DeckSpinnerSelection(this, R.id.toolbar_spinner);
         mDeckSpinnerSelection.initializeActionBarDeckSpinner();
         selectDeckAndSave(deckId);
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -63,6 +63,7 @@ import com.afollestad.materialdialogs.MaterialDialog;
 import com.ichi2.anki.dialogs.CardBrowserMySearchesDialog;
 import com.ichi2.anki.dialogs.CardBrowserOrderDialog;
 import com.ichi2.anki.dialogs.ConfirmationDialog;
+import com.ichi2.anki.dialogs.DeckSelectionDialog;
 import com.ichi2.anki.dialogs.IntegerDialog;
 import com.ichi2.anki.dialogs.RescheduleDialog;
 import com.ichi2.anki.dialogs.SimpleMessageDialog;
@@ -82,6 +83,7 @@ import com.ichi2.libanki.Consts;
 import com.ichi2.libanki.Decks;
 import com.ichi2.libanki.Utils;
 import com.ichi2.libanki.Deck;
+import com.ichi2.libanki.stats.Stats;
 import com.ichi2.themes.Themes;
 import com.ichi2.upgrade.Upgrade;
 import com.ichi2.utils.BooleanGetter;
@@ -115,7 +117,20 @@ import static com.ichi2.libanki.stats.Stats.SECONDS_PER_DAY;
 import static com.ichi2.anim.ActivityTransitionAnimation.Direction.*;
 
 public class CardBrowser extends NavigationDrawerActivity implements
-        DeckDropDownAdapter.SubtitleListener, TagsDialogListener {
+        DeckDropDownAdapter.SubtitleListener,
+        DeckSelectionDialog.DeckSelectionListener,
+        TagsDialogListener {
+
+    @Override
+    public void onDeckSelected(@Nullable DeckSelectionDialog.SelectableDeck deck) {
+        if (deck == null) {
+            return;
+        }
+        long deckId = deck.getDeckId();
+        mDeckSpinnerSelection.inizatizeActionBarDeckSpinner();
+        selectDeckAndSave(deckId);
+    }
+
 
     enum Column {
         QUESTION,
@@ -143,7 +158,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
     * When the list is changed, the position member of its elements should get changed.*/
     @NonNull
     private CardCollection<CardCache> mCards = new CardCollection<>();
-    private List<Deck> mDropDownDecks;
+    public DeckSpinnerSelection mDeckSpinnerSelection;
     private ListView mCardsListView;
     private SearchView mSearchView;
     private MultiColumnListAdapter mCardsAdapter;
@@ -266,8 +281,6 @@ public class CardBrowser extends NavigationDrawerActivity implements
         EDITED,
     };
     private long mLastRenderStart = 0;
-    private DeckDropDownAdapter mDropDownAdapter;
-    private Spinner mActionBarSpinner;
     private TextView mActionBarTitle;
     private boolean mReloadRequired = false;
     private boolean mInMultiSelectMode = false;
@@ -599,28 +612,6 @@ public class CardBrowser extends NavigationDrawerActivity implements
         // Load reference to action bar title
         mActionBarTitle = findViewById(R.id.toolbar_title);
 
-        // Add drop-down menu to select deck to action bar.
-        mDropDownDecks = getCol().getDecks().allSorted();
-        mDropDownAdapter = new DeckDropDownAdapter(this, mDropDownDecks);
-        ActionBar mActionBar = getSupportActionBar();
-        if (mActionBar != null) {
-            mActionBar.setDisplayShowTitleEnabled(false);
-        }
-        mActionBarSpinner = findViewById(R.id.toolbar_spinner);
-        mActionBarSpinner.setAdapter(mDropDownAdapter);
-        mActionBarSpinner.setOnItemSelectedListener(new OnItemSelectedListener() {
-            @Override
-            public void onItemSelected(AdapterView<?> parent, View view, int position, long id) {
-                deckDropDownItemChanged(position);
-            }
-
-            @Override
-            public void onNothingSelected(AdapterView<?> parent) {
-                // do nothing
-            }
-        });
-        mActionBarSpinner.setVisibility(View.VISIBLE);
-
         mOrder = CARD_ORDER_NONE;
         String colOrder = getCol().getConf().getString("sortType");
         for (int c = 0; c < fSortTypes.length; ++c) {
@@ -758,15 +749,33 @@ public class CardBrowser extends NavigationDrawerActivity implements
 
         getWindow().setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_ALWAYS_HIDDEN);
 
+        long deckId = getCol().getDecks().selected();
+        mDeckSpinnerSelection = new DeckSpinnerSelection(CardBrowser.this, R.id.toolbar_spinner, false);
+        mDeckSpinnerSelection.inizatizeActionBarDeckSpinner();
+        selectDeckAndSave(deckId);
+
         // If a valid value for last deck exists then use it, otherwise use libanki selected deck
         if (getLastDeckId() != null && getLastDeckId() == ALL_DECKS_ID) {
             selectAllDecks();
         } else  if (getLastDeckId() != null && getCol().getDecks().get(getLastDeckId(), false) != null) {
-            selectDeckById(getLastDeckId());
+            mDeckSpinnerSelection.selectDeckById(getLastDeckId());
         } else {
-            selectDeckById(getCol().getDecks().selected());
+            mDeckSpinnerSelection.selectDeckById(getCol().getDecks().selected());
         }
     }
+
+    private void selectDeckAndSave(long deckId) {
+        mDeckSpinnerSelection.selectDeckById(deckId);
+        if (deckId == ALL_DECKS_ID){
+            mRestrictOnDeck = "";
+            saveLastDeckId(ALL_DECKS_ID);
+        } else {
+            String deckName = getCol().getDecks().name(deckId);
+            mRestrictOnDeck = "deck:\"" + deckName + "\" ";
+        }
+        searchCards();
+    }
+
 
 
     @Override
@@ -841,7 +850,8 @@ public class CardBrowser extends NavigationDrawerActivity implements
 
     @VisibleForTesting
     void selectAllDecks() {
-        selectDropDownItem(0);
+        mDeckSpinnerSelection.selectDropDownItem(0);
+        saveLastDeckId(Stats.ALL_DECKS_ID);
     }
 
 
@@ -1430,41 +1440,6 @@ public class CardBrowser extends NavigationDrawerActivity implements
         showDialogFragment(dialog);
     }
 
-    /** Selects the given position in the deck list */
-    public void selectDropDownItem(int position) {
-        mActionBarSpinner.setSelection(position);
-        deckDropDownItemChanged(position);
-    }
-
-    /**
-     * Performs changes relating to the Deck DropDown Item changing
-     * Exists as mActionBarSpinner.setSelection() caused a loop in roboelectirc (calling onItemSelected())
-     */
-    private void deckDropDownItemChanged(int position) {
-        if (position == 0) {
-            mRestrictOnDeck = "";
-            saveLastDeckId(ALL_DECKS_ID);
-        } else {
-            Deck deck = mDropDownDecks.get(position - 1);
-            mRestrictOnDeck = "deck:\"" + deck.getString("name") + "\" ";
-            saveLastDeckId(deck.getLong("id"));
-        }
-        searchCards();
-    }
-
-    @VisibleForTesting(otherwise = VisibleForTesting.NONE)
-    void selectDeckId(long targetDid) {
-        for (int i = 0; i < mDropDownDecks.size(); i++) {
-            if (mDropDownDecks.get(i).getLong("id") == targetDid) {
-                deckDropDownItemChanged(i + 1);
-                return;
-            }
-        }
-        throw new IllegalStateException("Could not find did " + targetDid);
-    }
-
-
-
     @Override
     public void onSaveInstanceState(Bundle savedInstanceState) {
         // Save current search terms
@@ -1545,7 +1520,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
 
     private void updateList() {
         mCardsAdapter.notifyDataSetChanged();
-        mDropDownAdapter.notifyDataSetChanged();
+        mDeckSpinnerSelection.notifyDataSetChanged();
         onSelectionChanged();
         updatePreviewMenuItem();
     }
@@ -1567,17 +1542,6 @@ public class CardBrowser extends NavigationDrawerActivity implements
         return positions;
     }
 
-    // Iterates the drop down decks, and selects the one matching the given id
-    private boolean selectDeckById(@NonNull Long deckId) {
-        for (int dropDownDeckIdx = 0; dropDownDeckIdx < mDropDownDecks.size(); dropDownDeckIdx++) {
-            if (mDropDownDecks.get(dropDownDeckIdx).getLong("id") == deckId) {
-                selectDropDownItem(dropDownDeckIdx + 1);
-                return true;
-            }
-        }
-        return false;
-    }
-
     // convenience method for updateCardsInList(...)
     private void updateCardInList(Card card) {
         List<Card> cards = new ArrayList<>(1);
@@ -1588,8 +1552,8 @@ public class CardBrowser extends NavigationDrawerActivity implements
     /** Returns the decks which are valid targets for "Change Deck" */
     @VisibleForTesting
     List<Deck> getValidDecksForChangeDeck() {
-        List<Deck> nonDynamicDecks = new ArrayList<>(mDropDownDecks.size());
-        for (Deck d : mDropDownDecks) {
+        List<Deck> nonDynamicDecks = new ArrayList<>(mDeckSpinnerSelection.getDropDownDecks().size());
+        for (Deck d : mDeckSpinnerSelection.getDropDownDecks()) {
             if (Decks.isDynamic(d)) {
                 continue;
             }
@@ -2759,7 +2723,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
         // show title and hide spinner
         mActionBarTitle.setVisibility(View.VISIBLE);
         mActionBarTitle.setText(String.valueOf(checkedCardCount()));
-        mActionBarSpinner.setVisibility(View.GONE);
+        mDeckSpinnerSelection.setSpinnerVisibility(View.GONE);
         // reload the actionbar using the multi-select mode actionbar
         supportInvalidateOptionsMenu();
     }
@@ -2780,7 +2744,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
         mCardsAdapter.notifyDataSetChanged();
         // update action bar
         supportInvalidateOptionsMenu();
-        mActionBarSpinner.setVisibility(View.VISIBLE);
+        mDeckSpinnerSelection.setSpinnerVisibility(View.VISIBLE);
         mActionBarTitle.setVisibility(View.GONE);
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -750,6 +750,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
 
         long deckId = getCol().getDecks().selected();
         mDeckSpinnerSelection = new DeckSpinnerSelection(this, R.id.toolbar_spinner);
+        mDeckSpinnerSelection.setShowAllDecks(true);
         mDeckSpinnerSelection.initializeActionBarDeckSpinner();
         selectDeckAndSave(deckId);
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -764,7 +764,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
         }
     }
 
-    private void selectDeckAndSave(long deckId) {
+    public void selectDeckAndSave(long deckId) {
         mDeckSpinnerSelection.selectDeckById(deckId);
         if (deckId == ALL_DECKS_ID) {
             mRestrictOnDeck = "";

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckSpinnerSelection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckSpinnerSelection.java
@@ -211,7 +211,7 @@ public class DeckSpinnerSelection {
         FunctionalInterfaces.Filter<Deck> nonDynamic = (d) -> !Decks.isDynamic(d);
         List<DeckSelectionDialog.SelectableDeck> decks = DeckSelectionDialog.SelectableDeck.fromCollection(col, nonDynamic);
         if (mShowAllDecks) {
-            decks.add(0, new DeckSelectionDialog.SelectableDeck(ALL_DECKS_ID, "ALL DECKS"));
+            decks.add(new DeckSelectionDialog.SelectableDeck(ALL_DECKS_ID, mContext.getResources().getString(R.string.card_browser_all_decks)));
         }
 
         DeckSelectionDialog dialog = DeckSelectionDialog.newInstance(mContext.getString(R.string.search_deck), null, false, decks);

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckSpinnerSelection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckSpinnerSelection.java
@@ -48,7 +48,7 @@ public class DeckSpinnerSelection {
     private final AnkiActivity mContext;
     private List<Deck> mDropDownDecks;
     private DeckDropDownAdapter mDeckDropDownAdapter;
-    private boolean mIsIncludeAllDeckOption = false;
+    private boolean mShowAllDecks = false;
     private static final long ALL_DECKS_ID = 0L;
 
 
@@ -59,8 +59,8 @@ public class DeckSpinnerSelection {
         mSpinner = mContext.findViewById(spinnerId);
     }
 
-    public void setIncludeAllDeckOption(boolean includeAllDeckOption) {
-        mIsIncludeAllDeckOption = includeAllDeckOption;
+    public void setShowAllDecks(boolean showAllDecks) {
+        mShowAllDecks = showAllDecks;
     }
 
     public void initializeActionBarDeckSpinner() {
@@ -186,7 +186,7 @@ public class DeckSpinnerSelection {
     private boolean searchInList(long deckId) {
         for (int dropDownDeckIdx = 0; dropDownDeckIdx < mAllDeckIds.size(); dropDownDeckIdx++) {
             if (mAllDeckIds.get(dropDownDeckIdx) == deckId) {
-                int position = mIsIncludeAllDeckOption ? dropDownDeckIdx : dropDownDeckIdx + 1;
+                int position = mShowAllDecks ? dropDownDeckIdx + 1 : dropDownDeckIdx;
                 selectDropDownItem(position);
                 return true;
             }
@@ -210,9 +210,8 @@ public class DeckSpinnerSelection {
     public void displayDeckOverrideDialog(Collection col) {
         FunctionalInterfaces.Filter<Deck> nonDynamic = (d) -> !Decks.isDynamic(d);
         List<DeckSelectionDialog.SelectableDeck> decks = DeckSelectionDialog.SelectableDeck.fromCollection(col, nonDynamic);
-
-        if (!mIsIncludeAllDeckOption) {
-            decks.add(new DeckSelectionDialog.SelectableDeck(ALL_DECKS_ID, "All Decks"));
+        if (mShowAllDecks) {
+            decks.add(0, new DeckSelectionDialog.SelectableDeck(ALL_DECKS_ID, "ALL DECKS"));
         }
 
         DeckSelectionDialog dialog = DeckSelectionDialog.newInstance(mContext.getString(R.string.search_deck), null, false, decks);

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckSpinnerSelection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckSpinnerSelection.java
@@ -30,20 +30,15 @@ import com.ichi2.libanki.Collection;
 import com.ichi2.libanki.Deck;
 import com.ichi2.libanki.Decks;
 import com.ichi2.libanki.stats.Stats;
-import com.ichi2.utils.DeckComparator;
 import com.ichi2.utils.FunctionalInterfaces;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
-import java.util.function.Consumer;
 
 import androidx.annotation.NonNull;
 import androidx.appcompat.app.ActionBar;
 import androidx.core.content.ContextCompat;
 import timber.log.Timber;
-
-import static com.ichi2.anki.CardBrowser.clearLastDeckId;
 
 public class DeckSpinnerSelection {
 
@@ -53,18 +48,19 @@ public class DeckSpinnerSelection {
     private final AnkiActivity mContext;
     private List<Deck> mDropDownDecks;
     private DeckDropDownAdapter mDeckDropDownAdapter;
-    private final boolean mNoteEditorSpinner;
+    private boolean mIsIncludeAllDeckOption = false;
     private static final long ALL_DECKS_ID = 0L;
-    private static final String PERSISTENT_STATE_FILE = "DeckPickerState";
-    private static final String LAST_DECK_ID_KEY = "lastDeckId";
 
 
-    public DeckSpinnerSelection(@NonNull AnkiActivity context, @NonNull int spinnerId, @NonNull boolean noteEditorSpinner) {
+    public DeckSpinnerSelection(@NonNull AnkiActivity context, @NonNull int spinnerId) {
         this.mContext = context;
-        this.mNoteEditorSpinner = noteEditorSpinner;
         ActionBar actionBar = mContext.getSupportActionBar();
         actionBar.setDisplayShowTitleEnabled(false);
         mSpinner = mContext.findViewById(spinnerId);
+    }
+
+    public void setIncludeAllDeckOption(boolean includeAllDeckOption) {
+        mIsIncludeAllDeckOption = includeAllDeckOption;
     }
 
     public void initializeActionBarDeckSpinner() {
@@ -97,7 +93,7 @@ public class DeckSpinnerSelection {
             String currentName = d.getString("name");
             String lineContent = null;
             if (d.isStd()) {
-                lineContent = currentName ;
+                lineContent = currentName;
             } else if (!addNote && currentEditedCard != null && currentEditedCard.getDid() == thisDid) {
                 lineContent = mContext.getApplicationContext().getString(R.string.current_and_default_deck, currentName, col.getDecks().name(currentEditedCard.getODid()));
             } else {
@@ -190,7 +186,7 @@ public class DeckSpinnerSelection {
     private boolean searchInList(long deckId) {
         for (int dropDownDeckIdx = 0; dropDownDeckIdx < mAllDeckIds.size(); dropDownDeckIdx++) {
             if (mAllDeckIds.get(dropDownDeckIdx) == deckId) {
-                int position = mNoteEditorSpinner ? dropDownDeckIdx : dropDownDeckIdx + 1;
+                int position = mIsIncludeAllDeckOption ? dropDownDeckIdx : dropDownDeckIdx + 1;
                 selectDropDownItem(position);
                 return true;
             }
@@ -215,7 +211,7 @@ public class DeckSpinnerSelection {
         FunctionalInterfaces.Filter<Deck> nonDynamic = (d) -> !Decks.isDynamic(d);
         List<DeckSelectionDialog.SelectableDeck> decks = DeckSelectionDialog.SelectableDeck.fromCollection(col, nonDynamic);
 
-        if (!mNoteEditorSpinner) {
+        if (!mIsIncludeAllDeckOption) {
             decks.add(new DeckSelectionDialog.SelectableDeck(ALL_DECKS_ID, "All Decks"));
         }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckSpinnerSelection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckSpinnerSelection.java
@@ -1,0 +1,212 @@
+/****************************************************************************************
+ * Copyright (c) 2021 Akshay Jadhav <jadhavakshay0701@gmail.com>                        *
+ *                                                                                      *
+ * This program is free software; you can redistribute it and/or modify it under        *
+ * the terms of the GNU General Public License as published by the Free Software        *
+ * Foundation; either version 3 of the License, or (at your option) any later           *
+ * version.                                                                             *
+ *                                                                                      *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *                                                                                      *
+ * You should have received a copy of the GNU General Public License along with         *
+ * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ ****************************************************************************************/
+
+package com.ichi2.anki;
+
+import android.graphics.Color;
+import android.view.MotionEvent;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.ArrayAdapter;
+import android.widget.Spinner;
+import android.widget.TextView;
+
+import com.ichi2.anki.dialogs.DeckSelectionDialog;
+import com.ichi2.anki.widgets.DeckDropDownAdapter;
+import com.ichi2.libanki.Card;
+import com.ichi2.libanki.Collection;
+import com.ichi2.libanki.Deck;
+import com.ichi2.libanki.Decks;
+import com.ichi2.libanki.stats.Stats;
+import com.ichi2.utils.DeckComparator;
+import com.ichi2.utils.FunctionalInterfaces;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Consumer;
+
+import androidx.annotation.NonNull;
+import androidx.appcompat.app.ActionBar;
+import androidx.core.content.ContextCompat;
+import timber.log.Timber;
+
+public class DeckSpinnerSelection {
+
+    private long mDeckId;
+    private ArrayList<Long> mAllDeckIds;
+    private Spinner mSpinner;
+    private AnkiActivity mContext;
+    private List<Deck> mDropDownDecks;
+    private DeckDropDownAdapter mDeckDropDownAdapter;
+    private SpinnerType mSpinnerType;
+
+    public enum SpinnerType {
+        NOTE_EDITOR,
+        CARD_BROWSER,
+        STATISTICS
+    }
+
+    public DeckSpinnerSelection(@NonNull AnkiActivity context, @NonNull int spinnerId, @NonNull SpinnerType spinnerType) {
+        this.mContext = context;
+        this.mSpinnerType = spinnerType;
+        ActionBar actionBar = mContext.getSupportActionBar();
+        actionBar.setDisplayShowTitleEnabled(false);
+        mSpinner = mContext.findViewById(spinnerId);
+    }
+
+    public void inizatizeActionBarDeckSpinner() {
+
+        // Add drop-down menu to select deck to action bar.
+        mDropDownDecks = mContext.getCol().getDecks().allSorted();
+
+        mAllDeckIds = new ArrayList<>(mDropDownDecks.size());
+        for (Deck d : mDropDownDecks) {
+            long thisDid = d.getLong("id");
+            mAllDeckIds.add(thisDid);
+        }
+
+        mDeckDropDownAdapter = new DeckDropDownAdapter(mContext, mDropDownDecks);
+
+        mSpinner.setAdapter(mDeckDropDownAdapter);
+
+        setSpinnerListner();
+
+
+        // Default to libanki's selected deck
+        selectDeckById(mContext.getCol().getDecks().selected());
+
+    }
+
+    public void initializeNoteEditorDeckSpinner(@NonNull Card currentEditedCard, @NonNull boolean addNote) {
+        Collection col = mContext.getCol();
+        mDropDownDecks = col.getDecks().allSorted();
+        final ArrayList<String> deckNames = new ArrayList<>(mDropDownDecks.size());
+        mAllDeckIds = new ArrayList<>(mDropDownDecks.size());
+        for (Deck d : mDropDownDecks) {
+            // add current deck and all other non-filtered decks to deck list
+            long thisDid = d.getLong("id");
+            String currentName = d.getString("name");
+            String lineContent = null;
+            if (d.isStd()) {
+                lineContent = currentName ;
+            } else if (!addNote && currentEditedCard != null && currentEditedCard.getDid() == thisDid) {
+                lineContent = mContext.getApplicationContext().getString(R.string.current_and_default_deck, currentName, col.getDecks().name(currentEditedCard.getODid()));
+            } else {
+                continue;
+            }
+            mAllDeckIds.add(thisDid);
+            deckNames.add(lineContent);
+        }
+
+        ArrayAdapter<String> noteDeckAdapter = new ArrayAdapter<String>(mContext, android.R.layout.simple_spinner_item, deckNames) {
+            @Override
+            public View getDropDownView(int position, View convertView, ViewGroup parent) {
+
+                // Cast the drop down items (popup items) as text view
+                TextView tv = (TextView) super.getDropDownView(position, convertView, parent);
+
+                // If this item is selected
+                if (position == mSpinner.getSelectedItemPosition()) {
+                    tv.setBackgroundColor(ContextCompat.getColor(mContext, R.color.note_editor_selected_item_background));
+                    tv.setTextColor(ContextCompat.getColor(mContext, R.color.note_editor_selected_item_text));
+                }
+
+                // Return the modified view
+                return tv;
+            }
+        };
+
+        mSpinner.setAdapter(noteDeckAdapter);
+        setSpinnerListner();
+    }
+
+    public void setSpinnerListner() {
+        mSpinner.setOnTouchListener((view, motionEvent) -> {
+            if (motionEvent.getAction() == MotionEvent.ACTION_UP) {
+                displayDeckOverrideDialog(mContext.getCol());
+            }
+            return true;
+        });
+
+        setSpinnerVisibility(View.VISIBLE);
+    }
+
+    public void updateDeckPosition() {
+        int position = mAllDeckIds.indexOf(mDeckId);
+        if (position != -1) {
+            selectDropDownItem(position);
+        } else {
+            Timber.e("updateDeckPosition() error :: mCurrentDid=%d, position=%d", mDeckId, position);
+        }
+    }
+
+    public void notifyDataSetChanged() {
+        mDeckDropDownAdapter.notifyDataSetChanged();
+    }
+
+    public void setEnabledActionBarSpinner(boolean enabled) {
+        mSpinner.setEnabled(enabled);
+    }
+
+    public void setSpinnerVisibility(int view) {
+        mSpinner.setVisibility(view);
+    }
+
+    public List<Deck> getDropDownDecks() {
+        return mDropDownDecks;
+    }
+
+    public void setDeckId(Long deckId) {
+        this.mDeckId = deckId;
+    }
+
+    public Long getDeckId() {
+        return mDeckId;
+    }
+
+    public Spinner getSpinner() {
+        return mSpinner;
+    }
+
+    // Iterates the drop down decks, and selects the one matching the given id
+    public boolean selectDeckById(long deckId) {
+        for (int dropDownDeckIdx = 0; dropDownDeckIdx < mAllDeckIds.size(); dropDownDeckIdx++) {
+            if (mAllDeckIds.get(dropDownDeckIdx) == deckId) {
+                int position = mSpinnerType == SpinnerType.NOTE_EDITOR ? dropDownDeckIdx : dropDownDeckIdx + 1;
+                selectDropDownItem(position);
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public void selectDropDownItem(int position) {
+        mSpinner.setSelection(position);
+        if (position == 0) {
+            mDeckId = Stats.ALL_DECKS_ID;
+        } else {
+            mDeckId = mAllDeckIds.get(position - 1);
+        }
+    }
+
+    public void displayDeckOverrideDialog(Collection col) {
+        FunctionalInterfaces.Filter<Deck> nonDynamic = (d) -> !Decks.isDynamic(d);
+        List<DeckSelectionDialog.SelectableDeck> decks = DeckSelectionDialog.SelectableDeck.fromCollection(col, nonDynamic);
+        DeckSelectionDialog dialog = DeckSelectionDialog.newInstance(mContext.getString(R.string.search_deck), null, false, decks);
+        AnkiActivity.showDialogFragment(mContext, dialog);
+    }
+}

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckSpinnerSelection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckSpinnerSelection.java
@@ -67,7 +67,7 @@ public class DeckSpinnerSelection {
         mSpinner = mContext.findViewById(spinnerId);
     }
 
-    public void inizatizeActionBarDeckSpinner() {
+    public void initializeActionBarDeckSpinner() {
 
         // Add drop-down menu to select deck to action bar.
         mDropDownDecks = mContext.getCol().getDecks().allSorted();

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckSpinnerSelection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckSpinnerSelection.java
@@ -49,11 +49,11 @@ public class DeckSpinnerSelection {
 
     private long mDeckId;
     private ArrayList<Long> mAllDeckIds;
-    private Spinner mSpinner;
-    private AnkiActivity mContext;
+    private final Spinner mSpinner;
+    private final AnkiActivity mContext;
     private List<Deck> mDropDownDecks;
     private DeckDropDownAdapter mDeckDropDownAdapter;
-    private boolean mNoteEditorSpinner;
+    private final boolean mNoteEditorSpinner;
     private static final long ALL_DECKS_ID = 0L;
     private static final String PERSISTENT_STATE_FILE = "DeckPickerState";
     private static final String LAST_DECK_ID_KEY = "lastDeckId";
@@ -183,13 +183,15 @@ public class DeckSpinnerSelection {
             selectAllDecks();
             return true;
         }
+        return searchInList(deckId);
+    }
+
+
+    private boolean searchInList(long deckId) {
         for (int dropDownDeckIdx = 0; dropDownDeckIdx < mAllDeckIds.size(); dropDownDeckIdx++) {
             if (mAllDeckIds.get(dropDownDeckIdx) == deckId) {
                 int position = mNoteEditorSpinner ? dropDownDeckIdx : dropDownDeckIdx + 1;
                 selectDropDownItem(position);
-                if (!mNoteEditorSpinner) {
-                    saveLastDeckId(deckId);
-                }
                 return true;
             }
         }
@@ -198,15 +200,6 @@ public class DeckSpinnerSelection {
 
     void selectAllDecks() {
         selectDropDownItem(0);
-        saveLastDeckId(Stats.ALL_DECKS_ID);
-    }
-
-    private void saveLastDeckId(Long id) {
-        if (id == null) {
-            clearLastDeckId();
-            return;
-        }
-        mContext.getSharedPreferences(PERSISTENT_STATE_FILE, 0).edit().putLong(LAST_DECK_ID_KEY, id).apply();
     }
 
     public void selectDropDownItem(int position) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -51,7 +51,6 @@ import android.view.KeyEvent;
 import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.MenuItem;
-import android.view.MotionEvent;
 import android.view.View;
 import android.view.ViewGroup;
 import android.view.ViewGroup.MarginLayoutParams;
@@ -97,7 +96,6 @@ import com.ichi2.async.TaskManager;
 import com.ichi2.compat.CompatHelper;
 import com.ichi2.libanki.Card;
 import com.ichi2.libanki.Collection;
-import com.ichi2.libanki.Decks;
 import com.ichi2.libanki.Models;
 import com.ichi2.libanki.Model;
 import com.ichi2.libanki.Note;
@@ -110,9 +108,7 @@ import com.ichi2.anki.widgets.PopupMenuWithIcons;
 import com.ichi2.utils.AdaptionUtil;
 import com.ichi2.utils.CheckCameraPermission;
 import com.ichi2.utils.ContentResolverUtil;
-import com.ichi2.utils.DeckComparator;
 import com.ichi2.utils.FileUtil;
-import com.ichi2.utils.FunctionalInterfaces;
 import com.ichi2.utils.FunctionalInterfaces.Consumer;
 import com.ichi2.utils.KeyUtils;
 import com.ichi2.utils.MapUtil;
@@ -613,8 +609,9 @@ public class NoteEditor extends AnkiActivity implements
         if (!mAddNote && mEditorNote.model().getJSONArray("tmpls").length()>1) {
             deckTextView.setText(R.string.CardEditorCardDeck);
         }
-        mDeckSpinnerSelection = new DeckSpinnerSelection(NoteEditor.this, R.id.note_deck_spinner, true);
+        mDeckSpinnerSelection = new DeckSpinnerSelection(this, R.id.note_deck_spinner);
         mDeckSpinnerSelection.initializeNoteEditorDeckSpinner(mCurrentEditedCard, mAddNote);
+        mDeckSpinnerSelection.setIncludeAllDeckOption(true);
 
         mCurrentDid = intent.getLongExtra(EXTRA_DID, mCurrentDid);
         String mGetTextFromSearchView = intent.getStringExtra(EXTRA_TEXT_FROM_SEARCH_VIEW);

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -611,7 +611,6 @@ public class NoteEditor extends AnkiActivity implements
         }
         mDeckSpinnerSelection = new DeckSpinnerSelection(this, R.id.note_deck_spinner);
         mDeckSpinnerSelection.initializeNoteEditorDeckSpinner(mCurrentEditedCard, mAddNote);
-        mDeckSpinnerSelection.setIncludeAllDeckOption(true);
 
         mCurrentDid = intent.getLongExtra(EXTRA_DID, mCurrentDid);
         String mGetTextFromSearchView = intent.getStringExtra(EXTRA_TEXT_FROM_SEARCH_VIEW);

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -90,6 +90,7 @@ import com.ichi2.anki.noteeditor.CustomToolbarButton;
 import com.ichi2.anki.noteeditor.Toolbar;
 import com.ichi2.anki.receiver.SdCardReceiver;
 import com.ichi2.anki.servicelayer.NoteService;
+import com.ichi2.anki.widgets.DeckDropDownAdapter;
 import com.ichi2.async.CollectionTask;
 import com.ichi2.async.TaskListenerWithContext;
 import com.ichi2.async.TaskManager;
@@ -157,6 +158,7 @@ import static com.ichi2.libanki.Models.NOT_FOUND_NOTE_TYPE;
  */
 public class NoteEditor extends AnkiActivity implements
         DeckSelectionDialog.DeckSelectionListener,
+        DeckDropDownAdapter.SubtitleListener,
         TagsDialogListener {
     // DA 2020-04-13 - Refactoring Plans once tested:
     // * There is a difference in functionality depending on whether we are editing
@@ -225,7 +227,7 @@ public class NoteEditor extends AnkiActivity implements
     private TextView mTagsButton;
     private TextView mCardsButton;
     private Spinner mNoteTypeSpinner;
-    private Spinner mNoteDeckSpinner;
+    private DeckSpinnerSelection mDeckSpinnerSelection;
 
     // Non Null after onCollectionLoaded, but still null after construction. So essentially @NonNull but it would fail.
     private Note mEditorNote;
@@ -234,7 +236,6 @@ public class NoteEditor extends AnkiActivity implements
     private Card mCurrentEditedCard;
     private ArrayList<String> mSelectedTags;
     private long mCurrentDid;
-    private ArrayList<Long> mAllDeckIds;
     private ArrayList<Long> mAllModelIds;
     private Map<Integer, Integer> mModelChangeFieldMap;
     private HashMap<Integer, Integer> mModelChangeCardMap;
@@ -267,18 +268,17 @@ public class NoteEditor extends AnkiActivity implements
 
     @Override
     public void onDeckSelected(@Nullable DeckSelectionDialog.SelectableDeck deck) {
-        if (deck != null) {
-            mCurrentDid = deck.getDeckId();
-            initializeNoteDeckSpinner();
-            mNoteDeckSpinner.setSelection(mAllDeckIds.indexOf(deck.getDeckId()), false);
+        if (deck == null) {
+            return;
         }
+        mCurrentDid = deck.getDeckId();
+        mDeckSpinnerSelection.initializeNoteEditorDeckSpinner(mCurrentEditedCard, mAddNote);
+        mDeckSpinnerSelection.selectDeckById(deck.getDeckId());
     }
 
-    private void displayDeckOverrideDialog(Collection col) {
-        FunctionalInterfaces.Filter<Deck> nonDynamic = (d) -> !Decks.isDynamic(d);
-        List<DeckSelectionDialog.SelectableDeck> decks = DeckSelectionDialog.SelectableDeck.fromCollection(col, nonDynamic);
-        DeckSelectionDialog dialog = DeckSelectionDialog.newInstance(getString(R.string.search_deck), null, false, decks);
-        AnkiActivity.showDialogFragment(NoteEditor.this, dialog);
+    @Override
+    public String getSubtitleText() {
+        return "";
     }
 
     private enum AddClozeType {
@@ -613,17 +613,8 @@ public class NoteEditor extends AnkiActivity implements
         if (!mAddNote && mEditorNote.model().getJSONArray("tmpls").length()>1) {
             deckTextView.setText(R.string.CardEditorCardDeck);
         }
-        mNoteDeckSpinner = findViewById(R.id.note_deck_spinner);
-        initializeNoteDeckSpinner();
-        mNoteDeckSpinner.setOnTouchListener(new View.OnTouchListener() {
-
-                public boolean onTouch(View view, MotionEvent motionEvent) {
-                    if (motionEvent.getAction() == MotionEvent.ACTION_UP) {
-                        displayDeckOverrideDialog(getCol());
-                    }
-                    return true;
-                }
-            });
+        mDeckSpinnerSelection = new DeckSpinnerSelection(NoteEditor.this, R.id.note_deck_spinner, true);
+        mDeckSpinnerSelection.initializeNoteEditorDeckSpinner(mCurrentEditedCard, mAddNote);
 
         mCurrentDid = intent.getLongExtra(EXTRA_DID, mCurrentDid);
         String mGetTextFromSearchView = intent.getStringExtra(EXTRA_TEXT_FROM_SEARCH_VIEW);
@@ -689,49 +680,6 @@ public class NoteEditor extends AnkiActivity implements
         }
     }
 
-    public void initializeNoteDeckSpinner() {
-        List<Deck> decks = getCol().getDecks().all();
-        Collections.sort(decks, DeckComparator.INSTANCE);
-        final ArrayList<String> deckNames = new ArrayList<>(decks.size());
-        mAllDeckIds = new ArrayList<>(decks.size());
-        for (Deck d : decks) {
-            // add current deck and all other non-filtered decks to deck list
-            long thisDid = d.getLong("id");
-            String currentName = d.getString("name");
-            String lineContent = null;
-            if (d.isStd()) {
-                lineContent = currentName ;
-            } else if (!mAddNote && mCurrentEditedCard != null && mCurrentEditedCard.getDid() == thisDid) {
-                lineContent = getApplicationContext().getString(R.string.current_and_default_deck, currentName, getCol().getDecks().name(mCurrentEditedCard.getODid()));
-            } else {
-                continue;
-            }
-            deckNames.add(lineContent);
-            mAllDeckIds.add(thisDid);
-        }
-
-        ArrayAdapter<String> noteDeckAdapter = new ArrayAdapter<String>(this, android.R.layout.simple_spinner_item, deckNames) {
-            @Override
-            public View getDropDownView(int position, View convertView, ViewGroup parent) {
-
-                // Cast the drop down items (popup items) as text view
-                TextView tv = (TextView) super.getDropDownView(position, convertView, parent);
-
-                // If this item is selected
-                if (position == mNoteDeckSpinner.getSelectedItemPosition()) {
-                    tv.setBackgroundColor(ContextCompat.getColor(NoteEditor.this, R.color.note_editor_selected_item_background));
-                    tv.setTextColor(ContextCompat.getColor(NoteEditor.this, R.color.note_editor_selected_item_text));
-                }
-
-                // Return the modified view
-                return tv;
-            }
-        };
-        mNoteDeckSpinner.setAdapter(noteDeckAdapter);
-        noteDeckAdapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
-    }
-
-
     private void modifyCurrentSelection(Toolbar.TextFormatter formatter, FieldEditText textBox) {
 
         // get the current text and selection locations
@@ -796,8 +744,8 @@ public class NoteEditor extends AnkiActivity implements
 
             case KeyEvent.KEYCODE_D:
                 //null check in case Spinner is moved into options menu in the future
-                if (event.isCtrlPressed() && (mNoteDeckSpinner != null)) {
-                    displayDeckOverrideDialog(getCol());
+                if (event.isCtrlPressed() && (mDeckSpinnerSelection.getSpinner() != null)) {
+                    mDeckSpinnerSelection.displayDeckOverrideDialog(getCol());
                 }
                 break;
 
@@ -1975,7 +1923,7 @@ public class NoteEditor extends AnkiActivity implements
         }
         // nb: setOnItemSelectedListener and populateEditFields need to occur after this
         setNoteTypePosition();
-        updateDeckPosition();
+        mDeckSpinnerSelection.updateDeckPosition();
         updateTags();
         updateCards(mEditorNote.model());
         updateToolbar();
@@ -2122,17 +2070,6 @@ public class NoteEditor extends AnkiActivity implements
         mNoteTypeSpinner.setSelection(position, false);
     }
 
-
-    private void updateDeckPosition() {
-        int position = mAllDeckIds.indexOf(mCurrentDid);
-        if (position != -1) {
-            mNoteDeckSpinner.setSelection(position, false);
-        } else {
-            Timber.e("updateDeckPosition() error :: mCurrentDid=%d, position=%d", mCurrentDid, position);
-        }
-    }
-
-
     private void updateTags() {
         if (mSelectedTags == null) {
             mSelectedTags = new ArrayList<>(0);
@@ -2253,7 +2190,7 @@ public class NoteEditor extends AnkiActivity implements
                 // Update deck
                 if (!getCol().getConf().optBoolean("addToCur", true)) {
                     mCurrentDid = model.getLong("did");
-                    updateDeckPosition();
+                    mDeckSpinnerSelection.updateDeckPosition();
                 }
 
                 refreshNoteData(FieldChangeType.changeFieldCount(shouldReplaceNewlines()));
@@ -2305,17 +2242,15 @@ public class NoteEditor extends AnkiActivity implements
                 updateTags();
                 findViewById(R.id.CardEditorTagButton).setEnabled(false);
                 //((LinearLayout) findViewById(R.id.CardEditorCardsButton)).setEnabled(false);
-                mNoteDeckSpinner.setEnabled(false);
-                int position = mAllDeckIds.indexOf(mCurrentEditedCard.getDid());
-                if (position != -1) {
-                    mNoteDeckSpinner.setSelection(position, false);
-                }
+                mDeckSpinnerSelection.setEnabledActionBarSpinner(false);
+                mDeckSpinnerSelection.setDeckId(mCurrentEditedCard.getDid());
+                mDeckSpinnerSelection.updateDeckPosition();
             } else {
                 populateEditFields(FieldChangeType.refresh(shouldReplaceNewlines()), false);
                 updateCards(mCurrentEditedCard.model());
                 findViewById(R.id.CardEditorTagButton).setEnabled(true);
                 //((LinearLayout) findViewById(R.id.CardEditorCardsButton)).setEnabled(false);
-                mNoteDeckSpinner.setEnabled(true);
+                mDeckSpinnerSelection.setEnabledActionBarSpinner(true);
             }
         }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Statistics.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Statistics.java
@@ -116,6 +116,7 @@ public class Statistics extends NavigationDrawerActivity implements
 
         mDeckSpinnerSelection = new DeckSpinnerSelection(this, R.id.toolbar_spinner);
         mDeckSpinnerSelection.initializeActionBarDeckSpinner();
+        mDeckSpinnerSelection.setShowAllDecks(true);
     }
 
     @Override

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Statistics.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Statistics.java
@@ -115,7 +115,7 @@ public class Statistics extends NavigationDrawerActivity implements
 //        StatisticFragment.updateAllFragments();
 
         mDeckSpinnerSelection = new DeckSpinnerSelection(Statistics.this, R.id.toolbar_spinner, false);
-        mDeckSpinnerSelection.inizatizeActionBarDeckSpinner();
+        mDeckSpinnerSelection.initializeActionBarDeckSpinner();
     }
 
     @Override
@@ -215,7 +215,7 @@ public class Statistics extends NavigationDrawerActivity implements
         if (deck == null) {
             return;
         }
-        mDeckSpinnerSelection.inizatizeActionBarDeckSpinner();
+        mDeckSpinnerSelection.initializeActionBarDeckSpinner();
         mDeckSpinnerSelection.selectDeckById(deck.getDeckId());
         mTaskHandler.setDeckId(deck.getDeckId());
         mViewPager.getAdapter().notifyDataSetChanged();

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Statistics.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Statistics.java
@@ -114,7 +114,7 @@ public class Statistics extends NavigationDrawerActivity implements
         supportInvalidateOptionsMenu();
 //        StatisticFragment.updateAllFragments();
 
-        mDeckSpinnerSelection = new DeckSpinnerSelection(Statistics.this, R.id.toolbar_spinner, false);
+        mDeckSpinnerSelection = new DeckSpinnerSelection(this, R.id.toolbar_spinner);
         mDeckSpinnerSelection.initializeActionBarDeckSpinner();
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Statistics.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Statistics.java
@@ -114,7 +114,7 @@ public class Statistics extends NavigationDrawerActivity implements
         supportInvalidateOptionsMenu();
 //        StatisticFragment.updateAllFragments();
 
-        mDeckSpinnerSelection = new DeckSpinnerSelection(Statistics.this, R.id.toolbar_spinner, DeckSpinnerSelection.SpinnerType.STATISTICS);
+        mDeckSpinnerSelection = new DeckSpinnerSelection(Statistics.this, R.id.toolbar_spinner, false);
         mDeckSpinnerSelection.inizatizeActionBarDeckSpinner();
     }
 
@@ -212,12 +212,13 @@ public class Statistics extends NavigationDrawerActivity implements
 
     @Override
     public void onDeckSelected(@Nullable DeckSelectionDialog.SelectableDeck deck) {
-        if (deck != null) {
-            mDeckSpinnerSelection.inizatizeActionBarDeckSpinner();
-            mDeckSpinnerSelection.selectDeckById(deck.getDeckId());
-            mTaskHandler.setDeckId(deck.getDeckId());
-            mViewPager.getAdapter().notifyDataSetChanged();
+        if (deck == null) {
+            return;
         }
+        mDeckSpinnerSelection.inizatizeActionBarDeckSpinner();
+        mDeckSpinnerSelection.selectDeckById(deck.getDeckId());
+        mTaskHandler.setDeckId(deck.getDeckId());
+        mViewPager.getAdapter().notifyDataSetChanged();
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Statistics.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Statistics.java
@@ -113,10 +113,11 @@ public class Statistics extends NavigationDrawerActivity implements
         // Prepare options menu only after loading everything
         supportInvalidateOptionsMenu();
 //        StatisticFragment.updateAllFragments();
-
+        long deckId = getCol().getDecks().selected();
         mDeckSpinnerSelection = new DeckSpinnerSelection(this, R.id.toolbar_spinner);
         mDeckSpinnerSelection.initializeActionBarDeckSpinner();
         mDeckSpinnerSelection.setShowAllDecks(true);
+        mDeckSpinnerSelection.selectDeckById(deckId);
     }
 
     @Override

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckSelectionDialog.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckSelectionDialog.java
@@ -36,6 +36,7 @@ import com.ichi2.anki.analytics.AnalyticsDialogFragment;
 import com.ichi2.anki.exception.FilteredAncestor;
 import com.ichi2.libanki.Collection;
 import com.ichi2.libanki.Deck;
+import com.ichi2.libanki.stats.Stats;
 import com.ichi2.utils.FunctionalInterfaces;
 import com.ichi2.utils.FilterResultsUtils;
 
@@ -398,6 +399,9 @@ public class DeckSelectionDialog extends AnalyticsDialogFragment {
 
         @Override
         public int compareTo(@NonNull SelectableDeck o) {
+            if (o.mDeckId == Stats.ALL_DECKS_ID || this.mDeckId == Stats.ALL_DECKS_ID){
+                return -1;
+            }
             return this.mName.compareTo(o.mName);
         }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/widgets/DeckDropDownAdapter.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/widgets/DeckDropDownAdapter.java
@@ -17,6 +17,7 @@
 package com.ichi2.anki.widgets;
 
 import android.content.Context;
+import android.graphics.Color;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;

--- a/AnkiDroid/src/main/java/com/ichi2/anki/widgets/DeckDropDownAdapter.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/widgets/DeckDropDownAdapter.java
@@ -17,7 +17,6 @@
 package com.ichi2.anki.widgets;
 
 import android.content.Context;
-import android.graphics.Color;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;

--- a/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.java
@@ -386,7 +386,7 @@ public class CardBrowserTest extends RobolectricTest {
 
         assertThat("The target deck should not yet be selected", b.getLastDeckId(), not(is(targetDid)));
 
-        b.selectDeckId(targetDid);
+        b.mDeckSpinnerSelection.selectDeckById(targetDid);
 
         assertThat("The target deck should be selected", b.getLastDeckId(), is(targetDid));
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.java
@@ -386,7 +386,7 @@ public class CardBrowserTest extends RobolectricTest {
 
         assertThat("The target deck should not yet be selected", b.getLastDeckId(), not(is(targetDid)));
 
-        b.mDeckSpinnerSelection.selectDeckById(targetDid);
+        b.selectDeckAndSave(targetDid);
 
         assertThat("The target deck should be selected", b.getLastDeckId(), is(targetDid));
 

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/FinderTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/FinderTest.java
@@ -352,7 +352,7 @@ public class FinderTest extends RobolectricTest {
         assertEquals(currentDid, did);
         CardBrowser cb = super.startActivityNormallyOpenCollectionWithIntent(CardBrowser.class, new Intent());
         int pos = cb.getChangeDeckPositionFromId(currentDid);
-        cb.selectDropDownItem(pos + 1);    //Adjusting for All Decks option at position 0
+        cb.mDeckSpinnerSelection.selectDropDownItem(pos + 1);    //Adjusting for All Decks option at position 0
         advanceRobolectricLooperWithSleep();
         assertEquals(1L, cb.getCardCount());
     }


### PR DESCRIPTION
## Need
With Current Spinner in card browser,note editor, statistics activity, user can select any deck, but
->If number of decks is very big it will be hard for the user to search a particular deck in the spinner.
->Anki-desktop does have search decks feature in browser activity.

# work done 

- [✔️ ] Used `DeckSelectionDialog` class to implement search deck dialog In CardBrowser ,Statistics And NoteEditor.

- [✔️] Extracted spinner code from Card Browser, NoteEditor, And Statistics 

## Output Pervious And Current
<img src="https://user-images.githubusercontent.com/52353967/115113860-fd20b280-9fa9-11eb-8272-831da5e818b4.gif" width="250" height="500" />



