### PR TITLE
Implementing instances of com.ichi2.preferences.IncrementerNumberRangePreference

### DIFF
--- a/AnkiDroid/src/main/res/xml/cram_deck_options.xml
+++ b/AnkiDroid/src/main/res/xml/cram_deck_options.xml
@@ -23,7 +23,7 @@
             android:key="search"
             android:title="@string/deck_conf_cram_search" />
 
-        <com.ichi2.preferences.NumberRangePreference
+        <com.ichi2.preferences.IncrementerNumberRangePreference
             android:key="limit"
             android:numeric="integer"
             android:title="@string/deck_conf_cram_limit"

--- a/AnkiDroid/src/main/res/xml/deck_options.xml
+++ b/AnkiDroid/src/main/res/xml/deck_options.xml
@@ -80,13 +80,13 @@
                 android:title="@string/deck_conf_new_cards_day"
                 app:max="9999"
                 app:min="0" />
-            <com.ichi2.preferences.NumberRangePreference
+            <com.ichi2.preferences.IncrementerNumberRangePreference
                 android:key="newGradIvl"
                 android:summary="@string/deck_conf_days"
                 android:title="@string/deck_conf_graduating_ivl"
                 app:max="99"
                 app:min="1" />
-            <com.ichi2.preferences.NumberRangePreference
+            <com.ichi2.preferences.IncrementerNumberRangePreference
                 android:key="newEasy"
                 android:summary="@string/deck_conf_days"
                 android:title="@string/deck_conf_easy_ivl"
@@ -105,7 +105,7 @@
                 android:title="@string/deck_conf_new_bury" />
         </PreferenceScreen>
         <PreferenceScreen android:title="@string/deck_conf_rev_cards" >
-            <com.ichi2.preferences.NumberRangePreference
+            <com.ichi2.preferences.IncrementerNumberRangePreference
                 android:key="revPerDay"
                 android:title="@string/deck_conf_max_rev"
                 app:max="9999"
@@ -178,19 +178,19 @@
                 android:title="@string/deck_conf_steps"
                 app:allowEmpty="true" />
 
-            <com.ichi2.preferences.NumberRangePreference
+            <com.ichi2.preferences.IncrementerNumberRangePreference
                 android:key="lapNewIvl"
                 android:summary="@string/deck_conf_percent"
                 android:title="@string/deck_conf_new_lps_ivl"
                 app:max="100"
                 app:min="0" />
-            <com.ichi2.preferences.NumberRangePreference
+            <com.ichi2.preferences.IncrementerNumberRangePreference
                 android:key="lapMinIvl"
                 android:summary="@string/deck_conf_days"
                 android:title="@string/deck_conf_min_ivl"
                 app:max="99"
                 app:min="1" />
-            <com.ichi2.preferences.NumberRangePreference
+            <com.ichi2.preferences.IncrementerNumberRangePreference
                 android:key="lapLeechThres"
                 android:summary="@string/deck_conf_fails"
                 android:title="@string/deck_conf_leech_thres"
@@ -202,7 +202,7 @@
                 android:title="@string/deck_conf_leech_action" />
         </PreferenceScreen>
         <PreferenceScreen android:title="@string/deck_conf_general" >
-            <com.ichi2.preferences.NumberRangePreference
+            <com.ichi2.preferences.IncrementerNumberRangePreference
                 android:key="maxAnswerTime"
                 android:summary="@string/deck_conf_seconds"
                 android:title="@string/deck_conf_max_time"

--- a/AnkiDroid/src/main/res/xml/preferences_reviewing.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_reviewing.xml
@@ -38,13 +38,13 @@
             android:title="@string/day_offset_with_description"
             app:interval="1"
             app:min="0" />
-        <com.ichi2.preferences.NumberRangePreference
+        <com.ichi2.preferences.IncrementerNumberRangePreference
             android:key="learnCutoff"
             android:summary="@string/time_limit_summ"
             android:title="@string/learn_cutoff"
             app:max="999"
             app:min="0" />
-        <com.ichi2.preferences.NumberRangePreference
+        <com.ichi2.preferences.IncrementerNumberRangePreference
             android:key="timeLimit"
             android:summary="@string/time_limit_summ"
             android:title="@string/time_limit"


### PR DESCRIPTION
Implementing  com.ichi2.preferences.IncrementerNumberRangePreference instead of com.ichi2.preferences.NumberRangePreference for Preferences (preferences_reviewing.xml), DeckOptions (deck_options.xml) and FilteredDeckOptions (cram_deck_options.xml)

## Pull Request template

## Purpose / Description
There are some inconsistencies of input fields. For small distances between min and max the instance of com.ichi2.preferences.NumberRangePreference is useful

## Fixes
Fixes #8647

## Approach


## How Has This Been Tested?

I tested it with the emulator and made changes via the IncrementerNumberRangePreference

## Learning (optional, can help others)

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
