### PR TITLE
Dependency updates 20210422

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -248,7 +248,7 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.3.0-rc01'
     implementation 'androidx.browser:browser:1.3.0'
     implementation 'androidx.exifinterface:exifinterface:1.3.2'
-    implementation 'androidx.fragment:fragment:1.3.2'
+    implementation 'androidx.fragment:fragment:1.3.3'
     implementation 'androidx.localbroadcastmanager:localbroadcastmanager:1.0.0'
     implementation "androidx.preference:preference:1.1.1"
     implementation 'androidx.recyclerview:recyclerview:1.2.0'

--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -280,7 +280,7 @@ dependencies {
     implementation'ch.acra:acra-toast:5.7.0'
     implementation'ch.acra:acra-limiter:5.7.0'
 
-    implementation 'com.github.mikehardy:sqlite-android:3.35.1.1'
+    implementation 'com.github.requery:sqlite-android:3.35.4'
     implementation 'com.afollestad.material-dialogs:core:0.9.6.0'
     implementation 'com.getbase:floatingactionbutton:1.10.1'
     // io.github.java-diff-utils:java-diff-utils is the natural successor here, but requires API24, #7091

--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -305,7 +305,7 @@ dependencies {
     testImplementation 'androidx.test:core:1.3.0'
     testImplementation 'androidx.test.ext:junit:1.1.2'
     // debugImplementation required vs testImplementation: https://issuetracker.google.com/issues/128612536
-    debugImplementation 'androidx.fragment:fragment-testing:1.3.2'
+    debugImplementation 'androidx.fragment:fragment-testing:1.3.3'
 
     // May need a resolution strategy for support libs to our versions
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'

--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -298,7 +298,7 @@ dependencies {
     api project(":api")
 
     testImplementation 'org.junit.vintage:junit-vintage-engine:5.7.1'
-    testImplementation 'org.mockito:mockito-inline:3.8.0'
+    testImplementation 'org.mockito:mockito-inline:3.9.0'
     testImplementation 'org.hamcrest:hamcrest-all:1.3'
     testImplementation 'net.lachlanmckee:timber-junit-rule:1.0.1'
     testImplementation "org.robolectric:robolectric:4.5.1"


### PR DESCRIPTION
## Pull Request template

## Purpose / Description

Standard dependency updates PR

This finishes the migration from jcenter for us after sqlite-android ingested my jitpack work - we can use the "official" repository again, instead of jitpack-test-fork of the repo

## Fixes
Related #8632 

## How Has This Been Tested?

Local `./gradlew clean jacocoTestReport --rerun-tasks` agains an API30 emulator

## Learning (optional, can help others)
jitpack is pretty easy to work with even if you have an NDK package...

