### PR TITLE
Added lint rules to check for copyright header in .java files

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anim/ActivityTransitionAnimation.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anim/ActivityTransitionAnimation.java
@@ -1,3 +1,4 @@
+//noinspection MissingCopyrightHeader #8659
 package com.ichi2.anim;
 
 import android.app.Activity;

--- a/AnkiDroid/src/main/java/com/ichi2/anim/ViewAnimation.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anim/ViewAnimation.java
@@ -1,4 +1,4 @@
-
+//noinspection MissingCopyrightHeader #8659
 package com.ichi2.anim;
 
 import android.view.animation.AccelerateInterpolator;

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiActivity.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiActivity.java
@@ -1,4 +1,4 @@
-
+//noinspection MissingCopyrightHeader #8659
 package com.ichi2.anki;
 
 import android.app.Activity;

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiFont.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiFont.java
@@ -1,4 +1,4 @@
-
+//noinspection MissingCopyrightHeader #8659
 package com.ichi2.anki;
 
 import android.content.Context;

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardUtils.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardUtils.java
@@ -1,3 +1,4 @@
+//noinspection MissingCopyrightHeader #8659
 package com.ichi2.anki;
 
 import com.ichi2.libanki.Card;

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Lookup.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Lookup.java
@@ -1,4 +1,4 @@
-
+//noinspection MissingCopyrightHeader #8659
 package com.ichi2.anki;
 
 import android.content.ComponentName;

--- a/AnkiDroid/src/main/java/com/ichi2/anki/MetaDB.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/MetaDB.java
@@ -1,4 +1,4 @@
-
+//noinspection MissingCopyrightHeader #8659
 package com.ichi2.anki;
 
 import android.content.Context;

--- a/AnkiDroid/src/main/java/com/ichi2/anki/TtsParser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/TtsParser.java
@@ -1,3 +1,4 @@
+//noinspection MissingCopyrightHeader #8659
 package com.ichi2.anki;
 import com.ichi2.libanki.template.TemplateFilters;
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/UIUtils.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/UIUtils.java
@@ -1,4 +1,4 @@
-
+//noinspection MissingCopyrightHeader #8659
 package com.ichi2.anki;
 
 import android.app.Activity;

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/CardBrowserMySearchesDialog.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/CardBrowserMySearchesDialog.java
@@ -1,3 +1,4 @@
+//noinspection MissingCopyrightHeader #8659
 package com.ichi2.anki.dialogs;
 
 import android.app.Activity;

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/MediaCheckDialog.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/MediaCheckDialog.java
@@ -1,4 +1,4 @@
-
+//noinspection MissingCopyrightHeader #8659
 package com.ichi2.anki.dialogs;
 
 import android.os.Bundle;

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ModelBrowserContextMenu.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ModelBrowserContextMenu.java
@@ -1,3 +1,4 @@
+//noinspection MissingCopyrightHeader #8659
 package com.ichi2.anki.dialogs;
 
 import android.app.Dialog;

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ModelEditorContextMenu.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ModelEditorContextMenu.java
@@ -1,3 +1,4 @@
+//noinspection MissingCopyrightHeader #8659
 package com.ichi2.anki.dialogs;
 
 import android.app.Dialog;

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/tags/TagsDialog.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/tags/TagsDialog.java
@@ -1,3 +1,4 @@
+//noinspection MissingCopyrightHeader #8659
 package com.ichi2.anki.dialogs.tags;
 
 import android.annotation.SuppressLint;

--- a/AnkiDroid/src/main/java/com/ichi2/anki/exception/DeckRenameException.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/exception/DeckRenameException.java
@@ -1,4 +1,4 @@
-
+//noinspection MissingCopyrightHeader #8659
 package com.ichi2.anki.exception;
 
 import android.content.res.Resources;

--- a/AnkiDroid/src/main/java/com/ichi2/anki/exception/FilteredAncestor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/exception/FilteredAncestor.java
@@ -1,3 +1,4 @@
+//noinspection MissingCopyrightHeader #8659
 package com.ichi2.anki.exception;
 
 public class FilteredAncestor extends Exception {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/exception/ImportExportException.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/exception/ImportExportException.java
@@ -1,4 +1,4 @@
-
+//noinspection MissingCopyrightHeader #8659
 package com.ichi2.anki.exception;
 
 public class ImportExportException extends Exception {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/exception/MediaSyncException.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/exception/MediaSyncException.java
@@ -1,4 +1,4 @@
-
+//noinspection MissingCopyrightHeader #8659
 package com.ichi2.anki.exception;
 
 public class MediaSyncException extends Exception {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/exception/UserSubmittedException.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/exception/UserSubmittedException.java
@@ -1,3 +1,4 @@
+//noinspection MissingCopyrightHeader #8659
 package com.ichi2.anki.exception;
 
 /** An exception sent by user for sending report manually */

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/AudioClipField.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/AudioClipField.java
@@ -1,3 +1,4 @@
+//noinspection MissingCopyrightHeader #8659
 package com.ichi2.anki.multimediacard.fields;
 
 /**

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/AudioRecordingField.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/AudioRecordingField.java
@@ -1,3 +1,4 @@
+//noinspection MissingCopyrightHeader #8659
 package com.ichi2.anki.multimediacard.fields;
 
 /**

--- a/AnkiDroid/src/main/java/com/ichi2/anki/services/BootService.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/services/BootService.java
@@ -1,3 +1,4 @@
+//noinspection MissingCopyrightHeader #8659
 package com.ichi2.anki.services;
 
 import android.app.AlarmManager;

--- a/AnkiDroid/src/main/java/com/ichi2/compat/customtabs/CustomTabActivityHelper.java
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/customtabs/CustomTabActivityHelper.java
@@ -1,3 +1,4 @@
+//noinspection MissingCopyrightHeader #8659
 // Copyright 2015 Google Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/AnkiDroid/src/main/java/com/ichi2/compat/customtabs/CustomTabsFallback.java
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/customtabs/CustomTabsFallback.java
@@ -1,3 +1,4 @@
+//noinspection MissingCopyrightHeader #8659
 // Copyright 2015 Google Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/AnkiDroid/src/main/java/com/ichi2/compat/customtabs/CustomTabsHelper.java
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/customtabs/CustomTabsHelper.java
@@ -1,3 +1,4 @@
+//noinspection MissingCopyrightHeader #8659
 // Copyright 2015 Google Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/AnkiDroid/src/main/java/com/ichi2/compat/customtabs/KeepAliveService.java
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/customtabs/KeepAliveService.java
@@ -1,3 +1,4 @@
+//noinspection MissingCopyrightHeader #8659
 // Copyright 2015 Google Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/AnkiDroid/src/main/java/com/ichi2/compat/customtabs/ServiceConnection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/customtabs/ServiceConnection.java
@@ -1,3 +1,4 @@
+//noinspection MissingCopyrightHeader #8659
 // Copyright 2015 Google Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/AnkiDroid/src/main/java/com/ichi2/compat/customtabs/ServiceConnectionCallback.java
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/customtabs/ServiceConnectionCallback.java
@@ -1,3 +1,4 @@
+//noinspection MissingCopyrightHeader #8659
 // Copyright 2015 Google Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/CollectionGetter.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/CollectionGetter.java
@@ -1,3 +1,4 @@
+//noinspection MissingCopyrightHeader #8659
 package com.ichi2.libanki;
 
 public interface CollectionGetter {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/importer/NoteImporter.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/importer/NoteImporter.java
@@ -1,3 +1,4 @@
+//noinspection MissingCopyrightHeader #8659
 package com.ichi2.libanki.importer;
 
 import android.database.Cursor;

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/importer/TextImporter.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/importer/TextImporter.java
@@ -1,3 +1,4 @@
+//noinspection MissingCopyrightHeader #8659
 package com.ichi2.libanki.importer;
 
 import android.os.Build;

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/AbstractDeckTreeNode.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/AbstractDeckTreeNode.java
@@ -1,3 +1,4 @@
+//noinspection MissingCopyrightHeader #8659
 package com.ichi2.libanki.sched;
 
 import com.ichi2.libanki.Collection;

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/AbstractSched.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/AbstractSched.java
@@ -1,3 +1,4 @@
+//noinspection MissingCopyrightHeader #8659
 package com.ichi2.libanki.sched;
 
 import android.app.Activity;

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Counts.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Counts.java
@@ -1,3 +1,4 @@
+//noinspection MissingCopyrightHeader #8659
 package com.ichi2.libanki.sched;
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/DeckDueTreeNode.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/DeckDueTreeNode.java
@@ -1,3 +1,4 @@
+//noinspection MissingCopyrightHeader #8659
 package com.ichi2.libanki.sched;
 
 import com.ichi2.libanki.Collection;

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/template/Conditional.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/template/Conditional.java
@@ -1,3 +1,4 @@
+//noinspection MissingCopyrightHeader #8659
 package com.ichi2.libanki.template;
 
 import java.util.List;

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/template/MathJax.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/template/MathJax.java
@@ -1,3 +1,4 @@
+//noinspection MissingCopyrightHeader #8659
 package com.ichi2.libanki.template;
 
 import java.util.regex.Pattern;

--- a/AnkiDroid/src/main/java/com/ichi2/preferences/TimePreference.java
+++ b/AnkiDroid/src/main/java/com/ichi2/preferences/TimePreference.java
@@ -1,3 +1,4 @@
+//noinspection MissingCopyrightHeader #8659
 package com.ichi2.preferences;
 
 import android.content.Context;

--- a/AnkiDroid/src/main/java/com/ichi2/themes/HtmlColors.java
+++ b/AnkiDroid/src/main/java/com/ichi2/themes/HtmlColors.java
@@ -1,3 +1,4 @@
+//noinspection MissingCopyrightHeader #8659
 package com.ichi2.themes;
 
 import java.util.HashMap;

--- a/AnkiDroid/src/main/java/com/ichi2/ui/AppCompatPreferenceActivity.java
+++ b/AnkiDroid/src/main/java/com/ichi2/ui/AppCompatPreferenceActivity.java
@@ -1,3 +1,4 @@
+//noinspection MissingCopyrightHeader #8659
 /*
  * Copyright (C) 2014 The Android Open Source Project
  *

--- a/AnkiDroid/src/main/java/com/ichi2/ui/ButtonItemAdapter.java
+++ b/AnkiDroid/src/main/java/com/ichi2/ui/ButtonItemAdapter.java
@@ -1,3 +1,4 @@
+//noinspection MissingCopyrightHeader #8659
 /*
  * The MIT License (MIT)
 

--- a/AnkiDroid/src/main/java/com/ichi2/ui/SeekBarPreference.java
+++ b/AnkiDroid/src/main/java/com/ichi2/ui/SeekBarPreference.java
@@ -1,3 +1,4 @@
+//noinspection MissingCopyrightHeader #8659
 /* The following code was written by Matthew Wiggins
  * and is released under the APACHE 2.0 license
  *

--- a/AnkiDroid/src/main/java/com/ichi2/upgrade/Upgrade.java
+++ b/AnkiDroid/src/main/java/com/ichi2/upgrade/Upgrade.java
@@ -1,4 +1,4 @@
-
+//noinspection MissingCopyrightHeader #8659
 package com.ichi2.upgrade;
 
 import com.ichi2.libanki.Collection;

--- a/AnkiDroid/src/main/java/com/ichi2/utils/CollectionUtils.java
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/CollectionUtils.java
@@ -1,3 +1,4 @@
+//noinspection MissingCopyrightHeader #8659
 package com.ichi2.utils;
 
 import java.util.Collection;

--- a/AnkiDroid/src/main/java/com/ichi2/utils/JSON.java
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/JSON.java
@@ -1,3 +1,4 @@
+//noinspection MissingCopyrightHeader #8659
 /*
  * Copyright (C) 2010 The Android Open Source Project
  *

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/IssueRegistry.java
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/IssueRegistry.java
@@ -3,6 +3,7 @@ package com.ichi2.anki.lint;
 import com.android.tools.lint.detector.api.ApiKt;
 import com.android.tools.lint.detector.api.Issue;
 import com.ichi2.anki.lint.rules.ConstantFieldDetector;
+import com.ichi2.anki.lint.rules.CopyrightHeaderExists;
 import com.ichi2.anki.lint.rules.DirectCalendarInstanceUsage;
 import com.ichi2.anki.lint.rules.DirectSnackbarMakeUsage;
 import com.ichi2.anki.lint.rules.DirectSystemTimeInstantiation;
@@ -28,6 +29,7 @@ public class IssueRegistry extends com.android.tools.lint.client.api.IssueRegist
     public List<Issue> getIssues() {
         // Keep this list lexicographically ordered.
         List<Issue> issues = new ArrayList<>();
+        issues.add(CopyrightHeaderExists.ISSUE);
         issues.add(DirectCalendarInstanceUsage.ISSUE);
         issues.add(DirectDateInstantiation.ISSUE);
         issues.add(DirectGregorianInstantiation.ISSUE);

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/rules/CopyrightHeaderExists.java
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/CopyrightHeaderExists.java
@@ -1,0 +1,103 @@
+/*
+ *  Copyright (c) 2021 Almas Ahmad <ahmadalmas.786.aa@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.lint.rules;
+
+import com.android.tools.lint.detector.api.Context;
+import com.android.tools.lint.detector.api.Detector;
+import com.android.tools.lint.detector.api.Implementation;
+import com.android.tools.lint.detector.api.Issue;
+import com.android.tools.lint.detector.api.Location;
+import com.android.tools.lint.detector.api.Scope;
+import com.android.tools.lint.detector.api.SourceCodeScanner;
+import com.google.common.annotations.Beta;
+import com.google.common.annotations.VisibleForTesting;
+import com.ichi2.anki.lint.utils.Constants;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.jetbrains.uast.UClass;
+import org.jetbrains.uast.UElement;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.regex.Pattern;
+
+@SuppressWarnings("UnstableApiUsage")
+@Beta
+public class CopyrightHeaderExists extends Detector implements SourceCodeScanner {
+    // This string matches GPLv3 under all current circumstances. It does not currently work if split over two lines
+    private static final Pattern COPYRIGHT_PATTERN = Pattern.compile("version 3 of the License, or \\(at");
+    // Suppressing this lint doesn't seem to work as it's the first statement, so allow a
+    private static final Pattern IGNORE_CHECK_PATTERN = Pattern.compile("MissingCopyrightHeader");
+
+    @VisibleForTesting
+    static final String ID = "MissingCopyrightHeader";
+    @VisibleForTesting
+    static final String DESCRIPTION = "All files in AnkiDroid must contain a GPLv3-compatible copyright header";
+    private static final String EXPLANATION = "All files in AnkiDroid must contain a " +
+            "GPLv3-compatible copyright header" +
+            "The copyright header can be set in " +
+            "Settings - Editor - Copyright - Copyright Profiles - Add Profile - AnkiDroid. " +
+            "Or search in Settings for 'Copyright'" +
+            "A GPLv3 template is available:\n" +
+            "https://github.com/ankidroid/Anki-Android/issues/8211#issuecomment-825269673";
+    private static final Implementation implementation = new Implementation(CopyrightHeaderExists.class, Scope.JAVA_FILE_SCOPE);
+    public static final Issue ISSUE = Issue.create(
+            ID,
+            DESCRIPTION,
+            EXPLANATION,
+            Constants.ANKI_CODE_STYLE_CATEGORY,
+            Constants.ANKI_CODE_STYLE_PRIORITY,
+            Constants.ANKI_CODE_STYLE_SEVERITY,
+            implementation
+    );
+
+    @Nullable
+    @Override
+    public List<Class<? extends UElement>> getApplicableUastTypes() {
+        return Collections.singletonList(UClass.class);
+    }
+
+    @Override
+    public void afterCheckFile(@NotNull Context context) {
+
+        CharSequence contents = context.getContents();
+        if (contents == null
+                || COPYRIGHT_PATTERN.matcher(contents).find()
+                || IGNORE_CHECK_PATTERN.matcher(contents).find())
+        {
+            return;
+        }
+
+        // select from the start to the first line with content
+        int end = 0;
+        boolean foundChar = false;
+        for (int i = 0; i < contents.length(); i++) {
+            foundChar |= !Character.isWhitespace(contents.charAt(i));
+            if (foundChar && contents.charAt(i) == '\n') {
+                end = i;
+                break;
+            }
+        }
+
+        // If there is no line break, highlight the contents
+        int endOffset = end == 0 ? contents.length() : end;
+
+        Location location = Location.create(context.file, contents.subSequence(0, endOffset), 0, endOffset);
+        context.report(ISSUE, location, DESCRIPTION);
+    }
+}

--- a/lint-rules/src/test/java/com/ichi2/anki/lint/rules/CopyrightHeaderExistsTest.java
+++ b/lint-rules/src/test/java/com/ichi2/anki/lint/rules/CopyrightHeaderExistsTest.java
@@ -1,0 +1,85 @@
+/*
+ *  Copyright (c) 2021 Almas Ahmad <ahmadalmas.786.aa@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.lint.rules;
+
+import com.google.common.annotations.Beta;
+
+import org.intellij.lang.annotations.Language;
+import org.junit.Test;
+
+import static com.android.tools.lint.checks.infrastructure.TestFile.JavaTestFile.create;
+import static com.android.tools.lint.checks.infrastructure.TestLintTask.lint;
+import static org.junit.Assert.assertTrue;
+
+@SuppressWarnings("UnstableApiUsage")
+@Beta
+public class CopyrightHeaderExistsTest {
+
+    @Language("JAVA")
+    private final String mCopyrightHeader = "/*\n" +
+            " *  This program is free software; you can redistribute it and/or modify it under\n" +
+            " *  the terms of the GNU General Public License as published by the Free Software\n" +
+            " *  Foundation; either version 3 of the License, or (at your option) any later\n" +
+            " *  version.\n" +
+            " *\n" +
+            " *  This program is distributed in the hope that it will be useful, but WITHOUT ANY\n" +
+            " *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A\n" +
+            " *  PARTICULAR PURPOSE. See the GNU General Public License for more details.\n" +
+            " *\n" +
+            " *  You should have received a copy of the GNU General Public License along with\n" +
+            " *  this program.  If not, see <http://www.gnu.org/licenses/>.\n" +
+            " */";
+
+    @Language("JAVA")
+    private final String mNoCopyrightHeader = "\n" +
+            "package com.ichi2.upgrade;\n" +
+            "\n" +
+            "import com.ichi2.libanki.Collection;\n" +
+            "\n" +
+            "import com.ichi2.utils.JSONException;\n" +
+            "import com.ichi2.utils.JSONObject;\n" +
+            "\n" +
+            "import timber.log.Timber;\n" +
+            "\n" +
+            "public class Upgrade {\n" +
+            "}";
+
+
+    @Test
+    public void fileWithCopyrightHeaderPasses() {
+        lint()
+                .allowMissingSdk()
+                .files(create(mCopyrightHeader))
+                .issues(CopyrightHeaderExists.ISSUE)
+                .run()
+                .expectClean();
+    }
+
+    @Test
+    public void fileWithNoCopyrightHeaderFails() {
+        lint()
+                .allowMissingSdk()
+                .files(create(mNoCopyrightHeader))
+                .issues(CopyrightHeaderExists.ISSUE)
+                .run()
+                .expectErrorCount(1)
+                .check(output -> {
+                    assertTrue(output.contains(CopyrightHeaderExists.ID));
+                    assertTrue(output.contains(CopyrightHeaderExists.DESCRIPTION));
+                });
+    }
+}


### PR DESCRIPTION
Fixup of PR #8359 - blocked on #8659

> ## Pull Request template
> added a lint rule which will check that all files have copyright header and if not will explain contributer how to do so
> ## Fixes
> Fixes #8211 
> 
> ## Approach
> Feed `Copyright Header` in `Pattern`
> `Matcher` will tell if that pattern is found
> Reference use : https://github.com/vanniktech/lint-rules/blob/master/lint-rules-android-lint/src/main/java/com/vanniktech/lintrules/android/InvalidSingleLineCommentDetector.kt
> ## How Has This Been Tested?
> 
> CI should tell
> 
> ## Learning (optional, can help others)
> https://github.com/vanniktech/lint-rules
> ## Checklist
> 
> - [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
> - [x] You have a descriptive commit message with a short title (first line, max 50 chars).
> - [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
> - [x] You have commented your code, particularly in hard-to-understand areas
> - [x] You have performed a self-review of your own code
> - [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
> - [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)