### PR TITLE
Fix: Prevent crash on long pressing at end of card browser

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -687,30 +687,27 @@ public class CardBrowser extends NavigationDrawerActivity implements
         });
         mCardsListView.setOnItemLongClickListener((adapterView, view, position, id) -> {
             if (mInMultiSelectMode) {
-                if (!mCheckedCards.contains(mCardsListView.getItemAtPosition(position))) {
-                    for (int i = Math.min(mLastSelectedPosition, position); i <= Math.max(mLastSelectedPosition, position); i++) {
-                        // Fetch card at position i.
-                        CardCache card = (CardCache) mCardsListView.getItemAtPosition(i);
+                for (int i = Math.min(mLastSelectedPosition, position); i <= Math.max(mLastSelectedPosition, position); i++) {
+                    // Fetch card at position i.
+                    CardCache card = (CardCache) mCardsListView.getItemAtPosition(i);
 
-                        // If card is not in the list of checked cards, then add it.
-                        if (!mCheckedCards.contains(card)) {
-                            mCheckedCards.add(card);
-                            onSelectionChanged();
-                        }
+                    // If card is not in the list of checked cards, then add it.
+                    if (mCheckedCards.add(card)) {
+                        onSelectionChanged();
                     }
                 }
             } else {
                 mLastSelectedPosition = position;
                 saveScrollingState(position);
                 loadMultiSelectMode();
-            }
 
-            // click on whole cell triggers select
-            CheckBox cb = view.findViewById(R.id.card_checkbox);
-            cb.toggle();
-            onCheck(position, view);
-            recenterListView(view);
-            mCardsAdapter.notifyDataSetChanged();
+                // click on whole cell triggers select
+                CheckBox cb = view.findViewById(R.id.card_checkbox);
+                cb.toggle();
+                onCheck(position, view);
+                recenterListView(view);
+                mCardsAdapter.notifyDataSetChanged();
+            }
             return true;
         });
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -688,8 +688,10 @@ public class CardBrowser extends NavigationDrawerActivity implements
         mCardsListView.setOnItemLongClickListener((adapterView, view, position, id) -> {
             if (mInMultiSelectMode) {
                 for (int i = Math.min(mLastSelectedPosition, position); i <= Math.max(mLastSelectedPosition, position); i++) {
+                    // Fetch card at position i.
                     CardCache card = (CardCache) mCardsListView.getItemAtPosition(i);
 
+                    // If card is not in the list of checked cards, then add it, otherwise remove it.
                     if (!mCheckedCards.contains(card)) {
                         mCheckedCards.add(card);
                     } else {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -686,32 +686,17 @@ public class CardBrowser extends NavigationDrawerActivity implements
             }
         });
 
-        setLongClickListenerOnItems();
-
-        getWindow().setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_ALWAYS_HIDDEN);
-
-        // If a valid value for last deck exists then use it, otherwise use libanki selected deck
-        if (getLastDeckId() != null && getLastDeckId() == ALL_DECKS_ID) {
-            selectAllDecks();
-        } else  if (getLastDeckId() != null && getCol().getDecks().get(getLastDeckId(), false) != null) {
-            selectDeckById(getLastDeckId());
-        } else {
-            selectDeckById(getCol().getDecks().selected());
-        }
-    }
-
-    @VisibleForTesting
-    public void setLongClickListenerOnItems() {
         mCardsListView.setOnItemLongClickListener((adapterView, view, position, id) -> {
             if (mInMultiSelectMode) {
+                boolean hasChanged = false;
                 for (int i = Math.min(mLastSelectedPosition, position); i <= Math.max(mLastSelectedPosition, position); i++) {
-                    // Fetch card at position i.
                     CardCache card = (CardCache) mCardsListView.getItemAtPosition(i);
 
-                    // If card is not in the list of checked cards, then add it.
-                    if (mCheckedCards.add(card)) {
-                        onSelectionChanged();
-                    }
+                    // Add to the set of checked cards
+                    hasChanged |= mCheckedCards.add(card);
+                }
+                if (hasChanged) {
+                    onSelectionChanged();
                 }
             } else {
                 mLastSelectedPosition = position;
@@ -727,6 +712,17 @@ public class CardBrowser extends NavigationDrawerActivity implements
             }
             return true;
         });
+
+        getWindow().setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_ALWAYS_HIDDEN);
+
+        // If a valid value for last deck exists then use it, otherwise use libanki selected deck
+        if (getLastDeckId() != null && getLastDeckId() == ALL_DECKS_ID) {
+            selectAllDecks();
+        } else  if (getLastDeckId() != null && getCol().getDecks().get(getLastDeckId(), false) != null) {
+            selectDeckById(getLastDeckId());
+        } else {
+            selectDeckById(getCol().getDecks().selected());
+        }
     }
 
 
@@ -1983,7 +1979,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
         private void handleSearchResult() {
             Timber.i("CardBrowser:: Completed doInBackgroundSearchCards Successfully");
             updateList();
-
+            
             if ((mSearchView == null) || mSearchView.isIconified()) {
                 return;
             }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -685,6 +685,23 @@ public class CardBrowser extends NavigationDrawerActivity implements
                 openNoteEditorForCard(clickedCardId);
             }
         });
+
+        setLongClickListenerOnItems();
+
+        getWindow().setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_ALWAYS_HIDDEN);
+
+        // If a valid value for last deck exists then use it, otherwise use libanki selected deck
+        if (getLastDeckId() != null && getLastDeckId() == ALL_DECKS_ID) {
+            selectAllDecks();
+        } else  if (getLastDeckId() != null && getCol().getDecks().get(getLastDeckId(), false) != null) {
+            selectDeckById(getLastDeckId());
+        } else {
+            selectDeckById(getCol().getDecks().selected());
+        }
+    }
+
+    @VisibleForTesting
+    public void setLongClickListenerOnItems() {
         mCardsListView.setOnItemLongClickListener((adapterView, view, position, id) -> {
             if (mInMultiSelectMode) {
                 for (int i = Math.min(mLastSelectedPosition, position); i <= Math.max(mLastSelectedPosition, position); i++) {
@@ -710,17 +727,6 @@ public class CardBrowser extends NavigationDrawerActivity implements
             }
             return true;
         });
-
-        getWindow().setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_ALWAYS_HIDDEN);
-
-        // If a valid value for last deck exists then use it, otherwise use libanki selected deck
-        if (getLastDeckId() != null && getLastDeckId() == ALL_DECKS_ID) {
-            selectAllDecks();
-        } else  if (getLastDeckId() != null && getCol().getDecks().get(getLastDeckId(), false) != null) {
-            selectDeckById(getLastDeckId());
-        } else {
-            selectDeckById(getCol().getDecks().selected());
-        }
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -688,28 +688,29 @@ public class CardBrowser extends NavigationDrawerActivity implements
         mCardsListView.setOnItemLongClickListener((adapterView, view, position, id) -> {
             if (mInMultiSelectMode) {
                 for (int i = Math.min(mLastSelectedPosition, position); i <= Math.max(mLastSelectedPosition, position); i++) {
-                    // getting the view of particular view and then checking whether it's already checked or not
-                    View childView = mCardsListView.getChildAt(i);
-                    if (childView != null) {
-                        CheckBox cb = childView.findViewById(R.id.card_checkbox);
-                        if (!cb.isChecked()) {
-                            cb.toggle();
-                            onCheck(i, childView);
-                        }
+                    // getting the item at the particular position and then checking whether it's already checked or not
+                    mCheckedCards.add((CardCache) mCardsListView.getItemAtPosition(i));
+                    CardCache card = getCards().get(position);
+
+                    if (!mCheckedCards.contains(card)) {
+                        mCheckedCards.add(card);
+                    } else {
+                        mCheckedCards.remove(card);
                     }
+                    onSelectionChanged();
                 }
             } else {
                 mLastSelectedPosition = position;
                 saveScrollingState(position);
                 loadMultiSelectMode();
-
-                // click on whole cell triggers select
-                CheckBox cb = view.findViewById(R.id.card_checkbox);
-                cb.toggle();
-                onCheck(position, view);
-                recenterListView(view);
-                mCardsAdapter.notifyDataSetChanged();
             }
+
+            // click on whole cell triggers select
+            CheckBox cb = view.findViewById(R.id.card_checkbox);
+            cb.toggle();
+            onCheck(position, view);
+            recenterListView(view);
+            mCardsAdapter.notifyDataSetChanged();
             return true;
         });
 
@@ -1979,7 +1980,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
         private void handleSearchResult() {
             Timber.i("CardBrowser:: Completed doInBackgroundSearchCards Successfully");
             updateList();
-            
+
             if ((mSearchView == null) || mSearchView.isIconified()) {
                 return;
             }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -688,9 +688,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
         mCardsListView.setOnItemLongClickListener((adapterView, view, position, id) -> {
             if (mInMultiSelectMode) {
                 for (int i = Math.min(mLastSelectedPosition, position); i <= Math.max(mLastSelectedPosition, position); i++) {
-                    // getting the item at the particular position and then checking whether it's already checked or not
-                    mCheckedCards.add((CardCache) mCardsListView.getItemAtPosition(i));
-                    CardCache card = getCards().get(position);
+                    CardCache card = (CardCache) mCardsListView.getItemAtPosition(i);
 
                     if (!mCheckedCards.contains(card)) {
                         mCheckedCards.add(card);

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -687,17 +687,17 @@ public class CardBrowser extends NavigationDrawerActivity implements
         });
         mCardsListView.setOnItemLongClickListener((adapterView, view, position, id) -> {
             if (mInMultiSelectMode) {
-                for (int i = Math.min(mLastSelectedPosition, position); i <= Math.max(mLastSelectedPosition, position); i++) {
-                    // Fetch card at position i.
-                    CardCache card = (CardCache) mCardsListView.getItemAtPosition(i);
+                if (!mCheckedCards.contains(mCardsListView.getItemAtPosition(position))) {
+                    for (int i = Math.min(mLastSelectedPosition, position); i <= Math.max(mLastSelectedPosition, position); i++) {
+                        // Fetch card at position i.
+                        CardCache card = (CardCache) mCardsListView.getItemAtPosition(i);
 
-                    // If card is not in the list of checked cards, then add it, otherwise remove it.
-                    if (!mCheckedCards.contains(card)) {
-                        mCheckedCards.add(card);
-                    } else {
-                        mCheckedCards.remove(card);
+                        // If card is not in the list of checked cards, then add it.
+                        if (!mCheckedCards.contains(card)) {
+                            mCheckedCards.add(card);
+                            onSelectionChanged();
+                        }
                     }
-                    onSelectionChanged();
                 }
             } else {
                 mLastSelectedPosition = position;

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -690,10 +690,12 @@ public class CardBrowser extends NavigationDrawerActivity implements
                 for (int i = Math.min(mLastSelectedPosition, position); i <= Math.max(mLastSelectedPosition, position); i++) {
                     // getting the view of particular view and then checking whether it's already checked or not
                     View childView = mCardsListView.getChildAt(i);
-                    CheckBox cb = childView.findViewById(R.id.card_checkbox);
-                    if (!cb.isChecked()) {
-                        cb.toggle();
-                        onCheck(i, childView);
+                    if (childView != null) {
+                        CheckBox cb = childView.findViewById(R.id.card_checkbox);
+                        if (!cb.isChecked()) {
+                            cb.toggle();
+                            onCheck(i, childView);
+                        }
                     }
                 }
             } else {

--- a/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.java
@@ -7,6 +7,7 @@ import android.content.ComponentName;
 import android.content.Intent;
 import android.os.Bundle;
 import android.view.MenuItem;
+import android.view.View;
 import android.widget.AdapterView;
 import android.widget.ListView;
 
@@ -564,11 +565,11 @@ public class CardBrowserTest extends RobolectricTest {
 
     @Test
     public void checkIfLongSelectChecksAllCardsInBetween() {
-        CardBrowser browser = getBrowserWithNotes(10);
-        browser.setLongClickListenerOnItems();
-        selectOneOfManyCards(browser, 4);
-        selectOneOfManyCards(browser, 8);
-        assertThat(browser.checkedCardCount(), is(5));
+        // #8467 - selecting cards outside the view pane (20) caused a crash as we were using view-based positions
+        CardBrowser browser = getBrowserWithNotes(25);
+        selectOneOfManyCards(browser, 7); // HACK: Fix a bug in tests by choosing a value < 8
+        selectOneOfManyCards(browser, 24);
+        assertThat(browser.checkedCardCount(), is(18));
     }
 
     protected void assertUndoDoesNotContain(CardBrowser browser, @StringRes int resId) {
@@ -618,11 +619,17 @@ public class CardBrowserTest extends RobolectricTest {
         ShadowActivity shadowActivity = shadowOf(browser);
         ListView toSelect = shadowActivity.getContentView().findViewById(R.id.card_browser_list);
 
-        //roboelectric doesn't easily seem to allow us to fire an onItemLongClick
+        // Robolectric doesn't easily seem to allow us to fire an onItemLongClick
         AdapterView.OnItemLongClickListener listener = toSelect.getOnItemLongClickListener();
-        if (listener == null)
+        if (listener == null) {
             throw new IllegalStateException("no listener found");
-        listener.onItemLongClick(null, toSelect.getChildAt(position),
+        }
+
+        View childAt = toSelect.getChildAt(position);
+        if (childAt == null) {
+            Timber.w("Can't use childAt on position " + position + " for a single click as it is not visible");
+        }
+        listener.onItemLongClick(null, childAt,
                 position, toSelect.getItemIdAtPosition(position));
     }
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.java
@@ -100,7 +100,7 @@ public class CardBrowserTest extends RobolectricTest {
     public void selectNoneIsVisibleWhenSelectingOne() {
         CardBrowser browser = getBrowserWithMultipleNotes();
         advanceRobolectricLooperWithSleep();
-        selectOneOfManyCards(browser);
+        selectOneOfManyCards(browser, 0);
         advanceRobolectricLooperWithSleep();
         assertThat(browser.isShowingSelectNone(), is(true));
     }
@@ -108,14 +108,14 @@ public class CardBrowserTest extends RobolectricTest {
     @Test
     public void selectAllIsVisibleWhenSelectingOne() {
         CardBrowser browser = getBrowserWithMultipleNotes();
-        selectOneOfManyCards(browser);
+        selectOneOfManyCards(browser, 0);
         assertThat(browser.isShowingSelectAll(), is(true));
     }
 
     @Test
     public void browserIsInMultiSelectModeWhenSelectingOne() {
         CardBrowser browser = getBrowserWithMultipleNotes();
-        selectOneOfManyCards(browser);
+        selectOneOfManyCards(browser, 0);
         assertThat(browser.isInMultiSelectMode(), is(true));
     }
 
@@ -562,6 +562,14 @@ public class CardBrowserTest extends RobolectricTest {
         Assert.assertNotEquals("Modification time must change", initialMod, finalMod);
     }
 
+    @Test
+    public void checkIfLongSelectChecksAllCardsInBetween() {
+        CardBrowser browser = getBrowserWithNotes(10);
+        selectOneOfManyCards(browser, 4);
+        selectOneOfManyCards(browser, 8);
+        assertThat(browser.checkedCardCount(), is(5));
+    }
+
     protected void assertUndoDoesNotContain(CardBrowser browser, @StringRes int resId) {
         ShadowActivity shadowActivity = shadowOf(browser);
         MenuItem item = shadowActivity.getOptionsMenu().findItem(R.id.action_undo);
@@ -600,11 +608,10 @@ public class CardBrowserTest extends RobolectricTest {
         browser.clearCardData(positionToCorrupt);
     }
 
-    private void selectOneOfManyCards(CardBrowser browser) {
+    private void selectOneOfManyCards(CardBrowser browser, int position) {
         Timber.d("Selecting single card");
         ShadowActivity shadowActivity = shadowOf(browser);
         ListView toSelect = shadowActivity.getContentView().findViewById(R.id.card_browser_list);
-        int position = 0;
 
         //roboelectric doesn't easily seem to allow us to fire an onItemLongClick
         AdapterView.OnItemLongClickListener listener = toSelect.getOnItemLongClickListener();

--- a/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.java
@@ -565,6 +565,7 @@ public class CardBrowserTest extends RobolectricTest {
     @Test
     public void checkIfLongSelectChecksAllCardsInBetween() {
         CardBrowser browser = getBrowserWithNotes(10);
+        browser.setLongClickListenerOnItems();
         selectOneOfManyCards(browser, 4);
         selectOneOfManyCards(browser, 8);
         assertThat(browser.checkedCardCount(), is(5));

--- a/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.java
@@ -100,7 +100,7 @@ public class CardBrowserTest extends RobolectricTest {
     public void selectNoneIsVisibleWhenSelectingOne() {
         CardBrowser browser = getBrowserWithMultipleNotes();
         advanceRobolectricLooperWithSleep();
-        selectOneOfManyCards(browser, 0);
+        selectOneOfManyCards(browser);
         advanceRobolectricLooperWithSleep();
         assertThat(browser.isShowingSelectNone(), is(true));
     }
@@ -108,14 +108,14 @@ public class CardBrowserTest extends RobolectricTest {
     @Test
     public void selectAllIsVisibleWhenSelectingOne() {
         CardBrowser browser = getBrowserWithMultipleNotes();
-        selectOneOfManyCards(browser, 0);
+        selectOneOfManyCards(browser);
         assertThat(browser.isShowingSelectAll(), is(true));
     }
 
     @Test
     public void browserIsInMultiSelectModeWhenSelectingOne() {
         CardBrowser browser = getBrowserWithMultipleNotes();
-        selectOneOfManyCards(browser, 0);
+        selectOneOfManyCards(browser);
         assertThat(browser.isInMultiSelectMode(), is(true));
     }
 
@@ -607,6 +607,10 @@ public class CardBrowserTest extends RobolectricTest {
     private void deleteCardAtPosition(CardBrowser browser, int positionToCorrupt) {
         removeCardFromCollection(browser.getCardIds()[positionToCorrupt]);
         browser.clearCardData(positionToCorrupt);
+    }
+
+    private void selectOneOfManyCards(CardBrowser cardBrowser) {
+        selectOneOfManyCards(cardBrowser, 0);
     }
 
     private void selectOneOfManyCards(CardBrowser browser, int position) {


### PR DESCRIPTION
From #8468. fixed in prep for 2.15

> ## Purpose / Description
> App should not crash on long pressing an already selected card in the card browser.
>  
> ## Fixes
> Fixes #8467 
> 
> ## Approach
> `getChildAt()` method of `ListView` is wrongly used since it concerns the visible items and not the complete list of items. The approach followed to fix this is to make use of the `mCheckedCards` list. While iterating through the cards to select them, the `mCheckedCards` list is being updated and `onSelectionToggle()`  is being called to update the checked state of the list items.
> 
> ## How Has This Been Tested?
> 
> Verified that the mentioned issue does not occur after this change.
> 
> ## Checklist
> 
> - [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
> - [x] You have a descriptive commit message with a short title (first line, max 50 chars).
> - [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
> - [x] You have commented your code, particularly in hard-to-understand areas
> - [x] You have performed a self-review of your own code
> - [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
> - [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

My notes:

```
We were incorrectly using .getChildAt() which returns the view
based on the visual position. Once we got past the end of the
first "page" of the list, we got a crash.

We now update the data, and have the adapter set the checked state
when the data comes into the foreground

Fixes #8467
```