### PR TITLE
Fixes #8618: Add colIsOpen() checks in DeckPicker before executing dependent tasks

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -665,7 +665,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
     @Override
     public boolean onPrepareOptionsMenu(Menu menu) {
         // Null check to prevent crash when col inaccessible
-        if (CollectionHelper.getInstance().getColSafe(this) == null) {
+        if (!colIsOpen()) {
             return false;
         }
         return super.onPrepareOptionsMenu(menu);
@@ -681,13 +681,6 @@ public class DeckPicker extends NavigationDrawerActivity implements
         menu.findItem(R.id.action_check_database).setEnabled(sdCardAvailable);
         menu.findItem(R.id.action_check_media).setEnabled(sdCardAvailable);
         menu.findItem(R.id.action_empty_cards).setEnabled(sdCardAvailable);
-
-        // I haven't had an exception here, but it feels this may be flaky
-        try {
-            displaySyncBadge(menu);
-        } catch (Exception e) {
-            Timber.w(e, "Error Displaying Sync Badge");
-        }
 
         MenuItem toolbarSearchItem = menu.findItem(R.id.deck_picker_action_filter);
         mToolbarSearchView = (SearchView) toolbarSearchItem.getActionView();
@@ -709,6 +702,8 @@ public class DeckPicker extends NavigationDrawerActivity implements
         });
 
         if (colIsOpen()) {
+            displaySyncBadge(menu);
+
             // Show / hide undo
             if (mFragmented || !getCol().undoAvailable()) {
                 menu.findItem(R.id.action_undo).setVisible(false);
@@ -728,7 +723,8 @@ public class DeckPicker extends NavigationDrawerActivity implements
     }
 
 
-    private void displaySyncBadge(Menu menu) {
+    @VisibleForTesting
+    protected void displaySyncBadge(Menu menu) {
         MenuItem syncMenu = menu.findItem(R.id.action_sync);
         SyncStatus syncStatus = SyncStatus.getSyncStatus(this::getCol);
         switch (syncStatus) {
@@ -970,7 +966,9 @@ public class DeckPicker extends NavigationDrawerActivity implements
         }
         /* Complete task and enqueue fetching nonessential data for
           startup. */
-        TaskManager.launchCollectionTask(new CollectionTask.LoadCollectionComplete());
+        if (colIsOpen()) {
+            TaskManager.launchCollectionTask(new CollectionTask.LoadCollectionComplete());
+        }
         // Update sync status (if we've come back from a screen)
         supportInvalidateOptionsMenu();
     }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/DeckPickerTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/DeckPickerTest.java
@@ -5,6 +5,7 @@ import android.content.Intent;
 import android.content.SharedPreferences;
 import android.content.SharedPreferences.Editor;
 import android.content.pm.PackageManager;
+import android.view.Menu;
 
 import com.ichi2.anki.dialogs.DatabaseErrorDialog;
 import com.ichi2.libanki.Collection;
@@ -26,6 +27,8 @@ import androidx.test.ext.junit.runners.AndroidJUnit4;
 import static com.ichi2.anki.DeckPicker.UPGRADE_VERSION_KEY;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.mockito.Mockito.mock;
@@ -266,9 +269,82 @@ public class DeckPickerTest extends RobolectricTest {
         }
     }
 
+
+    @Test
+    public void doNotShowOptionsMenuWhenCollectionInaccessible() {
+        try {
+            enableNullCollection();
+            DeckPickerEx d = super.startActivityNormallyOpenCollectionWithIntent(DeckPickerEx.class, new Intent());
+            assertThat("Options menu not displayed when collection is inaccessible", d.mPrepareOptionsMenu, is(false));
+        } finally {
+            disableNullCollection();
+        }
+    }
+
+    @Test
+    public void showOptionsMenuWhenCollectionAccessible() {
+        try {
+            InitialActivityTest.grantWritePermissions();
+            DeckPickerEx d = super.startActivityNormallyOpenCollectionWithIntent(DeckPickerEx.class, new Intent());
+            assertThat("Options menu is displayed when collection is accessible", d.mPrepareOptionsMenu, is(true));
+        } finally {
+            InitialActivityTest.revokeWritePermissions();
+        }
+    }
+
+    @Test
+    public void doNotShowSyncBadgeWhenCollectionInaccessible() {
+        try {
+            enableNullCollection();
+            DeckPickerEx d = super.startActivityNormallyOpenCollectionWithIntent(DeckPickerEx.class, new Intent());
+            assertThat("Sync badge is not displayed when collection is inaccessible", d.mDisplaySyncBadge, is(false));
+        } finally {
+            disableNullCollection();
+        }
+    }
+
+    @Test
+    public void showSyncBadgeWhenCollectionAccessible() {
+        try {
+            InitialActivityTest.grantWritePermissions();
+            DeckPickerEx d = super.startActivityNormallyOpenCollectionWithIntent(DeckPickerEx.class, new Intent());
+            assertThat("Sync badge is displayed when collection is accessible", d.mDisplaySyncBadge, is(true));
+        } finally {
+            InitialActivityTest.revokeWritePermissions();
+        }
+    }
+
+    @Test
+    public void onResumeLoadCollectionFailureWithInaccessibleCollection() {
+        try {
+            InitialActivityTest.revokeWritePermissions();
+            enableNullCollection();
+            DeckPickerEx d = super.startActivityNormallyOpenCollectionWithIntent(DeckPickerEx.class, new Intent());
+
+            // Neither collection, not its models will be initialized without storage permission
+            assertThat("Lazy Collection initialization CollectionTask.LoadCollectionComplete fails", d.getCol(), is(nullValue()));
+        } finally {
+            disableNullCollection();
+        }
+    }
+
+    @Test
+    public void onResumeLoadCollectionSuccessWithAccessibleCollection() {
+        try {
+            InitialActivityTest.grantWritePermissions();
+            DeckPickerEx d = super.startActivityNormallyOpenCollectionWithIntent(DeckPickerEx.class, new Intent());
+            assertThat("Collection initialization ensured by CollectionTask.LoadCollectionComplete", d.getCol(), is(notNullValue()));
+            assertThat("Collection Models Loaded", d.getCol().getModels(), is(notNullValue()));
+        } finally {
+            InitialActivityTest.revokeWritePermissions();
+        }
+    }
+
     private static class DeckPickerEx extends DeckPicker {
         private int mDatabaseErrorDialog;
         private boolean mDisplayedAnalyticsOptIn;
+        private boolean mPrepareOptionsMenu;
+        private boolean mDisplaySyncBadge = false;
 
 
         @Override
@@ -285,6 +361,19 @@ public class DeckPickerTest extends RobolectricTest {
         protected void displayAnalyticsOptInDialog() {
             this.mDisplayedAnalyticsOptIn = true;
             super.displayAnalyticsOptInDialog();
+        }
+
+
+        @Override
+        public boolean onPrepareOptionsMenu(Menu menu) {
+            this.mPrepareOptionsMenu = super.onPrepareOptionsMenu(menu);
+            return mPrepareOptionsMenu;
+        }
+
+        @Override
+        protected void displaySyncBadge(Menu menu) {
+            this.mDisplaySyncBadge = true;
+            super.displaySyncBadge(menu);
         }
     }
 }


### PR DESCRIPTION
## Purpose / Description
When the app would start without the Storage Permission, three predictable StorageAccessExceptions would occur in the following methods in DeckPicker:
- ```onResume()```
- ```onPrepareOptionsMenu()```
- ```onCreateOptionsMenu()``` -> ```displaySyncBadge()```

## Fixes
Fixes #8618 

## Approach
In DeckPicker, we can simply rely on ```colIsOpen()``` to check if Collection is initialized instead of using ```getColSafe()```. ```getColSafe()``` uses ```colIsOpen()``` to check if Collection is initialized, if not, it attempts to lazily initialize it. This step is not required in DeckPicker since DeckPicker's ```handleStartup()``` is responsible for initializing Collection.

More importantly, ```getColSafe()``` throws a ```StorageAccessException``` if the app doesn't have write access to the AnkiDroid directory. Hence, it follows that we should avoid calling ```getColSafe()``` when we're unsure about whether we have the Storage Permission.

The app's behavior is kept the same.

## How Has This Been Tested?
Unit tests for each collection-dependent call that had a ```colIsOpen()``` check added before it, with & without Storage Permissions to ensure the code path remains the same.

Tested on:
- Samsung Galaxy A80 API 30 (Physical Device)

## Checklist

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
