### PR TITLE
Update AbstractFlashcardViewer.java

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -2316,11 +2316,11 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
             cardClass += " mathjax-needs-to-render";
         }
 
-        if (isInNightMode()) {
-            if (!mCardAppearance.hasUserDefinedNightMode(mCurrentCard)) {
-                content = HtmlColors.invertColors(content);
-            }
-        }
+       // if (isInNightMode()) {
+          //  if (!mCardAppearance.hasUserDefinedNightMode(mCurrentCard)) {
+              //  content = HtmlColors.invertColors(content);
+          //  }
+      //  }
 
         mCardContent = mCardTemplate.render(content, style, cardClass);
         Timber.d("base url = %s", mBaseUrl);


### PR DESCRIPTION
Fixes #5648

Purpose / Description
problem: In nightmode, when entering contents like "color:white" in front or back fields, then we review the flashcard we will find the card reads "color: #0". The color name after "color:" is replaced by the format of 0x......

Approach
The problem is that the current color inversion system tries to match a regex to the whole card content. The regex searches for css attributes like color: ... and background: .... so the contents in card will be searched successfully.
The old code calls this regex in nightmode, so I cancelled this call, and the bug disappeared.

How Has This Been Tested?
Reproduction Steps:
1.Enter "color: red" in front or back fields
2.Preview the flashcard
Then we will find the card reads "color:red",which is correctly