### PR TITLE
Run module-specific / variant-specific lint checks

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -69,7 +69,7 @@ jobs:
           command: ./gradlew :AnkiDroid:compilePlayReleaseJavaWithJavac compileLint lint-rules:compileTestJava
 
       - name: Run Lint Release
-        run: ./gradlew lintRelease
+        run: ./gradlew :api:lintRelease :AnkiDroid:lintPlayRelease
 
       - name: Test Lint Rules
         run: ./gradlew lint-rules:test


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
The conversion to variants in #8151 meant AnkiDroid did not have a valid
lintRelease target anymore so it was not running in CI as expected

## Fixes
Fixes #8669`

## Approach
Using the variant-specific name makes it work, and splitting the checks into
specific ones for each sub-module should make it obvious in the future if any
further variant-related work happens

## How Has This Been Tested?
Run `./gradlew lintRelease` on the command line locally and see it does not work for AnkiDroid but `:api:lintRelease` is good

Run `./gradlew lintPlayRelease` to reference new AnkiDroid variant name, see it does work

Run `./gradlew :api:lintRelease :AnkiDroid:lintPlayRelease` and see both expected checks run

Open AbstractFlashcardViewer and specifically remove suppression of non constant ids, see it fail locally

Now I'm pushing that up (will remove it after seeing lint fail in CI) to make sure it fails in CI

## Learning (optional, can help others)

I don't think I learned a thing from this except what I already knew which is that any change will have unintended consequences which requires another change

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
