### PR TITLE
Refactor: Use androidx Activity APIs in AbstractFlashcardViewer

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.java
@@ -382,7 +382,7 @@ public class Reviewer extends AbstractFlashcardViewer {
             lookUpOrSelectText();
         } else if (itemId == R.id.action_open_deck_options) {
             Intent i = new Intent(this, DeckOptions.class);
-            startActivityForResultWithAnimation(i, DECK_OPTIONS, FADE);
+            launchActivityForResultWithAnimation(i, mOnDeckOptionsActivityResult, FADE);
         } else if (itemId == R.id.action_select_tts) {
             Timber.i("Reviewer:: Select TTS button pressed");
             showSelectTtsDialogue();

--- a/AnkiDroid/src/test/java/com/ichi2/anki/AbstractFlashcardViewerTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/AbstractFlashcardViewerTest.java
@@ -1,6 +1,5 @@
 package com.ichi2.anki;
 
-import android.app.Activity;
 import android.content.Intent;
 
 import com.ichi2.anki.cardviewer.ViewerCommand;
@@ -13,8 +12,10 @@ import org.robolectric.Robolectric;
 import org.robolectric.android.controller.ActivityController;
 
 import androidx.annotation.NonNull;
+import androidx.activity.result.ActivityResult;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
+import static android.app.Activity.RESULT_OK;
 import static com.ichi2.anki.AbstractFlashcardViewer.WebViewSignalParserUtils.ANSWER_ORDINAL_1;
 import static com.ichi2.anki.AbstractFlashcardViewer.WebViewSignalParserUtils.ANSWER_ORDINAL_2;
 import static com.ichi2.anki.AbstractFlashcardViewer.WebViewSignalParserUtils.ANSWER_ORDINAL_3;
@@ -354,7 +355,9 @@ public class AbstractFlashcardViewerTest extends RobolectricTest {
         Note note = nafv.mCurrentCard.note();
         note.setField(1, "David");
 
-        nafv.onActivityResult(AbstractFlashcardViewer.EDIT_CURRENT_CARD, Activity.RESULT_OK, new Intent());
+        AbstractFlashcardViewer.onEditCardActivityResultCallback onActivityResult =
+                new AbstractFlashcardViewer.onEditCardActivityResultCallback(nafv);
+        onActivityResult.onActivityResult(new ActivityResult(RESULT_OK, new Intent()));
 
         waitForAsyncTasksToComplete();
 
@@ -381,7 +384,9 @@ public class AbstractFlashcardViewerTest extends RobolectricTest {
         Note note = nafv.mCurrentCard.note();
         note.setField(1, "David");
 
-        nafv.onActivityResult(AbstractFlashcardViewer.EDIT_CURRENT_CARD, Activity.RESULT_OK, new Intent());
+        AbstractFlashcardViewer.onEditCardActivityResultCallback onActivityResult =
+                new AbstractFlashcardViewer.onEditCardActivityResultCallback(nafv);
+        onActivityResult.onActivityResult(new ActivityResult(RESULT_OK, new Intent()));
 
         waitForAsyncTasksToComplete();
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/PreviewerTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/PreviewerTest.java
@@ -16,17 +16,17 @@
 
 package com.ichi2.anki;
 
-import android.app.Activity;
 import android.content.Intent;
 
 import com.ichi2.libanki.Card;
-import com.ichi2.libanki.Note;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import androidx.activity.result.ActivityResult;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
+import static android.app.Activity.RESULT_OK;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
@@ -47,7 +47,9 @@ public class PreviewerTest extends RobolectricTest {
 
         assertThat("Initially should be previewing selected card", previewer.getCurrentCardId(), is(cardToPreview.getId()));
 
-        previewer.onActivityResult(AbstractFlashcardViewer.EDIT_CURRENT_CARD, Activity.RESULT_OK, null);
+        AbstractFlashcardViewer.onEditCardActivityResultCallback onActivityResult =
+                new AbstractFlashcardViewer.onEditCardActivityResultCallback(previewer);
+        onActivityResult.onActivityResult(new ActivityResult(RESULT_OK, null));
 
         advanceRobolectricLooperWithSleep();
 
@@ -68,7 +70,9 @@ public class PreviewerTest extends RobolectricTest {
 
         cardToPreview.note().setField(0, "Hi");
 
-        previewer.onActivityResult(AbstractFlashcardViewer.EDIT_CURRENT_CARD, Activity.RESULT_OK, null);
+        AbstractFlashcardViewer.onEditCardActivityResultCallback onActivityResult =
+                new AbstractFlashcardViewer.onEditCardActivityResultCallback(previewer);
+        onActivityResult.onActivityResult(new ActivityResult(RESULT_OK, null));
 
         advanceRobolectricLooperWithSleep();
 


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
_Describe the problem or feature and motivation_

## Fixes
Fixes (partially): #8602 

## Approach
Each `startActivityForResult` and corresponding case in `onActivityResult` is refactored to use the new API.
This PR introduce a way to access the callback during testing, avoiding the lambda style for this reason. I have tried to follow the recommended way (https://developer.android.com/training/basics/intents/result#test) by using a custom `ActivityResultRegistry` to address this use case but I did not found a way to either inject it before the field initialisation or to shadow it using `Robolectric Shadows` (tried to implement one for `ActivityResultRegistry` but some tasks are not finished and this is the cause of the failure of some tests). 
In order to be sure that the style looks good before moving to the others, I just refactored the code in `AbstractFlashcardViewer` to give an example of this use for the sake of testing. I will refactor all other activities as soon as this PR will be merged.

## How Has This Been Tested?

Unit testing.
On emulators: API 30 and API 25.

## Learning (optional, can help others)
https://developer.android.com/training/basics/intents/result#test
https://www.programmersought.com/article/3398962077/
http://robolectric.org/javadoc/4.1/org/robolectric/shadow/api/Shadow.html
https://github.com/robolectric/robolectric/tree/master/shadows/framework/src/main/java/org/robolectric/shadows (use them as examples)

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
