### PR TITLE
Use framework / built-in sqlite implementation

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -279,7 +279,6 @@ dependencies {
     implementation'ch.acra:acra-toast:5.7.0'
     implementation'ch.acra:acra-limiter:5.7.0'
 
-    implementation 'com.github.requery:sqlite-android:3.35.4'
     implementation 'com.afollestad.material-dialogs:core:0.9.6.0'
     implementation 'com.getbase:floatingactionbutton:1.10.1'
     // io.github.java-diff-utils:java-diff-utils is the natural successor here, but requires API24, #7091

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/DB.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/DB.java
@@ -24,7 +24,6 @@ import android.content.ContentValues;
 import android.database.Cursor;
 import android.database.SQLException;
 import android.database.sqlite.SQLiteDatabase;
-import android.widget.Toast;
 
 import com.ichi2.anki.AnkiDroidApp;
 import com.ichi2.anki.BuildConfig;
@@ -35,8 +34,6 @@ import com.ichi2.utils.DatabaseChangeDecorator;
 import net.ankiweb.rsdroid.BackendFactory;
 import net.ankiweb.rsdroid.database.RustSQLiteOpenHelperFactory;
 
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
@@ -45,7 +42,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.sqlite.db.SupportSQLiteDatabase;
 import androidx.sqlite.db.SupportSQLiteOpenHelper;
-import io.requery.android.database.sqlite.RequerySQLiteOpenHelperFactory;
+import androidx.sqlite.db.framework.FrameworkSQLiteOpenHelperFactory;
 import timber.log.Timber;
 
 /**
@@ -104,7 +101,7 @@ public class DB {
         }
 
         if (sqliteOpenHelperFactory == null) {
-            return new RequerySQLiteOpenHelperFactory();
+            return new FrameworkSQLiteOpenHelperFactory();
         }
         return sqliteOpenHelperFactory;
     }


### PR DESCRIPTION
## Pull Request template

## Purpose / Description

This is an experiment. It should not have functional regressions but it may have performance regressions.

Attempting to shrink the final APK for 2.15

## Fixes
Related #8473 

## Approach

Switches away from requery/sqlite-android dependency and relies on framework sqlite

That shaves almost exactly 1MB from the APK at the cost of unknown performance changes in API21+ (used to be important in Android 2/3/4 days but may not be now...)

## How Has This Been Tested?

Just basic click around - seems to work but @Arthur-Milchior I think is the best stress test of whether this works or not. I'll post a testable APK link in a comment.

## Learning (optional, can help others)

The Android CursorWindow has been 2MB forever (I checked).

## Checklist

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
