### PR TITLE
NF: comment and rename Task related classes

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/async/SingleTaskManager.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/SingleTaskManager.java
@@ -75,7 +75,7 @@ public class SingleTaskManager extends TaskManager {
      * @return the newly created task
      */
     @Override
-    public <Progress, Result> CollectionTask<Progress, Result> launchCollectionTaskConcrete(CollectionTask.Task<Progress, Result> task) {
+    public <Progress, Result> CollectionTask<Progress, Result> launchCollectionTaskConcrete(TaskDelegate<Progress, Result> task) {
         return launchCollectionTask(task, null);
     }
 
@@ -93,7 +93,7 @@ public class SingleTaskManager extends TaskManager {
      * @return the newly created task
      */
     public <Progress, Result> CollectionTask<Progress, Result>
-    launchCollectionTaskConcrete(@NonNull CollectionTask.Task<Progress, Result> task,
+    launchCollectionTaskConcrete(@NonNull TaskDelegate<Progress, Result> task,
                          @Nullable TaskListener<? super Progress, ? super Result> listener) {
         // Start new task
         CollectionTask<Progress, Result> newTask = new CollectionTask<>(task, listener, mLatestInstance);

--- a/AnkiDroid/src/main/java/com/ichi2/async/TaskDelegate.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/TaskDelegate.java
@@ -1,0 +1,51 @@
+/****************************************************************************************
+ * Copyright (c) 2020 Arthur Milchior <arthur@milchior.fr>                              *
+ *                                                                                      *
+ * This program is free software; you can redistribute it and/or modify it under        *
+ * the terms of the GNU General Public License as published by the Free Software        *
+ * Foundation; either version 3 of the License, or (at your option) any later           *
+ * version.                                                                             *
+ *                                                                                      *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *                                                                                      *
+ * You should have received a copy of the GNU General Public License along with         *
+ * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ ****************************************************************************************/
+
+package com.ichi2.async;
+
+import com.ichi2.libanki.Collection;
+
+import androidx.annotation.NonNull;
+
+/**
+ * TaskDelegate contains the business logic of background tasks.
+ * While CollectionTask deals with all general task features, such as ensuring that no two tasks runs simultaneously
+ * and Timberings, the Task contains the code that we actually want to execute.
+ * <p>
+ * TaskManager.launchCollectionTask takes a Task, and potentially a TaskListener. It is in charge of running
+ * ensuring that the task is executed, by embedding this Task in an object that can actually be executed.
+ * <p>
+ * <p>
+ * Currently, background processes uses CollectionTask, which inherits from AsyncTask, which is deprecated. Using this
+ * delegation, we should hopefully eventually be able to stop using AsyncTask without making any change to the Task.
+ * <p>
+ * Tests can runs tasks in Foreground by changing the task manager. Those tasks can then be directly executed by
+ * ForegroundTaskManager without needing an executor.
+ * <p>
+ * The Task type is used to cancel planified tasks. In particular it means that no Task should
+ * be an anonymous class if we want to be able to cancel the task running it.
+ *
+ * @param <Progress> The type of values that the task can send to indicates its progress. E.g. a card to dislay while remaining work is done; the progression of a counter.
+ * @param <Result>   The type of result returned by the task at the end. E.g. the tree of decks, counts for a particular deck
+ */
+public abstract class TaskDelegate<Progress, Result> {
+    protected abstract Result task(@NonNull Collection col, @NonNull ProgressSenderAndCancelListener<Progress> collectionTask);
+
+
+    protected boolean requiresOpenCollection() {
+        return true;
+    }
+}

--- a/AnkiDroid/src/main/java/com/ichi2/async/TaskManager.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/TaskManager.java
@@ -67,11 +67,11 @@ public abstract class TaskManager {
         sTaskManager.setLatestInstanceConcrete(task);
     }
 
-    public static <Progress, Result> CollectionTask<Progress, Result> launchCollectionTask(CollectionTask.Task<Progress, Result> task) {
+    public static <Progress, Result> CollectionTask<Progress, Result> launchCollectionTask(TaskDelegate<Progress, Result> task) {
         return sTaskManager.launchCollectionTaskConcrete(task);
     }
 
-    public abstract <Progress, Result> CollectionTask<Progress, Result> launchCollectionTaskConcrete(CollectionTask.Task<Progress, Result> task);
+    public abstract <Progress, Result> CollectionTask<Progress, Result> launchCollectionTaskConcrete(TaskDelegate<Progress, Result> task);
 
 
     protected abstract void setLatestInstanceConcrete(CollectionTask task);
@@ -88,13 +88,13 @@ public abstract class TaskManager {
      * @return the newly created task
      */
     public static <Progress, Result> CollectionTask<Progress, Result>
-    launchCollectionTask(@NonNull CollectionTask.Task<Progress, Result> task,
+    launchCollectionTask(@NonNull TaskDelegate<Progress, Result> task,
                          @Nullable TaskListener<? super Progress, ? super Result> listener) {
         return sTaskManager.launchCollectionTaskConcrete(task, listener);
     }
 
     public abstract <Progress, Result> CollectionTask<Progress, Result>
-    launchCollectionTaskConcrete(@NonNull CollectionTask.Task<Progress, Result> task,
+    launchCollectionTaskConcrete(@NonNull TaskDelegate<Progress, Result> task,
                          @Nullable TaskListener<? super Progress, ? super Result> listener);
 
     /**

--- a/AnkiDroid/src/test/java/com/ichi2/anki/RobolectricTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/RobolectricTest.java
@@ -25,9 +25,9 @@ import com.ichi2.anki.dialogs.DialogHandler;
 import com.ichi2.anki.dialogs.utils.FragmentTestActivity;
 import com.ichi2.anki.exception.ConfirmModSchemaException;
 import com.ichi2.anki.exception.FilteredAncestor;
-import com.ichi2.async.CollectionTask;
 import com.ichi2.async.ForegroundTaskManager;
 import com.ichi2.async.SingleTaskManager;
+import com.ichi2.async.TaskDelegate;
 import com.ichi2.async.TaskListener;
 import com.ichi2.async.TaskManager;
 import com.ichi2.compat.customtabs.CustomTabActivityHelper;
@@ -414,7 +414,7 @@ public class RobolectricTest implements CollectionGetter {
     }
 
 
-    protected synchronized <Progress, Result extends Computation<?>> void waitFortask(CollectionTask.Task<Progress, Result> task, int timeoutMs) throws InterruptedException {
+    protected synchronized <Progress, Result extends Computation<?>> void waitFortask(TaskDelegate<Progress, Result> task, int timeoutMs) throws InterruptedException {
         boolean[] completed = new boolean[] { false };
         TaskListener<Progress, Result> listener = new TaskListener<Progress, Result>() {
             @Override

--- a/AnkiDroid/src/test/java/com/ichi2/async/AbstractCollectionTaskTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/async/AbstractCollectionTaskTest.java
@@ -24,13 +24,12 @@ import androidx.test.ext.junit.runners.AndroidJUnit4;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.arrayWithSize;
-import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.notNullValue;
 
 @RunWith(AndroidJUnit4.class)
 public abstract class AbstractCollectionTaskTest extends RobolectricTest {
 
-    protected <Progress, Result> Result execute(CollectionTask.Task<Progress, Result> task) {
+    protected <Progress, Result> Result execute(TaskDelegate<Progress, Result> task) {
         CollectionTask<Progress, Result> collectionTask = TaskManager.launchCollectionTask(task);
         try {
             return collectionTask.get();
@@ -39,7 +38,7 @@ public abstract class AbstractCollectionTaskTest extends RobolectricTest {
         }
     }
 
-    protected <Progress, Result> void waitForTask(CollectionTask.Task<Progress, Result> task, TaskListener<Progress, Result> listener) {
+    protected <Progress, Result> void waitForTask(TaskDelegate<Progress, Result> task, TaskListener<Progress, Result> listener) {
         TaskManager.launchCollectionTask(task, listener);
 
         waitForAsyncTasksToComplete();

--- a/AnkiDroid/src/test/java/com/ichi2/async/ForegroundTaskManager.java
+++ b/AnkiDroid/src/test/java/com/ichi2/async/ForegroundTaskManager.java
@@ -1,7 +1,6 @@
 package com.ichi2.async;
 
 import com.ichi2.libanki.CollectionGetter;
-import com.ichi2.libanki.Collection;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -22,7 +21,7 @@ public class ForegroundTaskManager extends TaskManager {
 
 
     @Override
-    public <Progress, Result> CollectionTask<Progress, Result> launchCollectionTaskConcrete(CollectionTask.Task<Progress, Result> task) {
+    public <Progress, Result> CollectionTask<Progress, Result> launchCollectionTaskConcrete(TaskDelegate<Progress, Result> task) {
         return launchCollectionTaskConcrete(task, null);
     }
 
@@ -34,13 +33,13 @@ public class ForegroundTaskManager extends TaskManager {
 
     @Override
     public <Progress, Result> CollectionTask<Progress, Result> launchCollectionTaskConcrete(
-            @NonNull CollectionTask.Task<Progress, Result> task,
+            @NonNull TaskDelegate<Progress, Result> task,
             @Nullable TaskListener<? super Progress, ? super Result> listener) {
         return executeTaskWithListener(task, listener, mColGetter);
     }
 
     public static <Progress, Result> CollectionTask<Progress, Result> executeTaskWithListener(
-            @NonNull CollectionTask.Task<Progress, Result> task,
+            @NonNull TaskDelegate<Progress, Result> task,
             @Nullable TaskListener<? super Progress, ? super Result> listener, CollectionGetter colGetter) {
         if (listener != null) {
             listener.onPreExecute();
@@ -110,7 +109,7 @@ public class ForegroundTaskManager extends TaskManager {
     public static class EmptyTask<Progress, Result> extends
             CollectionTask<Progress, Result> {
 
-        protected EmptyTask(Task<Progress, Result> task, TaskListener<? super Progress, ? super Result> listener) {
+        protected EmptyTask(TaskDelegate<Progress, Result> task, TaskListener<? super Progress, ? super Result> listener) {
             super(task, listener, null);
         }
     }


### PR DESCRIPTION
CollectionTask is not supposed to be extended, it would be a bad idea since we want actually to stop using
AsyncTask. Its only constructor can be package private instead of protected.

Task is moved to its own class, so that it's easier to see that it's not dependant of CollectionTask. Its renamed into
TaskDelegate to indicate that it's a delegate. It is not actually a task executed by an executor but its the delegate
that contains actual business logic



This is related to a Discord discussion with David who found the name confusing - a fact which is hard to argue with