### PR TITLE
NF: remove mDismissCardHandler

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -582,9 +582,6 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
     }
 
 
-    protected final NextCardHandler<BooleanGetter> mDismissCardHandler = new NextCardHandler();
-
-
     private final TaskListener<CardGetter, BooleanGetter> mUpdateCardHandler = new TaskListener<CardGetter, BooleanGetter>() {
         private boolean mNoMoreCards;
 
@@ -3363,7 +3360,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
      */
     protected boolean dismiss(CollectionTask.DismissNote dismiss) {
         blockControls(false);
-        TaskManager.launchCollectionTask(dismiss, mDismissCardHandler);
+        TaskManager.launchCollectionTask(dismiss, new NextCardHandler());
         return true;
     }
 


### PR DESCRIPTION
It was used in a single place, not always needed to initialize it, and its strange that the same listener may be used
for multiple actions while having a state
