### PR TITLE
Undo Activity

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -167,7 +167,7 @@ import com.github.zafarkhaja.semver.Version;
 import static com.ichi2.anim.ActivityTransitionAnimation.Direction.*;
 
 @SuppressWarnings({"PMD.AvoidThrowingRawExceptionTypes","PMD.FieldDeclarationsShouldBeAtStartOfClass"})
-public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity implements ReviewerUi, CommandProcessor, TagsDialog.TagsDialogListener {
+public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity implements ActivityWithUndo, ReviewerUi, CommandProcessor, TagsDialog.TagsDialogListener {
 
     /**
      * Result codes that are returned when this activity finishes.
@@ -1367,10 +1367,9 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
     }
 
 
-    protected void undo() {
-        if (isUndoAvailable()) {
-            TaskManager.launchCollectionTask(new CollectionTask.Undo(), new AnswerCardHandler(false));
-        }
+    @Override
+    public TaskListener<Card, BooleanGetter> getUndoListener() {
+        return new AnswerCardHandler(false);
     }
 
 
@@ -2898,10 +2897,6 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
     }
 
 
-    @VisibleForTesting
-    protected boolean isUndoAvailable() {
-        return getCol().undoAvailable();
-    }
 
     // ----------------------------------------------------------------------------
     // INNER CLASSES

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ActivityWithUndo.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ActivityWithUndo.java
@@ -1,0 +1,31 @@
+package com.ichi2.anki;
+
+import com.ichi2.async.CollectionTask;
+import com.ichi2.async.TaskListener;
+import com.ichi2.async.TaskListenerWithContext;
+import com.ichi2.async.TaskManager;
+import com.ichi2.libanki.Card;
+import com.ichi2.libanki.CollectionGetter;
+import com.ichi2.utils.BooleanGetter;
+
+
+import androidx.annotation.Nullable;
+import androidx.annotation.VisibleForTesting;
+
+public interface ActivityWithUndo extends CollectionGetter {
+    TaskListener<Card, BooleanGetter> getUndoListener();
+
+
+    @VisibleForTesting
+    default boolean isUndoAvailable() {
+        return getCol().undoAvailable();
+    }
+
+    default @Nullable
+    CollectionTask<Card, Card, BooleanGetter, BooleanGetter> undo() {
+        if (isUndoAvailable()) {
+            return TaskManager.launchCollectionTask(new CollectionTask.Undo(), getUndoListener());
+        }
+        return null;
+    }
+}

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -113,7 +113,7 @@ import static com.ichi2.libanki.stats.Stats.SECONDS_PER_DAY;
 import static com.ichi2.anim.ActivityTransitionAnimation.Direction.*;
 
 public class CardBrowser extends NavigationDrawerActivity implements
-        DeckDropDownAdapter.SubtitleListener, TagsDialog.TagsDialogListener {
+        ActivityWithUndo, DeckDropDownAdapter.SubtitleListener, TagsDialog.TagsDialogListener {
 
     enum Column {
         QUESTION,
@@ -1273,7 +1273,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
     @VisibleForTesting
     void onUndo() {
         if (getCol().undoAvailable()) {
-            TaskManager.launchCollectionTask(new CollectionTask.Undo(), mUndoHandler);
+            undo();
         }
     }
 
@@ -1751,7 +1751,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
             // snackbar to offer undo
             String deckName = browser.getCol().getDecks().name(browser.mNewDid);
             browser.mUndoSnackbar = UIUtils.showSnackbar(browser, String.format(browser.getString(R.string.changed_deck_message), deckName), SNACKBAR_DURATION,
-                                                         R.string.undo, v -> TaskManager.launchCollectionTask(new CollectionTask.Undo(), browser.mUndoHandler), browser.mCardsListView, null);
+                                                         R.string.undo, v -> browser.undo(), browser.mCardsListView, null);
         }
     }
 
@@ -1910,7 +1910,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
             // snackbar to offer undo
             String deletedMessage = browser.getResources().getQuantityString(R.plurals.card_browser_cards_deleted, mCardsDeleted, mCardsDeleted);
             browser.mUndoSnackbar = UIUtils.showSnackbar(browser, deletedMessage, SNACKBAR_DURATION,
-                    R.string.undo, v -> TaskManager.launchCollectionTask(new CollectionTask.Undo(), browser.mUndoHandler),
+                    R.string.undo, v -> browser.undo(),
                     browser.mCardsListView, null);
             browser.searchCards();
         }
@@ -1918,7 +1918,13 @@ public class CardBrowser extends NavigationDrawerActivity implements
 
 
 
-    private final UndoHandler mUndoHandler = new UndoHandler(this);
+
+
+    @Override
+    public TaskListenerWithContext<CardBrowser, Card, BooleanGetter> getUndoListener() {
+        return new UndoHandler(this);
+    }
+
     private static class UndoHandler extends ListenerWithProgressBarCloseOnFalse<Card, BooleanGetter> {
         public UndoHandler(CardBrowser browser) {
             super(browser);

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.java
@@ -80,6 +80,7 @@ import com.ichi2.libanki.Utils;
 import com.ichi2.libanki.sched.Counts;
 import com.ichi2.themes.Themes;
 import com.ichi2.utils.AndroidUiUtils;
+import com.ichi2.utils.BooleanGetter;
 import com.ichi2.utils.FunctionalInterfaces.Consumer;
 import com.ichi2.utils.PairWithBoolean;
 import com.ichi2.utils.Permissions;
@@ -263,6 +264,22 @@ public class Reviewer extends AbstractFlashcardViewer {
         }
     }
 
+    private void showFirstCard() {
+        Intent intent = getIntent();
+        Bundle extras = intent.getExtras();
+        CollectionTask.Task<Card, BooleanGetter> task;
+        boolean quick;
+        if (extras == null || !extras.containsKey("cid")) {
+            task = new CollectionTask.GetCard();
+            quick = false;
+        } else {
+            long cid = extras.getLong("cid");
+            task = new CollectionTask.GetSpecificCard(cid);
+            quick = true;
+        }
+        TaskManager.launchCollectionTask(task, new AnswerCardHandler(quick));
+    }
+
     @Override
     protected void onCollectionLoaded(Collection col) {
         super.onCollectionLoaded(col);
@@ -280,7 +297,7 @@ public class Reviewer extends AbstractFlashcardViewer {
 
         col.getSched().deferReset();     // Reset schedule in case card was previously loaded
         getCol().startTimebox();
-        TaskManager.launchCollectionTask(new CollectionTask.GetCard(), new AnswerCardHandler(false));
+        showFirstCard();
 
         disableDrawerSwipeOnConflicts();
         // Add a weak reference to current activity so that scheduler can talk to to Activity

--- a/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
@@ -334,6 +334,26 @@ public class CollectionTask<ProgressListener, ProgressBackground extends Progres
         }
     }
 
+    /** This task simply update with the card whose id is cid and return true.
+        It is usually very quick, but since it's a database access, it should still be in background
+     */
+    public static class GetSpecificCard extends Task<Card, BooleanGetter> {
+        private final long mCid;
+
+
+        public GetSpecificCard(long cid) {
+            mCid = cid;
+        }
+
+
+        protected BooleanGetter task(@NonNull Collection col, @NonNull ProgressSenderAndCancelListener<Card> collectionTask) {
+            Card card = col.getCard(mCid);
+            col.getSched().setCurrentCard(card);
+            collectionTask.doProgress(card);
+            return TRUE;
+        }
+    }
+
     public static class AnswerAndGetCard extends GetCard {
         private final @NonNull Card mOldCard;
         private final @Consts.BUTTON_TYPE int mEase;

--- a/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
@@ -334,7 +334,7 @@ public class CollectionTask<ProgressListener, ProgressBackground extends Progres
         }
     }
 
-    /** This task simply update with the card whose id is cid and return true.
+    /** This task simply update with the card whose id is cid, set this card in the scheduler, and return true.
         It is usually very quick, but since it's a database access, it should still be in background
      */
     public static class GetSpecificCard extends Task<Card, BooleanGetter> {

--- a/AnkiDroid/src/test/java/com/ichi2/anki/ReviewerKeyboardInputTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/ReviewerKeyboardInputTest.java
@@ -21,6 +21,8 @@ import android.view.KeyEvent;
 import com.ichi2.anki.reviewer.ReviewerUi;
 import com.ichi2.async.CollectionTask;
 import com.ichi2.libanki.Card;
+import com.ichi2.libanki.Collection;
+import com.ichi2.utils.BooleanGetter;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -445,10 +447,14 @@ public class ReviewerKeyboardInputTest extends RobolectricTest {
             handleKeyPress(buttonCode, '\0');
         }
 
+
         @Override
-        protected void undo() {
-            mUndoCalled = true;
+        public CollectionTask<Card, Card, BooleanGetter, BooleanGetter> undo() {
+             mUndoCalled = true;
+             return null;
         }
+
+
         public boolean getUndoCalled() {
             return mUndoCalled;
         }
@@ -504,7 +510,7 @@ public class ReviewerKeyboardInputTest extends RobolectricTest {
         }
 
         @Override
-        protected boolean isUndoAvailable() {
+        public boolean isUndoAvailable() {
             return mUndoAvailable;
         }
 


### PR DESCRIPTION
This does mulitple things:

# Factorizing code

The interface ActivityWithUndo ensure that the same Undo task can be executed by any activity implementing it. It only requires to provide a listener for undo, and provide the function undo and the Task creation.

# Ensure that the reviewer get opened back iff undo returns a card

Undo returns a card iff the card should be reviewed again. E.g. changing a deck do not return a card but suspending does. If a card is returned, then the reviewer is opened with this card. This is a change from previously, when the reviewer was opened with the card returned by the scheduler. It matters because it means that if we :
* suspend the last card
* wait a little
* undo

then the reviewer could have been open with a different card, if a card in learning was due again for example.

It also fixes #4312 since the reviewer is not opened if undo do not ask to review a card.



