### PR TITLE
NF: Allow to execute task and listener without manager

### DIFF
--- a/AnkiDroid/src/test/java/com/ichi2/async/ForegroundTaskManager.java
+++ b/AnkiDroid/src/test/java/com/ichi2/async/ForegroundTaskManager.java
@@ -36,12 +36,18 @@ public class ForegroundTaskManager extends TaskManager {
     public <ProgressListener, ProgressBackground extends ProgressListener, ResultListener, ResultBackground extends ResultListener> CollectionTask<ProgressListener, ProgressBackground, ResultListener, ResultBackground> launchCollectionTaskConcrete(
             @NonNull CollectionTask.Task<ProgressBackground, ResultBackground> task,
             @Nullable TaskListener<ProgressListener, ResultListener> listener) {
+        return executeTaskWithListener(task, listener, mColGetter);
+    }
+
+    public static <ProgressListener, ProgressBackground extends ProgressListener, ResultListener, ResultBackground extends ResultListener> CollectionTask<ProgressListener, ProgressBackground, ResultListener, ResultBackground> executeTaskWithListener(
+            @NonNull CollectionTask.Task<ProgressBackground, ResultBackground> task,
+            @Nullable TaskListener<ProgressListener, ResultListener> listener, CollectionGetter colGetter) {
         if (listener != null) {
             listener.onPreExecute();
         }
         final ResultBackground res;
         try {
-            res = task.task(mColGetter.getCol(), new MockTaskManager<>(listener));
+            res = task.task(colGetter.getCol(), new MockTaskManager<>(listener));
         } catch (Exception e) {
             Timber.w(e, "A new failure may have something to do with running in the foreground.");
             throw e;
@@ -79,7 +85,7 @@ public class ForegroundTaskManager extends TaskManager {
         return true;
     }
 
-    public class MockTaskManager<ProgressListener, ProgressBackground extends ProgressListener> implements ProgressSenderAndCancelListener<ProgressBackground> {
+    public static class MockTaskManager<ProgressListener, ProgressBackground extends ProgressListener> implements ProgressSenderAndCancelListener<ProgressBackground> {
 
         private final @Nullable TaskListener<ProgressListener, ?> mTaskListener;
 
@@ -101,7 +107,7 @@ public class ForegroundTaskManager extends TaskManager {
         }
     }
 
-    public class EmptyTask<ProgressListener, ProgressBackground extends ProgressListener, ResultListener, ResultBackground extends ResultListener> extends
+    public static class EmptyTask<ProgressListener, ProgressBackground extends ProgressListener, ResultListener, ResultBackground extends ResultListener> extends
             CollectionTask<ProgressListener, ProgressBackground, ResultListener, ResultBackground> {
 
         protected EmptyTask(Task<ProgressBackground, ResultBackground> task, TaskListener<ProgressListener, ResultListener> listener) {


### PR DESCRIPTION
I realized for a test that it may be easier to get to execute a task against a listener without involving the whole
manager process. This ensure this feature will be available to any tester when needed even if I don't use it know

That works with the general principles that, as long as a dev don't work on Async Task directly, then they will only see that they need to provide a task, a listener, and can ignore the entire remaining of the framework