### PR TITLE
Ensure that CheckCardSelection gets only checked cards

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -267,7 +267,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
     private TextView mActionBarTitle;
     private boolean mReloadRequired = false;
     private boolean mInMultiSelectMode = false;
-    private final Set<CardCache> mCheckedCards = Collections.synchronizedSet(new LinkedHashSet<>());
+    private final @NonNull Set<CardCache> mCheckedCards = Collections.synchronizedSet(new LinkedHashSet<>());
     private int mLastSelectedPosition;
     @Nullable
     private Menu mActionBarMenu;
@@ -1060,7 +1060,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
 
         if (!mCheckedCards.isEmpty()) {
             TaskManager.cancelAllTasks(CollectionTask.CheckCardSelection.class);
-            TaskManager.launchCollectionTask(new CollectionTask.CheckCardSelection(getCards()),
+            TaskManager.launchCollectionTask(new CollectionTask.CheckCardSelection(mCheckedCards),
                     mCheckSelectedCardsHandler);
         }
 

--- a/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
@@ -1974,10 +1974,10 @@ public class CollectionTask<ProgressListener, ProgressBackground extends Progres
      * @return If there are unselected cards, if there are unmarked cards
      */
     public static class CheckCardSelection extends Task<Void, Pair<Boolean, Boolean>> {
-        private final CardBrowser.CardCollection<CardBrowser.CardCache> mCheckedCards;
+        private final @NonNull Set<CardBrowser.CardCache> mCheckedCards;
 
 
-        public CheckCardSelection(CardBrowser.CardCollection<CardBrowser.CardCache> checkedCards) {
+        public CheckCardSelection(@NonNull Set<CardBrowser.CardCache> checkedCards) {
             this.mCheckedCards = checkedCards;
         }
 


### PR DESCRIPTION
Fixes #8466 hopefully (hard to tell since I can't reproduce)


I went over 3e79836 line by line in cardbrowser to check what could have caused the regression.

Here is the full story of the investigation:

Previously, `doInBackgroundCheckCardSelection` took an array of objects. It was called with an array of two elements, and never used the second one. So I intended to remove the second one. Actually, I removed the first one. See https://github.com/ankidroid/Anki-Android/commit/3e7983670370141b6dc2e1ab3d7a4036c0585def#r50222793

I'm all for atomic commits and hate that this touches 1700+ lines of code. Not that I could have done it otherwise, it was a huge pain.

I'll plainly admit, David, that you were right, this commit and PR introduced bug. For some reason it only got notice on some devices, but I must admit for the sake of truth that you are perfectly right.

I don't regret this PR and still believe this improve the current and future code quality and is worth the time I spent even if I had to debug it here. I'll simply state that I regret that you had to be involved and lost time on it @ShridharGoel. Worse, I'll have to ask you to check this PR on your device. As I can't reproduce, I can't cehck
