### PR TITLE
UX: Card Template Editor: monospace and accessibility

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.java
@@ -44,8 +44,6 @@ import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.EditText;
-import android.widget.RadioButton;
-import android.widget.RadioGroup;
 
 import com.afollestad.materialdialogs.MaterialDialog;
 import com.google.android.material.bottomnavigation.BottomNavigationView;

--- a/AnkiDroid/src/main/res/layout/card_template_editor_item.xml
+++ b/AnkiDroid/src/main/res/layout/card_template_editor_item.xml
@@ -36,6 +36,7 @@
                 android:layout_gravity="top"
                 android:gravity="top"
                 android:inputType="textMultiLine"
+                android:fontFamily="monospace"
                 tools:text="{{Front}}"/>
         </LinearLayout>
     </ScrollView>

--- a/AnkiDroid/src/main/res/layout/card_template_editor_item.xml
+++ b/AnkiDroid/src/main/res/layout/card_template_editor_item.xml
@@ -34,7 +34,6 @@
                 android:layout_margin="5dp"
                 android:layout_gravity="top"
                 android:gravity="top"
-                android:contentDescription="@string/front_field_name"
                 android:inputType="textMultiLine"/>
         </LinearLayout>
     </ScrollView>

--- a/AnkiDroid/src/main/res/layout/card_template_editor_item.xml
+++ b/AnkiDroid/src/main/res/layout/card_template_editor_item.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/main_layout"
     android:layout_height="fill_parent"
     android:layout_width="match_parent"
@@ -34,7 +35,8 @@
                 android:layout_margin="5dp"
                 android:layout_gravity="top"
                 android:gravity="top"
-                android:inputType="textMultiLine"/>
+                android:inputType="textMultiLine"
+                tools:text="{{Front}}"/>
         </LinearLayout>
     </ScrollView>
 


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
* I feel a monospace font is more legible for code
* Adds default text in the android designer
* Fixes accessibility (see commit message)


## How Has This Been Tested?

![image](https://user-images.githubusercontent.com/62114487/116827504-212ae900-ab91-11eb-94e7-7de8c613449c.png)


## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [x] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
