### PR TITLE
[UX] Material Text Dialogs: Show keyboard when opened

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/MaterialEditTextDialog.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/MaterialEditTextDialog.java
@@ -27,35 +27,39 @@ import java.util.Objects;
 
 import androidx.annotation.NonNull;
 
+/**
+ * A Dialog containing an EditText which displays a keyboard when opened
+ */
 public class MaterialEditTextDialog extends MaterialDialog {
     protected MaterialEditTextDialog(Builder builder) {
         super(builder);
     }
 
-    public static class Builder extends MaterialDialog.Builder {
+    /**
+     * Method to display keyboard when dialog shows.
+     * @param editText EditText present in the dialog.
+     * @param materialDialog Dialog which contains the EditText and needs the keyboard to be displayed.
+     */
+    public static void displayKeyboard(EditText editText, MaterialDialog materialDialog) {
+        AndroidUiUtils.setFocusAndOpenKeyboard(editText, Objects.requireNonNull(materialDialog.getWindow()));
+    }
 
-        public EditText editText;
+    public static class Builder extends MaterialDialog.Builder {
 
         public Builder(@NonNull Context context, EditText editText) {
             super(context);
-            this.editText = editText;
+            customView(editText, true);
         }
 
         @Override
-        public MaterialDialog show() {
-            customView(editText, true);
-            MaterialDialog materialDialog = super.show();
-            displayKeyboard(editText, materialDialog);
-            return materialDialog;
+        public MaterialDialog build() {
+            return new MaterialEditTextDialog(this);
         }
+    }
 
-        /**
-         * Method to display keyboard when dialog shows.
-         * @param editText EditText present in the dialog.
-         * @param materialDialog Dialog which contains the EditText and needs the keyboard to be displayed.
-         */
-        public void displayKeyboard(EditText editText, MaterialDialog materialDialog) {
-            AndroidUiUtils.setFocusAndOpenKeyboard(editText, Objects.requireNonNull(materialDialog.getWindow()));
-        }
+    @Override
+    public void show() {
+        super.show();
+        displayKeyboard((EditText) this.getCustomView(), this);
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ModelBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ModelBrowser.java
@@ -356,10 +356,9 @@ public class ModelBrowser extends AnkiActivity {
                         mModelNameInput.setSelection(mModelNameInput.getText().length());
 
                         //Create textbox to name new model
-                        new MaterialDialog.Builder(ModelBrowser.this)
+                        new MaterialEditTextDialog.Builder(ModelBrowser.this, mModelNameInput)
                                 .title(R.string.model_browser_add)
                                 .positiveText(R.string.dialog_ok)
-                                .customView(mModelNameInput, true)
                                 .onPositive((innerDialog, innerWhich) -> {
                                         String modelName = mModelNameInput.getText().toString();
                                         addNewNoteType(modelName, addSelectionSpinner.getSelectedItemPosition());
@@ -444,11 +443,10 @@ public class ModelBrowser extends AnkiActivity {
         mModelNameInput.setSingleLine(true);
         mModelNameInput.setText(mModels.get(mModelListPosition).getString("name"));
         mModelNameInput.setSelection(mModelNameInput.getText().length());
-        new MaterialDialog.Builder(this)
+        new MaterialEditTextDialog.Builder(this, mModelNameInput)
                             .title(R.string.rename_model)
                             .positiveText(R.string.rename)
                             .negativeText(R.string.dialog_cancel)
-                            .customView(mModelNameInput, true)
                             .onPositive((dialog, which) -> {
                                     Model model = mModels.get(mModelListPosition);
                                     String deckName = mModelNameInput.getText().toString()

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ModelFieldEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ModelFieldEditor.java
@@ -204,10 +204,9 @@ public class ModelFieldEditor extends AnkiActivity implements LocaleSelectionDia
         mFieldNameInput = new FixedEditText(this);
         mFieldNameInput.setSingleLine(true);
 
-        new MaterialDialog.Builder(this)
+        new MaterialEditTextDialog.Builder(this, mFieldNameInput)
                 .title(R.string.model_field_editor_add)
                 .positiveText(R.string.dialog_ok)
-                .customView(mFieldNameInput, true)
                 .onPositive((dialog, which) -> {
                     //Name is valid, now field is added
                     changeHandler listener = changeFieldHandler();
@@ -304,10 +303,9 @@ public class ModelFieldEditor extends AnkiActivity implements LocaleSelectionDia
         mFieldNameInput.setSingleLine(true);
         mFieldNameInput.setText(mFieldLabels.get(mCurrentPos));
         mFieldNameInput.setSelection(mFieldNameInput.getText().length());
-        new MaterialDialog.Builder(this)
+        new MaterialEditTextDialog.Builder(this, mFieldNameInput)
                 .title(R.string.model_field_editor_rename)
                 .positiveText(R.string.rename)
-                .customView(mFieldNameInput, true)
                 .onPositive((dialog, which) -> {
                     String fieldName = _uniqueName(mFieldNameInput);
                     if (fieldName == null) {
@@ -350,10 +348,9 @@ public class ModelFieldEditor extends AnkiActivity implements LocaleSelectionDia
     private void repositionFieldDialog() {
         mFieldNameInput = new FixedEditText(this);
         mFieldNameInput.setRawInputType(InputType.TYPE_CLASS_NUMBER);
-        new MaterialDialog.Builder(this)
+        new MaterialEditTextDialog.Builder(this, mFieldNameInput)
                 .title(String.format(getResources().getString(R.string.model_field_editor_reposition), 1, mFieldLabels.size()))
                 .positiveText(R.string.dialog_ok)
-                .customView(mFieldNameInput, true)
                 .onPositive((dialog, which) -> {
                         String newPosition = mFieldNameInput.getText().toString();
                         int pos;

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/CreateDeckDialog.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/CreateDeckDialog.java
@@ -21,6 +21,7 @@ import android.widget.EditText;
 
 import com.afollestad.materialdialogs.MaterialDialog;
 import com.ichi2.anki.AnkiActivity;
+import com.ichi2.anki.MaterialEditTextDialog;
 import com.ichi2.anki.R;
 import com.ichi2.anki.UIUtils;
 import com.ichi2.anki.exception.DeckRenameException;
@@ -30,9 +31,7 @@ import com.ichi2.libanki.Decks;
 import com.ichi2.ui.FixedEditText;
 
 import java.util.List;
-import java.util.Locale;
 import java.util.function.Consumer;
-import java.util.stream.Collectors;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -65,7 +64,7 @@ public class CreateDeckDialog {
         this.mDeckDialogType = deckDialogType;
         this.mDialogEditText = new FixedEditText(context);
         mAnkiActivity = new AnkiActivity();
-        mBuilder = new MaterialDialog.Builder(context);
+        mBuilder = new MaterialEditTextDialog.Builder(context, mDialogEditText);
     }
 
     public void setDeckName(@NonNull String deckName) {
@@ -96,7 +95,6 @@ public class CreateDeckDialog {
 
         return mBuilder.title(mTitle)
                 .positiveText(R.string.dialog_ok)
-                .customView(mDialogEditText, true)
                 .negativeText(R.string.dialog_cancel)
                 .onPositive((dialog, which) -> onPositiveButtonClicked())
                 .show();


### PR DESCRIPTION
## Purpose / Description
UX - saves a tap on the edit text

## Fixes
Related #8464


## How Has This Been Tested?
On my Android 11

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
