### PR TITLE
fixes: no custom study steps on schedv2

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/FilteredDeckOptions.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/FilteredDeckOptions.java
@@ -49,6 +49,8 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import timber.log.Timber;
 
 import static com.ichi2.anim.ActivityTransitionAnimation.Direction.FADE;
@@ -364,7 +366,7 @@ public class FilteredDeckOptions extends AppCompatPreferenceActivity implements 
             mPref = new DeckPreferenceHack();
             mPref.registerOnSharedPreferenceChangeListener(this);
 
-            this.addPreferencesFromResource(R.xml.cram_deck_options);
+            this.addPreferences(mCol);
             this.buildLists();
             this.updateSummaries();
         }
@@ -385,6 +387,36 @@ public class FilteredDeckOptions extends AppCompatPreferenceActivity implements 
         getSupportActionBar().setHomeButtonEnabled(true);
         getSupportActionBar().setDisplayHomeAsUpEnabled(true);
     }
+
+
+    @SuppressWarnings("deprecation")  // Tracked as #5019 on github: addPreferencesFromResource
+    private void addPreferences(@NonNull Collection col) {
+        this.addPreferencesFromResource(R.xml.cram_deck_options);
+
+        if (col.schedVer() != 1) {
+            Timber.d("sched v2: removing filtered deck custom study steps");
+            // getPreferenceScreen.removePreference didn't return true, so remove from the category
+            android.preference.PreferenceCategory category = (android.preference.PreferenceCategory) this.findPreference("studyOptions");
+            removePreference(category, "stepsOn");
+            removePreference(category, "steps");
+        }
+
+    }
+
+    @SuppressWarnings("deprecation")  // Tracked as #5019 on github: findPreference
+    private void removePreference(@Nullable android.preference.PreferenceCategory category, String key) {
+        @Nullable android.preference.Preference preference = this.findPreference(key);
+        if (category == null || preference == null) {
+            Timber.w("Failed to remove preference '%s'", key);
+            return;
+        }
+
+        boolean result = category.removePreference(preference);
+        if (!result) {
+            Timber.w("Failed to remove preference '%s'", key);
+        }
+    }
+
 
     @Override
     @SuppressWarnings("deprecation") // TODO Tracked in https://github.com/ankidroid/Anki-Android/issues/5019

--- a/AnkiDroid/src/main/res/xml/cram_deck_options.xml
+++ b/AnkiDroid/src/main/res/xml/cram_deck_options.xml
@@ -34,7 +34,7 @@
             android:key="order"
             android:title="@string/deck_conf_cram_order" />
     </PreferenceCategory>
-    <PreferenceCategory android:title="@string/study_options" >
+    <PreferenceCategory android:title="@string/study_options" android:key="studyOptions" >
         <CheckBoxPreference
             android:defaultValue="true"
             android:key="resched"


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
Sched V2 should not display custom study steps on filtered decks

## Fixes
Fixes #8641

## Approach
Had problems with `getPreferenceScreen().removePreference`

so went with assigning a key to the category and using that

The methods fail on nulls, so null checking is sadly necessary

## How Has This Been Tested?

![image](https://user-images.githubusercontent.com/62114487/116901569-0066a000-ac32-11eb-9eaf-f76c7815bc05.png)

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
