### PR TITLE
fix: added tag doesn't reflect in adapter

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/tags/TagsArrayAdapter.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/tags/TagsArrayAdapter.java
@@ -30,6 +30,7 @@ import java.util.List;
 import java.util.Locale;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import androidx.recyclerview.widget.RecyclerView;
 
 public class TagsArrayAdapter extends  RecyclerView.Adapter<TagsArrayAdapter.ViewHolder> implements Filterable {
@@ -49,14 +50,17 @@ public class TagsArrayAdapter extends  RecyclerView.Adapter<TagsArrayAdapter.Vie
     @NonNull
     private final TagsList mTags;
     /**
-     * A subset of all tags in {@link #mTags} satisfying the user's search
+     * A subset of all tags in {@link #mTags} satisfying the user's search.
+     *
+     * it will be null if the user search term is empty, in that case
+     * the adapter should use {@link #mTags} instead to access full list.
      */
-    @NonNull
+    @Nullable
     private List<String> mFilteredList;
 
     public TagsArrayAdapter(@NonNull TagsList tags) {
         mTags = tags;
-        mFilteredList = tags.copyOfAllTagList();
+        mFilteredList = null;
         sortData();
     }
 
@@ -86,13 +90,23 @@ public class TagsArrayAdapter extends  RecyclerView.Adapter<TagsArrayAdapter.Vie
 
     @Override
     public void onBindViewHolder(@NonNull ViewHolder holder, int position) {
-        String tag = mFilteredList.get(position);
+        String tag = getTagByIndex(position);
         holder.mTagItemCheckedTextView.setText(tag);
         holder.mTagItemCheckedTextView.setChecked(mTags.isChecked(tag));
     }
 
+    private String getTagByIndex(int index) {
+        if (mFilteredList == null) {
+            return mTags.get(index);
+        }
+        return mFilteredList.get(index);
+    }
+
     @Override
     public int getItemCount() {
+        if (mFilteredList == null) {
+            return mTags.size();
+        }
         return mFilteredList.size();
     }
 
@@ -106,7 +120,7 @@ public class TagsArrayAdapter extends  RecyclerView.Adapter<TagsArrayAdapter.Vie
         @Override
         protected FilterResults performFiltering(CharSequence constraint) {
             if (constraint.length() == 0) {
-                mFilteredList = mTags.copyOfAllTagList();
+                mFilteredList = null;
             } else {
                 mFilteredList = new ArrayList<>();
                 final String filterPattern = constraint.toString().toLowerCase(Locale.getDefault()).trim();

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/tags/TagsDialog.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/tags/TagsDialog.java
@@ -25,6 +25,7 @@ import java.util.Optional;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.annotation.VisibleForTesting;
 import androidx.appcompat.widget.SearchView;
 import androidx.appcompat.widget.Toolbar;
 import androidx.recyclerview.widget.LinearLayoutManager;
@@ -269,7 +270,8 @@ public class TagsDialog extends AnalyticsDialogFragment {
         return editText;
     }
 
-    public void addTag(String tag) {
+    @VisibleForTesting
+    protected void addTag(String tag) {
         if (!TextUtils.isEmpty(tag)) {
             String feedbackText;
             if (mTags.add(tag)) {


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
I have reverted to the old way of handling `mFilteredList`.

## Fixes
Fixes #8762

## Approach
`mFilteredList` will be only set when there is a search filter active, otherwise, it's null and the adapter will use the original full list.

## How Has This Been Tested?

Emulator

## Checklist

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
