### PR TITLE
Remove listener-related generic type

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -226,7 +226,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
 
     private String mExportFileName;
 
-    @Nullable private CollectionTask<?, ?, ?, ?> mEmptyCardTask = null;
+    @Nullable private CollectionTask<?, ?, ?> mEmptyCardTask = null;
 
     @VisibleForTesting
     public List<? extends AbstractDeckTreeNode<?>> mDueTree;
@@ -2809,7 +2809,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
             mOnePercent = mNumberOfCards / 100;
         }
 
-        private void confirmCancel(@NonNull DeckPicker deckPicker, @NonNull CollectionTask<?, ?, ?, ?>  task) {
+        private void confirmCancel(@NonNull DeckPicker deckPicker, @NonNull CollectionTask<?, ?, ?>  task) {
             new MaterialDialog.Builder(deckPicker)
                     .content(R.string.confirm_cancel)
                     .positiveText(deckPicker.getResources().getString(R.string.yes))
@@ -2822,7 +2822,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
         @Override
         public void actualOnPreExecute(@NonNull DeckPicker deckPicker) {
             DialogInterface.OnCancelListener onCancel = (dialogInterface) -> {
-                CollectionTask<?, ?, ?, ?>  emptyCardTask = deckPicker.mEmptyCardTask;
+                CollectionTask<?, ?, ?>  emptyCardTask = deckPicker.mEmptyCardTask;
                 if (emptyCardTask != null) {
                     confirmCancel(deckPicker, emptyCardTask);
                 }};

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -226,7 +226,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
 
     private String mExportFileName;
 
-    @Nullable private CollectionTask<?, ?, ?> mEmptyCardTask = null;
+    @Nullable private CollectionTask<?, ?> mEmptyCardTask = null;
 
     @VisibleForTesting
     public List<? extends AbstractDeckTreeNode<?>> mDueTree;
@@ -2809,7 +2809,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
             mOnePercent = mNumberOfCards / 100;
         }
 
-        private void confirmCancel(@NonNull DeckPicker deckPicker, @NonNull CollectionTask<?, ?, ?>  task) {
+        private void confirmCancel(@NonNull DeckPicker deckPicker, @NonNull CollectionTask<?, ?>  task) {
             new MaterialDialog.Builder(deckPicker)
                     .content(R.string.confirm_cancel)
                     .positiveText(deckPicker.getResources().getString(R.string.yes))
@@ -2822,7 +2822,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
         @Override
         public void actualOnPreExecute(@NonNull DeckPicker deckPicker) {
             DialogInterface.OnCancelListener onCancel = (dialogInterface) -> {
-                CollectionTask<?, ?, ?>  emptyCardTask = deckPicker.mEmptyCardTask;
+                CollectionTask<?, ?>  emptyCardTask = deckPicker.mEmptyCardTask;
                 if (emptyCardTask != null) {
                     confirmCancel(deckPicker, emptyCardTask);
                 }};

--- a/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
@@ -99,7 +99,7 @@ import static com.ichi2.utils.BooleanGetter.TRUE;
 /**
  * Loading in the background, so that AnkiDroid does not look like frozen.
  */
-public class CollectionTask<ProgressListener, ProgressBackground extends ProgressListener, ResultListener, ResultBackground extends ResultListener> extends BaseAsyncTask<Void, ProgressBackground, ResultBackground> {
+public class CollectionTask<ProgressBackground, ResultListener, ResultBackground extends ResultListener> extends BaseAsyncTask<Void, ProgressBackground, ResultBackground> {
 
     public abstract static class Task<ProgressBackground, ResultBackground> {
         protected abstract ResultBackground task(@NonNull Collection col, @NonNull ProgressSenderAndCancelListener<ProgressBackground> collectionTask);
@@ -145,11 +145,11 @@ public class CollectionTask<ProgressListener, ProgressBackground extends Progres
     public Task<ProgressBackground, ResultBackground> getTask() {
         return mTask;
     }
-    private final TaskListener<ProgressListener, ResultListener> mListener;
+    private final TaskListener<? super ProgressBackground, ResultListener> mListener;
     private CollectionTask mPreviousTask;
 
 
-    protected CollectionTask(Task<ProgressBackground, ResultBackground> task, TaskListener<ProgressListener, ResultListener> listener, CollectionTask previousTask) {
+    protected CollectionTask(Task<ProgressBackground, ResultBackground> task, TaskListener<? super ProgressBackground, ResultListener> listener, CollectionTask previousTask) {
         mTask = task;
         mListener = listener;
         mPreviousTask = previousTask;

--- a/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
@@ -99,7 +99,7 @@ import static com.ichi2.utils.BooleanGetter.TRUE;
 /**
  * Loading in the background, so that AnkiDroid does not look like frozen.
  */
-public class CollectionTask<ProgressBackground, ResultListener, ResultBackground extends ResultListener> extends BaseAsyncTask<Void, ProgressBackground, ResultBackground> {
+public class CollectionTask<ProgressBackground, ResultBackground> extends BaseAsyncTask<Void, ProgressBackground, ResultBackground> {
 
     public abstract static class Task<ProgressBackground, ResultBackground> {
         protected abstract ResultBackground task(@NonNull Collection col, @NonNull ProgressSenderAndCancelListener<ProgressBackground> collectionTask);
@@ -145,11 +145,11 @@ public class CollectionTask<ProgressBackground, ResultListener, ResultBackground
     public Task<ProgressBackground, ResultBackground> getTask() {
         return mTask;
     }
-    private final TaskListener<? super ProgressBackground, ResultListener> mListener;
+    private final TaskListener<? super ProgressBackground, ? super ResultBackground> mListener;
     private CollectionTask mPreviousTask;
 
 
-    protected CollectionTask(Task<ProgressBackground, ResultBackground> task, TaskListener<? super ProgressBackground, ResultListener> listener, CollectionTask previousTask) {
+    protected CollectionTask(Task<ProgressBackground, ResultBackground> task, TaskListener<? super ProgressBackground, ? super ResultBackground> listener, CollectionTask previousTask) {
         mTask = task;
         mListener = listener;
         mPreviousTask = previousTask;

--- a/AnkiDroid/src/main/java/com/ichi2/async/SingleTaskManager.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/SingleTaskManager.java
@@ -86,9 +86,9 @@ public class SingleTaskManager extends TaskManager {
      * @param listener to the status and result of the task, may be null
      * @return the newly created task
      */
-    public <ProgressBackground, ResultListener, ResultBackground extends ResultListener> CollectionTask<ProgressBackground, ResultBackground>
+    public <ProgressBackground, ResultBackground> CollectionTask<ProgressBackground, ResultBackground>
     launchCollectionTaskConcrete(@NonNull CollectionTask.Task<ProgressBackground, ResultBackground> task,
-                         @Nullable TaskListener<? super ProgressBackground, ResultListener> listener) {
+                         @Nullable TaskListener<? super ProgressBackground, ? super ResultBackground> listener) {
         // Start new task
         CollectionTask<ProgressBackground, ResultBackground> newTask = new CollectionTask<>(task, listener, mLatestInstance);
         addTasks(newTask);

--- a/AnkiDroid/src/main/java/com/ichi2/async/SingleTaskManager.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/SingleTaskManager.java
@@ -69,7 +69,7 @@ public class SingleTaskManager extends TaskManager {
      * @return the newly created task
      */
     @Override
-    public <ProgressBackground, ResultBackground> CollectionTask<ProgressBackground, ResultBackground, ResultBackground> launchCollectionTaskConcrete(CollectionTask.Task<ProgressBackground, ResultBackground> task) {
+    public <ProgressBackground, ResultBackground> CollectionTask<ProgressBackground, ResultBackground> launchCollectionTaskConcrete(CollectionTask.Task<ProgressBackground, ResultBackground> task) {
         return launchCollectionTask(task, null);
     }
 
@@ -86,11 +86,11 @@ public class SingleTaskManager extends TaskManager {
      * @param listener to the status and result of the task, may be null
      * @return the newly created task
      */
-    public <ProgressBackground, ResultListener, ResultBackground extends ResultListener> CollectionTask<ProgressBackground, ResultListener, ResultBackground>
+    public <ProgressBackground, ResultListener, ResultBackground extends ResultListener> CollectionTask<ProgressBackground, ResultBackground>
     launchCollectionTaskConcrete(@NonNull CollectionTask.Task<ProgressBackground, ResultBackground> task,
                          @Nullable TaskListener<? super ProgressBackground, ResultListener> listener) {
         // Start new task
-        CollectionTask<ProgressBackground, ResultListener, ResultBackground> newTask = new CollectionTask<>(task, listener, mLatestInstance);
+        CollectionTask<ProgressBackground, ResultBackground> newTask = new CollectionTask<>(task, listener, mLatestInstance);
         addTasks(newTask);
         newTask.execute();
         return newTask;

--- a/AnkiDroid/src/main/java/com/ichi2/async/SingleTaskManager.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/SingleTaskManager.java
@@ -86,9 +86,9 @@ public class SingleTaskManager extends TaskManager {
      * @param listener to the status and result of the task, may be null
      * @return the newly created task
      */
-    public <ProgressListener, ProgressBackground extends ProgressListener, ResultListener, ResultBackground extends ResultListener> CollectionTask<ProgressBackground, ResultListener, ResultBackground>
+    public <ProgressBackground, ResultListener, ResultBackground extends ResultListener> CollectionTask<ProgressBackground, ResultListener, ResultBackground>
     launchCollectionTaskConcrete(@NonNull CollectionTask.Task<ProgressBackground, ResultBackground> task,
-                         @Nullable TaskListener<ProgressListener, ResultListener> listener) {
+                         @Nullable TaskListener<? super ProgressBackground, ResultListener> listener) {
         // Start new task
         CollectionTask<ProgressBackground, ResultListener, ResultBackground> newTask = new CollectionTask<>(task, listener, mLatestInstance);
         addTasks(newTask);

--- a/AnkiDroid/src/main/java/com/ichi2/async/SingleTaskManager.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/SingleTaskManager.java
@@ -69,7 +69,7 @@ public class SingleTaskManager extends TaskManager {
      * @return the newly created task
      */
     @Override
-    public <ProgressBackground, ResultBackground> CollectionTask<ProgressBackground, ProgressBackground, ResultBackground, ResultBackground> launchCollectionTaskConcrete(CollectionTask.Task<ProgressBackground, ResultBackground> task) {
+    public <ProgressBackground, ResultBackground> CollectionTask<ProgressBackground, ResultBackground, ResultBackground> launchCollectionTaskConcrete(CollectionTask.Task<ProgressBackground, ResultBackground> task) {
         return launchCollectionTask(task, null);
     }
 
@@ -86,11 +86,11 @@ public class SingleTaskManager extends TaskManager {
      * @param listener to the status and result of the task, may be null
      * @return the newly created task
      */
-    public <ProgressListener, ProgressBackground extends ProgressListener, ResultListener, ResultBackground extends ResultListener> CollectionTask<ProgressListener, ProgressBackground, ResultListener, ResultBackground>
+    public <ProgressListener, ProgressBackground extends ProgressListener, ResultListener, ResultBackground extends ResultListener> CollectionTask<ProgressBackground, ResultListener, ResultBackground>
     launchCollectionTaskConcrete(@NonNull CollectionTask.Task<ProgressBackground, ResultBackground> task,
                          @Nullable TaskListener<ProgressListener, ResultListener> listener) {
         // Start new task
-        CollectionTask<ProgressListener, ProgressBackground, ResultListener, ResultBackground> newTask = new CollectionTask<>(task, listener, mLatestInstance);
+        CollectionTask<ProgressBackground, ResultListener, ResultBackground> newTask = new CollectionTask<>(task, listener, mLatestInstance);
         addTasks(newTask);
         newTask.execute();
         return newTask;

--- a/AnkiDroid/src/main/java/com/ichi2/async/TaskManager.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/TaskManager.java
@@ -76,15 +76,15 @@ public abstract class TaskManager {
      * @param listener to the status and result of the task, may be null
      * @return the newly created task
      */
-    public static <ProgressListener, ProgressBackground extends ProgressListener, ResultListener, ResultBackground extends ResultListener> CollectionTask<ProgressBackground, ResultListener, ResultBackground>
+    public static <ProgressBackground, ResultListener, ResultBackground extends ResultListener> CollectionTask<ProgressBackground, ResultListener, ResultBackground>
     launchCollectionTask(@NonNull CollectionTask.Task<ProgressBackground, ResultBackground> task,
-                         @Nullable TaskListener<ProgressListener, ResultListener> listener) {
+                         @Nullable TaskListener<? super ProgressBackground, ResultListener> listener) {
         return sTaskManager.launchCollectionTaskConcrete(task, listener);
     }
 
-    public abstract <ProgressListener, ProgressBackground extends ProgressListener, ResultListener, ResultBackground extends ResultListener> CollectionTask<ProgressBackground, ResultListener, ResultBackground>
+    public abstract <ProgressBackground, ResultListener, ResultBackground extends ResultListener> CollectionTask<ProgressBackground, ResultListener, ResultBackground>
     launchCollectionTaskConcrete(@NonNull CollectionTask.Task<ProgressBackground, ResultBackground> task,
-                         @Nullable TaskListener<ProgressListener, ResultListener> listener);
+                         @Nullable TaskListener<? super ProgressBackground, ResultListener> listener);
 
     /**
      * Block the current thread until the currently running CollectionTask instance (if any) has finished.

--- a/AnkiDroid/src/main/java/com/ichi2/async/TaskManager.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/TaskManager.java
@@ -56,11 +56,11 @@ public abstract class TaskManager {
         sTaskManager.setLatestInstanceConcrete(task);
     }
 
-    public static <ProgressBackground, ResultBackground> CollectionTask<ProgressBackground, ProgressBackground, ResultBackground, ResultBackground> launchCollectionTask(CollectionTask.Task<ProgressBackground, ResultBackground> task) {
+    public static <ProgressBackground, ResultBackground> CollectionTask<ProgressBackground, ResultBackground, ResultBackground> launchCollectionTask(CollectionTask.Task<ProgressBackground, ResultBackground> task) {
         return sTaskManager.launchCollectionTaskConcrete(task);
     }
 
-    public abstract <ProgressBackground, ResultBackground> CollectionTask<ProgressBackground, ProgressBackground, ResultBackground, ResultBackground> launchCollectionTaskConcrete(CollectionTask.Task<ProgressBackground, ResultBackground> task);
+    public abstract <ProgressBackground, ResultBackground> CollectionTask<ProgressBackground, ResultBackground, ResultBackground> launchCollectionTaskConcrete(CollectionTask.Task<ProgressBackground, ResultBackground> task);
 
 
     protected abstract void setLatestInstanceConcrete(CollectionTask task);
@@ -76,13 +76,13 @@ public abstract class TaskManager {
      * @param listener to the status and result of the task, may be null
      * @return the newly created task
      */
-    public static <ProgressListener, ProgressBackground extends ProgressListener, ResultListener, ResultBackground extends ResultListener> CollectionTask<ProgressListener, ProgressBackground, ResultListener, ResultBackground>
+    public static <ProgressListener, ProgressBackground extends ProgressListener, ResultListener, ResultBackground extends ResultListener> CollectionTask<ProgressBackground, ResultListener, ResultBackground>
     launchCollectionTask(@NonNull CollectionTask.Task<ProgressBackground, ResultBackground> task,
                          @Nullable TaskListener<ProgressListener, ResultListener> listener) {
         return sTaskManager.launchCollectionTaskConcrete(task, listener);
     }
 
-    public abstract <ProgressListener, ProgressBackground extends ProgressListener, ResultListener, ResultBackground extends ResultListener> CollectionTask<ProgressListener, ProgressBackground, ResultListener, ResultBackground>
+    public abstract <ProgressListener, ProgressBackground extends ProgressListener, ResultListener, ResultBackground extends ResultListener> CollectionTask<ProgressBackground, ResultListener, ResultBackground>
     launchCollectionTaskConcrete(@NonNull CollectionTask.Task<ProgressBackground, ResultBackground> task,
                          @Nullable TaskListener<ProgressListener, ResultListener> listener);
 

--- a/AnkiDroid/src/main/java/com/ichi2/async/TaskManager.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/TaskManager.java
@@ -56,11 +56,11 @@ public abstract class TaskManager {
         sTaskManager.setLatestInstanceConcrete(task);
     }
 
-    public static <ProgressBackground, ResultBackground> CollectionTask<ProgressBackground, ResultBackground, ResultBackground> launchCollectionTask(CollectionTask.Task<ProgressBackground, ResultBackground> task) {
+    public static <ProgressBackground, ResultBackground> CollectionTask<ProgressBackground, ResultBackground> launchCollectionTask(CollectionTask.Task<ProgressBackground, ResultBackground> task) {
         return sTaskManager.launchCollectionTaskConcrete(task);
     }
 
-    public abstract <ProgressBackground, ResultBackground> CollectionTask<ProgressBackground, ResultBackground, ResultBackground> launchCollectionTaskConcrete(CollectionTask.Task<ProgressBackground, ResultBackground> task);
+    public abstract <ProgressBackground, ResultBackground> CollectionTask<ProgressBackground, ResultBackground> launchCollectionTaskConcrete(CollectionTask.Task<ProgressBackground, ResultBackground> task);
 
 
     protected abstract void setLatestInstanceConcrete(CollectionTask task);
@@ -76,13 +76,13 @@ public abstract class TaskManager {
      * @param listener to the status and result of the task, may be null
      * @return the newly created task
      */
-    public static <ProgressBackground, ResultListener, ResultBackground extends ResultListener> CollectionTask<ProgressBackground, ResultListener, ResultBackground>
+    public static <ProgressBackground, ResultListener, ResultBackground extends ResultListener> CollectionTask<ProgressBackground, ResultBackground>
     launchCollectionTask(@NonNull CollectionTask.Task<ProgressBackground, ResultBackground> task,
                          @Nullable TaskListener<? super ProgressBackground, ResultListener> listener) {
         return sTaskManager.launchCollectionTaskConcrete(task, listener);
     }
 
-    public abstract <ProgressBackground, ResultListener, ResultBackground extends ResultListener> CollectionTask<ProgressBackground, ResultListener, ResultBackground>
+    public abstract <ProgressBackground, ResultListener, ResultBackground extends ResultListener> CollectionTask<ProgressBackground, ResultBackground>
     launchCollectionTaskConcrete(@NonNull CollectionTask.Task<ProgressBackground, ResultBackground> task,
                          @Nullable TaskListener<? super ProgressBackground, ResultListener> listener);
 

--- a/AnkiDroid/src/main/java/com/ichi2/async/TaskManager.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/TaskManager.java
@@ -76,15 +76,15 @@ public abstract class TaskManager {
      * @param listener to the status and result of the task, may be null
      * @return the newly created task
      */
-    public static <ProgressBackground, ResultListener, ResultBackground extends ResultListener> CollectionTask<ProgressBackground, ResultBackground>
+    public static <ProgressBackground, ResultBackground> CollectionTask<ProgressBackground, ResultBackground>
     launchCollectionTask(@NonNull CollectionTask.Task<ProgressBackground, ResultBackground> task,
-                         @Nullable TaskListener<? super ProgressBackground, ResultListener> listener) {
+                         @Nullable TaskListener<? super ProgressBackground, ? super ResultBackground> listener) {
         return sTaskManager.launchCollectionTaskConcrete(task, listener);
     }
 
-    public abstract <ProgressBackground, ResultListener, ResultBackground extends ResultListener> CollectionTask<ProgressBackground, ResultBackground>
+    public abstract <ProgressBackground, ResultBackground> CollectionTask<ProgressBackground, ResultBackground>
     launchCollectionTaskConcrete(@NonNull CollectionTask.Task<ProgressBackground, ResultBackground> task,
-                         @Nullable TaskListener<? super ProgressBackground, ResultListener> listener);
+                         @Nullable TaskListener<? super ProgressBackground, ? super ResultBackground> listener);
 
     /**
      * Block the current thread until the currently running CollectionTask instance (if any) has finished.

--- a/AnkiDroid/src/test/java/com/ichi2/async/AbstractCollectionTaskTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/async/AbstractCollectionTaskTest.java
@@ -31,7 +31,7 @@ import static org.hamcrest.Matchers.notNullValue;
 public abstract class AbstractCollectionTaskTest extends RobolectricTest {
 
     protected <Progress, Result> Result execute(CollectionTask.Task<Progress, Result> task) {
-        CollectionTask<Progress, Progress, Result, Result> collectionTask = TaskManager.launchCollectionTask(task);
+        CollectionTask<Progress, Result, Result> collectionTask = TaskManager.launchCollectionTask(task);
         try {
             return collectionTask.get();
         } catch (Exception e) {

--- a/AnkiDroid/src/test/java/com/ichi2/async/AbstractCollectionTaskTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/async/AbstractCollectionTaskTest.java
@@ -31,7 +31,7 @@ import static org.hamcrest.Matchers.notNullValue;
 public abstract class AbstractCollectionTaskTest extends RobolectricTest {
 
     protected <Progress, Result> Result execute(CollectionTask.Task<Progress, Result> task) {
-        CollectionTask<Progress, Result, Result> collectionTask = TaskManager.launchCollectionTask(task);
+        CollectionTask<Progress, Result> collectionTask = TaskManager.launchCollectionTask(task);
         try {
             return collectionTask.get();
         } catch (Exception e) {

--- a/AnkiDroid/src/test/java/com/ichi2/async/ForegroundTaskManager.java
+++ b/AnkiDroid/src/test/java/com/ichi2/async/ForegroundTaskManager.java
@@ -22,7 +22,7 @@ public class ForegroundTaskManager extends TaskManager {
 
 
     @Override
-    public <ProgressBackground, ResultBackground> CollectionTask<ProgressBackground, ProgressBackground, ResultBackground, ResultBackground> launchCollectionTaskConcrete(CollectionTask.Task<ProgressBackground, ResultBackground> task) {
+    public <ProgressBackground, ResultBackground> CollectionTask<ProgressBackground, ResultBackground, ResultBackground> launchCollectionTaskConcrete(CollectionTask.Task<ProgressBackground, ResultBackground> task) {
         return launchCollectionTaskConcrete(task, null);
     }
 
@@ -33,13 +33,13 @@ public class ForegroundTaskManager extends TaskManager {
 
 
     @Override
-    public <ProgressListener, ProgressBackground extends ProgressListener, ResultListener, ResultBackground extends ResultListener> CollectionTask<ProgressListener, ProgressBackground, ResultListener, ResultBackground> launchCollectionTaskConcrete(
+    public <ProgressListener, ProgressBackground extends ProgressListener, ResultListener, ResultBackground extends ResultListener> CollectionTask<ProgressBackground, ResultListener, ResultBackground> launchCollectionTaskConcrete(
             @NonNull CollectionTask.Task<ProgressBackground, ResultBackground> task,
             @Nullable TaskListener<ProgressListener, ResultListener> listener) {
         return executeTaskWithListener(task, listener, mColGetter);
     }
 
-    public static <ProgressListener, ProgressBackground extends ProgressListener, ResultListener, ResultBackground extends ResultListener> CollectionTask<ProgressListener, ProgressBackground, ResultListener, ResultBackground> executeTaskWithListener(
+    public static <ProgressListener, ProgressBackground extends ProgressListener, ResultListener, ResultBackground extends ResultListener> CollectionTask<ProgressBackground, ResultListener, ResultBackground> executeTaskWithListener(
             @NonNull CollectionTask.Task<ProgressBackground, ResultBackground> task,
             @Nullable TaskListener<ProgressListener, ResultListener> listener, CollectionGetter colGetter) {
         if (listener != null) {
@@ -107,10 +107,10 @@ public class ForegroundTaskManager extends TaskManager {
         }
     }
 
-    public static class EmptyTask<ProgressListener, ProgressBackground extends ProgressListener, ResultListener, ResultBackground extends ResultListener> extends
-            CollectionTask<ProgressListener, ProgressBackground, ResultListener, ResultBackground> {
+    public static class EmptyTask<ProgressBackground, ResultListener, ResultBackground extends ResultListener> extends
+            CollectionTask<ProgressBackground, ResultListener, ResultBackground> {
 
-        protected EmptyTask(Task<ProgressBackground, ResultBackground> task, TaskListener<ProgressListener, ResultListener> listener) {
+        protected EmptyTask(Task<ProgressBackground, ResultBackground> task, TaskListener<? super ProgressBackground, ResultListener> listener) {
             super(task, listener, null);
         }
     }

--- a/AnkiDroid/src/test/java/com/ichi2/async/ForegroundTaskManager.java
+++ b/AnkiDroid/src/test/java/com/ichi2/async/ForegroundTaskManager.java
@@ -33,15 +33,15 @@ public class ForegroundTaskManager extends TaskManager {
 
 
     @Override
-    public <ProgressBackground, ResultListener, ResultBackground extends ResultListener> CollectionTask<ProgressBackground, ResultBackground> launchCollectionTaskConcrete(
+    public <ProgressBackground, ResultBackground> CollectionTask<ProgressBackground, ResultBackground> launchCollectionTaskConcrete(
             @NonNull CollectionTask.Task<ProgressBackground, ResultBackground> task,
-            @Nullable TaskListener<? super ProgressBackground, ResultListener> listener) {
+            @Nullable TaskListener<? super ProgressBackground, ? super ResultBackground> listener) {
         return executeTaskWithListener(task, listener, mColGetter);
     }
 
-    public static <ProgressBackground, ResultListener, ResultBackground extends ResultListener> CollectionTask<ProgressBackground, ResultBackground> executeTaskWithListener(
+    public static <ProgressBackground, ResultBackground> CollectionTask<ProgressBackground, ResultBackground> executeTaskWithListener(
             @NonNull CollectionTask.Task<ProgressBackground, ResultBackground> task,
-            @Nullable TaskListener<? super ProgressBackground, ResultListener> listener, CollectionGetter colGetter) {
+            @Nullable TaskListener<? super ProgressBackground, ? super ResultBackground> listener, CollectionGetter colGetter) {
         if (listener != null) {
             listener.onPreExecute();
         }
@@ -107,10 +107,10 @@ public class ForegroundTaskManager extends TaskManager {
         }
     }
 
-    public static class EmptyTask<ProgressBackground, ResultListener, ResultBackground extends ResultListener> extends
+    public static class EmptyTask<ProgressBackground, ResultBackground> extends
             CollectionTask<ProgressBackground, ResultBackground> {
 
-        protected EmptyTask(Task<ProgressBackground, ResultBackground> task, TaskListener<? super ProgressBackground, ResultListener> listener) {
+        protected EmptyTask(Task<ProgressBackground, ResultBackground> task, TaskListener<? super ProgressBackground, ? super ResultBackground> listener) {
             super(task, listener, null);
         }
     }

--- a/AnkiDroid/src/test/java/com/ichi2/async/ForegroundTaskManager.java
+++ b/AnkiDroid/src/test/java/com/ichi2/async/ForegroundTaskManager.java
@@ -33,15 +33,15 @@ public class ForegroundTaskManager extends TaskManager {
 
 
     @Override
-    public <ProgressListener, ProgressBackground extends ProgressListener, ResultListener, ResultBackground extends ResultListener> CollectionTask<ProgressBackground, ResultListener, ResultBackground> launchCollectionTaskConcrete(
+    public <ProgressBackground, ResultListener, ResultBackground extends ResultListener> CollectionTask<ProgressBackground, ResultListener, ResultBackground> launchCollectionTaskConcrete(
             @NonNull CollectionTask.Task<ProgressBackground, ResultBackground> task,
-            @Nullable TaskListener<ProgressListener, ResultListener> listener) {
+            @Nullable TaskListener<? super ProgressBackground, ResultListener> listener) {
         return executeTaskWithListener(task, listener, mColGetter);
     }
 
-    public static <ProgressListener, ProgressBackground extends ProgressListener, ResultListener, ResultBackground extends ResultListener> CollectionTask<ProgressBackground, ResultListener, ResultBackground> executeTaskWithListener(
+    public static <ProgressBackground, ResultListener, ResultBackground extends ResultListener> CollectionTask<ProgressBackground, ResultListener, ResultBackground> executeTaskWithListener(
             @NonNull CollectionTask.Task<ProgressBackground, ResultBackground> task,
-            @Nullable TaskListener<ProgressListener, ResultListener> listener, CollectionGetter colGetter) {
+            @Nullable TaskListener<? super ProgressBackground, ResultListener> listener, CollectionGetter colGetter) {
         if (listener != null) {
             listener.onPreExecute();
         }
@@ -87,10 +87,10 @@ public class ForegroundTaskManager extends TaskManager {
 
     public static class MockTaskManager<ProgressListener, ProgressBackground extends ProgressListener> implements ProgressSenderAndCancelListener<ProgressBackground> {
 
-        private final @Nullable TaskListener<ProgressListener, ?> mTaskListener;
+        private final @Nullable TaskListener<? super ProgressBackground, ?> mTaskListener;
 
 
-        public MockTaskManager(@Nullable TaskListener<ProgressListener, ?> listener) {
+        public MockTaskManager(@Nullable TaskListener<? super ProgressBackground, ?> listener) {
             mTaskListener = listener;
         }
 

--- a/AnkiDroid/src/test/java/com/ichi2/async/ForegroundTaskManager.java
+++ b/AnkiDroid/src/test/java/com/ichi2/async/ForegroundTaskManager.java
@@ -22,7 +22,7 @@ public class ForegroundTaskManager extends TaskManager {
 
 
     @Override
-    public <ProgressBackground, ResultBackground> CollectionTask<ProgressBackground, ResultBackground, ResultBackground> launchCollectionTaskConcrete(CollectionTask.Task<ProgressBackground, ResultBackground> task) {
+    public <ProgressBackground, ResultBackground> CollectionTask<ProgressBackground, ResultBackground> launchCollectionTaskConcrete(CollectionTask.Task<ProgressBackground, ResultBackground> task) {
         return launchCollectionTaskConcrete(task, null);
     }
 
@@ -33,13 +33,13 @@ public class ForegroundTaskManager extends TaskManager {
 
 
     @Override
-    public <ProgressBackground, ResultListener, ResultBackground extends ResultListener> CollectionTask<ProgressBackground, ResultListener, ResultBackground> launchCollectionTaskConcrete(
+    public <ProgressBackground, ResultListener, ResultBackground extends ResultListener> CollectionTask<ProgressBackground, ResultBackground> launchCollectionTaskConcrete(
             @NonNull CollectionTask.Task<ProgressBackground, ResultBackground> task,
             @Nullable TaskListener<? super ProgressBackground, ResultListener> listener) {
         return executeTaskWithListener(task, listener, mColGetter);
     }
 
-    public static <ProgressBackground, ResultListener, ResultBackground extends ResultListener> CollectionTask<ProgressBackground, ResultListener, ResultBackground> executeTaskWithListener(
+    public static <ProgressBackground, ResultListener, ResultBackground extends ResultListener> CollectionTask<ProgressBackground, ResultBackground> executeTaskWithListener(
             @NonNull CollectionTask.Task<ProgressBackground, ResultBackground> task,
             @Nullable TaskListener<? super ProgressBackground, ResultListener> listener, CollectionGetter colGetter) {
         if (listener != null) {
@@ -108,7 +108,7 @@ public class ForegroundTaskManager extends TaskManager {
     }
 
     public static class EmptyTask<ProgressBackground, ResultListener, ResultBackground extends ResultListener> extends
-            CollectionTask<ProgressBackground, ResultListener, ResultBackground> {
+            CollectionTask<ProgressBackground, ResultBackground> {
 
         protected EmptyTask(Task<ProgressBackground, ResultBackground> task, TaskListener<? super ProgressBackground, ResultListener> listener) {
             super(task, listener, null);

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/CheckMediaTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/CheckMediaTest.java
@@ -48,7 +48,7 @@ public class CheckMediaTest extends RobolectricTest {
 
         assertThat(getCol().getMedia().getDb().queryScalar("SELECT count(*) FROM sqlite_master WHERE type='table' AND name='meta';"), is(0));
 
-        CollectionTask<Void, PairWithBoolean<List<List<String>>>, PairWithBoolean<List<List<String>>>> task = TaskManager.launchCollectionTask(new CollectionTask.CheckMedia());
+        CollectionTask<Void, PairWithBoolean<List<List<String>>>> task = TaskManager.launchCollectionTask(new CollectionTask.CheckMedia());
 
         task.get();
 

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/CheckMediaTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/CheckMediaTest.java
@@ -48,7 +48,7 @@ public class CheckMediaTest extends RobolectricTest {
 
         assertThat(getCol().getMedia().getDb().queryScalar("SELECT count(*) FROM sqlite_master WHERE type='table' AND name='meta';"), is(0));
 
-        CollectionTask<Void, Void, PairWithBoolean<List<List<String>>>, PairWithBoolean<List<List<String>>>> task = TaskManager.launchCollectionTask(new CollectionTask.CheckMedia());
+        CollectionTask<Void, PairWithBoolean<List<List<String>>>, PairWithBoolean<List<List<String>>>> task = TaskManager.launchCollectionTask(new CollectionTask.CheckMedia());
 
         task.get();
 


### PR DESCRIPTION
The typing of background tasks element is complex. I sincerely believe that a generic type system is far better than dealing with `Object[]`as we often did last year. However, this led me to think more about it, and I guess that `? extends FOO` has less parameters than introducing extra type variable. So here it is, a version of `CollectionTask` and `launchCollectionTask` with only two parameters.

If this get merged, I'll then remove `Background` suffix from variable type. But this will wait so that this PR remains simple