### PR TITLE
fix: crash changing collection when stats running

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/NavigationDrawerActivity.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NavigationDrawerActivity.java
@@ -37,14 +37,12 @@ import androidx.appcompat.app.ActionBarDrawerToggle;
 import androidx.appcompat.widget.SwitchCompat;
 import androidx.appcompat.widget.Toolbar;
 
-import android.provider.Settings;
 import android.view.KeyEvent;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
 
 import com.ichi2.anki.dialogs.HelpDialog;
-import com.ichi2.libanki.stats.Stats;
 import com.ichi2.themes.Themes;
 
 import java.util.Arrays;
@@ -369,6 +367,10 @@ public abstract class NavigationDrawerActivity extends AnkiActivity implements N
                 // Remember the theme we started with so we can restart the Activity if it changes
                 mOldTheme = Themes.getCurrentTheme(getApplicationContext());
                 startActivityForResultWithAnimation(new Intent(NavigationDrawerActivity.this, Preferences.class), REQUEST_PREFERENCES_UPDATE, FADE);
+                // #6192 - stop crash on changing collection path - cancel tasks if moving to settings
+                if (this instanceof Statistics) {
+                    finishWithAnimation(FADE);
+                }
             } else if (itemId == R.id.nav_help) {
                 Timber.i("Navigating to help");
                 showDialogFragment(HelpDialog.createInstance(this));

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Statistics.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Statistics.java
@@ -43,6 +43,7 @@ import com.google.android.material.tabs.TabLayout;
 import com.google.android.material.tabs.TabLayoutMediator;
 import com.ichi2.anim.ActivityTransitionAnimation;
 import com.ichi2.anki.dialogs.DeckSelectionDialog;
+import com.ichi2.anki.runtimetools.TaskOperations;
 import com.ichi2.anki.stats.AnkiStatsTaskHandler;
 import com.ichi2.anki.stats.ChartView;
 import com.ichi2.anki.widgets.DeckDropDownAdapter;
@@ -253,6 +254,7 @@ public class Statistics extends NavigationDrawerActivity implements
         //track current settings for each individual fragment
         protected long mDeckId;
         protected AsyncTask mStatisticsTask;
+        protected AsyncTask mStatisticsOverviewTask;
         private ViewPager2 mActivityPager;
         private TabLayout mSlidingTabLayout;
         private TabLayoutMediator mTabLayoutMediator;
@@ -310,14 +312,19 @@ public class Statistics extends NavigationDrawerActivity implements
 
         @Override
         public void onDestroy() {
-            if (mStatisticsTask != null && !mStatisticsTask.isCancelled()) {
-                mStatisticsTask.cancel(true);
-            }
+            cancelTasks();
             if (mActivityPager.getAdapter() != null) {
                 mActivityPager.getAdapter().unregisterAdapterDataObserver(mDataObserver);
             }
             super.onDestroy();
         }
+
+        protected void cancelTasks() {
+            Timber.w("canceling tasks");
+            TaskOperations.stopTaskGracefully(mStatisticsTask);
+            TaskOperations.stopTaskGracefully(mStatisticsOverviewTask);
+        }
+
 
         private String getTabTitle(int position) {
             Locale l = Locale.getDefault();
@@ -506,9 +513,7 @@ public class Statistics extends NavigationDrawerActivity implements
                     mProgressBar.setVisibility(View.VISIBLE);
                     mChart.setVisibility(View.GONE);
                     mDeckId = ((Statistics) requireActivity()).getDeckId();
-                    if (mStatisticsTask != null && !mStatisticsTask.isCancelled()) {
-                        mStatisticsTask.cancel(true);
-                    }
+                    cancelTasks();
                     createChart();
                 }
             }
@@ -585,7 +590,7 @@ public class Statistics extends NavigationDrawerActivity implements
 
         private void createStatisticOverview(){
             AnkiStatsTaskHandler handler = (((Statistics)requireActivity()).getTaskHandler());
-            mStatisticsTask = handler.createStatisticsOverview(mWebView, mProgressBar);
+            mStatisticsOverviewTask = handler.createStatisticsOverview(mWebView, mProgressBar);
         }
 
 
@@ -600,9 +605,7 @@ public class Statistics extends NavigationDrawerActivity implements
                 mProgressBar.setVisibility(View.VISIBLE);
                 mWebView.setVisibility(View.GONE);
                 mDeckId = ((Statistics) requireActivity()).getDeckId();
-                if (mStatisticsTask != null && !mStatisticsTask.isCancelled()) {
-                    mStatisticsTask.cancel(true);
-                }
+                cancelTasks();
                 createStatisticOverview();
             }
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/stats/AnkiStatsTaskHandler.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/stats/AnkiStatsTaskHandler.java
@@ -64,7 +64,7 @@ public class AnkiStatsTaskHandler {
     }
 
     public synchronized static AnkiStatsTaskHandler getInstance(Collection collection) {
-        if (sInstance == null) {
+        if (sInstance == null || sInstance.mCollectionData != collection) {
             sInstance = new AnkiStatsTaskHandler(collection);
         }
         return sInstance;

--- a/AnkiDroid/src/main/java/com/ichi2/anki/stats/AnkiStatsTaskHandler.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/stats/AnkiStatsTaskHandler.java
@@ -86,7 +86,7 @@ public class AnkiStatsTaskHandler {
         return deckPreviewStatistics;
     }
 
-    private static class CreateChartTask extends AsyncTask<View, Void, PlotSheet>{
+    private static class CreateChartTask extends StatsAsyncTask<PlotSheet>{
         private WeakReference<ChartView> mImageView;
         private WeakReference<ProgressBar> mProgressBar;
         private final WeakReference<Collection> mCollectionData;
@@ -106,7 +106,7 @@ public class AnkiStatsTaskHandler {
         }
 
         @Override
-        protected PlotSheet doInBackground(View... params) {
+        protected PlotSheet doInBackgroundSafe(View... params) {
             //make sure only one task of CreateChartTask is running, first to run should get sLock
             //only necessary on lower APIs because after honeycomb only one thread is used for all asynctasks
             sLock.lock();
@@ -149,7 +149,7 @@ public class AnkiStatsTaskHandler {
         }
     }
 
-    private static class CreateStatisticsOverview extends AsyncTask<View, Void, String>{
+    private static class CreateStatisticsOverview extends StatsAsyncTask<String>{
         private WeakReference<WebView> mWebView;
         private WeakReference<ProgressBar> mProgressBar;
         private final WeakReference<Collection> mCollectionData;
@@ -167,7 +167,7 @@ public class AnkiStatsTaskHandler {
         }
 
         @Override
-        protected String doInBackground(View... params) {
+        protected String doInBackgroundSafe(View... params) {
             //make sure only one task of CreateChartTask is running, first to run should get sLock
             //only necessary on lower APIs because after honeycomb only one thread is used for all asynctasks
             sLock.lock();

--- a/AnkiDroid/src/main/java/com/ichi2/anki/stats/StatsAsyncTask.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/stats/StatsAsyncTask.java
@@ -1,0 +1,43 @@
+/*
+ *  Copyright (c) 2021 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.stats;
+
+import android.os.AsyncTask;
+import android.view.View;
+
+import timber.log.Timber;
+
+/**
+ * Async task which handles cancellation (#6192)
+ */
+public abstract class StatsAsyncTask<TResult> extends AsyncTask<View, Void, TResult> {
+
+    @Override
+    protected final TResult doInBackground(View... views) {
+        try {
+            return doInBackgroundSafe(views);
+        } catch (Exception e) {
+            if (this.isCancelled()) {
+                Timber.w(e, "ignored exception in cancelled stats task");
+                return null;
+            }
+            throw e;
+        }
+    }
+
+    protected abstract TResult doInBackgroundSafe(View... views);
+}

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/sched/AbstractSchedTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/sched/AbstractSchedTest.java
@@ -319,6 +319,7 @@ mw.col.sched.extendLimits(1, 0)
         Note note = addNoteUsingBasicModel("foo", "bar");
 
         col.reset();
+        advanceRobolectricLooper();
 
         Card card = sched.getCard();
         assertNotNull(card);
@@ -328,6 +329,7 @@ mw.col.sched.extendLimits(1, 0)
         }
 
         sched.answerCard(card, sched.getGoodNewButton());
+        advanceRobolectricLooper();
 
         card = sched.getCard();
         assertNotNull(card);
@@ -338,26 +340,31 @@ mw.col.sched.extendLimits(1, 0)
 
 
         sched.answerCard(card, sched.getGoodNewButton());
+        advanceRobolectricLooper();
 
         card = sched.getCard();
         assertNotNull(card);
         assertEquals(new Counts(0, (schedVersion == 1) ? 2 : 1, 0), sched.counts(card));
         if (preload) {
             sched.preloadNextCard();
+            advanceRobolectricLooper();
         }
 
         assertNotNull(card);
 
         card = nonTaskUndo(col);
+        advanceRobolectricLooper();
         assertNotNull(card);
         assertEquals(new Counts(0, (schedVersion == 1) ? 3 : 1, 0), sched.counts(card));
         sched.count();
         if (preload) {
             sched.preloadNextCard();
+            advanceRobolectricLooper();
         }
 
 
         sched.answerCard(card, sched.getGoodNewButton());
+        advanceRobolectricLooper();
         card = sched.getCard();
         assertNotNull(card);
         if (preload) {


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
Crash if changing collection while a long-running stats task was executing

## Fixes
Fixes #6192 

## Approach
* Stop tasks on transition from Stats -> Preferences

## How Has This Been Tested?

On my Android 11

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
