### PR TITLE
Default sched ver to v2 and use new timezone code

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
@@ -620,7 +620,7 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
                             }
                             break;
                         case "schedVer":
-                            ((android.preference.CheckBoxPreference)pref).setChecked(conf.optInt("schedVer", 1) == 2);
+                            ((android.preference.CheckBoxPreference)pref).setChecked(col.schedVer() == 2);
                     }
                 } catch (NumberFormatException e) {
                     throw new RuntimeException(e);

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
@@ -108,7 +108,7 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
     // Other variables
     private final HashMap<String, String> mOriginalSumarries = new HashMap<>();
     private static final String [] sCollectionPreferences = {"showEstimates", "showProgress",
-            "learnCutoff", "timeLimit", "useCurrent", "newSpread", "dayOffset", "schedVer"};
+            "learnCutoff", "timeLimit", "useCurrent", "newSpread", "dayOffset", "schedVer", "newTimezoneHandling"};
 
     private static final int RESULT_LOAD_IMG = 111;
     private android.preference.CheckBoxPreference mBackgroundImage;

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
@@ -134,7 +134,7 @@ public class Collection implements CollectionGetter {
     private static final Pattern fClozePatternA = Pattern.compile("\\{\\{(.*?)cloze:");
     private static final Pattern fClozeTagStart = Pattern.compile("<%cloze:");
 
-    private static final int fDefaultSchedulerVersion = 1;
+    private static final int fDefaultSchedulerVersion = 2;
     private static final List<Integer> fSupportedSchedulerVersions = Arrays.asList(1, 2);
 
     // Not in libAnki.

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Storage.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Storage.java
@@ -97,6 +97,7 @@ public class Storage {
                 for (int i = StdModels.STD_MODELS.length-1; i>=0; i--) {
                     StdModels.STD_MODELS[i].add(col);
                 }
+                backend.useNewTimezoneCode(col);
                 col.save();
             }
             return col;

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/backend/DroidBackend.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/backend/DroidBackend.java
@@ -16,6 +16,7 @@
 
 package com.ichi2.libanki.backend;
 
+import com.ichi2.libanki.Collection;
 import com.ichi2.libanki.DB;
 import com.ichi2.libanki.DeckConfig;
 import com.ichi2.libanki.Decks;
@@ -68,4 +69,6 @@ public interface DroidBackend {
     default DeckConfig new_deck_config_legacy() {
         return new DeckConfig(Decks.DEFAULT_CONF);
     }
+
+    void useNewTimezoneCode(Collection col);
 }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/backend/JavaDroidBackend.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/backend/JavaDroidBackend.java
@@ -16,6 +16,7 @@
 
 package com.ichi2.libanki.backend;
 
+import com.ichi2.libanki.Collection;
 import com.ichi2.libanki.DB;
 import com.ichi2.libanki.backend.exception.BackendNotSupportedException;
 import com.ichi2.libanki.backend.model.SchedTimingToday;
@@ -69,5 +70,11 @@ public class JavaDroidBackend implements DroidBackend {
     @Override
     public int local_minutes_west(long timestampSeconds) throws BackendNotSupportedException {
         throw new BackendNotSupportedException();
+    }
+
+
+    @Override
+    public void useNewTimezoneCode(Collection col) {
+        // intentionally blank - unavailable on Java backend
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/backend/RustDroidBackend.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/backend/RustDroidBackend.java
@@ -16,7 +16,9 @@
 
 package com.ichi2.libanki.backend;
 
+import com.ichi2.libanki.Collection;
 import com.ichi2.libanki.DB;
+import com.ichi2.libanki.backend.exception.BackendNotSupportedException;
 import com.ichi2.libanki.backend.model.SchedTimingToday;
 import com.ichi2.libanki.backend.model.SchedTimingTodayProto;
 
@@ -80,5 +82,16 @@ public class RustDroidBackend implements DroidBackend {
     @Override
     public int local_minutes_west(long timestampSeconds) {
         return mBackend.getBackend().localMinutesWest(timestampSeconds).getVal();
+    }
+
+
+    @Override
+    public void useNewTimezoneCode(Collection col) {
+        // enable the new timezone code on a new collection
+        try {
+            col.getSched().set_creation_offset();
+        } catch (BackendNotSupportedException e) {
+            throw e.alreadyUsingRustBackend();
+        }
     }
 }

--- a/AnkiDroid/src/main/res/values/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values/10-preferences.xml
@@ -161,8 +161,8 @@
     <string name="day_offset_summ">XXX hours past midnight</string>
     <string name="xlabel_dayoffset_seekbar" maxLength="41">Midnight</string>
     <string name="ylabel_dayoffset_seekbar" maxLength="41">11PM</string>
-    <string name="sched_ver" maxLength="41">Experimental V2 scheduler</string>
-    <string name="sched_ver_summ">Enable the experimental scheduler. Forces changes in one direction on next sync</string>
+    <string name="sched_v2" maxLength="41">V2 scheduler</string>
+    <string name="sched_v2_summ">Enable the new scheduler. Forces changes in one direction on next sync</string>
     <string name="sched_ver_toggle_title">Confirm</string>
     <string name="sched_ver_2to1">This will reset any cards in learning, clear filtered decks, and change the scheduler version. Proceed?</string>
     <string name="sched_ver_1to2">The experimental scheduler could cause incorrect scheduling. Please ensure you have read the documentation first. Proceed?</string>

--- a/AnkiDroid/src/main/res/xml/preferences_advanced.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_advanced.xml
@@ -171,8 +171,8 @@
 
     <CheckBoxPreference
         android:key="schedVer"
-        android:title="@string/sched_ver"
-        android:summary="@string/sched_ver_summ" />
+        android:title="@string/sched_v2"
+        android:summary="@string/sched_v2_summ" />
     <Preference
         android:key="about_dialog_preference"
         android:title="@string/about_title">

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/StorageTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/StorageTest.java
@@ -77,8 +77,9 @@ public class StorageTest extends RobolectricTest {
                 JSONObject actualJson = new JSONObject(actual.get(i).toString());
                 JSONObject expectedJson = new JSONObject(expected.get(i).toString());
 
-                actualJson.remove("curModel");
-                expectedJson.remove("curModel");
+                remove(actualJson, expectedJson, "curModel");
+                remove(actualJson, expectedJson, "creationOffset");
+                remove(actualJson, expectedJson, "localOffset");
 
                 assertThat(actualJson.toString(), is(expectedJson.toString()));
                 continue;
@@ -92,8 +93,7 @@ public class StorageTest extends RobolectricTest {
                 renameKeys(expectedJson);
 
                 for (String k : actualJson) {
-                    actualJson.getJSONObject(k).remove("id");
-                    expectedJson.getJSONObject(k).remove("id");
+                    remove(actualJson.getJSONObject(k), expectedJson.getJSONObject(k), "id");
                 }
 
                 assertThat(actualJson.toString(4), is(expectedJson.toString(4)));
@@ -102,6 +102,12 @@ public class StorageTest extends RobolectricTest {
 
             assertThat(Integer.toString(i), actual.get(i), is(expected.get(i)));
         }
+    }
+
+
+    protected void remove(JSONObject actualJson, JSONObject expectedJson, String key) {
+        actualJson.remove(key);
+        expectedJson.remove(key);
     }
 
 

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/sched/SchedV2Test.java
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/sched/SchedV2Test.java
@@ -276,26 +276,20 @@ public class SchedV2Test extends RobolectricTest {
     }
 
     @Test
-    public void newTimezoneHandling() throws ConfirmModSchemaException, BackendNotSupportedException {
+    public void newTimezoneHandling() throws BackendNotSupportedException {
         // #5805
-        assertThat("localOffset should not be set if using V1 Scheduler", getCol().getConf().has("localOffset"), is(false));
-
         assertThat("Sync ver should be updated if we have a valid Rust collection", Consts.SYNC_VER, is(10));
-
-        getCol().changeSchedulerVer(2);
 
         assertThat("localOffset should be set if using V2 Scheduler", getCol().getConf().has("localOffset"), is(true));
 
         SchedV2 sched = (SchedV2) getCol().getSched();
 
-        assertThat("new timezone should not be enabled by default", sched._new_timezone_enabled(), is(false));
-
-        sched.set_creation_offset();
-
-        assertThat("new timezone should now be enabled", sched._new_timezone_enabled(), is(true));
+        assertThat("new timezone should be enabled by default", sched._new_timezone_enabled(), is(true));
 
         // a second call should be fine
         sched.set_creation_offset();
+
+        assertThat("new timezone should still be enabled", sched._new_timezone_enabled(), is(true));
 
         // we can obtain the offset from "crt" without an issue - do not test the return as it depends on the local timezone
         sched._current_timezone_offset();


### PR DESCRIPTION
## Purpose / Description
A new era - the V2 scheduler is stable in Anki Desktop

## Fixes
Fixes #8162 

## Approach
* Use a new string
* Upgrade to v2
* Upgrade to new timezone code


## How Has This Been Tested?

* Unit tests pass
* Tested on my device


## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
