### PR TITLE
Speed up card browser

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -2625,10 +2625,10 @@ public class CardBrowser extends NavigationDrawerActivity implements
             case REVIEWS:
                 return Integer.toString(getCard().getReps());
             case QUESTION:
-                updateSearchItemQA();
+                updateSearchItemQA(false);
                 return mQa.first;
             case ANSWER:
-                updateSearchItemQA();
+                updateSearchItemQA(false);
                 return mQa.second;
             default:
                 return null;
@@ -2649,7 +2649,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
                 // First column can not be the answer. If it were to
                 // change, this code should also be changed.
                 ) {
-                updateSearchItemQA();
+                updateSearchItemQA(reload);
             }
             mLoaded = true;
         }
@@ -2663,15 +2663,15 @@ public class CardBrowser extends NavigationDrawerActivity implements
            uses non-browser format. If answer starts by question, remove
            question.
         */
-        public void updateSearchItemQA() {
+        public void updateSearchItemQA(boolean reload) {
             if (mQa != null) {
                 return;
             }
             // render question and answer
-            Map<String, String> qa = getCard()._getQA(true, true);
+            Map<String, String> qa = getCard()._getQA(reload, true);
             // Render full question / answer if the bafmt (i.e. "browser appearance") setting forced blank result
             if ("".equals(qa.get("q")) || "".equals(qa.get("a"))) {
-                HashMap<String, String> qaFull = getCard()._getQA(true, false);
+                HashMap<String, String> qaFull = getCard()._getQA(reload, false);
                 if ("".equals(qa.get("q"))) {
                     qa.put("q", qaFull.get("q"));
                 }


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
we were hitting the database each time `updateSearchItemQA` was called to refresh the note (this is the typical case as the cardbrowser would display the answer and the question). This wasn't necessary in most cases as the note had just been loaded

## How Has This Been Tested?

Briefly on my phone, feels a lot faster

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
