### PR TITLE
Add play/pause audio in notes

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -3703,6 +3703,19 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
             return true;
         }
 
+        /**
+         * Check if the user clicked on another audio icon or the audio itself finished
+         * Also, Check if the user clicked on the running audio icon
+         * @param url
+         */
+        private void controlSound(String url) {
+            url = url.replaceFirst("playsound:", "");
+            if (!url.equals(mSoundPlayer.getCurrentAudioUri()) || mSoundPlayer.isCurrentAudioFinished()) {
+                onCurrentAudioChanged(url);
+            } else {
+                mSoundPlayer.playOrPauseSound();
+            }
+        }
 
         private void onCurrentAudioChanged(String url) {
             // Send a message that will be handled on the UI thread.

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -3516,10 +3516,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
         // We play sounds through these links when a user taps the sound icon.
         private boolean filterUrl(String url) {
             if (url.startsWith("playsound:")) {
-                // Send a message that will be handled on the UI thread.
-                Message msg = Message.obtain();
-                msg.obj = url.replaceFirst("playsound:", "");
-                mHandler.sendMessage(msg);
+                onCurrentAudioChanged(url);
                 return true;
             }
             if (url.startsWith("file") || url.startsWith("data:")) {
@@ -3704,6 +3701,14 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
                 Timber.w(e); // Don't crash if the intent is not handled
             }
             return true;
+        }
+
+
+        private void onCurrentAudioChanged(String url) {
+            // Send a message that will be handled on the UI thread.
+            Message msg = Message.obtain();
+            msg.obj = url.replaceFirst("playsound:", "");
+            mHandler.sendMessage(msg);
         }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -396,15 +396,6 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
     // LISTENERS
     // ----------------------------------------------------------------------------
 
-    private final Handler mHandler = new Handler() {
-
-        @Override
-        public void handleMessage(Message msg) {
-            mSoundPlayer.stopSounds();
-            mSoundPlayer.playSound((String) msg.obj, null, null, getSoundErrorListener());
-        }
-    };
-
     private final Handler mLongClickHandler = new Handler();
     private final Runnable mLongClickTestRunnable = new Runnable() {
         @Override
@@ -3516,7 +3507,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
         // We play sounds through these links when a user taps the sound icon.
         private boolean filterUrl(String url) {
             if (url.startsWith("playsound:")) {
-                onCurrentAudioChanged(url);
+                controlSound(url);
                 return true;
             }
             if (url.startsWith("file") || url.startsWith("data:")) {
@@ -3718,10 +3709,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
         }
 
         private void onCurrentAudioChanged(String url) {
-            // Send a message that will be handled on the UI thread.
-            Message msg = Message.obtain();
-            msg.obj = url.replaceFirst("playsound:", "");
-            mHandler.sendMessage(msg);
+            mSoundPlayer.playSound(url, null, null, getSoundErrorListener());
         }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Sound.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Sound.java
@@ -68,9 +68,14 @@ public class Sound {
     private static final Pattern sUriPattern = Pattern.compile("^(([^:/?#]+):)?(//([^/?#]*))?([^?#]*)(\\?([^#]*))?(#(.*))?$");
 
     /**
-     * Media player used to play the sounds
+     * Media player used to play the sounds. It's Nullable and that it is set only if a sound is playnig or paused, otherwise it is null.
      */
-    private MediaPlayer mMediaPlayer;
+    private MediaPlayer mMediaPlayer = null;
+
+    /**
+     * It's used to store the Uri of the current Audio in case of running or pausing.
+     */
+    private Uri mCurrentAudioUri = null;
 
     /**
      * AudioManager to request/release audio focus
@@ -301,11 +306,18 @@ public class Sound {
         }
     }
 
+    public boolean isCurrentAudioFinished() {
+        // When an audio finishes and I'm trying to replay it again, this method should check if the mMediaPlayer is null which means
+        // the audio finished to return true, so that I would be able to play the same sound again.
+        return mMediaPlayer == null;
+    }
+
     /** Plays a sound without ensuring that the playAllListener will release the audio */
     @SuppressWarnings({"PMD.EmptyIfStmt","PMD.CollapsibleIfStatements","deprecation"}) // audio API deprecation tracked on github as #5022
     private void playSoundInternal(String soundPath, OnCompletionListener playAllListener, VideoView videoView, OnErrorListener errorListener) {
         Timber.d("Playing %s has listener? %b", soundPath, playAllListener != null);
         Uri soundUri = Uri.parse(soundPath);
+        mCurrentAudioUri = soundUri;
 
         final OnErrorListener errorHandler = errorListener == null ?
                 (mp, what, extra, path) -> {
@@ -376,6 +388,13 @@ public class Sound {
                 releaseSound();
             }
         }
+    }
+
+    public String getCurrentAudioUri() {
+        if (mCurrentAudioUri == null) {
+            return null;
+        }
+        return mCurrentAudioUri.toString();
     }
 
     private static void configureVideo(VideoView videoView, int videoWidth, int videoHeight) {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Sound.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Sound.java
@@ -286,6 +286,21 @@ public class Sound {
         playSoundInternal(soundPath, completionListener, videoView, errorListener);
     }
 
+    /**
+     * Play or Pause the running sound. Called on pressing the content inside span tag.
+     */
+    public void playOrPauseSound() {
+        MediaPlayer mediaPlayer = mMediaPlayer;
+        if (mediaPlayer == null) {
+            return;
+        }
+        if (mMediaPlayer.isPlaying()) {
+            mMediaPlayer.pause();
+        } else {
+            mMediaPlayer.start();
+        }
+    }
+
     /** Plays a sound without ensuring that the playAllListener will release the audio */
     @SuppressWarnings({"PMD.EmptyIfStmt","PMD.CollapsibleIfStatements","deprecation"}) // audio API deprecation tracked on github as #5022
     private void playSoundInternal(String soundPath, OnCompletionListener playAllListener, VideoView videoView, OnErrorListener errorListener) {


### PR DESCRIPTION
## Purpose / Description
`Before` The learner can only replay the audio in notes.
`After` The learner can pause or resume the audio and It works with any number of audio files in the note.

## Fixes
Fixes #6774 

## Approach
Focusing on the URL of the audio. When the user clicks on another icon ⏯️, I'll work on the current URL not the previous one.

## How Has This Been Tested?
Using a real mobile phone "Xiaomi".

## Demo video

https://user-images.githubusercontent.com/48657780/117230198-d7563300-ae1c-11eb-8ea3-2ea53a007b16.mp4

## Aditional Notes
Related PRs  #8346


## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)

