### PR TITLE
build: android-gradle-plugin 4.2.0 + others

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -1,6 +1,6 @@
 plugins {
  // Gradle plugin portal 
- id 'com.github.triplet.play' version '3.0.0'
+ id 'com.github.triplet.play' version '3.4.0-agp4.2'
 }
 
 apply plugin: 'com.android.application'
@@ -175,8 +175,6 @@ android {
     }
     compileOptions {
         coreLibraryDesugaringEnabled true
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
     }
     packagingOptions {
         exclude 'META-INF/DEPENDENCIES'
@@ -242,7 +240,7 @@ dependencies {
     compileOnly "com.google.auto.service:auto-service-annotations:1.0"
     annotationProcessor "com.google.auto.service:auto-service:1.0"
 
-    implementation 'androidx.activity:activity:1.2.2'
+    implementation 'androidx.activity:activity:1.2.3'
     implementation 'androidx.annotation:annotation:1.2.0'
     implementation 'androidx.appcompat:appcompat:1.3.0-rc01'
     implementation 'androidx.browser:browser:1.3.0'
@@ -283,6 +281,7 @@ dependencies {
     implementation 'com.getbase:floatingactionbutton:1.10.1'
     // io.github.java-diff-utils:java-diff-utils is the natural successor here, but requires API24, #7091
     implementation 'org.bitbucket.cowwoc:diff-match-patch:1.2'
+    // noinspection GradleDependency - commons-compress 1.12 - later versions use `File.toPath`; API26 can remove?
     implementation 'org.apache.commons:commons-compress:1.12' // #6419 - handle >2GB apkg files
     implementation 'org.apache.commons:commons-collections4:4.4' // SetUniqueList
     implementation 'net.mikehardy:google-analytics-java7:2.0.13'

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,6 @@ import org.gradle.internal.jvm.Jvm
 buildscript {
     repositories {
         google()
-        jcenter()
         maven {
             url "https://plugins.gradle.org/m2/"
         }
@@ -19,18 +18,7 @@ buildscript {
         // End temporary #7558 work
     }
     dependencies {
-        // Temporary, for #7558 where AGP4.0.x works, 4.1.x fails, from https://issuetracker.google.com/issues/169584856
-        // Without workarounds we get 'com.android.tools.r8.CompilationFailedException: Compilation failed to complete'
-        // test case is to run `./gradlew assembleRelease` - if it gets to the point where it fails on keystore password, R8 already worked == success
-        //classpath 'com.android.tools:r8:25999632a8450072e0e39f2b28085ccb9766203f'  // This is diagnostic. Should Assertion error. Works?
-        //classpath 'com.android.tools:r8:89ac4c72113fdb73b43159522c932a1665de96c9' // This is diagnostic. Expect Assertion failure. Works?
-        //classpath 'com.android.tools:r8:2.2.28' // Release version, should work. Works.
-        //classpath 'com.android.tools:r8:2.1.74' // Cherry-picked / backport release, should work, fails with NullPointerException.
-        //classpath 'com.android.tools:r8:2.1.80' // Current stable release matched to AGP4.1.1 I think. Should work, fails with NullPointerException.
-        classpath 'com.android.tools:r8:2.2.60' // Current stable release matched to AGP4.2 I think. Should work.
-        // End of Temporary #7558 work
-
-        classpath 'com.android.tools.build:gradle:4.1.3' // This includes R8, and future versions will allow removal of #7558 workarounds.
+        classpath 'com.android.tools.build:gradle:4.2.0'
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
         classpath "app.brant:amazonappstorepublisher:0.1.0"

--- a/lint-rules/build.gradle
+++ b/lint-rules/build.gradle
@@ -11,11 +11,11 @@ repositories {
 }
 
 dependencies {
-    compileOnly "com.android.tools.lint:lint-api:27.1.3"
-    compileOnly "com.android.tools.lint:lint:27.1.3"
+    compileOnly "com.android.tools.lint:lint-api:27.2.0"
+    compileOnly "com.android.tools.lint:lint:27.2.0"
 
     testImplementation "junit:junit:4.13.2"
-    testImplementation "com.android.tools.lint:lint:27.1.3"
-    testImplementation "com.android.tools.lint:lint-tests:27.1.3"
+    testImplementation "com.android.tools.lint:lint:27.2.0"
+    testImplementation "com.android.tools.lint:lint-tests:27.2.0"
     testImplementation 'org.hamcrest:hamcrest-all:1.3'
 }


### PR DESCRIPTION
## Pull Request template

## Purpose / Description

- remove jcenter (deprecated, thankfully no longer needed)
- remove r8 workaround for previous issue, AGP 4.2.0 has fix built-in
- bump Triple-T / Play Publisher plugin to match AGP 4.2.0
- remove java 1_8 source/target compat annotation, it is default in 4.2
- add noinspection for commons-compress - has to wait until API26
- lint to 27.2.0
- fragment to 1.2.3

## Fixes

No link, but I want to get these in before branch cut. None of them should affect release-2.15 but it will help future cherry-picks to have the build toolchain up to date before the branch peels off

## Approach

The Play Publisher Plugin is probably the most problematic as it's got different branches for different android gradle plugin versions, but I've been working through that for a while so I already was aware.

The AGP42 transition is nice in that we can remove a pile of workarounds though for R8 and Java 1_8 compat

The rest is boring.

## How Has This Been Tested?

`./gradlew clean jacocoTestReport --rerun-tasks` against an API30 emulator. Build worked fine, app runs

`./gradlew clean assembleRelease --rerun-tasks` to make sure the R8 bug was truly fixed (that's the repro), it worked

Final test on this will be if an alpha release works correctly (it should...)

## Learning (optional, can help others)

https://developer.android.com/studio/releases/gradle-plugin#4-2-0

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
