### PR TITLE
Test for card browser changing color when card flag changes

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -1096,7 +1096,8 @@ public class CardBrowser extends NavigationDrawerActivity implements
     }
 
 
-    private void flagTask (int flag) {
+    @VisibleForTesting
+    public void flagTask (int flag) {
         TaskManager.launchCollectionTask(
                 new CollectionTask.Flag(getSelectedCardIds(), flag),
                 flagCardHandler());
@@ -2345,12 +2346,14 @@ public class CardBrowser extends NavigationDrawerActivity implements
        onSelectionChanged();
     }
 
-    private void onSelectAll() {
+    @VisibleForTesting
+    void onSelectAll() {
         mCheckedCards.addAll(mCards.unsafeGetWrapped());
         onSelectionChanged();
     }
 
-    private void onSelectNone() {
+    @VisibleForTesting
+    void onSelectNone() {
         mCheckedCards.clear();
         onSelectionChanged();
     }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.java
@@ -33,6 +33,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
+import java.util.Random;
 
 import javax.annotation.CheckReturnValue;
 
@@ -41,8 +42,6 @@ import androidx.test.core.app.ApplicationProvider;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import timber.log.Timber;
 
-import static android.os.Looper.getMainLooper;
-import static java.lang.Math.random;
 import static java.util.Arrays.stream;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
@@ -265,21 +264,27 @@ public class CardBrowserTest extends RobolectricTest {
 
     @Test
     public void flagsAreShownInBigDecksTest() {
-        CardBrowser cardBrowser = getBrowserWithNotes(75);
+        int numberOfNotes = 75;
+        CardBrowser cardBrowser = getBrowserWithNotes(numberOfNotes);
 
         // select a random card
-        cardBrowser.checkCardsAtPositions((int) (random() * 74));
-        final int flag = 1;
+        Random random = new Random(1);
+        int cardPosition = random.nextInt(numberOfNotes);
+        assumeThat("card position to select is 60", cardPosition, is(60));
+        cardBrowser.checkCardsAtPositions(cardPosition);
+        assumeTrue("card at position 60 is selected", cardBrowser.hasCheckedCardAtPosition(cardPosition));
+
         // flag the selected card with flag = 1
+        final int flag = 1;
         cardBrowser.flagTask(flag);
-        shadowOf(getMainLooper()).idle();
+        advanceRobolectricLooperWithSleep();
         // check if card flag turned to flag = 1
         assertThat("Card should be flagged", getCheckedCard(cardBrowser).getCard().userFlag(), is(flag));
 
         // unflag the selected card with flag = 0
         final int unflagFlag = 0;
         cardBrowser.flagTask(unflagFlag);
-        shadowOf(getMainLooper()).idle();
+        advanceRobolectricLooperWithSleep();
         // check if card flag actually changed from flag = 1
         assertThat("Card flag should be removed", getCheckedCard(cardBrowser).getCard().userFlag(), not(flag));
 
@@ -289,7 +294,7 @@ public class CardBrowserTest extends RobolectricTest {
         // flag all the cards with flag = 3
         final int flagForAll = 3;
         cardBrowser.flagTask(flagForAll);
-        shadowOf(getMainLooper()).idle();
+        advanceRobolectricLooperWithSleep();
         // check if all card flags turned to flag = 3
         assertThat(
                 "All cards should be flagged",


### PR DESCRIPTION
## Purpose / Description
> This is follow on work for issue #8485
> 
> It was fixed in #8735 but without a test confirming the fix and making sure it doesn't happen again
> 
> This issue tracks creation of a test that verifies the issue before the fix from #8735 and makes sure it is actually fixed

## Fixes
Fixes #8744

## Approach
After testing different approaches to reproduce the bug, I found that using a deck of about 75 cards minimum would cause the error.
After that I added the method `flagsAreShownInBigDecksTest` in `CardBrowserTest` class in which I selected and flagged a random card, unflagged the card, and in the end selected and flagged all the cards, testing each time that the flags are correct.

## How Has This Been Tested?
Checked out commit 3e798367 and verified that the test failed, then went back to normal branch, verifying the test pass.

## Checklist

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
