### PR TITLE
Modified the retrieval of fields to adjust for html

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Note.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Note.java
@@ -366,7 +366,26 @@ public class Note implements Cloneable {
 
 
     public String[] getFields() {
-        return mFields;
+        return Arrays.stream(mFields)
+                .map(Note::adjustStringForHtml)
+                .toArray(String[]::new);
+    }
+
+
+    private static String adjustStringForHtml(String str) {
+        return str
+                .replaceAll("<", "&lt;")
+                .replaceAll(">", "&gt;")
+                .replaceAll("\"", "&quot;")
+                .replaceAll("'", "&apos;")
+                .replaceAll("￠", "&cent;")
+                .replaceAll("£", "&pound;")
+                .replaceAll("¥", "&yen;")
+                .replaceAll("€", "&euro;")
+                .replaceAll("©", "&copy;")
+                .replaceAll("®", "&reg;")
+                .replaceAll("&lt;([^<>]+)&gt;","<$1>")
+                .replaceAll("&lt;/([^<>]+)&gt;","</$1>");
     }
 
 

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/ClozeTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/ClozeTest.java
@@ -94,20 +94,20 @@ public class ClozeTest extends RobolectricTest {
                 "string}}</p>");
         f.flush();
         assertEquals(1, d.addNote(f));
-        assertThat(f.firstCard().q(), containsString("<p>Cloze in html tag with <span class=cloze>[...]</span>"));
-        assertThat(f.firstCard().a(), containsString("<p>Cloze in html tag with <span class=cloze>multi-line\nstring</span>"));
+        assertThat(f.firstCard().q(), containsString("Cloze in html tag with <span class=cloze>[...]</span>"));
+        assertThat(f.firstCard().a(), containsString("Cloze in html tag with <span class=cloze>multi-line\nstring</span>"));
 
         //make sure multiline cloze things aren't too greedy
-        f.setItem("Text", "<p>Cloze in html tag with {{c1::multi-line\n" +
+        f.setItem("Text", "Cloze in html tag with {{c1::multi-line\n" +
                 "string}} and then {{c2:another\n" +
-                "one}}</p>");
+                "one}}");
         f.flush();
         assertEquals(1, d.addNote(f));
-        assertThat(f.firstCard().q(), containsString("<p>Cloze in html tag with <span class=cloze>[...]</span> and then {{c2:another\n" +
-                "one}}</p>"));
+        assertThat(f.firstCard().q(), containsString("Cloze in html tag with <span class=cloze>[...]</span> and then {{c2:another\n" +
+                "one}}"));
 
-        assertThat(f.firstCard().a(), containsString("<p>Cloze in html tag with <span class=cloze>multi-line\n" +
+        assertThat(f.firstCard().a(), containsString("Cloze in html tag with <span class=cloze>multi-line\n" +
                 "string</span> and then {{c2:another\n" +
-                "one}}</p>"));
+                "one}}"));
     }
 }


### PR DESCRIPTION
## Purpose / Description
Fixed bug where if the fields in a note contained html characters `<,>,",',￠,£,¥,€,©,®`, it wouldn't display them properly. Basically counting them as part of the actual html tags used to display contents of a note

## Fixes
Fixes #8784 

## Approach
Added method `adjustStringForHtml(String str)` in class `Card` that would replace said characters with their proper html equivalents except for actual tags. Made `getFields` return  a stream of mFields mapped to `adjustStringForHtml(field)`.

## How Has This Been Tested?
Testing out said characters in different types of cards and checking what is displayed.

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
