### PR TITLE
[Accessibility] Only two answer buttons option

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.java
@@ -115,6 +115,7 @@ public class Reviewer extends AbstractFlashcardViewer {
     private TextView mTextBarReview;
 
     private boolean mPrefHideDueCount;
+    private boolean alwaysShowOnlyTwoAnswerButtons;
 
     // ETA
     private int mEta;
@@ -810,6 +811,7 @@ public class Reviewer extends AbstractFlashcardViewer {
 
     @Override
     protected void displayAnswerBottomBar() {
+        SharedPreferences preferences = AnkiDroidApp.getSharedPrefs(getBaseContext());
         super.displayAnswerBottomBar();
         int buttonCount;
         try {
@@ -846,6 +848,9 @@ public class Reviewer extends AbstractFlashcardViewer {
         mEase1Layout.setVisibility(View.VISIBLE);
         mEase1Layout.setBackgroundResource(background[0]);
         mEase4Layout.setBackgroundResource(background[3]);
+
+        alwaysShowOnlyTwoAnswerButtons = preferences.getBoolean("alwaysShowOnlyTwoAnswerButtons", false);
+
         switch (buttonCount) {
             case 2:
                 // Ease 2 is "good"
@@ -856,39 +861,44 @@ public class Reviewer extends AbstractFlashcardViewer {
                 mNext2.setTextColor(textColor[2]);
                 mEase2Layout.requestFocus();
                 break;
-            case 3:
-                // Ease 2 is good
-                mEase2Layout.setVisibility(View.VISIBLE);
-                mEase2Layout.setBackgroundResource(background[2]);
-                mEase2.setText(R.string.ease_button_good);
-                mEase2.setTextColor(textColor[2]);
-                mNext2.setTextColor(textColor[2]);
-                // Ease 3 is easy
-                mEase3Layout.setVisibility(View.VISIBLE);
-                mEase3Layout.setBackgroundResource(background[3]);
-                mEase3.setText(R.string.ease_button_easy);
-                mEase3.setTextColor(textColor[3]);
-                mNext3.setTextColor(textColor[3]);
-                mEase2Layout.requestFocus();
-                break;
-            default:
-                mEase2Layout.setVisibility(View.VISIBLE);
-                // Ease 2 is "hard"
-                mEase2Layout.setVisibility(View.VISIBLE);
-                mEase2Layout.setBackgroundResource(background[1]);
-                mEase2.setText(R.string.ease_button_hard);
-                mEase2.setTextColor(textColor[1]);
-                mNext2.setTextColor(textColor[1]);
-                mEase2Layout.requestFocus();
-                // Ease 3 is good
-                mEase3Layout.setVisibility(View.VISIBLE);
-                mEase3Layout.setBackgroundResource(background[2]);
-                mEase3.setText(R.string.ease_button_good);
-                mEase3.setTextColor(textColor[2]);
-                mNext3.setTextColor(textColor[2]);
-                mEase4Layout.setVisibility(View.VISIBLE);
-                mEase3Layout.requestFocus();
-                break;
+                case 3:
+                    // Ease 2 is good
+                    mEase2Layout.setVisibility(View.VISIBLE);
+                    mEase2Layout.setBackgroundResource(background[2]);
+                    mEase2.setText(R.string.ease_button_good);
+                    mEase2.setTextColor(textColor[2]);
+                    mNext2.setTextColor(textColor[2]);
+                    if (!alwaysShowOnlyTwoAnswerButtons) {
+                        // Ease 3 is easy
+                        mEase3Layout.setVisibility(View.VISIBLE);
+                        mEase3Layout.setBackgroundResource(background[3]);
+                        mEase3.setText(R.string.ease_button_easy);
+                        mEase3.setTextColor(textColor[3]);
+                        mNext3.setTextColor(textColor[3]);
+                        mEase2Layout.requestFocus();
+                    }
+                    break;
+                default:
+    
+                if (!alwaysShowOnlyTwoAnswerButtons) {
+                    // Ease 2 is "hard"
+                    mEase2Layout.setVisibility(View.VISIBLE);
+                    mEase2Layout.setVisibility(View.VISIBLE);
+                    mEase2Layout.setBackgroundResource(background[1]);
+                    mEase2.setText(R.string.ease_button_hard);
+                    mEase2.setTextColor(textColor[1]);
+                    mNext2.setTextColor(textColor[1]);
+                    mEase2Layout.requestFocus();
+                    mEase4Layout.setVisibility(View.VISIBLE);
+                }
+                    // Ease 3 is good
+                    mEase3Layout.setVisibility(View.VISIBLE);
+                    mEase3Layout.setBackgroundResource(background[2]);
+                    mEase3.setText(R.string.ease_button_good);
+                    mEase3.setTextColor(textColor[2]);
+                    mNext3.setTextColor(textColor[2]);
+                    mEase3Layout.requestFocus();
+                    break;
         }
 
         // Show next review time

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.java
@@ -115,7 +115,6 @@ public class Reviewer extends AbstractFlashcardViewer {
     private TextView mTextBarReview;
 
     private boolean mPrefHideDueCount;
-    private boolean alwaysShowOnlyTwoAnswerButtons;
 
     // ETA
     private int mEta;
@@ -811,7 +810,6 @@ public class Reviewer extends AbstractFlashcardViewer {
 
     @Override
     protected void displayAnswerBottomBar() {
-        SharedPreferences preferences = AnkiDroidApp.getSharedPrefs(getBaseContext());
         super.displayAnswerBottomBar();
         int buttonCount;
         try {
@@ -849,7 +847,8 @@ public class Reviewer extends AbstractFlashcardViewer {
         mEase1Layout.setBackgroundResource(background[0]);
         mEase4Layout.setBackgroundResource(background[3]);
 
-        alwaysShowOnlyTwoAnswerButtons = preferences.getBoolean("alwaysShowOnlyTwoAnswerButtons", false);
+        boolean alwaysShowOnlyTwoAnswerButtons = AnkiDroidApp.getSharedPrefs(getBaseContext())
+                .getBoolean("alwaysShowOnlyTwoAnswerButtons", false);
 
         switch (buttonCount) {
             case 2:
@@ -878,19 +877,18 @@ public class Reviewer extends AbstractFlashcardViewer {
                         mEase2Layout.requestFocus();
                     }
                     break;
-                default:
-    
-                if (!alwaysShowOnlyTwoAnswerButtons) {
-                    // Ease 2 is "hard"
-                    mEase2Layout.setVisibility(View.VISIBLE);
-                    mEase2Layout.setVisibility(View.VISIBLE);
-                    mEase2Layout.setBackgroundResource(background[1]);
-                    mEase2.setText(R.string.ease_button_hard);
-                    mEase2.setTextColor(textColor[1]);
-                    mNext2.setTextColor(textColor[1]);
-                    mEase2Layout.requestFocus();
-                    mEase4Layout.setVisibility(View.VISIBLE);
-                }
+                default:    
+                    if (!alwaysShowOnlyTwoAnswerButtons) {
+                        // Ease 2 is "hard"
+                        mEase2Layout.setVisibility(View.VISIBLE);
+                        mEase2Layout.setVisibility(View.VISIBLE);
+                        mEase2Layout.setBackgroundResource(background[1]);
+                        mEase2.setText(R.string.ease_button_hard);
+                        mEase2.setTextColor(textColor[1]);
+                        mNext2.setTextColor(textColor[1]);
+                        mEase2Layout.requestFocus();
+                        mEase4Layout.setVisibility(View.VISIBLE);
+                    }
                     // Ease 3 is good
                     mEase3Layout.setVisibility(View.VISIBLE);
                     mEase3Layout.setBackgroundResource(background[2]);

--- a/AnkiDroid/src/main/res/values/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values/10-preferences.xml
@@ -145,6 +145,7 @@
     <string name="pref_backup_max" maxLength="41">Max number of backups</string>
     <string name="show_estimates" maxLength="41">Show button time</string>
     <string name="show_estimates_summ">Show next review time on answer buttons</string>
+    <string name="always_show_only_two_answer_buttons">Always show only two answer buttons</string>
     <string name="show_top_bar" maxLength="41">Show Top Bar</string>
     <string name="show_top_bar_summ">Show card counts, flag and mark in top bar</string>
     <string name="show_progress" maxLength="41">Show remaining</string>

--- a/AnkiDroid/src/main/res/xml/preferences_reviewing.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_reviewing.xml
@@ -83,6 +83,10 @@
             android:key="showEstimates"
             android:summary="@string/show_estimates_summ"
             android:title="@string/show_estimates" />
+        <CheckBoxPreference
+            android:defaultValue="false"
+            android:key="alwaysShowOnlyTwoAnswerButtons"
+            android:title="@string/always_show_only_two_answer_buttons" />
         <com.ichi2.ui.SeekBarPreference
             android:defaultValue="100"
             android:key="cardZoom"


### PR DESCRIPTION
## Purpose / Description
Added an option to narrow down the number of answer buttons for learners who have difficulty tapping accurately for various reasons.

**It's just a UI option, no changes to internal processing.**

## Approach
It provides a solution to **Miss Tap Hell** by simplifying the answer button.

<img src="https://user-images.githubusercontent.com/43168745/118035063-b43ffc00-b3a5-11eb-894e-8027723aaa0a.jpg" width="320"> → <img src="https://user-images.githubusercontent.com/43168745/118035083-ba35dd00-b3a5-11eb-89b8-e354ecfebc9e.jpg" width="320">
<img src="https://user-images.githubusercontent.com/43168745/118035107-befa9100-b3a5-11eb-9a1e-5b75c2053ce7.jpg" width="320">

## How Has This Been Tested?
I tried learning on the actual machine and confirmed that the learning was processed normally.
**Again, this is a UI-only setting and the meaning of each button never changes.**

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [x] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
