### PR TITLE
Ensure SelectableDeck's order is consistent

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckSelectionDialog.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckSelectionDialog.java
@@ -397,10 +397,17 @@ public class DeckSelectionDialog extends AnalyticsDialogFragment {
         }
 
 
+        /** All decks comes first. Then alphabetical order. */
         @Override
         public int compareTo(@NonNull SelectableDeck o) {
-            if (o.mDeckId == Stats.ALL_DECKS_ID || this.mDeckId == Stats.ALL_DECKS_ID){
+            if (this.mDeckId == Stats.ALL_DECKS_ID){
+                if (o.mDeckId == Stats.ALL_DECKS_ID) {
+                    return 0;
+                }
                 return -1;
+            }
+            if (o.mDeckId == Stats.ALL_DECKS_ID) {
+                return 1;
             }
             return this.mName.compareTo(o.mName);
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckSelectionDialog.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckSelectionDialog.java
@@ -37,6 +37,7 @@ import com.ichi2.anki.exception.FilteredAncestor;
 import com.ichi2.libanki.Collection;
 import com.ichi2.libanki.Deck;
 import com.ichi2.libanki.stats.Stats;
+import com.ichi2.utils.DeckNameComparator;
 import com.ichi2.utils.FunctionalInterfaces;
 import com.ichi2.utils.FilterResultsUtils;
 
@@ -409,7 +410,7 @@ public class DeckSelectionDialog extends AnalyticsDialogFragment {
             if (o.mDeckId == Stats.ALL_DECKS_ID) {
                 return 1;
             }
-            return this.mName.compareTo(o.mName);
+            return DeckNameComparator.INSTANCE.compare(this.mName, o.mName);
         }
 
 


### PR DESCRIPTION
fixes #8815

Obviously, that was not an order.
I don't know how to make a regression test, as it requires to know how to make the sorting fail. Not obvious. I tried by looking at the code https://android.googlesource.com/platform/libcore/+/fe39951/luni/src/main/java/java/util/Arrays.java and the implementation https://android.googlesource.com/platform/libcore/+/android-6.0.1_r21/luni/src/main/java/java/util/DualPivotQuicksort.java

Sadly I can't even find the error message we got, so maybe it's not even the right implementation.

I can at most say that a sequences of a few ALL_DECK_ID do not suffices to fail. Even a sequence of size 35 (there is a threshold at size 32. Before size 32, it uses a bubble sort!)

By the way, this is wrong any way, because it do not consider that "::" has special meaning. So there is a second commit for it.