### PR TITLE
Consider scrolling with 0 cards.

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -2173,8 +2173,8 @@ public class CardBrowser extends NavigationDrawerActivity implements
             int size = cards.size();
             // In all of those cases, there is nothing to do:
             if (size <= 0 ||
-                    firstVisibleItem > size ||
-                    lastVisibleItem - 1 < size) {
+                    firstVisibleItem >= size ||
+                    lastVisibleItem - 1 >= size) {
                 return;
             }
             boolean firstLoaded = cards.get(firstVisibleItem).isLoaded();

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -158,7 +158,8 @@ public class CardBrowser extends NavigationDrawerActivity implements
     @NonNull
     private CardCollection<CardCache> mCards = new CardCollection<>();
     public DeckSpinnerSelection mDeckSpinnerSelection;
-    private ListView mCardsListView;
+    @VisibleForTesting
+    public ListView mCardsListView;
     private SearchView mSearchView;
     private MultiColumnListAdapter mCardsAdapter;
     private String mSearchTerms;
@@ -2163,7 +2164,8 @@ public class CardBrowser extends NavigationDrawerActivity implements
     /**
      * Render the second column whenever the user stops scrolling
      */
-    private final class RenderOnScroll implements AbsListView.OnScrollListener {
+    @VisibleForTesting
+    public final class RenderOnScroll implements AbsListView.OnScrollListener {
         @Override
         public void onScroll(AbsListView view, int firstVisibleItem, int visibleItemCount, int totalItemCount) {
             // Show the progress bar if scrolling to given position requires rendering of the question / answer
@@ -2174,7 +2176,9 @@ public class CardBrowser extends NavigationDrawerActivity implements
             // In all of those cases, there is nothing to do:
             if (size <= 0 ||
                     firstVisibleItem >= size ||
-                    lastVisibleItem - 1 >= size) {
+                    lastVisibleItem - 1 >= size ||
+                    visibleItemCount <= 0
+            ) {
                 return;
             }
             boolean firstLoaded = cards.get(firstVisibleItem).isLoaded();

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -2171,21 +2171,25 @@ public class CardBrowser extends NavigationDrawerActivity implements
             CardCollection<CardCache> cards = getCards();
             // List is never cleared, only reset to a new list. So it's safe here.
             int size = cards.size();
-            if ((size > 0) && (firstVisibleItem < size) && ((lastVisibleItem - 1) < size)) {
-                boolean firstLoaded = cards.get(firstVisibleItem).isLoaded();
-                // Note: max value of lastVisibleItem is totalItemCount, so need to subtract 1
-                boolean lastLoaded = cards.get(lastVisibleItem - 1).isLoaded();
-                if (!firstLoaded || !lastLoaded) {
-                    if (!mPostAutoScroll) {
-                        showProgressBar();
-                    }
-                    // Also start rendering the items on the screen every 300ms while scrolling
-                    long currentTime = SystemClock.elapsedRealtime ();
-                    if ((currentTime - mLastRenderStart > 300 || lastVisibleItem >= totalItemCount)) {
-                        mLastRenderStart = currentTime;
-                        TaskManager.cancelAllTasks(CollectionTask.RenderBrowserQA.class);
-                        TaskManager.launchCollectionTask(renderBrowserQAParams(firstVisibleItem, visibleItemCount, cards), mRenderQAHandler);
-                    }
+            // In all of those cases, there is nothing to do:
+            if (size <= 0 ||
+                    firstVisibleItem > size ||
+                    lastVisibleItem - 1 < size) {
+                return;
+            }
+            boolean firstLoaded = cards.get(firstVisibleItem).isLoaded();
+            // Note: max value of lastVisibleItem is totalItemCount, so need to subtract 1
+            boolean lastLoaded = cards.get(lastVisibleItem - 1).isLoaded();
+            if (!firstLoaded || !lastLoaded) {
+                if (!mPostAutoScroll) {
+                    showProgressBar();
+                }
+                // Also start rendering the items on the screen every 300ms while scrolling
+                long currentTime = SystemClock.elapsedRealtime();
+                if ((currentTime - mLastRenderStart > 300 || lastVisibleItem >= totalItemCount)) {
+                    mLastRenderStart = currentTime;
+                    TaskManager.cancelAllTasks(CollectionTask.RenderBrowserQA.class);
+                    TaskManager.launchCollectionTask(renderBrowserQAParams(firstVisibleItem, visibleItemCount, cards), mRenderQAHandler);
                 }
             }
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -2179,6 +2179,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
                     lastVisibleItem - 1 >= size ||
                     visibleItemCount <= 0
             ) {
+                AnkiDroidApp.sendExceptionReport("Useless `onScroll` call, with size " + size +" firstVisibleItem " +firstVisibleItem+ ", lastVisibleItem "+lastVisibleItem+" and visibleItemCount "+visibleItemCount+".", "CardBroser.RenderOnScroll.onScroll");
                 return;
             }
             boolean firstLoaded = cards.get(firstVisibleItem).isLoaded();

--- a/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.java
@@ -683,4 +683,14 @@ public class CardBrowserTest extends RobolectricTest {
         advanceRobolectricLooperWithSleep();
         return multimediaController.get();
     }
+
+
+    // Regression test for #8821
+    @Test
+    public void emptyScroll() {
+        CardBrowser cardBrowser = getBrowserWithNotes(2);
+
+        CardBrowser.RenderOnScroll renderOnScroll = cardBrowser.new RenderOnScroll();
+        renderOnScroll.onScroll(cardBrowser.mCardsListView, 0, 0, 2);
+    }
 }


### PR DESCRIPTION
The first stack trace of #8821 can only be obtained if there is no item to display and if the first item to display is item 0.

Fixes #8821 

I have no idea how this can occur, it seems not to have any meaning to scroll to display 0 elements. But if the browser is closed, I guess it's technically true. Normally, in ths case, the scrolling should not have been triggered in the first place, but if we need to deal with it, this commit accept this nonsense.