### PR TITLE
Can open collection with no deck

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/FilteredDeckOptions.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/FilteredDeckOptions.java
@@ -153,6 +153,9 @@ public class FilteredDeckOptions extends AppCompatPreferenceActivity implements 
                         if (i > 0) {
                             JSONObject presetValues = new JSONObject(mDynExamples[i]);
                             JSONArray ar = presetValues.names();
+                            if (ar == null) {
+                                continue;
+                            }
                             for (String name: ar.stringIterable()) {
                                 if ("steps".equals(name)) {
                                     mUpdate.put("stepsOn", true);

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
@@ -256,10 +256,12 @@ public class Decks {
         JSONObject decksarray = new JSONObject(decks);
         JSONArray ids = decksarray.names();
         mDecks = new HashMap<>(decksarray.length());
-        for (String id: ids.stringIterable()) {
-            Deck o = new Deck(decksarray.getJSONObject(id));
-            long longId = Long.parseLong(id);
-            mDecks.put(longId, o);
+        if (ids != null) {
+            for (String id : ids.stringIterable()) {
+                Deck o = new Deck(decksarray.getJSONObject(id));
+                long longId = Long.parseLong(id);
+                mDecks.put(longId, o);
+            }
         }
         mNameMap = NameMap.constructor(mDecks.values());
         JSONObject confarray = new JSONObject(dconf);
@@ -1275,7 +1277,7 @@ public class Decks {
         return current().optString("desc","");
     }
 
-    @Deprecated
+    @VisibleForTesting
     @RustCleanup("This exists in Rust as DecksDictProxy, but its usage is warned against")
     public HashMap<Long, Deck> getDecks() {
         return mDecks;


### PR DESCRIPTION
Multiple functions did not check that `names()` could return null. So I add it. The behavior is the same than on empty jsonArray.

Fixes #8839. This issue should never have occurred, as it's impossible to get no deck at all, but somehow it occured. I've no idea what was going on here. The best I can imagine is someone having fun with the database directly, and checking what would occur if the default deck is removed manually. It's something I could have imagined doing myself just to check.

At least, I hope it's the correct explanation, because the other one would be that someone was able to remove the default deck, which is theoretically impossible, and in this case it's a slightly bigger problem on our side. Sadly, until we find out how to reproduce it, there is nothing I can do.

There is no regression test because I've no idea how to change the database BEFORE I open collection. To test it, I'd need to remove all decks from the database, then use `getCol`.
I tried to open the collection, remove the test, close the collection and reopen it. I suspect that we don't use a real database and a real save for test; or something like that.