### PR TITLE
fix blank image with ' in name

### DIFF
--- a/api/src/main/java/com/ichi2/anki/api/Utils.java
+++ b/api/src/main/java/com/ichi2/anki/api/Utils.java
@@ -34,7 +34,7 @@ class Utils {
     private static final Pattern stylePattern = Pattern.compile("(?s)<style.*?>.*?</style>");
     private static final Pattern scriptPattern = Pattern.compile("(?s)<script.*?>.*?</script>");
     private static final Pattern tagPattern = Pattern.compile("<.*?>");
-    private static final Pattern imgPattern = Pattern.compile("<img src=[\"']?([^\"'>]+)[\"']? ?/?>");
+    private static final Pattern imgPattern = Pattern.compile("(?i)<img[^>]+src=[\"']?([^\"'>]+)[\"']?[^>]*>");
     private static final Pattern htmlEntitiesPattern = Pattern.compile("&#?\\w+;");
     private static final String FIELD_SEPARATOR = Character.toString('\u001f');
 
@@ -92,7 +92,7 @@ class Utils {
      */
     private static String stripHTMLMedia(String s) {
         Matcher imgMatcher = imgPattern.matcher(s);
-        return stripHTML(imgMatcher.replaceAll(" $1 "));
+        return stripHTML(imgMatcher.replaceAll(" $2 "));
     }
 
     private static String stripHTML(String s) {


### PR DESCRIPTION
## Purpose / Description
Have a image name conatains ' make is blank so i handle this

## Fixes
fix #5347

## Approach
I change the regex 

## How Has This Been Tested?

Test in a java online compiler with some diffrent inputs like abc , a'bc

## Checklist

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
