### PR TITLE
Fixed problem with aggregated data to one day in weeklyBreakdown in stats page

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/stats/Stats.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/stats/Stats.java
@@ -994,9 +994,9 @@ public class Stats {
         }
 
         long cutoff = mCol.getSched().getDayCutoff();
-        ArrayList<double[]> list = new ArrayList<>(7); // one by day of the week
-        String query = "SELECT strftime('%w',datetime( cast(id/ 1000  -" + sd.get(Calendar.HOUR_OF_DAY) * 3600 +
-                " as int), 'unixepoch')) as wd, " +
+        ArrayList<double[]> list = new ArrayList<>(Collections.nCopies(7, new double[]{0,0,0})); // one by day of the week
+        String query = "SELECT cast(strftime('%w',datetime( cast(id/ 1000  -" + sd.get(Calendar.HOUR_OF_DAY) * 3600 +
+                " as int), 'unixepoch'))as int) as wd, " +
                 "sum(case when ease = 1 then 0 else 1 end) / " +
                 "cast(count() as float) * 100, " +
                 "count() " +
@@ -1008,13 +1008,15 @@ public class Stats {
         try (Cursor cur = mCol.getDb()
                     .query(query)) {
             while (cur.moveToNext()) {
-                list.add(new double[] { cur.getDouble(0), cur.getDouble(1), cur.getDouble(2) });
+                int weekday = cur.getInt(0);
+                list.add(weekday, new double[] {weekday, cur.getDouble(1), cur.getDouble(2) });
             }
         }
 
         //TODO adjust for breakdown, for now only copied from intervals
         // small adjustment for a proper chartbuilding with achartengine
-        if (list.size() == 0 ) {
+
+        if (list.size() == 0 ) { // todo do I remove this because of Collections.nCopies()?
             list.add(0, new double[] { 0, 0, 0 });
         }
 


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
When querying from `revlog` for weekly breakdown in statistics page, the weekday ordinal would always return 0 and so all logs would be shown for Sunday

## Fixes
Fixes #8853

## Approach
Added a cast in the query in `Stats::calculateWeeklyBreakdown` for weekday

## Checklist

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
