### PR TITLE
Fixed crash on file selection

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicAudioClipFieldController.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicAudioClipFieldController.java
@@ -111,6 +111,7 @@ public class BasicAudioClipFieldController extends FieldControllerBase implement
 
             cursor.moveToFirst();
             String audioClipFullName = cursor.getString(0);
+            audioClipFullName = checkFileName(audioClipFullName);
             audioClipFullNameParts = audioClipFullName.split("\\.");
             if (audioClipFullNameParts.length < 2) {
                 try {
@@ -161,6 +162,15 @@ public class BasicAudioClipFieldController extends FieldControllerBase implement
         }
     }
 
+    /**
+     * This method replaces any character that isn't a number, letter or underscore with underscore in file name.
+     * This method doesn't check that file name is valid or not it simply operates on all file name.
+     * @param audioClipFullName name of the file.
+     * @return file name which is valid.
+     */
+    private String checkFileName(String audioClipFullName) {
+        return audioClipFullName.replaceAll("\\W+", "_");
+    }
 
     @Override
     public void onDone() { /* nothing */ }


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
App crashes when audio file is selected whose file name is invalid

## Fixes
Fixes #8881 

## Approach
I have created a method that checks the filename is valid or not

## How Has This Been Tested?

Not tested on a physical device but tested by providing invalid inputs in the filename string.

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
