### PR TITLE
Fix: #8885

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -1867,6 +1867,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
                 AnkiDroidApp.sendExceptionReport(e, "DeckPicker.onPostExecute", "Could not dismiss mProgressDialog");
             }
             String syncMessage = data.message;
+            Timber.i("Sync Listener: onPostExecute: Data: %s", data.toString());
             if (!data.success) {
                 Object[] result = data.result;
                 Syncer.ConnectionResultType resultType = data.resultType;

--- a/AnkiDroid/src/main/java/com/ichi2/async/Connection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/Connection.java
@@ -47,6 +47,7 @@ import com.ichi2.utils.JSONException;
 import com.ichi2.utils.JSONObject;
 
 import java.io.IOException;
+import java.util.Arrays;
 
 import androidx.annotation.NonNull;
 import okhttp3.Response;
@@ -629,6 +630,21 @@ public class Connection extends BaseAsyncTask<Connection.Payload, Object, Connec
         public Payload(@NonNull Object[] data) {
             this.data = data;
             success = true;
+        }
+
+
+        @Override
+        public String toString() {
+            return "Payload{" +
+                    "mTaskType=" + mTaskType +
+                    ", data=" + Arrays.toString(data) +
+                    ", resultType=" + resultType +
+                    ", result=" + Arrays.toString(result) +
+                    ", success=" + success +
+                    ", returnType=" + returnType +
+                    ", exception=" + exception +
+                    ", message='" + message + '\'' +
+                    '}';
         }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sync/Syncer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sync/Syncer.java
@@ -182,7 +182,7 @@ public class Syncer {
                 long diff = Math.abs(rts - lts);
                 if (diff > 300) {
                     mCol.log("clock off");
-                    return new Pair<> (CLOCK_OFF, new Object[] {diff});
+                    return new Pair<> (CLOCK_OFF, diff);
                 }
                 if (lMod == rMod) {
                     Timber.i("Sync: no changes - returning");


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
Sync `onPostExecute` in `DeckPicker` expect `result[0]` to be Long, but it is provided with Object[]

## Fixes
Fixes #8885

## Approach
Following the call chain and looking for `Long` and `Object[]` I found that this is the exception trace.

https://github.com/ankidroid/Anki-Android/blob/60476b8331c63f42050d0142342b5c410aaeb11d/AnkiDroid/src/main/java/com/ichi2/libanki/sync/Syncer.java#L182-L186

Here the `new Object[] {diff}` is wrapped yet again in another `Object[]`, `data.result = new Object[]{ret.second};`

https://github.com/ankidroid/Anki-Android/blob/60476b8331c63f42050d0142342b5c410aaeb11d/AnkiDroid/src/main/java/com/ichi2/async/Connection.java#L371-L382

And in `DeckPicker` we expect it to be of type `Long`, so we get `Object[] cannot be cast to Long`

https://github.com/ankidroid/Anki-Android/blob/60476b8331c63f42050d0142342b5c410aaeb11d/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java#L1890-L1891


## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
