### PR TITLE
Fix NullPointerException in DeckPicker

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -2422,6 +2422,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
         }
     }
 
+    @VisibleForTesting
     public void __renderPage() {
         if (mDueTree == null) {
             // mDueTree may be set back to null when the activity restart.
@@ -2499,10 +2500,12 @@ public class DeckPicker extends NavigationDrawerActivity implements
             Timber.e(e, "RuntimeException setting time remaining");
         }
 
-        long current = getCol().getDecks().current().optLong("id");
-        if (mFocusedDeck != current) {
-            scrollDecklistToDeck(current);
-            mFocusedDeck = current;
+        if (getCol().getDecks().current() != null) {
+            long current = getCol().getDecks().current().optLong("id");
+            if (mFocusedDeck != current) {
+                scrollDecklistToDeck(current);
+                mFocusedDeck = current;
+            }
         }
     }
 
@@ -2692,7 +2695,8 @@ public class DeckPicker extends NavigationDrawerActivity implements
         public void actualOnPreExecute(@NonNull DeckPicker deckPicker) {
             deckPicker.mProgressDialog = StyledProgressDialog.show(deckPicker, null,
                     deckPicker.getResources().getString(R.string.delete_deck), false);
-            if (mDid == deckPicker.getCol().getDecks().current().optLong("id")) {
+            if (deckPicker.getCol().getDecks().current() != null
+                    && mDid == deckPicker.getCol().getDecks().current().optLong("id")) {
                 mRemovingCurrent = true;
             }
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -201,7 +201,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
     private RecyclerView mRecyclerView;
     private LinearLayoutManager mRecyclerViewLayoutManager;
     private DeckAdapter mDeckListAdapter;
-	
+
     private final Snackbar.Callback mSnackbarShowHideCallback = new Snackbar.Callback();
 
     private LinearLayout mNoDecksPlaceholder;
@@ -451,7 +451,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
         if (showedActivityFailedScreen(savedInstanceState)) {
             return;
         }
-        
+
         mCustomStudyDialogFactory = new CustomStudyDialogFactory(this::getCol, this).attachToActivity(this);
 
         //we need to restore here, as we need it before super.onCreate() is called.
@@ -1153,12 +1153,12 @@ public class DeckPicker extends NavigationDrawerActivity implements
         // For Android 8/8.1 we want to use software rendering by default or the Reviewer UI is broken #7369
         if (CompatHelper.getSdkVersion() == Build.VERSION_CODES.O ||
                 CompatHelper.getSdkVersion() == Build.VERSION_CODES.O_MR1) {
-                if (!preferences.contains("softwareRender")) {
-                    Timber.i("Android 8/8.1 detected with no render preference. Turning on software render.");
-                    preferences.edit().putBoolean("softwareRender", true).apply();
-                } else {
-                    Timber.i("Android 8/8.1 detected, software render preference already exists.");
-                }
+            if (!preferences.contains("softwareRender")) {
+                Timber.i("Android 8/8.1 detected with no render preference. Turning on software render.");
+                preferences.edit().putBoolean("softwareRender", true).apply();
+            } else {
+                Timber.i("Android 8/8.1 detected, software render preference already exists.");
+            }
         }
 
         if (!BackupManager.enoughDiscSpace(CollectionHelper.getCurrentAnkiDroidDirectory(this))) {
@@ -2499,12 +2499,10 @@ public class DeckPicker extends NavigationDrawerActivity implements
             Timber.e(e, "RuntimeException setting time remaining");
         }
 
-        if (getCol().getDecks().current() != null) {
-            long current = getCol().getDecks().current().optLong("id");
-            if (mFocusedDeck != current) {
-                scrollDecklistToDeck(current);
-                mFocusedDeck = current;
-            }
+        long current = getCol().getDecks().current().optLong("id");
+        if (mFocusedDeck != current) {
+            scrollDecklistToDeck(current);
+            mFocusedDeck = current;
         }
     }
 
@@ -2694,8 +2692,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
         public void actualOnPreExecute(@NonNull DeckPicker deckPicker) {
             deckPicker.mProgressDialog = StyledProgressDialog.show(deckPicker, null,
                     deckPicker.getResources().getString(R.string.delete_deck), false);
-            if (deckPicker.getCol().getDecks().current() != null
-                    && mDid == deckPicker.getCol().getDecks().current().optLong("id")) {
+            if (mDid == deckPicker.getCol().getDecks().current().optLong("id")) {
                 mRemovingCurrent = true;
             }
         }
@@ -2819,7 +2816,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
                     .negativeText(deckPicker.getResources().getString(R.string.dialog_no))
                     .onNegative((x, y) -> actualOnPreExecute(deckPicker))
                     .onPositive((x, y) -> task.safeCancel()).show()
-                    ;
+            ;
         }
 
         @Override
@@ -2829,7 +2826,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
                 if (emptyCardTask != null) {
                     confirmCancel(deckPicker, emptyCardTask);
                 }};
-            
+
             deckPicker.mProgressDialog = new MaterialDialog.Builder(deckPicker)
                     .progress(false, mNumberOfCards)
                     .title(R.string.emtpy_cards_finding)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -2422,7 +2422,6 @@ public class DeckPicker extends NavigationDrawerActivity implements
         }
     }
 
-    @VisibleForTesting
     public void __renderPage() {
         if (mDueTree == null) {
             // mDueTree may be set back to null when the activity restart.

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
@@ -1077,7 +1077,7 @@ public class Decks {
 
     public Deck current() {
         if (get(selected()) == null) {
-            select(Consts.DEFAULT_DECK_ID);
+            select(Consts.DEFAULT_DECK_ID); // Select default deck if the selected deck is null
         }
         return get(selected());
     }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
@@ -1076,6 +1076,9 @@ public class Decks {
 
 
     public Deck current() {
+        if (get(selected()) == null) {
+            select(Consts.DEFAULT_DECK_ID);
+        }
         return get(selected());
     }
 


### PR DESCRIPTION
## Purpose / Description
Fix NullPointerException in DeckPicker.

## Fixes
Fixes #8886 

## Approach
Select the default deck if the selected deck is null.

## Checklist

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
