### PR TITLE
Ignore "connection abort" type errors from network stack

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/async/Connection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/Connection.java
@@ -292,6 +292,7 @@ public class Connection extends BaseAsyncTask<Connection.Payload, Object, Connec
                 msg.contains("InterruptedIOException") ||
                 msg.contains("stream was reset") ||
                 msg.contains("Connection reset") ||
+                msg.contains("connection abort") ||
                 msg.contains("Broken pipe") ||
                 msg.contains("ConnectionShutdownException") ||
                 msg.contains("CLEARTEXT communication") ||


### PR DESCRIPTION
## Pull Request template

## Purpose / Description

Crash reports from network connection errors are just clutter for us, they are not actionable and we already handle them for the user. This is just shrinking quantity of exception reports in crash database

## Fixes
Fixes #8820 (again)

## Approach
Ignore non-actionable messages

## How Has This Been Tested?

Untested. But the code path is well tested

## Learning (optional, can help others)

I learned nothing from this issue, but that's the way it is sometimes. I learned about 4 other things in the last half hour from other issues so it evens out.

