### PR TITLE
NF: copy android's json tests

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/utils/JSON.java
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/JSON.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2010 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ichi2.utils;
+
+public class JSON {
+    /**
+     * Returns the input if it is a JSON-permissable value; throws otherwise.
+     */
+    static double checkDouble(double d) throws JSONException {
+        if (Double.isInfinite(d) || Double.isNaN(d)) {
+            throw new JSONException("Forbidden numeric value: " + d);
+        }
+        return d;
+    }
+
+    static String toString(Object value) {
+        if (value instanceof String) {
+            return (String) value;
+        } else if (value != null) {
+            return String.valueOf(value);
+        }
+        return null;
+    }
+}

--- a/AnkiDroid/src/main/java/com/ichi2/utils/JSONArray.java
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/JSONArray.java
@@ -42,6 +42,7 @@
 
 package com.ichi2.utils;
 
+
 import java.lang.reflect.Array;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -49,6 +50,7 @@ import java.util.Iterator;
 import java.util.List;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 public class JSONArray extends org.json.JSONArray {
     public JSONArray() {
@@ -279,9 +281,10 @@ public class JSONArray extends org.json.JSONArray {
         }
     }
 
-    public @NonNull String toString(int indentSpaces) {
+    @Override
+    public String toString(int indentSpace) {
         try {
-            return super.toString(indentSpaces);
+            return super.toString(indentSpace);
         } catch (org.json.JSONException e) {
             throw new JSONException(e);
         }
@@ -422,5 +425,26 @@ public class JSONArray extends org.json.JSONArray {
             l.add(object.getString(key));
         }
         return l;
+    }
+
+    /**
+     * Returns a new object whose values are the values in this array, and whose
+     * names are the values in {@code names}. Names and values are paired up by
+     * index from 0 through to the shorter array's length. Names that are not
+     * strings will be coerced to strings. This method returns null if either
+     * array is empty.
+     */
+    public @Nullable JSONObject toJSONObject(@NonNull JSONArray names) {
+        // copied from upstream
+        JSONObject result = new JSONObject();
+        int length = Math.min(names.length(), length());
+        if (length == 0) {
+            return null;
+        }
+        for (int i = 0; i < length; i++) {
+            String name = JSON.toString(names.opt(i));
+            result.put(name, opt(i));
+        }
+        return result;
     }
 }

--- a/AnkiDroid/src/test/java/com/ichi2/utils/JSONArrayTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/utils/JSONArrayTest.java
@@ -1,0 +1,522 @@
+/*
+ * Copyright (C) 2010 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ * The only difference with the original are:
+ * * the package, and hence the class actually tested, are com.ichi2.utils.
+ * * the class don't inherit TestCase
+ * * the equality of double uses explicitly a delta of 0
+ */
+package com.ichi2.utils;
+
+import com.ichi2.anki.RobolectricTest;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Collections;
+
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+
+import static org.junit.Assert.*;
+
+/**
+ * This black box test was written without inspecting the non-free org.json sourcecode.
+ */
+@RunWith(AndroidJUnit4.class)
+public class JSONArrayTest {
+
+    @Test
+    public void testEmptyArray() throws JSONException {
+        JSONArray array = new JSONArray();
+        assertEquals(0, array.length());
+        assertEquals("", array.join(" AND "));
+        try {
+            array.get(0);
+            fail();
+        } catch (JSONException e) {
+        }
+        try {
+            array.getBoolean(0);
+            fail();
+        } catch (JSONException e) {
+        }
+        assertEquals("[]", array.toString());
+        assertEquals("[]", array.toString(4));
+        // out of bounds is co-opted with defaulting
+        assertTrue(array.isNull(0));
+        assertNull(array.opt(0));
+        assertFalse(array.optBoolean(0));
+        assertTrue(array.optBoolean(0, true));
+        // bogus (but documented) behaviour: returns null rather than an empty object!
+        assertNull(array.toJSONObject(new JSONArray()));
+    }
+
+    @Test
+    public void testEqualsAndHashCode() throws JSONException {
+        JSONArray a = new JSONArray();
+        JSONArray b = new JSONArray();
+        assertTrue(a.equals(b));
+        assertEquals("equals() not consistent with hashCode()", a.hashCode(), b.hashCode());
+        a.put(true);
+        a.put(false);
+        b.put(true);
+        b.put(false);
+        assertTrue(a.equals(b));
+        assertEquals(a.hashCode(), b.hashCode());
+        b.put(true);
+        assertFalse(a.equals(b));
+        assertTrue(a.hashCode() != b.hashCode());
+    }
+    @Test
+    public void testBooleans() throws JSONException {
+        JSONArray array = new JSONArray();
+        array.put(true);
+        array.put(false);
+        array.put(2, false);
+        array.put(3, false);
+        array.put(2, true);
+        assertEquals("[true,false,true,false]", array.toString());
+        assertEquals(4, array.length());
+        assertEquals(Boolean.TRUE, array.get(0));
+        assertEquals(Boolean.FALSE, array.get(1));
+        assertEquals(Boolean.TRUE, array.get(2));
+        assertEquals(Boolean.FALSE, array.get(3));
+        assertFalse(array.isNull(0));
+        assertFalse(array.isNull(1));
+        assertFalse(array.isNull(2));
+        assertFalse(array.isNull(3));
+        assertEquals(true, array.optBoolean(0));
+        assertEquals(false, array.optBoolean(1, true));
+        assertEquals(true, array.optBoolean(2, false));
+        assertEquals(false, array.optBoolean(3));
+        assertEquals("true", array.getString(0));
+        assertEquals("false", array.getString(1));
+        assertEquals("true", array.optString(2));
+        assertEquals("false", array.optString(3, "x"));
+        assertEquals("[\n     true,\n     false,\n     true,\n     false\n]", array.toString(5));
+        JSONArray other = new JSONArray();
+        other.put(true);
+        other.put(false);
+        other.put(true);
+        other.put(false);
+        assertTrue(array.equals(other));
+        other.put(true);
+        assertFalse(array.equals(other));
+        other = new JSONArray();
+        other.put("true");
+        other.put("false");
+        other.put("truE");
+        other.put("FALSE");
+        assertFalse(array.equals(other));
+        assertFalse(other.equals(array));
+        assertEquals(true, other.getBoolean(0));
+        assertEquals(false, other.optBoolean(1, true));
+        assertEquals(true, other.optBoolean(2));
+        assertEquals(false, other.getBoolean(3));
+    }
+    @Test
+    public void testNulls() throws JSONException {
+        JSONArray array = new JSONArray();
+        array.put(3, null);
+        array.put(0, JSONObject.NULL);
+        assertEquals(4, array.length());
+        assertEquals("[null,null,null,null]", array.toString());
+        // there's 2 ways to represent null; each behaves differently!
+        assertEquals(JSONObject.NULL, array.get(0));
+        try {
+            array.get(1);
+            fail();
+        } catch (JSONException e) {
+        }
+        try {
+            array.get(2);
+            fail();
+        } catch (JSONException e) {
+        }
+        try {
+            array.get(3);
+            fail();
+        } catch (JSONException e) {
+        }
+        assertEquals(JSONObject.NULL, array.opt(0));
+        assertEquals(null, array.opt(1));
+        assertEquals(null, array.opt(2));
+        assertEquals(null, array.opt(3));
+        assertTrue(array.isNull(0));
+        assertTrue(array.isNull(1));
+        assertTrue(array.isNull(2));
+        assertTrue(array.isNull(3));
+        assertEquals("null", array.optString(0));
+        assertEquals("", array.optString(1));
+        assertEquals("", array.optString(2));
+        assertEquals("", array.optString(3));
+    }
+    /**
+     * Our behaviour is questioned by this bug:
+     * http://code.google.com/p/android/issues/detail?id=7257
+     */
+    @Test
+    public void testParseNullYieldsJSONObjectNull() throws JSONException {
+        JSONArray array = new JSONArray("[\"null\",null]");
+        array.put(null);
+        assertEquals("null", array.get(0));
+        assertEquals(JSONObject.NULL, array.get(1));
+        try {
+            array.get(2);
+            fail();
+        } catch (JSONException e) {
+        }
+        assertEquals("null", array.getString(0));
+        assertEquals("null", array.getString(1));
+        try {
+            array.getString(2);
+            fail();
+        } catch (JSONException e) {
+        }
+    }
+    @Test
+    public void testNumbers() throws JSONException {
+        JSONArray array = new JSONArray();
+        array.put(Double.MIN_VALUE);
+        array.put(9223372036854775806L);
+        array.put(Double.MAX_VALUE);
+        array.put(-0d);
+        assertEquals(4, array.length());
+        // toString() and getString(int) return different values for -0d
+        assertEquals("[4.9E-324,9223372036854775806,1.7976931348623157E308,-0]", array.toString());
+        assertEquals(Double.MIN_VALUE, array.get(0));
+        assertEquals(9223372036854775806L, array.get(1));
+        assertEquals(Double.MAX_VALUE, array.get(2));
+        assertEquals(-0d, array.get(3));
+        assertEquals(Double.MIN_VALUE, array.getDouble(0), 0);
+        assertEquals(9.223372036854776E18, array.getDouble(1), 0);
+        assertEquals(Double.MAX_VALUE, array.getDouble(2), 0);
+        assertEquals(-0d, array.getDouble(3), 0);
+        assertEquals(0, array.getLong(0));
+        assertEquals(9223372036854775806L, array.getLong(1));
+        assertEquals(Long.MAX_VALUE, array.getLong(2));
+        assertEquals(0, array.getLong(3));
+        assertEquals(0, array.getInt(0));
+        assertEquals(-2, array.getInt(1));
+        assertEquals(Integer.MAX_VALUE, array.getInt(2));
+        assertEquals(0, array.getInt(3));
+        assertEquals(Double.MIN_VALUE, array.opt(0));
+        assertEquals(Double.MIN_VALUE, array.optDouble(0), 0);
+        assertEquals(0, array.optLong(0, 1L));
+        assertEquals(0, array.optInt(0, 1));
+        assertEquals("4.9E-324", array.getString(0));
+        assertEquals("9223372036854775806", array.getString(1));
+        assertEquals("1.7976931348623157E308", array.getString(2));
+        assertEquals("-0.0", array.getString(3));
+        JSONArray other = new JSONArray();
+        other.put(Double.MIN_VALUE);
+        other.put(9223372036854775806L);
+        other.put(Double.MAX_VALUE);
+        other.put(-0d);
+        assertTrue(array.equals(other));
+        other.put(0, 0L);
+        assertFalse(array.equals(other));
+    }
+    @Test
+    public void testStrings() throws JSONException {
+        JSONArray array = new JSONArray();
+        array.put("true");
+        array.put("5.5");
+        array.put("9223372036854775806");
+        array.put("null");
+        array.put("5\"8' tall");
+        assertEquals(5, array.length());
+        assertEquals("[\"true\",\"5.5\",\"9223372036854775806\",\"null\",\"5\\\"8' tall\"]",
+                array.toString());
+        // although the documentation doesn't mention it, join() escapes text and wraps
+        // strings in quotes
+        assertEquals("\"true\" \"5.5\" \"9223372036854775806\" \"null\" \"5\\\"8' tall\"",
+                array.join(" "));
+        assertEquals("true", array.get(0));
+        assertEquals("null", array.getString(3));
+        assertEquals("5\"8' tall", array.getString(4));
+        assertEquals("true", array.opt(0));
+        assertEquals("5.5", array.optString(1));
+        assertEquals("9223372036854775806", array.optString(2, null));
+        assertEquals("null", array.optString(3, "-1"));
+        assertFalse(array.isNull(0));
+        assertFalse(array.isNull(3));
+        assertEquals(true, array.getBoolean(0));
+        assertEquals(true, array.optBoolean(0));
+        assertEquals(true, array.optBoolean(0, false));
+        assertEquals(0, array.optInt(0));
+        assertEquals(-2, array.optInt(0, -2));
+        assertEquals(5.5d, array.getDouble(1), 0);
+        assertEquals(5L, array.getLong(1));
+        assertEquals(5, array.getInt(1));
+        assertEquals(5, array.optInt(1, 3));
+        // The last digit of the string is a 6 but getLong returns a 7. It's probably parsing as a
+        // double and then converting that to a long. This is consistent with JavaScript.
+        assertEquals(9223372036854775807L, array.getLong(2));
+        assertEquals(9.223372036854776E18, array.getDouble(2), 0);
+        assertEquals(Integer.MAX_VALUE, array.getInt(2));
+        assertFalse(array.isNull(3));
+        try {
+            array.getDouble(3);
+            fail();
+        } catch (JSONException e) {
+        }
+        assertEquals(Double.NaN, array.optDouble(3), 0);
+        assertEquals(-1.0d, array.optDouble(3, -1.0d), 0);
+    }
+    @Test
+    public void testJoin() throws JSONException {
+        JSONArray array = new JSONArray();
+        array.put(null);
+        assertEquals("null", array.join(" & "));
+        array.put("\"");
+        assertEquals("null & \"\\\"\"", array.join(" & "));
+        array.put(5);
+        assertEquals("null & \"\\\"\" & 5", array.join(" & "));
+        array.put(true);
+        assertEquals("null & \"\\\"\" & 5 & true", array.join(" & "));
+        array.put(new JSONArray(Arrays.asList(true, false)));
+        assertEquals("null & \"\\\"\" & 5 & true & [true,false]", array.join(" & "));
+        array.put(new JSONObject(Collections.singletonMap("x", 6)));
+        assertEquals("null & \"\\\"\" & 5 & true & [true,false] & {\"x\":6}", array.join(" & "));
+    }
+    @Test
+    public void testJoinWithNull() throws JSONException {
+        JSONArray array = new JSONArray(Arrays.asList(5, 6));
+        assertEquals("5null6", array.join(null));
+    }
+    @Test
+    public void testJoinWithSpecialCharacters() throws JSONException {
+        JSONArray array = new JSONArray(Arrays.asList(5, 6));
+        assertEquals("5\"6", array.join("\""));
+    }
+    @Test
+    public void testToJSONObject() throws JSONException {
+        JSONArray keys = new JSONArray();
+        keys.put("a");
+        keys.put("b");
+        JSONArray values = new JSONArray();
+        values.put(5.5d);
+        values.put(false);
+        JSONObject object = values.toJSONObject(keys);
+        assertEquals(5.5d, object.get("a"));
+        assertEquals(false, object.get("b"));
+        keys.put(0, "a");
+        values.put(0, 11.0d);
+        assertEquals(5.5d, object.get("a"));
+    }
+    @Test
+    public void testToJSONObjectWithNulls() throws JSONException {
+        JSONArray keys = new JSONArray();
+        keys.put("a");
+        keys.put("b");
+        JSONArray values = new JSONArray();
+        values.put(5.5d);
+        values.put(null);
+        // null values are stripped!
+        JSONObject object = values.toJSONObject(keys);
+        assertEquals(1, object.length());
+        assertFalse(object.has("b"));
+        assertEquals("{\"a\":5.5}", object.toString());
+    }
+    @Test
+    public void testToJSONObjectMoreNamesThanValues() throws JSONException {
+        JSONArray keys = new JSONArray();
+        keys.put("a");
+        keys.put("b");
+        JSONArray values = new JSONArray();
+        values.put(5.5d);
+        JSONObject object = values.toJSONObject(keys);
+        assertEquals(1, object.length());
+        assertEquals(5.5d, object.get("a"));
+    }
+    @Test
+    public void testToJSONObjectMoreValuesThanNames() throws JSONException {
+        JSONArray keys = new JSONArray();
+        keys.put("a");
+        JSONArray values = new JSONArray();
+        values.put(5.5d);
+        values.put(11.0d);
+        JSONObject object = values.toJSONObject(keys);
+        assertEquals(1, object.length());
+        assertEquals(5.5d, object.get("a"));
+    }
+    @Test
+    public void testToJSONObjectNullKey() throws JSONException {
+        JSONArray keys = new JSONArray();
+        keys.put(JSONObject.NULL);
+        JSONArray values = new JSONArray();
+        values.put(5.5d);
+        JSONObject object = values.toJSONObject(keys);
+        assertEquals(1, object.length());
+        assertEquals(5.5d, object.get("null"));
+    }
+    @Test
+    public void testPutUnsupportedNumbers() throws JSONException {
+        JSONArray array = new JSONArray();
+        try {
+            array.put(Double.NaN);
+            fail();
+        } catch (JSONException e) {
+        }
+        try {
+            array.put(0, Double.NEGATIVE_INFINITY);
+            fail();
+        } catch (JSONException e) {
+        }
+        try {
+            array.put(0, Double.POSITIVE_INFINITY);
+            fail();
+        } catch (JSONException e) {
+        }
+    }
+    @Test
+    public void testPutUnsupportedNumbersAsObject() throws JSONException {
+        JSONArray array = new JSONArray();
+        array.put(Double.valueOf(Double.NaN));
+        array.put(Double.valueOf(Double.NEGATIVE_INFINITY));
+        array.put(Double.valueOf(Double.POSITIVE_INFINITY));
+        assertEquals(null, array.toString());
+    }
+    /**
+     * Although JSONArray is usually defensive about which numbers it accepts,
+     * it doesn't check inputs in its constructor.
+     */
+    @Test
+    public void testCreateWithUnsupportedNumbers() throws JSONException {
+        JSONArray array = new JSONArray(Arrays.asList(5.5, Double.NaN));
+        assertEquals(2, array.length());
+        assertEquals(5.5, array.getDouble(0), 0);
+        assertEquals(Double.NaN, array.getDouble(1), 0);
+    }
+    @Test
+    public void testToStringWithUnsupportedNumbers() throws JSONException {
+        // when the array contains an unsupported number, toString returns null!
+        JSONArray array = new JSONArray(Arrays.asList(5.5, Double.NaN));
+        assertNull(array.toString());
+    }
+
+    @Test
+    public void testListConstructorCopiesContents() throws JSONException {
+        List<Object> contents = Arrays.<Object>asList(5);
+        JSONArray array = new JSONArray(contents);
+        contents.set(0, 10);
+        assertEquals(5, array.get(0));
+    }
+    @Test
+    public void testTokenerConstructor() throws JSONException {
+        JSONArray object = new JSONArray(new JSONTokener("[false]"));
+        assertEquals(1, object.length());
+        assertEquals(false, object.get(0));
+    }
+    @Test
+    public void testTokenerConstructorWrongType() throws JSONException {
+        try {
+            new JSONArray(new JSONTokener("{\"foo\": false}"));
+            fail();
+        } catch (JSONException e) {
+        }
+    }
+    @Test
+    public void testTokenerConstructorNull() throws JSONException {
+        try {
+            new JSONArray((JSONTokener) null);
+            fail();
+        } catch (NullPointerException e) {
+        }
+    }
+    @Test
+    public void testTokenerConstructorParseFail() {
+        try {
+            new JSONArray(new JSONTokener("["));
+            fail();
+        } catch (JSONException e) {
+        } catch (StackOverflowError e) {
+            fail("Stack overflowed on input: \"[\"");
+        }
+    }
+    @Test
+    public void testStringConstructor() throws JSONException {
+        JSONArray object = new JSONArray("[false]");
+        assertEquals(1, object.length());
+        assertEquals(false, object.get(0));
+    }
+    @Test
+    public void testStringConstructorWrongType() throws JSONException {
+        try {
+            new JSONArray("{\"foo\": false}");
+            fail();
+        } catch (JSONException e) {
+        }
+    }
+    @Test
+    public void testStringConstructorNull() throws JSONException {
+        try {
+            new JSONArray((String) null);
+            fail();
+        } catch (NullPointerException e) {
+        }
+    }
+    @Test
+    public void testStringConstructorParseFail() {
+        try {
+            new JSONArray("[");
+            fail();
+        } catch (JSONException e) {
+        } catch (StackOverflowError e) {
+            fail("Stack overflowed on input: \"[\"");
+        }
+    }
+    @Test
+    public void testCreate() throws JSONException {
+        JSONArray array = new JSONArray(Arrays.asList(5.5, true));
+        assertEquals(2, array.length());
+        assertEquals(5.5, array.getDouble(0), 0);
+        assertEquals(true, array.get(1));
+        assertEquals("[5.5,true]", array.toString());
+    }
+    @Test
+    public void testAccessOutOfBounds() throws JSONException {
+        JSONArray array = new JSONArray();
+        array.put("foo");
+        assertEquals(null, array.opt(3));
+        assertEquals(null, array.opt(-3));
+        assertEquals("", array.optString(3));
+        assertEquals("", array.optString(-3));
+        try {
+            array.get(3);
+            fail();
+        } catch (JSONException e) {
+        }
+        try {
+            array.get(-3);
+            fail();
+        } catch (JSONException e) {
+        }
+        try {
+            array.getString(3);
+            fail();
+        } catch (JSONException e) {
+        }
+        try {
+            array.getString(-3);
+            fail();
+        } catch (JSONException e) {
+        }
+    }
+}

--- a/AnkiDroid/src/test/java/com/ichi2/utils/JSONObjectTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/utils/JSONObjectTest.java
@@ -1,6 +1,25 @@
 /*
+ * Copyright (C) 2010 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * The only difference with the original is the package, and hence the class actually tested.
+ *
+ * With the exception of clearly indicated code at the bottom which is:
+ *
  Copyright (c) 2020 David Allison <davidallisongithub@gmail.com>
 
+Most of the code is:
  This program is free software; you can redistribute it and/or modify it under
  the terms of the GNU General Public License as published by the Free Software
  Foundation; either version 3 of the License, or (at your option) any later
@@ -12,9 +31,21 @@
 
  You should have received a copy of the GNU General Public License along with
  this program.  If not, see <http://www.gnu.org/licenses/>.
- */
 
+ */
 package com.ichi2.utils;
+import junit.framework.TestCase;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.*;
+
+import androidx.annotation.NonNull;
+
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -27,11 +58,911 @@ import java.util.Map;
 import androidx.annotation.NonNull;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
+import static junit.framework.TestCase.*;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.IsNull.notNullValue;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.IsNull.notNullValue;
+
+/**
+ * This black box test was written without inspecting the non-free org.json sourcecode.
+ */
 @RunWith(AndroidJUnit4.class)
 public class JSONObjectTest {
+    @Test
+    public void testEmptyObject() throws JSONException {
+        JSONObject object = new JSONObject();
+        assertEquals(0, object.length());
+        // bogus (but documented) behaviour: returns null rather than the empty object!
+        assertNull(object.names());
+        // returns null rather than an empty array!
+        assertNull(object.toJSONArray(new JSONArray()));
+        assertEquals("{}", object.toString());
+        assertEquals("{}", object.toString(5));
+        try {
+            object.get("foo");
+            fail();
+        } catch (JSONException e) {
+        }
+        try {
+            object.getBoolean("foo");
+            fail();
+        } catch (JSONException e) {
+        }
+        try {
+            object.getDouble("foo");
+            fail();
+        } catch (JSONException e) {
+        }
+        try {
+            object.getInt("foo");
+            fail();
+        } catch (JSONException e) {
+        }
+        try {
+            object.getJSONArray("foo");
+            fail();
+        } catch (JSONException e) {
+        }
+        try {
+            object.getJSONObject("foo");
+            fail();
+        } catch (JSONException e) {
+        }
+        try {
+            object.getLong("foo");
+            fail();
+        } catch (JSONException e) {
+        }
+        try {
+            object.getString("foo");
+            fail();
+        } catch (JSONException e) {
+        }
+        assertFalse(object.has("foo"));
+        assertTrue(object.isNull("foo")); // isNull also means "is not present"
+        assertNull(object.opt("foo"));
+        assertEquals(false, object.optBoolean("foo"));
+        assertEquals(true, object.optBoolean("foo", true));
+        assertEquals(Double.NaN, object.optDouble("foo"));
+        assertEquals(5.0, object.optDouble("foo", 5.0));
+        assertEquals(0, object.optInt("foo"));
+        assertEquals(5, object.optInt("foo", 5));
+        assertEquals(null, object.optJSONArray("foo"));
+        assertEquals(null, object.optJSONObject("foo"));
+        assertEquals(0, object.optLong("foo"));
+        assertEquals(Long.MAX_VALUE-1, object.optLong("foo", Long.MAX_VALUE-1));
+        assertEquals("", object.optString("foo")); // empty string is default!
+        assertEquals("bar", object.optString("foo", "bar"));
+        assertNull(object.remove("foo"));
+    }
+
+    @Test
+    public void testEqualsAndHashCode() throws JSONException {
+        JSONObject a = new JSONObject();
+        JSONObject b = new JSONObject();
+        // JSON object doesn't override either equals or hashCode (!)
+        assertFalse(a.equals(b));
+        assertEquals(a.hashCode(), System.identityHashCode(a));
+    }
+    @Test
+    public void testGet() throws JSONException {
+        JSONObject object = new JSONObject();
+        Object value = new Object();
+        object.put("foo", value);
+        object.put("bar", new Object());
+        object.put("baz", new Object());
+        assertSame(value, object.get("foo"));
+        try {
+            object.get("FOO");
+            fail();
+        } catch (JSONException e) {
+        }
+        try {
+            object.put(null, value);
+            fail();
+        } catch (JSONException e) {
+        }
+        try {
+            object.get(null);
+            fail();
+        } catch (JSONException e) {
+        }
+    }
+    @Test
+    public void testPut() throws JSONException {
+        JSONObject object = new JSONObject();
+        assertSame(object, object.put("foo", true));
+        object.put("foo", false);
+        assertEquals(false, object.get("foo"));
+        object.put("foo", 5.0d);
+        assertEquals(5.0d, object.get("foo"));
+        object.put("foo", 0);
+        assertEquals(0, object.get("foo"));
+        object.put("bar", Long.MAX_VALUE - 1);
+        assertEquals(Long.MAX_VALUE - 1, object.get("bar"));
+        object.put("baz", "x");
+        assertEquals("x", object.get("baz"));
+        object.put("bar", JSONObject.NULL);
+        assertSame(JSONObject.NULL, object.get("bar"));
+    }
+    @Test
+    public void testPutNullRemoves() throws JSONException {
+        JSONObject object = new JSONObject();
+        object.put("foo", "bar");
+        object.put("foo", null);
+        assertEquals(0, object.length());
+        assertFalse(object.has("foo"));
+        try {
+            object.get("foo");
+            fail();
+        } catch (JSONException e) {
+        }
+    }
+    @Test
+    public void testPutOpt() throws JSONException {
+        JSONObject object = new JSONObject();
+        object.put("foo", "bar");
+        object.putOpt("foo", null);
+        assertEquals("bar", object.get("foo"));
+        object.putOpt(null, null);
+        assertEquals(1, object.length());
+        object.putOpt(null, "bar");
+        assertEquals(1, object.length());
+    }
+    @Test
+    public void testPutOptUnsupportedNumbers() throws JSONException {
+        JSONObject object = new JSONObject();
+        try {
+            object.putOpt("foo", Double.NaN);
+            fail();
+        } catch (JSONException e) {
+        }
+        try {
+            object.putOpt("foo", Double.NEGATIVE_INFINITY);
+            fail();
+        } catch (JSONException e) {
+        }
+        try {
+            object.putOpt("foo", Double.POSITIVE_INFINITY);
+            fail();
+        } catch (JSONException e) {
+        }
+    }
+    @Test
+    public void testRemove() throws JSONException {
+        JSONObject object = new JSONObject();
+        object.put("foo", "bar");
+        assertEquals(null, object.remove(null));
+        assertEquals(null, object.remove(""));
+        assertEquals(null, object.remove("bar"));
+        assertEquals("bar", object.remove("foo"));
+        assertEquals(null, object.remove("foo"));
+    }
+    @Test
+    public void testBooleans() throws JSONException {
+        JSONObject object = new JSONObject();
+        object.put("foo", true);
+        object.put("bar", false);
+        object.put("baz", "true");
+        object.put("quux", "false");
+        assertEquals(4, object.length());
+        assertEquals(true, object.getBoolean("foo"));
+        assertEquals(false, object.getBoolean("bar"));
+        assertEquals(true, object.getBoolean("baz"));
+        assertEquals(false, object.getBoolean("quux"));
+        assertFalse(object.isNull("foo"));
+        assertFalse(object.isNull("quux"));
+        assertTrue(object.has("foo"));
+        assertTrue(object.has("quux"));
+        assertFalse(object.has("missing"));
+        assertEquals(true, object.optBoolean("foo"));
+        assertEquals(false, object.optBoolean("bar"));
+        assertEquals(true, object.optBoolean("baz"));
+        assertEquals(false, object.optBoolean("quux"));
+        assertEquals(false, object.optBoolean("missing"));
+        assertEquals(true, object.optBoolean("foo", true));
+        assertEquals(false, object.optBoolean("bar", true));
+        assertEquals(true, object.optBoolean("baz", true));
+        assertEquals(false, object.optBoolean("quux", true));
+        assertEquals(true, object.optBoolean("missing", true));
+        object.put("foo", "truE");
+        object.put("bar", "FALSE");
+        assertEquals(true, object.getBoolean("foo"));
+        assertEquals(false, object.getBoolean("bar"));
+        assertEquals(true, object.optBoolean("foo"));
+        assertEquals(false, object.optBoolean("bar"));
+        assertEquals(true, object.optBoolean("foo", false));
+        assertEquals(false, object.optBoolean("bar", false));
+    }
+    @Test
+    public void testNumbers() throws JSONException {
+        JSONObject object = new JSONObject();
+        object.put("foo", Double.MIN_VALUE);
+        object.put("bar", 9223372036854775806L);
+        object.put("baz", Double.MAX_VALUE);
+        object.put("quux", -0d);
+        assertEquals(4, object.length());
+        String toString = object.toString();
+        assertTrue(toString, toString.contains("\"foo\":4.9E-324"));
+        assertTrue(toString, toString.contains("\"bar\":9223372036854775806"));
+        assertTrue(toString, toString.contains("\"baz\":1.7976931348623157E308"));
+        // toString() and getString() return different values for -0d!
+        assertTrue(toString, toString.contains("\"quux\":-0}") // no trailing decimal point
+                || toString.contains("\"quux\":-0,"));
+        assertEquals(Double.MIN_VALUE, object.get("foo"));
+        assertEquals(9223372036854775806L, object.get("bar"));
+        assertEquals(Double.MAX_VALUE, object.get("baz"));
+        assertEquals(-0d, object.get("quux"));
+        assertEquals(Double.MIN_VALUE, object.getDouble("foo"));
+        assertEquals(9.223372036854776E18, object.getDouble("bar"));
+        assertEquals(Double.MAX_VALUE, object.getDouble("baz"));
+        assertEquals(-0d, object.getDouble("quux"));
+        assertEquals(0, object.getLong("foo"));
+        assertEquals(9223372036854775806L, object.getLong("bar"));
+        assertEquals(Long.MAX_VALUE, object.getLong("baz"));
+        assertEquals(0, object.getLong("quux"));
+        assertEquals(0, object.getInt("foo"));
+        assertEquals(-2, object.getInt("bar"));
+        assertEquals(Integer.MAX_VALUE, object.getInt("baz"));
+        assertEquals(0, object.getInt("quux"));
+        assertEquals(Double.MIN_VALUE, object.opt("foo"));
+        assertEquals(9223372036854775806L, object.optLong("bar"));
+        assertEquals(Double.MAX_VALUE, object.optDouble("baz"));
+        assertEquals(0, object.optInt("quux"));
+        assertEquals(Double.MIN_VALUE, object.opt("foo"));
+        assertEquals(9223372036854775806L, object.optLong("bar"));
+        assertEquals(Double.MAX_VALUE, object.optDouble("baz"));
+        assertEquals(0, object.optInt("quux"));
+        assertEquals(Double.MIN_VALUE, object.optDouble("foo", 5.0d));
+        assertEquals(9223372036854775806L, object.optLong("bar", 1L));
+        assertEquals(Long.MAX_VALUE, object.optLong("baz", 1L));
+        assertEquals(0, object.optInt("quux", -1));
+        assertEquals("4.9E-324", object.getString("foo"));
+        assertEquals("9223372036854775806", object.getString("bar"));
+        assertEquals("1.7976931348623157E308", object.getString("baz"));
+        assertEquals("-0.0", object.getString("quux"));
+    }
+    @Test
+    public void testFloats() throws JSONException {
+        JSONObject object = new JSONObject();
+        try {
+            object.put("foo", (Float) Float.NaN);
+            fail();
+        } catch (JSONException e) {
+        }
+        try {
+            object.put("foo", (Float) Float.NEGATIVE_INFINITY);
+            fail();
+        } catch (JSONException e) {
+        }
+        try {
+            object.put("foo", (Float) Float.POSITIVE_INFINITY);
+            fail();
+        } catch (JSONException e) {
+        }
+    }
+    @Test
+    public void testOtherNumbers() throws JSONException {
+        Number nan = new Number() {
+            public int intValue() {
+                throw new UnsupportedOperationException();
+            }
+            public long longValue() {
+                throw new UnsupportedOperationException();
+            }
+            public float floatValue() {
+                throw new UnsupportedOperationException();
+            }
+            public double doubleValue() {
+                return Double.NaN;
+            }
+            @Override public String toString() {
+                return "x";
+            }
+        };
+        JSONObject object = new JSONObject();
+        try {
+            object.put("foo", nan);
+            fail("Object.put() accepted a NaN (via a custom Number class)");
+        } catch (JSONException e) {
+        }
+    }
+    @Test
+    public void testForeignObjects() throws JSONException {
+        Object foreign = new Object() {
+            @Override public String toString() {
+                return "x";
+            }
+        };
+        // foreign object types are accepted and treated as Strings!
+        JSONObject object = new JSONObject();
+        object.put("foo", foreign);
+        assertEquals("{\"foo\":\"x\"}", object.toString());
+    }
+    @Test
+    public void testNullKeys() {
+        try {
+            new JSONObject().put(null, false);
+            fail();
+        } catch (JSONException e) {
+        }
+        try {
+            new JSONObject().put(null, 0.0d);
+            fail();
+        } catch (JSONException e) {
+        }
+        try {
+            new JSONObject().put(null, 5);
+            fail();
+        } catch (JSONException e) {
+        }
+        try {
+            new JSONObject().put(null, 5L);
+            fail();
+        } catch (JSONException e) {
+        }
+        try {
+            new JSONObject().put(null, "foo");
+            fail();
+        } catch (JSONException e) {
+        }
+    }
+    @Test
+    public void testStrings() throws JSONException {
+        JSONObject object = new JSONObject();
+        object.put("foo", "true");
+        object.put("bar", "5.5");
+        object.put("baz", "9223372036854775806");
+        object.put("quux", "null");
+        object.put("height", "5\"8' tall");
+        assertTrue(object.toString().contains("\"foo\":\"true\""));
+        assertTrue(object.toString().contains("\"bar\":\"5.5\""));
+        assertTrue(object.toString().contains("\"baz\":\"9223372036854775806\""));
+        assertTrue(object.toString().contains("\"quux\":\"null\""));
+        assertTrue(object.toString().contains("\"height\":\"5\\\"8' tall\""));
+        assertEquals("true", object.get("foo"));
+        assertEquals("null", object.getString("quux"));
+        assertEquals("5\"8' tall", object.getString("height"));
+        assertEquals("true", object.opt("foo"));
+        assertEquals("5.5", object.optString("bar"));
+        assertEquals("true", object.optString("foo", "x"));
+        assertFalse(object.isNull("foo"));
+        assertEquals(true, object.getBoolean("foo"));
+        assertEquals(true, object.optBoolean("foo"));
+        assertEquals(true, object.optBoolean("foo", false));
+        assertEquals(0, object.optInt("foo"));
+        assertEquals(-2, object.optInt("foo", -2));
+        assertEquals(5.5d, object.getDouble("bar"));
+        assertEquals(5L, object.getLong("bar"));
+        assertEquals(5, object.getInt("bar"));
+        assertEquals(5, object.optInt("bar", 3));
+        // The last digit of the string is a 6 but getLong returns a 7. It's probably parsing as a
+        // double and then converting that to a long. This is consistent with JavaScript.
+        assertEquals(9223372036854775807L, object.getLong("baz"));
+        assertEquals(9.223372036854776E18, object.getDouble("baz"));
+        assertEquals(Integer.MAX_VALUE, object.getInt("baz"));
+        assertFalse(object.isNull("quux"));
+        try {
+            object.getDouble("quux");
+            fail();
+        } catch (JSONException e) {
+        }
+        assertEquals(Double.NaN, object.optDouble("quux"));
+        assertEquals(-1.0d, object.optDouble("quux", -1.0d));
+        object.put("foo", "TRUE");
+        assertEquals(true, object.getBoolean("foo"));
+    }
+    @Test
+    public void testJSONObjects() throws JSONException {
+        JSONObject object = new JSONObject();
+        JSONArray a = new JSONArray();
+        JSONObject b = new JSONObject();
+        object.put("foo", a);
+        object.put("bar", b);
+        assertSame(a, object.getJSONArray("foo"));
+        assertSame(b, object.getJSONObject("bar"));
+        try {
+            object.getJSONObject("foo");
+            fail();
+        } catch (JSONException e) {
+        }
+        try {
+            object.getJSONArray("bar");
+            fail();
+        } catch (JSONException e) {
+        }
+        assertEquals(a, object.optJSONArray("foo"));
+        assertEquals(b, object.optJSONObject("bar"));
+        assertEquals(null, object.optJSONArray("bar"));
+        assertEquals(null, object.optJSONObject("foo"));
+    }
+    @Test
+    public void testNullCoercionToString() throws JSONException {
+        JSONObject object = new JSONObject();
+        object.put("foo", JSONObject.NULL);
+        assertEquals("null", object.getString("foo"));
+    }
+    @Test
+    public void testArrayCoercion() throws JSONException {
+        JSONObject object = new JSONObject();
+        object.put("foo", "[true]");
+        try {
+            object.getJSONArray("foo");
+            fail();
+        } catch (JSONException e) {
+        }
+    }
+
+    @Test
+    public void testObjectCoercion() throws JSONException {
+        JSONObject object = new JSONObject();
+        object.put("foo", "{}");
+        try {
+            object.getJSONObject("foo");
+            fail();
+        } catch (JSONException e) {
+        }
+    }
+    @Test
+    public void testAccumulateValueChecking() throws JSONException {
+        JSONObject object = new JSONObject();
+        try {
+            object.accumulate("foo", Double.NaN);
+            fail();
+        } catch (JSONException e) {
+        }
+        object.accumulate("foo", 1);
+        try {
+            object.accumulate("foo", Double.NaN);
+            fail();
+        } catch (JSONException e) {
+        }
+        object.accumulate("foo", 2);
+        try {
+            object.accumulate("foo", Double.NaN);
+            fail();
+        } catch (JSONException e) {
+        }
+    }
+    @Test
+    public void testToJSONArray() throws JSONException {
+        JSONObject object = new JSONObject();
+        Object value = new Object();
+        object.put("foo", true);
+        object.put("bar", 5.0d);
+        object.put("baz", -0.0d);
+        object.put("quux", value);
+        JSONArray names = new JSONArray();
+        names.put("baz");
+        names.put("quux");
+        names.put("foo");
+        JSONArray array = object.toJSONArray(names);
+        assertEquals(-0.0d, array.get(0));
+        assertEquals(value, array.get(1));
+        assertEquals(true, array.get(2));
+        object.put("foo", false);
+        assertEquals(true, array.get(2));
+    }
+    @Test
+    public void testToJSONArrayMissingNames() throws JSONException {
+        JSONObject object = new JSONObject();
+        object.put("foo", true);
+        object.put("bar", 5.0d);
+        object.put("baz", JSONObject.NULL);
+        JSONArray names = new JSONArray();
+        names.put("bar");
+        names.put("foo");
+        names.put("quux");
+        names.put("baz");
+        JSONArray array = object.toJSONArray(names);
+        assertEquals(4, array.length());
+        assertEquals(5.0d, array.get(0));
+        assertEquals(true, array.get(1));
+        try {
+            array.get(2);
+            fail();
+        } catch (JSONException e) {
+        }
+        assertEquals(JSONObject.NULL, array.get(3));
+    }
+    @Test
+    public void testToJSONArrayNull() throws JSONException {
+        JSONObject object = new JSONObject();
+        assertEquals(null, object.toJSONArray(null));
+        object.put("foo", 5);
+        try {
+            object.toJSONArray(null);
+        } catch (JSONException e) {
+        }
+    }
+    @Test
+    public void testToJSONArrayEndsUpEmpty() throws JSONException {
+        JSONObject object = new JSONObject();
+        object.put("foo", 5);
+        JSONArray array = new JSONArray();
+        array.put("bar");
+        assertEquals(1, object.toJSONArray(array).length());
+    }
+    @Test
+    public void testToJSONArrayNonString() throws JSONException {
+        JSONObject object = new JSONObject();
+        object.put("foo", 5);
+        object.put("null", 10);
+        object.put("false", 15);
+        JSONArray names = new JSONArray();
+        names.put(JSONObject.NULL);
+        names.put(false);
+        names.put("foo");
+        // array elements are converted to strings to do name lookups on the map!
+        JSONArray array = object.toJSONArray(names);
+        assertEquals(3, array.length());
+        assertEquals(10, array.get(0));
+        assertEquals(15, array.get(1));
+        assertEquals(5, array.get(2));
+    }
+    @Test
+    public void testPutUnsupportedNumbers() throws JSONException {
+        JSONObject object = new JSONObject();
+        try {
+            object.put("foo", Double.NaN);
+            fail();
+        } catch (JSONException e) {
+        }
+        try {
+            object.put("foo", Double.NEGATIVE_INFINITY);
+            fail();
+        } catch (JSONException e) {
+        }
+        try {
+            object.put("foo", Double.POSITIVE_INFINITY);
+            fail();
+        } catch (JSONException e) {
+        }
+    }
+    @Test
+    public void testPutUnsupportedNumbersAsObjects() throws JSONException {
+        JSONObject object = new JSONObject();
+        try {
+            object.put("foo", (Double) Double.NaN);
+            fail();
+        } catch (JSONException e) {
+        }
+        try {
+            object.put("foo", (Double) Double.NEGATIVE_INFINITY);
+            fail();
+        } catch (JSONException e) {
+        }
+        try {
+            object.put("foo", (Double) Double.POSITIVE_INFINITY);
+            fail();
+        } catch (JSONException e) {
+        }
+    }
+    /**
+     * Although JSONObject is usually defensive about which numbers it accepts,
+     * it doesn't check inputs in its constructor.
+     */
+    @Test
+    public void testCreateWithUnsupportedNumbers() throws JSONException {
+        Map<String, Object> contents = new HashMap<String, Object>();
+        contents.put("foo", Double.NaN);
+        contents.put("bar", Double.NEGATIVE_INFINITY);
+        contents.put("baz", Double.POSITIVE_INFINITY);
+        JSONObject object = new JSONObject(contents);
+        assertEquals(Double.NaN, object.get("foo"));
+        assertEquals(Double.NEGATIVE_INFINITY, object.get("bar"));
+        assertEquals(Double.POSITIVE_INFINITY, object.get("baz"));
+    }
+    @Test
+    public void testToStringWithUnsupportedNumbers() {
+        // when the object contains an unsupported number, toString returns null!
+        JSONObject object = new JSONObject(Collections.singletonMap("foo", Double.NaN));
+        assertEquals(null, object.toString());
+    }
+    @Test
+    public void testMapConstructorCopiesContents() throws JSONException {
+        Map<String, Object> contents = new HashMap<String, Object>();
+        contents.put("foo", 5);
+        JSONObject object = new JSONObject(contents);
+        contents.put("foo", 10);
+        assertEquals(5, object.get("foo"));
+    }
+    @Test
+    public void testMapConstructorWithBogusEntries() {
+        Map<Object, Object> contents = new HashMap<Object, Object>();
+        contents.put(5, 5);
+        try {
+            new JSONObject(contents);
+            fail("JSONObject constructor doesn't validate its input!");
+        } catch (Exception e) {
+        }
+    }
+    @Test
+    public void testTokenerConstructor() throws JSONException {
+        JSONObject object = new JSONObject(new JSONTokener("{\"foo\": false}"));
+        assertEquals(1, object.length());
+        assertEquals(false, object.get("foo"));
+    }
+    @Test
+    public void testTokenerConstructorWrongType() throws JSONException {
+        try {
+            new JSONObject(new JSONTokener("[\"foo\", false]"));
+            fail();
+        } catch (JSONException e) {
+        }
+    }
+    @Test
+    public void testTokenerConstructorNull() throws JSONException {
+        try {
+            new JSONObject((JSONTokener) null);
+            fail();
+        } catch (NullPointerException e) {
+        }
+    }
+    @Test
+    public void testTokenerConstructorParseFail() {
+        try {
+            new JSONObject(new JSONTokener("{"));
+            fail();
+        } catch (JSONException e) {
+        }
+    }
+    @Test
+    public void testStringConstructor() throws JSONException {
+        JSONObject object = new JSONObject("{\"foo\": false}");
+        assertEquals(1, object.length());
+        assertEquals(false, object.get("foo"));
+    }
+    @Test
+    public void testStringConstructorWrongType() throws JSONException {
+        try {
+            new JSONObject("[\"foo\", false]");
+            fail();
+        } catch (JSONException e) {
+        }
+    }
+    @Test
+    public void testStringConstructorNull() throws JSONException {
+        try {
+            new JSONObject((String) null);
+            fail();
+        } catch (NullPointerException e) {
+        }
+    }
+    @Test
+    public void testStringonstructorParseFail() {
+        try {
+            new JSONObject("{");
+            fail();
+        } catch (JSONException e) {
+        }
+    }
+    @Test
+    public void testCopyConstructor() throws JSONException {
+        JSONObject source = new JSONObject();
+        source.put("a", JSONObject.NULL);
+        source.put("b", false);
+        source.put("c", 5);
+        JSONObject copy = new JSONObject(source, new String[] { "a", "c" });
+        assertEquals(2, copy.length());
+        assertEquals(JSONObject.NULL, copy.get("a"));
+        assertEquals(5, copy.get("c"));
+        assertEquals(null, copy.opt("b"));
+    }
+    @Test
+    public void testCopyConstructorMissingName() throws JSONException {
+        JSONObject source = new JSONObject();
+        source.put("a", JSONObject.NULL);
+        source.put("b", false);
+        source.put("c", 5);
+        JSONObject copy = new JSONObject(source, new String[]{ "a", "c", "d" });
+        assertEquals(2, copy.length());
+        assertEquals(JSONObject.NULL, copy.get("a"));
+        assertEquals(5, copy.get("c"));
+        assertEquals(0, copy.optInt("b"));
+    }
+    @Test
+    public void testAccumulateMutatesInPlace() throws JSONException {
+        JSONObject object = new JSONObject();
+        object.put("foo", 5);
+        object.accumulate("foo", 6);
+        JSONArray array = object.getJSONArray("foo");
+        assertEquals("[5,6]", array.toString());
+        object.accumulate("foo", 7);
+        assertEquals("[5,6,7]", array.toString());
+    }
+    @Test
+    public void testAccumulateExistingArray() throws JSONException {
+        JSONArray array = new JSONArray();
+        JSONObject object = new JSONObject();
+        object.put("foo", array);
+        object.accumulate("foo", 5);
+        assertEquals("[5]", array.toString());
+    }
+    @Test
+    public void testAccumulatePutArray() throws JSONException {
+        JSONObject object = new JSONObject();
+        object.accumulate("foo", 5);
+        assertEquals("{\"foo\":5}", object.toString());
+        object.accumulate("foo", new JSONArray());
+        assertEquals("{\"foo\":[5,[]]}", object.toString());
+    }
+    @Test
+    public void testAccumulateNull() {
+        JSONObject object = new JSONObject();
+        try {
+            object.accumulate(null, 5);
+            fail();
+        } catch (JSONException e) {
+        }
+    }
+    @Test
+    public void testEmptyStringKey() throws JSONException {
+        JSONObject object = new JSONObject();
+        object.put("", 5);
+        assertEquals(5, object.get(""));
+        assertEquals("{\"\":5}", object.toString());
+    }
+    @Test
+    public void testNullValue() throws JSONException {
+        JSONObject object = new JSONObject();
+        object.put("foo", JSONObject.NULL);
+        object.put("bar", null);
+        // there are two ways to represent null; each behaves differently!
+        assertTrue(object.has("foo"));
+        assertFalse(object.has("bar"));
+        assertTrue(object.isNull("foo"));
+        assertTrue(object.isNull("bar"));
+    }
+    @Test
+    public void testHas() throws JSONException {
+        JSONObject object = new JSONObject();
+        object.put("foo", 5);
+        assertTrue(object.has("foo"));
+        assertFalse(object.has("bar"));
+        assertFalse(object.has(null));
+    }
+
+    @Test
+    public void testOptNull() throws JSONException {
+        JSONObject object = new JSONObject();
+        object.put("foo", "bar");
+        assertEquals(null, object.opt(null));
+        assertEquals(false, object.optBoolean(null));
+        assertEquals(Double.NaN, object.optDouble(null));
+        assertEquals(0, object.optInt(null));
+        assertEquals(0L, object.optLong(null));
+        assertEquals(null, object.optJSONArray(null));
+        assertEquals(null, object.optJSONObject(null));
+        assertEquals("", object.optString(null));
+        assertEquals(true, object.optBoolean(null, true));
+        assertEquals(0.0d, object.optDouble(null, 0.0d));
+        assertEquals(1, object.optInt(null, 1));
+        assertEquals(1L, object.optLong(null, 1L));
+        assertEquals("baz", object.optString(null, "baz"));
+    }
+    @Test
+    public void testToStringWithIndentFactor() throws JSONException {
+        JSONObject object = new JSONObject();
+        object.put("foo", new JSONArray(Arrays.asList(5, 6)));
+        object.put("bar", new JSONObject());
+        String foobar = "{\n" +
+                "     \"foo\": [\n" +
+                "          5,\n" +
+                "          6\n" +
+                "     ],\n" +
+                "     \"bar\": {}\n" +
+                "}";
+        String barfoo = "{\n" +
+                "     \"bar\": {},\n" +
+                "     \"foo\": [\n" +
+                "          5,\n" +
+                "          6\n" +
+                "     ]\n" +
+                "}";
+        String string = object.toString(5);
+        assertTrue(string, foobar.equals(string) || barfoo.equals(string));
+    }
+    @Test
+    public void testNames() throws JSONException {
+        JSONObject object = new JSONObject();
+        object.put("foo", 5);
+        object.put("bar", 6);
+        object.put("baz", 7);
+        JSONArray array = object.names();
+        assertTrue(array.toString().contains("foo"));
+        assertTrue(array.toString().contains("bar"));
+        assertTrue(array.toString().contains("baz"));
+    }
+    @Test
+    public void testKeysEmptyObject() {
+        JSONObject object = new JSONObject();
+        assertFalse(object.keys().hasNext());
+        try {
+            object.keys().next();
+            fail();
+        } catch (NoSuchElementException e) {
+        }
+    }
+    @Test
+    public void testKeys() throws JSONException {
+        JSONObject object = new JSONObject();
+        object.put("foo", 5);
+        object.put("bar", 6);
+        object.put("foo", 7);
+        @SuppressWarnings("unchecked")
+        Iterator<String> keys = (Iterator<String>) object.keys();
+        Set<String> result = new HashSet<String>();
+        assertTrue(keys.hasNext());
+        result.add(keys.next());
+        assertTrue(keys.hasNext());
+        result.add(keys.next());
+        assertFalse(keys.hasNext());
+        assertEquals(new HashSet<String>(Arrays.asList("foo", "bar")), result);
+        try {
+            keys.next();
+            fail();
+        } catch (NoSuchElementException e) {
+        }
+    }
+    @Test
+    public void testMutatingKeysMutatesObject() throws JSONException {
+        JSONObject object = new JSONObject();
+        object.put("foo", 5);
+        Iterator keys = object.keys();
+        keys.next();
+        keys.remove();
+        assertEquals(0, object.length());
+    }
+    @Test
+    public void testQuote() {
+        // covered by JSONStringerTest.testEscaping
+    }
+    @Test
+    public void testQuoteNull() throws JSONException {
+        assertEquals("\"\"", JSONObject.quote(null));
+    }
+    @Test
+    public void testNumberToString() throws JSONException {
+        assertEquals("5", JSONObject.numberToString(5));
+        assertEquals("-0", JSONObject.numberToString(-0.0d));
+        assertEquals("9223372036854775806", JSONObject.numberToString(9223372036854775806L));
+        assertEquals("4.9E-324", JSONObject.numberToString(Double.MIN_VALUE));
+        assertEquals("1.7976931348623157E308", JSONObject.numberToString(Double.MAX_VALUE));
+        try {
+            JSONObject.numberToString(Double.NaN);
+            fail();
+        } catch (JSONException e) {
+        }
+        try {
+            JSONObject.numberToString(Double.NEGATIVE_INFINITY);
+            fail();
+        } catch (JSONException e) {
+        }
+        try {
+            JSONObject.numberToString(Double.POSITIVE_INFINITY);
+            fail();
+        } catch (JSONException e) {
+        }
+        assertEquals("0.001", JSONObject.numberToString(new BigDecimal("0.001")));
+        assertEquals("9223372036854775806",
+                JSONObject.numberToString(new BigInteger("9223372036854775806")));
+        try {
+            JSONObject.numberToString(null);
+            fail();
+        } catch (JSONException e) {
+        }
+    }
+
+
+
+    /* *************************************************************************
+
+    Ankidroid specific test
+    *************************************************************************** */
+
 
     private final String emptyJson = "{}";
     private final String correctJsonBasic = "{\"key1\":\"value1\"}";
@@ -51,6 +982,7 @@ public class JSONObjectTest {
     Map<String, Boolean> booleanMap;
 
     @Before
+    @Test
     public void setUp() {
         correctJsonObjectBasic = new JSONObject(correctJsonBasic);
         correctJsonObjectNested = new JSONObject(correctJsonNested);


### PR DESCRIPTION
This port the code from
https://android.googlesource.com/platform/dalvik/+/f2f7880a40aed1c8d9c27db49226e47396556aac/libcore/json/src/test/java/org/json

It adapts it by using junit, `@Test`, changing the deprecated test of equality of double (it adds explicitly the delta=0).

Since we'll move away from org.json in order to use fastxml.jackson, this is an extra security to ensure that we do not
change the behavior while we increase the speed.

This lead to discover that some code throwed RuntimeException instead of JSONException, this is corrected.

Some code from upstream are copied in our classes in order to ensure that all elements of the JSON tree are our kind of JSONObject