### PR TITLE
2.15 crash fix - card browser crash on uninitialized variable

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -1520,10 +1520,12 @@ public class CardBrowser extends NavigationDrawerActivity implements
 
 
     private void updateList() {
-        mCardsAdapter.notifyDataSetChanged();
-        mDeckSpinnerSelection.notifyDataSetChanged();
-        onSelectionChanged();
-        updatePreviewMenuItem();
+        if (colIsOpen() && mCardsAdapter!= null) {
+            mCardsAdapter.notifyDataSetChanged();
+            mDeckSpinnerSelection.notifyDataSetChanged();
+            onSelectionChanged();
+            updatePreviewMenuItem();
+        }
     }
 
     /**
@@ -2401,7 +2403,9 @@ public class CardBrowser extends NavigationDrawerActivity implements
             updateMultiselectMenu();
             mActionBarTitle.setText(String.format(Locale.ROOT, "%d", checkedCardCount()));
         } finally {
-            mCardsAdapter.notifyDataSetChanged();
+            if (colIsOpen() && mCardsAdapter != null) {
+                mCardsAdapter.notifyDataSetChanged();
+            }
         }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -18,6 +18,7 @@
 
 package com.ichi2.anki;
 
+import android.annotation.SuppressLint;
 import android.app.AlertDialog;
 import android.content.BroadcastReceiver;
 import android.content.Context;
@@ -107,7 +108,6 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
-import java.util.regex.Pattern;
 
 import timber.log.Timber;
 
@@ -156,7 +156,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
     /** List of cards in the browser.
     * When the list is changed, the position member of its elements should get changed.*/
     @NonNull
-    private CardCollection<CardCache> mCards = new CardCollection<>();
+    private final CardCollection<CardCache> mCards = new CardCollection<>();
     public DeckSpinnerSelection mDeckSpinnerSelection;
     @VisibleForTesting
     public ListView mCardsListView;
@@ -324,12 +324,12 @@ public class CardBrowser extends NavigationDrawerActivity implements
                 getCol().getConf().put("sortType", fSortTypes[1]);
                 AnkiDroidApp.getSharedPrefs(getBaseContext()).edit()
                         .putBoolean("cardBrowserNoSorting", true)
-                        .commit();
+                        .apply();
             } else {
                 getCol().getConf().put("sortType", fSortTypes[mOrder]);
                 AnkiDroidApp.getSharedPrefs(getBaseContext()).edit()
                         .putBoolean("cardBrowserNoSorting", false)
-                        .commit();
+                        .apply();
             }
             getCol().getConf().put("sortBackwards", mOrderAsc);
             searchCards();
@@ -645,7 +645,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
                 if (pos != mColumn1Index) {
                     mColumn1Index = pos;
                     AnkiDroidApp.getSharedPrefs(AnkiDroidApp.getInstance().getBaseContext()).edit()
-                            .putInt("cardBrowserColumn1", mColumn1Index).commit();
+                            .putInt("cardBrowserColumn1", mColumn1Index).apply();
                     Column[] fromMap = mCardsAdapter.getFromMapping();
                     fromMap[0] = COLUMN1_KEYS[mColumn1Index];
                     mCardsAdapter.setFromMapping(fromMap);
@@ -673,7 +673,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
                 if (pos != mColumn2Index) {
                     mColumn2Index = pos;
                     AnkiDroidApp.getSharedPrefs(AnkiDroidApp.getInstance().getBaseContext()).edit()
-                            .putInt("cardBrowserColumn2", mColumn2Index).commit();
+                            .putInt("cardBrowserColumn2", mColumn2Index).apply();
                     Column[] fromMap = mCardsAdapter.getFromMapping();
                     fromMap[1] = COLUMN2_KEYS[mColumn2Index];
                     mCardsAdapter.setFromMapping(fromMap);
@@ -1442,7 +1442,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
     }
 
     @Override
-    public void onSaveInstanceState(Bundle savedInstanceState) {
+    public void onSaveInstanceState(@NonNull Bundle savedInstanceState) {
         // Save current search terms
         savedInstanceState.putString("mSearchTerms", mSearchTerms);
         savedInstanceState.putLong("mOldCardId", mOldCardId);
@@ -1455,7 +1455,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
     }
 
     @Override
-    public void onRestoreInstanceState(Bundle savedInstanceState) {
+    public void onRestoreInstanceState(@NonNull Bundle savedInstanceState) {
         super.onRestoreInstanceState(savedInstanceState);
         mSearchTerms = savedInstanceState.getString("mSearchTerms");
         mOldCardId = savedInstanceState.getLong("mOldCardId");
@@ -1695,9 +1695,6 @@ public class CardBrowser extends NavigationDrawerActivity implements
     }
 
 
-    private ChangeDeckHandler changeDeckHandler() {
-        return new ChangeDeckHandler(this);
-    }
     private static class ChangeDeckHandler extends ListenerWithProgressBarCloseOnFalse<Object, PairWithBoolean<Card[]>> {
         public ChangeDeckHandler(CardBrowser browser) {
             super("Card Browser - changeDeckHandler.actualOnPostExecute(CardBrowser browser)", browser);
@@ -1758,6 +1755,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
     /**
      * Removes cards from view. Doesn't delete them in model (database).
      */
+    @SuppressWarnings("SameParameterValue")
     private void removeNotesView(Card[] cards, boolean reorderCards) {
         List<Long> cardIds = new ArrayList<>(cards.length);
         for (Card c : cards) {
@@ -1875,7 +1873,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
         @Override
         protected void actualOnValidPostExecute(CardBrowser browser, BooleanGetter result) {
             browser.hideProgressBar();
-            browser.mActionBarTitle.setText(Integer.toString(browser.checkedCardCount()));
+            browser.mActionBarTitle.setText(String.format(Locale.ROOT, "%d", browser.checkedCardCount()));
             browser.invalidateOptionsMenu();    // maybe the availability of undo changed
             // snackbar to offer undo
             String deletedMessage = browser.getResources().getQuantityString(R.plurals.card_browser_cards_deleted, mCardsDeleted, mCardsDeleted);
@@ -2151,6 +2149,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
     }
 
 
+    @SuppressWarnings("SameParameterValue")
     private void closeCardBrowser(int result) {
         closeCardBrowser(result, null);
     }
@@ -2400,7 +2399,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
             }
 
             updateMultiselectMenu();
-            mActionBarTitle.setText(Integer.toString(checkedCardCount()));
+            mActionBarTitle.setText(String.format(Locale.ROOT, "%d", checkedCardCount()));
         } finally {
             mCardsAdapter.notifyDataSetChanged();
         }
@@ -2886,6 +2885,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
     }
 
     @VisibleForTesting
+    @SuppressWarnings("SameParameterValue")
     void filterByFlag(int flag) {
         mCurrentFlag = flag;
         filterByFlag();
@@ -2898,6 +2898,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
     }
 
     @VisibleForTesting
+    @SuppressWarnings("SameParameterValue")
     void searchCards(String searchQuery) {
         mSearchTerms = searchQuery;
         searchCards();

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/sched/SchedTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/sched/SchedTest.java
@@ -1071,9 +1071,11 @@ public class SchedTest extends RobolectricTest {
         AbstractSched sched = col.getSched();
         Card c = sched.getCard();
         sched.answerCard(c, sched.answerButtons(c) - 1); // not upstream. But we are not expecting multiple getCard without review
+        waitForAsyncTasksToComplete();
         assertEquals(0, c.getOrd());
         c = sched.getCard();
         sched.answerCard(c, sched.answerButtons(c) - 1); // not upstream. But we are not expecting multiple getCard without review
+        waitForAsyncTasksToComplete();
         assertEquals(1, c.getOrd());
         c = sched.getCard();
         sched.answerCard(c, sched.answerButtons(c) - 1); // not upstream. But we are not expecting multiple getCard without review


### PR DESCRIPTION
## Pull Request template

## Purpose / Description

CardBrowser was crashing because of an order-of-operations race between initial layout and onCollectionLoaded initializing necessary data

## Fixes
Fixes #8882

## Approach

Examined other areas that made the same last-call-before-crash and they were protecting access to the unitialized variable with a guard for collection load and null. Replicated that style in this code path and one other I saw using the possibly-unitialized-at-that-moment variable.

Also de-linted prior and de-flaked post in separate commits

## How Has This Been Tested?

It's a race condition, I can't reproduce it but I can see how it would happen.
Ran `./gradlew jacocoTestReport` against an Android S emulator locally

## Learning (optional, can help others)

Null is the billion dollar mistake.

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
