### PR TITLE
fix(login): bubble custom sync server exception up during login

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/MyAccount.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/MyAccount.java
@@ -39,6 +39,7 @@ import com.google.android.material.textfield.TextInputLayout;
 import com.ichi2.anki.web.HostNumFactory;
 import com.ichi2.async.Connection;
 import com.ichi2.async.Connection.Payload;
+import com.ichi2.libanki.sync.CustomSyncServerUrlException;
 import com.ichi2.themes.StyledProgressDialog;
 import com.ichi2.ui.TextInputEditField;
 import com.ichi2.utils.AdaptionUtil;
@@ -309,6 +310,11 @@ public class MyAccount extends AnkiActivity {
     protected String getHumanReadableLoginErrorMessage(Exception exception) {
         if (exception == null) {
             return "";
+        }
+
+        if (exception instanceof CustomSyncServerUrlException) {
+            String url = ((CustomSyncServerUrlException)exception).getUrl();
+            return getResources().getString(R.string.sync_error_invalid_sync_server, url);
         }
 
         if (exception.getCause() != null) {

--- a/AnkiDroid/src/main/java/com/ichi2/async/Connection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/Connection.java
@@ -34,6 +34,7 @@ import com.ichi2.anki.R;
 import com.ichi2.anki.exception.MediaSyncException;
 import com.ichi2.anki.exception.UnknownHttpResponseException;
 import com.ichi2.libanki.Collection;
+import com.ichi2.libanki.sync.CustomSyncServerUrlException;
 import com.ichi2.libanki.sync.FullSyncer;
 import com.ichi2.libanki.sync.HostNum;
 import com.ichi2.libanki.sync.HttpSyncer;
@@ -233,7 +234,13 @@ public class Connection extends BaseAsyncTask<Connection.Payload, Object, Connec
             Timber.w(e);
             data.success = false;
             data.resultType = ERROR;
-            data.result = new Object[]{e.getResponseCode(), e.getMessage() };
+            data.result = new Object[] {e.getResponseCode(), e.getMessage()};
+            return data;
+        } catch (CustomSyncServerUrlException e2) {
+            Timber.w(e2);
+            data.success = false;
+            data.resultType = CUSTOM_SYNC_SERVER_URL;
+            data.result = new Object[] {e2};
             return data;
         } catch (Exception e2) {
             Timber.w(e2);


### PR DESCRIPTION
## Pull Request template

## Purpose / Description

Previously these sorts of exceptions were grouped into a general exception
that requested a user send a crash report, even though they are not actionable for us

Now we will detect custom sync server URL exception class specifically and just send
that back to the async listener, where existing user messaging should handle it fine

## Fixes
Fixes #8883 

## Approach
Use existing messaging handling for user-fixable errors for this specific exception instead of using general handlers

## How Has This Been Tested?

I reproduced this locally by 

1) manually editing the sync URL in prefs to something invalid, that our current UI won't let you enter at all. So it was forcibly bad.
2) going in to settings general and attempting to login - I saw the error report then developed the fix, now it shows a nice dialog just like on DeckPicker if you try to sync with a bad sync host

I also tested the non-error case by making sure the sync server was set to `https://sync.ankiweb.net` and following the same path to login, it logged in correctly

## Learning (optional, can help others)

Error handling is hard.

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
