### PR TITLE
De-lint DeckSpinnerSelection and select correct deck on add note or edit card

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckSpinnerSelection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckSpinnerSelection.java
@@ -78,11 +78,11 @@ public class DeckSpinnerSelection {
 
         mSpinner.setAdapter(mDeckDropDownAdapter);
 
-        setSpinnerListner();
+        setSpinnerListener();
 
     }
 
-    public void initializeNoteEditorDeckSpinner(@NonNull Card currentEditedCard, @NonNull boolean addNote) {
+    public void initializeNoteEditorDeckSpinner(@NonNull Card currentEditedCard, boolean addNote) {
         Collection col = mContext.getCol();
         mDropDownDecks = col.getDecks().allSorted();
         final ArrayList<String> deckNames = new ArrayList<>(mDropDownDecks.size());
@@ -91,7 +91,7 @@ public class DeckSpinnerSelection {
             // add current deck and all other non-filtered decks to deck list
             long thisDid = d.getLong("id");
             String currentName = d.getString("name");
-            String lineContent = null;
+            String lineContent;
             if (d.isStd()) {
                 lineContent = currentName;
             } else if (!addNote && currentEditedCard != null && currentEditedCard.getDid() == thisDid) {
@@ -122,10 +122,11 @@ public class DeckSpinnerSelection {
         };
 
         mSpinner.setAdapter(noteDeckAdapter);
-        setSpinnerListner();
+        setSpinnerListener();
+
     }
 
-    public void setSpinnerListner() {
+    public void setSpinnerListener() {
         mSpinner.setOnTouchListener((view, motionEvent) -> {
             if (motionEvent.getAction() == MotionEvent.ACTION_UP) {
                 displayDeckOverrideDialog(mContext.getCol());

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -1913,6 +1913,7 @@ public class NoteEditor extends AnkiActivity implements
         } else {
             mCurrentDid = mCurrentEditedCard.getDid();
         }
+        mDeckSpinnerSelection.selectDeckById(mCurrentDid);
     }
 
 
@@ -1934,8 +1935,7 @@ public class NoteEditor extends AnkiActivity implements
         }
         // nb: setOnItemSelectedListener and populateEditFields need to occur after this
         setNoteTypePosition();
-        mDeckSpinnerSelection.setDeckId(getCol().getDecks().selected());
-        mDeckSpinnerSelection.updateDeckPosition();
+        setDid(note);
         updateTags();
         updateCards(mEditorNote.model());
         updateToolbar();


### PR DESCRIPTION
## Pull Request template

## Purpose / Description

There was a little snarl of issues related to getting the deck spinner set to the correct deck if it was adding a new card or editing an existing card.

Adding a new card case was attempted in #8849 and fixed part of the issue but made another part not work with #8855 - this time both are working

## Fixes
Fixes #8855

## Approach

Very very carefully trace the code while checking both cases, throwing stacks in DeckSpinnerSelection every time it was called to set the spinner position so I could see who was calling it and with what arguments

## How Has This Been Tested?

1) Make sure spinner is correct for current selected deck
Open Deck list and select any deck
Click + to add a note, check deck spinner position
Repeat with other decks to make sure it stays in sync with current selected deck

2) Make sure spinner is correct for cards (including with sub-decks)
Open Deck list and select any deck (try with parent deck of child card too)
Open Card browser and select all decks then search for card in a subdeck
tap on sub-deck card
Check deck spinner position

At all times after test runs make sure the cards were actually created in the correct deck to avoid #8825
Also checked selecting random deck, then add card and select different deck, saving and making sure next card edit screen (for a second new card) maintained my newly selected deck and cards were created in it

## Learning (optional, can help others)

QA is priceless, thank you @mikunimaru for checking through all these

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
