### PR TITLE
modified the stop function in AudioPlayer

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/AudioPlayer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/AudioPlayer.java
@@ -39,11 +39,16 @@ public class AudioPlayer {
         mPlayer.setDataSource(audioPath);
         mPlayer.setOnCompletionListener(mp -> {
             onStopping();
-            mPlayer.stop();
+            stop(audioPath);
             onStopped();
         });
+        mPlayer.setOnPreparedListener(new MediaPlayer.OnPreparedListener() {
+            @Override
+            public void onPrepared(MediaPlayer mediaPlayer) {
+                mediaPlayer.start();
+            }
+        });
         mPlayer.prepare();
-        mPlayer.start();
     }
 
 
@@ -67,10 +72,12 @@ public class AudioPlayer {
         mPlayer.start();
     }
 
-
-    public void stop() {
+    
+    public void stop(String audioPath) {
         try {
+            mPlayer.setDataSource(audioPath);
             mPlayer.prepare();
+            mPlayer.pause();
             mPlayer.seekTo(0);
         } catch (Exception e) {
             Timber.e(e);

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/AudioView.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/AudioView.java
@@ -286,7 +286,7 @@ public class AudioView extends LinearLayout {
                         // -> Play, start from beginning
                         mStatus = Status.PLAYING;
                         setImageResource(mResPauseImage);
-                        mPlayer.stop();
+                        mPlayer.stop(getAudioPath());
                         mPlayer.start();
                         notifyPlay();
                         break;
@@ -340,7 +340,7 @@ public class AudioView extends LinearLayout {
             switch (mStatus) {
                 case PAUSED:
                 case PLAYING:
-                    mPlayer.stop();
+                    mPlayer.stop(getAudioPath());
                     mStatus = Status.STOPPED;
                     notifyStop();
                     break;

--- a/AnkiDroid/src/test/java/com/ichi2/anki/reviewer/KeyboardShortcutIntegrationTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/reviewer/KeyboardShortcutIntegrationTest.java
@@ -134,7 +134,7 @@ public class KeyboardShortcutIntegrationTest extends RobolectricTest {
         // now we're set up and recording, pressing Shift + V should move us to recording
         pressShiftAndVThenRelease();
 
-        verify(player, times(1)).stop();
+        verify(player, times(1)).stop(anyString());
         verify(recorder, times(1)).startRecording(anyString());
         verifyNoMoreInteractions(recorder, player);
         assertStatus(AudioView.Status.RECORDING);


### PR DESCRIPTION
## Purpose / Description
There was a bug when trying to check the pronunciation where if we use the keyboard shortcuts multiple times, the app crashes.

## Fixes
Fixes [#8637](https://github.com/ankidroid/Anki-Android/issues/8637)

## Approach
The app crashed because we were trying to record new audio while the previously recorded audio was playing. So I modified the stop() function in the AudioPlayer.java file to check the latest data source and also it resets the player after new audio is recorded.

Also added a onPrepared listener because the error - trying to use prepare() on a null object, kept crashing the app. 

## How Has This Been Tested?

Constantly press record Audio shortcut (shift + v) and play (v).
Tested this on a one plus 7t(physical device) and pixel 3A (emulator)


## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
