### PR TITLE
fix: SchedV2 was used instead of SchedV1

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
@@ -134,7 +134,13 @@ public class Collection implements CollectionGetter {
     private static final Pattern fClozePatternA = Pattern.compile("\\{\\{(.*?)cloze:");
     private static final Pattern fClozeTagStart = Pattern.compile("<%cloze:");
 
-    private static final int fDefaultSchedulerVersion = 2;
+    /**
+     * This is only used for collections which were created before
+     * the new collections default was v2
+     * In that case, 'schedVer' is not set, so this default is used.
+     * See: #8926
+     * */
+    private static final int fDefaultSchedulerVersion = 1;
     private static final List<Integer> fSupportedSchedulerVersions = Arrays.asList(1, 2);
 
     // Not in libAnki.
@@ -1323,6 +1329,16 @@ public class Collection implements CollectionGetter {
             mUndo.removeFirst();
         }
     }
+
+
+    public void onCreate() {
+        mDroidBackend.useNewTimezoneCode(this);
+        getConf().put("schedVer", 2);
+        setMod();
+        // we need to reload the scheduler: this was previously loaded as V1
+        _loadScheduler();
+    }
+
 
     @VisibleForTesting
     public static class UndoReview extends UndoAction {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Storage.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Storage.java
@@ -97,7 +97,7 @@ public class Storage {
                 for (int i = StdModels.STD_MODELS.length-1; i>=0; i--) {
                     StdModels.STD_MODELS[i].add(col);
                 }
-                backend.useNewTimezoneCode(col);
+                col.onCreate();
                 col.save();
             }
             return col;

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/sched/SchedUpgradeTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/sched/SchedUpgradeTest.java
@@ -1,0 +1,59 @@
+/*
+ *  Copyright (c) 2021 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.libanki.sched;
+
+import com.ichi2.anki.RobolectricTest;
+import com.ichi2.libanki.Collection;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+
+/** Issue 8926 */
+@RunWith(AndroidJUnit4.class)
+public class SchedUpgradeTest extends RobolectricTest {
+
+    @Override
+    protected boolean useInMemoryDatabase() {
+        // We want to be able to close the collection.
+        return false;
+    }
+
+
+    @Test
+    public void schedulerForNewCollectionIsV2() {
+        assertThat("A new collection should be sched v2", getCol().getSched(), not(instanceOf(Sched.class)));
+        assertThat(getCol().schedVer(), is(2));
+    }
+
+    @Test
+    public void schedulerForV1CollectionIsV1() {
+        // A V1 collection does not have the schedVer variable. This is not the same as a downgrade.
+        getCol().getConf().remove("schedVer");
+        getCol().setMod();
+        getCol().close();
+
+
+        assertThat("A collection with no schedVer should be v1", getCol().getSched(), instanceOf(Sched.class));
+        assertThat(getCol().schedVer(), is(1));
+
+    }
+}


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
Users reported being upgraded to SchedV2

SchedV1 did not have the 'schedVer' variable set unless a downgrade
was performed. Existing users of SchedV1 did not have this variable set
so they were using SchedV2 without having gone through the upgrade
process.

Therefore they used 'fDefaultSchedulerVersion' which was bumped to 2

## Fixes
Fixes #8926

## Approach
Now, instead of using the default, we set the value explicitly


## How Has This Been Tested?

Unit tests, and tested on my device:
* 2.14.6 -> 2.15.0 -> stays on V1
* 2.15.0 -> creates as V2

## Learning (optional, can help others)
SchedV1 did not have the 'schedVer' variable set unless a downgrade was performed. 

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
