### PR TITLE
Issue7748/paste image failure

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/utils/ContentResolverUtil.java
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/ContentResolverUtil.java
@@ -18,6 +18,7 @@ package com.ichi2.utils;
 
 import android.content.ContentResolver;
 import android.database.Cursor;
+import android.database.sqlite.SQLiteException;
 import android.net.Uri;
 import android.provider.MediaStore;
 import android.webkit.MimeTypeMap;
@@ -81,12 +82,15 @@ public class ContentResolverUtil {
     @CheckResult
     @Nullable
     private static String getFilenameViaDisplayName(ContentResolver contentResolver, Uri uri) {
-        String filename;
         // 7748: android.database.sqlite.SQLiteException: no such column: _display_name (code 1 SQLITE_ERROR[1]): ...
         try (Cursor c = contentResolver.query(uri, new String[] { MediaStore.MediaColumns.DISPLAY_NAME }, null, null, null)) {
-            c.moveToNext();
-            filename = c.getString(0);
+            if (c != null) {
+                c.moveToNext();
+                return c.getString(0);
+            }
+        } catch (SQLiteException e) {
+            Timber.w(e, "getFilenameViaDisplayName ContentResolver query failed.");
         }
-        return filename;
+        return null;
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/utils/ContentResolverUtil.java
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/ContentResolverUtil.java
@@ -26,6 +26,7 @@ import java.io.File;
 import java.util.Locale;
 
 import androidx.annotation.CheckResult;
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import timber.log.Timber;
 
@@ -53,9 +54,9 @@ public class ContentResolverUtil {
 
     @CheckResult
     @Nullable
-    private static String getFilenameViaMimeType(ContentResolver contentResolver, Uri uri) {
+    private static String getFilenameViaMimeType(ContentResolver contentResolver, @NonNull Uri uri) {
         // value: "png" when testing
-        String extension;
+        String extension = null;
 
         //Check uri format to avoid null
         if (uri.getScheme() != null && uri.getScheme().equals(ContentResolver.SCHEME_CONTENT)) {
@@ -65,7 +66,9 @@ public class ContentResolverUtil {
         } else {
             // If scheme is a File
             // This will replace white spaces with %20 and also other special characters. This will avoid returning null values on file name with spaces and special characters.
-            extension = MimeTypeMap.getFileExtensionFromUrl(Uri.fromFile(new File(uri.getPath())).toString().toLowerCase(Locale.ROOT));
+            if (uri.getPath() != null) {
+                extension = MimeTypeMap.getFileExtensionFromUrl(Uri.fromFile(new File(uri.getPath())).toString().toLowerCase(Locale.ROOT));
+            }
         }
         if (extension == null) {
             return null;


### PR DESCRIPTION
## Pull Request template

## Purpose / Description

Even if for some reason ContentResolver throws while fetching DISPLAY_NAME from MediaColumns, continue attempting to paste the image

## Fixes
Fixes #7748
Related #7754 - this stopped app from crashing +1

## Approach
Eat the underlying SQLiteException and return null, calling method tests for null (I checked all callers, there is only one caller...) and if it is null it will try a secondary method. Second level calling method eats Exception so no crash is possible still

## How Has This Been Tested?

Untested, just code inspection (only one caller to null check, all exceptions still eaten to prevent crash)

## Learning (optional, can help others)

There is no understanding of when or why pasting images can cause a query for DISPLAY_NAME on the pasted image to fail, but it is happening in Android 11, so this could be peeled out as a separate issue for low-priority investigation

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
