### PR TITLE
fix(DickPicker): invalidate options menu after deck delete

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -2701,6 +2701,10 @@ public class DeckPicker extends NavigationDrawerActivity implements
 
         @Override
         public void actualOnPostExecute(@NonNull DeckPicker deckPicker, @Nullable int[] v) {
+            // After deleting a deck there is no more undo stack
+            // Rebuild options menu with side effect of resetting undo button state
+            deckPicker.invalidateOptionsMenu();
+
             // In fragmented mode, if the deleted deck was the current deck, we need to reload
             // the study options fragment with a valid deck and re-center the deck list to the
             // new current deck. Otherwise we just update the list normally.


### PR DESCRIPTION
## Pull Request template

## Purpose / Description

Fix a crash when undo stack had items but then you delete a deck and try to undo after

## Fixes
Fixes #8935

## Approach

this causes a rebuild of the options menu with the side effect that undo
will be made invisible again - previously it was there even though deck delete
clears the undo queue, which led to crashes

## How Has This Been Tested?

I reproduced the crash on my actual device, inspected code, reproduced crash on API30 emulator, then fixed it and was no longer able to reproduce crash

## Learning (optional, can help others)

We probably need to inspect all uses of col.clearUndo() to see which CollectionTasks caused it to happen, and make sure that invalidateOptionsMenu() is called in the postExecute on whatever activity listeners were sent in with the task

But this one is fixed...

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
