### PR TITLE
perf: only load MathJax if MathJax exists

### DIFF
--- a/AnkiDroid/src/main/assets/card_template.html
+++ b/AnkiDroid/src/main/assets/card_template.html
@@ -9,8 +9,7 @@
         <style>
         ::style::
         </style>
-        <script src="file:///android_asset/mathjax/conf.js"> </script>
-        <script src="file:///android_asset/mathjax/tex-chtml.js"> </script>
+        ::script::
         <script src="file:///android_asset/jquery.min.js"> </script>
         <script src="file:///android_asset/scripts/card.js" type="text/javascript"> </script>
     </head>

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -2314,8 +2314,11 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
         // CSS class for card-specific styling
         String cardClass = mCardAppearance.getCardClass(mCurrentCard.getOrd() + 1, Themes.getCurrentTheme(this));
 
+        String scripts = "";
         if (MathJax.textContainsMathjax(content)) {
             cardClass += " mathjax-needs-to-render";
+            scripts += "        <script src=\"file:///android_asset/mathjax/conf.js\"> </script>\n" +
+                    "        <script src=\"file:///android_asset/mathjax/tex-chtml.js\"> </script>";
         }
 
         if (isInNightMode()) {
@@ -2324,7 +2327,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
             }
         }
 
-        mCardContent = mCardTemplate.render(content, style, cardClass);
+        mCardContent = mCardTemplate.render(content, style, scripts, cardClass);
         Timber.d("base url = %s", mBaseUrl);
 
         if (AnkiDroidApp.getSharedPrefs(this).getBoolean("html_javascript_debugging", false)) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/CardTemplate.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/CardTemplate.java
@@ -21,6 +21,7 @@ import androidx.annotation.NonNull;
 
 public class CardTemplate {
     private final String mPreStyle;
+    private final String mPreScript;
     private final String mPreClass;
     private final String mPreContent;
     private final String mPostContent;
@@ -30,15 +31,18 @@ public class CardTemplate {
         // Since this is a const loaded from an asset file, I'm fine with this.
         String classDelim = "::class::";
         String styleDelim = "::style::";
+        String scriptDelim = "::script::";
         String contentDelim = "::content::";
 
         int styleIndex = template.indexOf(styleDelim);
+        int scriptIndex = template.indexOf(scriptDelim);
         int classIndex = template.indexOf(classDelim);
         int contentIndex = template.indexOf(contentDelim);
 
         try {
             this.mPreStyle = template.substring(0, styleIndex);
-            this.mPreClass = template.substring(styleIndex + styleDelim.length(), classIndex);
+            this.mPreScript = template.substring(styleIndex + styleDelim.length(), scriptIndex);
+            this.mPreClass = template.substring(scriptIndex + scriptDelim.length(), classIndex);
             this.mPreContent = template.substring(classIndex + classDelim.length(), contentIndex);
             this.mPostContent = template.substring(contentIndex + contentDelim.length());
         } catch (StringIndexOutOfBoundsException ex) {
@@ -48,7 +52,7 @@ public class CardTemplate {
 
     @CheckResult
     @NonNull
-    public String render(String content, String style, String cardClass) {
-        return mPreStyle + style + mPreClass + cardClass + mPreContent + content + mPostContent;
+    public String render(String content, String style, String script, String cardClass) {
+        return mPreStyle + style + mPreScript + script + mPreClass + cardClass + mPreContent + content + mPostContent;
     }
 }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/cardviewer/CardTemplateTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/cardviewer/CardTemplateTest.java
@@ -34,6 +34,7 @@ public class CardTemplateTest {
             "        <style>\n" +
             "        ::style::\n" +
             "        </style>\n" +
+            "        ::script::\n" +
             "        <script src=\"file:///android_asset/mathjax/conf.js\"> </script>\n" +
             "        <script src=\"file:///android_asset/mathjax/MathJax.js\"> </script>\n" +
             "        <script src=\"file:///android_asset/scripts/card.js\" type=\"text/javascript\"> </script>\n" +
@@ -51,9 +52,10 @@ public class CardTemplateTest {
         String content = "foo";
         String style = "bar";
         String cardClass = "baz";
-        String result = new CardTemplate(data).render(content, style, cardClass);
+        String script = "script";
+        String result = new CardTemplate(data).render(content, style, script, cardClass);
 
-        assertThat(result, is(data.replace("::content::", content).replace("::style::", style).replace("::class::", cardClass)));
+        assertThat(result, is(data.replace("::content::", content).replace("::style::", style).replace("::class::", cardClass).replace("::script::", script)));
     }
 
     @Test
@@ -65,7 +67,7 @@ public class CardTemplateTest {
         String content = new String(new char[stringLength]).replace('\0', 'a');
 
 
-        String ret = new CardTemplate(data).render(content, content, content);
+        String ret = new CardTemplate(data).render(content, content, "", content);
     }
 
 }


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
User reported that 2.15 was significantly slower, this seems to be due to MathJax 3.

User's cards did not contain MathJax

## Fixes
Fixes #8927

Related: #6410 - didn't add perf metrics, which is bad, but since we have a user in the field, rather than a theoretical slowdown, this seems like the best option.

## Approach
We only load MathJax JS if we need it.

## How Has This Been Tested?
Manual debugging on my phone:
* Card with no MathJax works
* Card with MathJax works

Note: I couldn't repro the slowdown, so unsure if this is completely correct

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
