### PR TITLE
fix(model): generate req field for old client compatibility

### DIFF
--- a/AnkiDroid/src/test/java/com/ichi2/libanki/ModelTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/ModelTest.java
@@ -466,6 +466,48 @@ public class ModelTest extends RobolectricTest {
     }
 
     @Test
+    public void test_req() {
+
+        Collection col = getCol();
+        Models mm = col.getModels();
+        Model basic = mm.byName("Basic");
+        assertTrue(basic.has("req"));
+        reqSize(basic);
+        JSONArray r = basic.getJSONArray("req").getJSONArray(0);
+        assertEquals(0, r.getInt(0));
+        assertTrue(Arrays.asList(new String[] {REQ_ANY, REQ_ALL}).contains(r.getString(1)));
+        assertEquals(1, r.getJSONArray(2).length());
+        assertEquals(0, r.getJSONArray(2).getInt(0));
+
+        Model opt = mm.byName("Basic (optional reversed card)");
+        reqSize(opt);
+
+        r = opt.getJSONArray("req").getJSONArray(0);
+        assertTrue(Arrays.asList(new String[] {REQ_ANY, REQ_ALL}).contains(r.getString(1)));
+        assertEquals(1, r.getJSONArray(2).length());
+        assertEquals(0, r.getJSONArray(2).getInt(0));
+
+
+        assertEquals(new JSONArray("[1,\"all\",[1,2]]"), opt.getJSONArray("req").getJSONArray(1));
+
+        // testing any
+        opt.getJSONArray("tmpls").getJSONObject(1).put("qfmt", "{{Back}}{{Add Reverse}}");
+        mm.save(opt, true);
+        assertEquals(new JSONArray("[1, \"any\", [1, 2]]"), opt.getJSONArray("req").getJSONArray(1));
+        // testing null
+        opt.getJSONArray("tmpls").getJSONObject(1).put("qfmt", "{{^Add Reverse}}{{/Add Reverse}}");
+        mm.save(opt, true);
+        assertEquals(new JSONArray("[1, \"none\", []]"), opt.getJSONArray("req").getJSONArray(1));
+
+        opt = mm.byName("Basic (type in the answer)");
+        reqSize(opt);
+        r = opt.getJSONArray("req").getJSONArray(0);
+        assertTrue(Arrays.asList(new String[] {REQ_ANY, REQ_ALL}).contains(r.getString(1)));
+        // TODO: Port anki@4e33775ed4346ef136ece6ef5efec5ba46057c6b
+        assertEquals(new JSONArray("[0]"), r.getJSONArray(2));
+    }
+
+    @Test
     @Config(qualifiers = "en")
     public void regression_test_pipe() {
         Collection col = getCol();


### PR DESCRIPTION
## Pull Request template

## Purpose / Description

req is unused in current clients but that is new enough we'll keep it for
compatibility for now

## Fixes
Fixes #8945

## Approach
restore some old code from release-2.14 branch - this is copy and paste from release-2.14, just adding comment clarifying the reason the code is back, and pointers to discussion

## How Has This Been Tested?

Visual inspection of JSON generated during model creation on release-2.14, release-2.15 without, and release-2.15 with this code

## Learning (optional, can help others)
There are no changes without unintended consequences

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
