### PR TITLE
fix ContentProvider/API related crashes

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -260,7 +260,7 @@ dependencies {
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.12.3'
 
     // == Rust conversion (from Anki-Android-Backend on GitHub) ==
-    String backendVersion = "0.1.5" // We want both testing and implementation on the same version
+    String backendVersion = "0.1.6" // We want both testing and implementation on the same version
     // build with ./gradlew rsdroid:assembleRelease
     // In my experience, using `files()` currently requires a reindex operation, which is slow.
     // implementation files("C:\\GitHub\\Rust-Test\\rsdroid\\build\\outputs\\aar\\rsdroid-release.aar")


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
Adding a card in Akebi crashed

## Fixes
Fixes #8931
Fixes #8928 (hopefully)

## Approach

some of the methods on the Cursor for the database
were called internally by Android

These were throwing NotImplementedException

Fixed by upgrading the backend


Changed in the backend code to log a warning: they shouldn't be required as we don't support `.requery()`

## How Has This Been Tested?

Android 11 phone - now can add cards with Akebi

## Learning (optional, can help others)

TODO: Add follow on issue

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
