### PR TITLE
fix(amazon): assemble amazon release w/universal APK, publish correct path

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -208,7 +208,7 @@ play {
 amazon {
     securityProfile = file("${homePath}/src/AnkiDroid-Amazon-Publish-Security-Profile.json")
     applicationId = "amzn1.devportal.mobileapp.524a424d314931494c55383833305539"
-    pathToApks = [ file("./build/outputs/apk/release/AnkiDroid-universal-release.apk") ]
+    pathToApks = [ file("./build/outputs/apk/amazon/release/AnkiDroid-amazon-universal-release.apk") ]
     replaceEdit = true
 }
 

--- a/tools/release.sh
+++ b/tools/release.sh
@@ -152,6 +152,7 @@ for ABI in $ABIS; do
 done
 
 if [ "$PUBLIC" = "public" ]; then
+  ./gradlew assembleAmazonRelease  -Duniversal-apk=true
   ./gradlew publishToAmazonAppStore
   echo "Remember to add release notes and submit on Amazon: https://developer.amazon.com/apps-and-games/console/app/list"
 fi


### PR DESCRIPTION

## Pull Request template

## Purpose / Description

Amazon publish was close, but this was the first time I actually attempted to publish there.
Turns out there were a couple path issues

## Fixes
Related #8151

## Approach

- Remember to assembleAmazonRelease before publishing, with special "generate universal APK" argument
- Publish to Amazon from the new APK build path

## How Has This Been Tested?

Ran the publish locally and got it to work, it's in review now

## Learning (optional, can help others)

Teamwork makes the dream work - thanks @mrudultora we're back on the Amazon app store! It appears about 300 people a month download AnkiDroid from there, so this has to be useful to a growing number of people...

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
