### PR TITLE
Set deck to default if selected id doesn't exist

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
@@ -1076,7 +1076,7 @@ public class Decks {
 
 
     public Deck current() {
-        if (get(selected()) == null) {
+        if (get(selected()) == null || !mDecks.containsKey(selected())) {
             select(Consts.DEFAULT_DECK_ID); // Select default deck if the selected deck is null
         }
         return get(selected());


### PR DESCRIPTION
## Purpose / Description
If current deck id didn't exist in DB, wouldn't select Default deck

## Fixes
Fixes #8930

## Approach
Added a check for existence of selected deck id to the `if` statement in https://github.com/ankidroid/Anki-Android/commit/ef5f7badc5c8b7381f66a1ff4dd5e41f6fa539d6#diff-e576625ef3cb53556ff135a9fc296d94cbb848c62f59d4f065d1595d948310bcR1079-R1081

## How Has This Been Tested?
> You won't be able to test this with the interface - it resets current deck if you delete current deck.
> I think you need to close the app, then directly edit (read as: mess up) the database by setting the current deck pointer to something that does not exist. Then open the app and try a feature that uses current deck to make sure it handles the bad current deck pointer

Did as @mikehardy said above and manually changed curDeck in sqlite database to an invalid number ad verified that current selected deck gets set to default deck's ID

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
