### PR TITLE
Issue8944/template tokens space allowed

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/template/Tokenizer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/template/Tokenizer.java
@@ -200,11 +200,11 @@ public class Tokenizer implements Iterator<Tokenizer.Token> {
         }
         switch (start.charAt(0)) {
             case '#':
-                return new Token(OPEN_CONDITIONAL, start.substring(1));
+                return new Token(OPEN_CONDITIONAL, start.substring(1).trim());
             case '/':
-                return new Token(CLOSE_CONDITIONAL, start.substring(1));
+                return new Token(CLOSE_CONDITIONAL, start.substring(1).trim());
             case '^':
-                return new Token(OPEN_NEGATED, start.substring(1));
+                return new Token(OPEN_NEGATED, start.substring(1).trim());
             default:
                 return new Token(REPLACEMENT, start);
         }

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/template/TokenizerTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/template/TokenizerTest.java
@@ -144,6 +144,37 @@ public class TokenizerTest extends RobolectricTest {
     }
 
     @Test
+    public void test_space_in_token() {
+        assertThat(next_token("{{ # foo bar }} baz"),
+                Matchers.is(new IResult(
+                        new Tokenizer.Token(OPEN_CONDITIONAL,
+                                "foo bar"),
+                        " baz")));
+        assertThat(handlebar_token("{{ / foo bar }} baz"),
+                Matchers.is(new Tokenizer.IResult(
+                        new Tokenizer.Token(CLOSE_CONDITIONAL,
+                                "foo bar"),
+                        " baz")));
+        assertThat(handlebar_token("{{ ^ foo bar }} baz"),
+                Matchers.is(new Tokenizer.IResult(
+                        new Tokenizer.Token(OPEN_NEGATED,
+                                "foo bar"),
+                        " baz")));
+        // REPLACEMENT types will have leading and trailing spaces trimmed, but otherwise no changes
+        assertThat(handlebar_token("{{ ! foo}} bar"),
+                Matchers.is(new Tokenizer.IResult(
+                        new Tokenizer.Token(REPLACEMENT,
+                                "! foo"),
+                        " bar")));
+        // REPLACEMENT types will have leading and trailing spaces trimmed, but otherwise no changes
+        assertThat(handlebar_token("{{ ! foo with spaces before during and after }} bar"),
+                Matchers.is(new Tokenizer.IResult(
+                        new Tokenizer.Token(REPLACEMENT,
+                                "! foo with spaces before during and after"),
+                        " bar")));
+    }
+
+    @Test
     public void test_next_token() {
         assertThat(next_token("{{#foo}} bar"),
                 Matchers.is(new IResult(


### PR DESCRIPTION
## Pull Request template

## Purpose / Description

Template tokens can apparently have space between the token type and the token name.

There is a widely used deck that uses this apparently, and AnkiDesktop allows the spacing per Damien

## Fixes
Fixes #8944

## Approach

Add a fresh test to the wonderful existing test suite from @Arthur-Milchior (thank you, thank you) that proves it fails in the conditions laid out from the original issue reporter

Test fails

Add a replaceFirst call before returning the token, where the regex matches any space chars and removes them

Test passes

## How Has This Been Tested?

Unit testing

## Learning (optional, can help others)

Template parsing is hard because there are so many edge cases

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)

Does it count if I automated the changing of whitespace on purpose :thinking: 

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
