### PR TITLE
[Upstream feature] Separate learn and young on the stats screen

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/stats/ChartBuilder.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/stats/ChartBuilder.java
@@ -174,7 +174,9 @@ public class ChartBuilder {
                               new ColorWrap(Themes.getColorFromAttr(mChartView.getContext(), mColors[1])),
                               new ColorWrap(Themes.getColorFromAttr(mChartView.getContext(), mColors[2])),
                               new ColorWrap(Themes.getColorFromAttr(mChartView.getContext(), mColors[3])),
-                              new ColorWrap(Themes.getColorFromAttr(mChartView.getContext(), mColors[4]))};
+                              new ColorWrap(Themes.getColorFromAttr(mChartView.getContext(), mColors[4])),
+                              new ColorWrap(Themes.getColorFromAttr(mChartView.getContext(), mColors[5]))
+                            };
 
         PieChart pieChart = new PieChart(plotSheet, mSeriesList[0], colors);
         pieChart.setName(mChartView.getResources().getString(mValueLabels[0]) + ": " + (int) mSeriesList[0][0]);
@@ -182,15 +184,18 @@ public class ChartBuilder {
         LegendDrawable legendDrawable2 = new LegendDrawable();
         LegendDrawable legendDrawable3 = new LegendDrawable();
         LegendDrawable legendDrawable4 = new LegendDrawable();
+        LegendDrawable legendDrawable5 = new LegendDrawable();
         legendDrawable1.setColor(new ColorWrap(Themes.getColorFromAttr(mChartView.getContext(), mColors[1])));
         legendDrawable2.setColor(new ColorWrap(Themes.getColorFromAttr(mChartView.getContext(), mColors[2])));
         legendDrawable3.setColor(new ColorWrap(Themes.getColorFromAttr(mChartView.getContext(), mColors[3])));
         legendDrawable4.setColor(new ColorWrap(Themes.getColorFromAttr(mChartView.getContext(), mColors[4])));
+        legendDrawable4.setColor(new ColorWrap(Themes.getColorFromAttr(mChartView.getContext(), mColors[5])));
 
         legendDrawable1.setName(mChartView.getResources().getString(mValueLabels[1]) + ": " + (int) mSeriesList[0][1]);
         legendDrawable2.setName(mChartView.getResources().getString(mValueLabels[2]) + ": " + (int) mSeriesList[0][2]);
         legendDrawable3.setName(mChartView.getResources().getString(mValueLabels[3]) + ": " + (int) mSeriesList[0][3]);
         legendDrawable4.setName(mChartView.getResources().getString(mValueLabels[4]) + ": " + (int) mSeriesList[0][4]);
+        legendDrawable4.setName(mChartView.getResources().getString(mValueLabels[5]) + ": " + (int) mSeriesList[0][5]);
 
         plotSheet.unsetBorder();
         plotSheet.addDrawable(pieChart);
@@ -198,6 +203,7 @@ public class ChartBuilder {
         plotSheet.addDrawable(legendDrawable2);
         plotSheet.addDrawable(legendDrawable3);
         plotSheet.addDrawable(legendDrawable4);
+        plotSheet.addDrawable(legendDrawable5);
 
         return plotSheet;
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/stats/ChartBuilder.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/stats/ChartBuilder.java
@@ -175,7 +175,8 @@ public class ChartBuilder {
                               new ColorWrap(Themes.getColorFromAttr(mChartView.getContext(), mColors[2])),
                               new ColorWrap(Themes.getColorFromAttr(mChartView.getContext(), mColors[3])),
                               new ColorWrap(Themes.getColorFromAttr(mChartView.getContext(), mColors[4])),
-                              new ColorWrap(Themes.getColorFromAttr(mChartView.getContext(), mColors[5]))
+                              new ColorWrap(Themes.getColorFromAttr(mChartView.getContext(), mColors[5])),
+                              new ColorWrap(Themes.getColorFromAttr(mChartView.getContext(), mColors[6]))
                             };
 
         PieChart pieChart = new PieChart(plotSheet, mSeriesList[0], colors);
@@ -185,17 +186,20 @@ public class ChartBuilder {
         LegendDrawable legendDrawable3 = new LegendDrawable();
         LegendDrawable legendDrawable4 = new LegendDrawable();
         LegendDrawable legendDrawable5 = new LegendDrawable();
+        LegendDrawable legendDrawable6 = new LegendDrawable();
         legendDrawable1.setColor(new ColorWrap(Themes.getColorFromAttr(mChartView.getContext(), mColors[1])));
         legendDrawable2.setColor(new ColorWrap(Themes.getColorFromAttr(mChartView.getContext(), mColors[2])));
         legendDrawable3.setColor(new ColorWrap(Themes.getColorFromAttr(mChartView.getContext(), mColors[3])));
         legendDrawable4.setColor(new ColorWrap(Themes.getColorFromAttr(mChartView.getContext(), mColors[4])));
         legendDrawable4.setColor(new ColorWrap(Themes.getColorFromAttr(mChartView.getContext(), mColors[5])));
+        legendDrawable4.setColor(new ColorWrap(Themes.getColorFromAttr(mChartView.getContext(), mColors[6])));
 
         legendDrawable1.setName(mChartView.getResources().getString(mValueLabels[1]) + ": " + (int) mSeriesList[0][1]);
         legendDrawable2.setName(mChartView.getResources().getString(mValueLabels[2]) + ": " + (int) mSeriesList[0][2]);
         legendDrawable3.setName(mChartView.getResources().getString(mValueLabels[3]) + ": " + (int) mSeriesList[0][3]);
         legendDrawable4.setName(mChartView.getResources().getString(mValueLabels[4]) + ": " + (int) mSeriesList[0][4]);
         legendDrawable4.setName(mChartView.getResources().getString(mValueLabels[5]) + ": " + (int) mSeriesList[0][5]);
+        legendDrawable4.setName(mChartView.getResources().getString(mValueLabels[6]) + ": " + (int) mSeriesList[0][6]);
 
         plotSheet.unsetBorder();
         plotSheet.addDrawable(pieChart);
@@ -204,6 +208,7 @@ public class ChartBuilder {
         plotSheet.addDrawable(legendDrawable3);
         plotSheet.addDrawable(legendDrawable4);
         plotSheet.addDrawable(legendDrawable5);
+        plotSheet.addDrawable(legendDrawable6);
 
         return plotSheet;
     }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/stats/Stats.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/stats/Stats.java
@@ -1197,14 +1197,15 @@ public class Stats {
         mTitle = R.string.title_activity_template_editor;
         mBackwards = false;
         mAxisTitles = new int[] { R.string.stats_answer_type, R.string.stats_answers, R.string.stats_cumulative_correct_percentage };
-        mValueLabels = new int[] {R.string.statistics_mature, R.string.statistics_young,R.string.statistics_learn_and_relearn, R.string.statistics_unlearned, R.string.statistics_suspended, R.string.statistics_buried,};
-        mColors = new int[] { R.attr.stats_mature, R.attr.stats_young, R.attr.stats_learn, R.attr.stats_unseen, R.attr.stats_suspended, R.attr.stats_buried };
+        mValueLabels = new int[] {R.string.statistics_mature, R.string.statistics_young, R.string.statistics_learn, R.string.statistics_relearn, R.string.statistics_unlearned, R.string.statistics_suspended, R.string.statistics_buried,};
+        mColors = new int[] { R.attr.stats_mature, R.attr.stats_young, R.attr.stats_learn, R.attr.stats_relearn, R.attr.stats_unseen, R.attr.stats_suspended, R.attr.stats_buried };
         mType = type;
         double[] pieData;
         String query = "select " +
                 "sum(case when queue=" + Consts.QUEUE_TYPE_REV + " and ivl >= 21 then 1 else 0 end), -- mtr\n" +
                 "sum(case when queue=" + Consts.QUEUE_TYPE_REV + " and ivl < 21 then 1 else 0 end), -- yng\n" +
-                "sum(case when queue in (" + Consts.QUEUE_TYPE_LRN + "," + Consts.QUEUE_TYPE_DAY_LEARN_RELEARN  + ") then 1 else 0 end), -- lrn/relrn\n" +
+                "sum(case when queue=" + Consts.QUEUE_TYPE_DAY_LEARN_RELEARN + " then 1 else 0 end), -- lrn\n" +
+                "sum(case when queue=" + Consts.QUEUE_TYPE_LRN  + " then 1 else 0 end), -- relrn\n" +
                 "sum(case when queue=" + Consts.QUEUE_TYPE_NEW + " then 1 else 0 end), -- new\n" +
                 "sum(case when queue=" + Consts.QUEUE_TYPE_SUSPENDED + " then 1 else 0 end), -- susp\n" +
                 "sum(case when queue in (" + Consts.QUEUE_TYPE_MANUALLY_BURIED + "," + Consts.QUEUE_TYPE_SIBLING_BURIED + ") then 1 else 0 end) -- buried\n" +
@@ -1215,7 +1216,7 @@ public class Stats {
                     .query(query)) {
 
             cur.moveToFirst();
-            pieData = new double[]{ cur.getDouble(0), cur.getDouble(1), cur.getDouble(2), cur.getDouble(3), cur.getDouble(4), cur.getDouble(5)};
+            pieData = new double[]{ cur.getDouble(0), cur.getDouble(1), cur.getDouble(2), cur.getDouble(3), cur.getDouble(4), cur.getDouble(5), cur.getDouble(6)};
         }
 
         //TODO adjust for CardsTypes, for now only copied from intervals
@@ -1232,7 +1233,7 @@ public class Stats {
 //            list.add(new double[] { Math.max(12, list.get(list.size() - 1)[0] + 1), 0, 0 });
 //        }
 
-        mSeriesList = new double[1][6];
+        mSeriesList = new double[1][7];
         mSeriesList[0] = pieData;
         mFirstElement = 0.5;
         mLastElement = 9.5;

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/stats/Stats.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/stats/Stats.java
@@ -1197,13 +1197,14 @@ public class Stats {
         mTitle = R.string.title_activity_template_editor;
         mBackwards = false;
         mAxisTitles = new int[] { R.string.stats_answer_type, R.string.stats_answers, R.string.stats_cumulative_correct_percentage };
-        mValueLabels = new int[] {R.string.statistics_mature, R.string.statistics_young_and_learn, R.string.statistics_unlearned, R.string.statistics_suspended, R.string.statistics_buried};
-        mColors = new int[] { R.attr.stats_mature, R.attr.stats_young, R.attr.stats_unseen, R.attr.stats_suspended, R.attr.stats_buried };
+        mValueLabels = new int[] {R.string.statistics_mature, R.string.statistics_young,R.string.statistics_learn_and_relearn, R.string.statistics_unlearned, R.string.statistics_suspended, R.string.statistics_buried,};
+        mColors = new int[] { R.attr.stats_mature, R.attr.stats_young, R.attr.stats_learn, R.attr.stats_unseen, R.attr.stats_suspended, R.attr.stats_buried };
         mType = type;
         double[] pieData;
         String query = "select " +
                 "sum(case when queue=" + Consts.QUEUE_TYPE_REV + " and ivl >= 21 then 1 else 0 end), -- mtr\n" +
-                "sum(case when queue in (" + Consts.QUEUE_TYPE_LRN + "," + Consts.QUEUE_TYPE_DAY_LEARN_RELEARN + ") or (queue=" + Consts.QUEUE_TYPE_REV + " and ivl < 21) then 1 else 0 end), -- yng/lrn\n" +
+                "sum(case when queue=" + Consts.QUEUE_TYPE_REV + " and ivl < 21 then 1 else 0 end), -- yng\n" +
+                "sum(case when queue in (" + Consts.QUEUE_TYPE_LRN + "," + Consts.QUEUE_TYPE_DAY_LEARN_RELEARN  + ") then 1 else 0 end), -- lrn/relrn\n" +
                 "sum(case when queue=" + Consts.QUEUE_TYPE_NEW + " then 1 else 0 end), -- new\n" +
                 "sum(case when queue=" + Consts.QUEUE_TYPE_SUSPENDED + " then 1 else 0 end), -- susp\n" +
                 "sum(case when queue in (" + Consts.QUEUE_TYPE_MANUALLY_BURIED + "," + Consts.QUEUE_TYPE_SIBLING_BURIED + ") then 1 else 0 end) -- buried\n" +
@@ -1214,7 +1215,7 @@ public class Stats {
                     .query(query)) {
 
             cur.moveToFirst();
-            pieData = new double[]{ cur.getDouble(0), cur.getDouble(1), cur.getDouble(2), cur.getDouble(3), cur.getDouble(4) };
+            pieData = new double[]{ cur.getDouble(0), cur.getDouble(1), cur.getDouble(2), cur.getDouble(3), cur.getDouble(4), cur.getDouble(5)};
         }
 
         //TODO adjust for CardsTypes, for now only copied from intervals
@@ -1231,7 +1232,7 @@ public class Stats {
 //            list.add(new double[] { Math.max(12, list.get(list.size() - 1)[0] + 1), 0, 0 });
 //        }
 
-        mSeriesList = new double[1][5];
+        mSeriesList = new double[1][6];
         mSeriesList[0] = pieData;
         mFirstElement = 0.5;
         mLastElement = 9.5;

--- a/AnkiDroid/src/main/res/values/06-statistics.xml
+++ b/AnkiDroid/src/main/res/values/06-statistics.xml
@@ -26,6 +26,7 @@
     <string name="statistics_buried">Buried</string>
     <string name="statistics_relearn" comment="Labbel of the axis in the graph indicating the number of reviews of cards while they are in relearning mode.">Relearn</string>
     <string name="statistics_learn" comment="Label of the number of review of card in learning done in some amount of time">Learn</string>
+    <string name="statistics_learn_and_relearn">Learn+Relearn</string>
     <string name="statistics_cram">Cram</string>
     <string name="stats_cards">Cards</string>
     <string name="stats_cards_intervals">Cards with given interval</string>

--- a/AnkiDroid/src/main/res/values/06-statistics.xml
+++ b/AnkiDroid/src/main/res/values/06-statistics.xml
@@ -26,7 +26,6 @@
     <string name="statistics_buried">Buried</string>
     <string name="statistics_relearn" comment="Labbel of the axis in the graph indicating the number of reviews of cards while they are in relearning mode.">Relearn</string>
     <string name="statistics_learn" comment="Label of the number of review of card in learning done in some amount of time">Learn</string>
-    <string name="statistics_learn_and_relearn">Learn+Relearn</string>
     <string name="statistics_cram">Cram</string>
     <string name="stats_cards">Cards</string>
     <string name="stats_cards_intervals">Cards with given interval</string>


### PR DESCRIPTION
Changed to display young and learn separately
 in the pie chart of the statistics screen.

The latest version of the anki desktop stats circle graph separates young, learning, and relearning, so AnkiDroid splits it as well.way.

## Pull Request template

## Purpose / Description
Changed to display young and learn separately in the pie chart of the statistics screen.

## Approach
Divided young+learn in the pie chart of the statistics screen into "young", "learn" and "relearn"
![Screenshot_20210527-044532454_1](https://user-images.githubusercontent.com/43168745/119730740-06f2db00-beb1-11eb-8ac8-7d8d9af22451.jpg)
![Screenshot_20210527-070222661 (1)](https://user-images.githubusercontent.com/43168745/119738249-60600780-bebb-11eb-9116-14da672f0135.jpg)


## How Has This Been Tested?
I actually opened the statistics screen and confirmed that the total value of the numerical values was correct.

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [x] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
