### PR TITLE
fix: "{{FrontSide}}" should be blank on front 

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
@@ -54,6 +54,8 @@ import com.ichi2.utils.JSONArray;
 import com.ichi2.utils.JSONException;
 import com.ichi2.utils.JSONObject;
 
+import net.ankiweb.rsdroid.RustCleanup;
+
 import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileWriter;
@@ -1081,6 +1083,7 @@ public class Collection implements CollectionGetter {
     }
 
 
+    @RustCleanup("#8951 - Remove FrontSide added to the front")
     public HashMap<String, String> _renderQA(long cid, Model model, long did, int ord, String tags, String[] flist, int flags, boolean browser, String qfmt, String afmt) {
         // data is [cid, nid, mid, did, ord, tags, flds, cardFlags]
         // unpack fields and create dict
@@ -1116,6 +1119,7 @@ public class Collection implements CollectionGetter {
             if ("q".equals(type)) {
                 format = fClozePatternQ.matcher(format).replaceAll(String.format(Locale.US, "{{$1cq-%d:", cardNum));
                 format = fClozeTagStart.matcher(format).replaceAll(String.format(Locale.US, "<%%cq:%d:", cardNum));
+                fields.put("FrontSide", "");
             } else {
                 format = fClozePatternA.matcher(format).replaceAll(String.format(Locale.US, "{{$1ca-%d:", cardNum));
                 format = fClozeTagStart.matcher(format).replaceAll(String.format(Locale.US, "<%%ca:%d:", cardNum));

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
@@ -47,7 +47,6 @@ import com.ichi2.libanki.template.ParsedNode;
 import com.ichi2.libanki.template.TemplateError;
 import com.ichi2.libanki.utils.Time;
 import com.ichi2.upgrade.Upgrade;
-import com.ichi2.utils.DatabaseChangeDecorator;
 import com.ichi2.utils.FunctionalInterfaces;
 import com.ichi2.utils.VersionUtils;
 
@@ -60,7 +59,6 @@ import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.io.PrintWriter;
-import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Calendar;

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/ModelTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/ModelTest.java
@@ -26,6 +26,7 @@ import static com.ichi2.libanki.Utils.stripHTML;
 import static com.ichi2.utils.ListUtil.assertListEquals;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.endsWith;
 import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
@@ -35,6 +36,23 @@ import static org.junit.Assert.fail;
 
 @RunWith(AndroidJUnit4.class)
 public class ModelTest extends RobolectricTest {
+
+    @Test
+    public void test_frontSide_field() {
+        // #8951 - Anki Special-cases {{FrontSide}} on the front to return empty string
+        Collection col = getCol();
+        Model m = col.getModels().current();
+        m.getJSONArray("tmpls").getJSONObject(0).put("qfmt", "{{Front}}{{FrontSide}}");
+        col.getModels().save(m);
+        Note note = col.newNote();
+        note.setItem("Front", "helloworld");
+        col.addNote(note);
+        Card card = note.firstCard();
+        String q = card.q();
+        assertThat("field should be at the end of the template - empty string for front", q, endsWith("helloworld"));
+        assertThat("field should not have a problem", q, not(containsString("has a problem")));
+    }
+
     /*****************
      ** Models       *
      *****************/

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/ModelTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/ModelTest.java
@@ -1,12 +1,10 @@
 package com.ichi2.libanki;
 
-import com.ichi2.anki.R;
 import com.ichi2.anki.RobolectricTest;
 import com.ichi2.anki.exception.ConfirmModSchemaException;
 import com.ichi2.utils.JSONArray;
 import com.ichi2.utils.JSONObject;
 
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.annotation.Config;
@@ -27,12 +25,10 @@ import static com.ichi2.libanki.Models.REQ_ANY;
 import static com.ichi2.libanki.Utils.stripHTML;
 import static com.ichi2.utils.ListUtil.assertListEquals;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/ModelTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/ModelTest.java
@@ -53,6 +53,28 @@ public class ModelTest extends RobolectricTest {
         assertThat("field should not have a problem", q, not(containsString("has a problem")));
     }
 
+    @Test
+    public void test_field_named_frontSide() {
+        // #8951 - A field named "FrontSide" is ignored - this matches Anki 2.1.34 (8af8f565)
+        Collection col = getCol();
+        Model m = col.getModels().current();
+
+        // Add a field called FrontSide and FrontSide2 (to ensure that fields are added correctly)
+        col.getModels().addFieldModChanged(m, col.getModels().newField("FrontSide"));
+        col.getModels().addFieldModChanged(m, col.getModels().newField("FrontSide2"));
+        m.getJSONArray("tmpls").getJSONObject(0).put("qfmt", "{{Front}}{{FrontSide}}{{FrontSide2}}");
+        col.getModels().save(m);
+
+        Note note = col.newNote();
+        note.setItem("Front", "helloworld");
+        note.setItem("FrontSide", "1");
+        note.setItem("FrontSide2", "2");
+        col.addNote(note);
+        Card card = note.firstCard();
+        String q = card.q();
+        assertThat("FrontSide should be an empty string, even though it was set", q, endsWith("helloworld2"));
+    }
+
     /*****************
      ** Models       *
      *****************/


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
People use this - Anki has it special cased unintentionally due to hooks, but this is in use in AnkiDroid

It wasn't working before this, but the template `{{Front}}{{FrontSide}}` previously rendered as `helloworld{Unknown field FrontSide}` in 2.14.6



## Fixes
Fixes #8951

## Approach
Define the field on the front

## How Has This Been Tested?

Unit tested and tested on my phone
## Learning (optional, can help others)

Anki: https://github.com/ankitects/anki/blob/400254277bdc7b8aab0ac7eefd8f183cf9482e64/rslib/src/template.rs#L409-L417

Our change: 08217da (issue #7980)

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
