### PR TITLE
fix[stats] start at "Overview" tab in RTL mode

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/Statistics.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Statistics.java
@@ -36,6 +36,7 @@ import android.view.MenuInflater;
 import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
+import android.view.ViewTreeObserver;
 import android.webkit.WebView;
 import android.widget.ProgressBar;
 
@@ -104,6 +105,19 @@ public class Statistics extends NavigationDrawerActivity implements
         mViewPager.setAdapter(new Statistics.StatsPagerAdapter((this)));
         mViewPager.setOffscreenPageLimit(8);
         mSlidingTabLayout = findViewById(R.id.sliding_tabs);
+
+        // Fixes #8984: scroll to position 0 in RTL layouts
+        ViewTreeObserver tabObserver = mSlidingTabLayout.getViewTreeObserver();
+        tabObserver.addOnGlobalLayoutListener(new ViewTreeObserver.OnGlobalLayoutListener() {
+            // Note: we can't use a lambda as we use 'this' to refer to the class.
+            @Override
+            public void onGlobalLayout() {
+                // we need this here: If we select tab 0 before in an RTL context the layout has been drawn,
+                // then it doesn't perform a scroll animation and selects the wrong element
+                mSlidingTabLayout.getViewTreeObserver().removeOnGlobalLayoutListener(this);
+                mSlidingTabLayout.selectTab(mSlidingTabLayout.getTabAt(0));
+            }
+        });
 
         // Setup Task Handler
         mTaskHandler = AnkiStatsTaskHandler.getInstance(col);


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
This is disappointing: there is a bug in `TabLayout` which means that selecting index[0] before the control has been laid out will position the control at `LEFT`, rather than START (effective result, not actual code)

## Fixes
Fixes #8984

## Approach
Fix this by detecting the layout event for the control, and then selecting the tab: this uses a scroll animation, which works

## How Has This Been Tested?

Test on my Android 11 Google Pixel 3a, using the dev 'force RTL' option, and without: in both cases 'overview' is selected

## Learning (optional, can help others)
Every day, Android disappoints me a little more

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
