### PR TITLE
build: remove remnant dirs from r8 failure, restructure api publish repos

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,14 +8,6 @@ buildscript {
         maven {
             url "https://plugins.gradle.org/m2/"
         }
-        // Temporary, needed while investigating https://github.com/ankidroid/Anki-Android/issues/7558
-        maven {
-            url 'https://storage.googleapis.com/r8-releases/raw'
-        }
-        maven {
-            url "https://storage.googleapis.com/r8-releases/raw/master"
-        }
-        // End temporary #7558 work
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:4.2.1'


### PR DESCRIPTION


## Pull Request template

## Purpose / Description
F-Droid is struggling to build 2.15.x: https://gitlab.com/fdroid/fdroiddata/-/blob/master/metadata/com.ichi2.anki.yml#L715

I was unable to find the build log but @linsui notified us (thanks!)

## Fixes
Fixes #8982 maybe


## Approach

There were two remnant maven repos from an R8 build workarind in #7558 - I forgot to remove the entire 7758 when upstream resolved their issue

There is one legitimate maven repo definition for api publishing which I restructured to see if it will pass F-Droid scan, but if it does not, then F-Droid will have to do something to allow it, it's a legitimate repo definition based on local files to publish our API module. Perhaps they could ignore the api module and/or build via `./gradlew :AnkiDroid:assemblePlayRelease`

## How Has This Been Tested?

CI will test it sufficiently

## Learning (optional, can help others)

Not sure what I learned here, on reflection. Release engineering requires constant effort.

## Checklist
_Please, go through these checks before submitting the PR._

- [ ] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [ ] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [ ] You have commented your code, particularly in hard-to-understand areas
- [ ] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
