### PR TITLE
Fix for empty search results and wrong card count

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -853,7 +853,9 @@ public class CardBrowser extends NavigationDrawerActivity implements
     @VisibleForTesting
     void selectAllDecks() {
         mDeckSpinnerSelection.selectDropDownItem(0);
-        saveLastDeckId(Stats.ALL_DECKS_ID);
+        mRestrictOnDeck = "";
+        saveLastDeckId(ALL_DECKS_ID);
+        searchCards();
     }
 
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.java
@@ -572,6 +572,26 @@ public class CardBrowserTest extends RobolectricTest {
         assertThat(browser.checkedCardCount(), is(18));
     }
 
+    @Test
+    public void checkIfSearchAllDecksWorks() {
+        addNoteUsingBasicModel("Hello", "World");
+        long deck = addDeck("Deck 1");
+        getCol().getDecks().select(deck);
+        Card c2 = addNoteUsingBasicModel("Front", "Back").firstCard();
+        c2.setDid(deck);
+        c2.flush();
+
+        CardBrowser cardBrowser = getBrowserWithNoNewCards();
+        cardBrowser.searchCards("Hello");
+        advanceRobolectricLooperWithSleep();
+        assertThat("Cardbrowser has Deck 1 as selected deck", cardBrowser.getSelectedDeckNameForUi(), is("Deck 1"));
+        assertThat("Result should be empty", cardBrowser.getCardCount(), is(0));
+
+        cardBrowser.searchAllDecks();
+        advanceRobolectricLooperWithSleep();
+        assertThat("Result should contain one card", cardBrowser.getCardCount(), is(1));
+    }
+
     protected void assertUndoDoesNotContain(CardBrowser browser, @StringRes int resId) {
         ShadowActivity shadowActivity = shadowOf(browser);
         MenuItem item = shadowActivity.getOptionsMenu().findItem(R.id.action_undo);

--- a/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.java
@@ -575,7 +575,7 @@ public class CardBrowserTest extends RobolectricTest {
     @Test
     public void checkIfSearchAllDecksWorks() {
         addNoteUsingBasicModel("Hello", "World");
-        long deck = addDeck("Deck 1");
+        long deck = addDeck("Test Deck");
         getCol().getDecks().select(deck);
         Card c2 = addNoteUsingBasicModel("Front", "Back").firstCard();
         c2.setDid(deck);
@@ -584,7 +584,7 @@ public class CardBrowserTest extends RobolectricTest {
         CardBrowser cardBrowser = getBrowserWithNoNewCards();
         cardBrowser.searchCards("Hello");
         advanceRobolectricLooperWithSleep();
-        assertThat("Cardbrowser has Deck 1 as selected deck", cardBrowser.getSelectedDeckNameForUi(), is("Deck 1"));
+        assertThat("Card browser should have Test Deck as the selected deck", cardBrowser.getSelectedDeckNameForUi(), is("Test Deck"));
         assertThat("Result should be empty", cardBrowser.getCardCount(), is(0));
 
         cardBrowser.searchAllDecks();


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
Fix for empty search results and wrong card count.

## Fixes
Fixes #8975 

## Approach
Setting `mRestrictOnDeck` to an empty String and calling `searchCards()` method inside `selectAllDecks()`.
 
## How Has This Been Tested?

Verified that the bug has been fixed.

## Checklist

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [ ] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
