### PR TITLE
Use MathJax version 2 based functionality of colour

### DIFF
--- a/AnkiDroid/src/main/assets/mathjax/conf.js
+++ b/AnkiDroid/src/main/assets/mathjax/conf.js
@@ -6,6 +6,11 @@ window.MathJax = {
     packages: {
       "[+]": ["noerrors", "mhchem"],
     },
+    // Use \color from version 2 of MathJax
+    autoload: {
+      color: [],            // Don't autoload the color extension
+      colorv2: ['color']    // Autoload colorv2 on the first use of \color
+    }
   },
   startup: {
     typeset: false,


### PR DESCRIPTION
## Purpose / Description
MathJax has changed the working of `\color`. To keep the experience consistent of users, we can use the previous functionality.

## Fixes
Fixes the change mentioned in this comment: https://github.com/ankidroid/Anki-Android/issues/9002#issuecomment-850762986

## Approach
Reference: https://docs.mathjax.org/en/latest/input/tex/extensions/colorv2.html#tex-colorv2

## How Has This Been Tested?
Verified that it is working as expected.

## Learning
https://docs.mathjax.org/en/latest/input/tex/extensions/color.html
https://docs.mathjax.org/en/latest/input/tex/extensions/colorv2.html#tex-colorv2

![image](https://user-images.githubusercontent.com/35566748/120076713-a3d99200-c0c4-11eb-85d3-27a8f6c90816.png)

## Checklist

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
