### PR TITLE
Fix floating point numbers for steps in Deck Options

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/preferences/StepsPreference.java
+++ b/AnkiDroid/src/main/java/com/ichi2/preferences/StepsPreference.java
@@ -142,7 +142,7 @@ public class StepsPreference extends android.preference.EditTextPreference {
                     return null;
                 }
                 // Use whole numbers if we can (but still allow decimals)
-                int i =(int) d;
+                int i = (int) d;
                 if (i == d) {
                     stepsAr.put(i);
                 } else {

--- a/AnkiDroid/src/main/java/com/ichi2/preferences/StepsPreference.java
+++ b/AnkiDroid/src/main/java/com/ichi2/preferences/StepsPreference.java
@@ -20,6 +20,7 @@ import android.content.Context;
 import android.text.InputType;
 import android.text.TextUtils;
 import android.util.AttributeSet;
+import android.util.Log;
 
 import com.ichi2.anki.AnkiDroidApp;
 import com.ichi2.anki.R;
@@ -135,17 +136,17 @@ public class StepsPreference extends android.preference.EditTextPreference {
         }
         try {
             for (String s : steps.split("\\s+")) {
-                float f = Float.parseFloat(s);
+                double d = Double.parseDouble(s);
                 // 0 or less is not a valid step.
-                if (f <= 0) {
+                if (d <= 0) {
                     return null;
                 }
                 // Use whole numbers if we can (but still allow decimals)
-                int i = (int) f;
-                if (i == f) {
+                int i =(int) d;
+                if (i == d) {
                     stepsAr.put(i);
                 } else {
-                    stepsAr.put(f);
+                    stepsAr.put(d);
                 }
             }
         } catch (NumberFormatException | JSONException e) {


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
`JSONArray` has a `put` method with double input. When we set its input with float variable, it was casted to double and then we may see a number with different value.

## Fixes
Fixes #8995

## Approach
Change `float` variable to `double`.

## How Has This Been Tested?

Emulated device Samsung A50 SDK 28.

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
