### PR TITLE
Fixed Bug Crash TagsDialog not attached to a Context

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -1062,20 +1062,6 @@ public class NoteEditor extends AnkiActivity implements
 
 
     @Override
-    protected void onPause() {
-        dismissAllDialogFragments(); //remove the "field language" as it can't be reshown without a field reference
-        super.onPause();
-    }
-
-
-    @Override
-    protected void onResume() {
-        dismissAllDialogFragments(); // dismiss "tags" as it may have been attached after onPause is called
-        super.onResume();
-    }
-
-
-    @Override
     protected void onDestroy() {
         super.onDestroy();
         if (mUnmountReceiver != null) {
@@ -2313,12 +2299,6 @@ public class NoteEditor extends AnkiActivity implements
                 menu.add(Menu.NONE, mClozeMenuId, 0, R.string.multimedia_editor_popup_cloze);
             }
 
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
-                // This should be after "Paste as Plain Text"
-                menu.add(Menu.NONE, mSetLanguageId, 99, R.string.note_editor_set_field_language);
-            }
-
-
             return initialSize != menu.size();
         }
 
@@ -2330,20 +2310,9 @@ public class NoteEditor extends AnkiActivity implements
                 convertSelectedTextToCloze(mTextBox, AddClozeType.INCREMENT_NUMBER);
                 mode.finish();
                 return true;
-            } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N && itemId == mSetLanguageId) {
-                displaySelectInputLanguage();
-                mode.finish();
-                return true;
             } else {
                 return false;
             }
-        }
-
-
-        @RequiresApi(Build.VERSION_CODES.N)
-        private void displaySelectInputLanguage() {
-            DialogFragment dialogFragment = LocaleSelectionDialog.newInstance(this);
-            showDialogFragment(dialogFragment);
         }
 
 

--- a/AnkiDroid/src/main/res/values/02-strings.xml
+++ b/AnkiDroid/src/main/res/values/02-strings.xml
@@ -97,7 +97,6 @@
     <string name="note_editor_no_cards_created">No cards created. Please fill in more fields</string>
     <string name="note_editor_no_first_field">The first field is empty</string>
     <string name="note_editor_no_cloze_delations">This note type must contain cloze deletions</string>
-    <string name="note_editor_set_field_language">Set field language</string>
     <string name="note_editor_no_cards_created_all_fields">The current note type did not produce any cards.\nPlease choose another note type, or click ‘Cards’ and add a field substitution</string>
     <string name="note_editor_insert_cloze_no_cloze_note_type">Cloze deletions will only work on a Cloze note type</string>
     <string name="saving_facts">Saving note</string>


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
 Fixed Bug

## Fixes
Fixes #8973
Fixes #8972 🙌

## Approach
Removed the part of code which is closing the dialogue boxes when activity is in onPause or in onResume.

## How Has This Been Tested?
Tested on Samsung Galaxy M51, android 11 (Samsung One UI 3.1)


## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
