### PR TITLE
fix: open nav menu clears search

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -984,15 +984,15 @@ public class CardBrowser extends NavigationDrawerActivity implements
                     return true;
                 }
             });
+            // Fixes #6500 - keep the search consistent
+            if (!TextUtils.isEmpty(mSearchTerms)) {
+                mSearchItem.expandActionView(); // This calls mSearchView.setOnSearchClickListener
+                mSearchView.setQuery(mSearchTerms, false);
+            }
             mSearchView.setOnSearchClickListener(v -> {
                 // Provide SearchView with the previous search terms
                 mSearchView.setQuery(mSearchTerms, false);
             });
-            // Fixes #6500 - keep the search consistent
-            if (!TextUtils.isEmpty(mSearchTerms)) {
-                mSearchItem.expandActionView();
-                mSearchView.setQuery(mSearchTerms, false);
-            }
         } else {
             // multi-select mode
             getMenuInflater().inflate(R.menu.card_browser_multiselect, menu);

--- a/AnkiDroid/src/main/java/com/ichi2/ui/CardBrowserSearchView.java
+++ b/AnkiDroid/src/main/java/com/ichi2/ui/CardBrowserSearchView.java
@@ -1,0 +1,79 @@
+/*
+ *  Copyright (c) 2021 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.ui;
+
+import android.content.Context;
+import android.util.AttributeSet;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.appcompat.widget.SearchView;
+
+public class CardBrowserSearchView extends SearchView {
+    public CardBrowserSearchView(@NonNull Context context) {
+        super(context);
+    }
+
+
+    public CardBrowserSearchView(@NonNull Context context, @Nullable AttributeSet attrs) {
+        super(context, attrs);
+    }
+
+
+    public CardBrowserSearchView(@NonNull Context context, @Nullable AttributeSet attrs, int defStyleAttr) {
+        super(context, attrs, defStyleAttr);
+    }
+
+    /** Whether an action to set text should be ignored */
+    private boolean mIgnoreValueChange = false;
+
+    /** Whether an action to set text should be ignored */
+    public boolean shouldIgnoreValueChange() {
+        return mIgnoreValueChange;
+    }
+
+
+    @Override
+    public void onActionViewCollapsed() {
+        try {
+            mIgnoreValueChange = true;
+            super.onActionViewCollapsed();
+        } finally {
+            mIgnoreValueChange = false;
+        }
+    }
+
+
+    @Override
+    public void onActionViewExpanded() {
+        try {
+            mIgnoreValueChange = true;
+            super.onActionViewExpanded();
+        } finally {
+            mIgnoreValueChange = false;
+        }
+    }
+
+
+    @Override
+    public void setQuery(CharSequence query, boolean submit) {
+        if (mIgnoreValueChange) {
+            return;
+        }
+        super.setQuery(query, submit);
+    }
+}

--- a/AnkiDroid/src/main/res/menu/card_browser.xml
+++ b/AnkiDroid/src/main/res/menu/card_browser.xml
@@ -11,7 +11,7 @@
         android:id="@+id/action_search"
         android:icon="@drawable/ic_search_white"
         android:title="@string/deck_conf_cram_search"
-        ankidroid:actionViewClass="androidx.appcompat.widget.SearchView"
+        ankidroid:actionViewClass="com.ichi2.ui.CardBrowserSearchView"
         ankidroid:showAsAction="always|collapseActionView"/>
 
     <item


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
Opening the nav bar moved from the current search to the previous search

## Fixes
Fixes #9010 

## Approach
We do this with a temporary variable containing the current value
of the search bar.

There was a bug with setting this temporary, which we also fix:

Toggling the navbar called supportInvalidateOptionsMenu
This calls through to SearchView: as follows:

supportInvalidateOptionsMenu => MenuBuilder.clear()
MenuBuilder.clear() => collapseItemActionView(mExpandedItem);
=> onActionViewCollapsed
=> setQuery("", false);

We had a listener on setQuery, which then blanked the temp variable. class: CardBrowserSearchView fixes this, by ignoring these methods if it's triggered by collapse/expand

## How Has This Been Tested?

Unit tests pass, passes on my phone

⚠️ Felt like a significant effort to unit test this so I didn't attempt it. Please request if you want

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
