### PR TITLE
fix[Audio Import]: mpeg converted to mp3

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicAudioClipFieldController.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicAudioClipFieldController.java
@@ -39,6 +39,7 @@ import com.ichi2.ui.FixedTextView;
 import java.io.File;
 import java.io.InputStream;
 
+import androidx.annotation.VisibleForTesting;
 import timber.log.Timber;
 
 public class BasicAudioClipFieldController extends FieldControllerBase implements IFieldController {
@@ -168,8 +169,9 @@ public class BasicAudioClipFieldController extends FieldControllerBase implement
      * @param audioClipFullName name of the file.
      * @return file name which is valid.
      */
-    private String checkFileName(String audioClipFullName) {
-        return audioClipFullName.replaceAll("\\W+", "_");
+    @VisibleForTesting
+    static String checkFileName(String audioClipFullName) {
+        return audioClipFullName.replaceAll("[^\\w.]+", "_");
     }
 
     @Override

--- a/AnkiDroid/src/test/java/com/ichi2/anki/multimediacard/fields/BasicAudioClipFieldControllerTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/multimediacard/fields/BasicAudioClipFieldControllerTest.java
@@ -1,0 +1,38 @@
+/*
+ *  Copyright (c) 2021 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.multimediacard.fields;
+
+import org.junit.Test;
+
+import static com.ichi2.anki.multimediacard.fields.BasicAudioClipFieldController.checkFileName;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+public class BasicAudioClipFieldControllerTest {
+
+
+    @Test
+    public void test_bad_chars_stripped() {
+        assertThat(checkFileName("There's a good film on the day <b>after</b> tomorrow.mp3"), is("There_s_a_good_film_on_the_day_b_after_b_tomorrow.mp3"));
+    }
+
+    @Test
+    public void test_extension_is_not_stripped() {
+        assertThat(checkFileName("file_example_MP3_700KB.mp3"), is("file_example_MP3_700KB.mp3"));
+    }
+
+}


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
Audio imports of `mp3` files were instead shown as `mpeg`. These are much slower to load

## Fixes
Fixes #9008
Alleviates #9023

## Approach
Cause: we converted "a.mp3" to "a_mp3" which failed the file type conversion

Allow a dot

## How Has This Been Tested?

Unit tested. Tested on my Android 11

## Learning

We need more tests on this path

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
