### PR TITLE
Add Ktlint pre-commit hook

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -224,6 +224,14 @@ tasks.withType(JavaCompile) {
     options.incremental = true
 }
 
+// Install Git pre-commit hook for Ktlint
+task installGitHook(type: Copy) {
+    from new File(rootProject.rootDir, 'pre-commit')
+    into { new File(rootProject.rootDir, '.git/hooks') }
+    fileMode 0755
+}
+tasks.getByPath(':AnkiDroid:preBuild').dependsOn installGitHook
+
 apply from: "./robolectricDownloader.gradle"
 apply from: "./jacoco.gradle"
 apply from: "../lint.gradle"

--- a/pre-commit
+++ b/pre-commit
@@ -1,0 +1,22 @@
+#!/bin/sh
+set -e
+
+CHANGED_FILES="$(git --no-pager diff --name-status --no-color --cached | awk '$1 != "D" && $2 ~ /\.kts|\.kt/ { print $2 }')"
+
+if [ -z "$CHANGED_FILES" ]; then
+    echo "No Kotlin staged files. Hence, skipping pre-commit Ktlint run."
+    exit 0
+fi;
+
+echo "Running Ktlint over these files:"
+echo "$CHANGED_FILES"
+
+./gradlew ktlintFormat
+
+echo "Completed ./gradlew ktlintFormat run."
+echo "$CHANGED_FILES" | while read -r file; do
+    if [ -f "$file" ]; then
+        git add "$file"
+    fi
+done
+echo "Completed the pre-commit hook."


### PR DESCRIPTION
## Purpose / Description
Add Git pre-commit hook for Ktlint.
If this is installed, then `./gradlew ktlintFormat` will run for Kotlin files and then `git add $file` will run on those files before commit.

## Fixes
Fixes part of #9019 

## Approach
Added pre-commit file and task to install Git pre-commit hook for Ktlint before build.

## How Has This Been Tested?
Verified with a test commit.

## Learning
https://medium.com/@alistair.cerio/android-ktlint-and-pre-commit-git-hook-5dd606e230a9
https://emmanuelkehinde.io/setting-up-git-pre-commit-pre-push-hook-for-ktlint-check

Reference for the pre-commit script: https://gist.github.com/echorebel/4246cd4ec42098fce66c169d28aa2812#gistcomment-3734796

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)