### PR TITLE
Add padding to undo icon

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/UIUtils.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/UIUtils.java
@@ -9,6 +9,8 @@ import com.google.android.material.snackbar.Snackbar;
 import androidx.annotation.NonNull;
 import androidx.annotation.StringRes;
 import androidx.core.content.ContextCompat;
+
+import android.util.DisplayMetrics;
 import android.view.View;
 import android.widget.TextView;
 import android.widget.Toast;
@@ -153,5 +155,16 @@ public class UIUtils {
             };
             TaskManager.launchCollectionTask(new CollectionTask.SaveCollection(syncIgnoresDatabaseModification), listener);
         }
+    }
+
+    /**
+     * This method converts dp unit to equivalent pixels, depending on device density.
+     *
+     * @param dp A value in dp (density independent pixels) unit.
+     * @param context Context to get resources and device specific display metrics.
+     * @return A float value to represent px value which is equivalent to the passed dp value.
+     */
+    public static float convertDpToPixel(float dp, Context context){
+        return dp * ((float) context.getResources().getDisplayMetrics().densityDpi / DisplayMetrics.DENSITY_DEFAULT);
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/ui/RtlCompliantActionProvider.java
+++ b/AnkiDroid/src/main/java/com/ichi2/ui/RtlCompliantActionProvider.java
@@ -24,6 +24,7 @@ import android.view.View;
 import android.widget.ImageView;
 
 import com.ichi2.anki.R;
+import com.ichi2.anki.UIUtils;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.VisibleForTesting;
@@ -87,6 +88,10 @@ public class RtlCompliantActionProvider extends ActionProvider {
         final Drawable iconDrawable = forItem.getIcon();
         iconDrawable.setAutoMirrored(true);
         actionView.setImageDrawable(iconDrawable);
+
+        // Add top and bottom padding of 16 dp
+        actionView.setPadding(0, (int) (UIUtils.convertDpToPixel(16f, mContext)),
+                0, (int) (UIUtils.convertDpToPixel(16f, mContext)));
 
         actionView.setOnClickListener(v -> {
             if (!forItem.isEnabled()) {


### PR DESCRIPTION
## Purpose / Description
Fix the issue where undo button becomes difficult to click.

## Fixes
Fixes #9014 

## Approach
Added padding of 16 dp to top and bottom of the undo icon.

## How Has This Been Tested?
Verified.

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
