### PR TITLE
Fixed Cloze Card Preview

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplatePreviewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplatePreviewer.java
@@ -268,7 +268,11 @@ public class CardTemplatePreviewer extends AbstractFlashcardViewer {
         return new PreviewerCard(col, cardListIndex);
     }
 
-    /** Get a dummy card */
+
+    /**
+     * This method generates a note from a sample model, or fails if invalid. It does not currently have knowledge of field content
+     * A cloze uses the same model. Its content (not provided in params) determines validity of an ordinal
+     */
     protected @Nullable Card getDummyCard(Model model, int ordinal) {
         Timber.d("getDummyCard() Creating dummy note for ordinal %s", ordinal);
         if (model == null) {
@@ -279,6 +283,11 @@ public class CardTemplatePreviewer extends AbstractFlashcardViewer {
         for (int i = 0; i < fieldNames.size() && i < n.getFields().length; i++) {
             n.setField(i, fieldNames.get(i));
         }
+
+        if (model.isCloze()) {
+            ordinal = 0;
+        }
+
         try {
             JSONObject template = model.getJSONArray("tmpls").getJSONObject(ordinal);
             return getCol().getNewLinkedCard(new PreviewerCard(getCol(), n), n, template, 1, 0L, false);


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
 This PR Fixes the error which occur while opening the card which is having cloze text from card browser. 

## Fixes
 Fixes #9005

## Approach
I Changed the ordinal to 0 for all the cloze cards.

## How Has This Been Tested?

Tested on Samsung Galaxy M51, android 11 (Samsung One UI 3.1)

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [ ] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
