### PR TITLE
Fix crash on opening StudyOptionsFragment

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsActivity.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsActivity.java
@@ -42,13 +42,9 @@ public class StudyOptionsActivity extends NavigationDrawerActivity implements St
         CustomStudyDialogFactory customStudyDialogFactory = new CustomStudyDialogFactory(this::getCol, this);
         customStudyDialogFactory.attachToActivity(this);
         super.onCreate(savedInstanceState);
-        // The empty frame layout is a workaround for fragments not showing when they are added
-        // to android.R.id.content when an action bar is used in Android 2.1 (and potentially
-        // higher) with the appcompat package.
-        View mainView = getLayoutInflater().inflate(R.layout.studyoptions, null);
         setContentView(R.layout.studyoptions);
         // create inherited navigation drawer layout here so that it can be used by parent class
-        initNavigationDrawer(mainView);
+        initNavigationDrawer(findViewById(android.R.id.content));
         if (savedInstanceState == null) {
             loadStudyOptionsFragment();
         }


### PR DESCRIPTION
## Purpose / Description
Fix crash on opening StudyOptionsFragment.

## Fixes
Fixes #9054 

## Approach
Passed correct view to `initNavigationDrawer()` from `StudyOptionsFragment`. 

## How Has This Been Tested?

Verified that StudyOptionsFragment is working fine. Also tested in fragmented mode.

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [ ] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
