### PR TITLE
Remove boolean check in onProgressUpdate of DeckPicker

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -1827,13 +1827,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
         @Override
         public void onProgressUpdate(Object... values) {
             Resources res = getResources();
-            if (values[0] instanceof Boolean) {
-                // This is the part Download missing media of syncing
-                int total = (Integer) values[1];
-                int done = (Integer) values[2];
-                values[0] = (values[3]);
-                values[1] = res.getString(R.string.sync_downloading_media, done, total);
-            } else if (values[0] instanceof Integer) {
+            if (values[0] instanceof Integer) {
                 int id = (Integer) values[0];
                 if (id != 0) {
                     mCurrentMessage = res.getString(id);
@@ -1850,7 +1844,6 @@ public class DeckPicker extends NavigationDrawerActivity implements
                 }
             }
             if (mProgressDialog != null && mProgressDialog.isShowing()) {
-                // mProgressDialog.setTitle((String) values[0]);
                 mProgressDialog.setContent(mCurrentMessage + "\n"
                         + res
                         .getString(R.string.sync_up_down_size, mCountUp / 1024, mCountDown / 1024));

--- a/AnkiDroid/src/main/res/values/04-network.xml
+++ b/AnkiDroid/src/main/res/values/04-network.xml
@@ -52,7 +52,6 @@
     <string name="sync_uploading_message">Uploading…</string>
     <string name="sync_downloading_message">Downloading…</string>
     <string name="sync_title">Synchronization</string>
-    <string name="sync_downloading_media">Downloading media %1$d/%2$d…</string>
     <string name="sync_log_uploading_message">Full sync from local</string>
     <string name="sync_log_clocks_unsynchronized">Your clock’s off by %1$d seconds%2$s. Make sure that the date, time, and timezone on your phone are set correctly, then sync again.</string>
     <string name="sync_log_clocks_unsynchronized_tz">, the time zone’s possibly wrong</string>


### PR DESCRIPTION
## Purpose / Description
Remove boolean check in `onProgressUpdate()` in DeckPicker since `doProgress()` is never called with a Boolean as the first value. That code is unused and was creating problem in the Kotlin conversion of DeckPicker because of a type inference or type conversion kind of issue while assigning values to values[0] and values[1].

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [ ] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
