### PR TITLE
fix: SQL Cursor string conversion error

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -269,7 +269,7 @@ dependencies {
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.12.3'
 
     // == Rust conversion (from Anki-Android-Backend on GitHub) ==
-    String backendVersion = "0.1.8" // We want both testing and implementation on the same version
+    String backendVersion = "0.1.9" // We want both testing and implementation on the same version
     // build with ./gradlew rsdroid:assembleRelease
     // In my experience, using `files()` currently requires a reindex operation, which is slow.
     // implementation files("C:\\GitHub\\Rust-Test\\rsdroid\\build\\outputs\\aar\\rsdroid-release.aar")

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/stats/Stats.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/stats/Stats.java
@@ -994,9 +994,9 @@ public class Stats {
         }
 
         long cutoff = mCol.getSched().getDayCutoff();
-        ArrayList<double[]> list = new ArrayList<>(Collections.nCopies(7, new double[]{0,0,0})); // one by day of the week
-        String query = "SELECT cast(strftime('%w',datetime( cast(id/ 1000  -" + sd.get(Calendar.HOUR_OF_DAY) * 3600 +
-                " as int), 'unixepoch'))as int) as wd, " +
+        ArrayList<double[]> list = new ArrayList<>(7); // one by day of the week
+        String query = "SELECT strftime('%w',datetime( cast(id/ 1000  -" + sd.get(Calendar.HOUR_OF_DAY) * 3600 +
+                " as int), 'unixepoch')) as wd, " +
                 "sum(case when ease = 1 then 0 else 1 end) / " +
                 "cast(count() as float) * 100, " +
                 "count() " +
@@ -1008,15 +1008,13 @@ public class Stats {
         try (Cursor cur = mCol.getDb()
                     .query(query)) {
             while (cur.moveToNext()) {
-                int weekday = cur.getInt(0);
-                list.add(weekday, new double[] {weekday, cur.getDouble(1), cur.getDouble(2) });
+                list.add(new double[] { cur.getDouble(0), cur.getDouble(1), cur.getDouble(2) });
             }
         }
 
         //TODO adjust for breakdown, for now only copied from intervals
         // small adjustment for a proper chartbuilding with achartengine
-
-        if (list.size() == 0 ) { // todo do I remove this because of Collections.nCopies()?
+        if (list.size() == 0 ) {
             list.add(0, new double[] { 0, 0, 0 });
         }
 


### PR DESCRIPTION
## Purpose / Description
The backend had an issue where numeric types were not correctly converted from strings.

"2" was converted to 0

This rarely occurred, as most of the time we did the conversion in the SQL

This caused the statistics to show the incorrect value for hours studied

See: https://github.com/david-allison-1/Anki-Android-Backend/pull/111

And https://developer.android.com/reference/android/database/CursorWindow#getLong(int,%20int)

## Fixes
Fixes #8877

## How Has This Been Tested?

⚠️  Unit Tested only

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
