### PR TITLE
Add preference for setting double click time interval in study screen

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -189,10 +189,6 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
     public static final int EASE_3 = 3;
     public static final int EASE_4 = 4;
 
-    /** Maximum time in milliseconds to wait before accepting answer button presses. */
-    @VisibleForTesting
-    protected static final int DOUBLE_TAP_IGNORE_THRESHOLD = 200;
-
     /** Time to wait in milliseconds before resuming fullscreen mode **/
     protected static final int INITIAL_HIDE_DELAY = 200;
 
@@ -244,6 +240,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
     private boolean mScrollingButtons;
     private boolean mGesturesEnabled;
     private boolean mLargeAnswerButtons;
+    private int mDoubleTapTimeInterval = DEFAULT_DOUBLE_TAP_TIME_INTERVAL;
     // Android WebView
     protected boolean mSpeakText;
     protected boolean mDisableClipboard = false;
@@ -323,6 +320,9 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
     private boolean mButtonHeightSet = false;
 
     private static final int sShowChosenAnswerLength = 2000;
+
+    public static final String DOUBLE_TAP_TIME_INTERVAL = "doubleTapTimeInterval";
+    public static final int DEFAULT_DOUBLE_TAP_TIME_INTERVAL = 200;
 
     /**
      * A record of the last time the "show answer" or ease buttons were pressed. We keep track
@@ -424,7 +424,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
         public void onClick(View view) {
             Timber.i("AbstractFlashcardViewer:: Show answer button pressed");
             // Ignore what is most likely an accidental double-tap.
-            if (getElapsedRealTime() - mLastClickTime < DOUBLE_TAP_IGNORE_THRESHOLD) {
+            if (getElapsedRealTime() - mLastClickTime < mDoubleTapTimeInterval) {
                 return;
             }
             mLastClickTime = getElapsedRealTime();
@@ -475,7 +475,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
             // or if the button was not touched,
             if (mPrevCard == mCurrentCard || !mHasBeenTouched)  {
                 // Only perform if the click was not an accidental double-tap
-                if (getElapsedRealTime() - mLastClickTime >= DOUBLE_TAP_IGNORE_THRESHOLD) {
+                if (getElapsedRealTime() - mLastClickTime >= mDoubleTapTimeInterval) {
                     // For whatever reason, performClick does not return a visual feedback anymore
                     if (!mHasBeenTouched) {
                         view.setPressed(true);
@@ -1921,6 +1921,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
         mPrefShowTopbar = preferences.getBoolean("showTopbar", true);
         mFocusTypeAnswer = preferences.getBoolean("autoFocusTypeInAnswer", false);
         mLargeAnswerButtons = preferences.getBoolean("showLargeAnswerButtons", false);
+        mDoubleTapTimeInterval = preferences.getInt(DOUBLE_TAP_TIME_INTERVAL, DEFAULT_DOUBLE_TAP_TIME_INTERVAL);
 
         mGesturesEnabled = AnkiDroidApp.initiateGestures(preferences);
         mLinkOverridesTouchGesture = preferences.getBoolean("linkOverridesTouchGesture", false);

--- a/AnkiDroid/src/main/res/values/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values/10-preferences.xml
@@ -145,6 +145,8 @@
     <string name="vertical_centering" maxLength="41">Center align</string>
     <string name="vertical_centering_summ">Center the content of cards vertically</string>
     <string name="pref_backup_max" maxLength="41">Max number of backups</string>
+    <string name="pref_double_tap_time_interval" maxLength="41">Double tap time interval (milliseconds)</string>
+    <string name="pref_double_tap_time_interval_summary">A second tap of the answer buttons will be ignored if this time has not elapsed. This prevents accidental double taps</string>
     <string name="show_estimates" maxLength="41">Show button time</string>
     <string name="show_estimates_summ">Show next review time on answer buttons</string>
     <string name="show_large_answer_buttons" maxLength="41">Show large answer buttons</string>

--- a/AnkiDroid/src/main/res/xml/preferences_reviewing.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_reviewing.xml
@@ -56,6 +56,13 @@
             android:key="newTimezoneHandling"
             android:title="@string/new_timezone"
             android:defaultValue="false" />
+        <com.ichi2.preferences.NumberRangePreference
+            android:defaultValue="200"
+            android:key="doubleTapTimeInterval"
+            android:summary="@string/pref_double_tap_time_interval_summary"
+            android:title="@string/pref_double_tap_time_interval"
+            app:min="0"
+            app:max="2000" />
 
     </PreferenceCategory>
     <PreferenceCategory android:title="@string/pref_cat_flashcard" >

--- a/AnkiDroid/src/test/java/com/ichi2/anki/AbstractFlashcardViewerTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/AbstractFlashcardViewerTest.java
@@ -58,7 +58,7 @@ public class AbstractFlashcardViewerTest extends RobolectricTest {
 
         @Override
         protected long getElapsedRealTime() {
-            lastTime += DOUBLE_TAP_IGNORE_THRESHOLD;
+            lastTime += AnkiDroidApp.getSharedPrefs(getBaseContext()).getInt(DOUBLE_TAP_TIME_INTERVAL, DEFAULT_DOUBLE_TAP_TIME_INTERVAL);
             return lastTime;
         }
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/TestCardTemplatePreviewer.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/TestCardTemplatePreviewer.java
@@ -3,7 +3,9 @@ package com.ichi2.anki;
 public class TestCardTemplatePreviewer extends CardTemplatePreviewer {
     protected boolean mShowingAnswer = false;
     public boolean getShowingAnswer() { return mShowingAnswer; }
-    public void disableDoubleClickPrevention() { mLastClickTime = (AbstractFlashcardViewer.DOUBLE_TAP_IGNORE_THRESHOLD * -2); }
+    public void disableDoubleClickPrevention() {
+        mLastClickTime = (AnkiDroidApp.getSharedPrefs(getBaseContext()).getInt(DOUBLE_TAP_TIME_INTERVAL, DEFAULT_DOUBLE_TAP_TIME_INTERVAL) * -2);
+    }
 
 
     @Override


### PR DESCRIPTION
## Purpose / Description
Add preference for setting double click time interval in study screen.

## Fixes
Fixes #9042 

## Approach
Added setting to change the time interval.

## How Has This Been Tested?
Verified by changing the time interval and checking.

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [ ] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)