### PR TITLE
[Preference] Paste clipboard image as PNG

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/MediaRegistration.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/MediaRegistration.java
@@ -92,7 +92,7 @@ public class MediaRegistration {
             } catch (IOException e) {
                 Timber.w("MediaRegistration : Unable to convert file to png format");
                 AnkiDroidApp.sendExceptionReport(e, "Unable to convert file to png format");;
-                UIUtils.showThemedToast(mContext, mContext.getResources().getString(R.string.multimedia_editor_something_wrong_details, e.getMessage()), true);
+                UIUtils.showThemedToast(mContext, mContext.getResources().getString(R.string.multimedia_editor_png_paste_error, e.getMessage()), true);
                 return null;
             }
         } else {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/MediaRegistration.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/MediaRegistration.java
@@ -19,6 +19,8 @@ package com.ichi2.anki;
 
 
 import android.content.Context;
+import android.graphics.Bitmap;
+import android.graphics.BitmapFactory;
 import android.net.Uri;
 
 import com.ichi2.anki.multimediacard.fields.ImageField;
@@ -28,6 +30,7 @@ import com.ichi2.utils.ContentResolverUtil;
 import com.ichi2.utils.FileUtil;
 
 import java.io.File;
+import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.HashMap;
@@ -76,10 +79,28 @@ public class MediaRegistration {
             fileName = fileNameAndExtension.getKey();
         }
 
-        File clipCopy = File.createTempFile(fileName, fileNameAndExtension.getValue());
-        String tempFilePath = clipCopy.getAbsolutePath();
-        long bytesWritten = CompatHelper.getCompat().copyFile(fd, tempFilePath);
+        File clipCopy;
+        long bytesWritten;
 
+        if (!".png".equals(fileNameAndExtension.getValue()) && CollectionHelper.getInstance().getCol(mContext).getConf().optBoolean("pastePNG")) {
+            clipCopy = File.createTempFile(fileName, ".png");
+            bytesWritten = CompatHelper.getCompat().copyFile(fd, clipCopy.getAbsolutePath());
+            Bitmap bm = BitmapFactory.decodeFile(clipCopy.getAbsolutePath());
+            try (FileOutputStream outStream = new FileOutputStream(clipCopy.getAbsolutePath())) {
+                bm.compress(Bitmap.CompressFormat.PNG, 100, outStream);
+                outStream.flush();
+            } catch (IOException e) {
+                Timber.w("MediaRegistration : Unable to convert file to png format");
+                AnkiDroidApp.sendExceptionReport(e, "Unable to convert file to png format");;
+                UIUtils.showThemedToast(mContext, mContext.getResources().getString(R.string.multimedia_editor_something_wrong_details, e.getMessage()), true);
+                return null;
+            }
+        } else {
+            clipCopy = File.createTempFile(fileName, fileNameAndExtension.getValue());
+            bytesWritten = CompatHelper.getCompat().copyFile(fd, clipCopy.getAbsolutePath());
+        }
+
+        String tempFilePath = clipCopy.getAbsolutePath();
         // register media for webView
         if (!registerMediaForWebView(tempFilePath)) {
             return null;
@@ -110,8 +131,7 @@ public class MediaRegistration {
             if (!mPastedImageCache.containsKey(uri.toString())) {
                 mPastedImageCache.put(uri.toString(), loadImageIntoCollection(uri));
             }
-            String imageTag = mPastedImageCache.get(uri.toString());
-            return imageTag;
+            return mPastedImageCache.get(uri.toString());
         } catch (NullPointerException | SecurityException ex) {
             // Tested under FB Messenger and GMail, both apps do nothing if this occurs.
             // This typically works if the user copies again - don't know the exact cause

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
@@ -147,6 +147,12 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
      */
     private static final String DAY_OFFSET = "dayOffset";
     /**
+     * Represents in Android preference the collection's configuration "pastePNG" , i.e.
+     * whether to convert clipboard uri to png format or not.
+     * TODO: convert to png if a image file has transparency, or at least if it supports it.
+     */
+    private static final String PASTE_PNG = "pastePNG";
+    /**
      * Represents in Android preferences whether the scheduler should use version 1 or 2.
      */
     private static final String SCHED_VER = "schedVer";
@@ -655,6 +661,9 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
                         case DAY_OFFSET:
                             ((SeekBarPreference)pref).setValue(getDayOffset(col));
                             break;
+                        case PASTE_PNG:
+                            ((android.preference.CheckBoxPreference)pref).setChecked(conf.optBoolean("pastePNG"));
+                            break;
                         case NEW_TIMEZONE_HANDLING:
                             android.preference.CheckBoxPreference checkBox = (android.preference.CheckBoxPreference) pref;
                             checkBox.setChecked(col.getSched()._new_timezone_enabled());
@@ -783,6 +792,10 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
                     setDayOffset(((SeekBarPreference) pref).getValue());
                     break;
                 }
+                case PASTE_PNG:
+                    getCol().getConf().put("pastePNG", ((android.preference.CheckBoxPreference) pref).isChecked());
+                    getCol().setMod();
+                    break;
                 case "minimumCardsDueForNotification": {
                     android.preference.ListPreference listpref = (android.preference.ListPreference) screen.findPreference("minimumCardsDueForNotification");
                     if (listpref != null) {

--- a/AnkiDroid/src/main/res/values/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values/10-preferences.xml
@@ -191,6 +191,9 @@
     <string name="html_javascript_debugging" maxLength="41">HTML / Javascript Debugging</string>
     <string name="html_javascript_debugging_summ">Enable remote WebView connections, and save card HTML to AnkiDroid directory</string>
 
+    <!-- Paste clipboard image as png option -->
+    <string name="paste_as_png" maxLength="41">Paste clipboard images as PNG</string>
+    <string name="paste_as_png_summary" maxLength="41">By default Anki pastes images on the clipboard as JPG files to save disk space. You can use this option to paste as PNG images instead.</string>
     <!-- Advanced statistics settings -->
     <string name="advanced_statistics_title" maxLength="41">Advanced statistics</string>
     <string name="enable_advanced_statistics_title" maxLength="41">Enable advanced statistics</string>

--- a/AnkiDroid/src/main/res/values/16-multimedia-editor.xml
+++ b/AnkiDroid/src/main/res/values/16-multimedia-editor.xml
@@ -93,6 +93,7 @@
     <string name="multimedia_editor_progress_wait_title">Wait</string>
     <!-- not a good message, when an unexpected error happens -->
     <string name="multimedia_editor_something_wrong">Something went wrong</string>
+    <string name="multimedia_editor_something_wrong_details">Error converting clipboard image to png: %s</string>
     <string name="multimedia_editor_attach_mm_content" comment="used for screen readers. Not visible to the user">Attach multimedia content to the %1$s field</string>
     <string name="multimedia_editor_attach_media">Attach media</string>
 

--- a/AnkiDroid/src/main/res/values/16-multimedia-editor.xml
+++ b/AnkiDroid/src/main/res/values/16-multimedia-editor.xml
@@ -93,7 +93,7 @@
     <string name="multimedia_editor_progress_wait_title">Wait</string>
     <!-- not a good message, when an unexpected error happens -->
     <string name="multimedia_editor_something_wrong">Something went wrong</string>
-    <string name="multimedia_editor_something_wrong_details">Error converting clipboard image to png: %s</string>
+    <string name="multimedia_editor_png_paste_error">Error converting clipboard image to png: %s</string>
     <string name="multimedia_editor_attach_mm_content" comment="used for screen readers. Not visible to the user">Attach multimedia content to the %1$s field</string>
     <string name="multimedia_editor_attach_media">Attach media</string>
 

--- a/AnkiDroid/src/main/res/xml/preferences_general.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_general.xml
@@ -66,6 +66,12 @@
             android:key="analyticsOptIn"
             android:summary="@string/analytics_summ"
             android:title="@string/analytics_title" />
+        <CheckBoxPreference
+            android:defaultValue="false"
+            android:title="@string/paste_as_png"
+            android:summary="@string/paste_as_png_summary"
+            android:maxLength="41"
+            android:key="pastePNG"/>
         <ListPreference
             android:defaultValue="2"
             android:entries="@array/error_reporting_choice_labels"


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
AnkiDesktop have feature of "Paste Clipboard Image As PNG " in the preference window ,
currently AnkiDroid do support to copy and paste image but not have this preference option in app.

Supercedes + Closes #8804 - copied the implementation with fixing lint and minor changes

## Fixes
Fixes #8709

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [x] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
