### PR TITLE
OnRenderProcessGone: do nothing if minimised

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplatePreviewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplatePreviewer.java
@@ -166,7 +166,7 @@ public class CardTemplatePreviewer extends AbstractFlashcardViewer {
 
 
     @Override
-    protected void displayCardQuestion() {
+    public void displayCardQuestion() {
         super.displayCardQuestion();
         mShowingAnswer = false;
         updateButtonsState();

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Previewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Previewer.java
@@ -195,7 +195,7 @@ public class Previewer extends AbstractFlashcardViewer {
 
 
     @Override
-    protected void displayCardQuestion() {
+    public void displayCardQuestion() {
         super.displayCardQuestion();
         mShowingAnswer = false;
         updateButtonsState();

--- a/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/OnRenderProcessGoneDelegate.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/OnRenderProcessGoneDelegate.java
@@ -1,0 +1,147 @@
+/*
+ *  Copyright (c) 2021 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.cardviewer;
+
+import android.annotation.TargetApi;
+import android.content.res.Resources;
+import android.os.Build;
+import android.webkit.RenderProcessGoneDetail;
+import android.webkit.WebView;
+
+import com.afollestad.materialdialogs.MaterialDialog;
+import com.ichi2.anki.AbstractFlashcardViewer;
+import com.ichi2.anki.R;
+import com.ichi2.anki.UIUtils;
+import com.ichi2.libanki.Card;
+
+import java.util.concurrent.locks.Lock;
+
+import androidx.annotation.Nullable;
+import androidx.annotation.RequiresApi;
+import timber.log.Timber;
+
+public class OnRenderProcessGoneDelegate {
+
+    private final AbstractFlashcardViewer mTarget;
+
+    /**
+     * Last card that the WebView Renderer crashed on.
+     * If we get 2 crashes on the same card, then we likely have an infinite loop and want to exit gracefully.
+     */
+    @Nullable
+    private Long mLastCrashingCardId = null;
+
+    public OnRenderProcessGoneDelegate(AbstractFlashcardViewer target) {
+        this.mTarget = target;
+    }
+
+    /** Fix: #5780 - WebView Renderer OOM crashes reviewer */
+    @RequiresApi(api = Build.VERSION_CODES.O)
+    public boolean onRenderProcessGone(WebView view, RenderProcessGoneDetail detail) {
+        Timber.i("Obtaining write lock for card");
+        Lock writeLock = mTarget.getWriteLock();
+        WebView mCardWebView = mTarget.getWebView();
+        Card mCurrentCard = mTarget.getCurrentCard();
+        Timber.i("Obtained write lock for card");
+        try {
+            writeLock.lock();
+            if (mCardWebView == null || !mCardWebView.equals(view)) {
+                //A view crashed that wasn't ours.
+                //We have nothing to handle. Returning false is a desire to crash, so return true.
+                Timber.i("Unrelated WebView Renderer terminated. Crashed: %b",  detail.didCrash());
+                return true;
+            }
+
+            Timber.e("WebView Renderer process terminated. Crashed: %b",  detail.didCrash());
+
+            mTarget.destroyWebViewFrame();
+
+            //We only want to show one message per branch.
+
+            //It's not necessarily an OOM crash, false implies a general code which is for "system terminated".
+            int errorCauseId = detail.didCrash() ? R.string.webview_crash_unknown : R.string.webview_crash_oom;
+            String errorCauseString = mTarget.getResources().getString(errorCauseId);
+
+            if (!canRecoverFromWebViewRendererCrash()) {
+                Timber.e("Unrecoverable WebView Render crash");
+                String errorMessage = mTarget.getResources().getString(R.string.webview_crash_fatal, errorCauseString);
+                UIUtils.showThemedToast(mTarget, errorMessage, false);
+                mTarget.finishWithoutAnimation();
+                return true;
+            }
+
+            if (webViewRendererLastCrashedOnCard(mCurrentCard.getId())) {
+                Timber.e("Web Renderer crash loop on card: %d", mCurrentCard.getId());
+                displayRenderLoopDialog(mCurrentCard, detail);
+                return true;
+            }
+
+            // If we get here, the error is non-fatal and we should re-render the WebView
+            // This logic may need to be better defined. The card could have changed by the time we get here.
+            mLastCrashingCardId = mCurrentCard.getId();
+
+
+            String nonFatalError = mTarget.getResources().getString(R.string.webview_crash_nonfatal, errorCauseString);
+            UIUtils.showThemedToast(mTarget, nonFatalError, false);
+
+            mTarget.recreateWebViewFrame();
+        } finally {
+            writeLock.unlock();
+            Timber.d("Relinquished writeLock");
+        }
+        mTarget.displayCardQuestion();
+
+        //We handled the crash and can continue.
+        return true;
+    }
+
+    @TargetApi(Build.VERSION_CODES.O)
+    private void displayRenderLoopDialog(Card currentCard, RenderProcessGoneDetail detail) {
+        String cardInformation = Long.toString(currentCard.getId());
+        Resources res = mTarget.getResources();
+
+        String errorDetails = detail.didCrash()
+                ? res.getString(R.string.webview_crash_unknwon_detailed)
+                : res.getString(R.string.webview_crash_oom_details);
+        new MaterialDialog.Builder(mTarget)
+                .title(res.getString(R.string.webview_crash_loop_dialog_title))
+                .content(res.getString(R.string.webview_crash_loop_dialog_content, cardInformation, errorDetails))
+                .positiveText(R.string.dialog_ok)
+                .cancelable(false)
+                .canceledOnTouchOutside(false)
+                .onPositive((materialDialog, dialogAction) -> mTarget.finishWithoutAnimation())
+                .show();
+    }
+
+
+
+    private boolean webViewRendererLastCrashedOnCard(long cardId) {
+        return mLastCrashingCardId != null && mLastCrashingCardId == cardId;
+    }
+
+
+    private boolean canRecoverFromWebViewRendererCrash() {
+        // DEFECT
+        // If we don't have a card to render, we're in a bad state. The class doesn't currently track state
+        // well enough to be able to know exactly where we are in the initialisation pipeline.
+        // so it's best to mark the crash as non-recoverable.
+        // We should fix this, but it's very unlikely that we'll ever get here. Logs will tell
+
+        // Revisit webViewCrashedOnCard() if changing this. Logic currently assumes we have a card.
+        return mTarget.getCurrentCard() != null;
+    }
+}

--- a/AnkiDroid/src/test/java/com/ichi2/anki/TestCardTemplatePreviewer.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/TestCardTemplatePreviewer.java
@@ -14,7 +14,7 @@ public class TestCardTemplatePreviewer extends CardTemplatePreviewer {
 
 
     @Override
-    protected void displayCardQuestion() {
+    public void displayCardQuestion() {
         super.displayCardQuestion();
         mShowingAnswer = false;
     }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/cardviewer/OnRenderProcessGoneDelegateTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/cardviewer/OnRenderProcessGoneDelegateTest.java
@@ -1,0 +1,170 @@
+/*
+ *  Copyright (c) 2021 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.cardviewer;
+
+import android.content.res.Resources;
+import android.webkit.RenderProcessGoneDetail;
+import android.webkit.WebView;
+
+import com.ichi2.anki.AbstractFlashcardViewer;
+import com.ichi2.anki.BackupManagerTest.ThrowingAnswer;
+import com.ichi2.libanki.Card;
+
+import org.junit.Test;
+
+import java.util.concurrent.locks.Lock;
+
+import androidx.annotation.NonNull;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class OnRenderProcessGoneDelegateTest {
+
+    @Test
+    public void singleCallCausesRefresh() {
+        AbstractFlashcardViewer mock = getViewer();
+        OnRenderProcessGoneDelegateImpl delegate = getInstance(mock);
+
+        callOnRenderProcessGone(delegate);
+
+        verify(mock, times(1)).displayCardQuestion();
+        assertThat(delegate.mDisplayedToast, is(true));
+    }
+
+
+    @Test
+    public void secondCallCausesDialog() {
+        AbstractFlashcardViewer mock = getViewer();
+        OnRenderProcessGoneDelegateImpl delegate = getInstance(mock);
+
+        callOnRenderProcessGone(delegate);
+
+        verify(mock, times(1)).displayCardQuestion();
+
+        callOnRenderProcessGone(delegate);
+
+        verify(mock, times(1)
+                .description("displayCardQuestion should not be called again as the screen should close"))
+                .displayCardQuestion();
+        assertThat(delegate.mDisplayedDialog, is(true));
+        verify(mock, times(1).description("After the dialog, the screen should be closed")).finishWithoutAnimation();
+    }
+
+    @Test
+    public void nothingHappensIfWebViewIsNotTheSame() {
+        AbstractFlashcardViewer mock = getViewer();
+        OnRenderProcessGoneDelegateImpl delegate = getInstance(mock);
+
+        callOnRenderProcessGone(delegate, mock(WebView.class));
+
+        verify(mock, never().description("No mutating methods should be called if the WebView is not relevant")).destroyWebViewFrame();
+    }
+
+    @SuppressWarnings("ResultOfMethodCallIgnored")
+    @Test
+    public void unrecoverableCrashDoesNotRecreateWebView() {
+        AbstractFlashcardViewer mock = getViewer();
+        OnRenderProcessGoneDelegateImpl delegate = getInstance(mock);
+
+        doReturn(null).when(mock).getCurrentCard();
+        callOnRenderProcessGone(delegate);
+
+        verify(mock, times(1)).destroyWebViewFrame();
+        verify(mock, never()).recreateWebViewFrame();
+
+        assertThat("A toast should be displayed", delegate.mDisplayedToast, is(true));
+        verify(mock, times(1).description("screen should be closed")).finishWithoutAnimation();
+    }
+
+
+    protected void callOnRenderProcessGone(OnRenderProcessGoneDelegateImpl delegate) {
+        callOnRenderProcessGone(delegate, delegate.getTarget().getWebView());
+    }
+
+
+    private void callOnRenderProcessGone(OnRenderProcessGoneDelegateImpl delegate, WebView webView) {
+        boolean result = delegate.onRenderProcessGone(webView, getCrashDetail());
+        assertThat("onRenderProcessGone should only return false if we want the app killed", result, is(true));
+    }
+
+
+    @SuppressWarnings("ResultOfMethodCallIgnored")
+    @NonNull
+    protected AbstractFlashcardViewer getViewer() {
+        WebView mockWebView = mock(WebView.class);
+        AbstractFlashcardViewer mock = mock(AbstractFlashcardViewer.class, new ThrowingAnswer());
+        doReturn(mock(Lock.class)).when(mock).getWriteLock();
+        doReturn(mock(Resources.class)).when(mock).getResources();
+        doReturn(mockWebView).when(mock).getWebView();
+        doReturn(mock(Card.class)).when(mock).getCurrentCard();
+        doNothing().when(mock).destroyWebViewFrame();
+        doNothing().when(mock).recreateWebViewFrame();
+        doNothing().when(mock).displayCardQuestion();
+        doNothing().when(mock).finishWithoutAnimation();
+        return mock;
+    }
+
+    @NonNull
+    protected OnRenderProcessGoneDelegateImpl getInstance(AbstractFlashcardViewer mock) {
+        return spy(new OnRenderProcessGoneDelegateImpl(mock));
+    }
+
+    protected RenderProcessGoneDetail getCrashDetail() {
+        RenderProcessGoneDetail mock = mock(RenderProcessGoneDetail.class);
+        when(mock.didCrash()).thenReturn(true); // this value doesn't matter for now as it only defines a string
+        return mock;
+    }
+
+    public static class OnRenderProcessGoneDelegateImpl extends OnRenderProcessGoneDelegate {
+
+        private boolean mDisplayedToast;
+        private boolean mDisplayedDialog;
+
+
+        public OnRenderProcessGoneDelegateImpl(AbstractFlashcardViewer target) {
+            super(target);
+        }
+
+
+        @Override
+        protected void displayFatalError(RenderProcessGoneDetail detail) {
+            this.mDisplayedToast = true;
+        }
+
+
+        @Override
+        protected void displayNonFatalError(RenderProcessGoneDetail detail) {
+            this.mDisplayedToast = true;
+        }
+
+
+        @Override
+        protected void displayRenderLoopDialog(long currentCardId, RenderProcessGoneDetail detail) {
+            this.mDisplayedDialog = true;
+            this.onCloseRenderLoopDialog();
+        }
+    }
+}


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
On Android 11, OnRenderProcessGone occurred quite a lot for me with basic (sound/image) cards. This was while the app was minimised, sometimes for a long time, and the toast which was displayed was confusing.

One instance of the "OOM" string is seen in a Russian forum

String: `WebView renderer crashed. Cause: Out Of Memory`



## Fixes
Fixes #8459

## Approach
I feel there's no need to do anything in this case, as the OOM is likely recoverable and non-repeatable while the user is
reviewing, so we avoid doing anything

So, use [lifecycle components](https://developer.android.com/topic/libraries/architecture/lifecycle) and do nothing if the activity isn't after the "STARTED" state.


## How Has This Been Tested?

Mostly unit tested, crashing still appears to work via `AbstractFlashcardViewer.crashWebViewRenderer`

## Learning (optional, can help others)
* onRenderProcessGone changed from my Android 9 to my Android 11
* https://developer.android.com/topic/libraries/architecture/lifecycle

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
