### PR TITLE
ktlint: Disable no wildcard imports rule

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -200,6 +200,10 @@ android {
         }
     }
     ndkVersion "22.0.7026061"
+
+    ktlint {
+        disabledRules = ["no-wildcard-imports"]
+    }
 }
 
 play {


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
`ktLintFormat` fails if a wildcard was present as the `format` did not fix this, and then the `lint` failed

* Prevents huge changes in imports

## Fixes
Alleviates #9093

## Approach
Don't worry about wildcards

Cherry-picked from 46324c097f49d7f03a1d435e357f7f02af38d7e2

## How Has This Been Tested?

My branch now passes with this cherry-picked

## Learning (optional, can help others)

* alternate solution: https://stackoverflow.com/questions/63354680/ktlint-fails-with-wildcard-import-cannot-be-auto-corrected
* https://github.com/JLLeitschuh/ktlint-gradle#configuration (open `Groovy` section)

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
