### PR TITLE
fix: Remove noise from ktLintFormat output

### DIFF
--- a/pre-commit
+++ b/pre-commit
@@ -11,7 +11,10 @@ fi;
 echo "Running Ktlint over these files:"
 echo "$CHANGED_FILES"
 
-./gradlew ktlintFormat
+# -q removes noise from the output if it fails.
+# TODO: -w is better, but https://github.com/JLLeitschuh/ktlint-gradle/issues/457 adds noise
+# -w should display: "CriticalExceptionTest.kt:19:1 Wildcard import (cannot be auto-corrected)"
+./gradlew -q ktlintFormat
 
 echo "Completed ./gradlew ktlintFormat run."
 echo "$CHANGED_FILES" | while read -r file; do


### PR DESCRIPTION
A user would struggle to determine what the error was if `ktLintFormat` failed

`-q` (error only) is overkill as it removes useful output, but there is a large amount of warnings in the current version of the ktLint plugin

GitHub ref: JLLeitschuh/ktlint-gradle/issues/457

This can be converted to `-w` (warnings only) afterwards

A typical error is:

```
 KtLint found code style violations. Please see the following reports:
     - C:\\...\ktlintTestSourceSetFormat\ktlintTestSourceSetFormat.txt
```

After adding `-w`, we'd also get the more useful:

```
CriticalExceptionTest.kt:19:1 Wildcard import (cannot be auto-corrected)
```

Fixes #9093

## How Has This Been Tested?

⚠️ Untested, only via commandline not via hook


## Learning
* https://docs.gradle.org/current/userguide/command_line_interface.html#sec:command_line_logging
* https://github.com/JLLeitschuh/ktlint-gradle/issues/457


## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
