### PR TITLE
Kotlin: enable `AutoCloseable.use { }`

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -306,6 +306,7 @@ dependencies {
     implementation 'com.github.yalantis:ucrop:2.2.6'
     implementation 'com.drakeet.drawer:drawer:1.0.3'
     implementation 'org.jetbrains.kotlin:kotlin-stdlib:1.5.10'
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.5.10"
     api project(":api")
 
     testImplementation 'org.junit.vintage:junit-vintage-engine:5.7.2'

--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -305,8 +305,8 @@ dependencies {
     implementation "com.github.zafarkhaja:java-semver:0.9.0" // For AnkiDroid JS API Versioning
     implementation 'com.github.yalantis:ucrop:2.2.6'
     implementation 'com.drakeet.drawer:drawer:1.0.3'
-    implementation 'org.jetbrains.kotlin:kotlin-stdlib:1.5.10'
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.5.10"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     api project(":api")
 
     testImplementation 'org.junit.vintage:junit-vintage-engine:5.7.2'

--- a/api/build.gradle
+++ b/api/build.gradle
@@ -53,7 +53,7 @@ apply from: "../lint.gradle"
 
 dependencies {
     implementation 'androidx.annotation:annotation:1.2.0'
-    implementation 'org.jetbrains.kotlin:kotlin-stdlib:1.5.10'
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     testImplementation 'org.junit.vintage:junit-vintage-engine:5.7.2'
     testImplementation 'org.robolectric:robolectric:4.5.1'
 

--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,9 @@ import org.gradle.internal.jvm.Jvm
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
+    // The version for the Kotlin plugin and dependencies
+    ext.kotlin_version = '1.5.10'
+
     repositories {
         google()
         maven {
@@ -15,7 +18,7 @@ buildscript {
         // in the individual module build.gradle files
         classpath "app.brant:amazonappstorepublisher:0.1.0"
 
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.5.10"
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "org.jlleitschuh.gradle:ktlint-gradle:10.0.0"
     }
 }

--- a/lint-rules/build.gradle
+++ b/lint-rules/build.gradle
@@ -15,7 +15,7 @@ dependencies {
     compileOnly "com.android.tools.lint:lint-api:27.2.1"
     compileOnly "com.android.tools.lint:lint:27.2.1"
 
-    compileOnly 'org.jetbrains.kotlin:kotlin-stdlib:1.5.10'
+    compileOnly "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
 
     testImplementation "junit:junit:4.13.2"
     testImplementation "com.android.tools.lint:lint:27.2.1"


### PR DESCRIPTION
Kotlin by default targets JDK 6

This lib allows usage of `AutoCloseable.use { }` instead of just `Closeable.use { }`

## How Has This Been Tested?

Briefly tried it and it seems to work now

## Learning (optional, can help others)

* https://stackoverflow.com/a/43269795
* https://mbonnin.medium.com/the-different-kotlin-stdlibs-explained-83d7c6bf293 

## Checklist

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
