### PR TITLE
Migrate AnkiDroid folder to External Scoped App-Specific Directory

### DIFF
--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/libanki/DBTest.java
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/libanki/DBTest.java
@@ -1,11 +1,14 @@
 package com.ichi2.anki.tests.libanki;
 
 import android.Manifest;
+import android.app.Application;
+import android.content.Context;
 import android.database.sqlite.SQLiteDatabase;
 import android.database.sqlite.SQLiteDatabaseCorruptException;
 import android.os.Build;
 
 import com.ichi2.anki.CollectionHelper;
+import com.ichi2.anki.tests.InstrumentedTest;
 import com.ichi2.compat.CompatHelper;
 import com.ichi2.libanki.DB;
 
@@ -19,11 +22,13 @@ import java.io.FileOutputStream;
 import java.util.Random;
 
 import androidx.sqlite.db.SupportSQLiteDatabase;
+import androidx.test.core.app.ApplicationProvider;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.platform.app.InstrumentationRegistry;
 import androidx.test.rule.GrantPermissionRule;
 
 @RunWith(AndroidJUnit4.class)
-public class DBTest {
+public class DBTest extends InstrumentedTest {
 
     @Rule
     public GrantPermissionRule mRuntimePermissionRule =
@@ -32,7 +37,7 @@ public class DBTest {
     @Test
     public void testDBCorruption() throws Exception {
 
-        String storagePath = CollectionHelper.getDefaultAnkiDroidDirectory();
+        String storagePath = CollectionHelper.getDefaultAnkiDroidDirectory(getTestContext());
         File illFatedDBFile = new File(storagePath, "illFatedDB.anki2");
 
         // Make sure we have clean state to start with

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.java
@@ -348,7 +348,7 @@ public class AnkiDroidApp extends Application {
                 CollectionHelper.initializeAnkiDroidDirectory(dir);
             } catch (StorageAccessException e) {
                 Timber.e(e, "Could not initialize AnkiDroid directory");
-                String defaultDir = CollectionHelper.getDefaultAnkiDroidDirectory();
+                String defaultDir = CollectionHelper.getDefaultAnkiDroidDirectory(this);
                 if (isSdCardMounted() && CollectionHelper.getCurrentAnkiDroidDirectory(this).equals(defaultDir)) {
                     // Don't send report if the user is using a custom directory as SD cards trip up here a lot
                     sendExceptionReport(e, "AnkiDroidApp.onCreate");

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.java
@@ -151,6 +151,17 @@ import static timber.log.Timber.DebugTree;
 )
 public class AnkiDroidApp extends Application {
 
+    /**
+     * Toggles Scoped Storage functionality introduced in later commits <p>
+     * Can be set to true or false only by altering the declaration itself.
+     * This restriction ensures that this flag will only be used by developers for testing <p>
+     * Set to false by default, so won't migrate data or use new scoped dirs <p>
+     * If true, enables data migration & use of scoped dirs in later commits <p>
+     * Should be set to true for testing Scoped Storage <p>
+     * TODO: Should be removed once app is fully functional under Scoped Storage
+     */
+    public static final boolean TESTING_SCOPED_STORAGE = false;
+
     private static final String WEBVIEW_VER_NAME = "WEBVIEW_VER_NAME";
 
     public static final String XML_CUSTOM_NAMESPACE = "http://arbitrary.app.namespace/com.ichi2.anki";

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CollectionHelper.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CollectionHelper.java
@@ -243,7 +243,7 @@ public class CollectionHelper {
      */
     @SuppressWarnings("deprecation") // TODO Tracked in https://github.com/ankidroid/Anki-Android/issues/5304
     @CheckResult
-    public static String getDefaultAnkiDroidDirectory() {
+    public static String getDefaultAnkiDroidDirectory(@NonNull Context context) {
         return new File(Environment.getExternalStorageDirectory(), "AnkiDroid").getAbsolutePath();
     }
 
@@ -264,7 +264,7 @@ public class CollectionHelper {
         return PreferenceExtensions.getOrSetString(
                 preferences,
                 "deckPath",
-                CollectionHelper::getDefaultAnkiDroidDirectory);
+                () -> getDefaultAnkiDroidDirectory(context));
     }
 
     /**

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
@@ -349,7 +349,7 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
                                 .positiveText(R.string.dialog_ok)
                                 .negativeText(R.string.reset_custom_buttons)
                                 .onPositive((dialog, which) -> dialog.dismiss())
-                                .onNegative((dialog, which) -> collectionPathPreference.setText(CollectionHelper.getDefaultAnkiDroidDirectory()))
+                                .onNegative((dialog, which) -> collectionPathPreference.setText(CollectionHelper.getDefaultAnkiDroidDirectory(this)))
                                 .show();
                         return false;
                     }


### PR DESCRIPTION
## Purpose / Description
Migrating user data to a scoped storage directory (external only for now) in order to preserve access to user data under scoped storage.

## Fixes
Takes a step towards fixing #5304. Fixes #9107.

## Approach
Uses storage permission (which AnkiDroid already asks for) to access legacy storage and migrates the data to the External App-Specific Directory (given by ```getExternalFilesDir()```)
Migration is done by launching a ```MigrateToScoped``` task  of type ```CollectionTask.Task```

Any file within the AnkiDroid folder can be accessed under Scoped Storage post-migration.

## Next Steps

1. Option to choose their default directory (internal or external)
2. Support accessing certain non-app-specific locations - needed in some cases for accessing media (eg: like adding an audio clip to a note which was recorded by some other app, and isn't in the AnkiDroid folder)

## How Has This Been Tested?

- SAMSUNG Galaxy A80 (SM-A805F) API 30 (Physical Device)
- SAMSUNG Galaxy S7 (SM-G930F) API 26 (Physical Device)

Tested Robustness manually by repeatedly closing the app mid-migration. Reopening & allowing the migration to complete resulted in the collection being opened successfully.

## Important
- User Data is only being copied from the Legacy Directory, not deleted for now. That can be done once all use cases work under Scoped Storage
- To enable the Scoped Storage Functionality, set AnkiDroidApp's ```TESTING_SCOPED_STORAGE``` to ```true```
- ```TESTING_SCOPED_STORAGE``` is set to false by default and will be set to true once the app can access external media (to be done in a later PR)

## Checklist

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

## Demonstration Video

In this video, I first open the version of the app without Scoped Storage Functionality. I then install the PR's version (0:18 in the video) and it migrates my data from the Legacy Directory to the Scoped Storage Directory. After which, the application doesn't require permission to access the AnkiDroid folder. Media stored elsewhere will be handled in a later PR. 

https://user-images.githubusercontent.com/29615198/122638163-0c3bf200-d10c-11eb-9a8e-f627433f7ed1.mp4


