### PR TITLE
Treat SVG elements as non-empty fields

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Utils.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Utils.java
@@ -110,6 +110,7 @@ public class Utils {
     private static final Pattern stylePattern = Pattern.compile("(?si)<style.*?>.*?</style>");
     private static final Pattern scriptPattern = Pattern.compile("(?si)<script.*?>.*?</script>");
     private static final Pattern tagPattern = Pattern.compile("(?s)<.*?>");
+    private static final Pattern svgPattern = Pattern.compile("<svg\\s*.*>\\s*.*<\\/svg>");
     private static final Pattern imgPattern = Pattern.compile("(?i)<img[^>]+src=[\"']?([^\"'>]+)[\"']?[^>]*>");
     private static final Pattern soundPattern = Pattern.compile("(?i)\\[sound:([^]]+)]");
     private static final Pattern htmlEntitiesPattern = Pattern.compile("&#?\\w+;");
@@ -1114,8 +1115,9 @@ public class Utils {
         Set<String> nonempty_fields = new HashSet<>(fields.size());
         for (Map.Entry<String, String> kv: fields.entrySet()) {
             String value = kv.getValue();
+            Matcher svgMatcher = svgPattern.matcher(value);
             value = Utils.stripHTMLMedia(value).trim();
-            if (!TextUtils.isEmpty(value)) {
+            if (!TextUtils.isEmpty(value) || svgMatcher.matches()) {
                 nonempty_fields.add(kv.getKey());
             }
         }

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/UtilsTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/UtilsTest.java
@@ -118,6 +118,10 @@ public class UtilsTest {
         m.put("bar", " plop  ");
         s.add("bar");
         Assert.assertEquals(s, nonEmptyFields(m));
+        String svgElement = "<svg height=\"25\" width=\"25\"><line x1=\"0\" y1=\"0\" x2=\"200\" y2=\"200\" style=\"stroke:rgb(255,0,0);\"/></svg>";
+        m.put("svg", svgElement);
+        s.add("svg");
+        Assert.assertEquals(s, nonEmptyFields(m));
     }
 
 


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
Created a note with a `Field` that contains an SVG HTML element only to present computed shapes. AnkiDroid treats fields with SVG element only as empty fields because they don't contain any text.

## Fixes
None

## Approach
If a field contains an SVG element, the user is attempting to present scalable vector graphics, meaning the field is not actually empty when Utils.stripHTMLMedia is called.

## How Has This Been Tested?
Yes.

1. Create Basic card
2. In "Front" field, edit as HTML
3. Add a valid SVG (eg `<svg height="25" width="25"><line x1="0" y1="0" x2="200" y2="200" style="stroke:rgb(255,0,0);"/></svg>`)

## Learning (optional, can help others)
N/A

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [ ] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
