### PR TITLE
fix: Use primary color for Custom Tabs top bar

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiActivity.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiActivity.java
@@ -401,7 +401,7 @@ public class AnkiActivity extends AppCompatActivity implements SimpleMessageDial
             return;
         }
 
-        int toolbarColor = Themes.getColorFromAttr(this, R.attr.customTabToolbarColor);
+        int toolbarColor = Themes.getColorFromAttr(this, R.attr.colorPrimary);
         int navBarColor = Themes.getColorFromAttr(this, R.attr.customTabNavBarColor);
 
         CustomTabColorSchemeParams colorSchemeParams =

--- a/AnkiDroid/src/main/res/values/attrs.xml
+++ b/AnkiDroid/src/main/res/values/attrs.xml
@@ -118,6 +118,5 @@
     <attr name="fab_labelsTextColor" format="color">#fff</attr>
     <attr name="fab_item_background" format="reference"/>
     <!--Custom Tabs colors-->
-    <attr name="customTabToolbarColor" format="color"/>
     <attr name="customTabNavBarColor" format="color"/>
 </resources>

--- a/AnkiDroid/src/main/res/values/theme_black.xml
+++ b/AnkiDroid/src/main/res/values/theme_black.xml
@@ -107,7 +107,6 @@
         <item name="md_dark_theme">true</item>
         <item name="md_background_color">@color/theme_black_primary_light</item>
         <!--Custom Tabs colors-->
-        <item name="customTabToolbarColor">#000000</item>
         <item name="customTabNavBarColor">#070707</item>
     </style>
 

--- a/AnkiDroid/src/main/res/values/theme_dark.xml
+++ b/AnkiDroid/src/main/res/values/theme_dark.xml
@@ -114,7 +114,6 @@
         <item name="android:listPreferredItemHeight">56dip</item>
         <item name="md_dark_theme">true</item>
         <!--Custom Tabs colors-->
-        <item name="customTabToolbarColor">#3d3d3d</item>
         <item name="customTabNavBarColor">@color/material_grey_800</item>
     </style>
 

--- a/AnkiDroid/src/main/res/values/theme_light.xml
+++ b/AnkiDroid/src/main/res/values/theme_light.xml
@@ -128,7 +128,6 @@ APIs. It's visible when there aren't enough decks to fill the screen.
         <item name="android:listPreferredItemHeight">56dip</item>
         <item name="md_dark_theme">false</item>
         <!--Custom Tabs colors-->
-        <item name="customTabToolbarColor">@color/material_light_blue_700</item>
         <item name="customTabNavBarColor">@color/material_light_blue_500</item>
     </style>
 

--- a/AnkiDroid/src/main/res/values/theme_plain.xml
+++ b/AnkiDroid/src/main/res/values/theme_plain.xml
@@ -46,7 +46,6 @@
         <item name="fab_normal">@color/theme_plain_accent</item>
         <item name="fab_pressed">#c8607d8b</item> <!-- 55 less opacity than fab_normal -->
         <!--Custom Tabs colors-->
-        <item name="customTabToolbarColor">@color/material_grey_600</item>
         <item name="customTabNavBarColor">@color/material_grey_500</item>
     </style>
 


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
App bar changed color when opening Custom Tabs - was jarring to me

## Fixes
Fixes #8365

## Approach
Now we match the app, so the color transition is less jarring

## How Has This Been Tested?

Personal device

<details>

![image](https://user-images.githubusercontent.com/62114487/123194809-02651680-d49f-11eb-941a-c9cc5cdeaa17.png)
![image](https://user-images.githubusercontent.com/62114487/123194814-04c77080-d49f-11eb-9c1a-7d1763b3f02a.png)
![image](https://user-images.githubusercontent.com/62114487/123194825-06913400-d49f-11eb-8c22-a94f8664231f.png)
![image](https://user-images.githubusercontent.com/62114487/123194830-085af780-d49f-11eb-994d-67c2ae9f325c.png)


</details>

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

For screenshots: see the Details element above