### PR TITLE
NF: Gesture refactor to allow for mappable gestures

### DIFF
--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/reviewer/PeripheralKeymapTest.java
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/reviewer/PeripheralKeymapTest.java
@@ -40,7 +40,7 @@ public class PeripheralKeymapTest {
     @Test
     public void testNumpadAction() {
         // #7736 Ensures that a numpad key is passed through (mostly testing num lock)
-        List<Integer> processed = new ArrayList<>();
+        List<ViewerCommand> processed = new ArrayList<>();
 
         PeripheralKeymap peripheralKeymap = new PeripheralKeymap(MockReviewerUi.displayingAnswer(), processed::add);
         peripheralKeymap.setup();

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -1920,8 +1920,8 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
         mLinkOverridesTouchGesture = preferences.getBoolean("linkOverridesTouchGesture", false);
         if (mGesturesEnabled) {
             mGestureProcessor.init(preferences);
-            mGestureVolumeUp = ViewerCommand.fromString(preferences.getString("gestureVolumeUp", "0"));
-            mGestureVolumeDown = ViewerCommand.fromString(preferences.getString("gestureVolumeDown", "0"));
+            mGestureVolumeUp = Gesture.VOLUME_UP.fromPreference(preferences);
+            mGestureVolumeDown = Gesture.VOLUME_DOWN.fromPreference(preferences);
         }
 
         if (preferences.getBoolean("keepScreenOn", false)) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -345,7 +345,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
      */
     private int mGestureVolumeUp;
     private int mGestureVolumeDown;
-    private final GestureProcessor mGestureProcessor = new GestureProcessor(this);
+    protected final GestureProcessor mGestureProcessor = new GestureProcessor(this);
 
     private String mCardContent;
     private String mBaseUrl;

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -90,9 +90,11 @@ import com.afollestad.materialdialogs.MaterialDialog;
 import com.drakeet.drawer.FullDraggableContainer;
 import com.google.android.material.snackbar.Snackbar;
 import com.ichi2.anim.ViewAnimation;
+import com.ichi2.anki.cardviewer.Gesture;
 import com.ichi2.anki.cardviewer.GestureProcessor;
 import com.ichi2.anki.cardviewer.MissingImageHandler;
 import com.ichi2.anki.cardviewer.OnRenderProcessGoneDelegate;
+import com.ichi2.anki.cardviewer.ViewerCommand;
 import com.ichi2.anki.dialogs.tags.TagsDialog;
 import com.ichi2.anki.dialogs.tags.TagsDialogFactory;
 import com.ichi2.anki.dialogs.tags.TagsDialogListener;
@@ -343,8 +345,8 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
     /**
      * Gesture Allocation
      */
-    private int mGestureVolumeUp;
-    private int mGestureVolumeDown;
+    private ViewerCommand mGestureVolumeUp;
+    private ViewerCommand mGestureVolumeDown;
     protected final GestureProcessor mGestureProcessor = new GestureProcessor(this);
 
     private String mCardContent;
@@ -1515,7 +1517,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
     public boolean dispatchKeyEvent(KeyEvent event) {
         if (event.getAction() == KeyEvent.ACTION_DOWN) {
             // assign correct gesture code
-            int gesture = COMMAND_NOTHING;
+            ViewerCommand gesture = COMMAND_NOTHING;
 
             switch (event.getKeyCode()) {
                 case KeyEvent.KEYCODE_VOLUME_UP:
@@ -1918,8 +1920,8 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
         mLinkOverridesTouchGesture = preferences.getBoolean("linkOverridesTouchGesture", false);
         if (mGesturesEnabled) {
             mGestureProcessor.init(preferences);
-            mGestureVolumeUp = Integer.parseInt(preferences.getString("gestureVolumeUp", "0"));
-            mGestureVolumeDown = Integer.parseInt(preferences.getString("gestureVolumeDown", "0"));
+            mGestureVolumeUp = ViewerCommand.fromString(preferences.getString("gestureVolumeUp", "0"));
+            mGestureVolumeDown = ViewerCommand.fromString(preferences.getString("gestureVolumeDown", "0"));
         }
 
         if (preferences.getBoolean("keepScreenOn", false)) {
@@ -2690,7 +2692,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
         return dismiss(new CollectionTask.BuryNote(mCurrentCard));
     }
 
-    public boolean executeCommand(@ViewerCommandDef int which) {
+    public boolean executeCommand(ViewerCommand which) {
         if (isControlBlocked() && which != COMMAND_EXIT) {
             return false;
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Previewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Previewer.java
@@ -25,6 +25,7 @@ import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
 
+import com.ichi2.anki.cardviewer.ViewerCommand;
 import com.ichi2.libanki.Collection;
 import com.ichi2.libanki.Utils;
 import com.ichi2.themes.Themes;
@@ -223,7 +224,7 @@ public class Previewer extends AbstractFlashcardViewer {
 
 
     @Override
-    public boolean executeCommand(int which) {
+    public boolean executeCommand(ViewerCommand which) {
         /* do nothing */
         return false;
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.java
@@ -63,6 +63,7 @@ import androidx.core.view.MenuItemCompat;
 import androidx.vectordrawable.graphics.drawable.VectorDrawableCompat;
 
 import com.ichi2.anki.cardviewer.CardAppearance;
+import com.ichi2.anki.cardviewer.Gesture;
 import com.ichi2.anki.dialogs.ConfirmationDialog;
 import com.ichi2.anki.multimediacard.AudioView;
 import com.ichi2.anki.dialogs.RescheduleDialog;
@@ -92,7 +93,6 @@ import java.util.Collections;
 import timber.log.Timber;
 
 import static com.ichi2.anki.reviewer.CardMarker.*;
-import static com.ichi2.anki.cardviewer.ViewerCommand.COMMAND_NOTHING;
 import static com.ichi2.anim.ActivityTransitionAnimation.Direction.*;
 
 
@@ -1201,18 +1201,9 @@ public class Reviewer extends AbstractFlashcardViewer {
 
 
     private void disableDrawerSwipeOnConflicts() {
-        SharedPreferences preferences = AnkiDroidApp.getSharedPrefs(getBaseContext());
-        boolean gesturesEnabled = preferences.getBoolean("gestures", false);
-        if (gesturesEnabled) {
-            int gestureSwipeUp = Integer.parseInt(preferences.getString("gestureSwipeUp", "9"));
-            int gestureSwipeDown = Integer.parseInt(preferences.getString("gestureSwipeDown", "0"));
-            int gestureSwipeRight = Integer.parseInt(preferences.getString("gestureSwipeRight", "17"));
-            if (gestureSwipeUp != COMMAND_NOTHING ||
-                    gestureSwipeDown != COMMAND_NOTHING ||
-                    gestureSwipeRight != COMMAND_NOTHING) {
-                mHasDrawerSwipeConflicts = true;
-                super.disableDrawerSwipe();
-            }
+        if (mGestureProcessor.isBound(Gesture.SWIPE_UP, Gesture.SWIPE_DOWN, Gesture.SWIPE_RIGHT)) {
+            mHasDrawerSwipeConflicts = true;
+            super.disableDrawerSwipe();
         }
     }
 
@@ -1267,6 +1258,11 @@ public class Reviewer extends AbstractFlashcardViewer {
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)
     public AudioView getAudioView() {
         return mMicToolBar;
+    }
+
+    @VisibleForTesting(otherwise = VisibleForTesting.NONE)
+    public boolean hasDrawerSwipeConflicts() {
+        return mHasDrawerSwipeConflicts;
     }
 
     /**

--- a/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/Gesture.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/Gesture.kt
@@ -15,22 +15,38 @@
  */
 package com.ichi2.anki.cardviewer
 
+import android.content.SharedPreferences
 import com.ichi2.anki.R
 
-enum class Gesture(@get:JvmName("getResourceId") val mResourceId: Int) {
-    SWIPE_UP(R.string.gestures_swipe_up),
-    SWIPE_DOWN(R.string.gestures_swipe_down),
-    SWIPE_LEFT(R.string.gestures_swipe_left),
-    SWIPE_RIGHT(R.string.gestures_swipe_right),
-    LONG_TAP(R.string.gestures_long_tap),
-    DOUBLE_TAP(R.string.gestures_double_tap),
-    TAP_TOP_LEFT(R.string.gestures_corner_tap_top_left),
-    TAP_TOP(R.string.gestures_tap_top),
-    TAP_TOP_RIGHT(R.string.gestures_corner_tap_top_right),
-    TAP_LEFT(R.string.gestures_tap_left),
-    TAP_CENTER(R.string.gestures_corner_tap_middle_center),
-    TAP_RIGHT(R.string.gestures_tap_right),
-    TAP_BOTTOM_LEFT(R.string.gestures_corner_tap_bottom_left),
-    TAP_BOTTOM(R.string.gestures_tap_bottom),
-    TAP_BOTTOM_RIGHT(R.string.gestures_corner_tap_bottom_right);
+// TODO: Code and preference defaults are inconsistent: #8066
+enum class Gesture(
+    @get:JvmName("getResourceId") val mResourceId: Int,
+    private val mPreferenceKey: String,
+    private val mPreferenceDefault: ViewerCommand
+) {
+    SWIPE_UP(R.string.gestures_swipe_up, "gestureSwipeUp", ViewerCommand.COMMAND_EDIT),
+    SWIPE_DOWN(R.string.gestures_swipe_down, "gestureSwipeDown", ViewerCommand.COMMAND_NOTHING),
+    SWIPE_LEFT(R.string.gestures_swipe_left, "gestureSwipeLeft", ViewerCommand.COMMAND_UNDO),
+    SWIPE_RIGHT(R.string.gestures_swipe_right, "gestureSwipeRight", ViewerCommand.COMMAND_EXIT),
+    LONG_TAP(R.string.gestures_long_tap, "gestureLongclick", ViewerCommand.COMMAND_LOOKUP),
+    DOUBLE_TAP(R.string.gestures_double_tap, "gestureDoubleTap", ViewerCommand.COMMAND_FLIP_OR_ANSWER_BETTER_THAN_RECOMMENDED),
+    TAP_TOP_LEFT(R.string.gestures_corner_tap_top_left, "gestureTapTopLeft", ViewerCommand.COMMAND_NOTHING),
+    TAP_TOP(R.string.gestures_tap_top, "gestureTapTop", ViewerCommand.COMMAND_BURY_CARD),
+    TAP_TOP_RIGHT(R.string.gestures_corner_tap_top_right, "gestureTapTopRight", ViewerCommand.COMMAND_NOTHING),
+    TAP_LEFT(R.string.gestures_tap_left, "gestureTapLeft", ViewerCommand.COMMAND_FLIP_OR_ANSWER_EASE2),
+    TAP_CENTER(R.string.gestures_corner_tap_middle_center, "gestureTapCenter", ViewerCommand.COMMAND_NOTHING),
+    TAP_RIGHT(R.string.gestures_tap_right, "gestureTapRight", ViewerCommand.COMMAND_FLIP_OR_ANSWER_RECOMMENDED),
+    TAP_BOTTOM_LEFT(R.string.gestures_corner_tap_bottom_left, "gestureTapBottomLeft", ViewerCommand.COMMAND_NOTHING),
+    TAP_BOTTOM(R.string.gestures_tap_bottom, "gestureTapBottom", ViewerCommand.COMMAND_FLIP_OR_ANSWER_EASE1),
+    TAP_BOTTOM_RIGHT(R.string.gestures_corner_tap_bottom_right, "gestureTapBottomRight", ViewerCommand.COMMAND_NOTHING),
+    VOLUME_UP(R.string.gestures_volume_up, "gestureVolumeUp", ViewerCommand.COMMAND_NOTHING),
+    VOLUME_DOWN(R.string.gestures_volume_down, "gestureVolumeDown", ViewerCommand.COMMAND_NOTHING);
+
+    fun fromPreference(prefs: SharedPreferences): ViewerCommand {
+        val value = prefs.getString(mPreferenceKey, null) ?: return mPreferenceDefault
+
+        val valueAsInt = Integer.parseInt(value)
+
+        return ViewerCommand.fromInt(valueAsInt) ?: mPreferenceDefault
+    }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/GestureProcessor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/GestureProcessor.java
@@ -51,28 +51,28 @@ public class GestureProcessor {
 
     public void init(SharedPreferences preferences) {
         mEnabled = preferences.getBoolean("gestures", false);
-        mGestureDoubleTap = ViewerCommand.fromString(preferences.getString("gestureDoubleTap", "7"));
-        mGestureLongclick = ViewerCommand.fromString(preferences.getString("gestureLongclick", "11"));
+        mGestureDoubleTap = Gesture.DOUBLE_TAP.fromPreference(preferences);
+        mGestureLongclick = Gesture.LONG_TAP.fromPreference(preferences);
 
-        mGestureSwipeUp = ViewerCommand.fromString(preferences.getString("gestureSwipeUp", "9"));
-        mGestureSwipeDown = ViewerCommand.fromString(preferences.getString("gestureSwipeDown", "0"));
-        mGestureSwipeLeft = ViewerCommand.fromString(preferences.getString("gestureSwipeLeft", "8"));
-        mGestureSwipeRight = ViewerCommand.fromString(preferences.getString("gestureSwipeRight", "17"));
+        mGestureSwipeUp = Gesture.SWIPE_UP.fromPreference(preferences);
+        mGestureSwipeDown = Gesture.SWIPE_DOWN.fromPreference(preferences);
+        mGestureSwipeLeft = Gesture.SWIPE_LEFT.fromPreference(preferences);
+        mGestureSwipeRight = Gesture.SWIPE_RIGHT.fromPreference(preferences);
 
         mGestureMapper.init(preferences);
 
-        mGestureTapLeft = ViewerCommand.fromString(preferences.getString("gestureTapLeft", "3"));
-        mGestureTapRight = ViewerCommand.fromString(preferences.getString("gestureTapRight", "6"));
-        mGestureTapTop = ViewerCommand.fromString(preferences.getString("gestureTapTop", "12"));
-        mGestureTapBottom = ViewerCommand.fromString(preferences.getString("gestureTapBottom", "2"));
+        mGestureTapLeft = Gesture.TAP_LEFT.fromPreference(preferences);
+        mGestureTapRight = Gesture.TAP_RIGHT.fromPreference(preferences);
+        mGestureTapTop = Gesture.TAP_TOP.fromPreference(preferences);
+        mGestureTapBottom = Gesture.TAP_BOTTOM.fromPreference(preferences);
 
         boolean useCornerTouch = preferences.getBoolean("gestureCornerTouch", false);
         if (useCornerTouch) {
-            mGestureTapTopLeft = ViewerCommand.fromString(preferences.getString("gestureTapTopLeft", "0"));
-            mGestureTapTopRight = ViewerCommand.fromString(preferences.getString("gestureTapTopRight", "0"));
-            mGestureTapCenter = ViewerCommand.fromString(preferences.getString("gestureTapCenter", "0"));
-            mGestureTapBottomLeft = ViewerCommand.fromString(preferences.getString("gestureTapBottomLeft", "0"));
-            mGestureTapBottomRight = ViewerCommand.fromString(preferences.getString("gestureTapBottomRight", "0"));
+            mGestureTapTopLeft = Gesture.TAP_TOP_LEFT.fromPreference(preferences);
+            mGestureTapTopRight = Gesture.TAP_TOP_RIGHT.fromPreference(preferences);
+            mGestureTapCenter = Gesture.TAP_CENTER.fromPreference(preferences);
+            mGestureTapBottomLeft = Gesture.TAP_BOTTOM_LEFT.fromPreference(preferences);
+            mGestureTapBottomRight = Gesture.TAP_BOTTOM_RIGHT.fromPreference(preferences);
         }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/GestureProcessor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/GestureProcessor.java
@@ -58,11 +58,14 @@ public class GestureProcessor {
 
     private final ViewerCommand.CommandProcessor mProcessor;
 
+    private boolean mEnabled = false;
+
     public GestureProcessor(ViewerCommand.CommandProcessor processor) {
         mProcessor = processor;
     }
 
     public void init(SharedPreferences preferences) {
+        mEnabled = preferences.getBoolean("gestures", false);
         mGestureDoubleTap = Integer.parseInt(preferences.getString("gestureDoubleTap", "7"));
         mGestureLongclick = Integer.parseInt(preferences.getString("gestureLongclick", "11"));
 
@@ -139,5 +142,35 @@ public class GestureProcessor {
             case LONG_TAP: return mGestureLongclick;
             default: return COMMAND_NOTHING;
         }
+    }
+
+
+    /**
+     * Whether the class has been enabled.
+     * This requires the "gestures" preference is enabled,
+     * and {@link GestureProcessor#init(SharedPreferences)} has been called
+     */
+    public boolean isEnabled() {
+        return mEnabled;
+    }
+
+
+    /**
+     * Whether one of the provided gestures is bound
+     * @param gestures the gestures to check
+     * @return <code>false</code> if none of the gestures are bound. <code>true</code> otherwise
+     */
+    public boolean isBound(Gesture... gestures) {
+        if (!isEnabled()) {
+            return false;
+        }
+
+        for (Gesture gesture : gestures) {
+            if (mapGestureToCommand(gesture) != COMMAND_NOTHING) {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/GestureProcessor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/GestureProcessor.java
@@ -23,36 +23,21 @@ import com.ichi2.anki.reviewer.GestureMapper;
 import static com.ichi2.anki.cardviewer.ViewerCommand.COMMAND_NOTHING;
 
 public class GestureProcessor {
-    @ViewerCommand.ViewerCommandDef
-    private int mGestureDoubleTap;
-    @ViewerCommand.ViewerCommandDef
-    private int mGestureLongclick;
-    @ViewerCommand.ViewerCommandDef
-    private int mGestureSwipeUp;
-    @ViewerCommand.ViewerCommandDef
-    private int mGestureSwipeDown;
-    @ViewerCommand.ViewerCommandDef
-    private int mGestureSwipeLeft;
-    @ViewerCommand.ViewerCommandDef
-    private int mGestureSwipeRight;
-    @ViewerCommand.ViewerCommandDef
-    private int mGestureTapLeft;
-    @ViewerCommand.ViewerCommandDef
-    private int mGestureTapRight;
-    @ViewerCommand.ViewerCommandDef
-    private int mGestureTapTop;
-    @ViewerCommand.ViewerCommandDef
-    private int mGestureTapBottom;
-    @ViewerCommand.ViewerCommandDef
-    private int mGestureTapTopLeft;
-    @ViewerCommand.ViewerCommandDef
-    private int mGestureTapTopRight;
-    @ViewerCommand.ViewerCommandDef
-    private int mGestureTapCenter;
-    @ViewerCommand.ViewerCommandDef
-    private int mGestureTapBottomLeft;
-    @ViewerCommand.ViewerCommandDef
-    private int mGestureTapBottomRight;
+    private ViewerCommand mGestureDoubleTap;
+    private ViewerCommand mGestureLongclick;
+    private ViewerCommand mGestureSwipeUp;
+    private ViewerCommand mGestureSwipeDown;
+    private ViewerCommand mGestureSwipeLeft;
+    private ViewerCommand mGestureSwipeRight;
+    private ViewerCommand mGestureTapLeft;
+    private ViewerCommand mGestureTapRight;
+    private ViewerCommand mGestureTapTop;
+    private ViewerCommand mGestureTapBottom;
+    private ViewerCommand mGestureTapTopLeft;
+    private ViewerCommand mGestureTapTopRight;
+    private ViewerCommand mGestureTapCenter;
+    private ViewerCommand mGestureTapBottomLeft;
+    private ViewerCommand mGestureTapBottomRight;
 
     private final GestureMapper mGestureMapper = new GestureMapper();
 
@@ -66,28 +51,28 @@ public class GestureProcessor {
 
     public void init(SharedPreferences preferences) {
         mEnabled = preferences.getBoolean("gestures", false);
-        mGestureDoubleTap = Integer.parseInt(preferences.getString("gestureDoubleTap", "7"));
-        mGestureLongclick = Integer.parseInt(preferences.getString("gestureLongclick", "11"));
+        mGestureDoubleTap = ViewerCommand.fromString(preferences.getString("gestureDoubleTap", "7"));
+        mGestureLongclick = ViewerCommand.fromString(preferences.getString("gestureLongclick", "11"));
 
-        mGestureSwipeUp = Integer.parseInt(preferences.getString("gestureSwipeUp", "9"));
-        mGestureSwipeDown = Integer.parseInt(preferences.getString("gestureSwipeDown", "0"));
-        mGestureSwipeLeft = Integer.parseInt(preferences.getString("gestureSwipeLeft", "8"));
-        mGestureSwipeRight = Integer.parseInt(preferences.getString("gestureSwipeRight", "17"));
+        mGestureSwipeUp = ViewerCommand.fromString(preferences.getString("gestureSwipeUp", "9"));
+        mGestureSwipeDown = ViewerCommand.fromString(preferences.getString("gestureSwipeDown", "0"));
+        mGestureSwipeLeft = ViewerCommand.fromString(preferences.getString("gestureSwipeLeft", "8"));
+        mGestureSwipeRight = ViewerCommand.fromString(preferences.getString("gestureSwipeRight", "17"));
 
         mGestureMapper.init(preferences);
 
-        mGestureTapLeft = Integer.parseInt(preferences.getString("gestureTapLeft", "3"));
-        mGestureTapRight = Integer.parseInt(preferences.getString("gestureTapRight", "6"));
-        mGestureTapTop = Integer.parseInt(preferences.getString("gestureTapTop", "12"));
-        mGestureTapBottom = Integer.parseInt(preferences.getString("gestureTapBottom", "2"));
+        mGestureTapLeft = ViewerCommand.fromString(preferences.getString("gestureTapLeft", "3"));
+        mGestureTapRight = ViewerCommand.fromString(preferences.getString("gestureTapRight", "6"));
+        mGestureTapTop = ViewerCommand.fromString(preferences.getString("gestureTapTop", "12"));
+        mGestureTapBottom = ViewerCommand.fromString(preferences.getString("gestureTapBottom", "2"));
 
         boolean useCornerTouch = preferences.getBoolean("gestureCornerTouch", false);
         if (useCornerTouch) {
-            mGestureTapTopLeft = Integer.parseInt(preferences.getString("gestureTapTopLeft", "0"));
-            mGestureTapTopRight = Integer.parseInt(preferences.getString("gestureTapTopRight", "0"));
-            mGestureTapCenter = Integer.parseInt(preferences.getString("gestureTapCenter", "0"));
-            mGestureTapBottomLeft = Integer.parseInt(preferences.getString("gestureTapBottomLeft", "0"));
-            mGestureTapBottomRight = Integer.parseInt(preferences.getString("gestureTapBottomRight", "0"));
+            mGestureTapTopLeft = ViewerCommand.fromString(preferences.getString("gestureTapTopLeft", "0"));
+            mGestureTapTopRight = ViewerCommand.fromString(preferences.getString("gestureTapTopRight", "0"));
+            mGestureTapCenter = ViewerCommand.fromString(preferences.getString("gestureTapCenter", "0"));
+            mGestureTapBottomLeft = ViewerCommand.fromString(preferences.getString("gestureTapBottomLeft", "0"));
+            mGestureTapBottomRight = ViewerCommand.fromString(preferences.getString("gestureTapBottomRight", "0"));
         }
     }
 
@@ -118,12 +103,12 @@ public class GestureProcessor {
 
 
     protected boolean execute(Gesture gesture) {
-        int command = mapGestureToCommand(gesture);
+        ViewerCommand command = mapGestureToCommand(gesture);
         return mProcessor.executeCommand(command);
     }
 
 
-    private int mapGestureToCommand(Gesture gesture) {
+    private ViewerCommand mapGestureToCommand(Gesture gesture) {
         switch (gesture) {
             case SWIPE_UP: return mGestureSwipeUp;
             case SWIPE_DOWN: return mGestureSwipeDown;

--- a/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/ViewerCommand.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/ViewerCommand.java
@@ -16,75 +16,89 @@
 
 package com.ichi2.anki.cardviewer;
 
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
+import com.ichi2.anki.R;
 
-import androidx.annotation.IntDef;
+import java.util.Arrays;
+
+import androidx.annotation.Nullable;
 
 /** Abstraction: Discuss moving many of these to 'Reviewer' */
-public class ViewerCommand {
-    public static final int COMMAND_NOTHING = 0;
-    public static final int COMMAND_SHOW_ANSWER = 1;
-    public static final int COMMAND_FLIP_OR_ANSWER_EASE1 = 2;
-    public static final int COMMAND_FLIP_OR_ANSWER_EASE2 = 3;
-    public static final int COMMAND_FLIP_OR_ANSWER_EASE3 = 4;
-    public static final int COMMAND_FLIP_OR_ANSWER_EASE4 = 5;
-    public static final int COMMAND_FLIP_OR_ANSWER_RECOMMENDED = 6;
-    public static final int COMMAND_FLIP_OR_ANSWER_BETTER_THAN_RECOMMENDED = 7;
-    public static final int COMMAND_UNDO = 8;
-    public static final int COMMAND_EDIT = 9;
-    public static final int COMMAND_MARK = 10;
-    public static final int COMMAND_LOOKUP = 11;
-    public static final int COMMAND_BURY_CARD = 12;
-    public static final int COMMAND_SUSPEND_CARD = 13;
-    public static final int COMMAND_DELETE = 14;
-    public static final int COMMAND_PLAY_MEDIA = 16;
-    public static final int COMMAND_EXIT = 17;
-    public static final int COMMAND_BURY_NOTE = 18;
-    public static final int COMMAND_SUSPEND_NOTE = 19;
-    public static final int COMMAND_TOGGLE_FLAG_RED = 20;
-    public static final int COMMAND_TOGGLE_FLAG_ORANGE = 21;
-    public static final int COMMAND_TOGGLE_FLAG_GREEN = 22;
-    public static final int COMMAND_TOGGLE_FLAG_BLUE = 23;
-    public static final int COMMAND_UNSET_FLAG = 24;
-    public static final int COMMAND_ANSWER_FIRST_BUTTON = 25;
-    public static final int COMMAND_ANSWER_SECOND_BUTTON = 26;
-    public static final int COMMAND_ANSWER_THIRD_BUTTON = 27;
-    public static final int COMMAND_ANSWER_FOURTH_BUTTON = 28;
-    /** Answer "Good" */
-    public static final int COMMAND_ANSWER_RECOMMENDED = 29;
-    public static final int COMMAND_PAGE_UP = 30;
-    public static final int COMMAND_PAGE_DOWN = 31;
+public enum ViewerCommand {
 
-    public static final int COMMAND_TAG = 32;
-    public static final int COMMAND_CARD_INFO = 33;
-    public static final int COMMAND_ABORT_AND_SYNC = 34;
-    public static final int COMMAND_RECORD_VOICE = 35;
-    public static final int COMMAND_REPLAY_VOICE = 36;
+    COMMAND_NOTHING(R.string.nothing, 0),
+    COMMAND_SHOW_ANSWER(R.string.show_answer, 1),
+    COMMAND_FLIP_OR_ANSWER_EASE1(R.string.gesture_answer_1, 2),
+    COMMAND_FLIP_OR_ANSWER_EASE2(R.string.gesture_answer_2, 3),
+    COMMAND_FLIP_OR_ANSWER_EASE3(R.string.gesture_answer_3, 4),
+    COMMAND_FLIP_OR_ANSWER_EASE4(R.string.gesture_answer_4, 5),
+    COMMAND_FLIP_OR_ANSWER_RECOMMENDED(R.string.gesture_answer_green, 6),
+    COMMAND_FLIP_OR_ANSWER_BETTER_THAN_RECOMMENDED(R.string.gesture_answer_better_recommended, 7),
+    COMMAND_UNDO(R.string.undo, 8),
+    COMMAND_EDIT(R.string.cardeditor_title_edit_card, 9),
+    COMMAND_MARK(R.string.menu_mark_note, 10),
+    COMMAND_LOOKUP(R.string.lookup_button_content, 11),
+    COMMAND_BURY_CARD(R.string.menu_bury, 12),
+    COMMAND_SUSPEND_CARD(R.string.menu_suspend_card, 13),
+    COMMAND_DELETE(R.string.menu_delete_note, 14),
+    COMMAND_UNUSED_15(R.string.nothing, 15),
+    COMMAND_PLAY_MEDIA(R.string.gesture_play,16),
+    COMMAND_EXIT(R.string.nothing, 17),
+    COMMAND_BURY_NOTE(R.string.menu_bury_note, 18),
+    COMMAND_SUSPEND_NOTE(R.string.menu_suspend_note, 19),
+    COMMAND_TOGGLE_FLAG_RED(R.string.gesture_flag_red, 20),
+    COMMAND_TOGGLE_FLAG_ORANGE(R.string.gesture_flag_orange, 21),
+    COMMAND_TOGGLE_FLAG_GREEN(R.string.gesture_flag_green, 22),
+    COMMAND_TOGGLE_FLAG_BLUE(R.string.gesture_flag_blue, 23),
+    COMMAND_UNSET_FLAG(R.string.gesture_flag_remove, 24),
+    COMMAND_ANSWER_FIRST_BUTTON(R.string.gesture_answer_1, 25),
+    COMMAND_ANSWER_SECOND_BUTTON(R.string.gesture_answer_2, 26),
+    COMMAND_ANSWER_THIRD_BUTTON(R.string.gesture_answer_3, 27),
+    COMMAND_ANSWER_FOURTH_BUTTON(R.string.gesture_answer_4, 28),
+    COMMAND_ANSWER_RECOMMENDED(R.string.gesture_answer_green, 29),
+    COMMAND_PAGE_UP(R.string.gesture_page_up, 30),
+    COMMAND_PAGE_DOWN(R.string.gesture_page_down, 31),
+    COMMAND_TAG(R.string.add_tag, 32),
+    COMMAND_CARD_INFO(R.string.card_info_title, 33),
+    COMMAND_ABORT_AND_SYNC(R.string.gesture_abort_sync, 34),
+    COMMAND_RECORD_VOICE(R.string.record_voice, 35),
+    COMMAND_REPLAY_VOICE(R.string.replay_voice, 36),
+    COMMAND_TOGGLE_WHITEBOARD(R.string.gesture_toggle_whiteboard, 37);
 
-    public static final int COMMAND_TOGGLE_WHITEBOARD = 37;
+    private final int mResourceId;
+    private final int mPreferenceValue;
 
-    @Retention(RetentionPolicy.SOURCE)
-    @IntDef({COMMAND_NOTHING, COMMAND_SHOW_ANSWER, COMMAND_FLIP_OR_ANSWER_EASE1, COMMAND_FLIP_OR_ANSWER_EASE2,
-            COMMAND_FLIP_OR_ANSWER_EASE3, COMMAND_FLIP_OR_ANSWER_EASE4, COMMAND_FLIP_OR_ANSWER_RECOMMENDED,
-            COMMAND_FLIP_OR_ANSWER_BETTER_THAN_RECOMMENDED, COMMAND_UNDO, COMMAND_EDIT, COMMAND_MARK, COMMAND_LOOKUP,
-            COMMAND_BURY_CARD, COMMAND_SUSPEND_CARD, COMMAND_DELETE, COMMAND_PLAY_MEDIA, COMMAND_EXIT,
-            COMMAND_BURY_NOTE, COMMAND_SUSPEND_NOTE, COMMAND_TOGGLE_FLAG_RED, COMMAND_TOGGLE_FLAG_ORANGE,
-            COMMAND_TOGGLE_FLAG_GREEN, COMMAND_TOGGLE_FLAG_BLUE, COMMAND_UNSET_FLAG, COMMAND_ANSWER_FIRST_BUTTON,
-            COMMAND_ANSWER_SECOND_BUTTON, COMMAND_ANSWER_THIRD_BUTTON, COMMAND_ANSWER_FOURTH_BUTTON, COMMAND_ANSWER_RECOMMENDED,
-            COMMAND_PAGE_UP, COMMAND_PAGE_DOWN, COMMAND_TAG, COMMAND_CARD_INFO, COMMAND_ABORT_AND_SYNC, COMMAND_RECORD_VOICE,
-            COMMAND_REPLAY_VOICE, COMMAND_TOGGLE_WHITEBOARD
-    })
-    public @interface ViewerCommandDef {}
+
+    ViewerCommand(int resourceId, int preferenceValue) {
+        this.mResourceId = resourceId;
+        this.mPreferenceValue = preferenceValue;
+    }
+
+    public int getResourceId() {
+        return mResourceId;
+    }
+
+    @Nullable
+    public static ViewerCommand fromString(String value) {
+        return fromInt(Integer.parseInt(value));
+    }
+
+    @Nullable
+    public static ViewerCommand fromInt(int valueAsInt) {
+        // PERF: this is slow, but won't be used for long
+        return Arrays.stream(ViewerCommand.values()).filter(x -> x.mPreferenceValue == valueAsInt).findFirst().orElse(null);
+    }
+
+
+    public String toPreferenceString() {
+        return Integer.toString(mPreferenceValue);
+    }
+
 
     public interface CommandProcessor {
         /**
-         *
-         * @param which The command (defined in {@code ViewerCommand}) to execute
-         * @return Whether the action was successfully processed.
-         * <p>example failure: answering an ease on the front of the card</p>
+          * <p>example failure: answering an ease on the front of the card</p>
          */
         @SuppressWarnings("UnusedReturnValue")
-        boolean executeCommand(@ViewerCommandDef int which);
+        boolean executeCommand(ViewerCommand which);
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/PeripheralCommand.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/PeripheralCommand.java
@@ -18,6 +18,8 @@ package com.ichi2.anki.reviewer;
 
 import android.view.KeyEvent;
 
+import com.ichi2.anki.cardviewer.ViewerCommand;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -36,12 +38,12 @@ public class PeripheralCommand {
     @NonNull
     private final CardSide mCardSide;
 
-    private final @ViewerCommandDef int mCommand;
+    private final ViewerCommand mCommand;
 
     private final ModifierKeys mModifierKeys;
 
 
-    private PeripheralCommand(int keyCode, @ViewerCommandDef int command, @NonNull CardSide side, ModifierKeys modifierKeys) {
+    private PeripheralCommand(int keyCode, ViewerCommand command, @NonNull CardSide side, ModifierKeys modifierKeys) {
         this.mKeyCode = keyCode;
         this.mUnicodeCharacter = null;
         this.mCommand = command;
@@ -49,7 +51,7 @@ public class PeripheralCommand {
         this.mModifierKeys = modifierKeys;
     }
 
-    private PeripheralCommand(@Nullable Character unicodeCharacter, @ViewerCommandDef int command, @NonNull CardSide side, ModifierKeys modifierKeys) {
+    private PeripheralCommand(@Nullable Character unicodeCharacter, ViewerCommand command, @NonNull CardSide side, ModifierKeys modifierKeys) {
         this.mModifierKeys = modifierKeys;
         this.mKeyCode = null;
         this.mUnicodeCharacter = unicodeCharacter;
@@ -57,7 +59,7 @@ public class PeripheralCommand {
         this.mCardSide = side;
     }
 
-    public int getCommand() {
+    public ViewerCommand getCommand() {
         return mCommand;
     }
 
@@ -77,20 +79,20 @@ public class PeripheralCommand {
         return mCardSide == CardSide.ANSWER || mCardSide == CardSide.BOTH;
     }
 
-    public static PeripheralCommand unicode(char unicodeChar, @ViewerCommandDef int command, CardSide side) {
+    public static PeripheralCommand unicode(char unicodeChar, ViewerCommand command, CardSide side) {
         return unicode(unicodeChar, command, side, ModifierKeys.allowShift());
     }
 
-    private static PeripheralCommand unicode(char unicodeChar, @ViewerCommandDef int command, CardSide side, ModifierKeys modifierKeys) {
+    private static PeripheralCommand unicode(char unicodeChar, ViewerCommand command, CardSide side, ModifierKeys modifierKeys) {
         // Note: cast is needed to select the correct constructor
         return new PeripheralCommand((Character) unicodeChar, command, side, modifierKeys);
     }
 
-    public static PeripheralCommand keyCode(int keyCode, @ViewerCommandDef int command, CardSide side) {
+    public static PeripheralCommand keyCode(int keyCode, ViewerCommand command, CardSide side) {
         return keyCode(keyCode, command, side, ModifierKeys.none());
     }
 
-    private static PeripheralCommand keyCode(int keyCode, @ViewerCommandDef int command, CardSide side, ModifierKeys modifiers) {
+    private static PeripheralCommand keyCode(int keyCode, ViewerCommand command, CardSide side, ModifierKeys modifiers) {
         return new PeripheralCommand(keyCode, command, side, modifiers);
     }
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/AbstractFlashcardViewerCommandTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/AbstractFlashcardViewerCommandTest.java
@@ -146,7 +146,7 @@ public class AbstractFlashcardViewerCommandTest extends RobolectricTest {
         testDoubleTapUnsets(ViewerCommand.COMMAND_TOGGLE_FLAG_BLUE);
     }
 
-    private void testDoubleTapUnsets(int command) {
+    private void testDoubleTapUnsets(ViewerCommand command) {
         CommandTestCardViewer viewer = getViewer();
 
         viewer.executeCommand(command);

--- a/AnkiDroid/src/test/java/com/ichi2/anki/ReviewerNoParamTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/ReviewerNoParamTest.java
@@ -278,7 +278,7 @@ public class ReviewerNoParamTest extends RobolectricTest {
         Editor settings = AnkiDroidApp.getSharedPrefs(getTargetContext()).edit();
         for (Gesture g: gestures) {
             String k = getKey(g);
-            settings.putString(k, Integer.toString(ViewerCommand.COMMAND_NOTHING));
+            settings.putString(k, ViewerCommand.COMMAND_NOTHING.toPreferenceString());
         }
         settings.apply();
     }
@@ -287,7 +287,7 @@ public class ReviewerNoParamTest extends RobolectricTest {
     private void enableGesture(Gesture gesture) {
         Editor settings = AnkiDroidApp.getSharedPrefs(getTargetContext()).edit();
         String k = getKey(gesture);
-        settings.putString(k, Integer.toString(ViewerCommand.COMMAND_ANSWER_FIRST_BUTTON));
+        settings.putString(k, ViewerCommand.COMMAND_ANSWER_FIRST_BUTTON.toPreferenceString());
         settings.apply();
     }
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/ReviewerNoParamTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/ReviewerNoParamTest.java
@@ -16,15 +16,23 @@
 
 package com.ichi2.anki;
 
+import android.content.Intent;
+import android.content.SharedPreferences.Editor;
 import android.graphics.Color;
 
+import com.ichi2.anki.cardviewer.Gesture;
+import com.ichi2.anki.cardviewer.GestureProcessor;
 import com.ichi2.anki.cardviewer.ViewerCommand;
 import com.ichi2.anki.model.WhiteboardPenColor;
 import com.ichi2.libanki.Consts;
 
+import net.ankiweb.rsdroid.database.NotImplementedException;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.robolectric.Robolectric;
+import org.robolectric.android.controller.ActivityController;
 
 import androidx.annotation.CheckResult;
 import androidx.annotation.NonNull;
@@ -167,6 +175,131 @@ public class ReviewerNoParamTest extends RobolectricTest {
         assertThat("Hide should be called after answering a card", reviewer.getDelayedHideCount(), greaterThan(hideCount));
     }
 
+    @Test
+    public void defaultDrawerConflictIsTrueIfGesturesEnabled() {
+        enableGestureSetting();
+        ReviewerExt reviewer = startReviewerFullScreen();
+
+        assertThat(reviewer.hasDrawerSwipeConflicts(), is(true));
+    }
+
+
+    @Test
+    public void noDrawerConflictsBeforeOnCreate() {
+        enableGestureSetting();
+        ActivityController<Reviewer> controller = Robolectric.buildActivity(Reviewer.class, new Intent());
+        try {
+            assertThat("no conflicts before onCreate", controller.get().hasDrawerSwipeConflicts(), is(false));
+        } finally {
+            try {
+                enableGesture(Gesture.SWIPE_UP);
+            } catch (Exception e) {
+                // ignore
+            }
+        }
+    }
+
+    @Test
+    public void noDrawerConflictsIfGesturesDisabled() {
+        disableGestureSetting();
+        enableGesture(Gesture.SWIPE_UP);
+        ReviewerExt reviewer = startReviewerFullScreen();
+        assertThat("gestures should be disabled", getGestureProcessor().isEnabled(), is(false));
+        assertThat(reviewer.hasDrawerSwipeConflicts(), is(false));
+    }
+
+
+    @Test
+    public void noDrawerConflictsIfNoGestures() {
+        enableGestureSetting();
+        disableConflictGestures();
+        ReviewerExt reviewer = startReviewerFullScreen();
+        assertThat("gestures should be enabled", getGestureProcessor().isEnabled(), is(true));
+        assertThat("no conflicts, so no conflicts detected", reviewer.hasDrawerSwipeConflicts(), is(false));
+    }
+
+    @Test
+    public void drawerConflictsIfUp() {
+        enableGestureSetting();
+        disableConflictGestures();
+        enableGesture(Gesture.SWIPE_UP);
+        ReviewerExt reviewer = startReviewerFullScreen();
+        assertThat("gestures should be enabled", getGestureProcessor().isEnabled(), is(true));
+        assertThat(reviewer.hasDrawerSwipeConflicts(), is(true));
+    }
+
+
+    @Test
+    public void drawerConflictsIfDown() {
+        enableGestureSetting();
+        disableConflictGestures();
+        enableGesture(Gesture.SWIPE_DOWN);
+        ReviewerExt reviewer = startReviewerFullScreen();
+        assertThat("gestures should be enabled", getGestureProcessor().isEnabled(), is(true));
+        assertThat(reviewer.hasDrawerSwipeConflicts(), is(true));
+    }
+
+    @Test
+    public void drawerConflictsIfRight() {
+        enableGestureSetting();
+        disableConflictGestures();
+        enableGesture(Gesture.SWIPE_RIGHT);
+        ReviewerExt reviewer = startReviewerFullScreen();
+        assertThat("gestures should be enabled", getGestureProcessor().isEnabled(), is(true));
+        assertThat(reviewer.hasDrawerSwipeConflicts(), is(true));
+    }
+
+
+    protected GestureProcessor getGestureProcessor() {
+        GestureProcessor gestureProcessor = new GestureProcessor(null);
+        gestureProcessor.init(AnkiDroidApp.getSharedPrefs(this.getTargetContext()));
+        return gestureProcessor;
+    }
+
+    protected void disableConflictGestures() {
+        disableGestures(Gesture.SWIPE_UP, Gesture.SWIPE_DOWN, Gesture.SWIPE_RIGHT);
+    }
+
+    private void enableGestureSetting() {
+        setGestureSetting(true);
+    }
+
+    private void disableGestureSetting() {
+        setGestureSetting(false);
+    }
+
+    private void setGestureSetting(boolean value) {
+        Editor settings = AnkiDroidApp.getSharedPrefs(getTargetContext()).edit();
+        settings.putBoolean("gestures", value);
+        settings.apply();
+    }
+
+    private void disableGestures(Gesture... gestures) {
+        Editor settings = AnkiDroidApp.getSharedPrefs(getTargetContext()).edit();
+        for (Gesture g: gestures) {
+            String k = getKey(g);
+            settings.putString(k, Integer.toString(ViewerCommand.COMMAND_NOTHING));
+        }
+        settings.apply();
+    }
+
+    /** Enables a gesture (without changing the overall setting of whether gestures are allowed) */
+    private void enableGesture(Gesture gesture) {
+        Editor settings = AnkiDroidApp.getSharedPrefs(getTargetContext()).edit();
+        String k = getKey(gesture);
+        settings.putString(k, Integer.toString(ViewerCommand.COMMAND_ANSWER_FIRST_BUTTON));
+        settings.apply();
+    }
+
+    private String getKey(Gesture gesture) {
+        switch (gesture) {
+            case SWIPE_UP: return "gestureSwipeUp";
+            case SWIPE_DOWN: return "gestureSwipeDown";
+            case SWIPE_LEFT: return "gestureSwipeLeft";
+            case SWIPE_RIGHT: return "gestureSwipeRight";
+            default: throw new NotImplementedException(gesture.toString());
+        }
+    }
 
     private ReviewerExt startReviewerFullScreen() {
         AnkiDroidApp.getSharedPrefs(getTargetContext()).edit().putString("fullscreenMode", "1").apply();

--- a/AnkiDroid/src/test/java/com/ichi2/anki/cardviewer/GestureProcessorTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/cardviewer/GestureProcessorTest.java
@@ -34,21 +34,22 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 public class GestureProcessorTest implements ViewerCommand.CommandProcessor {
 
     private final GestureProcessor mSut = new GestureProcessor(this);
-    private final List<Integer> mExecutedCommands = new ArrayList<>();
+    private final List<ViewerCommand> mExecutedCommands = new ArrayList<>();
 
     @Override
-    public boolean executeCommand(int which) {
+    public boolean executeCommand(ViewerCommand which) {
         this.mExecutedCommands.add(which);
         return true;
     }
 
-    int singleResult() {
+    ViewerCommand singleResult() {
         assertThat(mExecutedCommands, hasSize(1));
         return mExecutedCommands.get(0);
     }
@@ -70,13 +71,13 @@ public class GestureProcessorTest implements ViewerCommand.CommandProcessor {
     public void integrationTest() {
         SharedPreferences prefs = mock(SharedPreferences.class, Mockito.RETURNS_DEEP_STUBS);
 
-        when(prefs.getString(ArgumentMatchers.anyString(), ArgumentMatchers.anyString())).thenReturn("0");
-        when(prefs.getString(eq("gestureTapCenter"), ArgumentMatchers.anyString())).thenReturn("1");
+        when(prefs.getString(nullable(String.class), nullable(String.class))).thenReturn("0");
+        when(prefs.getString(eq("gestureTapCenter"), nullable(String.class))).thenReturn("1");
         when(prefs.getBoolean(eq("gestureCornerTouch"), ArgumentMatchers.anyBoolean())).thenReturn(true);
 
         mSut.init(prefs);
 
         mSut.onTap(100, 100, 50, 50);
-        assertThat(singleResult(), is(1));
+        assertThat(singleResult(), is(ViewerCommand.COMMAND_SHOW_ANSWER));
     }
 }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/reviewer/PeripheralKeymapTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/reviewer/PeripheralKeymapTest.java
@@ -34,7 +34,7 @@ import static org.mockito.Mockito.when;
 public class PeripheralKeymapTest {
     @Test
     public void flagAndAnswerDoNotConflict() {
-        List<Integer> processed = new ArrayList<>();
+        List<ViewerCommand> processed = new ArrayList<>();
 
         PeripheralKeymap peripheralKeymap = new PeripheralKeymap(new MockReviewerUi(), processed::add);
         peripheralKeymap.setup();


### PR DESCRIPTION
## Purpose / Description
#8078 contains a large refactor to our gesture processing which allows arbitrary mapping of key inputs to commands

Currently, we map from Gesture -> Command

And we want to map from `Command -> [Gesture]` after the linked PR is completed

This brings the code closer to this PR, in a series of non-functional commits

The aim is that this change is fairly trivially reviewable, so we get closer to the idea

## How Has This Been Tested?

Unit tested

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
