### PR TITLE
Show total card count in DeckPicker when no cards are due

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -2500,7 +2500,13 @@ public class DeckPicker extends NavigationDrawerActivity implements
                     time = Utils.timeQuantityTopDeckPicker(AnkiDroidApp.getInstance(), eta*60);
                 }
                 if (due != null && getSupportActionBar() != null) {
-                    getSupportActionBar().setSubtitle(res.getQuantityString(R.plurals.deckpicker_title, due, due, time));
+                    String subTitle;
+                    if (due == 0) {
+                        subTitle = res.getQuantityString(R.plurals.deckpicker_title_zero_due, getCol().cardCount(), getCol().cardCount());
+                    } else {
+                        subTitle = res.getQuantityString(R.plurals.deckpicker_title, due, due, time);
+                    }
+                    getSupportActionBar().setSubtitle(subTitle);
                 }
             }
         } catch (RuntimeException e) {

--- a/AnkiDroid/src/main/res/values/01-core.xml
+++ b/AnkiDroid/src/main/res/values/01-core.xml
@@ -211,4 +211,9 @@
     <string name="sync_conflict_local_confirm_new">Replace your collection on AnkiWeb with your collection from AnkiDroid?</string>
     <string name="sync_conflict_title_new">Select collection to keep</string>
     <string name="sync_conflict_replace_title">Replace collection</string>
+
+    <plurals name="deckpicker_title_zero_due">
+        <item quantity="one">%1$d card (0 due)</item>
+        <item quantity="other">%1$d cards (0 due)</item>
+    </plurals>
 </resources>


### PR DESCRIPTION
## Purpose / Description
Show total card count in DeckPicker when no cards are due so that users can understand that there cards are still there, just the due count is zero.

## Approach
If number of due cards is zero, then change the subtitle in the toolbar of the DeckPicker.

## How Has This Been Tested?

Verified the functionality on device.

<details>
<summary>Screenshot</summary>

![State with cards due](https://user-images.githubusercontent.com/35566748/123318885-5595a280-d54d-11eb-8efa-6b7061b560e3.jpg)

![New state with no cards due](https://user-images.githubusercontent.com/35566748/123318894-57f7fc80-d54d-11eb-924f-1d948f7f1d18.jpg)

</details>

## Checklist

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [ ] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
