### PR TITLE
Dependency updates 20210625

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -1,6 +1,6 @@
 plugins {
  // Gradle plugin portal 
- id 'com.github.triplet.play' version '3.4.0-agp4.2'
+ id 'com.github.triplet.play' version '3.5.0'
 }
 
 apply plugin: 'com.android.application'

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ import org.gradle.internal.jvm.Jvm
 
 buildscript {
     // The version for the Kotlin plugin and dependencies
-    ext.kotlin_version = '1.5.10'
+    ext.kotlin_version = '1.5.20'
 
     repositories {
         google()


### PR DESCRIPTION

Standard dependency updates branch sync

I think I need this for the 2.16alph1 publish I just tried that failed

```

* What went wrong:
Execution failed for task ':AnkiDroid:publishPlayReleaseApk'.
> Querying the mapped value of property(org.gradle.api.file.Directory, property(org.gradle.api.file.Directory, property(org.gradle.api.file.Directory, map(org.gradle.api.file.Directory flatmap(provider(task 'packagePlayRelease', class com.android.build.gradle.tasks.PackageApplication)) check-type())))) before task ':AnkiDroid:packagePlayRelease' has completed is not supported
```