### PR TITLE
Added non ssl connections for private IPs

### DIFF
--- a/AnkiDroid/src/main/res/xml/network_security_config.xml
+++ b/AnkiDroid/src/main/res/xml/network_security_config.xml
@@ -11,5 +11,8 @@
     <domain-config cleartextTrafficPermitted="true">
         <domain includeSubdomains="true">localhost</domain>
         <domain includeSubdomains="true">127.0.0.1</domain>
+        <domain includeSubdomains="true">10.0.0.0</domain>
+        <domain includeSubdomains="true">172.16.0.0</domain>
+        <domain includeSubdomains="true">192.168.0.0</domain>
     </domain-config>
 </network-security-config>


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
Allow non-SSL connections in RFC1918 reserved / local subnet space

## Fixes
Fixes #9103

## Approach
Added IP ranges of private networks. 
mentioned on:- https://datatracker.ietf.org/doc/html/rfc1918#section-3

## How Has This Been Tested?

Not Yet 😔

## Learning (optional, can help others)
https://developer.android.com/training/articles/security-config#ConfigCustom
https://developer.android.com/guide/topics/manifest/application-element
https://stackoverflow.com/questions/51902629/how-to-allow-all-network-connection-types-http-and-https-in-android-9-pie
https://developer.android.com/training/articles/security-ssl

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [ ] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
