### PR TITLE
Fix for negative card Counts in reviewer

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Counts.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Counts.java
@@ -23,9 +23,9 @@ public class Counts {
     }
 
     public Counts(int new_, int lrn, int rev) {
-        mNew = new_;
-        mLrn = lrn;
-        mRev = rev;
+        mNew = Math.max(new_, 0);
+        mLrn = Math.max(lrn, 0);
+        mRev = Math.max(rev, 0);
     }
 
     public int getLrn() {
@@ -46,13 +46,13 @@ public class Counts {
     public void changeCount(@NonNull Queue index, int number) {
         switch (index) {
             case NEW:
-                mNew += number;
+                addNew(number);
                 break;
             case LRN:
-                mLrn += number;
+                addLrn(number);
                 break;
             case REV:
-                mRev += number;
+                addRev(number);
                 break;
             default:
                 throw new RuntimeException("Index " + index + " does not exists.");
@@ -60,15 +60,15 @@ public class Counts {
     }
 
     public void addNew(int new_) {
-        mNew += new_;
+        mNew = Math.max(mNew + new_, 0);
     }
 
     public void addLrn(int lrn) {
-        mLrn += lrn;
+        mLrn = Math.max(mLrn + lrn, 0);
     }
 
     public void addRev(int rev) {
-        mRev += rev;
+        mRev = Math.max(mRev + rev, 0);
     }
 
 


### PR DESCRIPTION
## Purpose / Description
Sometimes Some of the counters in Review Screen would be negative

## Fixes
Fixes #9100 

## Approach
Made `addLrn`, `addNew` and `addRev` return 0 if the result of adding was negative. Also made the `changeCount` use these methods to set values

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
