### PR TITLE
test: delay GestureMapper init from static init to runtime

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/GestureMapper.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/GestureMapper.java
@@ -30,19 +30,23 @@ public class GestureMapper {
     private int mSwipeMinDistance = -1;
     private int mSwipeThresholdVelocity = -1;
 
-    private static final int DEFAULT_SWIPE_MIN_DISTANCE;
-    private static final int DEFAULT_SWIPE_THRESHOLD_VELOCITY;
-
-    static {
-        // Set good default values for swipe detection
-        final ViewConfiguration vc = ViewConfiguration.get(AnkiDroidApp.getInstance());
-        DEFAULT_SWIPE_MIN_DISTANCE = vc.getScaledPagingTouchSlop();
-        DEFAULT_SWIPE_THRESHOLD_VELOCITY = vc.getScaledMinimumFlingVelocity();
-    }
+    private static ViewConfiguration VIEW_CONFIGURATION = null;
+    private static int DEFAULT_SWIPE_MIN_DISTANCE;
+    private static int DEFAULT_SWIPE_THRESHOLD_VELOCITY;
 
     public void init(SharedPreferences preferences) {
         int sensitivity = preferences.getInt("swipeSensitivity", 100);
         boolean useCornerTouch = preferences.getBoolean("gestureCornerTouch", false);
+
+        // ViewConfiguration can be used statically but it must be initialized during Android application lifecycle
+        // Else, when Robolectric executes in the CI it accesses AnkiDroidApp.getInstance before it exists #9173
+        if (VIEW_CONFIGURATION == null) {
+            // Set good default values for swipe detection
+            VIEW_CONFIGURATION = ViewConfiguration.get(AnkiDroidApp.getInstance());
+            DEFAULT_SWIPE_MIN_DISTANCE = VIEW_CONFIGURATION.getScaledPagingTouchSlop();
+            DEFAULT_SWIPE_THRESHOLD_VELOCITY = VIEW_CONFIGURATION.getScaledMinimumFlingVelocity();
+        }
+
         if (sensitivity != 100) {
             float sens = 100.0f/sensitivity;
             mSwipeMinDistance = (int) (DEFAULT_SWIPE_MIN_DISTANCE * sens + 0.5f);


### PR DESCRIPTION
Should workaround issue with robolectric in CI, Fixes #9173

## Approach
I regrettably altered real code in order to satisfy some not-quite-reproducible test constraint, which is personally irritating

But works

## How Has This Been Tested?

It needs to pass unit tests in CI, it appears to https://github.com/mikehardy/Anki-Android/runs/2956584797?check_suite_focus=true

## Learning (optional, can help others)
Something about the way the RobolectricTestRunner does buildActivity in certain environments means that AnkiDroidApp.sInstance is null it appears - it calls the Activity constructor before calling Application.onCreate, so initialization fails if you use a static initializer that touchs the Application

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
