### PR TITLE
Dependency updates 20210630

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -253,14 +253,14 @@ dependencies {
     compileOnly "com.google.auto.service:auto-service-annotations:1.0"
     annotationProcessor "com.google.auto.service:auto-service:1.0"
 
-    implementation 'androidx.activity:activity:1.2.3'
+    implementation 'androidx.activity:activity-ktx:1.2.3'
     implementation 'androidx.annotation:annotation:1.2.0'
     implementation 'androidx.appcompat:appcompat:1.3.0'
     implementation 'androidx.browser:browser:1.3.0'
     implementation 'androidx.exifinterface:exifinterface:1.3.2'
-    implementation 'androidx.fragment:fragment:1.3.5'
+    implementation 'androidx.fragment:fragment-ktx:1.3.5'
     implementation 'androidx.localbroadcastmanager:localbroadcastmanager:1.0.0'
-    implementation "androidx.preference:preference:1.1.1"
+    implementation "androidx.preference:preference-ktx:1.1.1"
     implementation 'androidx.recyclerview:recyclerview:1.2.1'
     implementation 'androidx.sqlite:sqlite-framework:2.1.0'
     implementation 'androidx.swiperefreshlayout:swiperefreshlayout:1.1.0'

--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -249,7 +249,7 @@ dependencies {
     }
 
     coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:1.1.5'
-    compileOnly 'org.jetbrains:annotations:21.0.0'
+    compileOnly 'org.jetbrains:annotations:21.0.1'
     compileOnly "com.google.auto.service:auto-service-annotations:1.0"
     annotationProcessor "com.google.auto.service:auto-service:1.0"
 

--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -314,14 +314,14 @@ dependencies {
     testImplementation 'org.hamcrest:hamcrest-all:1.3'
     testImplementation 'net.lachlanmckee:timber-junit-rule:1.0.1'
     testImplementation "org.robolectric:robolectric:4.5.1"
-    testImplementation 'androidx.test:core:1.3.0'
-    testImplementation 'androidx.test.ext:junit:1.1.2'
+    testImplementation 'androidx.test:core:1.4.0'
+    testImplementation 'androidx.test.ext:junit:1.1.3'
     // debugImplementation required vs testImplementation: https://issuetracker.google.com/issues/128612536
     debugImplementation 'androidx.fragment:fragment-testing:1.3.5'
 
     // May need a resolution strategy for support libs to our versions
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'
-    androidTestImplementation 'androidx.test.espresso:espresso-contrib:3.3.0'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.2'
-    androidTestImplementation 'androidx.test:rules:1.3.0'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
+    androidTestImplementation 'androidx.test.espresso:espresso-contrib:3.4.0'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.3'
+    androidTestImplementation 'androidx.test:rules:1.4.0'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ buildscript {
         classpath "app.brant:amazonappstorepublisher:0.1.0"
 
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-        classpath "org.jlleitschuh.gradle:ktlint-gradle:10.0.0"
+        classpath "org.jlleitschuh.gradle:ktlint-gradle:10.1.0"
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.2.1'
+        classpath 'com.android.tools.build:gradle:4.2.2'
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
         classpath "app.brant:amazonappstorepublisher:0.1.0"


### PR DESCRIPTION

Standard dependency updates PR, but it looks like google had a big day

Android Studio 4.2.2 is out, so bump gradle plugin
All test deps bumped

Most interestingly, if we use kotlin we should have the -ktx versions of libraries that support it I think, so switching to those deps