### PR TITLE
fix: volume button crash

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -2696,6 +2696,11 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
     }
 
     public boolean executeCommand(@NonNull ViewerCommand which) {
+        //noinspection ConstantConditions - remove this once we move to kotlin
+        if (which == null) {
+            Timber.w("command should not be null");
+            which = COMMAND_NOTHING;
+        }
         if (isControlBlocked() && which != COMMAND_EXIT) {
             return false;
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -345,8 +345,10 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
     /**
      * Gesture Allocation
      */
-    private ViewerCommand mGestureVolumeUp;
-    private ViewerCommand mGestureVolumeDown;
+    @NonNull
+    private ViewerCommand mGestureVolumeUp = COMMAND_NOTHING;
+    @NonNull
+    private ViewerCommand mGestureVolumeDown = COMMAND_NOTHING;
     protected final GestureProcessor mGestureProcessor = new GestureProcessor(this);
 
     private String mCardContent;

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -2693,7 +2693,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
         return dismiss(new CollectionTask.BuryNote(mCurrentCard));
     }
 
-    public boolean executeCommand(ViewerCommand which) {
+    public boolean executeCommand(@NonNull ViewerCommand which) {
         if (isControlBlocked() && which != COMMAND_EXIT) {
             return false;
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Previewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Previewer.java
@@ -224,7 +224,7 @@ public class Previewer extends AbstractFlashcardViewer {
 
 
     @Override
-    public boolean executeCommand(ViewerCommand which) {
+    public boolean executeCommand(@NonNull ViewerCommand which) {
         /* do nothing */
         return false;
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/ViewerCommand.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/ViewerCommand.java
@@ -20,6 +20,7 @@ import com.ichi2.anki.R;
 
 import java.util.Arrays;
 
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 /** Abstraction: Discuss moving many of these to 'Reviewer' */
@@ -99,6 +100,6 @@ public enum ViewerCommand {
           * <p>example failure: answering an ease on the front of the card</p>
          */
         @SuppressWarnings("UnusedReturnValue")
-        boolean executeCommand(ViewerCommand which);
+        boolean executeCommand(@NonNull ViewerCommand which);
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/PeripheralCommand.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/PeripheralCommand.java
@@ -38,12 +38,13 @@ public class PeripheralCommand {
     @NonNull
     private final CardSide mCardSide;
 
+    @NonNull
     private final ViewerCommand mCommand;
 
     private final ModifierKeys mModifierKeys;
 
 
-    private PeripheralCommand(int keyCode, ViewerCommand command, @NonNull CardSide side, ModifierKeys modifierKeys) {
+    private PeripheralCommand(int keyCode, @NonNull ViewerCommand command, @NonNull CardSide side, ModifierKeys modifierKeys) {
         this.mKeyCode = keyCode;
         this.mUnicodeCharacter = null;
         this.mCommand = command;
@@ -51,7 +52,7 @@ public class PeripheralCommand {
         this.mModifierKeys = modifierKeys;
     }
 
-    private PeripheralCommand(@Nullable Character unicodeCharacter, ViewerCommand command, @NonNull CardSide side, ModifierKeys modifierKeys) {
+    private PeripheralCommand(@Nullable Character unicodeCharacter, @NonNull ViewerCommand command, @NonNull CardSide side, ModifierKeys modifierKeys) {
         this.mModifierKeys = modifierKeys;
         this.mKeyCode = null;
         this.mUnicodeCharacter = unicodeCharacter;
@@ -59,6 +60,7 @@ public class PeripheralCommand {
         this.mCardSide = side;
     }
 
+    @NonNull
     public ViewerCommand getCommand() {
         return mCommand;
     }
@@ -79,20 +81,20 @@ public class PeripheralCommand {
         return mCardSide == CardSide.ANSWER || mCardSide == CardSide.BOTH;
     }
 
-    public static PeripheralCommand unicode(char unicodeChar, ViewerCommand command, CardSide side) {
+    public static PeripheralCommand unicode(char unicodeChar, @NonNull ViewerCommand command, CardSide side) {
         return unicode(unicodeChar, command, side, ModifierKeys.allowShift());
     }
 
-    private static PeripheralCommand unicode(char unicodeChar, ViewerCommand command, CardSide side, ModifierKeys modifierKeys) {
+    private static PeripheralCommand unicode(char unicodeChar, @NonNull ViewerCommand command, CardSide side, ModifierKeys modifierKeys) {
         // Note: cast is needed to select the correct constructor
         return new PeripheralCommand((Character) unicodeChar, command, side, modifierKeys);
     }
 
-    public static PeripheralCommand keyCode(int keyCode, ViewerCommand command, CardSide side) {
+    public static PeripheralCommand keyCode(int keyCode, @NonNull ViewerCommand command, CardSide side) {
         return keyCode(keyCode, command, side, ModifierKeys.none());
     }
 
-    private static PeripheralCommand keyCode(int keyCode, ViewerCommand command, CardSide side, ModifierKeys modifiers) {
+    private static PeripheralCommand keyCode(int keyCode, @NonNull ViewerCommand command, CardSide side, ModifierKeys modifiers) {
         return new PeripheralCommand(keyCode, command, side, modifiers);
     }
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/cardviewer/GestureProcessorTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/cardviewer/GestureProcessorTest.java
@@ -29,6 +29,8 @@ import org.mockito.Mockito;
 import java.util.ArrayList;
 import java.util.List;
 
+import androidx.annotation.NonNull;
+
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
@@ -44,7 +46,7 @@ public class GestureProcessorTest implements ViewerCommand.CommandProcessor {
     private final List<ViewerCommand> mExecutedCommands = new ArrayList<>();
 
     @Override
-    public boolean executeCommand(ViewerCommand which) {
+    public boolean executeCommand(@NonNull ViewerCommand which) {
         this.mExecutedCommands.add(which);
         return true;
     }


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
Crash if gestures were disabled and volume buttons were pressed

## Fixes
Fixes #9164

## Approach
Don't default the values to null

## How Has This Been Tested?
Android 11

Not going to unit test this. I didn't add in the gestures for `VOLUME`, and they'll be removed very soon.

## Learning (optional, can help others)
* See if we can more for unit tests from other contributors
* Move to Kotlin more - nulls are bad


## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
