### PR TITLE
Key Binding: Implement Binding class

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/Binding.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/Binding.java
@@ -1,0 +1,66 @@
+/*
+ *  Copyright (c) 2021 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.reviewer;
+
+import android.view.KeyEvent;
+
+import androidx.annotation.Nullable;
+
+public class Binding {
+    public static class ModifierKeys {
+        // null == true/false works.
+        @Nullable
+        private final Boolean mShift;
+        @Nullable
+        private final Boolean mCtrl;
+        @Nullable
+        private final Boolean mAlt;
+
+
+        private ModifierKeys(@Nullable Boolean shift, @Nullable Boolean ctrl, @Nullable Boolean alt) {
+            this.mShift = shift;
+            this.mCtrl = ctrl;
+            this.mAlt = alt;
+        }
+
+
+        public static ModifierKeys none() {
+            return new ModifierKeys(false, false, false);
+        }
+
+        public static ModifierKeys ctrl() {
+            return new ModifierKeys(false, true, false);
+        }
+
+        public static ModifierKeys shift() {
+            return new ModifierKeys(true, false, false);
+        }
+
+        /** Allows shift, but not Ctrl/Alt */
+        public static ModifierKeys allowShift() {
+            return new ModifierKeys(null, false, false);
+        }
+
+
+        public boolean matches(KeyEvent event) {
+            // return false if Ctrl+1 is pressed and 1 is expected
+            return (mShift == null || mShift == event.isShiftPressed()) &&
+                    (mCtrl == null || mCtrl == event.isCtrlPressed()) &&
+                    (mAlt == null || mAlt == event.isAltPressed());
+        }
+    }
+}

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/Binding.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/Binding.java
@@ -18,9 +18,86 @@ package com.ichi2.anki.reviewer;
 
 import android.view.KeyEvent;
 
+import com.ichi2.anki.cardviewer.Gesture;
+
 import androidx.annotation.Nullable;
 
 public class Binding {
+
+    @Nullable
+    private final ModifierKeys mModifierKeys;
+
+    @Nullable
+    private final Integer mKeyCode;
+
+    @Nullable
+    private final Character mUnicodeCharacter;
+
+    @Nullable
+    private final Gesture mGesture;
+
+    private Binding(@Nullable ModifierKeys modifierKeys, @Nullable Integer keyCode, @Nullable Character unicodeCharacter, @Nullable Gesture gesture) {
+        this.mModifierKeys = modifierKeys;
+        this.mKeyCode = keyCode;
+        this.mUnicodeCharacter = unicodeCharacter;
+        this.mGesture = gesture;
+    }
+
+    @Nullable
+    public Character getUnicodeCharacter() {
+        return mUnicodeCharacter;
+    }
+
+    @Nullable
+    public Integer getKeycode() {
+        return mKeyCode;
+    }
+
+    @Nullable
+    public Gesture getGesture() {
+        return mGesture;
+    }
+
+    /** 
+     * Specifies a unicode binding from an unknown input device
+     * Should be due to the "default" key bindings and never from user input
+     * When we know the device, we can know whether shift is, or isn't pressed.
+     * If we don't, then a star could be mapped to a button, OR shift + button
+     * */
+    public static Binding unicode(char unicodeChar) {
+        return unicode(ModifierKeys.allowShift(), unicodeChar);
+    }
+
+    public static Binding unicode(ModifierKeys modifierKeys, char unicodeChar) {
+        return new Binding(modifierKeys, null, (Character) unicodeChar, null);
+    }
+
+    public static Binding keyCode(int keyCode) {
+        return keyCode(ModifierKeys.none(), keyCode);
+    }
+
+    public static Binding keyCode(ModifierKeys modifiers, int keyCode) {
+        return new Binding(modifiers, keyCode, null, null);
+    }
+
+    public static Binding gesture(Gesture gesture) {
+        return new Binding(null, null, null, gesture);
+    }
+
+    public boolean isKey() {
+        return mKeyCode != null || mUnicodeCharacter != null;
+    }
+
+    public boolean isGesture() {
+        return mGesture != null;
+    }
+
+
+    public boolean matchesModifier(KeyEvent event) {
+        return mModifierKeys == null || mModifierKeys.matches(event);
+    }
+
+
     public static class ModifierKeys {
         // null == true/false works.
         @Nullable

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/PeripheralCommand.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/PeripheralCommand.java
@@ -30,11 +30,6 @@ import static com.ichi2.anki.cardviewer.ViewerCommand.*;
 import static com.ichi2.anki.reviewer.Binding.*;
 
 public class PeripheralCommand {
-    @Nullable
-    private final Integer mKeyCode;
-
-    @Nullable
-    private final Character mUnicodeCharacter;
 
     @NonNull
     private final CardSide mCardSide;
@@ -42,21 +37,12 @@ public class PeripheralCommand {
     @NonNull
     private final ViewerCommand mCommand;
 
-    private final ModifierKeys mModifierKeys;
+    @NonNull
+    private final Binding mBinding;
 
 
-    private PeripheralCommand(int keyCode, @NonNull ViewerCommand command, @NonNull CardSide side, ModifierKeys modifierKeys) {
-        this.mKeyCode = keyCode;
-        this.mUnicodeCharacter = null;
-        this.mCommand = command;
-        this.mCardSide = side;
-        this.mModifierKeys = modifierKeys;
-    }
-
-    private PeripheralCommand(@Nullable Character unicodeCharacter, @NonNull ViewerCommand command, @NonNull CardSide side, ModifierKeys modifierKeys) {
-        this.mModifierKeys = modifierKeys;
-        this.mKeyCode = null;
-        this.mUnicodeCharacter = unicodeCharacter;
+    public PeripheralCommand(@NonNull Binding binding, @NonNull ViewerCommand command, @NonNull CardSide side) {
+        this.mBinding = binding;
         this.mCommand = command;
         this.mCardSide = side;
     }
@@ -66,12 +52,14 @@ public class PeripheralCommand {
         return mCommand;
     }
 
+    @Nullable
     public Character getUnicodeCharacter() {
-        return mUnicodeCharacter;
+        return mBinding.getUnicodeCharacter();
     }
 
+    @Nullable
     public Integer getKeycode() {
-        return mKeyCode;
+        return mBinding.getKeycode();
     }
 
     public boolean isQuestion() {
@@ -82,78 +70,76 @@ public class PeripheralCommand {
         return mCardSide == CardSide.ANSWER || mCardSide == CardSide.BOTH;
     }
 
-    public static PeripheralCommand unicode(char unicodeChar, @NonNull ViewerCommand command, CardSide side) {
-        return unicode(unicodeChar, command, side, ModifierKeys.allowShift());
+
+    private static PeripheralCommand keyCode(int keycode, @NonNull ViewerCommand command, CardSide side, ModifierKeys modifiers) {
+        return new PeripheralCommand(Binding.keyCode(modifiers, keycode), command, side);
     }
 
-    private static PeripheralCommand unicode(char unicodeChar, @NonNull ViewerCommand command, CardSide side, ModifierKeys modifierKeys) {
-        // Note: cast is needed to select the correct constructor
-        return new PeripheralCommand((Character) unicodeChar, command, side, modifierKeys);
+
+    private static PeripheralCommand unicode(char c, @NonNull ViewerCommand command, CardSide side) {
+        return new PeripheralCommand(Binding.unicode(c), command, side);
     }
 
-    public static PeripheralCommand keyCode(int keyCode, @NonNull ViewerCommand command, CardSide side) {
-        return keyCode(keyCode, command, side, ModifierKeys.none());
-    }
 
-    private static PeripheralCommand keyCode(int keyCode, @NonNull ViewerCommand command, CardSide side, ModifierKeys modifiers) {
-        return new PeripheralCommand(keyCode, command, side, modifiers);
+    private static PeripheralCommand keyCode(int keycode, @NonNull ViewerCommand command, CardSide side) {
+        return new PeripheralCommand(Binding.keyCode(keycode), command, side);
     }
 
     public static List<PeripheralCommand> getDefaultCommands() {
         List<PeripheralCommand> ret = new ArrayList<>(28); // Number of elements below
 
-        ret.add(PeripheralCommand.keyCode(KeyEvent.KEYCODE_1, COMMAND_ANSWER_FIRST_BUTTON, CardSide.ANSWER));
-        ret.add(PeripheralCommand.keyCode(KeyEvent.KEYCODE_2, COMMAND_ANSWER_SECOND_BUTTON, CardSide.ANSWER));
-        ret.add(PeripheralCommand.keyCode(KeyEvent.KEYCODE_3, COMMAND_ANSWER_THIRD_BUTTON, CardSide.ANSWER));
-        ret.add(PeripheralCommand.keyCode(KeyEvent.KEYCODE_4, COMMAND_ANSWER_FOURTH_BUTTON, CardSide.ANSWER));
+        ret.add(keyCode(KeyEvent.KEYCODE_1, COMMAND_ANSWER_FIRST_BUTTON, CardSide.ANSWER));
+        ret.add(keyCode(KeyEvent.KEYCODE_2, COMMAND_ANSWER_SECOND_BUTTON, CardSide.ANSWER));
+        ret.add(keyCode(KeyEvent.KEYCODE_3, COMMAND_ANSWER_THIRD_BUTTON, CardSide.ANSWER));
+        ret.add(keyCode(KeyEvent.KEYCODE_4, COMMAND_ANSWER_FOURTH_BUTTON, CardSide.ANSWER));
 
-        ret.add(PeripheralCommand.keyCode(KeyEvent.KEYCODE_NUMPAD_1, COMMAND_ANSWER_FIRST_BUTTON, CardSide.ANSWER));
-        ret.add(PeripheralCommand.keyCode(KeyEvent.KEYCODE_NUMPAD_2, COMMAND_ANSWER_SECOND_BUTTON, CardSide.ANSWER));
-        ret.add(PeripheralCommand.keyCode(KeyEvent.KEYCODE_NUMPAD_3, COMMAND_ANSWER_THIRD_BUTTON, CardSide.ANSWER));
-        ret.add(PeripheralCommand.keyCode(KeyEvent.KEYCODE_NUMPAD_4, COMMAND_ANSWER_FOURTH_BUTTON, CardSide.ANSWER));
+        ret.add(keyCode(KeyEvent.KEYCODE_NUMPAD_1, COMMAND_ANSWER_FIRST_BUTTON, CardSide.ANSWER));
+        ret.add(keyCode(KeyEvent.KEYCODE_NUMPAD_2, COMMAND_ANSWER_SECOND_BUTTON, CardSide.ANSWER));
+        ret.add(keyCode(KeyEvent.KEYCODE_NUMPAD_3, COMMAND_ANSWER_THIRD_BUTTON, CardSide.ANSWER));
+        ret.add(keyCode(KeyEvent.KEYCODE_NUMPAD_4, COMMAND_ANSWER_FOURTH_BUTTON, CardSide.ANSWER));
 
-        ret.add(PeripheralCommand.keyCode(KeyEvent.KEYCODE_BUTTON_Y, COMMAND_FLIP_OR_ANSWER_EASE1, CardSide.BOTH));
-        ret.add(PeripheralCommand.keyCode(KeyEvent.KEYCODE_BUTTON_X, COMMAND_FLIP_OR_ANSWER_EASE2, CardSide.BOTH));
-        ret.add(PeripheralCommand.keyCode(KeyEvent.KEYCODE_BUTTON_B, COMMAND_FLIP_OR_ANSWER_EASE3, CardSide.BOTH));
-        ret.add(PeripheralCommand.keyCode(KeyEvent.KEYCODE_BUTTON_A, COMMAND_FLIP_OR_ANSWER_EASE4, CardSide.BOTH));
+        ret.add(keyCode(KeyEvent.KEYCODE_BUTTON_Y, COMMAND_FLIP_OR_ANSWER_EASE1, CardSide.BOTH));
+        ret.add(keyCode(KeyEvent.KEYCODE_BUTTON_X, COMMAND_FLIP_OR_ANSWER_EASE2, CardSide.BOTH));
+        ret.add(keyCode(KeyEvent.KEYCODE_BUTTON_B, COMMAND_FLIP_OR_ANSWER_EASE3, CardSide.BOTH));
+        ret.add(keyCode(KeyEvent.KEYCODE_BUTTON_A, COMMAND_FLIP_OR_ANSWER_EASE4, CardSide.BOTH));
 
-        ret.add(PeripheralCommand.keyCode(KeyEvent.KEYCODE_SPACE, COMMAND_ANSWER_RECOMMENDED, CardSide.ANSWER));
-        ret.add(PeripheralCommand.keyCode(KeyEvent.KEYCODE_ENTER, COMMAND_ANSWER_RECOMMENDED, CardSide.ANSWER));
-        ret.add(PeripheralCommand.keyCode(KeyEvent.KEYCODE_NUMPAD_ENTER, COMMAND_ANSWER_RECOMMENDED, CardSide.ANSWER));
+        ret.add(keyCode(KeyEvent.KEYCODE_SPACE, COMMAND_ANSWER_RECOMMENDED, CardSide.ANSWER));
+        ret.add(keyCode(KeyEvent.KEYCODE_ENTER, COMMAND_ANSWER_RECOMMENDED, CardSide.ANSWER));
+        ret.add(keyCode(KeyEvent.KEYCODE_NUMPAD_ENTER, COMMAND_ANSWER_RECOMMENDED, CardSide.ANSWER));
         // See: 1643 - Unsure if this will work - nothing came through on the emulator.
-        ret.add(PeripheralCommand.keyCode(KeyEvent.KEYCODE_DPAD_CENTER, COMMAND_FLIP_OR_ANSWER_RECOMMENDED, CardSide.BOTH));
+        ret.add(keyCode(KeyEvent.KEYCODE_DPAD_CENTER, COMMAND_FLIP_OR_ANSWER_RECOMMENDED, CardSide.BOTH));
 
-        ret.add(PeripheralCommand.keyCode(KeyEvent.KEYCODE_E, COMMAND_EDIT, CardSide.BOTH));
+        ret.add(keyCode(KeyEvent.KEYCODE_E, COMMAND_EDIT, CardSide.BOTH));
 
         // Using a char rather than "Ctrl + 1" is not ideal due to the potential need to handle Shift/Fn + character on
         // international layouts but is what Anki Desktop does
-        ret.add(PeripheralCommand.unicode('*', COMMAND_MARK, CardSide.BOTH));
-        ret.add(PeripheralCommand.unicode('-', COMMAND_BURY_CARD, CardSide.BOTH));
-        ret.add(PeripheralCommand.unicode('=', COMMAND_BURY_NOTE, CardSide.BOTH));
-        ret.add(PeripheralCommand.unicode('@', COMMAND_SUSPEND_CARD, CardSide.BOTH));
-        ret.add(PeripheralCommand.unicode('!', COMMAND_SUSPEND_NOTE, CardSide.BOTH));
-        ret.add(PeripheralCommand.keyCode(KeyEvent.KEYCODE_R, COMMAND_PLAY_MEDIA, CardSide.BOTH));
-        ret.add(PeripheralCommand.keyCode(KeyEvent.KEYCODE_F5, COMMAND_PLAY_MEDIA, CardSide.BOTH));
-        ret.add(PeripheralCommand.keyCode(KeyEvent.KEYCODE_V, COMMAND_REPLAY_VOICE, CardSide.BOTH));
-        ret.add(PeripheralCommand.keyCode(KeyEvent.KEYCODE_V, COMMAND_RECORD_VOICE, CardSide.BOTH, ModifierKeys.shift()));
-        ret.add(PeripheralCommand.keyCode(KeyEvent.KEYCODE_Z, COMMAND_UNDO, CardSide.BOTH));
+        ret.add(unicode('*', COMMAND_MARK, CardSide.BOTH));
+        ret.add(unicode('-', COMMAND_BURY_CARD, CardSide.BOTH));
+        ret.add(unicode('=', COMMAND_BURY_NOTE, CardSide.BOTH));
+        ret.add(unicode('@', COMMAND_SUSPEND_CARD, CardSide.BOTH));
+        ret.add(unicode('!', COMMAND_SUSPEND_NOTE, CardSide.BOTH));
+        ret.add(keyCode(KeyEvent.KEYCODE_R, COMMAND_PLAY_MEDIA, CardSide.BOTH));
+        ret.add(keyCode(KeyEvent.KEYCODE_F5, COMMAND_PLAY_MEDIA, CardSide.BOTH));
+        ret.add(keyCode(KeyEvent.KEYCODE_V, COMMAND_REPLAY_VOICE, CardSide.BOTH));
+        ret.add(keyCode(KeyEvent.KEYCODE_V, COMMAND_RECORD_VOICE, CardSide.BOTH, ModifierKeys.shift()));
+        ret.add(keyCode(KeyEvent.KEYCODE_Z, COMMAND_UNDO, CardSide.BOTH));
 
-        ret.add(PeripheralCommand.keyCode(KeyEvent.KEYCODE_1, COMMAND_TOGGLE_FLAG_RED, CardSide.BOTH, ModifierKeys.ctrl()));
-        ret.add(PeripheralCommand.keyCode(KeyEvent.KEYCODE_2, COMMAND_TOGGLE_FLAG_ORANGE, CardSide.BOTH, ModifierKeys.ctrl()));
-        ret.add(PeripheralCommand.keyCode(KeyEvent.KEYCODE_3, COMMAND_TOGGLE_FLAG_GREEN, CardSide.BOTH, ModifierKeys.ctrl()));
-        ret.add(PeripheralCommand.keyCode(KeyEvent.KEYCODE_4, COMMAND_TOGGLE_FLAG_BLUE, CardSide.BOTH, ModifierKeys.ctrl()));
+        ret.add(keyCode(KeyEvent.KEYCODE_1, COMMAND_TOGGLE_FLAG_RED, CardSide.BOTH, ModifierKeys.ctrl()));
+        ret.add(keyCode(KeyEvent.KEYCODE_2, COMMAND_TOGGLE_FLAG_ORANGE, CardSide.BOTH, ModifierKeys.ctrl()));
+        ret.add(keyCode(KeyEvent.KEYCODE_3, COMMAND_TOGGLE_FLAG_GREEN, CardSide.BOTH, ModifierKeys.ctrl()));
+        ret.add(keyCode(KeyEvent.KEYCODE_4, COMMAND_TOGGLE_FLAG_BLUE, CardSide.BOTH, ModifierKeys.ctrl()));
 
-        ret.add(PeripheralCommand.keyCode(KeyEvent.KEYCODE_NUMPAD_1, COMMAND_TOGGLE_FLAG_RED, CardSide.BOTH, ModifierKeys.ctrl()));
-        ret.add(PeripheralCommand.keyCode(KeyEvent.KEYCODE_NUMPAD_2, COMMAND_TOGGLE_FLAG_ORANGE, CardSide.BOTH, ModifierKeys.ctrl()));
-        ret.add(PeripheralCommand.keyCode(KeyEvent.KEYCODE_NUMPAD_3, COMMAND_TOGGLE_FLAG_GREEN, CardSide.BOTH, ModifierKeys.ctrl()));
-        ret.add(PeripheralCommand.keyCode(KeyEvent.KEYCODE_NUMPAD_4, COMMAND_TOGGLE_FLAG_BLUE, CardSide.BOTH, ModifierKeys.ctrl()));
+        ret.add(keyCode(KeyEvent.KEYCODE_NUMPAD_1, COMMAND_TOGGLE_FLAG_RED, CardSide.BOTH, ModifierKeys.ctrl()));
+        ret.add(keyCode(KeyEvent.KEYCODE_NUMPAD_2, COMMAND_TOGGLE_FLAG_ORANGE, CardSide.BOTH, ModifierKeys.ctrl()));
+        ret.add(keyCode(KeyEvent.KEYCODE_NUMPAD_3, COMMAND_TOGGLE_FLAG_GREEN, CardSide.BOTH, ModifierKeys.ctrl()));
+        ret.add(keyCode(KeyEvent.KEYCODE_NUMPAD_4, COMMAND_TOGGLE_FLAG_BLUE, CardSide.BOTH, ModifierKeys.ctrl()));
 
         return ret;
     }
 
 
     public boolean matchesModifier(KeyEvent event) {
-        return mModifierKeys.matches(event);
+        return mBinding.matchesModifier(event);
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/PeripheralCommand.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/PeripheralCommand.java
@@ -27,6 +27,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import static com.ichi2.anki.cardviewer.ViewerCommand.*;
+import static com.ichi2.anki.reviewer.Binding.*;
 
 public class PeripheralCommand {
     @Nullable
@@ -161,49 +162,5 @@ public class PeripheralCommand {
         QUESTION,
         ANSWER,
         BOTH
-    }
-
-
-    public static class ModifierKeys {
-        // null == true/false works.
-        @Nullable
-        private final Boolean mShift;
-        @Nullable
-        private final Boolean mCtrl;
-        @Nullable
-        private final Boolean mAlt;
-
-
-        private ModifierKeys(@Nullable Boolean shift, @Nullable Boolean ctrl, @Nullable Boolean alt) {
-            this.mShift = shift;
-            this.mCtrl = ctrl;
-            this.mAlt = alt;
-        }
-
-
-        public static ModifierKeys none() {
-            return new ModifierKeys(false, false, false);
-        }
-
-        public static ModifierKeys ctrl() {
-            return new ModifierKeys(false, true, false);
-        }
-
-        public static ModifierKeys shift() {
-            return new ModifierKeys(true, false, false);
-        }
-
-        /** Allows shift, but not Ctrl/Alt */
-        public static ModifierKeys allowShift() {
-            return new ModifierKeys(null, false, false);
-        }
-
-
-        public boolean matches(KeyEvent event) {
-            // return false if Ctrl+1 is pressed and 1 is expected
-            return (mShift == null || mShift == event.isShiftPressed()) &&
-                    (mCtrl == null || mCtrl == event.isCtrlPressed()) &&
-                    (mAlt == null || mAlt == event.isAltPressed());
-        }
     }
 }


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
Implement part of the "Binding" class from #8078 for PR #6052.

* Bindings are compared (via a HashMap) to find the correct binding and serialised to the preferences.

We do not implement equality or serialisation here. Equality is going to require a harsh review, and serialisation depends on the implementations, so these are deferred.

The linked PR sadly skips the issue that the default in-app bindings need to handle when `*` is mapped on a keyboard with and without a shift key being pressed.

When a user defines these changes in the UI, it won't matter, but is important for sensible defaults

## How Has This Been Tested?

Unit tests only

## Learning

https://github.com/ankidroid/Anki-Android/issues/7840

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
