### PR TITLE
KeyBinding: Implement HashMap lookup

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -312,6 +312,7 @@ dependencies {
 
     testImplementation 'org.junit.vintage:junit-vintage-engine:5.7.2'
     testImplementation 'org.mockito:mockito-inline:3.11.2'
+    testImplementation "org.mockito.kotlin:mockito-kotlin:3.2.0"
     testImplementation 'org.hamcrest:hamcrest-all:1.3'
     testImplementation 'net.lachlanmckee:timber-junit-rule:1.0.1'
     testImplementation "org.robolectric:robolectric:4.5.1"

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/Binding.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/Binding.java
@@ -63,7 +63,6 @@ public class Binding {
         return mGesture;
     }
 
-    @VisibleForTesting(otherwise = VisibleForTesting.NONE)
     @Nullable
     public ModifierKeys getModifierKeys() {
         return mModifierKeys;
@@ -119,29 +118,6 @@ public class Binding {
     public boolean isGesture() {
         return mGesture != null;
     }
-
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-        Binding binding = (Binding) o;
-        return Objects.equals(mKeyCode, binding.mKeyCode) &&
-                Objects.equals(mUnicodeCharacter, binding.mUnicodeCharacter) &&
-                Objects.equals(mGesture, binding.mGesture) &&
-                Objects.equals(mModifierKeys, binding.mModifierKeys);
-    }
-
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(mKeyCode, mUnicodeCharacter, mGesture, mModifierKeys);
-    }
-
 
     public boolean matchesModifier(KeyEvent event) {
         return mModifierKeys == null || mModifierKeys.matches(event);
@@ -201,37 +177,6 @@ public class Binding {
 
         protected boolean altMatches(boolean altPressed) {
             return mAlt == altPressed;
-        }
-
-
-        @Override
-        public boolean equals(Object o) {
-            // equals allowing subclasses
-            if (this == o) {
-                return true;
-            }
-            if (!(o instanceof ModifierKeys)) {
-                return false;
-            }
-
-            ModifierKeys keys = (ModifierKeys) o;
-
-            // special case: easy comparison
-            if (keys.getClass() == ModifierKeys.class) {
-                return keys.mShift == mShift && keys.mCtrl == mCtrl && keys.mAlt == mAlt;
-            }
-
-            // allow subclasses to work - a subclass which overrides shiftMatches will return true on one of the tests
-            return (shiftMatches(true) == keys.shiftMatches(true) || shiftMatches(false) == keys.shiftMatches(false)) &&
-                    (ctrlMatches(true) == keys.ctrlMatches(true) || ctrlMatches(false) == keys.ctrlMatches(false)) &&
-                    (altMatches(true) == keys.altMatches(true) || altMatches(false) == keys.altMatches(false));
-        }
-
-        @Override
-        public int hashCode() {
-            // AKA: use .equals to allow subclasses to work - this will be very inefficient if placed in a HashMap
-            // But we don't store data in a HashMap, so we're fine
-            return 0;
         }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/PeripheralCommand.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/PeripheralCommand.java
@@ -121,7 +121,7 @@ public class PeripheralCommand {
         ret.add(unicode('*', COMMAND_MARK, CardSide.BOTH));
         ret.add(unicode('-', COMMAND_BURY_CARD, CardSide.BOTH));
         ret.add(unicode('=', COMMAND_BURY_NOTE, CardSide.BOTH));
-        ret.add(unicode('@', COMMAND_SUSPEND_CARD, CardSide.BOTH)); //21
+        ret.add(unicode('@', COMMAND_SUSPEND_CARD, CardSide.BOTH));
         ret.add(unicode('!', COMMAND_SUSPEND_NOTE, CardSide.BOTH));
         ret.add(keyCode(KeyEvent.KEYCODE_R, COMMAND_PLAY_MEDIA, CardSide.BOTH));
         ret.add(keyCode(KeyEvent.KEYCODE_F5, COMMAND_PLAY_MEDIA, CardSide.BOTH));

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/PeripheralCommand.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/PeripheralCommand.java
@@ -62,6 +62,11 @@ public class PeripheralCommand {
         return mBinding.getKeycode();
     }
 
+    @NonNull
+    public Binding getBinding() {
+        return mBinding;
+    }
+
     public boolean isQuestion() {
         return mCardSide == CardSide.QUESTION || mCardSide == CardSide.BOTH;
     }
@@ -116,7 +121,7 @@ public class PeripheralCommand {
         ret.add(unicode('*', COMMAND_MARK, CardSide.BOTH));
         ret.add(unicode('-', COMMAND_BURY_CARD, CardSide.BOTH));
         ret.add(unicode('=', COMMAND_BURY_NOTE, CardSide.BOTH));
-        ret.add(unicode('@', COMMAND_SUSPEND_CARD, CardSide.BOTH));
+        ret.add(unicode('@', COMMAND_SUSPEND_CARD, CardSide.BOTH)); //21
         ret.add(unicode('!', COMMAND_SUSPEND_NOTE, CardSide.BOTH));
         ret.add(keyCode(KeyEvent.KEYCODE_R, COMMAND_PLAY_MEDIA, CardSide.BOTH));
         ret.add(keyCode(KeyEvent.KEYCODE_F5, COMMAND_PLAY_MEDIA, CardSide.BOTH));

--- a/AnkiDroid/src/test/java/com/ichi2/anki/reviewer/BindingTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/reviewer/BindingTest.kt
@@ -1,0 +1,94 @@
+/*
+ *  Copyright (c) 2021 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.ichi2.anki.reviewer
+
+import android.view.KeyEvent
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.`is`
+import org.hamcrest.Matchers.hasItem
+import org.junit.Test
+import org.mockito.ArgumentMatchers.anyInt
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import kotlin.reflect.KFunction1
+import kotlin.reflect.KFunction2
+
+class BindingTest {
+    @Test
+    fun modifierKeys_Are_Loaded() {
+        testModifierKeys("shift", KeyEvent::isShiftPressed, Binding.ModifierKeys::shiftMatches)
+        testModifierKeys("ctrl", KeyEvent::isCtrlPressed, Binding.ModifierKeys::ctrlMatches)
+        testModifierKeys("alt", KeyEvent::isAltPressed, Binding.ModifierKeys::altMatches)
+    }
+
+    @Test
+    fun unicodeKeyIsLoaded() {
+        val binding = unicodeCharacter('a')
+
+        assertThat(binding.unicodeCharacter, `is`('a'))
+    }
+
+    @Test
+    fun keycodeIsLoaded() {
+        val binding = keyCode(KeyEvent.KEYCODE_A)
+
+        assertThat(binding.keycode, `is`(KeyEvent.KEYCODE_A))
+    }
+
+    @Test
+    fun equalityTest() {
+        val allBindings = PeripheralCommand.getDefaultCommands().map { x -> x.binding }.toList()
+
+        assertThat(allBindings, hasItem(unicodeCharacter('@')))
+        assertThat(allBindings, hasItem(keyCode(KeyEvent.KEYCODE_1)))
+    }
+
+    private fun unicodeCharacter(c: Char): Binding {
+        val mock = mock<KeyEvent> {
+            on { getUnicodeChar(anyInt()) } doReturn c.code
+            on { unicodeChar } doReturn c.code
+        }
+
+        val binding = Binding.key(mock).first { x -> x.unicodeCharacter != null }
+        return binding
+    }
+
+    private fun keyCode(keyCode: Int): Binding {
+        val mock = mock<KeyEvent> {
+            on { getKeyCode() } doReturn keyCode
+        }
+
+        return Binding.key(mock).first { x -> x.keycode != null }
+    }
+
+    private fun testModifierKeys(name: String, event: KFunction1<KeyEvent, Boolean>, getValue: KFunction2<Binding.ModifierKeys, Boolean, Boolean>) {
+        fun testModifierResult(event: KFunction1<KeyEvent, Boolean>, returnedFromMock: Boolean) {
+            val mock = mock<KeyEvent> {
+                on(event) doReturn returnedFromMock
+            }
+
+            val bindings = Binding.key(mock)
+
+            for (binding in bindings) {
+                assertThat("Should match when '$name:$returnedFromMock': ", getValue(binding.modifierKeys!!, true), `is`(returnedFromMock))
+                assertThat("Should match when '$name:${!returnedFromMock}': ", getValue(binding.modifierKeys!!, false), `is`(!returnedFromMock))
+            }
+        }
+
+        testModifierResult(event, true)
+        testModifierResult(event, false)
+    }
+}

--- a/AnkiDroid/src/test/java/com/ichi2/anki/reviewer/BindingTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/reviewer/BindingTest.kt
@@ -18,7 +18,6 @@ package com.ichi2.anki.reviewer
 import android.view.KeyEvent
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.`is`
-import org.hamcrest.Matchers.hasItem
 import org.junit.Test
 import org.mockito.ArgumentMatchers.anyInt
 import org.mockito.kotlin.doReturn
@@ -48,32 +47,6 @@ class BindingTest {
         assertThat(binding.keycode, `is`(KeyEvent.KEYCODE_A))
     }
 
-    @Test
-    fun equalityTest() {
-        val allBindings = PeripheralCommand.getDefaultCommands().map { x -> x.binding }.toList()
-
-        assertThat(allBindings, hasItem(unicodeCharacter('@')))
-        assertThat(allBindings, hasItem(keyCode(KeyEvent.KEYCODE_1)))
-    }
-
-    private fun unicodeCharacter(c: Char): Binding {
-        val mock = mock<KeyEvent> {
-            on { getUnicodeChar(anyInt()) } doReturn c.code
-            on { unicodeChar } doReturn c.code
-        }
-
-        val binding = Binding.key(mock).first { x -> x.unicodeCharacter != null }
-        return binding
-    }
-
-    private fun keyCode(keyCode: Int): Binding {
-        val mock = mock<KeyEvent> {
-            on { getKeyCode() } doReturn keyCode
-        }
-
-        return Binding.key(mock).first { x -> x.keycode != null }
-    }
-
     private fun testModifierKeys(name: String, event: KFunction1<KeyEvent, Boolean>, getValue: KFunction2<Binding.ModifierKeys, Boolean, Boolean>) {
         fun testModifierResult(event: KFunction1<KeyEvent, Boolean>, returnedFromMock: Boolean) {
             val mock = mock<KeyEvent> {
@@ -90,5 +63,24 @@ class BindingTest {
 
         testModifierResult(event, true)
         testModifierResult(event, false)
+    }
+
+    companion object {
+        fun unicodeCharacter(c: Char): Binding {
+            val mock = mock<KeyEvent> {
+                on { getUnicodeChar(anyInt()) } doReturn c.code
+                on { unicodeChar } doReturn c.code
+            }
+
+            return Binding.key(mock).first { x -> x.unicodeCharacter != null }
+        }
+
+        fun keyCode(keyCode: Int): Binding {
+            val mock = mock<KeyEvent> {
+                on { getKeyCode() } doReturn keyCode
+            }
+
+            return Binding.key(mock).first { x -> x.keycode != null }
+        }
     }
 }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/reviewer/MappableBindingTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/reviewer/MappableBindingTest.kt
@@ -1,0 +1,42 @@
+/*
+ *  Copyright (c) 2021 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.ichi2.anki.reviewer
+
+import android.view.KeyEvent
+import com.ichi2.anki.reviewer.PeripheralKeymap.MappableBinding
+import com.ichi2.anki.reviewer.PeripheralKeymap.MappableBinding.fromBinding
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.hasItem
+import org.junit.Test
+
+class MappableBindingTest {
+    @Test
+    fun equalityTest() {
+        val allBindings = PeripheralCommand.getDefaultCommands()
+            .map { x -> x.binding }
+            .map(MappableBinding::fromBinding)
+            .toList()
+
+        assertThat(allBindings, hasItem(unicodeCharacter('@')))
+        assertThat(allBindings, hasItem(keyCode(KeyEvent.KEYCODE_1)))
+    }
+
+    @Suppress("SameParameterValue")
+    private fun keyCode(code: Int) = fromBinding(BindingTest.keyCode(code))
+
+    @Suppress("SameParameterValue")
+    private fun unicodeCharacter(char: Char) = fromBinding(BindingTest.unicodeCharacter(char))
+}

--- a/AnkiDroid/src/test/java/com/ichi2/anki/reviewer/PeripheralKeymapTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/reviewer/PeripheralKeymapTest.java
@@ -42,10 +42,11 @@ public class PeripheralKeymapTest {
         when(event.getUnicodeChar()).thenReturn(0);
         when(event.isCtrlPressed()).thenReturn(true);
         when(event.getUnicodeChar(0)).thenReturn(49);
+        when(event.getKeyCode()).thenReturn(KeyEvent.KEYCODE_1);
 
         assertThat((char) event.getUnicodeChar(), is('\0'));
         assertThat((char) event.getUnicodeChar(0), is('1'));
-        peripheralKeymap.onKeyDown(8, event);
+        peripheralKeymap.onKeyDown(KeyEvent.KEYCODE_1, event);
 
         assertThat(processed, hasSize(1));
         assertThat(processed.get(0), is(ViewerCommand.COMMAND_TOGGLE_FLAG_RED));


### PR DESCRIPTION
## Purpose / Description
So close now! After implementing equality, we need to implement string processing

This isn't an ideal solution (hashcode returning 0, eww), but it allows a `Binding` to be added to a HashMap. This massively improves the ability of someone to perform a `Binding -> Command` lookup, which is what we're looking for.

Taken somewhat from #8078 to help with #6052

## How Has This Been Tested?

A few unit tests, tried it out with my keyboard and it still works.

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
