### PR TITLE
implement serde for Key Binding

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/utils/StringUtil.java
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/StringUtil.java
@@ -75,4 +75,17 @@ public class StringUtil {
         return string.substring(start, end);
     }
 
+    /** Converts the string to where the first letter is uppercase, and the rest of the string is lowercase */
+    @Contract("null -> null; !null -> !null")
+    public static String toTitleCase(@Nullable String s) {
+        if (s == null) {
+            return null;
+        }
+
+        if (s.length() > 0) {
+            s = s.substring(0, 1).toUpperCase() + s.substring(1).toLowerCase();
+        }
+
+        return s;
+    }
 }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/reviewer/BindingAndroidTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/reviewer/BindingAndroidTest.kt
@@ -1,0 +1,39 @@
+/*
+ *  Copyright (c) 2021 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.reviewer
+
+import android.view.KeyEvent
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.ichi2.anki.reviewer.Binding.ModifierKeys.alt
+import com.ichi2.anki.reviewer.Binding.ModifierKeys.ctrl
+import com.ichi2.anki.reviewer.Binding.ModifierKeys.shift
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class BindingAndroidTest {
+
+    @Test
+    fun testKeycodeToString() {
+        // These use native functions. We may need KeyEvent.keyCodeToString
+        assertEquals(BindingTest.keyPrefix + "87", Binding.keyCode(KeyEvent.KEYCODE_MEDIA_NEXT).toString())
+        assertEquals(BindingTest.keyPrefix + "Ctrl+88", Binding.keyCode(ctrl(), KeyEvent.KEYCODE_MEDIA_PREVIOUS).toString())
+        assertEquals(BindingTest.keyPrefix + "Shift+25", Binding.keyCode(shift(), KeyEvent.KEYCODE_VOLUME_DOWN).toString())
+        assertEquals(BindingTest.keyPrefix + "Alt+24", Binding.keyCode(alt(), KeyEvent.KEYCODE_VOLUME_UP).toString())
+    }
+}

--- a/AnkiDroid/src/test/java/com/ichi2/anki/reviewer/BindingAndroidTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/reviewer/BindingAndroidTest.kt
@@ -18,9 +18,9 @@ package com.ichi2.anki.reviewer
 
 import android.view.KeyEvent
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.ichi2.anki.reviewer.Binding.ModifierKeys.alt
-import com.ichi2.anki.reviewer.Binding.ModifierKeys.ctrl
-import com.ichi2.anki.reviewer.Binding.ModifierKeys.shift
+import com.ichi2.anki.cardviewer.Gesture
+import com.ichi2.anki.reviewer.Binding.ModifierKeys.*
+import com.ichi2.anki.reviewer.PeripheralKeymap.MappableBinding
 import org.junit.Assert.assertEquals
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -35,5 +35,24 @@ class BindingAndroidTest {
         assertEquals(BindingTest.keyPrefix + "Ctrl+88", Binding.keyCode(ctrl(), KeyEvent.KEYCODE_MEDIA_PREVIOUS).toString())
         assertEquals(BindingTest.keyPrefix + "Shift+25", Binding.keyCode(shift(), KeyEvent.KEYCODE_VOLUME_DOWN).toString())
         assertEquals(BindingTest.keyPrefix + "Alt+24", Binding.keyCode(alt(), KeyEvent.KEYCODE_VOLUME_UP).toString())
+    }
+
+    @Test
+    fun testFromString() {
+        assertBindingEquals(Binding.unicode('Ä'), Binding.fromString(BindingTest.unicodePrefix + "Ä"))
+        assertBindingEquals(Binding.unicode(ctrl(), 'Ä'), Binding.fromString(BindingTest.unicodePrefix + "Ctrl+Ä"))
+        assertBindingEquals(Binding.unicode(shift(), 'Ä'), Binding.fromString(BindingTest.unicodePrefix + "Shift+Ä"))
+        assertBindingEquals(Binding.unicode(alt(), 'Ä'), Binding.fromString(BindingTest.unicodePrefix + "Alt+Ä"))
+        assertBindingEquals(Binding.keyCode(KeyEvent.KEYCODE_MEDIA_NEXT), Binding.fromString(BindingTest.keyPrefix + KeyEvent.keyCodeToString(KeyEvent.KEYCODE_MEDIA_NEXT)))
+        assertBindingEquals(Binding.keyCode(ctrl(), KeyEvent.KEYCODE_MEDIA_PREVIOUS), Binding.fromString(BindingTest.keyPrefix + "Ctrl+" + KeyEvent.keyCodeToString(KeyEvent.KEYCODE_MEDIA_PREVIOUS)))
+        assertBindingEquals(Binding.keyCode(shift(), KeyEvent.KEYCODE_VOLUME_DOWN), Binding.fromString(BindingTest.keyPrefix + "Shift+" + KeyEvent.keyCodeToString(KeyEvent.KEYCODE_VOLUME_DOWN)))
+        assertBindingEquals(Binding.keyCode(alt(), KeyEvent.KEYCODE_VOLUME_UP), Binding.fromString(BindingTest.keyPrefix + "Alt+" + KeyEvent.keyCodeToString(KeyEvent.KEYCODE_VOLUME_UP)))
+        assertBindingEquals(Binding.gesture(Gesture.TAP_TOP), Binding.fromString(BindingTest.gesturePrefix + Gesture.TAP_TOP.name))
+    }
+
+    private fun assertBindingEquals(fst: Binding?, snd: Binding?) {
+        val first = MappableBinding.fromBinding(fst)
+        val second = MappableBinding.fromBinding(snd)
+        assertEquals(first, second)
     }
 }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/reviewer/BindingTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/reviewer/BindingTest.kt
@@ -63,6 +63,12 @@ class BindingTest {
         assertEquals(gesturePrefix + "TAP_TOP", Binding.gesture(Gesture.TAP_TOP).toString())
     }
 
+    @Test
+    fun testUnknownToString() {
+        // This seems sensible - serialising an unknown will mean that nothing is saved.
+        assertThat(Binding.unknown().toString(), `is`(""))
+    }
+
     private fun testModifierKeys(name: String, event: KFunction1<KeyEvent, Boolean>, getValue: KFunction2<Binding.ModifierKeys, Boolean, Boolean>) {
         fun testModifierResult(event: KFunction1<KeyEvent, Boolean>, returnedFromMock: Boolean) {
             val mock = mock<KeyEvent> {

--- a/AnkiDroid/src/test/java/com/ichi2/anki/reviewer/BindingTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/reviewer/BindingTest.kt
@@ -16,8 +16,10 @@
 package com.ichi2.anki.reviewer
 
 import android.view.KeyEvent
+import com.ichi2.anki.cardviewer.Gesture
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.`is`
+import org.junit.Assert.assertEquals
 import org.junit.Test
 import org.mockito.ArgumentMatchers.anyInt
 import org.mockito.kotlin.doReturn
@@ -47,6 +49,20 @@ class BindingTest {
         assertThat(binding.keycode, `is`(KeyEvent.KEYCODE_A))
     }
 
+    @Test
+    fun testUnicodeToString() {
+        assertEquals(unicodePrefix + "Ä", Binding.unicode('Ä').toString())
+        assertEquals(unicodePrefix + "Ctrl+Ä", Binding.unicode(Binding.ModifierKeys.ctrl(), 'Ä').toString())
+        assertEquals(unicodePrefix + "Shift+Ä", Binding.unicode(Binding.ModifierKeys.shift(), 'Ä').toString())
+        assertEquals(unicodePrefix + "Alt+Ä", Binding.unicode(Binding.ModifierKeys.alt(), 'Ä').toString())
+        assertEquals(unicodePrefix + "Ctrl+Alt+Shift+Ä", Binding.unicode(allModifierKeys(), 'Ä').toString())
+    }
+
+    @Test
+    fun testGestureToString() {
+        assertEquals(gesturePrefix + "TAP_TOP", Binding.gesture(Gesture.TAP_TOP).toString())
+    }
+
     private fun testModifierKeys(name: String, event: KFunction1<KeyEvent, Boolean>, getValue: KFunction2<Binding.ModifierKeys, Boolean, Boolean>) {
         fun testModifierResult(event: KFunction1<KeyEvent, Boolean>, returnedFromMock: Boolean) {
             val mock = mock<KeyEvent> {
@@ -66,6 +82,12 @@ class BindingTest {
     }
 
     companion object {
+        const val gesturePrefix = '\u235D'
+        const val keyPrefix = '\u2328'
+        const val unicodePrefix = '\u2705'
+
+        fun allModifierKeys() = Binding.ModifierKeys(true, true, true)
+
         fun unicodeCharacter(c: Char): Binding {
             val mock = mock<KeyEvent> {
                 on { getUnicodeChar(anyInt()) } doReturn c.code

--- a/AnkiDroid/src/test/java/com/ichi2/utils/StringUtilTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/utils/StringUtilTest.java
@@ -23,7 +23,8 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.sameInstance;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 public class StringUtilTest {
 
@@ -84,5 +85,25 @@ public class StringUtilTest {
     @Test
     public void strip_does_nothing_on_stripped_string() {
         assertEquals("Java", StringUtil.strip("Java"));
+    }
+
+    @Test
+    public void toTitleCase_null_is_null() {
+        assertThat(StringUtil.toTitleCase(null), nullValue());
+    }
+
+    @Test
+    public void toTitleCase_single_letter() {
+        assertThat(StringUtil.toTitleCase("a"), is("A"));
+    }
+
+    @Test
+    public void toTitleCase_single_upper_letter() {
+        assertThat(StringUtil.toTitleCase("A"), is("A"));
+    }
+
+    @Test
+    public void toTitleCase_string() {
+        assertThat(StringUtil.toTitleCase("aB"), is("Ab"));
     }
 }


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
Key Bindings need to be serialized and deserialized from preferences

This brings in the code for #8078 to handle this aspect  of #6052 

## How Has This Been Tested?

Should be non-functional, unit tests lifted from the PR

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)