### PR TITLE
Populate all hours in hourly stats chart

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/stats/Stats.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/stats/Stats.java
@@ -877,6 +877,9 @@ public class Stats {
         long cut = cutoff - rolloverHour * 3600;
 
         ArrayList<double[]> list = new ArrayList<>(24); // number of hours
+        for (int i = 0; i < 24; i++) {
+            list.add(new double[] { i, 0, 0 });
+        }
         String query = "select " +
                 "23 - ((cast((" + cut + " - id/1000) / 3600.0 as int)) % 24) as hour, " +
                 "sum(case when ease = 1 then 0 else 1 end) / " +
@@ -888,7 +891,8 @@ public class Stats {
         try (Cursor cur = mCol.getDb()
                     .query(query)) {
             while (cur.moveToNext()) {
-                list.add(new double[] { cur.getDouble(0), cur.getDouble(1), cur.getDouble(2) });
+                double[] hourData = new double[] { cur.getDouble(0), cur.getDouble(1), cur.getDouble(2) };
+                list.set((int)hourData[0], hourData);
             }
         }
 


### PR DESCRIPTION
## Pull Request template

## Purpose / Description

The hourly stats chart was built in a way that led to user surprise - only hours that had data were populated in the chartbuilder data set, so the chart's X axis was data-dependent and the axis labels themselves were variable and sometimes non-existant

## Fixes
Fixes #8920

## Approach
Pre-populate all the hours so the chart is consistent every time

## How Has This Been Tested?
Visually on an emulator with some test data

Before
![image](https://user-images.githubusercontent.com/782704/124374187-c2e8b800-dc5e-11eb-9346-0a79f9cb56cf.png)


After
![image](https://user-images.githubusercontent.com/782704/124374169-9765cd80-dc5e-11eb-9b9d-11b7fa928c7b.png)


## Learning (optional, can help others)
_Describe the research stage_

_Links to blog posts, patterns, libraries or addons used to solve this problem_

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
