### PR TITLE
Run Unit Tests in Foreground

### DIFF
--- a/AnkiDroid/src/test/java/com/ichi2/anki/AbstractFlashcardViewerKeyboardInputTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/AbstractFlashcardViewerKeyboardInputTest.java
@@ -39,6 +39,7 @@ public class AbstractFlashcardViewerKeyboardInputTest extends RobolectricTest {
     }
 
     @Test
+    @RunInBackground
     public void enterShowsAnswer() {
         KeyboardInputTestCardViewer underTest = KeyboardInputTestCardViewer.create();
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.java
@@ -88,6 +88,7 @@ public class CardBrowserTest extends RobolectricTest {
     }
 
     @Test
+    @RunInBackground
     public void selectAllIsNotVisibleOnceCalled() {
         CardBrowser browser = getBrowserWithMultipleNotes();
         selectMenuItem(browser, R.id.action_select_all);
@@ -96,6 +97,7 @@ public class CardBrowserTest extends RobolectricTest {
     }
 
     @Test
+    @RunInBackground
     public void selectNoneIsVisibleOnceSelectAllCalled() {
         CardBrowser browser = getBrowserWithMultipleNotes();
         selectMenuItem(browser, R.id.action_select_all);
@@ -104,6 +106,7 @@ public class CardBrowserTest extends RobolectricTest {
     }
 
     @Test
+    @RunInBackground
     public void selectNoneIsVisibleWhenSelectingOne() {
         CardBrowser browser = getBrowserWithMultipleNotes();
         advanceRobolectricLooperWithSleep();

--- a/AnkiDroid/src/test/java/com/ichi2/anki/ReviewerTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/ReviewerTest.java
@@ -83,6 +83,7 @@ public class ReviewerTest extends RobolectricTest {
     }
 
     @Test
+    @RunInBackground
     public void verifyNormalStartup() {
         try (ActivityScenario<Reviewer> scenario = ActivityScenario.launch(Reviewer.class)) {
             scenario.onActivity(reviewer -> assertNotNull("Collection should be non-null", reviewer.getCol()));
@@ -90,6 +91,7 @@ public class ReviewerTest extends RobolectricTest {
     }
 
     @Test
+    @RunInBackground
     public void exitCommandWorksAfterControlsAreBlocked() {
         ensureCollectionLoadIsSynchronous();
         try (ActivityScenario<Reviewer> scenario = ActivityScenario.launch(Reviewer.class)) {

--- a/AnkiDroid/src/test/java/com/ichi2/anki/RobolectricTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/RobolectricTest.java
@@ -45,6 +45,7 @@ import com.ichi2.libanki.sched.AbstractSched;
 import com.ichi2.libanki.sched.Sched;
 import com.ichi2.libanki.sched.SchedV2;
 import com.ichi2.testutils.MockTime;
+import com.ichi2.testutils.TaskSchedulerRule;
 import com.ichi2.utils.Computation;
 import com.ichi2.utils.JSONException;
 
@@ -57,6 +58,7 @@ import org.junit.Assert;
 import org.junit.Assume;
 import org.junit.AssumptionViolatedException;
 import org.junit.Before;
+import org.junit.Rule;
 import org.robolectric.Robolectric;
 import org.robolectric.android.controller.ActivityController;
 import org.robolectric.shadows.ShadowDialog;
@@ -94,8 +96,17 @@ public class RobolectricTest implements CollectionGetter {
         return true;
     }
 
+    @Rule
+    public final TaskSchedulerRule mTaskScheduler = new TaskSchedulerRule();
+
     @Before
     public void setUp() {
+        if (mTaskScheduler.shouldRunInForeground()) {
+            runTasksInForeground();
+        } else {
+            runTasksInBackground();
+        }
+
 
         RustBackendLoader.init();
 
@@ -172,8 +183,6 @@ public class RobolectricTest implements CollectionGetter {
             //called on each AnkiDroidApp.onCreate(), and spams the build
             //there is no onDestroy(), so call it here.
             Timber.uprootAll();
-
-            runTasksInBackground();
         }
     }
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/RunInBackground.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/RunInBackground.java
@@ -1,0 +1,29 @@
+/*
+ *  Copyright (c) 2021 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki;
+
+import java.lang.annotation.Retention;
+
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * Specifies that the test cannot yet be run in the background, so we need the legacy background executor
+ * We should aim to remove this, as tests will be lass flaky and faster without it.
+ */
+@Retention(RUNTIME)
+public @interface RunInBackground {
+}

--- a/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/RecursivePictureMenuTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/RecursivePictureMenuTest.java
@@ -20,6 +20,7 @@ import android.view.View;
 
 import com.ichi2.anki.R;
 import com.ichi2.anki.RobolectricTest;
+import com.ichi2.anki.RunInBackground;
 import com.ichi2.anki.analytics.UsageAnalytics;
 import com.ichi2.anki.dialogs.HelpDialog.LinkItem;
 import com.ichi2.anki.dialogs.RecursivePictureMenu.Item;
@@ -49,6 +50,7 @@ public class RecursivePictureMenuTest extends RobolectricTest {
     private FragmentTestActivity mActivity;
 
     @Test
+    @RunInBackground
     public void testNormalStartupSelectingItem() {
         Item linkedItem = getItemLinkingTo(R.string.link_anki);
 
@@ -60,6 +62,7 @@ public class RecursivePictureMenuTest extends RobolectricTest {
 
 
     @Test
+    @RunInBackground
     public void testSelectingHeader() {
         int numberOfChildItems = 2;
         Item header = getHeaderWithSubItems(numberOfChildItems);

--- a/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/utils/HelpDialogTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/utils/HelpDialogTest.java
@@ -18,6 +18,7 @@ package com.ichi2.anki.dialogs.utils;
 
 
 import com.ichi2.anki.RobolectricTest;
+import com.ichi2.anki.RunInBackground;
 import com.ichi2.anki.dialogs.HelpDialog;
 import com.ichi2.anki.dialogs.RecursivePictureMenu;
 
@@ -34,6 +35,7 @@ import static org.hamcrest.Matchers.is;
 public class HelpDialogTest extends RobolectricTest {
 
     @Test
+    @RunInBackground
     public void testMenuDoesNotCrash() {
         RecursivePictureMenu dialog = (RecursivePictureMenu) HelpDialog.createInstance(getTargetContext());
 
@@ -45,6 +47,7 @@ public class HelpDialogTest extends RobolectricTest {
     }
 
     @Test
+    @RunInBackground
     public void testmenuSupportAnkiDroidDoesNotCrash() {
         RecursivePictureMenu dialog = (RecursivePictureMenu) HelpDialog.createInstanceForSupportAnkiDroid(getTargetContext());
 

--- a/AnkiDroid/src/test/java/com/ichi2/async/CollectionTaskCheckDatabaseTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/async/CollectionTaskCheckDatabaseTest.java
@@ -18,6 +18,7 @@ package com.ichi2.async;
 
 import android.util.Pair;
 
+import com.ichi2.anki.RunInBackground;
 import com.ichi2.libanki.Collection;
 import com.ichi2.testutils.CollectionUtils;
 
@@ -29,6 +30,7 @@ import static org.hamcrest.Matchers.is;
 public class CollectionTaskCheckDatabaseTest extends AbstractCollectionTaskTest {
 
     @Test
+    @RunInBackground
     public void checkDatabaseWithLockedCollectionReturnsLocked() {
         lockDatabase();
 

--- a/AnkiDroid/src/test/java/com/ichi2/async/CollectionTaskSearchCardsTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/async/CollectionTaskSearchCardsTest.java
@@ -17,6 +17,7 @@
 package com.ichi2.async;
 
 import com.ichi2.anki.CardBrowser;
+import com.ichi2.anki.RunInBackground;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -37,6 +38,7 @@ public class CollectionTaskSearchCardsTest extends AbstractCollectionTaskTest {
 
     @SuppressWarnings("unchecked")
     @Test
+    @RunInBackground
     public void searchCardsNumberOfResultCount() {
         addNoteUsingBasicModel("Hello", "World");
         addNoteUsingBasicModel("One", "Two");

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/CheckMediaTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/CheckMediaTest.java
@@ -17,6 +17,7 @@
 package com.ichi2.libanki;
 
 import com.ichi2.anki.RobolectricTest;
+import com.ichi2.anki.RunInBackground;
 import com.ichi2.async.CollectionTask;
 import com.ichi2.async.TaskManager;
 import com.ichi2.utils.Computation;
@@ -42,6 +43,7 @@ public class CheckMediaTest extends RobolectricTest {
 
 
     @Test
+    @RunInBackground
     public void checkMediaWorksAfterMissingMetaTable() throws ExecutionException, InterruptedException {
         // 7421
         getCol().getMedia().getDb().getDatabase().execSQL("drop table meta");

--- a/AnkiDroid/src/test/java/com/ichi2/testutils/TaskSchedulerRule.java
+++ b/AnkiDroid/src/test/java/com/ichi2/testutils/TaskSchedulerRule.java
@@ -1,0 +1,43 @@
+/*
+ *  Copyright (c) 2021 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.testutils;
+
+import com.ichi2.anki.RunInBackground;
+
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+
+/** A {@link org.junit.Rule} which detects if the test method has the {@link com.ichi2.anki.RunInBackground} annotation */
+public class TaskSchedulerRule implements TestRule {
+
+    private Boolean mRunInForeground = null;
+
+    @Override
+    public Statement apply(final Statement base, final Description description) {
+        mRunInForeground = description.getAnnotation(RunInBackground.class) == null;
+        return base;
+    }
+
+    /** Whether the currently executing test should be run in the foreground */
+    public boolean shouldRunInForeground() {
+        if (mRunInForeground == null) {
+            throw new IllegalStateException("Rule was queried before apply was called");
+        }
+        return mRunInForeground;
+    }
+}


### PR DESCRIPTION
Requested by Arthur in https://github.com/ankidroid/Anki-Android/pull/8442#issuecomment-873667461

This implements running unit tests in the foreground using a custom scheduler. This should both reduce the flakiness of tests (as there are no race conditions for background tasks) and massively speed up the tests (as we no longer need to `sleep()`).

Original PR had the following comment:

> As requested by @mikehardy on https://github.com/ankidroid/Anki-Android/pull/7005#pullrequestreview-627234122

----

Implementation: Default to new scheduler for methods using `RobolectricTest`

Use a rule to detect `@RunInBackground`, and if it's found, default back to the old scheduler

See: https://github.com/junit-team/junit4/wiki/Rules#custom-rules, or commit messages

Supersedes #8442

----

I'd rather not support this change in the short term (above typical duties as a maintainer). I have other changes that are higher priority to me for 2.16.

This was an "alternate solution" to #8442.