### PR TITLE
Fix tablet deck picker / study options getCol crashes

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsFragment.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsFragment.java
@@ -386,7 +386,7 @@ public class StudyOptionsFragment extends Fragment implements Toolbar.OnMenuItem
             mToolbar.setOnMenuItemClickListener(this);
             Menu menu = mToolbar.getMenu();
             // Switch on or off rebuild/empty/custom study depending on whether or not filtered deck
-            if (getCol().getDecks().isDyn(getCol().getDecks().selected())) {
+            if (getCol() != null && getCol().getDecks().isDyn(getCol().getDecks().selected())) {
                 menu.findItem(R.id.action_rebuild).setVisible(true);
                 menu.findItem(R.id.action_empty).setVisible(true);
                 menu.findItem(R.id.action_custom_study).setVisible(false);
@@ -412,9 +412,9 @@ public class StudyOptionsFragment extends Fragment implements Toolbar.OnMenuItem
                 menu.findItem(R.id.action_export).setVisible(false);
             }
             // Switch on or off unbury depending on if there are cards to unbury
-            menu.findItem(R.id.action_unbury).setVisible(getCol().getSched().haveBuried());
+            menu.findItem(R.id.action_unbury).setVisible(getCol() != null && getCol().getSched().haveBuried());
             // Switch on or off undo depending on whether undo is available
-            if (!getCol().undoAvailable()) {
+            if (getCol() == null || !getCol().undoAvailable()) {
                 menu.findItem(R.id.action_undo).setVisible(false);
             } else {
                 menu.findItem(R.id.action_undo).setVisible(true);
@@ -740,8 +740,13 @@ public class StudyOptionsFragment extends Fragment implements Toolbar.OnMenuItem
         return HtmlCompat.fromHtml(withFixedNewlines, HtmlCompat.FROM_HTML_MODE_LEGACY);
     }
 
-    private Collection getCol() {
-        return CollectionHelper.getInstance().getCol(getContext());
+    private @Nullable Collection getCol() {
+        try {
+            return CollectionHelper.getInstance().getCol(getContext());
+        } catch (Exception e) {
+            // This may happen if the backend is locked or similar.
+        }
+        return null;
     }
 
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/DeckPickerTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/DeckPickerTest.java
@@ -5,8 +5,6 @@ import android.content.Intent;
 import android.content.SharedPreferences;
 import android.content.SharedPreferences.Editor;
 import android.content.pm.PackageManager;
-import android.database.SQLException;
-import android.os.Bundle;
 import android.view.Menu;
 
 import com.ichi2.anki.dialogs.DatabaseErrorDialog;
@@ -20,18 +18,22 @@ import com.ichi2.testutils.BackupManagerTestUtilities;
 import com.ichi2.testutils.DbUtils;
 import com.ichi2.utils.ResourceLoader;
 
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.robolectric.ParameterizedRobolectricTestRunner;
+import org.robolectric.ParameterizedRobolectricTestRunner.Parameter;
+import org.robolectric.ParameterizedRobolectricTestRunner.Parameters;
 import org.robolectric.Robolectric;
-import org.robolectric.annotation.Config;
+import org.robolectric.RuntimeEnvironment;
 
 import java.io.File;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 
 import androidx.sqlite.db.framework.FrameworkSQLiteOpenHelperFactory;
 import androidx.test.core.app.ActivityScenario;
-import androidx.test.ext.junit.runners.AndroidJUnit4;
 
 import static com.ichi2.anki.DeckPicker.UPGRADE_VERSION_KEY;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -49,8 +51,21 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@RunWith(AndroidJUnit4.class)
+@RunWith(ParameterizedRobolectricTestRunner.class)
 public class DeckPickerTest extends RobolectricTest {
+
+    @Parameter
+    public String mQualifiers;
+
+    @Parameters
+    public static java.util.Collection<String> initParameters() {
+        return Arrays.asList("normal"); //, "xlarge");
+    }
+
+    @Before
+    public void before() {
+        RuntimeEnvironment.setQualifiers(mQualifiers);
+    }
 
     @Test
     public void verifyCodeMessages() {
@@ -411,8 +426,8 @@ public class DeckPickerTest extends RobolectricTest {
     }
 
     @Test
-    @Config(qualifiers = "xlarge-port")
     public void checkDisplayOfStudyOptionsOnTablet() {
+        assumeTrue("We are running on a tablet", mQualifiers.contains("xlarge"));
         DeckPickerEx deckPickerEx = super.startActivityNormallyOpenCollectionWithIntent(DeckPickerEx.class, new Intent());
 
         StudyOptionsFragment studyOptionsFragment = (StudyOptionsFragment) deckPickerEx.getSupportFragmentManager().findFragmentById(R.id.studyoptions_fragment);

--- a/AnkiDroid/src/test/java/com/ichi2/anki/DeckPickerTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/DeckPickerTest.java
@@ -59,7 +59,7 @@ public class DeckPickerTest extends RobolectricTest {
 
     @Parameters
     public static java.util.Collection<String> initParameters() {
-        return Arrays.asList("normal"); //, "xlarge");
+        return Arrays.asList("normal", "xlarge");
     }
 
     @Before


### PR DESCRIPTION
## Pull Request template

## Purpose / Description

I'm testing on full gamut of emulators API21-31 including a tablet.
Turns out on a tablet when you run it first time the study options fragment attempts to load and do some complex things with the toolbar that involve collection state

But there's no permission to touch the collection on first run yet, so it crashes the app.

Also when I went to add testing I found that if the backend was locked it would crash.


## Fixes
Unlogged

## Approach
Mark getCol() nullable and make it exception-tolerant, check getCol() return to see if it's Null and choose sensible defaults if so, to avoid the crash

## How Has This Been Tested?

Reproduced easily with a Tablet running AnkiDroid first time.
Can no longer reproduce after.

Also parameterized the DeckPickerTest which uncovered 4 different ways it could crash, 1 of which is not easily user-testable but was an issue - when backend was locked - fixed that

## Learning (optional, can help others)
Our testing infrastructure is pretty rich, it was easy to just add a parameter and have robolectric hammer this use case on my behalf

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
