### PR TITLE
Fix DeckPickerTest tablet special cases to run in background

### DIFF
--- a/AnkiDroid/src/test/java/com/ichi2/anki/DeckPickerTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/DeckPickerTest.java
@@ -257,6 +257,7 @@ public class DeckPickerTest extends RobolectricTest {
     }
 
     @Test
+    @RunInBackground
     public void databaseLockedNoPermissionIntegrationTest() {
         // no permissions -> grant permissions -> db locked
         try {
@@ -298,6 +299,7 @@ public class DeckPickerTest extends RobolectricTest {
 
 
     @Test
+    @RunInBackground
     public void doNotShowOptionsMenuWhenCollectionInaccessible() {
         try {
             enableNullCollection();
@@ -320,6 +322,7 @@ public class DeckPickerTest extends RobolectricTest {
     }
 
     @Test
+    @RunInBackground
     public void doNotShowSyncBadgeWhenCollectionInaccessible() {
         try {
             enableNullCollection();
@@ -342,6 +345,7 @@ public class DeckPickerTest extends RobolectricTest {
     }
 
     @Test
+    @RunInBackground
     public void onResumeLoadCollectionFailureWithInaccessibleCollection() {
         try {
             InitialActivityTest.revokeWritePermissions();


### PR DESCRIPTION
## Pull Request template

## Purpose / Description

Original PR #9204  worked fine but was in flight at same time as test foreground
work happened, the combination was a failure, this sets the 4 exception case
tests (getCol() returns null or db locked exception) to background mode, where
everything appears to work

I triple-checked actual Pixel C emulator to verify it is still working in
a no-permissions first startup case both with and without a collection present,
it is actually working now where it did actually crash before so this is test-only really

## Fixes
Related #9204
Related #9203 

## Approach
Just background tests that break in foreground mode

## How Has This Been Tested?

Local unit test run failed on command line and master before the fix
local unit test run passes after
API30 Pixel C works correctly on first startup with no permission still

## Learning (optional, can help others)
Parallel development is hard

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
