### PR TITLE
Add option to press back twice to return to main screen

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -391,7 +391,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
     private boolean mFocusTypeAnswer;
 
     /** Preference: Whether the user wants press back twice to return to the main screen" */
-    private boolean mDisablePressBack;
+    private boolean mExitViaDoubleTapBack;
 
     private final OnRenderProcessGoneDelegate mOnRenderProcessGoneDelegate = new OnRenderProcessGoneDelegate(this);
 
@@ -426,7 +426,6 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
         @Override
         public void onClick(View view) {
             Timber.i("AbstractFlashcardViewer:: Show answer button pressed");
-            mBackButtonPressedToReturn = false;
             // Ignore what is most likely an accidental double-tap.
             if (getElapsedRealTime() - mLastClickTime < mDoubleTapTimeInterval) {
                 return;
@@ -1101,11 +1100,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
             super.onBackPressed();
         } else {
             Timber.i("Back key pressed");
-            if (!mDisablePressBack) {
-                closeReviewer(RESULT_DEFAULT, false);
-                return;
-            }
-            if (mBackButtonPressedToReturn) {
+            if (!mExitViaDoubleTapBack || mBackButtonPressedToReturn) {
                 closeReviewer(RESULT_DEFAULT, false);
             } else {
                 UIUtils.showThemedToast(this, getString(R.string.back_pressed_once_reviewer), true);
@@ -1934,7 +1929,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
         mFocusTypeAnswer = preferences.getBoolean("autoFocusTypeInAnswer", false);
         mLargeAnswerButtons = preferences.getBoolean("showLargeAnswerButtons", false);
         mDoubleTapTimeInterval = preferences.getInt(DOUBLE_TAP_TIME_INTERVAL, DEFAULT_DOUBLE_TAP_TIME_INTERVAL);
-        mDisablePressBack = preferences.getBoolean("disablePressBack", false);
+        mExitViaDoubleTapBack = preferences.getBoolean("exitViaDoubleTapBack", false);
 
         mGesturesEnabled = preferences.getBoolean("gestures", false);
         mLinkOverridesTouchGesture = preferences.getBoolean("linkOverridesTouchGesture", false);
@@ -2133,6 +2128,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
     protected void displayCardQuestion(boolean reload) {
         Timber.d("displayCardQuestion()");
         sDisplayAnswer = false;
+        mBackButtonPressedToReturn = false;
 
         setInterface();
 
@@ -2208,6 +2204,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
         actualHideEaseButtons();
         Timber.d("displayCardAnswer()");
         mMissingImageHandler.onCardSideChange();
+        mBackButtonPressedToReturn = false;
 
         // prevent answering (by e.g. gestures) before card is loaded
         if (mCurrentCard == null) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -265,6 +265,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
 
     // Default short animation duration, provided by Android framework
     protected int mShortAnimDuration;
+    private boolean mBackButtonPressedToReturn = false;
 
     // Preferences from the collection
     private boolean mShowNextReviewTime;
@@ -389,6 +390,9 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
     /** Preference: Whether the user wants to focus "type in answer" */
     private boolean mFocusTypeAnswer;
 
+    /** Preference: Whether the user wants press back twice to return to the main screen" */
+    private boolean mDisablePressBack;
+
     private final OnRenderProcessGoneDelegate mOnRenderProcessGoneDelegate = new OnRenderProcessGoneDelegate(this);
 
     // ----------------------------------------------------------------------------
@@ -422,6 +426,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
         @Override
         public void onClick(View view) {
             Timber.i("AbstractFlashcardViewer:: Show answer button pressed");
+            mBackButtonPressedToReturn = false;
             // Ignore what is most likely an accidental double-tap.
             if (getElapsedRealTime() - mLastClickTime < mDoubleTapTimeInterval) {
                 return;
@@ -1096,7 +1101,16 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
             super.onBackPressed();
         } else {
             Timber.i("Back key pressed");
-            closeReviewer(RESULT_DEFAULT, false);
+            if (!mDisablePressBack) {
+                closeReviewer(RESULT_DEFAULT, false);
+                return;
+            }
+            if (mBackButtonPressedToReturn) {
+                closeReviewer(RESULT_DEFAULT, false);
+            } else {
+                UIUtils.showThemedToast(this, getString(R.string.back_pressed_once_reviewer), true);
+            }
+            mBackButtonPressedToReturn = true;
         }
     }
 
@@ -1920,6 +1934,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
         mFocusTypeAnswer = preferences.getBoolean("autoFocusTypeInAnswer", false);
         mLargeAnswerButtons = preferences.getBoolean("showLargeAnswerButtons", false);
         mDoubleTapTimeInterval = preferences.getInt(DOUBLE_TAP_TIME_INTERVAL, DEFAULT_DOUBLE_TAP_TIME_INTERVAL);
+        mDisablePressBack = preferences.getBoolean("disablePressBack", false);
 
         mGesturesEnabled = preferences.getBoolean("gestures", false);
         mLinkOverridesTouchGesture = preferences.getBoolean("linkOverridesTouchGesture", false);

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -1051,12 +1051,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
             if (mFloatingActionMenu.isFABOpen()) {
                 mFloatingActionMenu.closeFloatingActionMenu();
             } else {
-                if (!preferences.getBoolean("disablePressBack", false)) {
-                    automaticSync();
-                    finishWithAnimation();
-                    return;
-                }
-                if (mBackButtonPressedToExit) {
+                if (!preferences.getBoolean("exitViaDoubleTapBack", false) || mBackButtonPressedToExit) {
                     automaticSync();
                     finishWithAnimation();
                 } else {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -1043,6 +1043,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
 
     @Override
     public void onBackPressed() {
+        SharedPreferences preferences = AnkiDroidApp.getSharedPrefs(getBaseContext());
         if (isDrawerOpen()) {
             super.onBackPressed();
         } else {
@@ -1050,6 +1051,11 @@ public class DeckPicker extends NavigationDrawerActivity implements
             if (mFloatingActionMenu.isFABOpen()) {
                 mFloatingActionMenu.closeFloatingActionMenu();
             } else {
+                if (!preferences.getBoolean("disablePressBack", false)) {
+                    automaticSync();
+                    finishWithAnimation();
+                    return;
+                }
                 if (mBackButtonPressedToExit) {
                     automaticSync();
                     finishWithAnimation();

--- a/AnkiDroid/src/main/res/values/02-strings.xml
+++ b/AnkiDroid/src/main/res/values/02-strings.xml
@@ -376,4 +376,5 @@
     <string name="password_empty">Password is required</string>
 
     <string name="back_pressed_once">Press back again to exit</string>
+    <string name="back_pressed_once_reviewer">Press back again to return</string>
 </resources>

--- a/AnkiDroid/src/main/res/values/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values/10-preferences.xml
@@ -194,6 +194,8 @@
     <!-- Paste clipboard image as png option -->
     <string name="paste_as_png" maxLength="41">Paste clipboard images as PNG</string>
     <string name="paste_as_png_summary">By default Anki pastes images on the clipboard as JPG files to save disk space. You can use this option to paste as PNG images instead.</string>
+    <string name="disable_back_pressed" maxLength="41">Tap back twice to go back/exit</string>
+    <string name="disable_back_pressed_summ">To avoid accidentally leaving the reviewer</string>
     <!-- Advanced statistics settings -->
     <string name="advanced_statistics_title" maxLength="41">Advanced statistics</string>
     <string name="enable_advanced_statistics_title" maxLength="41">Enable advanced statistics</string>

--- a/AnkiDroid/src/main/res/values/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values/10-preferences.xml
@@ -194,8 +194,8 @@
     <!-- Paste clipboard image as png option -->
     <string name="paste_as_png" maxLength="41">Paste clipboard images as PNG</string>
     <string name="paste_as_png_summary">By default Anki pastes images on the clipboard as JPG files to save disk space. You can use this option to paste as PNG images instead.</string>
-    <string name="disable_back_pressed" maxLength="41">Tap back twice to go back/exit</string>
-    <string name="disable_back_pressed_summ">To avoid accidentally leaving the reviewer</string>
+    <string name="exit_via_double_tap_back" maxLength="41">Press back twice to go back/exit</string>
+    <string name="exit_via_double_tap_back_summ">To avoid accidentally leaving the reviewer or the app</string>
     <!-- Advanced statistics settings -->
     <string name="advanced_statistics_title" maxLength="41">Advanced statistics</string>
     <string name="enable_advanced_statistics_title" maxLength="41">Enable advanced statistics</string>

--- a/AnkiDroid/src/main/res/xml/preferences_advanced.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_advanced.xml
@@ -96,6 +96,11 @@
                 android:summary="@string/type_in_answer_focus_summ"
                 android:dependency="useInputTag"
                 android:title="@string/type_in_answer_focus" />
+            <CheckBoxPreference
+                android:defaultValue="false"
+                android:key="disablePressBack"
+                android:summary="@string/disable_back_pressed_summ"
+                android:title="@string/disable_back_pressed" />
         </PreferenceCategory>
         <PreferenceCategory
             android:key="category_plugins"

--- a/AnkiDroid/src/main/res/xml/preferences_advanced.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_advanced.xml
@@ -98,9 +98,9 @@
                 android:title="@string/type_in_answer_focus" />
             <CheckBoxPreference
                 android:defaultValue="false"
-                android:key="disablePressBack"
-                android:summary="@string/disable_back_pressed_summ"
-                android:title="@string/disable_back_pressed" />
+                android:key="exitViaDoubleTapBack"
+                android:summary="@string/exit_via_double_tap_back_summ"
+                android:title="@string/exit_via_double_tap_back" />
         </PreferenceCategory>
         <PreferenceCategory
             android:key="category_plugins"


### PR DESCRIPTION
## Purpose / Description
While reviewing I often accidentally hit the back button when answering a question. This is frustrating because it disrupts my studying, especially because after I reopen the deck I get a different card and I have to do the other one again later.

## Fixes
Fixes #9215 
Fixes #9210 

## Approach
I added an option in the advanced settings to enable this feature. If enabled, you have to press back twice to exit the app and return to the main screen.

## How Has This Been Tested?
Tested on Pixel_API_30

## Screenshots
![settings](https://user-images.githubusercontent.com/40232329/125075385-d06acb80-e0be-11eb-9540-827f92373635.png)
![toaster](https://user-images.githubusercontent.com/40232329/125075390-d19bf880-e0be-11eb-847d-5a56da993470.png)

## Checklist

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [x] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
