### PR TITLE
Don't publish lint.jar for API project

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -57,7 +57,7 @@ dependencies {
     testImplementation 'org.junit.vintage:junit-vintage-engine:5.7.2'
     testImplementation 'org.robolectric:robolectric:4.5.1'
 
-    lintPublish project(":lint-rules")
+    lintChecks project(":lint-rules")
 }
 
 task androidSourcesJar(type: Jar) {

--- a/api/src/main/java/com/ichi2/anki/FlashCardsContract.java
+++ b/api/src/main/java/com/ichi2/anki/FlashCardsContract.java
@@ -1,3 +1,5 @@
+//noinspection MissingCopyrightHeader - explicitly not GPL
+
 /*
  * Copying and distribution of this file, with or without modification, are permitted in any
  * medium without royalty. This file is offered as-is, without any warranty.

--- a/api/src/main/java/com/ichi2/anki/api/Basic2Model.java
+++ b/api/src/main/java/com/ichi2/anki/api/Basic2Model.java
@@ -1,3 +1,4 @@
+//noinspection MissingCopyrightHeader #8659
 package com.ichi2.anki.api;
 
 /**

--- a/api/src/main/java/com/ichi2/anki/api/BasicModel.java
+++ b/api/src/main/java/com/ichi2/anki/api/BasicModel.java
@@ -1,3 +1,4 @@
+//noinspection MissingCopyrightHeader #8659
 package com.ichi2.anki.api;
 
 /**


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
Our lint checks are internal and not for consumers.

Added in 018c1db71fc370440fc85e3071fd7bea17303921

## Fixes
Fixes #9214

## Approach
`lintPublish` publishes the checks into the aar

> Use this configuration to include lint checks you want Gradle to execute when building your project.

`lintChecks` performs the checks for the project

>Use this configuration in Android library projects to include lint checks you want Gradle to compile into a lint.jar file and package in your AAR. This causes projects that consume your AAR to also apply those lint checks. If you were previously using the lintChecks dependency configuration to include lint checks in the published AAR, you need to migrate those dependencies to instead use the lintPublish configuration.
>   ```groovy
>    dependencies {
>      // Executes lint checks from the ':checks' project
>      // at build time.
>      lintChecks project(':checks')
>      // Compiles lint checks from the ':checks-to-publish'
>      // into a lint.jar file and publishes it to your
>      // Android library.
>      lintPublish project(':checks-to-publish')
>    }
> ```

## How Has This Been Tested?

I added a `new GregorianCalendar()` and this still had a warning, might not have rebuilt enough.

## Learning

https://developer.android.com/studio/build/dependencies#dependency_configurations

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
