### PR TITLE
Added Check Database button in Sync error dialog box

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -91,6 +91,7 @@ import com.ichi2.anki.dialogs.ConfirmationDialog;
 import com.ichi2.anki.dialogs.CreateDeckDialog;
 import com.ichi2.anki.dialogs.DeckPickerNoSpaceToDowngradeDialog;
 import com.ichi2.anki.dialogs.DeckPickerNoSpaceToDowngradeDialog.FileSizeFormatter;
+import com.ichi2.anki.dialogs.SimpleMessageDialog;
 import com.ichi2.anki.dialogs.customstudy.CustomStudyDialog;
 import com.ichi2.anki.dialogs.DatabaseErrorDialog;
 import com.ichi2.anki.dialogs.DeckPickerAnalyticsOptInDialog;
@@ -1494,6 +1495,26 @@ public class DeckPicker extends NavigationDrawerActivity implements
     }
 
     /**
+     *  Show simple dialog with a message and two buttons - check database and cancel.
+     */
+    private void showCheckDatabase(@Nullable String message){
+        String title = getResources().getString(R.string.sync_error);
+        AsyncDialogFragment newFragment = SimpleMessageDialog.newInstance(title, message, true);
+        try{
+            new MaterialDialog.Builder(this)
+                    .title(title)
+                    .content(message)
+                    .positiveText(R.string.check_db)
+                    .onPositive(((dialog, which) -> performIntegrityCheck()))
+                    .negativeText(R.string.dialog_cancel)
+                    .show();
+        }catch (IllegalStateException e){
+            Timber.w(e);
+            DialogHandler.storeMessage(newFragment.getDialogHandlerMessage());
+            showSimpleNotification(title, message, NotificationChannels.Channel.GENERAL);
+        }
+    }
+    /**
      *  Show a simple snackbar message or notification if the activity is not in foreground
      * @param messageResource String resource for message
      */
@@ -1919,7 +1940,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
                             break;
                         case BASIC_CHECK_FAILED:
                             dialogMessage = res.getString(R.string.sync_basic_check_failed, res.getString(R.string.check_db));
-                            showSyncErrorMessage(joinSyncMessages(dialogMessage, syncMessage));
+                            showCheckDatabase(joinSyncMessages(dialogMessage, syncMessage));
                             break;
                         case DB_ERROR:
                             showSyncErrorDialog(SyncErrorDialog.DIALOG_SYNC_CORRUPT_COLLECTION, syncMessage);


### PR DESCRIPTION
## Purpose / Description
Few users didn't know how to 'Check Database' when the sync error dialog box is shown.

## Fixes
Fixes #9199

## Approach
Added a check database button in the sync error dialog box, so the user can immediately resolve the issue.

## How Has This Been Tested?
Tested on Physical Device oneplus 7T

## Screenshot
<img src='https://user-images.githubusercontent.com/73246484/124816348-09535500-df86-11eb-8c69-0f4874fd82da.jpg' width=225 height=525>

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
