### PR TITLE
fix[lint]: allow Kotlin companion objects 

### DIFF
--- a/lint-rules/src/main/java/com/ichi2/anki/lint/rules/ConstantFieldDetector.java
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/ConstantFieldDetector.java
@@ -23,7 +23,6 @@ import com.android.tools.lint.detector.api.JavaContext;
 import com.android.tools.lint.detector.api.Scope;
 import com.ichi2.anki.lint.utils.Constants;
 
-import com.android.annotations.NonNull;
 import org.jetbrains.uast.UElement;
 import org.jetbrains.uast.UVariable;
 import org.jetbrains.uast.UastVisibility;
@@ -53,7 +52,10 @@ public class ConstantFieldDetector extends FieldNamingPatternDetector {
         // For instance: the only thing that matters is final - are these constants:
         // public final int - no
         // private static final - maybe?
-        return variable.isStatic() && variable.getVisibility() == UastVisibility.PUBLIC && variable.isFinal();
+        return variable.isStatic()
+                && variable.getVisibility() == UastVisibility.PUBLIC
+                && variable.isFinal()
+                && !"Companion".equals(variable.getName()); // #9223 - fix for kotlin companion objects
     }
 
 

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/rules/ConstantFieldDetector.java
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/ConstantFieldDetector.java
@@ -75,7 +75,7 @@ public class ConstantFieldDetector extends FieldNamingPatternDetector {
 
 
     @Override
-    protected void reportVariable(@NonNull JavaContext context, @NonNull UVariable node, String variableName) {
+    protected void reportVariable(@NonNull JavaContext context, @NonNull UVariable node, @NonNull String variableName) {
         StringBuilder replacement = new StringBuilder();
         // If the s prefix was accidentally applied, remove it.
         if ((variableName.startsWith("s") || variableName.startsWith("m")) && variableName.length() > 1 && Character.isUpperCase(variableName.charAt(1))) {

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/rules/FieldNamingPatternDetector.java
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/FieldNamingPatternDetector.java
@@ -86,5 +86,5 @@ public abstract class FieldNamingPatternDetector extends Detector implements Det
     protected abstract boolean meetsNamingStandards(@NonNull String variableName);
 
     /** Report the problematic variable to the lint checker */
-    protected abstract void reportVariable(@NonNull JavaContext context, @NonNull UVariable node, String variableName);
+    protected abstract void reportVariable(@NonNull JavaContext context, @NonNull UVariable node, @NonNull String variableName);
 }

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/rules/NonPublicNonStaticFieldDetector.java
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/NonPublicNonStaticFieldDetector.java
@@ -68,7 +68,7 @@ public class NonPublicNonStaticFieldDetector extends FieldNamingPatternDetector 
 
 
     @Override
-    protected void reportVariable(@NonNull JavaContext context, @NonNull UVariable node, String variableName) {
+    protected void reportVariable(@NonNull JavaContext context, @NonNull UVariable node, @NonNull String variableName) {
         if (variableName.length() < 2) {
             // cast the node as it's ambiguous between two interfaces
             UElement uNode = node;


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
`ConstantFieldName` lint was triggered by auto-generated Kotlin
companion objects named "Companion" (expected: COMPANION)


## Fixes
Fixes #9223
Unblocks #9222

## Approach
As these are auto-generated, allow constants called "Companion"

## How Has This Been Tested?
Lint no longer fails on #9222

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)