### PR TITLE
Fix: Issues displaying "no webview" dialog

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -547,15 +547,14 @@ public class DeckPicker extends NavigationDrawerActivity implements
      * */
     public void handleStartup() {
         if (Permissions.hasStorageAccessPermission(this)) {
-            boolean colOpen = firstCollectionOpen();
-            if (colOpen) {
+            StartupFailure failure = InitialActivity.getStartupFailureType(this);
+            if (failure == null) {
                 // Show any necessary dialogs (e.g. changelog, special messages, etc)
                 SharedPreferences sharedPrefs = AnkiDroidApp.getSharedPrefs(this);
                 showStartupScreensAndDialogs(sharedPrefs, 0);
                 mStartupError = false;
             } else {
                 // Show error dialogs
-                StartupFailure failure = InitialActivity.getStartupFailureType(this);
                 handleStartupFailure(failure);
                 mStartupError = true;
             }
@@ -590,6 +589,15 @@ public class DeckPicker extends NavigationDrawerActivity implements
                 // This has a callback to continue with handleStartup
                 InitialActivity.downgradeBackend(this);
                 break;
+            case WEBVIEW_FAILED:
+                new MaterialDialog.Builder(this)
+                        .title(R.string.ankidroid_init_failed_webview_title)
+                        .content(getString(R.string.ankidroid_init_failed_webview, AnkiDroidApp.getWebViewErrorMessage()))
+                        .positiveText(R.string.close)
+                        .onPositive((d, w) -> exit())
+                        .cancelable(false)
+                        .show();
+                break;
             case DB_ERROR:
             default:
                 displayDatabaseFailure();
@@ -623,25 +631,6 @@ public class DeckPicker extends NavigationDrawerActivity implements
             view.setBackground(drawable);
             return true;
         }
-    }
-
-    /**
-     * Try to open the Collection for the first time
-     * @return whether or not we were successful
-     */
-    private boolean firstCollectionOpen() {
-        if (AnkiDroidApp.webViewFailedToLoad()) {
-            new MaterialDialog.Builder(this)
-                    .title(R.string.ankidroid_init_failed_webview_title)
-                    .content(getString(R.string.ankidroid_init_failed_webview, AnkiDroidApp.getWebViewErrorMessage()))
-                    .positiveText(R.string.close)
-                    .onPositive((d, w) -> exit())
-                    .cancelable(false)
-                    .show();
-            return false;
-        }
-
-        return CollectionHelper.getInstance().getColSafe(this) != null;
     }
 
     public void requestStoragePermission() {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/InitialActivity.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/InitialActivity.java
@@ -28,7 +28,7 @@ import net.ankiweb.rsdroid.RustBackendFailedException;
 import java.lang.ref.WeakReference;
 
 import androidx.annotation.CheckResult;
-import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import timber.log.Timber;
 
 /** Utilities for launching the first activity (currently the DeckPicker) */
@@ -38,9 +38,21 @@ public class InitialActivity {
 
     }
 
-    @NonNull
+    /** Returns null on success */
+    @Nullable
     @CheckResult
     public static StartupFailure getStartupFailureType(Context context) {
+
+        // A WebView failure means that we skip `AnkiDroidApp`, and therefore haven't loaded the collection
+        if (AnkiDroidApp.webViewFailedToLoad()) {
+            return StartupFailure.WEBVIEW_FAILED;
+        }
+
+        // If we're OK, return null
+        if (CollectionHelper.getInstance().getColSafe(context) != null) {
+            return null;
+        }
+
         if (!AnkiDroidApp.isSdCardMounted()) {
             return StartupFailure.SD_CARD_NOT_MOUNTED;
         } else if (!CollectionHelper.isCurrentAnkiDroidDirAccessible(context)) {
@@ -174,5 +186,7 @@ public class InitialActivity {
         DATABASE_DOWNGRADE_REQUIRED,
         DB_ERROR,
         DATABASE_LOCKED,
+        WEBVIEW_FAILED,
+        ;
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Storage.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Storage.java
@@ -32,6 +32,7 @@ import com.ichi2.utils.JSONException;
 import com.ichi2.utils.JSONObject;
 
 import java.io.File;
+import java.io.FileNotFoundException;
 import java.util.ArrayList;
 import java.util.Arrays;
 
@@ -57,6 +58,9 @@ public class Storage {
     /** Helper method for when the collection can't be opened */
     public static int getDatabaseVersion(String path) throws UnknownDatabaseVersionException {
         try {
+            if (!new File(path).exists()) {
+                throw new UnknownDatabaseVersionException(new FileNotFoundException(path));
+            }
             DB db = new DB(path);
             int result = db.queryScalar("SELECT ver FROM col");
             db.close();


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
After a bad init, we tested to see the database version

If there was no WebView, `AnkiDroidApp` hadn't performed an init

This caused a path where `new Db(path)` could be called when the
database wasn't created, using a Java style database init without
handling creating the `col` table

We then crashed as there was no default deck

----

After this, the "corrupt database" dialog obscured the "no webview" dialog

## Fixes
Fixes #9226

## Approach
* Don't create a collection if checking for database version
* Don't check for database version if the WebView (and therefore `AnkiDroidApp` failed to init)

## How Has This Been Tested?
Android 8 (with and without WebView)

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)