### PR TITLE
fix[Audio Insert]: Allow .ogg on Android 8

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicAudioClipFieldController.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicAudioClipFieldController.java
@@ -62,6 +62,8 @@ public class BasicAudioClipFieldController extends FieldControllerBase implement
         mBtnLibrary.setOnClickListener(v -> {
             Intent i = new Intent();
             i.setType("audio/*");
+            String[] extraMimeTypes = { "application/ogg" }; // #9226 allows ogg on Android 8
+            i.putExtra(Intent.EXTRA_MIME_TYPES, extraMimeTypes);
             i.setAction(Intent.ACTION_GET_CONTENT);
             // Only get openable files, to avoid virtual files issues with Android 7+
             i.addCategory(Intent.CATEGORY_OPENABLE);


### PR DESCRIPTION
`URLConnection.guessContentTypeFromName` returns `application/ogg`
instead of `audio/ogg` in Android 8



## Fixes
Fixes #9225 (using the default Android file picker)

## Approach
We use `EXTRA_MIME_TYPES`, which isn't fully supported

But neither is commas in the `setType` call:

https://stackoverflow.com/questions/1698050/multiple-mime-types-in-android

so it seems like the best option

## How Has This Been Tested?
Tested on an Android 8 emulator

## Learning (optional, can help others)
https://stackoverflow.com/questions/1698050/multiple-mime-types-in-android

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

![image](https://user-images.githubusercontent.com/62114487/124974596-e7f57600-e024-11eb-8c1a-3589d543daea.png)
