### PR TITLE
Fix CardBrowser shows wrong deck

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -125,6 +125,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
         }
         long deckId = deck.getDeckId();
         mDeckSpinnerSelection.initializeActionBarDeckSpinner();
+        mDeckSpinnerSelection.selectDeckById(deckId, true);
         selectDeckAndSave(deckId);
     }
 
@@ -759,14 +760,14 @@ public class CardBrowser extends NavigationDrawerActivity implements
         if (getLastDeckId() != null && getLastDeckId() == ALL_DECKS_ID) {
             selectAllDecks();
         } else  if (getLastDeckId() != null && getCol().getDecks().get(getLastDeckId(), false) != null) {
-            mDeckSpinnerSelection.selectDeckById(getLastDeckId());
+            mDeckSpinnerSelection.selectDeckById(getLastDeckId(), false);
         } else {
-            mDeckSpinnerSelection.selectDeckById(getCol().getDecks().selected());
+            mDeckSpinnerSelection.selectDeckById(getCol().getDecks().selected(), false);
         }
     }
 
     public void selectDeckAndSave(long deckId) {
-        mDeckSpinnerSelection.selectDeckById(deckId);
+        mDeckSpinnerSelection.selectDeckById(deckId, true);
         if (deckId == ALL_DECKS_ID) {
             mRestrictOnDeck = "";
         } else {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckSpinnerSelection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckSpinnerSelection.java
@@ -174,21 +174,32 @@ public class DeckSpinnerSelection {
         return mSpinner;
     }
 
-    // Iterates the drop down decks, and selects the one matching the given id
-    public boolean selectDeckById(long deckId) {
+    /**
+     * Iterates the drop down decks, and selects the one matching the given id.
+     * @param deckId The deck id to be selected.
+     * @param setAsCurrentDeck If true, deckId will be set as the current deck id of Collection
+     * (this means the deck selected here will continue to appear in any future Activity whose
+     * display data is loaded from Collection's current deck). If false, deckId will not be set as
+     * the current deck id of Collection.
+     * @return True if a deck with deckId exists, false otherwise.
+     */
+    public boolean selectDeckById(long deckId, boolean setAsCurrentDeck) {
         if (deckId == ALL_DECKS_ID) {
             selectAllDecks();
             return true;
         }
-        return searchInList(deckId);
+        return searchInList(deckId, setAsCurrentDeck);
     }
 
 
-    private boolean searchInList(long deckId) {
+    private boolean searchInList(long deckId, boolean setAsCurrentDeck) {
         for (int dropDownDeckIdx = 0; dropDownDeckIdx < mAllDeckIds.size(); dropDownDeckIdx++) {
             if (mAllDeckIds.get(dropDownDeckIdx) == deckId) {
                 int position = mShowAllDecks ? dropDownDeckIdx + 1 : dropDownDeckIdx;
                 selectDropDownItem(position);
+                if (setAsCurrentDeck) {
+                    mContext.getCol().getDecks().select(deckId);
+                }
                 return true;
             }
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -266,7 +266,7 @@ public class NoteEditor extends AnkiActivity implements
         }
         mCurrentDid = deck.getDeckId();
         mDeckSpinnerSelection.initializeNoteEditorDeckSpinner(mCurrentEditedCard, mAddNote);
-        mDeckSpinnerSelection.selectDeckById(deck.getDeckId());
+        mDeckSpinnerSelection.selectDeckById(deck.getDeckId(), false);
     }
 
     @Override
@@ -1822,7 +1822,7 @@ public class NoteEditor extends AnkiActivity implements
         } else {
             mCurrentDid = mCurrentEditedCard.getDid();
         }
-        mDeckSpinnerSelection.selectDeckById(mCurrentDid);
+        mDeckSpinnerSelection.selectDeckById(mCurrentDid, false);
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Statistics.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Statistics.java
@@ -132,7 +132,7 @@ public class Statistics extends NavigationDrawerActivity implements
         mDeckSpinnerSelection = new DeckSpinnerSelection(this, R.id.toolbar_spinner);
         mDeckSpinnerSelection.initializeActionBarDeckSpinner();
         mDeckSpinnerSelection.setShowAllDecks(true);
-        mDeckSpinnerSelection.selectDeckById(deckId);
+        mDeckSpinnerSelection.selectDeckById(deckId, false);
         mTaskHandler.setDeckId(deckId);
         mViewPager.getAdapter().notifyDataSetChanged();
     }
@@ -235,7 +235,7 @@ public class Statistics extends NavigationDrawerActivity implements
             return;
         }
         mDeckSpinnerSelection.initializeActionBarDeckSpinner();
-        mDeckSpinnerSelection.selectDeckById(deck.getDeckId());
+        mDeckSpinnerSelection.selectDeckById(deck.getDeckId(), true);
         mTaskHandler.setDeckId(deck.getDeckId());
         mViewPager.getAdapter().notifyDataSetChanged();
     }


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
Fix: CardBrowser displays a wrong deck.

## Fixes
Fixes #9013 

## Approach

The cause of this problem is that: In CardBrowser, onCreate() always loads a deck ID from Collection and then CardBrowser displays this deck (let's call it deck 1). 
Later, when we select deck 2 from the DeckSelectionDialog, although CardBrowser shows cards of deck 2, the ID of deck 2 is not saved to Collection. 
At this moment if we go to Settings and then back to CardBrowser, onCreate() of CardBrowser is called again, so deck 1 is loaded and showed again.

This problem also manifests itself when:
In CardBrowser with deck 1 shown
Switch to deck 2 (by selecting it from the DeckSelectionDialog like above)
Switch to Statistics (using the Navigation Drawer)
Switch back to CardBrowser (using the Navigation Drawer)
Now CardBrowser will display deck 1 again

@mikehardy I've verified that this problem always happen with above reproducing steps, regardless of deck sizes.

To solve this problem, in this PR I saved deck ID to Collection in onDeckSelected() of both CardBrowser and Statistics.

## How Has This Been Tested?

I've verified that this fix works in APIs 27 and 30. 
I've also run all automated tests and this fix does not cause any tests to fail.

## Checklist

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code