### PR TITLE
fix(stats): set hourly breakdown stats into 0-23 range by modulus

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/stats/Stats.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/stats/Stats.java
@@ -892,7 +892,7 @@ public class Stats {
                     .query(query)) {
             while (cur.moveToNext()) {
                 double[] hourData = new double[] { cur.getDouble(0), cur.getDouble(1), cur.getDouble(2) };
-                list.set((int)hourData[0], hourData);
+                list.set(((((int)hourData[0] % 24) + 24) % 24), hourData); // Force the data to be positive int in 0-23 range
             }
         }
 


### PR DESCRIPTION

## Pull Request template

## Purpose / Description
It appears based on a crash report that via an interaction between review times, day cutoff, and new scheduler timezone handling, attempting to display stats for a full day can generate stats for out of range hours.

## Fixes
Fixes #9230

## Approach
_How does this change address the problem?_

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration (SDK version(s), emulator or physical, etc)

I think the appropriate change is to mod the hour in the array.set by 24 to make sure it falls in range

## Learning (optional, can help others)
I learned again that I can't wait for the stats code to be purged from our codebase.

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
