### PR TITLE
NF: launchCollectionTask return Cancellable

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -111,6 +111,7 @@ import com.ichi2.anki.receiver.SdCardReceiver;
 import com.ichi2.anki.stats.AnkiStatsTaskHandler;
 import com.ichi2.anki.web.HostNumFactory;
 import com.ichi2.anki.widgets.DeckAdapter;
+import com.ichi2.async.Cancellable;
 import com.ichi2.async.Connection;
 import com.ichi2.async.Connection.Payload;
 import com.ichi2.async.CollectionTask;
@@ -231,7 +232,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
 
     private String mExportFileName;
 
-    @Nullable private CollectionTask<?, ?> mEmptyCardTask = null;
+    @Nullable private Cancellable mEmptyCardTask = null;
 
     @VisibleForTesting
     public List<? extends AbstractDeckTreeNode<?>> mDueTree;
@@ -2812,7 +2813,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
             mOnePercent = mNumberOfCards / 100;
         }
 
-        private void confirmCancel(@NonNull DeckPicker deckPicker, @NonNull CollectionTask<?, ?>  task) {
+        private void confirmCancel(@NonNull DeckPicker deckPicker, @NonNull Cancellable  task) {
             new MaterialDialog.Builder(deckPicker)
                     .content(R.string.confirm_cancel)
                     .positiveText(deckPicker.getResources().getString(R.string.yes))
@@ -2825,7 +2826,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
         @Override
         public void actualOnPreExecute(@NonNull DeckPicker deckPicker) {
             DialogInterface.OnCancelListener onCancel = (dialogInterface) -> {
-                CollectionTask<?, ?>  emptyCardTask = deckPicker.mEmptyCardTask;
+                Cancellable  emptyCardTask = deckPicker.mEmptyCardTask;
                 if (emptyCardTask != null) {
                     confirmCancel(deckPicker, emptyCardTask);
                 }};

--- a/AnkiDroid/src/main/java/com/ichi2/async/Cancellable.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/Cancellable.java
@@ -1,0 +1,61 @@
+// noinspection MissingCopyrightHeader
+/*
+ * Copyright (C) 2008 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ichi2.async;
+
+import android.os.AsyncTask;
+
+public interface Cancellable {
+    /**
+     * <p>Attempts to cancel execution of this task.  This attempt will
+     * fail if the task has already completed, already been cancelled,
+     * or could not be cancelled for some other reason. If successful,
+     * and this task has not started when <tt>cancel</tt> is called,
+     * this task should never run. If the task has already started,
+     * then the <tt>mayInterruptIfRunning</tt> parameter determines
+     * whether the thread executing this task should be interrupted in
+     * an attempt to stop the task.</p>
+     *
+     * <p>Calling this method will result in {@link AsyncTask#onCancelled(Object)} being
+     * invoked on the UI thread after {@link AsyncTask#doInBackground(Object[])} returns.
+     * Calling this method guarantees that onPostExecute(Object) is never
+     * subsequently invoked, even if <tt>cancel</tt> returns false, but
+     * {@link AsyncTask#onPostExecute} has not yet run.  To finish the
+     * task as early as possible, check {@link AsyncTask#isCancelled()} periodically from
+     * {@link AsyncTask#doInBackground(Object[])}.</p>
+     *
+     * <p>This only requests cancellation. It never waits for a running
+     * background task to terminate, even if <tt>mayInterruptIfRunning</tt> is
+     * true.</p>
+     *
+     * @param mayInterruptIfRunning <tt>true</tt> if the thread executing this
+     *        task should be interrupted; otherwise, in-progress tasks are allowed
+     *        to complete.
+     *
+     * @return <tt>false</tt> if the task could not be cancelled,
+     *         typically because it has already completed normally;
+     *         <tt>true</tt> otherwise
+     *
+     * @see AsyncTask#isCancelled()
+     * @see AsyncTask#onCancelled(Object)
+     */
+    boolean cancel(boolean mayInterruptIfRunning);
+
+    /** Cancel the current task.
+     * @return whether cancelling did occur.*/
+    boolean safeCancel();
+}

--- a/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
@@ -105,7 +105,7 @@ import static com.ichi2.utils.Computation.ERR;
  * @param <Progress> The type of progress that is sent by the TaskDelegate. E.g. a Card, a pairWithBoolean.
  * @param <Result>   The type of result that the TaskDelegate sends. E.g. a tree of decks, counts of a deck.
  */
-public class CollectionTask<Progress, Result> extends BaseAsyncTask<Void, Progress, Result> {
+public class CollectionTask<Progress, Result> extends BaseAsyncTask<Void, Progress, Result> implements Cancellable {
 
     /**
      * A reference to the application context to use to fetch the current Collection object.

--- a/AnkiDroid/src/main/java/com/ichi2/async/SingleTaskManager.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/SingleTaskManager.java
@@ -75,7 +75,7 @@ public class SingleTaskManager extends TaskManager {
      * @return the newly created task
      */
     @Override
-    public <Progress, Result> CollectionTask<Progress, Result> launchCollectionTaskConcrete(TaskDelegate<Progress, Result> task) {
+    public <Progress, Result> Cancellable launchCollectionTaskConcrete(TaskDelegate<Progress, Result> task) {
         return launchCollectionTask(task, null);
     }
 
@@ -92,7 +92,7 @@ public class SingleTaskManager extends TaskManager {
      * @param listener to the status and result of the task, may be null
      * @return the newly created task
      */
-    public <Progress, Result> CollectionTask<Progress, Result>
+    public <Progress, Result> Cancellable
     launchCollectionTaskConcrete(@NonNull TaskDelegate<Progress, Result> task,
                          @Nullable TaskListener<? super Progress, ? super Result> listener) {
         // Start new task

--- a/AnkiDroid/src/main/java/com/ichi2/async/TaskManager.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/TaskManager.java
@@ -67,11 +67,11 @@ public abstract class TaskManager {
         sTaskManager.setLatestInstanceConcrete(task);
     }
 
-    public static <Progress, Result> CollectionTask<Progress, Result> launchCollectionTask(TaskDelegate<Progress, Result> task) {
+    public static <Progress, Result> Cancellable launchCollectionTask(TaskDelegate<Progress, Result> task) {
         return sTaskManager.launchCollectionTaskConcrete(task);
     }
 
-    public abstract <Progress, Result> CollectionTask<Progress, Result> launchCollectionTaskConcrete(TaskDelegate<Progress, Result> task);
+    public abstract <Progress, Result> Cancellable launchCollectionTaskConcrete(TaskDelegate<Progress, Result> task);
 
 
     protected abstract void setLatestInstanceConcrete(CollectionTask task);
@@ -87,13 +87,13 @@ public abstract class TaskManager {
      * @param listener to the status and result of the task, may be null
      * @return the newly created task
      */
-    public static <Progress, Result> CollectionTask<Progress, Result>
+    public static <Progress, Result> Cancellable
     launchCollectionTask(@NonNull TaskDelegate<Progress, Result> task,
                          @Nullable TaskListener<? super Progress, ? super Result> listener) {
         return sTaskManager.launchCollectionTaskConcrete(task, listener);
     }
 
-    public abstract <Progress, Result> CollectionTask<Progress, Result>
+    public abstract <Progress, Result> Cancellable
     launchCollectionTaskConcrete(@NonNull TaskDelegate<Progress, Result> task,
                          @Nullable TaskListener<? super Progress, ? super Result> listener);
 

--- a/AnkiDroid/src/test/java/com/ichi2/async/AbstractCollectionTaskTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/async/AbstractCollectionTaskTest.java
@@ -17,8 +17,11 @@
 package com.ichi2.async;
 
 import com.ichi2.anki.RobolectricTest;
+import com.ichi2.utils.Computation;
 
 import org.junit.runner.RunWith;
+
+import java.util.List;
 
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
@@ -30,7 +33,7 @@ import static org.hamcrest.Matchers.notNullValue;
 public abstract class AbstractCollectionTaskTest extends RobolectricTest {
 
     protected <Progress, Result> Result execute(TaskDelegate<Progress, Result> task) {
-        CollectionTask<Progress, Result> collectionTask = TaskManager.launchCollectionTask(task);
+        CollectionTask<Progress, Result> collectionTask = (CollectionTask<Progress, Result>)TaskManager.launchCollectionTask(task);
         try {
             return collectionTask.get();
         } catch (Exception e) {

--- a/AnkiDroid/src/test/java/com/ichi2/async/ForegroundTaskManager.java
+++ b/AnkiDroid/src/test/java/com/ichi2/async/ForegroundTaskManager.java
@@ -21,7 +21,7 @@ public class ForegroundTaskManager extends TaskManager {
 
 
     @Override
-    public <Progress, Result> CollectionTask<Progress, Result> launchCollectionTaskConcrete(TaskDelegate<Progress, Result> task) {
+    public <Progress, Result> Cancellable launchCollectionTaskConcrete(TaskDelegate<Progress, Result> task) {
         return launchCollectionTaskConcrete(task, null);
     }
 
@@ -32,13 +32,13 @@ public class ForegroundTaskManager extends TaskManager {
 
 
     @Override
-    public <Progress, Result> CollectionTask<Progress, Result> launchCollectionTaskConcrete(
+    public <Progress, Result> Cancellable launchCollectionTaskConcrete(
             @NonNull TaskDelegate<Progress, Result> task,
             @Nullable TaskListener<? super Progress, ? super Result> listener) {
         return executeTaskWithListener(task, listener, mColGetter);
     }
 
-    public static <Progress, Result> CollectionTask<Progress, Result> executeTaskWithListener(
+    public static <Progress, Result> Cancellable executeTaskWithListener(
             @NonNull TaskDelegate<Progress, Result> task,
             @Nullable TaskListener<? super Progress, ? super Result> listener, CollectionGetter colGetter) {
         if (listener != null) {

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/CheckMediaTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/CheckMediaTest.java
@@ -50,7 +50,7 @@ public class CheckMediaTest extends RobolectricTest {
 
         assertThat(getCol().getMedia().getDb().queryScalar("SELECT count(*) FROM sqlite_master WHERE type='table' AND name='meta';"), is(0));
 
-        CollectionTask<Void, Computation<List<List<String>>>> task = TaskManager.launchCollectionTask(new CollectionTask.CheckMedia());
+        CollectionTask<Void, Computation<List<List<String>>>> task = (CollectionTask<Void, Computation<List<List<String>>>>) TaskManager.launchCollectionTask(new CollectionTask.CheckMedia());
 
         task.get();
 


### PR DESCRIPTION
This emphasis the fact that - outside of test - CollectionTask is not used anymore. It reduce the available API to
cancel and safeCancel