### PR TITLE
fix: lint was not working in Anki-Android

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -249,6 +249,8 @@ dependencies {
         }
     }
 
+    lintChecks project(":lint-rules")
+
     coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:1.1.5'
     compileOnly 'org.jetbrains:annotations:21.0.1'
     compileOnly "com.google.auto.service:auto-service-annotations:1.0"


### PR DESCRIPTION
Lint previously worked through the api module

aae98e787f7bcbcd5235d2e273d8ae6593335ffd removed this

Fix via adding a `lintChecks`

Fixes #9242

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
