### PR TITLE
Migrate AnkiDroid Folder to External Scoped App-Specific Directory

### DIFF
--- a/AnkiDroid/src/main/AndroidManifest.xml
+++ b/AnkiDroid/src/main/AndroidManifest.xml
@@ -403,6 +403,8 @@
         <!-- Service to perform web API queries -->
         <service android:name="com.ichi2.widget.AnkiDroidWidgetSmall$UpdateService" />
 
+        <service android:name="com.ichi2.anki.services.MigrationService"/>
+
         <!-- small widget -->
         <receiver
             android:name="com.ichi2.widget.AnkiDroidWidgetSmall"

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -2647,10 +2647,9 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
         }
 
         try {
-            CompatHelper.getCompat().copyFile(sourceFile.getAbsolutePath(), destinationFile.getAbsolutePath());
-        } catch (IOException e) {
-            Timber.w("Error trying to fetch media from migration source from %s to %s",
-                    sourceFile.getAbsolutePath(), destinationFile.getAbsolutePath());
+            CollectionHelper.getInstance().getMediaMigrationDeque().putFirst(new Pair<>(sourceFile, CollectionTask.MediaMigrationProducer.ACTION_PREEMPT));
+        } catch (InterruptedException e) {
+            Timber.w(e, "Error while preempting media request by requesting copy from %s to %s", sourceFile, destinationFile);
         }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CollectionHelper.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CollectionHelper.java
@@ -566,4 +566,8 @@ public class CollectionHelper {
     public void setColForTests(Collection col) {
         this.mCollection = col;
     }
+
+    public static String getMigrationSourcePath(Context context) {
+        return AnkiDroidApp.getSharedPrefs(context).getString("migrationSourcePath", getDefaultAnkiDroidDirectory(context));
+    }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CollectionHelper.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CollectionHelper.java
@@ -20,6 +20,7 @@ import android.content.Context;
 import android.content.SharedPreferences;
 import android.os.Environment;
 import android.text.format.Formatter;
+import android.util.Pair;
 
 import androidx.annotation.CheckResult;
 import androidx.annotation.NonNull;
@@ -41,6 +42,7 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.util.concurrent.LinkedBlockingDeque;
 
 import androidx.annotation.VisibleForTesting;
 import timber.log.Timber;
@@ -57,6 +59,8 @@ public class CollectionHelper {
     private Collection mCollection;
     // Name of anki2 file
     public static final String COLLECTION_FILENAME = "collection.anki2";
+    public static final String MEDIA_DIR_NAME = "collection.media";
+    private LinkedBlockingDeque<Pair<File, Integer>> mediaMigrationDeque;
 
     /**
      * Prevents {@link com.ichi2.async.CollectionLoader} from spuriously re-opening the {@link Collection}.
@@ -445,6 +449,10 @@ public class CollectionHelper {
         return context.getFilesDir().getAbsolutePath();
     }
 
+    public static String getCollectionMediaPath(@NonNull String ankiDroidDirPath) {
+        return new File(ankiDroidDirPath, MEDIA_DIR_NAME).getAbsolutePath();
+    }
+
     /**
      *
      * @return the path to the actual {@link Collection} file
@@ -651,5 +659,13 @@ public class CollectionHelper {
 
     public static String getMigrationSourcePath(Context context) {
         return AnkiDroidApp.getSharedPrefs(context).getString("migrationSourcePath", getDefaultAnkiDroidDirectory(context));
+    }
+
+    public void setMediaMigrationDeque(LinkedBlockingDeque<Pair<File, Integer>> deque) {
+        mediaMigrationDeque = deque;
+    }
+
+    public LinkedBlockingDeque<Pair<File, Integer>> getMediaMigrationDeque() {
+        return mediaMigrationDeque;
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -509,7 +509,17 @@ public class DeckPicker extends NavigationDrawerActivity implements
      * */
     public void handleStartup() {
         if (Permissions.hasStorageAccessPermission(this)) {
-            StartupFailure failure = InitialActivity.getStartupFailureType(this);
+            handleStartupScenarios();
+        } else {
+            requestStoragePermission();
+        }
+    }
+
+    /**
+     * Shows startup screens if everything the app needs to function is in order. If not, handles errors.
+     */
+    private void handleStartupScenarios() {
+        StartupFailure failure = InitialActivity.getStartupFailureType(this);
             if (failure == null) {
                 // Show any necessary dialogs (e.g. changelog, special messages, etc)
                 SharedPreferences sharedPrefs = AnkiDroidApp.getSharedPrefs(this);
@@ -520,9 +530,6 @@ public class DeckPicker extends NavigationDrawerActivity implements
                 handleStartupFailure(failure);
                 mStartupError = true;
             }
-        } else {
-            requestStoragePermission();
-        }
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -146,6 +146,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.List;
 import java.util.TreeMap;
+import java.util.concurrent.LinkedBlockingDeque;
 
 import kotlin.Unit;
 import timber.log.Timber;
@@ -523,7 +524,6 @@ public class DeckPicker extends NavigationDrawerActivity implements
      * */
     public void handleStartup() {
         SharedPreferences preferences = AnkiDroidApp.getSharedPrefs(this);
-
         // Resume migration if migrationSourcePath exists
         if (preferences.contains("migrationSourcePath")) {
             startOrResumeMigration();
@@ -571,7 +571,10 @@ public class DeckPicker extends NavigationDrawerActivity implements
             }
         }
         handleStartupScenarios();
-        startService(new Intent(this, MigrationService.class));
+        CollectionHelper.getInstance().setMediaMigrationDeque(new LinkedBlockingDeque<>());
+        Intent migrationServiceIntent = new Intent(this, MigrationService.class);
+        migrationServiceIntent.putExtra("deque", CollectionHelper.getInstance().getMediaMigrationDeque());
+        startService(migrationServiceIntent);
     }
 
     /**

--- a/AnkiDroid/src/main/java/com/ichi2/anki/services/MigrationService.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/services/MigrationService.kt
@@ -1,0 +1,152 @@
+/*
+ *  Copyright (c) 2021 Farjad Ilyas <ilyasfarjad@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.services
+
+import android.app.Service
+import android.content.Context
+import android.content.Intent
+import android.os.IBinder
+import androidx.core.app.NotificationCompat
+import androidx.core.app.NotificationManagerCompat
+import com.ichi2.anki.CollectionHelper
+import com.ichi2.anki.NotificationChannels
+import com.ichi2.anki.R
+import com.ichi2.async.*
+import com.ichi2.async.CollectionTask.MigrateUserData.MOVE
+import com.ichi2.utils.FileUtil
+import timber.log.Timber
+import java.io.File
+
+class MigrationService : Service() {
+
+    companion object {
+        /** The id of the notification for in-progress user data migration.  */
+        private const val MIGRATION_NOTIFY_ID = 2
+    }
+
+    lateinit var notificationBuilder: NotificationCompat.Builder
+    lateinit var notificationManager: NotificationManagerCompat
+    lateinit var listener: TaskListenerWithContext<Context, Int, Boolean>
+    var cancelled = false
+
+    private inner class MigrateUserDataListener(sourceSize: Long?) : TaskListenerWithContext<Context, Int?, Boolean?>(this) {
+        // All integer variables store data size in kilobytes
+        private var mSourceSize = 0
+        private var mCurrentProgress: Int
+        private val mUpdateInterval = 2000
+        private var mIncreaseSinceLastUpdate: Int
+        private var mMostRecentUpdateTime = 0L
+
+        override fun actualOnPreExecute(context: Context) {
+            notificationManager = NotificationManagerCompat.from(context)
+            if (!notificationManager.areNotificationsEnabled()) {
+                Timber.v("MigrateUserDataListener - notifications disabled, returning")
+                return
+            }
+
+            val channel = NotificationChannels.Channel.GENERAL
+
+            notificationBuilder = NotificationCompat.Builder(
+                context,
+                NotificationChannels.getId(channel)
+            )
+                .setSmallIcon(R.drawable.ic_stat_notify)
+                .setContentTitle(context.resources.getString(R.string.migrating_data_message))
+                .setContentText(context.resources.getString(R.string.migration_transferred_size, 0f, mSourceSize / 1024f))
+                .setPriority(NotificationCompat.PRIORITY_LOW)
+                .setOngoing(true)
+                .setSilent(true)
+                .setProgress(100, 0, false)
+
+            startForeground(MIGRATION_NOTIFY_ID, notificationBuilder.build())
+        }
+
+        override fun actualOnProgressUpdate(context: Context, value: Int?) {
+            super.actualOnProgressUpdate(context, value)
+
+            if (value == null) {
+                return
+            }
+
+            // Convert progress in bytes to kilobytes
+            mIncreaseSinceLastUpdate += value
+
+            // Update Progress Bar progress if progress > 1% of max
+            val currentTime = CollectionHelper.getInstance().getTimeSafe(context).intTimeMS()
+            if (currentTime - mMostRecentUpdateTime > mUpdateInterval) {
+                mMostRecentUpdateTime = currentTime
+                mCurrentProgress += mIncreaseSinceLastUpdate
+                mIncreaseSinceLastUpdate = 0
+                notificationBuilder.setProgress(mSourceSize, mCurrentProgress, false)
+                notificationBuilder.setContentText(
+                    context.resources.getString(
+                        R.string.migration_transferred_size,
+                        mCurrentProgress / 1024f, mSourceSize / 1024f
+                    )
+                )
+                notificationManager.notify(MIGRATION_NOTIFY_ID, notificationBuilder.build())
+            }
+        }
+
+        override fun actualOnPostExecute(context: Context, result: Boolean?) {
+            if (result == true) {
+                notificationBuilder.setContentTitle(context.resources.getString(R.string.migration_successful_message))
+            } else {
+                notificationBuilder.setContentTitle(context.resources.getString(R.string.migration_failed_message))
+            }
+
+            notificationBuilder.setProgress(0, 0, false).setOngoing(false)
+            notificationManager.notify(MIGRATION_NOTIFY_ID, notificationBuilder.build())
+
+            stopSelf()
+        }
+
+        override fun onCancelled() {
+            cancelled = true
+            stopSelf()
+        }
+
+        init {
+
+            // If sourceSize is not null, convert source size from bytes to kilobytes
+            mSourceSize = if (sourceSize == null) {
+                0
+            } else {
+                (sourceSize / 1024).toInt()
+            }
+            mCurrentProgress = 0
+            mIncreaseSinceLastUpdate = 0
+        }
+    }
+
+    override fun onCreate() {
+        val sourceDir = File(CollectionHelper.getMigrationSourcePath(this))
+        val destDir = File(CollectionHelper.getDefaultAnkiDroidDirectory(this))
+        CoroutineTask(
+            CollectionTask.MigrateUserData(sourceDir, destDir, MOVE),
+            MigrateUserDataListener(FileUtil.getDirectorySize(sourceDir))
+        ).execute()
+    }
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        return super.onStartCommand(intent, flags, startId)
+    }
+
+    override fun onBind(intent: Intent): IBinder? {
+        return null
+    }
+}

--- a/AnkiDroid/src/main/java/com/ichi2/async/CoroutineTask.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/async/CoroutineTask.kt
@@ -1,0 +1,63 @@
+/*
+ *  Copyright (c) 2021 Farjad Ilyas <ilyasfarjad@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.async
+
+import com.ichi2.anki.AnkiDroidApp
+import com.ichi2.anki.CollectionHelper
+import com.ichi2.libanki.Collection
+import kotlinx.coroutines.*
+
+/**
+ * Executes a TaskDelegate task & enables parallel execution of these tasks
+ * Delegates the business knowledge of the task to be performed to the TaskDelegate
+ *
+ * @param <Progress> The type of progress that is sent by the TaskDelegate. E.g. a Card, a pairWithBoolean.
+ * @param <Result>   The type of result that the TaskDelegate sends
+ */
+class CoroutineTask<Progress, Result>(val task: TaskDelegate<Progress, Result>, val listener: TaskListener<Progress, Result>?) : Cancellable, ProgressSenderAndCancelListener<Progress> {
+
+    private val mJob = Job()
+
+    override fun cancel(mayInterruptIfRunning: Boolean): Boolean {
+        if (mayInterruptIfRunning || (!mJob.isActive)) {
+            mJob.cancel()
+        }
+        return true
+    }
+
+    override fun safeCancel(): Boolean {
+        return cancel(true)
+    }
+
+    private fun getCol(): Collection? {
+        return CollectionHelper.getInstance().getCol(AnkiDroidApp.getInstance().applicationContext)
+    }
+
+    fun execute() {
+        CoroutineScope(Dispatchers.IO + mJob).launch {
+            listener?.onPreExecute()
+            val res: Result? = getCol()?.let { task.task(it, this@CoroutineTask) }
+            listener?.onPostExecute(res)
+        }
+    }
+
+    override fun isCancelled(): Boolean = mJob.isCancelled
+
+    override fun doProgress(value: Progress?) {
+        listener?.onProgressUpdate(value)
+    }
+}

--- a/AnkiDroid/src/main/java/com/ichi2/compat/CompatV21.java
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/CompatV21.java
@@ -182,6 +182,7 @@ public class CompatV21 implements Compat {
                     renameSuccessful = false;
                     break;
                 }
+                ioTask.doProgress((int) destFile.length() / 1024);
             }
             if (renameSuccessful) {
                 srcDir.delete();

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Sound.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Sound.java
@@ -348,6 +348,8 @@ public class Sound {
         Uri soundUri = Uri.parse(soundPath);
         mCurrentAudioUri = soundUri;
 
+        AbstractFlashcardViewer.fetchMediaFromMigrationSource(AnkiDroidApp.getInstance().getApplicationContext(), soundUri);
+
         final OnErrorListener errorHandler = errorListener == null ?
                 (mp, what, extra, path) -> {
                     Timber.w("Media Error: (%d, %d). Calling OnCompletionListener", what, extra);

--- a/AnkiDroid/src/main/res/values/02-strings.xml
+++ b/AnkiDroid/src/main/res/values/02-strings.xml
@@ -408,4 +408,7 @@
     <!--  Note Editor Toggle Sticky  -->
     <string name="note_editor_toggle_sticky">Make field %s sticky</string>
 
+    <!-- Syncing -->
+    <string name="sync_blocked_during_migration">Sync not available during user data migration</string>
+
 </resources>

--- a/AnkiDroid/src/main/res/values/03-dialogs.xml
+++ b/AnkiDroid/src/main/res/values/03-dialogs.xml
@@ -267,4 +267,10 @@
 
     <string name="import_deck_package">Deck package (.apkg)</string>
     <string name="import_collection_package">Collection package (.colpkg)</string>
+
+    <!-- Scoped Storage Migration -->
+    <string name="migrating_data_message">Migrating your data</string>
+    <string name="migration_successful_message">Migration successful</string>
+    <string name="migration_failed_message">Migration failed</string>
+    <string name="migration_transferred_size">Migrated %1$.2f MB of %2$.2f MB</string>
 </resources>


### PR DESCRIPTION
## Purpose / Description
Migrating user data stored in an AnkiDroid-specific folder to an App-Specific (external only for now) in order to preserve access to user data under scoped storage.

## Fixes
Takes a step towards fixing #5304. Fixes #9107.

## Approach
Uses storage permission (which AnkiDroid already asks for) to access legacy storage and migrates the data to the External App-Specific Directory (given by getExternalFilesDir())
Migration is done by launching a MigrateToScoped task

Any file within the AnkiDroid folder can be accessed under Scoped Storage post-migration.

## How Has This Been Tested?

- SAMSUNG Galaxy A80 (SM-A805F) API 30 (Physical Device)
- SAMSUNG Galaxy S7 (SM-G930F) API 26 (Physical Device)

Tested all different approaches used to move user data. Tested by repeatedly closing the app and confirming that it performs better the second time around once some data has been transferred.

## Important

- User Data is only being copied from the Legacy Directory, not deleted for now. That can be done once all use cases work under Scoped Storage
- To enable the Scoped Storage Functionality, set AnkiDroidApp's TESTING_SCOPED_STORAGE to true
- TESTING_SCOPED_STORAGE is set to false by default and will be set to true once the app can access external media (to be done in a later PR)

## Checklist

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
