### PR TITLE
Add preference for enabling onboarding in debug build

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
@@ -497,6 +497,14 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
                     });
                     screen.addPreference(lockDbPreference);
                 }
+                if (BuildConfig.DEBUG) {
+                    Timber.i("Debug mode, option for showing onboarding walkthrough");
+                    android.preference.CheckBoxPreference onboardingPreference = new android.preference.CheckBoxPreference(this);
+                    onboardingPreference.setKey("showOnboarding");
+                    onboardingPreference.setTitle(R.string.show_onboarding);
+                    onboardingPreference.setSummary(R.string.show_onboarding_desc);
+                    screen.addPreference(onboardingPreference);
+                }
                 // Adding change logs in both debug and release builds
                 Timber.i("Adding open changelog");
                 android.preference.Preference changelogPreference = new android.preference.Preference(this);

--- a/AnkiDroid/src/main/res/values/constants.xml
+++ b/AnkiDroid/src/main/res/values/constants.xml
@@ -276,4 +276,8 @@
         <item>x-large</item>
         <item>xx-large</item>
     </string-array>
+
+    <!-- Onboarding -->
+    <string name="show_onboarding" maxLength="41">Show onboarding walkthrough</string>
+    <string name="show_onboarding_desc">Display feature tutorial to learn more about the app</string>
 </resources>


### PR DESCRIPTION
## Purpose / Description
Add preference for enabling onboarding in debug build.
It can be accessed through 'Advanced' settings.

## Checklist

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [ ] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
