### PR TITLE
rename: tap -> touch

### DIFF
--- a/AnkiDroid/src/main/res/values/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values/10-preferences.xml
@@ -82,7 +82,7 @@
     <string name="gestures_swipe_left" maxLength="41">Swipe left</string>
     <string name="gestures_swipe_right" maxLength="41">Swipe right</string>
     <string name="gestures_double_tap" maxLength="41">Double touch</string>
-    <string name="gestures_long_tap" maxLength="41">Long tap</string>
+    <string name="gestures_long_tap" maxLength="41">Long touch</string>
     <string name="gestures_tap_top" maxLength="41">Touch top</string>
     <string name="gestures_tap_left" maxLength="41">Touch left</string>
     <string name="gestures_tap_right" maxLength="41">Touch right</string>


### PR DESCRIPTION
All others used "tap" in the key, but "touch" in the string

Added in 78aa1efb506ddf2408d006c8669aab79d5577d39

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
