### PR TITLE
fix: reset app bar button preferences immediately

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
@@ -409,8 +409,9 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
                     edit.remove("customButtonClearWhiteboard");
                     edit.remove("customButtonShowHideWhiteboard");
                     edit.apply();
-                    //finish();
-                    //TODO: Should reload the preferences screen on completion
+                    // #9263: refresh the screen to display the changes
+                    screen.removeAll();
+                    initSubscreen("com.ichi2.anki.prefs.custom_buttons", listener);
                     return true;
                 });
                 break;


### PR DESCRIPTION
Fixes #9263

## How Has This Been Tested?

Android 11, API 21 emulator, and API 25 tablet emulator

## Learning (optional, can help others)
* https://stackoverflow.com/a/31671831/13121290 seemed the best
* `setPreferenceScreen(null);` crashed, so didn't use it

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
