### PR TITLE
fill_parent to match_parent

### DIFF
--- a/AnkiDroid/src/main/res/layout-xlarge/homescreen.xml
+++ b/AnkiDroid/src/main/res/layout-xlarge/homescreen.xml
@@ -5,8 +5,8 @@
                                            android:fitsSystemWindows="true">
         <LinearLayout
             android:id="@+id/deckpicker_view"
-            android:layout_width="fill_parent"
-            android:layout_height="fill_parent"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
             android:background="?android:attr/colorBackground"
             android:orientation="horizontal">
             <include layout="@layout/deck_picker"
@@ -17,7 +17,7 @@
                 android:id="@+id/studyoptions_fragment"
                 android:layout_weight="2"
                 android:layout_width="1dip"
-                android:layout_height="fill_parent"/>
+                android:layout_height="match_parent"/>
         </LinearLayout>
 </androidx.coordinatorlayout.widget.CoordinatorLayout>
 

--- a/AnkiDroid/src/main/res/layout/activity_anki_stats.xml
+++ b/AnkiDroid/src/main/res/layout/activity_anki_stats.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.coordinatorlayout.widget.CoordinatorLayout android:id="@+id/root_layout"
-	android:layout_width="fill_parent"
-	android:layout_height="fill_parent"
+	android:layout_width="match_parent"
+	android:layout_height="match_parent"
 	xmlns:android="http://schemas.android.com/apk/res/android"
 	xmlns:app="http://schemas.android.com/apk/res-auto"
 	xmlns:tools="http://schemas.android.com/tools">

--- a/AnkiDroid/src/main/res/layout/card_browser.xml
+++ b/AnkiDroid/src/main/res/layout/card_browser.xml
@@ -2,14 +2,14 @@
 
 <androidx.coordinatorlayout.widget.CoordinatorLayout
     android:id="@+id/root_layout"
-    android:layout_width="fill_parent"
-    android:layout_height="fill_parent"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto">
 
     <LinearLayout
-        android:layout_width="fill_parent"
-        android:layout_height="fill_parent"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
         android:orientation="vertical" >
 
         <include layout="@layout/toolbar" />
@@ -37,8 +37,8 @@
 
         <ListView
             android:id="@+id/card_browser_list"
-            android:layout_width="fill_parent"
-            android:layout_height="fill_parent"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
             android:background="?android:attr/colorBackground"
             android:divider="?attr/cardBrowserDivider"
             android:overScrollFooter="@color/transparent"

--- a/AnkiDroid/src/main/res/layout/card_item_browser.xml
+++ b/AnkiDroid/src/main/res/layout/card_item_browser.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:id="@+id/card_item_browser"
-    android:layout_width="fill_parent"
+    android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:background="?attr/selectableItemBackground">
 
@@ -10,14 +10,14 @@
         android:focusable="false"
         android:focusableInTouchMode="false"
         android:layout_width="wrap_content"
-        android:layout_height="fill_parent"
+        android:layout_height="match_parent"
         android:visibility="gone"
         android:gravity= "center_vertical"/>
 
     <com.ichi2.ui.FixedTextView
         android:id="@+id/card_sfld"
         android:layout_width="0dip"
-        android:layout_height="fill_parent"
+        android:layout_height="match_parent"
         android:layout_weight="1"
         android:paddingLeft="3dp"
         android:paddingRight="3dp"
@@ -28,13 +28,13 @@
 
     <View
         android:layout_width="0.5dp"
-        android:layout_height="fill_parent"
+        android:layout_height="match_parent"
         android:background="?attr/cardBrowserDivider" />
 
     <com.ichi2.ui.FixedTextView
         android:id="@+id/card_column2"
         android:layout_width="0dip"
-        android:layout_height="fill_parent"
+        android:layout_height="match_parent"
         android:layout_weight="1"
         android:paddingStart="4dp"
         android:paddingEnd="2dp"

--- a/AnkiDroid/src/main/res/layout/card_template_editor_activity.xml
+++ b/AnkiDroid/src/main/res/layout/card_template_editor_activity.xml
@@ -1,15 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.coordinatorlayout.widget.CoordinatorLayout
     android:id="@+id/root_layout"
-    android:layout_width="fill_parent"
-    android:layout_height="fill_parent"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
     android:fitsSystemWindows="true"
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto">
     <LinearLayout
         android:id="@+id/card_template_editor_main"
-        android:layout_width="fill_parent"
-        android:layout_height="fill_parent"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
         android:gravity="center"
         android:orientation="vertical" >
         <include layout="@layout/toolbar" />

--- a/AnkiDroid/src/main/res/layout/card_template_editor_item.xml
+++ b/AnkiDroid/src/main/res/layout/card_template_editor_item.xml
@@ -3,7 +3,7 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/main_layout"
-    android:layout_height="fill_parent"
+    android:layout_height="match_parent"
     android:layout_width="match_parent"
     android:layout_gravity="center_horizontal"
     android:orientation="vertical"
@@ -12,26 +12,26 @@
     <!-- Editor -->
     <com.ichi2.ui.FixedTextView
         android:id="@+id/title_edit"
-        android:layout_width="fill_parent"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_margin="5dp"
         android:focusable="true"
         android:text="@string/card_template_editor_front" />
     <ScrollView
-        android:layout_width="fill_parent"
+        android:layout_width="match_parent"
         android:layout_height="0dp"
         android:layout_weight="1"
         android:fadeScrollbars="false"
         android:fillViewport="true" >
         <LinearLayout
-            android:layout_width="fill_parent"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:gravity="center"
             android:orientation="vertical" >
             <com.ichi2.ui.FixedEditText
                 android:id="@+id/editor_editText"
-                android:layout_width="fill_parent"
-                android:layout_height="fill_parent"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
                 android:layout_margin="5dp"
                 android:layout_gravity="top"
                 android:gravity="top"

--- a/AnkiDroid/src/main/res/layout/deck_item.xml
+++ b/AnkiDroid/src/main/res/layout/deck_item.xml
@@ -18,7 +18,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/DeckPickerHoriz"
     android:background="?attr/selectableItemBackground"
-    android:layout_width="fill_parent"
+    android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:gravity="center_vertical"
     android:orientation="horizontal"

--- a/AnkiDroid/src/main/res/layout/deck_picker_dialog.xml
+++ b/AnkiDroid/src/main/res/layout/deck_picker_dialog.xml
@@ -44,7 +44,7 @@
 
     <androidx.recyclerview.widget.RecyclerView android:id="@+id/deck_picker_dialog_list"
                                                android:scrollbars="vertical"
-                                               android:layout_width="fill_parent"
+                                               android:layout_width="match_parent"
                                                android:layout_height="wrap_content"
                                                android:layout_below="@id/deck_picker_dialog_summary"/>
 </RelativeLayout>

--- a/AnkiDroid/src/main/res/layout/deck_picker_dialog_list_item.xml
+++ b/AnkiDroid/src/main/res/layout/deck_picker_dialog_list_item.xml
@@ -18,7 +18,7 @@
 <!-- An item in a deck selection screen. Partially based off deck_item -->
 <com.ichi2.ui.FixedTextView xmlns:android="http://schemas.android.com/apk/res/android"
     android:id="@+id/deck_picker_dialog_list_item_value"
-    android:layout_width="fill_parent"
+    android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:minHeight="?android:attr/listPreferredItemHeight"
     android:paddingStart="@dimen/deck_picker_left_padding"

--- a/AnkiDroid/src/main/res/layout/feedback.xml
+++ b/AnkiDroid/src/main/res/layout/feedback.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:layout_width="fill_parent"
+    android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:gravity="center_vertical"
     android:orientation="vertical"
@@ -11,13 +11,13 @@
 
     <ScrollView
         android:id="@+id/scrollView1"
-        android:layout_width="fill_parent"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content" >
 
         <!-- We are using EditText as FixedEditText fails here (#8380) -->
         <EditText
             android:id="@+id/etFeedbackText"
-            android:layout_width="fill_parent"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:gravity="top"
             android:hint="@string/feedback_default_text"
@@ -27,13 +27,13 @@
     <CheckBox
         android:id="@+id/alwaysReportCheckbox"
         android:text="@string/feedback_report_automatically"
-        android:layout_width="fill_parent"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:paddingTop="15dp"
         android:paddingBottom="15dp"/>
 
     <ScrollView
-        android:layout_width="fill_parent"
+        android:layout_width="match_parent"
         android:layout_height="0dp"
         android:layout_weight="1"
         android:fadeScrollbars="false"
@@ -43,7 +43,7 @@
             android:paddingLeft="5dp"
             android:paddingRight="5dp"
             android:id="@+id/tvFeedbackDisclaimer"
-            android:layout_width="fill_parent"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:text="@string/feedback_disclaimer" />
     </ScrollView>

--- a/AnkiDroid/src/main/res/layout/fragment_anki_stats.xml
+++ b/AnkiDroid/src/main/res/layout/fragment_anki_stats.xml
@@ -1,11 +1,11 @@
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:layout_width="fill_parent"
-    android:layout_height="fill_parent">
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
 
     <com.ichi2.anki.stats.ChartView
-        android:layout_width="fill_parent"
+        android:layout_width="match_parent"
         android:id="@+id/image_view_chart"
-        android:layout_height="fill_parent"
+        android:layout_height="match_parent"
         android:layout_alignParentTop="true"
         android:layout_alignParentStart="true"
         android:layout_alignParentBottom="true"

--- a/AnkiDroid/src/main/res/layout/fragment_anki_stats_overview.xml
+++ b/AnkiDroid/src/main/res/layout/fragment_anki_stats_overview.xml
@@ -1,10 +1,10 @@
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:layout_width="fill_parent"
-    android:layout_height="fill_parent">
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
 
     <WebView
-        android:layout_width="fill_parent"
-        android:layout_height="fill_parent"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
         android:id="@+id/web_view_stats"
         android:layout_alignParentTop="true"
         android:layout_alignParentStart="true"

--- a/AnkiDroid/src/main/res/layout/info.xml
+++ b/AnkiDroid/src/main/res/layout/info.xml
@@ -18,12 +18,12 @@
 <androidx.coordinatorlayout.widget.CoordinatorLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:id="@+id/root_layout"
-    android:layout_width="fill_parent"
-    android:layout_height="fill_parent"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
     android:fitsSystemWindows="true">
     <LinearLayout
-        android:layout_width="fill_parent"
-        android:layout_height="fill_parent"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
         android:layout_centerHorizontal="true"
         android:layout_centerVertical="true"
         android:orientation="vertical" >
@@ -31,7 +31,7 @@
         <include layout="@layout/toolbar" />
 
         <RelativeLayout
-            android:layout_width="fill_parent"
+            android:layout_width="match_parent"
             android:layout_height="0dp"
             android:layout_marginBottom="4dip"
             android:layout_weight="1"
@@ -47,19 +47,19 @@
 
         <LinearLayout
             android:id="@+id/info_buttons"
-            android:layout_width="fill_parent"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content" >
 
             <Button
                 android:id="@+id/left_button"
                 android:layout_width="0dip"
-                android:layout_height="fill_parent"
+                android:layout_height="match_parent"
                 android:layout_weight="1" />
 
             <Button
                 android:id="@+id/right_button"
                 android:layout_width="0dip"
-                android:layout_height="fill_parent"
+                android:layout_height="match_parent"
                 android:layout_weight="1" />
         </LinearLayout>
         <Button

--- a/AnkiDroid/src/main/res/layout/locale_selection_dialog.xml
+++ b/AnkiDroid/src/main/res/layout/locale_selection_dialog.xml
@@ -37,7 +37,7 @@
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/locale_dialog_selection_list"
         android:scrollbars="vertical"
-        android:layout_width="fill_parent"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_below="@+id/locale_dialog_selection_toolbar"
         android:layout_above="@+id/locale_dialog_summary"

--- a/AnkiDroid/src/main/res/layout/model_browser.xml
+++ b/AnkiDroid/src/main/res/layout/model_browser.xml
@@ -3,8 +3,8 @@
 <androidx.coordinatorlayout.widget.CoordinatorLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:id="@+id/root_layout"
-    android:layout_width="fill_parent"
-    android:layout_height="fill_parent"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
     android:fitsSystemWindows="true">
     <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
         android:orientation="vertical" android:layout_width="match_parent"

--- a/AnkiDroid/src/main/res/layout/model_field_editor.xml
+++ b/AnkiDroid/src/main/res/layout/model_field_editor.xml
@@ -2,8 +2,8 @@
 <androidx.coordinatorlayout.widget.CoordinatorLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:id="@+id/root_layout"
-    android:layout_width="fill_parent"
-    android:layout_height="fill_parent"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
     android:fitsSystemWindows="true">
     <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
         android:orientation="vertical" android:layout_width="match_parent"

--- a/AnkiDroid/src/main/res/layout/multimedia_edit_field_activity.xml
+++ b/AnkiDroid/src/main/res/layout/multimedia_edit_field_activity.xml
@@ -1,8 +1,8 @@
 <androidx.coordinatorlayout.widget.CoordinatorLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:id="@+id/root_layout"
-    android:layout_width="fill_parent"
-    android:layout_height="fill_parent"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
     android:fitsSystemWindows="true">
     <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
         android:layout_width="match_parent"

--- a/AnkiDroid/src/main/res/layout/my_account.xml
+++ b/AnkiDroid/src/main/res/layout/my_account.xml
@@ -4,8 +4,8 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/root_layout"
-    android:layout_width="fill_parent"
-    android:layout_height="fill_parent"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
     android:fitsSystemWindows="true">
     <LinearLayout
         android:layout_width="match_parent"
@@ -21,7 +21,7 @@
 
             <LinearLayout
                 android:id="@+id/MyAccountLayout"
-                android:layout_width="fill_parent"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:orientation="vertical"
                 android:padding="15dp"
@@ -85,7 +85,7 @@
 
                 <Button
                     android:id="@+id/login_button"
-                    android:layout_width="fill_parent"
+                    android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:theme="@style/LargeButtonStyle"
                     android:singleLine="true"
@@ -118,7 +118,7 @@
         </ScrollView>
 
         <LinearLayout
-            android:layout_width="fill_parent"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:padding="3dp"
             android:orientation="vertical"

--- a/AnkiDroid/src/main/res/layout/my_account_logged_in.xml
+++ b/AnkiDroid/src/main/res/layout/my_account_logged_in.xml
@@ -3,12 +3,12 @@
 <androidx.coordinatorlayout.widget.CoordinatorLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:id="@+id/root_layout"
-    android:layout_width="fill_parent"
-    android:layout_height="fill_parent"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
     android:fitsSystemWindows="true">
     <RelativeLayout
-        android:layout_width="fill_parent"
-        android:layout_height="fill_parent"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
         android:foregroundGravity="center">
 
         <include layout="@layout/toolbar" />
@@ -41,7 +41,7 @@
 
             <Button
                 android:id="@+id/logout_button"
-                android:layout_width="fill_parent"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:theme="@style/LargeButtonStyle"
                 android:singleLine="true"

--- a/AnkiDroid/src/main/res/layout/night_mode_switch.xml
+++ b/AnkiDroid/src/main/res/layout/night_mode_switch.xml
@@ -5,7 +5,7 @@
     android:layout_height="match_parent">
     <androidx.appcompat.widget.SwitchCompat
         android:id="@+id/switch_compat"
-        android:layout_width="fill_parent"
+        android:layout_width="match_parent"
         android:contentDescription="@string/night_mode"
         android:layout_height="match_parent" />
 </LinearLayout>

--- a/AnkiDroid/src/main/res/layout/note_editor.xml
+++ b/AnkiDroid/src/main/res/layout/note_editor.xml
@@ -4,8 +4,8 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/root_layout"
-    android:layout_width="fill_parent"
-    android:layout_height="fill_parent"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
     android:fitsSystemWindows="true">
     <LinearLayout
             android:id="@+id/note_editor_layout"
@@ -19,19 +19,19 @@
         <ScrollView
             android:id="@+id/CardEditorScroll"
             android:layout_width="match_parent"
-            android:layout_height="fill_parent"
+            android:layout_height="match_parent"
             android:layout_gravity="center_horizontal"
             android:padding="5dp" >
 
             <LinearLayout
                 android:id="@+id/CardEditorLayout"
-                android:layout_width="fill_parent"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:orientation="vertical" >
 
                 <!-- Note type selector -->
                 <LinearLayout
-                    android:layout_width="fill_parent"
+                    android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:orientation="horizontal" >
                     <com.ichi2.ui.FixedTextView
@@ -47,14 +47,14 @@
                         android:text="@string/CardEditorModel" />
                     <Spinner
                         android:id="@+id/note_type_spinner"
-                        android:layout_width="fill_parent"
+                        android:layout_width="match_parent"
                         android:layout_height="@dimen/touch_target"
                         app:popupTheme="@style/ActionBar.Popup"/>
                 </LinearLayout>
 
                 <!-- Deck selector -->
                 <LinearLayout
-                    android:layout_width="fill_parent"
+                    android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:orientation="horizontal" >
                     <com.ichi2.ui.FixedTextView
@@ -70,7 +70,7 @@
                         android:text="@string/CardEditorNoteDeck" />
                     <Spinner
                         android:id="@+id/note_deck_spinner"
-                        android:layout_width="fill_parent"
+                        android:layout_width="match_parent"
                         android:layout_height="@dimen/touch_target"
                         app:popupTheme="@style/ActionBar.Popup"/>
                 </LinearLayout>
@@ -78,7 +78,7 @@
                 <!-- Front/Back/Attach views added in NoteEditor.populateEditFields(..) -->
                 <LinearLayout
                     android:id="@+id/CardEditorEditFieldsLayout"
-                    android:layout_width="fill_parent"
+                    android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:orientation="vertical"
                     android:focusable="true"
@@ -87,7 +87,7 @@
                     android:paddingHorizontal="6dip" />
                     <androidx.appcompat.widget.AppCompatButton
                         android:id="@+id/CardEditorTagButton"
-                        android:layout_width="fill_parent"
+                        android:layout_width="match_parent"
                         android:layout_height="40dp"
                         tools:text="Tags: AnkiDroid"
                         android:gravity="start|center_vertical"
@@ -99,7 +99,7 @@
                         android:background="@drawable/button_background"/>
                     <androidx.appcompat.widget.AppCompatButton
                         android:id="@+id/CardEditorCardsButton"
-                        android:layout_width="fill_parent"
+                        android:layout_width="match_parent"
                         android:layout_height="40dp"
                         tools:text="Cards: Card 1"
                         android:textAllCaps="false"

--- a/AnkiDroid/src/main/res/layout/progress_bar.xml
+++ b/AnkiDroid/src/main/res/layout/progress_bar.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:id="@+id/progress_bar_layout"
-    android:layout_width="fill_parent"
-    android:layout_height="fill_parent"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
     android:gravity="center"
     android:orientation="vertical">
         <ProgressBar

--- a/AnkiDroid/src/main/res/layout/reviewer_answer_buttons.xml
+++ b/AnkiDroid/src/main/res/layout/reviewer_answer_buttons.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout android:id="@+id/bottom_area_layout"
-    android:layout_width="fill_parent"
+    android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:orientation="vertical"
     xmlns:android="http://schemas.android.com/apk/res/android"
@@ -10,7 +10,7 @@
     <!-- "Type in the answer" bar -->
     <com.ichi2.ui.FixedEditText
         android:id="@+id/answer_field"
-        android:layout_width="fill_parent"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:hint="@string/type_answer_hint"
         android:imeOptions="actionDone"
@@ -63,13 +63,13 @@
 
     <FrameLayout
         android:id="@+id/answer_options_layout"
-        android:layout_width="fill_parent"
-        android:layout_height="fill_parent">
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
 
         <LinearLayout
             android:id="@+id/ease_buttons"
-            android:layout_width="fill_parent"
-            android:layout_height="fill_parent"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
             android:visibility="gone"
             android:focusable="false"
             android:orientation="horizontal">
@@ -163,7 +163,7 @@
 
         <LinearLayout
             android:id="@+id/flashcard_layout_flip"
-            android:layout_width="fill_parent"
+            android:layout_width="match_parent"
             android:layout_height="@dimen/touch_target"
             android:orientation="vertical"
             android:focusable="true"
@@ -174,8 +174,8 @@
                 android:duplicateParentState="true"
                 android:background="?attr/hardButtonRef"
                 android:id="@+id/flip_card"
-                android:layout_width="fill_parent"
-                android:layout_height="fill_parent"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
                 android:clickable="false"
                 android:text="@string/show_answer"
                 android:textColor="?attr/answerButtonTextColor" />

--- a/AnkiDroid/src/main/res/layout/reviewer_flashcard.xml
+++ b/AnkiDroid/src/main/res/layout/reviewer_flashcard.xml
@@ -25,28 +25,28 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_gravity="center"
     android:id="@+id/flashcard_frame"
-    android:layout_width="fill_parent"
-    android:layout_height="fill_parent"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
     android:layout_margin="0dip">
 
     <FrameLayout
         android:layout_gravity="center"
         android:id="@+id/flashcard"
-        android:layout_width="fill_parent"
-        android:layout_height="fill_parent" />
+        android:layout_width="match_parent"
+        android:layout_height="match_parent" />
     <FrameLayout
         android:layout_gravity="center"
         android:id="@+id/touch_layer"
-        android:layout_width="fill_parent"
-        android:layout_height="fill_parent"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
         android:layout_margin="0dip"
         android:longClickable="true" />
     <FrameLayout
         android:layout_gravity="center"
         android:id="@+id/whiteboard"
         android:layout_margin="0dip"
-        android:layout_width="fill_parent"
-        android:layout_height="fill_parent" />
+        android:layout_width="match_parent"
+        android:layout_height="match_parent" />
     <ImageView
         android:id="@+id/lookup_button"
         android:layout_width="60dp"

--- a/AnkiDroid/src/main/res/layout/reviewer_flashcard_fullscreen.xml
+++ b/AnkiDroid/src/main/res/layout/reviewer_flashcard_fullscreen.xml
@@ -19,24 +19,24 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_gravity="center"
     android:id="@+id/flashcard_frame"
-    android:layout_width="fill_parent"
-    android:layout_height="fill_parent">
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
     <FrameLayout
         android:layout_gravity="center"
         android:id="@+id/flashcard"
-        android:layout_width="fill_parent"
-        android:layout_height="fill_parent" />
+        android:layout_width="match_parent"
+        android:layout_height="match_parent" />
     <FrameLayout
         android:layout_gravity="center"
         android:id="@+id/touch_layer"
-        android:layout_width="fill_parent"
-        android:layout_height="fill_parent"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
         android:longClickable="true" />
     <FrameLayout
         android:layout_gravity="center"
         android:id="@+id/whiteboard"
-        android:layout_width="fill_parent"
-        android:layout_height="fill_parent" />
+        android:layout_width="match_parent"
+        android:layout_height="match_parent" />
     <ImageView
         android:id="@+id/lookup_button"
         android:layout_width="wrap_content"

--- a/AnkiDroid/src/main/res/layout/reviewer_flashcard_fullscreen_noanswers.xml
+++ b/AnkiDroid/src/main/res/layout/reviewer_flashcard_fullscreen_noanswers.xml
@@ -19,25 +19,25 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_gravity="center"
     android:id="@+id/flashcard_frame"
-    android:layout_width="fill_parent"
-    android:layout_height="fill_parent">
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
 
     <FrameLayout
         android:layout_gravity="center"
         android:id="@+id/flashcard"
-        android:layout_width="fill_parent"
-        android:layout_height="fill_parent" />
+        android:layout_width="match_parent"
+        android:layout_height="match_parent" />
     <FrameLayout
         android:layout_gravity="center"
         android:id="@+id/touch_layer"
-        android:layout_width="fill_parent"
-        android:layout_height="fill_parent"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
         android:longClickable="true" />
     <FrameLayout
         android:layout_gravity="center"
         android:id="@+id/whiteboard"
-        android:layout_width="fill_parent"
-        android:layout_height="fill_parent" />
+        android:layout_width="match_parent"
+        android:layout_height="match_parent" />
     <ImageView
         android:id="@+id/lookup_button"
         android:layout_width="wrap_content"

--- a/AnkiDroid/src/main/res/layout/reviewer_fullscreen.xml
+++ b/AnkiDroid/src/main/res/layout/reviewer_fullscreen.xml
@@ -9,7 +9,7 @@ xmlns:android="http://schemas.android.com/apk/res/android">
         android:layout_width="match_parent"
         android:layout_height="match_parent">
         <include layout="@layout/reviewer_topbar"
-            android:layout_width="fill_parent"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_alignParentTop="true"/>
         <include
@@ -18,8 +18,8 @@ xmlns:android="http://schemas.android.com/apk/res/android">
             android:layout_height="wrap_content"
             android:layout_below="@id/top_bar" />
         <include layout="@layout/reviewer_flashcard_fullscreen"
-            android:layout_width="fill_parent"
-            android:layout_height="fill_parent"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
             android:layout_below="@id/mic_tool_bar_layer"/>
         <include
             layout="@layout/reviewer_whiteboard_editor"
@@ -35,7 +35,7 @@ xmlns:android="http://schemas.android.com/apk/res/android">
         android:layout_height="match_parent"
         android:fitsSystemWindows="true">
         <include layout="@layout/toolbar"
-            android:layout_width="fill_parent"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:gravity="top"/>
     </FrameLayout>

--- a/AnkiDroid/src/main/res/layout/reviewer_fullscreen_noanswers.xml
+++ b/AnkiDroid/src/main/res/layout/reviewer_fullscreen_noanswers.xml
@@ -25,7 +25,7 @@
                 android:layout_height="match_parent">
                 <include layout="@layout/toolbar"/>
                 <include layout="@layout/reviewer_topbar"
-                    android:layout_width="fill_parent"
+                    android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_below="@id/toolbar"/>
                 <include

--- a/AnkiDroid/src/main/res/layout/reviewer_topbar.xml
+++ b/AnkiDroid/src/main/res/layout/reviewer_topbar.xml
@@ -2,7 +2,7 @@
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/top_bar"
-        android:layout_width="fill_parent"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:paddingLeft="@dimen/side_margin"
         android:paddingRight="@dimen/side_margin"

--- a/AnkiDroid/src/main/res/layout/studyoptions.xml
+++ b/AnkiDroid/src/main/res/layout/studyoptions.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.coordinatorlayout.widget.CoordinatorLayout android:id="@+id/root_layout"
-    android:layout_width="fill_parent"
-    android:layout_height="fill_parent"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
     xmlns:android="http://schemas.android.com/apk/res/android">
             <LinearLayout
                 android:layout_width="match_parent"
@@ -9,8 +9,8 @@
                 android:orientation="vertical">
                 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
                     android:id="@+id/studyoptions_frame"
-                    android:layout_width="fill_parent"
-                    android:layout_height="fill_parent" />
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent" />
             </LinearLayout>
         </androidx.coordinatorlayout.widget.CoordinatorLayout>
 

--- a/AnkiDroid/src/main/res/layout/studyoptions_fragment.xml
+++ b/AnkiDroid/src/main/res/layout/studyoptions_fragment.xml
@@ -3,19 +3,19 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/studyoptions_main"
-    android:layout_width="fill_parent"
-    android:layout_height="fill_parent"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
     android:orientation="vertical"
     android:fitsSystemWindows="true"
     android:gravity="center">
     <RelativeLayout
-        android:layout_width="fill_parent"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_gravity="center"
         android:orientation="vertical">
         <androidx.appcompat.widget.Toolbar
             android:id="@+id/studyOptionsToolbar"
-            android:layout_width="fill_parent"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:minHeight="?attr/actionBarSize"
             android:theme="@style/ActionBarStyle"
@@ -24,25 +24,25 @@
             app:popupTheme="@style/ActionBar.Popup"/>
         <LinearLayout
             android:layout_below="@id/studyOptionsToolbar"
-            android:layout_width="fill_parent"
+            android:layout_width="match_parent"
             android:layout_height="match_parent"
             android:orientation="horizontal">
             <View
                 android:id="@+id/studyoptions_gradient"
                 android:layout_width="15dp"
-                android:layout_height="fill_parent"
+                android:layout_height="match_parent"
                 android:background="@drawable/shadow_left"
                 android:visibility="gone"/>
             <RelativeLayout
-                android:layout_width="fill_parent"
-                android:layout_height="fill_parent"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
                 android:id="@+id/studyoptions_mainframe"
                 android:paddingBottom="32dp">
                 <ScrollView
                     android:id="@+id/studyoptions_scrollview"
                     android:layout_above="@id/bottom_area_layout"
                     android:layout_alignParentTop="true"
-                    android:layout_width="fill_parent"
+                    android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:paddingLeft="@dimen/study_options_padding"
                     android:paddingRight="@dimen/study_options_padding"

--- a/AnkiDroid/src/main/res/layout/styled_custom_study_details_dialog.xml
+++ b/AnkiDroid/src/main/res/layout/styled_custom_study_details_dialog.xml
@@ -22,7 +22,7 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
 
-    android:layout_width="fill_parent"
+    android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:gravity="start"
     android:orientation="vertical" >
@@ -53,7 +53,7 @@
 
     <com.ichi2.ui.FixedEditText
         android:id="@+id/custom_study_details_edittext2"
-        android:layout_width="fill_parent"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginBottom="16dip"
         android:layout_marginLeft="4dip"

--- a/AnkiDroid/src/main/res/layout/tags_dialog.xml
+++ b/AnkiDroid/src/main/res/layout/tags_dialog.xml
@@ -38,7 +38,7 @@
 
     <androidx.recyclerview.widget.RecyclerView android:id="@+id/tags_dialog_tags_list"
                                                android:scrollbars="vertical"
-                                               android:layout_width="fill_parent"
+                                               android:layout_width="match_parent"
                                                android:layout_height="wrap_content"
                                                android:layout_above="@id/tags_dialog_options_radiogroup"
                                                android:layout_below="@id/tags_dialog_toolbar"/>

--- a/AnkiDroid/src/main/res/layout/tags_item_list_dialog.xml
+++ b/AnkiDroid/src/main/res/layout/tags_item_list_dialog.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <CheckedTextView xmlns:android="http://schemas.android.com/apk/res/android"
     android:id="@+id/tags_dialog_tag_item"
-    android:layout_width="fill_parent"
+    android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:paddingLeft="8dp"
     android:minHeight="?android:attr/listPreferredItemHeight"

--- a/AnkiDroid/src/main/res/layout/toolbar.xml
+++ b/AnkiDroid/src/main/res/layout/toolbar.xml
@@ -4,7 +4,7 @@
 
     <androidx.appcompat.widget.Toolbar
         android:id="@+id/toolbar"
-        android:layout_width="fill_parent"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_alignParentTop="true"
         android:background="?attr/colorPrimary"

--- a/AnkiDroid/src/main/res/layout/video_player.xml
+++ b/AnkiDroid/src/main/res/layout/video_player.xml
@@ -2,11 +2,11 @@
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android" 
   android:orientation="vertical"
   android:layout_width="match_parent"
-  android:layout_height="fill_parent">
+  android:layout_height="match_parent">
     <VideoView 
         android:id="@+id/video_surface"
-        android:layout_width="fill_parent"
-        android:layout_height="fill_parent"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
         android:layout_gravity="center"
         android:layout_centerInParent="true" />
 </RelativeLayout>

--- a/AnkiDroid/src/main/res/layout/widget_add_note.xml
+++ b/AnkiDroid/src/main/res/layout/widget_add_note.xml
@@ -1,7 +1,7 @@
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:id="@+id/widget_add_note_root"
-    android:layout_width="fill_parent"
-    android:layout_height="fill_parent"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
     android:background="#00FFFFFF"
     android:clickable="true"
     android:focusable="false">

--- a/AnkiDroid/src/main/res/layout/widget_small.xml
+++ b/AnkiDroid/src/main/res/layout/widget_small.xml
@@ -1,8 +1,8 @@
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/ankidroid_widget_small_layout"
-    android:layout_width="fill_parent"
-    android:layout_height="fill_parent"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
     android:clickable="true"
     android:focusable="false"
     android:background="#00FFFFFF"
@@ -23,8 +23,8 @@
 
     <RelativeLayout
         android:id="@+id/ankidroid_widget_text_layout"
-        android:layout_width="fill_parent"
-        android:layout_height="fill_parent"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
         android:clickable="false"
         android:focusable="false"
         android:orientation="horizontal"

--- a/AnkiDroid/src/main/res/values/styles.xml
+++ b/AnkiDroid/src/main/res/values/styles.xml
@@ -46,7 +46,7 @@
     <style name="FooterButton" parent="FooterButtonBase"/>
 
     <style name="FooterButtonNextTime">
-        <item name="android:layout_width">fill_parent</item>
+        <item name="android:layout_width">match_parent</item>
         <item name="android:layout_height">wrap_content</item>
         <item name="android:layout_gravity">center</item>
         <item name="android:ellipsize">marquee</item>


### PR DESCRIPTION

fill_parent is deprecated, match_parent replaces it with the exact same constant value and semantics:

https://developer.android.com/reference/android/view/ViewGroup.LayoutParams.html#FILL_PARENT

> Special value for the height or width requested by a View. FILL_PARENT means that the view wants to be as big as its parent, minus the parent's padding, if any. This value is deprecated starting in API Level 8 and replaced by MATCH_PARENT.