### PR TITLE
deprecation: fix createVideoThumbnail

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/compat/Compat.java
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/Compat.java
@@ -17,13 +17,13 @@
 package com.ichi2.compat;
 
 import android.content.Context;
-import android.content.pm.PackageInfo;
-import android.text.Spanned;
 import android.widget.TimePicker;
 
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+
+import androidx.annotation.NonNull;
 
 /**
  * This interface defines a set of functions that are not available on all platforms.
@@ -31,7 +31,7 @@ import java.io.OutputStream;
  * A set of implementations for the supported platforms are available.
  * <p>
  * Each implementation ends with a {@code V<n>} prefix, identifying the minimum API version on which this implementation
- * can be used. For example, see {@link CompatV16}.
+ * can be used. For example, see {@link CompatV21}.
  * <p>
  * Each implementation should extend the previous implementation and implement this interface.
  * <p>
@@ -58,5 +58,6 @@ public interface Compat {
     void copyFile(String source, String target) throws IOException;
     long copyFile(String source, OutputStream target) throws IOException;
     long copyFile(InputStream source, String target) throws IOException;
+    boolean hasVideoThumbnail(@NonNull String path);
 }
 

--- a/AnkiDroid/src/main/java/com/ichi2/compat/CompatHelper.java
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/CompatHelper.java
@@ -26,8 +26,9 @@ public class CompatHelper {
 
 
     private CompatHelper() {
-
-        if (getSdkVersion() >= Build.VERSION_CODES.O) {
+        if (getSdkVersion() >= Build.VERSION_CODES.Q) {
+            mCompat = new CompatV29();
+        } else if (getSdkVersion() >= Build.VERSION_CODES.O) {
             mCompat = new CompatV26();
         } else if (getSdkVersion() >= Build.VERSION_CODES.M) {
             mCompat = new CompatV23();

--- a/AnkiDroid/src/main/java/com/ichi2/compat/CompatV21.java
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/CompatV21.java
@@ -17,7 +17,9 @@
 package com.ichi2.compat;
 
 import android.content.Context;
+import android.media.ThumbnailUtils;
 import android.os.Vibrator;
+import android.provider.MediaStore;
 import android.widget.TimePicker;
 
 import java.io.File;
@@ -116,4 +118,10 @@ public class CompatV21 implements Compat {
     @Override
     @SuppressWarnings("deprecation")
     public int getMinute(TimePicker picker) { return picker.getCurrentMinute(); }
+
+    @Override
+    @SuppressWarnings("deprecation")
+    public boolean hasVideoThumbnail(@NonNull String path) {
+        return ThumbnailUtils.createVideoThumbnail(path, MediaStore.Images.Thumbnails.MINI_KIND) != null;
+    }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/compat/CompatV29.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/CompatV29.kt
@@ -1,0 +1,43 @@
+/*
+ *  Copyright (c) 2021 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.ichi2.compat
+
+import android.annotation.TargetApi
+import android.media.ThumbnailUtils
+import android.util.Size
+import java.io.File
+
+/** Implementation of [Compat] for SDK level 29  */
+@TargetApi(29)
+class CompatV29 : CompatV26(), Compat {
+    override fun hasVideoThumbnail(path: String): Boolean {
+        return try {
+            ThumbnailUtils.createVideoThumbnail(File(path), THUMBNAIL_MINI_KIND, null)
+            // createVideoThumbnail throws an exception if it's null
+            true
+        } catch (e: Exception) {
+            // The default for audio is an IOException, so don't log it
+            // A log line is still produced:
+            // E/MediaMetadataRetrieverJNI: getEmbeddedPicture: Call to getEmbeddedPicture failed
+            false
+        }
+    }
+
+    companion object {
+        // obtained from AOSP source
+        private val THUMBNAIL_MINI_KIND = Size(512, 384)
+    }
+}

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Sound.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Sound.java
@@ -24,9 +24,7 @@ import android.media.AudioManager;
 import android.media.MediaPlayer;
 import android.media.MediaMetadataRetriever;
 import android.media.MediaPlayer.OnCompletionListener;
-import android.media.ThumbnailUtils;
 import android.net.Uri;
-import android.provider.MediaStore;
 
 import android.view.Display;
 import android.view.WindowManager;
@@ -36,6 +34,7 @@ import android.widget.VideoView;
 import com.ichi2.anki.AbstractFlashcardViewer;
 import com.ichi2.anki.AnkiDroidApp;
 import com.ichi2.anki.ReadText;
+import com.ichi2.compat.CompatHelper;
 import com.ichi2.utils.StringUtil;
 
 import java.lang.ref.WeakReference;
@@ -390,7 +389,6 @@ public class Sound {
     }
 
 
-    @SuppressWarnings("deprecation") // createVideoThumbnail
     private boolean hasVideoThumbnail(@Nullable Uri soundUri) {
         if (soundUri == null) {
             return false;
@@ -400,7 +398,7 @@ public class Sound {
             return false;
         }
 
-        return ThumbnailUtils.createVideoThumbnail(path, MediaStore.Images.Thumbnails.MINI_KIND) != null;
+        return CompatHelper.getCompat().hasVideoThumbnail(path);
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Sound.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Sound.java
@@ -339,8 +339,7 @@ public class Sound {
                 isVideo = (guessedType != null) && guessedType.startsWith("video/");
             }
             // Also check that there is a video thumbnail, as some formats like mp4 can be audio only
-            isVideo = isVideo &&
-                ThumbnailUtils.createVideoThumbnail(soundUri.getPath(), MediaStore.Images.Thumbnails.MINI_KIND) != null;
+            isVideo = isVideo && hasVideoThumbnail(soundUri);
             // No thumbnail: no video after all. (Or maybe not a video we can handle on the specific device.)
             // If video file but no SurfaceHolder provided then ask AbstractFlashcardViewer to provide a VideoView
             // holder
@@ -389,6 +388,12 @@ public class Sound {
             }
         }
     }
+
+    @SuppressWarnings("deprecation") // createVideoThumbnail
+    private boolean hasVideoThumbnail(Uri soundUri) {
+        return ThumbnailUtils.createVideoThumbnail(soundUri.getPath(), MediaStore.Images.Thumbnails.MINI_KIND) != null;
+    }
+
 
     public String getCurrentAudioUri() {
         if (mCurrentAudioUri == null) {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Sound.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Sound.java
@@ -389,9 +389,18 @@ public class Sound {
         }
     }
 
+
     @SuppressWarnings("deprecation") // createVideoThumbnail
-    private boolean hasVideoThumbnail(Uri soundUri) {
-        return ThumbnailUtils.createVideoThumbnail(soundUri.getPath(), MediaStore.Images.Thumbnails.MINI_KIND) != null;
+    private boolean hasVideoThumbnail(@Nullable Uri soundUri) {
+        if (soundUri == null) {
+            return false;
+        }
+        String path = soundUri.getPath();
+        if (path == null) {
+            return false;
+        }
+
+        return ThumbnailUtils.createVideoThumbnail(path, MediaStore.Images.Thumbnails.MINI_KIND) != null;
     }
 
 


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
I saw an exception in the logs when playing Audio cards, and wanted to avoid this

Now we display `E/MediaMetadataRetrieverJNI: getEmbeddedPicture: Call to getEmbeddedPicture failed`

## Fixes
Related: #5022

## Approach
* Use the new API
* Convert string to a path
* Convert `MINI_SIZE` to  sample representation (method now accepts a `Size`)
* Don't use a cancelListener

## How Has This Been Tested?

Android 11 device: no longer has a large stack trace in logs

## Learning (optional, can help others)

https://developer.android.com/reference/android/media/ThumbnailUtils#createVideoThumbnail(java.io.File,%20android.util.Size,%20android.os.CancellationSignal)
MINI_SIZE: https://github.com/aosp-mirror/platform_packages_providers_mediaprovider/blob/b430fcafc434c559324732b4296f1146b2f717f8/apex/framework/java/android/provider/MediaStore.java#L1697

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
