### PR TITLE
fix: holding a key should not repeat events

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/PeripheralKeymap.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/PeripheralKeymap.java
@@ -60,7 +60,7 @@ public class PeripheralKeymap {
 
 
     public boolean onKeyDown(int keyCode, KeyEvent event) {
-        if (!mHasSetup) {
+        if (!mHasSetup || event.getRepeatCount() > 0) {
             return false;
         }
         if (mReviewerUI.isDisplayingAnswer()) {

--- a/AnkiDroid/src/test/java/com/ichi2/anki/reviewer/KeyboardShortcutIntegrationTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/reviewer/KeyboardShortcutIntegrationTest.java
@@ -34,6 +34,7 @@ import org.robolectric.Shadows;
 
 import java.io.IOException;
 
+import androidx.annotation.NonNull;
 import androidx.test.core.app.ApplicationProvider;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
@@ -80,6 +81,23 @@ public class KeyboardShortcutIntegrationTest extends RobolectricTest {
         verify(recorder, times(1)).startRecording(anyString());
         verifyNoMoreInteractions(recorder);
     }
+
+    /**
+     * Press V
+     * Hold V
+     *
+     * Expected: Recording is triggered and is not untriggered
+     */
+    @Test
+    public void holdIsNotASecondAction() throws IOException {
+        AudioRecorder recorder = setupRecorderMock();
+
+        pressAndHoldShiftV();
+
+        verify(recorder, times(1)).startRecording(anyString());
+        verifyNoMoreInteractions(recorder);
+    }
+
 
     /**
      * Press "Shift + V"
@@ -169,6 +187,17 @@ public class KeyboardShortcutIntegrationTest extends RobolectricTest {
     }
 
 
+    private void pressAndHoldShiftV() {
+        depressShiftKey();
+
+        KeyEvent vKey = getVKey();
+        when(vKey.isShiftPressed()).thenReturn(true);
+        reviewer.onKeyDown(KeyEvent.KEYCODE_V, vKey);
+        when(vKey.getRepeatCount()).thenReturn(1);
+        reviewer.onKeyDown(KeyEvent.KEYCODE_V, vKey);
+    }
+
+
     protected void pressShiftAndVThenRelease() {
         depressShiftKey();
         depressVKeyWithShiftHeld();
@@ -199,6 +228,17 @@ public class KeyboardShortcutIntegrationTest extends RobolectricTest {
         when(mock.getUnicodeChar(anyInt())).thenReturn((int) 'v');
         reviewer.onKeyDown(KeyEvent.KEYCODE_V, mock);
     }
+
+
+    @NonNull
+    private KeyEvent getVKey() {
+        KeyEvent mock = mock(KeyEvent.class);
+        when(mock.getKeyCode()).thenReturn(KeyEvent.KEYCODE_V);
+        when(mock.getUnicodeChar()).thenReturn((int) 'v');
+        when(mock.getUnicodeChar(anyInt())).thenReturn((int) 'v');
+        return mock;
+    }
+
 
     private void depressVKeyWithShiftHeld() {
         KeyEvent mock = mock(KeyEvent.class);


### PR DESCRIPTION
**This is a change in functionality from 2.15.5**

We moved to onKeyDown on e439280bf3382a4af4146316f2ada063cce0f8ca
onKeyDown repeats, whereas onKeyUp didn't

So we handle repeats via not counting them as actions

## How Has This Been Tested?

Unit tested and tested with an Apple Keyboard & my Android 11

## Learning (optional, can help others)
* onKeyDown repeats

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
