### PR TITLE
fix: borders on fullscreen Reviewer

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -103,6 +103,7 @@ import com.ichi2.anki.cardviewer.CardAppearance;
 import com.ichi2.anki.receiver.SdCardReceiver;
 import com.ichi2.anki.reviewer.CardMarker;
 import com.ichi2.anki.cardviewer.CardTemplate;
+import com.ichi2.anki.reviewer.FullScreenMode;
 import com.ichi2.anki.reviewer.ReviewerCustomFonts;
 import com.ichi2.anki.reviewer.ReviewerUi;
 import com.ichi2.anki.cardviewer.TypedAnswer;
@@ -161,8 +162,6 @@ import java.util.regex.Pattern;
 
 import timber.log.Timber;
 
-import static com.ichi2.anki.Preferences.BUTTONS_AND_MENU;
-import static com.ichi2.anki.Preferences.FULL_SCREEN_MODE;
 import static com.ichi2.anki.cardviewer.CardAppearance.calculateDynamicFontSize;
 import static com.ichi2.anki.cardviewer.ViewerCommand.*;
 import static com.ichi2.anki.reviewer.CardMarker.*;
@@ -237,7 +236,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
     private boolean mPrefShowTopbar;
     private boolean mShowTimer;
     protected boolean mPrefWhiteboard;
-    private int mPrefFullscreenReview;
+    private FullScreenMode mPrefFullscreenReview = FullScreenMode.getDEFAULT();
     private int mRelativeButtonSize;
     private boolean mDoubleScrolling;
     private boolean mScrollingButtons;
@@ -954,7 +953,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
         mShortAnimDuration = getResources().getInteger(android.R.integer.config_shortAnimTime);
     }
 
-    protected int getContentViewAttr(int fullscreenMode) {
+    protected int getContentViewAttr(FullScreenMode fullscreenMode) {
         return R.layout.reviewer;
     }
 
@@ -1917,7 +1916,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
         // On newer Androids, ignore this setting, which should be hidden in the prefs anyway.
         mDisableClipboard = "0".equals(preferences.getString("dictionary", "0"));
         // mDeckFilename = preferences.getString("deckFilename", "");
-        mPrefFullscreenReview = Integer.parseInt(preferences.getString(FULL_SCREEN_MODE, BUTTONS_AND_MENU));
+        mPrefFullscreenReview = FullScreenMode.fromPreference(preferences);
         mRelativeButtonSize = preferences.getInt("answerButtonSize", 100);
         mSpeakText = preferences.getBoolean("tts", false);
         mPrefUseTimer = preferences.getBoolean("timeoutAnswer", false);

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -953,6 +953,11 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
         mShortAnimDuration = getResources().getInteger(android.R.integer.config_shortAnimTime);
     }
 
+    @NonNull
+    protected FullScreenMode getFullscreenMode() {
+        return mPrefFullscreenReview;
+    }
+
     protected int getContentViewAttr(FullScreenMode fullscreenMode) {
         return R.layout.reviewer;
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -108,6 +108,7 @@ import com.ichi2.anki.dialogs.customstudy.CustomStudyDialogFactory;
 import com.ichi2.anki.exception.ConfirmModSchemaException;
 import com.ichi2.anki.exception.FilteredAncestor;
 import com.ichi2.anki.receiver.SdCardReceiver;
+import com.ichi2.anki.reviewer.FullScreenMode;
 import com.ichi2.anki.stats.AnkiStatsTaskHandler;
 import com.ichi2.anki.web.HostNumFactory;
 import com.ichi2.anki.widgets.DeckAdapter;
@@ -149,9 +150,6 @@ import java.util.TreeMap;
 
 import timber.log.Timber;
 
-import static com.ichi2.anki.Preferences.BUTTONS_AND_MENU;
-import static com.ichi2.anki.Preferences.BUTTONS_ONLY;
-import static com.ichi2.anki.Preferences.FULL_SCREEN_MODE;
 import static com.ichi2.async.Connection.ConflictResolution.FULL_DOWNLOAD;
 
 import static com.ichi2.anim.ActivityTransitionAnimation.Direction.*;
@@ -1379,19 +1377,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
             preferences.edit().remove("intentAdditionInstantAdd").apply();
         }
 
-        if (preferences.contains("fullscreenReview")) {
-            Timber.i("Old version of Anki - Fixing Fullscreen");
-            // clear fullscreen flag as we use a integer
-            try {
-                boolean old = preferences.getBoolean("fullscreenReview", false);
-                preferences.edit().putString(FULL_SCREEN_MODE, old ? BUTTONS_ONLY: BUTTONS_AND_MENU).apply();
-            } catch (ClassCastException e) {
-                Timber.w(e);
-                // TODO:  can remove this catch as it was only here to fix an error in the betas
-                preferences.edit().remove(FULL_SCREEN_MODE).apply();
-            }
-            preferences.edit().remove("fullscreenReview").apply();
-        }
+        FullScreenMode.upgradeFromLegacyPreference(preferences);
     }
 
     private UndoTaskListener undoTaskListener(boolean isReview) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NavigationDrawerActivity.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NavigationDrawerActivity.java
@@ -30,6 +30,7 @@ import android.os.Handler;
 import com.drakeet.drawer.FullDraggableContainer;
 import com.google.android.material.navigation.NavigationView;
 
+import androidx.annotation.LayoutRes;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.coordinatorlayout.widget.CoordinatorLayout;
@@ -85,11 +86,11 @@ public abstract class NavigationDrawerActivity extends AnkiActivity implements N
     private Runnable mPendingRunnable;
 
     @Override
-    public void setContentView(int layoutResID) {
+    public void setContentView(@LayoutRes int layoutResID) {
         SharedPreferences preferences = AnkiDroidApp.getSharedPrefs(getBaseContext());
 
         // Using ClosableDrawerLayout as a parent view.
-        ClosableDrawerLayout closableDrawerLayout = (ClosableDrawerLayout) LayoutInflater.from(this).inflate(R.layout.navigation_drawer_layout, null, false);
+        ClosableDrawerLayout closableDrawerLayout = (ClosableDrawerLayout) LayoutInflater.from(this).inflate(getNavigationDrawerLayout(), null, false);
         // Get CoordinatorLayout using resource ID
         CoordinatorLayout coordinatorLayout = (CoordinatorLayout) LayoutInflater.from(this).inflate(layoutResID, closableDrawerLayout, false);
         if (preferences.getBoolean(FULL_SCREEN_NAVIGATION_DRAWER, false)) {
@@ -104,6 +105,15 @@ public abstract class NavigationDrawerActivity extends AnkiActivity implements N
         }
 
         setContentView(closableDrawerLayout);
+    }
+
+    private @LayoutRes int getNavigationDrawerLayout() {
+        return fitsSystemWindows() ? R.layout.navigation_drawer_layout : R.layout.navigation_drawer_layout_fullscreen;
+    }
+
+    /** Whether android:fitsSystemWindows="true" should be applied to the navigation drawer */
+    protected boolean fitsSystemWindows() {
+        return true;
     }
 
     // Navigation drawer initialisation

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
@@ -326,7 +326,7 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
                         screen.findPreference(FULL_SCREEN_MODE);
                 fullscreenPreference.setOnPreferenceChangeListener((preference, newValue) -> {
                     SharedPreferences prefs = AnkiDroidApp.getSharedPrefs(Preferences.this);
-                    if (prefs.getBoolean("gestures", false) || !FULL_SCREEN_MODE.equals(newValue)) {
+                    if (prefs.getBoolean("gestures", false) || !FULLSCREEN_ALL_GONE.equals(newValue)) {
                         return true;
                     } else {
                         UIUtils.showThemedToast(getApplicationContext(),

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
@@ -47,6 +47,7 @@ import com.ichi2.anki.contextmenu.CardBrowserContextMenu;
 import com.ichi2.anki.debug.DatabaseLock;
 import com.ichi2.anki.exception.ConfirmModSchemaException;
 import com.ichi2.anki.exception.StorageAccessException;
+import com.ichi2.anki.reviewer.FullScreenMode;
 import com.ichi2.anki.services.BootService;
 import com.ichi2.anki.services.NotificationService;
 import com.ichi2.anki.web.CustomSyncServer;
@@ -160,29 +161,6 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
      * Represents in Android preferences whether the scheduler should use version 1 or 2.
      */
     private static final String SCHED_VER = "schedVer";
-
-    /**
-     * Whether the reviewer content should take the full screen. Its possible values are defined just below.
-     */
-    public static final String FULL_SCREEN_MODE = "fullscreenMode";
-
-    public static final String BUTTONS_AND_MENU = "0";
-    /**
-     * Remove the menu bar, keeps answer button.
-     */
-    public static final String BUTTONS_ONLY = "1";
-    /**
-     * Remove both menu bar and buttons. Can only be set if gesture is on.
-     */
-    public static final String FULLSCREEN_ALL_GONE = "2";
-
-    @Retention(SOURCE)
-    @StringDef({
-        BUTTONS_AND_MENU,
-            BUTTONS_ONLY,
-            FULLSCREEN_ALL_GONE
-    })
-    public @interface REVIEWER_SCREEN_MODE {}
 
     /**
      * The number of cards that should be due today in a deck to justify adding a notification.
@@ -323,10 +301,10 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
                 screen = listener.getPreferenceScreen();
                 // Show error toast if the user tries to disable answer button without gestures on
                 android.preference.ListPreference fullscreenPreference = (android.preference.ListPreference)
-                        screen.findPreference(FULL_SCREEN_MODE);
+                        screen.findPreference(FullScreenMode.PREF_KEY);
                 fullscreenPreference.setOnPreferenceChangeListener((preference, newValue) -> {
                     SharedPreferences prefs = AnkiDroidApp.getSharedPrefs(Preferences.this);
-                    if (prefs.getBoolean("gestures", false) || !FULLSCREEN_ALL_GONE.equals(newValue)) {
+                    if (prefs.getBoolean("gestures", false) || !FullScreenMode.FULLSCREEN_ALL_GONE.getPreferenceValue().equals(newValue)) {
                         return true;
                     } else {
                         UIUtils.showThemedToast(getApplicationContext(),

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.java
@@ -68,6 +68,7 @@ import com.ichi2.anki.cardviewer.Gesture;
 import com.ichi2.anki.dialogs.ConfirmationDialog;
 import com.ichi2.anki.multimediacard.AudioView;
 import com.ichi2.anki.dialogs.RescheduleDialog;
+import com.ichi2.anki.reviewer.FullScreenMode;
 import com.ichi2.anki.reviewer.PeripheralKeymap;
 import com.ichi2.anki.reviewer.ReviewerUi;
 import com.ichi2.anki.workarounds.FirefoxSnackbarWorkaround;
@@ -93,9 +94,6 @@ import java.util.Collections;
 
 import timber.log.Timber;
 
-import static com.ichi2.anki.Preferences.BUTTONS_AND_MENU;
-import static com.ichi2.anki.Preferences.FULLSCREEN_ALL_GONE;
-import static com.ichi2.anki.Preferences.FULL_SCREEN_MODE;
 import static com.ichi2.anki.reviewer.CardMarker.*;
 import static com.ichi2.anim.ActivityTransitionAnimation.Direction.*;
 
@@ -256,11 +254,11 @@ public class Reviewer extends AbstractFlashcardViewer {
     }
 
     @Override
-    protected int getContentViewAttr(int fullscreenMode) {
+    protected int getContentViewAttr(FullScreenMode fullscreenMode) {
         switch (fullscreenMode) {
-            case 1:
+            case BUTTONS_ONLY:
                 return R.layout.reviewer_fullscreen;
-            case 2:
+            case FULLSCREEN_ALL_GONE:
                 return R.layout.reviewer_fullscreen_noanswers;
             default:
                 return R.layout.reviewer;
@@ -956,7 +954,7 @@ public class Reviewer extends AbstractFlashcardViewer {
         mPrefHideDueCount = preferences.getBoolean("hideDueCount", false);
         mPrefShowETA = preferences.getBoolean("showETA", true);
         this.mProcessor.setup();
-        mPrefFullscreenReview = Integer.parseInt(preferences.getString(FULL_SCREEN_MODE, BUTTONS_AND_MENU)) > 0;
+        mPrefFullscreenReview = FullScreenMode.isFullScreenReview(preferences);
         mActionButtons.setup(preferences);
         return preferences;
     }
@@ -1141,7 +1139,7 @@ public class Reviewer extends AbstractFlashcardViewer {
         );
         // Show / hide the Action bar together with the status bar
         SharedPreferences prefs = AnkiDroidApp.getSharedPrefs(a);
-        final @Preferences.REVIEWER_SCREEN_MODE String fullscreenMode = prefs.getString(FULL_SCREEN_MODE, BUTTONS_AND_MENU);
+        FullScreenMode fullscreenMode = FullScreenMode.fromPreference(prefs);
         a.getWindow().setStatusBarColor(Themes.getColorFromAttr(a, R.attr.colorPrimaryDark));
         View decorView = a.getWindow().getDecorView();
         decorView.setOnSystemUiVisibilityChangeListener
@@ -1158,13 +1156,13 @@ public class Reviewer extends AbstractFlashcardViewer {
                     Timber.d("System UI visibility change. Visible: %b", visible);
                     if (visible) {
                         showViewWithAnimation(toolbar);
-                        if (fullscreenMode.equals(FULLSCREEN_ALL_GONE)) {
+                        if (fullscreenMode.equals(FullScreenMode.FULLSCREEN_ALL_GONE)) {
                             showViewWithAnimation(topbar);
                             showViewWithAnimation(answerButtons);
                         }
                     } else {
                         hideViewWithAnimation(toolbar);
-                        if (fullscreenMode.equals(FULLSCREEN_ALL_GONE)) {
+                        if (fullscreenMode.equals(FullScreenMode.FULLSCREEN_ALL_GONE)) {
                             hideViewWithAnimation(topbar);
                             hideViewWithAnimation(answerButtons);
                         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.java
@@ -266,6 +266,11 @@ public class Reviewer extends AbstractFlashcardViewer {
     }
 
     @Override
+    protected boolean fitsSystemWindows() {
+        return getFullscreenMode().isFullScreenReview();
+    }
+
+    @Override
     protected void onCollectionLoaded(Collection col) {
         super.onCollectionLoaded(col);
         // Load the first card and start reviewing. Uses the answer card

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/FullScreenMode.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/FullScreenMode.kt
@@ -29,6 +29,7 @@ enum class FullScreenMode(private val mPrefValue: String) {
     FULLSCREEN_ALL_GONE("2");
 
     fun getPreferenceValue() = mPrefValue
+    fun isFullScreenReview() = this != BUTTONS_AND_MENU
 
     companion object {
         const val PREF_KEY = "fullscreenMode"
@@ -43,7 +44,7 @@ enum class FullScreenMode(private val mPrefValue: String) {
 
         @JvmStatic
         fun isFullScreenReview(prefs: SharedPreferences): Boolean =
-            fromPreference(prefs) != BUTTONS_AND_MENU
+            fromPreference(prefs).isFullScreenReview()
 
         @JvmStatic
         fun upgradeFromLegacyPreference(preferences: SharedPreferences) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/FullScreenMode.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/FullScreenMode.kt
@@ -53,15 +53,9 @@ enum class FullScreenMode(private val mPrefValue: String) {
             Timber.i("Old version of Anki - Fixing Fullscreen")
             // clear fullscreen flag as we use a integer
             val fullScreenModeKey = PREF_KEY
-            try {
-                val old = preferences.getBoolean("fullscreenReview", false)
-                val newValue = if (old) BUTTONS_ONLY else BUTTONS_AND_MENU
-                preferences.edit().putString(fullScreenModeKey, newValue.getPreferenceValue()).apply()
-            } catch (e: ClassCastException) {
-                Timber.w(e)
-                // TODO: can remove this catch as it was only here to fix an error in the betas
-                preferences.edit().remove(fullScreenModeKey).apply()
-            }
+            val old = preferences.getBoolean("fullscreenReview", false)
+            val newValue = if (old) BUTTONS_ONLY else BUTTONS_AND_MENU
+            preferences.edit().putString(fullScreenModeKey, newValue.getPreferenceValue()).apply()
             preferences.edit().remove("fullscreenReview").apply()
         }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/FullScreenMode.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/FullScreenMode.kt
@@ -1,0 +1,72 @@
+/*
+ *  Copyright (c) 2021 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.ichi2.anki.reviewer
+
+import android.content.SharedPreferences
+import timber.log.Timber
+
+/** Whether Reviewer content should take the full screen */
+enum class FullScreenMode(private val mPrefValue: String) {
+
+    /** Display both navigation and buttons (default) */
+    BUTTONS_AND_MENU("0"),
+    /** Remove the menu bar, keeps answer button. */
+    BUTTONS_ONLY("1"),
+    /** Remove both menu bar and buttons. Can only be set if gesture is on. */
+    FULLSCREEN_ALL_GONE("2");
+
+    fun getPreferenceValue() = mPrefValue
+
+    companion object {
+        const val PREF_KEY = "fullscreenMode"
+        @JvmStatic
+        val DEFAULT = BUTTONS_AND_MENU
+
+        @JvmStatic
+        fun fromPreference(prefs: SharedPreferences): FullScreenMode {
+            val value = prefs.getString(PREF_KEY, DEFAULT.mPrefValue)
+            return enumValues<FullScreenMode>().firstOrNull { it.mPrefValue == value } ?: DEFAULT
+        }
+
+        @JvmStatic
+        fun isFullScreenReview(prefs: SharedPreferences): Boolean =
+            fromPreference(prefs) != BUTTONS_AND_MENU
+
+        @JvmStatic
+        fun upgradeFromLegacyPreference(preferences: SharedPreferences) {
+            if (!preferences.contains("fullscreenReview")) return
+
+            Timber.i("Old version of Anki - Fixing Fullscreen")
+            // clear fullscreen flag as we use a integer
+            val fullScreenModeKey = PREF_KEY
+            try {
+                val old = preferences.getBoolean("fullscreenReview", false)
+                val newValue = if (old) BUTTONS_ONLY else BUTTONS_AND_MENU
+                preferences.edit().putString(fullScreenModeKey, newValue.getPreferenceValue()).apply()
+            } catch (e: ClassCastException) {
+                Timber.w(e)
+                // TODO: can remove this catch as it was only here to fix an error in the betas
+                preferences.edit().remove(fullScreenModeKey).apply()
+            }
+            preferences.edit().remove("fullscreenReview").apply()
+        }
+
+        @JvmStatic
+        fun setPreference(prefs: SharedPreferences, mode: FullScreenMode) {
+            prefs.edit().putString(PREF_KEY, mode.getPreferenceValue()).apply()
+        }
+    }
+}

--- a/AnkiDroid/src/main/res/layout/navigation_drawer_layout_fullscreen.xml
+++ b/AnkiDroid/src/main/res/layout/navigation_drawer_layout_fullscreen.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.drawerlayout.widget.ClosableDrawerLayout xmlns:android="http://schemas.android.com/apk/res/android"
+                                           android:id="@+id/drawer_layout"
+                                           android:layout_width="match_parent"
+                                           android:layout_height="match_parent">
+    <include layout="@layout/navigation_drawer" />
+</androidx.drawerlayout.widget.ClosableDrawerLayout>

--- a/AnkiDroid/src/test/java/com/ichi2/anki/ReviewerNoParamTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/ReviewerNoParamTest.java
@@ -17,6 +17,7 @@
 package com.ichi2.anki;
 
 import android.content.Intent;
+import android.content.SharedPreferences;
 import android.content.SharedPreferences.Editor;
 import android.graphics.Color;
 
@@ -24,6 +25,7 @@ import com.ichi2.anki.cardviewer.Gesture;
 import com.ichi2.anki.cardviewer.GestureProcessor;
 import com.ichi2.anki.cardviewer.ViewerCommand;
 import com.ichi2.anki.model.WhiteboardPenColor;
+import com.ichi2.anki.reviewer.FullScreenMode;
 import com.ichi2.libanki.Consts;
 
 import net.ankiweb.rsdroid.database.NotImplementedException;
@@ -38,8 +40,6 @@ import androidx.annotation.CheckResult;
 import androidx.annotation.NonNull;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
-import static com.ichi2.anki.Preferences.BUTTONS_ONLY;
-import static com.ichi2.anki.Preferences.FULL_SCREEN_MODE;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.is;
@@ -308,7 +308,8 @@ public class ReviewerNoParamTest extends RobolectricTest {
     }
 
     private ReviewerExt startReviewerFullScreen() {
-        AnkiDroidApp.getSharedPrefs(getTargetContext()).edit().putString(FULL_SCREEN_MODE, BUTTONS_ONLY).apply();
+        SharedPreferences sharedPrefs = AnkiDroidApp.getSharedPrefs(getTargetContext());
+        FullScreenMode.setPreference(sharedPrefs, FullScreenMode.BUTTONS_ONLY);
         ReviewerExt reviewer = ReviewerTest.startReviewer(this, ReviewerExt.class);
         return reviewer;
     }


### PR DESCRIPTION
When going fullscreen, the reviewer had white/blue borders rather than
filling the content

Cause:

d0d1edd moved to a single xml file for
the navigation drawer, rather than copy/pasting it into each file

Some layouts excluded `android:fitsSystemWindows="true"`, but the new
xml file always included this.

This caused the layout problems



## Fixes
Fixes #9267

## Approach
* add method: `fitsSystemWindows` and layout without the variable

## How Has This Been Tested?

My Android 11

## Learning (optional, can help others)
* I wasted a lot of time learning about `PhoneWindow` on Android Code Search

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
