### PR TITLE
Update usage of deprecated stream types in MediaPlayer and AudioManager

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/compat/Compat.java
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/Compat.java
@@ -17,6 +17,7 @@
 package com.ichi2.compat;
 
 import android.content.Context;
+import android.media.AudioManager;
 import android.widget.TimePicker;
 
 import java.io.IOException;
@@ -59,5 +60,7 @@ public interface Compat {
     long copyFile(String source, OutputStream target) throws IOException;
     long copyFile(InputStream source, String target) throws IOException;
     boolean hasVideoThumbnail(@NonNull String path);
+    void requestAudioFocus(AudioManager audioManager, AudioManager.OnAudioFocusChangeListener audioFocusChangeListener);
+    void abandonAudioFocus(AudioManager audioManager, AudioManager.OnAudioFocusChangeListener audioFocusChangeListener);
 }
 

--- a/AnkiDroid/src/main/java/com/ichi2/compat/CompatV21.java
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/CompatV21.java
@@ -17,6 +17,7 @@
 package com.ichi2.compat;
 
 import android.content.Context;
+import android.media.AudioManager;
 import android.media.ThumbnailUtils;
 import android.os.Vibrator;
 import android.provider.MediaStore;
@@ -123,5 +124,18 @@ public class CompatV21 implements Compat {
     @SuppressWarnings("deprecation")
     public boolean hasVideoThumbnail(@NonNull String path) {
         return ThumbnailUtils.createVideoThumbnail(path, MediaStore.Images.Thumbnails.MINI_KIND) != null;
+    }
+    
+    @Override
+    @SuppressWarnings("deprecation")
+    public void requestAudioFocus(AudioManager audioManager, AudioManager.OnAudioFocusChangeListener audioFocusChangeListener) {
+        audioManager.requestAudioFocus(audioFocusChangeListener, AudioManager.STREAM_MUSIC,
+                AudioManager.AUDIOFOCUS_GAIN_TRANSIENT_MAY_DUCK);
+    }
+
+    @Override
+    @SuppressWarnings("deprecation")
+    public void abandonAudioFocus(AudioManager audioManager, AudioManager.OnAudioFocusChangeListener audioFocusChangeListener) {
+        audioManager.abandonAudioFocus(audioFocusChangeListener);
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/compat/CompatV26.java
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/CompatV26.java
@@ -20,6 +20,8 @@ import android.annotation.TargetApi;
 import android.app.NotificationChannel;
 import android.app.NotificationManager;
 import android.content.Context;
+import android.media.AudioFocusRequest;
+import android.media.AudioManager;
 import android.os.VibrationEffect;
 import android.os.Vibrator;
 
@@ -82,5 +84,21 @@ public class CompatV26 extends CompatV23 implements Compat {
     @Override
     public long copyFile(@NonNull InputStream source, @NonNull String target) throws IOException {
         return Files.copy(source, Paths.get(target), StandardCopyOption.REPLACE_EXISTING);
+    }
+
+    @Override
+    public void requestAudioFocus(AudioManager audioManager, AudioManager.OnAudioFocusChangeListener audioFocusChangeListener) {
+        AudioFocusRequest audioFocusRequest = new AudioFocusRequest.Builder(AudioManager.AUDIOFOCUS_GAIN)
+                .setOnAudioFocusChangeListener(audioFocusChangeListener)
+                .build();
+        audioManager.requestAudioFocus(audioFocusRequest);
+    }
+
+    @Override
+    public void abandonAudioFocus(AudioManager audioManager, AudioManager.OnAudioFocusChangeListener audioFocusChangeListener) {
+        AudioFocusRequest audioFocusRequest = new AudioFocusRequest.Builder(AudioManager.AUDIOFOCUS_GAIN)
+                .setOnAudioFocusChangeListener(audioFocusChangeListener)
+                .build();
+        audioManager.abandonAudioFocusRequest(audioFocusRequest);
     }
 }


### PR DESCRIPTION
## Purpose / Description
Update usage of deprecated stream types in MediaPlayer and AudioManager.

Documentation links:
https://developer.android.com/reference/android/media/MediaPlayer#setAudioAttributes(android.media.AudioAttributes)
https://developer.android.com/reference/android/media/AudioManager#requestAudioFocus(android.media.AudioFocusRequest)

## Fixes
Fixes #9274 
Fixes #5022

## How Has This Been Tested?
Checked that audio functionality is working in note editor and reviewer.

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [ ] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
