### PR TITLE
Fix issue of extra whitespace on top of study options in tablet

### DIFF
--- a/AnkiDroid/src/main/res/layout/studyoptions_fragment.xml
+++ b/AnkiDroid/src/main/res/layout/studyoptions_fragment.xml
@@ -6,7 +6,6 @@
     android:layout_width="fill_parent"
     android:layout_height="fill_parent"
     android:orientation="vertical"
-    android:fitsSystemWindows="true"
     android:gravity="center">
     <RelativeLayout
         android:layout_width="fill_parent"


### PR DESCRIPTION
## Purpose / Description
Fix issue of extra whitespace on top of study options in tablet.

## Fixes
Fixes #9279 

## Approach
Removed `android:fitsSystemWindows="true"` from `study options_fragment.xml`.

## How Has This Been Tested?
Verified on emulator running Pixel C API 30.

## Screenshot
<img width="703" alt="Screenshot 2021-07-16 at 11 08 35 PM" src="https://user-images.githubusercontent.com/35566748/125987536-521017c4-f35e-4e27-ba82-1b6723047ac2.png">

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [ ] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)