### PR TITLE
NF: Start on Preference deprecation

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -571,7 +571,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
                 break;
             case DIRECTORY_NOT_ACCESSIBLE:
                 Timber.i("AnkiDroid directory inaccessible");
-                Intent i = Preferences.getPreferenceSubscreenIntent(this, "com.ichi2.anki.prefs.advanced");
+                Intent i = Preferences.AdvancedSettingsFragment.getSubscreenIntent(this);
                 startActivityForResultWithoutAnimation(i, REQUEST_PATH_UPDATE);
                 UIUtils.showThemedToast(this, R.string.directory_inaccessible, false);
                 break;

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
@@ -830,6 +830,15 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
         }
 
         /**
+         * Refreshes all values on the screen
+         * Call if a large number of values are changed from one preference.
+         */
+        protected void refreshScreen() {
+            getPreferenceScreen().removeAll();
+            initSubscreen();
+        }
+
+        /**
          * Returns a non-null context object
          * @throws IllegalStateException if the fragment is not attached to an activity
          */
@@ -1349,8 +1358,7 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
                 edit.remove("customButtonShowHideWhiteboard");
                 edit.apply();
                 // #9263: refresh the screen to display the changes
-                screen.removeAll();
-                initSubscreen();
+                refreshScreen();
                 return true;
             });
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
@@ -423,7 +423,7 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
                 });
                 // Workaround preferences
                 AdvancedSettingsFragment.removeUnnecessaryAdvancedPrefs(screen);
-                addThirdPartyAppsListener(this, screen);
+                AdvancedSettingsFragment.addThirdPartyAppsListener(this, screen);
                 break;
             case "com.ichi2.anki.prefs.custom_sync_server":
                 getSupportActionBar().setTitle(R.string.custom_sync_server_title);
@@ -477,26 +477,6 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
             throw new IllegalStateException("no context was associated with the activity.");
         }
         return context;
-    }
-
-
-    public static void addThirdPartyAppsListener(Activity activity, android.preference.PreferenceScreen screen) {
-        //#5864 - some people don't have a browser so we can't use <intent>
-        //and need to handle the keypress ourself.
-        android.preference.Preference showThirdParty = screen.findPreference("thirdpartyapps_link");
-        final String githubThirdPartyAppsUrl = "https://github.com/ankidroid/Anki-Android/wiki/Third-Party-Apps";
-        showThirdParty.setOnPreferenceClickListener((preference) -> {
-            try {
-                Intent openThirdPartyAppsIntent = new Intent(Intent.ACTION_VIEW, Uri.parse(githubThirdPartyAppsUrl));
-                activity.startActivity(openThirdPartyAppsIntent);
-            } catch (ActivityNotFoundException e) {
-                Timber.w(e);
-                //We use a different message here. We have limited space in the snackbar
-                String error = activity.getString(R.string.activity_start_failed_load_url, githubThirdPartyAppsUrl);
-                UIUtils.showSimpleSnackbar(activity, error, false);
-            }
-            return true;
-        });
     }
 
 
@@ -1303,9 +1283,28 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
                 }
             }
         }
-    }
 
+        public static void addThirdPartyAppsListener(Activity activity, android.preference.PreferenceScreen screen) {
+            //#5864 - some people don't have a browser so we can't use <intent>
+            //and need to handle the keypress ourself.
+            android.preference.Preference showThirdParty = screen.findPreference("thirdpartyapps_link");
+            final String githubThirdPartyAppsUrl = "https://github.com/ankidroid/Anki-Android/wiki/Third-Party-Apps";
+            showThirdParty.setOnPreferenceClickListener((preference) -> {
+                try {
+                    Intent openThirdPartyAppsIntent = new Intent(Intent.ACTION_VIEW, Uri.parse(githubThirdPartyAppsUrl));
+                    activity.startActivity(openThirdPartyAppsIntent);
+                } catch (ActivityNotFoundException e) {
+                    Timber.w(e);
+                    //We use a different message here. We have limited space in the snackbar
+                    String error = activity.getString(R.string.activity_start_failed_load_url, githubThirdPartyAppsUrl);
+                    UIUtils.showSimpleSnackbar(activity, error, false);
+                }
+                return true;
+            });
+        }
+    }
     public static abstract class CustomButtonsSettingsFragment extends SpecificSettingsFragment {
+
         @Override
         public int getPreferenceResource() {
             return R.xml.preferences_custom_buttons;

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
@@ -281,7 +281,7 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
             case "com.ichi2.anki.prefs.gestures":
                 listener.addPreferencesFromResource(R.xml.preferences_gestures);
                 screen = listener.getPreferenceScreen();
-                updateGestureCornerTouch(this, screen);
+                GesturesSettingsFragment.updateGestureCornerTouch(this, screen);
 
                 break;
             case "com.ichi2.anki.prefs.custom_buttons":
@@ -832,7 +832,7 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
                     AnkiCardContextMenu.ensureConsistentStateWithSharedPreferences(this);
                     break;
                 case "gestureCornerTouch": {
-                    updateGestureCornerTouch(this, screen);
+                    GesturesSettingsFragment.updateGestureCornerTouch(this, screen);
                 }
             }
             // Update the summary text to reflect new value
@@ -841,22 +841,6 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
             Timber.e(e, "Preferences: BadTokenException on showDialog");
         } catch (NumberFormatException e) {
             throw new RuntimeException(e);
-        }
-    }
-
-
-    public static void updateGestureCornerTouch(Context context, android.preference.PreferenceScreen screen) {
-        boolean gestureCornerTouch = AnkiDroidApp.getSharedPrefs(context).getBoolean("gestureCornerTouch", false);
-        if (gestureCornerTouch) {
-            screen.findPreference("gestureTapTop").setTitle(R.string.gestures_corner_tap_top_center);
-            screen.findPreference("gestureTapLeft").setTitle(R.string.gestures_corner_tap_middle_left);
-            screen.findPreference("gestureTapRight").setTitle(R.string.gestures_corner_tap_middle_right);
-            screen.findPreference("gestureTapBottom").setTitle(R.string.gestures_corner_tap_bottom_center);
-        } else {
-            screen.findPreference("gestureTapTop").setTitle(R.string.gestures_tap_top);
-            screen.findPreference("gestureTapLeft").setTitle(R.string.gestures_tap_left);
-            screen.findPreference("gestureTapRight").setTitle(R.string.gestures_tap_right);
-            screen.findPreference("gestureTapBottom").setTitle(R.string.gestures_tap_bottom);
         }
     }
 
@@ -1279,6 +1263,21 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
         @Override
         public int getPreferenceResource() {
             return R.xml.preferences_gestures;
+        }
+
+        public static void updateGestureCornerTouch(Context context, android.preference.PreferenceScreen screen) {
+            boolean gestureCornerTouch = AnkiDroidApp.getSharedPrefs(context).getBoolean("gestureCornerTouch", false);
+            if (gestureCornerTouch) {
+                screen.findPreference("gestureTapTop").setTitle(R.string.gestures_corner_tap_top_center);
+                screen.findPreference("gestureTapLeft").setTitle(R.string.gestures_corner_tap_middle_left);
+                screen.findPreference("gestureTapRight").setTitle(R.string.gestures_corner_tap_middle_right);
+                screen.findPreference("gestureTapBottom").setTitle(R.string.gestures_corner_tap_bottom_center);
+            } else {
+                screen.findPreference("gestureTapTop").setTitle(R.string.gestures_tap_top);
+                screen.findPreference("gestureTapLeft").setTitle(R.string.gestures_tap_left);
+                screen.findPreference("gestureTapRight").setTitle(R.string.gestures_tap_right);
+                screen.findPreference("gestureTapBottom").setTitle(R.string.gestures_tap_bottom);
+            }
         }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
@@ -96,7 +96,6 @@ import static com.ichi2.anim.ActivityTransitionAnimation.Direction.FADE;
 
 @SuppressWarnings("deprecation") // TODO Tracked in https://github.com/ankidroid/Anki-Android/issues/5019
 interface PreferenceContext {
-    void addPreferencesFromResource(int preferencesResId);
     android.preference.PreferenceScreen getPreferenceScreen();
 }
 
@@ -269,31 +268,6 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
     // ----------------------------------------------------------------------------
     // Class methods
     // ----------------------------------------------------------------------------
-
-    private static Intent getPreferenceSubscreenIntent(Context context, String subscreen) {
-        return SpecificSettingsFragment.getSubscreenIntent(context, subscreen, "Preferences$SettingsFragment");
-    }
-
-    private void initSubscreen(String action, PreferenceContext listener) {
-        android.preference.PreferenceScreen screen;
-        switch (action) {
-
-        }
-    }
-
-    /**
-     * Returns a non-null context object
-     * @throws IllegalStateException if the base context has not been attached
-     * This exists temporarily until initSubscreen() has been removed
-     */
-    @NonNull
-    private Context requireContext() {
-        Context context = getBaseContext();
-        if (context == null) {
-            throw new IllegalStateException("no context was associated with the activity.");
-        }
-        return context;
-    }
 
 
     /**
@@ -732,20 +706,21 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
     // ----------------------------------------------------------------------------
 
     @SuppressWarnings("deprecation") // Tracked as #5019 on github
-    public static class SettingsFragment extends android.preference.PreferenceFragment implements PreferenceContext, OnSharedPreferenceChangeListener {
+    public abstract static class SettingsFragment extends android.preference.PreferenceFragment implements PreferenceContext, OnSharedPreferenceChangeListener {
         @Override
         public void onCreate(Bundle savedInstanceState) {
             super.onCreate(savedInstanceState);
             String subscreen = getArguments().getString("subscreen");
             UsageAnalytics.sendAnalyticsScreenView(subscreen.replaceFirst("^com.ichi2.anki.", ""));
-            initSubscreen(subscreen);
+            initSubscreen();
             ((Preferences) getActivity()).initAllPreferences(getPreferenceScreen());
         }
 
-
-        protected void initSubscreen(String subscreen) {
-            ((Preferences) getActivity()).initSubscreen(subscreen, this);
-        }
+        /**
+         * Loads preferences (via addPreferencesFromResource) and sets up appropriate listeners for the preferences
+         * Called by base class, do not call directly.
+         */
+        protected abstract void initSubscreen();
 
 
         @Override
@@ -786,12 +761,6 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
         /** @return The XML file which defines the preferences displayed by this PreferenceFragment */
         @XmlRes
         public abstract int getPreferenceResource();
-
-
-        @Override
-        protected void initSubscreen(String subscreen) {
-            initSubscreen();
-        }
 
         /**
          * Refreshes all values on the screen
@@ -1099,6 +1068,7 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
     }
 
     public static class AdvancedSettingsFragment extends SpecificSettingsFragment {
+
         @Override
         public int getPreferenceResource() {
             return R.xml.preferences_advanced;

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
@@ -1194,35 +1194,29 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
                 }
                 return true;
             });
-            AppearanceSettingsFragment.initializeCustomFontsDialog(requireContext(), screen);
+            initializeCustomFontsDialog(screen);
         }
 
-
-        /**
-         * Initializes the list of custom fonts shown in the preferences.
-         */
-        public static void initializeCustomFontsDialog(Context context, android.preference.PreferenceScreen screen) {
+        /** Initializes the list of custom fonts shown in the preferences. */
+        private void initializeCustomFontsDialog(android.preference.PreferenceScreen screen) {
             android.preference.ListPreference defaultFontPreference = (android.preference.ListPreference) screen.findPreference("defaultFont");
             if (defaultFontPreference != null) {
-                defaultFontPreference.setEntries(getCustomFonts(context, "System default"));
-                defaultFontPreference.setEntryValues(getCustomFonts(context, ""));
+                defaultFontPreference.setEntries(getCustomFonts("System default"));
+                defaultFontPreference.setEntryValues(getCustomFonts(""));
             }
             android.preference.ListPreference browserEditorCustomFontsPreference = (android.preference.ListPreference) screen.findPreference("browserEditorFont");
-            browserEditorCustomFontsPreference.setEntries(getCustomFonts(context, "System default"));
-            browserEditorCustomFontsPreference.setEntryValues(getCustomFonts(context, "", true));
+            browserEditorCustomFontsPreference.setEntries(getCustomFonts("System default"));
+            browserEditorCustomFontsPreference.setEntryValues(getCustomFonts("", true));
+        }
+
+        /** Returns a list of the names of the installed custom fonts. */
+        private String[] getCustomFonts(String defaultValue) {
+            return getCustomFonts(defaultValue, false);
         }
 
 
-        /**
-         * Returns a list of the names of the installed custom fonts.
-         */
-        private static String[] getCustomFonts(Context context, String defaultValue) {
-            return getCustomFonts(context, defaultValue, false);
-        }
-
-
-        private static String[] getCustomFonts(Context context, String defaultValue, boolean useFullPath) {
-            List<AnkiFont> mFonts = Utils.getCustomFonts(context);
+        private String[] getCustomFonts(String defaultValue, boolean useFullPath) {
+            List<AnkiFont> mFonts = Utils.getCustomFonts(requireContext());
             int count = mFonts.size();
             Timber.d("There are %d custom fonts", count);
             String[] names = new String[count + 1];

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
@@ -549,6 +549,20 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
         }
     }
 
+    /**
+     * Returns a non-null context object
+     * @throws IllegalStateException if the base context has not been attached
+     * This exists temporarily until initSubscreen() has been removed
+     */
+    @NonNull
+    private Context requireContext() {
+        Context context = getBaseContext();
+        if (context == null) {
+            throw new IllegalStateException("no context was associated with the activity.");
+        }
+        return context;
+    }
+
 
     private void setupContextMenuPreference(android.preference.PreferenceScreen screen, String key, @StringRes int contextMenuName) {
         // FIXME: The menu is named in the system language (as it's defined in the manifest which may be
@@ -1214,6 +1228,18 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
             initSubscreen();
         }
 
+        /**
+         * Returns a non-null context object
+         * @throws IllegalStateException if the fragment is not attached to an activity
+         */
+        @NonNull
+        protected Context requireContext() {
+            Context context = getActivity();
+            if (context == null) {
+                throw new IllegalStateException("no context was associated with the activity.");
+            }
+            return context;
+        }
 
         /**
          * Loads preferences (via addPreferencesFromResource) and sets up appropriate listeners for the preferences

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
@@ -968,8 +968,7 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
             // Custom buttons options
             android.preference.Preference customButtonsPreference = screen.findPreference("custom_buttons_link");
             customButtonsPreference.setOnPreferenceClickListener(preference -> {
-                Intent i = getPreferenceSubscreenIntent(requireContext(),
-                        "com.ichi2.anki.prefs.custom_buttons");
+                Intent i = CustomButtonsSettingsFragment.getSubscreenIntent(requireContext());
                 startActivity(i);
                 return true;
             });
@@ -1312,6 +1311,10 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
         }
     }
     public static abstract class CustomButtonsSettingsFragment extends SpecificSettingsFragment {
+        public static Intent getSubscreenIntent(Context context) {
+            return Preferences.getPreferenceSubscreenIntent(context, "com.ichi2.anki.prefs.custom_buttons");
+        }
+
         @Override
         public int getPreferenceResource() {
             return R.xml.preferences_custom_buttons;

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
@@ -20,6 +20,7 @@
 
 package com.ichi2.anki;
 
+import android.app.Activity;
 import android.app.AlarmManager;
 import android.app.AlertDialog;
 import android.app.PendingIntent;
@@ -87,6 +88,8 @@ import androidx.annotation.Nullable;
 import androidx.annotation.StringRes;
 import androidx.annotation.VisibleForTesting;
 import androidx.annotation.XmlRes;
+import androidx.appcompat.app.ActionBar;
+import androidx.appcompat.app.AppCompatActivity;
 import timber.log.Timber;
 
 import static com.ichi2.anim.ActivityTransitionAnimation.Direction.FADE;
@@ -887,6 +890,30 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
             i.putExtra(android.preference.PreferenceActivity.EXTRA_SHOW_FRAGMENT_ARGUMENTS, extras);
             i.putExtra(android.preference.PreferenceActivity.EXTRA_NO_HEADERS, true);
             return i;
+        }
+
+        /** Sets the title of the window to the provided string */
+        protected void setTitle(@StringRes int stringRes) {
+            Activity activity = getActivity();
+
+            ActionBar supportActionBar = null;
+            if (activity instanceof AppCompatActivity) {
+                AppCompatActivity acActivity = (AppCompatActivity) activity;
+                acActivity.getSupportActionBar();
+            } else if (activity instanceof AppCompatPreferenceActivity) {
+                AppCompatPreferenceActivity apActivity = (AppCompatPreferenceActivity) activity;
+                supportActionBar = apActivity.getSupportActionBar();
+            } else {
+                Timber.w("Activity was of the wrong type");
+                return;
+            }
+
+            if (supportActionBar == null) {
+                Timber.w("No action bar detected");
+                return;
+            }
+
+            supportActionBar.setTitle(stringRes);
         }
 
         /**

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
@@ -71,7 +71,6 @@ import com.ichi2.utils.JSONObject;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
-import java.lang.annotation.Retention;
 import java.nio.channels.FileChannel;
 import java.util.Arrays;
 import java.util.Calendar;
@@ -84,13 +83,12 @@ import java.util.Set;
 import java.util.TreeMap;
 
 import androidx.annotation.NonNull;
-import androidx.annotation.StringDef;
 import androidx.annotation.StringRes;
 import androidx.annotation.VisibleForTesting;
+import androidx.annotation.XmlRes;
 import timber.log.Timber;
 
 import static com.ichi2.anim.ActivityTransitionAnimation.Direction.FADE;
-import static java.lang.annotation.RetentionPolicy.SOURCE;
 
 @SuppressWarnings("deprecation") // TODO Tracked in https://github.com/ankidroid/Anki-Android/issues/5019
 interface PreferenceContext {
@@ -1160,9 +1158,15 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
             super.onCreate(savedInstanceState);
             String subscreen = getArguments().getString("subscreen");
             UsageAnalytics.sendAnalyticsScreenView(subscreen.replaceFirst("^com.ichi2.anki.", ""));
-            ((Preferences) getActivity()).initSubscreen(subscreen, this);
+            initSubscreen(subscreen);
             ((Preferences) getActivity()).initAllPreferences(getPreferenceScreen());
         }
+
+
+        protected void initSubscreen(String subscreen) {
+            ((Preferences) getActivity()).initSubscreen(subscreen, this);
+        }
+
 
         @Override
         public void onResume() {
@@ -1186,6 +1190,35 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
         public void onSharedPreferenceChanged(SharedPreferences sharedPreferences, String key) {
             ((Preferences) getActivity()).updatePreference(sharedPreferences, key, this);
         }
+    }
+
+    /**
+     * Temporary abstraction
+     * Due to deprecation, we need to move from all Preference code in the Preference activity
+     * into separate fragments.
+     *
+     * Fragments will inherit from this class
+     *
+     * This class adds methods which were previously in Preferences, and are now shared between Settings Fragments
+     * To be merged with SettingsFragment once it can be made abstract
+     */
+    public abstract static class SpecificSettingsFragment extends SettingsFragment {
+        /** @return The XML file which defines the preferences displayed by this PreferenceFragment */
+        @XmlRes
+        public abstract int getPreferenceResource();
+
+
+        @Override
+        protected void initSubscreen(String subscreen) {
+            initSubscreen();
+        }
+
+
+        /**
+         * Loads preferences (via addPreferencesFromResource) and sets up appropriate listeners for the preferences
+         * Called by base class, do not call directly.
+         */
+        protected abstract void initSubscreen();
     }
 
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
@@ -277,39 +277,7 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
     private void initSubscreen(String action, PreferenceContext listener) {
         android.preference.PreferenceScreen screen;
         switch (action) {
-            case "com.ichi2.anki.prefs.custom_sync_server":
-                getSupportActionBar().setTitle(R.string.custom_sync_server_title);
-                listener.addPreferencesFromResource(R.xml.preferences_custom_sync_server);
-                screen = listener.getPreferenceScreen();
-                android.preference.Preference syncUrlPreference = screen.findPreference("syncBaseUrl");
-                android.preference.Preference mSyncUrlPreference = screen.findPreference("syncMediaUrl");
-                syncUrlPreference.setOnPreferenceChangeListener((preference, newValue) -> {
-                    String newUrl = newValue.toString();
-                    if (!URLUtil.isValidUrl(newUrl)) {
-                         new AlertDialog.Builder(this)
-                                .setTitle(R.string.custom_sync_server_base_url_invalid)
-                                .setPositiveButton(R.string.dialog_ok, null)
-                                .show();
 
-                        return false;
-                    }
-
-                    return true;
-                });
-                mSyncUrlPreference.setOnPreferenceChangeListener((preference, newValue) -> {
-                    String newUrl = newValue.toString();
-                    if (!URLUtil.isValidUrl(newUrl)) {
-                        new AlertDialog.Builder(this)
-                                .setTitle(R.string.custom_sync_server_media_url_invalid)
-                                .setPositiveButton(R.string.dialog_ok, null)
-                                .show();
-
-                        return false;
-                    }
-
-                    return true;
-                });
-                break;
         }
     }
 
@@ -1167,8 +1135,7 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
             // Custom sync server option
             android.preference.Preference customSyncServerPreference = screen.findPreference("custom_sync_server_link");
             customSyncServerPreference.setOnPreferenceClickListener(preference -> {
-                Intent i = getPreferenceSubscreenIntent(requireContext(),
-                        "com.ichi2.anki.prefs.custom_sync_server");
+                Intent i = CustomSyncServerSettingsFragment.getSubscreenIntent(requireContext());
                 startActivity(i);
                 return true;
             });
@@ -1378,10 +1345,51 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
         }
     }
 
-    public static abstract class CustomSyncServerSettingsFragment extends SpecificSettingsFragment {
+    public static class CustomSyncServerSettingsFragment extends SpecificSettingsFragment {
+
         @Override
         public int getPreferenceResource() {
             return R.xml.preferences_custom_sync_server;
+        }
+
+        @NonNull
+        public static Intent getSubscreenIntent(Context context) {
+            return getSubscreenIntent(context, "com.ichi2.anki.prefs.custom_sync_server", CustomSyncServerSettingsFragment.class.getSimpleName());
+        }
+
+        @Override
+        protected void initSubscreen() {
+            setTitle(R.string.custom_sync_server_title);
+            addPreferencesFromResource(R.xml.preferences_custom_sync_server);
+            android.preference.PreferenceScreen screen = getPreferenceScreen();
+            android.preference.Preference syncUrlPreference = screen.findPreference("syncBaseUrl");
+            android.preference.Preference mSyncUrlPreference = screen.findPreference("syncMediaUrl");
+            syncUrlPreference.setOnPreferenceChangeListener((preference, newValue) -> {
+                String newUrl = newValue.toString();
+                if (!URLUtil.isValidUrl(newUrl)) {
+                    new AlertDialog.Builder(requireContext())
+                            .setTitle(R.string.custom_sync_server_base_url_invalid)
+                            .setPositiveButton(R.string.dialog_ok, null)
+                            .show();
+
+                    return false;
+                }
+
+                return true;
+            });
+            mSyncUrlPreference.setOnPreferenceChangeListener((preference, newValue) -> {
+                String newUrl = newValue.toString();
+                if (!URLUtil.isValidUrl(newUrl)) {
+                    new AlertDialog.Builder(requireContext())
+                            .setTitle(R.string.custom_sync_server_media_url_invalid)
+                            .setPositiveButton(R.string.dialog_ok, null)
+                            .show();
+
+                    return false;
+                }
+
+                return true;
+            });
         }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
@@ -270,47 +270,13 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
     // Class methods
     // ----------------------------------------------------------------------------
 
-    public static Intent getPreferenceSubscreenIntent(Context context, String subscreen) {
+    private static Intent getPreferenceSubscreenIntent(Context context, String subscreen) {
         return SpecificSettingsFragment.getSubscreenIntent(context, subscreen, "Preferences$SettingsFragment");
     }
+
     private void initSubscreen(String action, PreferenceContext listener) {
         android.preference.PreferenceScreen screen;
         switch (action) {
-            case "com.ichi2.anki.prefs.custom_buttons":
-                getSupportActionBar().setTitle(R.string.custom_buttons);
-                listener.addPreferencesFromResource(R.xml.preferences_custom_buttons);
-                screen = listener.getPreferenceScreen();
-                // Reset toolbar button customizations
-                android.preference.Preference reset_custom_buttons = screen.findPreference("reset_custom_buttons");
-                reset_custom_buttons.setOnPreferenceClickListener(preference -> {
-                    SharedPreferences.Editor edit = AnkiDroidApp.getSharedPrefs(getBaseContext()).edit();
-                    edit.remove("customButtonUndo");
-                    edit.remove("customButtonScheduleCard");
-                    edit.remove("customButtonEditCard");
-                    edit.remove("customButtonTags");
-                    edit.remove("customButtonAddCard");
-                    edit.remove("customButtonReplay");
-                    edit.remove("customButtonCardInfo");
-                    edit.remove("customButtonSelectTts");
-                    edit.remove("customButtonDeckOptions");
-                    edit.remove("customButtonMarkCard");
-                    edit.remove("customButtonToggleMicToolBar");
-                    edit.remove("customButtonBury");
-                    edit.remove("customButtonSuspend");
-                    edit.remove("customButtonFlag");
-                    edit.remove("customButtonDelete");
-                    edit.remove("customButtonEnableWhiteboard");
-                    edit.remove("customButtonSaveWhiteboard");
-                    edit.remove("customButtonWhiteboardPenColor");
-                    edit.remove("customButtonClearWhiteboard");
-                    edit.remove("customButtonShowHideWhiteboard");
-                    edit.apply();
-                    // #9263: refresh the screen to display the changes
-                    screen.removeAll();
-                    initSubscreen("com.ichi2.anki.prefs.custom_buttons", listener);
-                    return true;
-                });
-                break;
             case "com.ichi2.anki.prefs.custom_sync_server":
                 getSupportActionBar().setTitle(R.string.custom_sync_server_title);
                 listener.addPreferencesFromResource(R.xml.preferences_custom_sync_server);
@@ -1337,14 +1303,56 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
             });
         }
     }
-    public static abstract class CustomButtonsSettingsFragment extends SpecificSettingsFragment {
+
+    public static class CustomButtonsSettingsFragment extends SpecificSettingsFragment {
+
+        @NonNull
         public static Intent getSubscreenIntent(Context context) {
-            return Preferences.getPreferenceSubscreenIntent(context, "com.ichi2.anki.prefs.custom_buttons");
+            return getSubscreenIntent(context,  "com.ichi2.anki.prefs.custom_buttons", CustomButtonsSettingsFragment.class.getSimpleName());
         }
+
 
         @Override
         public int getPreferenceResource() {
             return R.xml.preferences_custom_buttons;
+        }
+
+
+        @Override
+        protected void initSubscreen() {
+            setTitle(R.string.custom_buttons);
+            addPreferencesFromResource(R.xml.preferences_custom_buttons);
+            android.preference.PreferenceScreen screen = getPreferenceScreen();
+            // Reset toolbar button customizations
+            android.preference.Preference reset_custom_buttons = screen.findPreference("reset_custom_buttons");
+            reset_custom_buttons.setOnPreferenceClickListener(preference -> {
+                SharedPreferences.Editor edit = AnkiDroidApp.getSharedPrefs(requireContext()).edit();
+                edit.remove("customButtonUndo");
+                edit.remove("customButtonScheduleCard");
+                edit.remove("customButtonEditCard");
+                edit.remove("customButtonTags");
+                edit.remove("customButtonAddCard");
+                edit.remove("customButtonReplay");
+                edit.remove("customButtonCardInfo");
+                edit.remove("customButtonSelectTts");
+                edit.remove("customButtonDeckOptions");
+                edit.remove("customButtonMarkCard");
+                edit.remove("customButtonToggleMicToolBar");
+                edit.remove("customButtonBury");
+                edit.remove("customButtonSuspend");
+                edit.remove("customButtonFlag");
+                edit.remove("customButtonDelete");
+                edit.remove("customButtonEnableWhiteboard");
+                edit.remove("customButtonSaveWhiteboard");
+                edit.remove("customButtonWhiteboardPenColor");
+                edit.remove("customButtonClearWhiteboard");
+                edit.remove("customButtonShowHideWhiteboard");
+                edit.apply();
+                // #9263: refresh the screen to display the changes
+                screen.removeAll();
+                initSubscreen();
+                return true;
+            });
         }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
@@ -267,13 +267,7 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
     // ----------------------------------------------------------------------------
 
     public static Intent getPreferenceSubscreenIntent(Context context, String subscreen) {
-        Intent i = new Intent(context, Preferences.class);
-        i.putExtra(android.preference.PreferenceActivity.EXTRA_SHOW_FRAGMENT, "com.ichi2.anki.Preferences$SettingsFragment");
-        Bundle extras = new Bundle();
-        extras.putString("subscreen", subscreen);
-        i.putExtra(android.preference.PreferenceActivity.EXTRA_SHOW_FRAGMENT_ARGUMENTS, extras);
-        i.putExtra(android.preference.PreferenceActivity.EXTRA_NO_HEADERS, true);
-        return i;
+        return SpecificSettingsFragment.getSubscreenIntent(context, subscreen, "Preferences$SettingsFragment");
     }
     private void initSubscreen(String action, PreferenceContext listener) {
         android.preference.PreferenceScreen screen;
@@ -1041,6 +1035,17 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
                 throw new IllegalStateException("no context was associated with the activity.");
             }
             return context;
+        }
+
+        @NonNull
+        protected static Intent getSubscreenIntent(Context context, String subscreen, String className) {
+            Intent i = new Intent(context, Preferences.class);
+            i.putExtra(android.preference.PreferenceActivity.EXTRA_SHOW_FRAGMENT, "com.ichi2.anki.Preferences$" + className);
+            Bundle extras = new Bundle();
+            extras.putString("subscreen", subscreen);
+            i.putExtra(android.preference.PreferenceActivity.EXTRA_SHOW_FRAGMENT_ARGUMENTS, extras);
+            i.putExtra(android.preference.PreferenceActivity.EXTRA_NO_HEADERS, true);
+            return i;
         }
 
         /**

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
@@ -293,7 +293,7 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
                     mCategory.removePreference(mCheckBoxPref_Blink);
                 }
                 // Build languages
-                initializeLanguageDialog(screen, requireContext());
+                GeneralSettingsFragment.initializeLanguageDialog(screen, requireContext());
                 break;
             case "com.ichi2.anki.prefs.reviewing":
                 listener.addPreferencesFromResource(R.xml.preferences_reviewing);
@@ -1063,30 +1063,6 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
         }
     }
 
-    public static void initializeLanguageDialog(android.preference.PreferenceScreen screen, Context context) {
-        android.preference.ListPreference languageSelection = (android.preference.ListPreference) screen.findPreference(LANGUAGE);
-        if (languageSelection != null) {
-            Map<String, String> items = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
-            for (String localeCode : LanguageUtil.APP_LANGUAGES) {
-                Locale loc = LanguageUtil.getLocale(localeCode);
-                items.put(loc.getDisplayName(loc), loc.toString());
-            }
-            CharSequence[] languageDialogLabels = new CharSequence[items.size() + 1];
-            CharSequence[] languageDialogValues = new CharSequence[items.size() + 1];
-            languageDialogLabels[0] = context.getResources().getString(R.string.language_system);
-            languageDialogValues[0] = "";
-            int i = 1;
-            for (Map.Entry<String, String> e : items.entrySet()) {
-                languageDialogLabels[i] = e.getKey();
-                languageDialogValues[i] = e.getValue();
-                i++;
-            }
-
-            languageSelection.setEntries(languageDialogLabels);
-            languageSelection.setEntryValues(languageDialogValues);
-        }
-    }
-
     private void removeUnnecessaryAdvancedPrefs(android.preference.PreferenceScreen screen) {
         android.preference.PreferenceCategory plugins = (android.preference.PreferenceCategory) screen.findPreference("category_plugins");
         // Disable the emoji/kana buttons to scroll preference if those keys don't exist
@@ -1252,6 +1228,30 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
         @Override
         public int getPreferenceResource() {
             return R.xml.preferences_general;
+        }
+
+        public static void initializeLanguageDialog(android.preference.PreferenceScreen screen, Context context) {
+            android.preference.ListPreference languageSelection = (android.preference.ListPreference) screen.findPreference(LANGUAGE);
+            if (languageSelection != null) {
+                Map<String, String> items = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+                for (String localeCode : LanguageUtil.APP_LANGUAGES) {
+                    Locale loc = LanguageUtil.getLocale(localeCode);
+                    items.put(loc.getDisplayName(loc), loc.toString());
+                }
+                CharSequence[] languageDialogLabels = new CharSequence[items.size() + 1];
+                CharSequence[] languageDialogValues = new CharSequence[items.size() + 1];
+                languageDialogLabels[0] = context.getResources().getString(R.string.language_system);
+                languageDialogValues[0] = "";
+                int i = 1;
+                for (Map.Entry<String, String> e : items.entrySet()) {
+                    languageDialogLabels[i] = e.getKey();
+                    languageDialogValues[i] = e.getValue();
+                    i++;
+                }
+
+                languageSelection.setEntries(languageDialogLabels);
+                languageSelection.setEntryValues(languageDialogValues);
+            }
         }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
@@ -311,7 +311,7 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
                     }
                     return true;
                 });
-                initializeCustomFontsDialog(requireContext(), screen);
+                AppearanceSettingsFragment.initializeCustomFontsDialog(requireContext(), screen);
                 break;
             case "com.ichi2.anki.prefs.gestures":
                 listener.addPreferencesFromResource(R.xml.preferences_gestures);
@@ -1044,46 +1044,6 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
     }
 
 
-    /** Initializes the list of custom fonts shown in the preferences. */
-    public static void initializeCustomFontsDialog(Context context, android.preference.PreferenceScreen screen) {
-        android.preference.ListPreference defaultFontPreference = (android.preference.ListPreference) screen.findPreference("defaultFont");
-        if (defaultFontPreference != null) {
-            defaultFontPreference.setEntries(getCustomFonts(context, "System default"));
-            defaultFontPreference.setEntryValues(getCustomFonts(context, ""));
-        }
-        android.preference.ListPreference browserEditorCustomFontsPreference = (android.preference.ListPreference) screen.findPreference("browserEditorFont");
-        browserEditorCustomFontsPreference.setEntries(getCustomFonts(context, "System default"));
-        browserEditorCustomFontsPreference.setEntryValues(getCustomFonts(context, "", true));
-    }
-
-
-    /** Returns a list of the names of the installed custom fonts. */
-    private static String[] getCustomFonts(Context context, String defaultValue) {
-        return getCustomFonts(context, defaultValue, false);
-    }
-
-
-    private static String[] getCustomFonts(Context context, String defaultValue, boolean useFullPath) {
-        List<AnkiFont> mFonts = Utils.getCustomFonts(context);
-        int count = mFonts.size();
-        Timber.d("There are %d custom fonts", count);
-        String[] names = new String[count + 1];
-        names[0] = defaultValue;
-        if (useFullPath) {
-            for (int index = 1; index < count + 1; ++index) {
-                names[index] = mFonts.get(index - 1).getPath();
-                Timber.d("Adding custom font: %s", names[index]);
-            }
-        } else {
-            for (int index = 1; index < count + 1; ++index) {
-                names[index] = mFonts.get(index - 1).getName();
-                Timber.d("Adding custom font: %s", names[index]);
-            }
-        }
-        return names;
-    }
-
-
     private void closePreferences() {
         finish();
         ActivityTransitionAnimation.slide(this, FADE);
@@ -1270,6 +1230,45 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
         @Override
         public int getPreferenceResource() {
             return R.xml.preferences_appearance;
+        }
+
+        /** Initializes the list of custom fonts shown in the preferences. */
+        public static void initializeCustomFontsDialog(Context context, android.preference.PreferenceScreen screen) {
+            android.preference.ListPreference defaultFontPreference = (android.preference.ListPreference) screen.findPreference("defaultFont");
+            if (defaultFontPreference != null) {
+                defaultFontPreference.setEntries(getCustomFonts(context, "System default"));
+                defaultFontPreference.setEntryValues(getCustomFonts(context, ""));
+            }
+            android.preference.ListPreference browserEditorCustomFontsPreference = (android.preference.ListPreference) screen.findPreference("browserEditorFont");
+            browserEditorCustomFontsPreference.setEntries(getCustomFonts(context, "System default"));
+            browserEditorCustomFontsPreference.setEntryValues(getCustomFonts(context, "", true));
+        }
+
+
+        /** Returns a list of the names of the installed custom fonts. */
+        private static String[] getCustomFonts(Context context, String defaultValue) {
+            return getCustomFonts(context, defaultValue, false);
+        }
+
+
+        private static String[] getCustomFonts(Context context, String defaultValue, boolean useFullPath) {
+            List<AnkiFont> mFonts = Utils.getCustomFonts(context);
+            int count = mFonts.size();
+            Timber.d("There are %d custom fonts", count);
+            String[] names = new String[count + 1];
+            names[0] = defaultValue;
+            if (useFullPath) {
+                for (int index = 1; index < count + 1; ++index) {
+                    names[index] = mFonts.get(index - 1).getPath();
+                    Timber.d("Adding custom font: %s", names[index]);
+                }
+            } else {
+                for (int index = 1; index < count + 1; ++index) {
+                    names[index] = mFonts.get(index - 1).getName();
+                    Timber.d("Adding custom font: %s", names[index]);
+                }
+            }
+            return names;
         }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
@@ -282,31 +282,6 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
     private void initSubscreen(String action, PreferenceContext listener) {
         android.preference.PreferenceScreen screen;
         switch (action) {
-            case "com.ichi2.anki.prefs.reviewing":
-                listener.addPreferencesFromResource(R.xml.preferences_reviewing);
-                screen = listener.getPreferenceScreen();
-                // Show error toast if the user tries to disable answer button without gestures on
-                android.preference.ListPreference fullscreenPreference = (android.preference.ListPreference)
-                        screen.findPreference(FullScreenMode.PREF_KEY);
-                fullscreenPreference.setOnPreferenceChangeListener((preference, newValue) -> {
-                    SharedPreferences prefs = AnkiDroidApp.getSharedPrefs(Preferences.this);
-                    if (prefs.getBoolean("gestures", false) || !FullScreenMode.FULLSCREEN_ALL_GONE.getPreferenceValue().equals(newValue)) {
-                        return true;
-                    } else {
-                        UIUtils.showThemedToast(getApplicationContext(),
-                                R.string.full_screen_error_gestures, false);
-                        return false;
-                    }
-                });
-                // Custom buttons options
-                android.preference.Preference customButtonsPreference = screen.findPreference("custom_buttons_link");
-                customButtonsPreference.setOnPreferenceClickListener(preference -> {
-                    Intent i = getPreferenceSubscreenIntent(Preferences.this,
-                            "com.ichi2.anki.prefs.custom_buttons");
-                    startActivity(i);
-                    return true;
-                });
-                break;
             case "com.ichi2.anki.prefs.appearance":
                 listener.addPreferencesFromResource(R.xml.preferences_appearance);
                 screen = listener.getPreferenceScreen();
@@ -1257,10 +1232,37 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
         }
     }
 
-    public static abstract class ReviewingSettingsFragment extends SpecificSettingsFragment {
+    public static class ReviewingSettingsFragment extends SpecificSettingsFragment {
         @Override
         public int getPreferenceResource() {
             return R.xml.preferences_reviewing;
+        }
+
+        @Override
+        protected void initSubscreen() {
+            addPreferencesFromResource(R.xml.preferences_reviewing);
+            android.preference.PreferenceScreen screen = getPreferenceScreen();
+            // Show error toast if the user tries to disable answer button without gestures on
+            android.preference.ListPreference fullscreenPreference = (android.preference.ListPreference)
+                    screen.findPreference(FullScreenMode.PREF_KEY);
+            fullscreenPreference.setOnPreferenceChangeListener((preference, newValue) -> {
+                SharedPreferences prefs = AnkiDroidApp.getSharedPrefs(requireContext());
+                if (prefs.getBoolean("gestures", false) || !FullScreenMode.FULLSCREEN_ALL_GONE.getPreferenceValue().equals(newValue)) {
+                    return true;
+                } else {
+                    UIUtils.showThemedToast(requireContext(),
+                            R.string.full_screen_error_gestures, false);
+                    return false;
+                }
+            });
+            // Custom buttons options
+            android.preference.Preference customButtonsPreference = screen.findPreference("custom_buttons_link");
+            customButtonsPreference.setOnPreferenceClickListener(preference -> {
+                Intent i = getPreferenceSubscreenIntent(requireContext(),
+                        "com.ichi2.anki.prefs.custom_buttons");
+                startActivity(i);
+                return true;
+            });
         }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
@@ -345,8 +345,8 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
                     startActivity(i);
                     return true;
                 });
-                setupContextMenuPreference(requireContext(), screen, CardBrowserContextMenu.CARD_BROWSER_CONTEXT_MENU_PREF_KEY, R.string.card_browser_context_menu);
-                setupContextMenuPreference(requireContext(), screen, AnkiCardContextMenu.ANKI_CARD_CONTEXT_MENU_PREF_KEY, R.string.context_menu_anki_card_label);
+                AdvancedSettingsFragment.setupContextMenuPreference(requireContext(), screen, CardBrowserContextMenu.CARD_BROWSER_CONTEXT_MENU_PREF_KEY, R.string.card_browser_context_menu);
+                AdvancedSettingsFragment.setupContextMenuPreference(requireContext(), screen, AnkiCardContextMenu.ANKI_CARD_CONTEXT_MENU_PREF_KEY, R.string.context_menu_anki_card_label);
 
                 // Make it possible to test crash reporting, but only for DEBUG builds
                 if (BuildConfig.DEBUG && !AdaptionUtil.isUserATestClient()) {
@@ -478,16 +478,6 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
         return context;
     }
 
-
-    public static void setupContextMenuPreference(Context context, android.preference.PreferenceScreen screen, String key, @StringRes int contextMenuName) {
-        // FIXME: The menu is named in the system language (as it's defined in the manifest which may be
-        //  different than the app language
-        android.preference.CheckBoxPreference cardBrowserContextMenuPreference = (android.preference.CheckBoxPreference) screen.findPreference(key);
-        String menuName = context.getString(contextMenuName);
-        // Note: The below format strings are generic, not card browser specific despite the name
-        cardBrowserContextMenuPreference.setTitle(context.getString(R.string.card_browser_enable_external_context_menu, menuName));
-        cardBrowserContextMenuPreference.setSummary(context.getString(R.string.card_browser_enable_external_context_menu_summary, menuName));
-    }
 
     private void addThirdPartyAppsListener(android.preference.PreferenceScreen screen) {
         //#5864 - some people don't have a browser so we can't use <intent>
@@ -1301,6 +1291,16 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
         @NonNull
         public static Intent getSubscreenIntent(Context context) {
             return Preferences.getPreferenceSubscreenIntent(context, "com.ichi2.anki.prefs.advanced");
+        }
+
+        public static void setupContextMenuPreference(Context context, android.preference.PreferenceScreen screen, String key, @StringRes int contextMenuName) {
+            // FIXME: The menu is named in the system language (as it's defined in the manifest which may be
+            //  different than the app language
+            android.preference.CheckBoxPreference cardBrowserContextMenuPreference = (android.preference.CheckBoxPreference) screen.findPreference(key);
+            String menuName = context.getString(contextMenuName);
+            // Note: The below format strings are generic, not card browser specific despite the name
+            cardBrowserContextMenuPreference.setTitle(context.getString(R.string.card_browser_enable_external_context_menu, menuName));
+            cardBrowserContextMenuPreference.setSummary(context.getString(R.string.card_browser_enable_external_context_menu_summary, menuName));
         }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
@@ -278,12 +278,6 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
     private void initSubscreen(String action, PreferenceContext listener) {
         android.preference.PreferenceScreen screen;
         switch (action) {
-            case "com.ichi2.anki.prefs.gestures":
-                listener.addPreferencesFromResource(R.xml.preferences_gestures);
-                screen = listener.getPreferenceScreen();
-                GesturesSettingsFragment.updateGestureCornerTouch(this, screen);
-
-                break;
             case "com.ichi2.anki.prefs.custom_buttons":
                 getSupportActionBar().setTitle(R.string.custom_buttons);
                 listener.addPreferencesFromResource(R.xml.preferences_custom_buttons);
@@ -1259,10 +1253,22 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
         }
     }
 
-    public static abstract class GesturesSettingsFragment extends SpecificSettingsFragment {
+    public static class GesturesSettingsFragment extends SpecificSettingsFragment {
         @Override
         public int getPreferenceResource() {
             return R.xml.preferences_gestures;
+        }
+
+
+        @Override
+        protected void initSubscreen() {
+            addPreferencesFromResource(R.xml.preferences_gestures);
+            android.preference.PreferenceScreen screen = getPreferenceScreen();
+            updateGestureCornerTouch(screen);
+        }
+
+        private void updateGestureCornerTouch(android.preference.PreferenceScreen screen) {
+            updateGestureCornerTouch(requireContext(), screen);
         }
 
         public static void updateGestureCornerTouch(Context context, android.preference.PreferenceScreen screen) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
@@ -311,7 +311,7 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
                     }
                     return true;
                 });
-                initializeCustomFontsDialog(screen);
+                initializeCustomFontsDialog(requireContext(), screen);
                 break;
             case "com.ichi2.anki.prefs.gestures":
                 listener.addPreferencesFromResource(R.xml.preferences_gestures);
@@ -1045,26 +1045,26 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
 
 
     /** Initializes the list of custom fonts shown in the preferences. */
-    private void initializeCustomFontsDialog(android.preference.PreferenceScreen screen) {
+    public static void initializeCustomFontsDialog(Context context, android.preference.PreferenceScreen screen) {
         android.preference.ListPreference defaultFontPreference = (android.preference.ListPreference) screen.findPreference("defaultFont");
         if (defaultFontPreference != null) {
-            defaultFontPreference.setEntries(getCustomFonts("System default"));
-            defaultFontPreference.setEntryValues(getCustomFonts(""));
+            defaultFontPreference.setEntries(getCustomFonts(context, "System default"));
+            defaultFontPreference.setEntryValues(getCustomFonts(context, ""));
         }
         android.preference.ListPreference browserEditorCustomFontsPreference = (android.preference.ListPreference) screen.findPreference("browserEditorFont");
-        browserEditorCustomFontsPreference.setEntries(getCustomFonts("System default"));
-        browserEditorCustomFontsPreference.setEntryValues(getCustomFonts("", true));
+        browserEditorCustomFontsPreference.setEntries(getCustomFonts(context, "System default"));
+        browserEditorCustomFontsPreference.setEntryValues(getCustomFonts(context, "", true));
     }
 
 
     /** Returns a list of the names of the installed custom fonts. */
-    private String[] getCustomFonts(String defaultValue) {
-        return getCustomFonts(defaultValue, false);
+    private static String[] getCustomFonts(Context context, String defaultValue) {
+        return getCustomFonts(context, defaultValue, false);
     }
 
 
-    private String[] getCustomFonts(String defaultValue, boolean useFullPath) {
-        List<AnkiFont> mFonts = Utils.getCustomFonts(this);
+    private static String[] getCustomFonts(Context context, String defaultValue, boolean useFullPath) {
+        List<AnkiFont> mFonts = Utils.getCustomFonts(context);
         int count = mFonts.size();
         Timber.d("There are %d custom fonts", count);
         String[] names = new String[count + 1];

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
@@ -212,7 +212,8 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
 
     @Override
     protected boolean isValidFragment(String fragmentName) {
-        return SettingsFragment.class.getName().equals(fragmentName);
+        // Fragments are valid if they are inner classes of Preferences.java
+        return fragmentName.startsWith("com.ichi2.anki.Preferences$");
     }
 
 
@@ -1219,6 +1220,62 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
          * Called by base class, do not call directly.
          */
         protected abstract void initSubscreen();
+    }
+
+    public static abstract class GeneralSettingsFragment extends SpecificSettingsFragment {
+        @Override
+        public int getPreferenceResource() {
+            return R.xml.preferences_general;
+        }
+    }
+
+    public static abstract class ReviewingSettingsFragment extends SpecificSettingsFragment {
+        @Override
+        public int getPreferenceResource() {
+            return R.xml.preferences_reviewing;
+        }
+    }
+
+    public static abstract class AppearanceSettingsFragment extends SpecificSettingsFragment {
+        @Override
+        public int getPreferenceResource() {
+            return R.xml.preferences_appearance;
+        }
+    }
+
+    public static abstract class GesturesSettingsFragment extends SpecificSettingsFragment {
+        @Override
+        public int getPreferenceResource() {
+            return R.xml.preferences_gestures;
+        }
+    }
+
+    public static abstract class AdvancedSettingsFragment extends SpecificSettingsFragment {
+        @Override
+        public int getPreferenceResource() {
+            return R.xml.preferences_advanced;
+        }
+    }
+
+    public static abstract class CustomButtonsSettingsFragment extends SpecificSettingsFragment {
+        @Override
+        public int getPreferenceResource() {
+            return R.xml.preferences_custom_buttons;
+        }
+    }
+
+    public static abstract class AdvancedStatisticsSettingsFragment extends SpecificSettingsFragment {
+        @Override
+        public int getPreferenceResource() {
+            return R.xml.preferences_advanced_statistics;
+        }
+    }
+
+    public static abstract class CustomSyncServerSettingsFragment extends SpecificSettingsFragment {
+        @Override
+        public int getPreferenceResource() {
+            return R.xml.preferences_custom_sync_server;
+        }
     }
 
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
@@ -345,8 +345,8 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
                     startActivity(i);
                     return true;
                 });
-                setupContextMenuPreference(screen, CardBrowserContextMenu.CARD_BROWSER_CONTEXT_MENU_PREF_KEY, R.string.card_browser_context_menu);
-                setupContextMenuPreference(screen, AnkiCardContextMenu.ANKI_CARD_CONTEXT_MENU_PREF_KEY, R.string.context_menu_anki_card_label);
+                setupContextMenuPreference(requireContext(), screen, CardBrowserContextMenu.CARD_BROWSER_CONTEXT_MENU_PREF_KEY, R.string.card_browser_context_menu);
+                setupContextMenuPreference(requireContext(), screen, AnkiCardContextMenu.ANKI_CARD_CONTEXT_MENU_PREF_KEY, R.string.context_menu_anki_card_label);
 
                 // Make it possible to test crash reporting, but only for DEBUG builds
                 if (BuildConfig.DEBUG && !AdaptionUtil.isUserATestClient()) {
@@ -479,14 +479,14 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
     }
 
 
-    private void setupContextMenuPreference(android.preference.PreferenceScreen screen, String key, @StringRes int contextMenuName) {
+    public static void setupContextMenuPreference(Context context, android.preference.PreferenceScreen screen, String key, @StringRes int contextMenuName) {
         // FIXME: The menu is named in the system language (as it's defined in the manifest which may be
         //  different than the app language
         android.preference.CheckBoxPreference cardBrowserContextMenuPreference = (android.preference.CheckBoxPreference) screen.findPreference(key);
-        String menuName = getString(contextMenuName);
+        String menuName = context.getString(contextMenuName);
         // Note: The below format strings are generic, not card browser specific despite the name
-        cardBrowserContextMenuPreference.setTitle(getString(R.string.card_browser_enable_external_context_menu, menuName));
-        cardBrowserContextMenuPreference.setSummary(getString(R.string.card_browser_enable_external_context_menu_summary, menuName));
+        cardBrowserContextMenuPreference.setTitle(context.getString(R.string.card_browser_enable_external_context_menu, menuName));
+        cardBrowserContextMenuPreference.setSummary(context.getString(R.string.card_browser_enable_external_context_menu_summary, menuName));
     }
 
     private void addThirdPartyAppsListener(android.preference.PreferenceScreen screen) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
@@ -297,16 +297,16 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
                         }
                     } else {
                         mBackgroundImage.setChecked(false);
-                        String currentAnkiDroidDirectory = CollectionHelper.getCurrentAnkiDroidDirectory(this);
+                        String currentAnkiDroidDirectory = CollectionHelper.getCurrentAnkiDroidDirectory(requireContext());
                         File imgFile = new File(currentAnkiDroidDirectory, "DeckPickerBackground.png" );
                         if (imgFile.exists()) {
                             if (imgFile.delete()) {
-                                UIUtils.showThemedToast(this, getString(R.string.background_image_removed), false);
+                                UIUtils.showThemedToast(requireContext(), getString(R.string.background_image_removed), false);
                             } else {
-                                UIUtils.showThemedToast(this, getString(R.string.error_deleting_image), false);
+                                UIUtils.showThemedToast(requireContext(), getString(R.string.error_deleting_image), false);
                             }
                         } else {
-                            UIUtils.showThemedToast(this, getString(R.string.background_image_removed), false);
+                            UIUtils.showThemedToast(requireContext(), getString(R.string.background_image_removed), false);
                         }
                     }
                     return true;
@@ -545,12 +545,12 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
             if (requestCode == RESULT_LOAD_IMG && resultCode == RESULT_OK && null != data) {
                 Uri selectedImage = data.getData();
                 String[] filePathColumn = { MediaStore.MediaColumns.SIZE };
-                try (Cursor cursor = getContentResolver().query(selectedImage, filePathColumn, null, null, null)) {
+                try (Cursor cursor = requireContext().getContentResolver().query(selectedImage, filePathColumn, null, null, null)) {
                     cursor.moveToFirst();
                     // file size in MB
                     long fileLength = cursor.getLong(0) / (1024 * 1024);
 
-                    String currentAnkiDroidDirectory = CollectionHelper.getCurrentAnkiDroidDirectory(this);
+                    String currentAnkiDroidDirectory = CollectionHelper.getCurrentAnkiDroidDirectory(requireContext());
                     String imageName = "DeckPickerBackground.png";
                     File destFile = new File(currentAnkiDroidDirectory, imageName);
                     // Image size less than 10 MB copied to AnkiDroid folder
@@ -558,20 +558,20 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
                         try (FileChannel sourceChannel = ((FileInputStream) getContentResolver().openInputStream(selectedImage)).getChannel();
                              FileChannel destChannel = new FileOutputStream(destFile).getChannel()) {
                             destChannel.transferFrom(sourceChannel, 0, sourceChannel.size());
-                            UIUtils.showThemedToast(this, getString(R.string.background_image_applied), false);
+                            UIUtils.showThemedToast(requireContext(), getString(R.string.background_image_applied), false);
                         }
                     } else {
                         mBackgroundImage.setChecked(false);
-                        UIUtils.showThemedToast(this, getString(R.string.image_max_size_allowed, 10), false);
+                        UIUtils.showThemedToast(requireContext(), getString(R.string.image_max_size_allowed, 10), false);
                     }
                 }
             } else {
                 mBackgroundImage.setChecked(false);
-                UIUtils.showThemedToast(this, getString(R.string.no_image_selected), false);
+                UIUtils.showThemedToast(requireContext(), getString(R.string.no_image_selected), false);
             }
         } catch (OutOfMemoryError | Exception e) {
             Timber.w(e);
-            UIUtils.showThemedToast(this, getString(R.string.error_selecting_image, e.getLocalizedMessage()), false);
+            UIUtils.showThemedToast(requireContext(), getString(R.string.error_selecting_image, e.getLocalizedMessage()), false);
         }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
@@ -1297,6 +1297,11 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
         public int getPreferenceResource() {
             return R.xml.preferences_advanced;
         }
+
+        @NonNull
+        public static Intent getSubscreenIntent(Context context) {
+            return Preferences.getPreferenceSubscreenIntent(context, "com.ichi2.anki.prefs.advanced");
+        }
     }
 
     public static abstract class CustomButtonsSettingsFragment extends SpecificSettingsFragment {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
@@ -421,7 +421,7 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
                     UIUtils.showThemedToast(getApplicationContext(), android.R.string.ok, true);
                 });
                 // Workaround preferences
-                removeUnnecessaryAdvancedPrefs(screen);
+                AdvancedSettingsFragment.removeUnnecessaryAdvancedPrefs(screen);
                 addThirdPartyAppsListener(screen);
                 break;
             case "com.ichi2.anki.prefs.custom_sync_server":
@@ -913,24 +913,6 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
         }
     }
 
-    public static void removeUnnecessaryAdvancedPrefs(android.preference.PreferenceScreen screen) {
-        android.preference.PreferenceCategory plugins = (android.preference.PreferenceCategory) screen.findPreference("category_plugins");
-        // Disable the emoji/kana buttons to scroll preference if those keys don't exist
-        if (!CompatHelper.hasKanaAndEmojiKeys()) {
-            android.preference.CheckBoxPreference emojiScrolling = (android.preference.CheckBoxPreference) screen.findPreference("scrolling_buttons");
-            if (emojiScrolling != null && plugins != null) {
-                plugins.removePreference(emojiScrolling);
-            }
-        }
-        // Disable the double scroll preference if no scrolling keys
-        if (!CompatHelper.hasScrollKeys() && !CompatHelper.hasKanaAndEmojiKeys()) {
-            android.preference.CheckBoxPreference doubleScrolling = (android.preference.CheckBoxPreference) screen.findPreference("double_scrolling");
-            if (doubleScrolling != null && plugins != null) {
-                plugins.removePreference(doubleScrolling);
-            }
-        }
-    }
-
 
     private void closePreferences() {
         finish();
@@ -1301,6 +1283,24 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
             // Note: The below format strings are generic, not card browser specific despite the name
             cardBrowserContextMenuPreference.setTitle(context.getString(R.string.card_browser_enable_external_context_menu, menuName));
             cardBrowserContextMenuPreference.setSummary(context.getString(R.string.card_browser_enable_external_context_menu_summary, menuName));
+        }
+        
+        public static void removeUnnecessaryAdvancedPrefs(android.preference.PreferenceScreen screen) {
+            android.preference.PreferenceCategory plugins = (android.preference.PreferenceCategory) screen.findPreference("category_plugins");
+            // Disable the emoji/kana buttons to scroll preference if those keys don't exist
+            if (!CompatHelper.hasKanaAndEmojiKeys()) {
+                android.preference.CheckBoxPreference emojiScrolling = (android.preference.CheckBoxPreference) screen.findPreference("scrolling_buttons");
+                if (emojiScrolling != null && plugins != null) {
+                    plugins.removePreference(emojiScrolling);
+                }
+            }
+            // Disable the double scroll preference if no scrolling keys
+            if (!CompatHelper.hasScrollKeys() && !CompatHelper.hasKanaAndEmojiKeys()) {
+                android.preference.CheckBoxPreference doubleScrolling = (android.preference.CheckBoxPreference) screen.findPreference("double_scrolling");
+                if (doubleScrolling != null && plugins != null) {
+                    plugins.removePreference(doubleScrolling);
+                }
+            }
         }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
@@ -20,6 +20,7 @@
 
 package com.ichi2.anki;
 
+import android.app.Activity;
 import android.app.AlarmManager;
 import android.app.AlertDialog;
 import android.app.PendingIntent;
@@ -422,7 +423,7 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
                 });
                 // Workaround preferences
                 AdvancedSettingsFragment.removeUnnecessaryAdvancedPrefs(screen);
-                addThirdPartyAppsListener(screen);
+                addThirdPartyAppsListener(this, screen);
                 break;
             case "com.ichi2.anki.prefs.custom_sync_server":
                 getSupportActionBar().setTitle(R.string.custom_sync_server_title);
@@ -479,7 +480,7 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
     }
 
 
-    private void addThirdPartyAppsListener(android.preference.PreferenceScreen screen) {
+    public static void addThirdPartyAppsListener(Activity activity, android.preference.PreferenceScreen screen) {
         //#5864 - some people don't have a browser so we can't use <intent>
         //and need to handle the keypress ourself.
         android.preference.Preference showThirdParty = screen.findPreference("thirdpartyapps_link");
@@ -487,12 +488,12 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
         showThirdParty.setOnPreferenceClickListener((preference) -> {
             try {
                 Intent openThirdPartyAppsIntent = new Intent(Intent.ACTION_VIEW, Uri.parse(githubThirdPartyAppsUrl));
-                super.startActivity(openThirdPartyAppsIntent);
+                activity.startActivity(openThirdPartyAppsIntent);
             } catch (ActivityNotFoundException e) {
                 Timber.w(e);
                 //We use a different message here. We have limited space in the snackbar
-                String error = getString(R.string.activity_start_failed_load_url, githubThirdPartyAppsUrl);
-                UIUtils.showSimpleSnackbar(this, error, false);
+                String error = activity.getString(R.string.activity_start_failed_load_url, githubThirdPartyAppsUrl);
+                UIUtils.showSimpleSnackbar(activity, error, false);
             }
             return true;
         });
@@ -1284,7 +1285,7 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
             cardBrowserContextMenuPreference.setTitle(context.getString(R.string.card_browser_enable_external_context_menu, menuName));
             cardBrowserContextMenuPreference.setSummary(context.getString(R.string.card_browser_enable_external_context_menu_summary, menuName));
         }
-        
+
         public static void removeUnnecessaryAdvancedPrefs(android.preference.PreferenceScreen screen) {
             android.preference.PreferenceCategory plugins = (android.preference.PreferenceCategory) screen.findPreference("category_plugins");
             // Disable the emoji/kana buttons to scroll preference if those keys don't exist

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
@@ -20,7 +20,6 @@
 
 package com.ichi2.anki;
 
-import android.app.Activity;
 import android.app.AlarmManager;
 import android.app.AlertDialog;
 import android.app.PendingIntent;
@@ -1184,8 +1183,8 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
                 startActivity(i);
                 return true;
             });
-            AdvancedSettingsFragment.setupContextMenuPreference(requireContext(), screen, CardBrowserContextMenu.CARD_BROWSER_CONTEXT_MENU_PREF_KEY, R.string.card_browser_context_menu);
-            AdvancedSettingsFragment.setupContextMenuPreference(requireContext(), screen, AnkiCardContextMenu.ANKI_CARD_CONTEXT_MENU_PREF_KEY, R.string.context_menu_anki_card_label);
+            setupContextMenuPreference(screen, CardBrowserContextMenu.CARD_BROWSER_CONTEXT_MENU_PREF_KEY, R.string.card_browser_context_menu);
+            setupContextMenuPreference(screen, AnkiCardContextMenu.ANKI_CARD_CONTEXT_MENU_PREF_KEY, R.string.context_menu_anki_card_label);
 
             // Make it possible to test crash reporting, but only for DEBUG builds
             if (BuildConfig.DEBUG && !AdaptionUtil.isUserATestClient()) {
@@ -1260,21 +1259,21 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
                 UIUtils.showThemedToast(requireContext(), android.R.string.ok, true);
             });
             // Workaround preferences
-            AdvancedSettingsFragment.removeUnnecessaryAdvancedPrefs(screen);
-            AdvancedSettingsFragment.addThirdPartyAppsListener(getActivity(), screen);
+            removeUnnecessaryAdvancedPrefs(screen);
+            addThirdPartyAppsListener(screen);
         }
 
-        public static void setupContextMenuPreference(Context context, android.preference.PreferenceScreen screen, String key, @StringRes int contextMenuName) {
+        private void setupContextMenuPreference(android.preference.PreferenceScreen screen, String key, @StringRes int contextMenuName) {
             // FIXME: The menu is named in the system language (as it's defined in the manifest which may be
             //  different than the app language
             android.preference.CheckBoxPreference cardBrowserContextMenuPreference = (android.preference.CheckBoxPreference) screen.findPreference(key);
-            String menuName = context.getString(contextMenuName);
+            String menuName = getString(contextMenuName);
             // Note: The below format strings are generic, not card browser specific despite the name
-            cardBrowserContextMenuPreference.setTitle(context.getString(R.string.card_browser_enable_external_context_menu, menuName));
-            cardBrowserContextMenuPreference.setSummary(context.getString(R.string.card_browser_enable_external_context_menu_summary, menuName));
+            cardBrowserContextMenuPreference.setTitle(getString(R.string.card_browser_enable_external_context_menu, menuName));
+            cardBrowserContextMenuPreference.setSummary(getString(R.string.card_browser_enable_external_context_menu_summary, menuName));
         }
 
-        public static void removeUnnecessaryAdvancedPrefs(android.preference.PreferenceScreen screen) {
+        private void removeUnnecessaryAdvancedPrefs(android.preference.PreferenceScreen screen) {
             android.preference.PreferenceCategory plugins = (android.preference.PreferenceCategory) screen.findPreference("category_plugins");
             // Disable the emoji/kana buttons to scroll preference if those keys don't exist
             if (!CompatHelper.hasKanaAndEmojiKeys()) {
@@ -1292,27 +1291,27 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
             }
         }
 
-        public static void addThirdPartyAppsListener(Activity activity, android.preference.PreferenceScreen screen) {
-            //#5864 - some people don't have a browser so we can't use <intent>
-            //and need to handle the keypress ourself.
+
+        private void addThirdPartyAppsListener(android.preference.PreferenceScreen screen) {
+            // #5864 - some people don't have a browser so we can't use <intent>
+            // and need to handle the keypress ourself.
             android.preference.Preference showThirdParty = screen.findPreference("thirdpartyapps_link");
             final String githubThirdPartyAppsUrl = "https://github.com/ankidroid/Anki-Android/wiki/Third-Party-Apps";
             showThirdParty.setOnPreferenceClickListener((preference) -> {
                 try {
                     Intent openThirdPartyAppsIntent = new Intent(Intent.ACTION_VIEW, Uri.parse(githubThirdPartyAppsUrl));
-                    activity.startActivity(openThirdPartyAppsIntent);
+                    super.startActivity(openThirdPartyAppsIntent);
                 } catch (ActivityNotFoundException e) {
                     Timber.w(e);
                     //We use a different message here. We have limited space in the snackbar
-                    String error = activity.getString(R.string.activity_start_failed_load_url, githubThirdPartyAppsUrl);
-                    UIUtils.showSimpleSnackbar(activity, error, false);
+                    String error = getString(R.string.activity_start_failed_load_url, githubThirdPartyAppsUrl);
+                    UIUtils.showSimpleSnackbar(getActivity(), error, false);
                 }
                 return true;
             });
         }
     }
     public static abstract class CustomButtonsSettingsFragment extends SpecificSettingsFragment {
-
         @Override
         public int getPreferenceResource() {
             return R.xml.preferences_custom_buttons;

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
@@ -1229,10 +1229,10 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
                 mCategory.removePreference(mCheckBoxPref_Blink);
             }
             // Build languages
-            GeneralSettingsFragment.initializeLanguageDialog(screen, requireContext());
+            initializeLanguageDialog(screen);
         }
 
-        public static void initializeLanguageDialog(android.preference.PreferenceScreen screen, Context context) {
+        private void initializeLanguageDialog(android.preference.PreferenceScreen screen) {
             android.preference.ListPreference languageSelection = (android.preference.ListPreference) screen.findPreference(LANGUAGE);
             if (languageSelection != null) {
                 Map<String, String> items = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
@@ -1242,7 +1242,7 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
                 }
                 CharSequence[] languageDialogLabels = new CharSequence[items.size() + 1];
                 CharSequence[] languageDialogValues = new CharSequence[items.size() + 1];
-                languageDialogLabels[0] = context.getResources().getString(R.string.language_system);
+                languageDialogLabels[0] = getResources().getString(R.string.language_system);
                 languageDialogValues[0] = "";
                 int i = 1;
                 for (Map.Entry<String, String> e : items.entrySet()) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
@@ -913,7 +913,7 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
         }
     }
 
-    private void removeUnnecessaryAdvancedPrefs(android.preference.PreferenceScreen screen) {
+    public static void removeUnnecessaryAdvancedPrefs(android.preference.PreferenceScreen screen) {
         android.preference.PreferenceCategory plugins = (android.preference.PreferenceCategory) screen.findPreference("category_plugins");
         // Disable the emoji/kana buttons to scroll preference if those keys don't exist
         if (!CompatHelper.hasKanaAndEmojiKeys()) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
@@ -84,6 +84,7 @@ import java.util.Set;
 import java.util.TreeMap;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import androidx.annotation.StringRes;
 import androidx.annotation.VisibleForTesting;
 import androidx.annotation.XmlRes;
@@ -988,6 +989,11 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
                 throw new IllegalStateException("no context was associated with the activity.");
             }
             return context;
+        }
+
+        @Nullable
+        protected Collection getCol() {
+            return CollectionHelper.getInstance().getCol(requireContext());
         }
 
         @NonNull

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
@@ -293,7 +293,7 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
                     mCategory.removePreference(mCheckBoxPref_Blink);
                 }
                 // Build languages
-                initializeLanguageDialog(screen);
+                initializeLanguageDialog(screen, requireContext());
                 break;
             case "com.ichi2.anki.prefs.reviewing":
                 listener.addPreferencesFromResource(R.xml.preferences_reviewing);
@@ -1063,7 +1063,7 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
         }
     }
 
-    private void initializeLanguageDialog(android.preference.PreferenceScreen screen) {
+    public static void initializeLanguageDialog(android.preference.PreferenceScreen screen, Context context) {
         android.preference.ListPreference languageSelection = (android.preference.ListPreference) screen.findPreference(LANGUAGE);
         if (languageSelection != null) {
             Map<String, String> items = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
@@ -1073,7 +1073,7 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
             }
             CharSequence[] languageDialogLabels = new CharSequence[items.size() + 1];
             CharSequence[] languageDialogValues = new CharSequence[items.size() + 1];
-            languageDialogLabels[0] = getResources().getString(R.string.language_system);
+            languageDialogLabels[0] = context.getResources().getString(R.string.language_system);
             languageDialogValues[0] = "";
             int i = 1;
             for (Map.Entry<String, String> e : items.entrySet()) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
@@ -320,12 +320,12 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
                         return true;
                     } catch (StorageAccessException e) {
                         Timber.e(e, "Could not initialize directory: %s", newPath);
-                        MaterialDialog materialDialog = new MaterialDialog.Builder(Preferences.this)
+                        MaterialDialog materialDialog = new MaterialDialog.Builder(requireContext())
                                 .title(R.string.dialog_collection_path_not_dir)
                                 .positiveText(R.string.dialog_ok)
                                 .negativeText(R.string.reset_custom_buttons)
                                 .onPositive((dialog, which) -> dialog.dismiss())
-                                .onNegative((dialog, which) -> collectionPathPreference.setText(CollectionHelper.getDefaultAnkiDroidDirectory(this)))
+                                .onNegative((dialog, which) -> collectionPathPreference.setText(CollectionHelper.getDefaultAnkiDroidDirectory(requireContext())))
                                 .show();
                         return false;
                     }
@@ -333,7 +333,7 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
                 // Custom sync server option
                 android.preference.Preference customSyncServerPreference = screen.findPreference("custom_sync_server_link");
                 customSyncServerPreference.setOnPreferenceClickListener(preference -> {
-                    Intent i = getPreferenceSubscreenIntent(Preferences.this,
+                    Intent i = getPreferenceSubscreenIntent(requireContext(),
                             "com.ichi2.anki.prefs.custom_sync_server");
                     startActivity(i);
                     return true;
@@ -341,7 +341,7 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
                 // Advanced statistics option
                 android.preference.Preference advancedStatisticsPreference = screen.findPreference("advanced_statistics_link");
                 advancedStatisticsPreference.setOnPreferenceClickListener(preference -> {
-                    Intent i = getPreferenceSubscreenIntent(Preferences.this,
+                    Intent i = getPreferenceSubscreenIntent(requireContext(),
                             "com.ichi2.anki.prefs.advanced_statistics");
                     startActivity(i);
                     return true;
@@ -352,7 +352,7 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
                 // Make it possible to test crash reporting, but only for DEBUG builds
                 if (BuildConfig.DEBUG && !AdaptionUtil.isUserATestClient()) {
                     Timber.i("Debug mode, allowing for test crashes");
-                    android.preference.Preference triggerTestCrashPreference = new android.preference.Preference(this);
+                    android.preference.Preference triggerTestCrashPreference = new android.preference.Preference(requireContext());
                     triggerTestCrashPreference.setKey("trigger_crash_preference");
                     triggerTestCrashPreference.setTitle("Trigger test crash");
                     triggerTestCrashPreference.setSummary("Touch here for an immediate test crash");
@@ -365,15 +365,15 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
                 // Make it possible to test analytics, but only for DEBUG builds
                 if (BuildConfig.DEBUG) {
                     Timber.i("Debug mode, allowing for dynamic analytics config");
-                    android.preference.Preference analyticsDebugMode = new android.preference.Preference(this);
+                    android.preference.Preference analyticsDebugMode = new android.preference.Preference(requireContext());
                     analyticsDebugMode.setKey("analytics_debug_preference");
                     analyticsDebugMode.setTitle("Switch Analytics to dev mode");
                     analyticsDebugMode.setSummary("Touch here to use Analytics dev tag and 100% sample rate");
                     analyticsDebugMode.setOnPreferenceClickListener(preference -> {
                         if (UsageAnalytics.isEnabled()) {
-                            UIUtils.showThemedToast(this, "Analytics set to dev mode", true);
+                            UIUtils.showThemedToast(requireContext(), "Analytics set to dev mode", true);
                         } else {
-                            UIUtils.showThemedToast(this, "Done! Enable Analytics in 'General' settings to use.", true);
+                            UIUtils.showThemedToast(requireContext(), "Done! Enable Analytics in 'General' settings to use.", true);
                         }
                         UsageAnalytics.setDevMode();
                         return true;
@@ -382,19 +382,19 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
                 }
                 if (BuildConfig.DEBUG) {
                     Timber.i("Debug mode, allowing database lock preference");
-                    android.preference.Preference lockDbPreference = new android.preference.Preference(this);
+                    android.preference.Preference lockDbPreference = new android.preference.Preference(requireContext());
                     lockDbPreference.setKey("debug_lock_database");
                     lockDbPreference.setTitle("Lock Database");
                     lockDbPreference.setSummary("Touch here to lock the database (all threads block in-process, exception if using second process)");
                     lockDbPreference.setOnPreferenceClickListener(preference -> {
-                        DatabaseLock.engage(this);
+                        DatabaseLock.engage(requireContext());
                         return true;
                     });
                     screen.addPreference(lockDbPreference);
                 }
                 if (BuildConfig.DEBUG) {
                     Timber.i("Debug mode, option for showing onboarding walkthrough");
-                    android.preference.CheckBoxPreference onboardingPreference = new android.preference.CheckBoxPreference(this);
+                    android.preference.CheckBoxPreference onboardingPreference = new android.preference.CheckBoxPreference(requireContext());
                     onboardingPreference.setKey("showOnboarding");
                     onboardingPreference.setTitle(R.string.show_onboarding);
                     onboardingPreference.setSummary(R.string.show_onboarding_desc);
@@ -402,9 +402,9 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
                 }
                 // Adding change logs in both debug and release builds
                 Timber.i("Adding open changelog");
-                android.preference.Preference changelogPreference = new android.preference.Preference(this);
+                android.preference.Preference changelogPreference = new android.preference.Preference(requireContext());
                 changelogPreference.setTitle(R.string.open_changelog);
-                Intent infoIntent = new Intent(this, Info.class);
+                Intent infoIntent = new Intent(requireContext(), Info.class);
                 infoIntent.putExtra(Info.TYPE_EXTRA, Info.TYPE_NEW_VERSION);
                 changelogPreference.setIntent(infoIntent);
                 screen.addPreference(changelogPreference);
@@ -414,12 +414,12 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
                 fullSyncPreference.setDialogTitle(R.string.force_full_sync_title);
                 fullSyncPreference.setOkHandler(() -> {
                     if (getCol() == null) {
-                        UIUtils.showThemedToast(getApplicationContext(), R.string.directory_inaccessible, false);
+                        UIUtils.showThemedToast(requireContext(), R.string.directory_inaccessible, false);
                         return;
                     }
                     getCol().modSchemaNoCheck();
                     getCol().setMod();
-                    UIUtils.showThemedToast(getApplicationContext(), android.R.string.ok, true);
+                    UIUtils.showThemedToast(requireContext(), android.R.string.ok, true);
                 });
                 // Workaround preferences
                 AdvancedSettingsFragment.removeUnnecessaryAdvancedPrefs(screen);

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
@@ -310,10 +310,6 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
                     return true;
                 });
                 break;
-            case "com.ichi2.anki.prefs.advanced_statistics":
-                getSupportActionBar().setTitle(R.string.advanced_statistics_title);
-                listener.addPreferencesFromResource(R.xml.preferences_advanced_statistics);
-                break;
         }
     }
 
@@ -1179,8 +1175,7 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
             // Advanced statistics option
             android.preference.Preference advancedStatisticsPreference = screen.findPreference("advanced_statistics_link");
             advancedStatisticsPreference.setOnPreferenceClickListener(preference -> {
-                Intent i = getPreferenceSubscreenIntent(requireContext(),
-                        "com.ichi2.anki.prefs.advanced_statistics");
+                Intent i = AdvancedStatisticsSettingsFragment.getSubscreenIntent(requireContext());
                 startActivity(i);
                 return true;
             });
@@ -1364,10 +1359,22 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
         }
     }
 
-    public static abstract class AdvancedStatisticsSettingsFragment extends SpecificSettingsFragment {
+    public static class AdvancedStatisticsSettingsFragment extends SpecificSettingsFragment {
+
         @Override
         public int getPreferenceResource() {
             return R.xml.preferences_advanced_statistics;
+        }
+
+        @NonNull
+        public static Intent getSubscreenIntent(Context context) {
+            return getSubscreenIntent(context, "com.ichi2.anki.prefs.advanced_statistics", AdvancedStatisticsSettingsFragment.class.getSimpleName());
+        }
+
+        @Override
+        protected void initSubscreen() {
+            setTitle(R.string.advanced_statistics_title);
+            addPreferencesFromResource(R.xml.preferences_advanced_statistics);
         }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
@@ -282,19 +282,6 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
     private void initSubscreen(String action, PreferenceContext listener) {
         android.preference.PreferenceScreen screen;
         switch (action) {
-            case "com.ichi2.anki.prefs.general":
-                listener.addPreferencesFromResource(R.xml.preferences_general);
-                screen = listener.getPreferenceScreen();
-                if (AdaptionUtil.isRestrictedLearningDevice()) {
-                    android.preference.CheckBoxPreference mCheckBoxPref_Vibrate = (android.preference.CheckBoxPreference) screen.findPreference("widgetVibrate");
-                    android.preference.CheckBoxPreference mCheckBoxPref_Blink = (android.preference.CheckBoxPreference) screen.findPreference("widgetBlink");
-                    android.preference.PreferenceCategory mCategory = (android.preference.PreferenceCategory) screen.findPreference("category_general_notification_pref");
-                    mCategory.removePreference(mCheckBoxPref_Vibrate);
-                    mCategory.removePreference(mCheckBoxPref_Blink);
-                }
-                // Build languages
-                GeneralSettingsFragment.initializeLanguageDialog(screen, requireContext());
-                break;
             case "com.ichi2.anki.prefs.reviewing":
                 listener.addPreferencesFromResource(R.xml.preferences_reviewing);
                 screen = listener.getPreferenceScreen();
@@ -1224,10 +1211,25 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
         protected abstract void initSubscreen();
     }
 
-    public static abstract class GeneralSettingsFragment extends SpecificSettingsFragment {
+    public static class GeneralSettingsFragment extends SpecificSettingsFragment {
         @Override
         public int getPreferenceResource() {
             return R.xml.preferences_general;
+        }
+
+        @Override
+        protected void initSubscreen() {
+            addPreferencesFromResource(R.xml.preferences_general);
+            android.preference.PreferenceScreen screen = getPreferenceScreen();
+            if (AdaptionUtil.isRestrictedLearningDevice()) {
+                android.preference.CheckBoxPreference mCheckBoxPref_Vibrate = (android.preference.CheckBoxPreference) screen.findPreference("widgetVibrate");
+                android.preference.CheckBoxPreference mCheckBoxPref_Blink = (android.preference.CheckBoxPreference) screen.findPreference("widgetBlink");
+                android.preference.PreferenceCategory mCategory = (android.preference.PreferenceCategory) screen.findPreference("category_general_notification_pref");
+                mCategory.removePreference(mCheckBoxPref_Vibrate);
+                mCategory.removePreference(mCheckBoxPref_Blink);
+            }
+            // Build languages
+            GeneralSettingsFragment.initializeLanguageDialog(screen, requireContext());
         }
 
         public static void initializeLanguageDialog(android.preference.PreferenceScreen screen, Context context) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
@@ -281,7 +281,7 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
             case "com.ichi2.anki.prefs.gestures":
                 listener.addPreferencesFromResource(R.xml.preferences_gestures);
                 screen = listener.getPreferenceScreen();
-                updateGestureCornerTouch(screen);
+                updateGestureCornerTouch(this, screen);
 
                 break;
             case "com.ichi2.anki.prefs.custom_buttons":
@@ -832,7 +832,7 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
                     AnkiCardContextMenu.ensureConsistentStateWithSharedPreferences(this);
                     break;
                 case "gestureCornerTouch": {
-                    updateGestureCornerTouch(screen);
+                    updateGestureCornerTouch(this, screen);
                 }
             }
             // Update the summary text to reflect new value
@@ -845,8 +845,8 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
     }
 
 
-    private void updateGestureCornerTouch(android.preference.PreferenceScreen screen) {
-        boolean gestureCornerTouch = AnkiDroidApp.getSharedPrefs(this).getBoolean("gestureCornerTouch", false);
+    public static void updateGestureCornerTouch(Context context, android.preference.PreferenceScreen screen) {
+        boolean gestureCornerTouch = AnkiDroidApp.getSharedPrefs(context).getBoolean("gestureCornerTouch", false);
         if (gestureCornerTouch) {
             screen.findPreference("gestureTapTop").setTitle(R.string.gestures_corner_tap_top_center);
             screen.findPreference("gestureTapLeft").setTitle(R.string.gestures_corner_tap_middle_left);

--- a/AnkiDroid/src/main/res/xml/preference_headers.xml
+++ b/AnkiDroid/src/main/res/xml/preference_headers.xml
@@ -63,7 +63,7 @@
 
     <!-- Advanced Preferences -->
     <header
-        android:fragment="com.ichi2.anki.Preferences$SettingsFragment"
+        android:fragment="com.ichi2.anki.Preferences$AdvancedSettingsFragment"
         android:key="pref_screen_advanced"
         android:summary="@string/pref_cat_advanced_summ"
         android:title="@string/pref_cat_advanced">

--- a/AnkiDroid/src/main/res/xml/preference_headers.xml
+++ b/AnkiDroid/src/main/res/xml/preference_headers.xml
@@ -32,7 +32,7 @@
 
     <!-- Reviewing Preferences -->
     <header
-        android:fragment="com.ichi2.anki.Preferences$SettingsFragment"
+        android:fragment="com.ichi2.anki.Preferences$ReviewingSettingsFragment"
         android:summary="@string/pref_cat_reviewing_summ"
         android:title="@string/pref_cat_reviewing">
         <extra

--- a/AnkiDroid/src/main/res/xml/preference_headers.xml
+++ b/AnkiDroid/src/main/res/xml/preference_headers.xml
@@ -22,7 +22,7 @@
 
     <!--  General Preferences -->
     <header
-        android:fragment="com.ichi2.anki.Preferences$SettingsFragment"
+        android:fragment="com.ichi2.anki.Preferences$GeneralSettingsFragment"
         android:summary="@string/pref_cat_general_summ"
         android:title="@string/app_name">
         <extra

--- a/AnkiDroid/src/main/res/xml/preference_headers.xml
+++ b/AnkiDroid/src/main/res/xml/preference_headers.xml
@@ -53,7 +53,7 @@
 
     <!-- Navigation Prefrences -->
     <header
-        android:fragment="com.ichi2.anki.Preferences$SettingsFragment"
+        android:fragment="com.ichi2.anki.Preferences$GesturesSettingsFragment"
         android:summary="@string/pref_cat_gestures_summ"
         android:title="@string/pref_cat_gestures">
         <extra

--- a/AnkiDroid/src/main/res/xml/preference_headers.xml
+++ b/AnkiDroid/src/main/res/xml/preference_headers.xml
@@ -42,7 +42,7 @@
 
     <!-- Appearance Prefrences  -->
     <header
-        android:fragment="com.ichi2.anki.Preferences$SettingsFragment"
+        android:fragment="com.ichi2.anki.Preferences$AppearanceSettingsFragment"
         android:key="appearance_preference_group"
         android:summary="@string/pref_cat_appearance_summ"
         android:title="@string/pref_cat_appearance">

--- a/AnkiDroid/src/test/java/com/ichi2/testutils/PreferenceUtils.java
+++ b/AnkiDroid/src/test/java/com/ichi2/testutils/PreferenceUtils.java
@@ -31,7 +31,7 @@ public class PreferenceUtils {
 
     public static Set<String> getAllCustomButtonKeys(Context context) {
         AtomicReference<Set<String>> ret = new AtomicReference<>();
-        Intent i = Preferences.getPreferenceSubscreenIntent(context, "com.ichi2.anki.prefs.custom_buttons");
+        Intent i = Preferences.CustomButtonsSettingsFragment.getSubscreenIntent(context);
         try (ActivityScenario<Preferences> scenario = ActivityScenario.launch(i)) {
             scenario.moveToState(Lifecycle.State.STARTED);
             scenario.onActivity(a -> ret.set(a.getLoadedPreferenceKeys()));


### PR DESCRIPTION
## Pull Request template

## Purpose / Description

The first part of fixing preference deprecation is removing the dependency from `Activity -> PreferenceScreen` via `PreferenceContext`, the `PreferenceScreen` should be contained by a fragment, and the containing activity should not need knowledge of this.

## Fixes
Related: #5019 

## Approach
We pick the `initSubscreen(_, PreferenceContext)` method first. We extract each branch of this method into a separate class, handle navigation to the class, and then finally remove the method in `Preferences`. This allows us to remove one of the two method calls (sadly not the one that we want).

## How Has This Been Tested?

Preferences still work on my Android 11. Using CI to run unit tests as it's getting late.

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
