### PR TITLE
Add onboarding library with support for dimmed background

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -311,6 +311,7 @@ dependencies {
     implementation 'com.drakeet.drawer:drawer:1.0.3'
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+    implementation 'uk.co.samuelwall:material-tap-target-prompt:3.2.0'
     api project(":api")
 
     testImplementation 'org.junit.vintage:junit-vintage-engine:5.7.2'

--- a/AnkiDroid/src/main/java/com/ichi2/anki/PromptBackgroundAdapter.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/PromptBackgroundAdapter.kt
@@ -1,0 +1,55 @@
+/****************************************************************************************
+ *                                                                                      *
+ * Copyright (c) 2021 David Allison <davidallisongithub@gmail.com>                      *
+ * Copyright (c) 2021 Shridhar Goel <shridhar.goel@gmail.com>                           *
+ *                                                                                      *
+ * This program is free software; you can redistribute it and/or modify it under        *
+ * the terms of the GNU General Public License as published by the Free Software        *
+ * Foundation; either version 3 of the License, or (at your option) any later           *
+ * version.                                                                             *
+ *                                                                                      *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *                                                                                      *
+ * You should have received a copy of the GNU General Public License along with         *
+ * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ ****************************************************************************************/
+
+package com.ichi2.anki
+
+import android.graphics.Canvas
+import android.graphics.Rect
+import uk.co.samuelwall.materialtaptargetprompt.extras.PromptBackground
+import uk.co.samuelwall.materialtaptargetprompt.extras.PromptOptions
+
+/**
+ * Used for changing PromptBackgroundInterface to PromptBackground.
+ */
+class PromptBackgroundAdapter(private val mPromptBackgroundInterface: PromptBackgroundInterface) : PromptBackground() {
+    companion object {
+        fun PromptBackgroundInterface.toPromptBackground(): PromptBackground {
+            return PromptBackgroundAdapter(this)
+        }
+    }
+
+    override fun update(options: PromptOptions<out PromptOptions<*>>, revealModifier: Float, alphaModifier: Float) {
+        mPromptBackgroundInterface.update(options, revealModifier, alphaModifier)
+    }
+
+    override fun draw(canvas: Canvas) {
+        mPromptBackgroundInterface.draw(canvas)
+    }
+
+    override fun contains(x: Float, y: Float): Boolean {
+        return mPromptBackgroundInterface.contains(x, y)
+    }
+
+    override fun setColour(colour: Int) {
+        mPromptBackgroundInterface.setColour(colour)
+    }
+
+    override fun prepare(options: PromptOptions<out PromptOptions<*>>, clipToBounds: Boolean, clipBounds: Rect) {
+        mPromptBackgroundInterface.prepare(options, clipToBounds, clipBounds)
+    }
+}

--- a/AnkiDroid/src/main/java/com/ichi2/anki/PromptBackgroundInterface.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/PromptBackgroundInterface.kt
@@ -1,0 +1,114 @@
+/****************************************************************************************
+ *                                                                                      *
+ * Copyright (c) 2021 David Allison <davidallisongithub@gmail.com>                      *
+ * Copyright (c) 2021 Shridhar Goel <shridhar.goel@gmail.com>                           *
+ *                                                                                      *
+ * This program is free software; you can redistribute it and/or modify it under        *
+ * the terms of the GNU General Public License as published by the Free Software        *
+ * Foundation; either version 3 of the License, or (at your option) any later           *
+ * version.                                                                             *
+ *                                                                                      *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *                                                                                      *
+ * You should have received a copy of the GNU General Public License along with         *
+ * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ ****************************************************************************************/
+
+package com.ichi2.anki
+
+import android.graphics.Canvas
+import android.graphics.Rect
+import androidx.annotation.ColorInt
+import uk.co.samuelwall.materialtaptargetprompt.extras.PromptBackground
+import uk.co.samuelwall.materialtaptargetprompt.extras.PromptOptions
+
+/**
+ * Exposes [PromptBackground] as an interface.
+ *
+ * [PromptBackground] is an abstract class with only abstract methods, this unnecessarily forces
+ * inheritance from consumers if they want to extend it. This interface allows extension via implementation,
+ * flattening the class hierarchy. It can be created by a [PromptBackgroundInterfaceAdapter] and
+ * converted back to a [PromptBackground] via a [PromptBackgroundAdapter].
+ */
+interface PromptBackgroundInterface {
+    /**
+     * Prepares the background for drawing.
+     * Set the screen bounds which require a dimmed background.
+     *
+     * @param options The options from which the prompt was created.
+     * @param clipToBounds Should the prompt be clipped to the supplied clipBounds.
+     * @param clipBounds The bounds to clip the drawing to.
+     */
+    fun prepare(options: PromptOptions<*>, clipToBounds: Boolean, clipBounds: Rect)
+
+    /**
+     * Update the current prompt rendering state based on the prompt options and current reveal & alpha scales.
+     * Set the alpha value of mDimPaint based on the value of alphaModifier.
+     *
+     * @param options The options used to create the prompt.
+     * @param revealModifier The current size/revealed scale from 0 - 1.
+     * @param alphaModifier The current colour alpha scale from 0 - 1.
+     */
+    fun update(options: PromptOptions<*>, revealModifier: Float, alphaModifier: Float)
+
+    /**
+     * Draw the dimmed background and the prompt background.
+     *
+     * @param canvas The canvas to draw to.
+     */
+    fun draw(canvas: Canvas)
+
+    /**
+     * Check if the element contains the point.
+     *
+     * @param x x-coordinate.
+     * @param y y-coordinate.
+     * @return true if the element contains the point, false otherwise.
+     */
+    fun contains(x: Float, y: Float): Boolean
+
+    /**
+     * Sets the colour to use for the background.
+     *
+     * @param colour Colour integer representing the colour.
+     */
+    fun setColour(@ColorInt colour: Int)
+}
+
+/**
+ * Converts from abstract [PromptBackground] to [PromptBackgroundInterface] to allow extensions of a
+ * [PromptBackground] without the requirement to inherit from an empty abstract class.
+ */
+class PromptBackgroundInterfaceAdapter(private val mPromptBackground: PromptBackground) : PromptBackgroundInterface {
+    companion object {
+        /**
+         * Takes PromptBackground and returns PromptBackgroundInterfaceAdapter which
+         * implements PromptBackgroundInterface.
+         */
+        fun PromptBackground.toInterface(): PromptBackgroundInterface {
+            return PromptBackgroundInterfaceAdapter(this)
+        }
+    }
+
+    override fun update(options: PromptOptions<out PromptOptions<*>>, revealModifier: Float, alphaModifier: Float) {
+        mPromptBackground.update(options, revealModifier, alphaModifier)
+    }
+
+    override fun draw(canvas: Canvas) {
+        mPromptBackground.draw(canvas)
+    }
+
+    override fun contains(x: Float, y: Float): Boolean {
+        return mPromptBackground.contains(x, y)
+    }
+
+    override fun setColour(colour: Int) {
+        mPromptBackground.setColour(colour)
+    }
+
+    override fun prepare(options: PromptOptions<out PromptOptions<*>>, clipToBounds: Boolean, clipBounds: Rect) {
+        mPromptBackground.prepare(options, clipToBounds, clipBounds)
+    }
+}

--- a/AnkiDroid/src/main/java/com/ichi2/utils/DimmedPromptBackgroundDecorator.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/DimmedPromptBackgroundDecorator.kt
@@ -1,0 +1,89 @@
+/******************************************************************************************
+ *   Copyright (c) 2021 Shridhar Goel <shridhar.goel@gmail.com>                           *
+ *                                                                                        *
+ *   This program is free software; you can redistribute it and/or modify it under        *
+ *   the terms of the GNU General Public License as published by the Free Software        *
+ *   Foundation; either version 3 of the License, or (at your option) any later           *
+ *   version.                                                                             *
+ *                                                                                        *
+ *   This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ *   WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ *   PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *                                                                                        *
+ *   You should have received a copy of the GNU General Public License along with         *
+ *   this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ *                                                                                        *
+ *   This file incorporates work covered by the following copyright and                   *
+ *   permission notice:                                                                   *
+ *                                                                                        *
+ *     The implementation used here has been taken from the documentation of the          *
+ *     MaterialTapTargetPrompt library.                                                   *
+ *     Link: https://sjwall.github.io/MaterialTapTargetPrompt/shapes.html                 *
+ *                                                                                        *
+ *     Copyright 2016-2021 Samuel Wall                                                    *
+ *                                                                                        *
+ *     Licensed under the Apache License, Version 2.0 (the "License");                    *
+ *     you may not use this file except in compliance with the License.                   *
+ *     You may obtain a copy of the License at                                            *
+ *                                                                                        *
+ *     http://www.apache.org/licenses/LICENSE-2.0                                         *
+ *                                                                                        *
+ *     Unless required by applicable law or agreed to in writing, software                *
+ *     distributed under the License is distributed on an "AS IS" BASIS,                  *
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.           *
+ *     See the License for the specific language governing permissions and                *
+ *     limitations under the License.                                                     *
+ ******************************************************************************************/
+
+package com.ichi2.utils
+
+import android.content.res.Resources
+import android.graphics.*
+import com.ichi2.anki.PromptBackgroundInterface
+import com.ichi2.anki.PromptBackgroundInterfaceAdapter.Companion.toInterface
+import uk.co.samuelwall.materialtaptargetprompt.extras.PromptBackground
+import uk.co.samuelwall.materialtaptargetprompt.extras.PromptOptions
+
+/**
+ * Decorator for [DimmedPromptBackgroundInterface]: Dims the background of the screen so that the
+ * highlighted view remains in focus.
+ */
+class DimmedPromptBackgroundDecorator(val mPromptBackgroundInterface: PromptBackgroundInterface) : PromptBackgroundInterface {
+    constructor(mPromptBackground: PromptBackground) : this(mPromptBackground.toInterface())
+
+    private val mDimBounds = RectF()
+    private val mDimPaint: Paint = Paint()
+
+    init {
+        mDimPaint.color = Color.BLACK
+    }
+
+    override fun prepare(options: PromptOptions<*>, clipToBounds: Boolean, clipBounds: Rect) {
+        mPromptBackgroundInterface.prepare(options, clipToBounds, clipBounds)
+        val metrics = Resources.getSystem().displayMetrics
+        // Set the bounds to display as dimmed to the screen bounds.
+        mDimBounds.set(0f, 0f, metrics.widthPixels.toFloat(), (metrics.heightPixels * 2).toFloat())
+        // Multiplying metrics.heightPixels by 2 to fix issue where bottom area of the screen does not become dimmed.
+    }
+
+    override fun update(options: PromptOptions<*>, revealModifier: Float, alphaModifier: Float) {
+        mPromptBackgroundInterface.update(options, revealModifier, alphaModifier)
+        // Allow for the dimmed background to fade in and out.
+        mDimPaint.alpha = (150 * alphaModifier).toInt()
+    }
+
+    override fun draw(canvas: Canvas) {
+        // Draw the dimmed background.
+        canvas.drawRect(mDimBounds, mDimPaint)
+        // Draw the background.
+        mPromptBackgroundInterface.draw(canvas)
+    }
+
+    override fun contains(x: Float, y: Float): Boolean {
+        return mPromptBackgroundInterface.contains(x, y)
+    }
+
+    override fun setColour(colour: Int) {
+        mPromptBackgroundInterface.setColour(colour)
+    }
+}


### PR DESCRIPTION
## Purpose / Description
Add onboarding library with support for dimmed background.
https://github.com/sjwall/MaterialTapTargetPrompt.

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
