### PR TITLE
fix tests: detect CI - use build config

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -29,6 +29,7 @@ android {
 
     defaultConfig {
         applicationId "com.ichi2.anki"
+        buildConfigField "Boolean", "CI", (System.getenv("CI") == "true").toString()
 
         // The version number is of the form:
         // <major>.<minor>.<maintenance>[dev|alpha<build>|beta<build>|]

--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/DeckPickerTest.java
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/DeckPickerTest.java
@@ -60,7 +60,7 @@ public class DeckPickerTest {
     public void checkIfClickOnCountsLayoutOpensStudyOptionsOnMobile() {
         // Run the test only on emulator.
         assumeTrue(InstrumentedTest.isEmulator());
-        assumeFalse("Test flaky in CI - #9282, skipping", TestUtils.isCI());
+        assumeFalse("Test flaky in CI - #9282, skipping", TestUtils.wasBuiltOnCI());
 
         // For mobile. If it is not a mobile, then test will be ignored.
         assumeTrue(!isScreenSw600dp());
@@ -83,7 +83,7 @@ public class DeckPickerTest {
     public void checkIfStudyOptionsIsDisplayedOnTablet() {
         // Run the test only on emulator.
         assumeTrue(InstrumentedTest.isEmulator());
-        assumeFalse("Test flaky in CI - #9282, skipping", TestUtils.isCI());
+        assumeFalse("Test flaky in CI - #9282, skipping", TestUtils.wasBuiltOnCI());
 
         // For tablet. If it is not a tablet, then test will be ignored.
         assumeTrue(isScreenSw600dp());

--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/TestUtils.java
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/TestUtils.java
@@ -24,6 +24,7 @@ import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 import org.hamcrest.TypeSafeMatcher;
 
+import java.lang.reflect.Method;
 import java.util.Collection;
 
 import androidx.test.espresso.UiController;
@@ -108,11 +109,12 @@ public class TestUtils {
         };
     }
 
-    /**
-     * Detect if we are running in CI or not, via the convention/standard that all CI systems
-     * put the environment variable "CI" into the system environment, set to true
-     */
-    public static boolean isCI() {
-        return "true".equals(System.getenv("CI"));
+    /** @return if the instrumented tests were built on a CI machine */
+    public static boolean wasBuiltOnCI() {
+        // DO NOT COPY THIS INTO AN CODE WHICH IS RELEASED PUBLICLY
+
+        // We use BuildConfig as we couldn't detect an envvar after `adb root && adb shell setprop`. See: #9293
+        // TODO: See if we can fix this to use an envvar, and rename to isCi().
+        return BuildConfig.CI;
     }
 }


### PR DESCRIPTION
isCI was returning false on CI as the environment variable wasn't
passed to an emulators

I failed to read/set environment variables working
I failed to get system properties working reliably

## Fixes
Fixes #9293

## Approach
Use `BuildConfig`

## How Has This Been Tested?

Tested in CI on david-allison-1/Anki-Android
We already use the same code to detect a CI build in our gradle scripts

## Learning (optional, can help others)
Tried, but didn't work reliably:

* https://stackoverflow.com/questions/60540510/how-to-set-an-environment-variable-in-android
* https://stackoverflow.com/questions/5095234/how-to-get-root-access-on-android-emulator
* https://stackoverflow.com/questions/9937099/how-to-get-the-build-prop-values

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
