### PR TITLE
Implement elevation for popup menus in Night themes

### DIFF
--- a/AnkiDroid/src/main/res/values/attrs.xml
+++ b/AnkiDroid/src/main/res/values/attrs.xml
@@ -119,4 +119,6 @@
     <attr name="fab_item_background" format="reference"/>
     <!--Custom Tabs colors-->
     <attr name="customTabNavBarColor" format="color"/>
+    <!-- Popup menus' background color -->
+    <attr name="popupBackgroundColor" format="reference"/>
 </resources>

--- a/AnkiDroid/src/main/res/values/colors.xml
+++ b/AnkiDroid/src/main/res/values/colors.xml
@@ -114,5 +114,9 @@
     <color name="badge_warning">#ff5e13</color>
 
     <color name="fab_background">#777</color>
+
+    <color name="popup_background_theme_dark">#434343</color>
+    <color name="popup_background_theme_black">#252525</color>
+
 </resources>
 

--- a/AnkiDroid/src/main/res/values/styles.xml
+++ b/AnkiDroid/src/main/res/values/styles.xml
@@ -116,6 +116,7 @@
         <item name="android:drawSelectorOnTop">true</item>
         <item name="android:textColorPrimary">?attr/actionBarPopupTextColor</item>
         <item name="android:textColorSecondary">?attr/actionBarPopupTextColor</item>
+        <item name="android:colorBackground">?attr/popupBackgroundColor</item>
     </style>
 
     <style name="LargeButtonStyle">

--- a/AnkiDroid/src/main/res/values/theme_black.xml
+++ b/AnkiDroid/src/main/res/values/theme_black.xml
@@ -108,6 +108,7 @@
         <item name="md_background_color">@color/theme_black_primary_light</item>
         <!--Custom Tabs colors-->
         <item name="customTabNavBarColor">#070707</item>
+        <item name="popupBackgroundColor">@color/popup_background_theme_black</item>
     </style>
 
     <!-- Preferences screens -->

--- a/AnkiDroid/src/main/res/values/theme_dark.xml
+++ b/AnkiDroid/src/main/res/values/theme_dark.xml
@@ -115,6 +115,7 @@
         <item name="md_dark_theme">true</item>
         <!--Custom Tabs colors-->
         <item name="customTabNavBarColor">@color/material_grey_800</item>
+        <item name="popupBackgroundColor">@color/popup_background_theme_dark</item>
     </style>
 
     <!-- Preferences screens -->

--- a/AnkiDroid/src/main/res/values/theme_light.xml
+++ b/AnkiDroid/src/main/res/values/theme_light.xml
@@ -129,6 +129,7 @@ APIs. It's visible when there aren't enough decks to fill the screen.
         <item name="md_dark_theme">false</item>
         <!--Custom Tabs colors-->
         <item name="customTabNavBarColor">@color/material_light_blue_500</item>
+        <item name="popupBackgroundColor">@android:color/white</item>
     </style>
 
     <!-- Preferences screens -->


### PR DESCRIPTION
## Purpose / Description

AnkiDroid has 2 Night themes: Dark and Black.

Currently in these themes, especially the Black theme, the elevation of the popup menus is not easy to notice, making them look slightly off:

![overflow_before](https://user-images.githubusercontent.com/56965537/126275825-9b088cde-5a1d-4d8d-8184-c1c1e711749f.png)

There are 2 places having this problem: The toolbar's overflow menu (above picture) and the spinners' dropdown menu (following picture):

![spinner_before](https://user-images.githubusercontent.com/56965537/126275936-6c47b439-eab9-4fed-929b-187a7fe8900b.png)

## Approach

In [Material Design Guideline](https://material.io/design/color/dark-theme.html#properties), they suggest using a lighter background color to indicate elevation in these cases, which I think is appropriate.

Also according to Material Design Guideline, in Day themes (Light and Plain) we don't have this problem because in these themes we can use shadow to express elevation. However, shadow is either not possible or not effective in Night themes, because in these themes the shadow's color is either the same as, or very similar to, the theme's color. This makes elevation difficult to notice.

In this PR I proposed the idea that we define a separate color for popup menus to show their elevation.

For the Black theme, I chose a color value which is equivalent to a 8dp elevation (*) as stated in Material Design Guideline. Originally, this requires using a transparent overlay with an alpha component. Luckily there is a simpler way: we can use [this formula from SO](https://stackoverflow.com/a/2049362/3286500) to convert a RGBA color to a RGB color. Using this formula I got the 0x252525 value.

For the Dark theme, using the same formula above, I got value 0x434343.

(*) (I've tried values 4dp and 12dp but I think they were a little too dark and too bright respectively)

Here are the results after implementing elevation:

![overflow_after](https://user-images.githubusercontent.com/56965537/126276951-7835ee90-61d6-437e-9f42-66f65023b719.png)

![spinner_after](https://user-images.githubusercontent.com/56965537/126276969-42129ed1-22c7-4c84-87a4-f33e58b263c5.png)

## How Has This Been Tested?

I've verified (in both emulator and physical phone) that with this change, the popup menus are now easier to notice.

## Checklist

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
