### PR TITLE
feat: add pass fail

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -268,6 +268,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
 
     // Preferences from the collection
     private boolean mShowNextReviewTime;
+    private boolean mShowPassFail;
 
     // Answer card & cloze deletion variables
     private String mTypeCorrect = null;
@@ -1601,6 +1602,11 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
         mEase4Layout.setOnClickListener((View view) -> mEaseHandler.onClick(view));
         mEase4Layout.setOnTouchListener((View view, MotionEvent event) -> mEaseHandler.onTouch(view, event));
 
+        if (mShowPassFail) {
+            mEase2Layout.setVisibility(View.GONE);
+            mEase4Layout.setVisibility(View.GONE);
+        }
+
         mNext1 = findViewById(R.id.nextTime1);
         mNext2 = findViewById(R.id.nextTime2);
         mNext3 = findViewById(R.id.nextTime3);
@@ -1764,6 +1770,10 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
 
     protected boolean shouldShowNextReviewTime() {
         return mShowNextReviewTime;
+    }
+
+    protected boolean shouldShowPassFail() {
+        return mShowPassFail;
     }
 
     protected void displayAnswerBottomBar() {
@@ -1956,6 +1966,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
         // These are preferences we pull out of the collection instead of SharedPreferences
         try {
             mShowNextReviewTime = getCol().getConf().getBoolean("estTimes");
+            mShowPassFail = getCol().getConf().optBoolean("passFail", false);
 
             // Dynamic don't have review options; attempt to get deck-specific auto-advance options
             // but be prepared to go with all default if it's a dynamic deck

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
@@ -117,6 +117,10 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
      */
     private static final String SHOW_ESTIMATE = "showEstimates";
     /**
+     * Represents in Android preferences the collections configuration "passFail": i.e. whether the buttons should only show pass and fail.
+     */
+    private static final String SHOW_PASS_FAIL = "showPassFail";
+    /**
      * Represents in Android preferences the collections configuration "dueCounts": i.e.
      * whether the remaining number of cards should be shown.
      */
@@ -167,7 +171,7 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
      */
     public static final String MINIMUM_CARDS_DUE_FOR_NOTIFICATION = "minimumCardsDueForNotification";
     private static final String NEW_TIMEZONE_HANDLING = "newTimezoneHandling";
-    private static final String [] sCollectionPreferences = {SHOW_ESTIMATE, SHOW_PROGRESS,
+    private static final String [] sCollectionPreferences = {SHOW_ESTIMATE, SHOW_PASS_FAIL, SHOW_PROGRESS,
             LEARN_CUTOFF, TIME_LIMIT, USE_CURRENT, NEW_SPREAD, DAY_OFFSET, SCHED_VER, NEW_TIMEZONE_HANDLING};
 
     private static final int RESULT_LOAD_IMG = 111;
@@ -662,6 +666,9 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
                         case SHOW_ESTIMATE:
                             ((android.preference.CheckBoxPreference)pref).setChecked(conf.getBoolean("estTimes"));
                             break;
+                        case SHOW_PASS_FAIL:
+                            ((android.preference.CheckBoxPreference)pref).setChecked(conf.optBoolean("passFail", false));
+                            break;
                         case SHOW_PROGRESS:
                             ((android.preference.CheckBoxPreference)pref).setChecked(conf.getBoolean("dueCounts"));
                             break;
@@ -789,6 +796,10 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
                     break;
                 case SHOW_ESTIMATE:
                     getCol().getConf().put("estTimes", ((android.preference.CheckBoxPreference) pref).isChecked());
+                    getCol().setMod();
+                    break;
+                case SHOW_PASS_FAIL:
+                    getCol().getConf().put("passFail", ((android.preference.CheckBoxPreference) pref).isChecked());
                     getCol().setMod();
                     break;
                 case NEW_SPREAD:

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.java
@@ -892,51 +892,63 @@ public class Reviewer extends AbstractFlashcardViewer {
                 R.attr.hardButtonTextColor,
                 R.attr.goodButtonTextColor,
                 R.attr.easyButtonTextColor});
+
+        mEase1.setText(shouldShowPassFail() ? R.string.ease_button_fail : R.string.ease_button_again);
         mEase1Layout.setVisibility(View.VISIBLE);
         mEase1Layout.setBackgroundResource(background[0]);
         mEase4Layout.setBackgroundResource(background[3]);
+
+        int goodButtonText = shouldShowPassFail() ? R.string.ease_button_pass : R.string.ease_button_good;
+        int nonPassFailVisibility = shouldShowPassFail() ? View.GONE : View.VISIBLE;
+
         switch (buttonCount) {
             case 2:
                 // Ease 2 is "good"
                 mEase2Layout.setVisibility(View.VISIBLE);
                 mEase2Layout.setBackgroundResource(background[2]);
-                mEase2.setText(R.string.ease_button_good);
+                mEase2.setText(goodButtonText);
                 mEase2.setTextColor(textColor[2]);
                 mNext2.setTextColor(textColor[2]);
                 mEase2Layout.requestFocus();
+
                 break;
             case 3:
                 // Ease 2 is good
                 mEase2Layout.setVisibility(View.VISIBLE);
                 mEase2Layout.setBackgroundResource(background[2]);
-                mEase2.setText(R.string.ease_button_good);
+                mEase2.setText(goodButtonText);
                 mEase2.setTextColor(textColor[2]);
                 mNext2.setTextColor(textColor[2]);
+
                 // Ease 3 is easy
-                mEase3Layout.setVisibility(View.VISIBLE);
+                mEase3Layout.setVisibility(nonPassFailVisibility);
                 mEase3Layout.setBackgroundResource(background[3]);
                 mEase3.setText(R.string.ease_button_easy);
                 mEase3.setTextColor(textColor[3]);
                 mNext3.setTextColor(textColor[3]);
                 mEase2Layout.requestFocus();
+
                 break;
             default:
-                mEase2Layout.setVisibility(View.VISIBLE);
                 // Ease 2 is "hard"
-                mEase2Layout.setVisibility(View.VISIBLE);
+                mEase2Layout.setVisibility(nonPassFailVisibility);
                 mEase2Layout.setBackgroundResource(background[1]);
                 mEase2.setText(R.string.ease_button_hard);
                 mEase2.setTextColor(textColor[1]);
                 mNext2.setTextColor(textColor[1]);
                 mEase2Layout.requestFocus();
+
                 // Ease 3 is good
                 mEase3Layout.setVisibility(View.VISIBLE);
                 mEase3Layout.setBackgroundResource(background[2]);
-                mEase3.setText(R.string.ease_button_good);
+                mEase3.setText(goodButtonText);
                 mEase3.setTextColor(textColor[2]);
                 mNext3.setTextColor(textColor[2]);
-                mEase4Layout.setVisibility(View.VISIBLE);
+
+                // Ease 4 is easy
+                mEase4Layout.setVisibility(nonPassFailVisibility);
                 mEase3Layout.requestFocus();
+
                 break;
         }
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
@@ -151,7 +151,7 @@ public class Collection implements CollectionGetter {
             +
             // review options
             "\"activeDecks\": [1], " + "\"curDeck\": 1, " + "\"newSpread\": " + Consts.NEW_CARDS_DISTRIBUTE + ", "
-            + "\"collapseTime\": 1200, " + "\"timeLim\": 0, " + "\"estTimes\": true, " + "\"dueCounts\": true, "
+            + "\"collapseTime\": 1200, " + "\"timeLim\": 0, " + "\"estTimes\": true, " + "\"passFail\": false, " + "\"dueCounts\": true, "
             +
             // other config
             "\"curModel\": null, " + "\"nextPos\": 1, " + "\"sortType\": \"noteFld\", "

--- a/AnkiDroid/src/main/res/values/01-core.xml
+++ b/AnkiDroid/src/main/res/values/01-core.xml
@@ -67,6 +67,8 @@
     <string name="type_answer_hint">Type answer</string>
     <string name="show_answer">Show answer</string>
     <string name="hide_answer">Hide answer</string>
+    <string name="ease_button_pass">Pass</string>
+    <string name="ease_button_fail">Fail</string>
     <string name="ease_button_again">Again</string>
     <string name="ease_button_hard">Hard</string>
     <string name="ease_button_good">Good</string>

--- a/AnkiDroid/src/main/res/values/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values/10-preferences.xml
@@ -150,6 +150,8 @@
     <string name="pref_double_tap_time_interval_summary">A second tap of the answer buttons will be ignored if this time has not elapsed. This prevents accidental double taps</string>
     <string name="show_estimates" maxLength="41">Show button time</string>
     <string name="show_estimates_summ">Show next review time on answer buttons</string>
+    <string name="show_pass_fail" maxLength="41">Show pass fail</string>
+    <string name="show_pass_fail_summ">Replace the answer buttons with simple "Pass" and "Fail"</string>
     <string name="show_large_answer_buttons" maxLength="41">Show large answer buttons</string>
     <string name="show_large_answer_buttons_summ">Show answer button in 2 rows</string>
     <string name="show_top_bar" maxLength="41">Show Top Bar</string>

--- a/AnkiDroid/src/main/res/xml/preferences_reviewing.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_reviewing.xml
@@ -63,6 +63,10 @@
             android:title="@string/pref_double_tap_time_interval"
             app:min="0"
             app:max="2000" />
+        <CheckBoxPreference
+            android:key="showPassFail"
+            android:summary="@string/show_pass_fail_summ"
+            android:title="@string/show_pass_fail" />
 
     </PreferenceCategory>
     <PreferenceCategory android:title="@string/pref_cat_flashcard" >


### PR DESCRIPTION
## Purpose

Add an option to replace the ease action buttons with simple pass and fail.

## How Has This Been Tested?

Tested on my physical device (Huawei P9 Plus running Android 7.0), by enabling, checking a handful of cards, disabling, checking again, and repeating several times.

## Checklist

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars)
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [ ] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [x] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

## Screenshots

<div style="float:left;">
  <img src="https://user-images.githubusercontent.com/72546287/126437821-dc3080b0-80b8-404f-8901-7ae706421137.png">
  <img src="https://user-images.githubusercontent.com/72546287/126438298-953a15d5-8621-4523-983c-b38949daf1f4.png">
</div>