### PR TITLE
Improve Open Collective Donate Link

### DIFF
--- a/AnkiDroid/src/main/res/values/constants.xml
+++ b/AnkiDroid/src/main/res/values/constants.xml
@@ -205,7 +205,7 @@
     <string name="link_twitter">https://twitter.com/ankidroid</string>
     <string name="link_ankidroid_development_guide">https://github.com/ankidroid/Anki-Android/wiki/Development-Guide</string>
     <string name="link_ankidroid_faq">https://github.com/ankidroid/Anki-Android/wiki/FAQ</string>
-    <string name="link_opencollective_donate">https://opencollective.com/ankidroid#section-contribute</string>
+    <string name="link_opencollective_donate">https://opencollective.com/ankidroid/contribute</string>
     <string name="link_ankiweb_docs_cloze_deletion">https://docs.ankiweb.net/editing.html#cloze-deletion</string>
 
     <string-array name="leech_action_values">


### PR DESCRIPTION
Send to a specific page instead of a section of a page

The specific page has much less content and appears more optimised for
contributions

from: https://opencollective.com/ankidroid#section-contribute
to: https://opencollective.com/ankidroid/contribute

Untested