### PR TITLE
fix: remove '&amp;' from resource

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/CardSideSelectionDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/CardSideSelectionDialog.kt
@@ -26,7 +26,7 @@ class CardSideSelectionDialog {
     companion object {
         fun displayInstance(ctx: Context, callback: (c: CardSide) -> Unit) {
             val items = listOf(
-                R.string.card_side_both,
+                R.string.card_side_question_and_answer,
                 R.string.card_side_question,
                 R.string.card_side_answer
             )
@@ -36,7 +36,7 @@ class CardSideSelectionDialog {
                 .items(items.map { ctx.getString(it) })
                 .itemsCallback { _, _, which, _ ->
                     when (items[which]) {
-                        R.string.card_side_both -> callback(CardSide.BOTH)
+                        R.string.card_side_question_and_answer -> callback(CardSide.BOTH)
                         R.string.card_side_question -> callback(CardSide.QUESTION)
                         R.string.card_side_answer -> callback(CardSide.ANSWER)
                     }

--- a/AnkiDroid/src/main/res/values/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values/10-preferences.xml
@@ -309,7 +309,7 @@
     <string name="card_side_selection_title">Select card side</string>
     <string name="card_side_question">Question</string>
     <string name="card_side_answer">Answer</string>
-    <string name="card_side_both">Question &amp; Answer</string>
+    <string name="card_side_question_and_answer"><![CDATA[Question & Answer]]></string>
     <string name="display_binding_card_side_question" comment="When displaying a key bind on a preference
 this formatter is used if the bind only applies to the question">Q: %s</string>
     <string name="display_binding_card_side_answer" comment="When displaying a key bind on a preference


### PR DESCRIPTION
This caused an issue when downloading translations as the 'amp;' was stripped, casing XML build issues: #9318

We rename the string constant to fix the string on CrowdIn

Related: 
* Unblocks #9318 
* Related to #9319

## How Has This Been Tested?

Tested on my phone - dialog still works

## Learning (optional, can help others)
Our CrowdIn script may need work

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
