### PR TITLE
fix[Audio Insert]: Make audio files selectable

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicAudioClipFieldController.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicAudioClipFieldController.java
@@ -62,7 +62,7 @@ public class BasicAudioClipFieldController extends FieldControllerBase implement
         mBtnLibrary.setOnClickListener(v -> {
             Intent i = new Intent();
             i.setType("audio/*");
-            String[] extraMimeTypes = { "application/ogg" }; // #9226 allows ogg on Android 8
+            String[] extraMimeTypes = { "audio/*", "application/ogg" }; // #9226 allows ogg on Android 8
             i.putExtra(Intent.EXTRA_MIME_TYPES, extraMimeTypes);
             i.setAction(Intent.ACTION_GET_CONTENT);
             // Only get openable files, to avoid virtual files issues with Android 7+


### PR DESCRIPTION
## Purpose / Description
Audio files were not selectable from the System File Picker while adding an audio clip to a Note.

## Fixes
Fixes #9321.

## Approach
- No documentation on specifying multiple disjoint MIME types with
  ```Intent.ACTION_GET_CONTENT```

- ```Intent.ACTION_OPEN_DOCUMENT```'s documentation suggests passing ```*/*``` to
  ```setType()```, and specifying the desired disjoint MIME types in an array
  for the intent extra ```Intent.EXTRA_MIME_TYPE```. This suggestion works for
  ```Intent.ACTION_GET_CONTENT``` as well & is the one used to make audio
  files selectable so that they can be imported while adding an audio
  clip.

## How Has This Been Tested?
Tested on:
- Samsung Galaxy S7 API 26 (Physical Device)
- Pixel 4 XL API 30 (Emulator)

 Steps:
1. Add Note
2. Add Audio Clip
3. Click on LIBRARY
4. Audio files in the directory being viewed should be selectable, i.e., shouldn't be greyed out

## Learning (optional, can help others)
[Accepted answer](https://stackoverflow.com/a/23426753/12844135) on StackOverflow led to ```Intent.ACTION_OPEN_DOCUMENT``` documentation, which agreed with the accepted answer & worked with ```Intent.ACTION_GET_CONTENT``` as well.


## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
