### PR TITLE
SchemaV16: Implement Decks [WIP, but ready for review/merge]

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/DecksV16.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/DecksV16.kt
@@ -1,0 +1,745 @@
+/*
+ *  Copyright (c) 2021 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  This file incorporates work covered by the following copyright and
+ *  permission notice:
+ *
+ *  https://github.com/ankitects/anki/blob/c4db4bd2913234d077aa289543da6405a62f53dc/pylib/anki/decks.py
+ *
+ *  # Copyright: Ankitects Pty Ltd and contributors
+ *  # License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
+ *
+ */
+
+@file:Suppress(
+    "RedundantIf", "LiftReturnOrAssignment", "MemberVisibilityCanBePrivate", "FunctionName", "ConvertToStringTemplate", "LocalVariableName",
+    "NonPublicNonStaticFieldName", "ConstantFieldName"
+)
+
+package com.ichi2.libanki
+
+import com.ichi2.libanki.Utils.ids2str
+import com.ichi2.libanki.backend.DeckNameId
+import com.ichi2.libanki.backend.DeckTreeNode
+import com.ichi2.libanki.backend.DecksBackend
+import com.ichi2.libanki.utils.*
+import com.ichi2.utils.CollectionUtils
+import com.ichi2.utils.JSONArray
+import com.ichi2.utils.JSONObject
+import java8.util.Optional
+import java.util.*
+import BackendProto.Backend as pb
+
+private typealias Dict<K, V> = HashMap<K, V>
+private typealias ImmutableList<T> = kotlin.collections.List<T>
+private typealias List<T> = MutableList<T>
+private typealias str = String
+private typealias did = Long
+private typealias dcid = Long // Python3 has no 'long'
+private typealias bool = Boolean
+private typealias Tuple<T1, T2> = Pair<T1, T2>
+
+// legacy code may pass this in as the type argument to .id()
+const val defaultDeck = 0
+const val defaultDynamicDeck = 1
+
+/** Any kind of deck */
+// typealias Deck = Union<NonFilteredDeck, FilteredDeck>
+// typealias NonFilteredDeck = Dict<string, Any>
+// typealias FilteredDeck = Dict<string, Any>
+open class DeckV16 private constructor(private val deck: JSONObject) {
+    class NonFilteredDeck(val deck: JSONObject) : DeckV16(deck)
+    class FilteredDeck(val deck: JSONObject) : DeckV16(deck)
+
+    // to be usd rarely
+    fun getJsonObject(): JSONObject {
+        return deck
+    }
+
+    fun hasKey(s: String): Boolean = deck.has(s)
+
+    var name: str
+        get() = deck.getString("name")
+        set(value) {
+            deck.put("name", value)
+        }
+
+    var collapsed: bool
+        get() = deck.getBoolean("collapsed")
+        set(value) {
+            deck.put("collapsed", value)
+        }
+
+    var id: did
+        get() = deck.getLong("id")
+        set(value) {
+            deck.put("id", value)
+        }
+
+    var browserCollapsed: bool
+        get() = deck.optBoolean("browserCollapsed", false)
+        set(value) {
+            deck.put("browserCollapsed", value)
+        }
+
+    var conf: Long
+        get() = deck.getLong("conf")
+        set(value) {
+            deck.put("conf", value)
+        }
+
+    val dyn: Int
+        get() = deck.getInt("dyn")
+}
+
+// TODO: do we want optional<str>, or string here
+var Optional<DeckV16>.name: str
+    get() = this.get()!!.name
+    set(value) {
+        this.get()!!.name = value
+    }
+
+// /** Configuration of standard deck, as seen from the deck picker's gear. */
+// typealias Config = Dict<str, Any>
+// typealias DeckConfig = Union<FilteredDeck, Config>
+
+/** Configuration of some deck, filtered deck for filtered deck, config for standard deck */
+abstract class DeckConfigV16 private constructor(val config: JSONObject) {
+    class Config(val mConfigData: JSONObject) : DeckConfigV16(mConfigData) {
+        override fun deepClone(): DeckConfigV16 = Config(mConfigData.deepClone())
+    }
+
+    class FilteredDeck(val mDeckData: JSONObject) : DeckConfigV16(mDeckData) {
+        override fun deepClone(): DeckConfigV16 = FilteredDeck(mDeckData.deepClone())
+    }
+
+    var conf: Long
+        get() = config.getLong("conf")
+        set(value) {
+            config.put("conf", value)
+        }
+
+    var id: dcid
+        get() = config.getLong("id")
+        set(value) {
+            config.put("id", value)
+        }
+
+    var name: str
+        get() = config.getString("name")
+        set(value) {
+            config.put("name", value)
+        }
+
+    var dyn: bool
+        get() = config.getBoolean("dyn")
+        set(value) {
+            config.put("dyn", value)
+        }
+
+    fun getJSONObject(key: String): JSONObject = config.getJSONObject(key)
+    abstract fun deepClone(): DeckConfigV16
+}
+
+/** New/lrn/rev conf, from deck config */
+private typealias QueueConfig = Dict<str, Any>
+
+private typealias childMapNode = Dict<did, Any>
+// Change to Dict[int, "DeckManager.childMapNode"] when MyPy allow recursive type
+
+// TODO: col was a weakref
+
+/**
+ * Untested WIP implementation of Decks for Schema V16.
+ *
+ * It's planned to consolidate interfaces between this and decks.py
+ *
+ * Afterwards, we can finish up the implementations, run our tests, and use this with a V16
+ * collection, using decks as a separate table
+ */
+class DeckManager(private val col: Collection, private val mDecksBackend: DecksBackend) {
+
+    /* Registry save/load */
+
+    private fun save(grp: DeckConfigV16) {
+        when (grp) {
+            is DeckConfigV16.Config -> save(grp)
+            is DeckConfigV16.FilteredDeck -> save(DeckV16.FilteredDeck(grp.mDeckData))
+        }
+    }
+
+    fun save(g: DeckConfigV16.Config) {
+        // deck conf?
+        this.update_config(g)
+    }
+
+    fun save(g: DeckV16) {
+        this.update(g, preserve_usn = false)
+    }
+
+    // legacy
+    fun flush() {
+        // no-op
+    }
+
+    /* Deck save/load */
+
+    /** "Add a deck with NAME. Reuse deck if already exists. Return id as int." */
+    fun id(name: str, create: bool = true, type: Int = 0): Optional<did> {
+        val id = this.id_for_name(name)
+        if (id.isPresent) {
+            return id
+        } else if (!create) {
+            return Optional.empty()
+        }
+
+        val deck = this.new_deck_legacy(type != 0)
+        deck.name = name
+        this.update(deck, preserve_usn = false)
+
+        return Optional.of(deck.id)
+    }
+
+    /** Remove the deck. If cardsToo, delete any cards inside. */
+    fun rem(did: did, cardsToo: bool = true, childrenToo: bool = true) {
+        assert(cardsToo && childrenToo)
+        mDecksBackend.remove_deck(did)
+    }
+
+    /** A sorted sequence of deck names and IDs. */
+    fun all_names_and_ids(
+        skip_empty_default: bool = false,
+        include_filtered: bool = true
+    ): ImmutableList<DeckNameId> {
+
+        return mDecksBackend.all_names_and_ids(
+            skip_empty_default = skip_empty_default,
+            include_filtered = include_filtered
+        )
+    }
+
+    fun id_for_name(name: str): Optional<did> {
+        return mDecksBackend.id_for_name(name)
+    }
+
+    fun get_legacy(did: did): Optional<DeckV16> {
+        return mDecksBackend.get_deck_legacy(did)
+    }
+
+    fun get_all_legacy(): ImmutableList<DeckV16> {
+        return mDecksBackend.all_decks_legacy()
+    }
+    fun new_deck_legacy(filtered: bool): DeckV16 {
+        return mDecksBackend.new_deck_legacy(filtered)
+    }
+
+    fun deck_tree(): DeckTreeNode {
+        return mDecksBackend.deck_tree(now = 0L, top_deck_id = 0L)
+    }
+
+    /** All decks. Expensive; prefer all_names_and_ids() */
+    fun all(): ImmutableList<DeckV16> {
+        return this.get_all_legacy()
+    }
+
+    @Deprecated("decks.allIds() is deprecated, use .all_names_and_ids()")
+    fun allIds(): List<str> {
+        return this.all_names_and_ids().map {
+            x ->
+            x.id.toString()
+        }.toMutableList()
+    }
+
+    @Deprecated("decks.allNames() is deprecated, use .all_names_and_ids()")
+    fun allNames(dyn: bool = true, force_default: bool = true): List<str> {
+        return this.all_names_and_ids(
+            skip_empty_default = !force_default, include_filtered = dyn
+        ).map {
+            x ->
+            x.name
+        }.toMutableList()
+    }
+
+    fun collapse(did: did) {
+        val deck = this.get(did).get()
+        deck.collapsed = !deck.collapsed
+        this.save(deck)
+    }
+
+    fun collapseBrowser(did: did) {
+        val deck = this.get(did).get()
+        val collapsed = deck.browserCollapsed
+        deck.browserCollapsed = !collapsed
+        this.save(deck)
+    }
+
+    fun count(): Long {
+        return len(this.all_names_and_ids())
+    }
+
+    fun get(did: did, default: bool = true): Optional<DeckV16> {
+        val deck = this.get_legacy(did)
+        return when {
+            deck.isPresent -> deck
+            default -> this.get_legacy(1)
+            else -> Optional.empty()
+        }
+    }
+
+    /** Get deck with NAME, ignoring case. */
+    fun byName(name: str): Optional<DeckV16> {
+        val id = this.id_for_name(name)
+        if (id.isPresent) {
+            return this.get_legacy(id.get())
+        }
+        return Optional.empty()
+    }
+
+    /** Add or update an existing deck. Used for syncing and merging. */
+    fun update(g: DeckV16, preserve_usn: bool = true) {
+        g.id = mDecksBackend.add_or_update_deck_legacy(g, preserve_usn)
+    }
+
+    /** Rename deck prefix to NAME if not exists. Updates children. */
+    fun rename(g: DeckV16, newName: str) {
+        g.name = newName
+        this.update(g, preserve_usn = false)
+    }
+
+    /* Commented in the Java - also buggy in the Kotlin
+    Drag/drop
+
+    fun renameForDragAndDrop(draggedDeckDid: int, ontoDeckDid: Optional<unionDid>) {
+        var draggedDeck = this.get(draggedDeckDid)
+        var draggedDeckName = draggedDeck.name
+        var ontoDeckName = this.get(ontoDeckDid).name
+
+        if (ontoDeckDid is None || ontoDeckDid == "") {
+            if (len(path(draggedDeckName)) > 1) {
+                this.rename(draggedDeck, basename(draggedDeckName))
+            }
+        } else if (this._canDragAndDrop(draggedDeckName, ontoDeckName)) {
+            draggedDeck = this.get(draggedDeckDid)
+            draggedDeckName = draggedDeck.name
+            ontoDeckName = this.get(ontoDeckDid).name
+            assert(ontoDeckName.strip())
+            this.rename(
+                draggedDeck, ontoDeckName + "::" + basename(draggedDeckName)
+            )
+        }
+    }
+
+    fun _canDragAndDrop(draggedDeckName: str, ontoDeckName: str) : bool {
+        if (
+            draggedDeckName == ontoDeckName
+            || this._isParent(ontoDeckName, draggedDeckName)
+            || this._isAncestor(draggedDeckName, ontoDeckName)
+        ) {
+            return false
+        } else {
+            return true
+        }
+    }
+
+    fun _isParent(parentDeckName: str, childDeckName: str) : bool {
+    // incorrect
+        return path(childDeckName) == path(parentDeckName).add(basename(childDeckName))
+    }
+
+    fun _isAncestor(ancestorDeckName: str, descendantDeckName: str) : bool {
+        val ancestorPath = path(ancestorDeckName)
+        // incorrect
+        return ancestorPath == path(descendantDeckName).take(len(ancestorPath))
+    }
+    */
+
+    /* Deck configurations */
+
+    /** A list of all deck config. */
+    fun all_config(): ImmutableList<DeckConfigV16.Config> {
+        return mDecksBackend.all_config()
+    }
+
+    fun confForDid(did: did): DeckConfigV16 {
+        val deck = this.get(did, default = false)
+        assert(deck.isPresent)
+        val deckValue = deck.get()
+        if (deckValue.hasKey("conf")) {
+            val dcid = deckValue.conf // TODO: may be a string
+            var conf = this.get_config(dcid)
+            if (conf.isEmpty) {
+                // fall back on default
+                conf = this.get_config(1)
+            }
+            val knownConf = conf.get()
+            knownConf.dyn = false
+            return knownConf
+        }
+        // dynamic decks have embedded conf
+        return DeckConfigV16.FilteredDeck(deck.get().getJsonObject())
+    }
+
+    fun get_config(conf_id: dcid): Optional<DeckConfigV16> {
+        return mDecksBackend.get_config(conf_id)
+    }
+
+    fun update_config(conf: DeckConfigV16, preserve_usn: bool = false) {
+        conf.id = mDecksBackend.update_config(conf, preserve_usn)
+    }
+
+    fun add_config(
+        name: str,
+        clone_from: Optional<DeckConfigV16> = Optional.empty()
+    ): DeckConfigV16 {
+        val conf: DeckConfigV16
+        if (clone_from.isPresent) {
+            conf = clone_from.get().deepClone()
+            conf.id = 0L
+        } else {
+            conf = mDecksBackend.new_deck_config_legacy()
+        }
+        conf.name = name
+        this.update_config(conf)
+        return conf
+    }
+
+    fun add_config_returning_id(
+        name: str,
+        clone_from: Optional<DeckConfigV16> = Optional.empty()
+    ): dcid = this.add_config(name, clone_from).id
+
+    /** Remove a configuration and update all decks using it. */
+    fun remove_config(id: dcid) {
+        this.col.modSchema() // TODO: True was passed in as an arg
+        for (g in this.all()) {
+            // ignore cram decks
+            if (!g.hasKey("conf")) {
+                continue
+            }
+            if (g.conf.toString() == id.toString()) {
+                g.conf = 1L
+                this.save(g)
+            }
+        }
+        mDecksBackend.remove_deck_config(id)
+    }
+
+    fun setConf(grp: DeckConfigV16, id: dcid) {
+        grp.conf = id
+        this.save(grp)
+    }
+
+    fun didsForConf(conf: DeckConfigV16): List<did> {
+        val dids = mutableListOf<did>()
+        for (deck in this.all()) {
+            if (deck.hasKey("conf") && deck.conf == conf.id) {
+                dids.append(deck.id)
+            }
+        }
+        return dids
+    }
+
+    fun restoreToDefault(conf: DeckConfigV16) {
+        val oldOrder = conf.getJSONObject("new").getInt("order")
+        val new = mDecksBackend.new_deck_config_legacy()
+        new.id = conf.id
+        new.name = conf.name
+        this.update_config(new)
+        // if it was previously randomized, re-sort
+        if (oldOrder == 0) {
+            this.col.sched.resortConf(DeckConfig(new.config))
+        }
+    }
+
+    // legacy
+    fun allConf() = all_config()
+    fun getConf(conf_id: dcid) = get_config(conf_id)
+    fun updateConf(conf: DeckConfigV16, preserve_usn: bool = false) = update_config(conf, preserve_usn)
+    fun remConf(id: dcid) = remove_config(id)
+    fun confId(name: str, clone_from: Optional<DeckConfigV16> = Optional.empty()) =
+        add_config_returning_id(name, clone_from)
+
+    /* Deck utils */
+
+    fun name(did: did, default: bool = false): str {
+        val deck = this.get(did, default = default)
+        if (deck.isPresent) {
+            return deck.name
+        }
+        // TODO: Needs i18n, but the Java did the same, appears to be dead code
+        return "[no deck]"
+    }
+
+    fun nameOrNone(did: did): Optional<str> {
+        val deck = this.get(did, default = false)
+        if (deck.isPresent) {
+            return Optional.of(deck.name)
+        }
+        return Optional.empty()
+    }
+
+    fun setDeck(cids: LongArray, did: did) {
+        this.col.db.execute(
+            "update cards set did=?,usn=?,mod=? where id in " + ids2str(cids),
+            did,
+            this.col.usn(),
+            this.col.time.intTime(),
+        )
+    }
+
+    fun cids(did: did, children: bool = false): List<Long> {
+        if (!children) {
+            return this.col.db.queryLongList("select id from cards where did=?", did)
+        }
+        val dids = mutableListOf(did)
+        for ((name, id) in this.children(did)) {
+            dids.append(id)
+        }
+        return this.col.db.queryLongList("select id from cards where did in " + ids2str(dids))
+    }
+
+    fun for_card_ids(cids: List<Long>): List<did> {
+        return this.col.db.queryLongList("select did from cards where id in ${ids2str(cids)}")
+    }
+
+    /* Deck selection */
+
+    /** The currently active dids. */
+    fun active(): List<did> {
+        // TODO: Copied from the java, should use get_config
+        val activeDecks: JSONArray = col.conf.getJSONArray("activeDecks")
+        val result = LinkedList<Long>()
+        CollectionUtils.addAll(result, activeDecks.longIterable())
+        return result
+    }
+
+    /** The currently selected did. */
+    fun selected(): did {
+        return this.col.conf.getLong("curDeck")
+    }
+
+    fun current(): DeckV16 {
+        return this.get(this.selected()).get()
+    }
+
+    /** Select a new branch. */
+    fun select(did: did) {
+        // make sure arg is an int
+        // did = int(did) - code removed, logically impossible
+        val current = this.selected()
+        val active = this.deck_and_child_ids(did)
+        if (current != did || active != this.active()) {
+            this.col.conf.put("curDeck", did)
+            this.col.conf.put("activeDecks", active.toJsonArray())
+        }
+    }
+
+    /** don't use this, it will likely go away */
+    fun update_active() {
+        this.select(this.current().id)
+    }
+
+    /* Parents/children */
+
+    companion object {
+
+        @JvmStatic
+        fun find_deck_in_tree(node: pb.DeckTreeNode, deck_id: did): Optional<pb.DeckTreeNode> {
+            if (node.deckId == deck_id) {
+                return Optional.of(node)
+            }
+            for (child in node.childrenList) {
+                val match = find_deck_in_tree(child, deck_id)
+                if (match.isPresent) {
+                    return match
+                }
+            }
+            return Optional.empty()
+        }
+
+        @JvmStatic
+        fun path(name: str): ImmutableList<str> {
+            return name.split("::")
+        }
+
+        @JvmStatic
+        fun _path(name: str) = path(name)
+
+        @JvmStatic
+        fun basename(name: str): str {
+            return path(name)[-1]
+        }
+
+        @JvmStatic
+        fun _basename(str: str) = basename(str)
+
+        @JvmStatic
+        fun immediate_parent_path(name: str): List<str> {
+            return _path(name).dropLast(1).toMutableList()
+        }
+
+        @JvmStatic
+        fun immediate_parent(name: str): Optional<str> {
+            val pp = immediate_parent_path(name)
+            if (pp.isNotNullOrEmpty()) {
+                return Optional.of("::".join(pp))
+            }
+            return Optional.empty()
+        }
+
+        @JvmStatic
+        fun key(deck: DeckV16): ImmutableList<str> {
+            return path(deck.name)
+        }
+    }
+
+    /** All children of did, as (name, id). */
+    fun children(did: did): List<Tuple<str, did>> {
+        val name: str = this.get(did).name
+        val actv = mutableListOf<Tuple<str, did>>()
+        for (g in this.all_names_and_ids()) {
+            if (g.name.startsWith(name + "::")) {
+                actv.append(Tuple(g.name, g.id))
+            }
+        }
+        return actv
+    }
+
+    fun child_ids(parent_name: str): Iterable<did> {
+        val prefix = parent_name + "::"
+        return all_names_and_ids().filter {
+            x ->
+            x.name.startsWith(prefix)
+        }.map {
+            d ->
+            d.id
+        }.toMutableList()
+    }
+
+    fun deck_and_child_ids(deck_id: did): List<did> {
+        val parent_name = this.get_legacy(deck_id).name
+        val out = mutableListOf(deck_id)
+        out.extend(this.child_ids(parent_name))
+        return out
+    }
+
+    fun childDids(did: did, childMap: childMapNode): List<did> {
+        fun gather(node: childMapNode, arr: List<did>) {
+            for ((did, child) in node.items()) {
+                arr.append(did)
+                gather(child as childMapNode, arr)
+            }
+        }
+        val arr: List<did> = mutableListOf()
+        gather(childMap[did] as childMapNode, arr)
+        return arr
+    }
+
+    fun childMap(): childMapNode {
+        val nameMap = this.nameMap()
+        val childMap = childMapNode()
+
+        // go through all decks, sorted by name
+        for (deck in sorted(this.all())) {
+            val node = Dict<did, Any>()
+            childMap[deck.id] = node
+
+            // add note to immediate parent
+            val immediateParent = immediate_parent(deck.name)
+            if (immediateParent.isPresent) {
+                val pid = nameMap[immediateParent.get()]?.id
+                val value = childMap[pid] as childMapNode
+                value[deck.id] = node
+            }
+        }
+
+        return childMap
+    }
+
+    private fun sorted(all: ImmutableList<DeckV16>): ImmutableList<DeckV16> {
+        return all.sortedBy {
+            d ->
+            d.name
+        }
+    }
+
+    /** All parents of did. */
+    fun parents(
+        did: did,
+        nameMap: Optional<Dict<str, DeckV16>> = Optional.empty()
+    ): List<DeckV16> {
+        // get parent and grandparent names
+        val parents_names: MutableList<str> = mutableListOf()
+        for (part in immediate_parent_path(this.get(did).name)) {
+            if (parents_names.isNullOrEmpty()) {
+                parents_names.append(part)
+            } else {
+                parents_names.append(parents_names[-1] + "::" + part)
+            }
+        }
+        val parents: MutableList<DeckV16> = mutableListOf()
+        // convert to objects
+        for (parent_name in parents_names) {
+            var deck: DeckV16
+            if (nameMap.isPresent) {
+                deck = nameMap.get()[parent_name]!!
+            } else {
+                deck = this.get(this.id(parent_name).get()).get()!!
+            }
+            parents.append(deck)
+        }
+        return parents
+    }
+
+    /** All existing parents of name */
+    fun parentsByName(name: str): List<DeckV16> {
+        if (!name.contains("::")) {
+            return mutableListOf()
+        }
+        val names: List<str> = immediate_parent_path(name)
+        val head: List<str> = mutableListOf()
+        val parents: List<DeckV16> = mutableListOf()
+
+        while (names.isNotNullOrEmpty()) {
+            head.append(names.pop(0))
+            val deck = this.byName("::".join(head))
+            if (deck.isPresent) {
+                parents.append(deck.get())
+            }
+        }
+
+        return parents
+    }
+
+    fun nameMap(): Map<str, DeckV16> {
+        return all().map { d -> Pair(d.name, d) }.toMap()
+    }
+
+    /*
+     Dynamic decks
+     */
+
+    /** Return a new dynamic deck and set it as the current deck. */
+    fun newDyn(name: str): did {
+        val did = this.id(name, type = 1).get()
+        this.select(did)
+        return did
+    }
+
+    // 1 for dyn, 0 for standard
+    fun isDyn(did: did): Boolean {
+        return this.get(did).get().dyn != 0
+    }
+}

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/backend/DecksBackend.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/backend/DecksBackend.kt
@@ -1,0 +1,182 @@
+/*
+ *  Copyright (c) 2021 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+@file:Suppress("NonPublicNonStaticFieldName", "FunctionName")
+
+package com.ichi2.libanki.backend
+
+import BackendProto.Backend
+import com.google.protobuf.ByteString
+import com.ichi2.libanki.DeckConfigV16
+import com.ichi2.libanki.DeckV16
+import com.ichi2.utils.JSONObject
+import java8.util.Optional
+import net.ankiweb.rsdroid.BackendV1
+import net.ankiweb.rsdroid.database.NotImplementedException
+import net.ankiweb.rsdroid.exceptions.BackendDeckIsFilteredException
+import net.ankiweb.rsdroid.exceptions.BackendNotFoundException
+import java.io.UnsupportedEncodingException
+
+private typealias did = Long
+private typealias dcid = Long
+
+data class DeckNameId(val name: String, val id: did)
+
+data class DeckTreeNode(
+    val deck_id: Long,
+    val name: String,
+    val children: List<DeckTreeNode>,
+    val level: UInt,
+    val collapsed: Boolean,
+    val review_count: UInt,
+    val learn_count: UInt,
+    val new_count: UInt,
+    val filtered: Boolean
+)
+
+/** Anti-corruption layer, removing the dependency on protobuf types from libAnki code */
+interface DecksBackend {
+    fun get_config(conf_id: dcid): Optional<DeckConfigV16>
+    fun update_config(conf: DeckConfigV16, preserve_usn: Boolean): dcid
+    fun new_deck_config_legacy(): DeckConfigV16
+    fun all_config(): List<DeckConfigV16.Config>
+    fun add_or_update_deck_legacy(deck: DeckV16, preserve_usn: Boolean): did
+    fun id_for_name(name: String): Optional<did>
+    fun get_deck_legacy(did: did): Optional<DeckV16>
+    fun all_decks_legacy(): List<DeckV16>
+    fun new_deck_legacy(filtered: Boolean): DeckV16
+    /** A sorted sequence of deck names and IDs. */
+    fun all_names_and_ids(skip_empty_default: Boolean, include_filtered: Boolean): List<DeckNameId>
+    fun deck_tree(now: Long, top_deck_id: Long): DeckTreeNode
+    fun remove_deck_config(id: dcid)
+    fun remove_deck(did: did)
+}
+
+class DeckRenameError(message: String) : Exception(message)
+
+/** WIP: Backend implementation for usage in Decks.kt */
+class RustDroidDeckBackend(private val mBackend: BackendV1) : DecksBackend {
+
+    override fun get_config(conf_id: dcid): Optional<DeckConfigV16> {
+        return try {
+            val jsonObject = from_json_bytes(mBackend.getDeckConfigLegacy(conf_id))
+            val config = DeckConfigV16.Config(jsonObject)
+            Optional.of(config)
+        } catch (ex: BackendNotFoundException) {
+            Optional.empty()
+        }
+    }
+
+    override fun update_config(conf: DeckConfigV16, preserve_usn: Boolean): dcid {
+        return mBackend.addOrUpdateDeckConfigLegacy(conf.to_json_bytes(), preserve_usn).dcid
+    }
+
+    override fun new_deck_config_legacy(): DeckConfigV16 {
+        val jsonObject = from_json_bytes(mBackend.newDeckConfigLegacy())
+        return DeckConfigV16.Config(jsonObject)
+    }
+
+    override fun all_config(): MutableList<DeckConfigV16.Config> {
+        val jsonObject = from_json_bytes(mBackend.allDeckConfigLegacy())
+        throw NotImplementedException()
+    }
+
+    override fun add_or_update_deck_legacy(deck: DeckV16, preserve_usn: Boolean): did {
+        try {
+            val addOrUpdateResult = mBackend.addOrUpdateDeckLegacy(deck.to_json_bytes(), preserve_usn)
+            return addOrUpdateResult.did
+        } catch (ex: BackendDeckIsFilteredException) {
+            throw DeckRenameError("deck was filtered")
+        }
+    }
+
+    override fun id_for_name(name: String): Optional<did> {
+        try {
+            return Optional.of(mBackend.getDeckIDByName(name).did)
+        } catch (ex: BackendNotFoundException) {
+            return Optional.empty()
+        }
+    }
+
+    override fun get_deck_legacy(did: did): Optional<DeckV16> {
+        try {
+            val ret = from_json_bytes(mBackend.getDeckLegacy(did))
+            throw NotImplementedException("convert to either filtered or not filtered")
+        } catch (ex: BackendNotFoundException) {
+            return Optional.empty()
+        }
+    }
+
+    override fun new_deck_legacy(filtered: Boolean): DeckV16 {
+        val deck = from_json_bytes(mBackend.newDeckLegacy(filtered))
+        return if (filtered) {
+            DeckV16.FilteredDeck(deck)
+        } else {
+            DeckV16.NonFilteredDeck(deck)
+        }
+    }
+
+    override fun all_decks_legacy(): MutableList<DeckV16> {
+        throw NotImplementedException()
+        // mutableListOf(from_json_bytes(mBackend.allDecksLegacy).values())
+    }
+
+    override fun all_names_and_ids(skip_empty_default: Boolean, include_filtered: Boolean): List<DeckNameId> {
+        return mBackend.getDeckNames(skip_empty_default, include_filtered).entriesList.map {
+            entry ->
+            DeckNameId(entry.name, entry.id)
+        }
+    }
+
+    override fun deck_tree(now: Long, top_deck_id: Long): DeckTreeNode {
+        val tree = mBackend.deckTree(now, top_deck_id)
+        throw NotImplementedException()
+    }
+
+    override fun remove_deck_config(id: dcid) {
+        mBackend.removeDeckConfig(id)
+    }
+
+    override fun remove_deck(did: did) {
+        mBackend.removeDeck(did)
+    }
+
+    private fun DeckV16.to_json_bytes(): ByteString {
+        return toByteString(this.getJsonObject())
+    }
+
+    private fun DeckConfigV16.to_json_bytes(): ByteString {
+        return toByteString(this.config)
+    }
+
+    fun from_json_bytes(json: Backend.Json): JSONObject {
+        val str = jsonToString(json)
+        return JSONObject(str)
+    }
+
+    fun jsonToString(json: Backend.Json): String {
+        return try {
+            json.json.toString("UTF-8")
+        } catch (e: UnsupportedEncodingException) {
+            throw IllegalStateException("Could not deserialize JSON", e)
+        }
+    }
+
+    fun toByteString(conf: JSONObject): ByteString {
+        val asString: String = conf.toString()
+        return ByteString.copyFromUtf8(asString)
+    }
+}

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/utils/PythonExtensions.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/utils/PythonExtensions.kt
@@ -1,0 +1,69 @@
+/*
+ *  Copyright (c) 2021 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.libanki.utils
+
+import android.text.TextUtils
+import com.ichi2.utils.JSONArray
+import java.util.*
+
+fun <T> MutableList<T>.append(value: T) {
+    this.add(value)
+}
+
+fun <T> MutableList<T>.extend(elements: Iterable<T>) {
+    this.addAll(elements)
+}
+
+fun <T> len(l: Sequence<T>): Long {
+    return l.count().toLong()
+}
+
+fun <T> len(l: List<T>): Long {
+    return l.size.toLong()
+}
+
+fun <E> MutableList<E>.pop(i: Int): E {
+    return this.removeAt(i)
+}
+
+fun <K, V> HashMap<K, V>.items(): List<Pair<K, V>> {
+    return this.entries.map {
+        Pair(it.key, it.value)
+    }
+}
+
+fun <T> List<T>?.isNullOrEmpty(): Boolean {
+    return this == null || this.isEmpty()
+}
+
+fun <T> List<T>?.isNotNullOrEmpty(): Boolean {
+    return !this.isNullOrEmpty()
+}
+
+fun <T> list(vararg elements: T) = mutableListOf(elements)
+
+fun String.join(values: MutableList<String>): String {
+    return TextUtils.join(this, values)
+}
+
+fun <E> MutableList<E>.toJsonArray(): JSONArray {
+    val array = JSONArray()
+    for (i in this) {
+        array.put(i)
+    }
+    return array
+}


### PR DESCRIPTION
This converts decks.py to DecksV16.kt as it was in Anki 2.1.34

To move to the v16 schema, we need to upgrade the classes
associated with the collection columns

These have moved from JSON in a single column to one row per protobuf

After this is merged, we can start migrating Decks.java to use the
same interface and consolidate functionality.

Once the interfaces are the same, we can build a new "Collection" class
with the new table-based classes, flip to opening the collection via
the v16 upgrade mechanism, and then check for bugs.

Some of this functionality is explicitly WIP (`DecksBackend.kt`)

Related: #8988

## How Has This Been Tested?

Not working code - no tests
## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
