### PR TITLE
build(deps): bump lint_version from 27.2.2 to 30.0.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ import org.gradle.internal.jvm.Jvm
 buildscript {
     // The version for the Kotlin plugin and dependencies
     ext.kotlin_version = '1.5.21'
-    ext.lint_version = '27.2.2'
+    ext.lint_version = '30.0.0'
 
     repositories {
         google()

--- a/lint-rules/build.gradle
+++ b/lint-rules/build.gradle
@@ -19,6 +19,7 @@ dependencies {
 
     testImplementation "junit:junit:4.13.2"
     testImplementation "com.android.tools.lint:lint:$lint_version"
+    testImplementation "com.android.tools.lint:lint-api:$lint_version"
     testImplementation "com.android.tools.lint:lint-tests:$lint_version"
     testImplementation 'org.hamcrest:hamcrest-all:1.3'
 }

--- a/lint-rules/src/test/java/com/ichi2/anki/lint/rules/CopyrightHeaderExistsTest.java
+++ b/lint-rules/src/test/java/com/ichi2/anki/lint/rules/CopyrightHeaderExistsTest.java
@@ -73,6 +73,7 @@ public class CopyrightHeaderExistsTest {
     public void fileWithNoCopyrightHeaderFails() {
         lint()
                 .allowMissingSdk()
+                .allowCompilationErrors() // import failures
                 .files(create(mNoCopyrightHeader))
                 .issues(CopyrightHeaderExists.ISSUE)
                 .run()

--- a/lint-rules/src/test/java/com/ichi2/anki/lint/rules/FixedPreferencesTitleLengthTest.java
+++ b/lint-rules/src/test/java/com/ichi2/anki/lint/rules/FixedPreferencesTitleLengthTest.java
@@ -109,7 +109,7 @@ public class FixedPreferencesTitleLengthTest {
                 .run()
                 .expectErrorCount(3)
                 .expect("res/values/10-preferences.xml:12: Error: Preference title 'more_characters_than_limit' must be less than 41 characters (currently 48) [FixedPreferencesTitleLength]\n" +
-                        "    <string name=\"more_characters_than_limit\"  maxLength=\"41\">This String contains character more than limit £</string>\n" +
+                        "    <string name=\"more_characters_than_limit\"  maxLength=\"41\">This String contains character more than limit \u00A3</string>\n" +
                         "    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\n" +
                         "res/values/10-preferences.xml:3: Error: Preference title 'app_name' is missing \"maxLength=41\" attribute [PreferencesTitleMaxLengthAttr]\n" +
                         "    <string name=\"app_name\">app_name</string>\n" +


### PR DESCRIPTION
Fix errors which were introduced:

* api is now required
* Unicode Handling changed
* Compilation errors from missing imports were introduced

Bumps `lint_version` from 27.2.2 to 30.0.0.

Updates `lint-api` from 27.2.2 to 30.0.0

Updates `lint` from 27.2.2 to 30.0.0

Updates `lint-tests` from 27.2.2 to 30.0.0

---
updated-dependencies:
- dependency-name: com.android.tools.lint:lint-api
  dependency-type: direct:production
  update-type: version-update:semver-major
- dependency-name: com.android.tools.lint:lint
  dependency-type: direct:production
  update-type: version-update:semver-major
- dependency-name: com.android.tools.lint:lint-tests
  dependency-type: direct:production
  update-type: version-update:semver-major
...

Signed-off-by: dependabot[bot] <support@github.com>