### PR TITLE
build(deps): bump android gradle plugin to 7.0.0

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -1,6 +1,6 @@
 plugins {
  // Gradle plugin portal 
- id 'com.github.triplet.play' version '3.5.0'
+ id 'com.github.triplet.play' version '3.5.0-agp7.0'
 }
 
 apply plugin: 'com.android.application'
@@ -171,10 +171,6 @@ android {
         }
     }
 
-    dexOptions {
-        // Skip pre-dexing when running in a CI environment or when disabled via -Dpre-dex=false.
-        preDexLibraries = preDexEnabled && !ciBuild
-    }
     compileOptions {
         coreLibraryDesugaringEnabled true
     }

--- a/api/build.gradle
+++ b/api/build.gradle
@@ -18,8 +18,6 @@ android {
         minSdkVersion 14
         //noinspection OldTargetApi
         targetSdkVersion 29
-        versionCode 11030   // 4th digit: 1=alpha, 2=beta, 3=official
-        versionName version
     }
     buildTypes {
         release {

--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.2.2'
+        classpath 'com.android.tools.build:gradle:7.0.0'
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
         classpath "app.brant:amazonappstorepublisher:0.1.0"
@@ -35,11 +35,11 @@ allprojects {
 ext {
 
     jvmVersion = Jvm.current().javaVersion.majorVersion
-    if (jvmVersion != "8" && jvmVersion != "11" && jvmVersion != "14") {
+    if (jvmVersion != "11" && jvmVersion != "14") {
         println "\n\n\n"
         println "**************************************************************************************************************"
         println "\n\n\n"
-        println "ERROR: AnkiDroid builds with JVM LTS and current releases (currently major version 8, 11, or 14)."
+        println "ERROR: AnkiDroid builds with JVM 11 and 14"
         println "  Incompatible major version detected: '" + jvmVersion + "'"
         println "\n\n\n"
         println "**************************************************************************************************************"

--- a/gradle.properties
+++ b/gradle.properties
@@ -17,7 +17,12 @@ org.gradle.jvmargs=-Xmx1536m
 android.useAndroidX=true
 # Automatically convert third-party libraries to use AndroidX
 android.enableJetifier=true
-android.jetifier.blacklist=bcprov
+
+# bcprov processing works, but generates a warning (which treat as an error) with AGP7
+# bcprov will be processed cleanly (and this may be removed) with AGP7.1+
+# https://issuetracker.google.com/issues/159151549#comment12
+android.jetifier.ignorelist=bcprov
+
 
 # With de-coupled gradle sub-modules, they may run in parallel
 org.gradle.parallel=true


### PR DESCRIPTION
## Pull Request template

## Purpose / Description

More than anything, try it to make sure there are no major incompatibilities. Since there aren't, might as well post it up

## Fixes
Obsoletes #9328 

## Approach

- bcprov ignored via `ignorelist` now, may be removed w/AGP7.1 https://issuetracker.google.com/issues/159151549#comment12
- Triple-T publisher needs a switch to their agp7.0 track
- Obsolete versionCode/version/dexOptions removed (suggested by AGP migration task in Android Studio)
- AGP 7+ requires JDK11 to run, retire JDK8 from development


## How Has This Been Tested?

I tested it locally with API21 and API30 emulators up via `./gradlew clean jacocoTestReport`, no regressions detected

## Learning (optional, can help others)

Just reading release notes carefully and using the android gradle plugin migration assistant (which pointed out some of the deprecated / obsolete items in our gradle files)



## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
