### PR TITLE
AGP 7 lint fixes

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -1251,7 +1251,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
             // Only new cards may be repositioned
             List<Long> cardIds = getSelectedCardIds();
             for (long cardId : cardIds) {
-                if (getCol().getCard(cardId).getQueue() != Consts.CARD_TYPE_NEW) {
+                if (getCol().getCard(cardId).getQueue() != Consts.QUEUE_TYPE_NEW) {
                     SimpleMessageDialog dialog = SimpleMessageDialog.newInstance(
                             getString(R.string.vague_error),
                             getString(R.string.reposition_card_not_new_error),

--- a/AnkiDroid/src/main/java/com/ichi2/anki/provider/CardContentProvider.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/provider/CardContentProvider.java
@@ -1448,7 +1448,7 @@ public class CardContentProvider extends ContentProvider {
 
     private void throwSecurityException(String methodName, Uri uri) {
         String msg = String.format("Permission not granted for: %s", getLogMessage(methodName, uri));
-        Timber.e(msg);
+        Timber.e("%s", msg);
         throw new SecurityException(msg);
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
@@ -2047,6 +2047,7 @@ public class SchedV2 extends AbstractSched {
                 card.setQueue(Consts.QUEUE_TYPE_DAY_LEARN_RELEARN);
             }
         } else {
+            //noinspection WrongConstant
             card.setQueue(card.getType());
         }
     }

--- a/lint-release.xml
+++ b/lint-release.xml
@@ -350,4 +350,9 @@
     <issue id="SuspiciousImport" severity="ignore" />
     <issue id="WrongFolder" severity="ignore" />
     <issue id="WrongThreadInterprocedural" severity="ignore" />
+
+
+    <issue id="CustomX509TrustManager" severity="ignore" />
+    <!-- PERF: Could improve by not using notifyDataSetChanged() -->
+    <issue id="NotifyDataSetChanged" severity="ignore" />
 </lint>


### PR DESCRIPTION
This fixes all but one lint error coming from AGP 7

This helps get #9338 closer to completion.

The only missing lint check is pending intent mutability. The constant that we should use was introduced in API 23.

https://developer.android.com/about/versions/12/behavior-changes-12#test-pending-intent

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
