### PR TITLE
Use MediaStore instead of direct file path access for DeckPicker background preference

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
@@ -569,22 +569,18 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
         try {
             if (requestCode == RESULT_LOAD_IMG && resultCode == RESULT_OK && null != data) {
                 Uri selectedImage = data.getData();
-                String[] filePathColumn = { MediaStore.Images.Media.DATA };
+                String[] filePathColumn = { MediaStore.MediaColumns.SIZE };
                 try (Cursor cursor = getContentResolver().query(selectedImage, filePathColumn, null, null, null)) {
                     cursor.moveToFirst();
-                    int columnIndex = cursor.getColumnIndex(filePathColumn[0]);
-                    String imgPathString = cursor.getString(columnIndex);
-                    File sourceFile = new File(imgPathString);
-
                     // file size in MB
-                    long fileLength = sourceFile.length() / (1024 * 1024);
+                    long fileLength = cursor.getLong(0) / (1024 * 1024);
 
                     String currentAnkiDroidDirectory = CollectionHelper.getCurrentAnkiDroidDirectory(this);
                     String imageName = "DeckPickerBackground.png";
                     File destFile = new File(currentAnkiDroidDirectory, imageName);
                     // Image size less than 10 MB copied to AnkiDroid folder
                     if (fileLength < 10) {
-                        try (FileChannel sourceChannel = new FileInputStream(sourceFile).getChannel();
+                        try (FileChannel sourceChannel = ((FileInputStream) getContentResolver().openInputStream(selectedImage)).getChannel();
                              FileChannel destChannel = new FileOutputStream(destFile).getChannel()) {
                             destChannel.transferFrom(sourceChannel, 0, sourceChannel.size());
                             UIUtils.showThemedToast(this, getString(R.string.background_image_applied), false);


### PR DESCRIPTION
## Purpose / Description
Moves away from using direct file path access (using a ```File``` object) to the new DeckPicker background image selected by the user since the image may be in a directory which will not be accessible via direct file path access under Scoped Storage.
The set DeckPicker background feature will now work for all devices once Scoped Storage is enforced.

## Approach
Currently, ```ContentResolver``` is used to query the ```MediaStore.Images``` collection to obtain the path of the image selected by the user. Then, a ```File``` object (direct file path access) is used to obtain size & open the ```InputStream``` to copy the image.

Instead, the ```MediaStore.Images``` collection can directly be queried for image size, and ```ContentResolver``` can open the ```InputStream``` using the URI of the image selected by the user. This URI is already available.


## How Has This Been Tested?
Tested on the following devices, each of which were tested with ```requestLegacyExternalStorage``` set to true and false, and with no permissions granted:
- Pixel XL API 21 (Emulator)
- Pixel XL API 26 (Emulator)
- Galaxy S7 API 26 (Physical Device)
- Pixel 4 XL API 29 (Emulator)
- Pixel 4 XL API 30 (Emulator)


## Checklist

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
