### PR TITLE
status bar color in dark theme changed to dark grey

### DIFF
--- a/AnkiDroid/src/main/res/values/theme_dark.xml
+++ b/AnkiDroid/src/main/res/values/theme_dark.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <color name="theme_dark_primary">#3d3d3d</color>
-    <color name="theme_dark_primary_dark">@color/black</color>
+    <color name="theme_dark_primary_dark">@color/material_grey_900</color>
     <color name="theme_dark_primary_light">@color/material_grey_800</color>
     <color name="theme_dark_accent">@color/material_light_blue_700</color>
     <color name="theme_dark_primary_text">@color/white</color>


### PR DESCRIPTION
## Purpose / Description
Made the color of the status bar be dark grey instead of black in dark theme

## Fixes
Fixes #9317 

## Approach
changed `theme_dark_primary_dark` to dark grey from black

## How Has This Been Tested?
### Previously:
![Screenshot_1627754448](https://user-images.githubusercontent.com/59933477/127748650-746a55d0-7fb0-492b-9f67-b2f31275486d.png)

### Now:
![Screenshot_1627754357](https://user-images.githubusercontent.com/59933477/127748607-6fda7b37-fbbf-488f-8d79-e35ed567aaf2.png)

## Checklist

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
