### PR TITLE
targetSdk=30 compatibility for Add/View Image feature

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -1705,6 +1705,12 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
         webView.getSettings().setLoadWithOverviewMode(true);
         webView.getSettings().setJavaScriptEnabled(true);
         webView.setWebChromeClient(new AnkiDroidWebChromeClient());
+
+        // This setting toggles file system access within WebView
+        // The default configuration is already true in apps targeting API <= 29
+        // Hence, this setting is only useful for apps targeting API >= 30
+        webView.getSettings().setAllowFileAccess(true);
+
         // Problems with focus and input tags is the reason we keep the old type answer mechanism for old Androids.
         webView.setFocusableInTouchMode(mUseInputTag);
         webView.setScrollbarFadingEnabled(true);

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicImageFieldController.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicImageFieldController.java
@@ -443,8 +443,6 @@ public class BasicImageFieldController extends FieldControllerBase implements IF
     private @Nullable File internalizeUri(Uri uri) {
         File internalFile;
         Pair<String, String> uriFileInfo = getImageInfoFromUri(mActivity, uri);
-        String filePath = uriFileInfo.first;
-        String displayName = uriFileInfo.second;
 
         // Use the display name from the image info to create a new file with correct extension
         if (uriFileInfo.second == null) {
@@ -461,7 +459,7 @@ public class BasicImageFieldController extends FieldControllerBase implements IF
             return null;
         }
         try {
-            File returnFile = FileUtil.internalizeUri(uri, filePath, internalFile, mActivity.getContentResolver());
+            File returnFile = FileUtil.internalizeUri(uri, internalFile, mActivity.getContentResolver());
             Timber.d("internalizeUri successful. Returning internalFile.");
             return returnFile;
         } catch (Exception e) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/provider/CardContentProvider.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/provider/CardContentProvider.java
@@ -1108,7 +1108,7 @@ public class CardContentProvider extends ContentProvider {
                 return null;
             }
 
-            FileUtil.internalizeUri(fileUri, null, tempFile, cR);
+            FileUtil.internalizeUri(fileUri, tempFile, cR);
 
             String fname = media.addFile(tempFile);
             Timber.d("insert -> MEDIA: fname = %s", fname);

--- a/AnkiDroid/src/main/java/com/ichi2/utils/FileUtil.java
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/FileUtil.java
@@ -49,34 +49,21 @@ public class FileUtil {
     /**
      *
      * @param uri               uri to the content to be internalized, used if filePath not real/doesn't work.
-     * @param filePath          path to the file to be internalized.
      * @param internalFile      an internal cache temp file that the data is copied/internalized into.
      * @param contentResolver   this is needed to open an inputStream on the content uri.
      * @return  the internal file after copying the data across.
      * @throws IOException
      */
     @NonNull
-    public static File internalizeUri(
-            Uri uri, @Nullable String filePath, File internalFile, ContentResolver contentResolver
-    ) throws IOException {
-
+    public static File internalizeUri(Uri uri, File internalFile, ContentResolver contentResolver) throws IOException {
         // If we got a real file name, do a copy from it
         InputStream inputStream;
-        if (filePath != null) {
-            Timber.d("internalizeUri() got file path for direct copy from Uri %s", uri);
-            try {
-                inputStream = new FileInputStream(new File(filePath));
-            } catch (FileNotFoundException e) {
-                Timber.w(e, "internalizeUri() unable to open input stream on file %s", filePath);
-                throw e;
-            }
-        } else {
-            try {
-                inputStream = contentResolver.openInputStream(uri);
-            } catch (Exception e) {
-                Timber.w(e, "internalizeUri() unable to open input stream from content resolver for Uri %s", uri);
-                throw e;
-            }
+
+        try {
+            inputStream = contentResolver.openInputStream(uri);
+        } catch (Exception e) {
+            Timber.w(e, "internalizeUri() unable to open input stream from content resolver for Uri %s", uri);
+            throw e;
         }
 
         try {


### PR DESCRIPTION
## Purpose / Description

This change moves away from using direct file path access for the Add/View Image feature for the following reasons:
1.  For apps targeting API 29, unless the ```requestLegacyExternalStorage``` flag is set to ```true```, they will not be able to access media in shared storage using direct file path access (this is why Add Image works right now)
2. For apps targeting API 30+, they will be able to use direct file path access but will have to obtain permission to access media
3. MediaStore is the recommended approach to importing a media file that already exists
4. For apps targeting API 30+, ```WebView``` will not have access to the device filesystem by default. Hence, it won't be able to access the images stored in the AnkiDroid directory, even if AnkiDroid itself has permission to its directory. So under default ```WebView``` settings, images stored in this directory cannot be displayed by ```WebView```.

## Fixes
Fixes #7014 as a side effect since it _doesn't_ need to query for the path of the file represented by a URI using the deprecated ```MediaStore.MediaColumns.DATA```

## Approach
Solutions to the respective issues above:
1. Simply remove the code snippet in ```FileUtil.internalizeUri()``` which uses direct file path access. This method is used to copy an image of the user's choice to AnkiDroid's cache directory. The method already uses ```ContentResolver``` to open the ```InputStream``` as a backup option, so this will ensure Images can be added
2. Allow ```WebView``` to access the device filesystem using ```WebSettings#setAllowFileAccess(true)```

## How Has This Been Tested?

#### Steps
1. Add Note
2. Click on the paperclip next to one of the input fields to open menu
3. Click on Add Image
Select an image from a non-app-specific directory such as Downloads. The preview should be visible, cropping should work, and the image should be viewable once the change has been finalized with the check button on the top-right-hand corner.

Before this change, the Add Image feature would not work if:
- AnkiDroid targets API 29, but the ```requestLegacyExternalStorage``` flag is removed
- AnkiDroid targets API 30 but has not obtained permission to access media files

Tested on the following devices, each of which was tested successfully with ```requestLegacyExternalStorage``` removed, with no permissions granted, and targetSdk set to 29 & 30:

- Pixel XL API 21 (Emulator)
- Pixel XL API 26 (Emulator)
- Pixel 4 XL API 29 (Emulator)
- Pixel 4 XL API 30 (Emulator)

## Checklist

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code