### PR TITLE
NF: introduce assertThrowsJSONExceptionEncapsulating

### DIFF
--- a/AnkiDroid/src/test/java/com/ichi2/utils/JSONArrayTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/utils/JSONArrayTest.java
@@ -32,6 +32,7 @@ import java.util.Collections;
 
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
+import static com.ichi2.utils.JSONUtilsTest.assertThrowsJSONExceptionEncapsulating;
 import static org.junit.Assert.*;
 
 /**
@@ -45,16 +46,10 @@ public class JSONArrayTest {
         JSONArray array = new JSONArray();
         assertEquals(0, array.length());
         assertEquals("", array.join(" AND "));
-        try {
-            array.get(0);
-            fail();
-        } catch (JSONException e) {
-        }
-        try {
-            array.getBoolean(0);
-            fail();
-        } catch (JSONException e) {
-        }
+        assertThrowsJSONExceptionEncapsulating(
+                () -> array.get(0));
+        assertThrowsJSONExceptionEncapsulating(
+                () -> array.getBoolean(0));
         assertEquals("[]", array.toString());
         assertEquals("[]", array.toString(4));
         // out of bounds is co-opted with defaulting
@@ -138,21 +133,12 @@ public class JSONArrayTest {
         assertEquals("[null,null,null,null]", array.toString());
         // there's 2 ways to represent null; each behaves differently!
         assertEquals(JSONObject.NULL, array.get(0));
-        try {
-            array.get(1);
-            fail();
-        } catch (JSONException e) {
-        }
-        try {
-            array.get(2);
-            fail();
-        } catch (JSONException e) {
-        }
-        try {
-            array.get(3);
-            fail();
-        } catch (JSONException e) {
-        }
+        assertThrowsJSONExceptionEncapsulating(
+                () -> array.get(1));
+        assertThrowsJSONExceptionEncapsulating(
+                () -> array.get(2));
+        assertThrowsJSONExceptionEncapsulating(
+                () -> array.get(3));
         assertEquals(JSONObject.NULL, array.opt(0));
         assertEquals(null, array.opt(1));
         assertEquals(null, array.opt(2));
@@ -166,6 +152,7 @@ public class JSONArrayTest {
         assertEquals("", array.optString(2));
         assertEquals("", array.optString(3));
     }
+
     /**
      * Our behaviour is questioned by this bug:
      * http://code.google.com/p/android/issues/detail?id=7257
@@ -176,18 +163,12 @@ public class JSONArrayTest {
         array.put(null);
         assertEquals("null", array.get(0));
         assertEquals(JSONObject.NULL, array.get(1));
-        try {
-            array.get(2);
-            fail();
-        } catch (JSONException e) {
-        }
+        assertThrowsJSONExceptionEncapsulating(
+                () -> array.get(2));
         assertEquals("null", array.getString(0));
         assertEquals("null", array.getString(1));
-        try {
-            array.getString(2);
-            fail();
-        } catch (JSONException e) {
-        }
+        assertThrowsJSONExceptionEncapsulating(
+                () -> array.getString(2));
     }
     @Test
     public void testNumbers() throws JSONException {
@@ -271,11 +252,8 @@ public class JSONArrayTest {
         assertEquals(9.223372036854776E18, array.getDouble(2), 0);
         assertEquals(Integer.MAX_VALUE, array.getInt(2));
         assertFalse(array.isNull(3));
-        try {
-            array.getDouble(3);
-            fail();
-        } catch (JSONException e) {
-        }
+        assertThrowsJSONExceptionEncapsulating(
+                () -> array.getDouble(3));
         assertEquals(Double.NaN, array.optDouble(3), 0);
         assertEquals(-1.0d, array.optDouble(3, -1.0d), 0);
     }
@@ -369,21 +347,12 @@ public class JSONArrayTest {
     @Test
     public void testPutUnsupportedNumbers() throws JSONException {
         JSONArray array = new JSONArray();
-        try {
-            array.put(Double.NaN);
-            fail();
-        } catch (JSONException e) {
-        }
-        try {
-            array.put(0, Double.NEGATIVE_INFINITY);
-            fail();
-        } catch (JSONException e) {
-        }
-        try {
-            array.put(0, Double.POSITIVE_INFINITY);
-            fail();
-        } catch (JSONException e) {
-        }
+        assertThrowsJSONExceptionEncapsulating(
+                () -> array.put(Double.NaN));
+        assertThrowsJSONExceptionEncapsulating(
+                () -> array.put(0, Double.NEGATIVE_INFINITY));
+        assertThrowsJSONExceptionEncapsulating(
+                () -> array.put(0, Double.POSITIVE_INFINITY));
     }
     @Test
     public void testPutUnsupportedNumbersAsObject() throws JSONException {
@@ -426,11 +395,8 @@ public class JSONArrayTest {
     }
     @Test
     public void testTokenerConstructorWrongType() throws JSONException {
-        try {
-            new JSONArray(new JSONTokener("{\"foo\": false}"));
-            fail();
-        } catch (JSONException e) {
-        }
+        assertThrowsJSONExceptionEncapsulating(
+                () -> new JSONArray(new JSONTokener("{\"foo\": false}")));
     }
     @Test
     public void testTokenerConstructorNull() throws JSONException {
@@ -458,11 +424,8 @@ public class JSONArrayTest {
     }
     @Test
     public void testStringConstructorWrongType() throws JSONException {
-        try {
-            new JSONArray("{\"foo\": false}");
-            fail();
-        } catch (JSONException e) {
-        }
+        assertThrowsJSONExceptionEncapsulating(
+                () -> new JSONArray("{\"foo\": false}"));
     }
     @Test
     public void testStringConstructorNull() throws JSONException {
@@ -475,9 +438,8 @@ public class JSONArrayTest {
     @Test
     public void testStringConstructorParseFail() {
         try {
-            new JSONArray("[");
-            fail();
-        } catch (JSONException e) {
+            assertThrowsJSONExceptionEncapsulating(
+                    () -> new JSONArray("["));
         } catch (StackOverflowError e) {
             fail("Stack overflowed on input: \"[\"");
         }
@@ -498,25 +460,13 @@ public class JSONArrayTest {
         assertEquals(null, array.opt(-3));
         assertEquals("", array.optString(3));
         assertEquals("", array.optString(-3));
-        try {
-            array.get(3);
-            fail();
-        } catch (JSONException e) {
-        }
-        try {
-            array.get(-3);
-            fail();
-        } catch (JSONException e) {
-        }
-        try {
-            array.getString(3);
-            fail();
-        } catch (JSONException e) {
-        }
-        try {
-            array.getString(-3);
-            fail();
-        } catch (JSONException e) {
-        }
+        assertThrowsJSONExceptionEncapsulating(
+                () -> array.get(3));
+        assertThrowsJSONExceptionEncapsulating(
+                () -> array.get(-3));
+        assertThrowsJSONExceptionEncapsulating(
+                () -> array.getString(3));
+        assertThrowsJSONExceptionEncapsulating(
+                () -> array.getString(-3));
     }
 }

--- a/AnkiDroid/src/test/java/com/ichi2/utils/JSONObjectTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/utils/JSONObjectTest.java
@@ -58,6 +58,7 @@ import java.util.Map;
 import androidx.annotation.NonNull;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
+import static com.ichi2.utils.JSONUtilsTest.assertThrowsJSONExceptionEncapsulating;
 import static junit.framework.TestCase.*;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.IsNull.notNullValue;
@@ -80,46 +81,22 @@ public class JSONObjectTest {
         assertNull(object.toJSONArray(new JSONArray()));
         assertEquals("{}", object.toString());
         assertEquals("{}", object.toString(5));
-        try {
-            object.get("foo");
-            fail();
-        } catch (JSONException e) {
-        }
-        try {
-            object.getBoolean("foo");
-            fail();
-        } catch (JSONException e) {
-        }
-        try {
-            object.getDouble("foo");
-            fail();
-        } catch (JSONException e) {
-        }
-        try {
-            object.getInt("foo");
-            fail();
-        } catch (JSONException e) {
-        }
-        try {
-            object.getJSONArray("foo");
-            fail();
-        } catch (JSONException e) {
-        }
-        try {
-            object.getJSONObject("foo");
-            fail();
-        } catch (JSONException e) {
-        }
-        try {
-            object.getLong("foo");
-            fail();
-        } catch (JSONException e) {
-        }
-        try {
-            object.getString("foo");
-            fail();
-        } catch (JSONException e) {
-        }
+        assertThrowsJSONExceptionEncapsulating(
+                () -> object.get("foo"));
+        assertThrowsJSONExceptionEncapsulating(
+                () -> object.getBoolean("foo"));
+        assertThrowsJSONExceptionEncapsulating(
+                () -> object.getDouble("foo"));
+        assertThrowsJSONExceptionEncapsulating(
+                () -> object.getInt("foo"));
+        assertThrowsJSONExceptionEncapsulating(
+                () -> object.getJSONArray("foo"));
+        assertThrowsJSONExceptionEncapsulating(
+                () -> object.getJSONObject("foo"));
+        assertThrowsJSONExceptionEncapsulating(
+                () -> object.getLong("foo"));
+        assertThrowsJSONExceptionEncapsulating(
+                () -> object.getString("foo"));
         assertFalse(object.has("foo"));
         assertTrue(object.isNull("foo")); // isNull also means "is not present"
         assertNull(object.opt("foo"));
@@ -132,7 +109,7 @@ public class JSONObjectTest {
         assertEquals(null, object.optJSONArray("foo"));
         assertEquals(null, object.optJSONObject("foo"));
         assertEquals(0, object.optLong("foo"));
-        assertEquals(Long.MAX_VALUE-1, object.optLong("foo", Long.MAX_VALUE-1));
+        assertEquals(Long.MAX_VALUE - 1, object.optLong("foo", Long.MAX_VALUE - 1));
         assertEquals("", object.optString("foo")); // empty string is default!
         assertEquals("bar", object.optString("foo", "bar"));
         assertNull(object.remove("foo"));
@@ -154,21 +131,12 @@ public class JSONObjectTest {
         object.put("bar", new Object());
         object.put("baz", new Object());
         assertSame(value, object.get("foo"));
-        try {
-            object.get("FOO");
-            fail();
-        } catch (JSONException e) {
-        }
-        try {
-            object.put(null, value);
-            fail();
-        } catch (JSONException e) {
-        }
-        try {
-            object.get(null);
-            fail();
-        } catch (JSONException e) {
-        }
+        assertThrowsJSONExceptionEncapsulating(
+                () -> object.get("FOO"));
+        assertThrowsJSONExceptionEncapsulating(
+                () -> object.put(null, value));
+        assertThrowsJSONExceptionEncapsulating(
+                () -> object.get(null));
     }
     @Test
     public void testPut() throws JSONException {
@@ -194,11 +162,8 @@ public class JSONObjectTest {
         object.put("foo", null);
         assertEquals(0, object.length());
         assertFalse(object.has("foo"));
-        try {
-            object.get("foo");
-            fail();
-        } catch (JSONException e) {
-        }
+        assertThrowsJSONExceptionEncapsulating(
+                () -> object.get("foo"));
     }
     @Test
     public void testPutOpt() throws JSONException {
@@ -214,21 +179,12 @@ public class JSONObjectTest {
     @Test
     public void testPutOptUnsupportedNumbers() throws JSONException {
         JSONObject object = new JSONObject();
-        try {
-            object.putOpt("foo", Double.NaN);
-            fail();
-        } catch (JSONException e) {
-        }
-        try {
-            object.putOpt("foo", Double.NEGATIVE_INFINITY);
-            fail();
-        } catch (JSONException e) {
-        }
-        try {
-            object.putOpt("foo", Double.POSITIVE_INFINITY);
-            fail();
-        } catch (JSONException e) {
-        }
+        assertThrowsJSONExceptionEncapsulating(
+                () -> object.putOpt("foo", Double.NaN));
+        assertThrowsJSONExceptionEncapsulating(
+                () -> object.putOpt("foo", Double.NEGATIVE_INFINITY));
+        assertThrowsJSONExceptionEncapsulating(
+                () -> object.putOpt("foo", Double.POSITIVE_INFINITY));
     }
     @Test
     public void testRemove() throws JSONException {
@@ -327,21 +283,12 @@ public class JSONObjectTest {
     @Test
     public void testFloats() throws JSONException {
         JSONObject object = new JSONObject();
-        try {
-            object.put("foo", (Float) Float.NaN);
-            fail();
-        } catch (JSONException e) {
-        }
-        try {
-            object.put("foo", (Float) Float.NEGATIVE_INFINITY);
-            fail();
-        } catch (JSONException e) {
-        }
-        try {
-            object.put("foo", (Float) Float.POSITIVE_INFINITY);
-            fail();
-        } catch (JSONException e) {
-        }
+        assertThrowsJSONExceptionEncapsulating(
+                () -> object.put("foo", (Float) Float.NaN));
+        assertThrowsJSONExceptionEncapsulating(
+                () -> object.put("foo", (Float) Float.NEGATIVE_INFINITY));
+        assertThrowsJSONExceptionEncapsulating(
+                () -> object.put("foo", (Float) Float.POSITIVE_INFINITY));
     }
     @Test
     public void testOtherNumbers() throws JSONException {
@@ -349,25 +296,32 @@ public class JSONObjectTest {
             public int intValue() {
                 throw new UnsupportedOperationException();
             }
+
+
             public long longValue() {
                 throw new UnsupportedOperationException();
             }
+
+
             public float floatValue() {
                 throw new UnsupportedOperationException();
             }
+
+
             public double doubleValue() {
                 return Double.NaN;
             }
-            @Override public String toString() {
+
+
+            @Override
+            public String toString() {
                 return "x";
             }
         };
         JSONObject object = new JSONObject();
-        try {
-            object.put("foo", nan);
-            fail("Object.put() accepted a NaN (via a custom Number class)");
-        } catch (JSONException e) {
-        }
+        assertThrowsJSONExceptionEncapsulating(
+                () -> object.put("foo", nan),
+                "Object.put() accepted a NaN (via a custom Number class)");
     }
     @Test
     public void testForeignObjects() throws JSONException {
@@ -383,31 +337,16 @@ public class JSONObjectTest {
     }
     @Test
     public void testNullKeys() {
-        try {
-            new JSONObject().put(null, false);
-            fail();
-        } catch (JSONException e) {
-        }
-        try {
-            new JSONObject().put(null, 0.0d);
-            fail();
-        } catch (JSONException e) {
-        }
-        try {
-            new JSONObject().put(null, 5);
-            fail();
-        } catch (JSONException e) {
-        }
-        try {
-            new JSONObject().put(null, 5L);
-            fail();
-        } catch (JSONException e) {
-        }
-        try {
-            new JSONObject().put(null, "foo");
-            fail();
-        } catch (JSONException e) {
-        }
+        assertThrowsJSONExceptionEncapsulating(
+                () -> new JSONObject().put(null, false));
+        assertThrowsJSONExceptionEncapsulating(
+                () -> new JSONObject().put(null, 0.0d));
+        assertThrowsJSONExceptionEncapsulating(
+                () -> new JSONObject().put(null, 5));
+        assertThrowsJSONExceptionEncapsulating(
+                () -> new JSONObject().put(null, 5L));
+        assertThrowsJSONExceptionEncapsulating(
+                () -> new JSONObject().put(null, "foo"));
     }
     @Test
     public void testStrings() throws JSONException {
@@ -444,11 +383,7 @@ public class JSONObjectTest {
         assertEquals(9.223372036854776E18, object.getDouble("baz"));
         assertEquals(Integer.MAX_VALUE, object.getInt("baz"));
         assertFalse(object.isNull("quux"));
-        try {
-            object.getDouble("quux");
-            fail();
-        } catch (JSONException e) {
-        }
+        assertThrowsJSONExceptionEncapsulating(() -> object.getDouble("quux"));
         assertEquals(Double.NaN, object.optDouble("quux"));
         assertEquals(-1.0d, object.optDouble("quux", -1.0d));
         object.put("foo", "TRUE");
@@ -463,16 +398,10 @@ public class JSONObjectTest {
         object.put("bar", b);
         assertSame(a, object.getJSONArray("foo"));
         assertSame(b, object.getJSONObject("bar"));
-        try {
-            object.getJSONObject("foo");
-            fail();
-        } catch (JSONException e) {
-        }
-        try {
-            object.getJSONArray("bar");
-            fail();
-        } catch (JSONException e) {
-        }
+        assertThrowsJSONExceptionEncapsulating(
+                () -> object.getJSONObject("foo"));
+        assertThrowsJSONExceptionEncapsulating(
+                () -> object.getJSONArray("bar"));
         assertEquals(a, object.optJSONArray("foo"));
         assertEquals(b, object.optJSONObject("bar"));
         assertEquals(null, object.optJSONArray("bar"));
@@ -488,43 +417,27 @@ public class JSONObjectTest {
     public void testArrayCoercion() throws JSONException {
         JSONObject object = new JSONObject();
         object.put("foo", "[true]");
-        try {
-            object.getJSONArray("foo");
-            fail();
-        } catch (JSONException e) {
-        }
+        assertThrowsJSONExceptionEncapsulating(() -> object.getJSONArray("foo"));
     }
 
     @Test
     public void testObjectCoercion() throws JSONException {
         JSONObject object = new JSONObject();
         object.put("foo", "{}");
-        try {
-            object.getJSONObject("foo");
-            fail();
-        } catch (JSONException e) {
-        }
+        assertThrowsJSONExceptionEncapsulating(
+                () -> object.getJSONObject("foo"));
     }
     @Test
     public void testAccumulateValueChecking() throws JSONException {
         JSONObject object = new JSONObject();
-        try {
-            object.accumulate("foo", Double.NaN);
-            fail();
-        } catch (JSONException e) {
-        }
+        assertThrowsJSONExceptionEncapsulating(
+                () -> object.accumulate("foo", Double.NaN));
         object.accumulate("foo", 1);
-        try {
-            object.accumulate("foo", Double.NaN);
-            fail();
-        } catch (JSONException e) {
-        }
+        assertThrowsJSONExceptionEncapsulating(null,
+                () -> object.accumulate("foo", Double.NaN));
         object.accumulate("foo", 2);
-        try {
-            object.accumulate("foo", Double.NaN);
-            fail();
-        } catch (JSONException e) {
-        }
+        assertThrowsJSONExceptionEncapsulating(null,
+                () -> object.accumulate("foo", Double.NaN));
     }
     @Test
     public void testToJSONArray() throws JSONException {
@@ -560,11 +473,8 @@ public class JSONObjectTest {
         assertEquals(4, array.length());
         assertEquals(5.0d, array.get(0));
         assertEquals(true, array.get(1));
-        try {
-            array.get(2);
-            fail();
-        } catch (JSONException e) {
-        }
+        assertThrowsJSONExceptionEncapsulating(
+                () -> array.get(2));
         assertEquals(JSONObject.NULL, array.get(3));
     }
     @Test
@@ -605,40 +515,22 @@ public class JSONObjectTest {
     @Test
     public void testPutUnsupportedNumbers() throws JSONException {
         JSONObject object = new JSONObject();
-        try {
-            object.put("foo", Double.NaN);
-            fail();
-        } catch (JSONException e) {
-        }
-        try {
-            object.put("foo", Double.NEGATIVE_INFINITY);
-            fail();
-        } catch (JSONException e) {
-        }
-        try {
-            object.put("foo", Double.POSITIVE_INFINITY);
-            fail();
-        } catch (JSONException e) {
-        }
+        assertThrowsJSONExceptionEncapsulating(
+                () -> object.put("foo", Double.NaN));
+        assertThrowsJSONExceptionEncapsulating(
+                () -> object.put("foo", Double.NEGATIVE_INFINITY));
+        assertThrowsJSONExceptionEncapsulating(
+                () -> object.put("foo", Double.POSITIVE_INFINITY));
     }
     @Test
     public void testPutUnsupportedNumbersAsObjects() throws JSONException {
         JSONObject object = new JSONObject();
-        try {
-            object.put("foo", (Double) Double.NaN);
-            fail();
-        } catch (JSONException e) {
-        }
-        try {
-            object.put("foo", (Double) Double.NEGATIVE_INFINITY);
-            fail();
-        } catch (JSONException e) {
-        }
-        try {
-            object.put("foo", (Double) Double.POSITIVE_INFINITY);
-            fail();
-        } catch (JSONException e) {
-        }
+        assertThrowsJSONExceptionEncapsulating(
+                () -> object.put("foo", (Double) Double.NaN));
+        assertThrowsJSONExceptionEncapsulating(
+                () -> object.put("foo", (Double) Double.NEGATIVE_INFINITY));
+        assertThrowsJSONExceptionEncapsulating(
+                () -> object.put("foo", (Double) Double.POSITIVE_INFINITY));
     }
     /**
      * Although JSONObject is usually defensive about which numbers it accepts,
@@ -687,11 +579,8 @@ public class JSONObjectTest {
     }
     @Test
     public void testTokenerConstructorWrongType() throws JSONException {
-        try {
-            new JSONObject(new JSONTokener("[\"foo\", false]"));
-            fail();
-        } catch (JSONException e) {
-        }
+        assertThrowsJSONExceptionEncapsulating(
+                () -> new JSONObject(new JSONTokener("[\"foo\", false]")));
     }
     @Test
     public void testTokenerConstructorNull() throws JSONException {
@@ -703,11 +592,8 @@ public class JSONObjectTest {
     }
     @Test
     public void testTokenerConstructorParseFail() {
-        try {
-            new JSONObject(new JSONTokener("{"));
-            fail();
-        } catch (JSONException e) {
-        }
+        assertThrowsJSONExceptionEncapsulating(
+                () -> new JSONObject(new JSONTokener("{")));
     }
     @Test
     public void testStringConstructor() throws JSONException {
@@ -717,11 +603,8 @@ public class JSONObjectTest {
     }
     @Test
     public void testStringConstructorWrongType() throws JSONException {
-        try {
-            new JSONObject("[\"foo\", false]");
-            fail();
-        } catch (JSONException e) {
-        }
+        assertThrowsJSONExceptionEncapsulating(
+                () -> new JSONObject("[\"foo\", false]"));
     }
     @Test
     public void testStringConstructorNull() throws JSONException {
@@ -733,11 +616,8 @@ public class JSONObjectTest {
     }
     @Test
     public void testStringonstructorParseFail() {
-        try {
-            new JSONObject("{");
-            fail();
-        } catch (JSONException e) {
-        }
+        assertThrowsJSONExceptionEncapsulating(
+                () -> new JSONObject("{"));
     }
     @Test
     public void testCopyConstructor() throws JSONException {
@@ -792,11 +672,8 @@ public class JSONObjectTest {
     @Test
     public void testAccumulateNull() {
         JSONObject object = new JSONObject();
-        try {
-            object.accumulate(null, 5);
-            fail();
-        } catch (JSONException e) {
-        }
+        assertThrowsJSONExceptionEncapsulating(null,
+                () -> object.accumulate(null, 5));
     }
     @Test
     public void testEmptyStringKey() throws JSONException {
@@ -931,29 +808,17 @@ public class JSONObjectTest {
         assertEquals("9223372036854775806", JSONObject.numberToString(9223372036854775806L));
         assertEquals("4.9E-324", JSONObject.numberToString(Double.MIN_VALUE));
         assertEquals("1.7976931348623157E308", JSONObject.numberToString(Double.MAX_VALUE));
-        try {
-            JSONObject.numberToString(Double.NaN);
-            fail();
-        } catch (JSONException e) {
-        }
-        try {
-            JSONObject.numberToString(Double.NEGATIVE_INFINITY);
-            fail();
-        } catch (JSONException e) {
-        }
-        try {
-            JSONObject.numberToString(Double.POSITIVE_INFINITY);
-            fail();
-        } catch (JSONException e) {
-        }
+        assertThrowsJSONExceptionEncapsulating(
+                () -> JSONObject.numberToString(Double.NaN));
+        assertThrowsJSONExceptionEncapsulating(
+                () -> JSONObject.numberToString(Double.NEGATIVE_INFINITY));
+        assertThrowsJSONExceptionEncapsulating(
+                () -> JSONObject.numberToString(Double.POSITIVE_INFINITY));
         assertEquals("0.001", JSONObject.numberToString(new BigDecimal("0.001")));
         assertEquals("9223372036854775806",
                 JSONObject.numberToString(new BigInteger("9223372036854775806")));
-        try {
-            JSONObject.numberToString(null);
-            fail();
-        } catch (JSONException e) {
-        }
+        assertThrowsJSONExceptionEncapsulating(
+                () -> JSONObject.numberToString(null));
     }
 
 

--- a/AnkiDroid/src/test/java/com/ichi2/utils/JSONUtilsTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/utils/JSONUtilsTest.java
@@ -1,0 +1,59 @@
+package com.ichi2.utils;
+
+import androidx.annotation.Nullable;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.fail;
+
+public class JSONUtilsTest {
+
+    /**
+     * Fail if e cause is not expected
+     */
+    public static void assertJSONExceptionEncapsulate(Class<? extends Throwable> expected, JSONException e) {
+        Throwable cause = e.getCause();
+        if (expected != null) {
+            assertNotNull(cause);
+            assertEquals(expected, cause.getClass());
+        } else {
+            assertNull(cause);
+        }
+    }
+
+
+    /**
+     * @param r fail if r don't throw a JSONException whose cause is org.json.JSONException
+     */
+    public static void assertThrowsJSONExceptionEncapsulating(Runnable r) {
+        assertThrowsJSONExceptionEncapsulating(r, null);
+    }
+
+    /**
+     * @param r fail if r don't throw a JSONException whose cause is expected
+     */
+    public static void assertThrowsJSONExceptionEncapsulating(Class<? extends Throwable> expected, Runnable r) {
+        assertThrowsJSONExceptionEncapsulating(expected, r, null);
+    }
+
+    /**
+     * @param r fail with reason if r don't throw a JSONException whose cause is org.json.JSONException
+     */
+    public static void assertThrowsJSONExceptionEncapsulating(Runnable r, @Nullable String reason) {
+        assertThrowsJSONExceptionEncapsulating(org.json.JSONException.class, r, reason);
+    }
+
+    /**
+     * @param r fail with reason if r don't throw a JSONException whose cause is expected
+     */
+    public static void assertThrowsJSONExceptionEncapsulating(Class<? extends Throwable> expected, Runnable r, @Nullable String reason) {
+        try {
+            r.run();
+            fail(reason);
+        } catch (JSONException e) {
+            assertJSONExceptionEncapsulate(expected, e);
+        }
+    }
+
+}


### PR DESCRIPTION
The goal is to factorize a test pattern that occurred plenty of time, and furthermore to allow exception test to be more specific, so that not only we know there is an exception, but also we know what it encapsulates.