### PR TITLE
Use MediaStore to save whiteboard for API>28

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/Whiteboard.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Whiteboard.java
@@ -20,6 +20,7 @@
 package com.ichi2.anki;
 
 import android.annotation.SuppressLint;
+import android.content.Context;
 import android.content.SharedPreferences;
 import android.graphics.Bitmap;
 import android.graphics.Canvas;
@@ -31,20 +32,18 @@ import android.graphics.Point;
 import android.graphics.Rect;
 import android.graphics.RectF;
 import android.graphics.Region;
-import android.os.Environment;
 import android.view.MotionEvent;
 import android.view.View;
 import android.widget.Button;
 import android.widget.LinearLayout;
 
 import com.ichi2.anki.dialogs.WhiteBoardWidthDialog;
+import com.ichi2.compat.CompatHelper;
 import com.ichi2.libanki.utils.Time;
 import com.ichi2.libanki.utils.TimeUtils;
 import com.ichi2.utils.DisplayUtils;
 
-import java.io.File;
 import java.io.FileNotFoundException;
-import java.io.FileOutputStream;
 import java.lang.ref.WeakReference;
 import java.util.ArrayList;
 import java.util.Iterator;
@@ -586,35 +585,18 @@ public class Whiteboard extends View {
         return mCurrentlyDrawing;
     }
 
-    @SuppressWarnings( {"deprecation", "RedundantSuppression"}) // TODO Tracked in https://github.com/ankidroid/Anki-Android/issues/5304
     protected String saveWhiteboard(Time time) throws FileNotFoundException {
-
         Bitmap bitmap = Bitmap.createBitmap(this.getWidth(), this.getHeight(), Bitmap.Config.ARGB_8888);
         Canvas canvas = new Canvas(bitmap);
-
-        File pictures = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_PICTURES);
-        File ankiDroidFolder = new File(pictures, "AnkiDroid");
-
-        if (!ankiDroidFolder.exists()) {
-            //noinspection ResultOfMethodCallIgnored
-            ankiDroidFolder.mkdirs();
-        }
-
-        String baseFileName = "Whiteboard";
-        String timeStamp = TimeUtils.getTimestamp(time);
-        String finalFileName = baseFileName + timeStamp + ".png";
-
-        File saveWhiteboardImageFile = new File(ankiDroidFolder, finalFileName);
-
         if (mForegroundColor != Color.BLACK) {
             canvas.drawColor(Color.BLACK);
         } else {
             canvas.drawColor(Color.WHITE);
         }
-
         this.draw(canvas);
-        bitmap.compress(Bitmap.CompressFormat.JPEG, 95, new FileOutputStream(saveWhiteboardImageFile));
-        return saveWhiteboardImageFile.getAbsolutePath();
+        String baseFileName = "Whiteboard" + TimeUtils.getTimestamp(time);
+        // TODO: Fix inconsistent CompressFormat 'JPEG' and file extension 'png'
+        return CompatHelper.getCompat().saveImage(getContext(), bitmap, baseFileName, "png", Bitmap.CompressFormat.JPEG, 95);
     }
 
     @VisibleForTesting

--- a/AnkiDroid/src/main/java/com/ichi2/compat/Compat.java
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/Compat.java
@@ -19,6 +19,7 @@ package com.ichi2.compat;
 import android.app.PendingIntent;
 import android.content.Context;
 import android.content.Intent;
+import android.graphics.Bitmap;
 import android.media.AudioFocusRequest;
 import android.media.AudioManager;
 import android.widget.TimePicker;
@@ -26,6 +27,7 @@ import android.widget.TimePicker;
 import com.ichi2.async.ProgressSenderAndCancelListener;
 
 import java.io.File;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -215,5 +217,22 @@ public interface Compat {
      * supplied.
      */
     PendingIntent getImmutableBroadcastIntent(Context context, int requestCode, Intent intent, @PendingIntentFlags int flags);
+
+    /**
+     * Writes an image represented by bitmap to the Pictures/AnkiDroid folder under the primary
+     * external storage directory. Requires the WRITE_EXTERNAL_STORAGE permission to be obtained on devices running
+     * API <= 28. If this condition isn't satisfied, this method will throw a {@link FileNotFoundException}.
+     *
+     * @param context Used to insert the image into the appropriate MediaStore collection for API >= 29
+     * @param bitmap Bitmap to be saved
+     * @param baseFileName the filename of the image to be saved excluding the file extension
+     * @param extension File extension of the image to be saved
+     * @param format The format bitmap should be compressed to
+     * @param quality Hint to the compressor specifying the quality of the compressed image
+     * @return The path of the saved image
+     * @throws FileNotFoundException if the device's API is <= 28 and has not obtained the
+     * WRITE_EXTERNAL_STORAGE permission
+     */
+    String saveImage(Context context, Bitmap bitmap, String baseFileName, String extension, Bitmap.CompressFormat format, int quality) throws FileNotFoundException;
 }
 

--- a/AnkiDroid/src/main/java/com/ichi2/compat/CompatV21.java
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/CompatV21.java
@@ -19,9 +19,11 @@ package com.ichi2.compat;
 import android.app.PendingIntent;
 import android.content.Context;
 import android.content.Intent;
+import android.graphics.Bitmap;
 import android.media.AudioFocusRequest;
 import android.media.AudioManager;
 import android.media.ThumbnailUtils;
+import android.os.Environment;
 import android.os.Vibrator;
 import android.provider.MediaStore;
 import android.widget.TimePicker;
@@ -31,6 +33,7 @@ import com.ichi2.utils.FileUtil;
 
 import java.io.File;
 import java.io.FileInputStream;
+import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -224,5 +227,19 @@ public class CompatV21 implements Compat {
     public PendingIntent getImmutableBroadcastIntent(Context context, int requestCode, Intent intent, int flags) {
         //noinspection WrongConstant
         return PendingIntent.getBroadcast(context, requestCode, intent, flags | FLAG_IMMUTABLE);
+    }
+
+    @Override
+    @SuppressWarnings({"deprecation", "RedundantSuppression"})
+    public String saveImage(Context context, Bitmap bitmap, String baseFileName, String extension, Bitmap.CompressFormat format, int quality) throws FileNotFoundException {
+        File pictures = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_PICTURES);
+        File ankiDroidFolder = new File(pictures, "AnkiDroid");
+        if (!ankiDroidFolder.exists()) {
+            //noinspection ResultOfMethodCallIgnored
+            ankiDroidFolder.mkdirs();
+        }
+        File imageFile = new File(ankiDroidFolder, baseFileName + "." + extension);
+        bitmap.compress(format, quality, new FileOutputStream(imageFile));
+        return imageFile.getAbsolutePath();
     }
 }


### PR DESCRIPTION
## Purpose / Description
MediaStore has the following advantages over direct file path access and is the recommended approach for saving media files

- MediaStore is more future-proof than direct file path access. For instance, direct file path access does not work for apps targeting API 29 unless they set the requestLegacyExternalStorage flag to true

- MediaStore offers up to 2x faster random read and write speeds


## Approach
- Use MediaStore's ```insert()``` instead of direct file path access in ```saveWhiteboard()```
- Continue to use File API for API <= 28 since the MediaStore implementation is not available below API 29. Hence, the ```WRITE_EXTERNAL_STORAGE``` permission will need to be requested for phones running API 28 and lower. This is in line with Google's recommendation of continuing to ask for storage permissions for API <= 28.

## How Has This Been Tested?

1. Open Reviewer
2. Enable Whiteboard
3. Draw on the whiteboard
4. Save the whiteboard

#### Testing conditions
- Only devices with API<=28 had obtained ```WRITE_EXTERNAL_STORAGE``` permission
- ```requestLegacyExternalStorage``` flag was removed
- The check for storage permission in DeckPicker's ```handleStartup()``` had to be removed to use the app without storage permission for testing

#### Devices
- Pixel XL API 21 (Emulator)
- Pixel XL API 26 (Emulator)
- Pixel 4 XL API 29 (Emulator)
- Pixel 4 XL API 30 (Emulator)

In all tests, the saving the whiteboard was successful - showed a toast & the whiteboard was saved to ```Pictures/AnkiDroid``` (same directory used before this change).

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code