### PR TITLE
feat: preference upgrades

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -257,6 +257,7 @@ dependencies {
     implementation 'androidx.annotation:annotation:1.2.0'
     implementation 'androidx.appcompat:appcompat:1.3.1'
     implementation 'androidx.browser:browser:1.3.0'
+    implementation "androidx.core:core-ktx:1.6.0"
     implementation 'androidx.exifinterface:exifinterface:1.3.3'
     implementation 'androidx.fragment:fragment-ktx:1.3.6'
     implementation 'androidx.localbroadcastmanager:localbroadcastmanager:1.0.0'
@@ -320,6 +321,7 @@ dependencies {
     testImplementation "org.robolectric:robolectric:4.6.1"
     testImplementation 'androidx.test:core:1.4.0'
     testImplementation 'androidx.test.ext:junit:1.1.3'
+    testImplementation "org.jetbrains.kotlin:kotlin-reflect:1.5.21"
     // debugImplementation required vs testImplementation: https://issuetracker.google.com/issues/128612536
     debugImplementation 'androidx.fragment:fragment-testing:1.3.6'
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -1166,11 +1166,9 @@ public class DeckPicker extends NavigationDrawerActivity implements
             Timber.i("No space left");
             showDialogFragment(DeckPickerBackupNoSpaceLeftDialog.newInstance());
             preferences.edit().remove("noSpaceLeft").apply();
-        } else if ("".equals(preferences.getString("lastVersion", ""))) {
-            Timber.i("Fresh install");
-            preferences.edit().putString("lastVersion", VersionUtils.getPkgVersionName()).apply();
+        } else if (InitialActivity.performSetupFromFreshInstallOrClearedPreferences(preferences)) {
             onFinishedStartup();
-        } else if (skip < 2 && !preferences.getString("lastVersion", "").equals(VersionUtils.getPkgVersionName())) {
+        } else if (skip < 2 && !InitialActivity.isLatestVersion(preferences)) {
             Timber.i("AnkiDroid is being updated and a collection already exists.");
             // The user might appreciate us now, see if they will help us get better?
             if (!preferences.contains(UsageAnalytics.ANALYTICS_OPTIN_KEY)) {
@@ -1289,7 +1287,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
             } else {
                 Timber.i("Dev Build - not showing 'new features'");
                 // Don't show new features dialog for development builds
-                preferences.edit().putString("lastVersion", VersionUtils.getPkgVersionName()).apply();
+                InitialActivity.setUpgradedToLatestVersion(preferences);
                 String ver = getResources().getString(R.string.updated_version, VersionUtils.getPkgVersionName());
                 UIUtils.showSnackbar(this, ver, true, -1, null, findViewById(R.id.root_layout), null);
                 showStartupScreensAndDialogs(preferences, 2);

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Info.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Info.java
@@ -21,6 +21,7 @@ package com.ichi2.anki;
 import android.annotation.SuppressLint;
 import android.content.ClipData;
 import android.content.Context;
+import android.content.SharedPreferences;
 import android.content.res.Resources;
 import android.content.res.TypedArray;
 import android.net.Uri;
@@ -67,8 +68,8 @@ public class Info extends AnkiActivity {
         int mType = getIntent().getIntExtra(TYPE_EXTRA, TYPE_ABOUT);
         // If the page crashes, we do not want to display it again (#7135 maybe)
         if (mType == TYPE_NEW_VERSION) {
-            AnkiDroidApp.getSharedPrefs(Info.this.getBaseContext()).edit()
-                    .putString("lastVersion", VersionUtils.getPkgVersionName()).apply();
+            SharedPreferences prefs = AnkiDroidApp.getSharedPrefs(this.getBaseContext());
+            InitialActivity.setUpgradedToLatestVersion(prefs);
         }
 
         setContentView(R.layout.info);

--- a/AnkiDroid/src/main/java/com/ichi2/anki/InitialActivity.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/InitialActivity.java
@@ -145,6 +145,7 @@ public class InitialActivity {
         }
 
         Timber.i("Fresh install");
+        PreferenceUpgradeService.setPreferencesUpToDate(preferences);
         setUpgradedToLatestVersion(preferences);
 
         return true;

--- a/AnkiDroid/src/main/java/com/ichi2/anki/InitialActivity.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/InitialActivity.java
@@ -17,9 +17,11 @@
 package com.ichi2.anki;
 
 import android.content.Context;
+import android.content.SharedPreferences;
 
 import com.ichi2.anki.exception.OutOfSpaceException;
 import com.ichi2.anki.servicelayer.PreferenceUpgradeService;
+import com.ichi2.utils.VersionUtils;
 
 import net.ankiweb.rsdroid.BackendException;
 import net.ankiweb.rsdroid.BackendFactory;
@@ -28,6 +30,7 @@ import net.ankiweb.rsdroid.RustBackendFailedException;
 import java.lang.ref.WeakReference;
 
 import androidx.annotation.CheckResult;
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import timber.log.Timber;
 
@@ -119,6 +122,49 @@ public class InitialActivity {
     public static boolean upgradePreferences(Context context, long previousVersionCode) {
         return PreferenceUpgradeService.upgradePreferences(context, previousVersionCode);
     }
+
+    /**
+     *  @return Whether a fresh install occurred and a "fresh install" setup for preferences was performed
+     *  This only refers to a fresh install from the preferences perspective, not from the Anki data perspective.
+     *
+     *  NOTE: A user can wipe app data, which will mean this returns true WITHOUT deleting their collection.
+     *  The above note will need to be reevaluated after scoped storage migration takes place
+     *
+     *
+     *  On the other hand, restoring an app backup can cause this to return true before the Anki collection is created
+     *  in practice, this doesn't occur due to CollectionHelper.getCol creating a new collection, and it's called before
+     *  this in the startup script
+     */
+    @CheckResult
+    public static boolean performSetupFromFreshInstallOrClearedPreferences(@NonNull SharedPreferences preferences) {
+        boolean lastVersionWasSet = !"".equals(preferences.getString("lastVersion", ""));
+
+        if (lastVersionWasSet) {
+            Timber.d("Not a fresh install [preferences]");
+            return false;
+        }
+
+        Timber.i("Fresh install");
+        setUpgradedToLatestVersion(preferences);
+
+        return true;
+    }
+
+    /** Sets the preference stating that the latest version has been applied */
+    public static void setUpgradedToLatestVersion(@NonNull SharedPreferences preferences) {
+        Timber.i("Marked prefs as upgraded to latest version: %s", VersionUtils.getPkgVersionName());
+        preferences.edit().putString("lastVersion", VersionUtils.getPkgVersionName()).apply();
+    }
+
+    /** @return false: The app has been upgraded since the last launch OR the app was launched for the first time.
+     * Implementation detail:
+     * This is not called in the case of performSetupFromFreshInstall returning true.
+     * So this should not use the default value
+     */
+    public static boolean isLatestVersion(SharedPreferences preferences) {
+        return preferences.getString("lastVersion", "").equals(VersionUtils.getPkgVersionName());
+    }
+
 
     // I disapprove, but it's best to keep consistency with the rest of the app
     @SuppressWarnings("deprecation") // #7108: AsyncTask

--- a/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/PreferenceUpgradeService.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/PreferenceUpgradeService.kt
@@ -17,62 +17,30 @@ package com.ichi2.anki.servicelayer
 
 import android.content.Context
 import android.content.SharedPreferences
+import androidx.annotation.VisibleForTesting
+import androidx.core.content.edit
 import com.ichi2.anki.AnkiDroidApp
 import com.ichi2.anki.reviewer.FullScreenMode
 import timber.log.Timber
 
-object PreferenceUpgradeService {
-    /**
-     * The latest package version number that included changes to the preferences that requires handling. All
-     * collections being upgraded to (or after) this version must update preferences.
-     *
-     * #9309 Do not modify this variable - it no longer works.
-     *
-     * Instead, add an unconditional check for the old preference before the call to
-     * "needsPreferenceUpgrade", and perform the upgrade.
-     */
-    const val CHECK_PREFERENCES_AT_VERSION = 20500225
+private typealias VersionIdentifier = Int
+private typealias LegacyVersionIdentifier = Long
 
+object PreferenceUpgradeService {
     @JvmStatic
-    fun upgradePreferences(context: Context?, previousVersionCode: Long): Boolean =
+    fun upgradePreferences(context: Context?, previousVersionCode: LegacyVersionIdentifier): Boolean =
         upgradePreferences(AnkiDroidApp.getSharedPrefs(context), previousVersionCode)
 
     /** @return Whether any preferences were upgraded */
-    internal fun upgradePreferences(preferences: SharedPreferences, previousVersionCode: Long): Boolean {
-        var hasUpgradedPreferences = false
+    internal fun upgradePreferences(preferences: SharedPreferences, previousVersionCode: LegacyVersionIdentifier): Boolean {
+        val pendingPreferenceUpgrades = PreferenceUpgrade.getPendingUpgrades(preferences, previousVersionCode)
 
-        // perform any new preference upgrades here and set hasUpgradedPreferences
+        pendingPreferenceUpgrades.forEach {
+            it.performUpgrade(preferences)
+        }
 
-        if (!needsLegacyPreferenceUpgrade(previousVersionCode)) {
-            return hasUpgradedPreferences
-        }
-        hasUpgradedPreferences = true
-
-        Timber.i("running upgradePreferences()")
-        // clear all prefs if super old version to prevent any errors
-        if (previousVersionCode < 20300130) {
-            Timber.i("Old version of Anki - Clearing preferences")
-            preferences.edit().clear().apply()
-        }
-        // when upgrading from before 2.5alpha35
-        if (previousVersionCode < 20500135) {
-            Timber.i("Old version of Anki - Fixing Zoom")
-            // Card zooming behaviour was changed the preferences renamed
-            val oldCardZoom = preferences.getInt("relativeDisplayFontSize", 100)
-            val oldImageZoom = preferences.getInt("relativeImageSize", 100)
-            preferences.edit().putInt("cardZoom", oldCardZoom).apply()
-            preferences.edit().putInt("imageZoom", oldImageZoom).apply()
-            if (!preferences.getBoolean("useBackup", true)) {
-                preferences.edit().putInt("backupMax", 0).apply()
-            }
-            preferences.edit().remove("useBackup").apply()
-            preferences.edit().remove("intentAdditionInstantAdd").apply()
-        }
-        FullScreenMode.upgradeFromLegacyPreference(preferences)
-        return hasUpgradedPreferences
+        return pendingPreferenceUpgrades.isNotEmpty()
     }
-
-    internal fun needsLegacyPreferenceUpgrade(previous: Long): Boolean = previous < CHECK_PREFERENCES_AT_VERSION
 
     /**
      * Specifies that no preference upgrades need to happen.
@@ -81,6 +49,119 @@ object PreferenceUpgradeService {
      */
     @JvmStatic
     fun setPreferencesUpToDate(preferences: SharedPreferences) {
-        // intentionally left blank
+        Timber.i("Marking preferences as up to date")
+        PreferenceUpgrade.setPreferenceToLatestVersion(preferences)
+    }
+
+    abstract class PreferenceUpgrade private constructor(val mVersionIdentifier: VersionIdentifier) {
+        /*
+        To add a new preference upgrade:
+          * yield a new class from getAllInstances (do not use `legacyPreviousVersionCode` in the constructor)
+          * Implement the upgrade() method
+          * Set mVersionIdentifier to 1 more than the previous versionIdentifier
+          * Run tests in PreferenceUpgradeServiceTest
+         */
+
+        companion object {
+            /** A version code where the value doesn't matter as we're not using the result */
+            private const val IGNORED_LEGACY_VERSION_CODE = 0L
+
+            /** Returns all instances of preference upgrade classes */
+            internal fun getAllInstances(legacyPreviousVersionCode: LegacyVersionIdentifier) = sequence<PreferenceUpgrade> {
+                yield(LegacyPreferenceUpgrade(legacyPreviousVersionCode))
+            }
+
+            /** Returns a list of preference upgrade classes which have not been applied */
+            fun getPendingUpgrades(preferences: SharedPreferences, legacyPreviousVersionCode: LegacyVersionIdentifier): List<PreferenceUpgrade> {
+                val currentPrefVersion: VersionIdentifier = getPreferenceVersion(preferences)
+
+                return getAllInstances(legacyPreviousVersionCode).filter {
+                    it.mVersionIdentifier > currentPrefVersion
+                }.toList()
+            }
+
+            /** Sets the preference version such that no upgrades need to be applied */
+            fun setPreferenceToLatestVersion(preferences: SharedPreferences) {
+                val versionWhichRequiresNoUpgrades = getLatestVersion()
+                setPreferenceVersion(preferences, versionWhichRequiresNoUpgrades)
+            }
+
+            internal fun getPreferenceVersion(preferences: SharedPreferences) =
+                preferences.getInt("preferenceUpgradeVersion", 0)
+
+            internal fun setPreferenceVersion(preferences: SharedPreferences, versionIdentifier: VersionIdentifier) {
+                Timber.i("upgrading preference version to '$versionIdentifier'")
+                preferences.edit { putInt("preferenceUpgradeVersion", versionIdentifier) }
+            }
+
+            /** Returns the collection of all preference version numbers */
+            @VisibleForTesting
+            fun getAllVersionIdentifiers(): Sequence<VersionIdentifier> =
+                getAllInstances(IGNORED_LEGACY_VERSION_CODE).map { it.mVersionIdentifier }
+
+            /**
+             * @return the latest "version" of the preferences
+             * If the preferences are set to this version, then no upgrades will take place
+             */
+            private fun getLatestVersion(): VersionIdentifier = getAllVersionIdentifiers().maxOrNull() ?: 0
+        }
+
+        /** Handles preference upgrades before 2021-08-01,
+         * upgrades were detected via a version code comparison
+         * rather than comparing a preference value
+         */
+        private class LegacyPreferenceUpgrade(val mPreviousVersionCode: LegacyVersionIdentifier) : PreferenceUpgrade(1) {
+            override fun upgrade(preferences: SharedPreferences) {
+                if (!needsLegacyPreferenceUpgrade(mPreviousVersionCode)) {
+                    return
+                }
+
+                Timber.i("running upgradePreferences()")
+                // clear all prefs if super old version to prevent any errors
+                if (mPreviousVersionCode < 20300130) {
+                    Timber.i("Old version of Anki - Clearing preferences")
+                    preferences.edit().clear().apply()
+                }
+                // when upgrading from before 2.5alpha35
+                if (mPreviousVersionCode < 20500135) {
+                    Timber.i("Old version of Anki - Fixing Zoom")
+                    // Card zooming behaviour was changed the preferences renamed
+                    val oldCardZoom = preferences.getInt("relativeDisplayFontSize", 100)
+                    val oldImageZoom = preferences.getInt("relativeImageSize", 100)
+                    preferences.edit().putInt("cardZoom", oldCardZoom).apply()
+                    preferences.edit().putInt("imageZoom", oldImageZoom).apply()
+                    if (!preferences.getBoolean("useBackup", true)) {
+                        preferences.edit().putInt("backupMax", 0).apply()
+                    }
+                    preferences.edit().remove("useBackup").apply()
+                    preferences.edit().remove("intentAdditionInstantAdd").apply()
+                }
+                FullScreenMode.upgradeFromLegacyPreference(preferences)
+            }
+
+            fun needsLegacyPreferenceUpgrade(previous: Long): Boolean = previous < CHECK_PREFERENCES_AT_VERSION
+
+            companion object {
+                /**
+                 * The latest package version number that included changes to the preferences that requires handling. All
+                 * collections being upgraded to (or after) this version must update preferences.
+                 *
+                 * #9309 Do not modify this variable - it no longer works.
+                 *
+                 * Instead, add an unconditional check for the old preference before the call to
+                 * "needsPreferenceUpgrade", and perform the upgrade.
+                 */
+                const val CHECK_PREFERENCES_AT_VERSION = 20500225
+            }
+        }
+
+        fun performUpgrade(preferences: SharedPreferences) {
+            Timber.i("Running preference upgrade: ${this.javaClass.simpleName}")
+            upgrade(preferences)
+
+            setPreferenceVersion(preferences, this.mVersionIdentifier)
+        }
+
+        protected abstract fun upgrade(preferences: SharedPreferences)
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/PreferenceUpgradeService.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/PreferenceUpgradeService.kt
@@ -73,4 +73,14 @@ object PreferenceUpgradeService {
     }
 
     internal fun needsLegacyPreferenceUpgrade(previous: Long): Boolean = previous < CHECK_PREFERENCES_AT_VERSION
+
+    /**
+     * Specifies that no preference upgrades need to happen.
+     * Typically because the app has been run for the first time, or the preferences
+     * have been deleted
+     */
+    @JvmStatic
+    fun setPreferencesUpToDate(preferences: SharedPreferences) {
+        // intentionally left blank
+    }
 }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/DeckPickerTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/DeckPickerTest.java
@@ -243,7 +243,7 @@ public class DeckPickerTest extends RobolectricTest {
         AnkiDroidApp.sSentExceptionReportHack = false;
         try {
             BackendEmulatingOpenConflict.enable();
-            InitialActivityTest.setupForDatabaseConflict();
+            InitialActivityWithConflictTest.setupForDatabaseConflict();
 
             DeckPickerEx d = super.startActivityNormallyOpenCollectionWithIntent(DeckPickerEx.class, new Intent());
 
@@ -252,7 +252,7 @@ public class DeckPickerTest extends RobolectricTest {
             assertThat("No exception reports should be thrown", AnkiDroidApp.sSentExceptionReportHack, is(false));
         } finally {
             BackendEmulatingOpenConflict.disable();
-            InitialActivityTest.setupForDefault();
+            InitialActivityWithConflictTest.setupForDefault();
         }
     }
 
@@ -261,20 +261,20 @@ public class DeckPickerTest extends RobolectricTest {
     public void databaseLockedNoPermissionIntegrationTest() {
         // no permissions -> grant permissions -> db locked
         try {
-            InitialActivityTest.setupForDefault();
+            InitialActivityWithConflictTest.setupForDefault();
             BackendEmulatingOpenConflict.enable();
 
             DeckPickerEx d = super.startActivityNormallyOpenCollectionWithIntent(DeckPickerEx.class, new Intent());
 
             // grant permissions
-            InitialActivityTest.setupForDatabaseConflict();
+            InitialActivityWithConflictTest.setupForDatabaseConflict();
 
             d.onStoragePermissionGranted();
 
             assertThat("A specific dialog for a conflict should be shown", d.mDatabaseErrorDialog, is(DatabaseErrorDialog.DIALOG_DB_LOCKED));
         } finally {
             BackendEmulatingOpenConflict.disable();
-            InitialActivityTest.setupForDefault();
+            InitialActivityWithConflictTest.setupForDefault();
         }
     }
 
@@ -282,7 +282,7 @@ public class DeckPickerTest extends RobolectricTest {
     public void deckPickerOpensWithHelpMakeAnkiDroidBetterDialog() {
         // Refactor: It would be much better to use a spy - see if we can get this into Robolecteic
         try {
-            InitialActivityTest.grantWritePermissions();
+            InitialActivityWithConflictTest.grantWritePermissions();
             BackupManagerTestUtilities.setupSpaceForBackup(getTargetContext());
             // We don't show it if the user is new.
             AnkiDroidApp.getSharedPrefs(getTargetContext()).edit().putString("lastVersion", "0.1").apply();
@@ -292,7 +292,7 @@ public class DeckPickerTest extends RobolectricTest {
             assertThat("Analytics opt-in should be displayed", d.mDisplayedAnalyticsOptIn, is(true));
 
         } finally {
-            InitialActivityTest.revokeWritePermissions();
+            InitialActivityWithConflictTest.revokeWritePermissions();
             BackupManagerTestUtilities.reset();
         }
     }
@@ -313,11 +313,11 @@ public class DeckPickerTest extends RobolectricTest {
     @Test
     public void showOptionsMenuWhenCollectionAccessible() {
         try {
-            InitialActivityTest.grantWritePermissions();
+            InitialActivityWithConflictTest.grantWritePermissions();
             DeckPickerEx d = super.startActivityNormallyOpenCollectionWithIntent(DeckPickerEx.class, new Intent());
             assertThat("Options menu is displayed when collection is accessible", d.mPrepareOptionsMenu, is(true));
         } finally {
-            InitialActivityTest.revokeWritePermissions();
+            InitialActivityWithConflictTest.revokeWritePermissions();
         }
     }
 
@@ -336,11 +336,11 @@ public class DeckPickerTest extends RobolectricTest {
     @Test
     public void showSyncBadgeWhenCollectionAccessible() {
         try {
-            InitialActivityTest.grantWritePermissions();
+            InitialActivityWithConflictTest.grantWritePermissions();
             DeckPickerEx d = super.startActivityNormallyOpenCollectionWithIntent(DeckPickerEx.class, new Intent());
             assertThat("Sync badge is displayed when collection is accessible", d.mDisplaySyncBadge, is(true));
         } finally {
-            InitialActivityTest.revokeWritePermissions();
+            InitialActivityWithConflictTest.revokeWritePermissions();
         }
     }
 
@@ -348,7 +348,7 @@ public class DeckPickerTest extends RobolectricTest {
     @RunInBackground
     public void onResumeLoadCollectionFailureWithInaccessibleCollection() {
         try {
-            InitialActivityTest.revokeWritePermissions();
+            InitialActivityWithConflictTest.revokeWritePermissions();
             enableNullCollection();
             DeckPickerEx d = super.startActivityNormallyOpenCollectionWithIntent(DeckPickerEx.class, new Intent());
 
@@ -362,12 +362,12 @@ public class DeckPickerTest extends RobolectricTest {
     @Test
     public void onResumeLoadCollectionSuccessWithAccessibleCollection() {
         try {
-            InitialActivityTest.grantWritePermissions();
+            InitialActivityWithConflictTest.grantWritePermissions();
             DeckPickerEx d = super.startActivityNormallyOpenCollectionWithIntent(DeckPickerEx.class, new Intent());
             assertThat("Collection initialization ensured by CollectionTask.LoadCollectionComplete", d.getCol(), is(notNullValue()));
             assertThat("Collection Models Loaded", d.getCol().getModels(), is(notNullValue()));
         } finally {
-            InitialActivityTest.revokeWritePermissions();
+            InitialActivityWithConflictTest.revokeWritePermissions();
         }
     }
 
@@ -377,7 +377,7 @@ public class DeckPickerTest extends RobolectricTest {
         try {
             setupColV16();
 
-            InitialActivityTest.setupForValid(getTargetContext());
+            InitialActivityWithConflictTest.setupForValid(getTargetContext());
 
             DeckPicker deckPicker = super.startActivityNormallyOpenCollectionWithIntent(DeckPickerEx.class, new Intent());
             waitForAsyncTasksToComplete();
@@ -388,7 +388,7 @@ public class DeckPickerTest extends RobolectricTest {
 
             assertThat("Decks should be visible", deckPicker.getDeckCount(), is(1));
         } finally {
-            InitialActivityTest.setupForDefault();
+            InitialActivityWithConflictTest.setupForDefault();
         }
     }
 
@@ -400,7 +400,7 @@ public class DeckPickerTest extends RobolectricTest {
             // corrupt col
             DbUtils.performQuery(getTargetContext(), "drop table deck_config");
 
-            InitialActivityTest.setupForValid(getTargetContext());
+            InitialActivityWithConflictTest.setupForValid(getTargetContext());
 
             DeckPickerEx deckPicker = super.startActivityNormallyOpenCollectionWithIntent(DeckPickerEx.class, new Intent());
             waitForAsyncTasksToComplete();
@@ -408,7 +408,7 @@ public class DeckPickerTest extends RobolectricTest {
             assertThat("Collection should not be open", !CollectionHelper.getInstance().colIsOpen());
             assertThat("An error dialog should be displayed", deckPicker.mDatabaseErrorDialog, is(DatabaseErrorDialog.DIALOG_LOAD_FAILED));
         } finally {
-            InitialActivityTest.setupForDefault();
+            InitialActivityWithConflictTest.setupForDefault();
         }
     }
 
@@ -418,7 +418,7 @@ public class DeckPickerTest extends RobolectricTest {
         try {
             setupColV16();
 
-            InitialActivityTest.setupForValid(getTargetContext());
+            InitialActivityWithConflictTest.setupForValid(getTargetContext());
 
             DeckPickerNoSpaceForBackup deckPicker = super.startActivityNormallyOpenCollectionWithIntent(clazz, new Intent());
             waitForAsyncTasksToComplete();
@@ -426,7 +426,7 @@ public class DeckPickerTest extends RobolectricTest {
             assertThat("Collection should not be open", !CollectionHelper.getInstance().colIsOpen());
             assertThat("A downgrade failed dialog should be shown", deckPicker.mDisplayedDowngradeFailed, is(true));
         } finally {
-            InitialActivityTest.setupForDefault();
+            InitialActivityWithConflictTest.setupForDefault();
         }
     }
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/InitialActivityTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/InitialActivityTest.kt
@@ -1,0 +1,80 @@
+/*
+ *  Copyright (c) 2021 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki
+
+import android.content.SharedPreferences
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.ichi2.testutils.EmptyApplication
+import org.hamcrest.CoreMatchers.equalTo
+import org.hamcrest.MatcherAssert.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+
+@RunWith(AndroidJUnit4::class)
+@Config(application = EmptyApplication::class) // no point in Application init if we don't use it
+class InitialActivityTest : RobolectricTest() {
+
+    private lateinit var mSharedPreferences: SharedPreferences
+
+    @Before
+    fun before() {
+        mSharedPreferences = AnkiDroidApp.getSharedPrefs(ApplicationProvider.getApplicationContext())
+    }
+
+    @Test
+    fun perform_setup_returns_true_after_first_launch_or_data_wipe() {
+        val result = InitialActivity.performSetupFromFreshInstallOrClearedPreferences(mSharedPreferences)
+        assertThat(result, equalTo(true))
+    }
+
+    @Test
+    fun perform_setup_returns_false_after_setup() {
+        InitialActivity.setUpgradedToLatestVersion(mSharedPreferences)
+
+        val resultAfterUpgrade = InitialActivity.performSetupFromFreshInstallOrClearedPreferences(mSharedPreferences)
+        assertThat("should not perform initial setup if setup has already occurred", resultAfterUpgrade, equalTo(false))
+    }
+
+    @Test
+    fun initially_not_latest_version() {
+        assertThat(InitialActivity.isLatestVersion(mSharedPreferences), equalTo(false))
+    }
+
+    @Test
+    fun not_latest_version_with_valid_value() {
+        mSharedPreferences.edit().putString("lastVersion", "0.1").apply()
+        assertThat(InitialActivity.isLatestVersion(mSharedPreferences), equalTo(false))
+    }
+
+    @Test
+    fun latest_version_upgrade_is_now_latest_version() {
+        InitialActivity.setUpgradedToLatestVersion(mSharedPreferences)
+        assertThat(InitialActivity.isLatestVersion(mSharedPreferences), equalTo(true))
+    }
+
+    @Test
+    fun perform_setup_integration_test() {
+        val sharedPrefs = AnkiDroidApp.getSharedPrefs(ApplicationProvider.getApplicationContext())
+        val initialSetupResult = InitialActivity.performSetupFromFreshInstallOrClearedPreferences(AnkiDroidApp.getSharedPrefs(ApplicationProvider.getApplicationContext()))
+        assertThat(initialSetupResult, equalTo(true))
+        val secondResult = InitialActivity.performSetupFromFreshInstallOrClearedPreferences(sharedPrefs)
+        assertThat("should not perform initial setup if setup has already occurred", secondResult, equalTo(false))
+    }
+}

--- a/AnkiDroid/src/test/java/com/ichi2/anki/InitialActivityWithConflictTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/InitialActivityWithConflictTest.java
@@ -40,7 +40,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 
 @RunWith(AndroidJUnit4.class)
 @Config(application = EmptyApplication.class) // no point in Application init if we don't use it
-public class InitialActivityTest extends RobolectricTest {
+public class InitialActivityWithConflictTest extends RobolectricTest {
     @Before
     @Override
     public void setUp() {

--- a/AnkiDroid/src/test/java/com/ichi2/anki/servicemodel/PreferenceUpgradeServiceTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/servicemodel/PreferenceUpgradeServiceTest.kt
@@ -1,0 +1,103 @@
+/*
+ *  Copyright (c) 2021 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.servicemodel
+
+import android.content.SharedPreferences
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.ichi2.anki.AnkiDroidApp
+import com.ichi2.anki.RobolectricTest
+import com.ichi2.anki.servicelayer.PreferenceUpgradeService
+import com.ichi2.anki.servicelayer.PreferenceUpgradeService.PreferenceUpgrade
+import com.ichi2.testutils.EmptyApplication
+import org.hamcrest.CoreMatchers.equalTo
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.lessThan
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+
+@RunWith(AndroidJUnit4::class)
+@Config(application = EmptyApplication::class) // no point in Application init if we don't use it
+class PreferenceUpgradeServiceTest : RobolectricTest() {
+
+    private lateinit var mPrefs: SharedPreferences
+
+    @Before
+    fun before() {
+        mPrefs = AnkiDroidApp.getSharedPrefs(targetContext)
+    }
+
+    @Test
+    fun first_app_load_performs_no_upgrades() {
+        PreferenceUpgradeService.setPreferencesUpToDate(mPrefs)
+        val result = PreferenceUpgradeService.upgradePreferences(mPrefs, 0)
+        assertThat("no upgrade should have taken place", result, equalTo(false))
+    }
+
+    @Test
+    fun preference_upgrade_leads_to_max_version_in_preferences() {
+        val result = PreferenceUpgradeService.upgradePreferences(mPrefs, 0)
+        assertThat("preferences were upgraded", result, equalTo(true))
+        val version = PreferenceUpgrade.getPreferenceVersion(mPrefs)
+        PreferenceUpgradeService.setPreferencesUpToDate(mPrefs)
+        val secondVersion = PreferenceUpgrade.getPreferenceVersion(mPrefs)
+        assertThat("setPreferencesUpToDate should not change the version", secondVersion, equalTo(version))
+    }
+
+    @Test
+    fun two_upgrades_does_nothing() {
+        val result = PreferenceUpgradeService.upgradePreferences(mPrefs, 0)
+        assertThat("preferences were upgraded", result, equalTo(true))
+        val secondResult = PreferenceUpgradeService.upgradePreferences(mPrefs, 0)
+        assertThat("a second preference upgrade does nothing", secondResult, equalTo(false))
+    }
+
+    @Test
+    fun each_version_code_is_distinct() {
+        val codes = PreferenceUpgrade.getAllVersionIdentifiers().toList()
+        assertThat("all version IDs should be distinct", codes.size, equalTo(codes.distinct().size))
+    }
+
+    @Test
+    fun version_codes_do_not_decrease() {
+        // in this test, we ensure that version codes are monotonically increasing.
+        val codes = PreferenceUpgrade.getAllVersionIdentifiers()
+
+        codes.zip(codes.drop(1)).forEach {
+            assertThat(
+                "versions should be increasing, but found (${it.first}) before (${it.second})",
+                it.first,
+                lessThan(it.second)
+            )
+        }
+    }
+
+    @Test
+    fun one_version_code_per_nested_class() {
+        val nestedClasses = PreferenceUpgrade::class.nestedClasses.filter { it.simpleName != "Companion" }
+        val nestedClassCount = nestedClasses.size
+        val upgradeCount = PreferenceUpgrade.getAllVersionIdentifiers().toList().size
+
+        assertThat(
+            "Different count of nested classes ($nestedClassCount) and upgrades ($upgradeCount). \n" +
+                "nested classes:\n ${nestedClasses.map { it.simpleName }.joinToString("\n")}",
+            nestedClassCount,
+            equalTo(upgradeCount)
+        )
+    }
+}


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
Due to the version number depending on the processor architecture, we can no longer use this to handle preference upgrades. We need a new mechanism to apply preferences

## Fixes
Fixes #9309 

## Approach
* Refactor the startup flow to `InitialActivity`
* Define a `PreferenceUpgrade` class and a preference (int) for the preference version
  * Each subclass performs one upgrade via an `upgrade()` method
* On each version change, check to see if there are any pending upgrades, and execute them if so

## How Has This Been Tested?

Unit tests and on my phone

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
