### PR TITLE
Make HTML/JS debugging default to true in prefs in DEBUG build

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.java
@@ -316,6 +316,11 @@ public class AnkiDroidApp extends Application {
             UIUtils.showThemedToast(this.getApplicationContext(), getString(R.string.user_is_a_robot), false);
         }
 
+        // make default HTML / JS debugging true for debug build
+        if (BuildConfig.DEBUG) {
+            preferences.edit().putBoolean("html_javascript_debugging", true).apply();
+        }
+        
         CardBrowserContextMenu.ensureConsistentStateWithSharedPreferences(this);
         AnkiCardContextMenu.ensureConsistentStateWithSharedPreferences(this);
         NotificationChannels.setup(getApplicationContext());


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
While developing the JS API features, it needs to change the HTML / JS Debugging to true when app reinstalled.

## Fixes
Fixes _Link to the issues._

## Approach
Added if condition in AnkiDroidApp.java and edited prefs

## How Has This Been Tested?
Tested on emulator

## Learning (optional, can help others)
_Describe the research stage_

_Links to blog posts, patterns, libraries or addons used to solve this problem_

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
