### PR TITLE
lint: Only enforce variable naming in java

### DIFF
--- a/lint-rules/src/main/java/com/ichi2/anki/lint/IssueRegistry.java
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/IssueRegistry.java
@@ -2,7 +2,7 @@ package com.ichi2.anki.lint;
 
 import com.android.tools.lint.detector.api.ApiKt;
 import com.android.tools.lint.detector.api.Issue;
-import com.ichi2.anki.lint.rules.ConstantFieldDetector;
+import com.ichi2.anki.lint.rules.ConstantJavaFieldDetector;
 import com.ichi2.anki.lint.rules.CopyrightHeaderExists;
 import com.ichi2.anki.lint.rules.DirectCalendarInstanceUsage;
 import com.ichi2.anki.lint.rules.DirectSnackbarMakeUsage;
@@ -15,7 +15,7 @@ import com.ichi2.anki.lint.rules.DuplicateCrowdInStrings;
 import com.ichi2.anki.lint.rules.DuplicateTextInPreferencesXml;
 import com.ichi2.anki.lint.rules.FixedPreferencesTitleLength;
 import com.ichi2.anki.lint.rules.InconsistentAnnotationUsage;
-import com.ichi2.anki.lint.rules.NonPublicNonStaticFieldDetector;
+import com.ichi2.anki.lint.rules.NonPublicNonStaticJavaFieldDetector;
 import com.ichi2.anki.lint.rules.PrintStackTraceUsage;
 
 import com.android.annotations.NonNull;
@@ -41,8 +41,8 @@ public class IssueRegistry extends com.android.tools.lint.client.api.IssueRegist
         issues.add(DuplicateTextInPreferencesXml.ISSUE);
         issues.add(InconsistentAnnotationUsage.ISSUE);
         issues.add(PrintStackTraceUsage.ISSUE);
-        issues.add(NonPublicNonStaticFieldDetector.ISSUE);
-        issues.add(ConstantFieldDetector.ISSUE);
+        issues.add(NonPublicNonStaticJavaFieldDetector.ISSUE);
+        issues.add(ConstantJavaFieldDetector.ISSUE);
         issues.add(FixedPreferencesTitleLength.ISSUE_MAX_LENGTH);
         issues.add(FixedPreferencesTitleLength.ISSUE_TITLE_LENGTH);
         return issues;

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/rules/ConstantJavaFieldDetector.java
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/ConstantJavaFieldDetector.java
@@ -31,9 +31,9 @@ import org.jetbrains.uast.UastVisibility;
  * https://github.com/ankidroid/Anki-Android/wiki/Code-style#constant-final-variables-names-must-be-all-uppercase-using-underscore-to-separate-words
  * Constant (final variables) names must be all uppercase using underscore to separate words.
  */
-public class ConstantFieldDetector extends FieldNamingPatternDetector {
+public class ConstantJavaFieldDetector extends JavaFieldNamingPatternDetector {
 
-    private static final Implementation implementation = new Implementation(ConstantFieldDetector.class, Scope.JAVA_FILE_SCOPE);
+    private static final Implementation implementation = new Implementation(ConstantJavaFieldDetector.class, Scope.JAVA_FILE_SCOPE);
 
     public static Issue ISSUE = Issue.create(
             "ConstantFieldName",

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/rules/JavaFieldNamingPatternDetector.java
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/JavaFieldNamingPatternDetector.java
@@ -29,7 +29,7 @@ import org.jetbrains.uast.UVariable;
 import java.util.Collections;
 import java.util.List;
 
-public abstract class FieldNamingPatternDetector extends Detector implements Detector.UastScanner {
+public abstract class JavaFieldNamingPatternDetector extends Detector implements Detector.UastScanner {
 
     @Nullable
     @Override
@@ -56,6 +56,11 @@ public abstract class FieldNamingPatternDetector extends Detector implements Det
 
         @Override
         public void visitVariable(@NonNull UVariable node) {
+            // Only apply naming patterns to Java
+            if (mContext.file.getAbsolutePath().endsWith(".kt")) {
+                return;
+            }
+
             // HACK: Using visitField didn't return any results
             if (!(node instanceof UField)) {
                 return;

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/rules/NonPublicNonStaticJavaFieldDetector.java
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/NonPublicNonStaticJavaFieldDetector.java
@@ -23,7 +23,6 @@ import com.android.tools.lint.detector.api.JavaContext;
 import com.android.tools.lint.detector.api.Scope;
 import com.ichi2.anki.lint.utils.Constants;
 
-import com.android.annotations.NonNull;
 import org.jetbrains.uast.UElement;
 import org.jetbrains.uast.UVariable;
 import org.jetbrains.uast.UastVisibility;
@@ -31,9 +30,9 @@ import org.jetbrains.uast.UastVisibility;
 /**
  * https://github.com/ankidroid/Anki-Android/wiki/Code-style#non-public-non-static-field-names-should-start-with-m
  */
-public class NonPublicNonStaticFieldDetector extends FieldNamingPatternDetector {
+public class NonPublicNonStaticJavaFieldDetector extends JavaFieldNamingPatternDetector {
 
-    private static final Implementation implementation = new Implementation(NonPublicNonStaticFieldDetector.class, Scope.JAVA_FILE_SCOPE);
+    private static final Implementation implementation = new Implementation(NonPublicNonStaticJavaFieldDetector.class, Scope.JAVA_FILE_SCOPE);
 
     public static Issue ISSUE = Issue.create(
             "NonPublicNonStaticFieldName",

--- a/lint-rules/src/test/java/com/ichi2/anki/lint/rules/JavaConstantFieldDetectorTest.java
+++ b/lint-rules/src/test/java/com/ichi2/anki/lint/rules/JavaConstantFieldDetectorTest.java
@@ -24,7 +24,7 @@ import static com.android.tools.lint.checks.infrastructure.TestLintTask.lint;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 
-public class ConstantFieldDetectorTest {
+public class JavaConstantFieldDetectorTest {
 
     @Language("JAVA")
     private static final String BADLY_NAMED_VARIABLE = "public class Xx { " +
@@ -43,7 +43,7 @@ public class ConstantFieldDetectorTest {
                 .allowMissingSdk()
                 .allowCompilationErrors()
                 .files(create(BADLY_NAMED_VARIABLE))
-                .issues(ConstantFieldDetector.ISSUE)
+                .issues(ConstantJavaFieldDetector.ISSUE)
                 .run()
                 .expectErrorCount(5)
                 .check(output -> {

--- a/lint-rules/src/test/java/com/ichi2/anki/lint/rules/JavaNonPublicNonStaticFieldDetectorTest.java
+++ b/lint-rules/src/test/java/com/ichi2/anki/lint/rules/JavaNonPublicNonStaticFieldDetectorTest.java
@@ -16,13 +16,15 @@
 
 package com.ichi2.anki.lint.rules;
 
+import com.android.tools.lint.checks.infrastructure.TestFile;
+
 import org.intellij.lang.annotations.Language;
 import org.junit.Test;
 
 import static com.android.tools.lint.checks.infrastructure.TestFile.JavaTestFile.create;
 import static com.android.tools.lint.checks.infrastructure.TestLintTask.lint;
 
-public class NonPublicNonStaticFieldDetectorTest {
+public class JavaNonPublicNonStaticFieldDetectorTest {
 
     @Language("JAVA")
     private static final String BADLY_NAMED_VARIABLE = "public class Xx { " +
@@ -42,13 +44,26 @@ public class NonPublicNonStaticFieldDetectorTest {
             "}" +
             "}";
 
+    @Language("kotlin")
+    private static final String BADLY_NAMED_VARIABLE_KOTLIN = "class Xx { " +
+            "/**" +
+            "*/" +
+            "private val withCommentShows: Int = -1\n" +
+            "val publicIsFine: Int = 1\n" +
+            "private val ad: Int = 1\n" +
+            "private val mad: Int = 1\n" +
+            "private val a : Int = 1\n" +
+            "private val m: Int = 1\n" +
+            "private val mOk: String\n" +
+            "}";
+
     @Test
     public void showsErrorForNullable() {
         lint()
                 .allowMissingSdk()
                 .allowCompilationErrors()
                 .files(create(BADLY_NAMED_VARIABLE))
-                .issues(NonPublicNonStaticFieldDetector.ISSUE)
+                .issues(NonPublicNonStaticJavaFieldDetector.ISSUE)
                 .run()
                 .expectErrorCount(5)
                 .check(output -> {
@@ -56,4 +71,15 @@ public class NonPublicNonStaticFieldDetectorTest {
                 });
     }
 
+    @Test
+    public void kotlin_no_errors() {
+        // #9377 - Kotlin explicitly should not follow our style guide
+        lint()
+                .allowMissingSdk()
+                .allowCompilationErrors()
+                .files(TestFile.KotlinTestFile.create(BADLY_NAMED_VARIABLE_KOTLIN))
+                .issues(NonPublicNonStaticJavaFieldDetector.ISSUE)
+                .run()
+                .expectClean();
+    }
 }


### PR DESCRIPTION
We want to move away from AOSP naming for Kotlin

As it makes getters and primary constructors less useful
as the naming conflicts with other policies we want to enforce
AOSP naming is also against Google suggestions

Fixes #9377

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
