### PR TITLE
Don't allow v2 to v1 conversion [Anki Ecosystem]

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
@@ -1088,7 +1088,14 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
                         }
                     });
                     builder.onNegative((dialog, which) -> schedVerPreference.setChecked(false));
+                    builder.onNeutral((dialog, which) -> {
+                        // call v2 scheduler documentation website
+                        Uri uri = Uri.parse(getString(R.string.link_anki_2_scheduler));
+                        Intent intent = new Intent(Intent.ACTION_VIEW, uri);
+                        startActivity(intent);
+                    });
                     builder.positiveText(R.string.dialog_ok);
+                    builder.neutralText(R.string.help);
                     builder.negativeText(R.string.dialog_cancel);
                     builder.show();
                     return false;

--- a/AnkiDroid/src/main/res/values/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values/10-preferences.xml
@@ -171,7 +171,6 @@
     <string name="sched_v2" maxLength="41">V2 scheduler</string>
     <string name="sched_v2_summ">Enable the new scheduler. Forces changes in one direction on next sync</string>
     <string name="sched_ver_toggle_title">Confirm</string>
-    <string name="sched_ver_2to1">This will reset any cards in learning, clear filtered decks, and change the scheduler version. Proceed?</string>
     <string name="sched_ver_1to2">The experimental scheduler could cause incorrect scheduling. Please ensure you have read the documentation first. Proceed?</string>
     <string name="pref_keep_screen_on" maxLength="41">Keep screen on</string>
     <string name="pref_keep_screen_on_summ">Disable screen timeout</string>

--- a/AnkiDroid/src/main/res/values/constants.xml
+++ b/AnkiDroid/src/main/res/values/constants.xml
@@ -212,6 +212,7 @@
     <string name="link_ankidroid_development_guide">https://github.com/ankidroid/Anki-Android/wiki/Development-Guide</string>
     <string name="link_ankidroid_faq">https://github.com/ankidroid/Anki-Android/wiki/FAQ</string>
     <string name="link_opencollective_donate">https://opencollective.com/ankidroid/contribute</string>
+    <string name="link_anki_2_scheduler">https://faqs.ankiweb.net/the-anki-2.1-scheduler.html</string>
     <string name="link_ankiweb_docs_cloze_deletion">https://docs.ankiweb.net/editing.html#cloze-deletion</string>
 
     <string-array name="leech_action_values">

--- a/AnkiDroid/src/main/res/xml/preferences_advanced.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_advanced.xml
@@ -172,10 +172,6 @@
         </PreferenceCategory>
 
 
-    <CheckBoxPreference
-        android:key="schedVer"
-        android:title="@string/sched_v2"
-        android:summary="@string/sched_v2_summ" />
     <Preference
         android:key="about_dialog_preference"
         android:title="@string/about_title">


### PR DESCRIPTION
Fixes #9265

## Done

- removed schedVerPreference from xml and included in java.
- showing schedVerPreference only if user is on V1.
- Added help button in confirmation dialog of v1-> v2 scheduler.

<img src="https://user-images.githubusercontent.com/52353967/128537057-0e6b4613-03ef-45b2-932b-babece9eca46.jpg" width="250" height="500" />

## How Has This Been Tested?
tested on local & emulator devices.

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [x] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
