### PR TITLE
Reset onboarding

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/OnboardingUtils.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/OnboardingUtils.kt
@@ -18,7 +18,9 @@
 package com.ichi2.anki
 
 import android.content.Context
-import java.util.BitSet
+import timber.log.Timber
+import java.util.*
+import kotlin.collections.HashSet
 
 class OnboardingUtils {
 
@@ -28,6 +30,19 @@ class OnboardingUtils {
          * Preference can be toggled by visiting 'Advanced' settings in the app.
          */
         const val SHOW_ONBOARDING = "showOnboarding"
+        private val featureConstants: MutableSet<String> = HashSet()
+
+        /** Register this feature category as an onboarding feature.
+         * It ensures it gets reset if asked. */
+        fun addFeature(featureCategory: String) {
+            featureConstants.add(featureCategory)
+        }
+
+        /** Register all feature categories as onboarding features.
+         * They all get reset when reset is pressed. */
+        fun addFeatures(featureCategory: Vector<String>) {
+            featureCategory.forEach(::addFeature)
+        }
 
         /**
          * Check if the tutorial for a feature should be displayed or not.
@@ -63,6 +78,17 @@ class OnboardingUtils {
         private fun getAllVisited(context: Context, featureConstant: String): BitSet {
             val currentValue = AnkiDroidApp.getSharedPrefs(context).getLong(featureConstant, 0)
             return BitSet.valueOf(longArrayOf(currentValue))
+        }
+
+        fun reset(context: Context) {
+            Timber.i("Resetting all onboarding")
+            reset(context, featureConstants)
+        }
+
+        private fun reset(context: Context, featureConstants: Collection<String>) {
+            var editor = AnkiDroidApp.getSharedPrefs(context).edit()
+            featureConstants.forEach { editor.putLong(it, 0) }
+            editor.apply()
         }
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/OnboardingUtils.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/OnboardingUtils.kt
@@ -32,7 +32,7 @@ class OnboardingUtils {
         /**
          * Check if the tutorial for a feature should be displayed or not.
          */
-        fun <T> isVisited(featureIdentifier: T, context: Context): Boolean where T : Enum<T>, T : OnboardingFlag {
+        fun isVisited(featureIdentifier: OnboardingFlag, context: Context): Boolean {
             // Return if onboarding is not enabled.
             if (!AnkiDroidApp.getSharedPrefs(context).getBoolean(SHOW_ONBOARDING, false)) {
                 return true
@@ -48,7 +48,7 @@ class OnboardingUtils {
         /**
          * Set the tutorial for a feature as visited.
          */
-        fun <T> setVisited(featureIdentifier: T, context: Context) where T : Enum<T>, T : OnboardingFlag {
+        fun setVisited(featureIdentifier: OnboardingFlag, context: Context) {
             val visitedFeatures = getAllVisited(context, featureIdentifier.getFeatureConstant())
 
             // Set the bit at the index defined for a feature once the tutorial for that feature is seen by the user.

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
@@ -1170,6 +1170,18 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
                 onboardingPreference.setSummary(R.string.show_onboarding_desc);
                 screen.addPreference(onboardingPreference);
             }
+            if (BuildConfig.DEBUG) {
+                Timber.i("Debug mode, option for resetting onboarding walkthrough");
+                android.preference.Preference onboardingPreference = new android.preference.Preference(requireContext());
+                onboardingPreference.setKey("resetOnboarding");
+                onboardingPreference.setTitle(R.string.reset_onboarding);
+                onboardingPreference.setSummary(R.string.reset_onboarding_desc);
+                onboardingPreference.setOnPreferenceClickListener(preference -> {
+                    OnboardingUtils.Companion.reset(requireContext());
+                    return true;
+                });
+                screen.addPreference(onboardingPreference);
+            }
             // Adding change logs in both debug and release builds
             Timber.i("Adding open changelog");
             android.preference.Preference changelogPreference = new android.preference.Preference(requireContext());

--- a/AnkiDroid/src/main/res/values/constants.xml
+++ b/AnkiDroid/src/main/res/values/constants.xml
@@ -284,6 +284,8 @@
     </string-array>
 
     <!-- Onboarding -->
+    <string name="reset_onboarding" maxLength="41">Reset onboarding walkthrough</string>
     <string name="show_onboarding" maxLength="41">Show onboarding walkthrough</string>
     <string name="show_onboarding_desc">Display feature tutorial to learn more about the app</string>
+    <string name="reset_onboarding_desc">Show all tutorials again</string>
 </resources>

--- a/AnkiDroid/src/test/java/com/ichi2/anki/OnboardingFlagTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/OnboardingFlagTest.kt
@@ -79,6 +79,16 @@ class OnboardingFlagTest : RobolectricTest() {
         assertFalse(isVisited(SecondEnum.LAST))
     }
 
+    @Test
+    fun verifyReset() {
+        OnboardingUtils.addFeature(FIRST_ENUM)
+        setVisited(FirstEnum.FIRST)
+        setVisited(SecondEnum.LAST)
+        OnboardingUtils.reset(targetContext)
+        assertFalse(isVisited(FirstEnum.FIRST))
+        assertTrue(isVisited(SecondEnum.LAST))
+    }
+
     private enum class FirstEnum(var mValue: Int) : OnboardingFlag {
         FIRST(0),
         MIDDLE(1);

--- a/AnkiDroid/src/test/java/com/ichi2/anki/OnboardingFlagTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/OnboardingFlagTest.kt
@@ -105,11 +105,11 @@ class OnboardingFlagTest : RobolectricTest() {
         }
     }
 
-    private fun <T> isVisited(featureIdentifier: T): Boolean where T : Enum<T>, T : OnboardingFlag {
+    private fun isVisited(featureIdentifier: OnboardingFlag): Boolean {
         return OnboardingUtils.isVisited(featureIdentifier, targetContext)
     }
 
-    private fun <T> setVisited(featureIdentifier: T) where T : Enum<T>, T : OnboardingFlag {
+    private fun setVisited(featureIdentifier: OnboardingFlag) {
         OnboardingUtils.setVisited(featureIdentifier, targetContext)
     }
 }


### PR DESCRIPTION
This allow all onboarding flags to be reset. It is useful for testing, in order to avoid resetting AnkiDroid data. I also expect it may be useful for users if they want to see again everything, to either show the app to other people or just check whether they can learn new things.

I'd like a review from @ShridharGoel since it's your part of the code.