### PR TITLE
Fix V2 Scheduler .colpkg collection import

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Storage.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Storage.java
@@ -75,7 +75,7 @@ public class Storage {
         return Collection(context, path, server, log, new SystemTime());
     }
     public static Collection Collection(Context context, String path, boolean server, boolean log, @NonNull Time time) {
-        assert path.endsWith(".anki2");
+        assert (path.endsWith(".anki2") || path.endsWith(".anki21"));
         File dbFile = new File(path);
         boolean create = !dbFile.exists();
         DroidBackend backend = DroidBackendFactory.getInstance(useBackend());


### PR DESCRIPTION
## Purpose / Description
App crashes upon an attempt to import a .colpkg collection if the collection being imported uses the V2 Scheduler

## Fixes
Fixes #9386 

## Approach
- Allow V2 .```colpkg``` collections to be imported by allowing files ending
  with ```.anki21``` to be used to initialize the Collection object in
  ```Storage.Collection()```

- Previously only files ending in ```.anki2``` could be used due to an
  assertion

## How Has This Been Tested?
Tested importing .apkg and .colpkg collections which used the V1 or V2 scheduler on the following devices:
- Pixel 4 XL API 30 (Emulator)
- Pixel XL API 26 (Emulator)


## Checklist

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
