### PR TITLE
Ensure Import Collection is functional under Scoped Storage

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/IntentHandler.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/IntentHandler.java
@@ -59,7 +59,7 @@ public class IntentHandler extends Activity {
         LaunchType launchType = getLaunchType(intent);
         switch (launchType) {
             case FILE_IMPORT:
-                runIfStoragePermissions.consume(() -> handleFileImport(intent, reloadIntent, action));
+                handleFileImport(intent, reloadIntent, action);
                 break;
             case SYNC:
                 runIfStoragePermissions.consume(() -> handleSyncIntent(reloadIntent, action));

--- a/AnkiDroid/src/main/java/com/ichi2/utils/ImportUtils.java
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/ImportUtils.java
@@ -17,6 +17,7 @@
 package com.ichi2.utils;
 
 import android.app.Activity;
+import android.content.ContentResolver;
 import android.content.Context;
 import android.content.Intent;
 import android.database.Cursor;
@@ -137,22 +138,12 @@ public class ImportUtils {
                 return handleContentProviderFile(context, intent, clipUri);
             }
 
-            // If the file is being sent from a content provider we need to read the content before we can open the file
-            if ("content".equals(intent.getData().getScheme())) {
+            // If Uri is of scheme which is supported by ContentResolver, read the contents
+            String intentUriScheme = intent.getData().getScheme();
+            if (intentUriScheme.equals(ContentResolver.SCHEME_CONTENT) || intentUriScheme.equals(ContentResolver.SCHEME_FILE)
+                    || intentUriScheme.equals(ContentResolver.SCHEME_ANDROID_RESOURCE)) {
                 Timber.i("Attempting to read content from intent.");
                 return handleContentProviderFile(context, intent, intent.getData());
-            } else if ("file".equals(intent.getData().getScheme())) {
-                Timber.i("Attempting to read file from intent.");
-                // When the VIEW intent is sent as a file, we can open it directly without copying from content provider
-                String filename = intent.getData().getPath();
-                Timber.d("Importing regular file: %s", filename);
-                if (isValidPackageName(filename)) {
-                    // If file has apkg extension then send message to show Import dialog
-                    sendShowImportFileDialogMsg(filename);
-                    return ImportResult.fromSuccess();
-                } else {
-                    return ImportResult.fromErrorString(context.getResources().getString(R.string.import_error_not_apkg_extension, filename));
-                }
             } else {
                 return ImportResult.fromErrorString(context.getResources().getString(R.string.import_error_unhandled_scheme, intent.getData()));
             }


### PR DESCRIPTION
## Purpose / Description
The Import Collection feature asks the user to pick a file to import (.apkg/.colpkg). The Uri of the file is returned as the data of the intent. If the scheme of the URI is 'file', ```ImportUtils.handleFileImportInternal()``` uses direct file path access to read from the selected collection. Direct file path access to non-app-specific directories will not work under Scoped Storage.

## Approach
Remove the direct file path access approach & use the existing ContentResolver approach to open URIs of the 'file' scheme, in addition to any other supported schemes.

As a side effect, this means that no storage permissions are required to Import a collection, hence the check for a Storage Permission grant before ```IntentHandler``` handles the File Import can be removed.

## How Has This Been Tested?
Tested by importing .apkg & .colpkg collections under the following scenarios:
- No storage permissions have been granted
- ```requestLegacyExternalStorage``` flag removed

Tested on the following devices:
- Pixel 4 XL API 30 (Emulator)
- Pixel XL API 26 (Emulator)

Collections were successfully imported, regardless of how the Import was initiated (from device's files app directly, or from DeckPicker's Import option)


## Checklist

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
