### PR TITLE
feat: add "TagManager" abstract class for V16 upgrade

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
@@ -105,7 +105,7 @@ public class Collection implements CollectionGetter {
     private final Media mMedia;
     private final Decks mDecks;
     private Models mModels;
-    private final Tags mTags;
+    private final TagManager mTags;
 
     private AbstractSched mSched;
 
@@ -2111,7 +2111,7 @@ public class Collection implements CollectionGetter {
     }
 
 
-    public Tags getTags() {
+    public TagManager getTags() {
         return mTags;
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Note.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Note.java
@@ -26,7 +26,6 @@ import com.ichi2.utils.JSONObject;
 import java.util.AbstractSet;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.regex.Matcher;
@@ -91,7 +90,7 @@ public class Note implements Cloneable {
             mMid = cursor.getLong(1);
             mMod = cursor.getLong(2);
             mUsn = cursor.getInt(3);
-            mTags = mCol.getTags().split(cursor.getString(4));
+            mTags = new ArrayList<>(mCol.getTags().split(cursor.getString(4)));
             mFields = Utils.splitFields(cursor.getString(5));
             mFlags = cursor.getInt(6);
             mData = cursor.getString(7);
@@ -243,7 +242,7 @@ public class Note implements Cloneable {
 
 
     public void setTagsFromStr(String str) {
-        mTags = mCol.getTags().split(str);
+        mTags = new ArrayList<>(mCol.getTags().split(str));
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/TagManager.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/TagManager.kt
@@ -43,7 +43,11 @@ abstract class TagManager {
     /** Given a list of tags, add any missing ones to tag registry. */
     fun register(tags: Iterable<String>) = register(tags, null)
     /** Given a list of tags, add any missing ones to tag registry. */
-    abstract fun register(tags: Iterable<String>, usn: Int? = null)
+    fun register(tags: Iterable<String>, usn: Int? = null) = register(tags, usn, false)
+    /** Given a list of tags, add any missing ones to tag registry.
+     * @param clear_first Whether to clear the tags in the database before registering the provided tags
+     * */
+    abstract fun register(tags: Iterable<String>, usn: Int? = null, clear_first: Boolean = false)
     abstract fun all(): List<String>
     /** Add any missing tags from notes to the tags list. The old list is cleared first */
     fun registerNotes() = registerNotes(null)

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/TagManager.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/TagManager.kt
@@ -1,0 +1,129 @@
+/*
+ *  Copyright (c) 2021 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.libanki
+
+import net.ankiweb.rsdroid.RustCleanup
+import java.util.*
+
+/**
+ * Manages the tag cache and tags for notes.
+ *
+ * This is the public API surface for tags, to unify [Tags] and [TagsV16]
+ */
+@RustCleanup("remove docs: this exists to unify Tags.java and TagsV16")
+abstract class TagManager {
+
+    /*
+     * Registry save/load
+     * ***********************************************************
+     */
+    abstract fun load(json: String)
+    abstract fun flush()
+
+    /*
+     * Registering and fetching tags
+     * ***********************************************************
+     */
+
+    /** Given a list of tags, add any missing ones to tag registry. */
+    fun register(tags: Iterable<String>) = register(tags, null)
+    /** Given a list of tags, add any missing ones to tag registry. */
+    abstract fun register(tags: Iterable<String>, usn: Int? = null)
+    abstract fun all(): List<String>
+    /** Add any missing tags from notes to the tags list. The old list is cleared first */
+    fun registerNotes() = registerNotes(null)
+    /**
+     * Add any missing tags from notes to the tags list.
+     * @param nids The old list is cleared first if this is null
+     */
+    abstract fun registerNotes(nids: kotlin.collections.Collection<Long>? = null)
+
+    abstract fun allItems(): MutableIterable<MutableMap.MutableEntry<String, Int>>
+    abstract fun save()
+    /**
+     * byDeck returns the tags of the cards in the deck
+     * @param did the deck id
+     * @param children whether to include the deck's children
+     * @return a list of the tags
+     */
+    abstract fun byDeck(did: Long, children: Boolean): ArrayList<String>
+
+    /*
+    * Bulk addition/removal from notes
+    * ***********************************************************
+    */
+
+    /**
+     * FIXME: This method must be fixed before it is used. See note below.
+     * Add/remove tags in bulk. TAGS is space-separated.
+     *
+     * @param ids The cards to tag.
+     * @param tags List of tags to add/remove. They are space-separated.
+     */
+    fun bulkAdd(ids: List<Long>, tags: String) = bulkAdd(ids, tags, true)
+    /**
+     * FIXME: This method must be fixed before it is used. Its behaviour is currently incorrect.
+     * This method is currently unused in AnkiDroid so it will not cause any errors in its current state.
+     *
+     * @param ids The cards to tag.
+     * @param tags List of tags to add/remove. They are space-separated.
+     * @param add True/False to add/remove.
+     */
+    abstract fun bulkAdd(ids: List<Long>, tags: String, add: Boolean = true)
+    fun bulkRem(ids: List<Long>, tags: String) = bulkAdd(ids, tags, false)
+
+    /*
+     * String-based utilities
+     * ***********************************************************
+     */
+
+    /** Parse a string and return a list of tags. */
+    abstract fun split(tags: String): ArrayList<String>
+    /** Join tags into a single string, with leading and trailing spaces. */
+    abstract fun join(tags: kotlin.collections.Collection<String>): String
+
+    /** Delete tags if they exist. */
+    abstract fun remFromStr(deltags: String, tags: String): String
+
+    /*
+     * List-based utilities
+     * ***********************************************************
+     */
+
+    /** Strip duplicates, adjust case to match existing tags, and sort. */
+    abstract fun canonify(tagList: List<String>): TreeSet<String>
+    /** @return True if TAG is in TAGS. Ignore case. */
+    abstract fun inList(tag: String, tags: Iterable<String>): Boolean
+
+    /*
+     * Sync handling
+     * ***********************************************************
+     */
+
+    abstract fun beforeUpload()
+
+    /*
+     * ***********************************************************
+     * The methods below are not in LibAnki.
+     * ***********************************************************
+     */
+
+    /** Add a tag to the collection. We use this method instead of exposing mTags publicly.*/
+    abstract fun add(tag: String, usn: Int?)
+
+    abstract fun minusOneValue(): Boolean
+}

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/TagManager.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/TagManager.kt
@@ -125,5 +125,7 @@ abstract class TagManager {
     /** Add a tag to the collection. We use this method instead of exposing mTags publicly.*/
     abstract fun add(tag: String, usn: Int?)
 
-    abstract fun minusOneValue(): Boolean
+    /** Whether any tags have a usn of -1 */
+    @RustCleanup("not optimised")
+    open fun minusOneValue(): Boolean = allItems().any { (_, value) -> value == -1 }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/TagManager.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/TagManager.kt
@@ -16,6 +16,7 @@
 
 package com.ichi2.libanki
 
+import com.ichi2.libanki.backend.model.TagUsnTuple
 import net.ankiweb.rsdroid.RustCleanup
 import java.util.*
 
@@ -52,7 +53,7 @@ abstract class TagManager {
      */
     abstract fun registerNotes(nids: kotlin.collections.Collection<Long>? = null)
 
-    abstract fun allItems(): MutableIterable<MutableMap.MutableEntry<String, Int>>
+    abstract fun allItems(): Iterable<TagUsnTuple>
     abstract fun save()
     /**
      * byDeck returns the tags of the cards in the deck
@@ -127,5 +128,5 @@ abstract class TagManager {
 
     /** Whether any tags have a usn of -1 */
     @RustCleanup("not optimised")
-    open fun minusOneValue(): Boolean = allItems().any { (_, value) -> value == -1 }
+    open fun minusOneValue(): Boolean = allItems().any { it.usn == -1 }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/TagManager.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/TagManager.kt
@@ -18,7 +18,6 @@ package com.ichi2.libanki
 
 import com.ichi2.libanki.backend.model.TagUsnTuple
 import net.ankiweb.rsdroid.RustCleanup
-import java.util.*
 
 /**
  * Manages the tag cache and tags for notes.
@@ -32,7 +31,9 @@ abstract class TagManager {
      * Registry save/load
      * ***********************************************************
      */
+    @RustCleanup("Tags.java only")
     abstract fun load(json: String)
+    @RustCleanup("Tags.java only")
     abstract fun flush()
 
     /*
@@ -58,6 +59,7 @@ abstract class TagManager {
     abstract fun registerNotes(nids: kotlin.collections.Collection<Long>? = null)
 
     abstract fun allItems(): Iterable<TagUsnTuple>
+    @RustCleanup("Tags.java only")
     abstract fun save()
     /**
      * byDeck returns the tags of the cards in the deck
@@ -65,7 +67,7 @@ abstract class TagManager {
      * @param children whether to include the deck's children
      * @return a list of the tags
      */
-    abstract fun byDeck(did: Long, children: Boolean): ArrayList<String>
+    abstract fun byDeck(did: Long, children: Boolean = false): List<String>
 
     /*
     * Bulk addition/removal from notes
@@ -110,7 +112,8 @@ abstract class TagManager {
      */
 
     /** Strip duplicates, adjust case to match existing tags, and sort. */
-    abstract fun canonify(tagList: List<String>): TreeSet<String>
+    @RustCleanup("List, not Collection")
+    abstract fun canonify(tagList: List<String>): java.util.AbstractSet<String>
     /** @return True if TAG is in TAGS. Ignore case. */
     abstract fun inList(tag: String, tags: Iterable<String>): Boolean
 
@@ -119,6 +122,7 @@ abstract class TagManager {
      * ***********************************************************
      */
 
+    @RustCleanup("Tags.java only")
     abstract fun beforeUpload()
 
     /*

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/TagManager.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/TagManager.kt
@@ -97,7 +97,7 @@ abstract class TagManager {
      */
 
     /** Parse a string and return a list of tags. */
-    abstract fun split(tags: String): ArrayList<String>
+    abstract fun split(tags: String): MutableList<String>
     /** Join tags into a single string, with leading and trailing spaces. */
     abstract fun join(tags: kotlin.collections.Collection<String>): String
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Tags.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Tags.java
@@ -144,9 +144,6 @@ public class Tags extends TagManager {
         return mTags.entrySet();
     }
 
-    public boolean minusOneValue() {
-        return mTags.containsValue(-1);
-    }
 
 
     public void save() {
@@ -355,5 +352,11 @@ public class Tags extends TagManager {
     /** Add a tag to the collection. We use this method instead of exposing mTags publicly.*/
     public void add(@NonNull String key, @Nullable Integer value) {
         mTags.put(key, value);
+    }
+
+    /** Whether any tags have a usn of -1 */
+    @Override
+    public boolean minusOneValue() {
+        return mTags.containsValue(-1);
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Tags.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Tags.java
@@ -26,7 +26,6 @@ import com.ichi2.utils.JSONObject;
 
 import java.util.ArrayList;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -35,7 +34,8 @@ import java.util.TreeMap;
 import java.util.TreeSet;
 import java.util.regex.Pattern;
 
-import okhttp3.internal.Util;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 
 /**
@@ -50,7 +50,7 @@ instead of a JSONObject. It is much more convenient to work with a TreeMap in Ja
 may be a performance penalty in doing so (on startup and shutdown).
  */
 @SuppressWarnings({"PMD.AvoidThrowingRawExceptionTypes"})
-public class Tags {
+public class Tags extends TagManager {
 
     private static final Pattern sCanonify = Pattern.compile("[\"']");
 
@@ -69,7 +69,7 @@ public class Tags {
     }
 
 
-    public void load(String json) {
+    public void load(@NonNull String json) {
         JSONObject tags = new JSONObject(json);
         for (String t : tags) {
             mTags.put(t, tags.getInt(t));
@@ -98,13 +98,7 @@ public class Tags {
      * ***********************************************************
      */
 
-    /** Given a list of tags, add any missing ones to tag registry. */
-    public void register(Iterable<String> tags) {
-        register(tags, null);
-    }
-
-
-    public void register(Iterable<String> tags, Integer usn) {
+    public void register(@NonNull Iterable<String> tags, @Nullable Integer usn) {
         //boolean found = false;
         for (String t : tags) {
             if (!mTags.containsKey(t)) {
@@ -118,18 +112,13 @@ public class Tags {
     }
 
 
+    @NonNull
     public List<String> all() {
         return new ArrayList<>(mTags.keySet());
     }
 
-
-    public void registerNotes() {
-        registerNotes(null);
-    }
-
-
     /** Add any missing tags from notes to the tags list. */
-    public void registerNotes(java.util.Collection<Long> nids) {
+    public void registerNotes(@Nullable java.util.Collection<Long> nids) {
         // when called with a null argument, the old list is cleared first.
         String lim;
         if (nids != null) {
@@ -150,6 +139,7 @@ public class Tags {
     }
 
 
+    @NonNull
     public Set<Map.Entry<String, Integer>> allItems() {
         return mTags.entrySet();
     }
@@ -164,12 +154,8 @@ public class Tags {
     }
 
 
-    /**
-    * byDeck returns the tags of the cards in the deck
-    * @param did the deck id
-    * @param children whether to include the deck's children
-    * @return a list of the tags
-    */
+    /** {@inheritDoc} */
+    @NonNull
     public ArrayList<String> byDeck(long did, boolean children) {
         List<String> tags;
         if (children) {
@@ -192,27 +178,8 @@ public class Tags {
      * ***********************************************************
      */
 
-    /**
-     * FIXME: This method must be fixed before it is used. See note below.
-     * Add/remove tags in bulk. TAGS is space-separated.
-     *
-     * @param ids The cards to tag.
-     * @param tags List of tags to add/remove. They are space-separated.
-     */
-    public void bulkAdd(List<Long> ids, String tags) {
-        bulkAdd(ids, tags, true);
-    }
-
-
-    /**
-     * FIXME: This method must be fixed before it is used. Its behaviour is currently incorrect.
-     * This method is currently unused in AnkiDroid so it will not cause any errors in its current state.
-     *
-     * @param ids The cards to tag.
-     * @param tags List of tags to add/remove. They are space-separated.
-     * @param add True/False to add/remove.
-     */
-    public void bulkAdd(List<Long> ids, String tags, boolean add) {
+    /** {@inheritDoc} */
+    public void bulkAdd(@NonNull List<Long> ids, @NonNull String tags, boolean add) {
         List<String> newTags = split(tags);
         if (newTags == null || newTags.isEmpty()) {
             return;
@@ -257,18 +224,14 @@ public class Tags {
     }
 
 
-    public void bulkRem(List<Long> ids, String tags) {
-        bulkAdd(ids, tags, false);
-    }
-
-
     /*
      * String-based utilities
      * ***********************************************************
      */
 
-    /** Parse a string and return a list of tags. */
-    public ArrayList<String> split(String tags) {
+    /** {@inheritDoc} */
+    @NonNull
+    public ArrayList<String> split(@NonNull String tags) {
         ArrayList<String> list = new ArrayList<>(tags.length());
         for (String s : tags.replace('\u3000', ' ').split("\\s")) {
             if (s.length() > 0) {
@@ -279,9 +242,10 @@ public class Tags {
     }
 
 
-    /** Join tags into a single string, with leading and trailing spaces. */
-    public String join(java.util.Collection<String> tags) {
-        if (tags == null || tags.size() == 0) {
+    /** {@inheritDoc} */
+    @NonNull
+    public String join(@NonNull java.util.Collection<String> tags) {
+        if (tags.size() == 0) {
             return "";
         } else {
             String joined = TextUtils.join(" ", tags);
@@ -307,8 +271,9 @@ public class Tags {
         return Pattern.compile(pat_replaced, Pattern.CASE_INSENSITIVE|Pattern.UNICODE_CASE).matcher(str).matches();
     }
 
-    /** Delete tags if they exist. */
-    public String remFromStr(String deltags, String tags) {
+    /** {@inheritDoc}  */
+    @NonNull
+    public String remFromStr(@NonNull String deltags, @NonNull String tags) {
         List<String> currentTags = split(tags);
         for (String tag : split(deltags)) {
             List<String> remove = new ArrayList<>(); // Usually not a lot of tags are removed simultaneously.
@@ -332,7 +297,8 @@ public class Tags {
      * ***********************************************************
      */
 
-    /** Strip duplicates, adjust case to match existing tags, and sort. */
+    /** {@inheritDoc} */
+    @NonNull
     public TreeSet<String> canonify(List<String> tagList) {
         // NOTE: The python version creates a list of tags, puts them into a set, then sorts them. The TreeSet
         // used here already guarantees uniqueness and sort order, so we return it as-is without those steps.
@@ -350,8 +316,8 @@ public class Tags {
     }
 
 
-    /** True if TAG is in TAGS. Ignore case. */
-    public boolean inList(String tag, Iterable<String> tags) {
+    /** {@inheritDoc} */
+    public boolean inList(@NonNull String tag, Iterable<String> tags) {
         for (String t : tags) {
             if (t.equalsIgnoreCase(tag)) {
                 return true;
@@ -387,7 +353,7 @@ public class Tags {
 
 
     /** Add a tag to the collection. We use this method instead of exposing mTags publicly.*/
-    public void add(String key, Integer value) {
+    public void add(@NonNull String key, @Nullable Integer value) {
         mTags.put(key, value);
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Tags.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Tags.java
@@ -100,7 +100,8 @@ public class Tags extends TagManager {
      * ***********************************************************
      */
 
-    public void register(@NonNull Iterable<String> tags, @Nullable Integer usn) {
+    /** {@inheritDoc} */
+    public void register(@NonNull Iterable<String> tags, @Nullable Integer usn, boolean clear_first) {
         //boolean found = false;
         for (String t : tags) {
             if (!mTags.containsKey(t)) {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Tags.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Tags.java
@@ -22,6 +22,7 @@ import android.content.ContentValues;
 import android.database.Cursor;
 import android.text.TextUtils;
 
+import com.ichi2.libanki.backend.model.TagUsnTuple;
 import com.ichi2.utils.JSONObject;
 
 import java.util.ArrayList;
@@ -33,6 +34,7 @@ import java.util.Set;
 import java.util.TreeMap;
 import java.util.TreeSet;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -140,8 +142,11 @@ public class Tags extends TagManager {
 
 
     @NonNull
-    public Set<Map.Entry<String, Integer>> allItems() {
-        return mTags.entrySet();
+    public Set<TagUsnTuple> allItems() {
+        return mTags.entrySet()
+                .stream()
+                .map(entry -> new TagUsnTuple(entry.getKey(), entry.getValue()))
+                .collect(Collectors.toSet());
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/TagsV16.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/TagsV16.kt
@@ -30,7 +30,6 @@ import com.ichi2.libanki.backend.model.TagUsnTuple
 import com.ichi2.libanki.utils.join
 import com.ichi2.libanki.utils.list
 import com.ichi2.libanki.utils.set
-import java.util.*
 import java.util.regex.Pattern
 
 /**
@@ -39,32 +38,32 @@ import java.util.regex.Pattern
  * tracked, so unused tags can only be removed from the list with a DB check.
  * This module manages the tag cache and tags for notes.
  */
-class TagsV16(val mCol: Collection, private val mBackend: TagsBackend) {
+class TagsV16(val mCol: Collection, private val mBackend: TagsBackend) : TagManager() {
 
     /** all tags */
-    fun all(): List<String> = mBackend.all_tags().map { it.tag }
+    override fun all(): List<String> = mBackend.all_tags().map { it.tag }
 
     /** List of (tag, usn) */
-    fun allItems(): List<TagUsnTuple> = mBackend.all_tags()
+    override fun allItems(): List<TagUsnTuple> = mBackend.all_tags()
 
     /*
     # Registering and fetching tags
     #############################################################
     */
 
-    fun register(
-        tags: kotlin.collections.Collection<String>,
-        usn: Optional<Int> = Optional.empty(),
-        clear: Boolean = false
+    override fun register(
+        tags: Iterable<String>,
+        usn: Int?,
+        clear: Boolean
     ) {
 
         val preserve_usn: Boolean
         val usn_: Int
-        if (!usn.isPresent) {
+        if (usn == null) {
             preserve_usn = false
             usn_ = 0
         } else {
-            usn_ = usn.get()
+            usn_ = usn
             preserve_usn = true
         }
 
@@ -74,13 +73,13 @@ class TagsV16(val mCol: Collection, private val mBackend: TagsBackend) {
     }
 
     /** Add any missing tags from notes to the tags list. */
-    fun registerNotes(nids: Optional<List<Long>> = Optional.empty()) {
+    override fun registerNotes(nids: kotlin.collections.Collection<Long>?) {
 
         // when called without an argument, the old list is cleared first.
         val clear: Boolean
         val lim: String
-        if (nids.isPresent) {
-            lim = " where id in " + ids2str(nids.get())
+        if (nids != null) {
+            lim = " where id in " + ids2str(nids)
             clear = false
         } else {
             lim = ""
@@ -96,7 +95,7 @@ class TagsV16(val mCol: Collection, private val mBackend: TagsBackend) {
         )
     }
 
-    fun byDeck(did: Long, children: Boolean = false): List<String> {
+    override fun byDeck(did: Long, children: Boolean): List<String> {
         val basequery = "select n.tags from cards c, notes n WHERE c.nid = n.id"
         val query: String
         val res: List<String>
@@ -143,17 +142,12 @@ class TagsV16(val mCol: Collection, private val mBackend: TagsBackend) {
     // legacy routines
 
     /**  Add tags in bulk. TAGS is space-separated. */
-    fun bulkAdd(ids: List<Long>, tags: String, add: Boolean = true) {
-
+    override fun bulkAdd(ids: List<Long>, tags: String, add: Boolean) {
         if (add) {
             bulk_add(ids, tags)
         } else {
             bulk_update(ids, tags, "", false)
         }
-    }
-
-    fun bulkRem(ids: List<Long>, tags: String) {
-        bulkAdd(ids, tags, false)
     }
 
     /*
@@ -162,7 +156,7 @@ class TagsV16(val mCol: Collection, private val mBackend: TagsBackend) {
      */
 
     /** Parse a string and return a list of tags. */
-    fun split(tags: String): MutableList<String> {
+    override fun split(tags: String): MutableList<String> {
         return tags.replace('\u3000', ' ')
             .split("\\s".toRegex())
             .filter { it.isNotEmpty() }
@@ -170,7 +164,7 @@ class TagsV16(val mCol: Collection, private val mBackend: TagsBackend) {
     }
 
     /** Join tags into a single string, with leading and trailing spaces. */
-    fun join(tags: List<String>): String {
+    override fun join(tags: kotlin.collections.Collection<String>): String {
         if (tags.isEmpty()) {
             return ""
         }
@@ -190,7 +184,7 @@ class TagsV16(val mCol: Collection, private val mBackend: TagsBackend) {
     }
 
     /** Delete tags if they exist. */
-    fun remFromStr(deltags: String, tags: String): String {
+    override fun remFromStr(deltags: String, tags: String): String {
         fun wildcard(search: String, str: String): Boolean {
             // TODO: needs testing
             val escaped = Pattern.quote(search).replace("\\*", ".*")
@@ -221,12 +215,41 @@ class TagsV16(val mCol: Collection, private val mBackend: TagsBackend) {
      */
 
     // this is now a no-op - the tags are canonified when the note is saved
-    fun canonify(tagList: List<String>): List<String> {
-        return tagList
+    override fun canonify(tagList: List<String>): java.util.AbstractSet<String> {
+        // libAnki difference: tagList was returned directly
+        return HashSet(tagList)
     }
 
     /** True if TAG is in TAGS. Ignore case.*/
-    fun inList(tag: String, tags: List<String>): Boolean {
+    override fun inList(tag: String, tags: Iterable<String>): Boolean {
         return tags.map { it.lowercase() }.contains(tag.lowercase())
+    }
+
+    /*
+     * Not in libAnki
+     */
+
+    override fun add(tag: String, usn: Int?) {
+        register(listOf(tag), usn)
+    }
+
+    /*
+     * Interface compatibility - to be removed
+     */
+
+    override fun load(json: String) {
+        // intentionally left blank
+    }
+
+    override fun flush() {
+        // intentionally left blank
+    }
+
+    override fun save() {
+        // intentionally left blank//
+    }
+
+    override fun beforeUpload() {
+        // intentionally left blank//
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sync/Syncer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sync/Syncer.java
@@ -29,6 +29,7 @@ import com.ichi2.anki.exception.UnknownHttpResponseException;
 import com.ichi2.async.Connection;
 import com.ichi2.libanki.DB;
 import com.ichi2.libanki.Model;
+import com.ichi2.libanki.backend.model.TagUsnTuple;
 import com.ichi2.libanki.sched.AbstractSched;
 import com.ichi2.libanki.Collection;
 import com.ichi2.libanki.Consts;
@@ -817,16 +818,16 @@ public class Syncer {
     private JSONArray getTags() {
         JSONArray result = new JSONArray();
         if (mCol.getServer()) {
-            for (Map.Entry<String, Integer> t : mCol.getTags().allItems()) {
-                if (t.getValue() >= mMinUsn) {
-                    result.put(t.getKey());
+            for (TagUsnTuple t : mCol.getTags().allItems()) {
+                if (t.getUsn() >= mMinUsn) {
+                    result.put(t.getTag());
                 }
             }
         } else {
-            for (Map.Entry<String, Integer> t : mCol.getTags().allItems()) {
-                if (t.getValue() == -1) {
-                    String tag = t.getKey();
-                    mCol.getTags().add(t.getKey(), mMaxUsn);
+            for (TagUsnTuple t : mCol.getTags().allItems()) {
+                if (t.getUsn() == -1) {
+                    String tag = t.getTag();
+                    mCol.getTags().add(t.getTag(), mMaxUsn);
                     result.put(tag);
                 }
             }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/utils/PythonExtensions.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/utils/PythonExtensions.kt
@@ -60,7 +60,7 @@ fun <T> list(values: Collection<T>): List<T> = ArrayList(values)
 
 fun <T> set(values: List<T>): HashSet<T> = HashSet(values)
 
-fun String.join(values: Collection<String>): String {
+fun String.join(values: Iterable<String>): String {
     return TextUtils.join(this, values)
 }
 


### PR DESCRIPTION
## Pull Request template

## Purpose / Description

* We want `Collection` to return either a `Tags.java` or a `TagsV16.kt` to allow implementation of the Schema v16 upgrade

## Fixes
Related: #8988 

## Approach
* Add an abstract class and have both implement the methods 
* Consolidate the interfaces, both on the Java and on the Kotlin
* Don't consolidate implementations, as we plan to remove `Tags.java`

## How Has This Been Tested?

* ⚠️ Untested, draft to ensure unit tests pass

## Learning (optional, can help others)
`@JvmOverrides` doesn't work on abstract methods

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
