### PR TITLE
feat: migrate from col.getConf() to config methods on `col`

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -1963,7 +1963,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
 
         // These are preferences we pull out of the collection instead of SharedPreferences
         try {
-            mShowNextReviewTime = getCol().getConf().getBoolean("estTimes");
+            mShowNextReviewTime = getCol().get_config_boolean("estTimes");
 
             // Dynamic don't have review options; attempt to get deck-specific auto-advance options
             // but be prepared to go with all default if it's a dynamic deck

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -430,7 +430,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
         @Override
         public void onSelection(String searchName) {
             Timber.d("OnSelection using search named: %s", searchName);
-            JSONObject savedFiltersObj = getCol().getConf().optJSONObject("savedFilters");
+            JSONObject savedFiltersObj = getCol().get_config("savedFilters", (JSONObject) null);
             Timber.d("SavedFilters are %s", savedFiltersObj.toString());
             if (savedFiltersObj != null) {
                 mSearchTerms = savedFiltersObj.optString(searchName);
@@ -444,7 +444,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
         @Override
         public void onRemoveSearch(String searchName) {
             Timber.d("OnRemoveSelection using search named: %s", searchName);
-            JSONObject savedFiltersObj = getCol().getConf().optJSONObject("savedFilters");
+            JSONObject savedFiltersObj = getCol().get_config("savedFilters", (JSONObject) null);
             if (savedFiltersObj != null && savedFiltersObj.has(searchName)) {
                 savedFiltersObj.remove(searchName);
                 getCol().set_config("savedFilters", savedFiltersObj);
@@ -463,7 +463,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
                         getString(R.string.card_browser_list_my_searches_new_search_error_empty_name), true);
                 return;
             }
-            JSONObject savedFiltersObj = getCol().getConf().optJSONObject("savedFilters");
+            JSONObject savedFiltersObj = getCol().get_config("savedFilters", (JSONObject) null);
             boolean should_save = false;
             if (savedFiltersObj == null) {
                 savedFiltersObj = new JSONObject();
@@ -960,7 +960,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
             mSaveSearchItem = menu.findItem(R.id.action_save_search);
             mSaveSearchItem.setVisible(false); //the searchview's query always starts empty.
             mMySearchesItem = menu.findItem(R.id.action_list_my_searches);
-            JSONObject savedFiltersObj = getCol().getConf().optJSONObject("savedFilters");
+            JSONObject savedFiltersObj = getCol().get_config("savedFilters", (JSONObject) null);
             mMySearchesItem.setVisible(savedFiltersObj != null && savedFiltersObj.length() > 0);
             mSearchItem = menu.findItem(R.id.action_search);
             mSearchItem.setOnActionExpandListener(new MenuItem.OnActionExpandListener() {
@@ -1153,7 +1153,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
                     searchTerms, CardBrowserMySearchesDialog.CARD_BROWSER_MY_SEARCHES_TYPE_SAVE));
             return true;
         } else if (itemId == R.id.action_list_my_searches) {
-            JSONObject savedFiltersObj = getCol().getConf().optJSONObject("savedFilters");
+            JSONObject savedFiltersObj = getCol().get_config("savedFilters", (JSONObject) null);
             HashMap<String, String> savedFilters;
             if (savedFiltersObj != null) {
                 savedFilters = new HashMap<>(savedFiltersObj.length());

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -322,22 +322,22 @@ public class CardBrowser extends NavigationDrawerActivity implements
             mOrderAsc = false;
             if (mOrder == 0) {
                 // if the sort value in the card browser was changed, then perform a new search
-                getCol().getConf().put("sortType", fSortTypes[1]);
+                getCol().set_config("sortType", fSortTypes[1]);
                 AnkiDroidApp.getSharedPrefs(getBaseContext()).edit()
                         .putBoolean("cardBrowserNoSorting", true)
                         .apply();
             } else {
-                getCol().getConf().put("sortType", fSortTypes[mOrder]);
+                getCol().set_config("sortType", fSortTypes[mOrder]);
                 AnkiDroidApp.getSharedPrefs(getBaseContext()).edit()
                         .putBoolean("cardBrowserNoSorting", false)
                         .apply();
             }
-            getCol().getConf().put("sortBackwards", mOrderAsc);
+            getCol().set_config("sortBackwards", mOrderAsc);
             searchCards();
         } else if (which != CARD_ORDER_NONE) {
             // if the same element is selected again, reverse the order
             mOrderAsc = !mOrderAsc;
-            getCol().getConf().put("sortBackwards", mOrderAsc);
+            getCol().set_config("sortBackwards", mOrderAsc);
             mCards.reverse();
             updateList();
         }
@@ -447,7 +447,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
             JSONObject savedFiltersObj = getCol().getConf().optJSONObject("savedFilters");
             if (savedFiltersObj != null && savedFiltersObj.has(searchName)) {
                 savedFiltersObj.remove(searchName);
-                getCol().getConf().put("savedFilters", savedFiltersObj);
+                getCol().set_config("savedFilters", savedFiltersObj);
                 getCol().flush();
                 if (savedFiltersObj.length() == 0) {
                     mMySearchesItem.setVisible(false);
@@ -477,7 +477,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
                                         getString(R.string.card_browser_list_my_searches_new_search_error_dup), true);
             }
             if (should_save) {
-                getCol().getConf().put("savedFilters", savedFiltersObj);
+                getCol().set_config("savedFilters", savedFiltersObj);
                 getCol().flush();
                 mSearchView.setQuery("", false);
                 mMySearchesItem.setVisible(true);

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -620,7 +620,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
         mActionBarTitle = findViewById(R.id.toolbar_title);
 
         mOrder = CARD_ORDER_NONE;
-        String colOrder = getCol().getConf().getString("sortType");
+        String colOrder = getCol().get_config_string("sortType");
         for (int c = 0; c < fSortTypes.length; ++c) {
             if (fSortTypes[c].equals(colOrder)) {
                 mOrder = c;
@@ -634,7 +634,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
         //setConf. However older version of AnkiDroid didn't call
         //upgradeJSONIfNecessary during setConf, which means the
         //conf saved may still have this bug.
-        mOrderAsc = Upgrade.upgradeJSONIfNecessary(getCol(), getCol().getConf(), "sortBackwards", false);
+        mOrderAsc = Upgrade.upgradeJSONIfNecessary(getCol(), "sortBackwards", false);
 
         mCards.reset();
         mCardsListView = findViewById(R.id.card_browser_list);

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -431,7 +431,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
         public void onSelection(String searchName) {
             Timber.d("OnSelection using search named: %s", searchName);
             JSONObject savedFiltersObj = getCol().get_config("savedFilters", (JSONObject) null);
-            Timber.d("SavedFilters are %s", savedFiltersObj.toString());
+            Timber.d("SavedFilters are %s", savedFiltersObj == null ? null : savedFiltersObj.toString());
             if (savedFiltersObj != null) {
                 mSearchTerms = savedFiltersObj.optString(searchName);
                 Timber.d("OnSelection using search terms: %s", mSearchTerms);

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -1804,10 +1804,9 @@ public class NoteEditor extends AnkiActivity implements
             return;
         }
         if (note == null || mAddNote || mCurrentEditedCard == null) {
-            JSONObject conf = getCol().getConf();
             JSONObject model = getCol().getModels().current();
             if (getCol().get_config("addToCur", true)) {
-                mCurrentDid = conf.getLong("curDeck");
+                mCurrentDid = getCol().get_config_long("curDeck");
                 if (getCol().getDecks().isDyn(mCurrentDid)) {
                     /*
                      * If the deck in mCurrentDid is a filtered (dynamic) deck, then we can't create cards in it,

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -1806,7 +1806,7 @@ public class NoteEditor extends AnkiActivity implements
         if (note == null || mAddNote || mCurrentEditedCard == null) {
             JSONObject conf = getCol().getConf();
             JSONObject model = getCol().getModels().current();
-            if (conf.optBoolean("addToCur", true)) {
+            if (getCol().get_config("addToCur", true)) {
                 mCurrentDid = conf.getLong("curDeck");
                 if (getCol().getDecks().isDyn(mCurrentDid)) {
                     /*
@@ -2109,7 +2109,7 @@ public class NoteEditor extends AnkiActivity implements
                 currentDeck.put("mid", newId);
                 getCol().getDecks().save(currentDeck);
                 // Update deck
-                if (!getCol().getConf().optBoolean("addToCur", true)) {
+                if (!getCol().get_config("addToCur", true)) {
                     mCurrentDid = model.getLong("did");
                 }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
@@ -314,7 +314,7 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
                             ((NumberRangePreference)pref).setValue(conf.getInt("timeLim") / 60);
                             break;
                         case USE_CURRENT:
-                            ((android.preference.ListPreference)pref).setValueIndex(conf.optBoolean("addToCur", true) ? 0 : 1);
+                            ((android.preference.ListPreference)pref).setValueIndex(col.get_config("addToCur", true) ? 0 : 1);
                             break;
                         case NEW_SPREAD:
                             ((android.preference.ListPreference)pref).setValueIndex(conf.getInt("newSpread"));
@@ -323,7 +323,7 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
                             ((SeekBarPreference)pref).setValue(getDayOffset(col));
                             break;
                         case PASTE_PNG:
-                            ((android.preference.CheckBoxPreference)pref).setChecked(conf.optBoolean("pastePNG"));
+                            ((android.preference.CheckBoxPreference)pref).setChecked(col.get_config("pastePNG", false));
                             break;
                         case NEW_TIMEZONE_HANDLING:
                             android.preference.CheckBoxPreference checkBox = (android.preference.CheckBoxPreference) pref;
@@ -359,7 +359,7 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
                 Calendar calendar = col.crtGregorianCalendar();
                 return calendar.get(Calendar.HOUR_OF_DAY);
             case 2:
-                return col.getConf().optInt("rollover", 4);
+                return col.get_config("rollover", 4);
         }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
@@ -299,25 +299,24 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
             Collection col = getCol();
             if (col != null) {
                 try {
-                    JSONObject conf = col.getConf();
                     switch (pref.getKey()) {
                         case SHOW_ESTIMATE:
-                            ((android.preference.CheckBoxPreference)pref).setChecked(conf.getBoolean("estTimes"));
+                            ((android.preference.CheckBoxPreference)pref).setChecked(col.get_config_boolean("estTimes"));
                             break;
                         case SHOW_PROGRESS:
-                            ((android.preference.CheckBoxPreference)pref).setChecked(conf.getBoolean("dueCounts"));
+                            ((android.preference.CheckBoxPreference)pref).setChecked(col.get_config_boolean("dueCounts"));
                             break;
                         case LEARN_CUTOFF:
-                            ((NumberRangePreference)pref).setValue(conf.getInt("collapseTime") / 60);
+                            ((NumberRangePreference)pref).setValue(col.get_config_int("collapseTime") / 60);
                             break;
                         case TIME_LIMIT:
-                            ((NumberRangePreference)pref).setValue(conf.getInt("timeLim") / 60);
+                            ((NumberRangePreference)pref).setValue(col.get_config_int("timeLim") / 60);
                             break;
                         case USE_CURRENT:
                             ((android.preference.ListPreference)pref).setValueIndex(col.get_config("addToCur", true) ? 0 : 1);
                             break;
                         case NEW_SPREAD:
-                            ((android.preference.ListPreference)pref).setValueIndex(conf.getInt("newSpread"));
+                            ((android.preference.ListPreference)pref).setValueIndex(col.get_config_int("newSpread"));
                             break;
                         case DAY_OFFSET:
                             ((SeekBarPreference)pref).setValue(getDayOffset(col));

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
@@ -375,7 +375,7 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
                 getCol().setMod();
                 break;
             case 2:
-                getCol().getConf().put("rollover", hours);
+                getCol().set_config("rollover", hours);
                 getCol().flush();
                 break;
         }
@@ -424,36 +424,29 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
                     closePreferences();
                     break;
                 case SHOW_PROGRESS:
-                    getCol().getConf().put("dueCounts", ((android.preference.CheckBoxPreference) pref).isChecked());
-                    getCol().setMod();
+                    getCol().getCol().set_config("dueCounts", ((android.preference.CheckBoxPreference) pref).isChecked());
                     break;
                 case SHOW_ESTIMATE:
-                    getCol().getConf().put("estTimes", ((android.preference.CheckBoxPreference) pref).isChecked());
-                    getCol().setMod();
+                    getCol().getCol().set_config("estTimes", ((android.preference.CheckBoxPreference) pref).isChecked());
                     break;
                 case NEW_SPREAD:
-                    getCol().getConf().put("newSpread", Integer.parseInt(((android.preference.ListPreference) pref).getValue()));
-                    getCol().setMod();
+                    getCol().getCol().set_config("newSpread", Integer.parseInt(((android.preference.ListPreference) pref).getValue()));
                     break;
                 case TIME_LIMIT:
-                    getCol().getConf().put("timeLim", ((NumberRangePreference) pref).getValue() * 60);
-                    getCol().setMod();
+                    getCol().getCol().set_config("timeLim", ((NumberRangePreference) pref).getValue() * 60);
                     break;
                 case LEARN_CUTOFF:
-                    getCol().getConf().put("collapseTime", ((NumberRangePreference) pref).getValue() * 60);
-                    getCol().setMod();
+                    getCol().getCol().set_config("collapseTime", ((NumberRangePreference) pref).getValue() * 60);
                     break;
                 case USE_CURRENT:
-                    getCol().getConf().put("addToCur", "0".equals(((android.preference.ListPreference) pref).getValue()));
-                    getCol().setMod();
+                    getCol().getCol().set_config("addToCur", "0".equals(((android.preference.ListPreference) pref).getValue()));
                     break;
                 case DAY_OFFSET: {
                     setDayOffset(((SeekBarPreference) pref).getValue());
                     break;
                 }
                 case PASTE_PNG:
-                    getCol().getConf().put("pastePNG", ((android.preference.CheckBoxPreference) pref).isChecked());
-                    getCol().setMod();
+                    getCol().set_config("pastePNG", ((android.preference.CheckBoxPreference) pref).isChecked());
                     break;
                 case MINIMUM_CARDS_DUE_FOR_NOTIFICATION: {
                     android.preference.ListPreference listpref = (android.preference.ListPreference) screen.findPreference(MINIMUM_CARDS_DUE_FOR_NOTIFICATION);

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.java
@@ -1108,7 +1108,7 @@ public class Reviewer extends AbstractFlashcardViewer {
 
     protected void restoreCollectionPreferences() {
         super.restoreCollectionPreferences();
-        mShowRemainingCardCount = getCol().getConf().getBoolean("dueCounts");
+        mShowRemainingCardCount = getCol().get_config_boolean("dueCounts");
     }
 
     @Override

--- a/AnkiDroid/src/main/java/com/ichi2/anki/services/BootService.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/services/BootService.java
@@ -161,7 +161,7 @@ public class BootService extends BroadcastReceiver {
                     SharedPreferences sp = AnkiDroidApp.getSharedPrefs(context);
                     return sp.getInt("dayOffset", defValue);
                 case 2:
-                    return col.getConf().optInt("rollover", defValue);
+                    return col.get_config("rollover", defValue);
             }
         } catch (Exception e) {
             Timber.w(e);

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
@@ -2094,6 +2094,11 @@ public class Collection implements CollectionGetter {
         return mConf.has(key);
     }
 
+    public boolean has_config_not_null(String key) {
+        // not in libAnki
+        return has_config(key) && !mConf.isNull(key);
+    }
+
     /** @throws JSONException object does not exist or can't be cast */
     public boolean get_config_boolean(@NonNull String key) {
         return mConf.getBoolean(key);

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
@@ -56,6 +56,8 @@ import com.ichi2.utils.JSONObject;
 
 import net.ankiweb.rsdroid.RustCleanup;
 
+import org.jetbrains.annotations.Contract;
+
 import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileWriter;
@@ -182,7 +184,7 @@ public class Collection implements CollectionGetter {
         mStartReps = 0;
         mStartTime = 0;
         _loadScheduler();
-        if (!mConf.optBoolean("newBury", false)) {
+        if (!get_config("newBury", false)) {
             set_config("newBury", true);
         }
     }
@@ -201,7 +203,7 @@ public class Collection implements CollectionGetter {
 
 
     public int schedVer() {
-        int ver = mConf.optInt("schedVer", fDefaultSchedulerVersion);
+        int ver = get_config("schedVer", fDefaultSchedulerVersion);
         if (fSupportedSchedulerVersions.contains(ver)) {
             return ver;
         } else {
@@ -2077,6 +2079,59 @@ public class Collection implements CollectionGetter {
         mConf = conf;
     }
 
+    // region JSON-Related Config
+
+    // Anki Desktop has a get_config and set_config method handling an "Any"
+    // We're not dynamically typed, so add additional methods for each JSON type that
+    // we can handle
+
+    // methods with a default can be named `get_config` as the `defaultValue` argument defines the return type
+    // NOTE: get_config("key", 1) and get_config("key", 1L) will return different types
+
+    @Nullable
+    @Contract("_, !null -> !null")
+    public Boolean get_config(@NonNull String key, @Nullable Boolean defaultValue) {
+        if (!mConf.has(key)) {
+            return defaultValue;
+        }
+        return mConf.getBoolean(key);
+    }
+
+    @Nullable
+    @Contract("_, !null -> !null")
+    public Long get_config(@NonNull String key, @Nullable Long defaultValue) {
+        if (!mConf.has(key)) {
+            return defaultValue;
+        }
+        return mConf.getLong(key);
+    }
+
+    @Nullable
+    @Contract("_, !null -> !null")
+    public Integer get_config(@NonNull String key, @Nullable Integer defaultValue) {
+        if (!mConf.has(key)) {
+            return defaultValue;
+        }
+        return mConf.getInt(key);
+    }
+
+    @Contract("_, !null -> !null")
+    public Double get_config(@NonNull String key, @Nullable Double defaultValue) {
+        if (!mConf.has(key)) {
+            return defaultValue;
+        }
+        return mConf.getDouble(key);
+    }
+
+    @Nullable
+    @Contract("_, !null -> !null")
+    public String get_config(@NonNull String key, @Nullable String defaultValue) {
+        if (!mConf.has(key)) {
+            return defaultValue;
+        }
+        return mConf.getString(key);
+    }
+
     public void set_config(@NonNull String key, boolean value) {
         setMod();
         mConf.put(key, value);
@@ -2116,6 +2171,8 @@ public class Collection implements CollectionGetter {
         setMod();
         mConf.remove(key);
     }
+
+    //endregion
 
     public long getScm() {
         return mScm;

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
@@ -529,7 +529,7 @@ public class Collection implements CollectionGetter {
         type = "next" + Character.toUpperCase(type.charAt(0)) + type.substring(1);
         int id;
         try {
-            id = mConf.getInt(type);
+            id = get_config_int(type);
         } catch (JSONException e) {
             Timber.w(e);
             id = 1;
@@ -1260,7 +1260,7 @@ public class Collection implements CollectionGetter {
 
 
     public long getTimeLimit() {
-        return mConf.getLong("timeLim");
+        return get_config_long("timeLim");
     }
 
 
@@ -1272,13 +1272,13 @@ public class Collection implements CollectionGetter {
 
     /* Return (elapsedTime, reps) if timebox reached, or null. */
     public Pair<Integer, Integer> timeboxReached() {
-        if (mConf.getLong("timeLim") == 0) {
+        if (get_config_long("timeLim") == 0) {
             // timeboxing disabled
             return null;
         }
         long elapsed = getTime().intTime() - mStartTime;
-        if (elapsed > mConf.getLong("timeLim")) {
-            return new Pair<>(mConf.getInt("timeLim"), mSched.getReps() - mStartReps);
+        if (elapsed > get_config_long("timeLim")) {
+            return new Pair<>(get_config_int("timeLim"), mSched.getReps() - mStartReps);
         }
         return null;
     }
@@ -2075,7 +2075,7 @@ public class Collection implements CollectionGetter {
         // bug #5523. This bug should occur only for people using anki
         // prior to version 2.16 and has been corrected with
         // dae/anki#347
-        Upgrade.upgradeJSONIfNecessary(this, conf, "sortBackwards", false);
+        Upgrade.upgradeJSONIfNecessary(this, "sortBackwards", false);
         mConf = conf;
     }
 
@@ -2087,6 +2087,35 @@ public class Collection implements CollectionGetter {
 
     // methods with a default can be named `get_config` as the `defaultValue` argument defines the return type
     // NOTE: get_config("key", 1) and get_config("key", 1L) will return different types
+
+    /** @throws JSONException object does not exist or can't be cast */
+    public boolean get_config_boolean(@NonNull String key) {
+        return mConf.getBoolean(key);
+    }
+
+    /** @throws JSONException object does not exist or can't be cast */
+    public long get_config_long(@NonNull String key) {
+        return mConf.getLong(key);
+    }
+
+    /** @throws JSONException object does not exist or can't be cast */
+    public int get_config_int(@NonNull String key) {
+        return mConf.getInt(key);
+    }
+
+    /** @throws JSONException object does not exist or can't be cast */
+    public double get_config_double(@NonNull String key) {
+        return mConf.getDouble(key);
+    }
+
+    /**
+     * If the value is null in the JSON, a string of "null" will be returned
+     * @throws JSONException object does not exist, or can't be cast
+     */
+    @NonNull
+    public String get_config_string(@NonNull String key) {
+        return mConf.getString(key);
+    }
 
     @Nullable
     @Contract("_, !null -> !null")

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
@@ -2109,6 +2109,14 @@ public class Collection implements CollectionGetter {
     }
 
     /**
+     * Edits to this object are not persisted to preferences.
+     * @throws JSONException object does not exist or can't be cast
+     */
+    public JSONObject get_config_object(@NonNull String key) {
+        return new JSONObject(mConf.getJSONObject(key));
+    }
+
+    /**
      * If the value is null in the JSON, a string of "null" will be returned
      * @throws JSONException object does not exist, or can't be cast
      */
@@ -2159,6 +2167,16 @@ public class Collection implements CollectionGetter {
             return defaultValue;
         }
         return mConf.getString(key);
+    }
+
+    /** Edits to the config are not persisted to the preferences */
+    @Nullable
+    @Contract("_, !null -> !null")
+    public JSONObject get_config(@NonNull String key, @Nullable JSONObject defaultValue) {
+        if (!mConf.has(key)) {
+            return defaultValue == null ? null : new JSONObject(defaultValue);
+        }
+        return new JSONObject(mConf.getJSONObject(key));
     }
 
     public void set_config(@NonNull String key, boolean value) {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
@@ -2116,6 +2116,14 @@ public class Collection implements CollectionGetter {
         return new JSONObject(mConf.getJSONObject(key));
     }
 
+    /** Edits to the array are not persisted to the preferences
+     * @throws JSONException object does not exist or can't be cast
+     */
+    @NonNull
+    public JSONArray get_config_array(@NonNull String key) {
+        return new JSONArray(mConf.getJSONArray(key));
+    }
+
     /**
      * If the value is null in the JSON, a string of "null" will be returned
      * @throws JSONException object does not exist, or can't be cast
@@ -2177,6 +2185,16 @@ public class Collection implements CollectionGetter {
             return defaultValue == null ? null : new JSONObject(defaultValue);
         }
         return new JSONObject(mConf.getJSONObject(key));
+    }
+
+    /** Edits to the array are not persisted to the preferences */
+    @Nullable
+    @Contract("_, !null -> !null")
+    public JSONArray get_config(@NonNull String key, @Nullable JSONArray defaultValue) {
+        if (!mConf.has(key)) {
+            return defaultValue == null ? null : new JSONArray(defaultValue);
+        }
+        return new JSONArray(mConf.getJSONArray(key));
     }
 
     public void set_config(@NonNull String key, boolean value) {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
@@ -183,8 +183,7 @@ public class Collection implements CollectionGetter {
         mStartTime = 0;
         _loadScheduler();
         if (!mConf.optBoolean("newBury", false)) {
-            mConf.put("newBury", true);
-            setMod();
+            set_config("newBury", true);
         }
     }
 
@@ -219,7 +218,7 @@ public class Collection implements CollectionGetter {
             mSched = new SchedV2(this);
             if (!getServer() && isUsingRustBackend()) {
                 try {
-                    getConf().put("localOffset", getSched()._current_timezone_offset());
+                    set_config("localOffset", getSched()._current_timezone_offset());
                 } catch (BackendNotSupportedException e) {
                     throw e.alreadyUsingRustBackend();
                 }
@@ -243,8 +242,7 @@ public class Collection implements CollectionGetter {
         } else {
             v2Sched.moveToV2();
         }
-        mConf.put("schedVer", ver);
-        setMod();
+        set_config("schedVer", ver);
         _loadScheduler();
     }
 
@@ -331,6 +329,7 @@ public class Collection implements CollectionGetter {
      * Mark DB modified. DB operations and the deck/tag/model managers do this automatically, so this is only necessary
      * if you modify properties of this object or the conf dict.
      */
+    @RustCleanup("no longer required in v16 - all update immediately")
     public void setMod() {
         mDb.setMod(true);
     }
@@ -533,7 +532,7 @@ public class Collection implements CollectionGetter {
             Timber.w(e);
             id = 1;
         }
-        mConf.put(type, id + 1);
+        set_config(type, id + 1);
         return id;
     }
 
@@ -1254,7 +1253,7 @@ public class Collection implements CollectionGetter {
      */
 
     public void setTimeLimit(long seconds) {
-        mConf.put("timeLim", seconds);
+        set_config("timeLim", seconds);
     }
 
 
@@ -1336,8 +1335,7 @@ public class Collection implements CollectionGetter {
 
     public void onCreate() {
         mDroidBackend.useNewTimezoneCode(this);
-        getConf().put("schedVer", 2);
-        setMod();
+        set_config("schedVer", 2);
         // we need to reload the scheduler: this was previously loaded as V1
         _loadScheduler();
     }
@@ -1670,7 +1668,7 @@ public class Collection implements CollectionGetter {
         Timber.d("resetNewCardInsertionPosition");
         notifyProgress.run();
         // new card position
-        mConf.put("nextPos", mDb.queryScalar("SELECT max(due) + 1 FROM cards WHERE type = " + Consts.CARD_TYPE_NEW));
+        set_config("nextPos", mDb.queryScalar("SELECT max(due) + 1 FROM cards WHERE type = " + Consts.CARD_TYPE_NEW));
         return Collections.emptyList();
     }
 
@@ -2079,6 +2077,45 @@ public class Collection implements CollectionGetter {
         mConf = conf;
     }
 
+    public void set_config(@NonNull String key, boolean value) {
+        setMod();
+        mConf.put(key, value);
+    }
+
+    public void set_config(@NonNull String key, long value) {
+        setMod();
+        mConf.put(key, value);
+    }
+
+    public void set_config(@NonNull String key, int value) {
+        setMod();
+        mConf.put(key, value);
+    }
+
+    public void set_config(@NonNull String key, double value) {
+        setMod();
+        mConf.put(key, value);
+    }
+
+    public void set_config(@NonNull String key, String value) {
+        setMod();
+        mConf.put(key, value);
+    }
+
+    public void set_config(@NonNull String key, JSONArray value) {
+        setMod();
+        mConf.put(key, value);
+    }
+
+    public void set_config(@NonNull String key, JSONObject value) {
+        setMod();
+        mConf.put(key, value);
+    }
+
+    public void remove_config(@NonNull String key) {
+        setMod();
+        mConf.remove(key);
+    }
 
     public long getScm() {
         return mScm;

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
@@ -2088,6 +2088,12 @@ public class Collection implements CollectionGetter {
     // methods with a default can be named `get_config` as the `defaultValue` argument defines the return type
     // NOTE: get_config("key", 1) and get_config("key", 1L) will return different types
 
+
+    public boolean has_config(@NonNull String key) {
+        // not in libAnki
+        return mConf.has(key);
+    }
+
     /** @throws JSONException object does not exist or can't be cast */
     public boolean get_config_boolean(@NonNull String key) {
         return mConf.getBoolean(key);

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
@@ -1071,7 +1071,7 @@ public class Decks {
      * The currently selected did.
      */
     public long selected() {
-        return mCol.getConf().getLong("curDeck");
+        return mCol.get_config_long("curDeck");
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
@@ -1090,7 +1090,7 @@ public class Decks {
         String name = mDecks.get(did).getString("name");
 
         // current deck
-        mCol.getConf().put("curDeck", did);
+        mCol.set_config("curDeck", did);
         // and active decks (current + all children)
         TreeMap<String, Long> actv = children(did); // Note: TreeMap is already sorted
         actv.put(name, did);
@@ -1098,8 +1098,8 @@ public class Decks {
         for (Long n : actv.values()) {
             activeDecks.put(n);
         }
-        mCol.getConf().put("activeDecks", activeDecks);
-        mCol.setMod();
+
+        mCol.set_config("activeDecks", activeDecks);
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
@@ -1060,7 +1060,7 @@ public class Decks {
      * The currently active dids. Make sure to copy before modifying.
      */
     public LinkedList<Long> active() {
-        JSONArray activeDecks = mCol.getConf().getJSONArray("activeDecks");
+        JSONArray activeDecks = mCol.get_config_array("activeDecks");
         LinkedList<Long> result = new LinkedList<>();
         addAll(result, activeDecks.longIterable());
         return result;

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/DecksV16.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/DecksV16.kt
@@ -518,7 +518,7 @@ class DeckManager(private val col: Collection, private val mDecksBackend: DecksB
 
     /** The currently selected did. */
     fun selected(): did {
-        return this.col.conf.getLong("curDeck")
+        return this.col.get_config_long("curDeck")
     }
 
     fun current(): DeckV16 {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/DecksV16.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/DecksV16.kt
@@ -532,8 +532,8 @@ class DeckManager(private val col: Collection, private val mDecksBackend: DecksB
         val current = this.selected()
         val active = this.deck_and_child_ids(did)
         if (current != did || active != this.active()) {
-            this.col.conf.put("curDeck", did)
-            this.col.conf.put("activeDecks", active.toJsonArray())
+            this.col.set_config("curDeck", did)
+            this.col.set_config("activeDecks", active.toJsonArray())
         }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/DecksV16.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/DecksV16.kt
@@ -510,7 +510,7 @@ class DeckManager(private val col: Collection, private val mDecksBackend: DecksB
     /** The currently active dids. */
     fun active(): MutableList<did> {
         // TODO: Copied from the java, should use get_config
-        val activeDecks: JSONArray = col.conf.getJSONArray("activeDecks")
+        val activeDecks: JSONArray = col.get_config_array("activeDecks")
         val result = LinkedList<Long>()
         CollectionUtils.addAll(result, activeDecks.longIterable())
         return result

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Finder.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Finder.java
@@ -415,7 +415,7 @@ public class Finder {
             return new Pair<>("", false);
         }
         // use deck default
-        String type = mCol.getConf().getString("sortType");
+        String type = mCol.get_config_string("sortType");
         String sort = null;
         if (type.startsWith("note")) {
             if (type.startsWith("noteCrt")) {
@@ -444,7 +444,7 @@ public class Finder {
             // deck has invalid sort order; revert to noteCrt
             sort = "n.id, c.ord";
         }
-        boolean sortBackwards = mCol.getConf().getBoolean("sortBackwards");
+        boolean sortBackwards = mCol.get_config_boolean("sortBackwards");
         return new Pair<>(" ORDER BY " + sort, sortBackwards);
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Models.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Models.java
@@ -282,8 +282,7 @@ public class Models {
 
 
     public void setCurrent(Model m) {
-        mCol.getConf().put("curModel", m.getLong("id"));
-        mCol.setMod();
+        mCol.set_config("curModel", m.getLong("id"));
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Models.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Models.java
@@ -270,7 +270,7 @@ public class Models {
             m = get(mCol.getDecks().current().optLong("mid", -1));
         }
         if (m == null) {
-            m = get(mCol.getConf().optLong("curModel", -1));
+            m = get(mCol.get_config("curModel", -1L));
         }
         if (m == null) {
             if (!mModels.isEmpty()) {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/ModelsV16.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/ModelsV16.kt
@@ -190,8 +190,7 @@ class ModelManager(private val col: Collection) {
     }
 
     fun setCurrent(m: NoteType) {
-        col.conf.put("curModel", m.id)
-        col.setMod()
+        col.set_config("curModel", m.id)
     }
 
     /*

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/ModelsV16.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/ModelsV16.kt
@@ -181,7 +181,7 @@ class ModelManager(private val col: Collection) {
     fun current(forDeck: bool = true): NoteType {
         var m = get(col.decks.current().getLong("mid"))
         if (!forDeck || !m.isPresent) {
-            m = get(col.conf.optLong("curModel", -1L))
+            m = get(col.get_config("curModel", -1L)!!)
         }
         if (m.isPresent) {
             return m.get()

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/importer/Anki2Importer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/importer/Anki2Importer.java
@@ -816,7 +816,7 @@ public class Anki2Importer extends Importer {
             mCol.getSched().maybeRandomizeDeck(did);
         }
         // make sure new position is correct
-        mDst.getConf().put("nextPos", mDst.getDb().queryLongScalar(
+        mDst.set_config("nextPos", mDst.getDb().queryLongScalar(
                 "select max(due)+1 from cards where type = " + CARD_TYPE_NEW));
         mDst.save();
     }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Sched.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Sched.java
@@ -1109,7 +1109,7 @@ public class Sched extends SchedV2 {
             update(deck);
         }
         // unbury if the day has rolled over
-        int unburied = mCol.getConf().optInt("lastUnburied", 0);
+        int unburied = mCol.get_config("lastUnburied", 0);
         if (unburied < mToday) {
             SyncStatus.ignoreDatabaseModification(this::unburyCards);
         }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Sched.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Sched.java
@@ -184,7 +184,7 @@ public class Sched extends SchedV2 {
      */
     @Override
     public void unburyCards() {
-        mCol.getConf().put("lastUnburied", mToday);
+        mCol.set_config("lastUnburied", mToday);
         mCol.log(mCol.getDb().queryLongList("select id from cards where " + queueIsBuriedSnippet()));
         mCol.getDb().execute("update cards set " + _restoreQueueSnippet() + " where " + queueIsBuriedSnippet());
     }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Sched.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Sched.java
@@ -387,7 +387,7 @@ public class Sched extends SchedV2 {
         if (_fillLrn()) {
             long cutoff = getTime().intTime();
             if (collapse) {
-                cutoff += mCol.getConf().getInt("collapseTime");
+                cutoff += mCol.get_config_int("collapseTime");
             }
             if (mLrnQueue.getFirstDue() < cutoff) {
                 return mLrnQueue.removeFirstCard();
@@ -592,7 +592,7 @@ public class Sched extends SchedV2 {
                     "SELECT sum(left / 1000) FROM (SELECT left FROM cards WHERE did = ?"
                             + " AND queue = " + Consts.QUEUE_TYPE_LRN + " AND due < ?"
                             + " LIMIT ?)",
-                    did, (getTime().intTime() + mCol.getConf().getInt("collapseTime")), mReportLimit);
+                    did, (getTime().intTime() + mCol.get_config_int("collapseTime")), mReportLimit);
             return cnt + mCol.getDb().queryScalar(
                     "SELECT count() FROM (SELECT 1 FROM cards WHERE did = ?"
                             + " AND queue = " + Consts.QUEUE_TYPE_DAY_LEARN_RELEARN + " AND due <= ?"

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
@@ -2242,7 +2242,7 @@ public class SchedV2 extends AbstractSched {
 
     @Override
     public boolean _new_timezone_enabled() {
-        return getCol().has_config("creationOffset") && !getCol().getConf().isNull("creationOffset");
+        return getCol().has_config_not_null("creationOffset");
     }
 
     @Nullable

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
@@ -2199,7 +2199,7 @@ public class SchedV2 extends AbstractSched {
         int unburied = mCol.getConf().optInt("lastUnburied", 0);
         if (unburied < mToday) {
             SyncStatus.ignoreDatabaseModification(this::unburyCards);
-            mCol.getConf().put("lastUnburied", mToday);
+            mCol.set_config("lastUnburied", mToday);
         }
     }
 
@@ -2277,16 +2277,12 @@ public class SchedV2 extends AbstractSched {
     @Override
     public void set_creation_offset() throws BackendNotSupportedException {
         int mins_west = getCol().getBackend().local_minutes_west(getCol().getCrt());
-        getCol().getConf().put("creationOffset", mins_west);
-        getCol().setMod();
+        getCol().set_config("creationOffset", mins_west);
     }
 
     @Override
     public void clear_creation_offset() {
-        if (getCol().getConf().has("creationOffset")) {
-            getCol().getConf().remove("creationOffset");
-            getCol().setMod();
-        }
+        getCol().remove_config("creationOffset");
     }
 
     protected void update(@NonNull Deck g) {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
@@ -899,7 +899,7 @@ public class SchedV2 extends AbstractSched {
 
 
     private void _updateNewCardRatio() {
-        if (mCol.getConf().getInt("newSpread") == Consts.NEW_CARDS_DISTRIBUTE) {
+        if (mCol.get_config_int("newSpread") == Consts.NEW_CARDS_DISTRIBUTE) {
             if (mNewCount != 0) {
                 mNewCardModulus = (mNewCount + mRevCount) / mNewCount;
                 // if there are cards to review, ensure modulo >= 2
@@ -920,7 +920,7 @@ public class SchedV2 extends AbstractSched {
         if (mHaveCounts && mNewCount == 0) {
             return false;
         }
-        @Consts.NEW_CARD_ORDER int spread = mCol.getConf().getInt("newSpread");
+        @Consts.NEW_CARD_ORDER int spread = mCol.get_config_int("newSpread");
         if (spread == Consts.NEW_CARDS_LAST) {
             return false;
         } else if (spread == Consts.NEW_CARDS_FIRST) {
@@ -1015,7 +1015,7 @@ public class SchedV2 extends AbstractSched {
      */
 
     private boolean _updateLrnCutoff(boolean force) {
-        long nextCutoff = getTime().intTime() + mCol.getConf().getInt("collapseTime");
+        long nextCutoff = getTime().intTime() + mCol.get_config_int("collapseTime");
         if (nextCutoff - mLrnCutoff > 60 || force) {
             mLrnCutoff = nextCutoff;
             return true;
@@ -1076,7 +1076,7 @@ public class SchedV2 extends AbstractSched {
         if (!mLrnQueue.isEmpty()) {
             return true;
         }
-        long cutoff = getTime().intTime() + mCol.getConf().getLong("collapseTime");
+        long cutoff = getTime().intTime() + mCol.get_config_long("collapseTime");
         mLrnQueue.clear();
         /* Difference with upstream: Current card can't come in the queue.
              *
@@ -1107,7 +1107,7 @@ public class SchedV2 extends AbstractSched {
         if (_fillLrn()) {
             long cutoff = getTime().intTime();
             if (collapse) {
-                cutoff += mCol.getConf().getInt("collapseTime");
+                cutoff += mCol.get_config_int("collapseTime");
             }
             if (mLrnQueue.getFirstDue() < cutoff) {
                 return mLrnQueue.removeFirstCard();
@@ -1123,7 +1123,7 @@ public class SchedV2 extends AbstractSched {
         if (_fillLrn()) {
             long cutoff = getTime().intTime();
             if (collapse) {
-                cutoff += mCol.getConf().getInt("collapseTime");
+                cutoff += mCol.get_config_int("collapseTime");
             }
             // mLrnCount -= 1; see decrementCounts()
             return mLrnQueue.getFirstDue() < cutoff;
@@ -1275,7 +1275,7 @@ public class SchedV2 extends AbstractSched {
             int fuzz = new Random().nextInt(Math.max(maxExtra, 1));
             card.setDue(Math.min(mDayCutoff - 1, card.getDue() + fuzz));
             card.setQueue(Consts.QUEUE_TYPE_LRN);
-            if (card.getDue() < (getTime().intTime() + mCol.getConf().getInt("collapseTime"))) {
+            if (card.getDue() < (getTime().intTime() + mCol.get_config_int("collapseTime"))) {
                 mLrnCount += 1;
                 // if the queue is not empty and there's nothing else to do, make
                 // sure we don't put it at the head of the queue and end up showing
@@ -1476,7 +1476,7 @@ public class SchedV2 extends AbstractSched {
                     "SELECT count() FROM (SELECT null FROM cards WHERE did = ?"
                             + " AND queue = " + Consts.QUEUE_TYPE_LRN + " AND due < ?"
                             + " LIMIT ?)",
-                    did, (getTime().intTime() + mCol.getConf().getInt("collapseTime")), mReportLimit);
+                    did, (getTime().intTime() + mCol.get_config_int("collapseTime")), mReportLimit);
             return cnt + mCol.getDb().queryScalar(
                     "SELECT count() FROM (SELECT null FROM cards WHERE did = ?"
                             + " AND queue = " + Consts.QUEUE_TYPE_DAY_LEARN_RELEARN + " AND due <= ?"
@@ -2431,7 +2431,7 @@ public class SchedV2 extends AbstractSched {
             return context.getString(R.string.sched_end);
         }
         String s = Utils.timeQuantityNextIvl(context, ivl);
-        if (ivl < mCol.getConf().getInt("collapseTime")) {
+        if (ivl < mCol.get_config_int("collapseTime")) {
             s = context.getString(R.string.less_than_time, s);
         }
         return s;

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
@@ -2242,8 +2242,7 @@ public class SchedV2 extends AbstractSched {
 
     @Override
     public boolean _new_timezone_enabled() {
-        JSONObject conf = getCol().getConf();
-        return conf.has("creationOffset") && !conf.isNull("creationOffset");
+        return getCol().has_config("creationOffset") && !getCol().getConf().isNull("creationOffset");
     }
 
     @Nullable

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
@@ -687,7 +687,7 @@ public class SchedV2 extends AbstractSched {
             }
         }
         // Day learning first and card due?
-        boolean dayLearnFirst = mCol.getConf().optBoolean("dayLearnFirst", false);
+        boolean dayLearnFirst = mCol.get_config("dayLearnFirst", false);
         if (dayLearnFirst) {
             c = _getLrnDayCard();
             if (c != null) {
@@ -730,7 +730,7 @@ public class SchedV2 extends AbstractSched {
             }
         }
         // Day learning first and card due?
-        boolean dayLearnFirst = mCol.getConf().optBoolean("dayLearnFirst", false);
+        boolean dayLearnFirst = mCol.get_config("dayLearnFirst", false);
         if (dayLearnFirst) {
             if (_fillLrnDay()) {
                 return new CardQueue<?>[]{mLrnQueue, mLrnDayQueue};
@@ -2196,7 +2196,7 @@ public class SchedV2 extends AbstractSched {
             update(deck);
         }
         // unbury if the day has rolled over
-        int unburied = mCol.getConf().optInt("lastUnburied", 0);
+        int unburied = mCol.get_config("lastUnburied", 0);
         if (unburied < mToday) {
             SyncStatus.ignoreDatabaseModification(this::unburyCards);
             mCol.set_config("lastUnburied", mToday);
@@ -2205,7 +2205,7 @@ public class SchedV2 extends AbstractSched {
 
 
     private long _dayCutoff() {
-        int rolloverTime = mCol.getConf().optInt("rollover", 4);
+        int rolloverTime = mCol.get_config("rollover", 4);
         if (rolloverTime < 0) {
             rolloverTime = 24 + rolloverTime;
         }
@@ -2234,7 +2234,7 @@ public class SchedV2 extends AbstractSched {
     }
 
     private int _rolloverHour() {
-        return getCol().getConf().optInt("rollover", 4);
+        return getCol().get_config("rollover", 4);
     }
 
     // New timezone handling
@@ -2264,14 +2264,14 @@ public class SchedV2 extends AbstractSched {
     @Override
     public int _current_timezone_offset() throws BackendNotSupportedException {
         if (getCol().getServer()) {
-            return getCol().getConf().optInt("localOffset", 0);
+            return getCol().get_config("localOffset", 0);
         } else {
             return getCol().getBackend().local_minutes_west(getTime().intTime());
         }
     }
 
     private int _creation_timezone_offset() {
-        return getCol().getConf().optInt("creationOffset", 0);
+        return getCol().get_config("creationOffset", 0);
     }
 
     @Override

--- a/AnkiDroid/src/main/java/com/ichi2/upgrade/Upgrade.java
+++ b/AnkiDroid/src/main/java/com/ichi2/upgrade/Upgrade.java
@@ -10,15 +10,15 @@ import timber.log.Timber;
 
 public class Upgrade {
 
-    public static boolean upgradeJSONIfNecessary(Collection col, JSONObject conf, String name, boolean defaultValue) {
+    public static boolean upgradeJSONIfNecessary(Collection col, String name, boolean defaultValue) {
         boolean val = defaultValue;
         try {
-            val = conf.getBoolean(name);
+            val = col.get_config_boolean(name);
         } catch (JSONException e) {
             Timber.w(e);
             // workaround to repair wrong values from older libanki versions
             try {
-                conf.put(name, val);
+                 col.set_config(name, val);
             } catch (JSONException e1) {
                 Timber.w(e1);
                 // do nothing

--- a/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.java
@@ -598,7 +598,7 @@ public class CardBrowserTest extends RobolectricTest {
         advanceRobolectricLooperWithSleep();
 
         // Make sure card has default value in sortType field
-        assertThat("Initially Card Browser has order = noteFld", getCol().getConf().get("sortType"), is("noteFld"));
+        assertThat("Initially Card Browser has order = noteFld", getCol().get_config_string("sortType"), is("noteFld"));
 
         // Store the current (before changing the database) Mod Time
         long initialMod = getCol().getMod();
@@ -616,7 +616,7 @@ public class CardBrowserTest extends RobolectricTest {
         // Find the current (after database has been changed) Mod time
         long finalMod = getCol().getMod();
 
-        assertThat("Card Browser has the new sortType field", getCol().getConf().get("sortType"), is("cardEase"));
+        assertThat("Card Browser has the new sortType field", getCol().get_config_string("sortType"), is("cardEase"));
         Assert.assertNotEquals("Modification time must change", initialMod, finalMod);
     }
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/DeckOptionsTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/DeckOptionsTest.java
@@ -1,21 +1,12 @@
 package com.ichi2.anki;
 
-import android.content.SharedPreferences;
-
 import com.ichi2.libanki.Collection;
-import com.ichi2.libanki.Deck;
-import com.ichi2.libanki.Decks;
-import com.ichi2.utils.JSONObject;
 
-import org.apache.http.util.Asserts;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import androidx.test.ext.junit.runners.AndroidJUnit4;
-
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
 
 @RunWith(AndroidJUnit4.class)
 public class DeckOptionsTest extends RobolectricTest {
@@ -25,17 +16,14 @@ public class DeckOptionsTest extends RobolectricTest {
         Collection col = getCol();
 
         // Verify that for newly created deck hardFactor is default.
-        JSONObject conf = col.getConf();
-        double hardFactor = conf.optDouble("hardFactor", 1.2);
+        double hardFactor = col.get_config("hardFactor", 1.2);
         Assert.assertEquals(1.2, hardFactor, 0.01);
 
         // Modify hard factor.
-        conf.put("hardFactor", 1.0);
-        col.setConf(conf);
+        col.set_config("hardFactor", 1.0);
 
         // Verify that hardFactor value has changed.
-        conf = col.getConf();
-        hardFactor = conf.optDouble("hardFactor", 1.2);
+        hardFactor = col.get_config("hardFactor", 1.2);
         Assert.assertEquals(1.0, hardFactor, 0.01);
     }
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/NoteEditorTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/NoteEditorTest.java
@@ -218,12 +218,12 @@ public class NoteEditorTest extends RobolectricTest {
         // value returned if deck not found
         final int DECK_ID_NOT_FOUND = -404;
         long currentDid = addDeck("Basic::Test");
-        getCol().getConf().put("curDeck", currentDid);
+        getCol().set_config("curDeck", currentDid);
         Note n = super.addNoteUsingBasicModel("Test", "Note");
         n.model().put("did", currentDid);
         NoteEditor editor = getNoteEditorEditingExistingBasicNote("Test", "Note", FromScreen.DECK_LIST);
 
-        getCol().getConf().put("curDeck", Consts.DEFAULT_DECK_ID); // Change DID if going through default path
+        getCol().set_config("curDeck", Consts.DEFAULT_DECK_ID); // Change DID if going through default path
         Intent copyNoteIntent = getCopyNoteIntent(editor);
         NoteEditor newNoteEditor = super.startActivityNormallyOpenCollectionWithIntent(NoteEditor.class, copyNoteIntent);
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/PreferencesTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/PreferencesTest.java
@@ -59,7 +59,7 @@ public class PreferencesTest extends RobolectricTest {
 
         preferences.setDayOffset(2);
 
-        assertThat("rollover config should be set to new value", getCol().getConf().optInt("rollover", 4), is(2));
+        assertThat("rollover config should be set to new value", getCol().get_config("rollover", 4), is(2));
     }
 
     @NonNull

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/DecksTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/DecksTest.java
@@ -13,6 +13,7 @@ import java.util.List;
 
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
+import static com.ichi2.testutils.AnkiAssert.assertDoesNotThrow;
 import static com.ichi2.testutils.AnkiAssert.assertEqualsArrayList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
@@ -23,8 +24,6 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.ArgumentMatchers.isNotNull;
-import static org.mockito.ArgumentMatchers.isNull;
 
 @RunWith(AndroidJUnit4.class)
 public class DecksTest extends RobolectricTest {
@@ -241,7 +240,7 @@ public class DecksTest extends RobolectricTest {
         Decks decks = col.getDecks();
         long id = addDeck("test");
         decks.select(id);
-        assertThat("curDeck should be saved as a long. A deck id.", col.getConf().get("curDeck") instanceof Long);
+        assertDoesNotThrow("curDeck should be saved as a long. A deck id.", () -> col.get_config_long("curDeck"));
     }
 
 

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/FinderTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/FinderTest.java
@@ -213,20 +213,20 @@ public class FinderTest extends RobolectricTest {
         assertEquals(0, col.findCards("front:do").size());
         assertEquals(5, col.findCards("front:*").size());
         // ordering
-        col.getConf().put("sortType", "noteCrt");
+        col.set_config("sortType", "noteCrt");
         col.flush();
         assertTrue(latestCardIds.contains(getLastListElement(col.findCards("front:*", true))));
         assertTrue(latestCardIds.contains(getLastListElement(col.findCards("", true))));
 
-        col.getConf().put("sortType", "noteFld");
+        col.set_config("sortType", "noteFld");
         col.flush();
         assertEquals(catCard.getId(), (long) col.findCards("", true).get(0));
         assertTrue(latestCardIds.contains(getLastListElement(col.findCards("", true))));
-        col.getConf().put("sortType", "cardMod");
+        col.set_config("sortType", "cardMod");
         col.flush();
         assertTrue(latestCardIds.contains(getLastListElement(col.findCards("", true))));
         assertEquals(firstCardId, (long) col.findCards("", true).get(0));
-        col.getConf().put("sortBackwards", true);
+        col.set_config("sortBackwards", true);
         col.flush();
         assertTrue(latestCardIds.contains(col.findCards("", true).get(0)));
         /* TODO: Port BuiltinSortKind

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/UndoTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/UndoTest.java
@@ -44,7 +44,7 @@ public class UndoTest extends RobolectricTest {
         assertNull(col.undoType());
         // let's adjust a study option
         col.save("studyopts");
-        col.getConf().put("abc", 5);
+        col.set_config("abc", 5);
         // it should be listed as undoable
         assertEquals("studyopts", col.undoName(getTargetContext().getResources()));
         // with about 5 minutes until it's clobbered
@@ -76,7 +76,7 @@ public class UndoTest extends RobolectricTest {
     @Test
     public void test_review() throws Exception {
         Collection col = getColV2();
-        col.getConf().put("counts", COUNT_REMAINING);
+        col.set_config("counts", COUNT_REMAINING);
         Note note = col.newNote();
         note.setItem("Front", "one");
         col.addNote(note);

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/UndoTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/UndoTest.java
@@ -54,7 +54,7 @@ public class UndoTest extends RobolectricTest {
         // undoing should restore the old value
         col.undo();
         assertNull(col.undoType());
-        assertFalse(col.getConf().has("abc"));
+        assertFalse(col.has_config("abc"));
         // an (auto)save will clear the undo
         col.save("foo");
         assertEquals("foo", col.undoName(getTargetContext().getResources()));

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/sched/AbstractSchedTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/sched/AbstractSchedTest.java
@@ -313,7 +313,7 @@ mw.col.sched.extendLimits(1, 0)
         Collection col = getCol();
         DeckConfig conf = col.getDecks().confForDid(1);
         conf.getJSONObject("new").put("delays", new JSONArray(new double[] {1, 3, 5, 10}));
-        col.getConf().put("collapseTime", 20 * 60);
+        col.set_config("collapseTime", 20 * 60);
         AbstractSched sched = col.getSched();
 
         Note note = addNoteUsingBasicModel("foo", "bar");

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/sched/SchedUpgradeTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/sched/SchedUpgradeTest.java
@@ -47,8 +47,7 @@ public class SchedUpgradeTest extends RobolectricTest {
     @Test
     public void schedulerForV1CollectionIsV1() {
         // A V1 collection does not have the schedVer variable. This is not the same as a downgrade.
-        getCol().getConf().remove("schedVer");
-        getCol().setMod();
+        getCol().remove_config("schedVer");
         getCol().close();
 
 

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/sched/SchedV2Test.java
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/sched/SchedV2Test.java
@@ -280,7 +280,7 @@ public class SchedV2Test extends RobolectricTest {
         // #5805
         assertThat("Sync ver should be updated if we have a valid Rust collection", Consts.SYNC_VER, is(10));
 
-        assertThat("localOffset should be set if using V2 Scheduler", getCol().getConf().has("localOffset"), is(true));
+        assertThat("localOffset should be set if using V2 Scheduler", getCol().has_config("localOffset"), is(true));
 
         SchedV2 sched = (SchedV2) getCol().getSched();
 

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/sched/SchedV2Test.java
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/sched/SchedV2Test.java
@@ -114,7 +114,7 @@ public class SchedV2Test extends RobolectricTest {
         Collection col = getCol();
         col.setCrt(1587852900L);
         //30 minutes learn ahead. required as we have 20m delay
-        col.getConf().put("collapseTime", 1800);
+        col.set_config("collapseTime", 1800);
 
         long homeDeckId = addDeck("Poorretention");
 

--- a/AnkiDroid/src/test/java/com/ichi2/testutils/AnkiAssert.java
+++ b/AnkiDroid/src/test/java/com/ichi2/testutils/AnkiAssert.java
@@ -18,6 +18,15 @@ import static org.junit.Assert.fail;
 public class AnkiAssert {
 
     /** Helper to sort out "JUnit tests should include assert() or fail()" quality check */
+    public static void assertDoesNotThrow(String message, @NonNull Runnable runnable) {
+        try {
+            runnable.run();
+        } catch (Exception e) {
+            throw new AssertionError(message + "\nmethod should not throw", e);
+        }
+    }
+
+    /** Helper to sort out "JUnit tests should include assert() or fail()" quality check */
     public static void assertDoesNotThrow(@NonNull Runnable runnable) {
         try {
             runnable.run();


### PR DESCRIPTION
We want to move from a JSONObject-based approach to accessing a table of configuration

Anki uses the following class:

https://github.com/david-allison-1/anki/blob/20432ccecf62f34860c99a24732cf6ba6abba6af/pylib/anki/config.py

To do this, we need an interface to access the collection. Anki uses `get_config` and `set_config`, the problem with these methods is that Anki uses `Any`, and we want strongly typed access.


Related: #8988 

## Approach
* Define strongly typed methods
* Migrate all of AnkiDroid to use these methods

⚠️ All config changes now call `setMod`. `setMod` will be removed in a later version of Anki Desktop as it's no longer necessary. Since we're not on v16 yet, `setMod` still has an effect, but it's likely the effect that we wanted anyway (mark the collection as modified if a setting is)

## How Has This Been Tested?

* Unit tested only

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
