### PR TITLE
Update anki URLs to use HTTPS by default 

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -146,7 +146,7 @@ import static com.ichi2.libanki.Models.NOT_FOUND_NOTE_TYPE;
  * sides: a question and an answer. Any number of fields can appear on each side. When you add a note to Anki, cards
  * which show that note are generated. Some models generate one card, others generate more than one.
  *
- * @see <a href="http://ankisrs.net/docs/manual.html#cards">the Anki Desktop manual</a>
+ * @see <a href="https://docs.ankiweb.net/getting-started.html#cards">the Anki Desktop manual</a>
  */
 public class NoteEditor extends AnkiActivity implements
         DeckSelectionDialog.DeckSelectionListener,

--- a/AnkiDroid/src/main/java/com/ichi2/anki/export/ActivityExportingDelegate.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/export/ActivityExportingDelegate.java
@@ -145,7 +145,7 @@ public class ActivityExportingDelegate implements ExportDialogListener, ExportCo
                 .setType("application/apkg")
                 .setStream(uri)
                 .setSubject(mActivity.getString(R.string.export_email_subject, attachment.getName()))
-                .setHtmlText(mActivity.getString(R.string.export_email_text_new))
+                .setHtmlText(mActivity.getString(R.string.export_email_text_new, mActivity.getString(R.string.link_manual), mActivity.getString(R.string.link_distributions)))
                 .getIntent();
         if (shareIntent.resolveActivity(mActivity.getPackageManager()) != null) {
             mActivity.startActivityWithoutAnimation(shareIntent);

--- a/AnkiDroid/src/main/java/com/ichi2/anki/export/ActivityExportingDelegate.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/export/ActivityExportingDelegate.java
@@ -145,7 +145,7 @@ public class ActivityExportingDelegate implements ExportDialogListener, ExportCo
                 .setType("application/apkg")
                 .setStream(uri)
                 .setSubject(mActivity.getString(R.string.export_email_subject, attachment.getName()))
-                .setHtmlText(mActivity.getString(R.string.export_email_text))
+                .setHtmlText(mActivity.getString(R.string.export_email_text_new))
                 .getIntent();
         if (shareIntent.resolveActivity(mActivity.getPackageManager()) != null) {
             mActivity.startActivityWithoutAnimation(shareIntent);

--- a/AnkiDroid/src/main/res/values/02-strings.xml
+++ b/AnkiDroid/src/main/res/values/02-strings.xml
@@ -183,8 +183,8 @@
         <![CDATA[
         Hi!
         <br/><br/>
-        This is an Anki flashcards deck sent from <a href="https://ankidroid.org/docs/manual.html">AnkiDroid</a>.
-        Try to open it using one of the available <a href="https://apps.ankiweb.net/#download">Anki distributions</a> and enjoy easy and efficient learning!
+        This is an Anki flashcards deck sent from <a href="%1$s">AnkiDroid</a>.
+        Try to open it using one of the available <a href="%2$s">Anki distributions</a> and enjoy easy and efficient learning!
         ]]>
     </string>
     <string name="export_unsuccessful">Error exporting apkg file</string>

--- a/AnkiDroid/src/main/res/values/02-strings.xml
+++ b/AnkiDroid/src/main/res/values/02-strings.xml
@@ -179,12 +179,12 @@
     <string name="export_save_apkg_unsuccessful">Save Anki package failed</string>
     <string name="export_successful">File “%s” was exported. Do you want to send it with another app?</string>
     <string name="export_email_subject">AnkiDroid exported flashcards: %s</string>
-    <string name="export_email_text">
+    <string name="export_email_text_new">
         <![CDATA[
         Hi!
         <br/><br/>
         This is an Anki flashcards deck sent from <a href="https://ankidroid.org/docs/manual.html">AnkiDroid</a>.
-        Try to open it using one of the available <a href="http://ankisrs.net/#download">Anki distributions</a> and enjoy easy and efficient learning!
+        Try to open it using one of the available <a href="https://apps.ankiweb.net/#download">Anki distributions</a> and enjoy easy and efficient learning!
         ]]>
     </string>
     <string name="export_unsuccessful">Error exporting apkg file</string>

--- a/AnkiDroid/src/main/res/values/constants.xml
+++ b/AnkiDroid/src/main/res/values/constants.xml
@@ -170,7 +170,7 @@
         <item>0</item>
         <item>3</item>
     </string-array>
-    <string name="link_anki">http://ankisrs.net</string>
+    <string name="link_anki">https://ankisrs.net</string>
     <string name="link_anki_manual">https://docs.ankiweb.net/#/</string>
     <string name="link_anki_forum">https://forums.ankiweb.net/</string>
     <string name="link_forum">http://groups.google.com/group/anki-android</string>
@@ -178,7 +178,7 @@
     <string name="link_issue_tracker">https://github.com/ankidroid/Anki-Android/issues</string>
     <string name="licence_wiki">http://www.gnu.org/licenses/gpl.html</string>
     <string name="link_source">https://github.com/ankidroid/Anki-Android</string>
-    <string name="link_donation">http://ankisrs.net/support</string>
+    <string name="link_donation">https://ankisrs.net/support</string>
     <string name="link_market">market://details?id=com.ichi2.anki</string>
     <string name="link_market_kindle">http://www.amazon.com/gp/mas/dl/android?p=com.ichi2.anki</string>
     <string name="link_translation">http://crowdin.net/project/ankidroid</string>
@@ -199,7 +199,7 @@
     <string name="link_faq_external_http_content">https://github.com/ankidroid/Anki-Android/wiki/FAQ#external-content</string>
     <string name="shared_decks_url">https://ankiweb.net/shared/decks/</string>
     <string name="repair_deck">https://docs.ankiweb.net/#/files?id=corrupt-collections</string>
-    <string name="resetpw_url">http://ankiweb.net/account/resetpw</string>
+    <string name="resetpw_url">https://ankiweb.net/account/resetpw</string>
     <string name="register_url">https://ankiweb.net/account/register</string>
     <string name="link_reddit">https://www.reddit.com/r/Anki/</string>
     <string name="link_ankidroid_privacy_policy">https://github.com/ankidroid/Anki-Android/wiki/Privacy-Policy</string>

--- a/AnkiDroid/src/main/res/values/constants.xml
+++ b/AnkiDroid/src/main/res/values/constants.xml
@@ -214,6 +214,7 @@
     <string name="link_opencollective_donate">https://opencollective.com/ankidroid/contribute</string>
     <string name="link_anki_2_scheduler">https://faqs.ankiweb.net/the-anki-2.1-scheduler.html</string>
     <string name="link_ankiweb_docs_cloze_deletion">https://docs.ankiweb.net/editing.html#cloze-deletion</string>
+    <string name="link_distributions">https://apps.ankiweb.net/#download</string>
 
     <string-array name="leech_action_values">
         <item>0</item>

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 </p>
 
 # AnkiDroid
-A semi-official port of the open source [Anki](http://ankisrs.net/index.html) spaced repetition flashcard system to Android. Memorize anything with AnkiDroid!
+A semi-official port of the open source [Anki](https://apps.ankiweb.net/index.html) spaced repetition flashcard system to Android. Memorize anything with AnkiDroid!
 
 <img src="docs/graphics/logos/ankidroid_logo.png" align="right" width="40%" height="100%"></img>
 

--- a/api/src/main/java/com/ichi2/anki/FlashCardsContract.java
+++ b/api/src/main/java/com/ichi2/anki/FlashCardsContract.java
@@ -16,7 +16,7 @@ import android.net.Uri;
  * <p>
  * FlashCardsContract defines the access to flash card related information. Flash cards consist of
  * notes and cards. To find out more about notes and cards, see
- * <a href="http://ankisrs.net/docs/manual.html#the-basics">the basics section in the Anki manual.</a>
+ * <a href="https://docs.ankiweb.net/getting-started.html#key-concepts">the basics section in the Anki manual.</a>
  * </p>
  * <p></p>
  * <p>
@@ -131,7 +131,7 @@ public class FlashCardsContract {
      * For queries, the {@code selectionArgs} parameter can contain an optional selection statement for the notes table
      * in the sql database. E.g. "mid = 12345678" could be used to limit to a particular model ID.
      * The {@code selection} parameter is an optional search string for the Anki browser. The syntax is described
-     * <a href="http://ankisrs.net/docs/manual.html#searching">in the search section of the Anki manual</a>.
+     * <a href="https://docs.ankiweb.net/searching.html">in the search section of the Anki manual</a>.
      * <p>
      * <p>
      * Example for querying notes with a certain tag:

--- a/api/src/main/java/com/ichi2/anki/api/AddContentApi.java
+++ b/api/src/main/java/com/ichi2/anki/api/AddContentApi.java
@@ -393,7 +393,7 @@ public final class AddContentApi {
 
     /**
      * Insert a new model into AnkiDroid.
-     * See the <a href="http://ankisrs.net/docs/manual.html#cards-and-templates">Anki Desktop Manual</a> for more help
+     * See the <a href="https://docs.ankiweb.net/templates/intro.html">Anki Desktop Manual</a> for more help
      * @param name name of model
      * @param fields array of field names
      * @param cards array of names for the card templates


### PR DESCRIPTION
## Pull Request template

## Purpose / Description

Replaces all `http://anki*` URLs with HTTPS.

For most, this is simply best practise, but e.g., for the `resetpw`, this could negatively affect a user if the connection is initiated over http.

## How Has This Been Tested?

All URLs are available via `HTTPS`.

## Learning (optional, can help others)
HTTP-URLs can be a security issue even if the http URL redirects to https on the server.

If is secure if the connection is already established, the connection is secure (assuming the server and client do not do anything wrong like disabling certificate checks)
But if an attacker is present on the network during the setup, he can just intercept the http-connection-setup, and forward that to their own server. Then you would never see the request on the server. This is not possible if the setup were already over https.