### PR TITLE
make "Add From Gallery" visible on Amazon Build Flavor

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -1567,12 +1567,6 @@ public class NoteEditor extends AnkiActivity implements
                 MenuInflater inflater = popup.getMenuInflater();
                 inflater.inflate(R.menu.popupmenu_multimedia_options, popup.getMenu());
 
-                /* To check whether Camera Permission is asked in AndroidManifest.xml */
-                if (!CheckCameraPermission.manifestContainsPermission(this)) {
-                    MenuItem item = popup.getMenu().findItem(R.id.menu_multimedia_photo);
-                    item.setVisible(false);
-                }
-
                 popup.setOnMenuItemClickListener(item -> {
 
                     int itemId = item.getItemId();

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/activity/MultimediaEditFieldActivity.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/activity/MultimediaEditFieldActivity.java
@@ -144,7 +144,8 @@ public class MultimediaEditFieldActivity extends AnkiActivity
         }
 
         // Request permission to use the camera if image field
-        if (field instanceof ImageField && !Permissions.canUseCamera(this)) {
+        if (field instanceof ImageField && CheckCameraPermission.manifestContainsPermission(this) &&
+                !Permissions.canUseCamera(this)) {
             Timber.d("Requesting Camera Permissions");
             ActivityCompat.requestPermissions(this, new String[] {Manifest.permission.CAMERA},
                     REQUEST_CAMERA_PERMISSION);

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicImageFieldController.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicImageFieldController.java
@@ -180,8 +180,11 @@ public class BasicImageFieldController extends FieldControllerBase implements IF
         layout.addView(mImageFileSize, ViewGroup.LayoutParams.MATCH_PARENT);
         layout.addView(mImageFileSizeWarning, ViewGroup.LayoutParams.MATCH_PARENT);
         layout.addView(mBtnGallery, ViewGroup.LayoutParams.MATCH_PARENT);
-        layout.addView(mBtnCamera, ViewGroup.LayoutParams.MATCH_PARENT);
         layout.addView(mCropButton, ViewGroup.LayoutParams.MATCH_PARENT);
+
+        if (com.ichi2.utils.CheckCameraPermission.manifestContainsPermission(context)) {
+            layout.addView(mBtnCamera, ViewGroup.LayoutParams.MATCH_PARENT);
+        }
     }
 
 


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
Fix a bug causing "Add From Gallery" option missing from the note editor on Amazon Build Flavor

## Fixes
Fixes #9323

## How Has This Been Tested?
This has been tested on an emulator

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code