### PR TITLE
CompatV21 & V29 saveImage(): return Uri instead path

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.java
@@ -368,7 +368,7 @@ public class Reviewer extends AbstractFlashcardViewer {
             Timber.i("Reviewer:: Save whiteboard button pressed");
             if (mWhiteboard != null) {
                 try {
-                    String savedWhiteboardFileName = mWhiteboard.saveWhiteboard(getCol().getTime());
+                    String savedWhiteboardFileName = mWhiteboard.saveWhiteboard(getCol().getTime()).getPath();
                     UIUtils.showThemedToast(Reviewer.this, getString(R.string.white_board_image_saved, savedWhiteboardFileName), true);
                 } catch (Exception e) {
                     Timber.w(e);

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Whiteboard.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Whiteboard.java
@@ -32,6 +32,7 @@ import android.graphics.Point;
 import android.graphics.Rect;
 import android.graphics.RectF;
 import android.graphics.Region;
+import android.net.Uri;
 import android.view.MotionEvent;
 import android.view.View;
 import android.widget.Button;
@@ -585,7 +586,7 @@ public class Whiteboard extends View {
         return mCurrentlyDrawing;
     }
 
-    protected String saveWhiteboard(Time time) throws FileNotFoundException {
+    protected Uri saveWhiteboard(Time time) throws FileNotFoundException {
         Bitmap bitmap = Bitmap.createBitmap(this.getWidth(), this.getHeight(), Bitmap.Config.ARGB_8888);
         Canvas canvas = new Canvas(bitmap);
         if (mForegroundColor != Color.BLACK) {

--- a/AnkiDroid/src/main/java/com/ichi2/compat/Compat.java
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/Compat.java
@@ -22,6 +22,7 @@ import android.content.Intent;
 import android.graphics.Bitmap;
 import android.media.AudioFocusRequest;
 import android.media.AudioManager;
+import android.net.Uri;
 import android.widget.TimePicker;
 
 import com.ichi2.async.ProgressSenderAndCancelListener;
@@ -233,6 +234,6 @@ public interface Compat {
      * @throws FileNotFoundException if the device's API is <= 28 and has not obtained the
      * WRITE_EXTERNAL_STORAGE permission
      */
-    String saveImage(Context context, Bitmap bitmap, String baseFileName, String extension, Bitmap.CompressFormat format, int quality) throws FileNotFoundException;
+    Uri saveImage(Context context, Bitmap bitmap, String baseFileName, String extension, Bitmap.CompressFormat format, int quality) throws FileNotFoundException;
 }
 

--- a/AnkiDroid/src/main/java/com/ichi2/compat/CompatV21.java
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/CompatV21.java
@@ -23,6 +23,7 @@ import android.graphics.Bitmap;
 import android.media.AudioFocusRequest;
 import android.media.AudioManager;
 import android.media.ThumbnailUtils;
+import android.net.Uri;
 import android.os.Environment;
 import android.os.Vibrator;
 import android.provider.MediaStore;
@@ -41,6 +42,7 @@ import java.io.OutputStream;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.core.content.FileProvider;
 import timber.log.Timber;
 
 /** Baseline implementation of {@link Compat}. Check  {@link Compat}'s for more detail. */
@@ -231,7 +233,7 @@ public class CompatV21 implements Compat {
 
     @Override
     @SuppressWarnings({"deprecation", "RedundantSuppression"})
-    public String saveImage(Context context, Bitmap bitmap, String baseFileName, String extension, Bitmap.CompressFormat format, int quality) throws FileNotFoundException {
+    public Uri saveImage(Context context, Bitmap bitmap, String baseFileName, String extension, Bitmap.CompressFormat format, int quality) throws FileNotFoundException {
         File pictures = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_PICTURES);
         File ankiDroidFolder = new File(pictures, "AnkiDroid");
         if (!ankiDroidFolder.exists()) {
@@ -240,6 +242,6 @@ public class CompatV21 implements Compat {
         }
         File imageFile = new File(ankiDroidFolder, baseFileName + "." + extension);
         bitmap.compress(format, quality, new FileOutputStream(imageFile));
-        return imageFile.getAbsolutePath();
+        return Uri.fromFile(imageFile);
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/compat/CompatV29.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/CompatV29.kt
@@ -20,6 +20,7 @@ import android.content.ContentValues
 import android.content.Context
 import android.graphics.Bitmap
 import android.media.ThumbnailUtils
+import android.net.Uri
 import android.os.Environment
 import android.provider.MediaStore
 import android.util.Size
@@ -42,7 +43,7 @@ class CompatV29 : CompatV26(), Compat {
         }
     }
 
-    override fun saveImage(context: Context, bitmap: Bitmap, baseFileName: String, extension: String, format: Bitmap.CompressFormat, quality: Int): String {
+    override fun saveImage(context: Context, bitmap: Bitmap, baseFileName: String, extension: String, format: Bitmap.CompressFormat, quality: Int): Uri {
         val imagesCollection = MediaStore.Images.Media.getContentUri(MediaStore.VOLUME_EXTERNAL_PRIMARY)
         val destDir = File(Environment.DIRECTORY_PICTURES, "AnkiDroid")
         val date = CollectionHelper.getInstance().getTimeSafe(context).intTimeMS()
@@ -65,7 +66,7 @@ class CompatV29 : CompatV26(), Compat {
         newImage.clear()
         newImage.put(MediaStore.Images.Media.IS_PENDING, 0)
         context.contentResolver.update(newImageUri, newImage, null, null)
-        return newImageUri.path.toString()
+        return newImageUri
     }
 
     companion object {


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
we need to access the saved whiteboard file in a drawing activity, but with the new scoped storage implementation we can't return the absolute path, Google doesn't want us to use absolute paths & wants us to use Uris instead.

## Learning (optional, can help others)
_Describe the research stage_

_Links to blog posts, patterns, libraries or addons used to solve this problem_

## Checklist
_Please, go through these checks before submitting the PR._

- [ ] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [ ] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [ ] You have commented your code, particularly in hard-to-understand areas
- [ ] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
