### PR TITLE
Decoupled Notification From Widget

### DIFF
--- a/AnkiDroid/src/main/AndroidManifest.xml
+++ b/AnkiDroid/src/main/AndroidManifest.xml
@@ -408,6 +408,11 @@
                 />
         </receiver>
 
+        <!-- Small Widget Update Alarm-->
+        <receiver android:name="com.ichi2.widget.WidgetAlarm"
+            android:enabled="true"
+            android:exported="true"/>
+
         <!-- "Add Note" widget -->
         <receiver
             android:name="com.ichi2.widget.AddNoteWidget"

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DecksMetaData.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DecksMetaData.kt
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2021 Prateek Singh <prateeksingh3212@gmail.com>
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.ichi2.anki
+
+import android.content.Context
+import android.util.Pair
+import com.ichi2.libanki.Collection
+import com.ichi2.libanki.Decks
+import com.ichi2.libanki.sched.Counts
+import timber.log.Timber
+
+data class DecksMetaData(val context: Context) {
+    private val mDecks: Decks?
+
+    // Lambda to check the collection is not null.
+    private val mCollection: (context: Context) -> Collection? = {
+        val collection = CollectionHelper.getInstance()
+        if (collection.getColSafe(it) != null) {
+            collection.getCol(it)
+        } else {
+            null
+        }
+    }
+
+    init {
+        mDecks = mCollection(context)?.decks
+    }
+
+    /**
+     * Total number of due cards and their expected time to compete.
+     * @return Pair of Total Due Cards and Expected time to complete. <br></br>
+     * **first** is due cards. <br></br>
+     * **second** is Expected time.
+     */
+    fun getTotalDueCards(): Pair<Int, Int> {
+
+        val collection = mCollection(context) ?: return Pair(0, 0)
+
+        val total = Counts()
+        // Ensure queues are reset if we cross over to the next day.
+        collection.sched._checkDay()
+
+        // Only count the top-level decks in the total
+        val nodes = collection.sched.deckDueTree()
+        for (node in nodes) {
+            total.addNew(node.newCount)
+            total.addLrn(node.lrnCount)
+            total.addRev(node.revCount)
+        }
+        val eta = collection.sched.eta(total, false)
+        Timber.d("getTotalDueCards: count -> ${total.count()} eta -> $eta")
+
+        return Pair(total.count(), eta)
+    }
+}

--- a/AnkiDroid/src/main/java/com/ichi2/anki/MetaDB.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/MetaDB.java
@@ -9,6 +9,7 @@ import android.util.Pair;
 
 import com.ichi2.anki.model.WhiteboardPenColor;
 import com.ichi2.libanki.Sound;
+import com.ichi2.widget.WidgetCleanup;
 
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -438,12 +439,12 @@ public class MetaDB {
         }
     }
 
-
     /**
      * Return the current status of the widget.
-     * 
-     * @return [due, eta]
-     */
+     * @return [due, eta] <br>
+     * */
+    @Deprecated
+    @WidgetCleanup(reason = "Widget Status table will be removed from database in future.")
     public static int[] getWidgetSmallStatus(Context context) {
         openDBIfClosed(context);
         Cursor cursor = null;
@@ -463,7 +464,11 @@ public class MetaDB {
         return new int[]{0, 0};
     }
 
-
+    /**
+     * Widget Status table will be removed from database in future.
+     * */
+    @Deprecated
+    @WidgetCleanup(reason = "Widget Status table will be removed from database in future.")
     public static int getNotificationStatus(Context context) {
         openDBIfClosed(context);
         Cursor cursor = null;
@@ -483,7 +488,11 @@ public class MetaDB {
         return due;
     }
 
-
+    /**
+     * Widget Status table will be removed from database in future.
+     * */
+    @Deprecated
+    @WidgetCleanup(reason = "Widget Status table will be removed from database in future.")
     public static void storeSmallWidgetStatus(Context context, Pair<Integer, Integer> status) {
         openDBIfClosed(context);
         try {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/services/BootService.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/services/BootService.java
@@ -142,7 +142,7 @@ public class BootService extends BroadcastReceiver {
         alarmManager.setRepeating(
                 AlarmManager.RTC_WAKEUP,
                 calendar.getTimeInMillis(),
-                AlarmManager.INTERVAL_DAY,
+                AlarmManager.INTERVAL_HALF_HOUR,
                 notificationIntent
         );
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/services/NotificationService.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/services/NotificationService.java
@@ -30,7 +30,7 @@ import com.ichi2.anki.NotificationChannels;
 import com.ichi2.anki.Preferences;
 import com.ichi2.anki.R;
 import com.ichi2.compat.CompatHelper;
-import com.ichi2.widget.WidgetStatus;
+import com.ichi2.anki.DecksMetaData;
 
 import timber.log.Timber;
 
@@ -50,7 +50,7 @@ public class NotificationService extends BroadcastReceiver {
 
         SharedPreferences preferences = AnkiDroidApp.getSharedPrefs(context);
         int minCardsDue = Integer.parseInt(preferences.getString(MINIMUM_CARDS_DUE_FOR_NOTIFICATION, Integer.toString(Preferences.PENDING_NOTIFICATIONS_ONLY)));
-        int dueCardsCount = WidgetStatus.fetchDue(context);
+        int dueCardsCount = new DecksMetaData(context).getTotalDueCards().first;
         if (dueCardsCount >= minCardsDue) {
             // Build basic notification
             String cardsDueText = context.getResources()

--- a/AnkiDroid/src/main/java/com/ichi2/anki/services/NotificationService.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/services/NotificationService.java
@@ -51,7 +51,21 @@ public class NotificationService extends BroadcastReceiver {
         SharedPreferences preferences = AnkiDroidApp.getSharedPrefs(context);
         int minCardsDue = Integer.parseInt(preferences.getString(MINIMUM_CARDS_DUE_FOR_NOTIFICATION, Integer.toString(Preferences.PENDING_NOTIFICATIONS_ONLY)));
         int dueCardsCount = new DecksMetaData(context).getTotalDueCards().first;
+
+        // Gets the number of last due cards when user received notification.
+        int lastDueCards = preferences.getInt("dueCards", 0);
+
         if (dueCardsCount >= minCardsDue) {
+
+            // Used to avoid unnecessary notification which is having same due cards number as shown in previous notification.
+            if (lastDueCards == dueCardsCount) {
+                Timber.d("Not Delivering Notification - No new changes found from last notification");
+                return;
+            }
+
+            // Updating last due cards.
+            preferences.edit().putInt("dueCards", dueCardsCount).apply();
+
             // Build basic notification
             String cardsDueText = context.getResources()
                     .getQuantityString(R.plurals.widget_minimum_cards_due_notification_ticker_text, dueCardsCount, dueCardsCount);

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Deck.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Deck.java
@@ -62,4 +62,5 @@ public class Deck extends JSONObject {
     public boolean isStd() {
         return getInt("dyn") == Consts.DECK_STD;
     }
+
 }

--- a/AnkiDroid/src/main/java/com/ichi2/widget/AnkiDroidWidgetSmall.java
+++ b/AnkiDroid/src/main/java/com/ichi2/widget/AnkiDroidWidgetSmall.java
@@ -27,6 +27,7 @@ import android.content.SharedPreferences;
 import android.content.res.Configuration;
 import android.os.Bundle;
 import android.os.IBinder;
+import android.util.Log;
 import android.util.TypedValue;
 import android.view.View;
 import android.widget.RemoteViews;
@@ -35,8 +36,10 @@ import com.ichi2.anki.AnkiDroidApp;
 import com.ichi2.anki.IntentHandler;
 import com.ichi2.anki.R;
 import com.ichi2.anki.analytics.UsageAnalytics;
+import com.ichi2.anki.services.NotificationService;
 import com.ichi2.compat.CompatHelper;
 
+import androidx.localbroadcastmanager.content.LocalBroadcastManager;
 import timber.log.Timber;
 
 public class AnkiDroidWidgetSmall extends AppWidgetProvider {
@@ -59,6 +62,7 @@ public class AnkiDroidWidgetSmall extends AppWidgetProvider {
         Timber.d("SmallWidget: Widget enabled");
         SharedPreferences preferences = AnkiDroidApp.getSharedPrefs(context);
         preferences.edit().putBoolean("widgetSmallEnabled", true).commit();
+        new WidgetAlarm().setAlarm(context);
         UsageAnalytics.sendAnalyticsEvent(this.getClass().getSimpleName(), "enabled");
     }
 
@@ -70,6 +74,7 @@ public class AnkiDroidWidgetSmall extends AppWidgetProvider {
         SharedPreferences preferences = AnkiDroidApp.getSharedPrefs(context);
         preferences.edit().putBoolean("widgetSmallEnabled", false).commit();
         UsageAnalytics.sendAnalyticsEvent(this.getClass().getSimpleName(), "disabled");
+        new WidgetAlarm().stopAlarm(context);
     }
 
     @Override
@@ -120,6 +125,7 @@ public class AnkiDroidWidgetSmall extends AppWidgetProvider {
 
 
         public void doUpdate(Context context) {
+            Timber.d("Updating widget");
             AppWidgetManager.getInstance(context)
                     .updateAppWidget(new ComponentName(context, AnkiDroidWidgetSmall.class), buildUpdate(context, true));
         }

--- a/AnkiDroid/src/main/java/com/ichi2/widget/WidgetAlarm.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/widget/WidgetAlarm.kt
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2021 Prateek Singh <prateeksingh3212@gmail.com>
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.widget
+
+import android.app.AlarmManager
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import com.ichi2.anki.CollectionHelper
+import com.ichi2.compat.CompatHelper
+import timber.log.Timber
+import java.util.*
+
+/**
+ * Updates the widget using Alarm Manager.
+ * Used this implementation to conserve the battery as suggested by android documentation.
+ * */
+class WidgetAlarm() : BroadcastReceiver() {
+
+    // Updates the widget in every 30 minutes.
+    private val TIME_INTERVAL: Long = AlarmManager.INTERVAL_HALF_HOUR
+    private val REQUEST_CODE: Int = 5
+
+    override fun onReceive(context: Context?, intent: Intent?) {
+        Timber.d("Widget Alarm BRODCAST RECIVED")
+        // Update the widget.
+        AnkiDroidWidgetSmall.UpdateService().doUpdate(context)
+    }
+
+    /**
+     * Starts the Widget Alarm. Used to update Widget in fixed interval of time.
+     * @param context Application Context.
+     * */
+    fun setAlarm(context: Context) {
+        val calendar: Calendar = CollectionHelper.getInstance().getCol(context).time.calendar()
+        calendar.add(Calendar.MILLISECOND, TIME_INTERVAL.toInt())
+
+        val alarmIntent = Intent(context, WidgetAlarm::class.java).let { intent ->
+            CompatHelper.getCompat().getImmutableBroadcastIntent(context, REQUEST_CODE, intent, 0)
+        }
+        with(context.getSystemService(Context.ALARM_SERVICE) as AlarmManager) {
+            setRepeating(AlarmManager.RTC, calendar.timeInMillis, TIME_INTERVAL, alarmIntent)
+            Timber.d("Widget Alarm Set At: ${calendar.timeInMillis} interval -> $TIME_INTERVAL")
+        }
+    }
+
+    /**
+     * Stops the Widget Alarm.
+     * @param context Application Context.
+     * */
+    fun stopAlarm(context: Context) {
+        val alarmIntent = Intent(context, WidgetAlarm::class.java)
+        val pendingIntent = CompatHelper.getCompat().getImmutableBroadcastIntent(context, REQUEST_CODE, alarmIntent, 0)
+        val alarmManager = context.getSystemService(Context.ALARM_SERVICE) as AlarmManager
+        alarmManager.cancel(pendingIntent)
+        Timber.d("Small Widget Alarm Stopped.")
+    }
+}

--- a/AnkiDroid/src/main/java/com/ichi2/widget/WidgetCleanup.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/widget/WidgetCleanup.kt
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2021 Prateek Singh <prateeksingh3212@gmail.com>
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.widget
+
+/**
+ * Specifies that resources used by widget is no longer needed
+ * and can be removed in next cleanup.
+ * @param reason Specify why resource is not required.
+ * */
+@Retention(AnnotationRetention.SOURCE)
+@Target(AnnotationTarget.FUNCTION, AnnotationTarget.FIELD)
+annotation class WidgetCleanup(val reason: String)

--- a/AnkiDroid/src/main/java/com/ichi2/widget/WidgetStatus.java
+++ b/AnkiDroid/src/main/java/com/ichi2/widget/WidgetStatus.java
@@ -78,11 +78,6 @@ public final class WidgetStatus {
                 return context;
             }
             new AnkiDroidWidgetSmall.UpdateService().doUpdate(context);
-
-            // Shows the notification when widget is not set on Home Screen
-            Intent intent = new Intent(NotificationService.INTENT_ACTION);
-            Context appContext = context.getApplicationContext();
-            LocalBroadcastManager.getInstance(appContext).sendBroadcast(intent);
             return context;
         }
     }

--- a/AnkiDroid/src/main/java/com/ichi2/widget/WidgetStatus.java
+++ b/AnkiDroid/src/main/java/com/ichi2/widget/WidgetStatus.java
@@ -44,9 +44,6 @@ public final class WidgetStatus {
 
     /**
      * Request the widget to update its status.
-     * TODO Mike - we can reduce battery usage by widget users by removing updatePeriodMillis from metadata
-     *             and replacing it with an alarm we set so device doesn't wake to update the widget, see:
-     *             https://developer.android.com/guide/topics/appwidgets/#MetaData
      */
     @SuppressWarnings("deprecation") // #7108: AsyncTask
     public static void update(Context context) {

--- a/AnkiDroid/src/main/res/xml/widget_provider_small.xml
+++ b/AnkiDroid/src/main/res/xml/widget_provider_small.xml
@@ -3,4 +3,4 @@
     android:initialLayout="@layout/widget_small"
     android:minHeight="40dp"
     android:minWidth="40dp"
-    android:updatePeriodMillis="3600000" />
+    android:updatePeriodMillis="0" />


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
 Notification is tightly coupled with SmallWidget status which results in  Notification whenever widget updates.

## Fixes
Fixes #8114 
Fixes #6476

## Approach
We can make the new repository which holds the meta Data (or Meta information) of all decks like Total deck cards, Total New cards to Review, Total Learning cards etc in sqlite Database and whenever the data is required by widget , Notification or any other activity, Service.

This discussion is documented in this PR ([this](https://github.com/ankidroid/Anki-Android/pull/5642)). 

### Flow Chart of Above Explained.

![untitled](https://user-images.githubusercontent.com/76490368/128639673-1a948cea-980d-4bfa-a6d2-7da5c5670d9f.png)

Flow Chart of Above Explained.

## How Has This Been Tested?

Firefox browser and Galaxy M51 (API 30) Aspect ratio 20:9

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
