### PR TITLE
fix tests[EmptyApplication] Reset static state

### DIFF
--- a/AnkiDroid/src/test/java/com/ichi2/anki/InitialActivityWithConflictTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/InitialActivityWithConflictTest.java
@@ -21,14 +21,12 @@ import android.content.Context;
 
 import com.ichi2.testutils.BackendEmulatingOpenConflict;
 import com.ichi2.testutils.BackupManagerTestUtilities;
-import com.ichi2.testutils.EmptyApplication;
 
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.Shadows;
-import org.robolectric.annotation.Config;
 import org.robolectric.shadows.ShadowApplication;
 import org.robolectric.shadows.ShadowEnvironment;
 
@@ -39,7 +37,6 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 @RunWith(AndroidJUnit4.class)
-@Config(application = EmptyApplication.class) // no point in Application init if we don't use it
 public class InitialActivityWithConflictTest extends RobolectricTest {
     @Before
     @Override

--- a/AnkiDroid/src/test/java/com/ichi2/testutils/EmptyApplication.java
+++ b/AnkiDroid/src/test/java/com/ichi2/testutils/EmptyApplication.java
@@ -18,5 +18,15 @@ package com.ichi2.testutils;
 
 import android.app.Application;
 
+import com.ichi2.anki.AnkiDroidApp;
+
 public class EmptyApplication extends Application {
+
+    @Override
+    public void onCreate() {
+        super.onCreate();
+
+        // reset the static state of the app
+        AnkiDroidApp.simulateRestoreFromBackup();
+    }
 }


### PR DESCRIPTION
`EmptyApplication`: reset state so tests fail when run in a batch
This ensures that tests are not flaky

Running a test suite could set static state

This could mean that a test depending on `EmptyApplication` would pass
when run in a batch, but not individually (`testInitialActivityResult`)

Fixes test: `testInitialActivityResult` when run standalone

Fixes #9419

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
