### PR TITLE
Fixed Reviewer card counts not changing after adding card

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.java
@@ -996,7 +996,9 @@ public class Reviewer extends AbstractFlashcardViewer {
     protected void updateScreenCounts() {
         if (mCurrentCard == null) return;
         super.updateActionBar();
+        Timber.d("updateScreenCounts");
         ActionBar actionBar = getSupportActionBar();
+        mSched.reset();
         Counts counts = mSched.counts(mCurrentCard);
 
         if (actionBar != null) {


### PR DESCRIPTION
## Purpose / Description
Screen counts in Reviewer wouldn't update if a note was added

## Fixes
Fixes #9430

## Approach
Resetted `mShed` in `Reviewer::updateScreenCounts` so that the `counts` object has the updated values

## How Has This Been Tested?
tested it manually

## Checklist

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
