### PR TITLE
Handle Intents under Scoped Storage

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CollectionHelper.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CollectionHelper.java
@@ -234,6 +234,44 @@ public class CollectionHelper {
         }
     }
 
+    /**
+     * Checks if current directory being used by AnkiDroid to store user data is a Legacy Storage Directory.
+     * This directory is stored under the key "deckPath" in SharedPreferences
+     * @return <code>true</code> if AnkiDroid is storing user data in a Legacy Storage Directory.
+     */
+    public static boolean isLegacyStorage(Context context) {
+        String currentDirPath = CollectionHelper.getCurrentAnkiDroidDirectory(context);
+        String externalScopedDirPath = CollectionHelper.getAppSpecificExternalAnkiDroidDirectory(context);
+        String internalScopedDirPath = CollectionHelper.getAppSpecificInternalAnkiDroidDirectory(context);
+
+        File currentDir = new File(currentDirPath);
+        File[] externalScopedDirs = context.getExternalFilesDirs(null);
+        File internalScopedDir = new File(internalScopedDirPath);
+
+        Timber.i("isLegacyStorage(): current dir: %s\nscoped external dir: %s\nscoped internal dir: %s",
+                currentDirPath, externalScopedDirPath, internalScopedDirPath);
+
+        // Loop to check if the current AnkiDroid directory or any of its parents are the same as the root directories
+        // for app-specific external or internal storage - the only directories which will be accessible without
+        // permissions under scoped storage
+        File currentDirParent = currentDir;
+        while (currentDirParent != null) {
+            if (currentDirParent.compareTo(internalScopedDir) == 0) {
+                return false;
+            }
+            for (File externalScopedDir : externalScopedDirs) {
+                if (currentDirParent.compareTo(externalScopedDir) == 0) {
+                    return false;
+                }
+            }
+            currentDirParent = currentDirParent.getParentFile();
+        }
+
+        // If the current AnkiDroid directory isn't a sub directory of the app-specific external or internal storage
+        // directories, then it must be in a legacy storage directory
+        return true;
+    }
+
 
     /**
      * Get the absolute path to a directory that is suitable to be the default starting location


### PR DESCRIPTION
## Purpose / Description
```IntentHandler``` wouldn't handle SYNC & REVIEW intents if storage permissions had not been granted to AnkiDroid. However, if the user data is stored in an app-specific directory (for eg: after the upcoming migration to scoped storage feature), then AnkiDroid doesn't need storage permissions to be granted in order to handle intents.

## Approach
```IntentHandler``` uses ```performActionIfStoragePermission()``` to ensure that storage permissions have been granted before handling an Intent. We can alter the condition applied here so that an Intent is handled if one of the two following conditions are satisfied:

- AnkiDroid is using an app-specific directory to store user data
- AnkiDroid is using a legacy directory to store user data but has access to it since storage permission has been granted (as long as AnkiDroid targets API < 30 & requests legacy storage)

## How Has This Been Tested?

Tested on:
- Pixel 4 XL API 30 (Emulator)
- Pixel XL API 26 (Emulator)

## Checklist

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code