### PR TITLE
CardTemplateEditor: initialize insertFieldDialogFactory inside showInsertFieldDialog method

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.java
@@ -95,7 +95,6 @@ public class CardTemplateEditor extends AnkiActivity implements DeckSelectionDia
     protected ViewPager2 mViewPager;
     private TabLayout mSlidingTabLayout;
     private TemporaryModel mTempModel;
-    private InsertFieldDialogFactory mInsertFieldDialogFactory;
 
     @Nullable
     private List<String> mFieldNames;
@@ -139,7 +138,6 @@ public class CardTemplateEditor extends AnkiActivity implements DeckSelectionDia
         // Load the args either from the intent or savedInstanceState bundle
         mEditorPosition = new HashMap<>();
         mEditorViewId = new HashMap<>();
-        mInsertFieldDialogFactory = new InsertFieldDialogFactory(s -> getCurrentFragment().insertField(s)).attachToActivity(this);
 
         if (savedInstanceState == null) {
             // get model id
@@ -544,7 +542,10 @@ public class CardTemplateEditor extends AnkiActivity implements DeckSelectionDia
             if (mTemplateEditor.mFieldNames == null) {
                 return;
             }
-            InsertFieldDialog insertFieldDialog = mTemplateEditor.mInsertFieldDialogFactory
+
+            InsertFieldDialogFactory insertFieldDialogFactory = new InsertFieldDialogFactory(this::insertField).attachToActivity(mTemplateEditor);
+
+            InsertFieldDialog insertFieldDialog = insertFieldDialogFactory
                     .newInsertFieldDialog()
                     .withArguments(mTemplateEditor.mFieldNames);
             mTemplateEditor.showDialogFragment(insertFieldDialog);


### PR DESCRIPTION

## Pull Request template



## Description
crash cause by attend to calling null insertFieldDialogFactory,
because I was initialized insertFieldDialogFactory in only onCreate method of cardtempleteeditor 
and after coming back from the preview page to the editor page onCreate was not again called i.e the dialog factor was null.

## Fixes
Fixes #9442

## Checklist
_Please, go through these checks before submitting the PR._

- [ ] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [ ] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [ ] You have commented your code, particularly in hard-to-understand areas
- [ ] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
