### PR TITLE
Use 'kotlin_version' variable for kotlin-reflect

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -321,7 +321,7 @@ dependencies {
     testImplementation "org.robolectric:robolectric:4.6.1"
     testImplementation 'androidx.test:core:1.4.0'
     testImplementation 'androidx.test.ext:junit:1.1.3'
-    testImplementation "org.jetbrains.kotlin:kotlin-reflect:1.5.21"
+    testImplementation "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
     // debugImplementation required vs testImplementation: https://issuetracker.google.com/issues/128612536
     debugImplementation 'androidx.fragment:fragment-testing:1.3.6'
 


### PR DESCRIPTION
All of these dependencies have version numbers in lockstep

Noticed from #9446 and #9447