### PR TITLE
fix[Deck Import]: Check if storage is accessible before importing deck via Intent

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/IntentHandler.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/IntentHandler.java
@@ -60,7 +60,7 @@ public class IntentHandler extends Activity {
         LaunchType launchType = getLaunchType(intent);
         switch (launchType) {
             case FILE_IMPORT:
-                handleFileImport(intent, reloadIntent, action);
+                runIfStoragePermissions.consume(() -> handleFileImport(intent, reloadIntent, action));
                 break;
             case SYNC:
                 runIfStoragePermissions.consume(() -> handleSyncIntent(reloadIntent, action));


### PR DESCRIPTION
## Purpose / Description
If AnkiDroid is using a non-app-specific directory to store user data and storage permission hasn't been granted, the Deck Import dialog appears over the DeckPicker startup dialog if an import is requested via an Intent. This allows the user to attempt to import the Deck when AnkiDroid can't access user data in the non-app-specific directory, resulting in a crash.

## Problem fixed
1. Fresh Install of AnkiDroid
2. Click on a deck from the device's files app
3. Click on Replace (See Image below)

![fresh-import-deck](https://user-images.githubusercontent.com/29615198/130762117-0ff42d0d-2814-4566-a30d-f39ab1925edf.JPG)


## Approach
In ```IntentHandler```, only allow the deck to be imported if one of the following two conditions have been met:
- AnkiDroid uses an app-specific directory to store user data which doesn't require storage permission
- AnkiDroid uses a non-app-specific directory to store user data, but has granted permission, and the app still targets API < 30 so legacy storage directories are accessible given that storage permissions have been granted.

## How Has This Been Tested?
Tested by attempting to import a deck on a fresh install of AnkiDroid on the following devices:
- Pixel 4 XL API 30  (Emulator)
- Pixel 4XL API 26 (Emulator)


## Checklist

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
