### PR TITLE
feat: Import file type selection

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -120,7 +120,6 @@ import com.ichi2.libanki.Collection;
 import com.ichi2.libanki.Decks;
 import com.ichi2.libanki.Model;
 import com.ichi2.libanki.ModelManager;
-import com.ichi2.libanki.Models;
 import com.ichi2.libanki.Utils;
 import com.ichi2.libanki.importer.AnkiPackageImporter;
 import com.ichi2.libanki.sched.AbstractDeckTreeNode;
@@ -140,8 +139,6 @@ import com.ichi2.widget.WidgetStatus;
 import com.ichi2.utils.JSONException;
 
 import java.io.File;
-import java.util.ArrayList;
-import java.io.FileOutputStream;
 import java.util.List;
 import java.util.TreeMap;
 
@@ -756,7 +753,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
             return true;
         } else if (itemId == R.id.action_import) {
             Timber.i("DeckPicker:: Import button pressed");
-            showImportDialog(ImportDialog.DIALOG_IMPORT_HINT);
+            openImportFilePicker();
             return true;
         } else if (itemId == R.id.action_new_filtered_deck) {
             CreateDeckDialog createFilteredDeckDialog = new CreateDeckDialog(DeckPicker.this, R.string.new_deck, CreateDeckDialog.DeckDialogType.FILTERED_DECK, null);
@@ -1388,30 +1385,24 @@ public class DeckPicker extends NavigationDrawerActivity implements
         }
     }
 
-    @Override
-    public void showImportDialog(int id) {
-        showImportDialog(id, "");
-    }
-
-
-    @Override
     public void showImportDialog(int id, String message) {
-        // On API19+ we only use import dialog to confirm, otherwise we use it the whole time
-        if ((id == ImportDialog.DIALOG_IMPORT_ADD_CONFIRM) || (id == ImportDialog.DIALOG_IMPORT_REPLACE_CONFIRM)) {
-            Timber.d("showImportDialog() delegating to ImportDialog");
-            AsyncDialogFragment newFragment = ImportDialog.newInstance(id, message);
-            showAsyncDialogFragment(newFragment);
-        } else {
-            Timber.d("showImportDialog() delegating to file picker intent");
-            Intent intent = new Intent(Intent.ACTION_OPEN_DOCUMENT);
-            intent.addCategory(Intent.CATEGORY_OPENABLE);
-            intent.setType("*/*");
-            intent.putExtra("android.content.extra.SHOW_ADVANCED", true);
-            intent.putExtra("android.content.extra.FANCY", true);
-            intent.putExtra("android.content.extra.SHOW_FILESIZE", true);
-            startActivityForResultWithoutAnimation(intent, PICK_APKG_FILE);
-        }
+        Timber.d("showImportDialog() delegating to ImportDialog");
+        AsyncDialogFragment newFragment = ImportDialog.newInstance(id, message);
+        showAsyncDialogFragment(newFragment);
     }
+
+
+    private void openImportFilePicker() {
+        Timber.d("openImportFilePicker() delegating to file picker intent");
+        Intent intent = new Intent(Intent.ACTION_OPEN_DOCUMENT);
+        intent.addCategory(Intent.CATEGORY_OPENABLE);
+        intent.setType("*/*");
+        intent.putExtra("android.content.extra.SHOW_ADVANCED", true);
+        intent.putExtra("android.content.extra.FANCY", true);
+        intent.putExtra("android.content.extra.SHOW_FILESIZE", true);
+        startActivityForResultWithoutAnimation(intent, PICK_APKG_FILE);
+    }
+
 
     public void onSdCardNotMounted() {
         UIUtils.showThemedToast(this, getResources().getString(R.string.sd_card_not_mounted), false);

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -88,6 +88,7 @@ import com.ichi2.anki.dialogs.ConfirmationDialog;
 import com.ichi2.anki.dialogs.CreateDeckDialog;
 import com.ichi2.anki.dialogs.DeckPickerNoSpaceToDowngradeDialog;
 import com.ichi2.anki.dialogs.DeckPickerNoSpaceToDowngradeDialog.FileSizeFormatter;
+import com.ichi2.anki.dialogs.ImportFileSelectionFragment;
 import com.ichi2.anki.dialogs.customstudy.CustomStudyDialog;
 import com.ichi2.anki.dialogs.DatabaseErrorDialog;
 import com.ichi2.anki.dialogs.DeckPickerAnalyticsOptInDialog;
@@ -174,7 +175,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
     private static final int SHOW_INFO_NEW_VERSION = 9;
     public static final int SHOW_STUDYOPTIONS = 11;
     private static final int ADD_NOTE = 12;
-    private static final int PICK_APKG_FILE = 13;
+    public static final int PICK_APKG_FILE = 13;
     private static final int PICK_EXPORT_FILE = 14;
 
     // For automatic syncing
@@ -753,7 +754,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
             return true;
         } else if (itemId == R.id.action_import) {
             Timber.i("DeckPicker:: Import button pressed");
-            openImportFilePicker();
+            showDialogFragment(ImportFileSelectionFragment.createInstance(this));
             return true;
         } else if (itemId == R.id.action_new_filtered_deck) {
             CreateDeckDialog createFilteredDeckDialog = new CreateDeckDialog(DeckPicker.this, R.string.new_deck, CreateDeckDialog.DeckDialogType.FILTERED_DECK, null);
@@ -1389,18 +1390,6 @@ public class DeckPicker extends NavigationDrawerActivity implements
         Timber.d("showImportDialog() delegating to ImportDialog");
         AsyncDialogFragment newFragment = ImportDialog.newInstance(id, message);
         showAsyncDialogFragment(newFragment);
-    }
-
-
-    private void openImportFilePicker() {
-        Timber.d("openImportFilePicker() delegating to file picker intent");
-        Intent intent = new Intent(Intent.ACTION_OPEN_DOCUMENT);
-        intent.addCategory(Intent.CATEGORY_OPENABLE);
-        intent.setType("*/*");
-        intent.putExtra("android.content.extra.SHOW_ADVANCED", true);
-        intent.putExtra("android.content.extra.FANCY", true);
-        intent.putExtra("android.content.extra.SHOW_FILESIZE", true);
-        startActivityForResultWithoutAnimation(intent, PICK_APKG_FILE);
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/analytics/UsageAnalytics.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/analytics/UsageAnalytics.java
@@ -442,6 +442,11 @@ public class UsageAnalytics {
         public static final String NCIKU = "nciku";
         @AnalyticsConstant
         public static final String EIJIRO = "eijiro";
+
+        @AnalyticsConstant
+        public static final String IMPORT_APKG_FILE = "Import APKG";
+        @AnalyticsConstant
+        public static final String IMPORT_COLPKG_FILE = "Import COLPKG";
     }
 
     @VisibleForTesting(otherwise = VisibleForTesting.NONE) // TOOD: Make this package-protected

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/HelpDialog.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/HelpDialog.java
@@ -46,6 +46,7 @@ import java.util.Calendar;
 import java.util.List;
 
 import androidx.annotation.DrawableRes;
+import androidx.annotation.NonNull;
 import androidx.annotation.StringRes;
 import androidx.fragment.app.DialogFragment;
 import timber.log.Timber;
@@ -247,7 +248,7 @@ public class HelpDialog {
 
         @FunctionalInterface
         public interface ActivityConsumer extends Serializable {
-            void consume(AnkiActivity activity);
+            void consume(@NonNull AnkiActivity activity);
         }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ImportDialog.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ImportDialog.java
@@ -16,34 +16,23 @@
 
 package com.ichi2.anki.dialogs;
 
-import android.content.DialogInterface;
 import android.content.res.Resources;
 import android.os.Bundle;
 
 import com.afollestad.materialdialogs.MaterialDialog;
-import com.ichi2.anki.CollectionHelper;
 import com.ichi2.anki.R;
-import com.ichi2.anki.UIUtils;
-import com.ichi2.libanki.Utils;
-import com.ichi2.utils.ImportUtils;
 
-import java.io.File;
 import java.net.URLDecoder;
-import java.util.List;
 
 import androidx.annotation.NonNull;
 import timber.log.Timber;
 
 public class ImportDialog extends AsyncDialogFragment {
 
-    public static final int DIALOG_IMPORT_HINT = 0;
-    public static final int DIALOG_IMPORT_SELECT = 1;
     public static final int DIALOG_IMPORT_ADD_CONFIRM = 2;
     public static final int DIALOG_IMPORT_REPLACE_CONFIRM = 3;
 
     public interface ImportDialogListener {
-        void showImportDialog(int id, String message);
-        void showImportDialog(int id);
         void importAdd(String importPath);
         void importReplace(String importPath);
         void dismissAllDialogFragments();
@@ -77,45 +66,6 @@ public class ImportDialog extends AsyncDialogFragment {
         builder.cancelable(true);
 
         switch (type) {
-            case DIALOG_IMPORT_HINT: {
-                // Instruct the user that they need to put their APKG files into the AnkiDroid directory
-                return builder.title(res.getString(R.string.import_title))
-                        .content(res.getString(R.string.import_hint, CollectionHelper.getCurrentAnkiDroidDirectory(getActivity())))
-                        .positiveText(R.string.dialog_ok)
-                        .negativeText(R.string.dialog_cancel)
-                        .onPositive((dialog, which) -> ((ImportDialogListener) getActivity()).showImportDialog(DIALOG_IMPORT_SELECT))
-                        .onNegative((dialog, which) -> dismissAllDialogFragments())
-                        .show();
-            }
-            case DIALOG_IMPORT_SELECT: {
-                // Allow user to choose from the list of available APKG files
-                List<File> fileList = Utils.getImportableDecks(getActivity());
-                if (fileList.isEmpty()) {
-                    UIUtils.showThemedToast(getActivity(),
-                            getResources().getString(R.string.upgrade_import_no_file_found, "'.apkg'"), false);
-                    return builder.showListener(DialogInterface::cancel).show();
-                } else {
-                    String[] tts = new String[fileList.size()];
-                    final String[] importValues = new String[fileList.size()];
-                    for (int i = 0; i < tts.length; i++) {
-                        tts[i] = fileList.get(i).getName();
-                        importValues[i] = fileList.get(i).getAbsolutePath();
-                    }
-                    return builder.title(res.getString(R.string.import_select_title))
-                            .items(tts)
-                            .itemsCallback((materialDialog, view, i, charSequence) -> {
-                                String importPath = importValues[i];
-                                // If collection package, we assume the collection will be replaced
-                                if (ImportUtils.isCollectionPackage(filenameFromPath(importPath))) {
-                                    ((ImportDialogListener) getActivity()).showImportDialog(DIALOG_IMPORT_REPLACE_CONFIRM, importPath);
-                                    // Otherwise we add the file since exported decks / shared decks can't be imported via replace anyway
-                                } else {
-                                    ((ImportDialogListener) getActivity()).showImportDialog(DIALOG_IMPORT_ADD_CONFIRM, importPath);
-                                }
-                            })
-                            .show();
-                }
-            }
             case DIALOG_IMPORT_ADD_CONFIRM: {
                 String displayFileName = convertToDisplayName(getArguments().getString("dialogMessage"));
                 return builder.title(res.getString(R.string.import_title))

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ImportFileSelectionFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ImportFileSelectionFragment.kt
@@ -1,0 +1,66 @@
+/*
+ *  Copyright (c) 2021 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.dialogs
+
+import android.content.Intent
+import com.ichi2.anki.AnkiActivity
+import com.ichi2.anki.DeckPicker
+import com.ichi2.anki.R
+import com.ichi2.anki.analytics.UsageAnalytics
+import com.ichi2.anki.dialogs.HelpDialog.FunctionItem
+import timber.log.Timber
+
+class ImportFileSelectionFragment {
+    companion object {
+        @JvmStatic
+        fun createInstance(@Suppress("UNUSED_PARAMETER") context: DeckPicker): RecursivePictureMenu? {
+            // this needs a deckPicker for now. See use of PICK_APKG_FILE
+
+            // This is required for serialization of the lambda
+            val openFilePicker = FunctionItem.ActivityConsumer { a -> openImportFilePicker(a) }
+
+            val importItems = arrayListOf<RecursivePictureMenu.Item>(
+                FunctionItem(
+                    R.string.import_deck_package,
+                    R.drawable.ic_manual_black_24dp,
+                    UsageAnalytics.Actions.IMPORT_APKG_FILE,
+                    openFilePicker
+                ),
+                FunctionItem(
+                    R.string.import_collection_package,
+                    R.drawable.ic_manual_black_24dp,
+                    UsageAnalytics.Actions.IMPORT_COLPKG_FILE,
+                    openFilePicker
+                ),
+            )
+            return RecursivePictureMenu.createInstance(importItems, R.string.menu_import)
+        }
+
+        // needs to be static for serialization
+        @JvmStatic
+        private fun openImportFilePicker(activity: AnkiActivity) {
+            Timber.d("openImportFilePicker() delegating to file picker intent")
+            val intent = Intent(Intent.ACTION_OPEN_DOCUMENT)
+            intent.addCategory(Intent.CATEGORY_OPENABLE)
+            intent.type = "*/*"
+            intent.putExtra("android.content.extra.SHOW_ADVANCED", true)
+            intent.putExtra("android.content.extra.FANCY", true)
+            intent.putExtra("android.content.extra.SHOW_FILESIZE", true)
+            activity.startActivityForResultWithoutAnimation(intent, DeckPicker.PICK_APKG_FILE)
+        }
+    }
+}

--- a/AnkiDroid/src/main/res/values/02-strings.xml
+++ b/AnkiDroid/src/main/res/values/02-strings.xml
@@ -146,7 +146,6 @@
     <string name="show_hint">Show %s</string>
     <string name="info_rate">Rate AnkiDroid</string>
     <string name="import_title">Importing</string>
-    <string name="import_select_title">Choose a file to import</string>
     <string name="import_message_add" comment="Adding a new deck to the collection (import)">Add</string>
     <string name="import_message_replace_confirm">This will delete your existing collection and replace it with the data of file %s</string>
     <string name="import_message_add_confirm">Add “%s” to collection? This may take a long time</string>
@@ -189,8 +188,6 @@
         ]]>
     </string>
     <string name="export_unsuccessful">Error exporting apkg file</string>
-    <string name="import_hint">Place the apkg file in directory “%s” and touch “OK” to import cards</string>
-    <string name="upgrade_import_no_file_found">No importable %1$s file found</string>
     <string name="study_options" comment="Name for a preference category in Filtered deck (aka Cram deck, aka Custom study) options">Options</string>
     <string name="menu__deck_options">Deck options</string>
     <string name="menu__study_options" comment="Menu item that opens options for a Filtered deck (aka Cram deck, aka Custom study)">Study options</string>

--- a/AnkiDroid/src/main/res/values/03-dialogs.xml
+++ b/AnkiDroid/src/main/res/values/03-dialogs.xml
@@ -264,4 +264,7 @@
     sched V2. For V1, it was counting the number of repetitions of cards in learning. This approximation is acceptable
     for the sake of simplicity and because V1 will leave.-->
     <string name="deck_picker_counts">Open the deck overview page containing the number of cards to see today.</string>
+
+    <string name="import_deck_package">Deck package (.apkg)</string>
+    <string name="import_collection_package">Collection package (.colpkg)</string>
 </resources>

--- a/AnkiDroid/src/test/java/com/ichi2/anki/DeckPickerImportTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/DeckPickerImportTest.java
@@ -27,7 +27,6 @@ import org.junit.runner.RunWith;
 
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
-import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.fail;
 
@@ -38,7 +37,7 @@ public class DeckPickerImportTest extends RobolectricTest {
     public void importAddShowsImportDialog() {
         DeckPickerImport deckPicker = super.startActivityNormallyOpenCollectionWithIntent(DeckPickerImport.class, new Intent());
 
-        deckPicker.showImportDialog(ImportDialog.DIALOG_IMPORT_ADD_CONFIRM);
+        deckPicker.showImportDialog(ImportDialog.DIALOG_IMPORT_ADD_CONFIRM, "");
 
         assertThat(deckPicker.getAsyncDialogFragmentClass(), Matchers.typeCompatibleWith(ImportDialog.class));
     }
@@ -47,18 +46,9 @@ public class DeckPickerImportTest extends RobolectricTest {
     public void replaceShowsImportDialog() {
         DeckPickerImport deckPicker = super.startActivityNormallyOpenCollectionWithIntent(DeckPickerImport.class, new Intent());
 
-        deckPicker.showImportDialog(ImportDialog.DIALOG_IMPORT_REPLACE_CONFIRM);
+        deckPicker.showImportDialog(ImportDialog.DIALOG_IMPORT_REPLACE_CONFIRM, "");
 
         assertThat(deckPicker.getAsyncDialogFragmentClass(), Matchers.typeCompatibleWith(ImportDialog.class));
-    }
-
-    @Test
-    public void hintDoesNotShowDialog() {
-        DeckPickerImport deckPicker = super.startActivityNormallyOpenCollectionWithIntent(DeckPickerImport.class, new Intent());
-
-        deckPicker.showImportDialog(ImportDialog.DIALOG_IMPORT_HINT);
-
-        assertThat(deckPicker.dialogFragment, nullValue());
     }
 
     private static class DeckPickerImport extends DeckPicker {

--- a/AnkiDroid/src/test/java/com/ichi2/anki/analytics/AnalyticsConstantsTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/analytics/AnalyticsConstantsTest.java
@@ -71,6 +71,8 @@ public class AnalyticsConstantsTest {
         listOfConstantFields.add("fora");
         listOfConstantFields.add("nciku");
         listOfConstantFields.add("eijiro");
+        listOfConstantFields.add("Import APKG");
+        listOfConstantFields.add("Import COLPKG");
     }
 
     @NonNull


### PR DESCRIPTION
## Purpose / Description
Suggested by @mindinsomnia 

Currently, selecting "Import" opens up a file picker, with no indication of what files can be imported.

## Approach
* Display a dialog, displaying the types of files which can be imported

## How Has This Been Tested?
Tested on my Android 11

![image](https://user-images.githubusercontent.com/62114487/131277675-e398d579-bc6f-4fcc-b7e6-7277c6856dc4.png)

## Learning

The "search" doesn't work on my Pixel - you can't select a deck if you perform a search while in the file picker. Not a regression, I'll add in an issue

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
  - [ ] Issue with RecursivePictureMenu
