### PR TITLE
FAB Animation fix

### DIFF
--- a/AnkiDroid/src/main/res/layout/floating_add_button.xml
+++ b/AnkiDroid/src/main/res/layout/floating_add_button.xml
@@ -35,6 +35,8 @@
             android:orientation="horizontal"
             android:layout_gravity="bottom|end"
             android:visibility="gone"
+            android:alpha="0"
+            android:translationY="600px"
             >
             <TextView
                 android:layout_width="wrap_content"
@@ -70,6 +72,8 @@
             android:orientation="horizontal"
             android:layout_gravity="bottom|end"
             android:visibility="gone"
+            android:alpha="0"
+            android:translationY="400px"
             >
             <TextView
                 android:layout_width="wrap_content"
@@ -105,6 +109,8 @@
             android:layout_gravity="bottom|end"
             android:orientation="horizontal"
             android:visibility="gone"
+            android:alpha="0"
+            android:translationY="200px"
             >
             <TextView
                 android:layout_width="wrap_content"


### PR DESCRIPTION
## Purpose / Description
The FloatingActionButton was not displaying the animation on first "run" (either when starting the app or when returning from another section).  It is my first PR on here (and it's been a while since I've worked with android apps) so I hope I've done everything right (or almost everything).

## Fixes
This hopefully fixes issue #9426. 

## Approach
The code responsible for the animation of the FAB appears to be located in `DeckPickerFloatingActionMenu.java`. After some testing, I've noticed that the animation works perfectly after the first animation cycle (that is, after the menu has been shown and hidden once), but fails to work the first time. After making sure there were no issues with the function `animationEnabled()`, I've inspected the animation code a little and noticed that the "hide" animation sets certain parameters that the views animate to (i.e. alpha from `1` to `0` etc.). It appears that the first time the show animation  was supposed to animate from alpha `1` to alpha `1` (because the hide animation hadn't yet played and thus the parameters were not set) so there was nothing really left for it to animate. I set the parameters specified at the end by the hide function and voilà, it worked. I decided it was best however to set the parameters directly in XML and not alter the code for such a simple fix.

## How Has This Been Tested?

I've tested it on two physical devices, one running Android 11 (API 29)  and one running Android 5.1 (API 22). It works as expected, with the animation being shown the first time. I do not have access to other devices right now so if anyone else wants to test this, please do. 


## Checklist
_Please, go through these checks before submitting the PR._

-  [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
-  [x] You have a descriptive commit message with a short title (first line, max 50 chars).
-  [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
-  [x] You have commented your code, particularly in hard-to-understand areas
-  [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [x] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
