### PR TITLE
fix: FAB rotation

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPickerFloatingActionMenu.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPickerFloatingActionMenu.java
@@ -118,7 +118,7 @@ public class DeckPickerFloatingActionMenu {
             mAddSharedLayout.setVisibility(View.VISIBLE);
             mAddDeckLayout.setVisibility(View.VISIBLE);
             mFabBGLayout.setVisibility(View.VISIBLE);
-            mFabMain.animate().rotationBy(140);
+            mFabMain.animate().rotationBy(135); // 135 = 90 + 45
             mAddNoteLayout.animate().translationY(0).setDuration(30);
             mAddSharedLayout.animate().translationY(0).setDuration(50);
             mAddDeckLayout.animate().translationY(0).setDuration(100);


### PR DESCRIPTION
## Purpose / Description
The bottom icon was a 50 degree rotation, instead of a 45 degree rotation. Visible as the plus was not level

## Fixes
Fixes #9485


## How Has This Been Tested?

![image](https://user-images.githubusercontent.com/62114487/132056195-447fc7cc-34e0-4a19-b6a8-399cfb7c0110.png)

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
