### PR TITLE
feat: change nav drawer icons

### DIFF
--- a/AnkiDroid/src/main/res/drawable/ic_bar_chart_black.xml
+++ b/AnkiDroid/src/main/res/drawable/ic_bar_chart_black.xml
@@ -13,9 +13,10 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   ~
-  ~ Modifications:
+  ~ Modifications (David Allison, 2021):
   ~  fill color set to black
   ~  tint removed
+  ~  flip left/right to better match the equalizer icon we previously used
   -->
 
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
@@ -25,5 +26,5 @@
     android:viewportHeight="24">
   <path
       android:fillColor="#FF000000"
-      android:pathData="M5,9.2h3L8,19L5,19zM10.6,5h2.8v14h-2.8zM16.2,13L19,13v6h-2.8z"/>
+      android:pathData="M5,13.2h3L8,19L5,19zM10.6,5h2.8v14h-2.8zM16.2,9L19,9v10h-2.8z"/>
 </vector>

--- a/AnkiDroid/src/main/res/drawable/ic_bar_chart_black.xml
+++ b/AnkiDroid/src/main/res/drawable/ic_bar_chart_black.xml
@@ -1,0 +1,29 @@
+<!--
+  ~ Copyright 2xxx, Google Material Design Icons
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  ~
+  ~ Modifications:
+  ~  fill color set to black
+  ~  tint removed
+  -->
+
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:fillColor="#FF000000"
+      android:pathData="M5,9.2h3L8,19L5,19zM10.6,5h2.8v14h-2.8zM16.2,13L19,13v6h-2.8z"/>
+</vector>

--- a/AnkiDroid/src/main/res/drawable/ic_equalizer_black.xml
+++ b/AnkiDroid/src/main/res/drawable/ic_equalizer_black.xml
@@ -1,9 +1,0 @@
-<vector xmlns:android="http://schemas.android.com/apk/res/android"
-        android:width="24dp"
-        android:height="24dp"
-        android:viewportWidth="24.0"
-        android:viewportHeight="24.0">
-    <path
-        android:fillColor="#FF000000"
-        android:pathData="M10,20h4L14,4h-4v16zM4,20h4v-8L4,12v8zM16,9v11h4L20,9h-4z"/>
-</vector>

--- a/AnkiDroid/src/main/res/drawable/ic_flashcard_black.xml
+++ b/AnkiDroid/src/main/res/drawable/ic_flashcard_black.xml
@@ -1,0 +1,29 @@
+<!--
+  ~ Copyright 2xxx, Google Material Design Icons
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  ~
+  ~ Modifications (GitHub: joshakaw, 2021):
+  ~  Base icon: payments - outline from Google Material Icons
+  ~  Removed the circle from the middle of the rounded rectangle
+  ~  Added some rounded corners to the background card outline
+  -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:width="24dp"
+    android:height="24dp">
+    <path
+        android:pathData="M19 14V6C19 4.9 18.1 4 17 4H3C1.9 4 1 4.9 1 6v8c0 1.1 0.9 2 2 2h14c1.1 0 2 -0.9 2 -2zm-2 0H3V6H17ZM23 8.9846154V18c0 1.1 -0.9 2 -2 2H5.9846154A1.9846154 1.9846154 45 0 1 4 18.015385V18H21V7h0.01538A1.9846154 1.9846154 45 0 1 23 8.9846154Z"
+        android:fillColor="#000000" />
+</vector>

--- a/AnkiDroid/src/main/res/drawable/ic_search_black.xml
+++ b/AnkiDroid/src/main/res/drawable/ic_search_black.xml
@@ -1,9 +1,0 @@
-<vector xmlns:android="http://schemas.android.com/apk/res/android"
-        android:width="24dp"
-        android:height="24dp"
-        android:viewportWidth="24.0"
-        android:viewportHeight="24.0">
-    <path
-        android:fillColor="#FF000000"
-        android:pathData="M15.5,14h-0.79l-0.28,-0.27C15.41,12.59 16,11.11 16,9.5 16,5.91 13.09,3 9.5,3S3,5.91 3,9.5 5.91,16 9.5,16c1.61,0 3.09,-0.59 4.23,-1.57l0.27,0.28v0.79l5,4.99L20.49,19l-4.99,-5zM9.5,14C7.01,14 5,11.99 5,9.5S7.01,5 9.5,5 14,7.01 14,9.5 11.99,14 9.5,14z"/>
-</vector>

--- a/AnkiDroid/src/main/res/menu/navigation_drawer.xml
+++ b/AnkiDroid/src/main/res/menu/navigation_drawer.xml
@@ -8,7 +8,7 @@
             android:title="@string/decks" />
         <item
             android:id="@+id/nav_browser"
-            android:icon="@drawable/ic_search_black"
+            android:icon="@drawable/ic_flashcard_black"
             android:title="@string/card_browser"/>
         <item
             android:id="@+id/nav_stats"

--- a/AnkiDroid/src/main/res/menu/navigation_drawer.xml
+++ b/AnkiDroid/src/main/res/menu/navigation_drawer.xml
@@ -12,7 +12,7 @@
             android:title="@string/card_browser"/>
         <item
             android:id="@+id/nav_stats"
-            android:icon="@drawable/ic_equalizer_black"
+            android:icon="@drawable/ic_bar_chart_black"
             android:title="@string/statistics"/>
     </group>
     <group  android:id="@+id/group2">


### PR DESCRIPTION
## Pull Request template

## Purpose / Description

From the issue:

* The 'Card Browser' icon (a magnifying glass) does not necessarily represent what the menu entails.
* The 'Statistics' icon is too thick as compared to every other icon

## Fixes
Fixes #9428

## Notes

We reverse the 'bar chart' icon to make it closer to the equalizer icon (which will hopefully reduce complaints)

Due to this, it no longer fully matches the material icon

## How Has This Been Tested?

![image](https://user-images.githubusercontent.com/62114487/132062376-3b869c70-d7b3-49cc-8cd7-52eabc5513b4.png)

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
