### PR TITLE
build(deps): bump ktlint-gradle from 10.1.0 to 10.2.0

### DIFF
--- a/AnkiDroid/src/test/java/com/ichi2/anki/HandlerUtilsTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/HandlerUtilsTest.kt
@@ -21,8 +21,8 @@ import android.os.SystemClock
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.ichi2.utils.HandlerUtils
 import org.hamcrest.MatcherAssert.assertThat
-import org.hamcrest.Matchers.`is`
 import org.hamcrest.Matchers.closeTo
+import org.hamcrest.Matchers.`is`
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.shadows.ShadowLooper.runUiThreadTasksIncludingDelayedTasks

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ buildscript {
         classpath "app.brant:amazonappstorepublisher:0.1.0"
 
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-        classpath "org.jlleitschuh.gradle:ktlint-gradle:10.1.0"
+        classpath "org.jlleitschuh.gradle:ktlint-gradle:10.2.0"
     }
 }
 


### PR DESCRIPTION
also fixes a breaking lint change introduced by this PR regarding the ordering of `is` - going from first to last

Supersedes #9506 

----

Bumps ktlint-gradle from 10.1.0 to 10.2.0.

---
updated-dependencies:
- dependency-name: org.jlleitschuh.gradle:ktlint-gradle
  dependency-type: direct:production
  update-type: version-update:semver-minor
...

Signed-off-by: dependabot[bot] <support@github.com>