### PR TITLE
changed fab option icons to fit more to overall app theme

### DIFF
--- a/AnkiDroid/src/main/res/drawable/ic_add_deck_filled.xml
+++ b/AnkiDroid/src/main/res/drawable/ic_add_deck_filled.xml
@@ -1,0 +1,29 @@
+<!--
+  ~ Copyright 2021, Google Material Design Icons
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  ~
+  ~ Modifications (GitHub: joshakaw, 2021):
+  ~  Base icon: payments - outline from Google Material Icons
+  ~  Removed the circle from the middle of the rounded rectangle
+  ~  Added a plus icon inside the foreground bill.
+  -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:pathData="M3.1992,3.9688C2.0992,3.9688 1.1992,4.8688 1.1992,5.9688L1.1992,13.9688C1.1992,15.0688 2.0992,15.9688 3.1992,15.9688L17.1992,15.9688C18.2992,15.9688 19.1992,15.0688 19.1992,13.9688L19.1992,5.9688C19.1992,4.8688 18.2992,3.9688 17.1992,3.9688L3.1992,3.9688zM5.9395,6.0488L7.9395,6.0488L7.9395,8.8477L10.7402,8.8477L10.7402,10.8477L7.9395,10.8477L7.9395,13.6484L5.9395,13.6484L5.9395,10.8477L3.2402,10.8477L3.2402,8.8477L5.9395,8.8477L5.9395,6.0488zM21.1992,6.9688L21.1992,17.9688L4.1992,17.9688L4.1992,17.9844A1.9846,1.9846 0,0 0,6.1836 19.9688L21.1992,19.9688C22.2992,19.9688 23.1992,19.0688 23.1992,17.9688L23.1992,8.9531A1.9846,1.9846 0,0 0,21.2148 6.9688L21.1992,6.9688z"
+      android:fillColor="#ffffff"/>
+</vector>

--- a/AnkiDroid/src/main/res/drawable/ic_add_note.xml
+++ b/AnkiDroid/src/main/res/drawable/ic_add_note.xml
@@ -1,0 +1,30 @@
+<!--
+  ~ Copyright 2021, Google Material Design Icons
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  ~
+  ~ Modifications (GitHub: joshakaw, 2021):
+  ~  Base icon: payments - outline from Google Material Icons
+  ~  Removed the circle from the middle of the rounded rectangle
+  ~  Removed the background outline of the 2nd card
+  ~  Added a plus icon, and removed, with padding, the area that the plus took up
+  -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:pathData="M18.3711,6.2324C17.3254,6.2419 16.1991,6.2498 15.7422,6.2441L4.4961,6.2441C3.3961,6.2441 2.4961,7.1441 2.4961,8.2441L2.4961,16.2441C2.4961,17.3441 3.3961,18.2441 4.4961,18.2441L18.4961,18.2441C19.5961,18.2441 20.4961,17.3441 20.4961,16.2441C20.4338,14.8996 20.4687,10.7235 20.502,8.1699C20.5161,7.0871 19.5684,6.2216 18.3711,6.2324zM6.9805,8.3496L8.9805,8.3496L8.9805,11.1484L11.7793,11.1484L11.7793,13.1484L8.9805,13.1484L8.9805,15.9492L6.9805,15.9492L6.9805,13.1484L4.2793,13.1484L4.2793,11.1484L6.9805,11.1484L6.9805,8.3496z"
+      android:fillColor="#ffffff"/>
+</vector>

--- a/AnkiDroid/src/main/res/drawable/ic_folder_white.xml
+++ b/AnkiDroid/src/main/res/drawable/ic_folder_white.xml
@@ -1,9 +1,0 @@
-<vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="24dp"
-    android:height="24dp"
-    android:viewportWidth="24"
-    android:viewportHeight="24">
-  <path
-      android:pathData="M10,4L4,4C2.9,4 2.01,4.9 2.01,6L2,18C2,19.1 2.9,20 4,20L20,20C21.1,20 22,19.1 22,18L22,8C22,6.9 21.1,6 20,6L12,6L10,4Z"
-      android:fillColor="#ffffff"/>
-</vector>

--- a/AnkiDroid/src/main/res/layout/floating_add_button.xml
+++ b/AnkiDroid/src/main/res/layout/floating_add_button.xml
@@ -57,7 +57,7 @@
                 android:layout_height="wrap_content"
                 android:layout_margin="10dp"
                 app:backgroundTint="?attr/fab_normal"
-                android:src="@drawable/ic_folder_white"
+                android:src="@drawable/ic_add_deck_filled"
                 app:fabSize="mini"
                 />
         </LinearLayout>
@@ -131,7 +131,7 @@
                 android:layout_height="wrap_content"
                 android:layout_margin="10dp"
                 app:backgroundTint="?attr/fab_normal"
-                android:src="@drawable/ic_add_white"
+                android:src="@drawable/ic_add_note"
                 app:fabSize="mini"
                 />
         </LinearLayout>


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
The FAB icons currently used do not necessarily represent interacting with a deck of cards (folder and + icon).

## Fixes
Fixes #9499 

## Approach
The icons now accurately represent the options whenever the user is interacting with them.

## How Has This Been Tested?

This has been tested on the Physical Device - Redmi 9 Prime.

## Learning (optional, can help others)


_Links to blog posts, patterns, libraries or addons used to solve this problem_

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [ ] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [x] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

![img1](https://user-images.githubusercontent.com/77961530/133031150-13c5b24f-4b27-4f02-bc35-b0216f063bce.jpeg)


https://user-images.githubusercontent.com/77961530/133031381-15f16e98-41fb-4c41-a5e0-2de2a7f0b14c.mp4