### PR TITLE
DecksV16: merge interface with DeckManager

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckOptions.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckOptions.java
@@ -61,7 +61,6 @@ import com.ichi2.utils.JSONException;
 import com.ichi2.utils.JSONObject;
 import com.ichi2.utils.NamedJSONComparator;
 
-import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Collections;
 import java.util.HashMap;
@@ -809,7 +808,7 @@ public class DeckOptions extends AppCompatPreferenceActivity implements OnShared
     @SuppressWarnings("deprecation") // TODO Tracked in https://github.com/ankidroid/Anki-Android/issues/5019
     protected void buildLists() {
         android.preference.ListPreference deckConfPref = (android.preference.ListPreference) findPreference("deckConf");
-        ArrayList<DeckConfig> confs = mCol.getDecks().allConf();
+        List<DeckConfig> confs = mCol.getDecks().allConf();
         Collections.sort(confs, NamedJSONComparator.INSTANCE);
         String[] confValues = new String[confs.size()];
         String[] confLabels = new String[confs.size()];

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/AnkiPackageExporter.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/AnkiPackageExporter.java
@@ -94,7 +94,7 @@ class Exporter {
         if (mDid == null) {
             cids = Utils.list2ObjectArray(mCol.getDb().queryLongList("select id from cards"));
         } else {
-            cids = mCol.getDecks().cids(mDid, true);
+            cids = Utils.list2ObjectArray(mCol.getDecks().cids(mDid, true));
         }
         mCount = cids.length;
         return cids;

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/DeckConfig.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/DeckConfig.java
@@ -16,19 +16,22 @@
  */
 package com.ichi2.libanki;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.ichi2.utils.JSONObject;
 
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import timber.log.Timber;
 
-public class DeckConfig extends JSONObject{
+public class DeckConfig extends JSONObject {
+    @NonNull
+    private final Source mSource;
+
     /**
      * Creates a new empty deck config object
      */
-    private DeckConfig() {
+    private DeckConfig(@NonNull Source source) {
         super();
+        this.mSource = source;
     }
 
     /**
@@ -36,18 +39,18 @@ public class DeckConfig extends JSONObject{
      *
      * This function will perform deepCopy on the passed object
      *
-     * @see DeckConfig#from(JSONObject) if you want to create a
-     *                                  DeckConfig without deepCopy
      */
-    public DeckConfig(JSONObject json) {
+    public DeckConfig(JSONObject json, @NonNull Source source) {
         super(json);
+        mSource = source;
     }
 
     /**
      * Creates a deck config object form a json string
      */
-    public DeckConfig(String json) {
+    public DeckConfig(String json, @NonNull Source source) {
         super(json);
+        mSource = source;
     }
 
     public static @Nullable Boolean parseTimer(JSONObject config) {
@@ -85,7 +88,20 @@ public class DeckConfig extends JSONObject{
 
     @Override
     public DeckConfig deepClone() {
-        DeckConfig dc = new DeckConfig();
+        DeckConfig dc = new DeckConfig(this.getSource());
         return deepClonedInto(dc);
+    }
+
+    @NonNull
+    public Source getSource() {
+        return mSource;
+    }
+
+    /** Specifies how to save the config */
+    public enum Source {
+        /** From an entry in dconf */
+        DECK_CONFIG,
+        /** filtered decks have their config embedded in the deck */
+        DECK_EMBEDDED
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/DeckManager.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/DeckManager.kt
@@ -23,8 +23,8 @@ import com.ichi2.anki.exception.DeckRenameException
 import com.ichi2.anki.exception.FilteredAncestor
 import com.ichi2.utils.DeckComparator
 import com.ichi2.utils.DeckNameComparator
-import com.ichi2.utils.JSONObject
 import com.ichi2.utils.KotlinCleanup
+import net.ankiweb.rsdroid.RustCleanup
 import java.util.*
 
 abstract class DeckManager {
@@ -35,9 +35,11 @@ abstract class DeckManager {
      */
 
     abstract fun load(decks: String, dconf: String)
-    fun save() = save(null)
+    @RustCleanup("Unused in V16")
+    abstract fun save()
     /** Can be called with either a deck or a deck configuration. */
-    abstract fun save(g: JSONObject?)
+    abstract fun save(g: Deck)
+    abstract fun save(g: DeckConfig)
     abstract fun flush()
 
     /*

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/DeckManager.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/DeckManager.kt
@@ -73,6 +73,7 @@ abstract class DeckManager {
     abstract fun collapse(did: Long)
 
     /** Return the number of decks. */
+    @RustCleanup("This is a long in V16 - shouldn't make a difference, but needs investigation")
     abstract fun count(): Int
     @CheckResult
     /** Obtains the deck from the DeckID, or default if the deck was not found */

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/DeckManager.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/DeckManager.kt
@@ -193,27 +193,6 @@ abstract class DeckManager {
         return deck.getString("name") + Decks.DECK_SEPARATOR + subdeckName
     }
 
-    /* Methods only visible for testing */
-
-    /**
-     *
-     * @param name The name whose parents should exists
-     * @return The name, with potentially change in capitalization and unicode normalization, so that the parent's name corresponds to an existing deck.
-     * @throws FilteredAncestor if a parent is filtered
-     */
-    @VisibleForTesting
-    @Throws(FilteredAncestor::class)
-    protected abstract fun _ensureParents(name: String): String
-
-    /**
-     *
-     * Similar as ensure parent, to use when the method can't fail and it's better to allow more change to ancestor's names.
-     * @param name The name whose parents should exists
-     * @return The name similar to input, changed as required, and as little as required, so that no ancestor is filtered and the parent's name is an existing deck.
-     */
-    @VisibleForTesting
-    protected abstract fun _ensureParentsNotFiltered(name: String): String
-
     /*
      * Not in libAnki
      */

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/DeckManager.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/DeckManager.kt
@@ -21,6 +21,8 @@ import androidx.annotation.VisibleForTesting
 import com.ichi2.anki.exception.ConfirmModSchemaException
 import com.ichi2.anki.exception.DeckRenameException
 import com.ichi2.anki.exception.FilteredAncestor
+import com.ichi2.utils.DeckComparator
+import com.ichi2.utils.DeckNameComparator
 import com.ichi2.utils.JSONObject
 import net.ankiweb.rsdroid.RustCleanup
 import java.util.*
@@ -180,8 +182,6 @@ abstract class DeckManager {
 
     /* Methods only visible for testing */
 
-    @VisibleForTesting
-    abstract fun allSortedNames(): List<String>
     /**
      *
      * @param name The name whose parents should exists
@@ -212,7 +212,19 @@ abstract class DeckManager {
      * This method does not exist in the original python module but *must* be used for any user
      * interface components that display a deck list to ensure the ordering is consistent.
      */
-    abstract fun allSorted(): List<Deck>
+    /** {@inheritDoc}  */
+    fun allSorted(): List<Deck?> {
+        val decks: List<Deck?> = all()
+        Collections.sort(decks, DeckComparator.INSTANCE)
+        return decks
+    }
+
+    @VisibleForTesting
+    fun allSortedNames(): List<String> {
+        val names = allNames()
+        Collections.sort(names, DeckNameComparator.INSTANCE)
+        return names
+    }
 
     @RustCleanup("potentially an extension function")
     fun allDynamicDeckIds(): Array<Long> {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/DeckManager.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/DeckManager.kt
@@ -16,7 +16,6 @@
 
 package com.ichi2.libanki
 
-import android.text.TextUtils
 import androidx.annotation.CheckResult
 import androidx.annotation.VisibleForTesting
 import com.ichi2.anki.exception.ConfirmModSchemaException
@@ -180,11 +179,11 @@ abstract class DeckManager {
 
     /** @return the fully qualified name of the subdeck, or null if unavailable */
     fun getSubdeckName(did: Long, subdeckName: String?): String? {
-        if (TextUtils.isEmpty(subdeckName)) {
+        if (subdeckName.isNullOrEmpty()) {
             return null
         }
-        val newName = subdeckName!!.replace("\"".toRegex(), "")
-        if (TextUtils.isEmpty(newName)) {
+        val newName = subdeckName.replace("\"".toRegex(), "")
+        if (newName.isEmpty()) {
             return null
         }
         val deck = get(did, false) ?: return null

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/DeckManager.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/DeckManager.kt
@@ -24,7 +24,7 @@ import com.ichi2.anki.exception.FilteredAncestor
 import com.ichi2.utils.DeckComparator
 import com.ichi2.utils.DeckNameComparator
 import com.ichi2.utils.JSONObject
-import net.ankiweb.rsdroid.RustCleanup
+import com.ichi2.utils.KotlinCleanup
 import java.util.*
 
 abstract class DeckManager {
@@ -220,13 +220,14 @@ abstract class DeckManager {
     }
 
     @VisibleForTesting
+    @KotlinCleanup("potentially an extension function")
     fun allSortedNames(): List<String> {
         val names = allNames()
         Collections.sort(names, DeckNameComparator.INSTANCE)
         return names
     }
 
-    @RustCleanup("potentially an extension function")
+    @KotlinCleanup("potentially an extension function")
     fun allDynamicDeckIds(): Array<Long> {
         val ids = allIds()
         val validValues = ArrayList<Long>(ids.size)

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/DeckManager.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/DeckManager.kt
@@ -129,8 +129,8 @@ abstract class DeckManager {
 
     fun name(did: Long): String = name(did, _default = false)
     abstract fun name(did: Long, _default: Boolean = false): String
-    fun cids(did: Long): Array<Long> = cids(did, false)
-    abstract fun cids(did: Long, children: Boolean): Array<Long>
+    fun cids(did: Long): MutableList<Long> = cids(did, false)
+    abstract fun cids(did: Long, children: Boolean): MutableList<Long>
     abstract fun checkIntegrity()
 
     /*

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/DeckManager.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/DeckManager.kt
@@ -16,6 +16,7 @@
 
 package com.ichi2.libanki
 
+import android.text.TextUtils
 import androidx.annotation.CheckResult
 import androidx.annotation.VisibleForTesting
 import com.ichi2.anki.exception.ConfirmModSchemaException
@@ -178,7 +179,17 @@ abstract class DeckManager {
     fun getActualDescription(): String = current().optString("desc", "")
 
     /** @return the fully qualified name of the subdeck, or null if unavailable */
-    abstract fun getSubdeckName(did: Long, subdeckName: String?): String?
+    fun getSubdeckName(did: Long, subdeckName: String?): String? {
+        if (TextUtils.isEmpty(subdeckName)) {
+            return null
+        }
+        val newName = subdeckName!!.replace("\"".toRegex(), "")
+        if (TextUtils.isEmpty(newName)) {
+            return null
+        }
+        val deck = get(did, false) ?: return null
+        return deck.getString("name") + Decks.DECK_SEPARATOR + subdeckName
+    }
 
     /* Methods only visible for testing */
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/DeckManager.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/DeckManager.kt
@@ -103,7 +103,7 @@ abstract class DeckManager {
      */
 
     /** * A list of all deck config. */
-    abstract fun allConf(): ArrayList<DeckConfig>
+    abstract fun allConf(): List<DeckConfig>
     abstract fun confForDid(did: Long): DeckConfig
     abstract fun getConf(confId: Long): DeckConfig?
     abstract fun updateConf(g: DeckConfig)

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/DeckManager.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/DeckManager.kt
@@ -174,8 +174,8 @@ abstract class DeckManager {
      * The methods below are not in LibAnki.
      * ***********************************************************
      */
-
-    abstract fun getActualDescription(): String
+    @KotlinCleanup("convert to extension method (possibly in servicelayer)")
+    fun getActualDescription(): String = current().optString("desc", "")
 
     /** @return the fully qualified name of the subdeck, or null if unavailable */
     abstract fun getSubdeckName(did: Long, subdeckName: String?): String?

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/DeckManager.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/DeckManager.kt
@@ -124,7 +124,8 @@ abstract class DeckManager {
      * ***********************************************************
      */
 
-    abstract fun name(did: Long): String
+    fun name(did: Long): String = name(did, _default = false)
+    abstract fun name(did: Long, _default: Boolean = false): String
     fun cids(did: Long): Array<Long> = cids(did, false)
     abstract fun cids(did: Long, children: Boolean): Array<Long>
     abstract fun checkIntegrity()

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
@@ -274,7 +274,7 @@ public class Decks extends DeckManager {
         mDconf = HashUtil.HashMapInit(confarray.length());
         if (ids != null) {
             for (String id : ids.stringIterable()) {
-                mDconf.put(Long.parseLong(id), new DeckConfig(confarray.getJSONObject(id)));
+                mDconf.put(Long.parseLong(id), new DeckConfig(confarray.getJSONObject(id), DeckConfig.Source.DECK_CONFIG));
             }
         }
         mChanged = false;
@@ -780,7 +780,7 @@ public class Decks extends DeckManager {
             return conf;
         }
         // dynamic decks have embedded conf
-        return new DeckConfig(deck);
+        return new DeckConfig(deck, DeckConfig.Source.DECK_EMBEDDED);
     }
 
 
@@ -800,7 +800,7 @@ public class Decks extends DeckManager {
     @Override
     public long confId(@NonNull String name, @NonNull String cloneFrom) {
         long id;
-        DeckConfig c = new DeckConfig(cloneFrom);
+        DeckConfig c = new DeckConfig(cloneFrom, DeckConfig.Source.DECK_CONFIG);
         do {
             id = mCol.getTime().intTimeMS();
         } while (mDconf.containsKey(id));

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
@@ -30,7 +30,6 @@ import com.ichi2.anki.exception.DeckRenameException;
 import com.ichi2.anki.exception.FilteredAncestor;
 
 import com.ichi2.utils.DeckComparator;
-import com.ichi2.utils.DeckNameComparator;
 import com.ichi2.utils.HashUtil;
 import com.ichi2.utils.JSONArray;
 import com.ichi2.utils.JSONObject;
@@ -73,7 +72,7 @@ public class Decks extends DeckManager {
     public static final String CURRENT_DECK = "curDeck";
     /** Configuration saving the set of active decks (i.e. current decks and its descendants) */
     public static final String ACTIVE_DECKS = "activeDecks";
-    
+
 
     //not in libAnki
     @SuppressWarnings("WeakerAccess")
@@ -472,25 +471,6 @@ public class Decks extends DeckManager {
     @Override
     public List<Deck> all() {
         return new ArrayList<>(mDecks.values());
-    }
-
-
-    /** {@inheritDoc} */
-    @NonNull
-    @Override
-    public List<Deck> allSorted() {
-        List<Deck> decks = all();
-        Collections.sort(decks, DeckComparator.INSTANCE);
-        return decks;
-    }
-
-    @NonNull
-    @Override
-    @VisibleForTesting
-    public List<String> allSortedNames() {
-        List<String> names = allNames();
-        Collections.sort(names, DeckNameComparator.INSTANCE);
-        return names;
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
@@ -760,7 +760,7 @@ public class Decks extends DeckManager {
     /** {@inheritDoc} */
     @NonNull
     @Override
-    public ArrayList<DeckConfig> allConf() {
+    public List<DeckConfig> allConf() {
         return new ArrayList<>(mDconf.values());
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
@@ -682,9 +682,13 @@ public class Decks extends DeckManager {
     }
 
 
-    /** {@inheritDoc} */
+    /**
+     *
+     * @param name The name whose parents should exists
+     * @return The name, with potentially change in capitalization and unicode normalization, so that the parent's name corresponds to an existing deck.
+     * @throws FilteredAncestor if a parent is filtered
+     */
     @NonNull
-    @Override
     @VisibleForTesting
     protected String _ensureParents(@NonNull String name) throws FilteredAncestor {
         String s = "";
@@ -714,9 +718,9 @@ public class Decks extends DeckManager {
 
 
     /** {@inheritDoc} */
-    @Override
+    @NonNull
     @VisibleForTesting
-    protected  String _ensureParentsNotFiltered(String name) {
+    protected String _ensureParentsNotFiltered(String name) {
         String s = "";
         String[] path = path(name);
         if (path.length < 2) {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
@@ -1235,22 +1235,4 @@ public class Decks extends DeckManager {
     public static boolean isDynamic(Deck deck) {
         return deck.isDyn();
     }
-
-    /** {@inheritDoc} */
-    @Override
-    @Nullable
-    public String getSubdeckName(long did, @Nullable String subdeckName) {
-        if (TextUtils.isEmpty(subdeckName)) {
-            return null;
-        }
-        String newName = subdeckName.replaceAll("\"", "");
-        if (TextUtils.isEmpty(newName)) {
-            return null;
-        }
-        Deck deck = get(did, false);
-        if (deck == null) {
-            return null;
-        }
-        return deck.getString("name") + DECK_SEPARATOR + subdeckName;
-    }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
@@ -1222,12 +1222,6 @@ public class Decks extends DeckManager {
         return sParentCache.get(deckName);
     }
 
-    @NonNull
-    @Override
-    public String getActualDescription() {
-        return current().optString("desc","");
-    }
-
     @VisibleForTesting
     @RustCleanup("This exists in Rust as DecksDictProxy, but its usage is warned against")
     public HashMap<Long, Deck> getDecks() {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
@@ -280,9 +280,26 @@ public class Decks extends DeckManager {
         mChanged = false;
     }
 
+
     /** {@inheritDoc} */
     @Override
-    public void save(JSONObject g) {
+    public void save() {
+        save((JSONObject) null);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void save(@NonNull Deck g) {
+        save((JSONObject) g);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void save(@NonNull DeckConfig g) {
+        save((JSONObject) g);
+    }
+
+    private void save(JSONObject g) {
         if (g != null) {
             g.put("mod", mCol.getTime().intTime());
             g.put("usn", mCol.usn());

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
@@ -850,14 +850,7 @@ public class Decks extends DeckManager {
      * ***********************************************************
      */
 
-
     @NonNull
-    @Override
-    public String name(long did) {
-        return name(did, false);
-    }
-
-
     public String name(long did, boolean _default) {
         Deck deck = get(did, _default);
         if (deck != null) {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
@@ -905,15 +905,15 @@ public class Decks extends DeckManager {
 
     @NonNull
     @Override
-    public Long[] cids(long did, boolean children) {
+    public List<Long> cids(long did, boolean children) {
         if (!children) {
-            return Utils.list2ObjectArray(mCol.getDb().queryLongList("select id from cards where did=?", did));
+            return mCol.getDb().queryLongList("select id from cards where did=?", did);
         }
         java.util.Collection<Long> values = children(did).values();
         List<Long> dids = new ArrayList<>(values.size() + 1);
         dids.add(did);
         dids.addAll(values);
-        return Utils.list2ObjectArray(mCol.getDb().queryLongList("select id from cards where did in " + Utils.ids2str(dids)));
+        return mCol.getDb().queryLongList("select id from cards where did in " + Utils.ids2str(dids));
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/DecksV16.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/DecksV16.kt
@@ -724,6 +724,11 @@ class DecksV16(private val col: Collection, private val decksBackend: DecksBacke
         return childMap
     }
 
+    fun parents(did: Long): List<Deck> {
+        val parents = parents(did, Optional.empty())
+        return parents.map { x -> Deck(x.getJsonObject()) }
+    }
+
     @RustCleanup("not needed")
     fun beforeUpload() {
         // intentionally blank

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/DecksV16.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/DecksV16.kt
@@ -720,6 +720,11 @@ class DecksV16(private val col: Collection, private val decksBackend: DecksBacke
         return childMap
     }
 
+    @RustCleanup("not needed")
+    fun beforeUpload() {
+        // intentionally blank
+    }
+
     private fun sorted(all: ImmutableList<DeckV16>): ImmutableList<DeckV16> {
         return all.sortedBy {
             d ->

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/DecksV16.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/DecksV16.kt
@@ -476,6 +476,10 @@ class DecksV16(private val col: Collection, private val decksBackend: DecksBacke
         setConf(DeckV16.Generic(grp), id)
     }
 
+    fun restoreToDefault(conf: DeckConfig) {
+        restoreToDefault(DeckConfigV16.Generic(conf))
+    }
+
     @RustCleanup("maybe an issue here - grp was deckConfig in V16")
     fun setConf(grp: DeckV16, id: dcid) {
         grp.conf = id

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/DecksV16.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/DecksV16.kt
@@ -532,8 +532,8 @@ class DecksV16(private val col: Collection, private val decksBackend: DecksBacke
 
     /* Deck utils */
 
-    fun name(did: did, default: bool = false): str {
-        val deck = this.get(did, _default = default).toV16Optional()
+    fun name(did: did, _default: bool = false): str {
+        val deck = this.get(did, _default = _default).toV16Optional()
         if (deck.isPresent) {
             return deck.name
         }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/DecksV16.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/DecksV16.kt
@@ -42,6 +42,7 @@ import com.ichi2.utils.JSONArray
 import com.ichi2.utils.JSONObject
 import java8.util.Optional
 import net.ankiweb.rsdroid.RustCleanup
+import timber.log.Timber
 import java.util.*
 import BackendProto.Backend as pb
 
@@ -56,6 +57,7 @@ const val defaultDynamicDeck = 1
 open class DeckV16 private constructor(private val deck: JSONObject) {
     class NonFilteredDeck(val deck: JSONObject) : DeckV16(deck)
     class FilteredDeck(val deck: JSONObject) : DeckV16(deck)
+    internal class Generic(val deck: JSONObject) : DeckV16(deck)
 
     // to be usd rarely
     fun getJsonObject(): JSONObject {
@@ -119,6 +121,10 @@ abstract class DeckConfigV16 private constructor(val config: JSONObject) {
         override fun deepClone(): DeckConfigV16 = FilteredDeck(deckData.deepClone())
     }
 
+    class Generic(val deckData: JSONObject) : DeckConfigV16(deckData) {
+        override fun deepClone(): DeckConfigV16 = Generic(deckData.deepClone())
+    }
+
     var conf: Long
         get() = config.getLong("conf")
         set(value) {
@@ -172,6 +178,19 @@ class DecksV16(private val col: Collection, private val decksBackend: DecksBacke
             is DeckConfigV16.Config -> save(grp)
             is DeckConfigV16.FilteredDeck -> save(DeckV16.FilteredDeck(grp.deckData))
         }
+    }
+
+    @RustCleanup("not in V16")
+    fun save() {
+        Timber.w(Exception("Decks.save() called - probably a bug"))
+    }
+
+    fun save(g: Deck) {
+        save(DeckV16.Generic(g))
+    }
+
+    fun save(g: DeckConfig) {
+        save(DeckConfigV16.Generic(g))
     }
 
     fun save(g: DeckConfigV16.Config) {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/DecksV16.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/DecksV16.kt
@@ -319,11 +319,11 @@ class DecksV16(private val col: Collection, private val decksBackend: DecksBacke
         return len(this.all_names_and_ids())
     }
 
-    fun get(did: did, default: bool = true): Deck? {
+    fun get(did: did, _default: bool = true): Deck? {
         val deck = this.get_legacy(did)
         return when {
             deck != null -> deck
-            default -> this.get_legacy(1)
+            _default -> this.get_legacy(1)
             else -> null
         }
     }
@@ -412,7 +412,7 @@ class DecksV16(private val col: Collection, private val decksBackend: DecksBacke
     }
 
     fun confForDid(did: did): DeckConfigV16 {
-        val deck = this.get(did, default = false).toV16Optional()
+        val deck = this.get(did, _default = false).toV16Optional()
         assert(deck.isPresent)
         val deckValue = deck.get()
         if (deckValue.hasKey("conf")) {
@@ -532,7 +532,7 @@ class DecksV16(private val col: Collection, private val decksBackend: DecksBacke
     /* Deck utils */
 
     fun name(did: did, default: bool = false): str {
-        val deck = this.get(did, default = default).toV16Optional()
+        val deck = this.get(did, _default = default).toV16Optional()
         if (deck.isPresent) {
             return deck.name
         }
@@ -541,7 +541,7 @@ class DecksV16(private val col: Collection, private val decksBackend: DecksBacke
     }
 
     fun nameOrNone(did: did): Optional<str> {
-        val deck = this.get(did, default = false).toV16Optional()
+        val deck = this.get(did, _default = false).toV16Optional()
         if (deck.isPresent) {
             return Optional.of(deck.name)
         }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/DecksV16.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/DecksV16.kt
@@ -594,8 +594,8 @@ class DecksV16(private val col: Collection, private val decksBackend: DecksBacke
         return this.col.get_config_long(CURRENT_DECK)
     }
 
-    fun current(): DeckV16 {
-        return DeckV16.Generic(this.get(this.selected())!!)
+    fun current(): Deck {
+        return this.get(this.selected())!!
     }
 
     /** Select a new branch. */

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/DecksV16.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/DecksV16.kt
@@ -217,6 +217,11 @@ class DecksV16(private val col: Collection, private val decksBackend: DecksBacke
         decksBackend.remove_deck(did)
     }
 
+    @Suppress("deprecation")
+    fun allNames(dyn: Boolean): List<String> {
+        return allNames(dyn = dyn, force_default = true)
+    }
+
     /** A sorted sequence of deck names and IDs. */
     fun all_names_and_ids(
         skip_empty_default: bool = false,

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/DecksV16.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/DecksV16.kt
@@ -520,6 +520,11 @@ class DecksV16(private val col: Collection, private val decksBackend: DecksBacke
         return this.col.db.queryLongList("select id from cards where did in " + ids2str(dids))
     }
 
+    @RustCleanup("needs testing")
+    fun checkIntegrity() {
+        // I believe this is now handled in libAnki
+    }
+
     fun for_card_ids(cids: List<Long>): List<did> {
         return this.col.db.queryLongList("select did from cards where id in ${ids2str(cids)}")
     }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/DecksV16.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/DecksV16.kt
@@ -318,7 +318,7 @@ class DecksV16(private val col: Collection, private val decksBackend: DecksBacke
         this.save(deck)
     }
 
-    fun count(): Long {
+    fun count(): Int {
         return len(this.all_names_and_ids())
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/DecksV16.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/DecksV16.kt
@@ -339,6 +339,10 @@ class DecksV16(private val col: Collection, private val decksBackend: DecksBacke
         update(DeckV16.Generic(g), preserve_usn = true)
     }
 
+    fun rename(g: Deck, newName: String) {
+        rename(DeckV16.Generic(g), newName)
+    }
+
     /** Add or update an existing deck. Used for syncing and merging. */
     fun update(g: DeckV16, preserve_usn: bool = true) {
         g.id = decksBackend.add_or_update_deck_legacy(g, preserve_usn)

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/DecksV16.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/DecksV16.kt
@@ -476,6 +476,9 @@ class DecksV16(private val col: Collection, private val decksBackend: DecksBacke
         setConf(DeckV16.Generic(grp), id)
     }
 
+    fun didsForConf(conf: DeckConfig): List<Long> =
+        didsForConf(DeckConfigV16.Generic(conf))
+
     fun restoreToDefault(conf: DeckConfig) {
         restoreToDefault(DeckConfigV16.Generic(conf))
     }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/DecksV16.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/DecksV16.kt
@@ -334,6 +334,11 @@ class DecksV16(private val col: Collection, private val decksBackend: DecksBacke
         return Optional.empty()
     }
 
+    fun update(g: Deck) {
+        // we preserve USN here as this method is used for syncing and merging
+        update(DeckV16.Generic(g), preserve_usn = true)
+    }
+
     /** Add or update an existing deck. Used for syncing and merging. */
     fun update(g: DeckV16, preserve_usn: bool = true) {
         g.id = decksBackend.add_or_update_deck_legacy(g, preserve_usn)

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/DecksV16.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/DecksV16.kt
@@ -517,7 +517,7 @@ class DecksV16(private val col: Collection, private val decksBackend: DecksBacke
 
     // legacy
     fun allConf() = all_config().map { x -> DeckConfig(x.config) }.toMutableList()
-    fun getConf(confId: dcid) = get_config(confId)
+    fun getConf(confId: dcid): DeckConfig? = get_config(confId).map { x -> DeckConfig(x.config) }.orElse(null)
 
     fun confId(name: String, cloneFrom: String): Long {
         val config: Optional<DeckConfigV16> = Optional.of(DeckConfigV16.Config(JSONObject(cloneFrom)))

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/DecksV16.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/DecksV16.kt
@@ -41,6 +41,7 @@ import com.ichi2.utils.CollectionUtils
 import com.ichi2.utils.JSONArray
 import com.ichi2.utils.JSONObject
 import java8.util.Optional
+import net.ankiweb.rsdroid.RustCleanup
 import java.util.*
 import BackendProto.Backend as pb
 
@@ -188,6 +189,11 @@ class DecksV16(private val col: Collection, private val decksBackend: DecksBacke
     }
 
     /* Deck save/load */
+    @RustCleanup("only for java interface: newDyn was used for filtered decks")
+    fun id(name: str): did {
+        // use newDyn for now
+        return id(name, true, 0).get()
+    }
 
     /** "Add a deck with NAME. Reuse deck if already exists. Return id as int." */
     fun id(name: str, create: bool = true, type: Int = 0): Optional<did> {
@@ -689,7 +695,7 @@ class DecksV16(private val col: Collection, private val decksBackend: DecksBacke
             if (nameMap.isPresent) {
                 deck = nameMap.get()[parent_name]!!
             } else {
-                deck = this.get(this.id(parent_name).get()).get()!!
+                deck = this.get(this.id(parent_name)).get()!!
             }
             parents.append(deck)
         }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/DecksV16.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/DecksV16.kt
@@ -288,11 +288,8 @@ class DecksV16(private val col: Collection, private val decksBackend: DecksBacke
     }
 
     @Deprecated("decks.allIds() is deprecated, use .all_names_and_ids()")
-    fun allIds(): MutableList<str> {
-        return this.all_names_and_ids().map {
-            x ->
-            x.id.toString()
-        }.toMutableList()
+    fun allIds(): Set<did> {
+        return this.all_names_and_ids().map { x -> x.id }.toSet()
     }
 
     @Deprecated("decks.allNames() is deprecated, use .all_names_and_ids()")

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/DecksV16.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/DecksV16.kt
@@ -670,12 +670,12 @@ class DecksV16(private val col: Collection, private val decksBackend: DecksBacke
     }
 
     /** All children of did, as (name, id). */
-    fun children(did: did): MutableList<Tuple<str, did>> {
+    fun children(did: did): TreeMap<str, did> {
         val name: str = this.get(did)!!.toV16().name
-        val actv = mutableListOf<Tuple<str, did>>()
+        val actv = TreeMap<str, did>()
         for (g in this.all_names_and_ids()) {
             if (g.name.startsWith(name + "::")) {
-                actv.append(Tuple(g.name, g.id))
+                actv.put(g.name, g.id)
             }
         }
         return actv

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/DecksV16.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/DecksV16.kt
@@ -581,8 +581,8 @@ class DecksV16(private val col: Collection, private val decksBackend: DecksBacke
     /* Deck selection */
 
     /** The currently active dids. */
-    fun active(): MutableList<did> {
-        // TODO: Copied from the java, should use get_config
+    @RustCleanup("Probably better as a queue")
+    fun active(): LinkedList<did> {
         val activeDecks: JSONArray = col.get_config_array(ACTIVE_DECKS)
         val result = LinkedList<Long>()
         CollectionUtils.addAll(result, activeDecks.longIterable())

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/DecksV16.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/DecksV16.kt
@@ -517,7 +517,7 @@ class DecksV16(private val col: Collection, private val decksBackend: DecksBacke
 
     // legacy
     fun allConf() = all_config().map { x -> DeckConfig(x.config) }.toMutableList()
-    fun getConf(conf_id: dcid) = get_config(conf_id)
+    fun getConf(confId: dcid) = get_config(confId)
 
     fun confId(name: String, cloneFrom: String): Long {
         val config: Optional<DeckConfigV16> = Optional.of(DeckConfigV16.Config(JSONObject(cloneFrom)))

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/DecksV16.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/DecksV16.kt
@@ -183,6 +183,10 @@ class DecksV16(private val col: Collection, private val decksBackend: DecksBacke
         this.update(g, preserve_usn = false)
     }
 
+    @RustCleanup("unused in V16")
+    fun load(@Suppress("UNUSED_PARAMETER") decks: String, @Suppress("UNUSED_PARAMETER") dconf: String) {
+    }
+
     // legacy
     fun flush() {
         // no-op

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/DecksV16.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/DecksV16.kt
@@ -715,7 +715,8 @@ class DecksV16(private val col: Collection, private val decksBackend: DecksBacke
         return arr
     }
 
-    fun childMap(): childMapNode {
+    @RustCleanup("used to return childMapNode")
+    fun childMap(): Decks.Node {
         val nameMap = this.nameMap()
         val childMap = childMapNode()
 
@@ -733,7 +734,16 @@ class DecksV16(private val col: Collection, private val decksBackend: DecksBacke
             }
         }
 
-        return childMap
+        return childMap.toNode()
+    }
+
+    @RustCleanup("needs testing")
+    fun childMapNode.toNode(): Decks.Node {
+        val ret = Decks.Node()
+        for (x in this) {
+            ret[x.key] = (x.value as childMapNode).toNode()
+        }
+        return ret
     }
 
     fun parents(did: Long): List<Deck> {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/DecksV16.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/DecksV16.kt
@@ -516,7 +516,7 @@ class DecksV16(private val col: Collection, private val decksBackend: DecksBacke
     }
 
     // legacy
-    fun allConf() = all_config()
+    fun allConf() = all_config().map { x -> DeckConfig(x.config) }.toMutableList()
     fun getConf(conf_id: dcid) = get_config(conf_id)
 
     fun confId(name: String, cloneFrom: String): Long {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/DecksV16.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/DecksV16.kt
@@ -472,7 +472,12 @@ class DecksV16(private val col: Collection, private val decksBackend: DecksBacke
         decksBackend.remove_deck_config(id)
     }
 
-    fun setConf(grp: DeckConfigV16, id: dcid) {
+    fun setConf(grp: Deck, id: Long) {
+        setConf(DeckV16.Generic(grp), id)
+    }
+
+    @RustCleanup("maybe an issue here - grp was deckConfig in V16")
+    fun setConf(grp: DeckV16, id: dcid) {
         grp.conf = id
         this.save(grp)
     }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/DecksV16.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/DecksV16.kt
@@ -227,8 +227,8 @@ class DecksV16(private val col: Collection, private val decksBackend: DecksBacke
     /** "Add a deck with NAME. Reuse deck if already exists. Return id as int." */
     fun id(name: str, create: bool = true, type: Int = 0): Optional<did> {
         val id = this.id_for_name(name)
-        if (id.isPresent) {
-            return id
+        if (id != null) {
+            return Optional.of(id)
         } else if (!create) {
             return Optional.empty()
         }
@@ -263,8 +263,8 @@ class DecksV16(private val col: Collection, private val decksBackend: DecksBacke
         )
     }
 
-    fun id_for_name(name: str): Optional<did> {
-        return decksBackend.id_for_name(name)
+    fun id_for_name(name: str): did? {
+        return decksBackend.id_for_name(name).orElse(null)
     }
 
     fun get_legacy(did: did): Optional<DeckV16> {
@@ -334,8 +334,8 @@ class DecksV16(private val col: Collection, private val decksBackend: DecksBacke
     /** Get deck with NAME, ignoring case. */
     fun byName(name: str): Optional<DeckV16> {
         val id = this.id_for_name(name)
-        if (id.isPresent) {
-            return this.get_legacy(id.get())
+        if (id != null) {
+            return this.get_legacy(id)
         }
         return Optional.empty()
     }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/DecksV16.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/DecksV16.kt
@@ -218,6 +218,12 @@ class DecksV16(private val col: Collection, private val decksBackend: DecksBacke
         return id(name, true, 0).get()
     }
 
+    @RustCleanup("only for java interface - should be removed")
+    @RustCleanup("This needs major testing - the behavior had changed")
+    fun id_safe(name: String, @Suppress("UNUSED_PARAMETER") type: String): Long {
+        return id(name, create = true, type = 0).get()
+    }
+
     /** "Add a deck with NAME. Reuse deck if already exists. Return id as int." */
     fun id(name: str, create: bool = true, type: Int = 0): Optional<did> {
         val id = this.id_for_name(name)

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/DecksV16.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/DecksV16.kt
@@ -517,6 +517,7 @@ class DecksV16(private val col: Collection, private val decksBackend: DecksBacke
         return add_config_returning_id(name, config)
     }
 
+    fun updateConf(g: DeckConfig) = updateConf(DeckConfigV16.Generic(g), preserve_usn = false)
     fun updateConf(conf: DeckConfigV16, preserve_usn: bool = false) = update_config(conf, preserve_usn)
     fun remConf(id: dcid) = remove_config(id)
     fun confId(name: str, clone_from: Optional<DeckConfigV16> = Optional.empty()) =

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/DecksV16.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/DecksV16.kt
@@ -470,6 +470,12 @@ class DecksV16(private val col: Collection, private val decksBackend: DecksBacke
     // legacy
     fun allConf() = all_config()
     fun getConf(conf_id: dcid) = get_config(conf_id)
+
+    fun confId(name: String, cloneFrom: String): Long {
+        val config: Optional<DeckConfigV16> = Optional.of(DeckConfigV16.Config(JSONObject(cloneFrom)))
+        return add_config_returning_id(name, config)
+    }
+
     fun updateConf(conf: DeckConfigV16, preserve_usn: bool = false) = update_config(conf, preserve_usn)
     fun remConf(id: dcid) = remove_config(id)
     fun confId(name: str, clone_from: Optional<DeckConfigV16> = Optional.empty()) =

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/DecksV16.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/DecksV16.kt
@@ -669,6 +669,10 @@ class DecksV16(private val col: Collection, private val decksBackend: DecksBacke
         return actv
     }
 
+    fun childDids(did: Long, childMap: Decks.Node): List<Long> {
+        return childDids(did, childMapNode(childMap))
+    }
+
     fun child_ids(parent_name: str): Iterable<did> {
         val prefix = parent_name + "::"
         return all_names_and_ids().filter {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/DecksV16.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/DecksV16.kt
@@ -329,12 +329,12 @@ class DecksV16(private val col: Collection, private val decksBackend: DecksBacke
     }
 
     /** Get deck with NAME, ignoring case. */
-    fun byName(name: str): Optional<DeckV16> {
+    fun byName(name: str): Deck? {
         val id = this.id_for_name(name)
         if (id != null) {
-            return this.get_legacy(id).toV16Optional()
+            return this.get_legacy(id)
         }
-        return Optional.empty()
+        return null
     }
 
     fun update(g: Deck) {
@@ -777,19 +777,19 @@ class DecksV16(private val col: Collection, private val decksBackend: DecksBacke
     }
 
     /** All existing parents of name */
-    fun parentsByName(name: str): MutableList<DeckV16> {
+    fun parentsByName(name: str): MutableList<Deck> {
         if (!name.contains("::")) {
             return mutableListOf()
         }
         val names: MutableList<str> = immediate_parent_path(name)
         val head: MutableList<str> = mutableListOf()
-        val parents: MutableList<DeckV16> = mutableListOf()
+        val parents: MutableList<Deck> = mutableListOf()
 
         while (names.isNotNullOrEmpty()) {
             head.append(names.pop(0))
             val deck = this.byName("::".join(head))
-            if (deck.isPresent) {
-                parents.append(deck.get())
+            if (deck != null) {
+                parents.append(deck)
             }
         }
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/DecksV16.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/DecksV16.kt
@@ -411,7 +411,8 @@ class DecksV16(private val col: Collection, private val decksBackend: DecksBacke
         return decksBackend.all_config()
     }
 
-    fun confForDid(did: did): DeckConfigV16 {
+    @RustCleanup("Return v16 config - we return a typed object here")
+    fun confForDid(did: did): DeckConfig {
         val deck = this.get(did, _default = false).toV16Optional()
         assert(deck.isPresent)
         val deckValue = deck.get()
@@ -424,10 +425,10 @@ class DecksV16(private val col: Collection, private val decksBackend: DecksBacke
             }
             val knownConf = conf.get()
             knownConf.dyn = false
-            return knownConf
+            return DeckConfig(knownConf.config)
         }
         // dynamic decks have embedded conf
-        return DeckConfigV16.FilteredDeck(deck.get().getJsonObject())
+        return DeckConfig(DeckConfigV16.FilteredDeck(deck.get().getJsonObject()).config)
     }
 
     fun get_config(conf_id: dcid): Optional<DeckConfigV16> {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/backend/DroidBackend.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/backend/DroidBackend.java
@@ -67,7 +67,7 @@ public interface DroidBackend {
 
     @RustV1Cleanup("backend.newDeckConfigLegacy")
     default DeckConfig new_deck_config_legacy() {
-        return new DeckConfig(Decks.DEFAULT_CONF);
+        return new DeckConfig(Decks.DEFAULT_CONF, DeckConfig.Source.DECK_CONFIG);
     }
 
     void useNewTimezoneCode(Collection col);

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sync/Syncer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sync/Syncer.java
@@ -802,7 +802,7 @@ public class Syncer {
         }
         JSONArray confs = rchg.getJSONArray(1);
         for (JSONObject deckConfig: confs.jsonObjectIterable()) {
-            DeckConfig r = new DeckConfig(deckConfig);
+            DeckConfig r = new DeckConfig(deckConfig, DeckConfig.Source.DECK_CONFIG);
             DeckConfig l = mCol.getDecks().getConf(r.getLong("id"));
             // if missing locally or server is newer, update
             if (l == null || r.getLong("mod") > l.getLong("mod")) {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/utils/PythonExtensions.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/utils/PythonExtensions.kt
@@ -33,8 +33,8 @@ fun <T> len(l: Sequence<T>): Long {
     return l.count().toLong()
 }
 
-fun <T> len(l: List<T>): Long {
-    return l.size.toLong()
+fun <T> len(l: List<T>): Int {
+    return l.size
 }
 
 fun len(l: JSONArray): Long {

--- a/AnkiDroid/src/main/java/com/ichi2/utils/KotlinCleanup.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/KotlinCleanup.kt
@@ -1,0 +1,26 @@
+/*
+ *  Copyright (c) 2021 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.utils
+
+/** Use when code can be changed after further conversion to Kotlin */
+@Target(
+    AnnotationTarget.CLASS, AnnotationTarget.FUNCTION,
+    AnnotationTarget.VALUE_PARAMETER, AnnotationTarget.EXPRESSION
+)
+@Retention(AnnotationRetention.SOURCE)
+@MustBeDocumented
+annotation class KotlinCleanup(val message: String)

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/DecksTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/DecksTest.java
@@ -52,7 +52,7 @@ public class DecksTest extends RobolectricTest {
         for (String deckName: TEST_DECKS) {
             addDeck(deckName);
         }
-        JSONObject brokenDeck = decks.byName("cmxieunwoogyxsctnjmv::INSBGDS");
+        Deck brokenDeck = decks.byName("cmxieunwoogyxsctnjmv::INSBGDS");
         Asserts.notNull(brokenDeck,"We should get deck with given name");
         // Changing the case. That could exists in an old collection or during sync.
         brokenDeck.put("name", "CMXIEUNWOOGYXSCTNJMV::INSBGDS");

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/DecksTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/DecksTest.java
@@ -270,7 +270,7 @@ public class DecksTest extends RobolectricTest {
     @Test
     public void testEnsureParents() throws FilteredAncestor {
         Collection col = getCol();
-        DeckManager decks = col.getDecks();
+        Decks decks = (Decks) col.getDecks();
         addDeck("test");
         String subsubdeck_name = decks._ensureParents("  tESt :: sub :: subdeck");
         assertEquals("test::sub:: subdeck", subsubdeck_name);// Only parents are renamed, not the last deck.
@@ -298,7 +298,7 @@ public class DecksTest extends RobolectricTest {
     @Test
     public void testEnsureParentsNotFiltered() throws FilteredAncestor {
         Collection col = getCol();
-        DeckManager decks = col.getDecks();
+        Decks decks = (Decks) col.getDecks();
         addDeck("test");
         String subsubdeck_name = decks._ensureParentsNotFiltered("  tESt :: sub :: subdeck");
         assertEquals("test::sub:: subdeck", subsubdeck_name);// Only parents are renamed, not the last deck.


### PR DESCRIPTION
This allows DecksV16 to be returned from a V16 collection instance

Related: #8988

Supersedes #9508 (or this PR may go in first to cut down on the reviews for this one)
Blocks #9518

## How Has This Been Tested?

Tests only - we can now start testing for real

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
