### PR TITLE
decks: reset active on reset()

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/DeckManager.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/DeckManager.kt
@@ -194,6 +194,9 @@ abstract class DeckManager {
         return deck.getString("name") + Decks.DECK_SEPARATOR + subdeckName
     }
 
+    @RustCleanup("to be removed")
+    abstract fun update_active()
+
     /*
      * Not in libAnki
      */

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
@@ -1192,6 +1192,12 @@ public class Decks extends DeckManager {
         return get(did).isDyn();
     }
 
+
+    @Override
+    public void update_active() {
+        // intentionally blank
+    }
+
     /*
      * ******************************
      * utils methods

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/DecksV16.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/DecksV16.kt
@@ -620,7 +620,7 @@ class DecksV16(private val col: Collection, private val decksBackend: DecksBacke
     }
 
     /** don't use this, it will likely go away */
-    fun update_active() {
+    override fun update_active() {
         this.select(this.current().id)
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
@@ -215,9 +215,11 @@ public class SchedV2 extends AbstractSched {
         mHaveQueues = false;
         mHaveCounts = false;
         discardCurrentCard();
+        mCol.getDecks().update_active();
     }
 
     public void reset() {
+        mCol.getDecks().update_active();
         _updateCutoff();
         resetCounts(false);
         resetQueues(false);


### PR DESCRIPTION
Taken from https://github.com/ankitects/anki/commit/1cddd6d23e779b618c98e4cb001607e2fa089e49

In the v16 code, `decks.reset_active()` is only called by `sched.reset()`

Since we've split out the scheduler for performance, we want to do this twice.

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
