### PR TITLE
Dynamic Decks: change properties to match V16 of the Rust

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
@@ -109,7 +109,8 @@ public class Decks extends DeckManager {
                 // list of (search, limit, order); we only use first element for now
                 + "\"terms\": [[\"\", 100, 0]],"
                 + "\"resched\": true,"
-                + "\"previewDelay\": 10"
+                + "\"previewDelay\": 10,"
+                + "\"browserCollapsed\": false"
             + "}";
 
     public static final String DEFAULT_CONF = ""

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
@@ -108,7 +108,8 @@ public class Decks extends DeckManager {
                 + "\"separate\": true,"
                 // list of (search, limit, order); we only use first element for now
                 + "\"terms\": [[\"\", 100, 0]],"
-                + "\"resched\": true"
+                + "\"resched\": true,"
+                + "\"previewDelay\": 10"
             + "}";
 
     public static final String DEFAULT_CONF = ""

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
@@ -108,8 +108,7 @@ public class Decks extends DeckManager {
                 + "\"separate\": true,"
                 // list of (search, limit, order); we only use first element for now
                 + "\"terms\": [[\"\", 100, 0]],"
-                + "\"resched\": true,"
-                + "\"return\": true" // currently unused
+                + "\"resched\": true"
             + "}";
 
     public static final String DEFAULT_CONF = ""

--- a/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/CustomStudyDialogTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/CustomStudyDialogTest.java
@@ -95,7 +95,7 @@ public class CustomStudyDialogTest extends RobolectricTest {
         customStudy.remove("mod");
         customStudy.remove("name");
 
-        String expected = "{\"newToday\":[0,0],\"revToday\":[0,0],\"lrnToday\":[0,0],\"timeToday\":[0,0],\"collapsed\":false,\"dyn\":1,\"desc\":\"\",\"usn\":-1,\"delays\":null,\"separate\":true,\"terms\":[[\"deck:\\\"Default\\\" prop:due<=1\",99999,6]],\"resched\":true,\"return\":true}";
+        String expected = "{\"newToday\":[0,0],\"revToday\":[0,0],\"lrnToday\":[0,0],\"timeToday\":[0,0],\"collapsed\":false,\"dyn\":1,\"desc\":\"\",\"usn\":-1,\"delays\":null,\"separate\":true,\"terms\":[[\"deck:\\\"Default\\\" prop:due<=1\",99999,6]],\"resched\":true}";
         assertThat(customStudy.toString(), is(expected));
     }
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/CustomStudyDialogTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/CustomStudyDialogTest.java
@@ -28,7 +28,7 @@ import com.ichi2.anki.dialogs.customstudy.CustomStudyDialogFactory;
 import com.ichi2.libanki.Collection;
 import com.ichi2.libanki.Deck;
 import com.ichi2.libanki.sched.AbstractSched;
-import com.ichi2.testutils.ParametersUtils;
+import com.ichi2.testutils.JsonUtils;
 
 import org.hamcrest.Matchers;
 import org.junit.After;
@@ -95,8 +95,23 @@ public class CustomStudyDialogTest extends RobolectricTest {
         customStudy.remove("mod");
         customStudy.remove("name");
 
-        String expected = "{\"newToday\":[0,0],\"revToday\":[0,0],\"lrnToday\":[0,0],\"timeToday\":[0,0],\"collapsed\":false,\"dyn\":1,\"desc\":\"\",\"usn\":-1,\"delays\":null,\"separate\":true,\"terms\":[[\"deck:\\\"Default\\\" prop:due<=1\",99999,6]],\"resched\":true,\"previewDelay\":10,\"browserCollapsed\":false}";
-        assertThat(customStudy.toString(), is(expected));
+        String expected = "{" +
+                "\"browserCollapsed\":false," +
+                "\"collapsed\":false," +
+                "\"delays\":null," +
+                "\"desc\":\"\"," +
+                "\"dyn\":1," +
+                "\"lrnToday\":[0,0]," +
+                "\"newToday\":[0,0]," +
+                "\"previewDelay\":10," +
+                "\"resched\":true," +
+                "\"revToday\":[0,0]," +
+                "\"separate\":true," +
+                "\"terms\":[[\"deck:\\\"Default\\\" prop:due<=1\",99999,6]]," +
+                "\"timeToday\":[0,0]," +
+                "\"usn\":-1" +
+                "}";
+        assertThat(JsonUtils.toOrderedString(customStudy), is(expected));
     }
 
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/CustomStudyDialogTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/CustomStudyDialogTest.java
@@ -95,7 +95,7 @@ public class CustomStudyDialogTest extends RobolectricTest {
         customStudy.remove("mod");
         customStudy.remove("name");
 
-        String expected = "{\"newToday\":[0,0],\"revToday\":[0,0],\"lrnToday\":[0,0],\"timeToday\":[0,0],\"collapsed\":false,\"dyn\":1,\"desc\":\"\",\"usn\":-1,\"delays\":null,\"separate\":true,\"terms\":[[\"deck:\\\"Default\\\" prop:due<=1\",99999,6]],\"resched\":true}";
+        String expected = "{\"newToday\":[0,0],\"revToday\":[0,0],\"lrnToday\":[0,0],\"timeToday\":[0,0],\"collapsed\":false,\"dyn\":1,\"desc\":\"\",\"usn\":-1,\"delays\":null,\"separate\":true,\"terms\":[[\"deck:\\\"Default\\\" prop:due<=1\",99999,6]],\"resched\":true,\"previewDelay\":10}";
         assertThat(customStudy.toString(), is(expected));
     }
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/CustomStudyDialogTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/CustomStudyDialogTest.java
@@ -95,7 +95,7 @@ public class CustomStudyDialogTest extends RobolectricTest {
         customStudy.remove("mod");
         customStudy.remove("name");
 
-        String expected = "{\"newToday\":[0,0],\"revToday\":[0,0],\"lrnToday\":[0,0],\"timeToday\":[0,0],\"collapsed\":false,\"dyn\":1,\"desc\":\"\",\"usn\":-1,\"delays\":null,\"separate\":true,\"terms\":[[\"deck:\\\"Default\\\" prop:due<=1\",99999,6]],\"resched\":true,\"previewDelay\":10}";
+        String expected = "{\"newToday\":[0,0],\"revToday\":[0,0],\"lrnToday\":[0,0],\"timeToday\":[0,0],\"collapsed\":false,\"dyn\":1,\"desc\":\"\",\"usn\":-1,\"delays\":null,\"separate\":true,\"terms\":[[\"deck:\\\"Default\\\" prop:due<=1\",99999,6]],\"resched\":true,\"previewDelay\":10,\"browserCollapsed\":false}";
         assertThat(customStudy.toString(), is(expected));
     }
 

--- a/AnkiDroid/src/test/java/com/ichi2/testutils/JsonUtils.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/testutils/JsonUtils.kt
@@ -1,0 +1,50 @@
+/*
+ *  Copyright (c) 2021 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.testutils
+
+import com.ichi2.utils.JSONObject
+import org.json.JSONException
+import org.json.JSONStringer
+
+object JsonUtils {
+    /**
+     * Returns the string, using a well-defined order for the keys
+     * COULD_BE_BETTER: This would be much better as a Matcher for JSON
+     * COULD_BE_BETTER: Only handles one level of ordering
+     */
+    @JvmStatic
+    fun JSONObject.toOrderedString(): String {
+        val stringer = JSONStringer()
+        writeTo(stringer)
+        return stringer.toString()
+    }
+
+    private fun JSONObject.iterateEntries() = sequence {
+        for (k in this@iterateEntries) {
+            yield(Pair(k, this@iterateEntries.get(k)))
+        }
+    }
+
+    @Throws(JSONException::class)
+    private fun JSONObject.writeTo(stringer: JSONStringer) {
+        stringer.`object`()
+        for ((key, value) in this.iterateEntries().toList().sortedBy { x -> x.first }) {
+            stringer.key(key).value(value)
+        }
+        stringer.endObject()
+    }
+}


### PR DESCRIPTION
## Purpose / Description
When compared to the V16 schema:

* "return" was missing
* "previewDelay" was 10
* "browserCollapsed" was false

I then ordered the resulting string, as that makes comparisons easier

This doesn't yet fix a unit test, there's one more change which will require a follow-on PR (pending performance discussion)


#8988

## How Has This Been Tested?

One unit test still passes. I'll let CI do the rest

## Learning (optional, can help others)
* https://github.com/ankitects/anki/blob/1fe18718f7aa3b0e295b934f2130079635e86780/rslib/src/decks/schema11.rs#L61-L62
* https://github.com/ankitects/anki/blob/514c73f5478c151a65f0fbca3dd69a1d8c1a5631/rslib/src/decks/mod.rs#L61
* https://github.com/ankitects/anki/blob/1fe18718f7aa3b0e295b934f2130079635e86780/rslib/src/decks/schema11.rs#L94-L95

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
