### PR TITLE
lint[tests]: Copyright and NonPublicNonStaticFieldName

### DIFF
--- a/AnkiDroid/src/test/java/com/ichi2/anki/AbstractFlashcardViewerTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/AbstractFlashcardViewerTest.java
@@ -36,7 +36,7 @@ public class AbstractFlashcardViewerTest extends RobolectricTest {
 
     public static class NonAbstractFlashcardViewer extends AbstractFlashcardViewer {
         public Integer mAnswered;
-        private int lastTime = 0;
+        private int mLastTime = 0;
 
         @Override
         protected void setTitle() {
@@ -58,8 +58,8 @@ public class AbstractFlashcardViewerTest extends RobolectricTest {
 
         @Override
         protected long getElapsedRealTime() {
-            lastTime += AnkiDroidApp.getSharedPrefs(getBaseContext()).getInt(DOUBLE_TAP_TIME_INTERVAL, DEFAULT_DOUBLE_TAP_TIME_INTERVAL);
-            return lastTime;
+            mLastTime += AnkiDroidApp.getSharedPrefs(getBaseContext()).getInt(DOUBLE_TAP_TIME_INTERVAL, DEFAULT_DOUBLE_TAP_TIME_INTERVAL);
+            return mLastTime;
         }
 
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.java
@@ -1,3 +1,19 @@
+/*
+ *  Copyright (c) 2020 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package com.ichi2.anki;
 
 import android.Manifest;

--- a/AnkiDroid/src/test/java/com/ichi2/anki/DeckPickerCheckDatabaseListenerTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/DeckPickerCheckDatabaseListenerTest.java
@@ -35,7 +35,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 @RunWith(AndroidJUnit4.class)
 public class DeckPickerCheckDatabaseListenerTest extends RobolectricTest {
 
-    private DeckPickerTestImpl impl;
+    private DeckPickerTestImpl mImpl;
 
     @Override
     public void setUp() {
@@ -45,8 +45,8 @@ public class DeckPickerCheckDatabaseListenerTest extends RobolectricTest {
                 Robolectric.buildActivity(DeckPickerTestImpl.class, new Intent())
                 .create().start().resume();
         saveControllerForCleanup((controller));
-        impl = controller.get();
-        impl.resetVariables();
+        mImpl = controller.get();
+        mImpl.resetVariables();
     }
 
     @Test
@@ -55,7 +55,7 @@ public class DeckPickerCheckDatabaseListenerTest extends RobolectricTest {
 
         execute(result);
 
-        assertThat("Load Failed dialog should be shown if no data is supplied", impl.didDisplayDialogLoadFailed());
+        assertThat("Load Failed dialog should be shown if no data is supplied", mImpl.didDisplayDialogLoadFailed());
     }
 
     @Test
@@ -65,7 +65,7 @@ public class DeckPickerCheckDatabaseListenerTest extends RobolectricTest {
 
         execute(result);
 
-        assertThat("Load Failed dialog should be shown if empty data is supplied", impl.didDisplayDialogLoadFailed());
+        assertThat("Load Failed dialog should be shown if empty data is supplied", mImpl.didDisplayDialogLoadFailed());
     }
 
     @Test
@@ -75,8 +75,8 @@ public class DeckPickerCheckDatabaseListenerTest extends RobolectricTest {
 
         execute(result);
 
-        assertThat("Load Failed dialog should not be shown if invalid data is supplied", !impl.didDisplayDialogLoadFailed());
-        assertThat("Dialog should be displayed", impl.didDisplayMessage());
+        assertThat("Load Failed dialog should not be shown if invalid data is supplied", !mImpl.didDisplayDialogLoadFailed());
+        assertThat("Dialog should be displayed", mImpl.didDisplayMessage());
     }
 
     @Test
@@ -86,9 +86,9 @@ public class DeckPickerCheckDatabaseListenerTest extends RobolectricTest {
 
         execute(result);
 
-        assertThat("Load Failed dialog should be shown if failed data is supplied", impl.didDisplayDialogLoadFailed());
-        assertThat("Locked Database dialog should be shown if Db was locked", !impl.didDisplayLockedDialog());
-        assertThat("Dialog should not be displayed", !impl.didDisplayMessage());
+        assertThat("Load Failed dialog should be shown if failed data is supplied", mImpl.didDisplayDialogLoadFailed());
+        assertThat("Locked Database dialog should be shown if Db was locked", !mImpl.didDisplayLockedDialog());
+        assertThat("Dialog should not be displayed", !mImpl.didDisplayMessage());
     }
 
     @Test
@@ -98,9 +98,9 @@ public class DeckPickerCheckDatabaseListenerTest extends RobolectricTest {
 
         execute(result);
 
-        assertThat("Load Failed dialog should not be shown if invalid data is supplied", !impl.didDisplayDialogLoadFailed());
-        assertThat("Locked Database dialog should be shown if Db was locked", impl.didDisplayLockedDialog());
-        assertThat("Dialog should not be displayed", !impl.didDisplayMessage());
+        assertThat("Load Failed dialog should not be shown if invalid data is supplied", !mImpl.didDisplayDialogLoadFailed());
+        assertThat("Locked Database dialog should be shown if Db was locked", mImpl.didDisplayLockedDialog());
+        assertThat("Dialog should not be displayed", !mImpl.didDisplayMessage());
     }
 
     @NonNull
@@ -137,7 +137,7 @@ public class DeckPickerCheckDatabaseListenerTest extends RobolectricTest {
     }
 
     private void execute(Pair<Boolean, CheckDatabaseResult> result) {
-        DeckPicker.CheckDatabaseListener listener = getInstance(impl);
+        DeckPicker.CheckDatabaseListener listener = getInstance(mImpl);
 
         listener.onPostExecute(result);
     }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/DeckPickerImportTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/DeckPickerImportTest.java
@@ -53,18 +53,18 @@ public class DeckPickerImportTest extends RobolectricTest {
 
     private static class DeckPickerImport extends DeckPicker {
 
-        private AsyncDialogFragment dialogFragment;
+        private AsyncDialogFragment mDialogFragment;
 
         private Class<?> getAsyncDialogFragmentClass() {
-            if (dialogFragment == null) {
+            if (mDialogFragment == null) {
                 fail("No async fragment shown");
             }
-            return dialogFragment.getClass();
+            return mDialogFragment.getClass();
         }
 
         @Override
         public void showAsyncDialogFragment(AsyncDialogFragment newFragment) {
-            this.dialogFragment = newFragment;
+            this.mDialogFragment = newFragment;
             super.showAsyncDialogFragment(newFragment);
         }
     }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/RobolectricTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/RobolectricTest.java
@@ -87,10 +87,10 @@ public class RobolectricTest implements CollectionGetter {
 
     private static boolean mBackground = true;
 
-    private final ArrayList<ActivityController<?>> controllersForCleanup = new ArrayList<>();
+    private final ArrayList<ActivityController<?>> mControllersForCleanup = new ArrayList<>();
 
     protected void saveControllerForCleanup(ActivityController<?> controller) {
-        controllersForCleanup.add(controller);
+        mControllersForCleanup.add(controller);
     }
 
     protected boolean useInMemoryDatabase() {
@@ -151,7 +151,7 @@ public class RobolectricTest implements CollectionGetter {
     public void tearDown() {
 
         // If you don't clean up your ActivityControllers you will get OOM errors
-        for (ActivityController<?> controller : controllersForCleanup) {
+        for (ActivityController<?> controller : mControllersForCleanup) {
             Timber.d("Calling destroy on controller %s", controller.get().toString());
             try {
                 controller.destroy();
@@ -160,7 +160,7 @@ public class RobolectricTest implements CollectionGetter {
                 // No exception here should halt test execution since tests are over anyway.
             }
         }
-        controllersForCleanup.clear();
+        mControllersForCleanup.clear();
 
         try {
             if (CollectionHelper.getInstance().colIsOpen()) {

--- a/AnkiDroid/src/test/java/com/ichi2/anki/StudyOptionsFragmentTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/StudyOptionsFragmentTest.java
@@ -1,3 +1,19 @@
+/*
+ *  Copyright (c) 2020 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package com.ichi2.anki;
 
 import android.text.Spanned;

--- a/AnkiDroid/src/test/java/com/ichi2/anki/analytics/AnalyticsConstantsTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/analytics/AnalyticsConstantsTest.java
@@ -83,11 +83,11 @@ public class AnalyticsConstantsTest {
 
     @RunWith(Parameterized.class)
     public static class AnalyticsConstantsFieldValuesTest {
-        private final String analyticsString;
+        private final String mAnalyticsString;
 
 
         public AnalyticsConstantsFieldValuesTest(String analyticsString) {
-            this.analyticsString = analyticsString;
+            this.mAnalyticsString = analyticsString;
         }
 
 
@@ -105,7 +105,7 @@ public class AnalyticsConstantsTest {
         @Test
         public void checkAnalyticsString() throws IllegalAccessException {
             assertEquals("Re-check if you renamed any string in the analytics string constants of Actions class or AnalyticsConstantsTest.listOfConstantFields. If so, revert them as those string constants must not change as they are compared in analytics.",
-                    analyticsString, getStringFromReflection(analyticsString));
+                    mAnalyticsString, getStringFromReflection(mAnalyticsString));
         }
 
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/cardviewer/MissingImageHandlerTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/cardviewer/MissingImageHandlerTest.java
@@ -161,12 +161,12 @@ public class MissingImageHandlerTest {
     public void testInefficientImage() {
         //Tests that the runnable passed to processInefficientImage only runs once
         class runTest implements Runnable {
-            private int nTimesRun = 0;
+            private int mNTimesRun = 0;
             @Override
             public void run() {
-                nTimesRun++;
+                mNTimesRun++;
             }
-            public int getNTimesRun() { return nTimesRun; }
+            public int getNTimesRun() { return mNTimesRun; }
         }
         runTest runnableTest = new runTest();
         processInefficientImage(runnableTest);

--- a/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/CustomStudyDialogTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/CustomStudyDialogTest.java
@@ -50,13 +50,13 @@ import static org.mockito.Mockito.*;
 @RunWith(AndroidJUnit4.class)
 public class CustomStudyDialogTest extends RobolectricTest {
 
-    CustomStudyListener mockListener;
+    CustomStudyListener mMockListener;
 
 
     @Override
     public void setUp() {
         super.setUp();
-        mockListener = mock(CustomStudyListener.class);
+        mMockListener = mock(CustomStudyListener.class);
     }
 
 
@@ -64,7 +64,7 @@ public class CustomStudyDialogTest extends RobolectricTest {
     @After
     public void tearDown() {
         super.tearDown();
-        reset(mockListener);
+        reset(mMockListener);
     }
 
 
@@ -76,7 +76,7 @@ public class CustomStudyDialogTest extends RobolectricTest {
                 .getArguments();
 
 
-        CustomStudyDialogFactory factory = new CustomStudyDialogFactory(this::getCol, mockListener);
+        CustomStudyDialogFactory factory = new CustomStudyDialogFactory(this::getCol, mMockListener);
         FragmentScenario<CustomStudyDialog> scenario = FragmentScenario.launch(CustomStudyDialog.class, args, factory);
 
         scenario.moveToState(Lifecycle.State.STARTED);
@@ -134,7 +134,7 @@ public class CustomStudyDialogTest extends RobolectricTest {
         when(mockSched.newCount()).thenReturn(0);
 
 
-        CustomStudyDialogFactory factory = new CustomStudyDialogFactory(() -> mockCollection, mockListener);
+        CustomStudyDialogFactory factory = new CustomStudyDialogFactory(() -> mockCollection, mMockListener);
         FragmentScenario<CustomStudyDialog> scenario = FragmentScenario.launch(CustomStudyDialog.class, args, R.style.Theme_AppCompat, factory);
 
         scenario.moveToState(Lifecycle.State.STARTED);

--- a/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/tags/TagsListTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/tags/TagsListTest.java
@@ -36,7 +36,7 @@ import static org.mockito.Mockito.never;
 public class TagsListTest {
 
 
-    final List<String> SORTED_TAGS = Arrays.asList(
+    static final List<String> SORTED_TAGS = Arrays.asList(
             "colors",
             "faces",
             "programming",
@@ -46,7 +46,7 @@ public class TagsListTest {
             "names"
     );
 
-    final List<String> TAGS = Arrays.asList(
+    static final List<String> TAGS = Arrays.asList(
             "programming",
             "learn",
             "names",
@@ -57,14 +57,14 @@ public class TagsListTest {
     );
 
 
-    final List<String> CHECKED_TAGS = Arrays.asList(
+    static final List<String> CHECKED_TAGS = Arrays.asList(
             "programming",
             "faces",
             "colors"
     );
 
 
-    TagsList TAGS_LIST;
+    TagsList mTagsList;
 
 
     private static <E> List<E> join(List<E> l1, List<E> l2) {
@@ -102,7 +102,7 @@ public class TagsListTest {
 
     @Before
     public void setUp() throws Exception {
-        TAGS_LIST = new TagsList(TAGS, CHECKED_TAGS);
+        mTagsList = new TagsList(TAGS, CHECKED_TAGS);
     }
 
 
@@ -149,105 +149,105 @@ public class TagsListTest {
 
     @Test
     public void test_isChecked_index() {
-        assertTrue("Tag at index 0 should be checked", TAGS_LIST.isChecked(0));
-        assertTrue("Tag at index 3 should be checked", TAGS_LIST.isChecked(3));
-        assertFalse("Tag at index 1 should be unchecked", TAGS_LIST.isChecked(1));
-        assertFalse("Tag at index 6 should be unchecked", TAGS_LIST.isChecked(6));
+        assertTrue("Tag at index 0 should be checked", mTagsList.isChecked(0));
+        assertTrue("Tag at index 3 should be checked", mTagsList.isChecked(3));
+        assertFalse("Tag at index 1 should be unchecked", mTagsList.isChecked(1));
+        assertFalse("Tag at index 6 should be unchecked", mTagsList.isChecked(6));
     }
 
 
     @Test
     public void test_isChecked_object() {
-        assertTrue("'programming' tag should be checked", TAGS_LIST.isChecked("programming"));
-        assertTrue("'faces' tag should be checked", TAGS_LIST.isChecked("faces"));
-        assertFalse("'cars' tag should be unchecked", TAGS_LIST.isChecked("cars"));
-        assertFalse("'flags' tag should be unchecked", TAGS_LIST.isChecked("flags"));
+        assertTrue("'programming' tag should be checked", mTagsList.isChecked("programming"));
+        assertTrue("'faces' tag should be checked", mTagsList.isChecked("faces"));
+        assertFalse("'cars' tag should be unchecked", mTagsList.isChecked("cars"));
+        assertFalse("'flags' tag should be unchecked", mTagsList.isChecked("flags"));
     }
 
 
     @Test
     public void test_add() {
         assertTrue("Adding 'anki' tag should return true, as the 'anki' is a new tag",
-                TAGS_LIST.add("anki"));
+                mTagsList.add("anki"));
         assertFalse("Adding 'colors' tag should return false, as the 'colors' is a already existing tag",
-                TAGS_LIST.add("colors"));
+                mTagsList.add("colors"));
 
         assertEquals("The newly added 'anki' tag should be found when retrieving all tags list",
-                join(TAGS, "anki"), TAGS_LIST.copyOfAllTagList());
+                join(TAGS, "anki"), mTagsList.copyOfAllTagList());
         assertSameElementsIgnoreOrder("Adding operations should have nothing to do with the checked status of tags",
-                CHECKED_TAGS, TAGS_LIST.copyOfCheckedTagList());
+                CHECKED_TAGS, mTagsList.copyOfCheckedTagList());
     }
 
 
     @Test
     public void test_check() {
         assertFalse("Attempting to check tag 'anki' should return false, as 'anki' is not found in all tags list",
-                TAGS_LIST.check("anki")); //not in the list
+                mTagsList.check("anki")); //not in the list
         assertFalse("Attempting to check tag 'colors' should return false, as 'colors' is already checked",
-                TAGS_LIST.check("colors")); // already checked
+                mTagsList.check("colors")); // already checked
         assertTrue("Attempting to check tag 'flags' should return true, as 'flags' is found in all tags and is not already checked",
-                TAGS_LIST.check("flags"));
+                mTagsList.check("flags"));
 
 
         assertEquals("Changing the status of tags to be checked should have noting to do with all tag list",
-                TAGS, TAGS_LIST.copyOfAllTagList());//no change
+                TAGS, mTagsList.copyOfAllTagList());//no change
         assertSameElementsIgnoreOrder("The checked 'flags' tag should be found when retrieving list of checked tag",
-                join(CHECKED_TAGS, "flags"), TAGS_LIST.copyOfCheckedTagList());
+                join(CHECKED_TAGS, "flags"), mTagsList.copyOfCheckedTagList());
     }
 
 
     @Test
     public void test_uncheck() {
         assertFalse("Attempting to uncheck tag 'anki' should return false, as 'anki' is not found in all tags list",
-                TAGS_LIST.uncheck("anki")); //not in the list
+                mTagsList.uncheck("anki")); //not in the list
         assertFalse("Attempting to uncheck tag 'flags' should return false, as 'flags' is already unchecked",
-                TAGS_LIST.uncheck("flags")); // already unchecked
+                mTagsList.uncheck("flags")); // already unchecked
         assertTrue("Attempting to uncheck tag 'colors' should return true, as 'colors' is found in all tags and is checked",
-                TAGS_LIST.uncheck("colors"));
+                mTagsList.uncheck("colors"));
 
 
         assertEquals("Changing the status of tags to be unchecked should have noting to do with all tag list",
-                TAGS, TAGS_LIST.copyOfAllTagList());//no change
+                TAGS, mTagsList.copyOfAllTagList());//no change
         assertSameElementsIgnoreOrder("The unchecked 'colors' tag should be not be found when retrieving list of checked tag",
-                minus(CHECKED_TAGS, "colors"), TAGS_LIST.copyOfCheckedTagList());
+                minus(CHECKED_TAGS, "colors"), mTagsList.copyOfCheckedTagList());
     }
 
 
     @Test
     public void test_toggleAllCheckedStatuses() {
-        assertEquals(TAGS, TAGS_LIST.copyOfAllTagList());
-        assertSameElementsIgnoreOrder(CHECKED_TAGS, TAGS_LIST.copyOfCheckedTagList());
+        assertEquals(TAGS, mTagsList.copyOfAllTagList());
+        assertSameElementsIgnoreOrder(CHECKED_TAGS, mTagsList.copyOfCheckedTagList());
 
-        assertTrue(TAGS_LIST.toggleAllCheckedStatuses());
+        assertTrue(mTagsList.toggleAllCheckedStatuses());
 
-        assertEquals(TAGS, TAGS_LIST.copyOfAllTagList());
-        assertSameElementsIgnoreOrder(TAGS, TAGS_LIST.copyOfCheckedTagList());
+        assertEquals(TAGS, mTagsList.copyOfAllTagList());
+        assertSameElementsIgnoreOrder(TAGS, mTagsList.copyOfCheckedTagList());
 
-        assertTrue(TAGS_LIST.toggleAllCheckedStatuses());
+        assertTrue(mTagsList.toggleAllCheckedStatuses());
 
-        assertEquals(TAGS, TAGS_LIST.copyOfAllTagList());
-        assertSameElementsIgnoreOrder(new ArrayList<>(), TAGS_LIST.copyOfCheckedTagList());
+        assertEquals(TAGS, mTagsList.copyOfAllTagList());
+        assertSameElementsIgnoreOrder(new ArrayList<>(), mTagsList.copyOfCheckedTagList());
     }
 
 
     @Test
     public void test_size_if_checked_have_no_extra_items_not_found_in_allTags() {
-        assertEquals(TAGS.size(), TAGS_LIST.size());
+        assertEquals(TAGS.size(), mTagsList.size());
     }
 
     @Test
     public void test_size_if_checked_have_extra_items_not_found_in_allTags() {
-        TAGS_LIST = new TagsList(TAGS, join(CHECKED_TAGS, "NEW"));
-        assertEquals(TAGS.size() + 1, TAGS_LIST.size());
+        mTagsList = new TagsList(TAGS, join(CHECKED_TAGS, "NEW"));
+        assertEquals(TAGS.size() + 1, mTagsList.size());
     }
 
 
     @Test
     public void test_sort() {
-        assertEquals(TAGS, TAGS_LIST.copyOfAllTagList());
-        TAGS_LIST.sort();
+        assertEquals(TAGS, mTagsList.copyOfAllTagList());
+        mTagsList.sort();
         assertEquals("Calling #sort on TagsList should result on sorting all tags",
-                SORTED_TAGS, TAGS_LIST.copyOfAllTagList());
+                SORTED_TAGS, mTagsList.copyOfAllTagList());
     }
 
 
@@ -255,10 +255,10 @@ public class TagsListTest {
     public void test_sort_will_not_call_collectionsSort() {
         try (MockedStatic<Collections> MockCollection = mockStatic(Collections.class)) {
 
-            assertEquals(TAGS, TAGS_LIST.copyOfAllTagList());
-            TAGS_LIST.sort();
+            assertEquals(TAGS, mTagsList.copyOfAllTagList());
+            mTagsList.sort();
             assertEquals("Calling #sort on TagsList should result on sorting all tags",
-                    SORTED_TAGS, TAGS_LIST.copyOfAllTagList());
+                    SORTED_TAGS, mTagsList.copyOfAllTagList());
 
             MockCollection.verify(() -> Collections.sort(any(), any()), never());
         }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/multimediacard/AudioRecorderTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/multimediacard/AudioRecorderTest.java
@@ -81,19 +81,19 @@ public class AudioRecorderTest extends RobolectricTest {
     public void testRecordingLowSampling() throws IOException {
 
         class initHandlerWithError implements Runnable {
-            private int timesRun = 0;
-            private boolean hasThrown = false;
+            private int mTimesRun = 0;
+            private boolean mHasThrown = false;
             @Override
             public void run() {
-                timesRun++;
-                if(!hasThrown) {
-                    hasThrown = true;
+                mTimesRun++;
+                if(!mHasThrown) {
+                    mHasThrown = true;
                     //the try-catch in AudioRecorder should catch this exception and move to low-sampling mode
                     throw new RuntimeException();
                 }
             }
             public int getTimesRun() {
-                return timesRun;
+                return mTimesRun;
             }
         }
         initHandlerWithError recordingHandler = new initHandlerWithError();

--- a/AnkiDroid/src/test/java/com/ichi2/anki/multimediacard/activity/MultimediaEditFieldActivityTestBase.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/multimediacard/activity/MultimediaEditFieldActivityTestBase.java
@@ -1,3 +1,19 @@
+/*
+ *  Copyright (c) 2020 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package com.ichi2.anki.multimediacard.activity;
 
 import android.Manifest;

--- a/AnkiDroid/src/test/java/com/ichi2/anki/multimediacard/fields/BasicImageFieldControllerTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/multimediacard/fields/BasicImageFieldControllerTest.java
@@ -1,3 +1,19 @@
+/*
+ *  Copyright (c) 2020 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package com.ichi2.anki.multimediacard.fields;
 
 import android.app.Activity;

--- a/AnkiDroid/src/test/java/com/ichi2/anki/multimediacard/fields/ImageFieldTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/multimediacard/fields/ImageFieldTest.java
@@ -1,3 +1,19 @@
+/*
+ *  Copyright (c) 2020 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package com.ichi2.anki.multimediacard.fields;
 
 import com.ichi2.libanki.Collection;

--- a/AnkiDroid/src/test/java/com/ichi2/anki/reviewer/KeyboardShortcutIntegrationTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/reviewer/KeyboardShortcutIntegrationTest.java
@@ -35,7 +35,6 @@ import org.robolectric.Shadows;
 
 import java.io.IOException;
 
-import androidx.annotation.NonNull;
 import androidx.test.core.app.ApplicationProvider;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
@@ -52,7 +51,7 @@ import static org.mockito.Mockito.when;
 @RunWith(AndroidJUnit4.class)
 public class KeyboardShortcutIntegrationTest extends RobolectricTest {
 
-    private Reviewer reviewer;
+    private Reviewer mReviewer;
 
 
     @Before
@@ -61,7 +60,7 @@ public class KeyboardShortcutIntegrationTest extends RobolectricTest {
         super.setUp();
         addNoteUsingBasicModel("Hello", "World");
         Shadows.shadowOf((Application) ApplicationProvider.getApplicationContext()).grantPermissions(Manifest.permission.RECORD_AUDIO);
-        reviewer = super.startActivityNormallyOpenCollectionWithIntent(Reviewer.class, new Intent());
+        mReviewer = super.startActivityNormallyOpenCollectionWithIntent(Reviewer.class, new Intent());
         waitForAsyncTasksToComplete();
     }
 
@@ -162,22 +161,22 @@ public class KeyboardShortcutIntegrationTest extends RobolectricTest {
 
 
     protected void assertStatus(AudioView.Status recording) {
-        assertThat(reviewer.getAudioView().getStatus(), is(recording));
+        assertThat(mReviewer.getAudioView().getStatus(), is(recording));
     }
 
 
     protected AudioPlayer setupPlayerMock() {
-        assertThat(reviewer.openMicToolbar(), is(true));
+        assertThat(mReviewer.openMicToolbar(), is(true));
         AudioPlayer player = mock(AudioPlayer.class);
-        reviewer.getAudioView().setPlayer(player);
+        mReviewer.getAudioView().setPlayer(player);
         return player;
     }
 
 
     protected AudioRecorder setupRecorderMock() {
-        assertThat(reviewer.openMicToolbar(), is(true));
+        assertThat(mReviewer.openMicToolbar(), is(true));
         AudioRecorder recorder = mock(AudioRecorder.class);
-        reviewer.getAudioView().setRecorder(recorder);
+        mReviewer.getAudioView().setRecorder(recorder);
         return recorder;
     }
 
@@ -193,9 +192,9 @@ public class KeyboardShortcutIntegrationTest extends RobolectricTest {
 
         KeyEvent vKey = KeyEventUtils.getVKey();
         when(vKey.isShiftPressed()).thenReturn(true);
-        reviewer.onKeyDown(KeyEvent.KEYCODE_V, vKey);
+        mReviewer.onKeyDown(KeyEvent.KEYCODE_V, vKey);
         when(vKey.getRepeatCount()).thenReturn(1);
-        reviewer.onKeyDown(KeyEvent.KEYCODE_V, vKey);
+        mReviewer.onKeyDown(KeyEvent.KEYCODE_V, vKey);
     }
 
 
@@ -212,14 +211,14 @@ public class KeyboardShortcutIntegrationTest extends RobolectricTest {
         when(mock.getKeyCode()).thenReturn(KeyEvent.KEYCODE_V);
         when(mock.getUnicodeChar()).thenReturn((int) 'v');
         when(mock.getUnicodeChar(anyInt())).thenReturn((int) 'v');
-        reviewer.onKeyUp(KeyEvent.KEYCODE_V, mock);
+        mReviewer.onKeyUp(KeyEvent.KEYCODE_V, mock);
     }
 
 
     private void releaseShiftKey() {
         KeyEvent mock = mock(KeyEvent.class);
         when(mock.getKeyCode()).thenReturn(KeyEvent.KEYCODE_SHIFT_LEFT);
-        reviewer.onKeyUp(KeyEvent.KEYCODE_SHIFT_LEFT, mock);
+        mReviewer.onKeyUp(KeyEvent.KEYCODE_SHIFT_LEFT, mock);
     }
 
     private void depressVKey() {
@@ -227,7 +226,7 @@ public class KeyboardShortcutIntegrationTest extends RobolectricTest {
         when(mock.getKeyCode()).thenReturn(KeyEvent.KEYCODE_V);
         when(mock.getUnicodeChar()).thenReturn((int) 'v');
         when(mock.getUnicodeChar(anyInt())).thenReturn((int) 'v');
-        reviewer.onKeyDown(KeyEvent.KEYCODE_V, mock);
+        mReviewer.onKeyDown(KeyEvent.KEYCODE_V, mock);
     }
 
 
@@ -235,7 +234,7 @@ public class KeyboardShortcutIntegrationTest extends RobolectricTest {
         KeyEvent mock = mock(KeyEvent.class);
         when(mock.isShiftPressed()).thenReturn(true);
         when(mock.getKeyCode()).thenReturn(KeyEvent.KEYCODE_V);
-        reviewer.onKeyDown(KeyEvent.KEYCODE_V, mock);
+        mReviewer.onKeyDown(KeyEvent.KEYCODE_V, mock);
     }
 
 
@@ -253,6 +252,6 @@ public class KeyboardShortcutIntegrationTest extends RobolectricTest {
         when(mock.getSource()).thenReturn(257);
         when(mock.getRepeatCount()).thenReturn(0);
 
-        reviewer.onKeyDown(KeyEvent.KEYCODE_SHIFT_LEFT, mock);
+        mReviewer.onKeyDown(KeyEvent.KEYCODE_SHIFT_LEFT, mock);
     }
 }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/services/NoteServiceTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/services/NoteServiceTest.java
@@ -44,10 +44,10 @@ import static org.junit.Assert.assertThrows;
 @RunWith(AndroidJUnit4.class)
 public class NoteServiceTest extends RobolectricTest {
 
-    Collection testCol;
+    Collection mTestCol;
     @Before
     public void before() {
-        testCol = getCol();
+        mTestCol = getCol();
     }
 
     //temporary folder to test importMediaToDirectory function
@@ -57,12 +57,12 @@ public class NoteServiceTest extends RobolectricTest {
     //tests if the text fields of the notes are the same after calling updateJsonNoteFromMultimediaNote
     @Test
     public void updateJsonNoteTest() {
-        Model testModel = testCol.getModels().byName("Basic");
+        Model testModel = mTestCol.getModels().byName("Basic");
         IMultimediaEditableNote multiMediaNote = NoteService.createEmptyNote(testModel);
         multiMediaNote.getField(0).setText("foo");
         multiMediaNote.getField(1).setText("bar");
 
-        Note basicNote = new Note(testCol, testModel);
+        Note basicNote = new Note(mTestCol, testModel);
         basicNote.setField(0, "this should be changed to foo");
         basicNote.setField(1, "this should be changed to bar");
 
@@ -82,7 +82,7 @@ public class NoteServiceTest extends RobolectricTest {
 
         //model with ID 45
         testModel = new Model("{\"flds\": [{\"name\": \"foo bar\", \"ord\": \"1\"}], \"id\": \"45\"}");
-        Note noteWithID45 = new Note(testCol, testModel);
+        Note noteWithID45 = new Note(mTestCol, testModel);
 
         Throwable expectedException = assertThrows(RuntimeException.class, () -> NoteService.updateJsonNoteFromMultimediaNote(multiMediaNoteWithID42, noteWithID45));
         assertEquals(expectedException.getMessage(), "Source and Destination Note ID do not match.");
@@ -105,9 +105,9 @@ public class NoteServiceTest extends RobolectricTest {
         audioField.setAudioPath(mFile.getAbsolutePath());
         testAudioClip.setField(0, audioField);
 
-        NoteService.saveMedia(testCol, testAudioClip);
+        NoteService.saveMedia(mTestCol, testAudioClip);
 
-        File outFile = new File(testCol.getMedia().dir(), mFile.getName());
+        File outFile = new File(mTestCol.getMedia().dir(), mFile.getName());
 
         assertEquals("path should be equal to the new file made in NoteService.saveMedia", outFile.getAbsolutePath(), audioField.getAudioPath());
 
@@ -131,9 +131,9 @@ public class NoteServiceTest extends RobolectricTest {
         imgField.setImagePath(mFile.getAbsolutePath());
         testImage.setField(0, imgField);
 
-        NoteService.saveMedia(testCol, testImage);
+        NoteService.saveMedia(mTestCol, testImage);
 
-        File outFile = new File(testCol.getMedia().dir(), mFile.getName());
+        File outFile = new File(mTestCol.getMedia().dir(), mFile.getName());
 
         assertEquals("path should be equal to the new file made in NoteService.saveMedia", outFile.getAbsolutePath(), imgField.getImagePath());
     }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/stats/AnkiStatsTaskHandlerTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/stats/AnkiStatsTaskHandlerTest.java
@@ -39,27 +39,27 @@ import static org.mockito.Mockito.*;
 public class AnkiStatsTaskHandlerTest extends RobolectricTest {
 
     @Mock
-    private Collection col;
+    private Collection mCol;
 
     @Mock
-    private TextView view;
+    private TextView mView;
 
     @Before
     public void setUp() {
         MockitoAnnotations.openMocks(this);
-        when(col.getDb()).thenReturn(null);
+        when(mCol.getDb()).thenReturn(null);
     }
 
     @Test
     @SuppressWarnings("deprecation") // #7108: AsyncTask
     public void testCreateReviewSummaryStatistics() throws ExecutionException, InterruptedException {
-        Mockito.verify(col, atMost(0)).getDb();
+        Mockito.verify(mCol, atMost(0)).getDb();
         android.os.AsyncTask<Pair<Collection, TextView>, Void, String> result = AnkiStatsTaskHandler
-                .createReviewSummaryStatistics(col, view);
+                .createReviewSummaryStatistics(mCol, mView);
 
         result.get();
         advanceRobolectricLooper();
 
-        Mockito.verify(col, atLeast(1)).getDb();
+        Mockito.verify(mCol, atLeast(1)).getDb();
     }
 }

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/ExportingTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/ExportingTest.java
@@ -9,24 +9,24 @@ import androidx.test.ext.junit.runners.AndroidJUnit4;
 
 @RunWith(AndroidJUnit4.class)
 public class ExportingTest extends RobolectricTest {
-    private Collection col;
+    private Collection mCol;
 
     /*****************
      ** Exporting    *
      *****************/
     private void setup() {
-        col = getCol();
-        Note note = col.newNote();
+        mCol = getCol();
+        Note note = mCol.newNote();
         note.setItem("Front", "foo");
         note.setItem("Back", "bar<br>");
         note.setTagsFromStr("tag, tag2");
-        col.addNote(note);
+        mCol.addNote(note);
         // with a different col
-        note = col.newNote();
+        note = mCol.newNote();
         note.setItem("Front", "baz");
         note.setItem("Back", "qux");
         note.model().put("did", addDeck("new col"));
-        col.addNote(note);
+        mCol.addNote(note);
     }
 
 

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/TextCardExporterTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/TextCardExporterTest.java
@@ -34,27 +34,27 @@ import static org.junit.Assert.assertEquals;
 
 @RunWith(AndroidJUnit4.class)
 public class TextCardExporterTest extends RobolectricTest {
-    private Collection col;
-    private List<Note> noteList = new ArrayList<Note>();
+    private Collection mCol;
+    private final List<Note> mNoteList = new ArrayList<>();
 
 
     @Before
     public void setUp() {
         super.setUp();
-        col = getCol();
-        Note note = col.newNote();
+        mCol = getCol();
+        Note note = mCol.newNote();
         note.setItem("Front", "foo");
         note.setItem("Back", "bar<br>");
         note.setTagsFromStr("tag, tag2");
-        col.addNote(note);
-        noteList.add(note);
+        mCol.addNote(note);
+        mNoteList.add(note);
         // with a different note
-        note = col.newNote();
+        note = mCol.newNote();
         note.setItem("Front", "baz");
         note.setItem("Back", "qux");
         note.model().put("did", addDeck("new col"));
-        col.addNote(note);
-        noteList.add(note);
+        mCol.addNote(note);
+        mNoteList.add(note);
     }
 
 
@@ -63,14 +63,14 @@ public class TextCardExporterTest extends RobolectricTest {
         Path tempExportDir = Files.createTempDirectory("AnkiDroid-test_export_textcard");
         File exportedFile = new File(tempExportDir.toFile(), "export.txt");
 
-        TextCardExporter exporter = new TextCardExporter(col, true);
+        TextCardExporter exporter = new TextCardExporter(mCol, true);
         exporter.doExport(exportedFile.getAbsolutePath());
         String content = new String(Files.readAllBytes(Paths.get(exportedFile.getAbsolutePath())));
         String expected = "";
         // Alternatively we can choose to strip styling from content, instead of adding styling to expected
-        expected += String.format(Locale.US, "<style>%s</style>", noteList.get(0).model().getString("css"));
+        expected += String.format(Locale.US, "<style>%s</style>", mNoteList.get(0).model().getString("css"));
         expected += "foo\tbar<br>\n";
-        expected += String.format(Locale.US, "<style>%s</style>", noteList.get(1).model().getString("css"));
+        expected += String.format(Locale.US, "<style>%s</style>", mNoteList.get(1).model().getString("css"));
         expected += "baz\tqux\n";
         assertEquals(expected, content);
     }
@@ -81,7 +81,7 @@ public class TextCardExporterTest extends RobolectricTest {
         Path tempExportDir = Files.createTempDirectory("AnkiDroid-test_export_textcard");
         File exportedFile = new File(tempExportDir.toFile(), "export.txt");
 
-        TextCardExporter exporter = new TextCardExporter(col, false);
+        TextCardExporter exporter = new TextCardExporter(mCol, false);
         exporter.doExport(exportedFile.getAbsolutePath());
         String content = new String(Files.readAllBytes(Paths.get(exportedFile.getAbsolutePath())));
         String expected = "foo\tbar\nbaz\tqux\n";

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/UtilsIntegrationTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/UtilsIntegrationTest.java
@@ -1,3 +1,19 @@
+/*
+ *  Copyright (c) 2020 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package com.ichi2.libanki;
 
 import com.ichi2.anki.RobolectricTest;

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/sched/AbstractSchedTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/sched/AbstractSchedTest.java
@@ -209,23 +209,23 @@ public class AbstractSchedTest extends RobolectricTest {
 
 
     private class IncreaseToday {
-        private final long aId, bId, cId, dId;
-        private final DeckManager decks;
-        private final AbstractSched sched;
+        private final long mAId, mBId, mCId, mDId;
+        private final DeckManager mDecks;
+        private final AbstractSched mSched;
 
         public IncreaseToday() {
-            decks = getCol().getDecks();
-            sched = getCol().getSched();
-            aId = addDeck("A");
-            bId = addDeck("A::B");
-            cId = addDeck("A::B::C");
-            dId = addDeck("A::B::D");
+            mDecks = getCol().getDecks();
+            mSched = getCol().getSched();
+            mAId = addDeck("A");
+            mBId = addDeck("A::B");
+            mCId = addDeck("A::B::C");
+            mDId = addDeck("A::B::D");
         }
 
         private void assertNewCountIs(String explanation, long did, int expected) {
-            decks.select(did);
-            sched.resetCounts();
-            assertThat(explanation, sched.newCount(), is(expected));
+            mDecks.select(did);
+            mSched.resetCounts();
+            assertThat(explanation, mSched.newCount(), is(expected));
         }
 
         private void increaseAndAssertNewCountsIs(String explanation, long did, int a, int b, int c, int d) {
@@ -234,28 +234,28 @@ public class AbstractSchedTest extends RobolectricTest {
         }
 
         private void assertNewCountsIs(String explanation, int a, int b, int c, int d) {
-            assertNewCountIs(explanation, aId, a);
-            assertNewCountIs(explanation, bId, b);
-            assertNewCountIs(explanation, cId, c);
-            assertNewCountIs(explanation, dId, d);
+            assertNewCountIs(explanation, mAId, a);
+            assertNewCountIs(explanation, mBId, b);
+            assertNewCountIs(explanation, mCId, c);
+            assertNewCountIs(explanation, mDId, d);
         }
 
         private void extendNew(long did) {
-            decks.select(did);
-            sched.extendLimits(1, 0);
+            mDecks.select(did);
+            mSched.extendLimits(1, 0);
         }
 
         public void test() {
             Collection col = getCol();
             ModelManager models = col.getModels();
 
-            DeckConfig dconf = decks.getConf(1);
+            DeckConfig dconf = mDecks.getConf(1);
             assertThat(dconf, notNullValue());
             dconf.getJSONObject("new").put("perDay", 0);
-            decks.save(dconf);
+            mDecks.save(dconf);
 
             Model model = models.byName("Basic");
-            for (long did : new long[]{cId, dId}) {
+            for (long did : new long[]{mCId, mDId}) {
                 // The note is added in model's did. So change model's did.
                 model.put("did", did);
                 for (int i = 0; i < 4; i++) {
@@ -264,27 +264,27 @@ public class AbstractSchedTest extends RobolectricTest {
             }
 
             assertNewCountsIs("All daily limits are 0", 0, 0, 0, 0);
-            increaseAndAssertNewCountsIs("Adding a review in C add it in its parents too", cId, 1, 1, 1, 0);
-            increaseAndAssertNewCountsIs("Adding a review in A add it in its children too", aId, 2, 2, 2, 1);
-            increaseAndAssertNewCountsIs("Adding a review in B add it in its parents and children too", bId,3, 3, 3, 2);
-            increaseAndAssertNewCountsIs("Adding a review in D add it in its parents too", dId, 4, 4, 3, 3);
-            increaseAndAssertNewCountsIs("Adding a review in D add it in its parents too", dId, 5, 5, 3, 4);
+            increaseAndAssertNewCountsIs("Adding a review in C add it in its parents too", mCId, 1, 1, 1, 0);
+            increaseAndAssertNewCountsIs("Adding a review in A add it in its children too", mAId, 2, 2, 2, 1);
+            increaseAndAssertNewCountsIs("Adding a review in B add it in its parents and children too", mBId,3, 3, 3, 2);
+            increaseAndAssertNewCountsIs("Adding a review in D add it in its parents too", mDId, 4, 4, 3, 3);
+            increaseAndAssertNewCountsIs("Adding a review in D add it in its parents too", mDId, 5, 5, 3, 4);
 
-            decks.select(cId);
+            mDecks.select(mCId);
             col.reset();
             for (int i = 0; i < 3; i++) {
-                Card card = sched.getCard();
-                sched.answerCard(card, sched.answerButtons(card));
+                Card card = mSched.getCard();
+                mSched.answerCard(card, mSched.answerButtons(card));
             }
             assertNewCountsIs("All cards from C are reviewed. Still 4 cards to review in D, but only two available because of A's limit.", 2, 2, 0, 2);
 
-            increaseAndAssertNewCountsIs("Increasing the number of card in C increase it in its parents too. This allow for more review in any children, and in particular in D.", cId, 3, 3, 1, 3);
+            increaseAndAssertNewCountsIs("Increasing the number of card in C increase it in its parents too. This allow for more review in any children, and in particular in D.", mCId, 3, 3, 1, 3);
             // D increase because A's limit changed.
             // This means that increasing C, which is not related to D, can increase D
             // This follows upstream but is really counter-intuitive.
 
 
-            increaseAndAssertNewCountsIs("Adding a review in C add it in its parents too, even if c has no more card. This allow one more card in d.", cId, 4, 4, 1, 4);
+            increaseAndAssertNewCountsIs("Adding a review in C add it in its parents too, even if c has no more card. This allow one more card in d.", mCId, 4, 4, 1, 4);
             /* I would have expected :
              increaseAndAssertNewCountsIs("", cId, 3, 3, 1, 3);
              But it seems that applying "increase c", while not actually increasing c (because there are no more new card)

--- a/AnkiDroid/src/test/java/com/ichi2/preferences/PreferenceExtensionsTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/preferences/PreferenceExtensionsTest.java
@@ -1,3 +1,19 @@
+/*
+ *  Copyright (c) 2020 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package com.ichi2.preferences;
 
 import android.content.SharedPreferences;

--- a/AnkiDroid/src/test/java/com/ichi2/preferences/PreferenceExtensionsTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/preferences/PreferenceExtensionsTest.java
@@ -45,7 +45,7 @@ public class PreferenceExtensionsTest {
     private SharedPreferences mMockPreferences;
 
     @Mock
-    private SharedPreferences.Editor mockEditor;
+    private SharedPreferences.Editor mMockEditor;
 
     private String getOrSetString(String key, Supplier<String> supplier) {
         return PreferenceExtensions.getOrSetString(mMockPreferences, key, supplier);
@@ -56,8 +56,8 @@ public class PreferenceExtensionsTest {
         MockitoAnnotations.openMocks(this);
         Mockito.when(mMockPreferences.contains(VALID_KEY)).thenReturn(true);
         Mockito.when(mMockPreferences.getString(eq(VALID_KEY), anyString())).thenReturn(VALID_RESULT);
-        Mockito.when(mMockPreferences.edit()).thenReturn(mockEditor);
-        Mockito.when(mockEditor.putString(anyString(), anyString())).thenReturn(mockEditor);
+        Mockito.when(mMockPreferences.edit()).thenReturn(mMockEditor);
+        Mockito.when(mMockEditor.putString(anyString(), anyString())).thenReturn(mMockEditor);
     }
 
     private String getForMissingKey() {
@@ -80,8 +80,8 @@ public class PreferenceExtensionsTest {
     @Test
     public void missingKeySetsPreference() {
         getForMissingKey();
-        Mockito.verify(mockEditor).putString(MISSING_KEY, LAMBDA_RETURN);
-        Mockito.verify(mockEditor).apply();
+        Mockito.verify(mMockEditor).putString(MISSING_KEY, LAMBDA_RETURN);
+        Mockito.verify(mMockEditor).apply();
     }
 
     @SuppressWarnings("unused")

--- a/AnkiDroid/src/test/java/com/ichi2/preferences/TimePreferenceTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/preferences/TimePreferenceTest.java
@@ -28,13 +28,13 @@ import static org.junit.Assert.assertEquals;
 
 @RunWith(Parameterized.class)
 public class TimePreferenceTest {
-    private final String parsableHour;
-    private final int expectedHour;
+    private final String mParsableHour;
+    private final int mExpectedHour;
 
 
     public TimePreferenceTest(String parsableHour, int expectedHour) {
-        this.parsableHour = parsableHour;
-        this.expectedHour = expectedHour;
+        this.mParsableHour = parsableHour;
+        this.mExpectedHour = expectedHour;
     }
 
 
@@ -49,8 +49,8 @@ public class TimePreferenceTest {
     
     @Test
     public void shouldParseHours() {
-        int actualHour = TimePreference.parseHours(this.parsableHour);
+        int actualHour = TimePreference.parseHours(this.mParsableHour);
 
-        assertEquals(expectedHour, actualHour);
+        assertEquals(mExpectedHour, actualHour);
     }
 }

--- a/AnkiDroid/src/test/java/com/ichi2/testutils/AnkiAssert.java
+++ b/AnkiDroid/src/test/java/com/ichi2/testutils/AnkiAssert.java
@@ -1,3 +1,19 @@
+/*
+ *  Copyright (c) 2020 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package com.ichi2.testutils;
 
 import android.util.Pair;

--- a/AnkiDroid/src/test/java/com/ichi2/testutils/MockContentResolver.java
+++ b/AnkiDroid/src/test/java/com/ichi2/testutils/MockContentResolver.java
@@ -1,3 +1,19 @@
+/*
+ *  Copyright (c) 2020 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package com.ichi2.testutils;
 
 import android.content.ContentResolver;

--- a/AnkiDroid/src/test/java/com/ichi2/testutils/NullApplication.java
+++ b/AnkiDroid/src/test/java/com/ichi2/testutils/NullApplication.java
@@ -1,3 +1,19 @@
+/*
+ *  Copyright (c) 2020 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package com.ichi2.testutils;
 
 import android.app.Application;

--- a/AnkiDroid/src/test/java/com/ichi2/utils/ArrayUtilTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/utils/ArrayUtilTest.java
@@ -26,13 +26,13 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 public class ArrayUtilTest {
-    private final Integer[] sampleItems = new Integer[] {1, 2, 3, 4, 5, 6};
+    private final Integer[] mSampleItems = new Integer[] {1, 2, 3, 4, 5, 6};
 
 
     @Test
     public void arrayToArrayList() {
         List<Integer> list = new ArrayList<>();
-        Collections.addAll(list, sampleItems);
-        assertThat(ArrayUtil.toArrayList(sampleItems), is(list));
+        Collections.addAll(list, mSampleItems);
+        assertThat(ArrayUtil.toArrayList(mSampleItems), is(list));
     }
 }

--- a/AnkiDroid/src/test/java/com/ichi2/utils/CollectionUtilsTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/utils/CollectionUtilsTest.java
@@ -16,7 +16,6 @@
 
 package com.ichi2.utils;
 
-import org.hamcrest.Matchers;
 import org.junit.Test;
 
 import java.util.ArrayList;
@@ -28,7 +27,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 
 public class CollectionUtilsTest {
 
-    List<Integer> testList = new ArrayList<Integer>() {{
+    List<Integer> mTestList = new ArrayList<Integer>() {{
         add(1);
         add(2);
         add(3);
@@ -36,7 +35,7 @@ public class CollectionUtilsTest {
 
     @Test
     public void testGetLastListElement() {
-        assertThat(CollectionUtils.getLastListElement(testList), is(3));
+        assertThat(CollectionUtils.getLastListElement(mTestList), is(3));
     }
 
     @Test(expected = IndexOutOfBoundsException.class)
@@ -48,7 +47,7 @@ public class CollectionUtilsTest {
     @Test
     public void testAddAll() {
         List<Integer> toTest = new ArrayList<>();
-        CollectionUtils.addAll(toTest, testList);
+        CollectionUtils.addAll(toTest, mTestList);
         assertEqualsArrayList(new Integer [] {1, 2, 3}, toTest);
     }
 }

--- a/AnkiDroid/src/test/java/com/ichi2/utils/DeckNameComparatorTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/utils/DeckNameComparatorTest.java
@@ -9,18 +9,18 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 public class DeckNameComparatorTest {
-    private DeckNameComparator deckNameComparator;
+    private DeckNameComparator mDeckNameComparator;
 
     @Before
     public void setUp() {
-        deckNameComparator = new DeckNameComparator();
+        mDeckNameComparator = new DeckNameComparator();
     }
 
     //Testing DeckNameComparator by sorting an array of deck names.
     @Test
     public void sortDeckNames() {
         String[] deckNames = new String[]{"AA", "ab", "BB", "aa", "aa::bb", "aa::ab", "aa::ab::Aa", "aa::ab::aB", "aa::ab:bB"};
-        sort(deckNames, deckNameComparator);
+        sort(deckNames, mDeckNameComparator);
 
         assertThat(deckNames, is(new String[]{"AA", "aa", "aa::ab", "aa::ab::Aa", "aa::ab::aB", "aa::ab:bB", "aa::bb", "ab", "BB"}));
     }

--- a/AnkiDroid/src/test/java/com/ichi2/utils/FileUtilTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/utils/FileUtilTest.java
@@ -44,7 +44,7 @@ public class FileUtilTest {
 
     @Rule
     public TemporaryFolder temporaryFolder = new TemporaryFolder();
-    long testFolderSize;
+    long mTestFolderSize;
 
     private static class DummyListener implements ProgressSenderAndCancelListener<Integer> {
         @Override
@@ -95,7 +95,7 @@ public class FileUtilTest {
         for (int i = 0; i < files.size(); ++i) {
             final File file = files.get(i);
             writeStringToFile(file, "File " + (i + 1) + " called " + file.getName());
-            testFolderSize += file.length();
+            mTestFolderSize += file.length();
         }
 
         return grandParentDir;
@@ -182,7 +182,7 @@ public class FileUtilTest {
 
         // Test for success scenario
         File dir = createSrcFilesForTest(temporaryRootDir, "dir");
-        assertEquals(FileUtil.getDirectorySize(dir), testFolderSize);
+        assertEquals(FileUtil.getDirectorySize(dir), mTestFolderSize);
 
         // Test for failure scenario by passing a file as an argument instead of a directory
         assertThrows(IOException.class, () -> FileUtil.getDirectorySize(new File(dir, "file1.txt")));

--- a/AnkiDroid/src/test/java/com/ichi2/utils/JSONObjectTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/utils/JSONObjectTest.java
@@ -34,7 +34,6 @@ Most of the code is:
 
  */
 package com.ichi2.utils;
-import junit.framework.TestCase;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -47,15 +46,11 @@ import java.util.*;
 import androidx.annotation.NonNull;
 
 
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import java.util.HashMap;
 import java.util.Map;
 
-import androidx.annotation.NonNull;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
 import static junit.framework.TestCase.*;
@@ -964,34 +959,34 @@ public class JSONObjectTest {
     *************************************************************************** */
 
 
-    private final String emptyJson = "{}";
-    private final String correctJsonBasic = "{\"key1\":\"value1\"}";
-    private final String correctJsonNested = "{\"key1\":{\"key1a\":\"value1a\",\"key1b\":\"value1b\"},\"key2\":\"value2\"}";
-    private final String correctJsonWithArray = "{\"key1\":\"value1\",\"key2\":[{\"key2a\":\"value2a\"},{\"key2b\":\"value2b\"}],\"key3\":\"value3\"}";
-    private final String correctJsonNestedWithArray = "{\"key1\":{\"key1a\":\"value1a\",\"key1b\":\"value1b\"},\"key2\":[{\"key2a\":\"value2a\"},{\"key2b\":\"value2b\"}],\"key3\":\"value3\"}";
-    private final String noOpeningBracket = "\"key1\":\"value1\"}";
-    private final String extraOpeningBracket = "{{\"key1\": \"value1\"}";
-    private final String noClosingBracket = "{\"key1\":value1";
-    private final String wrongKeyValueSeparator = "{\"key1\":\"value1\",\"key2\" \"value2\"}";
-    private final String duplicateKey = "{\"key1\":\"value1\",\"key1\":\"value2\"}";
+    private final String mEmptyJson = "{}";
+    private final String mCorrectJsonBasic = "{\"key1\":\"value1\"}";
+    private final String mCorrectJsonNested = "{\"key1\":{\"key1a\":\"value1a\",\"key1b\":\"value1b\"},\"key2\":\"value2\"}";
+    private final String mCorrectJsonWithArray = "{\"key1\":\"value1\",\"key2\":[{\"key2a\":\"value2a\"},{\"key2b\":\"value2b\"}],\"key3\":\"value3\"}";
+    private final String mCorrectJsonNestedWithArray = "{\"key1\":{\"key1a\":\"value1a\",\"key1b\":\"value1b\"},\"key2\":[{\"key2a\":\"value2a\"},{\"key2b\":\"value2b\"}],\"key3\":\"value3\"}";
+    private final String mNoOpeningBracket = "\"key1\":\"value1\"}";
+    private final String mExtraOpeningBracket = "{{\"key1\": \"value1\"}";
+    private final String mNoClosingBracket = "{\"key1\":value1";
+    private final String mWrongKeyValueSeparator = "{\"key1\":\"value1\",\"key2\" \"value2\"}";
+    private final String mDuplicateKey = "{\"key1\":\"value1\",\"key1\":\"value2\"}";
 
-    private JSONObject correctJsonObjectBasic;
-    private JSONObject correctJsonObjectNested;
-    private JSONObject correctJsonObjectWithArray;
-    private JSONObject correctJsonObjectNestedWithArray;
-    Map<String, Boolean> booleanMap;
+    private JSONObject mCorrectJsonObjectBasic;
+    private JSONObject mCorrectJsonObjectNested;
+    private JSONObject mCorrectJsonObjectWithArray;
+    private JSONObject mCorrectJsonObjectNestedWithArray;
+    Map<String, Boolean> mBooleanMap;
 
     @Before
     @Test
     public void setUp() {
-        correctJsonObjectBasic = new JSONObject(correctJsonBasic);
-        correctJsonObjectNested = new JSONObject(correctJsonNested);
-        correctJsonObjectWithArray = new JSONObject(correctJsonWithArray);
-        correctJsonObjectNestedWithArray = new JSONObject(correctJsonNestedWithArray);
+        mCorrectJsonObjectBasic = new JSONObject(mCorrectJsonBasic);
+        mCorrectJsonObjectNested = new JSONObject(mCorrectJsonNested);
+        mCorrectJsonObjectWithArray = new JSONObject(mCorrectJsonWithArray);
+        mCorrectJsonObjectNestedWithArray = new JSONObject(mCorrectJsonNestedWithArray);
 
-        booleanMap = new HashMap<>();
+        mBooleanMap = new HashMap<>();
         for (int i = 0 ; i < 10 ; ++i) {
-            booleanMap.put("key" + i, i%2 == 0);
+            mBooleanMap.put("key" + i, i%2 == 0);
         }
     }
 
@@ -1005,48 +1000,48 @@ public class JSONObjectTest {
     @Test
     public void formatTest() {
         // Correct formats
-        new JSONObject(correctJsonBasic);
-        new JSONObject(correctJsonNested);
-        new JSONObject(correctJsonWithArray);
-        new JSONObject(emptyJson);
+        new JSONObject(mCorrectJsonBasic);
+        new JSONObject(mCorrectJsonNested);
+        new JSONObject(mCorrectJsonWithArray);
+        new JSONObject(mEmptyJson);
 
         // Incorrect formats
-        Assert.assertThrows(JSONException.class, () -> new JSONObject(noOpeningBracket));
-        Assert.assertThrows(JSONException.class, () -> new JSONObject(extraOpeningBracket));
-        Assert.assertThrows(JSONException.class, () -> new JSONObject(noClosingBracket));
-        Assert.assertThrows(JSONException.class, () -> new JSONObject(wrongKeyValueSeparator));
-        Assert.assertThrows(JSONException.class, () -> new JSONObject(duplicateKey));
+        Assert.assertThrows(JSONException.class, () -> new JSONObject(mNoOpeningBracket));
+        Assert.assertThrows(JSONException.class, () -> new JSONObject(mExtraOpeningBracket));
+        Assert.assertThrows(JSONException.class, () -> new JSONObject(mNoClosingBracket));
+        Assert.assertThrows(JSONException.class, () -> new JSONObject(mWrongKeyValueSeparator));
+        Assert.assertThrows(JSONException.class, () -> new JSONObject(mDuplicateKey));
     }
 
     @Test
     public void copyJsonTest() {
-        Assert.assertEquals(correctJsonObjectBasic.toString(), new JSONObject(correctJsonObjectBasic).toString());
-        Assert.assertEquals(correctJsonObjectNested.toString(), new JSONObject(correctJsonObjectNested).toString());
-        Assert.assertEquals(correctJsonObjectWithArray.toString(), new JSONObject(correctJsonObjectWithArray).toString());
+        Assert.assertEquals(mCorrectJsonObjectBasic.toString(), new JSONObject(mCorrectJsonObjectBasic).toString());
+        Assert.assertEquals(mCorrectJsonObjectNested.toString(), new JSONObject(mCorrectJsonObjectNested).toString());
+        Assert.assertEquals(mCorrectJsonObjectWithArray.toString(), new JSONObject(mCorrectJsonObjectWithArray).toString());
     }
 
     @Test
     public void objectToObjectTest() {
-        Assert.assertEquals(correctJsonObjectBasic.toString(), JSONObject.objectToObject(correctJsonObjectBasic).toString());
-        Assert.assertEquals(correctJsonObjectNested.toString(), JSONObject.objectToObject(correctJsonObjectNested).toString());
-        Assert.assertNotEquals(correctJsonObjectNested.toString(), JSONObject.objectToObject(correctJsonObjectWithArray).toString());
+        Assert.assertEquals(mCorrectJsonObjectBasic.toString(), JSONObject.objectToObject(mCorrectJsonObjectBasic).toString());
+        Assert.assertEquals(mCorrectJsonObjectNested.toString(), JSONObject.objectToObject(mCorrectJsonObjectNested).toString());
+        Assert.assertNotEquals(mCorrectJsonObjectNested.toString(), JSONObject.objectToObject(mCorrectJsonObjectWithArray).toString());
     }
 
     @Test
     public void getTest() {
-        JSONObject correctJsonObjectBasicCopy = new JSONObject(correctJsonBasic);
+        JSONObject correctJsonObjectBasicCopy = new JSONObject(mCorrectJsonBasic);
         correctJsonObjectBasicCopy.put("int-key", 2);
         correctJsonObjectBasicCopy.put("int_key", 6);
         correctJsonObjectBasicCopy.put("long_key", 2L);
         correctJsonObjectBasicCopy.put("double_key", 2d);
         correctJsonObjectBasicCopy.putOpt("boolean_key", (boolean) true);
-        correctJsonObjectBasicCopy.putOpt("object_key", correctJsonBasic);
+        correctJsonObjectBasicCopy.putOpt("object_key", mCorrectJsonBasic);
 
         Assert.assertEquals(6, correctJsonObjectBasicCopy.getInt("int_key"));
         Assert.assertEquals(2L, correctJsonObjectBasicCopy.getLong("long_key"));
         Assert.assertEquals(2d, correctJsonObjectBasicCopy.getDouble("double_key"), 1e-10);
         Assert.assertTrue(correctJsonObjectBasicCopy.getBoolean("boolean_key"));
-        Assert.assertEquals(correctJsonBasic, correctJsonObjectBasicCopy.get("object_key"));
+        Assert.assertEquals(mCorrectJsonBasic, correctJsonObjectBasicCopy.get("object_key"));
 
         // Check that putOpt doesn't add pair when one is null
         correctJsonObjectBasicCopy.putOpt("boolean_key_2", null);
@@ -1077,11 +1072,11 @@ public class JSONObjectTest {
         JSONObjectSubType jsonObjectSubType = new JSONObjectSubType();
 
         // Clone base JSONObject Type into JSONObjectSubType
-        correctJsonObjectNestedWithArray.deepClonedInto(jsonObjectSubType);
+        mCorrectJsonObjectNestedWithArray.deepClonedInto(jsonObjectSubType);
 
         // Test by passing result of base JSONObject's toString() to removeQuotes()
         // This is already done in the JSONObjectSubType object
-        Assert.assertEquals(removeQuotes(correctJsonObjectNestedWithArray.toString()), jsonObjectSubType.toString());
+        Assert.assertEquals(removeQuotes(mCorrectJsonObjectNestedWithArray.toString()), jsonObjectSubType.toString());
     }
 
 
@@ -1090,14 +1085,14 @@ public class JSONObjectTest {
      */
     @Test
     public void deepCloneReferenceTest() {
-        JSONObject clone = correctJsonObjectBasic.deepClone();
+        JSONObject clone = mCorrectJsonObjectBasic.deepClone();
         // Both objects should point to different memory address
-        Assert.assertNotEquals(clone, correctJsonObjectBasic);
+        Assert.assertNotEquals(clone, mCorrectJsonObjectBasic);
     }
 
     @Test
     public void fromMapTest() {
-        JSONObject fromMapJsonObject = JSONObject.fromMap(booleanMap);
+        JSONObject fromMapJsonObject = JSONObject.fromMap(mBooleanMap);
         for (int i = 0 ; i < 10 ; ++i) {
             Assert.assertEquals(fromMapJsonObject.getBoolean("key" + i), i%2 == 0);
         }

--- a/AnkiDroid/src/test/java/com/ichi2/utils/MapUtilTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/utils/MapUtilTest.java
@@ -25,27 +25,27 @@ import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 public class MapUtilTest {
-    private Map<Integer, String> map;
+    private Map<Integer, String> mMap;
 
 
     @Before
     public void initializeMap() {
-        map = new HashMap<>();
-        map.put(12, "Anki");
-        map.put(5, "AnkiMobile");
-        map.put(20, "AnkiDroid");
-        map.put(30, "AnkiDesktop");
+        mMap = new HashMap<>();
+        mMap.put(12, "Anki");
+        mMap.put(5, "AnkiMobile");
+        mMap.put(20, "AnkiDroid");
+        mMap.put(30, "AnkiDesktop");
     }
 
 
     @Test
     public void getKeyByValueIsEqualTest() {
-        assertThat(getKeyByValue(map, "AnkiDroid"), is(20));
+        assertThat(getKeyByValue(mMap, "AnkiDroid"), is(20));
     }
 
 
     @Test
     public void getKeyByValueIsNotEqualTest() {
-        assertThat(getKeyByValue(map, "AnkiDesktop"), not(5));
+        assertThat(getKeyByValue(mMap, "AnkiDesktop"), not(5));
     }
 }

--- a/AnkiDroid/src/test/java/com/ichi2/utils/MaxExecFunctionTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/utils/MaxExecFunctionTest.java
@@ -29,40 +29,40 @@ import static org.mockito.Mockito.*;
 @RunWith(AndroidJUnit4.class)
 public class MaxExecFunctionTest extends TestCase {
 
-    private Runnable function;
+    private Runnable mFunction;
 
     @Before
     public void before(){
-        function = mock(Runnable.class);
+        mFunction = mock(Runnable.class);
     }
 
     @Test
     public void doNotExceedMaxExecs(){
-        final MaxExecFunction m = new MaxExecFunction(3,function);
+        final MaxExecFunction m = new MaxExecFunction(3, mFunction);
 
         for (int i = 0; i < 50; i++) {
             m.exec();
         }
 
-        verify(function,times(3)).run();
+        verify(mFunction,times(3)).run();
     }
 
     @Test
     public void onlyOnceForAReference(){
         final Object ref = new Object();
-        final MaxExecFunction m = new MaxExecFunction(3,function);
+        final MaxExecFunction m = new MaxExecFunction(3, mFunction);
 
         for (int i = 0; i < 50; i++) {
             m.execOnceForReference(ref);
         }
 
-        verify(function,times(1)).run();
+        verify(mFunction,times(1)).run();
     }
 
 
     @Test
     public void doNotExceedMaxExecsWithMultipleReferences(){
-        final MaxExecFunction m = new MaxExecFunction(3,function);
+        final MaxExecFunction m = new MaxExecFunction(3, mFunction);
 
         for (int i = 0; i < 10; i++) {
             final Object ref = new Object();
@@ -71,7 +71,7 @@ public class MaxExecFunctionTest extends TestCase {
             }
         }
 
-        verify(function,times(3)).run();
+        verify(mFunction,times(3)).run();
     }
 
 }

--- a/AnkiDroid/src/test/java/com/ichi2/utils/UniqueArrayListTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/utils/UniqueArrayListTest.java
@@ -41,7 +41,7 @@ import static org.mockito.Mockito.never;
 public class UniqueArrayListTest {
 
 
-    private List<String> dupData = Arrays.asList(
+    private List<String> mDupData = Arrays.asList(
             "55",
             "TEst",
             "TEst",
@@ -58,7 +58,7 @@ public class UniqueArrayListTest {
             "55"
     );
 
-    private List<String> noDupData = Arrays.asList(
+    private List<String> mNoDupData = Arrays.asList(
             "55",
             "TEst",
             "12",
@@ -156,8 +156,8 @@ public class UniqueArrayListTest {
 
     @Test
     public void testFromCollection() {
-        UniqueArrayList<String> uniqueArrayList = UniqueArrayList.from(dupData);
-        assertEquals(noDupData, uniqueArrayList);
+        UniqueArrayList<String> uniqueArrayList = UniqueArrayList.from(mDupData);
+        assertEquals(mNoDupData, uniqueArrayList);
 
         uniqueArrayList = new UniqueArrayList<>();
         assertTrue(uniqueArrayList.isEmpty());

--- a/AnkiDroid/src/test/java/com/wildplot/android/rendering/FloatMatcher.java
+++ b/AnkiDroid/src/test/java/com/wildplot/android/rendering/FloatMatcher.java
@@ -3,12 +3,12 @@ package com.wildplot.android.rendering;
 import org.mockito.ArgumentMatcher;
 
 class FloatMatcher implements ArgumentMatcher<Float> {
-    private final double expected;
-    private final double precision;
+    private final double mExpected;
+    private final double mPrecision;
 
     private FloatMatcher(double expectedValue, double precision) {
-        expected = expectedValue;
-        this.precision = precision;
+        mExpected = expectedValue;
+        mPrecision = precision;
     }
 
     static FloatMatcher closeTo(double expectedValue, double precision) {
@@ -17,6 +17,6 @@ class FloatMatcher implements ArgumentMatcher<Float> {
 
     @Override
     public boolean matches(Float actualValue) {
-        return Math.abs(((double) actualValue) - expected) <= precision;
+        return Math.abs(((double) actualValue) - mExpected) <= mPrecision;
     }
 }

--- a/AnkiDroid/src/test/java/com/wildplot/android/rendering/PieChartParameterizedTest.java
+++ b/AnkiDroid/src/test/java/com/wildplot/android/rendering/PieChartParameterizedTest.java
@@ -48,46 +48,46 @@ public class PieChartParameterizedTest {
     public ColorWrap[] colors;
 
     @Mock
-    GraphicsWrap graphics;
+    GraphicsWrap mGraphics;
 
     @Mock
-    PlotSheet plot;
+    PlotSheet mPlot;
 
-    PieChart pieChart;
+    PieChart mPieChart;
 
-    private MockedStatic<Color> colorMockedStatic;
+    private MockedStatic<Color> mColorMockedStatic;
 
     @Before
     public void setUp() {
-        colorMockedStatic = Mockito.mockStatic(Color.class);
+        mColorMockedStatic = Mockito.mockStatic(Color.class);
         MockitoAnnotations.openMocks(this);
         when(Color.argb(anyInt(), anyInt(), anyInt(), anyInt())).thenReturn(0);
-        when(plot.getFrameThickness()).thenReturn(new float[]{0, 0, 0, 0});
+        when(mPlot.getFrameThickness()).thenReturn(new float[]{0, 0, 0, 0});
 
         FontMetricsWrap fm = mock(FontMetricsWrap.class);
         when(fm.getHeight()).thenReturn(10f);
         when(fm.stringWidth(any(String.class))).thenReturn(30f);
-        when(graphics.getFontMetrics()).thenReturn(fm);
+        when(mGraphics.getFontMetrics()).thenReturn(fm);
 
         RectangleWrap r = createRectangleMock(100, 100);
-        when(graphics.getClipBounds()).thenReturn(r);
-        pieChart = new PieChart(plot, values, colors);
+        when(mGraphics.getClipBounds()).thenReturn(r);
+        mPieChart = new PieChart(mPlot, values, colors);
     }
 
     @After
     public void tearDown() {
-        colorMockedStatic.close();
+        mColorMockedStatic.close();
     }
 
     @Test
     public void testPaintDrawsAllArcs() {
-        pieChart.paint(graphics);
+        mPieChart.paint(mGraphics);
         // ordered verification is used to prevent failures when there are tiny adjacent sectors
-        InOrder inOrder = inOrder(graphics);
+        InOrder inOrder = inOrder(mGraphics);
         for (int i = 0; i < values.length; i++) {
             if (arcLengths[i] == 0) continue;
-            inOrder.verify(graphics).setColor(colors[i]);
-            inOrder.verify(graphics).fillArc(anyFloat(), anyFloat(), anyFloat(), anyFloat(),
+            inOrder.verify(mGraphics).setColor(colors[i]);
+            inOrder.verify(mGraphics).fillArc(anyFloat(), anyFloat(), anyFloat(), anyFloat(),
                     floatThat(closeTo(startAngles[i])),
                     floatThat(closeTo(arcLengths[i])));
         }

--- a/AnkiDroid/src/test/java/com/wildplot/android/rendering/PieChartTest.java
+++ b/AnkiDroid/src/test/java/com/wildplot/android/rendering/PieChartTest.java
@@ -28,77 +28,77 @@ public class PieChartTest {
     private static final double PRECISION = 1E-3F;
 
     @Mock
-    private GraphicsWrap graphics;
+    private GraphicsWrap mGraphics;
 
     @Mock
-    private PlotSheet plot;
+    private PlotSheet mPlot;
 
-    private PieChart pieChart;
+    private PieChart mPieChart;
 
-    private MockedStatic<Color> colorMockedStatic;
+    private MockedStatic<Color> mColorMockedStatic;
 
 
     @Before
     public void setUp() {
-        colorMockedStatic = mockStatic(Color.class);
+        mColorMockedStatic = mockStatic(Color.class);
         MockitoAnnotations.openMocks(this);
         when(Color.argb(anyInt(), anyInt(), anyInt(), anyInt())).thenReturn(0);
-        when(plot.getFrameThickness()).thenReturn(new float[]{0, 0, 0, 0});
+        when(mPlot.getFrameThickness()).thenReturn(new float[]{0, 0, 0, 0});
 
         FontMetricsWrap fm = mock(FontMetricsWrap.class);
         when(fm.getHeight()).thenReturn(10f);
         when(fm.stringWidth(anyString())).thenReturn(30f);
-        when(graphics.getFontMetrics()).thenReturn(fm);
+        when(mGraphics.getFontMetrics()).thenReturn(fm);
     }
 
     @After
     public void tearDown() {
-        colorMockedStatic.close();
+        mColorMockedStatic.close();
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void constructorShouldThrowIfSizesMismatch() {
-        new PieChart(plot, new double[]{1, 1}, new ColorWrap[]{ColorWrap.RED});
+        new PieChart(mPlot, new double[]{1, 1}, new ColorWrap[]{ColorWrap.RED});
     }
 
     @Test
     public void paintShouldNotDrawAnythingIfValuesAreZero() {
-        pieChart = new PieChart(plot, new double[]{0, 0}, new ColorWrap[]{
+        mPieChart = new PieChart(mPlot, new double[]{0, 0}, new ColorWrap[]{
                 ColorWrap.RED, ColorWrap.GREEN});
-        pieChart.paint(graphics);
-        verify(graphics, never()).fillArc(anyFloat(), anyFloat(), anyFloat(), anyFloat(),
+        mPieChart.paint(mGraphics);
+        verify(mGraphics, never()).fillArc(anyFloat(), anyFloat(), anyFloat(), anyFloat(),
                 anyFloat(), anyFloat());
     }
 
     @Test
     public void paintShouldDrawFullRedCircleIfOneValue() {
-        pieChart = new PieChart(plot, new double[]{1.}, new ColorWrap[]{
+        mPieChart = new PieChart(mPlot, new double[]{1.}, new ColorWrap[]{
                 ColorWrap.RED});
         RectangleWrap r = createRectangleMock(100, 100);
-        when(graphics.getClipBounds()).thenReturn(r);
-        pieChart.paint(graphics);
-        verify(graphics).setColor(ColorWrap.RED);
-        verify(graphics).fillArc(anyFloat(), anyFloat(), anyFloat(), anyFloat(),
+        when(mGraphics.getClipBounds()).thenReturn(r);
+        mPieChart.paint(mGraphics);
+        verify(mGraphics).setColor(ColorWrap.RED);
+        verify(mGraphics).fillArc(anyFloat(), anyFloat(), anyFloat(), anyFloat(),
                 floatThat(closeTo(-90F)),
                 floatThat(closeTo(360F)));
     }
 
     @Test
     public void paintShouldDrawTwoSectorsWithGivenColors() {
-        pieChart = new PieChart(plot, new double[]{1, 1}, new ColorWrap[]{
+        mPieChart = new PieChart(mPlot, new double[]{1, 1}, new ColorWrap[]{
                 ColorWrap.RED, ColorWrap.GREEN});
         RectangleWrap r = createRectangleMock(100, 100);
-        when(graphics.getClipBounds()).thenReturn(r);
+        when(mGraphics.getClipBounds()).thenReturn(r);
 
-        pieChart.paint(graphics);
+        mPieChart.paint(mGraphics);
 
-        verify(graphics).setColor(ColorWrap.RED);
-        verify(graphics).fillArc(anyFloat(), anyFloat(), anyFloat(), anyFloat(),
+        verify(mGraphics).setColor(ColorWrap.RED);
+        verify(mGraphics).fillArc(anyFloat(), anyFloat(), anyFloat(), anyFloat(),
                 floatThat(closeTo(-90F)),
                 floatThat(closeTo(180F)));
 
-        verify(graphics).setColor(ColorWrap.GREEN);
-        verify(graphics).fillArc(anyFloat(), anyFloat(), anyFloat(), anyFloat(),
+        verify(mGraphics).setColor(ColorWrap.GREEN);
+        verify(mGraphics).fillArc(anyFloat(), anyFloat(), anyFloat(), anyFloat(),
                 floatThat(closeTo(90F)),
                 floatThat(closeTo(180F)));
     }

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/rules/NonPublicNonStaticJavaFieldDetector.java
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/NonPublicNonStaticJavaFieldDetector.java
@@ -27,12 +27,14 @@ import org.jetbrains.uast.UElement;
 import org.jetbrains.uast.UVariable;
 import org.jetbrains.uast.UastVisibility;
 
+import java.util.EnumSet;
+
 /**
  * https://github.com/ankidroid/Anki-Android/wiki/Code-style#non-public-non-static-field-names-should-start-with-m
  */
 public class NonPublicNonStaticJavaFieldDetector extends JavaFieldNamingPatternDetector {
 
-    private static final Implementation implementation = new Implementation(NonPublicNonStaticJavaFieldDetector.class, Scope.JAVA_FILE_SCOPE);
+    private static final Implementation implementation = new Implementation(NonPublicNonStaticJavaFieldDetector.class, EnumSet.of(Scope.JAVA_FILE, Scope.TEST_SOURCES));
 
     public static Issue ISSUE = Issue.create(
             "NonPublicNonStaticFieldName",


### PR DESCRIPTION
## Fixes
Related: #9538 

## Learning (optional, can help others)
Adding `TEST_SCOPE` allows a lint rule to be run in tests, even without `checkTestSources true` in the lint options.

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
