### PR TITLE
style(lint): report lint errors via text on stdout

### DIFF
--- a/lint.gradle
+++ b/lint.gradle
@@ -1,5 +1,9 @@
 android {
     lintOptions {
+        textReport true
+        textOutput "stdout"
+        explainIssues false
+        showAll true
         abortOnError = true
         warningsAsErrors true
         lintConfig file("../lint-release.xml")


### PR DESCRIPTION
This lets you see build errors from lint right where you want them

Fixes #9553

## How Has This Been Tested?

Local runs, works

## Learning (optional, can help others)

lintOptions are documented pretty well and they have a special stdout mode for text output:
https://developer.android.com/reference/tools/gradle-api/7.1/com/android/build/api/dsl/LintOptions

If you do `textOutput = "stdout"` it does not work. It complains it cannot cast String to File, so it is not recognizing it as the special stdout specifier somehow.

If you do `textOutput "stdout"` it works, because...of course.
