### PR TITLE
Add V16 collection classes

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/CollectionV16.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/CollectionV16.kt
@@ -1,0 +1,55 @@
+/*
+ *  Copyright (c) 2021 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.ichi2.libanki
+
+import android.content.Context
+import com.ichi2.libanki.backend.RustConfigBackend
+import com.ichi2.libanki.backend.RustDroidDeckBackend
+import com.ichi2.libanki.backend.RustDroidV16Backend
+import com.ichi2.libanki.backend.RustTagsBackend
+import com.ichi2.libanki.utils.Time
+
+class CollectionV16(
+    context: Context,
+    db: DB,
+    path: String?,
+    server: Boolean,
+    log: Boolean,
+    time: Time,
+    backend: RustDroidV16Backend
+) : Collection(context, db, path, server, log, time, backend) {
+
+    /** Workaround as we shouldn't be overriding members which are used in the constructor */
+    override fun getBackend(): RustDroidV16Backend {
+        return super.getBackend() as RustDroidV16Backend
+    }
+
+    override fun initTags(): TagManager {
+        return TagsV16(this, RustTagsBackend(backend.backend))
+    }
+
+    override fun initDecks(deckConf: String?): DeckManager {
+        return DecksV16(this, RustDroidDeckBackend(backend.backend))
+    }
+
+    override fun initModels(): ModelManager {
+        return ModelsV16(this, backend.backend)
+    }
+
+    override fun initConf(conf: String): ConfigManager {
+        return ConfigV16(RustConfigBackend(backend.backend))
+    }
+}

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/DB.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/DB.java
@@ -31,9 +31,6 @@ import com.ichi2.anki.CollectionHelper;
 import com.ichi2.anki.dialogs.DatabaseErrorDialog;
 import com.ichi2.utils.DatabaseChangeDecorator;
 
-import net.ankiweb.rsdroid.BackendFactory;
-import net.ankiweb.rsdroid.database.RustSQLiteOpenHelperFactory;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
@@ -69,13 +66,13 @@ public class DB {
     /**
      * Open a connection to the SQLite collection database.
      */
-    public DB(String ankiFilename, @Nullable BackendFactory backendFactory) {
+    public DB(String ankiFilename, @Nullable OpenHelperFactory openHelperFactory) {
 
         SupportSQLiteOpenHelper.Configuration configuration = SupportSQLiteOpenHelper.Configuration.builder(AnkiDroidApp.getInstance())
                 .name(ankiFilename)
                 .callback(getDBCallback())
                 .build();
-        SupportSQLiteOpenHelper helper = getSqliteOpenHelperFactory(backendFactory).create(configuration);
+        SupportSQLiteOpenHelper helper = getSqliteOpenHelperFactory(openHelperFactory).create(configuration);
         // Note: This line creates the database and schema when executed using a Rust backend
         mDatabase = new DatabaseChangeDecorator(helper.getWritableDatabase());
         mDatabase.disableWriteAheadLogging();
@@ -95,9 +92,9 @@ public class DB {
     }
 
 
-    private SupportSQLiteOpenHelper.Factory getSqliteOpenHelperFactory(@Nullable BackendFactory backendFactory) {
-        if (backendFactory != null) {
-            return new RustSQLiteOpenHelperFactory(backendFactory);
+    private SupportSQLiteOpenHelper.Factory getSqliteOpenHelperFactory(@Nullable OpenHelperFactory openHelper) {
+        if (openHelper != null) {
+            return openHelper.getFactory();
         }
 
         if (sqliteOpenHelperFactory == null) {
@@ -375,5 +372,10 @@ public class DB {
         } else {
             Timber.w("Not in a transaction. Cannot end transaction.");
         }
+    }
+
+    @FunctionalInterface
+    public interface OpenHelperFactory {
+        SupportSQLiteOpenHelper.Factory getFactory();
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Storage.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Storage.java
@@ -92,7 +92,7 @@ public class Storage {
             }
             db.execute("PRAGMA temp_store = memory");
             // add db to col and do any remaining upgrades
-            Collection col = new Collection(context, db, path, server, log, time, backend);
+            Collection col = backend.createCollection(context, db, path, server, log, time);
             if (ver < Consts.SCHEMA_VERSION) {
                 _upgrade(col, ver);
             } else if (ver > Consts.SCHEMA_VERSION) {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/backend/DroidBackend.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/backend/DroidBackend.java
@@ -16,21 +16,28 @@
 
 package com.ichi2.libanki.backend;
 
+import android.content.Context;
+
 import com.ichi2.libanki.Collection;
 import com.ichi2.libanki.DB;
 import com.ichi2.libanki.DeckConfig;
 import com.ichi2.libanki.Decks;
 import com.ichi2.libanki.backend.exception.BackendNotSupportedException;
 import com.ichi2.libanki.backend.model.SchedTimingToday;
+import com.ichi2.libanki.utils.Time;
 
 import net.ankiweb.rsdroid.RustV1Cleanup;
 
+import androidx.annotation.NonNull;
 import androidx.annotation.VisibleForTesting;
 
 /**
  * Interface to the rust backend listing all currently supported functionality.
  */
 public interface DroidBackend {
+    /** Should only be called from "Storage.java" */
+    Collection createCollection(@NonNull Context context, @NonNull DB db, String path, boolean server, boolean log, @NonNull Time time);
+
     DB openCollectionDatabase(String path);
     void closeCollection();
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/backend/JavaDroidBackend.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/backend/JavaDroidBackend.java
@@ -16,12 +16,17 @@
 
 package com.ichi2.libanki.backend;
 
+import android.content.Context;
+
 import com.ichi2.libanki.Collection;
 import com.ichi2.libanki.DB;
 import com.ichi2.libanki.backend.exception.BackendNotSupportedException;
 import com.ichi2.libanki.backend.model.SchedTimingToday;
+import com.ichi2.libanki.utils.Time;
 
 import net.ankiweb.rsdroid.RustCleanup;
+
+import androidx.annotation.NonNull;
 
 /**
  * A class which implements the Rust backend functionality in Java - this is to allow moving our current Java code to
@@ -31,6 +36,12 @@ import net.ankiweb.rsdroid.RustCleanup;
  */
 @RustCleanup("After the rust conversion is complete - this will be removed")
 public class JavaDroidBackend implements DroidBackend {
+    @Override
+    public Collection createCollection(@NonNull Context context, @NonNull DB db, String path, boolean server, boolean log, @NonNull Time time) {
+        return new Collection(context, db, path, server, log, time, this);
+    }
+
+
     @Override
     public DB openCollectionDatabase(String path) {
         return new DB(path);

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/backend/RustDroidBackend.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/backend/RustDroidBackend.java
@@ -26,6 +26,7 @@ import com.ichi2.libanki.backend.model.SchedTimingTodayProto;
 import com.ichi2.libanki.utils.Time;
 
 import net.ankiweb.rsdroid.BackendFactory;
+import net.ankiweb.rsdroid.database.RustSQLiteOpenHelperFactory;
 
 import BackendProto.AdBackend;
 import androidx.annotation.NonNull;
@@ -49,7 +50,7 @@ public class RustDroidBackend implements DroidBackend {
 
     @Override
     public DB openCollectionDatabase(String path) {
-        return new DB(path, mBackend);
+        return new DB(path, () -> new RustSQLiteOpenHelperFactory(mBackend));
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/backend/RustDroidBackend.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/backend/RustDroidBackend.java
@@ -16,15 +16,19 @@
 
 package com.ichi2.libanki.backend;
 
+import android.content.Context;
+
 import com.ichi2.libanki.Collection;
 import com.ichi2.libanki.DB;
 import com.ichi2.libanki.backend.exception.BackendNotSupportedException;
 import com.ichi2.libanki.backend.model.SchedTimingToday;
 import com.ichi2.libanki.backend.model.SchedTimingTodayProto;
+import com.ichi2.libanki.utils.Time;
 
 import net.ankiweb.rsdroid.BackendFactory;
 
 import BackendProto.AdBackend;
+import androidx.annotation.NonNull;
 
 /** The Backend in Rust */
 public class RustDroidBackend implements DroidBackend {
@@ -38,6 +42,10 @@ public class RustDroidBackend implements DroidBackend {
         this.mBackend = backend;
     }
 
+    @Override
+    public Collection createCollection(@NonNull Context context, @NonNull DB db, String path, boolean server, boolean log, @NonNull Time time) {
+        return new Collection(context, db, path, server, log, time, this);
+    }
 
     @Override
     public DB openCollectionDatabase(String path) {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/backend/RustDroidV16Backend.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/backend/RustDroidV16Backend.kt
@@ -16,6 +16,7 @@
 package com.ichi2.libanki.backend
 
 import android.content.Context
+import androidx.sqlite.db.SupportSQLiteOpenHelper
 import com.ichi2.libanki.Collection
 import com.ichi2.libanki.CollectionV16
 import com.ichi2.libanki.DB
@@ -37,4 +38,28 @@ class RustDroidV16Backend(private val backendFactory: BackendFactory) : RustDroi
 
     override fun createCollection(context: Context, db: DB, path: String?, server: Boolean, log: Boolean, time: Time): Collection =
         CollectionV16(context, db, path, server, log, time, this)
+
+    override fun openCollectionDatabase(path: String?): DB {
+        return DB(path) { RustV2SQLiteOpenHelperFactory(backendFactory) }
+    }
+
+    /**
+     * A [SupportSQLiteOpenHelper.Factory] which will upgrade the collection
+     * to the schema of the backend on open
+     */
+    class RustV2SQLiteOpenHelperFactory(@Suppress("UNUSED") private val backendFactory: BackendFactory) : SupportSQLiteOpenHelper.Factory {
+        override fun create(configuration: SupportSQLiteOpenHelper.Configuration): SupportSQLiteOpenHelper {
+            TODO("Needs backend upgrade")
+            // return RustV2SupportSQLiteOpenHelper(configuration, backendFactory)
+        }
+    }
+    /*
+    Cannot override until a backend upgrade
+    class RustV2SupportSQLiteOpenHelper(configuration: SupportSQLiteOpenHelper.Configuration, backendFactory: BackendFactory?) : RustSupportSQLiteOpenHelper(configuration, backendFactory) {
+        override fun openCollection(backend: BackendV1, configuration: SupportSQLiteOpenHelper.Configuration) {
+            // openCollection upgrades the database to the version of the backend
+            backend.openCollection(configuration.name, "", "", "")
+        }
+    }
+    */
 }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/backend/RustDroidV16Backend.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/backend/RustDroidV16Backend.kt
@@ -1,0 +1,40 @@
+/*
+ *  Copyright (c) 2021 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.ichi2.libanki.backend
+
+import android.content.Context
+import com.ichi2.libanki.Collection
+import com.ichi2.libanki.CollectionV16
+import com.ichi2.libanki.DB
+import com.ichi2.libanki.utils.Time
+import net.ankiweb.rsdroid.BackendFactory
+import net.ankiweb.rsdroid.BackendV1
+
+/**
+ * Unused.
+ *
+ * Signifies that the AnkiDroid backend should be used when accessing the JSON columns in `col`
+ * as these have moved to separate tables
+ */
+class RustDroidV16Backend(private val backendFactory: BackendFactory) : RustDroidBackend(backendFactory) {
+    val backend: BackendV1
+        get() = backendFactory.backend
+
+    override fun databaseCreationInitializesData(): Boolean = true
+
+    override fun createCollection(context: Context, db: DB, path: String?, server: Boolean, log: Boolean, time: Time): Collection =
+        CollectionV16(context, db, path, server, log, time, this)
+}


### PR DESCRIPTION
## Pull Request template

## Purpose / Description

* We introduce a `CollectionV16` class which uses the `V16` classes for models/decks etc...
* We introduce a `RustV2SupportSQLiteOpenHelper` & `RustV2SQLiteOpenHelperFactory` which are Android-based abstractions. 
  * The point is to call `openCollection`, which will have functionality changed in the next release to open + upgrade the collection
  * This is the same behavior as Anki Desktop
* Introduce `RustDroidV16Backend` to combine the above. This class is unused for now, but will be added to `DroidBackendFactory` once a backend release is made

Related: #8988

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
