### PR TITLE
compareNewDatabases: fixes for `conf` and `models`

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
@@ -154,7 +154,7 @@ public class Collection implements CollectionGetter {
             +
             // review options
             "\"activeDecks\": [1], " + "\"curDeck\": 1, " + "\"newSpread\": " + Consts.NEW_CARDS_DISTRIBUTE + ", "
-            + "\"collapseTime\": 1200, " + "\"timeLim\": 0, " + "\"estTimes\": true, " + "\"dueCounts\": true, "
+            + "\"collapseTime\": 1200, " + "\"timeLim\": 0, " + "\"estTimes\": true, " + "\"dueCounts\": true, \"dayLearnFirst\":false, "
             +
             // other config
             "\"curModel\": null, " + "\"nextPos\": 1, " + "\"sortType\": \"noteFld\", "

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Models.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Models.java
@@ -86,7 +86,6 @@ public class Models extends ModelManager {
             + "\"latexsvg\": false,"
             + "\"mod\": 0, "
             + "\"usn\": 0, "
-            + "\"vers\": [], " // FIXME: remove when other clients have caught up
             + "\"type\": "
             + Consts.MODEL_STD
             + ", "

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Models.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Models.java
@@ -100,9 +100,7 @@ public class Models extends ModelManager {
 
     private static final String defaultField = "{\"name\": \"\", " + "\"ord\": null, " + "\"sticky\": false, " +
     // the following alter editing, and are used as defaults for the template wizard
-            "\"rtl\": false, " + "\"font\": \"Arial\", " + "\"size\": 20, " +
-            // reserved for future use
-            "\"media\": [] }";
+            "\"rtl\": false, " + "\"font\": \"Arial\", " + "\"size\": 20 }";
 
     private static final String defaultTemplate = "{\"name\": \"\", " + "\"ord\": null, " + "\"qfmt\": \"\", "
             + "\"afmt\": \"\", " + "\"did\": null, " + "\"bqfmt\": \"\"," + "\"bafmt\": \"\"," + "\"bfont\": \"Arial\"," +

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Models.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Models.java
@@ -105,7 +105,7 @@ public class Models extends ModelManager {
 
     private static final String defaultTemplate = "{\"name\": \"\", " + "\"ord\": null, " + "\"qfmt\": \"\", "
             + "\"afmt\": \"\", " + "\"did\": null, " + "\"bqfmt\": \"\"," + "\"bafmt\": \"\"," + "\"bfont\": \"Arial\"," +
-            "\"bsize\": 12 }";
+            "\"bsize\": 0 }";
 
     // /** Regex pattern used in removing tags from text before diff */
     // private static final Pattern sFactPattern = Pattern.compile("%\\([tT]ags\\)s");

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Models.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Models.java
@@ -90,12 +90,12 @@ public class Models extends ModelManager {
             + Consts.MODEL_STD
             + ", "
             + "\"css\": \".card {\\n"
-            + " font-family: arial;\\n"
-            + " font-size: 20px;\\n"
-            + " text-align: center;\\n"
-            + " color: black;\\n"
-            + " background-color: white;\\n"
-            + "}\""
+            + "  font-family: arial;\\n"
+            + "  font-size: 20px;\\n"
+            + "  text-align: center;\\n"
+            + "  color: black;\\n"
+            + "  background-color: white;\\n"
+            + "}\n\""
             + "}";
 
     private static final String defaultField = "{\"name\": \"\", " + "\"ord\": null, " + "\"sticky\": false, " +

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Models.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Models.java
@@ -83,6 +83,7 @@ public class Models extends ModelManager {
             + "\\\\begin{document}\\n"
             + "\", "
             + "\"latexPost\": \"\\\\end{document}\", "
+            + "\"latexsvg\": false,"
             + "\"mod\": 0, "
             + "\"usn\": 0, "
             + "\"vers\": [], " // FIXME: remove when other clients have caught up

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Storage.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Storage.java
@@ -149,7 +149,7 @@ public class Storage {
         // remove did from notes
         if (db.queryScalar("SELECT ver FROM col") == 2) {
             db.execute("ALTER TABLE notes RENAME TO notes2");
-            _addSchema(db, time);
+            _addSchema(db, true, time);
             db.execute("insert into notes select id, guid, mid, mod, usn, tags, flds, sfld, csum, flags, data from notes2");
             db.execute("DROP TABLE notes2");
             db.execute("UPDATE col SET ver = 3");
@@ -320,17 +320,12 @@ public class Storage {
             db.execute("PRAGMA page_size = 4096");
             db.execute("PRAGMA legacy_file_format = 0");
             db.execute("VACUUM");
-            _addSchema(db, time);
+            _addSchema(db, true, time);
             _updateIndices(db);
         }
 
         db.execute("ANALYZE");
         return Consts.SCHEMA_VERSION;
-    }
-
-
-    private static void _addSchema(DB db, @NonNull Time time) {
-        _addSchema(db, true, time);
     }
 
 

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/StorageTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/StorageTest.java
@@ -20,6 +20,7 @@ import android.database.Cursor;
 
 import com.ichi2.anki.CollectionHelper;
 import com.ichi2.anki.RobolectricTest;
+import com.ichi2.testutils.JsonUtils;
 import com.ichi2.utils.JSONObject;
 
 import org.junit.Test;
@@ -182,15 +183,17 @@ public class StorageTest extends RobolectricTest {
         }
 
 
-        protected void assertConfEqual(CollectionData expected) {
+        protected void assertConfEqual(CollectionData expectedData) {
             JSONObject actualJson = new JSONObject(this.mConf);
-            JSONObject expectedJson = new JSONObject(expected.mConf);
+            JSONObject expectedJson = new JSONObject(expectedData.mConf);
 
             remove(actualJson, expectedJson, "curModel");
             remove(actualJson, expectedJson, "creationOffset");
             remove(actualJson, expectedJson, "localOffset");
 
-            assertThat(actualJson.toString(), is(expectedJson.toString()));
+            String actual = JsonUtils.toOrderedString(actualJson);
+            String expected = JsonUtils.toOrderedString(expectedJson);
+            assertThat(actual, is(expected));
         }
     }
 

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/StorageTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/StorageTest.java
@@ -22,17 +22,18 @@ import com.ichi2.anki.CollectionHelper;
 import com.ichi2.anki.RobolectricTest;
 import com.ichi2.utils.JSONObject;
 
-import org.json.JSONException;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
 
 import androidx.core.util.Pair;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
@@ -54,9 +55,9 @@ public class StorageTest extends RobolectricTest {
 
 
     @Test
-    public void compareNewDatabases() throws JSONException {
+    public void compareNewDatabases() {
 
-        List<Object> expected = getResults();
+        CollectionData expected = getResults();
 
         // If you don't tear down the database you'll get unexpected IllegalStateExceptions related to connections
         CollectionHelper.getInstance().closeCollection(false, "compareNewDatabases");
@@ -66,42 +67,9 @@ public class StorageTest extends RobolectricTest {
 
         Storage.setUseBackend(true);
 
-        List<Object> actual = getResults();
+        CollectionData actual = getResults();
 
-
-        for (int i = 0; i < expected.size(); i++) {
-            if (i == 1 || i == 2 || i == 3) {
-                continue;
-            }
-            if (i == 8) {
-                JSONObject actualJson = new JSONObject(actual.get(i).toString());
-                JSONObject expectedJson = new JSONObject(expected.get(i).toString());
-
-                remove(actualJson, expectedJson, "curModel");
-                remove(actualJson, expectedJson, "creationOffset");
-                remove(actualJson, expectedJson, "localOffset");
-
-                assertThat(actualJson.toString(), is(expectedJson.toString()));
-                continue;
-            }
-
-            if (i == 9) {
-                JSONObject actualJson = new JSONObject(actual.get(i).toString());
-                JSONObject expectedJson = new JSONObject(expected.get(i).toString());
-
-                renameKeys(actualJson);
-                renameKeys(expectedJson);
-
-                for (String k : actualJson) {
-                    remove(actualJson.getJSONObject(k), expectedJson.getJSONObject(k), "id");
-                }
-
-                assertThat(actualJson.toString(4), is(expectedJson.toString(4)));
-                continue;
-            }
-
-            assertThat(Integer.toString(i), actual.get(i), is(expected.get(i)));
-        }
+        actual.assertEqualTo(expected);
     }
 
 
@@ -119,7 +87,7 @@ public class StorageTest extends RobolectricTest {
             keys.add(new Pair<>(name, actualJson.getJSONObject(name).getString("name")));
         }
 
-        keys.sort((x,y) -> x.second.compareTo(y.second));
+        keys.sort(Comparator.comparing(x -> x.second));
 
         for (int i = 0; i < keys.size(); i++) {
             String keyName = keys.get(i).first;
@@ -130,17 +98,100 @@ public class StorageTest extends RobolectricTest {
     }
 
 
-    protected List<Object> getResults() {
-        List<Object> results = new ArrayList<>();
+    protected CollectionData getResults() {
+        CollectionData results = new CollectionData();
         try (Cursor c = getCol().getDb().query("select * from col")) {
             c.moveToFirst();
 
 
             for (int i = 0; i < c.getColumnCount(); i++) {
-                results.add(c.getString(i));
+                results.loadV11(i, c.getString(i));
             }
         }
         return results;
+    }
+
+    public class CollectionData {
+        String mId;
+        String mCrt;
+        String mMod;
+        String mScm;
+        String mVer;
+        String mDty;
+        String mUsn;
+        String mLs;
+        String mConf;
+        String mModels;
+        String mDecks;
+        String mDConf;
+        String mTags;
+
+
+        public void loadV11(int i, String string) {
+            switch (i) {
+                case 0: mId = string; return;
+                case 1: mCrt = string; return;
+                case 2: mMod = string; return;
+                case 3: mScm = string; return;
+                case 4: mVer = string; return;
+                case 5: mDty = string; return;
+                case 6: mUsn = string; return;
+                case 7: mLs = string; return;
+                case 8: mConf = string; return;
+                case 9: mModels = string; return;
+                case 10: mDecks = string; return;
+                case 11: mDConf = string; return;
+                case 12: mTags = string; return;
+                default: throw new IllegalStateException("unknown i: " + i);
+            }
+        }
+
+
+        public void assertEqualTo(CollectionData expected) {
+            assertThat(this.mId, equalTo(expected.mId));
+            // ignore due to timestamp: mCrt
+            // ignore due to timestamp: mMod
+            // ignore due to timestamp: mScm
+            assertThat(this.mVer, equalTo(expected.mVer));
+            assertThat(this.mDty, equalTo(expected.mDty));
+            assertThat(this.mUsn, equalTo(expected.mUsn));
+            assertThat(this.mLs, equalTo(expected.mLs));
+
+            assertConfEqual(expected);
+
+            assertModelsEqual(expected);
+
+            assertThat(this.mDecks, equalTo(expected.mDecks));
+            assertThat(this.mDConf, equalTo(expected.mDConf));
+            assertThat(this.mTags, equalTo(expected.mTags));
+        }
+
+
+        protected void assertModelsEqual(CollectionData expected) {
+            JSONObject actualJson = new JSONObject(this.mModels);
+            JSONObject expectedJson = new JSONObject(expected.mModels);
+
+            renameKeys(actualJson);
+            renameKeys(expectedJson);
+
+            for (String k : actualJson) {
+                remove(actualJson.getJSONObject(k), expectedJson.getJSONObject(k), "id");
+            }
+
+            assertThat(actualJson.toString(4), is(expectedJson.toString(4)));
+        }
+
+
+        protected void assertConfEqual(CollectionData expected) {
+            JSONObject actualJson = new JSONObject(this.mConf);
+            JSONObject expectedJson = new JSONObject(expected.mConf);
+
+            remove(actualJson, expectedJson, "curModel");
+            remove(actualJson, expectedJson, "creationOffset");
+            remove(actualJson, expectedJson, "localOffset");
+
+            assertThat(actualJson.toString(), is(expectedJson.toString()));
+        }
     }
 
 }

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/StorageTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/StorageTest.java
@@ -166,7 +166,17 @@ public class StorageTest extends RobolectricTest {
             }
 
             mConf = col.getConf().toString();
-            throw new NotImplementedException("models etc...");
+            mModels = loadModelsV16(col);
+            throw new NotImplementedException("decks/dconf/tags");
+        }
+
+        /** Extract models from models.all() and reformat as the JSON style used in the `col.models` column */
+        private String loadModelsV16(Collection col) {
+            JSONObject ret = new JSONObject();
+            for (Model m : col.getModels().all()) {
+                ret.put(m.getString("id"), m);
+            }
+            return ret.toString(0);
         }
 
 
@@ -219,18 +229,22 @@ public class StorageTest extends RobolectricTest {
         }
 
 
-        protected void assertModelsEqual(CollectionData expected) {
+        protected void assertModelsEqual(CollectionData expectedData) {
             JSONObject actualJson = new JSONObject(this.mModels);
-            JSONObject expectedJson = new JSONObject(expected.mModels);
+            JSONObject expectedJson = new JSONObject(expectedData.mModels);
 
             renameKeys(actualJson);
             renameKeys(expectedJson);
 
             for (String k : actualJson) {
                 remove(actualJson.getJSONObject(k), expectedJson.getJSONObject(k), "id");
+                // mod is set in V11, but not in V16
+                remove(actualJson.getJSONObject(k), expectedJson.getJSONObject(k), "mod");
             }
 
-            assertThat(actualJson.toString(4), is(expectedJson.toString(4)));
+            String actual = JsonUtils.toOrderedString(actualJson);
+            String expected = JsonUtils.toOrderedString(expectedJson);
+            assertThat(actual, is(expected));
         }
 
 

--- a/AnkiDroid/src/test/java/com/ichi2/testutils/JsonUtils.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/testutils/JsonUtils.kt
@@ -16,6 +16,7 @@
 
 package com.ichi2.testutils
 
+import com.ichi2.utils.JSONArray
 import com.ichi2.utils.JSONObject
 import org.json.JSONException
 import org.json.JSONStringer
@@ -33,6 +34,29 @@ object JsonUtils {
         return stringer.toString()
     }
 
+    @JvmStatic
+    fun JSONArray.toOrderedString(): String {
+        val stringer = JSONStringer()
+        writeTo(stringer)
+        return stringer.toString()
+    }
+
+    private fun JSONArray.values() = sequence {
+        var i = 0
+        while (i < this@values.length()) {
+            yield(this@values[i])
+            i++
+        }
+    }
+
+    private fun JSONArray.writeTo(stringer: JSONStringer) {
+        stringer.array()
+        for (value in this.values()) {
+            stringer.value(toOrderedString(value))
+        }
+        stringer.endArray()
+    }
+
     private fun JSONObject.iterateEntries() = sequence {
         for (k in this@iterateEntries) {
             yield(Pair(k, this@iterateEntries.get(k)))
@@ -43,8 +67,16 @@ object JsonUtils {
     private fun JSONObject.writeTo(stringer: JSONStringer) {
         stringer.`object`()
         for ((key, value) in this.iterateEntries().toList().sortedBy { x -> x.first }) {
-            stringer.key(key).value(value)
+            stringer.key(key).value(toOrderedString(value))
         }
         stringer.endObject()
+    }
+
+    private fun toOrderedString(value: Any): Any {
+        return when (value) {
+            is JSONObject -> { JSONObject(value.toOrderedString()) }
+            is JSONArray -> { JSONArray(value.toOrderedString()) }
+            else -> { value }
+        }
     }
 }


### PR DESCRIPTION
The test is still broken. This is going to require some refactoring work. This is the first stage.

We fix `conf` to match Anki Desktop and extract from an object array to a class

Open to opinions on whether this is a more readable approach

#8988

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
