### PR TITLE
⚠️ Various default data changes for Anki 2.1.34 compatibility

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
@@ -121,7 +121,6 @@ public class Decks extends DeckManager {
                     + "\"delays\": [1, 10],"
                     + "\"ints\": [1, 4, 7]," // 7 is not currently used
                     + "\"initialFactor\": "+Consts.STARTING_FACTOR+","
-                    + "\"separate\": true,"
                     + "\"order\": " + Consts.NEW_CARDS_DUE + ","
                     + "\"perDay\": 20,"
                     // may not be set on old decks
@@ -138,8 +137,6 @@ public class Decks extends DeckManager {
                 + "\"rev\": {"
                     + "\"perDay\": 200,"
                     + "\"ease4\": 1.3,"
-                    + "\"fuzz\": 0.05,"
-                    + "\"minSpace\": 1," // not currently used
                     + "\"ivlFct\": 1,"
                     + "\"maxIvl\": 36500,"
                     // may not be set on old decks

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
@@ -132,7 +132,7 @@ public class Decks extends DeckManager {
                     + "\"minInt\": 1,"
                     + "\"leechFails\": 8,"
                     // type 0=suspend, 1=tagonly
-                    + "\"leechAction\": " + Consts.LEECH_SUSPEND
+                    + "\"leechAction\": " + Consts.LEECH_TAGONLY
                 + "},"
                 + "\"rev\": {"
                     + "\"perDay\": 200,"

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
@@ -90,8 +90,8 @@ public class Decks extends DeckManager {
                 + "\"collapsed\": false,"
                 + "\"browserCollapsed\": false,"
                 // added in beta11
-                + "\"extendNew\": 10,"
-                + "\"extendRev\": 50"
+                + "\"extendNew\": 0,"
+                + "\"extendRev\": 0"
             + "}";
 
     private static final String defaultDynamicDeck = ""

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
@@ -116,6 +116,7 @@ public class Decks extends DeckManager {
     public static final String DEFAULT_CONF = ""
             + "{"
                 + "\"name\": \"Default\","
+                + "\"dyn\": false," // previously optional. Default was false
                 + "\"new\": {"
                     + "\"delays\": [1, 10],"
                     + "\"ints\": [1, 4, 7]," // 7 is not currently used

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
@@ -137,6 +137,7 @@ public class Decks extends DeckManager {
                 + "\"rev\": {"
                     + "\"perDay\": 200,"
                     + "\"ease4\": 1.3,"
+                    + "\"hardFactor\": 1.2,"
                     + "\"ivlFct\": 1,"
                     + "\"maxIvl\": 36500,"
                     // may not be set on old decks

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
@@ -88,6 +88,7 @@ public class Decks extends DeckManager {
                 + "\"desc\": \"\","
                 + "\"dyn\": 0," // anki uses int/bool interchangably here
                 + "\"collapsed\": false,"
+                + "\"browserCollapsed\": false,"
                 // added in beta11
                 + "\"extendNew\": 10,"
                 + "\"extendRev\": 50"

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Models.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Models.java
@@ -295,7 +295,6 @@ public class Models extends ModelManager {
         m.put("mod", mCol.getTime().intTime());
         m.put("flds", new JSONArray());
         m.put("tmpls", new JSONArray());
-        m.put("tags", new JSONArray());
         m.put("id", 0);
         return m;
     }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Models.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Models.java
@@ -103,7 +103,7 @@ public class Models extends ModelManager {
             "\"rtl\": false, " + "\"font\": \"Arial\", " + "\"size\": 20 }";
 
     private static final String defaultTemplate = "{\"name\": \"\", " + "\"ord\": null, " + "\"qfmt\": \"\", "
-            + "\"afmt\": \"\", " + "\"did\": null, " + "\"bqfmt\": \"\"," + "\"bafmt\": \"\"," + "\"bfont\": \"Arial\"," +
+            + "\"afmt\": \"\", " + "\"did\": null, " + "\"bqfmt\": \"\"," + "\"bafmt\": \"\"," + "\"bfont\": \"\"," +
             "\"bsize\": 0 }";
 
     // /** Regex pattern used in removing tags from text before diff */

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/StdModels.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/StdModels.java
@@ -140,7 +140,15 @@ public class StdModels {
         String cardTypeClozeName = AnkiDroidApp.getAppResources().getString(R.string.cloze_model_name);
         JSONObject t = Models.newTemplate(cardTypeClozeName);
         String fmt = "{{cloze:" + txt + "}}";
-        m.put("css", m.getString("css") + ".cloze {" + "font-weight: bold;" + "color: blue;" + "}");
+        m.put("css", m.getString("css") +
+                "\n" +
+                ".cloze {\n" +
+                " font-weight: bold;\n" +
+                " color: blue;\n" +
+                "}\n" +
+                ".nightMode .cloze {\n" +
+                " color: lightblue;\n" +
+                "}\n");
         t.put("qfmt", fmt);
         t.put("afmt", fmt + "<br>\n{{" + fieldExtraName + "}}");
         mm.addTemplateInNewModel(m, t);

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/StdModels.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/StdModels.java
@@ -134,7 +134,7 @@ public class StdModels {
         String txt = AnkiDroidApp.getAppResources().getString(R.string.text_field_name);
         JSONObject fm = mm.newField(txt);
         mm.addFieldInNewModel(m, fm);
-        String fieldExtraName = AnkiDroidApp.getAppResources().getString(R.string.extra_field_name);
+        String fieldExtraName = AnkiDroidApp.getAppResources().getString(R.string.extra_field_name_new);
         fm = mm.newField(fieldExtraName);
         mm.addFieldInNewModel(m, fm);
         String cardTypeClozeName = AnkiDroidApp.getAppResources().getString(R.string.cloze_model_name);

--- a/AnkiDroid/src/main/res/values/18-standard-models.xml
+++ b/AnkiDroid/src/main/res/values/18-standard-models.xml
@@ -5,7 +5,7 @@
     <string name="front_field_name">Front</string>
     <string name="back_field_name">Back</string>
     <string name="text_field_name" comment="Field's name in Cloze Note type">Text</string>
-    <string name="extra_field_name">Extra</string>
+    <string name="extra_field_name_new">Back Extra</string>
     <string name="field_to_ask_front_name">Add Reverse</string>
 
 

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/StorageTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/StorageTest.java
@@ -33,6 +33,7 @@ import java.util.Comparator;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import androidx.core.util.Pair;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
@@ -169,7 +170,11 @@ public class StorageTest extends RobolectricTest {
             mModels = loadModelsV16(col);
             mDecks = loadDecksV16(col);
             mDConf = loadDConf(col);
-            mTags = ""; // by default this is empty
+            mTags = new JSONObject(col.mTags.all().stream()
+                    .map(x -> new Pair<>(x, 0))
+                    .collect(Collectors.toMap(x -> x.first, x -> x.second))
+            )
+                    .toString();
         }
 
 

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/StorageTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/StorageTest.java
@@ -35,6 +35,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import androidx.annotation.NonNull;
 import androidx.core.util.Pair;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
@@ -173,7 +174,7 @@ public class StorageTest extends RobolectricTest {
             mTags = new JSONObject(col.mTags.all().stream()
                     .map(x -> new Pair<>(x, 0))
                     .collect(Collectors.toMap(x -> x.first, x -> x.second))
-            )
+                    )
                     .toString();
         }
 
@@ -247,8 +248,33 @@ public class StorageTest extends RobolectricTest {
 
             assertModelsEqual(expected);
             assertJsonEqual(this.mDecks, expected.mDecks, "mod");
-            assertJsonEqual(this.mDConf, expected.mDConf);
+            assertDConfEqual(this.mDConf, expected.mDConf);
             assertThat(this.mTags, equalTo(expected.mTags));
+        }
+
+
+        private void assertDConfEqual(String actualConf, String expectedConf) {
+            actualConf = removeUnusedNewIntervalValue(actualConf);
+            expectedConf = removeUnusedNewIntervalValue(expectedConf);
+
+            assertJsonEqual(actualConf, expectedConf);
+        }
+
+
+        @NonNull
+        private String removeUnusedNewIntervalValue(String actualDecks) {
+            // remove ints[2] - this is unused. And Anki Desktop is inconsistent with the initial value
+
+            // permalinks for defaults (0 is used):
+            // 0: https://github.com/ankitects/anki/blob/7ba35b7249e1ac829843f365105a13c6209d4f57/rslib/src/deckconfig/schema11.rs#L340
+            // 7: https://github.com/ankitects/anki/blob/7ba35b7249e1ac829843f365105a13c6209d4f57/rslib/src/deckconfig/schema11.rs#L92
+            JSONObject obj = new JSONObject(actualDecks);
+            for (String key : obj.names().toStringList()) {
+                obj.getJSONObject(key).getJSONObject("new").getJSONArray("ints").remove(2);
+            }
+
+
+            return obj.toString();
         }
 
 

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/StorageTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/StorageTest.java
@@ -21,12 +21,14 @@ import android.database.Cursor;
 import com.ichi2.anki.CollectionHelper;
 import com.ichi2.anki.RobolectricTest;
 import com.ichi2.testutils.JsonUtils;
+import com.ichi2.utils.JSONArray;
 import com.ichi2.utils.JSONObject;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -281,11 +283,53 @@ public class StorageTest extends RobolectricTest {
                 remove(actualJson.getJSONObject(k), expectedJson.getJSONObject(k), "id");
                 // mod is set in V11, but not in V16
                 remove(actualJson.getJSONObject(k), expectedJson.getJSONObject(k), "mod");
+
+                removeSingletonReq(actualJson.getJSONObject(k), expectedJson.getJSONObject(k));
+
+
             }
 
             String actual = JsonUtils.toOrderedString(actualJson);
             String expected = JsonUtils.toOrderedString(expectedJson);
             assertThat(actual, is(expected));
+        }
+
+        /** A req over a singleton can either be "any" or "all". Remove singletons which match */
+        private void removeSingletonReq(JSONObject actualJson, JSONObject expectedJson) {
+            JSONArray areq = actualJson.optJSONArray("req");
+            JSONArray ereq = expectedJson.optJSONArray("req");
+
+            if (areq == null || ereq == null) {
+                return;
+            }
+
+            List<Integer> toRemove = new ArrayList<>();
+            for (int i = 0; i < Math.min(areq.length(), ereq.length()); i++) {
+                JSONArray a = areq.getJSONArray(i);
+                JSONArray e = ereq.getJSONArray(i);
+
+                if (areEqualSingletonReqs(a, e)) {
+                    toRemove.add(i);
+                }
+            }
+
+            Collections.reverse(toRemove);
+
+            for (int i : toRemove) {
+                areq.remove(i);
+                ereq.remove(i);
+            }
+        }
+
+
+        private boolean areEqualSingletonReqs(JSONArray a, JSONArray e) {
+            JSONArray areq = a.getJSONArray(2);
+            JSONArray breq = e.getJSONArray(2);
+            if (areq.length() != 1 || breq.length() != 1) {
+                return false;
+            }
+
+            return areq.getInt(0) == breq.getInt(0);
         }
 
 


### PR DESCRIPTION
## Purpose / Description
This almost fixes all the data discrepancies between our version of AnkiDroid, and Anki 2.1.34. I want to make the transition to V16 as simple as possible, and this involves investigating all the data discrepancies to ensure that the V16 code will function as our backend did.

This lets us use the V16 code, while keeping some of the more complex and Android-specific aspects of our code as using Java for now (syncing due to complexity and media due to performance characteristics of Android which need to be checked))

Main changes:

* Extra was renamed to 'Back Extra'. This is a string change
* Cloze now by default does not perform night mode inversion
* Default leech action set to "tag"

There are a number of large changes here, so this should be reviewed with care, and probably thrown to me for pre-alpha testing on my phone. 

Adding @Arthur-Milchior due to the size/scope of this.

## Fixes
Related: #8988

## Approach
* Obtain a V16 collection
* Serialise each `col` value as JSON
* Compare to a new database from V11

Fix our issues to match Anki Desktop

## How Has This Been Tested?

⚠️ Only unit tests

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)