### PR TITLE
fix(deck-options) - Sync Graduating Intervals

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckOptions.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckOptions.java
@@ -226,6 +226,7 @@ public class DeckOptions extends AppCompatPreferenceActivity implements OnShared
 
                                 newInts.put(value);
                                 newInts.put(mOptions.getJSONObject("new").getJSONArray("ints").getInt(1));
+                                newInts.put(mOptions.getJSONObject("new").getJSONArray("ints").optInt(2, 7));
                                 mOptions.getJSONObject("new").put("ints", newInts);
                                 break;
                             }
@@ -234,6 +235,7 @@ public class DeckOptions extends AppCompatPreferenceActivity implements OnShared
 
                                 newInts.put(mOptions.getJSONObject("new").getJSONArray("ints").getInt(0));
                                 newInts.put(value);
+                                newInts.put(mOptions.getJSONObject("new").getJSONArray("ints").optInt(2, 7));
                                 mOptions.getJSONObject("new").put("ints", newInts);
                                 break;
                             }


### PR DESCRIPTION
We were sending a two-element array, rather than a three element array. This was incorrect, but the third element was unused, so it was fine.

The new Anki Desktop backend serialised this array differently, which broke syncing the graduating/easy interval

We fix this by adding a third unused element to `dconf.new.ints`

We default to 7, as this is what Anki Desktop used to use

Checked with dae and he's not fussed with the value as it's currently unused.

Fixes #8889

## How Has This Been Tested?

Tested on my Android 11, easy interval syncs, grad interval syncs
## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
