### PR TITLE
fix(NumberRangePreferenceCompat): use defaults

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/preferences/NumberRangePreferenceCompat.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/preferences/NumberRangePreferenceCompat.kt
@@ -34,23 +34,28 @@ open class NumberRangePreferenceCompat : EditTextPreference {
     constructor(context: Context?, attrs: AttributeSet?, defStyleAttr: Int, defStyleRes: Int) : super(context, attrs, defStyleAttr, defStyleRes) {
         min = getMinFromAttributes(attrs)
         max = getMaxFromAttributes(attrs)
+        defaultValue = getDefaultValueFromAttributes(attrs)
     }
     constructor(context: Context?, attrs: AttributeSet?, defStyleAttr: Int) : super(context, attrs, defStyleAttr) {
         min = getMinFromAttributes(attrs)
         max = getMaxFromAttributes(attrs)
+        defaultValue = getDefaultValueFromAttributes(attrs)
     }
     constructor(context: Context?, attrs: AttributeSet?) : super(context, attrs) {
         min = getMinFromAttributes(attrs)
         max = getMaxFromAttributes(attrs)
+        defaultValue = getDefaultValueFromAttributes(attrs)
     }
-    constructor(context: Context?) : super(context)
+    constructor(context: Context?) : super(context) {
+        defaultValue = null
+    }
+
+    val defaultValue: String?
 
     var min = 0
-        get() = field
-        protected set(value) { field = value }
+        protected set
     var max = 0
-        get() = field
-        private set(value) { field = value }
+        private set
 
     /** The maximum available number of digits */
     val maxDigits: Int get() = max.toString().length
@@ -62,7 +67,7 @@ open class NumberRangePreferenceCompat : EditTextPreference {
      * their Integer equivalents.
      */
     override fun getPersistedString(defaultReturnValue: String?): String? {
-        return getPersistedInt(min).toString()
+        return getPersistedInt(getDefaultValue()).toString()
     }
 
     override fun persistString(value: String): Boolean {
@@ -126,12 +131,29 @@ open class NumberRangePreferenceCompat : EditTextPreference {
     }
 
     /**
+     * Returns the default Value, or null if not specified
+     *
+     * This method should only be called once from the constructor.
+     */
+    private fun getDefaultValueFromAttributes(attrs: AttributeSet?): String? {
+        return attrs?.getAttributeValue("http://schemas.android.com/apk/res/android", "defaultValue")
+    }
+
+    /**
      * Get the persisted value held by this preference.
      *
      * @return the persisted value.
      */
     fun getValue(): Int {
-        return getPersistedInt(min)
+        return getPersistedInt(getDefaultValue())
+    }
+
+    private fun getDefaultValue(): Int {
+        return try {
+            return defaultValue?.toInt() ?: min
+        } catch (e: Exception) {
+            min
+        }
     }
 
     /**


### PR DESCRIPTION
When moving to the new AndroidX preferences, we ported the code.

The previous code did not take the `defaultValue` into account when using `getPersistedString`.

This presumably previously worked. Now it doesn't. So the default value was set to 0. Which disabled backups.

Fixes #9595

## How Has This Been Tested?

I tried to unit test this, but it will require a fair amount of infrastructure (mocking attributes is easy, mocking the context for Preference plumbing is much more complex, and adds an XML dependency for loading the attributes) - 

It's likely best to leave this for a big bang "open preference screen and see default values" test. This would be of much higher utility and will catch almost all regressions.

Tested on my device

## Learning 

If it ain't broke, don't deprecate it. 

If it is broke, at least try to make the replacement easily testable.

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)