### PR TITLE
Dependency updates 20211008

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -315,7 +315,7 @@ dependencies {
     api project(":api")
 
     testImplementation 'org.junit.vintage:junit-vintage-engine:5.8.1'
-    testImplementation 'org.mockito:mockito-inline:3.12.4'
+    testImplementation 'org.mockito:mockito-inline:4.0.0'
     testImplementation "org.mockito.kotlin:mockito-kotlin:3.2.0"
     testImplementation 'org.hamcrest:hamcrest-all:1.3'
     testImplementation 'net.lachlanmckee:timber-junit-rule:1.0.1'


### PR DESCRIPTION

Standard dependency updates PR

Pretty boring set of bumps (a good thing) - even the mockito one which is breaking for them was just deprecation removals on their part and because our build policy is typically to not allow deprecations, it was a non-event for us.