### PR TITLE
Fixes #9384 Kotlin: Compile warnings should break the build

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -234,6 +234,10 @@ task installGitHook(type: Copy) {
 }
 tasks.getByPath(':AnkiDroid:preBuild').dependsOn installGitHook
 
+tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
+    kotlinOptions.allWarningsAsErrors = true
+}
+
 apply from: "./robolectricDownloader.gradle"
 apply from: "./jacoco.gradle"
 apply from: "../lint.gradle"

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiFont.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiFont.kt
@@ -55,13 +55,13 @@ class AnkiFont private constructor(val name: String, private val family: String,
          * Factory for AnkiFont creation. Creates a typeface wrapper from a font file representing.
          *
          * @param ctx Activity context, needed to access assets
-         * @param path Path to typeface file, needed when this is a custom font.
+         * @param filePath Path to typeface file, needed when this is a custom font.
          * @param fromAssets True if the font is to be found in assets of application
          * @return A new AnkiFont object or null if the file can't be interpreted as typeface.
          */
         @JvmStatic
-        fun createAnkiFont(ctx: Context, path: String, fromAssets: Boolean): AnkiFont? {
-            var path = path
+        fun createAnkiFont(ctx: Context, filePath: String, fromAssets: Boolean): AnkiFont? {
+            var path = filePath
             val fontfile = File(path)
             val name = Utils.splitFilename(fontfile.name)[0]
             var family = name
@@ -71,29 +71,29 @@ class AnkiFont private constructor(val name: String, private val family: String,
             }
             val tf = getTypeface(ctx, path) // unable to create typeface
                 ?: return null
-            if (tf.isBold || name.toLowerCase(Locale.ROOT).contains("bold")) {
+            if (tf.isBold || name.lowercase().contains("bold")) {
                 attributes.add("font-weight: bolder;")
                 family = family.replaceFirst("(?i)-?Bold".toRegex(), "")
-            } else if (name.toLowerCase(Locale.ROOT).contains("light")) {
+            } else if (name.lowercase().contains("light")) {
                 attributes.add("font-weight: lighter;")
                 family = family.replaceFirst("(?i)-?Light".toRegex(), "")
             } else {
                 attributes.add("font-weight: normal;")
             }
-            if (tf.isItalic || name.toLowerCase(Locale.ROOT).contains("italic")) {
+            if (tf.isItalic || name.lowercase().contains("italic")) {
                 attributes.add("font-style: italic;")
                 family = family.replaceFirst("(?i)-?Italic".toRegex(), "")
-            } else if (name.toLowerCase(Locale.ROOT).contains("oblique")) {
+            } else if (name.lowercase().contains("oblique")) {
                 attributes.add("font-style: oblique;")
                 family = family.replaceFirst("(?i)-?Oblique".toRegex(), "")
             } else {
                 attributes.add("font-style: normal;")
             }
-            if (name.toLowerCase(Locale.ROOT).contains("condensed") || name.toLowerCase(Locale.ROOT).contains("narrow")) {
+            if (name.lowercase().contains("condensed") || name.lowercase().contains("narrow")) {
                 attributes.add("font-stretch: condensed;")
                 family = family.replaceFirst("(?i)-?Condensed".toRegex(), "")
                 family = family.replaceFirst("(?i)-?Narrow(er)?".toRegex(), "")
-            } else if (name.toLowerCase(Locale.ROOT).contains("expanded") || name.toLowerCase(Locale.ROOT).contains("wide")) {
+            } else if (name.lowercase().contains("expanded") || name.lowercase().contains("wide")) {
                 attributes.add("font-stretch: expanded;")
                 family = family.replaceFirst("(?i)-?Expanded".toRegex(), "")
                 family = family.replaceFirst("(?i)-?Wide(r)?".toRegex(), "")

--- a/AnkiDroid/src/main/java/com/ichi2/anki/UIUtils.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/UIUtils.kt
@@ -96,10 +96,10 @@ object UIUtils {
         length: Int,
         actionTextResource: Int,
         listener: View.OnClickListener?,
-        root: View?,
+        rootView: View?,
         callback: Snackbar.Callback?
     ): Snackbar? {
-        var root = root
+        var root = rootView
         if (root == null) {
             root = activity.findViewById(android.R.id.content)
             if (root == null) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/OnRenderProcessGoneDelegate.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/OnRenderProcessGoneDelegate.kt
@@ -135,7 +135,7 @@ open class OnRenderProcessGoneDelegate(val target: AbstractFlashcardViewer) {
             .positiveText(R.string.dialog_ok)
             .cancelable(false)
             .canceledOnTouchOutside(false)
-            .onPositive { materialDialog: MaterialDialog?, dialogAction: DialogAction? -> onCloseRenderLoopDialog() }
+            .onPositive { _: MaterialDialog?, _: DialogAction? -> onCloseRenderLoopDialog() }
             .show()
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/MappableBinding.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/MappableBinding.kt
@@ -161,6 +161,7 @@ class MappableBinding(val binding: Binding, private val screen: Screen) {
         @CheckResult
         fun List<MappableBinding>.toPreferenceString(): String = "1/" + TextUtils.join(PREF_SEPARATOR.toString(), this.mapNotNull { it.toPreferenceString() })
 
+        @Suppress("UNUSED_PARAMETER")
         @CheckResult
         fun fromString(s: String, v: Version = Version.ONE): MappableBinding? {
             if (s.isEmpty()) {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/DecksV16.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/DecksV16.kt
@@ -317,13 +317,13 @@ class DecksV16(private val col: Collection, private val decksBackend: DecksBacke
     }
 
     override fun collapse(did: did) {
-        val deck = this.get(did)!!.toV16()
+        val deck = this.get(did).toV16()
         deck.collapsed = !deck.collapsed
         this.save(deck)
     }
 
     fun collapseBrowser(did: did) {
-        val deck = this.get(did)!!.toV16()
+        val deck = this.get(did).toV16()
         val collapsed = deck.browserCollapsed
         deck.browserCollapsed = !collapsed
         this.save(deck)
@@ -579,7 +579,7 @@ class DecksV16(private val col: Collection, private val decksBackend: DecksBacke
             return this.col.db.queryLongList("select id from cards where did=?", did)
         }
         val dids = mutableListOf(did)
-        for ((name, id) in this.children(did)) {
+        for ((_, id) in this.children(did)) {
             dids.append(id)
         }
         return this.col.db.queryLongList("select id from cards where did in " + ids2str(dids))
@@ -611,7 +611,7 @@ class DecksV16(private val col: Collection, private val decksBackend: DecksBacke
     }
 
     override fun current(): Deck {
-        return this.get(this.selected())!!
+        return this.get(this.selected())
     }
 
     /** Select a new branch. */
@@ -687,7 +687,7 @@ class DecksV16(private val col: Collection, private val decksBackend: DecksBacke
 
     /** All children of did, as (name, id). */
     override fun children(did: did): TreeMap<str, did> {
-        val name: str = this.get(did)!!.toV16().name
+        val name: str = this.get(did).toV16().name
         val actv = TreeMap<str, did>()
         for (g in this.all_names_and_ids()) {
             if (g.name.startsWith(name + "::")) {
@@ -719,10 +719,11 @@ class DecksV16(private val col: Collection, private val decksBackend: DecksBacke
         return out
     }
 
+    @Suppress("UNCHECKED_CAST")
     fun childDids(did: did, childMap: childMapNode): MutableList<did> {
         fun gather(node: childMapNode, arr: MutableList<did>) {
-            for ((did, child) in node.items()) {
-                arr.append(did)
+            for ((itemDid, child) in node.items()) {
+                arr.append(itemDid)
                 gather(child as childMapNode, arr)
             }
         }
@@ -731,6 +732,7 @@ class DecksV16(private val col: Collection, private val decksBackend: DecksBacke
         return arr
     }
 
+    @Suppress("UNCHECKED_CAST")
     @RustCleanup("used to return childMapNode")
     override fun childMap(): Decks.Node {
         val nameMap = this.nameMap()
@@ -755,6 +757,7 @@ class DecksV16(private val col: Collection, private val decksBackend: DecksBacke
         return childMap.toNode()
     }
 
+    @Suppress("UNCHECKED_CAST")
     @RustCleanup("needs testing")
     fun childMapNode.toNode(): Decks.Node {
         val ret = Decks.Node()
@@ -798,7 +801,7 @@ class DecksV16(private val col: Collection, private val decksBackend: DecksBacke
             if (nameMap.isPresent) {
                 deck = nameMap.get()[parent_name]!!
             } else {
-                deck = this.get(this.id(parent_name))!!
+                deck = this.get(this.id(parent_name))
             }
             parents.append(deck)
         }
@@ -842,7 +845,7 @@ class DecksV16(private val col: Collection, private val decksBackend: DecksBacke
 
     // 1 for dyn, 0 for standard
     override fun isDyn(did: did): Boolean {
-        return this.get(did)!!.toV16().dyn != 0
+        return this.get(did).toV16().dyn != 0
     }
 
     fun Deck?.toV16Optional(): Optional<DeckV16> {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/TagsV16.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/TagsV16.kt
@@ -54,7 +54,7 @@ class TagsV16(val col: Collection, private val backend: TagsBackend) : TagManage
     override fun register(
         tags: Iterable<String>,
         usn: Int?,
-        clear: Boolean
+        clear_first: Boolean
     ) {
 
         val preserve_usn: Boolean
@@ -68,7 +68,7 @@ class TagsV16(val col: Collection, private val backend: TagsBackend) : TagManage
         }
 
         backend.register_tags(
-            tags = " ".join(tags), preserve_usn = preserve_usn, usn = usn_, clear_first = clear
+            tags = " ".join(tags), preserve_usn = preserve_usn, usn = usn_, clear_first = clear_first
         )
     }
 
@@ -91,7 +91,7 @@ class TagsV16(val col: Collection, private val backend: TagsBackend) : TagManage
                     " ".join(col.db.queryStringList("select distinct tags from notes" + lim))
                 )
             ),
-            clear = clear,
+            clear_first = clear,
         )
     }
 
@@ -105,7 +105,7 @@ class TagsV16(val col: Collection, private val backend: TagsBackend) : TagManage
             return list(set(split(" ".join(res))))
         }
         val dids = mutableListOf(did)
-        for ((name, id) in col.decks.children(did)) {
+        for ((_, id) in col.decks.children(did)) {
             dids.add(id)
         }
         query = basequery + " AND c.did IN " + ids2str(dids)

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/backend/DecksBackend.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/backend/DecksBackend.kt
@@ -153,7 +153,7 @@ class RustDroidDeckBackend(private val backend: BackendV1) : DecksBackend {
     }
 
     override fun deck_tree(now: Long, top_deck_id: Long): DeckTreeNode {
-        val tree = backend.deckTree(now, top_deck_id)
+        backend.deckTree(now, top_deck_id)
         throw NotImplementedException()
     }
 


### PR DESCRIPTION
Add Kotlin option in gradle file to show compile warnings as errors

## Pull Request template

## Purpose / Description
Break the build by showing compiler warnings as errors

## Fixes
Fixes #9384 

## Approach
_How does this change address the problem?_

It breaks the build for compiler warnings
## How Has This Been Tested?

Tested by building the app

## Learning (optional, can help others)
_Describe the research stage_


## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
