### PR TITLE
fix: crash if deck set via 'decide by note type'

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -53,12 +53,10 @@ import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.MenuItem;
 import android.view.View;
-import android.view.ViewGroup;
 import android.view.ViewGroup.MarginLayoutParams;
 import android.view.WindowManager;
 import android.widget.AdapterView;
 import android.widget.AdapterView.OnItemSelectedListener;
-import android.widget.ArrayAdapter;
 import android.widget.EditText;
 import android.widget.ImageButton;
 import android.widget.LinearLayout;
@@ -98,6 +96,7 @@ import com.ichi2.async.TaskManager;
 import com.ichi2.compat.CompatHelper;
 import com.ichi2.libanki.Card;
 import com.ichi2.libanki.Collection;
+import com.ichi2.libanki.Consts;
 import com.ichi2.libanki.Models;
 import com.ichi2.libanki.Model;
 import com.ichi2.libanki.Note;
@@ -112,7 +111,6 @@ import com.ichi2.utils.FunctionalInterfaces.Consumer;
 import com.ichi2.utils.HashUtil;
 import com.ichi2.utils.KeyUtils;
 import com.ichi2.utils.MapUtil;
-import com.ichi2.utils.NamedJSONComparator;
 import com.ichi2.utils.NoteFieldDecorator;
 import com.ichi2.utils.TextViewUtil;
 import com.ichi2.widget.WidgetStatus;
@@ -122,7 +120,6 @@ import com.ichi2.utils.JSONObject;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
@@ -2081,7 +2078,7 @@ public class NoteEditor extends AnkiActivity implements
                 getCol().getDecks().save(currentDeck);
                 // Update deck
                 if (!getCol().get_config("addToCur", true)) {
-                    mCurrentDid = model.getLong("did");
+                    mCurrentDid = model.optLong("did", Consts.DEFAULT_DECK_ID);
                 }
 
                 refreshNoteData(FieldChangeType.changeFieldCount(shouldReplaceNewlines()));
@@ -2308,6 +2305,15 @@ public class NoteEditor extends AnkiActivity implements
         return mEditFields.get(index);
     }
 
+
+    @VisibleForTesting(otherwise = VisibleForTesting.NONE)
+    void setCurrentlySelectedModel(long mid) {
+        int position = mAllModelIds.indexOf(mid);
+        if (position == -1) {
+            throw new IllegalStateException(mid + " not found");
+        }
+        mNoteTypeSpinner.setSelection(position);
+    }
 
     private class EditFieldTextWatcher implements TextWatcher {
         private final int mIndex;

--- a/AnkiDroid/src/test/java/com/ichi2/anki/NoteEditorTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/NoteEditorTest.java
@@ -39,6 +39,7 @@ import org.robolectric.shadows.ShadowActivity;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 
 import androidx.test.core.app.ActivityScenario;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
@@ -343,6 +344,20 @@ public class NoteEditorTest extends RobolectricTest {
         NoteEditor editor = getNoteEditorAddingNote(FromScreen.DECK_LIST, NoteEditor.class);
 
         assertThat("Fields should have their first word capitalized by default", editor.getFieldForTest(0).isCapitalized(), is(true));
+    }
+
+    @Test
+    @Config(qualifiers = "en")
+    public void addToCurrentWithNoDeckSelectsDefault_issue_9616() {
+        getCol().getConf().put("addToCur", false);
+        Model cloze = Objects.requireNonNull(getCol().getModels().byName("Cloze"));
+        cloze.remove("did");
+        getCol().getModels().save(cloze);
+        NoteEditor editor = getNoteEditorAddingNote(FromScreen.DECK_LIST, NoteEditor.class);
+
+        editor.setCurrentlySelectedModel(cloze.getLong("id"));
+
+        assertThat(editor.getDeckId(), is(Consts.DEFAULT_DECK_ID));
     }
 
     private Intent getCopyNoteIntent(NoteEditor editor) {


### PR DESCRIPTION
Crash if `Settings - AnkiDroid - AnkiDroid - deck for new cards - decide by note type` is set and a model has no deck id

Issue was a `did` for a model can be null. If so, we use the default deck

Fixes #9616

## How Has This Been Tested?

Unit test only 

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
