### PR TITLE
Update sync error dialog

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -1765,7 +1765,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
                             break;
                         case BASIC_CHECK_FAILED:
                             dialogMessage = res.getString(R.string.sync_basic_check_failed, res.getString(R.string.check_db));
-                            showSyncErrorMessage(joinSyncMessages(dialogMessage, syncMessage));
+                            showSyncErrorDialog(SyncErrorDialog.DIALOG_SYNC_BASIC_CHECK_ERROR, joinSyncMessages(dialogMessage, syncMessage));
                             break;
                         case DB_ERROR:
                             showSyncErrorDialog(SyncErrorDialog.DIALOG_SYNC_CORRUPT_COLLECTION, syncMessage);

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/SyncErrorDialog.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/SyncErrorDialog.java
@@ -41,6 +41,7 @@ public class SyncErrorDialog extends AsyncDialogFragment {
     public static final int DIALOG_SYNC_SANITY_ERROR_CONFIRM_KEEP_REMOTE = 8;
     public static final int DIALOG_MEDIA_SYNC_ERROR = 9;
     public static final int DIALOG_SYNC_CORRUPT_COLLECTION = 10;
+    public static final int DIALOG_SYNC_BASIC_CHECK_ERROR = 11;
 
     public interface SyncErrorDialogListener {
         void showSyncErrorDialog(int dialogType);
@@ -51,6 +52,7 @@ public class SyncErrorDialog extends AsyncDialogFragment {
         Collection getCol();
         void mediaCheck();
         void dismissAllDialogFragments();
+        void integrityCheck();
     }
 
 
@@ -185,6 +187,15 @@ public class SyncErrorDialog extends AsyncDialogFragment {
                         .cancelable(false)
                         .show();
 
+            }
+            case DIALOG_SYNC_BASIC_CHECK_ERROR: {
+                return builder.positiveText(R.string.check_db)
+                        .negativeText(R.string.dialog_cancel)
+                        .onPositive((dialog, which) -> {
+                            ((SyncErrorDialogListener) getActivity()).integrityCheck();
+                            dismissAllDialogFragments();
+                        })
+                        .show();
             }
             default:
                 return null;


### PR DESCRIPTION
## Purpose / Description
Update the sync error dialog to allow users to run "check database" from the dialog when there is a "basic check" error.

## Fixes
Fixes #9199

## How Has This Been Tested?
Trigger a "basic check" error to verify that the updated dialog is shown. Also, verify that the "check database" function is run when the option is selected.

## Screenshot
![Screenshot_20211011_221704](https://user-images.githubusercontent.com/9289224/136895924-1bedf6ab-c321-4f19-af65-e7989c263236.png)

## Checklist
_Please, go through these checks before submitting the PR._
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
