### PR TITLE
fix(automatic-answer): Don't start if paused

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -365,7 +365,8 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
     /** Preference: Whether the user wants press back twice to return to the main screen" */
     private boolean mExitViaDoubleTapBack;
 
-    private final OnRenderProcessGoneDelegate mOnRenderProcessGoneDelegate = new OnRenderProcessGoneDelegate(this);
+    @VisibleForTesting
+    final OnRenderProcessGoneDelegate mOnRenderProcessGoneDelegate = new OnRenderProcessGoneDelegate(this);
 
     // ----------------------------------------------------------------------------
     // LISTENERS
@@ -854,7 +855,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
         super.onPause();
         Timber.d("onPause()");
 
-        mAutomaticAnswer.stopAll();
+        mAutomaticAnswer.disable();
         mLongClickHandler.removeCallbacks(mLongClickTestRunnable);
         mLongClickHandler.removeCallbacks(mStartLongClickAction);
 
@@ -872,6 +873,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
         resumeTimer();
         // Set the context for the Sound manager
         mSoundPlayer.setContext(new WeakReference<>(this));
+        mAutomaticAnswer.enable();
         // Reset the activity title
         setTitle();
         updateActionBar();
@@ -2652,7 +2654,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
             }
         }
 
-        mAutomaticAnswer.stopAll();
+        mAutomaticAnswer.disable();
         mTimerHandler.removeCallbacks(mRemoveChosenAnswerText);
         mLongClickHandler.removeCallbacks(mLongClickTestRunnable);
         mLongClickHandler.removeCallbacks(mStartLongClickAction);


### PR DESCRIPTION
The main issue was that onRenderProcessGone may occur when the app is paused on some devices. This can cause "auto answer" to start

rename: stopAll -> disable()
add: enable()
call enable onResume()
call disable onPause()

Fixes #9632

## How Has This Been Tested?

Unit tested

## Learning (optional, can help others)
This is so much easier logically now the class has been extracted

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
