### PR TITLE
fix(info-test): speed up test

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/Info.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Info.java
@@ -37,6 +37,7 @@ import com.ichi2.utils.IntentUtil;
 import com.ichi2.utils.VersionUtils;
 import com.ichi2.utils.ViewGroupUtils;
 
+import androidx.annotation.VisibleForTesting;
 import timber.log.Timber;
 
 import static com.ichi2.anim.ActivityTransitionAnimation.Direction.START;
@@ -96,7 +97,6 @@ public class Info extends AnkiActivity {
             marketButton.setVisibility(View.GONE);
         }
 
-        StringBuilder sb = new StringBuilder();
 
         // Apply Theme colors
         TypedArray typedArray = getTheme().obtainStyledAttributes(new int[] {android.R.attr.colorBackground, android.R.attr.textColor});
@@ -108,28 +108,8 @@ public class Info extends AnkiActivity {
 
         switch (type) {
             case TYPE_ABOUT: {
-                String[] content = res.getStringArray(R.array.about_content);
-                sb.append("<html><style>body {color:").append(textColor).append(";}</style>");
-
-                sb.append("<body text=\"#000000\" link=\"#E37068\" alink=\"#E37068\" vlink=\"#E37068\">");
-                sb.append(
-                        String.format(content[0], res.getString(R.string.app_name), res.getString(R.string.link_anki)))
-                        .append("<br/><br/>");
-                sb.append(
-                        String.format(content[1], res.getString(R.string.link_issue_tracker),
-                                res.getString(R.string.link_wiki), res.getString(R.string.link_forum))).append(
-                        "<br/><br/>");
-                sb.append(
-                        String.format(content[2], res.getString(R.string.link_wikipedia_open_source),
-                                res.getString(R.string.link_contribution))).append(" ");
-                sb.append(
-                        String.format(content[3], res.getString(R.string.link_translation),
-                                res.getString(R.string.link_donation))).append("<br/><br/>");
-                sb.append(
-                        String.format(content[4], res.getString(R.string.licence_wiki),
-                                res.getString(R.string.link_source))).append("<br/><br/>");
-                sb.append("</body></html>");
-                mWebView.loadDataWithBaseURL("", sb.toString(), "text/html", "utf-8", null);
+                String htmlContent = getAboutAnkiDroidHtml(res, textColor);
+                mWebView.loadDataWithBaseURL("", htmlContent, "text/html", "utf-8", null);
                 Button debugCopy = (findViewById(R.id.right_button));
                 debugCopy.setText(res.getString(R.string.feedback_copy_debug));
                 debugCopy.setOnClickListener(v -> copyDebugInfo());
@@ -165,6 +145,34 @@ public class Info extends AnkiActivity {
                 finishWithoutAnimation();
                 break;
         }
+    }
+
+
+    @VisibleForTesting
+    static String getAboutAnkiDroidHtml(Resources res, String textColor) {
+        StringBuilder sb = new StringBuilder();
+        String[] content = res.getStringArray(R.array.about_content);
+        sb.append("<html><style>body {color:").append(textColor).append(";}</style>");
+
+        sb.append("<body text=\"#000000\" link=\"#E37068\" alink=\"#E37068\" vlink=\"#E37068\">");
+        sb.append(
+                String.format(content[0], res.getString(R.string.app_name), res.getString(R.string.link_anki)))
+                .append("<br/><br/>");
+        sb.append(
+                String.format(content[1], res.getString(R.string.link_issue_tracker),
+                        res.getString(R.string.link_wiki), res.getString(R.string.link_forum))).append(
+                "<br/><br/>");
+        sb.append(
+                String.format(content[2], res.getString(R.string.link_wikipedia_open_source),
+                        res.getString(R.string.link_contribution))).append(" ");
+        sb.append(
+                String.format(content[3], res.getString(R.string.link_translation),
+                        res.getString(R.string.link_donation))).append("<br/><br/>");
+        sb.append(
+                String.format(content[4], res.getString(R.string.licence_wiki),
+                        res.getString(R.string.link_source))).append("<br/><br/>");
+        sb.append("</body></html>");
+        return sb.toString();
     }
 
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/InfoTestNoOnCreate.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/InfoTestNoOnCreate.java
@@ -16,6 +16,8 @@
 
 package com.ichi2.anki;
 
+import com.ichi2.testutils.AnkiAssert;
+import com.ichi2.testutils.EmptyApplication;
 import com.ichi2.utils.LanguageUtil;
 
 import org.junit.Before;
@@ -24,14 +26,14 @@ import org.junit.runner.RunWith;
 import org.robolectric.ParameterizedRobolectricTestRunner;
 import org.robolectric.ParameterizedRobolectricTestRunner.Parameter;
 import org.robolectric.ParameterizedRobolectricTestRunner.Parameters;
-import org.robolectric.Robolectric;
 import org.robolectric.RuntimeEnvironment;
-import org.robolectric.android.controller.ActivityController;
+import org.robolectric.annotation.Config;
 
 import java.util.Arrays;
 
 @RunWith(ParameterizedRobolectricTestRunner.class)
-public class InfoTest extends RobolectricTest {
+@Config(application = EmptyApplication.class)
+public class InfoTestNoOnCreate extends RobolectricTest {
 
     @Parameter
     public String locale;
@@ -53,7 +55,6 @@ public class InfoTest extends RobolectricTest {
 
     @Test
     public void testCreatingActivityWithLocale() {
-        ActivityController<Info> infoController = Robolectric.buildActivity(Info.class).create();
-        saveControllerForCleanup(infoController);
+        AnkiAssert.assertDoesNotThrow(() -> Info.getAboutAnkiDroidHtml(getTargetContext().getResources(), "#FFFFFF"));
     }
 }


### PR DESCRIPTION
Speeds up test from 1m17 to 7s

We do this via removing the dependency on Application/Info.java

The downside is that tests in the file will no longer complete onCreate due to the "backup - no application class" code being triggered so rename it to "NoOnCreate"

Fixes #9611
Related #9555

![image](https://user-images.githubusercontent.com/62114487/137255026-f84e1ca9-86b8-4e2b-9c33-0cfe09563e16.png)
![image](https://user-images.githubusercontent.com/62114487/137255030-d6d3e19a-fdd6-41ba-ac9c-34cdd60b64d8.png)


## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
