### PR TITLE
feat(media): Option to allow imports of all files

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicAudioClipFieldController.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicAudioClipFieldController.java
@@ -56,14 +56,21 @@ public class BasicAudioClipFieldController extends FieldControllerBase implement
 
         Collection col = CollectionHelper.getInstance().getCol(context);
         mStoringDirectory = new File(col.getMedia().dir());
+        // #9639: .opus is application/octet-stream in API 26,
+        // requires a workaround as we don't want to enable application/octet-stream by default
+        boolean allowAllFiles = AnkiDroidApp.getSharedPrefs(context).getBoolean("mediaImportAllowAllFiles", false);
 
         Button btnLibrary = new Button(mActivity);
         btnLibrary.setText(mActivity.getText(R.string.multimedia_editor_image_field_editing_library));
         btnLibrary.setOnClickListener(v -> {
             Intent i = new Intent();
-            i.setType("audio/*");
-            String[] extraMimeTypes = { "audio/*", "application/ogg" }; // #9226 allows ogg on Android 8
-            i.putExtra(Intent.EXTRA_MIME_TYPES, extraMimeTypes);
+            i.setType(allowAllFiles ? "*/*" : "audio/*");
+            if (!allowAllFiles) {
+                // application/ogg takes precedence over "*/*" for application/octet-stream
+                // so don't add it if we're want */*
+                String[] extraMimeTypes = { "audio/*", "application/ogg" }; // #9226 allows ogg on Android 8
+                i.putExtra(Intent.EXTRA_MIME_TYPES, extraMimeTypes);
+            }
             i.setAction(Intent.ACTION_GET_CONTENT);
             // Only get openable files, to avoid virtual files issues with Android 7+
             i.addCategory(Intent.CATEGORY_OPENABLE);

--- a/AnkiDroid/src/main/res/values/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values/10-preferences.xml
@@ -198,6 +198,9 @@
     <string name="paste_as_png_summary">By default Anki pastes images on the clipboard as JPG files to save disk space. You can use this option to paste as PNG images instead.</string>
     <string name="exit_via_double_tap_back" maxLength="41">Press back twice to go back/exit</string>
     <string name="exit_via_double_tap_back_summ">To avoid accidentally leaving the reviewer or the app</string>
+    <!-- Allow all files in media imports -->
+    <string name="media_import_allow_all_files" maxLength="41">Allow all files in media imports</string>
+    <string name="media_import_allow_all_files_summ">If Android doesn’t recognize a media file</string>
     <!-- Advanced statistics settings -->
     <string name="advanced_statistics_title" maxLength="41">Advanced statistics</string>
     <string name="enable_advanced_statistics_title" maxLength="41">Enable advanced statistics</string>

--- a/AnkiDroid/src/main/res/xml/preferences_advanced.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_advanced.xml
@@ -102,6 +102,14 @@
                 android:key="exitViaDoubleTapBack"
                 android:summary="@string/exit_via_double_tap_back_summ"
                 android:title="@string/exit_via_double_tap_back" />
+            <!-- #9639 - allow all files in media selection dialog - .opus is application/octet-stream
+            in older versions of Android (fixed between API 26 and API 30)
+             We don't want to allow this by default, but we want an override -->
+            <CheckBoxPreference
+                android:defaultValue="false"
+                android:key="mediaImportAllowAllFiles"
+                android:summary="@string/media_import_allow_all_files_summ"
+                android:title="@string/media_import_allow_all_files" />
         </PreferenceCategory>
         <PreferenceCategory
             android:key="category_plugins"


### PR DESCRIPTION
Cause: `.opus` files are `application/octet-stream` in old version of
Android

Solution: Preference: "mediaImportAllowAllFiles" (default: false)

We can't accept `application/octet-stream` as this picks up all binary
files, so we add a preference that only advanced users will use

Additional issues: `EXTRA_MIME_TYPES` with `application/ogg` takes
precedence over `*/*`, disallowing `application/octet-stream` even
though it is a wildcard, so don't pass it in if using `*/*`

Fixes #9639

## How Has This Been Tested?


Android 26 emulator

## Learning (optional, can help others)
I need a faster PC, emulators aren't really viable for testing

`EXTRA_MIME_TYPES` issue as above - glad I tested this properly

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

![image](https://user-images.githubusercontent.com/62114487/137407335-0e5b5081-cc80-40ea-a3e9-a8a7c91b52a2.png)