### PR TITLE
fix(note-editor): Add border to attach icon

### DIFF
--- a/AnkiDroid/src/main/res/drawable/ic_attachment_black.xml
+++ b/AnkiDroid/src/main/res/drawable/ic_attachment_black.xml
@@ -5,5 +5,7 @@
         android:viewportHeight="24.0">
     <path
         android:fillColor="#FF000000"
+        android:strokeColor="#FFFFFFFF"
+        android:strokeWidth="0.15"
         android:pathData="M2,12.5C2,9.46 4.46,7 7.5,7H18c2.21,0 4,1.79 4,4s-1.79,4 -4,4H9.5C8.12,15 7,13.88 7,12.5S8.12,10 9.5,10H17v2H9.41c-0.55,0 -0.55,1 0,1H18c1.1,0 2,-0.9 2,-2s-0.9,-2 -2,-2H7.5C5.57,9 4,10.57 4,12.5S5.57,16 7.5,16H17v2H7.5C4.46,18 2,15.54 2,12.5z"/>
 </vector>

--- a/AnkiDroid/src/main/res/drawable/ic_attachment_white.xml
+++ b/AnkiDroid/src/main/res/drawable/ic_attachment_white.xml
@@ -1,5 +1,7 @@
-<vector android:height="24dp" android:tint="#FFFFFF"
+<vector android:height="24dp"
     android:viewportHeight="24.0" android:viewportWidth="24.0"
     android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
-    <path android:fillColor="#FF000000" android:pathData="M2,12.5C2,9.46 4.46,7 7.5,7H18c2.21,0 4,1.79 4,4s-1.79,4 -4,4H9.5C8.12,15 7,13.88 7,12.5S8.12,10 9.5,10H17v2H9.41c-0.55,0 -0.55,1 0,1H18c1.1,0 2,-0.9 2,-2s-0.9,-2 -2,-2H7.5C5.57,9 4,10.57 4,12.5S5.57,16 7.5,16H17v2H7.5C4.46,18 2,15.54 2,12.5z"/>
+    <path android:fillColor="#FFFFFFFF"
+        android:strokeColor="#FF000000"
+        android:strokeWidth="0.15" android:pathData="M2,12.5C2,9.46 4.46,7 7.5,7H18c2.21,0 4,1.79 4,4s-1.79,4 -4,4H9.5C8.12,15 7,13.88 7,12.5S8.12,10 9.5,10H17v2H9.41c-0.55,0 -0.55,1 0,1H18c1.1,0 2,-0.9 2,-2s-0.9,-2 -2,-2H7.5C5.57,9 4,10.57 4,12.5S5.57,16 7.5,16H17v2H7.5C4.46,18 2,15.54 2,12.5z"/>
 </vector>


### PR DESCRIPTION
Xiaomi night mode inversion gets these icons incorrect

Therefore we show white on white

Adding a border works around this

Fixes (pending user) #9570 

## How Has This Been Tested?
No change visually

![image](https://user-images.githubusercontent.com/62114487/137642752-b13cd8dd-c7d9-4e60-bc88-3f7009d7dcd8.png)
![image](https://user-images.githubusercontent.com/62114487/137642754-10ccf593-88d0-44d4-99c1-786e57496af1.png)

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
