### PR TITLE
feat(deck-name): Disallow empty input

### DIFF
--- a/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/CreateDeckDialogTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/CreateDeckDialogTest.java
@@ -15,6 +15,11 @@
  ****************************************************************************************/
 
 package com.ichi2.anki.dialogs;
+import android.widget.EditText;
+
+import com.afollestad.materialdialogs.DialogAction;
+import com.afollestad.materialdialogs.MaterialDialog;
+import com.afollestad.materialdialogs.internal.MDButton;
 import com.ichi2.anki.DeckPicker;
 import com.ichi2.anki.R;
 import com.ichi2.anki.RobolectricTest;
@@ -25,6 +30,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
 
+import java.util.Objects;
 import java.util.concurrent.atomic.AtomicReference;
 import androidx.lifecycle.Lifecycle;
 import androidx.test.core.app.ActivityScenario;
@@ -137,4 +143,19 @@ public class CreateDeckDialogTest extends RobolectricTest {
         });
     }
 
+    @Test
+    public void nameMayNotBeZeroLength() {
+        mActivityScenario.onActivity(activity -> {
+            CreateDeckDialog createDeckDialog = new CreateDeckDialog(activity, R.string.new_deck, CreateDeckDialog.DeckDialogType.DECK, null);
+            MaterialDialog materialDialog = createDeckDialog.showDialog();
+            MDButton actionButton = materialDialog.getActionButton(DialogAction.POSITIVE);
+
+            assertThat("Ok is disabled if zero length input", actionButton.isEnabled(), is(false));
+
+            EditText editText = Objects.requireNonNull(materialDialog.getInputEditText());
+
+            editText.setText("NotEmpty");
+            assertThat("Ok is enabled if not zero length input", actionButton.isEnabled(), is(true));
+        });
+    }
 } 


### PR DESCRIPTION
We move from a MaterialEditTextDialog to a MaterialDialog.Builder
This means that the `.input()` call works, and we can specify
`.inputRange()`

Fixes #9505

## How Has This Been Tested?

Unit test and 

![image](https://user-images.githubusercontent.com/62114487/137683088-364a9fac-6387-4a21-a7f9-ee70eb8fe6ce.png)
![image](https://user-images.githubusercontent.com/62114487/137683097-9abe3ab9-0244-4137-a146-4e2fd2a968f8.png)

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
