### PR TITLE
fix(card-browser): Don't always show default deck

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -763,6 +763,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
         long deckId = getCol().getDecks().selected();
         mDeckSpinnerSelection = new DeckSpinnerSelection(this, col, this.findViewById(R.id.toolbar_spinner));
         mDeckSpinnerSelection.setShowAllDecks(true);
+        mDeckSpinnerSelection.setAlwaysShowDefaultDeck(false);
         mDeckSpinnerSelection.initializeActionBarDeckSpinner(this.getSupportActionBar());
         selectDeckAndSave(deckId);
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/DeckService.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/DeckService.kt
@@ -1,0 +1,35 @@
+/*
+ *  Copyright (c) 2021 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.servicelayer
+
+import com.ichi2.libanki.Collection
+import com.ichi2.libanki.Consts
+import com.ichi2.libanki.did
+
+object DeckService {
+    @JvmStatic
+    fun shouldShowDefaultDeck(col: Collection): Boolean =
+        defaultDeckHasCards(col) || hasChildren(col, Consts.DEFAULT_DECK_ID)
+
+    @Suppress("SameParameterValue")
+    private fun hasChildren(col: Collection, did: did) =
+        col.decks.children(did).size > 0
+
+    @JvmStatic
+    fun defaultDeckHasCards(col: Collection) =
+        col.db.queryScalar("select 1 from cards where did = 1") != 0
+}

--- a/AnkiDroid/src/main/java/com/ichi2/anki/widgets/DeckAdapter.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/widgets/DeckAdapter.java
@@ -39,7 +39,7 @@ import android.widget.RelativeLayout;
 import android.widget.TextView;
 
 import com.ichi2.anki.R;
-import com.ichi2.compat.CompatHelper;
+import com.ichi2.anki.servicelayer.DeckService;
 import com.ichi2.libanki.Collection;
 
 import com.ichi2.libanki.Deck;
@@ -312,7 +312,7 @@ public class DeckAdapter<T extends AbstractDeckTreeNode<T>> extends RecyclerView
             // If the default deck is empty, hide it by not adding it to the deck list.
             // We don't hide it if it's the only deck or if it has sub-decks.
             if (node.getDid() == 1 && nodes.size() > 1 && !node.hasChildren()) {
-                if (mCol.getDb().queryScalar("select 1 from cards where did = 1") == 0) {
+                if (!DeckService.defaultDeckHasCards(mCol)) {
                     continue;
                 }
             }


### PR DESCRIPTION
Instead, only if it would be visible in the deck picker

Fixes #9372

## How Has This Been Tested?

* Android 11
* Setting it as default, then deleting it: defaults to "all decks"

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
