### PR TITLE
[JS API] Setter functions for current card

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -2799,12 +2799,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
             }
             // mark card using javascript
             if (url.startsWith("signal:mark_current_card")) {
-                if (mAnkiDroidJsAPI.isAnkiApiNull(mAnkiDroidJsAPI.MARK_CARD)) {
-                    mAnkiDroidJsAPI.showDeveloperContact(mAnkiDroidJsAPI.ankiJsErrorCodeDefault);
-                    return true;
-                } else if (!mAnkiDroidJsAPI.getJsApiListMap().get(mAnkiDroidJsAPI.MARK_CARD)) {
-                    // see 02-string.xml
-                    mAnkiDroidJsAPI.showDeveloperContact(mAnkiDroidJsAPI.ankiJsErrorCodeMarkCard);
+                if (!mAnkiDroidJsAPI.retErrorCode(mAnkiDroidJsAPI.getConst().MARK_CARD, mAnkiDroidJsAPI.getConst().ankiJsErrorCodeMarkCard)) {
                     return true;
                 }
 
@@ -2813,12 +2808,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
             }
             // flag card (blue, green, orange, red) using javascript from AnkiDroid webview
             if (url.startsWith("signal:flag_")) {
-                if (mAnkiDroidJsAPI.isAnkiApiNull(mAnkiDroidJsAPI.TOGGLE_FLAG)) {
-                    mAnkiDroidJsAPI.showDeveloperContact(mAnkiDroidJsAPI.ankiJsErrorCodeDefault);
-                    return true;
-                } else if (!mAnkiDroidJsAPI.getJsApiListMap().get(mAnkiDroidJsAPI.TOGGLE_FLAG)) {
-                    // see 02-string.xml
-                    mAnkiDroidJsAPI.showDeveloperContact(mAnkiDroidJsAPI.ankiJsErrorCodeFlagCard);
+                if (!mAnkiDroidJsAPI.retErrorCode(mAnkiDroidJsAPI.getConst().TOGGLE_FLAG, mAnkiDroidJsAPI.getConst().ankiJsErrorCodeFlagCard)) {
                     return true;
                 }
 
@@ -3081,6 +3071,6 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
     }
 
     public AnkiDroidJsAPI javaScriptFunction() {
-        return new AnkiDroidJsAPI(this, mCurrentCard);
+        return new AnkiDroidJsAPI(this);
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidJsAPIConst.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidJsAPIConst.kt
@@ -1,0 +1,165 @@
+/****************************************************************************************
+ * Copyright (c) 2020 Mani infinyte01@gmail.com                                         *
+ *                                                                                      *
+ *                                                                                      *
+ * This program is free software; you can redistribute it and/or modify it under        *
+ * the terms of the GNU General Public License as published by the Free Software        *
+ * Foundation; either version 3 of the License, or (at your option) any later           *
+ * version.                                                                             *
+ *                                                                                      *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *                                                                                      *
+ * You should have received a copy of the GNU General Public License along with         *
+ * this program.  If not, see <http:></http:>//www.gnu.org/licenses/>.                  *
+ *                                                                                      *
+ * *************************************************************************************/
+
+package com.ichi2.anki
+
+class AnkiDroidJsAPIConst {
+    // JS API ERROR CODE
+    @kotlin.jvm.JvmField
+    var ankiJsErrorCodeDefault: Int = 0
+    @kotlin.jvm.JvmField
+    val ankiJsErrorCodeMarkCard: Int = 1
+    @kotlin.jvm.JvmField
+    val ankiJsErrorCodeFlagCard: Int = 2
+
+    @kotlin.jvm.JvmField
+    val ankiJsErrorCodeBuryCard: Int = 3
+    @kotlin.jvm.JvmField
+    val ankiJsErrorCodeBuryNote: Int = 4
+    @kotlin.jvm.JvmField
+    val ankiJsErrorCodeSuspendCard: Int = 5
+    @kotlin.jvm.JvmField
+    val ankiJsErrorCodeSuspendNote: Int = 6
+
+    @kotlin.jvm.JvmField
+    val ankiJsErrorCodeSetCardDid: Int = 7
+    @kotlin.jvm.JvmField
+    val ankiJsErrorCodeSetCardNid: Int = 8
+    @kotlin.jvm.JvmField
+    val ankiJsErrorCodeSetCardODid: Int = 9
+    @kotlin.jvm.JvmField
+    val ankiJsErrorCodeSetCardType: Int = 10
+    @kotlin.jvm.JvmField
+    val ankiJsErrorCodeSetCardDue: Int = 11
+    @kotlin.jvm.JvmField
+    val ankiJsErrorCodeSetCardIvl: Int = 12
+    @kotlin.jvm.JvmField
+    val ankiJsErrorCodeSetCardLastIvl: Int = 13
+    @kotlin.jvm.JvmField
+    val ankiJsErrorCodeSetCardQueue: Int = 14
+    @kotlin.jvm.JvmField
+    val ankiJsErrorCodeSetCardReps: Int = 15
+    @kotlin.jvm.JvmField
+    val ankiJsErrorCodeSetCardLapses: Int = 16
+    @kotlin.jvm.JvmField
+    val ankiJsErrorCodeSetCardLeft: Int = 17
+    @kotlin.jvm.JvmField
+    val ankiJsErrorCodeSetCardMod: Int = 18
+    @kotlin.jvm.JvmField
+    val ankiJsErrorCodeSetCardOrd: Int = 19
+    @kotlin.jvm.JvmField
+    val ankiJsErrorCodeSetCardFactor: Int = 20
+    @kotlin.jvm.JvmField
+    val ankiJsErrorCodeSetCardWasNew: Int = 21
+
+    // js api developer contact
+    @kotlin.jvm.JvmField
+    var mCardSuppliedDeveloperContact = ""
+    @kotlin.jvm.JvmField
+    var mCardSuppliedApiVersion = ""
+
+    val sCurrentJsApiVersion = "0.0.1"
+    val sMinimumJsApiVersion = "0.0.1"
+
+    @kotlin.jvm.JvmField
+    val MARK_CARD = "markCard"
+    @kotlin.jvm.JvmField
+    val TOGGLE_FLAG = "toggleFlag"
+
+    @kotlin.jvm.JvmField
+    val BURY_CARD = "buryCard"
+    @kotlin.jvm.JvmField
+    val BURY_NOTE = "buryNote"
+    @kotlin.jvm.JvmField
+    val SUSPEND_CARD = "suspendCard"
+    @kotlin.jvm.JvmField
+    val SUSPEND_NOTE = "suspendNote"
+
+    @kotlin.jvm.JvmField
+    val SET_CARD_DID = "setCardDid"
+
+    @kotlin.jvm.JvmField
+    val SET_CARD_NID = "setCardNid"
+
+    @kotlin.jvm.JvmField
+    val SET_CARD_ODID = "setCardODid"
+
+    @kotlin.jvm.JvmField
+    val SET_CARD_TYPE = "setCardType"
+
+    @kotlin.jvm.JvmField
+    val SET_CARD_DUE = "setCardDue"
+
+    @kotlin.jvm.JvmField
+    val SET_CARD_IVL = "setCardIvl"
+
+    @kotlin.jvm.JvmField
+    val SET_CARD_LAST_IVL = "setCardLastIvl"
+
+    @kotlin.jvm.JvmField
+    val SET_CARD_QUEUE = "setCardQueue"
+
+    @kotlin.jvm.JvmField
+    val SET_CARD_REPS = "setCardReps"
+
+    @kotlin.jvm.JvmField
+    val SET_CARD_LAPSES = "setCardLapses"
+
+    @kotlin.jvm.JvmField
+    val SET_CARD_LEFT = "setCardLeft"
+
+    @kotlin.jvm.JvmField
+    val SET_CARD_MOD = "setCardMod"
+
+    @kotlin.jvm.JvmField
+    val SET_CARD_ORD = "setCardOrd"
+
+    @kotlin.jvm.JvmField
+    val SET_CARD_Factor = "setCardFactor"
+
+    @kotlin.jvm.JvmField
+    val SET_CARD_WAS_NEW = "setCardWasNew"
+
+    fun initApiMap(): HashMap<String, Boolean> {
+        val mJsApiListMap = HashMap<String, Boolean>()
+        mJsApiListMap[MARK_CARD] = false
+        mJsApiListMap[TOGGLE_FLAG] = false
+
+        mJsApiListMap[BURY_CARD] = false
+        mJsApiListMap[BURY_NOTE] = false
+        mJsApiListMap[SUSPEND_CARD] = false
+        mJsApiListMap[SUSPEND_NOTE] = false
+
+        mJsApiListMap[SET_CARD_DID] = false
+        mJsApiListMap[SET_CARD_NID] = false
+        mJsApiListMap[SET_CARD_ODID] = false
+        mJsApiListMap[SET_CARD_TYPE] = false
+        mJsApiListMap[SET_CARD_DUE] = false
+        mJsApiListMap[SET_CARD_IVL] = false
+        mJsApiListMap[SET_CARD_LAST_IVL] = false
+        mJsApiListMap[SET_CARD_QUEUE] = false
+        mJsApiListMap[SET_CARD_REPS] = false
+        mJsApiListMap[SET_CARD_LAPSES] = false
+        mJsApiListMap[SET_CARD_LEFT] = false
+        mJsApiListMap[SET_CARD_MOD] = false
+        mJsApiListMap[SET_CARD_ORD] = false
+        mJsApiListMap[SET_CARD_Factor] = false
+        mJsApiListMap[SET_CARD_WAS_NEW] = false
+        return mJsApiListMap
+    }
+}

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.java
@@ -123,9 +123,9 @@ public class Reviewer extends AbstractFlashcardViewer {
 
     // TODO: Consider extracting to ViewModel
     // Card counts
-    private SpannableString mNewCount;
-    private SpannableString mLrnCount;
-    private SpannableString mRevCount;
+    protected SpannableString mNewCount;
+    protected SpannableString mLrnCount;
+    protected SpannableString mRevCount;
 
     private TextView mTextBarNew;
     private TextView mTextBarLearn;
@@ -145,7 +145,7 @@ public class Reviewer extends AbstractFlashcardViewer {
     protected String mTempAudioPath;
 
     // ETA
-    private int mEta;
+    protected int mEta;
     private boolean mPrefShowETA;
 
     /** Handle Mark/Flag state of cards */
@@ -1666,61 +1666,6 @@ public class Reviewer extends AbstractFlashcardViewer {
 
     @Override
     public AnkiDroidJsAPI javaScriptFunction() {
-        return new ReviewerJavaScriptFunction(this, mCurrentCard);
-    }
-
-    public class ReviewerJavaScriptFunction extends AnkiDroidJsAPI {
-        public ReviewerJavaScriptFunction(@NonNull AbstractFlashcardViewer activity, @NonNull Card currentCard) {
-            super(activity, currentCard);
-        }
-
-        @JavascriptInterface
-        @Override
-        public String ankiGetNewCardCount() {
-            return mNewCount.toString();
-        }
-
-        @JavascriptInterface
-        @Override
-        public String ankiGetLrnCardCount() {
-            return mLrnCount.toString();
-        }
-
-        @JavascriptInterface
-        @Override
-        public String ankiGetRevCardCount() {
-            return mRevCount.toString();
-        }
-
-        @JavascriptInterface
-        @Override
-        public int ankiGetETA() {
-            return mEta;
-        }
-
-        @JavascriptInterface
-        @Override
-        public String ankiGetNextTime1() {
-            return mEaseButton1.getNextTime();
-        }
-
-        @JavascriptInterface
-        @Override
-        public String ankiGetNextTime2() {
-            return mEaseButton2.getNextTime();
-        }
-
-        @JavascriptInterface
-        @Override
-        public String ankiGetNextTime3() {
-            return mEaseButton3.getNextTime();
-        }
-
-        @JavascriptInterface
-        @Override
-        public String ankiGetNextTime4() {
-            return mEaseButton4.getNextTime();
-        }
-
+        return new ReviewerJavaScriptFunction(this);
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ReviewerJavaScriptFunction.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ReviewerJavaScriptFunction.kt
@@ -1,0 +1,215 @@
+/****************************************************************************************
+ * Copyright (c) 2020 David Allison <davidallisongithub@gmail.com>                      *
+ * Copyright (c) 2020 Mani infinyte01@gmail.com                                         *
+ *                                                                                      *
+ *                                                                                      *
+ * This program is free software; you can redistribute it and/or modify it under        *
+ * the terms of the GNU General Public License as published by the Free Software        *
+ * Foundation; either version 3 of the License, or (at your option) any later           *
+ * version.                                                                             *
+ *                                                                                      *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *                                                                                      *
+ * You should have received a copy of the GNU General Public License along with         *
+ * this program.  If not, see <http:></http:>//www.gnu.org/licenses/>.                  *
+ *                                                                                      *
+ * *************************************************************************************/
+
+package com.ichi2.anki
+
+import android.webkit.JavascriptInterface
+
+class ReviewerJavaScriptFunction(private var activity: Reviewer) : AnkiDroidJsAPI(activity) {
+
+    @JavascriptInterface
+    override fun ankiGetNewCardCount(): String? {
+        return activity.mNewCount.toString()
+    }
+
+    @JavascriptInterface
+    override fun ankiGetLrnCardCount(): String? {
+        return activity.mLrnCount.toString()
+    }
+
+    @JavascriptInterface
+    override fun ankiGetRevCardCount(): String? {
+        return activity.mRevCount.toString()
+    }
+
+    @JavascriptInterface
+    override fun ankiGetETA(): Int {
+        return activity.mEta
+    }
+
+    @JavascriptInterface
+    override fun ankiGetNextTime1(): String {
+        return activity.mEaseButton1.nextTime
+    }
+
+    @JavascriptInterface
+    override fun ankiGetNextTime2(): String {
+        return activity.mEaseButton2.nextTime
+    }
+
+    @JavascriptInterface
+    override fun ankiGetNextTime3(): String {
+        return activity.mEaseButton3.nextTime
+    }
+
+    @JavascriptInterface
+    override fun ankiGetNextTime4(): String {
+        return activity.mEaseButton4.nextTime
+    }
+
+    @JavascriptInterface
+    override fun ankiSetCardNid(nid: Long): Boolean {
+        if (!retErrorCode(const.SET_CARD_NID, const.ankiJsErrorCodeSetCardNid)) {
+            return false
+        }
+
+        activity.currentCard.nid = nid
+        return true
+    }
+
+    @JavascriptInterface
+    override fun ankiSetCardDid(did: Long): Boolean {
+        if (!retErrorCode(const.SET_CARD_DID, const.ankiJsErrorCodeSetCardDid)) {
+            return false
+        }
+
+        activity.currentCard.did = did
+        return true
+    }
+
+    @JavascriptInterface
+    override fun ankiSetCardODid(odid: Long): Boolean {
+        if (!retErrorCode(const.SET_CARD_ODID, const.ankiJsErrorCodeSetCardODid)) {
+            return false
+        }
+
+        activity.currentCard.oDid = odid
+        return true
+    }
+
+    @JavascriptInterface
+    override fun ankiSetCardType(type: Int): Boolean {
+        if (!retErrorCode(const.SET_CARD_TYPE, const.ankiJsErrorCodeSetCardType)) {
+            return false
+        }
+
+        activity.currentCard.type = type
+        return true
+    }
+
+    @JavascriptInterface
+    override fun ankiSetCardDue(due: Long): Boolean {
+        if (!retErrorCode(const.SET_CARD_DUE, const.ankiJsErrorCodeSetCardDue)) {
+            return false
+        }
+
+        activity.currentCard.due = due
+        return true
+    }
+
+    @JavascriptInterface
+    override fun ankiSetCardIvl(ivl: Int): Boolean {
+        if (!retErrorCode(const.SET_CARD_IVL, const.ankiJsErrorCodeSetCardIvl)) {
+            return false
+        }
+
+        activity.currentCard.ivl = ivl
+        return true
+    }
+
+    @JavascriptInterface
+    override fun ankiSetCardLastIvl(ivl: Int): Boolean {
+        if (!retErrorCode(const.SET_CARD_LAST_IVL, const.ankiJsErrorCodeSetCardLastIvl)) {
+            return false
+        }
+
+        activity.currentCard.lastIvl = ivl
+        return true
+    }
+
+    @JavascriptInterface
+    override fun ankiSetCardQueue(queue: Int): Boolean {
+        if (!retErrorCode(const.SET_CARD_QUEUE, const.ankiJsErrorCodeSetCardQueue)) {
+            return false
+        }
+
+        activity.currentCard.queue = queue
+        return true
+    }
+
+    @JavascriptInterface
+    override fun ankiSetCardReps(reps: Int): Boolean {
+        if (!retErrorCode(const.SET_CARD_REPS, const.ankiJsErrorCodeSetCardReps)) {
+            return false
+        }
+
+        activity.currentCard.reps = reps
+        return true
+    }
+
+    @JavascriptInterface
+    override fun ankiSetCardLapses(lapses: Int): Boolean {
+        if (!retErrorCode(const.SET_CARD_LAPSES, const.ankiJsErrorCodeSetCardLapses)) {
+            return false
+        }
+
+        activity.currentCard.lapses = lapses
+        return true
+    }
+
+    @JavascriptInterface
+    override fun ankiSetCardLeft(left: Int): Boolean {
+        if (!retErrorCode(const.SET_CARD_LEFT, const.ankiJsErrorCodeSetCardLeft)) {
+            return false
+        }
+
+        activity.currentCard.left = left
+        return true
+    }
+
+    @JavascriptInterface
+    override fun ankiSetCardMod(mod: Long): Boolean {
+        if (!retErrorCode(const.SET_CARD_MOD, const.ankiJsErrorCodeSetCardMod)) {
+            return false
+        }
+
+        activity.currentCard.mod = mod
+        return true
+    }
+
+    @JavascriptInterface
+    override fun ankiSetCardOrd(ord: Int): Boolean {
+        if (!retErrorCode(const.SET_CARD_ORD, const.ankiJsErrorCodeSetCardOrd)) {
+            return false
+        }
+
+        activity.currentCard.ord = ord
+        return true
+    }
+
+    @JavascriptInterface
+    override fun ankiSetCardFactor(factor: Int): Boolean {
+        if (!retErrorCode(const.SET_CARD_Factor, const.ankiJsErrorCodeSetCardFactor)) {
+            return false
+        }
+
+        activity.currentCard.factor = factor
+        return true
+    }
+
+    @JavascriptInterface
+    override fun ankiSetCardWasNew(wasNew: Boolean): Boolean {
+        if (!retErrorCode(const.SET_CARD_WAS_NEW, const.ankiJsErrorCodeSetCardWasNew)) {
+            return false
+        }
+
+        activity.currentCard.wasNew = wasNew
+        return true
+    }
+}

--- a/AnkiDroid/src/main/res/values/02-strings.xml
+++ b/AnkiDroid/src/main/res/values/02-strings.xml
@@ -314,6 +314,7 @@
     <string name="update_js_api_version">AnkiDroid JS API update available. Contact developer %s, or view wiki</string>
     <string name="reviewer_invalid_api_version_visit_documentation">View</string>
     <string name="anki_js_error_code">(Error Code: %d)</string>
+    <string name="anki_set_card_msg">The current card values is %s and will be set to %s in reviewer</string>
 
     <!-- About AnkiDroid screen -->
     <string name="about_ankidroid_successfully_copied_debug">Copied debug information to clipboard</string>
@@ -407,5 +408,7 @@
 
     <!--  Note Editor Toggle Sticky  -->
     <string name="note_editor_toggle_sticky">Make field %s sticky</string>
+
+    <!--    -->
 
 </resources>

--- a/AnkiDroid/src/test/java/com/ichi2/anki/AnkiDroidJsAPITest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/AnkiDroidJsAPITest.kt
@@ -47,7 +47,11 @@ class AnkiDroidJsAPITest : RobolectricTest() {
         data.put("developer", "dev@mail.com")
 
         // this will be changed when new api added
-        val expected = "{\"markCard\":true,\"toggleFlag\":true}"
+        val expected = "{\"setCardDue\":true,\"setCardFactor\":true,\"setCardLeft\":true,\"toggleFlag\":true," +
+            "\"setCardOrd\":true,\"buryNote\":true,\"setCardLastIvl\":true,\"setCardDid\":true,\"setCardIvl\":true," +
+            "\"setCardODid\":true,\"suspendNote\":true,\"setCardLapses\":true,\"setCardMod\":true,\"markCard\":true," +
+            "\"setCardNid\":true,\"suspendCard\":true,\"buryCard\":true,\"setCardType\":true,\"setCardWasNew\":true," +
+            "\"setCardReps\":true,\"setCardQueue\":true}"
 
         waitForAsyncTasksToComplete()
         assertThat(javaScriptFunction.init(data.toString()), equalTo(expected))


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
There are some addons in Anki which modify values for current card. The most popular one is Auto Ease Factor addon, which calculate ease for cards/notes information then set the ease.

The AnkiDroid JS API already provides almost all information about current card but there is no js api to modify current card's information. So this PR will solve the problem.

## Fixes
Fixes _Link to the issues._

## Approach
Using JavaScript Interface call function defined for `mCurrentCard`. Also modifying the information required JS API to be init i.e developer contract must provided so if any changes in future done, the contract will notify user/developer that to use the current function the JS API must init.

## How Has This Been Tested?
Tested using chrome remote debugging, by calling all function in dev tools.

## Learning (optional, can help others)
https://developer.android.com/reference/android/webkit/JavascriptInterface

_Links to blog posts, patterns, libraries or addons used to solve this problem_

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
