### PR TITLE
Prevent Ktlint pre-commit hook failure in case of deleted files

### DIFF
--- a/pre-commit
+++ b/pre-commit
@@ -11,6 +11,8 @@ fi;
 echo "Running Ktlint over these files:"
 echo "$CHANGED_FILES"
 
+# Clean is required because of https://github.com/ankidroid/Anki-Android/issues/9521
+./gradlew clean
 # -q removes noise from the output if it fails.
 # TODO: -w is better, but https://github.com/JLLeitschuh/ktlint-gradle/issues/457 adds noise
 # -w should display: "CriticalExceptionTest.kt:19:1 Wildcard import (cannot be auto-corrected)"


### PR DESCRIPTION
## Purpose / Description
Prevent Ktlint pre-commit hook failure in case of deleted files.

## Fixes
Fixes #9521 

## Approach
Running `./gradlew clean` before the pre-commit hook fixes the issue.

## How Has This Been Tested?
Verified by creating the required scenario.

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
