### PR TITLE
 fix: automatic answer if TTS = "don't speak"/field is empty

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -1794,11 +1794,11 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
     }
 
     class ReadTextListener implements ReadText.ReadTextListener {
-        public void onDone() {
+        public void onDone(SoundSide playedSide) {
             Timber.d("done reading text");
-            if (ReadText.getmQuestionAnswer() == SoundSide.QUESTION) {
+            if (playedSide == SoundSide.QUESTION) {
                 mAutomaticAnswer.scheduleAutomaticDisplayAnswer();
-            } else if (ReadText.getmQuestionAnswer() == SoundSide.ANSWER) {
+            } else if (playedSide == SoundSide.ANSWER) {
                 mAutomaticAnswer.scheduleAutomaticDisplayQuestion();
             }
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -248,7 +248,6 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
     private boolean mLargeAnswerButtons;
     private int mDoubleTapTimeInterval = DEFAULT_DOUBLE_TAP_TIME_INTERVAL;
     // Android WebView
-    protected boolean mSpeakText;
     protected boolean mDisableClipboard = false;
 
     @NonNull protected AutomaticAnswer mAutomaticAnswer = AutomaticAnswer.defaultInstance(this);
@@ -375,7 +374,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
 
     @VisibleForTesting
     final OnRenderProcessGoneDelegate mOnRenderProcessGoneDelegate = new OnRenderProcessGoneDelegate(this);
-    private final TTS mTTS = new TTS();
+    protected final TTS mTTS = new TTS();
 
     // ----------------------------------------------------------------------------
     // LISTENERS
@@ -825,9 +824,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
         }
 
         // Initialize text-to-speech. This is an asynchronous operation.
-        if (mSpeakText) {
-            ReadText.initializeTts(this, new ReadTextListener());
-        }
+        mTTS.initialize(this, new ReadTextListener());
 
         // Initialize dictionary lookup feature
         Lookup.initialize(this);
@@ -877,9 +874,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
             mSched.discardCurrentCard();
         }
         Timber.d("onDestroy()");
-        if (mSpeakText) {
-            ReadText.releaseTts(this);
-        }
+        mTTS.releaseTts(this);
         if (mUnmountReceiver != null) {
             unregisterReceiver(mUnmountReceiver);
         }
@@ -1695,7 +1690,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
         // mDeckFilename = preferences.getString("deckFilename", "");
         mPrefFullscreenReview = FullScreenMode.fromPreference(preferences);
         mRelativeButtonSize = preferences.getInt("answerButtonSize", 100);
-        mSpeakText = preferences.getBoolean("tts", false);
+        mTTS.setEnabled(preferences.getBoolean("tts", false));
         mScrollingButtons = preferences.getBoolean("scrolling_buttons", false);
         mDoubleScrolling = preferences.getBoolean("double_scrolling", false);
         mPrefShowTopbar = preferences.getBoolean("showTopbar", true);
@@ -1875,17 +1870,12 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
             mAnswerField.setVisibility(View.GONE);
         }
 
-        //if (mSpeakText) {
-        // ReadText.setLanguageInformation(Model.getModel(DeckManager.getMainDeck(),
-        // mCurrentCard.getCardModelId(), false).getId(), mCurrentCard.getCardModelId());
-        //}
-
         updateCard(displayString);
         hideEaseButtons();
 
         mAutomaticAnswer.onDisplayQuestion();
         // If Card-based TTS is enabled, we "automatic display" after the TTS has finished as we don't know the duration
-        if (!mSpeakText) {
+        if (!mTTS.isEnabled()) {
             mAutomaticAnswer.scheduleAutomaticDisplayAnswer(mUseTimerDynamicMS);
         }
 
@@ -1932,7 +1922,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
 
         mAutomaticAnswer.onDisplayAnswer();
         // If Card-based TTS is enabled, we "automatic display" after the TTS has finished as we don't know the duration
-        if (!mSpeakText) {
+        if (!mTTS.isEnabled()) {
             mAutomaticAnswer.scheduleAutomaticDisplayQuestion(mUseTimerDynamicMS);
         }
     }
@@ -2071,7 +2061,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
 
         if (getConfigForCurrentCard().optBoolean("autoplay", false) || doAudioReplay) {
             // Use TTS if TTS preference enabled and no other sound source
-            boolean useTTS = mSpeakText &&
+            boolean useTTS = mTTS.isEnabled() &&
                     !(sDisplayAnswer && mSoundPlayer.hasAnswer()) && !(!sDisplayAnswer && mSoundPlayer.hasQuestion());
             // We need to play the sounds from the proper side of the card
             if (!useTTS) { // Text to speech not in effect here

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ReadText.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ReadText.java
@@ -251,7 +251,7 @@ public class ReadText {
                 mTts.setOnUtteranceProgressListener(new UtteranceProgressListener() {
                     @Override
                     public void onDone(String arg0) {
-                        listener.onDone();
+                        listener.onDone(getmQuestionAnswer());
                     }
                     @Override
                     @Deprecated
@@ -337,7 +337,7 @@ public class ReadText {
 
 
     public interface ReadTextListener{
-        void onDone();
+        void onDone(Sound.SoundSide playedSide);
     }
 
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ReadText.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ReadText.java
@@ -336,7 +336,7 @@ public class ReadText {
     }
 
 
-    interface ReadTextListener{
+    public interface ReadTextListener{
         void onDone();
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ReadText.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ReadText.java
@@ -256,7 +256,7 @@ public class ReadText {
                     @Override
                     @Deprecated
                     public void onError(String utteranceId) {
-                        Timber.v("Andoid TTS failed. Check logcat for error. Indicates a problem with Android TTS engine.");
+                        Timber.v("Android TTS failed. Check logcat for error. Indicates a problem with Android TTS engine.");
 
                         final Uri helpUrl = Uri.parse(mReviewer.get().getString(R.string.link_faq_tts));
                         final AnkiActivity ankiActivity = (AnkiActivity) mReviewer.get();

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.java
@@ -718,7 +718,7 @@ public class Reviewer extends AbstractFlashcardViewer {
         if (colIsOpen() && getCol().getDecks().isDyn(getParentDid())) {
             menu.findItem(R.id.action_open_deck_options).setVisible(false);
         }
-        if (mSpeakText && !mActionButtons.getStatus().selectTtsIsDisabled()) {
+        if (mTTS.isEnabled() && !mActionButtons.getStatus().selectTtsIsDisabled()) {
             menu.findItem(R.id.action_select_tts).setVisible(true);
         }
         // Setup bury / suspend providers

--- a/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/TTS.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/TTS.kt
@@ -29,6 +29,9 @@ import com.ichi2.libanki.template.TemplateFilters
 import timber.log.Timber
 
 class TTS {
+    @get:JvmName("isEnabled")
+    var enabled: Boolean = false
+
     private val mTTS: ReadText? = null
 
     /**
@@ -85,5 +88,25 @@ class TTS {
         val clozeReplacement = context.getString(R.string.reviewer_tts_cloze_spoken_replacement)
         val clozeReplaced = text.replace(TemplateFilters.CLOZE_DELETION_REPLACEMENT, clozeReplacement)
         return Utils.stripHTML(clozeReplaced)
+    }
+
+    fun initialize(ctx: Context, listener: ReadText.ReadTextListener) {
+        if (!enabled) {
+            return
+        }
+        ReadText.initializeTts(ctx, listener)
+    }
+
+    /**
+     * Request that TextToSpeech is stopped and shutdown after it it no longer being used
+     * by the context that initialized it.
+     * No-op if the current instance of TextToSpeech was initialized by another Context
+     * @param context The context used during {@link #initializeTts(Context, ReadTextListener)}
+     */
+    fun releaseTts(context: Context) {
+        if (!enabled) {
+            return
+        }
+        ReadText.releaseTts(context)
     }
 }


### PR DESCRIPTION
The supplied listener wasn't called if the TTS wasn't invoked

We reorder saving to `metaDB` in case the automatic display answer were blocking

Fixes #9170
Fixes #9630
Related #4609

## How Has This Been Tested?
On my Android 11

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
