### PR TITLE
fix(card-template-preview): second template data

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.java
@@ -712,6 +712,7 @@ public class CardTemplateEditor extends AnkiActivity implements DeckSelectionDia
             int ordinal = mTemplateEditor.mViewPager.getCurrentItem();
             long noteId = getArguments().getLong("noteId");
             i.putExtra("ordinal", ordinal);
+            i.putExtra("cardListIndex", 0);
 
             // If we have a card for this position, send it, otherwise an empty cardlist signals to show a blank
             if (noteId != -1L) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplatePreviewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplatePreviewer.java
@@ -47,6 +47,8 @@ public class CardTemplatePreviewer extends AbstractFlashcardViewer {
     private String mEditedModelFileName = null;
     private Model mEditedModel = null;
     private int mOrdinal;
+    /** The index of the card in cardList to show */
+    private int mCardListIndex;
     /** The list (currently singular) of cards to be previewed
      * A single template was selected, and there was an associated card which exists
      */
@@ -81,6 +83,7 @@ public class CardTemplatePreviewer extends AbstractFlashcardViewer {
             mEditedModelFileName = parameters.getString(TemporaryModel.INTENT_MODEL_FILENAME);
             mCardList = parameters.getLongArray("cardList");
             mOrdinal = parameters.getInt("ordinal");
+            mCardListIndex = parameters.getInt("cardListIndex");
             mShowingAnswer = parameters.getBoolean("showingAnswer", mShowingAnswer);
         }
 
@@ -278,6 +281,7 @@ public class CardTemplatePreviewer extends AbstractFlashcardViewer {
         outState.putString(TemporaryModel.INTENT_MODEL_FILENAME, mEditedModelFileName);
         outState.putLongArray("cardList", mCardList);
         outState.putInt("ordinal", mOrdinal);
+        outState.putInt("cardListIndex", mCardListIndex);
         outState.putBundle("noteEditorBundle", mNoteEditorBundle);
         outState.putBoolean("showingAnswer", mShowingAnswer);
         super.onSaveInstanceState(outState);
@@ -292,8 +296,8 @@ public class CardTemplatePreviewer extends AbstractFlashcardViewer {
             closeCardTemplatePreviewer();
             return;
         }
-        if (mCardList != null && mOrdinal >= 0 && mOrdinal < mCardList.length) {
-            mCurrentCard = new PreviewerCard(col, mCardList[mOrdinal]);
+        if (mCardList != null && mCardListIndex >= 0 && mCardListIndex < mCardList.length) {
+            mCurrentCard = new PreviewerCard(col, mCardList[mCardListIndex]);
         }
 
         if (mNoteEditorBundle != null) {

--- a/AnkiDroid/src/test/java/com/ichi2/anki/CardTemplatePreviewerTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/CardTemplatePreviewerTest.java
@@ -40,6 +40,8 @@ import java.util.List;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
+import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
@@ -210,6 +212,26 @@ public class CardTemplatePreviewerTest extends RobolectricTest {
         TestCardTemplatePreviewer testCardTemplatePreviewer = super.startActivityNormallyOpenCollectionWithIntent(TestCardTemplatePreviewer.class, intent);
 
         assertTwoCards(testCardTemplatePreviewer);
+    }
+
+    @Test
+    public void cardTemplatePreviewerSecondOrd_issue8001() {
+        long cid = addNoteUsingBasicAndReversedModel("hello", "world").cards().get(1).getId();
+
+        Model model = getCurrentDatabaseModelCopy("Basic (and reversed card)");
+        String tempModelPath = TemporaryModel.saveTempModel(getTargetContext(), model);
+
+        Intent intent = new Intent(Intent.ACTION_VIEW);
+        intent.putExtra(TemporaryModel.INTENT_MODEL_FILENAME, tempModelPath);
+        intent.putExtra("ordinal", 1);
+        intent.putExtra("cardListIndex", 0);
+        intent.putExtra("cardList", new long[] { cid });
+
+        TestCardTemplatePreviewer testCardTemplatePreviewer = super.startActivityNormallyOpenCollectionWithIntent(TestCardTemplatePreviewer.class, intent);
+
+        assertThat(testCardTemplatePreviewer.getCardContent(), containsString("world"));
+        assertThat(testCardTemplatePreviewer.getCardContent(), not(containsString("hello")));
+        assertThat(testCardTemplatePreviewer.getCardContent(), not(containsString("Front")));
     }
 
 


### PR DESCRIPTION
The second template had the data "Front/Back"

This was because we used "ordinal" instead of "listIndex"

Fixes #8001

## How Has This Been Tested?

Unit tests and manually

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
