### PR TITLE
[fix:] Exisiting clients with default Custom media sync value 

### DIFF
--- a/AnkiDroid/src/test/java/com/ichi2/anki/servicemodel/PreferenceUpgradeServiceTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/servicemodel/PreferenceUpgradeServiceTest.kt
@@ -17,11 +17,13 @@
 package com.ichi2.anki.servicemodel
 
 import android.content.SharedPreferences
+import androidx.core.content.edit
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.ichi2.anki.AnkiDroidApp
 import com.ichi2.anki.RobolectricTest
 import com.ichi2.anki.servicelayer.PreferenceUpgradeService
 import com.ichi2.anki.servicelayer.PreferenceUpgradeService.PreferenceUpgrade
+import com.ichi2.anki.web.CustomSyncServer
 import com.ichi2.testutils.EmptyApplication
 import org.hamcrest.CoreMatchers.equalTo
 import org.hamcrest.MatcherAssert.assertThat
@@ -99,5 +101,14 @@ class PreferenceUpgradeServiceTest : RobolectricTest() {
             nestedClassCount,
             equalTo(upgradeCount)
         )
+    }
+
+    @Test
+    fun check_custom_media_sync_url() {
+        var syncURL = "https://msync.ankiweb.net"
+        mPrefs.edit { putString(CustomSyncServer.PREFERENCE_CUSTOM_MEDIA_SYNC_URL, syncURL) }
+        assertThat("Preference of custom media sync url is set to ($syncURL).", CustomSyncServer.getMediaSyncUrl(mPrefs).equals(syncURL))
+        PreferenceUpgrade.RemoveLegacyMediaSyncUrl().performUpgrade(mPrefs)
+        assertThat("Preference of custom media sync url is removed.", CustomSyncServer.getMediaSyncUrl(mPrefs).equals(null))
     }
 }


### PR DESCRIPTION
## Fixes
Fixes #9600

## Approach
The users will have the custom default value set to null

## How Has This Been Tested?
Unit tests

## Screenshots
Before the changes
![bbbb](https://user-images.githubusercontent.com/46752548/138135636-d956175b-c339-45eb-9bce-e45805383886.png)
After the changes
![aaa](https://user-images.githubusercontent.com/46752548/138135142-b35a0b5d-2ea8-4106-a098-7c18f90f9eda.png)

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
