### PR TITLE
Dependency updates 20211021

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -285,7 +285,7 @@ dependencies {
     // build with ./gradlew rsdroid:assembleRelease
     // In my experience, using `files()` currently requires a reindex operation, which is slow.
     // implementation files("C:\\GitHub\\Rust-Test\\rsdroid\\build\\outputs\\aar\\rsdroid-release.aar")
-    implementation 'com.google.protobuf:protobuf-java:3.18.1' // This is required when loading from a file
+    implementation 'com.google.protobuf:protobuf-java:3.19.0' // This is required when loading from a file
     implementation "io.github.david-allison-1:anki-android-backend:$backendVersion"
     // build with ./gradlew rsdroid-testing:assembleRelease
     // RobolectricTest.java: replace RustBackendLoader.init(); with RustBackendLoader.loadRsdroid(path);


### PR DESCRIPTION

Standard dependency updates PR from the dependabot tracking branch

protobuf may be interesting but is supposedly non-breaking. Mockito either works in testing or doesn't.
Both obviously passed CI already