### PR TITLE
perf(build): setting to strip resources

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -83,6 +83,10 @@ android {
                 Properties localProperties = new Properties()
                 localProperties.load(project.rootProject.file('local.properties').newDataInputStream())
                 testCoverageEnabled localProperties['enable_coverage'] != "false"
+                // not profiled: optimization for build times
+                if (localProperties['enable_languages'] == "false") {
+                    android.defaultConfig.resConfigs "en"
+                }
             } else {
                 testCoverageEnabled true
             }


### PR DESCRIPTION
Default is no change.

Add

```
enable_languages=false
```

to a file named `local.properties` to activate

This may be a placebo in terms of build times. Functionality is tested and resources are stripped

## Learning

A 'rebuild' doesn't clean the gradle cache. I'm fine to go by intuition on speedups from this. Best was 41 -> 31 seconds on a rebuild

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
