### PR TITLE
fix(handler): deprecation

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -141,6 +141,7 @@ import com.ichi2.utils.Computation;
 import com.ichi2.utils.FunctionalInterfaces.Consumer;
 import com.ichi2.utils.FunctionalInterfaces.Function;
 
+import com.ichi2.utils.HandlerUtils;
 import com.ichi2.utils.HashUtil;
 import com.ichi2.utils.JSONException;
 import com.ichi2.utils.JSONObject;
@@ -380,8 +381,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
     // LISTENERS
     // ----------------------------------------------------------------------------
 
-    @SuppressWarnings("deprecation") //  #7111: new Handler()
-    private final Handler mLongClickHandler = new Handler();
+    private final Handler mLongClickHandler = HandlerUtils.newHandler();
     private final Runnable mLongClickTestRunnable = new Runnable() {
         @Override
         public void run() {
@@ -706,8 +706,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
     }
 
 
-    @SuppressWarnings("deprecation") //  #7111: new Handler()
-    private final Handler mTimerHandler = new Handler();
+    private final Handler mTimerHandler = HandlerUtils.newHandler();
 
     private final Runnable mRemoveChosenAnswerText = new Runnable() {
         @Override
@@ -2678,8 +2677,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
             return null;
         }
 
-        @SuppressWarnings("deprecation") //  #7111: new Handler()
-        private final Handler mScrollHandler = new Handler();
+        private final Handler mScrollHandler = HandlerUtils.newHandler();
         private final Runnable mScrollXRunnable = () -> mIsXScrolling = false;
         private final Runnable mScrollYRunnable = () -> mIsYScrolling = false;
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -89,6 +89,7 @@ import com.ichi2.themes.Themes;
 import com.ichi2.ui.CardBrowserSearchView;
 import com.ichi2.upgrade.Upgrade;
 import com.ichi2.utils.FunctionalInterfaces;
+import com.ichi2.utils.HandlerUtils;
 import com.ichi2.utils.HashUtil;
 import com.ichi2.utils.LanguageUtil;
 import com.ichi2.utils.Computation;
@@ -2789,14 +2790,12 @@ public class CardBrowser extends NavigationDrawerActivity implements
      * The views expand / contract when switching between multi-select mode so we manually
      * adjust so that the vertical position of the given view is maintained
      */
-    @SuppressWarnings("deprecation") //  #7111: new Handler()
     private void recenterListView(@NonNull View view) {
         final int position = mCardsListView.getPositionForView(view);
         // Get the current vertical position of the top of the selected view
         final int top = view.getTop();
-        final Handler handler = new Handler();
         // Post to event queue with some delay to give time for the UI to update the layout
-        handler.postDelayed(() -> {
+        HandlerUtils.postDelayedOnNewHandler(() -> {
             // Scroll to the same vertical position before the layout was changed
             mCardsListView.setSelectionFromTop(position, top);
         }, 10);

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NavigationDrawerActivity.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NavigationDrawerActivity.java
@@ -49,6 +49,7 @@ import android.view.View;
 
 import com.ichi2.anki.dialogs.HelpDialog;
 import com.ichi2.themes.Themes;
+import com.ichi2.utils.HandlerUtils;
 
 import java.util.Arrays;
 
@@ -148,20 +149,18 @@ public abstract class NavigationDrawerActivity extends AnkiActivity implements N
         // between the sliding drawer and the action bar app icon
         mDrawerToggle = new ActionBarDrawerToggle(this, mDrawerLayout, 0, 0) {
             @Override
-            @SuppressWarnings("deprecation") //  #7111: new Handler()
             public void onDrawerClosed(View drawerView) {
                 super.onDrawerClosed(drawerView);
                 supportInvalidateOptionsMenu();
 
                 // If animations are disabled, this is executed before onNavigationItemSelected is called
                 // PERF: May be able to reduce this delay
-                new Handler().postDelayed(() -> {
+                HandlerUtils.postDelayedOnNewHandler(() -> {
                     if (mPendingRunnable != null) {
-                        new Handler().post(mPendingRunnable);
+                        HandlerUtils.postOnNewHandler(mPendingRunnable); // TODO: See if we can use the same handler here
                         mPendingRunnable = null;
                     }
                 }, 100);
-
             }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ReadText.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ReadText.java
@@ -29,6 +29,7 @@ import android.view.WindowManager;
 import com.afollestad.materialdialogs.MaterialDialog;
 import com.google.android.material.snackbar.Snackbar;
 import com.ichi2.libanki.Sound;
+import com.ichi2.utils.HandlerUtils;
 
 import java.lang.ref.WeakReference;
 import java.util.ArrayList;
@@ -134,10 +135,8 @@ public class ReadText {
         showDialogAfterDelay(builder, 500);
     }
 
-    @SuppressWarnings("deprecation") //  #7111: new Handler()
     protected static void showDialogAfterDelay(MaterialDialog.Builder builder, int delayMillis) {
-        final Handler handler = new Handler();
-        handler.postDelayed(() -> {
+        HandlerUtils.postDelayedOnNewHandler(() -> {
             try {
                 builder.build().show();
             } catch (WindowManager.BadTokenException e) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.java
@@ -88,6 +88,7 @@ import com.ichi2.themes.Themes;
 import com.ichi2.utils.AndroidUiUtils;
 import com.ichi2.utils.Computation;
 import com.ichi2.utils.FunctionalInterfaces.Consumer;
+import com.ichi2.utils.HandlerUtils;
 import com.ichi2.utils.Permissions;
 import com.ichi2.utils.ViewGroupUtils;
 import com.ichi2.widget.WidgetStatus;
@@ -561,9 +562,8 @@ public class Reviewer extends AbstractFlashcardViewer {
     }
 
     @Override
-    @SuppressWarnings("deprecation") //  #7111: new Handler()
     public boolean onMenuOpened(int featureId, Menu menu) {
-        new Handler().post(() -> {
+        HandlerUtils.postOnNewHandler(() -> {
             for (int i = 0; i < menu.size(); i++) {
                 MenuItem menuItem = menu.getItem(i);
                 shouldUseDefaultColor(menuItem);
@@ -586,9 +586,8 @@ public class Reviewer extends AbstractFlashcardViewer {
 
 
     @Override
-    @SuppressWarnings("deprecation") //  #7111: new Handler()
     public void onPanelClosed(int featureId, @NonNull Menu menu) {
-        new Handler().postDelayed(this::refreshActionBar, 100);
+        HandlerUtils.postDelayedOnNewHandler(this::refreshActionBar, 100);
     }
 
     @Override
@@ -1129,10 +1128,9 @@ public class Reviewer extends AbstractFlashcardViewer {
         }
     }
 
-    @SuppressWarnings("deprecation") //  #7111: new Handler()
-    protected final Handler mFullScreenHandler = new Handler() {
+    protected final Handler mFullScreenHandler = new Handler(HandlerUtils.getDefaultLooper()) {
         @Override
-        public void handleMessage(Message msg) {
+        public void handleMessage(@NonNull Message msg) {
             if (mPrefFullscreenReview) {
                 setFullScreen(Reviewer.this);
             }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DialogHandler.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DialogHandler.java
@@ -31,6 +31,7 @@ import com.ichi2.anki.R;
 import com.ichi2.async.Connection;
 import com.ichi2.libanki.Collection;
 import com.ichi2.anki.analytics.UsageAnalytics;
+import com.ichi2.utils.HandlerUtils;
 
 import java.lang.ref.WeakReference;
 import java.util.ArrayList;
@@ -77,8 +78,8 @@ public class DialogHandler extends Handler {
     final WeakReference<AnkiActivity> mActivity;
     private static Message sStoredMessage;
 
-    @SuppressWarnings("deprecation") //  #7111: new Handler() - using default constructor
-    public DialogHandler(AnkiActivity activity) {
+    public DialogHandler(AnkiActivity activity)  {
+        super(HandlerUtils.getDefaultLooper());
         // Use weak reference to main activity to prevent leaking the activity when it's closed
         mActivity = new WeakReference<>(activity);
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/AutomaticAnswer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/AutomaticAnswer.kt
@@ -17,7 +17,6 @@
 package com.ichi2.anki.reviewer
 
 import android.content.SharedPreferences
-import android.os.Handler
 import androidx.annotation.CheckResult
 import androidx.annotation.VisibleForTesting
 import com.ichi2.anki.R
@@ -25,6 +24,7 @@ import com.ichi2.anki.Reviewer
 import com.ichi2.anki.cardviewer.ViewerCommand
 import com.ichi2.anki.reviewer.AnswerButtons.*
 import com.ichi2.libanki.Collection
+import com.ichi2.utils.HandlerUtils
 import timber.log.Timber
 
 /**
@@ -88,9 +88,8 @@ class AutomaticAnswer(
      * Handler for the delay in auto showing question and/or answer
      * One toggle for both question and answer, could set longer delay for auto next question
      */
-    @Suppress("Deprecation") //  #7111: new Handler()
     @VisibleForTesting
-    val timeoutHandler = Handler()
+    val timeoutHandler = HandlerUtils.newHandler()
 
     @VisibleForTesting
     fun delayedShowQuestion(delay: Long) {

--- a/AnkiDroid/src/main/java/com/ichi2/utils/HandlerUtils.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/HandlerUtils.kt
@@ -22,6 +22,44 @@ import android.os.Looper
 
 object HandlerUtils {
 
+    @JvmStatic
+    fun getDefaultLooper(): Looper = Looper.getMainLooper()
+
+    @JvmStatic
+    fun newHandler(): Handler = Handler(getDefaultLooper())
+
+    /**
+     * Creates a new [Handler] and adds [r] to the message queue.
+     * The runnable will be run on main thread
+     *
+     * @param r The Runnable that will be executed.
+     */
+    @JvmStatic
+    fun postOnNewHandler(r: Runnable): Handler {
+        val newHandler = newHandler()
+        newHandler.post(r)
+        return newHandler
+    }
+
+    /**
+     * Causes the Runnable r to be added to the message queue, to be run
+     * after the specified amount of time elapses.
+     * The runnable will be run on main thread
+     *
+     * <b>The time-base is [android.os.SystemClock.uptimeMillis]</b>
+     * Time spent in deep sleep will add an additional delay to execution.
+     *
+     * @param r The Runnable that will be executed.
+     * @param delayMillis The delay (in milliseconds) until the Runnable
+     *        will be executed.
+     */
+    @JvmStatic
+    fun postDelayedOnNewHandler(r: Runnable, delayMillis: Long): Handler {
+        val newHandler = newHandler()
+        newHandler.postDelayed(r, delayMillis)
+        return newHandler
+    }
+
     /**
      * Add runnable to message queue and run on the thread to which this handler is attached.
      * This will run on the main thread if called from the main thread.


### PR DESCRIPTION
We move this from `myLooper` to `getMainLooper`

Due to comments on the issue, we add `HandlerUtils.getDefaultLooper` but I don't believe that mocking this is necessary due to a Robolectric Upgrade. Tests appear to be working

Fixes #7111

## How Has This Been Tested?

Had a quick check and this seems to work well

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
