### PR TITLE
fix: addNonClozeModel

### DIFF
--- a/AnkiDroid/src/test/java/com/ichi2/anki/RobolectricTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/RobolectricTest.kt
@@ -55,11 +55,7 @@ import org.robolectric.android.controller.ActivityController
 import org.robolectric.shadows.ShadowDialog
 import org.robolectric.shadows.ShadowLog
 import timber.log.Timber
-import java.lang.Exception
-import java.lang.IllegalArgumentException
-import java.lang.IllegalStateException
-import java.lang.RuntimeException
-import java.util.ArrayList
+import java.util.*
 import java.util.concurrent.locks.ReentrantLock
 import kotlin.concurrent.withLock
 
@@ -353,8 +349,10 @@ open class RobolectricTest : CollectionGetter {
         for (field in fields) {
             addField(model, field)
         }
-        model.put(FlashCardsContract.CardTemplate.QUESTION_FORMAT, qfmt)
-        model.put(FlashCardsContract.CardTemplate.ANSWER_FORMAT, afmt)
+        val t = Models.newTemplate("Card 1")
+        t.put(FlashCardsContract.CardTemplate.QUESTION_FORMAT, qfmt)
+        t.put(FlashCardsContract.CardTemplate.ANSWER_FORMAT, afmt)
+        col.models.addTemplateInNewModel(model, t)
         col.models.add(model)
         col.models.flush()
         return name


### PR DESCRIPTION
Was broken

Fixes V16 tests:

NoteEditorTest:
* errorSavingInvalidNoteWithAllFieldsDisplaysInvalidTemplate
* errorSavingNoteWithNoTemplatesShowsNoCardsCreated
* errorSavingInvalidNoteWitSomeFieldsDisplaysEnterMore

Fixes #7753

## How Has This Been Tested?

Unit test only
## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
