### PR TITLE
refactor: extract PreviousAnswerIndicator from CardViewer

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -290,8 +290,6 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
     private int mInitialFlipCardHeight;
     private boolean mButtonHeightSet = false;
 
-    private static final int sShowChosenAnswerLength = 2000;
-
     public static final String DOUBLE_TAP_TIME_INTERVAL = "doubleTapTimeInterval";
     public static final int DEFAULT_DOUBLE_TAP_TIME_INTERVAL = 200;
 
@@ -693,12 +691,6 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
         return nextCardHandler()
                 .alsoExecuteBefore(() -> blockControls(quick));
     }
-
-
-    private final Handler mTimerHandler = HandlerUtils.newHandler();
-
-    private final Runnable mRemoveChosenAnswerText = mPreviousAnswerIndicator::clear;
-
 
     protected int getAnswerButtonCount() {
         return getCol().getSched().answerButtons(mCurrentCard);
@@ -1235,12 +1227,9 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
         if (buttonNumber < ease) {
             return;
         }
-        // Set the dots appearing below the toolbar
+        // Temporarily sets the answer indicator dots appearing below the toolbar
         mPreviousAnswerIndicator.displayAnswerIndicator(ease, buttonNumber);
 
-        // remove chosen answer hint after a while
-        mTimerHandler.removeCallbacks(mRemoveChosenAnswerText);
-        mTimerHandler.postDelayed(mRemoveChosenAnswerText, sShowChosenAnswerLength);
         mSoundPlayer.stopSounds();
         mCurrentEase = ease;
 
@@ -2322,7 +2311,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
         }
 
         mAutomaticAnswer.disable();
-        mTimerHandler.removeCallbacks(mRemoveChosenAnswerText);
+        mPreviousAnswerIndicator.stopAutomaticHide();
         mLongClickHandler.removeCallbacks(mLongClickTestRunnable);
         mLongClickHandler.removeCallbacks(mStartLongClickAction);
 


### PR DESCRIPTION
## Purpose / Description
Removes 40 LOC from CardViewer

This is in preparation from moving the "answer card" functionality to the Reviewer

Also a good excuse to document the feature

## Approach
Gradual refactorings and some hard thought

## How Has This Been Tested?
Briefly on my device

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
