### PR TITLE
Optimizing pre-commit hook.

### DIFF
--- a/pre-commit
+++ b/pre-commit
@@ -11,12 +11,17 @@ fi;
 echo "Running Ktlint over these files:"
 echo "$CHANGED_FILES"
 
-# Clean is required because of https://github.com/ankidroid/Anki-Android/issues/9521
-./gradlew clean
+
 # -q removes noise from the output if it fails.
 # TODO: -w is better, but https://github.com/JLLeitschuh/ktlint-gradle/issues/457 adds noise
 # -w should display: "CriticalExceptionTest.kt:19:1 Wildcard import (cannot be auto-corrected)"
-./gradlew -q ktlintFormat
+# Cleaning and retrying only if the ktlint fails
+if ! ./gradlew -q ktlintFormat ; then
+    echo "Cleaning the project and retrying."
+    # Clean is required because of https://github.com/ankidroid/Anki-Android/issues/9521
+    ./gradlew clean
+    ./gradlew -q ktlintFormat
+fi;
 
 echo "Completed ./gradlew ktlintFormat run."
 echo "$CHANGED_FILES" | while read -r file; do


### PR DESCRIPTION
## Purpose / Description
Mentioned https://github.com/ankidroid/Anki-Android/pull/9662#issuecomment-947326079

## Fixes
Fixes #9693 

## Approach
`./gradlew clean` only runs when ktlint fails

## Screenshots
When clean was required
![image](https://user-images.githubusercontent.com/46752548/138559662-68c50af4-ee4f-4d5b-8639-725bf390b4f6.png)

When clean wasn't required
![image](https://user-images.githubusercontent.com/46752548/138559681-35f38048-0024-4795-936d-116d9099be63.png)



## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
