### PR TITLE
Fix of issue #9503

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/activity/MultimediaEditFieldActivity.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/activity/MultimediaEditFieldActivity.java
@@ -285,7 +285,7 @@ public class MultimediaEditFieldActivity extends AnkiActivity
         }
 
         if (bChangeToText) {
-            mField = new TextField();
+            mField = null;
         }
         saveAndExit();
     }


### PR DESCRIPTION
## Purpose / Description
Selecting "Add image" or "Add audio clip"  while editing a note, then saving without picking a file will clear any existing text in the field.

## Fixes
Fixes #9503 

## Approach
In MultimediaEditFieldActivity.java :Instead of returning a new Text Field, returned a null which gets shorted in NoteEditor.java's onActivityResult() method when no file is selected.

## How Has This Been Tested?
Tested in an emulator.
Existing text in the field aren't getting erased while reproducing the issue.

https://user-images.githubusercontent.com/58620100/138584124-619a040d-5b61-467a-9187-ca1223c081ff.mp4

https://user-images.githubusercontent.com/58620100/138584163-84601e99-ac29-48a6-ae38-58c2e4eaf0a1.mp4


## Learning (optional, can help others)
I went through the codebase and understood it to get the issue fixed.

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [ ] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
