### PR TITLE
build: increase memory available to gradle during build

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@
 
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
-org.gradle.jvmargs=-Xmx1536m
+org.gradle.jvmargs=-Xmx2048M -Dkotlin.daemon.jvm.options\="-Xmx3072M" -XX\:MaxPermSize\=768m -XX\:+HeapDumpOnOutOfMemoryError -Dfile.encoding\=UTF-8
 
 # AndroidX package structure to make it clearer which packages are bundled with the
 # Android operating system, and which are packaged with your app's APK


### PR DESCRIPTION
## Pull Request template

## Purpose / Description

Gradle has been running out of Java heap space recently, this is an attempt to work around that


## Fixes
Fixes #9712 - maybe

## Approach
Give gradle lots more ram

## How Has This Been Tested?

I ran `./gradlew jacocoUnitTestReport lintPlayRelease` locally and it did not fail, at least.
This only happens on CI maybe once a week though? That I have seen. So it does not reproduce easily.

## Learning (optional, can help others)
Brazenly stole this from a different very large project, hopefully it works.

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
