### PR TITLE
feat(instrumented tests): Use separate collection

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -60,7 +60,7 @@ android {
         targetSdkVersion 29 // change .travis.yml platform download at same time
         testApplicationId "com.ichi2.anki.tests"
         vectorDrawables.useSupportLibrary = true
-        testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
+        testInstrumentationRunner 'com.ichi2.testutils.NewCollectionPathTestRunner'
     }
     signingConfigs {
         release {

--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/ACRATest.java
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/ACRATest.java
@@ -66,10 +66,25 @@ public class ACRATest extends InstrumentedTest {
      * @exception NoSuchFieldException if the method isn't found, possibly IllegalAccess or InvocationAccess as well
      */
     private void setAcraConfig(String mode, SharedPreferences prefs) throws Exception {
-        Method method = mApp.getClass().getDeclaredMethod("set" + mode + "ACRAConfig", SharedPreferences.class);
+        Method method = findSetAcraConfigMethod(mode);
         method.setAccessible(true);
         method.invoke(mApp, prefs);
     }
+
+    /** @return the method: "set[Debug/Production]ACRAConfig" on the application instance */
+    private Method findSetAcraConfigMethod(String mode) {
+        Class<?> clazz = mApp.getClass();
+        String methodName = "set" + mode + "ACRAConfig";
+        while (clazz != null) {
+            try {
+                return clazz.getDeclaredMethod(methodName, SharedPreferences.class);
+            } catch (NoSuchMethodException e) {
+                clazz = clazz.getSuperclass();
+            }
+        }
+        throw new IllegalStateException(methodName + " not found");
+    }
+
 
     @Test
     public void testDebugConfiguration() throws Exception {

--- a/AnkiDroid/src/androidTest/java/com/ichi2/testutils/NewCollectionPathTestRunner.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/testutils/NewCollectionPathTestRunner.kt
@@ -1,0 +1,32 @@
+/*
+ *  Copyright (c) 2021 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.testutils
+
+import android.app.Application
+import android.content.Context
+import androidx.test.runner.AndroidJUnitRunner
+
+/**
+ * A test runner which sets [com.ichi2.anki.AnkiDroidApp.INSTRUMENTATION_TESTING] to true
+ * so a test collection path is used
+ */
+@Suppress("unused") // referenced by build.gradle
+class NewCollectionPathTestRunner : AndroidJUnitRunner() {
+    override fun newApplication(cl: ClassLoader?, className: String?, context: Context?): Application {
+        return super.newApplication(cl, TestingApplication::class.java.name, context)
+    }
+}

--- a/AnkiDroid/src/androidTest/java/com/ichi2/testutils/TestingApplication.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/testutils/TestingApplication.kt
@@ -1,0 +1,31 @@
+/*
+ *  Copyright (c) 2021 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.testutils
+
+import android.content.Context
+import com.ichi2.anki.AnkiDroidApp
+
+/**
+ * An application which sets [com.ichi2.anki.AnkiDroidApp.INSTRUMENTATION_TESTING] to true
+ * so a test collection path is used
+ */
+class TestingApplication : AnkiDroidApp() {
+    override fun attachBaseContext(base: Context?) {
+        INSTRUMENTATION_TESTING = true
+        super.attachBaseContext(base)
+    }
+}

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.java
@@ -151,6 +151,9 @@ import static timber.log.Timber.DebugTree;
 )
 public class AnkiDroidApp extends Application {
 
+    /** Running under instrumentation. a "/androidTest" folder will be created which contains a test collection */
+    public static boolean INSTRUMENTATION_TESTING = false;
+
     /**
      * Toggles Scoped Storage functionality introduced in later commits <p>
      * Can be set to true or false only by altering the declaration itself.

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CollectionHelper.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CollectionHelper.java
@@ -400,6 +400,11 @@ public class CollectionHelper {
      */
     public static String getCurrentAnkiDroidDirectory(Context context) {
         SharedPreferences preferences = AnkiDroidApp.getSharedPrefs(context);
+        if (AnkiDroidApp.INSTRUMENTATION_TESTING) {
+            // create an "androidTest" folder inside the current collection folder which contains the test data
+            // "/AnkiDroid/androidTest" would be a new collection path
+            return new File(getDefaultAnkiDroidDirectory(context), "androidTest").getAbsolutePath();
+        }
         return PreferenceExtensions.getOrSetString(
                 preferences,
                 "deckPath",


### PR DESCRIPTION
* Define a new test runner
* Use new test runner in `build.gradle`
* Which uses a new application class
* Which sets `AnkiDroidApp.INSTRUMENTATION_TESTING`
* Which is used in `getCurrentAnkiDroidDirectory`

Note: This folder will be created at "/AnkiDroid/androidTest" and will not be cleared

We also fix ACRATest to allow for subclasses

Fixes #9111
Fixes #6025

## How Has This Been Tested?
Tested on my Android 11. Also changed the code in `CollectionHelper` to a `throw` to confirm that it's executed

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
