### PR TITLE
Fix crash on updating template when full sync is required

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.java
@@ -991,8 +991,11 @@ public class CardTemplateEditor extends AnkiActivity implements DeckSelectionDia
                 Runnable confirm = () -> {
                     mTemplateEditor.getCol().modSchemaNoCheck();
                     addNewTemplate(model);
+                    mTemplateEditor.dismissAllDialogFragments();
                 };
+                Runnable cancel = () -> mTemplateEditor.dismissAllDialogFragments();
                 d.setConfirm(confirm);
+                d.setCancel(cancel);
                 mTemplateEditor.showDialogFragment(d);
             }
         }


### PR DESCRIPTION
## Purpose / Description
Prevent crash on updating template in case when full sync is required.

## Fixes
Fixes #9688 

## Approach
The previous dialog mentioning that `This will create %1$d card. Proceed?` needs to be closed. If it remains open even after full sync dialog is displayed and then user clicks on "OK' again then it leads to a crash.

## How Has This Been Tested?

Tested on Pixel 2 API 30 emulator.

## Checklist

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [ ] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
