### PR TITLE
fix: add note from cardbrowser didn't use selected deck.

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -1813,6 +1813,7 @@ public class NoteEditor extends AnkiActivity implements
         // determine what it should be again. An existing value means we are resuming the activity
         // where the target deck was already decided by the user.
         if (mCurrentDid != 0) {
+            mDeckSpinnerSelection.selectDeckById(mCurrentDid, false);
             return;
         }
         if (note == null || mAddNote || mCurrentEditedCard == null) {


### PR DESCRIPTION
## Purpose / Description
Add note from cardbrowser wasn't showing selected deck as the deck name in the spinner.

## Fixes
Fixes #9469

## How Has This Been Tested?
Only on my phone

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
