### PR TITLE
[Reviewer][Field:Type in Answer]Ensure visibility in Fullscreen+focus

### DIFF
--- a/AnkiDroid/src/main/res/layout/reviewer_fullscreen.xml
+++ b/AnkiDroid/src/main/res/layout/reviewer_fullscreen.xml
@@ -2,6 +2,7 @@
 android:layout_width="match_parent"
 android:layout_height="match_parent"
 android:focusableInTouchMode="true"
+android:fitsSystemWindows="true"
 xmlns:android="http://schemas.android.com/apk/res/android">
     <!-- Main content that takes up the fullscreen -->
     <RelativeLayout


### PR DESCRIPTION
## Purpose / Description
The android soft keyboard hides the FixedEditText View when fullscreen+Focus Type-in answer settings are enabled. This renders the user unable to see what they are typing or if anything is being typed at all.

## Fixes
Fixes #9691

## Approach
Add fitsSystemWindows="true" attribute in the root of reviewer_fullscreen layout. 

![make_edittext_visible_fullscreenReviewer](https://user-images.githubusercontent.com/81802035/139425869-7505fcab-8121-4dcf-a7ee-2722b97e8e28.gif)

## How Has This Been Tested?
This was manually tested on API 30. The following cases were considered: 
- Does it work in fullscreen
- Does it match the visual behaviour when not in full screen
- Does "Settings - Advanced - Focus 'type in answer'" still pop up the keyboard

## Learning (optional, can help others)
_Describe the research stage_
1. Initially, it was tried that the views would get squished and distorted to fit the compressed area. The layout structure itself was very hierarchical, Android Studio's 3D layout inspector was used to inspect it. Revamping the layout structure to constraint layouts in order to achieve a flat hierarchy was tried, but the results were unsatisfactory and the approach introduced unnecessary refactoring of the code. This idea was dropped.
2. Manifest files were inspected to check whether the concerned activity/application tag contains android:windowSoftInputMode attribute, which adjusts the views when the keyboard appears. It was found that attribute was indeed already set and not the cause of the problem. 
3. ScrollView Tag was added in the layout in multiple ways. This did ensure that the keyboard would be visible, but it completely distorted the visibility/alingment of the views in sibling layouts in the relative layout. This idea was dropped.
4. Finally, it was inspected that the fitsSystemWindows="true" was missing which was causing the actual problem. This was added to the RelativeLayout containing the flashcard, whiteboard editor, topbar, bottombar. 
i. It worked well for all the sibling views. The views in the sibling layouts were aligned and visible correctly this time. 
ii. However, it was noticed that the toolbar on the top when dragged  in, was only visible from the bottom half as the notifications panel hid the top half. 
iii. This was caused because the FrameLayout  for the toolbar was outside the relative layout. 
iv. So the fitsSystemWindows="true" atrribute was added to the root of the entire fullscreen layout instead of the child relative layout. This worked well for the entirety of the layout structure and was concluded as the final solution. 

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [ ] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
