### PR TITLE
lint: kotlin conversion corrupting emails

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidJsAPI.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidJsAPI.kt
@@ -13,7 +13,7 @@
  * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
  *                                                                                      *
  * You should have received a copy of the GNU General Public License along with         *
- * this program.  If not, see <http:></http:>//www.gnu.org/licenses/>.                  *
+ * this program.  If not, see http://www.gnu.org/licenses/>.                            *
  *                                                                                      *
  * *************************************************************************************/
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Card.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Card.kt
@@ -1,19 +1,19 @@
-/****************************************************************************************
- * Copyright (c) 2009 Daniel Svärd <daniel.svard></daniel.svard>@gmail.com>                             *
- * Copyright (c) 2011 Norbert Nagold <norbert.nagold></norbert.nagold>@gmail.com>                         *
- * Copyright (c) 2014 Houssam Salem <houssam.salem.au></houssam.salem.au>@gmail.com>                        *
- * *
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU General Public License as published by the Free Software        *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- * *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
- * *
- * You should have received a copy of the GNU General Public License along with         *
- * this program.  If not, see <http:></http:>//www.gnu.org/licenses/>.                           *
+/*
+ * Copyright (c) 2009 Daniel Svärd daniel.svard@gmail.com>
+ * Copyright (c) 2011 Norbert Nagold norbert.nagold@gmail.com>
+ * Copyright (c) 2014 Houssam Salem <houssam.salem.au@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 package com.ichi2.libanki
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/AnkiDroidJsAPITest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/AnkiDroidJsAPITest.kt
@@ -12,7 +12,7 @@
  * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
  *                                                                                      *
  * You should have received a copy of the GNU General Public License along with         *
- * this program.  If not, see <http:></http:>//www.gnu.org/licenses/>.                  *
+ * this program.  If not, see <http://www.gnu.org/licenses/>.                            *
  *                                                                                      *
  * *************************************************************************************/
 

--- a/lint-rules/build.gradle
+++ b/lint-rules/build.gradle
@@ -6,6 +6,10 @@ java {
     targetCompatibility = JavaVersion.VERSION_1_8
 }
 
+ktlint {
+    disabledRules = ["no-wildcard-imports"]
+}
+
 repositories {
     google()
     mavenCentral()

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/IssueRegistry.java
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/IssueRegistry.java
@@ -15,6 +15,7 @@ import com.ichi2.anki.lint.rules.DuplicateCrowdInStrings;
 import com.ichi2.anki.lint.rules.DuplicateTextInPreferencesXml;
 import com.ichi2.anki.lint.rules.FixedPreferencesTitleLength;
 import com.ichi2.anki.lint.rules.InconsistentAnnotationUsage;
+import com.ichi2.anki.lint.rules.KotlinMigrationBrokenEmails;
 import com.ichi2.anki.lint.rules.NonPublicNonStaticJavaFieldDetector;
 import com.ichi2.anki.lint.rules.PreferIsEmptyOverSizeCheck;
 import com.ichi2.anki.lint.rules.PrintStackTraceUsage;
@@ -42,6 +43,7 @@ public class IssueRegistry extends com.android.tools.lint.client.api.IssueRegist
         issues.add(DuplicateCrowdInStrings.ISSUE);
         issues.add(DuplicateTextInPreferencesXml.ISSUE);
         issues.add(InconsistentAnnotationUsage.ISSUE);
+        issues.add(KotlinMigrationBrokenEmails.ISSUE);
         issues.add(PreferIsEmptyOverSizeCheck.ISSUE);
         issues.add(PrintStackTraceUsage.ISSUE);
         issues.add(NonPublicNonStaticJavaFieldDetector.ISSUE);

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/rules/KotlinMigrationBrokenEmails.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/KotlinMigrationBrokenEmails.kt
@@ -1,0 +1,81 @@
+/*
+ *  Copyright (c) 2021 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.lint.rules
+
+import com.android.tools.lint.detector.api.*
+import com.google.common.annotations.Beta
+import com.google.common.annotations.VisibleForTesting
+import com.ichi2.anki.lint.utils.Constants
+import org.jetbrains.uast.UClass
+import org.jetbrains.uast.UElement
+import java.util.*
+import java.util.regex.Pattern
+
+@Beta
+class KotlinMigrationBrokenEmails : Detector(), SourceCodeScanner {
+    override fun getApplicableUastTypes(): List<Class<out UElement?>>? {
+        return listOf(UClass::class.java)
+    }
+
+    override fun afterCheckFile(context: Context) {
+        val contents = context.getContents()
+        if (contents == null || !BAD_KOLTIN_MIGRATION_PATTERN.matcher(contents).find()) {
+            return
+        }
+
+        // select from the start to the first line with content
+        var end = 0
+        var foundChar = false
+        for (i in contents.indices) {
+            foundChar = foundChar or !Character.isWhitespace(contents[i])
+            if (foundChar && contents[i] == '\n') {
+                end = i
+                break
+            }
+        }
+
+        // If there is no line break, highlight the contents
+        val endOffset = if (end == 0) contents.length else end
+        val location: Location = Location.create(context.file, contents.subSequence(0, endOffset), 0, endOffset)
+        context.report(ISSUE, location, DESCRIPTION)
+    }
+
+    companion object {
+        /** Java -> Kotlin converts <http:// to <http:></http:>// */
+        private val BAD_KOLTIN_MIGRATION_PATTERN = Pattern.compile(Pattern.quote("<http:></http:>"))
+
+        @VisibleForTesting
+        val ID = "KotlinMigrationBrokenEmails"
+
+        @VisibleForTesting
+        val DESCRIPTION = "Comment contents were corrupted by the Kotlin migration. For example: <http:></http:>"
+        private const val EXPLANATION = "<http:></http:> was detected in the file.\n" +
+            "Check all comments to see if this also affected emails.\n" +
+            "This can be fixed before conversion by changing the comments from /** to /* if appropriate"
+        private val implementation = Implementation(KotlinMigrationBrokenEmails::class.java, EnumSet.of(Scope.JAVA_FILE, Scope.TEST_SOURCES))
+        @JvmField
+        val ISSUE: Issue = Issue.create(
+            ID,
+            DESCRIPTION,
+            EXPLANATION,
+            Constants.ANKI_CODE_STYLE_CATEGORY,
+            Constants.ANKI_CODE_STYLE_PRIORITY,
+            Constants.ANKI_CODE_STYLE_SEVERITY,
+            implementation
+        )
+    }
+}


### PR DESCRIPTION
The Java -> Kotlin migration converts `<...>` into html tags if the comment is `/**` instead of `/*`

This often catches the copyright header of files, which is bad as it corrupts the emails in the copyright.

Pickup the email `<http:></http:>` and report this

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
