### PR TITLE
anki_eco: card previewer shows fields labels if all fields are null.

### DIFF
--- a/AnkiDroid/src/main/res/values/02-strings.xml
+++ b/AnkiDroid/src/main/res/values/02-strings.xml
@@ -266,6 +266,10 @@
     <string name="choose_an_image">Select image</string>
     <!-- Card Template Browser Appearance -->
     <string name="restore_default">Restore Default</string>
+    <string name="cloze_sample_text">This is a {{%1$s::sample}} cloze deletion.</string>
+    <string name="basic_answer_sample_text_user" comment="has a typo, so that user sees a highlighted difference in basic answer model
+    ">exomple</string>
+    <string name="basic_answer_sample_text">an example</string>
 
     <string name="reviewer_tts_cloze_spoken_replacement">Blank</string>
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/CardTemplatePreviewerTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/CardTemplatePreviewerTest.java
@@ -33,6 +33,7 @@ import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.android.controller.ActivityController;
+import org.robolectric.annotation.Config;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -85,6 +86,68 @@ public class CardTemplatePreviewerTest extends RobolectricTest {
         View showAnswerButton = testCardTemplatePreviewer.findViewById(R.id.preview_buttons_layout);
         showAnswerButton.performClick();
         Assert.assertTrue("Not showing the answer?", testCardTemplatePreviewer.getShowingAnswer());
+    }
+
+    @Test
+    public void testPreviewUnsavedTemplate_Basic() {
+        String modelName = "Basic";
+        Model collectionBasicModelOriginal = getCurrentDatabaseModelCopy(modelName);
+        List<String> fields = collectionBasicModelOriginal.getFieldsNames();
+        JSONObject template = collectionBasicModelOriginal.getJSONArray("tmpls").getJSONObject(0);
+        template.put("qfmt", template.getString("qfmt") + "PREVIEWER_TEST");
+        String tempModelPath = TemporaryModel.saveTempModel(getTargetContext(), collectionBasicModelOriginal);
+        Intent intent = new Intent(Intent.ACTION_VIEW);
+        intent.putExtra(TemporaryModel.INTENT_MODEL_FILENAME, tempModelPath);
+        intent.putExtra("index", 0);
+
+        ActivityController<TestCardTemplatePreviewer> previewerController = Robolectric.buildActivity(TestCardTemplatePreviewer.class, intent).create().start().resume().visible();
+        saveControllerForCleanup((previewerController));
+        TestCardTemplatePreviewer testCardTemplatePreviewer = previewerController.get();
+        String[] arr = testCardTemplatePreviewer.getDummyCard(collectionBasicModelOriginal, 0).note().getFields();
+        assertThat(arr[0], is("(" + fields.get(0) + ")"));
+        assertThat(arr[1], is("(" + fields.get(1) + ")"));
+    }
+
+    @Test
+    @Config(qualifiers = "en")
+    public void testPreviewUnsavedTemplate_Cloze() {
+        String modelName = "Cloze";
+        Model collectionBasicModelOriginal = getCurrentDatabaseModelCopy(modelName);
+        List<String> fields = collectionBasicModelOriginal.getFieldsNames();
+        JSONObject template = collectionBasicModelOriginal.getJSONArray("tmpls").getJSONObject(0);
+        template.put("qfmt", template.getString("qfmt") + "PREVIEWER_TEST");
+        String tempModelPath = TemporaryModel.saveTempModel(getTargetContext(), collectionBasicModelOriginal);
+        Intent intent = new Intent(Intent.ACTION_VIEW);
+        intent.putExtra(TemporaryModel.INTENT_MODEL_FILENAME, tempModelPath);
+        intent.putExtra("index", 0);
+
+        ActivityController<TestCardTemplatePreviewer> previewerController = Robolectric.buildActivity(TestCardTemplatePreviewer.class, intent).create().start().resume().visible();
+        saveControllerForCleanup((previewerController));
+        TestCardTemplatePreviewer testCardTemplatePreviewer = previewerController.get();
+        String[] arr = testCardTemplatePreviewer.getDummyCard(collectionBasicModelOriginal, 0).note().getFields();
+        assertThat(arr[0], is(testCardTemplatePreviewer.getString(R.string.cloze_sample_text, "c1")));
+        assertThat(arr[1], is("(" + fields.get(1) + ")"));
+    }
+
+    @Test
+    @Config(qualifiers = "en")
+    public void testPreviewUnsavedTemplate_basic_answer() {
+        String modelName = "Basic (type in the answer)";
+        Model collectionBasicModelOriginal = getCurrentDatabaseModelCopy(modelName);
+        List<String> fields = collectionBasicModelOriginal.getFieldsNames();
+        JSONObject template = collectionBasicModelOriginal.getJSONArray("tmpls").getJSONObject(0);
+        template.put("qfmt", template.getString("qfmt") + "PREVIEWER_TEST");
+        String tempModelPath = TemporaryModel.saveTempModel(getTargetContext(), collectionBasicModelOriginal);
+        Intent intent = new Intent(Intent.ACTION_VIEW);
+        intent.putExtra(TemporaryModel.INTENT_MODEL_FILENAME, tempModelPath);
+        intent.putExtra("index", 0);
+
+        ActivityController<TestCardTemplatePreviewer> previewerController = Robolectric.buildActivity(TestCardTemplatePreviewer.class, intent).create().start().resume().visible();
+        saveControllerForCleanup((previewerController));
+        TestCardTemplatePreviewer testCardTemplatePreviewer = previewerController.get();
+        String[] arr = testCardTemplatePreviewer.getDummyCard(collectionBasicModelOriginal, 0).note().getFields();
+        assertThat(arr[0], is("(" + fields.get(0) + ")"));
+        assertThat(arr[1], is(testCardTemplatePreviewer.getString(R.string.basic_answer_sample_text)));
     }
 
     @Test


### PR DESCRIPTION
## Purpose / Description
In anki desktop when we preview the card Template with all the note fields as null, it shows up card labels as field texts.

## Fixes
Fixes #9696 

## Approach
A bool variable has been taken which takes care whether the preview is from the note editor or the card template editor.
if the flow is cardtemplate editor -> cardtemplatepreviewer then we add  `(` and `)` before the fields being set as anki desktop does
there were two exceptions the cloze and basic (answer type) so accordingly the fields have been modifies as same as anki desktop.

## How Has This Been Tested?
Tested on my phone only.


https://user-images.githubusercontent.com/46752548/140165774-1db7398b-04a8-4559-91c6-f376c441d351.mp4


## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
