### PR TITLE
[Preferences:Focus type in answer]Enable dy default

### DIFF
--- a/AnkiDroid/src/main/res/xml/preferences_advanced.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_advanced.xml
@@ -92,7 +92,7 @@
                 if useInputTag is true
              -->
             <CheckBoxPreference
-                android:defaultValue="false"
+                android:defaultValue="true"
                 android:key="autoFocusTypeInAnswer"
                 android:summary="@string/type_in_answer_focus_summ"
                 android:dependency="useInputTag"


### PR DESCRIPTION
## Purpose / Description
Currently, the user has to manually enable the "Focus 'Type in answer'" preference from the settings. We would want this to be a default behaviour. This PR resolves that. 

## Fixes #3482

## Approach
The layout attribute was changed to default = true.

![AnkiDroid_enable_focus_type-in-ans_byDefault](https://user-images.githubusercontent.com/81802035/139578312-a962523d-6580-4949-87ac-83b6b177abaf.jpg)

## How Has This Been Tested?

This was manually tested in API 30. Data was deleted, the app was reinstalled to ensure that the default behaviour focuses on the FixedEditText in the Reviewer.

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [ ] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
