### PR TITLE
feat(v16): Implement col.render_output via rust

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -78,7 +78,6 @@ import android.widget.Button;
 import android.widget.FrameLayout;
 import android.widget.LinearLayout;
 import android.widget.RelativeLayout;
-import android.widget.TextView;
 
 import com.afollestad.materialdialogs.MaterialDialog;
 import com.drakeet.drawer.FullDraggableContainer;
@@ -137,7 +136,6 @@ import com.ichi2.utils.FunctionalInterfaces.Function;
 
 import com.ichi2.utils.HandlerUtils;
 import com.ichi2.utils.HashUtil;
-import com.ichi2.utils.JSONException;
 import com.ichi2.utils.JSONObject;
 import com.ichi2.utils.MaxExecFunction;
 import com.ichi2.utils.WebViewDebugging;
@@ -167,7 +165,6 @@ import timber.log.Timber;
 import static com.ichi2.anki.cardviewer.ViewerCommand.*;
 import static com.ichi2.libanki.Sound.SoundSide;
 
-import com.github.zafarkhaja.semver.Version;
 import static com.ichi2.anim.ActivityTransitionAnimation.Direction.*;
 
 @SuppressWarnings({"PMD.AvoidThrowingRawExceptionTypes","PMD.FieldDeclarationsShouldBeAtStartOfClass"})
@@ -2522,7 +2519,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
         String answerFormat = getAnswerFormat();
         String newAnswerContent = answerContent;
         if (answerFormat.contains("{{FrontSide}}")) { // possible audio removal necessary
-            String frontSideFormat = mCurrentCard._getQA(false).get("q");
+            String frontSideFormat = mCurrentCard.render_output(false).get("q");
             Matcher audioReferences = Sound.SOUND_PATTERN.matcher(frontSideFormat);
             // remove the first instance of audio contained in "{{FrontSide}}"
             while (audioReferences.find()) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -2519,7 +2519,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
         String answerFormat = getAnswerFormat();
         String newAnswerContent = answerContent;
         if (answerFormat.contains("{{FrontSide}}")) { // possible audio removal necessary
-            String frontSideFormat = mCurrentCard.render_output(false).get("q");
+            String frontSideFormat = mCurrentCard.render_output(false).getQuestionText();
             Matcher audioReferences = Sound.SOUND_PATTERN.matcher(frontSideFormat);
             // remove the first instance of audio contained in "{{FrontSide}}"
             while (audioReferences.find()) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -26,7 +26,6 @@ import android.content.IntentFilter;
 import android.content.SharedPreferences;
 import android.graphics.Typeface;
 import android.os.Bundle;
-import android.os.Handler;
 import android.os.SystemClock;
 
 import androidx.activity.result.ActivityResultLauncher;
@@ -2725,10 +2724,10 @@ public class CardBrowser extends NavigationDrawerActivity implements
                 return;
             }
             // render question and answer
-            Map<String, String> qa = getCard()._getQA(true, true);
+            Map<String, String> qa = getCard().render_output(true, true);
             // Render full question / answer if the bafmt (i.e. "browser appearance") setting forced blank result
             if ("".equals(qa.get("q")) || "".equals(qa.get("a"))) {
-                HashMap<String, String> qaFull = getCard()._getQA(true, false);
+                HashMap<String, String> qaFull = getCard().render_output(true, false);
                 if ("".equals(qa.get("q"))) {
                     qa.put("q", qaFull.get("q"));
                 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -83,6 +83,7 @@ import com.ichi2.libanki.Card;
 import com.ichi2.libanki.Collection;
 import com.ichi2.libanki.Consts;
 import com.ichi2.libanki.Decks;
+import com.ichi2.libanki.TemplateManager.TemplateRenderContext.TemplateRenderOutput;
 import com.ichi2.libanki.Utils;
 import com.ichi2.libanki.Deck;
 import com.ichi2.themes.Themes;
@@ -2724,20 +2725,20 @@ public class CardBrowser extends NavigationDrawerActivity implements
                 return;
             }
             // render question and answer
-            Map<String, String> qa = getCard().render_output(true, true);
+            TemplateRenderOutput qa = getCard().render_output(true, true);
             // Render full question / answer if the bafmt (i.e. "browser appearance") setting forced blank result
-            if ("".equals(qa.get("q")) || "".equals(qa.get("a"))) {
-                HashMap<String, String> qaFull = getCard().render_output(true, false);
-                if ("".equals(qa.get("q"))) {
-                    qa.put("q", qaFull.get("q"));
+            if ("".equals(qa.getQuestionText()) || "".equals(qa.getAnswerText())) {
+                TemplateRenderOutput qaFull = getCard().render_output(true, false);
+                if ("".equals(qa.getQuestionText())) {
+                    qa.setQuestionText(qaFull.getQuestionText());
                 }
-                if ("".equals(qa.get("a"))) {
-                    qa.put("a", qaFull.get("a"));
+                if ("".equals(qa.getAnswerText())) {
+                    qa.setAnswerText(qaFull.getAnswerText());
                 }
             }
             // update the original hash map to include rendered question & answer
-            String q = qa.get("q");
-            String a = qa.get("a");
+            String q = qa.getQuestionText();
+            String a = qa.getAnswerText();
             // remove the question from the start of the answer if it exists
             if (a.startsWith(q)) {
                 a = a.substring(q.length());

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplatePreviewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplatePreviewer.java
@@ -24,8 +24,11 @@ import com.ichi2.libanki.Card;
 import com.ichi2.libanki.Collection;
 import com.ichi2.libanki.Model;
 import com.ichi2.libanki.Note;
+import com.ichi2.libanki.TemplateManager;
 import com.ichi2.libanki.utils.NoteUtils;
 import com.ichi2.utils.JSONObject;
+
+import net.ankiweb.rsdroid.RustCleanup;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -441,6 +444,17 @@ public class CardTemplatePreviewer extends AbstractFlashcardViewer {
                 return mEditedModel;
             }
             return super.model();
+        }
+
+
+        @NonNull
+        @Override
+        @RustCleanup("determine how Anki Desktop does this")
+        public TemplateManager.TemplateRenderContext.TemplateRenderOutput render_output(boolean reload, boolean browser) {
+            if (getRenderOutput() == null || reload) {
+                setRenderOutput(getCol().render_output_legacy(this, reload, browser));
+            }
+            return getRenderOutput();
         }
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/provider/CardContentProvider.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/provider/CardContentProvider.java
@@ -1240,7 +1240,7 @@ public class CardContentProvider extends ContentProvider {
                     rb.add(currentCard.qSimple());
                     break;
                 case FlashCardsContract.Card.ANSWER_SIMPLE:
-                    rb.add(currentCard.render_output(false).get("a"));
+                    rb.add(currentCard.render_output(false).getAnswerText());
                     break;
                 case FlashCardsContract.Card.ANSWER_PURE:
                     rb.add(currentCard.getPureAnswer());

--- a/AnkiDroid/src/main/java/com/ichi2/anki/provider/CardContentProvider.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/provider/CardContentProvider.java
@@ -1240,7 +1240,7 @@ public class CardContentProvider extends ContentProvider {
                     rb.add(currentCard.qSimple());
                     break;
                 case FlashCardsContract.Card.ANSWER_SIMPLE:
-                    rb.add(currentCard._getQA(false).get("a"));
+                    rb.add(currentCard.render_output(false).get("a"));
                     break;
                 case FlashCardsContract.Card.ANSWER_PURE:
                     rb.add(currentCard.getPureAnswer());

--- a/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/SchedulerService.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/SchedulerService.kt
@@ -64,7 +64,7 @@ class SchedulerService {
                 val sched = getCard.col.sched
                 Timber.i("Obtaining card")
                 val newCard = sched.getCard()
-                newCard?._getQA(true)
+                newCard?.render_output(true)
                 return Computation.ok(NextCard.withNoResult(newCard))
             }
         }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Card.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Card.kt
@@ -104,7 +104,9 @@ open class Card : Cloneable {
     private var data: String? = null
 
     // END SQL table entries
-    private var render_output: TemplateRenderOutput?
+    @set:JvmName("setRenderOutput")
+    @get:JvmName("getRenderOutput")
+    protected var render_output: TemplateRenderOutput?
     private var note: Note?
 
     /** Used by Sched to determine which queue to move the card to after answering. */
@@ -240,9 +242,12 @@ open class Card : Cloneable {
         return "<style>${render_output().css}</style>"
     }
 
+    /**
+     * @throws net.ankiweb.rsdroid.exceptions.BackendInvalidInputException: If the card does not exist
+     */
     @JvmOverloads
     @RustCleanup("move col.render_output back to Card once the java collection is removed")
-    fun render_output(reload: Boolean = false, browser: Boolean = false): TemplateRenderOutput {
+    open fun render_output(reload: Boolean = false, browser: Boolean = false): TemplateRenderOutput {
         if (render_output == null || reload) {
             render_output = col.render_output(this, reload, browser)
         }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Card.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Card.kt
@@ -31,6 +31,7 @@ import com.ichi2.libanki.template.TemplateError
 import com.ichi2.utils.Assert
 import com.ichi2.utils.JSONObject
 import com.ichi2.utils.LanguageUtil
+import net.ankiweb.rsdroid.RustCleanup
 import timber.log.Timber
 import java.util.*
 import java.util.concurrent.CancellationException
@@ -238,19 +239,10 @@ open class Card : Cloneable {
     }
 
     @JvmOverloads
+    @RustCleanup("move col.render_output back to Card once the java collection is removed")
     fun render_output(reload: Boolean = false, browser: Boolean = false): HashMap<String, String>? {
         if (render_output == null || reload) {
-            val f = note(reload)
-            val m = model()
-            val t = template()
-            val did = if (isInDynamicDeck) oDid else did
-            render_output = if (browser) {
-                val bqfmt = t.getString("bqfmt")
-                val bafmt = t.getString("bafmt")
-                col._renderQA(this.id, m, did, ord, f.stringTags(), f.fields, flags, browser, bqfmt, bafmt)
-            } else {
-                col._renderQA(this.id, m, did, ord, f.stringTags(), f.fields, flags)
-            }
+            render_output = col.render_output(this, reload, browser)
         }
         return render_output
     }
@@ -413,6 +405,9 @@ open class Card : Cloneable {
     fun setFlag(flag: Int) {
         flags = flag
     }
+
+    /** Should use [userFlag] */
+    fun internalGetFlags() = flags
 
     fun setUserFlag(flag: Int) {
         flags = setFlagInInt(flags, flag)

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Card.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Card.kt
@@ -102,7 +102,7 @@ open class Card : Cloneable {
     private var data: String? = null
 
     // END SQL table entries
-    private var qa: HashMap<String, String>?
+    private var render_output: HashMap<String, String>?
     private var note: Note?
 
     /** Used by Sched to determine which queue to move the card to after answering. */
@@ -114,7 +114,7 @@ open class Card : Cloneable {
     constructor(col: Collection) {
         this.col = col
         timerStarted = 0L
-        qa = null
+        render_output = null
         note = null
         // to flush, set nid, ord, and due
         this.id = this.col.time.timestampID(this.col.db, "cards")
@@ -135,7 +135,7 @@ open class Card : Cloneable {
     constructor(col: Collection, id: Long) {
         this.col = col
         timerStarted = 0L
-        qa = null
+        render_output = null
         note = null
         this.id = id
         load()
@@ -165,7 +165,7 @@ open class Card : Cloneable {
             flags = cursor.getInt(16)
             data = cursor.getString(17)
         }
-        qa = null
+        render_output = null
         note = null
     }
 
@@ -226,11 +226,11 @@ open class Card : Cloneable {
 
     @JvmOverloads
     fun q(reload: Boolean = false, browser: Boolean = false): String {
-        return css() + _getQA(reload, browser)!!["q"]
+        return css() + render_output(reload, browser)!!["q"]
     }
 
     fun a(): String {
-        return css() + _getQA()!!["a"]
+        return css() + render_output()!!["a"]
     }
 
     fun css(): String {
@@ -238,13 +238,13 @@ open class Card : Cloneable {
     }
 
     @JvmOverloads
-    fun _getQA(reload: Boolean = false, browser: Boolean = false): HashMap<String, String>? {
-        if (qa == null || reload) {
+    fun render_output(reload: Boolean = false, browser: Boolean = false): HashMap<String, String>? {
+        if (render_output == null || reload) {
             val f = note(reload)
             val m = model()
             val t = template()
             val did = if (isInDynamicDeck) oDid else did
-            qa = if (browser) {
+            render_output = if (browser) {
                 val bqfmt = t.getString("bqfmt")
                 val bafmt = t.getString("bafmt")
                 col._renderQA(this.id, m, did, ord, f.stringTags(), f.fields, flags, browser, bqfmt, bafmt)
@@ -252,7 +252,7 @@ open class Card : Cloneable {
                 col._renderQA(this.id, m, did, ord, f.stringTags(), f.fields, flags)
             }
         }
-        return qa
+        return render_output
     }
 
     open fun note(): Note {
@@ -315,7 +315,7 @@ open class Card : Cloneable {
      * ***********************************************************
      */
     fun qSimple(): String? {
-        return _getQA(false)!!["q"]
+        return render_output(false)!!["q"]
     }
 
     /*
@@ -323,7 +323,7 @@ open class Card : Cloneable {
      */
     val pureAnswer: String
         get() {
-            val s = _getQA(false)!!["a"]
+            val s = render_output(false)!!["a"]
             val target = "<hr id=answer>"
             val pos = s!!.indexOf(target)
             return if (pos == -1) {
@@ -544,7 +544,7 @@ open class Card : Cloneable {
         }
 
         fun loadQA(reload: Boolean, browser: Boolean) {
-            card._getQA(reload, browser)
+            card.render_output(reload, browser)
         }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
@@ -1385,6 +1385,13 @@ public class Collection implements CollectionGetter {
 
     @Nullable
     public TemplateRenderOutput render_output(@NonNull Card c, boolean reload, boolean browser) {
+        return render_output_legacy(c, reload, browser);
+    }
+
+
+    @NonNull
+    @RustCleanup("Hack for Card Template Previewer, needs review")
+    public TemplateRenderOutput render_output_legacy(@NonNull Card c, boolean reload, boolean browser) {
         Note f = c.note(reload);
         Model m = c.model();
         JSONObject t = c.template();

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
@@ -1380,6 +1380,27 @@ public class Collection implements CollectionGetter {
     }
 
 
+    @Nullable
+    public HashMap<String, String> render_output(@NonNull Card c, boolean reload, boolean browser) {
+        Note f = c.note(reload);
+        Model m = c.model();
+        JSONObject t = c.template();
+        long did;
+        if (c.isInDynamicDeck()) {
+            did = c.getODid();
+        } else {
+            did = c.getDid();
+        }
+        if (browser) {
+            String bqfmt = t.getString("bqfmt");
+            String bafmt = t.getString("bafmt");
+            return _renderQA(c.getId(), m, did, c.getOrd(), f.stringTags(), f.getFields(), c.internalGetFlags(), browser, bqfmt, bafmt);
+        } else {
+            return _renderQA(c.getId(), m, did, c.getOrd(), f.stringTags(), f.getFields(), c.internalGetFlags());
+        }
+    }
+
+
     @VisibleForTesting
     public static class UndoReview extends UndoAction {
         private final boolean mWasLeech;

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
@@ -33,6 +33,7 @@ import com.ichi2.anki.analytics.UsageAnalytics;
 import com.ichi2.anki.exception.ConfirmModSchemaException;
 import com.ichi2.async.CancelListener;
 import com.ichi2.async.CollectionTask;
+import com.ichi2.libanki.TemplateManager.TemplateRenderContext.TemplateRenderOutput;
 import com.ichi2.libanki.backend.DroidBackend;
 import com.ichi2.async.ProgressSender;
 import com.ichi2.async.TaskManager;
@@ -1116,12 +1117,14 @@ public class Collection implements CollectionGetter {
     /**
      * Returns hash of id, question, answer.
      */
+    @NonNull
     public HashMap<String, String> _renderQA(long cid, Model model, long did, int ord, String tags, String[] flist, int flags) {
         return _renderQA(cid, model, did, ord, tags, flist, flags, false, null, null);
     }
 
 
     @RustCleanup("#8951 - Remove FrontSide added to the front")
+    @NonNull
     public HashMap<String, String> _renderQA(long cid, Model model, long did, int ord, String tags, String[] flist, int flags, boolean browser, String qfmt, String afmt) {
         // data is [cid, nid, mid, did, ord, tags, flds, cardFlags]
         // unpack fields and create dict
@@ -1381,7 +1384,7 @@ public class Collection implements CollectionGetter {
 
 
     @Nullable
-    public HashMap<String, String> render_output(@NonNull Card c, boolean reload, boolean browser) {
+    public TemplateRenderOutput render_output(@NonNull Card c, boolean reload, boolean browser) {
         Note f = c.note(reload);
         Model m = c.model();
         JSONObject t = c.template();
@@ -1391,13 +1394,21 @@ public class Collection implements CollectionGetter {
         } else {
             did = c.getDid();
         }
+        HashMap<String, String> qa;
         if (browser) {
             String bqfmt = t.getString("bqfmt");
             String bafmt = t.getString("bafmt");
-            return _renderQA(c.getId(), m, did, c.getOrd(), f.stringTags(), f.getFields(), c.internalGetFlags(), browser, bqfmt, bafmt);
+            qa = _renderQA(c.getId(), m, did, c.getOrd(), f.stringTags(), f.getFields(), c.internalGetFlags(), browser, bqfmt, bafmt);
         } else {
-            return _renderQA(c.getId(), m, did, c.getOrd(), f.stringTags(), f.getFields(), c.internalGetFlags());
+            qa = _renderQA(c.getId(), m, did, c.getOrd(), f.stringTags(), f.getFields(), c.internalGetFlags());
         }
+
+        return new TemplateRenderOutput(
+                qa.get("q"),
+                qa.get("a"),
+                null,
+                null,
+                c.model().getString("css"));
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/CollectionV16.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/CollectionV16.kt
@@ -70,4 +70,8 @@ class CollectionV16(
             models.save(m) // equivalent to m.put("usn", -1)
         }
     }
+
+    override fun render_output(c: Card, reload: Boolean, browser: Boolean): TemplateManager.TemplateRenderContext.TemplateRenderOutput {
+        return TemplateManager.TemplateRenderContext.from_existing_card(c, browser).render()
+    }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/TemplateManager.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/TemplateManager.kt
@@ -248,10 +248,16 @@ class TemplateManager {
 
         /** Stores the rendered templates and extracted AV tags. */
         data class TemplateRenderOutput(
-            val question_text: str,
-            val answer_text: str,
-            val question_av_tags: List<AvTag>,
-            val answer_av_tags: List<AvTag>,
+            @get:JvmName("getQuestionText")
+            @set:JvmName("setQuestionText")
+            var question_text: str,
+            @get:JvmName("getAnswerText")
+            @set:JvmName("setAnswerText")
+            var answer_text: str,
+            @RustCleanup("make non-null")
+            val question_av_tags: List<AvTag>?,
+            @RustCleanup("make non-null")
+            val answer_av_tags: List<AvTag>?,
             val css: str = ""
         ) {
 


### PR DESCRIPTION
This extracts card rendering to Rust.

* extract return value to `TemplateManager.TemplateRenderContext.TemplateRenderOutput`.
* This now includes CSS, which is cached. This may be faster.
* We don't use `AvTags` which is now returned, this is pending from a follow-up PR

#5793

## How Has This Been Tested?

Fixed the unit tests which broke when using the new code. Neither is "well tested"

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
