### PR TITLE
Remove html debug as default in debug

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -87,8 +87,10 @@ android {
                 if (localProperties['enable_languages'] == "false") {
                     android.defaultConfig.resConfigs "en"
                 }
+                buildConfigField "boolean", "HTML_DEBUG", 'false'
             } else {
                 testCoverageEnabled true
+                buildConfigField "boolean", "HTML_DEBUG", 'true'
             }
 
             // make the icon red if in debug mode

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.java
@@ -330,7 +330,7 @@ public class AnkiDroidApp extends Application {
         }
 
         // make default HTML / JS debugging true for debug build
-        if (BuildConfig.DEBUG) {
+        if (BuildConfig.HTML_DEBUG) {
             preferences.edit().putBoolean("html_javascript_debugging", true).apply();
         }
         

--- a/AnkiDroid/src/test/java/com/ichi2/anki/AnkiDroidAppTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/AnkiDroidAppTest.java
@@ -25,6 +25,8 @@ import org.junit.runner.RunWith;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
 import static com.ichi2.anki.AnkiDroidApp.sendExceptionReport;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
 
 @RunWith(AndroidJUnit4.class)
 public class AnkiDroidAppTest {
@@ -40,5 +42,10 @@ public class AnkiDroidAppTest {
         //It's meant to be non-null, but it's developer-defined, and we don't want a crash in the reporting dialog
         //noinspection ConstantConditions
         AnkiAssert.assertDoesNotThrow(() -> sendExceptionReport(message, "AnkiDroidAppTest"));
+    }
+
+    @Test
+    public void htmlDebugIsFalse() {
+        assertThat(BuildConfig.HTML_DEBUG, equalTo(false));
     }
 }


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
The HTML Debug make tests slow. It is better to remove this. 

## Fixes
Fixes #9751

## Approach
Removed the code which make html debug default to true.

## How Has This Been Tested?
Tested on android devices

## Learning (optional, can help others)

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
