### PR TITLE
Ensure a single note type is highlighted

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/NoteTypeSpinnerUtils.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/NoteTypeSpinnerUtils.kt
@@ -25,6 +25,7 @@ import android.widget.TextView
 import androidx.core.content.ContextCompat
 import com.ichi2.anki.R
 import com.ichi2.libanki.Model
+import com.ichi2.themes.Themes.getColorFromAttr
 import com.ichi2.utils.NamedJSONComparator
 import java.util.*
 
@@ -40,16 +41,23 @@ object NoteTypeSpinnerUtils {
             modelNames.add(m.getString("name"))
             allModelIds.add(m.getLong("id"))
         }
+
+        val unselectedTextColor = getColorFromAttr(context, android.R.attr.textColorPrimary)
+        val selectedTextColor = ContextCompat.getColor(context, R.color.note_editor_selected_item_text)
+        val unselectedBackgroundColor = getColorFromAttr(context, android.R.attr.colorBackground)
+        val selectedBackgroundColor = ContextCompat.getColor(context, R.color.note_editor_selected_item_background)
         val noteTypeAdapter: ArrayAdapter<String> = object : ArrayAdapter<String>(context, android.R.layout.simple_spinner_item, modelNames) {
             override fun getDropDownView(position: Int, convertView: View?, parent: ViewGroup): View {
                 // Cast the drop down items (popup items) as text view
                 val tv = super.getDropDownView(position, convertView, parent) as TextView
 
+                val selectedPosition = noteTypeSpinner.selectedItemPosition
+                val selected = position == selectedPosition
                 // If this item is selected
-                if (position == noteTypeSpinner.selectedItemPosition) {
-                    tv.setBackgroundColor(ContextCompat.getColor(context, R.color.note_editor_selected_item_background))
-                    tv.setTextColor(ContextCompat.getColor(context, R.color.note_editor_selected_item_text))
-                }
+                val backgroundColor = if (selected) selectedBackgroundColor else unselectedBackgroundColor
+                val textColor = if (selected) selectedTextColor else unselectedTextColor
+                tv.setBackgroundColor(backgroundColor)
+                tv.setTextColor(textColor)
 
                 // Return the modified view
                 return tv


### PR DESCRIPTION
Fixes #9754

The error, I believe, was that the textview was recycled, which mean that we
need to reset the color.

Tested on my device. The problem disappeared. Tested in night and day mode, got
the correct color each time
