### PR TITLE
[EditNote][DeckSpinner] Fix Layout Height

### DIFF
--- a/AnkiDroid/src/main/res/layout/note_editor.xml
+++ b/AnkiDroid/src/main/res/layout/note_editor.xml
@@ -71,7 +71,7 @@
                     <Spinner
                         android:id="@+id/note_deck_spinner"
                         android:layout_width="match_parent"
-                        android:layout_height="@dimen/touch_target"
+                        android:layout_height="wrap_content"
                         app:popupTheme="@style/ActionBar.Popup"/>
                 </LinearLayout>
 


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
Currently, the deck spinner view is unable to display selected deck names which have
length extending beyond 2 lines. This PR fixes that issue and enables the Spinner view to display upto 5 lines, which is sufficient for all practical use cases.

## Fixes: #9750
![Layout_height_spinnerDeck](https://user-images.githubusercontent.com/81802035/139868490-0aa9a01b-ab73-47e6-be96-6ec719b0955b.png)


## Approach
Change spinner layout_height from "@dimen/touch_target" (=48dp) to "wrap_content"

## How Has This Been Tested?
Tested manually on API 30, Spinner View was verified to display selected deck names extending upto 5 lines.

## Learning (optional, can help others)
1. After fiddling with multiline_spinner_item, it was concluded that this was not causing the issue. 
2. The fact that a little portion of the 3rd line was also visible indicated that the multiline_spinner_item was visible completely, but just did not have sufficient parent layout height.
3. Spinner layout height was changed to wrap_content, this solved the issue.  

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [ ] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
