### PR TITLE
[EditNote][DeckSelectionDialog] Highlight Selected item

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckSelectionDialog.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckSelectionDialog.java
@@ -27,6 +27,7 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.Filter;
 import android.widget.Filterable;
+import android.widget.Spinner;
 import android.widget.TextView;
 
 import com.afollestad.materialdialogs.MaterialDialog;
@@ -39,6 +40,7 @@ import com.ichi2.libanki.Deck;
 import com.ichi2.libanki.DeckManager;
 import com.ichi2.libanki.backend.exception.DeckRenameException;
 import com.ichi2.libanki.stats.Stats;
+import com.ichi2.themes.Themes;
 import com.ichi2.utils.DeckNameComparator;
 import com.ichi2.utils.FunctionalInterfaces;
 import com.ichi2.utils.FilterResultsUtils;
@@ -53,6 +55,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.widget.SearchView;
 import androidx.appcompat.widget.Toolbar;
+import androidx.core.content.ContextCompat;
 import androidx.fragment.app.Fragment;
 import androidx.recyclerview.widget.DividerItemDecoration;
 import androidx.recyclerview.widget.LinearLayoutManager;
@@ -337,6 +340,21 @@ public class DeckSelectionDialog extends AnalyticsDialogFragment {
         @Override
         public void onBindViewHolder(@NonNull ViewHolder holder, int position) {
             SelectableDeck deck = mCurrentlyDisplayedDecks.get(position);
+            Spinner spinner =  getActivity().findViewById(R.id.note_deck_spinner);
+            String spinnerSelectedDeckName = spinner.getSelectedItem().toString();
+
+            final int unselectedTextColor = Themes.getColorFromAttr(getContext(), android.R.attr.textColorPrimary);
+            final int selectedTextColor = ContextCompat.getColor(getContext(), R.color.note_editor_selected_item_text);
+            final int unselectedBackgroundColor = Themes.getColorFromAttr(getContext(), android.R.attr.colorBackground);
+            final int selectedBackgroundColor = ContextCompat.getColor(getContext(), R.color.note_editor_selected_item_background);
+
+            if (spinnerSelectedDeckName.equals(deck.getName())) {
+                holder.mDeckTextView.setBackgroundColor(selectedBackgroundColor);
+                holder.mDeckTextView.setTextColor(selectedTextColor);
+            } else {
+                holder.mDeckTextView.setBackgroundColor(unselectedBackgroundColor);
+                holder.mDeckTextView.setTextColor(unselectedTextColor);
+            }
             holder.setDeck(deck);
         }
 


### PR DESCRIPTION
## Purpose / Description
The selected deck item of the deck spinner is not highlighted in the deck selection dialog. This is inconsistent from the behaviour of the noteTypeSpinner and a design flaw. This PR fixes that issue by highlighting the aforementioned.

## Fixes   #9755


https://user-images.githubusercontent.com/81802035/140179674-ae7948d5-972a-4247-8a57-f64349b46c94.mp4


https://user-images.githubusercontent.com/81802035/140179691-a4c396ea-d8bc-46fb-8dcf-c58bebdc51d2.mp4



## Approach
1. Retrieve the Spinner text, this is the name of the selected deck item.
2. In the RecyclerView DecksArrayAdapter, override OnBindViewHolder to compare the Spinner Text with the viewHolder's Item name(this would be the deck item in the RecyclerView of the DeckSelectionDialog).
3. If equal, highlight the textView item, else set default colors. 

## How Has This Been Tested?
This was manually tested  in API 30, both night  mode disbaled and enabled.

## Learning (optional, can help others)
1. NoteEditor: mDeckspinnerSelection.initializeNoteEditorDeckSpinner() is called

2. DeckSpinnerSelection: getDropDownView() is overriden to highlight the spinner selected item. This is supposed to implement the desired behaviour, but it doesn't. So this was inspected further. 

3. It was found that OnItemSelectedListener was not implemented anywhere for the adapter. It was tried but did not produce any results.

4. After some debugging, it was concluded that the code does reach initializeNoteEditorDeckSpinner(). Also, getView() was able to be overridden in #9756, which corroborates the fact that the code does reach initializeNoteEditorDeckSpinner(). The indication here is that perhaps the code doesn't reach only getDropDownView() from the NoteEditor activity.

5. This was inspected and it was found to be the case. This means that the drop down view is never created, however we already know that the deck names are visible in the dialog in the UI, this means that something else is responsible for creating the view. Since spinner mode is never even set to dialog, it is now concluded that the dialog is created elsewhere.
 
6. Surely enough, upon inspection of NoteEditor, it was found that a custom DeckSelectionDialog was implemented to display the deck collection. This indicated why getDropDownView() was not getting called, as we don't have a drop down view in the first place.
 
7. DeckSelectionDialog was inspected and RecyclerView was found to populate the UI with the deck names. From here, now we only needed to set setBackgroundColor of the itemView of the ViewHolder object when overriding onBindViewHolder() method.
  
8. But to determine which the selected Item was, we needed to know the position of the selected deck item. The code was inspected, and no particular position field/getter method was found. However, there was a getter method for the deckId. Now we just needed to match this with the mCurrentDid from the NoteEditor activity. Since passing the mCurrentDid from the activity to the fragment led to tight coupling between them, this introduced other challanges, alternate approach was needed to simplify.
  
9. Instead of passing mCurrentDid, we could directly inspect the Spinner view of the NoteEditor Activity from within the fragment itself. Then we could match the text from Spinner View(which displays the selected item) with the name of the deck in the viewholder of the dialog's recyclerView. getName() was found to exist and was used to retrieve the name of the deck in the viewholder. If  the strings are equal, highlight the viewholder, if not,  set the viewholder bgcolor transparent. This worked well, but upon manual testing, it was found that in night mode, the text color remained white even in the selected background color, which was not desirable. We needed the same colors as in the noteTypeSpinner drop down view for consistency.  

10. To fix this, NoteTypeSpinnerUtils was inspected and the selected/unslected text/background color were reused. To set the textColor, mDeckTextView had to be used. At this point, it was decided that rather than setting the background color through the itemView, mDeckTextView could be used directly.

11. Next, there were some hiccups in using the android textColorPrimary and colorBackground attributes in the java code. So the kotlin byte code was decompiled and it was found that Themes.getColorFromAttr had to be used in the java code.

After implementing the above, the desired consistent behaviour was achieved, both when nightmode is enabled or disabled.

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [ ] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
