### PR TITLE
fix(android, api31): implement compileSdkVersion 31 compatibility

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -26,7 +26,7 @@ idea {
 
 def homePath = System.properties['user.home']
 android {
-    compileSdkVersion 30 // change api compileSdkVersion at the same time
+    compileSdkVersion 31 // change api compileSdkVersion at the same time
 
     defaultConfig {
         applicationId "com.ichi2.anki"

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/AudioRecorder.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/AudioRecorder.java
@@ -20,7 +20,10 @@
 
 package com.ichi2.anki.multimediacard;
 
+import android.content.Context;
 import android.media.MediaRecorder;
+
+import com.ichi2.compat.CompatHelper;
 
 import java.io.IOException;
 
@@ -36,8 +39,8 @@ public class AudioRecorder {
     private Runnable mOnRecordingInitialized;
 
 
-    private MediaRecorder initMediaRecorder(String audioPath) {
-        MediaRecorder mr = new MediaRecorder();
+    private MediaRecorder initMediaRecorder(Context context, String audioPath) {
+        MediaRecorder mr = CompatHelper.getCompat().getMediaRecorder(context);
         mr.setAudioSource(MediaRecorder.AudioSource.MIC);
         mr.setOutputFormat(MediaRecorder.OutputFormat.THREE_GPP);
         onRecordingInitialized();
@@ -52,12 +55,12 @@ public class AudioRecorder {
         }
     }
 
-    public void startRecording(String audioPath) throws IOException {
+    public void startRecording(Context context, String audioPath) throws IOException {
         boolean highSampling = false;
         try {
             // try high quality AAC @ 44.1kHz / 192kbps first
             // can throw IllegalArgumentException if codec isn't supported
-            mRecorder = initMediaRecorder(audioPath);
+            mRecorder = initMediaRecorder(context, audioPath);
             mRecorder.setAudioEncoder(MediaRecorder.AudioEncoder.AAC);
             mRecorder.setAudioChannels(2);
             mRecorder.setAudioSamplingRate(44100);
@@ -74,7 +77,7 @@ public class AudioRecorder {
         if (!highSampling) {
             // if we are here, either the codec didn't work or output file was invalid
             // fall back on default
-            mRecorder = initMediaRecorder(audioPath);
+            mRecorder = initMediaRecorder(context, audioPath);
             mRecorder.setAudioEncoder(MediaRecorder.AudioEncoder.AMR_NB);
 
             mRecorder.prepare();

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/AudioView.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/AudioView.java
@@ -393,7 +393,7 @@ public class AudioView extends LinearLayout {
                     case STOPPED: // if already recorded or played
 
                         try {
-                            mAudioRecorder.startRecording(mAudioPath);
+                            mAudioRecorder.startRecording(mContext, mAudioPath);
                         } catch (Exception e) {
                             // either output file failed or codec didn't work, in any case fail out
                             Timber.e("RecordButton.onClick() :: error recording to %s\n%s", mAudioPath, e.getMessage());

--- a/AnkiDroid/src/main/java/com/ichi2/compat/Compat.java
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/Compat.java
@@ -22,6 +22,7 @@ import android.content.Intent;
 import android.graphics.Bitmap;
 import android.media.AudioFocusRequest;
 import android.media.AudioManager;
+import android.media.MediaRecorder;
 import android.net.Uri;
 import android.widget.TimePicker;
 
@@ -79,6 +80,7 @@ public interface Compat {
     int getHour(TimePicker picker);
     int getMinute(TimePicker picker);
     void vibrate(Context context, long durationMillis);
+    MediaRecorder getMediaRecorder(Context context);
     void copyFile(String source, String target) throws IOException;
     long copyFile(String source, OutputStream target) throws IOException;
     long copyFile(InputStream source, String target) throws IOException;

--- a/AnkiDroid/src/main/java/com/ichi2/compat/CompatHelper.java
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/CompatHelper.java
@@ -26,7 +26,9 @@ public class CompatHelper {
 
 
     private CompatHelper() {
-        if (getSdkVersion() >= Build.VERSION_CODES.Q) {
+        if (getSdkVersion() >= Build.VERSION_CODES.S) {
+            mCompat = new CompatV31();
+        } else if (getSdkVersion() >= Build.VERSION_CODES.Q) {
             mCompat = new CompatV29();
         } else if (getSdkVersion() >= Build.VERSION_CODES.O) {
             mCompat = new CompatV26();

--- a/AnkiDroid/src/main/java/com/ichi2/compat/CompatV21.java
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/CompatV21.java
@@ -22,6 +22,7 @@ import android.content.Intent;
 import android.graphics.Bitmap;
 import android.media.AudioFocusRequest;
 import android.media.AudioManager;
+import android.media.MediaRecorder;
 import android.media.ThumbnailUtils;
 import android.net.Uri;
 import android.os.Environment;
@@ -74,6 +75,13 @@ public class CompatV21 implements Compat {
         if (vibratorManager != null) {
             vibratorManager.vibrate(durationMillis);
         }
+    }
+
+    // Until API31 the MediaRecorder constructor was default, ignoring the Context
+    @Override
+    @SuppressWarnings("deprecation")
+    public MediaRecorder getMediaRecorder(Context context) {
+        return new MediaRecorder();
     }
 
     // Until API 26 do the copy using streams

--- a/AnkiDroid/src/main/java/com/ichi2/compat/CompatV26.java
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/CompatV26.java
@@ -73,6 +73,7 @@ public class CompatV26 extends CompatV23 implements Compat {
     }
 
     @Override
+    @SuppressWarnings("deprecation")
     public void vibrate(Context context, long durationMillis) {
         Vibrator vibratorManager = (Vibrator)context.getSystemService(Context.VIBRATOR_SERVICE);
         if (vibratorManager != null) {

--- a/AnkiDroid/src/main/java/com/ichi2/compat/CompatV29.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/CompatV29.kt
@@ -29,7 +29,7 @@ import java.io.File
 
 /** Implementation of [Compat] for SDK level 29  */
 @TargetApi(29)
-class CompatV29 : CompatV26(), Compat {
+open class CompatV29 : CompatV26(), Compat {
     override fun hasVideoThumbnail(path: String): Boolean {
         return try {
             ThumbnailUtils.createVideoThumbnail(File(path), THUMBNAIL_MINI_KIND, null)

--- a/AnkiDroid/src/main/java/com/ichi2/compat/CompatV31.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/CompatV31.kt
@@ -1,0 +1,37 @@
+/*
+ *  Copyright (c) 2021 Mike Hardy <mike@mikehardy.net>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.ichi2.compat
+
+import android.annotation.TargetApi
+import android.content.Context
+import android.media.MediaRecorder
+import android.os.VibrationEffect
+import android.os.VibratorManager
+
+/** Implementation of [Compat] for SDK level 31  */
+@TargetApi(31)
+class CompatV31 : CompatV29(), Compat {
+    override fun vibrate(context: Context, durationMillis: Long) {
+        val vibratorManager = context.getSystemService(Context.VIBRATOR_MANAGER_SERVICE) as VibratorManager
+        val effect = VibrationEffect.createOneShot(durationMillis, VibrationEffect.DEFAULT_AMPLITUDE)
+        val vibrator = vibratorManager.getDefaultVibrator()
+        vibrator.vibrate(effect)
+    }
+
+    override fun getMediaRecorder(context: Context): MediaRecorder {
+        return MediaRecorder(context)
+    }
+}

--- a/AnkiDroid/src/test/java/com/ichi2/anki/multimediacard/AudioRecorderTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/multimediacard/AudioRecorderTest.java
@@ -71,7 +71,7 @@ public class AudioRecorderTest extends RobolectricTest {
         Runnable recordingHandler = mock(Runnable.class);
 
         mAudioRecorder.setOnRecordingInitializedHandler(recordingHandler);
-        mAudioRecorder.startRecording("testpath");
+        mAudioRecorder.startRecording(getTargetContext(), "testpath");
 
         verify(recordingHandler, times(1)).run();
     }
@@ -98,7 +98,7 @@ public class AudioRecorderTest extends RobolectricTest {
         }
         initHandlerWithError recordingHandler = new initHandlerWithError();
         mAudioRecorder.setOnRecordingInitializedHandler(recordingHandler);
-        mAudioRecorder.startRecording("testpath");
+        mAudioRecorder.startRecording(getTargetContext(), "testpath");
 
         assertEquals("Initialization handler should run twice", 2, recordingHandler.getTimesRun());
     }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/reviewer/KeyboardShortcutIntegrationTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/reviewer/KeyboardShortcutIntegrationTest.java
@@ -40,6 +40,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
@@ -78,7 +79,7 @@ public class KeyboardShortcutIntegrationTest extends RobolectricTest {
 
         pressShiftAndVThenRelease();
 
-        verify(recorder, times(1)).startRecording(anyString());
+        verify(recorder, times(1)).startRecording(any(), anyString());
         verifyNoMoreInteractions(recorder);
     }
 
@@ -94,7 +95,7 @@ public class KeyboardShortcutIntegrationTest extends RobolectricTest {
 
         pressAndHoldShiftV();
 
-        verify(recorder, times(1)).startRecording(anyString());
+        verify(recorder, times(1)).startRecording(any(), anyString());
         verifyNoMoreInteractions(recorder);
     }
 
@@ -113,7 +114,7 @@ public class KeyboardShortcutIntegrationTest extends RobolectricTest {
 
         pressShiftAndVThenRelease();
 
-        verify(recorder, times(1)).startRecording(anyString());
+        verify(recorder, times(1)).startRecording(any(), anyString());
         verifyNoMoreInteractions(recorder, player);
         assertStatus(AudioView.Status.RECORDING);
 
@@ -153,7 +154,7 @@ public class KeyboardShortcutIntegrationTest extends RobolectricTest {
         pressShiftAndVThenRelease();
 
         verify(player, times(1)).stop();
-        verify(recorder, times(1)).startRecording(anyString());
+        verify(recorder, times(1)).startRecording(any(), anyString());
         verifyNoMoreInteractions(recorder, player);
         assertStatus(AudioView.Status.RECORDING);
 

--- a/api/build.gradle
+++ b/api/build.gradle
@@ -12,7 +12,7 @@ repositories {
     mavenCentral()
 }
 android {
-    compileSdkVersion 30
+    compileSdkVersion 31
 
     defaultConfig {
         minSdkVersion 14


### PR DESCRIPTION
## Pull Request template

## Purpose / Description

I want to unblock some of the dependencies that require minCompileSdk 31

## Fixes
Related #9768
Related #9726
Related #9725

## Approach

- added new CompatV31 object to compat infrastructure
- handled MediaRecorder() ctor deprecation by threading Context through, adding new Compat method
- handled Context.VIBRATOR_SERVICE deprecation with recommended new APIs in CompatV31 override

## How Has This Been Tested?

Apologies it is all one commit, but it's hard to bump a build version and handle the deprecation in different commits, since the necessary symbols are not available until you bump the compile version, at which point you get a build failure with the deprecation. I suppose I could have marked it as ignore deprecation but seemed small enough to just go for it

Works for me locally with `./gradlew jacocoUnitTestReport :api:lintRelease :AnkiDroid:lintPlayRelease`

## Learning (optional, can help others)

vibrator forward port: https://stackoverflow.com/a/68466169/9910298

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
