### PR TITLE
Dependency updates 20211104

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -259,7 +259,7 @@ dependencies {
 
     coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:1.1.5'
     compileOnly 'org.jetbrains:annotations:21.0.1'
-    compileOnly "com.google.auto.service:auto-service-annotations:1.0"
+    compileOnly "com.google.auto.service:auto-service-annotations:1.0.1"
     annotationProcessor "com.google.auto.service:auto-service:1.0"
 
     implementation 'androidx.activity:activity-ktx:1.3.1'

--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -260,13 +260,13 @@ dependencies {
     coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:1.1.5'
     compileOnly 'org.jetbrains:annotations:21.0.1'
     compileOnly "com.google.auto.service:auto-service-annotations:1.0.1"
-    annotationProcessor "com.google.auto.service:auto-service:1.0"
+    annotationProcessor "com.google.auto.service:auto-service:1.0.1"
 
-    implementation 'androidx.activity:activity-ktx:1.3.1'
+    implementation 'androidx.activity:activity-ktx:1.4.0'
     implementation 'androidx.annotation:annotation:1.3.0'
     implementation 'androidx.appcompat:appcompat:1.3.1'
-    implementation 'androidx.browser:browser:1.3.0'
-    implementation "androidx.core:core-ktx:1.6.0"
+    implementation 'androidx.browser:browser:1.4.0'
+    implementation "androidx.core:core-ktx:1.7.0"
     implementation 'androidx.exifinterface:exifinterface:1.3.3'
     implementation 'androidx.fragment:fragment-ktx:1.3.6'
     implementation 'androidx.localbroadcastmanager:localbroadcastmanager:1.0.0'

--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -263,7 +263,7 @@ dependencies {
     annotationProcessor "com.google.auto.service:auto-service:1.0"
 
     implementation 'androidx.activity:activity-ktx:1.3.1'
-    implementation 'androidx.annotation:annotation:1.2.0'
+    implementation 'androidx.annotation:annotation:1.3.0'
     implementation 'androidx.appcompat:appcompat:1.3.1'
     implementation 'androidx.browser:browser:1.3.0'
     implementation "androidx.core:core-ktx:1.6.0"

--- a/AnkiDroid/src/main/java/com/ichi2/anki/FieldEditText.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/FieldEditText.java
@@ -137,6 +137,7 @@ public class FieldEditText extends FixedEditText implements NoteService.NoteFiel
     }
 
     @Override
+    @SuppressWarnings("deprecation") // Tracked in #9775
     public InputConnection onCreateInputConnection(EditorInfo editorInfo) {
         InputConnection inputConnection = super.onCreateInputConnection(editorInfo);
         if (inputConnection == null) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/SharedDecksActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/SharedDecksActivity.kt
@@ -146,10 +146,10 @@ class SharedDecksActivity : AnkiActivity() {
         return sharedDecksDownloadFragment != null && sharedDecksDownloadFragment.isAdded
     }
 
-    override fun onCreateOptionsMenu(menu: Menu?): Boolean {
+    override fun onCreateOptionsMenu(menu: Menu): Boolean {
         menuInflater.inflate(R.menu.download_shared_decks_menu, menu)
 
-        val searchView = menu?.findItem(R.id.search)?.actionView as SearchView
+        val searchView = menu.findItem(R.id.search)?.actionView as SearchView
         searchView.queryHint = getString(R.string.search_using_deck_name)
         searchView.setOnQueryTextListener(object : SearchView.OnQueryTextListener {
             override fun onQueryTextSubmit(query: String?): Boolean {

--- a/api/build.gradle
+++ b/api/build.gradle
@@ -50,7 +50,7 @@ android {
 apply from: "../lint.gradle"
 
 dependencies {
-    implementation 'androidx.annotation:annotation:1.2.0'
+    implementation 'androidx.annotation:annotation:1.3.0'
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     testImplementation 'org.junit.vintage:junit-vintage-engine:5.8.1'
     testImplementation 'org.robolectric:robolectric:4.6.1'


### PR DESCRIPTION
## Pull Request template

## Purpose / Description

Not quite a standard dependency updates PR.

dependabot became quite confused on correct tree state for the PRs that needed minCompileSdk 31, despite my efforts on #9774 and push to the dependency updates branch

So I dug in there myself and did the pending / blocked dependency bumps, with two tweaks along the way to make it work

## Approach
- just bump the versions
- tweak SharedDecksActivity so parameter nullability in method matches superclass so it is an override
- mark InputConnectionCompat deprecation and track in #9775 

## How Has This Been Tested?

Local `./gradlew clean jacocoUnitTestReport lintPlayRelease --rerun-tasks` 

## Learning (optional, can help others)

The sun rises and sets every day, with a new deprecation to handle.

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x ] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
