### PR TITLE
refactor: TTS

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -116,6 +116,7 @@ import com.ichi2.async.TaskManager;
 import com.ichi2.compat.CompatHelper;
 import com.ichi2.libanki.Decks;
 import com.ichi2.libanki.SoundOrVideoTag;
+import com.ichi2.libanki.TTSTag;
 import com.ichi2.libanki.sched.AbstractSched;
 import com.ichi2.libanki.Card;
 import com.ichi2.libanki.Collection;
@@ -1830,10 +1831,10 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
                 // If the question is displayed or if the question should be replayed, read the question
                 if (mTtsInitialized) {
                     if (!sDisplayAnswer || doAudioReplay && replayQuestion) {
-                        mTTS.readCardText(this, mCurrentCard, SoundSide.QUESTION);
+                        readCardTts(SoundSide.QUESTION);
                     }
                     if (sDisplayAnswer) {
-                        mTTS.readCardText(this, mCurrentCard, SoundSide.ANSWER);
+                        readCardTts(SoundSide.ANSWER);
                     }
                 } else {
                     mReplayOnTtsInit = true;
@@ -1841,6 +1842,15 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
             }
         }
     }
+
+
+    private void readCardTts(SoundSide soundSide) {
+        List<TTSTag> tags = CardHtml.legacyGetTtsTags(mCurrentCard, soundSide, this);
+        if (tags != null) {
+            mTTS.readCardText(tags, mCurrentCard, soundSide);
+        }
+    }
+
 
     private void playSounds(SoundSide questionAndAnswer) {
         mSoundPlayer.playSounds(questionAndAnswer, getSoundErrorListener());

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ReadText.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ReadText.java
@@ -33,6 +33,7 @@ import com.ichi2.utils.HandlerUtils;
 
 import java.lang.ref.WeakReference;
 import java.util.ArrayList;
+import java.util.List;
 import java.util.Locale;
 
 import androidx.annotation.NonNull;
@@ -149,17 +150,15 @@ public class ReadText {
     /**
      * Read a card side using a TTS service.
      *
+     * @param textsToRead      Data for the TTS to read
      * @param cardSide         Card side to be read; SoundSide.SOUNDS_QUESTION or SoundSide.SOUNDS_ANSWER.
-     * @param cardSideContents Contents of the card side to be read, in HTML format. If it contains
-     *                         any &lt;tts service="android"&gt; elements, only their contents is
-     *                         read; otherwise, all text is read. See TtsParser for more details.
      * @param did              Index of the deck containing the card.
      * @param ord              The card template ordinal.
      */
-    public static void readCardSide(Sound.SoundSide cardSide, String cardSideContents, long did, int ord, String clozeReplacement) {
+    public static void readCardSide(List<TTSTag> textsToRead, Sound.SoundSide cardSide, long did, int ord) {
         boolean isFirstText = true;
         boolean playedSound = false;
-        for (TTSTag textToRead : TtsParser.getTextsToRead(cardSideContents, clozeReplacement)) {
+        for (TTSTag textToRead : textsToRead) {
             if (textToRead.getFieldText().isEmpty()) {
                 continue;
             }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/CardHtml.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/CardHtml.kt
@@ -17,7 +17,10 @@
 package com.ichi2.anki.cardviewer
 
 import com.ichi2.anki.R
-import com.ichi2.libanki.*
+import com.ichi2.libanki.Card
+import com.ichi2.libanki.Media
+import com.ichi2.libanki.Sound
+import com.ichi2.libanki.SoundOrVideoTag
 import com.ichi2.libanki.template.MathJax
 import com.ichi2.themes.HtmlColors
 import com.ichi2.utils.JSONObject
@@ -36,9 +39,10 @@ class CardHtml(
     private val side: Side,
     @RustCleanup("Slow function, only used with legacy code")
     private val getAnswerContentWithoutFrontSide_slow: (() -> String),
-    private var questionAv: List<AvTag>? = null,
-    private var answerAv: List<AvTag>? = null,
-    private val usingBackend: Boolean = answerAv != null
+    @RustCleanup("too many variables, combine once we move away from backend")
+    private var questionSound: List<SoundOrVideoTag>? = null,
+    private var answerSound: List<SoundOrVideoTag>? = null,
+    private val usingBackend: Boolean = answerSound != null
 ) {
     fun getSoundTags(sideFor: Side): List<SoundOrVideoTag> {
         if (sideFor == this.side) {
@@ -46,15 +50,15 @@ class CardHtml(
         }
 
         if (sideFor == Side.BACK && side == Side.FRONT) {
-            if (answerAv == null) {
-                answerAv = Sound.extractTagsFromLegacyContent(getAnswerContentWithoutFrontSide_slow())
+            if (answerSound == null) {
+                answerSound = Sound.extractTagsFromLegacyContent(getAnswerContentWithoutFrontSide_slow())
             }
-            return answerAv!!.filterIsInstance(SoundOrVideoTag::class.java)
+            return answerSound!!
         }
 
         // Back wanting front, only possible if questionAv != null
-        if (questionAv != null) {
-            return questionAv!!.filterIsInstance(SoundOrVideoTag::class.java)
+        if (questionSound != null) {
+            return questionSound!!
         }
 
         throw IllegalStateException("Attempted to get the front of the card when viewing back using legacy system")
@@ -64,15 +68,15 @@ class CardHtml(
     private fun getSoundsForCurrentSide(): List<SoundOrVideoTag> {
         // beforeSoundTemplateExpansion refers to the current side
         return if (this.side == Side.FRONT) {
-            if (questionAv == null) {
-                questionAv = Sound.extractTagsFromLegacyContent(beforeSoundTemplateExpansion)
+            if (questionSound == null) {
+                questionSound = Sound.extractTagsFromLegacyContent(beforeSoundTemplateExpansion)
             }
-            questionAv!!.filterIsInstance(SoundOrVideoTag::class.java)
+            questionSound!!
         } else {
-            if (answerAv == null) {
-                answerAv = Sound.extractTagsFromLegacyContent(getAnswerContentWithoutFrontSide_slow())
+            if (answerSound == null) {
+                answerSound = Sound.extractTagsFromLegacyContent(getAnswerContentWithoutFrontSide_slow())
             }
-            return answerAv!!.filterIsInstance(SoundOrVideoTag::class.java)
+            return answerSound!!
         }
     }
 
@@ -128,13 +132,17 @@ class CardHtml(
 
             val nightModeInversion = context.cardAppearance.isNightMode && !context.cardAppearance.hasUserDefinedNightMode(card)
 
-            val questionAv = card.render_output().question_av_tags
-            val answerAv = card.render_output().answer_av_tags
+            val renderOutput = card.render_output()
+            val questionAv = renderOutput.question_av_tags
+            val answerAv = renderOutput.answer_av_tags
+
+            val questionSound = questionAv?.filterIsInstance(SoundOrVideoTag::class.java)
+            val answerSound = answerAv?.filterIsInstance(SoundOrVideoTag::class.java)
 
             // legacy (slow) function to return the answer without the front side
             fun getAnswerWithoutFrontSideLegacy(): String = removeFrontSideAudio(card, card.a())
 
-            return CardHtml(content, card.ord, nightModeInversion, context, side, ::getAnswerWithoutFrontSideLegacy, questionAv, answerAv)
+            return CardHtml(content, card.ord, nightModeInversion, context, side, ::getAnswerWithoutFrontSideLegacy, questionSound, answerSound)
         }
 
         /**

--- a/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/CardHtml.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/CardHtml.kt
@@ -16,11 +16,10 @@
 
 package com.ichi2.anki.cardviewer
 
+import android.content.Context
 import com.ichi2.anki.R
-import com.ichi2.libanki.Card
-import com.ichi2.libanki.Media
-import com.ichi2.libanki.Sound
-import com.ichi2.libanki.SoundOrVideoTag
+import com.ichi2.anki.TtsParser
+import com.ichi2.libanki.*
 import com.ichi2.libanki.template.MathJax
 import com.ichi2.themes.HtmlColors
 import com.ichi2.utils.JSONObject
@@ -217,6 +216,19 @@ class CardHtml(
                 }
             }
             return newAnswerContent
+        }
+
+        @JvmStatic
+        fun legacyGetTtsTags(card: Card, cardSide: Sound.SoundSide, context: Context): List<TTSTag>? {
+            val cardSideContent: String = when {
+                Sound.SoundSide.QUESTION == cardSide -> card.q(true)
+                Sound.SoundSide.ANSWER == cardSide -> card.pureAnswer
+                else -> {
+                    Timber.w("Unrecognised cardSide")
+                    return null
+                }
+            }
+            return TtsParser.getTextsToRead(cardSideContent, context.getString(R.string.reviewer_tts_cloze_spoken_replacement))
         }
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/TTS.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/TTS.kt
@@ -22,6 +22,7 @@ import android.content.Context
 import com.ichi2.anki.CardUtils
 import com.ichi2.anki.R
 import com.ichi2.anki.ReadText
+import com.ichi2.anki.TtsParser
 import com.ichi2.libanki.Card
 import com.ichi2.libanki.Sound.SoundSide
 import com.ichi2.libanki.Utils
@@ -59,17 +60,16 @@ class TTS {
      * @param cardSide The side of the current card to play TTS for
      */
     fun readCardText(context: Context, card: Card, cardSide: SoundSide) {
-        val cardSideContent: String
-        cardSideContent = if (SoundSide.QUESTION == cardSide) {
-            card.q(true)
-        } else if (SoundSide.ANSWER == cardSide) {
-            card.pureAnswer
-        } else {
-            Timber.w("Unrecognised cardSide")
-            return
+        val cardSideContent: String = when {
+            SoundSide.QUESTION == cardSide -> card.q(true)
+            SoundSide.ANSWER == cardSide -> card.pureAnswer
+            else -> {
+                Timber.w("Unrecognised cardSide")
+                return
+            }
         }
-        val clozeReplacement = context.getString(R.string.reviewer_tts_cloze_spoken_replacement)
-        ReadText.readCardSide(cardSide, cardSideContent, CardUtils.getDeckIdForCard(card), getOrdUsingCardType(card), clozeReplacement)
+        val ttsTags = TtsParser.getTextsToRead(cardSideContent, context.getString(R.string.reviewer_tts_cloze_spoken_replacement))
+        ReadText.readCardSide(ttsTags, cardSide, CardUtils.getDeckIdForCard(card), getOrdUsingCardType(card))
     }
 
     /**

--- a/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/TTS.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/TTS.kt
@@ -22,12 +22,11 @@ import android.content.Context
 import com.ichi2.anki.CardUtils
 import com.ichi2.anki.R
 import com.ichi2.anki.ReadText
-import com.ichi2.anki.TtsParser
 import com.ichi2.libanki.Card
 import com.ichi2.libanki.Sound.SoundSide
+import com.ichi2.libanki.TTSTag
 import com.ichi2.libanki.Utils
 import com.ichi2.libanki.template.TemplateFilters
-import timber.log.Timber
 
 class TTS {
     @get:JvmName("isEnabled")
@@ -59,16 +58,7 @@ class TTS {
      * @param card     The card to play TTS for
      * @param cardSide The side of the current card to play TTS for
      */
-    fun readCardText(context: Context, card: Card, cardSide: SoundSide) {
-        val cardSideContent: String = when {
-            SoundSide.QUESTION == cardSide -> card.q(true)
-            SoundSide.ANSWER == cardSide -> card.pureAnswer
-            else -> {
-                Timber.w("Unrecognised cardSide")
-                return
-            }
-        }
-        val ttsTags = TtsParser.getTextsToRead(cardSideContent, context.getString(R.string.reviewer_tts_cloze_spoken_replacement))
+    fun readCardText(ttsTags: List<TTSTag>, card: Card, cardSide: SoundSide) {
         ReadText.readCardSide(ttsTags, cardSide, CardUtils.getDeckIdForCard(card), getOrdUsingCardType(card))
     }
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/ReadTextTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/ReadTextTest.java
@@ -22,8 +22,6 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import androidx.annotation.CheckResult;
-import androidx.annotation.NonNull;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
 import static com.ichi2.libanki.Sound.SoundSide.QUESTION;
@@ -65,45 +63,6 @@ public class ReadTextTest extends RobolectricTest{
         ReadText.initializeTts(getTargetContext(), mock(AbstractFlashcardViewer.ReadTextListener.class));
     }
 
-    @Test
-    public void clozeIsReplacedWithBlank() {
-
-        String content = "<style>.card {\n" +
-                " font-family: arial;\n" +
-                " font-size: 20px;\n" +
-                " text-align: center;\n" +
-                " color: black;\n" +
-                " background-color: white;\n" +
-                "}.cloze {font-weight: bold;color: blue;}</style>This is a <span class=cloze>[...]</span>";
-
-        getValueFromReadSide(content);
-
-        assertThat(ReadText.getTextToSpeak(), is("This is a blank"));
-    }
-
-
-    @Test
-    public void providedExampleClozeReplaces() {
-        String content = "<style>.card {\n" +
-                " font-family: arial;\n" +
-                " font-size: 20px;\n" +
-                " text-align: center;\n" +
-                " color: black;\n" +
-                " background-color: white;\n" +
-                "}.cloze {font-weight: bold;color: blue;}</style>A few lizards are venomous, eg <span class=cloze>[...]</span>. They have grooved teeth and sublingual venom glands.";
-
-        String actual = getValueFromReadSide(content);
-
-        assertThat(actual, is("A few lizards are venomous, eg blank. They have grooved teeth and sublingual venom glands."));
-    }
-
-
-
-    @CheckResult
-    private String getValueFromReadSide(@NonNull String content) {
-        ReadText.readCardSide(QUESTION, content, 1, 1, "blank");
-        return ReadText.getTextToSpeak();
-    }
 
     @Test
     public void SaveValue() {

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/TtsParserTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/TtsParserTest.kt
@@ -1,0 +1,55 @@
+/*
+ *  Copyright (c) 2021 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.libanki
+
+import androidx.annotation.CheckResult
+import com.ichi2.anki.TtsParser.getTextsToRead
+import org.hamcrest.CoreMatchers.equalTo
+import org.hamcrest.MatcherAssert.assertThat
+import org.junit.Test
+
+class TtsParserTest {
+    @Test
+    fun clozeIsReplacedWithBlank() {
+        val content = """<style>.card {
+ font-family: arial;
+ font-size: 20px;
+ text-align: center;
+ color: black;
+ background-color: white;
+}.cloze {font-weight: bold;color: blue;}</style>This is a <span class=cloze>[...]</span>"""
+        val actual = getTtsTagFrom(content)
+        assertThat(actual.fieldText, equalTo("This is a blank"))
+    }
+
+    @Test
+    fun providedExampleClozeReplaces() {
+        val content = """<style>.card {
+ font-family: arial;
+ font-size: 20px;
+ text-align: center;
+ color: black;
+ background-color: white;
+}.cloze {font-weight: bold;color: blue;}</style>A few lizards are venomous, eg <span class=cloze>[...]</span>. They have grooved teeth and sublingual venom glands."""
+        val actual = getTtsTagFrom(content)
+        assertThat(actual.fieldText, equalTo("A few lizards are venomous, eg blank. They have grooved teeth and sublingual venom glands."))
+    }
+
+    @CheckResult
+    private fun getTtsTagFrom(content: String): TTSTag =
+        getTextsToRead(content, "blank").single()
+}


### PR DESCRIPTION
Splits out the generation and reading of TTS

I have a follow-up commit which implements the Rust TTS tags, but I want it to be heavily unit tested (we currently have an "enable TTS" option, which then allows TTS to work (either read the card, or handle `<tts>` tags), and this interacts questionably with Anki, where TTS is only defined in the card template)

I'd like refactorings to go in before I add the tests.

This also splits out `TtsParserTest.kt`, which should ever so slightly speed up the tests (1ms test runs)

#5793

## Testing

Trusting CI on this one

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
