### PR TITLE
feat(record-audio): Show Preview of Fields

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/IMultimediaEditableNote.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/IMultimediaEditableNote.java
@@ -38,4 +38,7 @@ public interface IMultimediaEditableNote extends Serializable {
 
 
     boolean isModified();
+
+    int getInitialFieldCount();
+    IField getInitialField(int index);
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicAudioRecordingFieldController.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicAudioRecordingFieldController.java
@@ -21,11 +21,14 @@ package com.ichi2.anki.multimediacard.fields;
 
 import android.content.Context;
 import android.content.Intent;
-
+import android.view.Gravity;
 import android.widget.LinearLayout;
+import android.widget.ScrollView;
 
 import com.ichi2.anki.R;
 import com.ichi2.anki.multimediacard.AudioView;
+import com.ichi2.ui.FixedTextView;
+import com.ichi2.utils.UiUtil;
 
 import java.io.File;
 
@@ -57,6 +60,7 @@ public class BasicAudioRecordingFieldController extends FieldControllerBase impl
             mTempAudioPath = AudioView.generateTempAudioFile(mActivity);
         }
 
+        // FIXME: We should move this outside the scrollview as it should always be on the screen.
         mAudioView = AudioView.createRecorderInstance(mActivity, R.drawable.ic_play_arrow_white_24dp, R.drawable.ic_pause_white_24dp,
                 R.drawable.ic_stop_white_24dp, R.drawable.ic_rec, R.drawable.ic_rec_stop, mTempAudioPath);
         mAudioView.setOnRecordingFinishEventListener(v -> {
@@ -66,6 +70,33 @@ public class BasicAudioRecordingFieldController extends FieldControllerBase impl
             mField.setHasTemporaryMedia(true);
         });
         layout.addView(mAudioView, LinearLayout.LayoutParams.MATCH_PARENT);
+
+        addFieldPreview(context, layout);
+    }
+
+
+    private void addFieldPreview(Context context, LinearLayout layout) {
+        // add preview of the field data to provide context to the user
+        // use a separate scrollview to ensure that the content does not push the buttons off-screen when scrolled
+        ScrollView sv = new ScrollView(context);
+        layout.addView(sv);
+        LinearLayout previewLayout = new LinearLayout(context); // scrollView can only have one child
+        previewLayout.setOrientation(LinearLayout.VERTICAL);
+        sv.addView(previewLayout);
+
+        FixedTextView label = new FixedTextView(context);
+        label.setTextSize(20);
+        label.setText(UiUtil.makeBold(context.getString(R.string.audio_recording_field_list)));
+        label.setGravity(Gravity.CENTER_HORIZONTAL);
+        previewLayout.addView(label);
+        for (int i = 0; i < this.mNote.getInitialFieldCount(); i++) {
+            IField field = mNote.getInitialField(i);
+            FixedTextView textView = new FixedTextView(context);
+            textView.setText(field.getText());
+            textView.setTextSize(16);
+            textView.setPadding(16, 0, 16, 24);
+            previewLayout.addView(textView);
+        }
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/impl/MultimediaEditableNote.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/impl/MultimediaEditableNote.java
@@ -24,6 +24,11 @@ import com.ichi2.anki.multimediacard.fields.IField;
 
 import java.util.ArrayList;
 
+import androidx.annotation.Nullable;
+
+import static org.acra.util.IOUtils.deserialize;
+import static org.acra.util.IOUtils.serialize;
+
 /**
  * Implementation of the editable note.
  * <p>
@@ -35,6 +40,11 @@ public class MultimediaEditableNote implements IMultimediaEditableNote {
     private boolean mIsModified = false;
     private ArrayList<IField> mFields;
     private long mModelId;
+    /**
+     * Field values in the note editor, before any editing has taken place
+     * These values should not be modified
+     */
+    public ArrayList<IField> mInitialFields;
 
 
     private void setThisModified() {
@@ -110,4 +120,23 @@ public class MultimediaEditableNote implements IMultimediaEditableNote {
         return mModelId;
     }
 
+    public void freezeInitialFieldValues() {
+        mInitialFields = new ArrayList<>();
+        for (IField f : mFields) {
+            mInitialFields.add(cloneField(f));
+        }
+    }
+
+    public int getInitialFieldCount() {
+        return mInitialFields.size();
+    }
+
+    public IField getInitialField(int index) {
+        return cloneField(mInitialFields.get(index));
+    }
+
+    @Nullable
+    private IField cloneField(IField f) {
+        return deserialize(IField.class, serialize(f));
+    }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/NoteService.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/NoteService.java
@@ -80,13 +80,6 @@ public class NoteService {
     }
 
 
-    public static void updateMultimediaNoteFromJsonNote(Collection col, final Note editorNoteSrc, final IMultimediaEditableNote noteDst) {
-        if (noteDst instanceof MultimediaEditableNote) {
-            updateMultimediaNoteFromFields(col, editorNoteSrc.getFields(), editorNoteSrc.getMid(), (MultimediaEditableNote) noteDst);
-        }
-    }
-
-
     public static void updateMultimediaNoteFromFields(Collection col, String[] fields, long modelId, MultimediaEditableNote mmNote) {
         for (int i = 0; i < fields.length; i++) {
             String value = fields[i];

--- a/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/NoteService.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/NoteService.java
@@ -97,6 +97,7 @@ public class NoteService {
             mmNote.setField(i, field);
         }
         mmNote.setModelId(modelId);
+        mmNote.freezeInitialFieldValues();
         // TODO: set current id of the note as well
     }
 

--- a/AnkiDroid/src/main/res/values/16-multimedia-editor.xml
+++ b/AnkiDroid/src/main/res/values/16-multimedia-editor.xml
@@ -118,5 +118,6 @@
     <string name="save_dialog_content">Current image size is %sMB. Default image size limit is 1MB. Do you want to crop it?</string>
     <string name="select_image_failed">"Select image failed, Please retry"</string>
     <string name="activity_result_unexpected">App returned an unexpected value. You may need to use a different app</string>
+    <string name="audio_recording_field_list" comment="Displays a list of the field data in the note editor while audio recording is taking place">Field Contents</string>
 
 </resources>


### PR DESCRIPTION
* Display text of the fields from the note editor

This allows a user to better know what to say

* Images are not supported, only text
* Scrolling behaviour is incorrect, but unlikely to occur. It's not recommended (and difficult) to handle nested ScrollViews, so we'll need an alternative, probably moving the controls outside the standard linear layout

Fixes #5428

![image](https://user-images.githubusercontent.com/62114487/141687119-5a38640d-66a0-43e3-941b-618de93da184.png)


## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [x] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
