### PR TITLE
Changes for Issue 5844 - Forgotten AnkiWeb e-mail

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/MyAccount.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/MyAccount.java
@@ -227,9 +227,9 @@ public class MyAccount extends AnkiActivity {
         Uri url = Uri.parse(getResources().getString(R.string.register_url));
         signUpButton.setOnClickListener(v -> openUrl(url));
 
-        //Add new button to link to instructions on how to find AnkiWeb email
+        //Add button to link to instructions on how to find AnkiWeb email
         Button lostEmail = mLoginToMyAccountView.findViewById(R.id.lost_mail_instructions);
-        Uri lostMailUrl = Uri.parse("https://github.com/ankidroid/Anki-Android/wiki/FAQ#forgotten-ankiweb-email-instructions");
+        Uri lostMailUrl = Uri.parse(getResources().getString((R.string.link_ankiweb_lost_email_instructions)));
         lostEmail.setOnClickListener(v -> openUrl(lostMailUrl));
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/MyAccount.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/MyAccount.java
@@ -227,6 +227,12 @@ public class MyAccount extends AnkiActivity {
         Uri url = Uri.parse(getResources().getString(R.string.register_url));
         signUpButton.setOnClickListener(v -> openUrl(url));
 
+        //Add new button to link to instructions on how to find AnkiWeb email
+        Button lostEmail = mLoginToMyAccountView.findViewById(R.id.lost_mail_instructions);
+        Uri lostMailUrl = Uri.parse("https://github.com/ankidroid/Anki-Android/wiki/FAQ#forgotten-ankiweb-email-instructions");
+        lostEmail.setOnClickListener(v -> openUrl(lostMailUrl));
+
+
         mLoggedIntoMyAccountView = getLayoutInflater().inflate(R.layout.my_account_logged_in, null);
         mUsernameLoggedIn = mLoggedIntoMyAccountView.findViewById(R.id.username_logged_in);
         Button logoutButton = mLoggedIntoMyAccountView.findViewById(R.id.logout_button);

--- a/AnkiDroid/src/main/res/layout/my_account.xml
+++ b/AnkiDroid/src/main/res/layout/my_account.xml
@@ -153,6 +153,20 @@
                 android:layout_gravity="center"
                 android:singleLine="true"
                 android:text="@string/sign_up" />
+
+            <!-- Added new button for lost email -->
+            <Button
+                android:id="@+id/lost_mail_instructions"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:background="@null"
+                android:textSize="@dimen/abc_text_size_button_material"
+                android:textColor="?attr/colorAccent"
+                android:padding="3dp"
+                android:layout_gravity="center"
+                android:singleLine="true"
+                android:text="@string/lost_mail_instructions" />
+
         </LinearLayout>
     </LinearLayout>
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/AnkiDroid/src/main/res/values/04-network.xml
+++ b/AnkiDroid/src/main/res/values/04-network.xml
@@ -43,7 +43,7 @@
     <string name="alert_logging_message">Logging in…</string>
     <string name="invalid_username_password">Invalid email address or password</string>
     <string name="reset_password">Reset password</string>
-    <string name="lost_mail_instructions">Forgot AnkiWeb Account Email?</string>
+    <string name="lost_mail_instructions">Forgot Email?</string>
 
     <!-- AndroidManifest.xml -->
     <string name="preferences_title">Preferences</string>

--- a/AnkiDroid/src/main/res/values/04-network.xml
+++ b/AnkiDroid/src/main/res/values/04-network.xml
@@ -43,6 +43,7 @@
     <string name="alert_logging_message">Logging in…</string>
     <string name="invalid_username_password">Invalid email address or password</string>
     <string name="reset_password">Reset password</string>
+    <string name="lost_mail_instructions">Forgot AnkiWeb Account Email?</string>
 
     <!-- AndroidManifest.xml -->
     <string name="preferences_title">Preferences</string>

--- a/AnkiDroid/src/main/res/values/constants.xml
+++ b/AnkiDroid/src/main/res/values/constants.xml
@@ -215,6 +215,7 @@
     <string name="link_anki_2_scheduler">https://faqs.ankiweb.net/the-anki-2.1-scheduler.html</string>
     <string name="link_ankiweb_docs_cloze_deletion">https://docs.ankiweb.net/editing.html#cloze-deletion</string>
     <string name="link_distributions">https://apps.ankiweb.net/#download</string>
+    <string name="link_ankiweb_lost_email_instructions">https://github.com/ankidroid/Anki-Android/wiki/FAQ#forgotten-ankiweb-email-instructions</string>
 
     <string-array name="leech_action_values">
         <item>0</item>


### PR DESCRIPTION
## Pull Request - Changes for Issue 5844 - Forgotten AnkiWeb e-mail

## Purpose / Description
Allow user the ability to click a link for instructions on how to find their AnkiWeb Account Email

## Fixes
Fixes #5844

## Approach
This change adds a button on the login screen for the user to click to open up a web browser with instructions on how to find their AnkiWeb email. 

<img width="557" alt="Screen Shot 2021-11-17 at 6 09 39 PM" src="https://user-images.githubusercontent.com/65492746/142297359-b224352c-14d2-4cf9-9024-d3b6c6f83afc.png">



## How Has This Been Tested?

This was tested on a Pixel3A_API_31_arm64-v8a emulator with  SDK version: Android 12.0 (S)

## Learning (optional, can help others)


## Checklist

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [X] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
