### PR TITLE
revert: Highlight Selected Deck (f96bdfb)

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckSelectionDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckSelectionDialog.kt
@@ -25,11 +25,9 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.Filter
 import android.widget.Filterable
-import android.widget.Spinner
 import android.widget.TextView
 import androidx.appcompat.widget.SearchView
 import androidx.appcompat.widget.Toolbar
-import androidx.core.content.ContextCompat
 import androidx.recyclerview.widget.DividerItemDecoration
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
@@ -44,7 +42,6 @@ import com.ichi2.libanki.Deck
 import com.ichi2.libanki.DeckManager
 import com.ichi2.libanki.backend.exception.DeckRenameException
 import com.ichi2.libanki.stats.Stats
-import com.ichi2.themes.Themes
 import com.ichi2.utils.DeckNameComparator
 import com.ichi2.utils.FilterResultsUtils
 import com.ichi2.utils.FunctionalInterfaces
@@ -249,19 +246,6 @@ open class DeckSelectionDialog : AnalyticsDialogFragment() {
 
         override fun onBindViewHolder(holder: ViewHolder, position: Int) {
             val deck = mCurrentlyDisplayedDecks[position]
-            val spinner = activity!!.findViewById<Spinner>(R.id.note_deck_spinner)
-            val spinnerSelectedDeckName = spinner.selectedItem.toString()
-            val unselectedTextColor = Themes.getColorFromAttr(context, android.R.attr.textColorPrimary)
-            val selectedTextColor = ContextCompat.getColor(context!!, R.color.note_editor_selected_item_text)
-            val unselectedBackgroundColor = Themes.getColorFromAttr(context, android.R.attr.colorBackground)
-            val selectedBackgroundColor = ContextCompat.getColor(context!!, R.color.note_editor_selected_item_background)
-            if (spinnerSelectedDeckName == deck.name) {
-                holder.deckTextView.setBackgroundColor(selectedBackgroundColor)
-                holder.deckTextView.setTextColor(selectedTextColor)
-            } else {
-                holder.deckTextView.setBackgroundColor(unselectedBackgroundColor)
-                holder.deckTextView.setTextColor(unselectedTextColor)
-            }
             holder.setDeck(deck)
         }
 


### PR DESCRIPTION
This crashes the card browser and statistics screen when changing
the selected deck.

Note: This is the spinner, not "Change Deck" functionality

reverts f96bdfbc1f756e6e7b61d404e50c3acd3f3d7716

Fixes #9914
Reverts #9765
Reopens #9755

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
