### PR TITLE
Bump appcompat from 1.3.1 to 1.4.0

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -264,7 +264,7 @@ dependencies {
 
     implementation 'androidx.activity:activity-ktx:1.4.0'
     implementation 'androidx.annotation:annotation:1.3.0'
-    implementation 'androidx.appcompat:appcompat:1.3.1'
+    implementation 'androidx.appcompat:appcompat:1.4.0'
     implementation 'androidx.browser:browser:1.4.0'
     implementation "androidx.core:core-ktx:1.7.0"
     implementation 'androidx.exifinterface:exifinterface:1.3.3'

--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/LayoutValidationTest.java
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/LayoutValidationTest.java
@@ -42,7 +42,6 @@ public class LayoutValidationTest extends InstrumentedTest {
 
         // There are hidden public fields: abc_list_menu_item_layout for example
         HashSet<String> nonAnkiFieldNames = new HashSet<>();
-        nonAnkiFieldNames.addAll(getFieldNames(androidx.appcompat.resources.R.layout.class));
         nonAnkiFieldNames.addAll(getFieldNames(com.google.android.material.R.layout.class));
         nonAnkiFieldNames.addAll(getFieldNames(com.afollestad.materialdialogs.R.layout.class));
 

--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/LayoutValidationTest.java
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/LayoutValidationTest.java
@@ -1,3 +1,19 @@
+/*
+ *  Copyright (c) 2020 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package com.ichi2.anki.tests;
 
 import android.content.Context;


### PR DESCRIPTION
fix: androidx.appcompat.resources.R.layout no longer exists

Bumps appcompat from 1.3.1 to 1.4.0.

Fixes #9913 (superseded)

---
updated-dependencies:
- dependency-name: androidx.appcompat:appcompat
  dependency-type: direct:production
  update-type: version-update:semver-minor
...

Signed-off-by: dependabot[bot] <support@github.com>