### PR TITLE
feat: whiteboard editor with custom color pen.

### DIFF
--- a/AnkiDroid/src/main/res/layout/reviewer_whiteboard_editor.xml
+++ b/AnkiDroid/src/main/res/layout/reviewer_whiteboard_editor.xml
@@ -37,6 +37,12 @@
         style="@style/reviewer_whiteboard_editor_button_style"/>
 
     <Button
+        android:id="@+id/pen_color_custom"
+        android:background="@drawable/ic_color_lens_white_24dp"
+        android:backgroundTint="@color/black"
+        style="@style/reviewer_whiteboard_editor_button_style" />
+
+    <Button
         android:id="@+id/stroke_width"
         android:background="@drawable/ic_mode_edit_white"
         android:backgroundTint="@color/black"

--- a/AnkiDroid/src/main/res/values/02-strings.xml
+++ b/AnkiDroid/src/main/res/values/02-strings.xml
@@ -59,6 +59,8 @@
     <string name="webview_crash_fatal">Fatal Error: WebView renderer crashed. Cause: %s</string>
     <string name="webview_crash_loop_dialog_title">System WebView Rendering Failure</string>
     <string name="webview_crash_loop_dialog_content">System WebView failed to render card \'%1$s\'.\n %2$s</string>
+    <string name="custom_color_dialog_title">Enter color hex code</string>
+    <string name="custom_color_dialog_submit">Submit</string>
 
     <!-- Browser -->
     <string-array name="browser_column1_headings">

--- a/AnkiDroid/src/main/res/xml/color_code_input_dialog.xml
+++ b/AnkiDroid/src/main/res/xml/color_code_input_dialog.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="200dp"
+    android:layout_height="200dp"
+    android:gravity="center_horizontal"
+    android:orientation="vertical">
+
+    <EditText
+        android:id="@+id/customColorCode"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="top"
+        android:hint="#FFFFFF"
+        android:inputType="textShortMessage" />
+
+</LinearLayout>


### PR DESCRIPTION
## Purpose / Description
The whiteboard only had 4 or 5 colors as pen color, now user can use any color using the hex code of the color.

## Fixes
Fixes #9915 

## Approach
A custom color button was added, which when clicked pops up a new alert Dialog which asks for the color code, once submitted the color code is checked using regex (if its valid hex color code or not) and then the pen color is set as the color code entered.

## How Has This Been Tested?
on my phone only.

https://user-images.githubusercontent.com/46752548/143437502-ea52990b-e7c2-4e14-b577-61392f86c4ac.mp4

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
