### PR TITLE
Removed the unused string and updated the used link

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/Info.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Info.java
@@ -166,8 +166,7 @@ public class Info extends AnkiActivity {
                 String.format(content[2], res.getString(R.string.link_wikipedia_open_source),
                         res.getString(R.string.link_contribution))).append(" ");
         sb.append(
-                String.format(content[3], res.getString(R.string.link_translation),
-                        res.getString(R.string.link_donation))).append("<br/><br/>");
+                String.format(content[3], res.getString(R.string.link_translation))).append("<br/><br/>");
         sb.append(
                 String.format(content[4], res.getString(R.string.licence_wiki),
                         res.getString(R.string.link_source))).append("<br/><br/>");

--- a/AnkiDroid/src/main/res/values/constants.xml
+++ b/AnkiDroid/src/main/res/values/constants.xml
@@ -178,10 +178,9 @@
     <string name="link_issue_tracker">https://github.com/ankidroid/Anki-Android/issues</string>
     <string name="licence_wiki">http://www.gnu.org/licenses/gpl.html</string>
     <string name="link_source">https://github.com/ankidroid/Anki-Android</string>
-    <string name="link_donation">https://ankisrs.net/support</string>
     <string name="link_market">market://details?id=com.ichi2.anki</string>
     <string name="link_market_kindle">http://www.amazon.com/gp/mas/dl/android?p=com.ichi2.anki</string>
-    <string name="link_translation">http://crowdin.net/project/ankidroid</string>
+    <string name="link_translation">https://crowdin.net/project/ankidroid</string>
     <string name="link_wikipedia_open_source">http://en.wikipedia.org/wiki/Open_source_software</string>
     <string name="link_contribution">https://github.com/ankidroid/Anki-Android/wiki/Contributing</string>
     <string name="link_help">https://docs.ankidroid.org/help.html</string>


### PR DESCRIPTION
## Pull Request template

## Purpose / Description

- There was dead code in the method _getAboutAnkiDroidHtml()_ in the  _`AnkiDroid/src/main/java/com/ichi2/anki/Info.java`_ which remains unused. #9525.
- The <_string name="link_translation">_ in the  _`AnkiDroid/src/main/res/values/constants.xml`_ which acts as a link uses **http** over **https**.

## Fixes

- Updated the method in the codebase _`AnkiDroid/src/main/java/com/ichi2/anki/Info.java`_ and removed the unused string <_string name="link_donation">_ from _`AnkiDroid/src/main/res/values/constants.xml`_  w.r.t #9525 .
- Updated the link in  _`AnkiDroid/src/main/res/values/constants.xml`_ to use **https** over **http** w.r.t #9400 .

Fixes #9525

## Approach

- Updating the method _getAboutAnkiDroidHtml()_ in the  _`AnkiDroid/src/main/java/com/ichi2/anki/Info.java`_ to remove the dead code and removed the unused string <_string name="link_donation">_  from _`AnkiDroid/src/main/res/values/constants.xml`_ .
- Updating the <_string name="link_translation">_ in the  _`AnkiDroid/src/main/res/values/constants.xml`_  from `http://crowdin.net/project/ankidroid` to `https://crowdin.net/project/ankidroid`.

## How Has This Been Tested?

- Removing the dead code from the method and from the constant need not be tested.
- The updated link for <_string name="link_translation">_ now opens the link directly in secured **https** protocol rather than first connecting with **http** and then redirecting with **https** which happened initially.

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have performed a self-review of your own code
