### PR TITLE
Bump robolectric from 4.7.1 to 4.7.3

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -325,7 +325,7 @@ dependencies {
     testImplementation "org.mockito.kotlin:mockito-kotlin:4.0.0"
     testImplementation 'org.hamcrest:hamcrest-all:1.3'
     testImplementation 'net.lachlanmckee:timber-junit-rule:1.0.1'
-    testImplementation "org.robolectric:robolectric:4.7.1"
+    testImplementation "org.robolectric:robolectric:4.7.3"
     testImplementation 'androidx.test:core:1.4.0'
     testImplementation 'androidx.test.ext:junit:1.1.3'
     testImplementation "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"

--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -325,6 +325,7 @@ dependencies {
     testImplementation "org.mockito.kotlin:mockito-kotlin:4.0.0"
     testImplementation 'org.hamcrest:hamcrest-all:1.3'
     testImplementation 'net.lachlanmckee:timber-junit-rule:1.0.1'
+    // robolectricDownloader.gradle *may* need a new SDK jar entry if they release one or if we change targetSdk. Instructions in that gradle file.
     testImplementation "org.robolectric:robolectric:4.7.3"
     testImplementation 'androidx.test:core:1.4.0'
     testImplementation 'androidx.test.ext:junit:1.1.3'

--- a/api/build.gradle
+++ b/api/build.gradle
@@ -53,7 +53,7 @@ dependencies {
     implementation 'androidx.annotation:annotation:1.3.0'
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     testImplementation 'org.junit.vintage:junit-vintage-engine:5.8.1'
-    testImplementation 'org.robolectric:robolectric:4.7.1'
+    testImplementation 'org.robolectric:robolectric:4.7.3'
 
     lintChecks project(":lint-rules")
 }


### PR DESCRIPTION
## Purpose / Description
_Bump robolectric from 4.7.1 to 4.7.3_

## Fixes
Fixes _https://github.com/ankidroid/Anki-Android/pull/9959_

## Approach
_The new version(4.7.3) of robolectric jar fixes the issue of test pollution._

## How Has This Been Tested?

The build was successful and local testing.

## Learning (optional, can help others)
_Describe the research stage_

_Links [to blog posts, patterns, libraries or addons used to solve this problem](https://github.com/robolectric/robolectric/releases)_

## Checklist
_Please, go through these checks before submitting the PR._

- [done ] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [done ] You have a descriptive commit message with a short title (first line, max 50 chars).
- [done ] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [done ] You have commented your code, particularly in hard-to-understand areas
- [done ] You have performed a self-review of your own code
- [done ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [done ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
