### PR TITLE
Make SharedPreferences non-null in WhiteboardPenColor

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/model/WhiteboardPenColor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/model/WhiteboardPenColor.kt
@@ -19,12 +19,10 @@ package com.ichi2.anki.model
 import android.content.SharedPreferences
 import androidx.annotation.CheckResult
 import com.ichi2.anki.cardviewer.CardAppearance.Companion.isInNightMode
-import com.ichi2.utils.KotlinCleanup
 
 class WhiteboardPenColor(val lightPenColor: Int?, val darkPenColor: Int?) {
-    @KotlinCleanup("Make sharedPrefs non-null")
-    fun fromPreferences(sharedPrefs: SharedPreferences?): Int? {
-        val isInNightMode = isInNightMode(sharedPrefs!!)
+    fun fromPreferences(sharedPrefs: SharedPreferences): Int? {
+        val isInNightMode = isInNightMode(sharedPrefs)
         return if (isInNightMode) {
             darkPenColor
         } else {


### PR DESCRIPTION
## Purpose / Description
Make SharedPreferences non-null in WhiteboardPenColor.

## Checklist

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [ ] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
