### PR TITLE
Add comment informing that the actual changelog is only in release branches

### DIFF
--- a/AnkiDroid/src/main/assets/changelog.html
+++ b/AnkiDroid/src/main/assets/changelog.html
@@ -1,3 +1,5 @@
+<!-- The actual changelog is present only in the release branches -->
+
 <!DOCTYPE html>
 <html>
   <body>


### PR DESCRIPTION
According to a suggestion by @david-allison-1 over Discord, we can add a comment so that developers know that the actual changelog data is present only in the release branches.