### PR TITLE
fix: persist seek bar value on change

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/preferences/SeekBarPreferenceCompat.java
+++ b/AnkiDroid/src/main/java/com/ichi2/preferences/SeekBarPreferenceCompat.java
@@ -116,7 +116,7 @@ public class SeekBarPreferenceCompat extends androidx.preference.DialogPreferenc
         persistInt(value);
     }
 
-    private void onCompleted() {
+    private void onValueUpdated() {
         if (shouldPersist()) {
             persistInt(mValue);
         }
@@ -176,6 +176,7 @@ public class SeekBarPreferenceCompat extends androidx.preference.DialogPreferenc
         public void onProgressChanged(SeekBar seekBar, int value, boolean fromUser) {
             if (fromUser) {
                 getPreference().setRelativeValue(value);
+                getPreference().onValueUpdated();
                 onValueUpdated();
             }
         }
@@ -194,7 +195,6 @@ public class SeekBarPreferenceCompat extends androidx.preference.DialogPreferenc
 
         @Override
         public void onStopTrackingTouch(SeekBar seekBar) {
-            getPreference().onCompleted();
             this.getDialog().dismiss();
         }
 

--- a/AnkiDroid/src/main/java/com/ichi2/ui/SeekBarPreference.java
+++ b/AnkiDroid/src/main/java/com/ichi2/ui/SeekBarPreference.java
@@ -125,9 +125,16 @@ public class SeekBarPreference extends android.preference.DialogPreference imple
             mValue = (value * mInterval) + mMin;
             String t = String.valueOf(mValue);
             mValueText.setText(mSuffix == null ? t : t + mSuffix);
+            onValueUpdated();
         }
     }
 
+    private void onValueUpdated() {
+        if (shouldPersist()) {
+            persistInt(mValue);
+        }
+        callChangeListener(mValue);
+    }
 
     public int getValue() {
         if (mValue == 0) {
@@ -147,10 +154,6 @@ public class SeekBarPreference extends android.preference.DialogPreference imple
 
 
     public void onStopTrackingTouch(SeekBar seek) {
-        if (shouldPersist()) {
-            persistInt(mValue);
-        }
-        callChangeListener(mValue);
         this.getDialog().dismiss();
     }
 


### PR DESCRIPTION
Fixes #9947

## Purpose / Description
On non-touch device (e.g. Android TV), it was not possible to save the parameter value for a seek bar.

Behavior before the fix:
![before](https://user-images.githubusercontent.com/88279943/147833637-83082bff-5d83-4af0-b209-f76fb4de8fae.gif)

## Fixes
Persist the seek bar value  with onProgressChange instead of onStopTrackingTouch.

Behavior after the fix: 
![after](https://user-images.githubusercontent.com/88279943/147833660-1c457e85-1438-4a5e-a84a-3ab1c4f1f900.gif)

## How Has This Been Tested?
Tested as in the gifs above, for the seek bars:
- "Card zoom" (in the review settings) to test SeekBarPreferenceCompat
- "Time to show answer" (in the deck options) to test SeekBarPreference

with virtual devices 
- Android TV Android 10
- Pixel 5 Android 11

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
  => Not needed in my opinion, please let me know if you think otherwise.
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
  => See the gif above for an example (all the other are similar).
- [x] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
  => There is a suggestion, but unrelated to the change.  
<img src="https://user-images.githubusercontent.com/88279943/147836636-31cb291b-ecb2-47c1-9317-849ce8d50bdc.png" width="250">
