### PR TITLE
fix(widget): maybe fix displaying crash dialog

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/widget/AnkiDroidWidgetSmall.java
+++ b/AnkiDroid/src/main/java/com/ichi2/widget/AnkiDroidWidgetSmall.java
@@ -152,14 +152,17 @@ public class AnkiDroidWidgetSmall extends AppWidgetProvider {
                     mMountReceiver = new BroadcastReceiver() {
                         @Override
                         public void onReceive(Context context, Intent intent) {
+                            // baseContext() is null, applicationContext() throws a NPE,
+                            // context may not have the locale override from AnkiDroidApp
+                            context = AnkiDroidApp.getInstance();
                             String action = intent.getAction();
                             if (action != null && action.equals(Intent.ACTION_MEDIA_MOUNTED)) {
                                 Timber.d("mMountReceiver - Action = Media Mounted");
                                 if (remounted) {
-                                    WidgetStatus.update(getBaseContext());
+                                    WidgetStatus.update(context);
                                     remounted = false;
                                     if (mMountReceiver != null) {
-                                        AnkiDroidApp.getInstance().unregisterReceiver(mMountReceiver);
+                                        context.unregisterReceiver(mMountReceiver);
                                     }
                                 } else {
                                     remounted = true;


### PR DESCRIPTION
## Purpose / Description
A silent crash dialog was displayed 

The stack trace points to Context being null here.

## Fixes
Fixes (Maybe) #10108

## Approach
Use `context` which is passed into the method, rather than `getBaseContext()`

## How Has This Been Tested?
⚠️ Could not reproduce the issue, maybe phone-specific
Installed, used widget and restarted my phone, 

----

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
