### PR TITLE
NF: withChildren takes `@NonNull`

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/AbstractDeckTreeNode.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/AbstractDeckTreeNode.java
@@ -208,5 +208,5 @@ public abstract class AbstractDeckTreeNode<T extends AbstractDeckTreeNode<T>> im
     }
 
 
-    public abstract T withChildren(List<T> children);
+    public abstract T withChildren(@NonNull List<T> children);
 }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/DeckDueTreeNode.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/DeckDueTreeNode.java
@@ -141,7 +141,7 @@ public class DeckDueTreeNode extends AbstractDeckTreeNode<DeckDueTreeNode> {
 
 
     @Override
-    public DeckDueTreeNode withChildren(List<DeckDueTreeNode> children) {
+    public DeckDueTreeNode withChildren(@NonNull List<DeckDueTreeNode> children) {
         Collection col = getCol();
         String name = getFullDeckName();
         long did = getDid();

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/DeckTreeNode.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/DeckTreeNode.java
@@ -20,6 +20,8 @@ import com.ichi2.libanki.Collection;
 
 import java.util.List;
 
+import androidx.annotation.NonNull;
+
 public class DeckTreeNode extends AbstractDeckTreeNode<DeckTreeNode> {
     public DeckTreeNode(Collection col, String name, long did) {
         super(col, name, did);
@@ -27,7 +29,7 @@ public class DeckTreeNode extends AbstractDeckTreeNode<DeckTreeNode> {
 
 
     @Override
-    public DeckTreeNode withChildren(List<DeckTreeNode> children) {
+    public DeckTreeNode withChildren(@NonNull List<DeckTreeNode> children) {
         Collection col = getCol();
         String name = getFullDeckName();
         long did = getDid();


### PR DESCRIPTION
This will allow #10148 to migrate to Kotlin with all of the override methods
noted as not null