### PR TITLE
Ensure that both Drawable kt are compatible

### DIFF
--- a/AnkiDroid/src/main/java/com/wildplot/android/rendering/DrawableContainer.kt
+++ b/AnkiDroid/src/main/java/com/wildplot/android/rendering/DrawableContainer.kt
@@ -13,12 +13,11 @@
  * You should have received a copy of the GNU General Public License along with         *
  * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
  ****************************************************************************************/
-
 package com.wildplot.android.rendering
 
 import com.wildplot.android.rendering.graphics.wrapper.GraphicsWrap
 import com.wildplot.android.rendering.interfaces.Drawable
-import java.util.Vector
+import java.util.*
 
 class DrawableContainer(private val isOnFrame: Boolean, private val isCritical: Boolean) : Drawable {
     private val drawableVector = Vector<Drawable>()

--- a/AnkiDroid/src/main/java/com/wildplot/android/rendering/interfaces/Drawable.kt
+++ b/AnkiDroid/src/main/java/com/wildplot/android/rendering/interfaces/Drawable.kt
@@ -26,7 +26,7 @@ interface Drawable {
     /**
      * Paint the drawable object
      */
-    fun paint(g: GraphicsWrap?)
+    fun paint(g: GraphicsWrap)
 
     /**
      * Returns true if this Drawable can draw on the outer frame of the plot
@@ -34,7 +34,7 @@ interface Drawable {
      * If a legend or descriptions shall be drawn onto the outer frame this method of the corresponding Drawables has
      * to return true. For all other cases it is highly recommended to return false.
      */
-    val isOnFrame: Boolean
-    val isClusterable: Boolean
-    val isCritical: Boolean
+    fun isOnFrame(): Boolean
+    fun isClusterable(): Boolean
+    fun isCritical(): Boolean
 }


### PR DESCRIPTION
This was obtained by reverting DrawableContainer translation and retranslating
it.  The translation result was different. Probably because Drawable was already
translated.

I believe a general rule here should be that we should not translate a child
class until its parents are translated.

Fixes #10173
