### PR TITLE
fix: DeckOptions crash

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/preferences/NumberRangePreference.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/preferences/NumberRangePreference.kt
@@ -60,7 +60,7 @@ open class NumberRangePreference : android.preference.EditTextPreference {
      * type. The two methods below intercept the persistence and retrieval methods for Strings and replaces them with
      * their Integer equivalents.
      */
-    override fun getPersistedString(defaultReturnValue: String): String {
+    override fun getPersistedString(defaultReturnValue: String?): String? {
         return getPersistedInt(mMin).toString()
     }
 


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
Caused by bad override of `getPersistedString`. Java was `String` which was nullable

## Fixes
Fixes #10176

## Approach
I attempted a unit test for this, but there are internal issues. (see #10175). These issues should be resolved after the activity is converted to use the new
Preference Fragment style

## How Has This Been Tested?
Manually, no longer crashes

## Learning (optional, can help others)
We need tests on `DeckOptions`

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
