### PR TITLE
fix: crash when opening audio recording

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/AudioField.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/AudioField.kt
@@ -54,14 +54,14 @@ abstract class AudioField : FieldBase(), IField {
         return null
     }
 
-    override fun setAudioPath(pathToAudio: String): Boolean {
+    override fun setAudioPath(pathToAudio: String?): Boolean {
         mAudioPath = pathToAudio
         setThisModified()
         return true
     }
 
-    override fun getAudioPath(): String {
-        return mAudioPath!!
+    override fun getAudioPath(): String? {
+        return mAudioPath
     }
 
     override fun getText(): String? {
@@ -78,7 +78,7 @@ abstract class AudioField : FieldBase(), IField {
     abstract override fun setName(name: String)
     override fun getFormattedValue(): String {
         var formattedValue = ""
-        val file = File(audioPath)
+        val file = File(audioPath!!)
         if (file.exists()) {
             formattedValue = String.format("[sound:%s]", file.name)
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/IField.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/IField.java
@@ -23,6 +23,8 @@ import com.ichi2.libanki.Collection;
 
 import java.io.Serializable;
 
+import androidx.annotation.Nullable;
+
 /**
  * General interface for a field of any type.
  */
@@ -53,9 +55,9 @@ public interface IField extends Serializable {
 
 
     // For Audio type
-    boolean setAudioPath(String pathToAudio);
+    boolean setAudioPath(@Nullable String pathToAudio);
 
-
+    @Nullable
     String getAudioPath();
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/TextField.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/TextField.kt
@@ -55,7 +55,7 @@ class TextField : FieldBase(), IField {
         return null
     }
 
-    override fun setAudioPath(pathToAudio: String): Boolean {
+    override fun setAudioPath(pathToAudio: String?): Boolean {
         return false
     }
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/multimediacard/activity/MultimediaEditFieldActivityTestBase.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/multimediacard/activity/MultimediaEditFieldActivityTestBase.java
@@ -24,6 +24,7 @@ import com.ichi2.anki.RobolectricTest;
 import com.ichi2.anki.multimediacard.IMultimediaEditableNote;
 import com.ichi2.anki.multimediacard.fields.IField;
 import com.ichi2.anki.multimediacard.fields.IFieldController;
+import com.ichi2.anki.multimediacard.fields.TextField;
 import com.ichi2.anki.multimediacard.impl.MultimediaEditableNote;
 
 import org.mockito.Mockito;
@@ -43,6 +44,12 @@ public abstract class MultimediaEditFieldActivityTestBase extends RobolectricTes
         ShadowApplication app = Shadows.shadowOf(application);
         app.grantPermissions(Manifest.permission.CAMERA);
     }
+
+    protected void grantRecordAudioPermission() {
+        Application application = ApplicationProvider.getApplicationContext();
+        ShadowApplication app = Shadows.shadowOf(application);
+        app.grantPermissions(Manifest.permission.RECORD_AUDIO);
+    }
     
     protected IFieldController getControllerForField(IField field, IMultimediaEditableNote note, int fieldIndex) {
         Intent intent = new Intent(Intent.ACTION_VIEW);
@@ -55,6 +62,8 @@ public abstract class MultimediaEditFieldActivityTestBase extends RobolectricTes
     protected IMultimediaEditableNote getEmptyNote() {
         MultimediaEditableNote note = new MultimediaEditableNote();
         note.setNumFields(1);
+        note.setField(0, new TextField());
+        note.freezeInitialFieldValues();
         return note;
     }
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/multimediacard/fields/BasicAudioClipFieldControllerComplexTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/multimediacard/fields/BasicAudioClipFieldControllerComplexTest.kt
@@ -1,0 +1,35 @@
+/*
+ *  Copyright (c) 2021 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.ichi2.anki.multimediacard.fields
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.ichi2.anki.multimediacard.activity.MultimediaEditFieldActivityTestBase
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Test which requires an activity
+ */
+@RunWith(AndroidJUnit4::class)
+class BasicAudioClipFieldControllerComplexTest : MultimediaEditFieldActivityTestBase() {
+
+    @Test
+    fun testControllerInit() {
+        grantRecordAudioPermission()
+
+        getControllerForField(AudioRecordingField(), this.emptyNote, 0)
+    }
+}


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
Crashed when opening screen

## Fixes
Fixes #10179

## Approach
Nullability issue when converting from Kotlin:
audioPath is nullable in `IField`. Fix this in `IField`

## How Has This Been Tested?
Manual + Unit

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
