### PR TITLE
[Kotlin Pre-Migration] Compat 

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/MediaRegistration.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/MediaRegistration.kt
@@ -28,10 +28,6 @@ import com.ichi2.utils.ContentResolverUtil.getFileName
 import com.ichi2.utils.FileUtil.getFileNameAndExtension
 import timber.log.Timber
 import java.io.*
-import java.lang.Exception
-import java.lang.NullPointerException
-import java.util.*
-import kotlin.Throws
 
 /**
  * RegisterMediaForWebView is used for registering media in temp path,
@@ -62,7 +58,7 @@ class MediaRegistration(private val context: Context) {
         var bytesWritten: Long
         openInputStreamWithURI(uri).use { copyFd ->
             // no conversion to jpg in cases of gif and jpg and if png image with alpha channel
-            if (shouldConvertToJPG(fileNameAndExtension.value, copyFd!!)) {
+            if (shouldConvertToJPG(fileNameAndExtension.value, copyFd)) {
                 clipCopy = File.createTempFile(fileName, ".jpg")
                 bytesWritten = CompatHelper.compat.copyFile(fd, clipCopy.absolutePath)
                 // return null if jpg conversion false.
@@ -93,8 +89,8 @@ class MediaRegistration(private val context: Context) {
     }
 
     @Throws(FileNotFoundException::class)
-    private fun openInputStreamWithURI(uri: Uri): InputStream? {
-        return context.contentResolver.openInputStream(uri)
+    private fun openInputStreamWithURI(uri: Uri): InputStream {
+        return context.contentResolver.openInputStream(uri)!!
     }
 
     private fun convertToJPG(file: File): Boolean {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.kt
@@ -454,9 +454,9 @@ class Preferences : AnkiActivity() {
             prefs!!.registerOnSharedPreferenceChangeListener(this)
             // syncAccount's summary can change while preferences are still open (user logs
             // in from preferences screen), so we need to update it here.
-            updatePreference(activity as Preferences?, prefs, "syncAccount")
-            updatePreference(activity as Preferences?, prefs, "custom_sync_server_link")
-            updatePreference(activity as Preferences?, prefs, "advanced_statistics_link")
+            updatePreference(activity as Preferences, prefs, "syncAccount")
+            updatePreference(activity as Preferences, prefs, "custom_sync_server_link")
+            updatePreference(activity as Preferences, prefs, "advanced_statistics_link")
         }
 
         override fun onPause() {
@@ -465,7 +465,7 @@ class Preferences : AnkiActivity() {
         }
 
         override fun onSharedPreferenceChanged(sharedPreferences: SharedPreferences, key: String) {
-            updatePreference(activity as Preferences?, sharedPreferences, key)
+            updatePreference(activity as Preferences, sharedPreferences, key)
         }
 
         @Suppress("deprecation") // setTargetFragment
@@ -494,7 +494,7 @@ class Preferences : AnkiActivity() {
          * @param prefs instance of SharedPreferences
          * @param key key in prefs which is being updated
          */
-        private fun updatePreference(preferencesActivity: Preferences?, prefs: SharedPreferences?, key: String) {
+        private fun updatePreference(preferencesActivity: Preferences, prefs: SharedPreferences?, key: String) {
             try {
                 val screen = preferenceScreen
                 val pref = screen.findPreference<Preference>(key)
@@ -505,51 +505,52 @@ class Preferences : AnkiActivity() {
                 // Handle special cases
                 when (key) {
                     CustomSyncServer.PREFERENCE_CUSTOM_MEDIA_SYNC_URL, CustomSyncServer.PREFERENCE_CUSTOM_SYNC_BASE, CustomSyncServer.PREFERENCE_ENABLE_CUSTOM_SYNC_SERVER -> // This may be a tad hasty - performed before "back" is pressed.
-                        handleSyncServerPreferenceChange(preferencesActivity!!.baseContext)
+                        handleSyncServerPreferenceChange(preferencesActivity.baseContext)
                     "timeoutAnswer" -> {
                         val keepScreenOn = screen.findPreference<SwitchPreference>("keepScreenOn")
                         keepScreenOn!!.isChecked = (pref as SwitchPreference).isChecked
                     }
-                    LANGUAGE -> preferencesActivity!!.closePreferences()
+                    LANGUAGE -> preferencesActivity.closePreferences()
                     SHOW_PROGRESS -> {
-                        preferencesActivity!!.col.set_config("dueCounts", (pref as SwitchPreference).isChecked)
+                        preferencesActivity.col.set_config("dueCounts", (pref as SwitchPreference).isChecked)
                         preferencesActivity.col.setMod()
                     }
                     SHOW_ESTIMATE -> {
-                        preferencesActivity!!.col.set_config("estTimes", (pref as SwitchPreference).isChecked)
+                        preferencesActivity.col.set_config("estTimes", (pref as SwitchPreference).isChecked)
                         preferencesActivity.col.setMod()
                     }
                     NEW_SPREAD -> {
-                        preferencesActivity!!.col.set_config("newSpread", (pref as ListPreference).value.toInt())
+                        preferencesActivity.col.set_config("newSpread", (pref as ListPreference).value.toInt())
                         preferencesActivity.col.setMod()
                     }
                     TIME_LIMIT -> {
-                        preferencesActivity!!.col.set_config("timeLim", (pref as NumberRangePreferenceCompat).getValue() * 60)
+                        preferencesActivity.col.set_config("timeLim", (pref as NumberRangePreferenceCompat).getValue() * 60)
                         preferencesActivity.col.setMod()
                     }
                     LEARN_CUTOFF -> {
-                        preferencesActivity!!.col.set_config("collapseTime", (pref as NumberRangePreferenceCompat).getValue() * 60)
+                        preferencesActivity.col.set_config("collapseTime", (pref as NumberRangePreferenceCompat).getValue() * 60)
                         preferencesActivity.col.setMod()
                     }
                     USE_CURRENT -> {
-                        preferencesActivity!!.col.set_config("addToCur", "0" == (pref as ListPreference).value)
+                        preferencesActivity.col.set_config("addToCur", "0" == (pref as ListPreference).value)
                         preferencesActivity.col.setMod()
                     }
                     AUTOMATIC_ANSWER_ACTION -> {
-                        preferencesActivity!!.col.set_config(AutomaticAnswerAction.CONFIG_KEY, (pref as ListPreference).value.toInt())
+                        preferencesActivity.col.set_config(AutomaticAnswerAction.CONFIG_KEY, (pref as ListPreference).value.toInt())
                         preferencesActivity.col.setMod()
                     }
                     DAY_OFFSET -> {
-                        preferencesActivity!!.setDayOffset((pref as SeekBarPreferenceCompat).value)
+                        preferencesActivity.setDayOffset((pref as SeekBarPreferenceCompat).value)
                     }
                     PASTE_PNG -> {
-                        preferencesActivity!!.col.set_config("pastePNG", (pref as SwitchPreference).isChecked)
+
+                        preferencesActivity.col.set_config("pastePNG", (pref as SwitchPreference).isChecked)
                         preferencesActivity.col.setMod()
                     }
                     MINIMUM_CARDS_DUE_FOR_NOTIFICATION -> {
                         val listPreference = screen.findPreference<ListPreference>(MINIMUM_CARDS_DUE_FOR_NOTIFICATION)
                         if (listPreference != null) {
-                            preferencesActivity!!.updateNotificationPreference(listPreference)
+                            preferencesActivity.updateNotificationPreference(listPreference)
                             if (listPreference.value.toInt() < PENDING_NOTIFICATIONS_ONLY) {
                                 scheduleNotification(preferencesActivity.col.time, preferencesActivity)
                             } else {
@@ -564,10 +565,10 @@ class Preferences : AnkiActivity() {
                     }
                     AnkiDroidApp.FEEDBACK_REPORT_KEY -> {
                         val value = prefs!!.getString(AnkiDroidApp.FEEDBACK_REPORT_KEY, "")
-                        onPreferenceChanged(preferencesActivity!!, value!!)
+                        onPreferenceChanged(preferencesActivity, value!!)
                     }
                     "syncAccount" -> {
-                        val preferences = AnkiDroidApp.getSharedPrefs(preferencesActivity!!.baseContext)
+                        val preferences = AnkiDroidApp.getSharedPrefs(preferencesActivity.baseContext)
                         val username = preferences.getString("username", "")
                         val syncAccount = screen.findPreference<Preference>("syncAccount")
                         if (syncAccount != null) {
@@ -579,7 +580,7 @@ class Preferences : AnkiActivity() {
                         }
                     }
                     "providerEnabled" -> {
-                        val providerName = ComponentName(preferencesActivity!!, "com.ichi2.anki.provider.CardContentProvider")
+                        val providerName = ComponentName(preferencesActivity, "com.ichi2.anki.provider.CardContentProvider")
                         val pm = preferencesActivity.packageManager
                         val state: Int
                         if ((pref as SwitchPreference).isChecked) {
@@ -592,7 +593,7 @@ class Preferences : AnkiActivity() {
                         pm.setComponentEnabledSetting(providerName, state, PackageManager.DONT_KILL_APP)
                     }
                     NEW_TIMEZONE_HANDLING -> {
-                        if (preferencesActivity!!.col.schedVer() != 1 && preferencesActivity.col.isUsingRustBackend) {
+                        if (preferencesActivity.col.schedVer() != 1 && preferencesActivity.col.isUsingRustBackend) {
                             val sched = preferencesActivity.col.sched
                             val wasEnabled = sched._new_timezone_enabled()
                             val isEnabled = (pref as SwitchPreference).isChecked
@@ -609,14 +610,14 @@ class Preferences : AnkiActivity() {
                             }
                         }
                     }
-                    CardBrowserContextMenu.CARD_BROWSER_CONTEXT_MENU_PREF_KEY -> CardBrowserContextMenu.ensureConsistentStateWithSharedPreferences(preferencesActivity!!)
-                    AnkiCardContextMenu.ANKI_CARD_CONTEXT_MENU_PREF_KEY -> AnkiCardContextMenu.ensureConsistentStateWithSharedPreferences(preferencesActivity!!)
+                    CardBrowserContextMenu.CARD_BROWSER_CONTEXT_MENU_PREF_KEY -> CardBrowserContextMenu.ensureConsistentStateWithSharedPreferences(preferencesActivity)
+                    AnkiCardContextMenu.ANKI_CARD_CONTEXT_MENU_PREF_KEY -> AnkiCardContextMenu.ensureConsistentStateWithSharedPreferences(preferencesActivity)
                     "gestureCornerTouch" -> {
                         GesturesSettingsFragment.updateGestureCornerTouch(preferencesActivity, screen)
                     }
                 }
                 // Update the summary text to reflect new value
-                preferencesActivity!!.updateSummary(pref)
+                preferencesActivity.updateSummary(pref)
             } catch (e: BadTokenException) {
                 Timber.e(e, "Preferences: BadTokenException on showDialog")
             } catch (e: NumberFormatException) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/export/ActivityExportingDelegate.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/export/ActivityExportingDelegate.kt
@@ -54,7 +54,7 @@ import java.util.function.Supplier
 class ActivityExportingDelegate(private val activity: AnkiActivity, private val collectionSupplier: Supplier<Collection>) : ExportDialogListener, ExportCompleteDialogListener {
     private val mDialogsFactory: ExportDialogsFactory
     private val mSaveFileLauncher: ActivityResultLauncher<Intent>
-    private var mExportFileName: String? = null
+    private lateinit var mExportFileName: String
 
     @KotlinCleanup("make msg non-null")
     fun showExportDialog(msg: String?) {
@@ -176,7 +176,7 @@ class ActivityExportingDelegate(private val activity: AnkiActivity, private val 
                 Timber.w("exportToProvider() failed - ContentProvider returned null file descriptor for %s", uri)
                 return false
             }
-            if (deleteAfterExport && !File(mExportFileName!!).delete()) {
+            if (deleteAfterExport && !File(mExportFileName).delete()) {
                 Timber.w("Failed to delete temporary export file %s", mExportFileName)
             }
         } catch (e: Exception) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicMediaClipFieldController.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicMediaClipFieldController.kt
@@ -161,7 +161,7 @@ class BasicMediaClipFieldController : FieldControllerBase(), IFieldController {
         // Copy file contents into new temp file. Possibly check file size first and warn if large?
         try {
             mActivity.contentResolver.openInputStream(selectedClip).use { inputStream ->
-                CompatHelper.compat.copyFile(inputStream, clipCopy.absolutePath)
+                CompatHelper.compat.copyFile(inputStream!!, clipCopy.absolutePath)
 
                 // If everything worked, hand off the information
                 mField.setHasTemporaryMedia(true)

--- a/AnkiDroid/src/main/java/com/ichi2/compat/Compat.java
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/Compat.java
@@ -175,7 +175,8 @@ public interface Compat {
      * parameters.  May return null only if {@link PendingIntent#FLAG_NO_CREATE} has been
      * supplied.
      */
-    PendingIntent getImmutableActivityIntent(Context context, int requestCode, Intent intent, @PendingIntentFlags int flags);
+    @NonNull
+    PendingIntent getImmutableActivityIntent(@NonNull Context context, int requestCode, @NonNull Intent intent, @PendingIntentFlags int flags);
 
 
     /**

--- a/AnkiDroid/src/main/java/com/ichi2/compat/Compat.java
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/Compat.java
@@ -86,7 +86,8 @@ public interface Compat {
     @NonNull
     MediaRecorder getMediaRecorder(@NonNull Context context);
 
-    void copyFile(String source, String target) throws IOException;
+    void copyFile(@NonNull String source, @NonNull String target) throws IOException;
+
     long copyFile(String source, OutputStream target) throws IOException;
     long copyFile(InputStream source, String target) throws IOException;
 

--- a/AnkiDroid/src/main/java/com/ichi2/compat/Compat.java
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/Compat.java
@@ -82,7 +82,7 @@ public interface Compat {
 
     int getHour(@NonNull TimePicker picker);
 
-    int getMinute(TimePicker picker);
+    int getMinute(@NonNull TimePicker picker);
 
     void vibrate(@NonNull Context context, long durationMillis);
 

--- a/AnkiDroid/src/main/java/com/ichi2/compat/Compat.java
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/Compat.java
@@ -76,7 +76,7 @@ public interface Compat {
     /* Mock the Intent PROCESS_TEXT constants introduced in API 23. */
     String ACTION_PROCESS_TEXT = "android.intent.action.PROCESS_TEXT";
     String EXTRA_PROCESS_TEXT = "android.intent.extra.PROCESS_TEXT";
-    void setupNotificationChannel(Context context, String id, String name);
+    void setupNotificationChannel(@NonNull Context context, @NonNull String id, @NonNull String name);
     void setTime(TimePicker picker, int hour, int minute);
     int getHour(TimePicker picker);
     int getMinute(TimePicker picker);

--- a/AnkiDroid/src/main/java/com/ichi2/compat/Compat.java
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/Compat.java
@@ -128,7 +128,9 @@ public interface Compat {
      */
     void createDirectories(@NonNull File directory) throws IOException;
     boolean hasVideoThumbnail(@NonNull String path);
-    void requestAudioFocus(AudioManager audioManager, AudioManager.OnAudioFocusChangeListener audioFocusChangeListener, @Nullable AudioFocusRequest audioFocusRequest);
+
+    void requestAudioFocus(@NonNull AudioManager audioManager, @NonNull AudioManager.OnAudioFocusChangeListener audioFocusChangeListener, @Nullable AudioFocusRequest audioFocusRequest);
+
     void abandonAudioFocus(AudioManager audioManager, AudioManager.OnAudioFocusChangeListener audioFocusChangeListener, @Nullable AudioFocusRequest audioFocusRequest);
 
     @IntDef(flag = true,

--- a/AnkiDroid/src/main/java/com/ichi2/compat/Compat.java
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/Compat.java
@@ -80,7 +80,9 @@ public interface Compat {
     void setTime(TimePicker picker, int hour, int minute);
     int getHour(TimePicker picker);
     int getMinute(TimePicker picker);
-    void vibrate(Context context, long durationMillis);
+
+    void vibrate(@NonNull Context context, long durationMillis);
+
     MediaRecorder getMediaRecorder(Context context);
     void copyFile(String source, String target) throws IOException;
     long copyFile(String source, OutputStream target) throws IOException;

--- a/AnkiDroid/src/main/java/com/ichi2/compat/Compat.java
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/Compat.java
@@ -234,6 +234,7 @@ public interface Compat {
      * that we could not reproduce. See https://github.com/ankidroid/Anki-Android/issues/10358
      * @throws SecurityException – If a security manager exists and its SecurityManager.checkRead(String) method denies read access to the directory
      */
-    @NonNull FileStream contentOfDirectory(File directory) throws IOException  ;
+    @NonNull
+    FileStream contentOfDirectory(@NonNull File directory) throws IOException;
 }
 

--- a/AnkiDroid/src/main/java/com/ichi2/compat/Compat.java
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/Compat.java
@@ -220,7 +220,8 @@ public interface Compat {
      * @throws FileNotFoundException if the device's API is <= 28 and has not obtained the
      * WRITE_EXTERNAL_STORAGE permission
      */
-    Uri saveImage(Context context, Bitmap bitmap, String baseFileName, String extension, Bitmap.CompressFormat format, int quality) throws FileNotFoundException;
+    @NonNull
+    Uri saveImage(@NonNull Context context, @NonNull Bitmap bitmap, @NonNull String baseFileName, @NonNull String extension, @NonNull Bitmap.CompressFormat format, int quality) throws FileNotFoundException;
 
     /**
      *

--- a/AnkiDroid/src/main/java/com/ichi2/compat/Compat.java
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/Compat.java
@@ -77,7 +77,9 @@ public interface Compat {
     String ACTION_PROCESS_TEXT = "android.intent.action.PROCESS_TEXT";
     String EXTRA_PROCESS_TEXT = "android.intent.extra.PROCESS_TEXT";
     void setupNotificationChannel(@NonNull Context context, @NonNull String id, @NonNull String name);
-    void setTime(TimePicker picker, int hour, int minute);
+
+    void setTime(@NonNull TimePicker picker, int hour, int minute);
+
     int getHour(TimePicker picker);
     int getMinute(TimePicker picker);
 

--- a/AnkiDroid/src/main/java/com/ichi2/compat/Compat.java
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/Compat.java
@@ -88,7 +88,8 @@ public interface Compat {
 
     void copyFile(@NonNull String source, @NonNull String target) throws IOException;
 
-    long copyFile(String source, OutputStream target) throws IOException;
+    long copyFile(@NonNull String source, @NonNull OutputStream target) throws IOException;
+
     long copyFile(InputStream source, String target) throws IOException;
 
     /**

--- a/AnkiDroid/src/main/java/com/ichi2/compat/Compat.java
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/Compat.java
@@ -90,7 +90,7 @@ public interface Compat {
 
     long copyFile(@NonNull String source, @NonNull OutputStream target) throws IOException;
 
-    long copyFile(InputStream source, String target) throws IOException;
+    long copyFile(@NonNull InputStream source, @NonNull String target) throws IOException;
 
     /**
      * Deletes a provided file/directory. If the file is a directory then the directory must be empty

--- a/AnkiDroid/src/main/java/com/ichi2/compat/Compat.java
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/Compat.java
@@ -202,7 +202,8 @@ public interface Compat {
      * parameters.  May return null only if {@link PendingIntent#FLAG_NO_CREATE} has been
      * supplied.
      */
-    PendingIntent getImmutableBroadcastIntent(Context context, int requestCode, Intent intent, @PendingIntentFlags int flags);
+    @NonNull
+    PendingIntent getImmutableBroadcastIntent(@NonNull Context context, int requestCode, @NonNull Intent intent, @PendingIntentFlags int flags);
 
     /**
      * Writes an image represented by bitmap to the Pictures/AnkiDroid directory under the primary

--- a/AnkiDroid/src/main/java/com/ichi2/compat/Compat.java
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/Compat.java
@@ -131,7 +131,7 @@ public interface Compat {
 
     void requestAudioFocus(@NonNull AudioManager audioManager, @NonNull AudioManager.OnAudioFocusChangeListener audioFocusChangeListener, @Nullable AudioFocusRequest audioFocusRequest);
 
-    void abandonAudioFocus(AudioManager audioManager, AudioManager.OnAudioFocusChangeListener audioFocusChangeListener, @Nullable AudioFocusRequest audioFocusRequest);
+    void abandonAudioFocus(@NonNull AudioManager audioManager, @NonNull AudioManager.OnAudioFocusChangeListener audioFocusChangeListener, @Nullable AudioFocusRequest audioFocusRequest);
 
     @IntDef(flag = true,
             value = {

--- a/AnkiDroid/src/main/java/com/ichi2/compat/Compat.java
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/Compat.java
@@ -80,7 +80,8 @@ public interface Compat {
 
     void setTime(@NonNull TimePicker picker, int hour, int minute);
 
-    int getHour(TimePicker picker);
+    int getHour(@NonNull TimePicker picker);
+
     int getMinute(TimePicker picker);
 
     void vibrate(@NonNull Context context, long durationMillis);

--- a/AnkiDroid/src/main/java/com/ichi2/compat/Compat.java
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/Compat.java
@@ -83,7 +83,9 @@ public interface Compat {
 
     void vibrate(@NonNull Context context, long durationMillis);
 
-    MediaRecorder getMediaRecorder(Context context);
+    @NonNull
+    MediaRecorder getMediaRecorder(@NonNull Context context);
+
     void copyFile(String source, String target) throws IOException;
     long copyFile(String source, OutputStream target) throws IOException;
     long copyFile(InputStream source, String target) throws IOException;

--- a/AnkiDroid/src/main/java/com/ichi2/compat/CompatV21.java
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/CompatV21.java
@@ -164,8 +164,10 @@ public class CompatV21 implements Compat {
 
     // Until API 23 the methods have "current" in the name
     @Override
-    @SuppressWarnings({"deprecation", "RedundantSuppression"})
-    public int getHour(TimePicker picker) { return picker.getCurrentHour(); }
+    @SuppressWarnings( {"deprecation", "RedundantSuppression"})
+    public int getHour(@NonNull TimePicker picker) {
+        return picker.getCurrentHour();
+    }
 
     // Until API 23 the methods have "current" in the name
     @Override

--- a/AnkiDroid/src/main/java/com/ichi2/compat/CompatV21.java
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/CompatV21.java
@@ -183,8 +183,8 @@ public class CompatV21 implements Compat {
     }
     
     @Override
-    @SuppressWarnings({"deprecation", "RedundantSuppression"})
-    public void requestAudioFocus(AudioManager audioManager, AudioManager.OnAudioFocusChangeListener audioFocusChangeListener,
+    @SuppressWarnings( {"deprecation", "RedundantSuppression"})
+    public void requestAudioFocus(@NonNull AudioManager audioManager, @NonNull AudioManager.OnAudioFocusChangeListener audioFocusChangeListener,
                                   @Nullable AudioFocusRequest audioFocusRequest) {
         audioManager.requestAudioFocus(audioFocusChangeListener, AudioManager.STREAM_MUSIC,
                 AudioManager.AUDIOFOCUS_GAIN_TRANSIENT_MAY_DUCK);

--- a/AnkiDroid/src/main/java/com/ichi2/compat/CompatV21.java
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/CompatV21.java
@@ -78,9 +78,10 @@ public class CompatV21 implements Compat {
     }
 
     // Until API31 the MediaRecorder constructor was default, ignoring the Context
+    @NonNull
     @Override
-    @SuppressWarnings({"deprecation", "RedundantSuppression"})
-    public MediaRecorder getMediaRecorder(Context context) {
+    @SuppressWarnings( {"deprecation", "RedundantSuppression"})
+    public MediaRecorder getMediaRecorder(@NonNull Context context) {
         return new MediaRecorder();
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/compat/CompatV21.java
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/CompatV21.java
@@ -171,8 +171,10 @@ public class CompatV21 implements Compat {
 
     // Until API 23 the methods have "current" in the name
     @Override
-    @SuppressWarnings({"deprecation", "RedundantSuppression"})
-    public int getMinute(TimePicker picker) { return picker.getCurrentMinute(); }
+    @SuppressWarnings( {"deprecation", "RedundantSuppression"})
+    public int getMinute(@NonNull TimePicker picker) {
+        return picker.getCurrentMinute();
+    }
 
     @Override
     @SuppressWarnings({"deprecation", "RedundantSuppression"})

--- a/AnkiDroid/src/main/java/com/ichi2/compat/CompatV21.java
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/CompatV21.java
@@ -61,8 +61,8 @@ public class CompatV21 implements Compat {
 
     // Until API 23 the methods have "current" in the name
     @Override
-    @SuppressWarnings({"deprecation", "RedundantSuppression"})
-    public void setTime(TimePicker picker, int hour, int minute) {
+    @SuppressWarnings( {"deprecation", "RedundantSuppression"})
+    public void setTime(@NonNull TimePicker picker, int hour, int minute) {
         picker.setCurrentHour(hour);
         picker.setCurrentMinute(minute);
     }

--- a/AnkiDroid/src/main/java/com/ichi2/compat/CompatV21.java
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/CompatV21.java
@@ -57,7 +57,7 @@ public class CompatV21 implements Compat {
 
     // Until API26, ignore notification channels
     @Override
-    public void setupNotificationChannel(Context context, String id, String name) { /* pre-API26, do nothing */ }
+    public void setupNotificationChannel(@NonNull Context context, @NonNull String id, @NonNull String name) { /* pre-API26, do nothing */ }
 
     // Until API 23 the methods have "current" in the name
     @Override

--- a/AnkiDroid/src/main/java/com/ichi2/compat/CompatV21.java
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/CompatV21.java
@@ -69,9 +69,9 @@ public class CompatV21 implements Compat {
 
     // Until API 26 just specify time, after that specify effect also
     @Override
-    @SuppressWarnings({"deprecation", "RedundantSuppression"})
-    public void vibrate(Context context, long durationMillis) {
-        Vibrator vibratorManager = (Vibrator)context.getSystemService(Context.VIBRATOR_SERVICE);
+    @SuppressWarnings( {"deprecation", "RedundantSuppression"})
+    public void vibrate(@NonNull Context context, long durationMillis) {
+        Vibrator vibratorManager = (Vibrator) context.getSystemService(Context.VIBRATOR_SERVICE);
         if (vibratorManager != null) {
             vibratorManager.vibrate(durationMillis);
         }

--- a/AnkiDroid/src/main/java/com/ichi2/compat/CompatV21.java
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/CompatV21.java
@@ -209,9 +209,11 @@ public class CompatV21 implements Compat {
         return PendingIntent.getBroadcast(context, requestCode, intent, flags | FLAG_IMMUTABLE);
     }
 
+
+    @NonNull
     @Override
-    @SuppressWarnings({"deprecation", "RedundantSuppression"})
-    public Uri saveImage(Context context, Bitmap bitmap, String baseFileName, String extension, Bitmap.CompressFormat format, int quality) throws FileNotFoundException {
+    @SuppressWarnings( {"deprecation", "RedundantSuppression"})
+    public Uri saveImage(@NonNull Context context, @NonNull Bitmap bitmap, @NonNull String baseFileName, @NonNull String extension, @NonNull Bitmap.CompressFormat format, int quality) throws FileNotFoundException {
         File pictures = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_PICTURES);
         File ankiDroidDirectory = new File(pictures, "AnkiDroid");
         if (!ankiDroidDirectory.exists()) {

--- a/AnkiDroid/src/main/java/com/ichi2/compat/CompatV21.java
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/CompatV21.java
@@ -201,8 +201,10 @@ public class CompatV21 implements Compat {
         return PendingIntent.getActivity(context, requestCode, intent, flags | FLAG_IMMUTABLE);
     }
 
+
+    @NonNull
     @Override
-    public PendingIntent getImmutableBroadcastIntent(Context context, int requestCode, Intent intent, int flags) {
+    public PendingIntent getImmutableBroadcastIntent(@NonNull Context context, int requestCode, @NonNull Intent intent, int flags) {
         //noinspection WrongConstant
         return PendingIntent.getBroadcast(context, requestCode, intent, flags | FLAG_IMMUTABLE);
     }

--- a/AnkiDroid/src/main/java/com/ichi2/compat/CompatV21.java
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/CompatV21.java
@@ -191,8 +191,8 @@ public class CompatV21 implements Compat {
     }
 
     @Override
-    @SuppressWarnings({"deprecation", "RedundantSuppression"})
-    public void abandonAudioFocus(AudioManager audioManager, AudioManager.OnAudioFocusChangeListener audioFocusChangeListener,
+    @SuppressWarnings( {"deprecation", "RedundantSuppression"})
+    public void abandonAudioFocus(@NonNull AudioManager audioManager, @NonNull AudioManager.OnAudioFocusChangeListener audioFocusChangeListener,
                                   @Nullable AudioFocusRequest audioFocusRequest) {
         audioManager.abandonAudioFocus(audioFocusChangeListener);
     }

--- a/AnkiDroid/src/main/java/com/ichi2/compat/CompatV21.java
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/CompatV21.java
@@ -193,8 +193,10 @@ public class CompatV21 implements Compat {
         audioManager.abandonAudioFocus(audioFocusChangeListener);
     }
 
+
+    @NonNull
     @Override
-    public PendingIntent getImmutableActivityIntent(Context context, int requestCode, Intent intent, int flags) {
+    public PendingIntent getImmutableActivityIntent(@NonNull Context context, int requestCode, @NonNull Intent intent, int flags) {
         //noinspection WrongConstant
         return PendingIntent.getActivity(context, requestCode, intent, flags | FLAG_IMMUTABLE);
     }

--- a/AnkiDroid/src/main/java/com/ichi2/compat/CompatV26.java
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/CompatV26.java
@@ -73,8 +73,8 @@ public class CompatV26 extends CompatV23 implements Compat {
 
     @Override
     @SuppressWarnings("deprecation")
-    public void vibrate(Context context, long durationMillis) {
-        Vibrator vibratorManager = (Vibrator)context.getSystemService(Context.VIBRATOR_SERVICE);
+    public void vibrate(@NonNull Context context, long durationMillis) {
+        Vibrator vibratorManager = (Vibrator) context.getSystemService(Context.VIBRATOR_SERVICE);
         if (vibratorManager != null) {
             VibrationEffect effect = VibrationEffect.createOneShot(durationMillis, VibrationEffect.DEFAULT_AMPLITUDE);
             vibratorManager.vibrate(effect);

--- a/AnkiDroid/src/main/java/com/ichi2/compat/CompatV26.java
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/CompatV26.java
@@ -112,7 +112,7 @@ public class CompatV26 extends CompatV23 implements Compat {
 
 
     @Override
-    public void requestAudioFocus(AudioManager audioManager, AudioManager.OnAudioFocusChangeListener audioFocusChangeListener,
+    public void requestAudioFocus(@NonNull AudioManager audioManager, @NonNull AudioManager.OnAudioFocusChangeListener audioFocusChangeListener,
                                   @Nullable AudioFocusRequest audioFocusRequest) {
         // requestAudioFocus needs NonNull argument
         if (audioFocusRequest != null) {

--- a/AnkiDroid/src/main/java/com/ichi2/compat/CompatV26.java
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/CompatV26.java
@@ -121,7 +121,7 @@ public class CompatV26 extends CompatV23 implements Compat {
     }
 
     @Override
-    public void abandonAudioFocus(AudioManager audioManager, AudioManager.OnAudioFocusChangeListener audioFocusChangeListener,
+    public void abandonAudioFocus(@NonNull AudioManager audioManager, @NonNull AudioManager.OnAudioFocusChangeListener audioFocusChangeListener,
                                   @Nullable AudioFocusRequest audioFocusRequest) {
         // abandonAudioFocusRequest needs NonNull argument
         if (audioFocusRequest != null) {

--- a/AnkiDroid/src/main/java/com/ichi2/compat/CompatV26.java
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/CompatV26.java
@@ -139,7 +139,8 @@ public class CompatV26 extends CompatV23 implements Compat {
      * Hence this method, hasNext and next should be constant in time and space.
      */
     @Override
-    public @NonNull FileStream contentOfDirectory(File directory) throws IOException {
+    public @NonNull
+    FileStream contentOfDirectory(@NonNull File directory) throws IOException {
         final DirectoryStream<Path> paths_stream;
         try {
             paths_stream = newDirectoryStream(directory.toPath());

--- a/AnkiDroid/src/main/java/com/ichi2/compat/CompatV26.java
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/CompatV26.java
@@ -62,9 +62,9 @@ public class CompatV26 extends CompatV23 implements Compat {
      * @param name the user-visible name for the channel
      */
     @Override
-    public void setupNotificationChannel(Context context, String id, String name) {
-        Timber.i("Creating notification channel with id/name: %s/%s",id, name);
-        NotificationManager manager = (NotificationManager)context.getSystemService(Context.NOTIFICATION_SERVICE);
+    public void setupNotificationChannel(@NonNull Context context, @NonNull String id, @NonNull String name) {
+        Timber.i("Creating notification channel with id/name: %s/%s", id, name);
+        NotificationManager manager = (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
         NotificationChannel notificationChannel = new NotificationChannel(id, name, NotificationManager.IMPORTANCE_DEFAULT);
         notificationChannel.setShowBadge(true);
         notificationChannel.setLockscreenVisibility(NotificationCompat.VISIBILITY_PUBLIC);

--- a/AnkiDroid/src/main/java/com/ichi2/preferences/TimePreference.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/preferences/TimePreference.kt
@@ -10,13 +10,13 @@ import com.ichi2.compat.CompatHelper
 
 @Suppress("deprecation") // TODO Tracked in https://github.com/ankidroid/Anki-Android/issues/5019
 class TimePreference(context: Context?, attrs: AttributeSet?) : android.preference.DialogPreference(context, attrs) {
-    private var mTimepicker: TimePicker? = null
+    private lateinit var mTimepicker: TimePicker
     private var mHours = 0
     private var mMinutes = 0
     override fun onCreateDialogView(): View {
         mTimepicker = TimePicker(context)
-        mTimepicker!!.setIs24HourView(true)
-        return mTimepicker!!
+        mTimepicker.setIs24HourView(true)
+        return mTimepicker
     }
 
     override fun onSetInitialValue(restorePersistedValue: Boolean, defaultValue: Any?) {

--- a/AnkiDroid/src/main/java/com/ichi2/utils/FileUtil.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/FileUtil.kt
@@ -24,10 +24,7 @@ import timber.log.Timber
 import java.io.File
 import java.io.IOException
 import java.io.InputStream
-import java.lang.Exception
-import java.lang.IllegalArgumentException
-import java.util.AbstractMap
-import kotlin.Throws
+import java.util.*
 
 object FileUtil {
     /** Gets the free disk space given a file  */
@@ -54,9 +51,8 @@ object FileUtil {
     @KotlinCleanup("nonnull uri")
     fun internalizeUri(uri: Uri?, internalFile: File, contentResolver: ContentResolver): File {
         // If we got a real file name, do a copy from it
-        val inputStream: InputStream?
-        inputStream = try {
-            contentResolver.openInputStream(uri!!)
+        val inputStream: InputStream = try {
+            contentResolver.openInputStream(uri!!)!!
         } catch (e: Exception) {
             Timber.w(e, "internalizeUri() unable to open input stream from content resolver for Uri %s", uri)
             throw e

--- a/AnkiDroid/src/main/java/com/ichi2/utils/ImportUtils.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/ImportUtils.kt
@@ -270,7 +270,7 @@ object ImportUtils {
          * @param tempPath temporary path to store the cached file
          * @return whether or not copy was successful
          */
-        protected open fun copyFileToCache(context: Context, data: Uri?, tempPath: String?): Boolean {
+        protected open fun copyFileToCache(context: Context, data: Uri?, tempPath: String): Boolean {
             // Get an input stream to the data in ContentProvider
             val inputStream: InputStream? = try {
                 context.contentResolver.openInputStream(data!!)


### PR DESCRIPTION
[Kotlin Pre-Migration] Compat 
package com.ichi2.compat

Add NonNull/Nullable annotations to the java file before converting it to Kotlin in a subsequent PR. 
Reason: Complex call heirarchy, minimse the chances of breakage post conversion