### PR TITLE
fix(tests): Ensure tests use new collection

### DIFF
--- a/AnkiDroid/src/test/java/com/ichi2/anki/RobolectricTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/RobolectricTest.kt
@@ -80,6 +80,9 @@ open class RobolectricTest : CollectionGetter {
 
     @Before
     open fun setUp() {
+        // resolved issues with the collection being reused if useInMemoryDatabase is false
+        CollectionHelper.getInstance().setColForTests(null)
+
         if (mTaskScheduler.shouldRunInForeground()) {
             runTasksInForeground()
         } else {


### PR DESCRIPTION
I had issues where the collection path for a test did not match
my expected values. I believe that this is due to CollectionHelper
keeping an old instance of the collection around.

This resolves my issues, and maybe fixes a few flaky tests

## How Has This Been Tested?

CI is faster than my machine, so I'll see if this breaks anything

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
