### PR TITLE
fix: nullability of Preference classes

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/preferences/ConfirmationPreferenceCompat.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/preferences/ConfirmationPreferenceCompat.kt
@@ -28,19 +28,19 @@ class ConfirmationPreferenceCompat : DialogPreference {
     private var mOkHandler = Runnable {}
 
     @Suppress("Unused")
-    constructor(context: Context?, attrs: AttributeSet?, defStyleAttr: Int, defStyleRes: Int) : super(context, attrs, defStyleAttr, defStyleRes) {
+    constructor(context: Context, attrs: AttributeSet?, defStyleAttr: Int, defStyleRes: Int) : super(context, attrs, defStyleAttr, defStyleRes) {
     }
 
     @Suppress("Unused")
-    constructor(context: Context?, attrs: AttributeSet?, defStyleAttr: Int) : super(context, attrs, defStyleAttr) {
+    constructor(context: Context, attrs: AttributeSet?, defStyleAttr: Int) : super(context, attrs, defStyleAttr) {
     }
 
     @Suppress("Unused")
-    constructor(context: Context?, attrs: AttributeSet?) : super(context, attrs) {
+    constructor(context: Context, attrs: AttributeSet?) : super(context, attrs) {
     }
 
     @Suppress("Unused")
-    constructor(context: Context?) : super(context) {
+    constructor(context: Context) : super(context) {
     }
 
     @Suppress("Unused")

--- a/AnkiDroid/src/main/java/com/ichi2/preferences/ControlPreference.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/preferences/ControlPreference.kt
@@ -50,10 +50,10 @@ import java.util.stream.Collectors
  * * Allow maps other than the reviewer
  */
 class ControlPreference : ListPreference {
-    @Suppress("unused") constructor(context: Context?, attrs: AttributeSet?, defStyleAttr: Int, defStyleRes: Int) : super(context, attrs, defStyleAttr, defStyleRes)
-    @Suppress("unused") constructor(context: Context?, attrs: AttributeSet?, defStyleAttr: Int) : super(context, attrs, defStyleAttr)
-    @Suppress("unused") constructor(context: Context?, attrs: AttributeSet?) : super(context, attrs)
-    @Suppress("unused") constructor(context: Context?) : super(context)
+    @Suppress("unused") constructor(context: Context, attrs: AttributeSet?, defStyleAttr: Int, defStyleRes: Int) : super(context, attrs, defStyleAttr, defStyleRes)
+    @Suppress("unused") constructor(context: Context, attrs: AttributeSet?, defStyleAttr: Int) : super(context, attrs, defStyleAttr)
+    @Suppress("unused") constructor(context: Context, attrs: AttributeSet?) : super(context, attrs)
+    @Suppress("unused") constructor(context: Context) : super(context)
 
     /**
      * Could be better: ListPreference.`value` was broken in converting to the preference support library

--- a/AnkiDroid/src/main/java/com/ichi2/preferences/IncrementerNumberRangePreferenceCompat.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/preferences/IncrementerNumberRangePreferenceCompat.kt
@@ -30,10 +30,10 @@ import com.ichi2.anki.R
 
 /** Marker class to be used in preferences */
 class IncrementerNumberRangePreferenceCompat : NumberRangePreferenceCompat {
-    constructor(context: Context?, attrs: AttributeSet?, defStyleAttr: Int, defStyleRes: Int) : super(context, attrs, defStyleAttr, defStyleRes)
-    constructor(context: Context?, attrs: AttributeSet?, defStyleAttr: Int) : super(context, attrs, defStyleAttr)
-    constructor(context: Context?, attrs: AttributeSet?) : super(context, attrs)
-    constructor(context: Context?) : super(context)
+    constructor(context: Context, attrs: AttributeSet?, defStyleAttr: Int, defStyleRes: Int) : super(context, attrs, defStyleAttr, defStyleRes)
+    constructor(context: Context, attrs: AttributeSet?, defStyleAttr: Int) : super(context, attrs, defStyleAttr)
+    constructor(context: Context, attrs: AttributeSet?) : super(context, attrs)
+    constructor(context: Context) : super(context)
 
     class IncrementerNumberRangeDialogFragmentCompat : NumberRangePreferenceCompat.NumberRangeDialogFragmentCompat() {
         private var mLastValidEntry = 0
@@ -41,7 +41,7 @@ class IncrementerNumberRangePreferenceCompat : NumberRangePreferenceCompat {
         /**
          * Sets [.mEditText] width and gravity.
          */
-        override fun onBindDialogView(view: View?) {
+        override fun onBindDialogView(view: View) {
             super.onBindDialogView(view)
 
             // Layout parameters for mEditText
@@ -67,12 +67,13 @@ class IncrementerNumberRangePreferenceCompat : NumberRangePreferenceCompat {
          *
          * Sets orientation for layout
          */
-        override fun onCreateDialogView(context: Context?): View {
+        override fun onCreateDialogView(context: Context): View {
             val linearLayout = LinearLayout(context)
 
             val incrementButton = Button(context)
             val decrementButton = Button(context)
-            val editText: EditText = super.onCreateDialogView(context).findViewById(android.R.id.edit)
+            val dialogView = super.onCreateDialogView(context)!!
+            val editText: EditText = dialogView.findViewById(android.R.id.edit)
             (editText.parent as ViewGroup).removeView(editText)
 
             // Layout parameters for incrementButton and decrementButton

--- a/AnkiDroid/src/main/java/com/ichi2/preferences/NumberRangePreferenceCompat.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/preferences/NumberRangePreferenceCompat.kt
@@ -31,22 +31,22 @@ import com.ichi2.anki.AnkiDroidApp
 import timber.log.Timber
 
 open class NumberRangePreferenceCompat : EditTextPreference {
-    constructor(context: Context?, attrs: AttributeSet?, defStyleAttr: Int, defStyleRes: Int) : super(context, attrs, defStyleAttr, defStyleRes) {
+    constructor(context: Context, attrs: AttributeSet?, defStyleAttr: Int, defStyleRes: Int) : super(context, attrs, defStyleAttr, defStyleRes) {
         min = getMinFromAttributes(attrs)
         max = getMaxFromAttributes(attrs)
         defaultValue = getDefaultValueFromAttributes(attrs)
     }
-    constructor(context: Context?, attrs: AttributeSet?, defStyleAttr: Int) : super(context, attrs, defStyleAttr) {
+    constructor(context: Context, attrs: AttributeSet?, defStyleAttr: Int) : super(context, attrs, defStyleAttr) {
         min = getMinFromAttributes(attrs)
         max = getMaxFromAttributes(attrs)
         defaultValue = getDefaultValueFromAttributes(attrs)
     }
-    constructor(context: Context?, attrs: AttributeSet?) : super(context, attrs) {
+    constructor(context: Context, attrs: AttributeSet?) : super(context, attrs) {
         min = getMinFromAttributes(attrs)
         max = getMaxFromAttributes(attrs)
         defaultValue = getDefaultValueFromAttributes(attrs)
     }
-    constructor(context: Context?) : super(context) {
+    constructor(context: Context) : super(context) {
         defaultValue = null
     }
 
@@ -188,10 +188,10 @@ open class NumberRangePreferenceCompat : EditTextPreference {
          * Update settings to only allow integer input and set the maximum number of digits allowed in the text field based
          * on the current value of the [.mMax] field.
          */
-        override fun onBindDialogView(view: View?) {
+        override fun onBindDialogView(view: View) {
             super.onBindDialogView(view)
 
-            editText = view?.findViewById(android.R.id.edit)!!
+            editText = view.findViewById(android.R.id.edit)!!
 
             // Only allow integer input
             editText.inputType = InputType.TYPE_CLASS_NUMBER

--- a/AnkiDroid/src/main/java/com/ichi2/preferences/ResetLanguageDialogPreference.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/preferences/ResetLanguageDialogPreference.kt
@@ -28,10 +28,10 @@ import com.ichi2.anki.UIUtils
 import timber.log.Timber
 
 class ResetLanguageDialogPreference : DialogPreference {
-    constructor(context: Context?, attrs: AttributeSet?, defStyleAttr: Int, defStyleRes: Int) : super(context, attrs, defStyleAttr, defStyleRes)
-    constructor(context: Context?, attrs: AttributeSet?, defStyleAttr: Int) : super(context, attrs, defStyleAttr)
-    constructor(context: Context?, attrs: AttributeSet?) : super(context, attrs)
-    constructor(context: Context?) : super(context)
+    constructor(context: Context, attrs: AttributeSet?, defStyleAttr: Int, defStyleRes: Int) : super(context, attrs, defStyleAttr, defStyleRes)
+    constructor(context: Context, attrs: AttributeSet?, defStyleAttr: Int) : super(context, attrs, defStyleAttr)
+    constructor(context: Context, attrs: AttributeSet?) : super(context, attrs)
+    constructor(context: Context) : super(context)
 
     class ResetLanguageDialogFragmentCompat : PreferenceDialogFragmentCompat() {
 


### PR DESCRIPTION
`preference-ktx 1.2.0` adds new nullability annotations which breaks our Kotlin code

Unblocks issue #10278

## Testing

Letting CI handle this one. Build, but not tests were checked

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
