### PR TITLE
fix: DeckPickerContextMenu - refactor + move 'delete deck' to bottom of screen

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -253,6 +253,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
     private SearchView mToolbarSearchView;
 
     private CustomStudyDialogFactory mCustomStudyDialogFactory;
+    private DeckPickerContextMenu.Factory mContextMenuFactory;
 
     // ----------------------------------------------------------------------------
     // LISTENERS
@@ -313,7 +314,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
             long deckId = (long) v.getTag();
             Timber.i("DeckPicker:: Long tapped on deck with id %d", deckId);
             mContextMenuDid = deckId;
-            showDialogFragment(DeckPickerContextMenu.newInstance(deckId));
+            showDialogFragment(mContextMenuFactory.newDeckPickerContextMenu(deckId));
             return true;
         }
     };
@@ -418,6 +419,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
         mExportingDelegate = new ActivityExportingDelegate(this, this::getCol);
 
         mCustomStudyDialogFactory = new CustomStudyDialogFactory(this::getCol, this).attachToActivity(this);
+        mContextMenuFactory = new DeckPickerContextMenu.Factory(this::getCol).attachToActivity(this);
 
         //we need to restore here, as we need it before super.onCreate() is called.
         restoreWelcomeMessage(savedInstanceState);

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -2430,6 +2430,11 @@ public class DeckPicker extends NavigationDrawerActivity implements
     }
 
 
+    /**
+     * Deletes the provided deck, child decks. and all cards inside.
+     * Use {@link #confirmDeckDeletion(long)} for a confirmation dialog
+     * @param did the deck to delete
+     */
     public void deleteDeck(final long did) {
         TaskManager.launchCollectionTask(new CollectionTask.DeleteDeck(did), deleteDeckListener(did));
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckPickerConfirmDeleteDeckDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckPickerConfirmDeleteDeckDialog.kt
@@ -25,6 +25,8 @@ import com.ichi2.anki.R
 import com.ichi2.anki.analytics.AnalyticsDialogFragment
 
 class DeckPickerConfirmDeleteDeckDialog : AnalyticsDialogFragment() {
+    val deckId get() = requireArguments().getLong("deckId")
+
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
         super.onCreate(savedInstanceState)
         val res = resources
@@ -36,7 +38,7 @@ class DeckPickerConfirmDeleteDeckDialog : AnalyticsDialogFragment() {
             .negativeText(R.string.dialog_cancel)
             .cancelable(true)
             .onPositive { _: MaterialDialog?, _: DialogAction? ->
-                (activity as DeckPicker?)!!.deleteContextMenuDeck()
+                (activity as DeckPicker?)!!.deleteDeck(deckId)
                 (activity as DeckPicker?)!!.dismissAllDialogFragments()
             }
             .onNegative { _: MaterialDialog?, _: DialogAction? -> (activity as DeckPicker?)!!.dismissAllDialogFragments() }
@@ -45,10 +47,11 @@ class DeckPickerConfirmDeleteDeckDialog : AnalyticsDialogFragment() {
 
     companion object {
         @JvmStatic
-        fun newInstance(dialogMessage: String?): DeckPickerConfirmDeleteDeckDialog {
+        fun newInstance(dialogMessage: String?, deckId: Long): DeckPickerConfirmDeleteDeckDialog {
             val f = DeckPickerConfirmDeleteDeckDialog()
             val args = Bundle()
             args.putString("dialogMessage", dialogMessage)
+            args.putLong("deckId", deckId)
             f.arguments = args
             return f
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckPickerConfirmDeleteDeckDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckPickerConfirmDeleteDeckDialog.kt
@@ -23,9 +23,10 @@ import com.afollestad.materialdialogs.MaterialDialog
 import com.ichi2.anki.DeckPicker
 import com.ichi2.anki.R
 import com.ichi2.anki.analytics.AnalyticsDialogFragment
+import com.ichi2.utils.BundleUtils.requireLong
 
 class DeckPickerConfirmDeleteDeckDialog : AnalyticsDialogFragment() {
-    val deckId get() = requireArguments().getLong("deckId")
+    val deckId get() = requireArguments().requireLong("deckId")
 
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
         super.onCreate(savedInstanceState)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckPickerContextMenu.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckPickerContextMenu.kt
@@ -46,10 +46,12 @@ class DeckPickerContextMenu(private val collection: Collection) : AnalyticsDialo
         return this
     }
 
+    /** The selected deck for the context menu */
+    private val deckId get() = requireArguments().getLong("did")
+
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
         super.onCreate(savedInstanceState)
-        val did = requireArguments().getLong("did")
-        val title = collection.decks.name(did)
+        val title = collection.decks.name(deckId)
         val itemIds = listIds
         return MaterialDialog.Builder(requireActivity())
             .title(title)
@@ -91,7 +93,7 @@ class DeckPickerContextMenu(private val collection: Collection) : AnalyticsDialo
     @get:DECK_PICKER_CONTEXT_MENU
     private val listIds: IntArray
         get() {
-            val did = requireArguments().getLong("did")
+            val did = deckId
             val dyn = collection.decks.isDyn(did)
             val itemIds = ArrayList<Int>(11) // init with our fixed list size for performance
             itemIds.add(CONTEXT_MENU_BROWSE_CARDS)
@@ -130,10 +132,9 @@ class DeckPickerContextMenu(private val collection: Collection) : AnalyticsDialo
             }
             CONTEXT_MENU_CUSTOM_STUDY -> {
                 Timber.i("Custom study option selected")
-                val did = requireArguments().getLong("did")
                 val ankiActivity = requireActivity() as AnkiActivity
                 val d = FragmentFactoryUtils.instantiate(ankiActivity, CustomStudyDialog::class.java)
-                d.withArguments(CustomStudyDialog.CONTEXT_MENU_STANDARD, did)
+                d.withArguments(CustomStudyDialog.CONTEXT_MENU_STANDARD, deckId)
                 ankiActivity.showDialogFragment(d)
             }
             CONTEXT_MENU_CREATE_SHORTCUT -> {
@@ -150,7 +151,7 @@ class DeckPickerContextMenu(private val collection: Collection) : AnalyticsDialo
             }
             CONTEXT_MENU_UNBURY -> {
                 Timber.i("Unbury deck selected")
-                collection.sched.unburyCardsForDeck(requireArguments().getLong("did"))
+                collection.sched.unburyCardsForDeck(deckId)
                 (activity as StudyOptionsListener?)!!.onRequireDeckListUpdate()
                 (activity as AnkiActivity?)!!.dismissAllDialogFragments()
             }
@@ -169,8 +170,7 @@ class DeckPickerContextMenu(private val collection: Collection) : AnalyticsDialo
                 (activity as DeckPicker?)!!.createSubdeckDialog()
             }
             CONTEXT_MENU_BROWSE_CARDS -> {
-                val did = requireArguments().getLong("did")
-                collection.decks?.select(did)
+                collection.decks?.select(deckId)
                 val intent = Intent(activity, CardBrowser::class.java)
                 (activity as DeckPicker?)!!.startActivityForResultWithAnimation(intent, NavigationDrawerActivity.REQUEST_BROWSE_CARDS, ActivityTransitionAnimation.Direction.START)
             }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckPickerContextMenu.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckPickerContextMenu.kt
@@ -29,6 +29,7 @@ import com.ichi2.anki.StudyOptionsFragment.StudyOptionsListener
 import com.ichi2.anki.analytics.AnalyticsDialogFragment
 import com.ichi2.anki.dialogs.customstudy.CustomStudyDialog
 import com.ichi2.libanki.Collection
+import com.ichi2.utils.BundleUtils.requireLong
 import com.ichi2.utils.ExtendedFragmentFactory
 import com.ichi2.utils.FragmentFactoryUtils
 import timber.log.Timber
@@ -47,7 +48,7 @@ class DeckPickerContextMenu(private val collection: Collection) : AnalyticsDialo
     }
 
     /** The selected deck for the context menu */
-    private val deckId get() = requireArguments().getLong("did")
+    val deckId get() = requireArguments().requireLong("did")
 
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
         super.onCreate(savedInstanceState)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckPickerContextMenu.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckPickerContextMenu.kt
@@ -123,11 +123,11 @@ class DeckPickerContextMenu(private val collection: Collection) : AnalyticsDialo
         when (view.id) {
             CONTEXT_MENU_DELETE_DECK -> {
                 Timber.i("Delete deck selected")
-                (activity as DeckPicker?)!!.confirmDeckDeletion()
+                (activity as DeckPicker?)!!.confirmDeckDeletion(deckId)
             }
             CONTEXT_MENU_DECK_OPTIONS -> {
                 Timber.i("Open deck options selected")
-                (activity as DeckPicker?)!!.showContextMenuDeckOptions()
+                (activity as DeckPicker?)!!.showContextMenuDeckOptions(deckId)
                 (activity as AnkiActivity?)!!.dismissAllDialogFragments()
             }
             CONTEXT_MENU_CUSTOM_STUDY -> {
@@ -139,15 +139,15 @@ class DeckPickerContextMenu(private val collection: Collection) : AnalyticsDialo
             }
             CONTEXT_MENU_CREATE_SHORTCUT -> {
                 Timber.i("Create icon for a deck")
-                (activity as DeckPicker?)!!.createIcon(context)
+                (activity as DeckPicker?)!!.createIcon(context, deckId)
             }
             CONTEXT_MENU_RENAME_DECK -> {
                 Timber.i("Rename deck selected")
-                (activity as DeckPicker?)!!.renameDeckDialog()
+                (activity as DeckPicker?)!!.renameDeckDialog(deckId)
             }
             CONTEXT_MENU_EXPORT_DECK -> {
                 Timber.i("Export deck selected")
-                (activity as DeckPicker?)!!.showContextMenuExportDialog()
+                (activity as DeckPicker?)!!.exportDeck(deckId)
             }
             CONTEXT_MENU_UNBURY -> {
                 Timber.i("Unbury deck selected")
@@ -157,17 +157,17 @@ class DeckPickerContextMenu(private val collection: Collection) : AnalyticsDialo
             }
             CONTEXT_MENU_CUSTOM_STUDY_REBUILD -> {
                 Timber.i("Empty deck selected")
-                (activity as DeckPicker?)!!.rebuildFiltered()
+                (activity as DeckPicker?)!!.rebuildFiltered(deckId)
                 (activity as AnkiActivity?)!!.dismissAllDialogFragments()
             }
             CONTEXT_MENU_CUSTOM_STUDY_EMPTY -> {
                 Timber.i("Empty deck selected")
-                (activity as DeckPicker?)!!.emptyFiltered()
+                (activity as DeckPicker?)!!.emptyFiltered(deckId)
                 (activity as AnkiActivity?)!!.dismissAllDialogFragments()
             }
             CONTEXT_MENU_CREATE_SUBDECK -> {
                 Timber.i("Create Subdeck selected")
-                (activity as DeckPicker?)!!.createSubdeckDialog()
+                (activity as DeckPicker?)!!.createSubDeckDialog(deckId)
             }
             CONTEXT_MENU_BROWSE_CARDS -> {
                 collection.decks?.select(deckId)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckPickerContextMenu.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckPickerContextMenu.kt
@@ -107,12 +107,12 @@ class DeckPickerContextMenu(private val collection: Collection) : AnalyticsDialo
             if (!dyn) {
                 itemIds.add(CONTEXT_MENU_CUSTOM_STUDY)
             }
-            itemIds.add(CONTEXT_MENU_DELETE_DECK)
             itemIds.add(CONTEXT_MENU_EXPORT_DECK)
             if (collection.sched.haveBuried(did)) {
                 itemIds.add(CONTEXT_MENU_UNBURY)
             }
             itemIds.add(CONTEXT_MENU_CREATE_SHORTCUT)
+            itemIds.add(CONTEXT_MENU_DELETE_DECK)
             return ContextMenuHelper.integerListToArray(itemIds)
         }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckPickerContextMenu.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckPickerContextMenu.kt
@@ -28,9 +28,7 @@ import com.ichi2.anki.StudyOptionsFragment.StudyOptionsListener
 import com.ichi2.anki.analytics.AnalyticsDialogFragment
 import com.ichi2.anki.dialogs.customstudy.CustomStudyDialog
 import com.ichi2.utils.FragmentFactoryUtils
-import com.ichi2.utils.HashUtil.HashMapInit
 import timber.log.Timber
-import java.util.*
 
 class DeckPickerContextMenu : AnalyticsDialogFragment() {
     @kotlin.annotation.Retention(AnnotationRetention.SOURCE)
@@ -52,23 +50,28 @@ class DeckPickerContextMenu : AnalyticsDialogFragment() {
             .build()
     }
 
+    /**
+     * A map from an ID of a menu item to its name
+     *
+     * note: ordering of menu items is performed in [listIds]
+     * */
     private val keyValueMap: HashMap<Int, String>
         get() {
             val res = resources
-            val keyValueMap = HashMapInit<Int, String>(9)
-            keyValueMap[CONTEXT_MENU_RENAME_DECK] = res.getString(R.string.rename_deck)
-            keyValueMap[CONTEXT_MENU_DECK_OPTIONS] = res.getString(R.string.menu__deck_options)
-            keyValueMap[CONTEXT_MENU_CUSTOM_STUDY] = res.getString(R.string.custom_study)
-            keyValueMap[CONTEXT_MENU_DELETE_DECK] = res.getString(R.string.contextmenu_deckpicker_delete_deck)
-            keyValueMap[CONTEXT_MENU_EXPORT_DECK] = res.getString(R.string.export_deck)
-            keyValueMap[CONTEXT_MENU_UNBURY] = res.getString(R.string.unbury)
-            keyValueMap[CONTEXT_MENU_CUSTOM_STUDY_REBUILD] = res.getString(R.string.rebuild_cram_label)
-            keyValueMap[CONTEXT_MENU_CUSTOM_STUDY_EMPTY] = res.getString(R.string.empty_cram_label)
-            keyValueMap[CONTEXT_MENU_CREATE_SUBDECK] = res.getString(R.string.create_subdeck)
-            keyValueMap[CONTEXT_MENU_CREATE_SHORTCUT] = res.getString(R.string.create_shortcut)
-            keyValueMap[CONTEXT_MENU_BROWSE_CARDS] = res.getString(R.string.browse_cards)
-            return keyValueMap
-        } // init with our fixed list size for performance
+            return hashMapOf(
+                CONTEXT_MENU_RENAME_DECK to res.getString(R.string.rename_deck),
+                CONTEXT_MENU_DECK_OPTIONS to res.getString(R.string.menu__deck_options),
+                CONTEXT_MENU_CUSTOM_STUDY to res.getString(R.string.custom_study),
+                CONTEXT_MENU_DELETE_DECK to res.getString(R.string.contextmenu_deckpicker_delete_deck),
+                CONTEXT_MENU_EXPORT_DECK to res.getString(R.string.export_deck),
+                CONTEXT_MENU_UNBURY to res.getString(R.string.unbury),
+                CONTEXT_MENU_CUSTOM_STUDY_REBUILD to res.getString(R.string.rebuild_cram_label),
+                CONTEXT_MENU_CUSTOM_STUDY_EMPTY to res.getString(R.string.empty_cram_label),
+                CONTEXT_MENU_CREATE_SUBDECK to res.getString(R.string.create_subdeck),
+                CONTEXT_MENU_CREATE_SHORTCUT to res.getString(R.string.create_shortcut),
+                CONTEXT_MENU_BROWSE_CARDS to res.getString(R.string.browse_cards),
+            )
+        }
 
     /**
      * Retrieve the list of ids to put in the context menu list
@@ -80,7 +83,7 @@ class DeckPickerContextMenu : AnalyticsDialogFragment() {
             val col = CollectionHelper.getInstance().getCol(context)
             val did = requireArguments().getLong("did")
             val dyn = col.decks.isDyn(did)
-            val itemIds = ArrayList<Int>(10) // init with our fixed list size for performance
+            val itemIds = ArrayList<Int>(11) // init with our fixed list size for performance
             itemIds.add(CONTEXT_MENU_BROWSE_CARDS)
             if (dyn) {
                 itemIds.add(CONTEXT_MENU_CUSTOM_STUDY_REBUILD)

--- a/AnkiDroid/src/main/java/com/ichi2/utils/BundleUtils.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/BundleUtils.kt
@@ -35,4 +35,18 @@ object BundleUtils {
             null
         } else bundle.getLong(key)
     }
+
+    /**
+     * Retrieves a [Long] value from a [Bundle] using a key, throws if not found
+     *
+     * @param key A string key
+     * @return the value associated with [key]
+     * @throws IllegalStateException If [key] does not exist in the bundle
+     */
+    fun Bundle.requireLong(key: String): Long {
+        if (!this.containsKey(key)) {
+            throw IllegalStateException("key: '$key' not found")
+        }
+        return getLong(key)
+    }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/utils/BundleUtils.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/BundleUtils.kt
@@ -25,7 +25,7 @@ object BundleUtils {
      * Retrieves a [Long] value from a [Bundle] using a key, returns null if not found
      *
      * @param bundle the bundle to look into
-     * can be null to support nullable bundles like [Fragment.getArguments]
+     * can be null to support nullable bundles like [androidx.fragment.app.Fragment.getArguments]
      * @param key the key to use
      * @return the long value, or null if not found
      */

--- a/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/DeckPickerContextMenuTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/DeckPickerContextMenuTest.kt
@@ -23,6 +23,7 @@ import com.afollestad.materialdialogs.MaterialDialog
 import com.ichi2.anki.R
 import com.ichi2.anki.RobolectricTest
 import com.ichi2.libanki.Consts
+import com.ichi2.testutils.assertThrows
 import org.hamcrest.CoreMatchers.equalTo
 import org.hamcrest.MatcherAssert.assertThat
 import org.junit.Test
@@ -42,6 +43,11 @@ class DeckPickerContextMenuTest : RobolectricTest() {
                 equalTo(getResourceString(R.string.contextmenu_deckpicker_delete_deck))
             )
         }
+    }
+
+    @Test
+    fun ensure_cannot_be_instantiated_without_arguments() {
+        assertThrows<IllegalStateException> { DeckPickerContextMenu(col).deckId }
     }
 
     /**

--- a/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/DeckPickerContextMenuTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/DeckPickerContextMenuTest.kt
@@ -25,14 +25,12 @@ import com.ichi2.anki.RobolectricTest
 import com.ichi2.libanki.Consts
 import org.hamcrest.CoreMatchers.equalTo
 import org.hamcrest.MatcherAssert.assertThat
-import org.junit.Ignore
 import org.junit.Test
 import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
 class DeckPickerContextMenuTest : RobolectricTest() {
     @Test
-    @Ignore("assertion not met")
     fun delete_deck_is_last_in_menu_issue_10283() {
         // "Delete deck" was previously close to "Custom study" which caused misclicks.
         // This is less likely at the bottom of the list

--- a/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/DeckPickerContextMenuTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/DeckPickerContextMenuTest.kt
@@ -1,0 +1,69 @@
+/*
+ *  Copyright (c) 2022 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.dialogs
+
+import androidx.fragment.app.testing.FragmentScenario
+import androidx.lifecycle.Lifecycle
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.afollestad.materialdialogs.MaterialDialog
+import com.ichi2.anki.R
+import com.ichi2.anki.RobolectricTest
+import com.ichi2.libanki.Consts
+import org.hamcrest.CoreMatchers.equalTo
+import org.hamcrest.MatcherAssert.assertThat
+import org.junit.Ignore
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class DeckPickerContextMenuTest : RobolectricTest() {
+    @Test
+    @Ignore("assertion not met")
+    fun delete_deck_is_last_in_menu_issue_10283() {
+        // "Delete deck" was previously close to "Custom study" which caused misclicks.
+        // This is less likely at the bottom of the list
+        testDialog(Consts.DEFAULT_DECK_ID) { dialog ->
+            val lastItem = dialog.items!!.last()
+            assertThat(
+                "'Delete deck' should be last item in the menu",
+                lastItem,
+                equalTo(getResourceString(R.string.contextmenu_deckpicker_delete_deck))
+            )
+        }
+    }
+
+    /**
+     * Allows testing the [MaterialDialog] returned from the [DeckPickerContextMenu]
+     *
+     * @param deckId The deck ID to test
+     * @param execAssertions the assertions to perform on the [MaterialDialog] under test
+     */
+    private fun testDialog(@Suppress("SameParameterValue") deckId: Long, execAssertions: (MaterialDialog) -> Unit) {
+        val args = DeckPickerContextMenu(col)
+            .withArguments(deckId)
+            .arguments
+
+        val factory = DeckPickerContextMenu.Factory { col }
+        FragmentScenario.launch(DeckPickerContextMenu::class.java, args, R.style.Theme_AppCompat, factory)
+            .use { scenario ->
+                scenario.moveToState(Lifecycle.State.STARTED)
+                scenario.onFragment { f: DeckPickerContextMenu ->
+                    execAssertions(f.dialog as MaterialDialog)
+                }
+            }
+    }
+}


### PR DESCRIPTION
## Purpose / Description

'Delete deck' was in the middle of the options, making it more likely to fat-finger the button.

Moving the option seemed sensible, rather than the addition of an additional confirmation screen.

I will follow up with a change to make filtered decks show this warning

## Fixes
Fixes partially #10283 

## Approach

* refactor the class to allow addition of unit tests
* Add unit tests
* Move 'Delete deck' to the bottom of the list
* More refactorings (~30 lines less in `DeckPicker`)

## How Has This Been Tested?
Added unit tests + Manual testing
![image](https://user-images.githubusercontent.com/62114487/151686042-aed6d2fe-8267-4358-a59e-eca5ccb6adbc.png)

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
