### PR TITLE
feat(DeckPicker): confirm deleting filtered deck

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -2430,8 +2430,9 @@ public class DeckPicker extends NavigationDrawerActivity implements
         String ids = Utils.ids2str(dids);
         int cnt = getCol().getDb().queryScalar(
                 "select count() from cards where did in " + ids + " or odid in " + ids);
-        // Delete empty decks without warning
-        if (cnt == 0) {
+        boolean isDyn = getCol().getDecks().isDyn(did);
+        // Delete empty decks without warning. Filtered decks save filters in the deck data, so require confirmation.
+        if (cnt == 0 && !isDyn) {
             deleteDeck(did);
             dismissAllDialogFragments();
             return;
@@ -2439,7 +2440,6 @@ public class DeckPicker extends NavigationDrawerActivity implements
         // Otherwise we show a warning and require confirmation
         String msg;
         String deckName = "'" + getCol().getDecks().name(did) + "'";
-        boolean isDyn = getCol().getDecks().isDyn(did);
         if (isDyn) {
             msg = res.getString(R.string.delete_cram_deck_message, deckName);
         } else {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -104,6 +104,7 @@ import com.ichi2.anki.dialogs.customstudy.CustomStudyDialogFactory;
 import com.ichi2.anki.exception.ConfirmModSchemaException;
 import com.ichi2.anki.export.ActivityExportingDelegate;
 import com.ichi2.anki.receiver.SdCardReceiver;
+import com.ichi2.anki.servicelayer.DeckService;
 import com.ichi2.anki.servicelayer.SchedulerService;
 import com.ichi2.anki.servicelayer.UndoService;
 import com.ichi2.anki.stats.AnkiStatsTaskHandler;
@@ -142,7 +143,6 @@ import com.ichi2.utils.JSONException;
 
 import java.io.File;
 import java.util.List;
-import java.util.TreeMap;
 
 import kotlin.Unit;
 import timber.log.Timber;
@@ -2420,16 +2420,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
             return;
         }
         // Get the number of cards contained in this deck and its subdecks
-        TreeMap<String, Long> children = getCol().getDecks().children(did);
-        long[] dids = new long[children.size() + 1];
-        dids[0] = did;
-        int i = 1;
-        for (Long l : children.values()) {
-            dids[i++] = l;
-        }
-        String ids = Utils.ids2str(dids);
-        int cnt = getCol().getDb().queryScalar(
-                "select count() from cards where did in " + ids + " or odid in " + ids);
+        int cnt = DeckService.countCardsInDeckTree(getCol(), did);
         boolean isDyn = getCol().getDecks().isDyn(did);
         // Delete empty decks without warning. Filtered decks save filters in the deck data, so require confirmation.
         if (cnt == 0 && !isDyn) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/DeckService.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/DeckService.kt
@@ -18,7 +18,9 @@ package com.ichi2.anki.servicelayer
 
 import com.ichi2.libanki.Collection
 import com.ichi2.libanki.Consts
+import com.ichi2.libanki.Utils
 import com.ichi2.libanki.did
+import java.util.*
 
 object DeckService {
     @JvmStatic
@@ -32,4 +34,28 @@ object DeckService {
     @JvmStatic
     fun defaultDeckHasCards(col: Collection) =
         col.db.queryScalar("select 1 from cards where did = 1") != 0
+
+    /**
+     * Counts cards in the supplied deck and child decks.
+     *
+     * Includes the count of filtered decks
+     * Includes filtered cards outside the tree if the home deck is included
+     *
+     * @param did Id of the deck to search
+     * @return the number of cards in the supplied deck and child decks
+     */
+    @JvmStatic
+    fun countCardsInDeckTree(col: Collection, did: did): Int {
+        val children: TreeMap<String, Long> = col.decks.children(did)
+        val dids = LongArray(children.size + 1)
+        dids[0] = did
+        var i = 1
+        for (l in children.values) {
+            dids[i++] = l
+        }
+        val ids = Utils.ids2str(dids)
+        return col.db.queryScalar(
+            "select count() from cards where did in $ids or odid in $ids"
+        )
+    }
 }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/DeckPickerTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/DeckPickerTest.java
@@ -10,11 +10,13 @@ import android.content.pm.PackageManager;
 import android.view.Menu;
 
 import com.ichi2.anki.dialogs.DatabaseErrorDialog;
+import com.ichi2.anki.dialogs.DeckPickerConfirmDeleteDeckDialog;
 import com.ichi2.libanki.Collection;
 import com.ichi2.libanki.DB;
 import com.ichi2.libanki.DeckConfig;
 import com.ichi2.libanki.Storage;
 import com.ichi2.libanki.sched.AbstractSched;
+import com.ichi2.testutils.AnkiActivityUtils;
 import com.ichi2.testutils.BackendEmulatingOpenConflict;
 import com.ichi2.testutils.BackupManagerTestUtilities;
 import com.ichi2.testutils.DbUtils;
@@ -37,11 +39,13 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 
+import androidx.fragment.app.DialogFragment;
 import androidx.sqlite.db.framework.FrameworkSQLiteOpenHelperFactory;
 import androidx.test.core.app.ActivityScenario;
 
 import static com.ichi2.anki.DeckPicker.UPGRADE_VERSION_KEY;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
@@ -235,6 +239,19 @@ public class DeckPickerTest extends RobolectricTest {
         advanceRobolectricLooperWithSleep();
 
         assertThat("deck was deleted", getCol().getDecks().count(), is(1));
+    }
+
+    @Test
+    public void deletion_of_filtered_deck_shows_warning_issue_10238() {
+        // Filtered decks contain their own options, deleting one can cause a significant loss of work.
+        // And they are more likely to be empty temporarily
+        long did = addDynamicDeck("filtered");
+        DeckPicker deckPicker = startActivityNormallyOpenCollectionWithIntent(DeckPicker.class, new Intent());
+        deckPicker.confirmDeckDeletion(did);
+
+
+        DialogFragment fragment = AnkiActivityUtils.getDialogFragment(deckPicker);
+        assertThat("deck deletion confirmation window should be shown", fragment, instanceOf(DeckPickerConfirmDeleteDeckDialog.class));
     }
 
     @Test

--- a/AnkiDroid/src/test/java/com/ichi2/testutils/AnkiActivityUtils.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/testutils/AnkiActivityUtils.kt
@@ -1,0 +1,34 @@
+/*
+ *  Copyright (c) 2022 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.testutils
+
+import androidx.fragment.app.DialogFragment
+import com.ichi2.anki.AnkiActivity
+import com.ichi2.utils.KotlinCleanup
+
+object AnkiActivityUtils {
+    @Suppress("unused")
+    @KotlinCleanup("replace getDialogFragment with this")
+    inline fun <reified T : DialogFragment> AnkiActivity.getDialogFragmentKt(): T? {
+        return supportFragmentManager.findFragmentByTag("dialog") as T?
+    }
+
+    @JvmStatic
+    fun getDialogFragment(activity: AnkiActivity): DialogFragment? {
+        return activity.supportFragmentManager.findFragmentByTag("dialog") as DialogFragment?
+    }
+}


### PR DESCRIPTION
## Pull Request template

## Purpose / Description

Filtered decks contain deck options embedded, deleting one can lose a significant amount of work

So we should show a confirmation dialog when this occurs. We already have one available, so show it.

## Fixes
Fixes #10283 

## How Has This Been Tested?
Unit test + manual test

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
