### PR TITLE
feat(tests): printDirectoryTree

### DIFF
--- a/AnkiDroid/src/test/java/com/ichi2/testutils/FileSystemUtils.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/testutils/FileSystemUtils.kt
@@ -1,0 +1,94 @@
+/*
+ *  Copyright (c) 2022 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.testutils
+
+import androidx.annotation.CheckResult
+import timber.log.Timber
+import java.io.File
+
+/** Utilities which assist testing changes to files/directories */
+@Suppress("unused")
+object FileSystemUtils {
+
+    /**
+     * Prints a directory structure using [Timber.d]
+     * @param description The prefix to print before the tree is listed
+     * @param file the root of the tree to print
+     *
+     * ```
+     * D/FileSystemUtils: destination: C:\Users\User\AppData\Local\Temp\robolectric-Method_successfulMigration11404528269084729867\external-files\AnkiDroid-1
+     * +--AnkiDroid-1/
+     * |  +--backup/
+     * |  |  +--collection-2020-08-07-08-00.colpkg
+     * |  +--collection.media/
+     * |  |  +--folder/
+     * |  |  |  +--test.txt
+     * |  |  +--test.txt
+     * ```
+     */
+    fun printDirectoryTree(description: String, file: File) {
+        Timber.d("$description: $file\n${printDirectoryTree(file)}")
+    }
+
+    /** from https://stackoverflow.com/a/13130974/ */
+    @CheckResult
+    private fun printDirectoryTree(folder: File): String {
+        require(folder.isDirectory) { "folder is not a Directory" }
+        val indent = 0
+        val sb = StringBuilder()
+        printDirectoryTree(folder, indent, sb)
+        return sb.toString()
+    }
+
+    /** from https://stackoverflow.com/a/13130974/ */
+    private fun printDirectoryTree(
+        folder: File,
+        indent: Int,
+        sb: StringBuilder
+    ) {
+        require(folder.isDirectory) { "folder is not a Directory" }
+        sb.append(getIndentString(indent))
+        sb.append("+--")
+        sb.append(folder.name)
+        sb.append("/")
+        sb.append("\n")
+        for (file in folder.listFiles() ?: emptyArray()) {
+            if (file.isDirectory) {
+                printDirectoryTree(file, indent + 1, sb)
+            } else {
+                printFile(file, indent + 1, sb)
+            }
+        }
+    }
+
+    /** from https://stackoverflow.com/a/13130974/ */
+    private fun printFile(file: File, indent: Int, sb: StringBuilder) {
+        sb.append(getIndentString(indent))
+        sb.append("+--")
+        sb.append(file.name)
+        sb.append("\n")
+    }
+
+    /** from https://stackoverflow.com/a/13130974/ */
+    private fun getIndentString(indent: Int): String {
+        val sb = StringBuilder()
+        for (i in 0 until indent) {
+            sb.append("|  ")
+        }
+        return sb.toString()
+    }
+}


### PR DESCRIPTION
From StackOverflow: https://stackoverflow.com/a/13130974/

Used to print a directory tree to the console to allow for easy comparison of directories

Currently has no uses. I use this in scoped storage tests

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
