### PR TITLE
Disable "html_javascript_debugging" for unit/android tests

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.java
@@ -357,7 +357,7 @@ public class AnkiDroidApp extends Application {
         boolean isDebug = false;
         try {
             Class.forName("org.junit.Test");
-        } catch (ClassNotFoundException e) {
+        } catch (ClassNotFoundException ignored) {
             isDebug = true;
         }
         Timber.d("isDebug: %s", Boolean.toString(isDebug));

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.java
@@ -353,8 +353,16 @@ public class AnkiDroidApp extends Application {
             UIUtils.showThemedToast(this.getApplicationContext(), getString(R.string.user_is_a_robot), false);
         }
 
-        // make default HTML / JS debugging true for debug build
-        if (BuildConfig.DEBUG) {
+        // make default HTML / JS debugging true for debug build and disable for unit/android tests
+        boolean isDebug = false;
+        try {
+            Class.forName ("org.junit.Test");
+        } catch (ClassNotFoundException e) {
+            isDebug = true;
+        }
+        Timber.d("isDebug: %s", Boolean.toString(isDebug));
+
+        if (BuildConfig.DEBUG && isDebug) {
             preferences.edit().putBoolean("html_javascript_debugging", true).apply();
         }
         

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.java
@@ -354,15 +354,7 @@ public class AnkiDroidApp extends Application {
         }
 
         // make default HTML / JS debugging true for debug build and disable for unit/android tests
-        boolean isDebug = false;
-        try {
-            Class.forName("org.junit.Test");
-        } catch (ClassNotFoundException ignored) {
-            isDebug = true;
-        }
-        Timber.d("isDebug: %b", isDebug);
-
-        if (BuildConfig.DEBUG && isDebug) {
+        if (BuildConfig.DEBUG && AdaptionUtil.isDebug()) {
             preferences.edit().putBoolean("html_javascript_debugging", true).apply();
         }
         

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.java
@@ -354,7 +354,7 @@ public class AnkiDroidApp extends Application {
         }
 
         // make default HTML / JS debugging true for debug build and disable for unit/android tests
-        if (BuildConfig.DEBUG && AdaptionUtil.isRunningAsUnitTest()) {
+        if (BuildConfig.DEBUG && !AdaptionUtil.isRunningAsUnitTest()) {
             preferences.edit().putBoolean("html_javascript_debugging", true).apply();
         }
         

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.java
@@ -354,7 +354,7 @@ public class AnkiDroidApp extends Application {
         }
 
         // make default HTML / JS debugging true for debug build and disable for unit/android tests
-        if (BuildConfig.DEBUG && AdaptionUtil.isDebug()) {
+        if (BuildConfig.DEBUG && AdaptionUtil.isRunningAsUnitTest()) {
             preferences.edit().putBoolean("html_javascript_debugging", true).apply();
         }
         

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.java
@@ -360,7 +360,7 @@ public class AnkiDroidApp extends Application {
         } catch (ClassNotFoundException ignored) {
             isDebug = true;
         }
-        Timber.d("isDebug: %s", Boolean.toString(isDebug));
+        Timber.d("isDebug: %b", isDebug);
 
         if (BuildConfig.DEBUG && isDebug) {
             preferences.edit().putBoolean("html_javascript_debugging", true).apply();

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.java
@@ -356,7 +356,7 @@ public class AnkiDroidApp extends Application {
         // make default HTML / JS debugging true for debug build and disable for unit/android tests
         boolean isDebug = false;
         try {
-            Class.forName ("org.junit.Test");
+            Class.forName("org.junit.Test");
         } catch (ClassNotFoundException e) {
             isDebug = true;
         }

--- a/AnkiDroid/src/main/java/com/ichi2/utils/AdaptionUtil.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/AdaptionUtil.kt
@@ -161,4 +161,18 @@ object AdaptionUtil {
             val manufacturer = Build.MANUFACTURER ?: return false
             return manufacturer.lowercase(Locale.ROOT) == "vivo"
         }
+
+    // make default HTML / JS debugging true for debug build and disable for unit/android tests
+    @JvmStatic
+    val isDebug: Boolean
+        get() {
+            try {
+                Class.forName("org.junit.Test")
+            } catch (ignored: ClassNotFoundException) {
+                Timber.d("isDebug: %b", true)
+                return true
+            }
+            Timber.d("isDebug: %b", false)
+            return false
+        }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/utils/AdaptionUtil.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/AdaptionUtil.kt
@@ -162,17 +162,21 @@ object AdaptionUtil {
             return manufacturer.lowercase(Locale.ROOT) == "vivo"
         }
 
-    // make default HTML / JS debugging true for debug build and disable for unit/android tests
+    /** make default HTML / JS debugging true for debug build and disable for unit/android tests
+     * isRunningAsUnitTest checks if we are in debug or testing environment by checking if org.junit.Test class
+     * is imported.
+     * https://stackoverflow.com/questions/28550370/how-to-detect-whether-android-app-is-running-ui-test-with-espresso
+     */
     @JvmStatic
-    val isDebug: Boolean
+    val isRunningAsUnitTest: Boolean
         get() {
             try {
                 Class.forName("org.junit.Test")
             } catch (ignored: ClassNotFoundException) {
-                Timber.d("isDebug: %b", true)
-                return true
+                Timber.d("isRunningAsUnitTest: %b", false)
+                return false
             }
-            Timber.d("isDebug: %b", false)
-            return false
+            Timber.d("isRunningAsUnitTest: %b", true)
+            return true
         }
 }


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
enable html/js debugging only for debugging and not for tests

## Fixes
Fixes #9751

## Approach
check for org.junit.Test class being imported.
All CI's passing in my fork.

## How Has This Been Tested?

used timber logging to verify isDebug is true during normal run in avd and false when running unit/android tests.

## Learning
[stackoverflow](https://stackoverflow.com/questions/28550370/how-to-detect-whether-android-app-is-running-ui-test-with-espresso)

## Checklist
_Please, go through these checks before submitting the PR._

- [ X ] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [ X ] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ X ] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [ ] You have commented your code, particularly in hard-to-understand areas
- [ X ] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
