### PR TITLE
Note editor toolbar new item string as icon

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -1913,8 +1913,7 @@ public class NoteEditor extends AnkiActivity implements
 
             // 0th button shows as '1' and is Ctrl + 1
             int visualIndex = b.getIndex() + 1;
-            String text = Integer.toString(visualIndex);
-            Drawable bmp = mToolbar.createDrawableForString(text);
+            Drawable bmp = mToolbar.createDrawableForString(b.getIcon());
 
             View v = mToolbar.insertItem(0, bmp, b.toFormatter());
 
@@ -1946,14 +1945,14 @@ public class NoteEditor extends AnkiActivity implements
                 .apply();
     }
 
-    private void addToolbarButton(String prefix, String suffix) {
-        if (TextUtils.isEmpty(prefix) && TextUtils.isEmpty(suffix)) {
+    private void addToolbarButton(String icon, String prefix, String suffix) {
+        if (TextUtils.isEmpty(icon) && TextUtils.isEmpty(prefix) && TextUtils.isEmpty(suffix)) {
             return;
         }
 
         ArrayList<CustomToolbarButton> toolbarButtons = getToolbarButtons();
 
-        toolbarButtons.add(new CustomToolbarButton(toolbarButtons.size(), prefix, suffix));
+        toolbarButtons.add(new CustomToolbarButton(toolbarButtons.size(), icon, prefix, suffix));
         saveToolbarButtons(toolbarButtons);
 
         updateToolbar();
@@ -1988,10 +1987,11 @@ public class NoteEditor extends AnkiActivity implements
                 .onNeutral((m, v) -> openUrl(Uri.parse(getString(R.string.link_manual_note_format_toolbar))))
                 .onPositive((m, v) -> {
                     View view = m.getView();
+                    EditText etIcon =  view.findViewById(R.id.note_editor_toolbar_item_icon);
                     EditText et =  view.findViewById(R.id.note_editor_toolbar_before);
                     EditText et2 = view.findViewById(R.id.note_editor_toolbar_after);
 
-                    addToolbarButton(et.getText().toString(), et2.getText().toString());
+                    addToolbarButton(etIcon.getText().toString(), et.getText().toString(), et2.getText().toString());
                 })
                 .show();
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -1913,7 +1913,13 @@ public class NoteEditor extends AnkiActivity implements
 
             // 0th button shows as '1' and is Ctrl + 1
             int visualIndex = b.getIndex() + 1;
-            Drawable bmp = mToolbar.createDrawableForString(b.getIcon());
+            String text = Integer.toString(visualIndex);
+
+            if (!b.getButtonText().isEmpty()) {
+                text = b.getButtonText();
+            }
+
+            Drawable bmp = mToolbar.createDrawableForString(text);
 
             View v = mToolbar.insertItem(0, bmp, b.toFormatter());
 
@@ -1945,14 +1951,14 @@ public class NoteEditor extends AnkiActivity implements
                 .apply();
     }
 
-    private void addToolbarButton(String icon, String prefix, String suffix) {
-        if (TextUtils.isEmpty(icon) && TextUtils.isEmpty(prefix) && TextUtils.isEmpty(suffix)) {
+    private void addToolbarButton(String buttonText, String prefix, String suffix) {
+        if (TextUtils.isEmpty(prefix) && TextUtils.isEmpty(suffix)) {
             return;
         }
 
         ArrayList<CustomToolbarButton> toolbarButtons = getToolbarButtons();
 
-        toolbarButtons.add(new CustomToolbarButton(toolbarButtons.size(), icon, prefix, suffix));
+        toolbarButtons.add(new CustomToolbarButton(toolbarButtons.size(), buttonText, prefix, suffix));
         saveToolbarButtons(toolbarButtons);
 
         updateToolbar();

--- a/AnkiDroid/src/main/java/com/ichi2/anki/noteeditor/CustomToolbarButton.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/noteeditor/CustomToolbarButton.kt
@@ -22,13 +22,15 @@ import com.ichi2.utils.HashUtil.HashSetInit
 import timber.log.Timber
 import java.util.*
 
-class CustomToolbarButton(var index: Int, var icon: String, private val prefix: String, private val suffix: String) {
+typealias ButtonText = String
+
+class CustomToolbarButton(var index: Int, var buttonText: ButtonText, private val prefix: String, private val suffix: String) {
     fun toFormatter(): Toolbar.TextFormatter {
         return TextWrapper(prefix, suffix)
     }
 
     companion object {
-        private const val KEEP_EMPTY_ENTRIES = -1
+        const val KEEP_EMPTY_ENTRIES = -1
         fun fromString(s: String?): CustomToolbarButton? {
             if (s == null || s.isEmpty()) {
                 return null
@@ -66,7 +68,7 @@ class CustomToolbarButton(var index: Int, var icon: String, private val prefix: 
         fun toStringSet(buttons: ArrayList<CustomToolbarButton>): Set<String> {
             val ret = HashSetInit<String>(buttons.size)
             for (b in buttons) {
-                val values = arrayOf(b.index.toString(), b.icon, b.prefix, b.suffix)
+                val values = arrayOf(b.index.toString(), b.buttonText, b.prefix, b.suffix)
                 for (i in values.indices) {
                     values[i] = values[i].replace(Consts.FIELD_SEPARATOR, "")
                 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/noteeditor/CustomToolbarButton.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/noteeditor/CustomToolbarButton.kt
@@ -22,7 +22,7 @@ import com.ichi2.utils.HashUtil.HashSetInit
 import timber.log.Timber
 import java.util.*
 
-class CustomToolbarButton(var index: Int, private val prefix: String, private val suffix: String) {
+class CustomToolbarButton(var index: Int, var icon: String, private val prefix: String, private val suffix: String) {
     fun toFormatter(): Toolbar.TextFormatter {
         return TextWrapper(prefix, suffix)
     }
@@ -34,7 +34,7 @@ class CustomToolbarButton(var index: Int, private val prefix: String, private va
                 return null
             }
             val fields = s.split(Consts.FIELD_SEPARATOR.toRegex(), KEEP_EMPTY_ENTRIES.coerceAtLeast(0)).toTypedArray()
-            if (fields.size != 3) {
+            if (fields.size != 4) {
                 return null
             }
             val index: Int = try {
@@ -43,7 +43,7 @@ class CustomToolbarButton(var index: Int, private val prefix: String, private va
                 Timber.w(e)
                 return null
             }
-            return CustomToolbarButton(index, fields[1], fields[2])
+            return CustomToolbarButton(index, fields[1], fields[2], fields[3])
         }
 
         @JvmStatic
@@ -66,7 +66,7 @@ class CustomToolbarButton(var index: Int, private val prefix: String, private va
         fun toStringSet(buttons: ArrayList<CustomToolbarButton>): Set<String> {
             val ret = HashSetInit<String>(buttons.size)
             for (b in buttons) {
-                val values = arrayOf(b.index.toString(), b.prefix, b.suffix)
+                val values = arrayOf(b.index.toString(), b.icon, b.prefix, b.suffix)
                 for (i in values.indices) {
                     values[i] = values[i].replace(Consts.FIELD_SEPARATOR, "")
                 }

--- a/AnkiDroid/src/main/res/layout/note_editor_toolbar_add_custom_item.xml
+++ b/AnkiDroid/src/main/res/layout/note_editor_toolbar_add_custom_item.xml
@@ -30,6 +30,20 @@
 
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:hint="@string/note_editor_toolbar_icon">
+
+        <com.google.android.material.textfield.TextInputEditText
+            android:id="@+id/note_editor_toolbar_item_icon"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_margin="@dimen/content_vertical_padding"/>
+    </com.google.android.material.textfield.TextInputLayout>
+
+
+    <com.google.android.material.textfield.TextInputLayout
+
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
         android:hint="@string/before_text">
 
         <com.google.android.material.textfield.TextInputEditText

--- a/AnkiDroid/src/main/res/values/02-strings.xml
+++ b/AnkiDroid/src/main/res/values/02-strings.xml
@@ -350,7 +350,7 @@
     <string name="insert_mathjax">Insert MathJax Equation</string>
     <string name="insert_cloze">Insert Cloze Deletion</string>
 
-    <string name="note_editor_toolbar_icon">Character As Icon</string>
+    <string name="note_editor_toolbar_icon">Button text</string>
     <string name="before_text">HTML Before Selection</string>
     <string name="after_text">HTML After Selection</string>
     <string name="add_toolbar_item">Create Toolbar Item</string>

--- a/AnkiDroid/src/main/res/values/02-strings.xml
+++ b/AnkiDroid/src/main/res/values/02-strings.xml
@@ -350,6 +350,7 @@
     <string name="insert_mathjax">Insert MathJax Equation</string>
     <string name="insert_cloze">Insert Cloze Deletion</string>
 
+    <string name="note_editor_toolbar_icon">Character As Icon</string>
     <string name="before_text">HTML Before Selection</string>
     <string name="after_text">HTML After Selection</string>
     <string name="add_toolbar_item">Create Toolbar Item</string>


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
The Note Editor toolbar add new items as number from 1...N, so I created this PR for adding string / single character as icon for the new items. It helps in recognize the button instead of memorizing button action with the number. 

## Fixes
Fixes #9077
> 3. Allow me to change the naming of custom buttons

## Approach
1. I have added new variable `icon` after `index`. 
2. Earlier buttons saved in SharedPrefs as `index, prefix and suffix`. 
Now when new buttons added it saved to SharedPrefs as `index, icon, prefix and suffix`

## How Has This Been Tested?
Test on Emulator on device
<img src="https://user-images.githubusercontent.com/12841290/151710697-9c933d41-bac9-4dc4-b3c1-945832af8019.png" height=450px></img> <img src="https://user-images.githubusercontent.com/12841290/151710702-ecc1da05-027c-48bf-bba9-84436850a8a3.png" height=450px></img>

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration (SDK version(s), emulator or physical, etc)

## Learning (optional, can help others)
_Describe the research stage_

_Links to blog posts, patterns, libraries or addons used to solve this problem_

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [x] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
