### PR TITLE
test: add "editPreferences" helper function

### DIFF
--- a/AnkiDroid/src/test/java/com/ichi2/anki/RobolectricTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/RobolectricTest.kt
@@ -22,6 +22,7 @@ import android.content.SharedPreferences
 import android.os.Looper
 import androidx.annotation.CheckResult
 import androidx.annotation.NonNull
+import androidx.core.content.edit
 import androidx.fragment.app.DialogFragment
 import androidx.sqlite.db.SupportSQLiteOpenHelper
 import androidx.sqlite.db.framework.FrameworkSQLiteOpenHelperFactory
@@ -55,7 +56,6 @@ import org.robolectric.android.controller.ActivityController
 import org.robolectric.shadows.ShadowDialog
 import org.robolectric.shadows.ShadowLog
 import timber.log.Timber
-import java.util.*
 import java.util.concurrent.locks.ReentrantLock
 import kotlin.concurrent.withLock
 
@@ -266,6 +266,10 @@ open class RobolectricTest : CollectionGetter {
             }
         }
 
+    /**
+     * Returns an instance of [SharedPreferences] using the test context
+     * @see [editPreferences] for editing
+     */
     protected fun getPreferences(): SharedPreferences {
         return AnkiDroidApp.getSharedPrefs(targetContext)
     }
@@ -505,4 +509,14 @@ open class RobolectricTest : CollectionGetter {
             advanceRobolectricLooperWithSleep()
             return card
         }
+
+    /**
+     * Allows editing of preferences, followed by a call to [apply][SharedPreferences.Editor.apply]:
+     *
+     * ```
+     * editPreferences { putString("key", value) }
+     * ```
+     */
+    fun editPreferences(action: SharedPreferences.Editor.() -> Unit) =
+        getPreferences().edit(action = action)
 }


### PR DESCRIPTION
Nicer to read + type than `getPreferences().edit { }`

Test-only. Currently unused, to be used in scoped storage changes

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
