### PR TITLE
feat(scoped-storage): User data migration infra & safely move file

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -313,6 +313,7 @@ dependencies {
     // noinspection GradleDependency - commons-compress 1.12 - later versions use `File.toPath`; API26 can remove?
     implementation 'org.apache.commons:commons-compress:1.12' // #6419 - handle >2GB apkg files
     implementation 'org.apache.commons:commons-collections4:4.4' // SetUniqueList
+    implementation 'commons-io:commons-io:2.11.0' // FileUtils.contentEquals
     implementation 'net.mikehardy:google-analytics-java7:2.0.13'
     implementation 'com.squareup.okhttp3:okhttp:4.9.3'
     implementation 'com.arcao:slf4j-timber:3.1'

--- a/AnkiDroid/src/main/java/com/ichi2/anki/model/DiskFile.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/model/DiskFile.kt
@@ -1,0 +1,53 @@
+/*
+ *  Copyright (c) 2022 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.model
+
+import androidx.annotation.VisibleForTesting
+import org.apache.commons.io.FileUtils
+import java.io.File
+
+/**
+ * A file which exists (at time of instantiation) and is not a directory.
+ * [java.io.File] could be a directory. A [DiskFile] is definitely a file
+ *
+ * Note: The file could be deleted manually, but this now represents an edge case
+ * This allows us to assume that a file exists for future operations
+ */
+class DiskFile private constructor(val file: File) {
+    /** @see [File.renameTo] */
+    fun renameTo(destination: File): Boolean = file.renameTo(destination)
+    /** @see [FileUtils.contentEquals] */
+    fun contentEquals(f2: File): Boolean = FileUtils.contentEquals(file, f2)
+    override fun toString(): String = file.canonicalPath
+
+    companion object {
+        /**
+         * Returns a [DiskFile] from [file] if `DiskFile` precondition holds; i.e. [file] is an existing file.
+         * Otherwise returns `null`.
+         */
+        fun createInstance(file: File): DiskFile? {
+            if (!file.exists() || !file.isFile) {
+                return null
+            }
+            return DiskFile(file)
+        }
+
+        /** Creates an instance when the preconditions are known to be true */
+        @VisibleForTesting
+        fun createInstanceUnsafe(file: File) = DiskFile(file)
+    }
+}

--- a/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/scopedstorage/MigrateUserData.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/scopedstorage/MigrateUserData.kt
@@ -1,0 +1,71 @@
+/*
+ *  Copyright (c) 2022 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.servicelayer.scopedstorage
+
+import timber.log.Timber
+
+typealias NumberOfBytes = Long
+
+/**
+ * Migrating user data (images, backups etc..) to scoped storage
+ * This needs to be performed in the background to allow users to use AnkiDroid
+ *
+ * If this were performed in the foreground, users would be encouraged to uninstall the app
+ * which means the app permanently loses access to the AnkiDroid folder.
+ *
+ * This also handles preemption, allowing media files to skip the queue
+ * (if they're required for review)
+ */
+class MigrateUserData {
+    /**
+     * Context for an [Operation], allowing a change of execution behavior and
+     * allowing progress and exception reporting logic when executing
+     * a large mutable queue of tasks
+     */
+    @Suppress("unused")
+    abstract class MigrationContext {
+        abstract fun reportError(context: Operation, ex: Exception)
+        abstract fun reportProgress(transferred: NumberOfBytes)
+
+        /**
+         * Performs an operation, reports errors and continues on failure
+         */
+        fun execSafe(operation: Operation, op: (Operation) -> Unit) {
+            try {
+                op(operation)
+            } catch (e: Exception) {
+                Timber.w(e, "Failed while executing %s", operation)
+                reportError(operation, e)
+            }
+        }
+    }
+
+    abstract class Operation {
+        /**
+         * Executes an operation, returning a list of sub-operations, or an empty list ([operationCompleted])
+         * on failure.
+         *
+         * This allows an operation to be preempted in a single-threaded context with minimal delay
+         * For example, if an image is requested by the reviewer, we don't want it to be stuck
+         * behind copying a large folder
+         */
+        abstract fun execute(context: MigrationContext): List<Operation>
+    }
+}
+
+/** The operation was completed (not necessarily successfully) and no additional operations are required */
+internal fun operationCompleted() = emptyList<MigrateUserData.Operation>()

--- a/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/scopedstorage/MoveFile.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/scopedstorage/MoveFile.kt
@@ -1,0 +1,149 @@
+/*
+ *  Copyright (c) 2022 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.servicelayer.scopedstorage
+
+import androidx.annotation.VisibleForTesting
+import com.ichi2.anki.model.DiskFile
+import com.ichi2.anki.servicelayer.scopedstorage.MigrateUserData.EquivalentFileException
+import com.ichi2.anki.servicelayer.scopedstorage.MigrateUserData.Operation
+import com.ichi2.compat.CompatHelper
+import timber.log.Timber
+import java.io.File
+
+/**
+ * [Operation] which safely moves a file from one location to another
+ *
+ * Note: thrown exceptions are passed to the context via [MigrateUserData.MigrationContext.reportError]
+ *
+ * @throws MigrateUserData.FileConflictException If the source and destination exist and are different
+ * @throws MigrateUserData.EquivalentFileException sourceFile == destinationFile
+ * @throws MigrateUserData.MissingDirectoryException if source or destination's directory is missing
+ * @throws IllegalStateException File copy failed
+ * @throws java.io.IOException Unknown file operation failed
+ */
+internal data class MoveFile(val sourceFile: DiskFile, val destinationFile: File) : Operation() {
+    override fun execute(context: MigrateUserData.MigrationContext): List<Operation> {
+        val destinationExists = destinationFile.exists()
+
+        if (handledEquivalentFileContent(destinationExists, context)) {
+            return operationCompleted()
+        }
+
+        // destination exists, and does NOT match content: throw an exception
+        // this is intended to be handled by moving the file to a "conflict" folder
+        if (destinationExists) {
+            // if the source file doesn't exist, but the destination does, we assume that the move
+            // took place outside this "MoveFile" instance - possibly preempted by the
+            // user requesting the file
+            Timber.d("file already moved to $destinationFile")
+            if (sourceFile.file.exists()) {
+                context.reportError(this, MigrateUserData.FileConflictException(sourceFile, DiskFile.createInstance(destinationFile)!!))
+            }
+            return operationCompleted()
+        }
+
+        // attempt a quick rename
+        if (context.attemptRename && sourceFile.renameTo(destinationFile)) {
+            Timber.d("move successful from '$sourceFile' to '$destinationFile'")
+            context.reportProgress(destinationFile.length())
+            return operationCompleted()
+        }
+
+        // copy the file, and delete the source.
+        // If the program crashes between "copy" and "delete", then the next time the operation is
+        // run, the duplicate source file will be deleted
+        copyFile(
+            source = sourceFile.file,
+            destination = destinationFile
+        )
+
+        if (!destinationFile.exists()) {
+            context.reportError(this, IllegalStateException("Failed to copy file to $destinationFile"))
+            return operationCompleted()
+        }
+
+        // We've moved the file, so can delete the source file
+        deleteFile(sourceFile.file)
+
+        Timber.d("move successful from '$sourceFile' to '$destinationFile'")
+        context.reportProgress(destinationFile.length())
+
+        return operationCompleted()
+    }
+
+    /**
+     * If the file content was equivalent, and the operation was handled:
+     *
+     * @return whether the files have the same content (in which case, the case was handled)
+     *
+     *
+     * * Deletes source, if it has same content as destination but distinct path
+     * * If source and destination deleted: report 0 progress (this is a no-op)
+     *
+     * @throws MigrateUserData.EquivalentFileException sourceFile == destinationFile
+     * @throws MigrateUserData.MissingDirectoryException if source or destination's directory is missing
+     */
+    private fun handledEquivalentFileContent(destinationExists: Boolean, context: MigrateUserData.MigrationContext): Boolean {
+        if (!sourceFile.contentEquals(destinationFile)) {
+            return false
+        }
+        if (!destinationExists) { // neither file exists
+            ensureParentDirectoriesExist() // check to confirm nothing went wrong (SD card removal)
+            Timber.d("no-op - source deleted: '$sourceFile'")
+            // since the file was deleted, we can't know the size. Report 0 file size
+            context.reportProgress(0)
+            return true
+        }
+
+        if (sourceFile.file.canonicalPath == destinationFile.canonicalPath) {
+            // Deletion is destructive if both files are the same
+            throw EquivalentFileException(sourceFile.file, destinationFile)
+        }
+
+        // Both files exist and are identical. Delete source + report size
+        context.execSafe(this) {
+            val fileSize = sourceFile.file.length()
+            deleteFile(sourceFile.file)
+            context.reportProgress(fileSize)
+        }
+        return true
+    }
+
+    /**
+     * @throws MigrateUserData.MissingDirectoryException if source or destination's directory is missing
+     */
+    private fun ensureParentDirectoriesExist() {
+        val deletedDirectories = listOf(sourceFile.file, destinationFile)
+            .map { it.parentFile!! }
+            .filter { !it.exists() }
+        if (deletedDirectories.any()) {
+            throw MigrateUserData.MissingDirectoryException(deletedDirectories)
+        }
+    }
+
+    @VisibleForTesting
+    internal fun copyFile(source: File, destination: File) {
+        Timber.d("copying: $source to $destination")
+        CompatHelper.getCompat().copyFile(source.canonicalPath, destination.canonicalPath)
+    }
+
+    @VisibleForTesting
+    internal fun deleteFile(file: File) {
+        Timber.d("deleting '$file'")
+        CompatHelper.getCompat().deleteFile(file)
+    }
+}

--- a/AnkiDroid/src/test/java/com/ichi2/anki/RobolectricTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/RobolectricTest.kt
@@ -253,7 +253,7 @@ open class RobolectricTest : CollectionGetter {
         }
     }
 
-    protected val targetContext: Context
+    val targetContext: Context
         get() {
             return try {
                 ApplicationProvider.getApplicationContext()
@@ -434,6 +434,7 @@ open class RobolectricTest : CollectionGetter {
         advanceRobolectricLooper()
         if (!completed[0]) { throw IllegalStateException(String.format("Task %s didn't finish in %d ms", task.javaClass, timeoutMs)) }
     }
+
     /**
      * Call to assume that <code>actual</code> satisfies the condition specified by <code>matcher</code>.
      * If not, the test halts and is ignored.

--- a/AnkiDroid/src/test/java/com/ichi2/anki/model/DiskFileTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/model/DiskFileTest.kt
@@ -1,0 +1,81 @@
+/*
+ *  Copyright (c) 2022 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.model
+
+import com.ichi2.testutils.createTransientDirectory
+import com.ichi2.testutils.createTransientFile
+import org.hamcrest.CoreMatchers.*
+import org.hamcrest.MatcherAssert.assertThat
+import org.junit.Test
+import java.io.File
+
+/**
+ * Tests for [DiskFile]
+ */
+class DiskFileTest {
+    @Test
+    fun passes_if_existing_file() {
+        val filePath = createTransientFile()
+        assertThat(
+            "DiskFile should work with valid file",
+            DiskFile.createInstance(filePath),
+            not(nullValue())
+        )
+    }
+
+    @Test
+    fun fails_if_does_not_exist() {
+        val dir = createTransientDirectory()
+        assertThat("DiskFile requires an existing file", DiskFile.createInstance(File(dir, "aa.txt")), nullValue())
+    }
+
+    @Test
+    fun fails_if_directory() {
+        val dir = createTransientDirectory()
+        assertThat("directory should not be a DiskFile", DiskFile.createInstance(dir), nullValue())
+    }
+
+    @Test
+    fun content_equal_different() {
+        val left = createTransientDiskFile("hello")
+        val right = createTransientFile("world")
+
+        assertThat("files should not be equal", left.contentEquals(right), equalTo(false))
+    }
+
+    @Test
+    fun if_both_equal_then_content_equal() {
+        val left = createTransientDiskFile("hello")
+        val right = createTransientFile("hello")
+
+        assertThat("files should be equal", left.contentEquals(right), equalTo(true))
+    }
+
+    @Test
+    fun content_equal_right_not_exist() {
+        // we don't need to worry about "left" not existing, as this is an instance method
+        val left = createTransientDiskFile("hello")
+        val right = File(createTransientDirectory(), "not_exist.txt")
+
+        assertThat("files should not be equal: right doesn't exist", left.contentEquals(right), equalTo(false))
+    }
+
+    private fun createTransientDiskFile(@Suppress("SameParameterValue") content: String): DiskFile {
+        val left = createTransientFile(content)
+        return DiskFile.createInstance(left)!!
+    }
+}

--- a/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/MockMigrationContext.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/MockMigrationContext.kt
@@ -1,0 +1,36 @@
+/*
+ *  Copyright (c) 2022 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.servicelayer.scopedstorage
+
+@Suppress("unused", "MemberVisibilityCanBePrivate")
+class MockMigrationContext : MigrateUserData.MigrationContext() {
+    /** set [logExceptions] to populate this property */
+    val exceptions = mutableListOf<Exception>()
+    var logExceptions: Boolean = false
+    val progress = mutableListOf<NumberOfBytes>()
+
+    override fun reportError(context: MigrateUserData.Operation, ex: Exception) {
+        if (!logExceptions) {
+            throw ex
+        }
+        exceptions.add(ex)
+    }
+
+    override fun reportProgress(transferred: NumberOfBytes) {
+        progress.add(transferred)
+    }
+}

--- a/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/MockMigrationContext.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/MockMigrationContext.kt
@@ -16,7 +16,6 @@
 
 package com.ichi2.anki.servicelayer.scopedstorage
 
-@Suppress("unused", "MemberVisibilityCanBePrivate")
 class MockMigrationContext : MigrateUserData.MigrationContext() {
     /** set [logExceptions] to populate this property */
     val exceptions = mutableListOf<Exception>()

--- a/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/MoveFileTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/MoveFileTest.kt
@@ -1,0 +1,293 @@
+/*
+ *  Copyright (c) 2022 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.servicelayer.scopedstorage
+
+import com.ichi2.anki.RobolectricTest
+import com.ichi2.anki.model.DiskFile
+import com.ichi2.anki.servicelayer.scopedstorage.MigrateUserData.*
+import com.ichi2.testutils.*
+import org.hamcrest.CoreMatchers.*
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers
+import org.hamcrest.Matchers.hasSize
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mockito
+import org.mockito.kotlin.any
+import org.mockito.kotlin.spy
+import org.robolectric.ParameterizedRobolectricTestRunner
+import org.robolectric.ParameterizedRobolectricTestRunner.Parameters
+import timber.log.Timber
+import java.io.File
+
+@RunWith(ParameterizedRobolectricTestRunner::class)
+class MoveFileTest(private val attemptRename: Boolean) : RobolectricTest() {
+    companion object {
+        @Suppress("unused")
+        @Parameters(name = "attemptRename = {0}")
+        @JvmStatic
+        fun initParameters(): Collection<Array<Any>> {
+            return listOf(arrayOf(true), arrayOf(false))
+        }
+    }
+
+    private val executionContext: MockMigrationContext = MockMigrationContext()
+
+    @Test
+    fun move_file_is_success() {
+        val source = addUntrackedMediaFile("hello-world", listOf("hello.txt"))
+        val destinationFile = File(ankiDroidFolder(), "hello.txt")
+        val size = source.length()
+
+        MoveFile(source, destinationFile)
+            .execute()
+
+        assertThat("source file should no longer exist", source.file.exists(), equalTo(false))
+        assertThat("destination file should exist", destinationFile.exists(), equalTo(true))
+
+        assertThat("content should be copied", getContent(destinationFile), equalTo("hello-world"))
+        assertProgressReported(size)
+    }
+
+    @Test
+    fun move_file_twice_throws_no_exception() {
+        // For example: if an operation was preempted by a file transfer for the Reviewer
+        val source = addUntrackedMediaFile("hello-world", listOf("hello.txt"))
+        val destinationFile = File(ankiDroidFolder(), "hello.txt")
+        val size = source.length()
+
+        MoveFile(source, destinationFile).execute()
+        MoveFile(source, destinationFile).execute()
+
+        assertThat("source file should no longer exist", source.file.exists(), equalTo(false))
+        assertThat("destination file should exist", destinationFile.exists(), equalTo(true))
+
+        assertThat("content should be copied", getContent(destinationFile), equalTo("hello-world"))
+        assertProgressReported(size)
+    }
+
+    @Test
+    fun if_copy_does_not_move_then_no_issues() {
+        if (attemptRename) return // not relevant
+        // if the move doesn't work, do not delete the source file
+        val source = addUntrackedMediaFile("hello-world", listOf("hello.txt"))
+        val destinationFile = File(ankiDroidFolder(), "hello.txt")
+
+        executionContext.logExceptions = true
+        spy(MoveFile(source, destinationFile)) {
+            Mockito.doAnswer { Timber.w("testing: do nothing on copy") }.`when`(it).copyFile(any(), any())
+        }
+            .execute()
+
+        assertThat("copy should have failed, destination should not exist", destinationFile.exists(), equalTo(false))
+        assertThat("source file should still exist", source.file.exists(), equalTo(true))
+
+        val exception = getSingleThrownException()
+        assertThat(exception.message, containsString("Failed to copy file to"))
+    }
+
+    @Test
+    fun copy_exception_does_not_cause_issues() {
+        if (attemptRename) return // not relevant
+        // if the move doesn't work, do not delete the source file
+        val source = addUntrackedMediaFile("hello-world", listOf("hello.txt"))
+        val destinationFile = File(ankiDroidFolder(), "hello.txt")
+
+        // this is correct - exception is not in a logged context
+        executionContext.logExceptions = true
+        val exception = assertThrows<TestException> {
+            spy(MoveFile(source, destinationFile)) {
+                Mockito.doThrow(TestException("test-copyFile()")).`when`(it).copyFile(any(), any())
+            }
+                .execute()
+        }
+        assertThat("copy should have failed, destination should not exist", destinationFile.exists(), equalTo(false))
+        assertThat("source file should still exist", source.file.exists(), equalTo(true))
+        assertThat("source content is unchanged", getContent(source.file), equalTo("hello-world"))
+        assertThat(exception.message, containsString("test-copyFile()"))
+    }
+
+    @Test
+    fun no_op_if_both_files_deleted_but_directory_exists() {
+        // if the move doesn't work, do not delete the source file
+        val source = addUntrackedMediaFile("hello-world", listOf("hello.txt"))
+        val destinationFile = File(ankiDroidFolder(), "hello.txt")
+        // we make a `DiskFile` which doesn't exist - class is in a bad state
+        source.file.delete()
+        assertThat("destination should not exist", destinationFile.exists(), equalTo(false))
+        assertThat("source file should not exist", source.file.exists(), equalTo(false))
+
+        MoveFile(source, destinationFile)
+            .execute()
+
+        assertThat("no exceptions should have been reported", executionContext.exceptions, Matchers.emptyCollectionOf(Exception::class.java))
+        assertThat("empty progress should have been reported", executionContext.progress.single(), equalTo(0L))
+    }
+
+    @Test
+    fun source_is_deleted_if_both_files_are_the_same() {
+        // This can happen if a power off occurs between copying the file, and cleaning up the source
+        val source = addUntrackedMediaFile("hello-world", listOf("hello.txt"))
+        val destinationFile = File(ankiDroidFolder(), "hello.txt")
+        source.file.copyTo(destinationFile, overwrite = false)
+
+        val size = source.length()
+
+        assertThat("destination should exist", destinationFile.exists(), equalTo(true))
+        assertThat("source file should exist", source.file.exists(), equalTo(true))
+
+        MoveFile(source, destinationFile)
+            .execute()
+
+        assertThat("source file should be deleted", source.file.exists(), equalTo(false))
+        assertThat("destination file should not be deleted", destinationFile.exists(), equalTo(true))
+        assertThat("progress was reported", executionContext.progress.single(), equalTo(size))
+    }
+
+    @Test
+    fun if_both_files_same_and_delete_throws_exception() {
+        val source = addUntrackedMediaFile("hello-world", listOf("hello.txt"))
+        val destinationFile = File(ankiDroidFolder(), "hello.txt")
+        source.file.copyTo(destinationFile, overwrite = false)
+
+        executionContext.logExceptions = true
+        spy(MoveFile(source, destinationFile)) {
+            Mockito.doThrow(TestException("test-deleteFile()")).`when`(it).deleteFile(any())
+        }
+            .execute()
+
+        assertThat("source should still exist", source.file.exists(), equalTo(true))
+        assertThat("destination should still exist", destinationFile.exists(), equalTo(true))
+
+        val ex = executionContext.exceptions.single()
+        assertThat(ex.message, containsString("test-deleteFile()"))
+        assertThat("no progress - file was not deleted", executionContext.progress, hasSize(0))
+    }
+
+    @Test
+    fun error_if_copied_file_already_exists_and_is_different() {
+        // This can happen if someone adds a file in the new directory before the old directory
+        // is copied
+        val source = addUntrackedMediaFile("hello-oo", listOf("hello.txt"))
+        val destinationFile = addUntrackedMediaFile("world", listOf("world.txt")).file
+
+        executionContext.logExceptions = true
+        MoveFile(source, destinationFile)
+            .execute()
+
+        val conflictException = getSingleExceptionOfType<FileConflictException>()
+        assertThat("source is correct", conflictException.source.file.canonicalPath, equalTo(source.file.canonicalPath))
+        assertThat("destination is correct", conflictException.destination.file.canonicalPath, equalTo(destinationFile.canonicalPath))
+
+        assertThat("source content is unchanged", getContent(source.file), equalTo("hello-oo"))
+        assertThat("destination content is unchanged", getContent(destinationFile), equalTo("world"))
+    }
+
+    @Test
+    fun error_if_source_and_destination_are_same() {
+        val source = addUntrackedMediaFile("hello-oo", listOf("hello.txt"))
+        val destinationFile = source.file
+
+        val ex = assertThrows<EquivalentFileException> {
+            MoveFile(source, destinationFile)
+                .execute()
+        }
+
+        assertThat("source still exists", source.file.exists())
+        assertThat(ex.message, containsString("Source and destination path are the same"))
+    }
+
+    @Test
+    fun error_if_both_files_do_not_exist_but_no_directory() {
+        val sourceDirectoryToDelete = createTransientDirectory("toDelete")
+        val destinationDirectoryToDelete = createTransientDirectory("toDelete")
+        val sourceNotExist = DiskFile.createInstanceUnsafe(File(sourceDirectoryToDelete, "deletedFolder-in.txt"))
+        val destinationFileNotExist = File(destinationDirectoryToDelete, "deletedFolder-out.txt")
+        assertThat(
+            "deletion should work",
+            sourceDirectoryToDelete.delete() && destinationDirectoryToDelete.delete(),
+            equalTo(true)
+        )
+
+        val exception = assertThrows<MissingDirectoryException> {
+            MoveFile(sourceNotExist, destinationFileNotExist)
+                .execute()
+        }
+
+        assertThat("2 missing directories expected", exception.directories, hasSize(2))
+        assertThat("source was logged", exception.directories[0], equalTo(sourceDirectoryToDelete))
+        assertThat("destination was logged", exception.directories[1], equalTo(destinationDirectoryToDelete))
+    }
+
+    @Test
+    fun duplicate_file_is_cleaned_up_on_rerun() {
+        if (attemptRename) return // not relevant
+        // if a crash/"delete" fails, we want to ensure the duplicate file is cleaned up
+        val source = addUntrackedMediaFile("hello-world", listOf("hello.txt"))
+        val destinationFile = File(ankiDroidFolder(), "hello.txt")
+        val size = source.length()
+
+        executionContext.logExceptions = true
+        assertThrows<TestException> {
+            spy(MoveFile(source, destinationFile)) {
+                Mockito.doThrow(TestException("test-deleteFile()")).`when`(it).deleteFile(any())
+            }
+                .execute()
+        }
+
+        Timber.d("delete should have failed")
+        assertThat("source exists", source.file.exists(), equalTo(true))
+        assertThat("destination exists", destinationFile.exists(), equalTo(true))
+
+        MoveFile(source, destinationFile)
+            .execute()
+
+        // delete now works, BUT the file was already copied
+
+        assertThat("source file should no longer exist", source.file.exists(), equalTo(false))
+        assertThat("destination file should exist", destinationFile.exists(), equalTo(true))
+
+        assertThat("content should be copied", getContent(destinationFile), equalTo("hello-world"))
+        assertProgressReported(size)
+    }
+
+    /** Asserts that 1 element of progress of the provided size was reported */
+    private fun assertProgressReported(expectedSize: Long) {
+        val progress = executionContext.progress
+        assertThat("only one progress report expected", progress.size, equalTo(1))
+        assertThat("unexpected progress", progress.single(), equalTo(expectedSize))
+    }
+
+    private fun MoveFile.execute() {
+        executionContext.attemptRename = attemptRename
+        this.execute(executionContext)
+    }
+
+    private fun getContent(destinationFile: File) = FileUtil.readSingleLine(destinationFile)
+
+    private fun getSingleThrownException(): Exception {
+        val exceptions = executionContext.exceptions
+        assertThat("a single exception should be thrown", exceptions, hasSize(1))
+        return exceptions.single()
+    }
+
+    private inline fun <reified T : Exception> getSingleExceptionOfType(): T {
+        val exception = getSingleThrownException()
+        assertThat(exception, instanceOf(FileConflictException::class.java))
+        return exception as T
+    }
+}

--- a/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/Utils.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/Utils.kt
@@ -1,0 +1,50 @@
+/*
+ *  Copyright (c) 2022 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.servicelayer.scopedstorage
+
+import androidx.annotation.CheckResult
+import com.ichi2.anki.RobolectricTest
+import com.ichi2.anki.model.DiskFile
+import com.ichi2.libanki.Media
+import org.acra.util.IOUtils
+import java.io.File
+
+/** Adds a media file to collection.media which [Media] is not aware of */
+@CheckResult
+internal fun addUntrackedMediaFile(media: Media, content: String, path: List<String>): DiskFile {
+    val file = convertPathToMediaFile(media, path)
+    File(file.parent!!).mkdirs()
+    IOUtils.writeStringToFile(file, content)
+    return DiskFile.createInstance(file)!!
+}
+
+private fun convertPathToMediaFile(media: Media, path: List<String>): File {
+    val mutablePath = ArrayDeque(path)
+    var file = File(media.dir())
+    while (mutablePath.any()) {
+        file = File(file, mutablePath.removeFirst())
+    }
+    return file
+}
+
+/** A [File] reference to the AnkiDroid directory of the current collection */
+internal fun RobolectricTest.ankiDroidFolder() = File(col.path).parentFile!!
+
+/** Adds a file to collection.media which [Media] is not aware of */
+@CheckResult
+internal fun RobolectricTest.addUntrackedMediaFile(content: String, path: List<String>): DiskFile =
+    addUntrackedMediaFile(col.media, content, path)

--- a/AnkiDroid/src/test/java/com/ichi2/testutils/FileSystemUtils.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/testutils/FileSystemUtils.kt
@@ -100,7 +100,6 @@ object FileSystemUtils {
  * Returns a new directory in the OS's default temp directory, using the given [prefix] to generate its name.
  * This directory is deleted on exit
  */
-@Suppress("unused")
 fun createTransientDirectory(prefix: String? = null): File =
     createTempDirectory(prefix = prefix).let {
         val file = File(it.pathString)
@@ -109,7 +108,6 @@ fun createTransientDirectory(prefix: String? = null): File =
     }
 
 /** Returns a temp file with [content]. The file is deleted on exit. */
-@Suppress("unused")
 fun createTransientFile(content: String = ""): File =
     File(kotlin.io.path.createTempFile().pathString).also {
         it.deleteOnExit()

--- a/AnkiDroid/src/test/java/com/ichi2/testutils/FileSystemUtils.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/testutils/FileSystemUtils.kt
@@ -17,8 +17,11 @@
 package com.ichi2.testutils
 
 import androidx.annotation.CheckResult
+import org.acra.util.IOUtils
 import timber.log.Timber
 import java.io.File
+import kotlin.io.path.createTempDirectory
+import kotlin.io.path.pathString
 
 /** Utilities which assist testing changes to files/directories */
 @Suppress("unused")
@@ -92,3 +95,23 @@ object FileSystemUtils {
         return sb.toString()
     }
 }
+
+/**
+ * Returns a new directory in the OS's default temp directory, using the given [prefix] to generate its name.
+ * This directory is deleted on exit
+ */
+@Suppress("unused")
+fun createTransientDirectory(prefix: String? = null): File =
+    createTempDirectory(prefix = prefix).let {
+        val file = File(it.pathString)
+        file.deleteOnExit()
+        return@let file
+    }
+
+/** Returns a temp file with [content]. The file is deleted on exit. */
+@Suppress("unused")
+fun createTransientFile(content: String = ""): File =
+    File(kotlin.io.path.createTempFile().pathString).also {
+        it.deleteOnExit()
+        IOUtils.writeStringToFile(it, content)
+    }

--- a/AnkiDroid/src/test/java/com/ichi2/testutils/FileUtil.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/testutils/FileUtil.kt
@@ -1,0 +1,55 @@
+/*
+ *  Copyright (c) 2022 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.testutils
+
+import com.ichi2.anki.model.DiskFile
+import java.io.File
+import java.util.*
+
+object FileUtil {
+    /**
+     * Reads the single line of content in a file
+     * @return The single line of the file, as a string
+     * @throws IllegalArgumentException if file has more than one line
+     * @throws IllegalArgumentException if file does not exist
+     * @throws NoSuchElementException file has no lines
+     * */
+    fun readSingleLine(base: File, vararg path: String): String {
+        var file = base
+        for (pathSegment in path) {
+            file = File(file, pathSegment)
+        }
+        if (!file.exists()) {
+            throw IllegalArgumentException("path: $file does not exist")
+        }
+
+        return readAllLines(file).single()
+    }
+
+    /**
+     * Sequence of the lines of file
+     */
+    private fun readAllLines(file: File) = sequence {
+        Scanner(file).use { scanner ->
+            while (scanner.hasNextLine()) {
+                yield(scanner.nextLine().toString())
+            }
+        }
+    }
+}
+
+fun DiskFile.length(): Long = this.file.length()

--- a/AnkiDroid/src/test/java/com/ichi2/testutils/TestException.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/testutils/TestException.kt
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2021 David Allison <davidallisongithub@gmail.com>
+ *  Copyright (c) 2022 David Allison <davidallisongithub@gmail.com>
  *
  *  This program is free software; you can redistribute it and/or modify it under
  *  the terms of the GNU General Public License as published by the Free Software
@@ -16,15 +16,8 @@
 
 package com.ichi2.testutils
 
-/** assertThrows, allowing for lambda shorthand
- *
- * ```kotlin
- * val exception = assertThrows<IllegalStateException> {
- *     foo()
- * }
- * ```
- *
- * @see TestException if a test-only exception is needed
- * */
-inline fun <reified T : Throwable> assertThrows(r: Runnable): T =
-    AnkiAssert.assertThrows(r, T::class.java)
+/**
+ * An exception to be thrown by tests
+ * Ensures that an actual exception is not mistaken for an exception we want to catch
+ */
+class TestException(message: String) : RuntimeException(message)


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
When performing a scoped storage migration, we need to move user data in a background task, to ensure that a user will not be incentivised to uninstall the app when a slow migration is taking place.

We need to preempt this operation, for example to display files in the reviewer which have not yet been copied

We are very likely to be copying files across mount points, so `.renameTo` won't work, and we need to perform a manual copy.

This PR produces:

* `DiskFile` - an abstraction over `File` which must exist (and be a file) - name TBC
* `MigrateUserData` - holder for general concepts within user data migration
  * `MigrationContext` - Progress reporting, and allows logic based on exceptions occurring during an operation
  * `Operation` - An atomic unit of work, these should be small to allow preemption and may produce smaller operations to perform
* `MoveFile` - the `Operation` for moving a file

## Review Goals
* Ensure that a computer crash on each line of `MoveFile` would keep the class in a consistent state
* Ensure unit tests are thorough
* Nitpick this to the N-th degree. Especially if documentation is unclear

## Issue
#5304

## How Has This Been Tested?

Unit tests

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
