### PR TITLE
chore(copyright): add copyright headers to androidTest files

### DIFF
--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/ACRATest.java
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/ACRATest.java
@@ -1,3 +1,20 @@
+/***************************************************************************************
+ *                                                                                      *
+ * Copyright (c) 2018 Mike Hardy <github@mikehardy.net>                                 *
+ *                                                                                      *
+ * This program is free software; you can redistribute it and/or modify it under        *
+ * the terms of the GNU General Public License as published by the Free Software        *
+ * Foundation; either version 3 of the License, or (at your option) any later           *
+ * version.                                                                             *
+ *                                                                                      *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *                                                                                      *
+ * You should have received a copy of the GNU General Public License along with         *
+ * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ ****************************************************************************************/
+
 package com.ichi2.anki.tests;
 
 import android.Manifest;

--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/CollectionTest.java
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/CollectionTest.java
@@ -1,3 +1,20 @@
+/***************************************************************************************
+ *                                                                                      *
+ * Copyright (c) 2015 Timothy Rae <perceptualchaos2@gmail.com>                          *
+ *                                                                                      *
+ * This program is free software; you can redistribute it and/or modify it under        *
+ * the terms of the GNU General Public License as published by the Free Software        *
+ * Foundation; either version 3 of the License, or (at your option) any later           *
+ * version.                                                                             *
+ *                                                                                      *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *                                                                                      *
+ * You should have received a copy of the GNU General Public License along with         *
+ * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ ****************************************************************************************/
+
 package com.ichi2.anki.tests;
 
 import android.Manifest;

--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/libanki/DBTest.java
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/libanki/DBTest.java
@@ -1,3 +1,20 @@
+/***************************************************************************************
+ *                                                                                      *
+ * Copyright (c) 2018 Mike Hardy <github@mikehardy.net>                                 *
+ *                                                                                      *
+ * This program is free software; you can redistribute it and/or modify it under        *
+ * the terms of the GNU General Public License as published by the Free Software        *
+ * Foundation; either version 3 of the License, or (at your option) any later           *
+ * version.                                                                             *
+ *                                                                                      *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *                                                                                      *
+ * You should have received a copy of the GNU General Public License along with         *
+ * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ ****************************************************************************************/
+
 package com.ichi2.anki.tests.libanki;
 
 import android.Manifest;

--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/libanki/HttpTest.java
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/libanki/HttpTest.java
@@ -1,3 +1,20 @@
+/***************************************************************************************
+ *                                                                                      *
+ * Copyright (c) 2018 Mike Hardy <github@mikehardy.net>                                 *
+ *                                                                                      *
+ * This program is free software; you can redistribute it and/or modify it under        *
+ * the terms of the GNU General Public License as published by the Free Software        *
+ * Foundation; either version 3 of the License, or (at your option) any later           *
+ * version.                                                                             *
+ *                                                                                      *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *                                                                                      *
+ * You should have received a copy of the GNU General Public License along with         *
+ * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ ****************************************************************************************/
+
 package com.ichi2.anki.tests.libanki;
 
 import android.Manifest;

--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/libanki/ModelTest.java
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/libanki/ModelTest.java
@@ -1,3 +1,20 @@
+/***************************************************************************************
+ *                                                                                      *
+ * Copyright (c) 2020 Arthur Milchior <arthur@milchior.fr>                              *
+ *                                                                                      *
+ * This program is free software; you can redistribute it and/or modify it under        *
+ * the terms of the GNU General Public License as published by the Free Software        *
+ * Foundation; either version 3 of the License, or (at your option) any later           *
+ * version.                                                                             *
+ *                                                                                      *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *                                                                                      *
+ * You should have received a copy of the GNU General Public License along with         *
+ * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ ****************************************************************************************/
+
 package com.ichi2.anki.tests.libanki;
 
 import android.os.Build;

--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/libanki/RetryRule.java
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/libanki/RetryRule.java
@@ -1,3 +1,20 @@
+/***************************************************************************************
+ *                                                                                      *
+ * Copyright (c) 2018 Mike Hardy <github@mikehardy.net>                                 *
+ *                                                                                      *
+ * This program is free software; you can redistribute it and/or modify it under        *
+ * the terms of the GNU General Public License as published by the Free Software        *
+ * Foundation; either version 3 of the License, or (at your option) any later           *
+ * version.                                                                             *
+ *                                                                                      *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *                                                                                      *
+ * You should have received a copy of the GNU General Public License along with         *
+ * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ ****************************************************************************************/
+
 package com.ichi2.anki.tests.libanki;
 
 import org.junit.rules.TestRule;


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
#10327 pointed out there were missing copyright headers in androidTest directory, mostly mine

@david-allison-1 we should merge this then you should rebase #10327 on it I think?


## Approach
- I added my copyright header where missing
- one object was from @timrae but all his other work has been with the headers, seems sensible to add this one
- @Arthur-Milchior had one object (ModelTest) added in 2020 missing header, I copied a different header from him from 2020 and added it

## How Has This Been Tested?
They are code comments

## Learning (optional, can help others)
Managing copyright is a PITA