### PR TITLE
Keep image file names

### DIFF
--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/libanki/MediaTest.java
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/libanki/MediaTest.java
@@ -90,7 +90,7 @@ public class MediaTest extends InstrumentedTest {
         os = new FileOutputStream(path, false);
         os.write("world".getBytes());
         os.close();
-        assertEquals("foo (1).jpg", mTestCol.getMedia().addFile(path));
+        assertNotEquals("foo.jpg", mTestCol.getMedia().addFile(path));
     }
 
     @Test

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -1352,6 +1352,10 @@ public class NoteEditor extends AnkiActivity implements
                     MultimediaEditableNote note = getCurrentMultimediaEditableNote(col);
                     note.setField(index, field);
                     FieldEditText fieldEditText = mEditFields.get(index);
+                    // Import field media
+                    // This goes before setting formattedValue to update
+                    // media paths with the checksum when they have the same name
+                    NoteService.importMediaToDirectory(col, field);
                     // Completely replace text for text fields (because current text was passed in)
                     String formattedValue = field.getFormattedValue();
                     if (field.getType() == EFieldType.TEXT) {
@@ -1361,8 +1365,6 @@ public class NoteEditor extends AnkiActivity implements
                     else if (fieldEditText.getText() != null) {
                         insertStringInField(fieldEditText, formattedValue);
                     }
-                    //DA - I think we only want to save the field here, not the note.
-                    NoteService.saveMedia(col, note);
                     mChanged = true;
                 }
                 break;

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicImageFieldController.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicImageFieldController.java
@@ -297,6 +297,10 @@ public class BasicImageFieldController extends FieldControllerBase implements IF
         return File.createTempFile("img", "." + extension, storageDir);
     }
 
+    private File createCachedFile(@NonNull String filename) throws IOException {
+        return new File(mAnkiCacheDirectory, filename);
+    }
+
 
     private void drawUIComponents(Context context) {
         DisplayMetrics metrics = getDisplayMetrics();
@@ -494,11 +498,10 @@ public class BasicImageFieldController extends FieldControllerBase implements IF
             showSomethingWentWrong();
             return null;
         }
-        String uriFileExtension = uriFileName.substring(uriFileName.lastIndexOf('.') + 1);
         try {
-            internalFile = createNewCacheImageFile(uriFileExtension);
+            internalFile = createCachedFile(uriFileName);
         } catch (IOException e) {
-            Timber.w(e, "internalizeUri() failed to create new file with extension %s", uriFileExtension);
+            Timber.w(e, "internalizeUri() failed to create new file with name %s", uriFileName);
             showSomethingWentWrong();
             return null;
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/NoteService.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/NoteService.kt
@@ -150,7 +150,8 @@ object NoteService {
      *
      * @param field
      */
-    private fun importMediaToDirectory(col: com.ichi2.libanki.Collection, field: IField?) {
+    @JvmStatic
+    fun importMediaToDirectory(col: com.ichi2.libanki.Collection, field: IField?) {
         var tmpMediaPath: String? = null
         when (field!!.type) {
             EFieldType.AUDIO_RECORDING, EFieldType.MEDIA_CLIP -> tmpMediaPath = field.audioPath
@@ -166,6 +167,8 @@ object NoteService {
                 if (inFile.exists() && inFile.length() > 0) {
                     val fname = col.media.addFile(inFile)
                     val outFile = File(col.media.dir(), fname)
+                    // Update imagePath in case the file name wasn't unique
+                    field.imagePath = fname
                     if (field.hasTemporaryMedia() && outFile.absolutePath != tmpMediaPath) {
                         // Delete original
                         inFile.delete()

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Media.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Media.java
@@ -278,15 +278,8 @@ public class Media {
             if (Utils.fileChecksum(path).equals(csum)) {
                 return fname;
             }
-            // otherwise, increment the index in the filename
-            Pattern reg = Pattern.compile(" \\((\\d+)\\)$");
-            Matcher m = reg.matcher(root);
-            if (!m.find()) {
-                root = root + " (1)";
-            } else {
-                int n = Integer.parseInt(m.group(1));
-                root = String.format(Locale.US, " (%d)", n + 1);
-            }
+            // otherwise, increment the checksum in the filename
+            root = root + "-" + csum;
         }
     }
 


### PR DESCRIPTION
## Purpose / Description
Keep the selected images original file names or appends its checksum in it if not unique, like Anki desktop does.

## Fixes
Fixes #9116 

## Approach
- Most of the descriptions is [here](https://github.com/ankidroid/Anki-Android/issues/9116#issuecomment-1035609316). 
- To update the `<img>` tag I just put the field media import before text formatting, so it's possible to update the `ImagePath` at [importMediaToDirectory()](https://github.com/BrayanDSO/Anki-Android/blob/keepImgNames/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/NoteService.kt#L171) if changed.
- Stopped using [saveMedia()](https://github.com/BrayanDSO/Anki-Android/blob/keepImgNames/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/NoteService.kt#L122) because it doesn't make sense to loop all fields just to save the edited one.

## How Has This Been Tested?

Couldn't run the automated tests or build new ones because of #8482

Tested it manually with Android Studio Emulator (API 32, Pixel 2) and on my android phone (Samsung Galaxy Note 10 Lite SM-N770F/DS)

Procedure:
1. Attach an image
2. Check if file name was kept
3. Attach other image with the same file name
4. Check if checksum was appended to its name
5. Attach the first image again
6. Check if file name was kept (checksum shouldn't be appended when reading it)

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

## Personal considerations
1. As I've already said on my approach, by changing [internalizeUri()](https://github.com/ankidroid/Anki-Android/blob/v2.16alpha42/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicImageFieldController.java#L451), drawings file names now keep their original file names too. Since going from `imgRandomNumberSequence.extension`  to `unixtimestamp.extension` doesn't matter much IMO, I kept it to keep things simple