### PR TITLE
feat(media-import): Import video

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -75,7 +75,7 @@ import com.ichi2.anki.dialogs.tags.TagsDialogListener;
 import com.ichi2.anki.exception.ConfirmModSchemaException;
 import com.ichi2.anki.multimediacard.IMultimediaEditableNote;
 import com.ichi2.anki.multimediacard.activity.MultimediaEditFieldActivity;
-import com.ichi2.anki.multimediacard.fields.AudioClipField;
+import com.ichi2.anki.multimediacard.fields.MediaClipField;
 import com.ichi2.anki.multimediacard.fields.AudioRecordingField;
 import com.ichi2.anki.multimediacard.fields.EFieldType;
 import com.ichi2.anki.multimediacard.fields.IField;
@@ -1557,7 +1557,7 @@ public class NoteEditor extends AnkiActivity implements
                         return true;
                     } else if (itemId == R.id.menu_multimedia_audio_clip) {
                         Timber.i("NoteEditor:: Add audio clip button pressed");
-                        startMultimediaFieldEditorForField(index, new AudioClipField());
+                        startMultimediaFieldEditorForField(index, new MediaClipField());
                         return true;
                     } else if (itemId == R.id.menu_multimedia_photo) {
                         Timber.i("NoteEditor:: Add image button pressed");

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/activity/MultimediaEditFieldActivity.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/activity/MultimediaEditFieldActivity.java
@@ -37,7 +37,7 @@ import com.ichi2.anki.AnkiActivity;
 import com.ichi2.anki.R;
 import com.ichi2.anki.UIUtils;
 import com.ichi2.anki.multimediacard.IMultimediaEditableNote;
-import com.ichi2.anki.multimediacard.fields.AudioClipField;
+import com.ichi2.anki.multimediacard.fields.MediaClipField;
 import com.ichi2.anki.multimediacard.fields.AudioRecordingField;
 import com.ichi2.anki.multimediacard.fields.BasicControllerFactory;
 import com.ichi2.anki.multimediacard.fields.BasicImageFieldController;
@@ -215,7 +215,7 @@ public class MultimediaEditFieldActivity extends AnkiActivity
         getMenuInflater().inflate(R.menu.activity_edit_text, menu);
         menu.findItem(R.id.multimedia_edit_field_to_text).setVisible(mField.getType() != EFieldType.TEXT);
         menu.findItem(R.id.multimedia_edit_field_to_audio).setVisible(mField.getType() != EFieldType.AUDIO_RECORDING);
-        menu.findItem(R.id.multimedia_edit_field_to_audio_clip).setVisible(mField.getType() != EFieldType.AUDIO_CLIP);
+        menu.findItem(R.id.multimedia_edit_field_to_audio_clip).setVisible(mField.getType() != EFieldType.MEDIA_CLIP);
         menu.findItem(R.id.multimedia_edit_field_to_image).setVisible(mField.getType() != EFieldType.IMAGE);
         return true;
     }
@@ -299,8 +299,8 @@ public class MultimediaEditFieldActivity extends AnkiActivity
     }
 
     protected void toAudioClipField() {
-        if (mField.getType() != EFieldType.AUDIO_CLIP) {
-            ChangeUIRequest request = ChangeUIRequest.uiChange(new AudioClipField());
+        if (mField.getType() != EFieldType.MEDIA_CLIP) {
+            ChangeUIRequest request = ChangeUIRequest.uiChange(new MediaClipField());
             recreateEditingUi(request);
         }
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicAudioClipFieldController.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicAudioClipFieldController.kt
@@ -33,6 +33,7 @@ import com.ichi2.anki.R
 import com.ichi2.anki.UIUtils.showThemedToast
 import com.ichi2.compat.CompatHelper
 import com.ichi2.ui.FixedTextView
+import com.ichi2.utils.ExceptionUtil.executeSafe
 import com.ichi2.utils.KotlinCleanup
 import timber.log.Timber
 import java.io.File
@@ -90,14 +91,8 @@ class BasicAudioClipFieldController : FieldControllerBase(), IFieldController {
     @KotlinCleanup("make data non-null")
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
         if (resultCode != Activity.RESULT_CANCELED && requestCode == ACTIVITY_SELECT_AUDIO_CLIP) {
-            try {
+            executeSafe(mActivity, "handleAudioSelection:unhandled") {
                 handleAudioSelection(data!!)
-            } catch (e: Exception) {
-                AnkiDroidApp.sendExceptionReport(e, "handleAudioSelection:unhandled")
-                showThemedToast(
-                    AnkiDroidApp.getInstance().applicationContext,
-                    AnkiDroidApp.getInstance().getString(R.string.multimedia_editor_something_wrong), true
-                )
             }
         }
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicAudioClipFieldController.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicAudioClipFieldController.kt
@@ -91,18 +91,18 @@ class BasicAudioClipFieldController : FieldControllerBase(), IFieldController {
     @KotlinCleanup("make data non-null")
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
         if (resultCode != Activity.RESULT_CANCELED && requestCode == ACTIVITY_SELECT_AUDIO_CLIP) {
-            executeSafe(mActivity, "handleAudioSelection:unhandled") {
-                handleAudioSelection(data!!)
+            executeSafe(mActivity, "handleMediaSelection:unhandled") {
+                handleMediaSelection(data!!, "ankidroid_audioclip_")
             }
         }
     }
 
-    private fun handleAudioSelection(data: Intent) {
+    private fun handleMediaSelection(data: Intent, clipNamePrefix: String) {
         val selectedClip = data.data
 
         // Get information about the selected document
         val queryColumns = arrayOf(MediaStore.MediaColumns.DISPLAY_NAME, MediaStore.MediaColumns.SIZE, MediaStore.MediaColumns.MIME_TYPE)
-        var audioClipFullNameParts: Array<String>
+        var mediaClipFullNameParts: Array<String>
         mActivity.contentResolver.query(selectedClip!!, queryColumns, null, null, null).use { cursor ->
             if (cursor == null) {
                 showThemedToast(
@@ -112,19 +112,19 @@ class BasicAudioClipFieldController : FieldControllerBase(), IFieldController {
                 return
             }
             cursor.moveToFirst()
-            var audioClipFullName = cursor.getString(0)
-            audioClipFullName = checkFileName(audioClipFullName)
-            audioClipFullNameParts = audioClipFullName.split("\\.").toTypedArray()
-            if (audioClipFullNameParts.size < 2) {
-                audioClipFullNameParts = try {
-                    Timber.i("Audio clip name does not have extension, using second half of mime type")
-                    arrayOf(audioClipFullName, cursor.getString(2).split("/").toTypedArray()[1])
+            var mediaClipFullName = cursor.getString(0)
+            mediaClipFullName = checkFileName(mediaClipFullName)
+            mediaClipFullNameParts = mediaClipFullName.split("\\.").toTypedArray()
+            if (mediaClipFullNameParts.size < 2) {
+                mediaClipFullNameParts = try {
+                    Timber.i("Media clip name does not have extension, using second half of mime type")
+                    arrayOf(mediaClipFullName, cursor.getString(2).split("/").toTypedArray()[1])
                 } catch (e: Exception) {
                     Timber.w(e)
                     // This code is difficult to stabilize - it is not clear how to handle files with no extension
                     // and apparently we may fail to get MIME_TYPE information - in that case we will gather information
                     // about what people are experiencing in the real world and decide later, but without crashing at least
-                    AnkiDroidApp.sendExceptionReport(e, "Audio Clip addition failed. Name " + audioClipFullName + " / cursor mime type column type " + cursor.getType(2))
+                    AnkiDroidApp.sendExceptionReport(e, "Media Clip addition failed. Name " + mediaClipFullName + " / cursor mime type column type " + cursor.getType(2))
                     showThemedToast(
                         AnkiDroidApp.getInstance().applicationContext,
                         AnkiDroidApp.getInstance().getString(R.string.multimedia_editor_something_wrong), true
@@ -138,14 +138,14 @@ class BasicAudioClipFieldController : FieldControllerBase(), IFieldController {
         val clipCopy: File
         try {
             clipCopy = File.createTempFile(
-                "ankidroid_audioclip_" + audioClipFullNameParts[0],
-                "." + audioClipFullNameParts[1],
+                clipNamePrefix + mediaClipFullNameParts[0],
+                "." + mediaClipFullNameParts[1],
                 storingDirectory
             )
-            Timber.d("audio clip picker file path is: %s", clipCopy.absolutePath)
+            Timber.d("media clip picker file path is: %s", clipCopy.absolutePath)
         } catch (e: Exception) {
-            Timber.e(e, "Could not create temporary audio file. ")
-            AnkiDroidApp.sendExceptionReport(e, "handleAudioSelection:tempFile")
+            Timber.e(e, "Could not create temporary media file. ")
+            AnkiDroidApp.sendExceptionReport(e, "handleMediaSelection:tempFile")
             showThemedToast(
                 AnkiDroidApp.getInstance().applicationContext,
                 AnkiDroidApp.getInstance().getString(R.string.multimedia_editor_something_wrong), true
@@ -165,8 +165,8 @@ class BasicAudioClipFieldController : FieldControllerBase(), IFieldController {
                 tvAudioClip!!.visibility = View.VISIBLE
             }
         } catch (e: Exception) {
-            Timber.e(e, "Unable to copy audio file from ContentProvider")
-            AnkiDroidApp.sendExceptionReport(e, "handleAudioSelection:copyFromProvider")
+            Timber.e(e, "Unable to copy media file from ContentProvider")
+            AnkiDroidApp.sendExceptionReport(e, "handleMediaSelection:copyFromProvider")
             showThemedToast(
                 AnkiDroidApp.getInstance().applicationContext,
                 AnkiDroidApp.getInstance().getString(R.string.multimedia_editor_something_wrong), true
@@ -188,17 +188,18 @@ class BasicAudioClipFieldController : FieldControllerBase(), IFieldController {
 
     companion object {
         private const val ACTIVITY_SELECT_AUDIO_CLIP = 1
+        private const val ACTIVITY_SELECT_VIDEO_CLIP = 2
 
         /**
          * This method replaces any character that isn't a number, letter or underscore with underscore in file name.
          * This method doesn't check that file name is valid or not it simply operates on all file name.
-         * @param audioClipFullName name of the file.
+         * @param mediaClipFullName name of the file.
          * @return file name which is valid.
          */
         @JvmStatic
         @VisibleForTesting
-        fun checkFileName(audioClipFullName: String): String {
-            return audioClipFullName.replace("[^\\w.]+".toRegex(), "_")
+        fun checkFileName(mediaClipFullName: String): String {
+            return mediaClipFullName.replace("[^\\w.]+".toRegex(), "_")
         }
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicAudioClipFieldController.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicAudioClipFieldController.kt
@@ -51,7 +51,7 @@ class BasicAudioClipFieldController : FieldControllerBase(), IFieldController {
         // #9639: .opus is application/octet-stream in API 26,
         // requires a workaround as we don't want to enable application/octet-stream by default
         val btnLibrary = Button(mActivity)
-        btnLibrary.text = mActivity.getText(R.string.multimedia_editor_image_field_editing_library)
+        btnLibrary.text = mActivity.getText(R.string.multimedia_editor_import_audio)
         btnLibrary.setOnClickListener {
             openChooserPrompt(
                 "audio/*",
@@ -61,6 +61,18 @@ class BasicAudioClipFieldController : FieldControllerBase(), IFieldController {
             )
         }
         layout!!.addView(btnLibrary, ViewGroup.LayoutParams.MATCH_PARENT)
+        val btnVideo = Button(mActivity).apply {
+            text = mActivity.getText(R.string.multimedia_editor_import_video)
+            setOnClickListener {
+                openChooserPrompt(
+                    "video/*",
+                    emptyArray(),
+                    R.string.multimedia_editor_popup_video_clip,
+                    ACTIVITY_SELECT_VIDEO_CLIP
+                )
+            }
+        }
+        layout.addView(btnVideo, ViewGroup.LayoutParams.MATCH_PARENT)
         tvAudioClip = FixedTextView(mActivity)
         if (mField.audioPath == null) {
             (tvAudioClip as FixedTextView).setVisibility(View.GONE)
@@ -75,10 +87,9 @@ class BasicAudioClipFieldController : FieldControllerBase(), IFieldController {
         val allowAllFiles = AnkiDroidApp.getSharedPrefs(this.mActivity).getBoolean("mediaImportAllowAllFiles", false)
         val i = Intent()
         i.type = if (allowAllFiles) "*/*" else initialMimeType
-        if (!allowAllFiles) {
+        if (!allowAllFiles && extraMimeTypes.any()) {
             // application/ogg takes precedence over "*/*" for application/octet-stream
             // so don't add it if we're want */*
-            val extraMimeTypes = extraMimeTypes // #9226 allows ogg on Android 8
             i.putExtra(Intent.EXTRA_MIME_TYPES, extraMimeTypes)
         }
         i.action = Intent.ACTION_GET_CONTENT
@@ -93,6 +104,11 @@ class BasicAudioClipFieldController : FieldControllerBase(), IFieldController {
         if (resultCode != Activity.RESULT_CANCELED && requestCode == ACTIVITY_SELECT_AUDIO_CLIP) {
             executeSafe(mActivity, "handleMediaSelection:unhandled") {
                 handleMediaSelection(data!!, "ankidroid_audioclip_")
+            }
+        }
+        if (resultCode != Activity.RESULT_CANCELED && requestCode == ACTIVITY_SELECT_VIDEO_CLIP) {
+            executeSafe(mActivity, "handleMediaSelection:unhandled") {
+                handleMediaSelection(data!!, "ankidroid_videoclip_")
             }
         }
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicAudioRecordingFieldController.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicAudioRecordingFieldController.java
@@ -32,6 +32,8 @@ import com.ichi2.utils.UiUtil;
 
 import java.io.File;
 
+import androidx.annotation.NonNull;
+
 public class BasicAudioRecordingFieldController extends FieldControllerBase implements IFieldController {
 
     /**
@@ -42,7 +44,7 @@ public class BasicAudioRecordingFieldController extends FieldControllerBase impl
 
 
     @Override
-    public void createUI(Context context, LinearLayout layout) {
+    public void createUI(@NonNull Context context, LinearLayout layout) {
         String origAudioPath = mField.getAudioPath();
 
         boolean bExist = false;

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicControllerFactory.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicControllerFactory.kt
@@ -25,7 +25,7 @@ class BasicControllerFactory private constructor() : IControllerFactory {
             EFieldType.TEXT -> BasicTextFieldController()
             EFieldType.IMAGE -> BasicImageFieldController()
             EFieldType.AUDIO_RECORDING -> BasicAudioRecordingFieldController()
-            EFieldType.AUDIO_CLIP -> BasicAudioClipFieldController()
+            EFieldType.MEDIA_CLIP -> BasicMediaClipFieldController()
             else -> null
         }
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicMediaClipFieldController.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicMediaClipFieldController.kt
@@ -130,7 +130,7 @@ class BasicMediaClipFieldController : FieldControllerBase(), IFieldController {
             cursor.moveToFirst()
             var mediaClipFullName = cursor.getString(0)
             mediaClipFullName = checkFileName(mediaClipFullName)
-            mediaClipFullNameParts = mediaClipFullName.split("\\.").toTypedArray()
+            mediaClipFullNameParts = mediaClipFullName.split(".").toTypedArray()
             if (mediaClipFullNameParts.size < 2) {
                 mediaClipFullNameParts = try {
                     Timber.i("Media clip name does not have extension, using second half of mime type")

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicMediaClipFieldController.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicMediaClipFieldController.kt
@@ -24,7 +24,6 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.Button
 import android.widget.LinearLayout
-import android.widget.TextView
 import androidx.annotation.StringRes
 import androidx.annotation.VisibleForTesting
 import com.ichi2.anki.AnkiDroidApp
@@ -41,11 +40,9 @@ import java.io.File
 class BasicMediaClipFieldController : FieldControllerBase(), IFieldController {
     private var storingDirectory: File? = null
 
-    @KotlinCleanup("Convert to FixedTextView and make lateinit")
-    private var tvAudioClip: TextView? = null
+    private lateinit var tvAudioClip: FixedTextView
 
-    @KotlinCleanup("make context non-null")
-    override fun createUI(context: Context?, layout: LinearLayout?) {
+    override fun createUI(context: Context, layout: LinearLayout?) {
         val col = CollectionHelper.getInstance().getCol(context)
         storingDirectory = File(col.media.dir())
         // #9639: .opus is application/octet-stream in API 26,
@@ -75,10 +72,10 @@ class BasicMediaClipFieldController : FieldControllerBase(), IFieldController {
         layout.addView(btnVideo, ViewGroup.LayoutParams.MATCH_PARENT)
         tvAudioClip = FixedTextView(mActivity)
         if (mField.audioPath == null) {
-            (tvAudioClip as FixedTextView).setVisibility(View.GONE)
+            tvAudioClip.visibility = View.GONE
         } else {
-            (tvAudioClip as FixedTextView).setText(mField.audioPath)
-            (tvAudioClip as FixedTextView).setVisibility(View.VISIBLE)
+            tvAudioClip.text = mField.audioPath
+            tvAudioClip.visibility = View.VISIBLE
         }
         layout.addView(tvAudioClip, ViewGroup.LayoutParams.MATCH_PARENT)
     }
@@ -177,8 +174,8 @@ class BasicMediaClipFieldController : FieldControllerBase(), IFieldController {
                 // If everything worked, hand off the information
                 mField.setHasTemporaryMedia(true)
                 mField.audioPath = clipCopy.absolutePath
-                tvAudioClip!!.text = mField.formattedValue
-                tvAudioClip!!.visibility = View.VISIBLE
+                tvAudioClip.text = mField.formattedValue
+                tvAudioClip.visibility = View.VISIBLE
             }
         } catch (e: Exception) {
             Timber.e(e, "Unable to copy media file from ContentProvider")

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicMediaClipFieldController.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicMediaClipFieldController.kt
@@ -38,7 +38,7 @@ import com.ichi2.utils.KotlinCleanup
 import timber.log.Timber
 import java.io.File
 
-class BasicAudioClipFieldController : FieldControllerBase(), IFieldController {
+class BasicMediaClipFieldController : FieldControllerBase(), IFieldController {
     private var storingDirectory: File? = null
 
     @KotlinCleanup("Convert to FixedTextView and make lateinit")

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicTextFieldController.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicTextFieldController.kt
@@ -40,7 +40,6 @@ import com.ichi2.ui.FixedTextView
 import com.ichi2.utils.KotlinCleanup
 import timber.log.Timber
 import java.io.File
-import java.util.*
 
 /**
  * One of the most powerful controllers - creates UI and works with the field of textual type.
@@ -53,7 +52,7 @@ class BasicTextFieldController : FieldControllerBase(), IFieldController, Dialog
 
     // This is used to copy from another field value to this field
     private var mPossibleClones: ArrayList<String>? = null
-    override fun createUI(context: Context?, layout: LinearLayout?) {
+    override fun createUI(context: Context, layout: LinearLayout?) {
         mEditText = FixedEditText(mActivity)
         mEditText!!.minLines = 3
         mEditText!!.setText(mField.text)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/EFieldType.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/EFieldType.kt
@@ -26,5 +26,5 @@ enum class EFieldType {
     TEXT, // Just text
     IMAGE, // Just image
     AUDIO_RECORDING, // Just audio
-    AUDIO_CLIP // Just audio clip
+    MEDIA_CLIP // Just media (audio/video) clip
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/IFieldController.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/IFieldController.kt
@@ -58,9 +58,8 @@ interface IFieldController {
     // Called during editing Activity pause, allows state persistence across Activity restarts
     fun saveInstanceState(): Bundle?
 
-    @KotlinCleanup("make context non-null")
     // Layout is vertical inside a scroll view already
-    fun createUI(context: Context?, layout: LinearLayout?)
+    fun createUI(context: Context, layout: LinearLayout?)
 
     // If the controller ever starts an activity for result, this is going to be
     // called back on result.

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/MediaClipField.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/MediaClipField.kt
@@ -3,11 +3,11 @@
 package com.ichi2.anki.multimediacard.fields
 
 /**
- * Implementation of Audio Clip field type
+ * Implementation of Media Clip field type
  */
-class AudioClipField : AudioField() {
+class MediaClipField : AudioField() {
     override fun getType(): EFieldType {
-        return EFieldType.AUDIO_CLIP
+        return EFieldType.MEDIA_CLIP
     }
 
     override fun isModified(): Boolean {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/NoteService.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/NoteService.kt
@@ -77,7 +77,7 @@ object NoteService {
             } else if (value.startsWith("[sound:") && value.contains("rec")) {
                 AudioRecordingField()
             } else if (value.startsWith("[sound:")) {
-                AudioClipField()
+                MediaClipField()
             } else {
                 TextField()
             }
@@ -153,7 +153,7 @@ object NoteService {
     private fun importMediaToDirectory(col: com.ichi2.libanki.Collection, field: IField?) {
         var tmpMediaPath: String? = null
         when (field!!.type) {
-            EFieldType.AUDIO_RECORDING, EFieldType.AUDIO_CLIP -> tmpMediaPath = field.audioPath
+            EFieldType.AUDIO_RECORDING, EFieldType.MEDIA_CLIP -> tmpMediaPath = field.audioPath
             EFieldType.IMAGE -> tmpMediaPath = field.imagePath
             EFieldType.TEXT -> {
             }
@@ -171,7 +171,7 @@ object NoteService {
                         inFile.delete()
                     }
                     when (field.type) {
-                        EFieldType.AUDIO_RECORDING, EFieldType.AUDIO_CLIP -> field.audioPath = outFile.absolutePath
+                        EFieldType.AUDIO_RECORDING, EFieldType.MEDIA_CLIP -> field.audioPath = outFile.absolutePath
                         EFieldType.IMAGE -> field.imagePath = outFile.absolutePath
                         else -> {
                         }

--- a/AnkiDroid/src/main/java/com/ichi2/utils/ExceptionUtil.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/ExceptionUtil.kt
@@ -15,10 +15,13 @@
  */
 package com.ichi2.utils
 
+import android.content.Context
 import androidx.annotation.CheckResult
+import com.ichi2.anki.AnkiDroidApp
+import com.ichi2.anki.R
+import com.ichi2.anki.UIUtils
 import java.io.PrintWriter
 import java.io.StringWriter
-import java.lang.StringBuilder
 
 object ExceptionUtil {
     @JvmStatic
@@ -70,5 +73,17 @@ object ExceptionUtil {
         val sw = StringWriter()
         ex.printStackTrace(PrintWriter(sw))
         return sw.toString()
+    }
+
+    /** Executes a function, and logs the exception to ACRA and shows a toast if an issue occurs */
+    fun executeSafe(context: Context, origin: String, runnable: (() -> Unit)) {
+        try {
+            runnable.invoke()
+        } catch (e: Exception) {
+            AnkiDroidApp.sendExceptionReport(e, origin)
+            UIUtils.showThemedToast(
+                context, context.getString(R.string.multimedia_editor_something_wrong), true
+            )
+        }
     }
 }

--- a/AnkiDroid/src/main/res/values/16-multimedia-editor.xml
+++ b/AnkiDroid/src/main/res/values/16-multimedia-editor.xml
@@ -16,6 +16,7 @@
     <!-- Main editor popup menu items -->
     <string name="multimedia_editor_popup_image">Add image</string>
     <string name="multimedia_editor_popup_audio_clip">Add audio clip</string>
+    <string name="multimedia_editor_popup_video_clip">Add video clip</string>
     <string name="multimedia_editor_popup_audio">Record audio</string>
     <string name="multimedia_editor_popup_text">Advanced editor</string>
     <string name="multimedia_editor_popup_cloze">Cloze deletion</string>
@@ -74,7 +75,8 @@
     <!-- for buttons -->
     <string name="multimedia_editor_image_field_editing_galery">Gallery</string>
     <string name="multimedia_editor_image_field_editing_photo">Camera</string>
-    <string name="multimedia_editor_image_field_editing_library">Library</string>
+    <string name="multimedia_editor_import_audio">Audio</string>
+    <string name="multimedia_editor_import_video">Video</string>
 
     <!-- General -->
     <!-- message on the progress dialog for the user to wait, means process -->

--- a/AnkiDroid/src/test/java/com/ichi2/anki/multimediacard/fields/BasicMediaClipFieldControllerComplexTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/multimediacard/fields/BasicMediaClipFieldControllerComplexTest.kt
@@ -24,7 +24,7 @@ import org.junit.runner.RunWith
  * Test which requires an activity
  */
 @RunWith(AndroidJUnit4::class)
-class BasicAudioClipFieldControllerComplexTest : MultimediaEditFieldActivityTestBase() {
+class BasicMediaClipFieldControllerComplexTest : MultimediaEditFieldActivityTestBase() {
 
     @Test
     fun testControllerInit() {

--- a/AnkiDroid/src/test/java/com/ichi2/anki/multimediacard/fields/BasicMediaClipFieldControllerTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/multimediacard/fields/BasicMediaClipFieldControllerTest.java
@@ -18,11 +18,11 @@ package com.ichi2.anki.multimediacard.fields;
 
 import org.junit.Test;
 
-import static com.ichi2.anki.multimediacard.fields.BasicAudioClipFieldController.checkFileName;
+import static com.ichi2.anki.multimediacard.fields.BasicMediaClipFieldController.checkFileName;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
-public class BasicAudioClipFieldControllerTest {
+public class BasicMediaClipFieldControllerTest {
 
 
     @Test

--- a/AnkiDroid/src/test/java/com/ichi2/anki/services/NoteServiceTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/services/NoteServiceTest.java
@@ -18,7 +18,7 @@ package com.ichi2.anki.services;
 
 import com.ichi2.anki.RobolectricTest;
 import com.ichi2.anki.multimediacard.IMultimediaEditableNote;
-import com.ichi2.anki.multimediacard.fields.AudioClipField;
+import com.ichi2.anki.multimediacard.fields.MediaClipField;
 import com.ichi2.anki.multimediacard.fields.ImageField;
 import com.ichi2.anki.multimediacard.impl.MultimediaEditableNote;
 import com.ichi2.anki.servicelayer.NoteService;
@@ -101,7 +101,7 @@ public class NoteServiceTest extends RobolectricTest {
         MultimediaEditableNote testAudioClip = new MultimediaEditableNote();
         testAudioClip.setNumFields(1);
 
-        AudioClipField audioField = new AudioClipField();
+        MediaClipField audioField = new MediaClipField();
         audioField.setAudioPath(fileAudio.getAbsolutePath());
         testAudioClip.setField(0, audioField);
 


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
.mp4s could not be imported

## Fixes
Fixes #10315

## Approach
* Rename `AudioClip` -> `MediaClip`
* Add button for "Video": accept `video/*`
* Fix bug in extension parsing
* Fix a few `KotlinCleanup`s

I attempted a new controller, but it wasn't easily possible to decide which controller to open if we encounter a field with `[sound:` in it.

## How Has This Been Tested?

Android 11 Pixel 3a

![image](https://user-images.githubusercontent.com/62114487/153712970-ea5aacef-eb1c-4d97-8343-442062c7965a.png)


## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [x] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
