### PR TITLE
remove: Volume Gesture Option (replaced)

### DIFF
--- a/AnkiDroid/src/main/res/values/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values/10-preferences.xml
@@ -98,8 +98,6 @@
     <string name="gestures_corner_tap_bottom_left" maxLength="41">Touch bottom left</string>
     <string name="gestures_corner_tap_bottom_center">Touch bottom center</string>
     <string name="gestures_corner_tap_bottom_right" maxLength="41">Touch bottom right</string>
-    <string name="gestures_volume_up" maxLength="41">Volume up</string>
-    <string name="gestures_volume_down" maxLength="41">Volume down</string>
     <string name="more_scrolling_buttons" maxLength="41">eReader</string>
     <string name="more_scrolling_buttons_summ">Also use kanji/katakana, emoji/kao-moji buttons for scrolling</string>
     <string name="card_browser_enable_external_context_menu">‘%s’ Menu</string>

--- a/AnkiDroid/src/main/res/xml/preferences_gestures.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_gestures.xml
@@ -162,19 +162,5 @@
             android:entryValues="@array/gestures_values"
             android:key="gestureTapBottomRight"
             android:title="@string/gestures_corner_tap_bottom_right" />
-        <ListPreference
-            android:defaultValue="0"
-            android:dependency="gestures"
-            android:entries="@array/gestures_labels"
-            android:entryValues="@array/gestures_values"
-            android:key="gestureVolumeUp"
-            android:title="@string/gestures_volume_up" />
-        <ListPreference
-            android:defaultValue="0"
-            android:dependency="gestures"
-            android:entries="@array/gestures_labels"
-            android:entryValues="@array/gestures_values"
-            android:key="gestureVolumeDown"
-            android:title="@string/gestures_volume_down" />
     </PreferenceCategory>
 </PreferenceScreen>


### PR DESCRIPTION
Replaced with a general keymapping in "Settings - Controls"

Ref: dc6459f84b4c0fceb771a96aa04cdb6a46e13d4a

## Fixes
Fixes #10336

## How Has This Been Tested?

Pixel 3A, setting no longer appears

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
