### PR TITLE
remove preference "Link Overrides Touch Gestures"

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -285,7 +285,6 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
      */
     private GestureDetector mGestureDetector;
     private MyGestureDetector mGestureDetectorImpl;
-    private boolean mLinkOverridesTouchGesture;
 
     private boolean mIsXScrolling = false;
     private boolean mIsYScrolling = false;
@@ -1231,7 +1230,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
         mCardFrame.removeAllViews();
 
         // Initialize swipe
-        mGestureDetectorImpl = mLinkOverridesTouchGesture ? new LinkDetectingGestureDetector() : new MyGestureDetector();
+        mGestureDetectorImpl = new LinkDetectingGestureDetector();
         mGestureDetector = new GestureDetector(this, mGestureDetectorImpl);
 
         mEaseButtonsLayout = findViewById(R.id.ease_buttons);
@@ -1548,7 +1547,6 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
         mExitViaDoubleTapBack = preferences.getBoolean("exitViaDoubleTapBack", false);
 
         mGesturesEnabled = preferences.getBoolean("gestures", false);
-        mLinkOverridesTouchGesture = preferences.getBoolean("linkOverridesTouchGesture", false);
         if (mGesturesEnabled) {
             mGestureProcessor.init(preferences);
         }

--- a/AnkiDroid/src/main/res/values/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values/10-preferences.xml
@@ -73,8 +73,6 @@
     </string-array>
     <string name="gestures" maxLength="41">Enable gestures</string>
     <string name="gestures_summ">Assign gestures to actions such as answering and editing cards.</string>
-    <string name="gestures_allow_links" maxLength="41">Ignore touch gestures on links</string>
-    <string name="gestures_allow_links_summary">Touch gestures will not be processed if a link/hint is pressed.</string>
     <string name="gestures_corner_touch" maxLength="41">9-point touch</string>
     <string name="gestures_corner_touch_summary">Allow touch gestures in screen corners</string>
     <string name="gestures_full_screen_nav_drawer" maxLength="41">Full screen navigation drawer</string>

--- a/AnkiDroid/src/main/res/xml/preferences_gestures.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_gestures.xml
@@ -35,13 +35,6 @@
         android:defaultValue="false"
         android:dependency="gestures"
         android:disableDependentsState="false"
-        android:key="linkOverridesTouchGesture"
-        android:summary="@string/gestures_allow_links_summary"
-        android:title="@string/gestures_allow_links" />
-    <CheckBoxPreference
-        android:defaultValue="false"
-        android:dependency="gestures"
-        android:disableDependentsState="false"
         android:key="gestureCornerTouch"
         android:summary="@string/gestures_corner_touch_summary"
         android:title="@string/gestures_corner_touch" />


### PR DESCRIPTION
For discussion

## Purpose / Description
Link Overrides Touch Gestures feels like an unnecessary preference:

This is desired by all users I've seen, and "false" causes support queries, it doesn't feel worthwhile to have at this point

## Approach
Default to true and remove preference: tapping a link will now ignores touch gestures

We don't remove the orphaned preference: `linkOverridesTouchGesture`, I can do if this is a desire when we remove preferences

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
