### PR TITLE
Fix disabled gestures still appearing

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
@@ -65,6 +65,7 @@ import com.ichi2.preferences.NumberRangePreferenceCompat;
 import com.ichi2.preferences.ResetLanguageDialogPreference;
 import com.ichi2.preferences.SeekBarPreferenceCompat;
 import com.ichi2.preferences.ControlPreference;
+import com.ichi2.themes.Themes;
 import com.ichi2.utils.AdaptionUtil;
 import com.ichi2.utils.LanguageUtil;
 import com.ichi2.anki.analytics.UsageAnalytics;
@@ -201,6 +202,7 @@ public class Preferences extends AnkiActivity {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.preferences);
+        Themes.setThemeLegacy(this);
 
         enableToolbar();
 


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
_Fix regression_

## Fixes
Fixes #10339 

## Approach
- Tried to make sure the buttons were disabled by temporarily hardcoding it -> Android Studio preview showed it correctly, but when emulating it appeared enabled
- Guessed it was a font color/theme problem
- Set the preferences theme when creating it

## How Has This Been Tested?

1. Go to settings -> Gestures
2. Disable gestures
3. See if disabled options are greyed out

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
