### PR TITLE
fix(strings): missing positional arguments

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/async/Connection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/Connection.java
@@ -512,7 +512,7 @@ public class Connection extends BaseAsyncTask<Connection.Payload, Object, Connec
                     if (downloadedCount == 0 && uploadedCount == 0) {
                         mediaError = AnkiDroidApp.getAppResources().getString(R.string.sync_media_error) + "\n\n" + e.getLocalizedMessage();
                     } else {
-                        mediaError = AnkiDroidApp.getAppResources().getString(R.string.sync_media_partial, downloadedCount, uploadedCount) + "\n\n" + e.getLocalizedMessage();
+                        mediaError = AnkiDroidApp.getAppResources().getString(R.string.sync_media_partial_updated, downloadedCount, uploadedCount) + "\n\n" + e.getLocalizedMessage();
                     }
                 }
             }

--- a/AnkiDroid/src/main/res/values/04-network.xml
+++ b/AnkiDroid/src/main/res/values/04-network.xml
@@ -81,7 +81,7 @@
     <string name="sync_media_find">Finding changed media…</string>
     <string name="sync_media_no_changes">No changes to media files</string>
     <string name="sync_media_success">Media synced</string>
-    <string name="sync_media_partial">Media sync partially completed:\n%d media files downloaded.\n%d media files uploaded.</string>
+    <string name="sync_media_partial_updated">Media sync partially completed:\n%1$d media files downloaded.\n%2$d media files uploaded.</string>
     <string name="sync_media_changes_count">%d media changes to upload</string>
     <string name="sync_media_downloaded_count">%d media files downloaded</string>
     <string name="sync_sanity_failed">After syncing, the collection was in an inconsistent state. To fix this problem, AnkiDroid will force a full sync. Choose which side you would like to keep.</string>


### PR DESCRIPTION
An error was shown (fixed in this commit):
`Multiple substitutions specified in non-positional format of string resource string/sync_media_partial.`

## Fixes
Issue #10347 - not fixed

## Approach
Fixed via adding positional arguments

Update string to force re-translation:
`sync_media_partial` => `sync_media_partial_updated`

Introduced in c905ddbbeb96bde59ad66b3b36d94e2a43b6cd3a

## How Has This Been Tested?
Untested

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
