### PR TITLE
Changed SVG type and name of `replaybutton` in order to be desktop compatible

### DIFF
--- a/AnkiDroid/src/main/assets/flashcard.css
+++ b/AnkiDroid/src/main/assets/flashcard.css
@@ -67,7 +67,17 @@ body.ankidroid_dark_mode {
   background-color: #303030;
 }
 
+/*
+The replay button has two classes, the old one (replaybutton) and the new one (replay-button).
+The new class is compatible with Anki desktop, while the old class is what AnkiDroid used.
+Both are present here so that old code doesn't break
+*/
+
 .replay-button {
+  text-decoration: none;
+}
+
+.replaybutton{
   text-decoration: none;
 }
 
@@ -122,4 +132,30 @@ scale up, but not down.  */
 }
 .night_mode .replay-button svg {
   fill: white;
+}
+
+/*Old replay button class*/
+
+replaybutton span {
+  display: inline-block;
+  vertical-align: middle;
+  padding: 5px;
+}
+
+.replaybutton span svg{
+  stroke: none;
+  fill: black;
+  display: inline;
+  height: 1em;
+  width: 1em;
+  min-width: 32px;
+  min-height: 32px;
+}
+
+.replaybutton span img {
+  display: inline;
+  height: 1em;
+  width: 1em;
+  min-width: 32px;
+  min-height: 32px;
 }

--- a/AnkiDroid/src/main/assets/flashcard.css
+++ b/AnkiDroid/src/main/assets/flashcard.css
@@ -67,20 +67,9 @@ body.ankidroid_dark_mode {
   background-color: #303030;
 }
 
-/*
-The replay button has two classes, the old one (replaybutton) and the new one (replay-button).
-The new class is compatible with Anki desktop, while the old class is what AnkiDroid used.
-Both are present here so that old code doesn't break
-*/
-
 .replay-button {
   text-decoration: none;
 }
-
-.replaybutton{
-  text-decoration: none;
-}
-
 
 /*
 Use hard-coded max dimensions if using Chrome back-end. Chrome is able to
@@ -132,30 +121,4 @@ scale up, but not down.  */
 }
 .night_mode .replay-button svg {
   fill: white;
-}
-
-/*Old replay button class*/
-
-replaybutton span {
-  display: inline-block;
-  vertical-align: middle;
-  padding: 5px;
-}
-
-.replaybutton span svg{
-  stroke: none;
-  fill: black;
-  display: inline;
-  height: 1em;
-  width: 1em;
-  min-width: 32px;
-  min-height: 32px;
-}
-
-.replaybutton span img {
-  display: inline;
-  height: 1em;
-  width: 1em;
-  min-width: 32px;
-  min-height: 32px;
 }

--- a/AnkiDroid/src/main/assets/flashcard.css
+++ b/AnkiDroid/src/main/assets/flashcard.css
@@ -67,7 +67,7 @@ body.ankidroid_dark_mode {
   background-color: #303030;
 }
 
-.replaybutton {
+.replay-button {
   text-decoration: none;
 }
 
@@ -97,13 +97,13 @@ preferred over using JavaScript.
 changed. Use some fancy CSS to make the button align vertically, and
 scale up, but not down.  */
 
-.replaybutton span {
+.replay-button span {
   display: inline-block;
   vertical-align: middle;
   padding: 5px;
 }
 
-.replaybutton span svg {
+.replay-button span svg {
   stroke: none;
   fill: black;
   display: inline;
@@ -113,13 +113,13 @@ scale up, but not down.  */
   min-height: 32px;
 }
 
-.replaybutton span img {
+.replay-button span img {
   display: inline;
   height: 1em;
   width: 1em;
   min-width: 32px;
   min-height: 32px;
 }
-.night_mode .replaybutton svg {
+.night_mode .replay-button svg {
   fill: white;
 }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Sound.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Sound.java
@@ -247,12 +247,13 @@ public class Sound {
             // Construct the new content, appending the substring from the beginning of the content left until the
             // beginning of the sound marker
             // and then appending the html code to add the play button
-            String button = "<svg viewBox=\"0 0 32 32\"><polygon points=\"11,25 25,16 11,7\"/>Replay</svg>";
+            String button = "<svg viewBox=\"0 0 64 64\"><circle cx=\"32\" cy=\"32\" r=\"29\" fill = \"grey\"/><path d=\"M56.502,32.301l-37.502,20.101l0.329,-40.804l37.173,20.703Z\" fill = \"" +
+                    "black\"/>Replay</svg>";
             String soundMarker = matcher.group();
             int markerStart = contentLeft.indexOf(soundMarker);
             stringBuilder.append(contentLeft.substring(0, markerStart));
             // The <span> around the button (SVG or PNG image) is needed to make the vertical alignment work.
-            stringBuilder.append("<a class='replaybutton' href=\"playsound:").append(soundPath).append("\">")
+            stringBuilder.append("<a class='replay-button' href=\"playsound:").append(soundPath).append("\">")
                     .append("<span>").append(button)
                     .append("</span></a>");
             contentLeft = contentLeft.substring(markerStart + soundMarker.length());

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Sound.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Sound.java
@@ -247,13 +247,14 @@ public class Sound {
             // Construct the new content, appending the substring from the beginning of the content left until the
             // beginning of the sound marker
             // and then appending the html code to add the play button
-            String button = "<svg viewBox=\"0 0 64 64\"><circle cx=\"32\" cy=\"32\" r=\"29\" fill = \"grey\"/><path d=\"M56.502,32.301l-37.502,20.101l0.329,-40.804l37.173,20.703Z\" fill = \"" +
+            String button = "<svg viewBox=\"0 0 64 64\"><circle cx=\"32\" cy=\"32\" r=\"29\" fill = \"lightgrey\"/>" +
+                    "<path d=\"M56.502,32.301l-37.502,20.101l0.329,-40.804l37.173,20.703Z\" fill = \"" +
                     "black\"/>Replay</svg>";
             String soundMarker = matcher.group();
             int markerStart = contentLeft.indexOf(soundMarker);
             stringBuilder.append(contentLeft.substring(0, markerStart));
             // The <span> around the button (SVG or PNG image) is needed to make the vertical alignment work.
-            stringBuilder.append("<a class='replay-button' href=\"playsound:").append(soundPath).append("\">")
+            stringBuilder.append("<a class='replay-button replaybutton' href=\"playsound:").append(soundPath).append("\">")
                     .append("<span>").append(button)
                     .append("</span></a>");
             contentLeft = contentLeft.substring(markerStart + soundMarker.length());


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
SVG types of the audio replay button were different in Anki Desktop and AnkiDroid, thus any CSS style changes made on Anki were not visible on AnkiDroid. 
## Fixes
Fixes #10343 
## Approach
changed class name of button from `replaybutton` to `replay-button` to be compatible with anki desktop button styling.
changed SVG type from `<polygon>` to `<circle><path>` as defined in anki desktop to be compatible.

This allows any change in CSS styling of the replay button on Anki to be visible on AnkiDroid as well.
## How Has This Been Tested?

Tested on my phone: Xiaomi Redmi Note 8 Pro; Android 9; API 28

### Styled Button on Anki Desktop
![image](https://user-images.githubusercontent.com/86671025/154088035-9b5658ed-3041-43c5-897d-282891cd3479.png)

```
.replay-button svg {
  width: 20px;
  height: 20px;
}
.replay-button svg circle {
  fill: blue;
}
.replay-button svg path {
  stroke: white;
  fill: green;
}

```
### Before:
<img src="https://user-images.githubusercontent.com/86671025/154088872-f5318587-8d79-4d1e-b271-b9a6ec379fcb.png" width="300" >

### After:

#### Default Replay Button:
<img src="https://user-images.githubusercontent.com/86671025/154442890-6b330111-a039-424e-ab18-1d3505f99b28.png" width="300" >

#### Dark Mode:
<img src="https://user-images.githubusercontent.com/86671025/154443184-6ed6fe8f-bb76-4efc-956d-966dff7d4dd7.png" width="300" >

#### Styled Replay Button:
<img src="https://user-images.githubusercontent.com/86671025/154089035-407799c7-37e5-4dbb-bae3-4d54584df91d.png" width="300" >
## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
