### PR TITLE
feat(scoped-storage): DeleteEmptyDirectory operation

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/model/Directory.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/model/Directory.kt
@@ -1,0 +1,48 @@
+/*
+ *  Copyright (c) 2022 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.model
+
+import java.io.File
+
+/**
+ * A directory which is assumed to exist (existed when class was instantiated)
+ *
+ * @see [DiskFile]
+ */
+class Directory private constructor(val directory: File) {
+    /** @see [File.renameTo] */
+    fun renameTo(destination: File): Boolean = directory.renameTo(destination)
+    override fun toString(): String = directory.canonicalPath
+    fun listFiles(): Array<out File> = directory.listFiles() ?: emptyArray()
+
+    /**
+     * Whether a directory has files
+     * @return false if supplied argument is not a directory, or has no files. True if directory has files
+     */
+    fun hasFiles(): Boolean = listFiles().any()
+
+    companion object {
+        fun createInstance(file: File): Directory? {
+            if (!file.exists() || !file.isDirectory) {
+                return null
+            }
+            return Directory(file)
+        }
+        /** Creates an instance when the preconditions are known to be true */
+        fun createInstanceUnsafe(file: File) = Directory(file)
+    }
+}

--- a/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/scopedstorage/DeleteEmptyDirectory.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/scopedstorage/DeleteEmptyDirectory.kt
@@ -1,0 +1,42 @@
+/*
+ *  Copyright (c) 2022 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.servicelayer.scopedstorage
+
+import com.ichi2.anki.model.Directory
+import com.ichi2.compat.CompatHelper
+import timber.log.Timber
+import java.io.FileNotFoundException
+
+data class DeleteEmptyDirectory(val directory: Directory) : MigrateUserData.Operation() {
+    override fun execute(context: MigrateUserData.MigrationContext): List<MigrateUserData.Operation> {
+        if (directory.hasFiles()) {
+            context.reportError(this, MigrateUserData.DirectoryNotEmptyException(directory))
+            return operationCompleted()
+        }
+
+        try {
+            CompatHelper.getCompat().deleteFile(directory.directory)
+            Timber.d("deleted $directory")
+        } catch (ex: NoSuchFileException) { // API 26+
+            Timber.d("$directory already deleted")
+        } catch (ex: FileNotFoundException) { // API <26
+            Timber.d("$directory already deleted")
+        }
+
+        return operationCompleted()
+    }
+}

--- a/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/scopedstorage/MigrateUserData.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/scopedstorage/MigrateUserData.kt
@@ -16,6 +16,7 @@
 
 package com.ichi2.anki.servicelayer.scopedstorage
 
+import com.ichi2.anki.model.Directory
 import com.ichi2.anki.model.DiskFile
 import timber.log.Timber
 import java.io.File
@@ -56,6 +57,11 @@ class MigrateUserData {
      * This implies that the file move should be cancelled
      */
     class EquivalentFileException(val source: File, val destination: File) : RuntimeException("Source and destination path are the same")
+
+    /**
+     * If a directory could not be deleted as it still contained files
+     */
+    class DirectoryNotEmptyException(val directory: Directory) : RuntimeException("directory was not empty: $directory")
 
     /**
      * Context for an [Operation], allowing a change of execution behavior and

--- a/AnkiDroid/src/main/java/com/ichi2/compat/CompatV21.java
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/CompatV21.java
@@ -140,6 +140,9 @@ public class CompatV21 implements Compat {
     @Override
     public void deleteFile(@NonNull File file) throws IOException {
         if (!file.delete()) {
+            if (!file.exists()) {
+                throw new FileNotFoundException(file.getCanonicalPath());
+            }
             throw new IOException("Unable to delete: " + file.getCanonicalPath());
         }
     }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/model/DirectoryTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/model/DirectoryTest.kt
@@ -1,0 +1,85 @@
+/*
+ *  Copyright (c) 2022 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.model
+
+import org.acra.util.IOUtils
+import org.hamcrest.CoreMatchers.*
+import org.hamcrest.MatcherAssert
+import org.junit.Test
+import java.io.File
+import kotlin.io.path.createTempDirectory
+import kotlin.io.path.pathString
+
+/**
+ * Tests for [Directory]
+ */
+class DirectoryTest {
+    @Test
+    fun passes_if_existing_directory() {
+        val path = createTempDirectory().pathString
+        MatcherAssert.assertThat(
+            "Directory should work with valid directory",
+            Directory.createInstance(File(path)),
+            not(nullValue())
+        )
+    }
+
+    @Test
+    fun fails_if_does_not_exist() {
+        val subdirectory = File(createTempDirectory().pathString, "aa")
+        MatcherAssert.assertThat(
+            "Directory requires an existing directory",
+            Directory.createInstance(subdirectory),
+            nullValue()
+        )
+    }
+
+    @Test
+    fun fails_if_file() {
+        val dir = kotlin.io.path.createTempFile().pathString
+        MatcherAssert.assertThat(
+            "file should not become a Directory",
+            Directory.createInstance(File(dir)),
+            nullValue()
+        )
+    }
+
+    @Test
+    fun has_files_is_false_if_empty() {
+        val dir = createValidTempDir()
+        MatcherAssert.assertThat(
+            "empty directory should not have files",
+            dir.hasFiles(),
+            equalTo(false)
+        )
+    }
+
+    @Test
+    fun has_files_is_true_if_file() {
+        val dir = createValidTempDir()
+        IOUtils.writeStringToFile(File(dir.directory, "aa.txt"), "aa")
+        MatcherAssert.assertThat(
+            "non-empty directory should have files",
+            dir.hasFiles(),
+            equalTo(true)
+        )
+    }
+
+    private fun createValidTempDir(): Directory {
+        return Directory.createInstance(File(createTempDirectory().pathString))!!
+    }
+}

--- a/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/DeleteEmptyDirectoryTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/DeleteEmptyDirectoryTest.kt
@@ -1,0 +1,75 @@
+/*
+ *  Copyright (c) 2022 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.servicelayer.scopedstorage
+
+import com.ichi2.anki.model.Directory
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.hasSize
+import org.hamcrest.Matchers.instanceOf
+import org.junit.Test
+import java.io.File
+import kotlin.io.path.createTempDirectory
+import kotlin.io.path.pathString
+
+/**
+ * Tests for [DeleteEmptyDirectory]
+ */
+class DeleteEmptyDirectoryTest {
+
+    val context = MockMigrationContext()
+
+    @Test
+    fun succeeds_if_directory_is_empty() {
+        val toDelete = createEmptyDirectory()
+
+        val next = DeleteEmptyDirectory(toDelete).execute(context)
+
+        assertThat("no exceptions", context.exceptions, hasSize(0))
+        assertThat("no more operations", next, hasSize(0))
+    }
+
+    @Test
+    fun fails_if_directory_is_not_empty() {
+        val toDelete = createEmptyDirectory()
+        File(toDelete.directory, "aa.txt").createNewFile()
+
+        context.logExceptions = true
+        val next = DeleteEmptyDirectory(toDelete).execute(context)
+
+        assertThat("no exceptions", context.exceptions, hasSize(1))
+        assertThat(context.exceptions.single(), instanceOf(MigrateUserData.DirectoryNotEmptyException::class.java))
+        assertThat("no more operations", next, hasSize(0))
+    }
+
+    @Test
+    fun succeeds_if_directory_does_not_exist() {
+        val directory = createTempDirectory()
+        val dir = File(directory.pathString)
+        val toDelete = Directory.createInstance(dir)!!
+        dir.delete()
+
+        val next = DeleteEmptyDirectory(toDelete).execute(context)
+
+        assertThat("no exceptions", context.exceptions, hasSize(0))
+        assertThat("no more operations", next, hasSize(0))
+    }
+
+    private fun createEmptyDirectory() =
+        Directory.createInstance(File(createTempDirectory().pathString))!!
+
+    fun MigrateUserData.Operation.execute() = this.execute(context)
+}


### PR DESCRIPTION
## Purpose / Description
An operation to delete an empty directory

Moving a directory is the recursive operation of moving files then deleting the directory. This handles deleting the directory which allows us to create a "Move Directory" operation in a follow-up PR.

## Fixes
#5304

## How Has This Been Tested?

Unit tests

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
