### PR TITLE
feat(scoped-storage): MoveDirectory

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/scopedstorage/MoveDirectory.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/scopedstorage/MoveDirectory.kt
@@ -1,0 +1,70 @@
+/*
+ *  Copyright (c) 2022 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.servicelayer.scopedstorage
+
+import androidx.annotation.VisibleForTesting
+import com.ichi2.anki.model.Directory
+import timber.log.Timber
+import java.io.File
+
+data class MoveDirectory(val source: Directory, val destination: File) : MigrateUserData.Operation() {
+    override fun execute(context: MigrateUserData.MigrationContext): List<MigrateUserData.Operation> {
+
+        // This seems unlikely to happen. Both paths need to be on the same mount point
+        // We use directory.exists() to ensure that this operation doesn't occur twice. renameTo
+        // is likely to be expensive, so we use the creation of the target directory to mark
+        // that the rename previously failed
+        if (context.attemptRename && !destination.exists() && rename(source, destination)) {
+            Timber.d("successfully renamed '$source' to '$destination'")
+            return operationCompleted()
+        } else {
+            // mark in the context that rename should not be attempted again for any sub-operations
+            context.attemptRename = false
+        }
+
+        Timber.d("creating folder '$destination'")
+        if (!createDirectory(destination)) {
+            context.reportError(this, IllegalStateException("Could not create '$destination'"))
+            return operationCompleted()
+        }
+
+        val destinationDirectory = Directory.createInstance(destination)
+        if (destinationDirectory == null) {
+            context.reportError(this, IllegalStateException("Directory instantiation failed: '$destination'"))
+            return operationCompleted()
+        }
+
+        val moveOperations = source.listFiles().map(::toMoveOperation)
+        val deleteOperation = DeleteEmptyDirectory(source)
+        return moveOperations + deleteOperation
+    }
+
+    /**
+     * @returns An operation to move file or directory [sourceFile] to [destination]
+     */
+    @VisibleForTesting
+    internal fun toMoveOperation(sourceFile: File): MigrateUserData.Operation {
+        return MoveFileOrDirectory(sourceFile, destination)
+    }
+
+    /** Creates a directory if it doesn't already exist */
+    @VisibleForTesting
+    internal fun createDirectory(directory: File) = directory.exists() || directory.mkdirs()
+
+    @VisibleForTesting
+    internal fun rename(source: Directory, destination: File) = source.renameTo(destination)
+}

--- a/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/scopedstorage/MoveFileOrDirectory.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/scopedstorage/MoveFileOrDirectory.kt
@@ -1,0 +1,68 @@
+/*
+ *  Copyright (c) 2022 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.servicelayer.scopedstorage
+
+import com.ichi2.anki.model.Directory
+import com.ichi2.anki.model.DiskFile
+import org.apache.commons.io.FileUtils.isSymlink
+import timber.log.Timber
+import java.io.File
+
+/**
+ * [MoveFileOrDirectory] checks whether a `File` object is actually a `File`, a `Directory` or something else.
+ * The last case should not occur in AnkiDroid.
+ * It then delegates to `MoveFile` or `MoveDirectory` the actual move.
+ *
+ *  Checking whether a `File` object is a file/directory requires an I/O operation, which means that
+ *  it should not be done in a loop, as this would block preemption.
+ *
+ * @see [MoveDirectory]
+ * @see [MoveFile]
+ */
+data class MoveFileOrDirectory(
+    /** Source, known to exist */
+    val sourceFile: File,
+    /** Destination: known to exist */
+    val destination: File
+) : MigrateUserData.Operation() {
+
+    override fun execute(context: MigrateUserData.MigrationContext): List<MigrateUserData.Operation> {
+        when {
+            sourceFile.isFile -> {
+                val fileToCreate = DiskFile.createInstanceUnsafe(sourceFile)
+                return listOf(MoveFile(fileToCreate, File(destination, sourceFile.name)))
+            }
+            sourceFile.isDirectory -> {
+                if (isSymlink(sourceFile)) {
+                    Timber.d("skipping symlink: $sourceFile")
+                    return operationCompleted()
+                }
+                val directory = Directory.createInstanceUnsafe(sourceFile)
+                return listOf(MoveDirectory(directory, File(destination, sourceFile.name)))
+            }
+            else -> {
+                if (!sourceFile.exists()) {
+                    // probably already migrated
+                    Timber.d("File no longer exists: $sourceFile")
+                } else {
+                    context.reportError(this, IllegalStateException("File was neither file nor directory '${sourceFile.canonicalPath}'"))
+                }
+            }
+        }
+        return operationCompleted()
+    }
+}

--- a/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/MoveDirectoryTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/MoveDirectoryTest.kt
@@ -1,0 +1,212 @@
+/*
+ *  Copyright (c) 2022 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.servicelayer.scopedstorage
+
+import com.ichi2.anki.model.Directory
+import com.ichi2.anki.servicelayer.scopedstorage.MigrateUserData.Operation
+import com.ichi2.compat.CompatHelper
+import com.ichi2.testutils.TestException
+import com.ichi2.testutils.createTransientDirectory
+import com.ichi2.testutils.exists
+import com.ichi2.testutils.withTempFile
+import org.hamcrest.CoreMatchers.equalTo
+import org.hamcrest.CoreMatchers.instanceOf
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.*
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doAnswer
+import org.mockito.kotlin.spy
+import timber.log.Timber
+import java.io.File
+
+/**
+ * Test for [MoveDirectory]
+ */
+class MoveDirectoryTest {
+
+    private val executionContext: MockMigrationContext = MockMigrationContext()
+
+    @Test
+    fun test_success_integration_test_recursive() {
+        val source = createDirectory().withTempFile("tmp.txt")
+        source.createTransientDirectory("more files").withTempFile("tmp-2.txt")
+        val destinationFile = generateDestinationDirectoryRef()
+        executionContext.attemptRename = false
+
+        executeAll(MoveDirectory(source, destinationFile))
+
+        assertThat("source directory should not exist", source.exists(), equalTo(false))
+        assertThat("destination directory should exist", destinationFile.exists(), equalTo(true))
+        assertThat("file should be copied", File(destinationFile, "tmp.txt").exists(), equalTo(true))
+
+        val subdirectory = File(destinationFile, "more files")
+        assertThat("subdir was copied", subdirectory.exists(), equalTo(true))
+        assertThat("subdir file was copied", File(subdirectory, "tmp-2.txt").exists(), equalTo(true))
+    }
+
+    @Test
+    fun test_fast_rename() {
+        val source = createDirectory().withTempFile("tmp.txt")
+        val destinationFile = generateDestinationDirectoryRef()
+        executionContext.attemptRename = true
+
+        val ret = MoveDirectory(source, destinationFile).execute()
+
+        assertThat("fast rename returns no operations", ret, empty())
+        assertThat("source directory should not exist", source.exists(), equalTo(false))
+        assertThat("destination directory should exist", destinationFile.exists(), equalTo(true))
+        assertThat("file should be copied", File(destinationFile, "tmp.txt").exists(), equalTo(true))
+    }
+
+    @Test
+    fun failed_rename_avoids_further_renames() {
+        // This is a performance optimization,
+        val source = createDirectory().withTempFile("tmp.txt")
+        val destinationFile = generateDestinationDirectoryRef()
+        var renameCalled = 0
+
+        executionContext.logExceptions = true
+        // don't actually move the directory, or we'd have a problem
+        val moveDirectory = spy(MoveDirectory(source, destinationFile)) {
+            doAnswer { renameCalled++; return@doAnswer false }.`when`(it).rename(any(), any())
+        }
+
+        assertThat("rename was true", executionContext.attemptRename, equalTo(true))
+
+        moveDirectory.execute()
+
+        assertThat("rename is now false", executionContext.attemptRename, equalTo(false))
+        assertThat("rename was called", renameCalled, equalTo(1))
+
+        moveDirectory.execute()
+
+        assertThat("rename was not called again", renameCalled, equalTo(1))
+
+        assertThat(executionContext.exceptions, hasSize(0))
+        assertThat("source was not copied", File(source.directory, "tmp.txt").exists(), equalTo(true))
+    }
+
+    @Test
+    fun a_move_failure_is_not_fatal() {
+        val source = createDirectory()
+            .withTempFile("foo.txt")
+            .withTempFile("bar.txt")
+            .withTempFile("baz.txt")
+
+        val destinationFile = generateDestinationDirectoryRef()
+
+        // Use variables as we don't know which file will be returned in the middle from listFiles()
+        var beforeFile: File? = null
+        var failedFile: File? = null // ensure the second file fails
+        var afterFile: File? = null
+        executionContext.attemptRename = false
+        executionContext.logExceptions = true
+        var movesProcessed = 0
+        val operation = spy(MoveDirectory(source, destinationFile)) {
+            doAnswer { op ->
+                val sourceFile = op.arguments[0] as File
+                when (movesProcessed++) {
+                    0 -> beforeFile = sourceFile
+                    1 -> {
+                        failedFile = sourceFile
+                        return@doAnswer FailMove()
+                    }
+                    2 -> afterFile = sourceFile
+                    else -> throw IllegalStateException("only 3 files expected")
+                }
+
+                return@doAnswer op.callRealMethod() as Operation
+            }.`when`(it).toMoveOperation(any())
+        }
+        executeAll(operation)
+
+        assertThat(executionContext.exceptions, hasSize(2))
+        executionContext.exceptions[0].run {
+            assertThat(this, instanceOf(TestException::class.java))
+        }
+        executionContext.exceptions[1].run {
+            assertThat(this.message, containsString("directory was not empty"))
+        }
+
+        assertThat("source directory should not be deleted", source.exists(), equalTo(true))
+        assertThat("fail was not copied", failedFile!!.exists(), equalTo(true))
+        assertThat("file before failure was copied", beforeFile!!.exists(), equalTo(false))
+        assertThat("file after failure was copied", afterFile!!.exists(), equalTo(false))
+    }
+
+    @Test
+    fun empty_directory_is_deleted() {
+        val source = createDirectory()
+        val destinationFile = generateDestinationDirectoryRef()
+
+        executionContext.attemptRename = false
+
+        executeAll(MoveDirectory(source, destinationFile))
+
+        assertThat("source was deleted", source.directory.exists(), equalTo(false))
+    }
+
+    @Test
+    fun empty_directory_is_deleted_rename() {
+        val source = createDirectory()
+        val destinationFile = generateDestinationDirectoryRef()
+
+        executionContext.attemptRename = true
+
+        executeAll(MoveDirectory(source, destinationFile))
+
+        assertThat("source was deleted", source.directory.exists(), equalTo(false))
+    }
+
+    /** Helper function: executes an [Operation] and all sub-operations */
+    private fun executeAll(op: MoveDirectory) {
+        val l = ArrayDeque<Operation>()
+        l.addFirst(op)
+        while (l.any()) {
+            val head = l.removeFirst()
+            Timber.d("executing $head")
+            this.executionContext.execSafe(head) {
+                l.addAll(0, head.execute())
+            }
+        }
+    }
+
+    /** Creates an empty TMP directory to place the output files in */
+    private fun generateDestinationDirectoryRef(): File {
+        val createDirectory = createDirectory()
+        Timber.d("test: deleting $createDirectory")
+        CompatHelper.getCompat().deleteFile(createDirectory.directory)
+        return createDirectory.directory
+    }
+
+    private fun createDirectory(): Directory =
+        Directory.createInstance(createTransientDirectory())!!
+
+    /**
+     * Executes an [Operation] without executing the sub-operations
+     * @return the sub-operations returned from the execution of the operation
+     */
+    private fun Operation.execute(): List<Operation> = this.execute(executionContext)
+}
+
+/** A move operation which fails */
+class FailMove : Operation() {
+    override fun execute(context: MigrateUserData.MigrationContext): List<Operation> {
+        throw TestException("should fail but not crash")
+    }
+}

--- a/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/MoveFileOrDirectoryTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/MoveFileOrDirectoryTest.kt
@@ -1,0 +1,58 @@
+/*
+ *  Copyright (c) 2022 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.servicelayer.scopedstorage
+
+import com.ichi2.testutils.createTransientDirectory
+import com.ichi2.testutils.createTransientFile
+import org.hamcrest.CoreMatchers.instanceOf
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.hasSize
+import org.junit.Test
+import java.io.File
+
+/** Tests for [MoveFileOrDirectory] */
+class MoveFileOrDirectoryTest {
+
+    private val executionContext = MockMigrationContext()
+    private val destinationDir = createTransientDirectory()
+
+    @Test
+    fun applied_to_file_returns_file() {
+        val file = createTransientFile()
+        val nextOperations = execute(file)
+        assertThat("Only one operation should be next", nextOperations, hasSize(1))
+        assertThat("A file as input should return a file operation", nextOperations.single(), instanceOf(MoveFile::class.java))
+    }
+
+    @Test
+    fun applied_to_directory_returns_directory() {
+        val directory = createTransientDirectory()
+        val nextOperations = execute(directory)
+        assertThat("Only one operation should be next", nextOperations, hasSize(1))
+        assertThat("A file as input should return a file operation", nextOperations.single(), instanceOf(MoveDirectory::class.java))
+    }
+
+    @Test
+    fun applied_to_deleted_file_returns_nothing() {
+        val file = createTransientFile()
+        file.delete()
+        val nextOperations = execute(file)
+        assertThat("No operations should be next as file is deleted", nextOperations, hasSize(0))
+    }
+
+    private fun execute(file: File) = MoveFileOrDirectory(file, File(destinationDir, file.name)).execute(executionContext)
+}

--- a/AnkiDroid/src/test/java/com/ichi2/testutils/FileSystemUtils.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/testutils/FileSystemUtils.kt
@@ -17,7 +17,10 @@
 package com.ichi2.testutils
 
 import androidx.annotation.CheckResult
+import com.ichi2.anki.model.Directory
 import org.acra.util.IOUtils
+import org.hamcrest.CoreMatchers
+import org.hamcrest.MatcherAssert
 import timber.log.Timber
 import java.io.File
 import kotlin.io.path.createTempDirectory
@@ -113,3 +116,13 @@ fun createTransientFile(content: String = ""): File =
         it.deleteOnExit()
         IOUtils.writeStringToFile(it, content)
     }
+
+/** Creates a sub-directory with the given name which is deleted on exit */
+fun Directory.createTransientDirectory(name: String): Directory {
+    File(this.directory, name).also { directory ->
+        directory.deleteOnExit()
+        Timber.d("test: creating $directory")
+        MatcherAssert.assertThat("directory should have been created", directory.mkdirs(), CoreMatchers.equalTo(true))
+        return Directory.createInstance(directory)!!
+    }
+}

--- a/AnkiDroid/src/test/java/com/ichi2/testutils/FileUtil.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/testutils/FileUtil.kt
@@ -55,6 +55,7 @@ object FileUtil {
 }
 
 fun DiskFile.length(): Long = this.file.length()
+fun Directory.exists(): Boolean = this.directory.exists()
 
 /** Adds a file to the directory with the provided name and content */
 fun File.withTempFile(fileName: String, content: String = "default content"): File {


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
In scoped storage migration, we need to move specific directories to a new location in the background.

We need to preempt the operation, breaking it into atomic chunks allows us to do this

## Referneces
#5304 

## Approach
High-level Operation class, allowing a directory to be recursively moved while handling non-fatal operations and preemption

## How Has This Been Tested?
Unit Tested only

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
