### PR TITLE
Don't create backup after restore

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/BackupManager.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/BackupManager.kt
@@ -59,9 +59,9 @@ open class BackupManager {
 
     @KotlinCleanup("make colPath non-null")
     @Suppress("PMD.NPathComplexity")
-    fun performBackupInBackground(colPath: String?, interval: Int, force: Boolean, time: Time): Boolean {
+    fun performBackupInBackground(colPath: String?, interval: Int, time: Time): Boolean {
         val prefs = AnkiDroidApp.getSharedPrefs(AnkiDroidApp.getInstance().baseContext)
-        if (hasDisabledBackups(prefs) && !force) {
+        if (hasDisabledBackups(prefs)) {
             Timber.w("backups are disabled")
             return false
         }
@@ -76,7 +76,7 @@ open class BackupManager {
 
         // Abort backup if one was already made less than 5 hours ago
         val lastBackupDate = getLastBackupDate(deckBackups, df)
-        if (lastBackupDate != null && lastBackupDate.time + interval * 3600000L > time.intTimeMS() && !force) {
+        if (lastBackupDate != null && lastBackupDate.time + interval * 3600000L > time.intTimeMS()) {
             Timber.d("performBackup: No backup created. Last backup younger than 5 hours")
             return false
         }
@@ -241,12 +241,7 @@ open class BackupManager {
 
         @JvmStatic
         fun performBackupInBackground(path: String?, time: Time): Boolean {
-            return BackupManager().performBackupInBackground(path, BACKUP_INTERVAL, false, time)
-        }
-
-        @JvmStatic
-        fun performBackupInBackground(path: String?, force: Boolean, time: Time): Boolean {
-            return BackupManager().performBackupInBackground(path, BACKUP_INTERVAL, force, time)
+            return BackupManager().performBackupInBackground(path, BACKUP_INTERVAL, time)
         }
 
         /**

--- a/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
@@ -1188,11 +1188,9 @@ public class CollectionTask<Progress, Result> extends BaseAsyncTask<Void, Progre
 
             try {
                 CollectionHelper.getInstance().getCol(context);
-                // unload collection and trigger a backup
-                Time time = CollectionHelper.getInstance().getTimeSafe(context);
+                // unload collection
                 CollectionHelper.getInstance().closeCollection(true, "Importing new collection");
                 CollectionHelper.getInstance().lockCollection();
-                BackupManager.performBackupInBackground(colPath, true, time);
             } catch (Exception e) {
                 Timber.w(e);
             }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/BackupManagerTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/BackupManagerTest.java
@@ -30,7 +30,6 @@ import static com.ichi2.utils.StrictMock.strictMock;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doNothing;
@@ -44,7 +43,7 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 public class BackupManagerTest {
 
     @Test
-    public void failsIfNoBackupsAllowedAndForceIsDisabled() {
+    public void failsIfNoBackupsAllowed() {
         // arrange
 
         BackupManager bm = getPassingBackupManagerSpy();
@@ -53,40 +52,16 @@ public class BackupManagerTest {
 
 
         // act
-        boolean force = false;
-
-        boolean performBackupResult = performBackup(bm, force);
+        boolean performBackupResult = performBackup(bm);
 
         // assert
 
         assertThat("should fail if backups are disabled", performBackupResult, is(false));
 
-        verify(bm, times(1)).performBackupInBackground(anyString(), anyInt(), anyBoolean(), any());
+        verify(bm, times(1)).performBackupInBackground(anyString(), anyInt(), any());
         verify(bm, times(1)).hasDisabledBackups(any());
 
         verifyNoMoreInteractions(bm);
-    }
-
-    @Test
-    public void passesIfNoBackupsAllowedAndForceIsEnabled() {
-        // arrange
-
-        BackupManager bm = getPassingBackupManagerSpy();
-
-        doReturn(true).when(bm).hasDisabledBackups(any());
-
-
-        // act
-        boolean force = true;
-
-        boolean performBackupResult = performBackup(bm, force);
-
-        // assert
-
-        assertThat("should pass if backups are disabled and force is enabled", performBackupResult, is(true));
-
-        verify(bm, times(1)).hasDisabledBackups(any());
-        verify(bm, times(1)).performBackupInBackground(anyString(), anyInt(), anyBoolean(), any());
     }
 
     /** Meta test: ensuring passingBackupManagerSpy passes */
@@ -140,17 +115,9 @@ public class BackupManagerTest {
         return performBackup(bm, new MockTime(100000000));
     }
 
-    protected boolean performBackup(BackupManager bm, Time time) {
-        return performBackup(bm, time, false);
-    }
 
-    protected boolean performBackup(BackupManager bm, boolean force) {
-        return performBackup(bm, new MockTime(100000000), force);
-    }
-
-
-    private boolean performBackup(BackupManager bm, Time time, boolean force) {
-        return bm.performBackupInBackground("", 100, force, time);
+    private boolean performBackup(BackupManager bm, Time time) {
+        return bm.performBackupInBackground("", 100, time);
     }
 
     /** Returns a spy of BackupManager which would pass */


### PR DESCRIPTION
## Fixes
Fixes #8897

## Approach
1. Remove backup creation in `CollectionTask.java` after backup restoring
2. Remove `BackupManager.kt` `force` parameter since it isn't used anymore
3. Fix `BackupManagerTest.java`

## How Has This Been Tested?

Phone: Samsung Galaxy Note 10 Lite SM-N770F/DS, API 30
https://user-images.githubusercontent.com/69634269/154801101-a3b986d6-ead3-4570-9394-ea302d01fcdf.mp4


## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
