### PR TITLE
feat(lint): Verify Positional Format Strings

### DIFF
--- a/lint-rules/src/main/java/com/ichi2/anki/lint/IssueRegistry.java
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/IssueRegistry.java
@@ -17,6 +17,7 @@ import com.ichi2.anki.lint.rules.FixedPreferencesTitleLength;
 import com.ichi2.anki.lint.rules.InconsistentAnnotationUsage;
 import com.ichi2.anki.lint.rules.KotlinMigrationBrokenEmails;
 import com.ichi2.anki.lint.rules.KotlinMigrationFixLineBreaks;
+import com.ichi2.anki.lint.rules.NonPositionalFormatSubstitutions;
 import com.ichi2.anki.lint.rules.NonPublicNonStaticJavaFieldDetector;
 import com.ichi2.anki.lint.rules.PreferIsEmptyOverSizeCheck;
 import com.ichi2.anki.lint.rules.PrintStackTraceUsage;
@@ -48,6 +49,7 @@ public class IssueRegistry extends com.android.tools.lint.client.api.IssueRegist
         issues.add(KotlinMigrationFixLineBreaks.ISSUE);
         issues.add(PreferIsEmptyOverSizeCheck.ISSUE);
         issues.add(PrintStackTraceUsage.ISSUE);
+        issues.add(NonPositionalFormatSubstitutions.ISSUE);
         issues.add(NonPublicNonStaticJavaFieldDetector.ISSUE);
         issues.add(ConstantJavaFieldDetector.ISSUE);
         issues.add(FixedPreferencesTitleLength.ISSUE_MAX_LENGTH);

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/rules/NonPositionalFormatSubstitutions.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/NonPositionalFormatSubstitutions.kt
@@ -1,0 +1,93 @@
+/*
+ *  Copyright (c) 2022 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.lint.rules
+
+import com.android.SdkConstants
+import com.android.resources.ResourceFolderType
+import com.android.tools.lint.detector.api.Implementation
+import com.android.tools.lint.detector.api.Issue
+import com.android.tools.lint.detector.api.ResourceXmlDetector
+import com.android.tools.lint.detector.api.Scope.Companion.ALL_RESOURCES_SCOPE
+import com.android.tools.lint.detector.api.XmlContext
+import com.ichi2.anki.lint.utils.Aapt2Util
+import com.ichi2.anki.lint.utils.Constants
+import com.ichi2.anki.lint.utils.StringFormatDetector
+import org.w3c.dom.Element
+import org.w3c.dom.Node
+
+/**
+ * Fix for "Multiple substitutions specified in non-positional format"
+ * [https://github.com/ankidroid/Anki-Android/issues/10347](https://github.com/ankidroid/Anki-Android/issues/10347)
+ */
+class NonPositionalFormatSubstitutions : ResourceXmlDetector() {
+    companion object {
+        private val IMPLEMENTATION_XML = Implementation(NonPositionalFormatSubstitutions::class.java, ALL_RESOURCES_SCOPE)
+
+        /**
+         * Whether there are any duplicate strings, including capitalization adjustments.
+         */
+        @JvmField
+        val ISSUE = Issue.create(
+            "NonPositionalFormatSubstitutions",
+            "Multiple substitutions specified in non-positional format",
+            "An XML string contains ambiguous format parameters " +
+                "for example: %s %s. These should be positional (%1\$s %2\$s) to allow" +
+                "translators to select the ordering.",
+            Constants.ANKI_CROWDIN_CATEGORY,
+            Constants.ANKI_CROWDIN_PRIORITY,
+            Constants.ANKI_CROWDIN_SEVERITY,
+            IMPLEMENTATION_XML
+        )
+    }
+
+    override fun appliesTo(folderType: ResourceFolderType): Boolean = folderType == ResourceFolderType.VALUES
+
+    override fun getApplicableElements() = listOf(SdkConstants.TAG_STRING)
+
+    override fun visitElement(context: XmlContext, element: Element) {
+        // Check both the translated text and the "values" folder.
+
+        val childNodes = element.childNodes
+        if (childNodes.length <= 0) return
+
+        if (childNodes.length == 1) {
+            val child = childNodes.item(0)
+            if (child.nodeType == Node.TEXT_NODE) {
+                checkTextNode(
+                    context,
+                    element,
+                    StringFormatDetector.stripQuotes(child.nodeValue)
+                )
+            }
+        } else {
+            val sb = StringBuilder()
+            StringFormatDetector.addText(sb, element)
+            if (sb.isNotEmpty()) {
+                checkTextNode(context, element, sb.toString())
+            }
+        }
+    }
+
+    private fun checkTextNode(context: XmlContext, element: Element, text: String) {
+        if (Aapt2Util.verifyJavaStringFormat(text)) return
+
+        val location = context.createLocationHandle(element).resolve()
+
+        // For clarity, the unescaped string is: "%s to %1$s"
+        context.report(ISSUE, location, "Multiple substitutions specified in non-positional format. Convert \"%s\" to \"%1\$s\"")
+    }
+}

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/utils/Aapt2Util.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/utils/Aapt2Util.kt
@@ -1,0 +1,155 @@
+/*
+ *  Copyright (c) 2022 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * ----
+ * This file incorporates code under the following license
+ * https://cs.android.com/android/platform/superproject/+/master:frameworks/base/tools/aapt2/util/Util.cpp;drc=fbb7fe0da32896a871dd395845f1f510b075f8d5
+ *
+ *     Copyright (C) 2015 The Android Open Source Project
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+
+package com.ichi2.anki.lint.utils
+
+/**
+ * Converted from C++
+ * https://cs.android.com/android/platform/superproject/+/master:frameworks/base/tools/aapt2/util/Util.cpp;drc=fbb7fe0da32896a871dd395845f1f510b075f8d5
+ */
+object Aapt2Util {
+
+    fun verifyJavaStringFormat(str: String): Boolean {
+
+        var argCount = 0
+        var nonpositional = false
+
+        var index = 0
+        fun c() = str[index]
+
+        while (index < str.length) {
+
+            if (c() == '%' && index + 1 < str.length) {
+                index++
+
+                if (c() == '%' || c() == 'n') {
+                    index++
+                    continue
+                }
+
+                argCount++
+
+                val numDigits = consumeDigits(str, index)
+                if (numDigits > 0) {
+                    index += numDigits
+                    if (index < str.length && c() != '$') {
+                        // The digits were a size, but not a positional argument.
+                        nonpositional = true
+                    }
+                } else if (c() == '<') {
+                    // Reusing last argument, bad idea since positions can be moved around
+                    // during translation.
+                    nonpositional = true
+
+                    index++
+
+                    // Optionally we can have a $ after
+                    if (index <= str.length && c() == '$') {
+                        index++
+                    }
+                } else {
+                    nonpositional = true
+                }
+
+                // Ignore size, width, flags, etc.
+                while (index < str.length && (
+                    c() == '-' || c() == '#' || c() == '+' || c() == ' ' ||
+                        c() == ',' || c() == '(' || (c() in '0'..'9')
+                    )
+                ) {
+                    index++
+                }
+
+                /*
+                 * This is a shortcut to detect strings that are going to Time.format()
+                 * instead of String.format()
+                 *
+                 * Comparison of String.format() and Time.format() args:
+                 *
+                 * String: ABC E GH  ST X abcdefgh  nost x
+                 *   Time:    DEFGHKMS W Za  d   hkm  s w yz
+                 *
+                 * Therefore we know it's definitely Time if we have:
+                 *     DFKMWZkmwyz
+                 */
+                if (index < str.length) {
+                    when (c()) {
+                        'D' -> return true
+                        'F' -> return true
+                        'K' -> return true
+                        'M' -> return true
+                        'W' -> return true
+                        'Z' -> return true
+                        'k' -> return true
+                        'm' -> return true
+                        'w' -> return true
+                        'y' -> return true
+                        'z' -> return true
+                    }
+                }
+            }
+
+            if (index < str.length) {
+                index++
+            }
+        }
+
+        if (argCount > 1 && nonpositional) {
+            // Multiple arguments were specified, but some or all were non positional.
+            // Translated strings may rearrange the order of the arguments, which will break the
+            // string.
+            return false
+        }
+        return true
+    }
+
+    /**
+     * Returns the number of consecutive digits in [s], starting at position [index]
+     * @param s The string to search
+     * @param index The index to start searching for digits at
+     * @return Number of consecutive digits in [s], starting at position [index]
+     */
+    private fun consumeDigits(s: String, index: Int): Int {
+        var digits = 0
+        @Suppress("UseWithIndex")
+        for (i in index until s.length) {
+            if (!s[i].isDigit()) {
+                return digits
+            }
+            digits++
+        }
+        return 0
+    }
+}

--- a/lint-rules/src/test/java/com/ichi2/anki/lint/rules/NonPositionalFormatSubstitutionsTest.kt
+++ b/lint-rules/src/test/java/com/ichi2/anki/lint/rules/NonPositionalFormatSubstitutionsTest.kt
@@ -1,0 +1,89 @@
+/*
+ *  Copyright (c) 2022 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.lint.rules
+
+import com.android.tools.lint.checks.infrastructure.TestFiles
+import com.android.tools.lint.checks.infrastructure.TestLintTask
+import org.intellij.lang.annotations.Language
+import org.junit.Test
+
+/** Test for [NonPositionalFormatSubstitutions] */
+class NonPositionalFormatSubstitutionsTest {
+
+    /** One substitution is unambiguous  */
+    @Language("XML")
+    private val valid = """<resources>
+       <string name="hello">%s</string>
+    </resources>"""
+
+    /** Easiest test case: Two exact duplicates in the same file  */
+    @Language("XML")
+    private val invalid = """<resources>
+       <string name="hello">%s %s</string>
+    </resources>"""
+
+    @Language("XML")
+    private val unambiguous = "<resources><string name=\"hello\">%1\$s %2\$s</string></resources>"
+
+    /** %% is an encoded percentage */
+    @Language("XML")
+    private val encoded = "<resources><string name=\"hello\">%%</string></resources>"
+
+    @Test
+    fun errors_if_ambiguous() {
+        TestLintTask.lint()
+            .allowMissingSdk()
+            .allowCompilationErrors()
+            .files(TestFiles.xml("res/values/string.xml", invalid))
+            .issues(NonPositionalFormatSubstitutions.ISSUE)
+            .run()
+            .expectErrorCount(1)
+    }
+
+    @Test
+    fun no_errors_if_valid() {
+        TestLintTask.lint()
+            .allowMissingSdk()
+            .allowCompilationErrors()
+            .files(TestFiles.xml("res/values/string.xml", valid))
+            .issues(NonPositionalFormatSubstitutions.ISSUE)
+            .run()
+            .expectClean()
+    }
+
+    @Test
+    fun no_errors_if_unambiguous() {
+        TestLintTask.lint()
+            .allowMissingSdk()
+            .allowCompilationErrors()
+            .files(TestFiles.xml("res/values/string.xml", unambiguous))
+            .issues(NonPositionalFormatSubstitutions.ISSUE)
+            .run()
+            .expectClean()
+    }
+
+    @Test
+    fun no_errors_if_encoded() {
+        TestLintTask.lint()
+            .allowMissingSdk()
+            .allowCompilationErrors()
+            .files(TestFiles.xml("res/values/string.xml", encoded))
+            .issues(NonPositionalFormatSubstitutions.ISSUE)
+            .run()
+            .expectClean()
+    }
+}


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
AAPT displayed these issues as build as warnings, but they did not break CI

## Fixes
Fixes #10347



## Approach

So, add some lint to make sure this occurs.

We take AAPT's C++ code and convert it to Kotlin.


Errors looks like:

```
AnkiDroid\src\main\res\values\04-network.xml:84:
Multiple substitutions specified in non-positional format.
Convert "%s" to "%1$s"
[NonPositionalFormatSubstitutions from com.ichi2.anki.lint]
```

## How Has This Been Tested?
Unit tested

Tested on commit d39249805081d18d1cf05178874608d161ae5a7a (failed)

## Learning (optional, can help others)
https://cs.android.com/android/platform/superproject/+/master:frameworks/base/tools/aapt2/util/Util.cpp;drc=fbb7fe0da32896a871dd395845f1f510b075f8d5

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
