### PR TITLE
Move file stream

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/scopedstorage/MoveDirectory.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/scopedstorage/MoveDirectory.kt
@@ -49,9 +49,9 @@ data class MoveDirectory(val source: Directory, val destination: File) : Migrate
             return operationCompleted()
         }
 
-        val moveOperations = source.listFiles().map(::toMoveOperation)
+        val moveContentOperations = MoveDirectoryContent.createInstance(source, destination)
         val deleteOperation = DeleteEmptyDirectory(source)
-        return moveOperations + deleteOperation
+        return listOf(moveContentOperations, deleteOperation)
     }
 
     /**
@@ -71,14 +71,6 @@ data class MoveDirectory(val source: Directory, val destination: File) : Migrate
             return false
         }
         return true
-    }
-
-    /**
-     * @returns An operation to move file or directory [sourceFile] to [destination]
-     */
-    @VisibleForTesting
-    internal fun toMoveOperation(sourceFile: File): Operation {
-        return MoveFileOrDirectory(sourceFile, File(destination, sourceFile.name))
     }
 
     /** Creates a directory if it doesn't already exist */

--- a/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/scopedstorage/MoveDirectory.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/scopedstorage/MoveDirectory.kt
@@ -45,21 +45,32 @@ data class MoveDirectory(val source: Directory, val destination: File) : Migrate
             context.attemptRename = false
         }
 
-        Timber.d("creating folder '$destination'")
-        if (!createDirectory(destination)) {
-            context.reportError(this, IllegalStateException("Could not create '$destination'"))
-            return operationCompleted()
-        }
-
-        val destinationDirectory = Directory.createInstance(destination)
-        if (destinationDirectory == null) {
-            context.reportError(this, IllegalStateException("Directory instantiation failed: '$destination'"))
+        if (!createDirectory(context)) {
             return operationCompleted()
         }
 
         val moveOperations = source.listFiles().map(::toMoveOperation)
         val deleteOperation = DeleteEmptyDirectory(source)
         return moveOperations + deleteOperation
+    }
+
+    /**
+     * Create an empty directory at destination.
+     * Return whether it was successful.
+     */
+    internal fun createDirectory(context: MigrateUserData.MigrationContext): Boolean {
+        Timber.d("creating folder '$destination'")
+        if (!createDirectory(destination)) {
+            context.reportError(this, IllegalStateException("Could not create '$destination'"))
+            return false
+        }
+
+        val destinationDirectory = Directory.createInstance(destination)
+        if (destinationDirectory == null) {
+            context.reportError(this, IllegalStateException("Directory instantiation failed: '$destination'"))
+            return false
+        }
+        return true
     }
 
     /**

--- a/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/OperationTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/OperationTest.kt
@@ -20,7 +20,12 @@ package com.ichi2.anki.servicelayer.scopedstorage
 import com.ichi2.anki.model.Directory
 import com.ichi2.anki.servicelayer.scopedstorage.MigrateUserData.Operation
 import com.ichi2.compat.CompatHelper
+import com.ichi2.testutils.TestException
 import com.ichi2.testutils.createTransientDirectory
+import org.mockito.invocation.InvocationOnMock
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doAnswer
+import org.mockito.kotlin.spy
 import timber.log.Timber
 import java.io.File
 
@@ -56,5 +61,59 @@ interface OperationTest {
         Timber.d("test: deleting $createDirectory")
         CompatHelper.getCompat().deleteFile(createDirectory.directory)
         return createDirectory.directory
+    }
+
+    /**
+     * Allow to get a MoveDirectoryContent that works for at most three files and fail on the second one.
+     * It keeps track of which files is the failed one and which are before and after; since directory can list its file in
+     * any order, it ensure that we know which file failed. It also allows to test that move still occurs after a failure.
+     */
+    class SpyMoveDirectoryContent(private val moveDirectoryContent: MoveDirectoryContent) {
+        /**
+         * The first file moved, before the failed file. Null if no moved occurred.
+         */
+        var beforeFile: File? = null
+            private set
+        /**
+         * The second file, it moves fails. Null if no moved occurred.
+         */
+        var failedFile: File? = null // ensure the second file fails
+            private set
+        /**
+         * The last file moved, after the failed file. Null if no moved occurred.
+         */
+        var afterFile: File? = null
+            private set
+        var movesProcessed = 0
+            private set
+
+        fun toMoveOperation(op: InvocationOnMock): Operation {
+            val sourceFile = op.arguments[0] as File
+            when (movesProcessed++) {
+                0 -> beforeFile = sourceFile
+                1 -> {
+                    failedFile = sourceFile
+                    return FailMove()
+                }
+                2 -> afterFile = sourceFile
+                else -> throw IllegalStateException("only 3 files expected")
+            }
+            return op.callRealMethod() as Operation
+        }
+
+        /**
+         * The [MoveDirectoryContent] that performs the action mentioned in the class description.
+         */
+        val spy: MoveDirectoryContent
+            get() = spy(moveDirectoryContent) {
+                doAnswer { toMoveOperation(it) }.`when`(it).toMoveOperation(any())
+            }
+    }
+}
+
+/** A move operation which fails */
+class FailMove : Operation() {
+    override fun execute(context: MigrateUserData.MigrationContext): List<Operation> {
+        throw TestException("should fail but not crash")
     }
 }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/OperationTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/OperationTest.kt
@@ -28,14 +28,13 @@ interface OperationTest {
     val executionContext: MockMigrationContext
 
     /** Helper function: executes an [Operation] and all sub-operations */
-    fun executeAll(op: Operation) {
-        val ops = ArrayDeque<Operation>()
-        ops.addFirst(op)
-        while (ops.any()) {
-            val head = ops.removeFirst()
+    fun executeAll(vararg ops: Operation) {
+        val opsTodo = ArrayDeque(ops.toList())
+        while (opsTodo.any()) {
+            val head = opsTodo.removeFirst()
             Timber.d("executing $head")
             this.executionContext.execSafe(head) {
-                ops.addAll(0, head.execute())
+                opsTodo.addAll(0, head.execute())
             }
         }
     }


### PR DESCRIPTION
This commit ensure that, starting at API 26, Operation uses a stream instead of a list of directory.
It uses the same set of tests than previous `MoveDirectory`.

Edit: it's entirely rewritten. It depends of 10375