### PR TITLE
Text pasted into Note Editor is now plain text by default

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/FieldEditText.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/FieldEditText.java
@@ -264,21 +264,19 @@ public class FieldEditText extends FixedEditText implements NoteService.NoteFiel
         * it ensures that the user sees the exact plain text which is actually being saved, not the formatted text.
         */
 
+        // https://stackoverflow.com/a/45319485
         if (id == android.R.id.paste) {
+            /**
+             * Modified StackOverflow answer:
+             * Pasting as plain text for VERSION_CODES < M required modifying 
+             * the user's clipboard, and hence has not been used.
+             *
+             * During testing, older devices pasted text as plain text by default, 
+             * so there was no need for a TO-DO
+             */
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
                 id = android.R.id.pasteAsPlainText;
             }
-
-            /**
-             * @see <a href="https://stackoverflow.com/a/45319485">StackOverflow Answer</a>
-             *
-             * This answer for pasting as plain text for VERSION_CODES < M
-             * required modifying the user's clipboard, and hence has not been used.
-             *
-             * On reproducing on an old device, "paste" option by default pasted as plain text,
-             * hence there was no need for a TO-DO
-             */
-
         }
         return super.onTextContextMenuItem(id);
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/FieldEditText.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/FieldEditText.java
@@ -262,7 +262,7 @@ public class FieldEditText extends FixedEditText implements NoteService.NoteFiel
         * The following code replaces the instruction "paste with formatting" with "paste as plan text"
         * Since AnkiDroid does not know how to use formatted text and strips the formatting when saving the note,
         * it ensures that the user sees the exact plain text which is actually being saved, not the formatted text.
-        * */
+        */
 
         if (id == android.R.id.paste) {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/FieldEditText.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/FieldEditText.java
@@ -257,7 +257,14 @@ public class FieldEditText extends FixedEditText implements NoteService.NoteFiel
        if (id == android.R.id.paste && ClipboardUtil.hasImage(mClipboard)) {
            return onImagePaste(ClipboardUtil.getImageUri(mClipboard));
        }
-
+        //Converts pasted text to plain text
+        if (id == android.R.id.paste) {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+                id = android.R.id.pasteAsPlainText;
+            } else {
+                //TODO: Add code to convert to plain text for version < M
+            }
+        }
         return super.onTextContextMenuItem(id);
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/FieldEditText.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/FieldEditText.java
@@ -257,13 +257,28 @@ public class FieldEditText extends FixedEditText implements NoteService.NoteFiel
        if (id == android.R.id.paste && ClipboardUtil.hasImage(mClipboard)) {
            return onImagePaste(ClipboardUtil.getImageUri(mClipboard));
        }
-        //Converts pasted text to plain text
+
+        /*
+        * The following code replaces the instruction "paste with formatting" with "paste as plan text"
+        * Since AnkiDroid does not know how to use formatted text and strips the formatting when saving the note,
+        * it ensures that the user sees the exact plain text which is actually being saved, not the formatted text.
+        * */
+
         if (id == android.R.id.paste) {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
                 id = android.R.id.pasteAsPlainText;
-            } else {
-                //TODO: Add code to convert to plain text for version < M
             }
+
+            /**
+             * @see <a href="https://stackoverflow.com/a/45319485">StackOverflow Answer</a>
+             *
+             * This answer for pasting as plain text for VERSION_CODES < M
+             * required modifying the user's clipboard, and hence has not been used.
+             *
+             * On reproducing on an old device, "paste" option by default pasted as plain text,
+             * hence there was no need for a TO-DO
+             */
+
         }
         return super.onTextContextMenuItem(id);
     }


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
When pasting into the editor, the text appeared formatted to the user, even though it was being stripped when saved. This is an inconsistency between what is displayed to the user and what is saved. 

## Fixes 
Fixes #10349 

## Approach

IMP: **This approach works only for devices running versions >= M**

I catch the `paste` action using `onTextContextMenuItem()`, and change the action to `pasteAsPlainText` before the pasting is done. This way, the text that is pasted is stripped before it is pasted. 

#### Before

![image](https://user-images.githubusercontent.com/86671025/154820321-81aecb36-d54e-4973-84de-2c20b5e724cf.png)

#### After

![image](https://user-images.githubusercontent.com/86671025/154820325-543a8dc6-29fc-4bf7-9902-1210973223c2.png)


## How Has This Been Tested?

Tested on my phone: Xaomi Redmi Note 8 Pro API 28 (Android 9)

## Learning (optional, can help others)

https://stackoverflow.com/a/45319485

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
