### PR TITLE
NF: add contentOfDirectory method

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/compat/Compat.java
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/Compat.java
@@ -1,5 +1,6 @@
 /****************************************************************************************
  * Copyright (c) 2011 Flavio Lerda <flerda@gmail.com>                                   *
+ * Copyright (c) 2022 Arthur Milchior <arthur@milchior.fr>                              *
  *                                                                                      *
  * This program is free software; you can redistribute it and/or modify it under        *
  * the terms of the GNU General Public License as published by the Free Software        *
@@ -254,5 +255,13 @@ public interface Compat {
      * WRITE_EXTERNAL_STORAGE permission
      */
     Uri saveImage(Context context, Bitmap bitmap, String baseFileName, String extension, Bitmap.CompressFormat format, int quality) throws FileNotFoundException;
+
+    /**
+     *
+     * @param directory A directory.
+     * @return a FileStream over file and folder of this directory.
+     *         null in case of trouble. This stream must be closed explicitly when done with it.
+     */
+    @Nullable FileStream contentOfDirectory(File directory);
 }
 

--- a/AnkiDroid/src/main/java/com/ichi2/compat/CompatV21.java
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/CompatV21.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2015 Timothy Rae <perceptualchaos2@gmail.com>
+ * Copyright (c) 2022 Arthur Milchior <arthur@milchior.fr>
  *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software
@@ -272,5 +273,35 @@ public class CompatV21 implements Compat {
         File imageFile = new File(ankiDroidFolder, baseFileName + "." + extension);
         bitmap.compress(format, quality, new FileOutputStream(imageFile));
         return Uri.fromFile(imageFile);
+    }
+
+    /* This method actually read the full content of the directory.
+    * It is linear in time and space in the number of file and folder in the directory.
+    * However, hasNext and next should be constant in time and space. */
+    @Override
+    public @Nullable FileStream contentOfDirectory(@NonNull File directory) {
+        File[] paths = directory.listFiles();
+        if (paths == null) {
+            return null;
+        }
+        int length = paths.length;
+        return new FileStream() {
+            @Override
+            public void close() {
+                // No op. Nothing to close here.
+            }
+
+
+            private int mOrd = 0;
+            @Override
+            public boolean hasNext() {
+                return mOrd < length;
+            }
+
+            @Override
+            public File next() {
+                return paths[mOrd++];
+            }
+        };
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/compat/FileStream.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/FileStream.kt
@@ -1,0 +1,49 @@
+/*
+ *  Copyright (c) 2022 Arthur Milchior <Arthur@Milchior.fr>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.compat
+
+import java.io.File
+import java.io.IOException
+
+/**
+ * A type to read a sequence of [File]. It is essentially [DirectoryStream]<File>, but accessible
+ * in all API. The result should be closed after use.
+ * This is not standard Iterator, because  `hasNext` and `next` may throw the checked exception [IOException]
+ * If `hasNext` returned true, we have two guarantees:
+ * * if the next function call on this object is to `hasNext`, it returns true.
+ * * if the next call on this object is to `next`, this method should not throw.
+ * @see [DirectoryStream]
+ * @see [Iterable]
+ */
+interface FileStream : AutoCloseable {
+
+    /**
+     * @see [Iterator.hasNext], but can throw a IOException
+     */
+    @Throws(IOException::class)
+    fun hasNext(): Boolean
+
+    /**
+     * Before the first call, and between each call to this method, you should call [hasNext].
+     * If [hasNext] ever returned `false` on an object `o`, you should not call [next] ever on `o`.
+     * If this instruction is not followed, a [IOException] may be thrown.
+     * @See [Iterator.next]
+     * @See [DirectoryStream]
+     */
+    @Throws(IOException::class)
+    fun next(): File
+}

--- a/AnkiDroid/src/test/java/com/ichi2/compat/DirectoryContentTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/compat/DirectoryContentTest.kt
@@ -1,0 +1,95 @@
+/*
+ *  Copyright (c) 2022 Arthur Milchior <Arthur@Milchior.fr>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.compat
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.ichi2.testutils.createTransientDirectory
+import com.ichi2.testutils.createTransientFile
+import com.ichi2.testutils.withTempFile
+import org.hamcrest.CoreMatchers.equalTo
+import org.hamcrest.CoreMatchers.not
+import org.hamcrest.MatcherAssert.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+
+@RunWith(AndroidJUnit4::class)
+@Config(sdk = [21, 26])
+class DirectoryContentTest {
+    @Test
+    fun empty_dir_test() {
+        val directory = createTransientDirectory()
+        CompatHelper.getCompat().contentOfDirectory(directory)!!.use {
+            assertThat("Iterator should not have next", it.hasNext(), equalTo(false))
+        }
+    }
+
+    @Test
+    fun ensure_absolute_path() {
+        // Relative paths caused me hours of debugging. Never again.
+        val directory = createTransientDirectory()
+            .withTempFile("zero")
+        val iterator = CompatHelper.getCompat().contentOfDirectory(directory)!!
+        val file = iterator.next()
+        assertThat("Paths should be canonical", file.path, equalTo(file.canonicalPath))
+    }
+
+    @Test
+    fun dir_test_three_files() {
+        val directory = createTransientDirectory()
+            .withTempFile("zero")
+            .withTempFile("one")
+            .withTempFile("two")
+        val iterator = CompatHelper.getCompat().contentOfDirectory(directory)!!
+        val found = Array(3) { false }
+        for (i in 1..3) {
+            assertThat("Iterator should have a $i-th element", iterator.hasNext(), equalTo(true))
+            val file = iterator.next()
+            val fileNumber = when (file.name) {
+                "zero" -> 0
+                "one" -> 1
+                "two" -> 2
+                else -> -1
+            }
+            assertThat("File ${file.name} should not be in ${directory.path}", fileNumber, not(equalTo(-1)))
+            assertThat("File ${file.name} should not be listed twice", found[fileNumber], equalTo(false))
+            found[fileNumber] = true
+        }
+        assertThat("Iterator should not have next anymore", iterator.hasNext(), equalTo(false))
+        iterator.close()
+    }
+
+    @Test
+    fun non_existent_dir_test() {
+        val directory = createTransientDirectory()
+        directory.delete()
+        assertThat(
+            "for non existent file, we expect nul",
+            CompatHelper.getCompat().contentOfDirectory(directory), equalTo(null)
+        )
+    }
+
+    @Test
+    fun file_test() {
+        val file = createTransientFile("foo")
+        file.delete()
+        assertThat(
+            "for file which is not a folder, we expect null",
+            CompatHelper.getCompat().contentOfDirectory(file), equalTo(null)
+        )
+    }
+}


### PR DESCRIPTION
This method returns an iterator over directory content as File.

Starting at API 26, this uses [Files.newDirectoryStream], ensuring that all
operations are constant time and space. For lower API, it simulates this method
using `listFiles`, whose space and time are linear in the number of file of the directory.

This is a first commit created to factorize more the MoveDirectory operation