### PR TITLE
NF: MoveFileOrDirectoryTest consistent with other Move

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/scopedstorage/MoveDirectory.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/scopedstorage/MoveDirectory.kt
@@ -24,7 +24,7 @@ import java.io.File
 
 /**
  * [Operation] which safely moves a directory at path `source` to path `destination`.
- * `destination is the new path of the directory.
+ * `destination` is the new path of the directory.
  *
  * Note: thrown exceptions are passed to the context via [MigrateUserData.MigrationContext.reportError]
  *

--- a/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/scopedstorage/MoveDirectory.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/scopedstorage/MoveDirectory.kt
@@ -18,8 +18,17 @@ package com.ichi2.anki.servicelayer.scopedstorage
 
 import androidx.annotation.VisibleForTesting
 import com.ichi2.anki.model.Directory
+import com.ichi2.anki.servicelayer.scopedstorage.MigrateUserData.Operation
 import timber.log.Timber
 import java.io.File
+
+/**
+ * [Operation] which safely moves a directory at path `source` to path `destination`.
+ * `destination is the new path of the directory.
+ *
+ * Note: thrown exceptions are passed to the context via [MigrateUserData.MigrationContext.reportError]
+ *
+ */
 
 data class MoveDirectory(val source: Directory, val destination: File) : MigrateUserData.Operation() {
     override fun execute(context: MigrateUserData.MigrationContext): List<MigrateUserData.Operation> {
@@ -57,8 +66,8 @@ data class MoveDirectory(val source: Directory, val destination: File) : Migrate
      * @returns An operation to move file or directory [sourceFile] to [destination]
      */
     @VisibleForTesting
-    internal fun toMoveOperation(sourceFile: File): MigrateUserData.Operation {
-        return MoveFileOrDirectory(sourceFile, destination)
+    internal fun toMoveOperation(sourceFile: File): Operation {
+        return MoveFileOrDirectory(sourceFile, File(destination, sourceFile.name))
     }
 
     /** Creates a directory if it doesn't already exist */

--- a/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/scopedstorage/MoveFile.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/scopedstorage/MoveFile.kt
@@ -25,7 +25,7 @@ import timber.log.Timber
 import java.io.File
 
 /**
- * [Operation] which safely moves a file from one location to another
+ * [Operation] which safely moves a file at path `sourceFile` to path `destinationFile`.
  *
  * Note: thrown exceptions are passed to the context via [MigrateUserData.MigrationContext.reportError]
  *

--- a/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/scopedstorage/MoveFileOrDirectory.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/scopedstorage/MoveFileOrDirectory.kt
@@ -30,6 +30,9 @@ import java.io.File
  *  Checking whether a `File` object is a file/directory requires an I/O operation, which means that
  *  it should not be done in a loop, as this would block preemption.
  *
+ *  @param sourceFile is the file or directory to move
+ *  @param destination the new path of the file or directory (not the directory containing it)
+ *
  * @see [MoveDirectory]
  * @see [MoveFile]
  */
@@ -44,7 +47,7 @@ data class MoveFileOrDirectory(
         when {
             sourceFile.isFile -> {
                 val fileToCreate = DiskFile.createInstanceUnsafe(sourceFile)
-                return listOf(MoveFile(fileToCreate, File(destination, sourceFile.name)))
+                return listOf(MoveFile(fileToCreate, destination))
             }
             sourceFile.isDirectory -> {
                 if (isSymlink(sourceFile)) {
@@ -52,7 +55,7 @@ data class MoveFileOrDirectory(
                     return operationCompleted()
                 }
                 val directory = Directory.createInstanceUnsafe(sourceFile)
-                return listOf(MoveDirectory(directory, File(destination, sourceFile.name)))
+                return listOf(MoveDirectory(directory, destination))
             }
             else -> {
                 if (!sourceFile.exists()) {

--- a/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/MoveFileOrDirectoryTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/MoveFileOrDirectoryTest.kt
@@ -18,6 +18,7 @@ package com.ichi2.anki.servicelayer.scopedstorage
 
 import com.ichi2.testutils.createTransientDirectory
 import com.ichi2.testutils.createTransientFile
+import org.hamcrest.CoreMatchers.equalTo
 import org.hamcrest.CoreMatchers.instanceOf
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.hasSize
@@ -35,7 +36,11 @@ class MoveFileOrDirectoryTest {
         val file = createTransientFile()
         val nextOperations = execute(file)
         assertThat("Only one operation should be next", nextOperations, hasSize(1))
-        assertThat("A file as input should return a file operation", nextOperations.single(), instanceOf(MoveFile::class.java))
+        val nextOperation = nextOperations[0]
+        assertThat("A file as input should return a file operation", nextOperation, instanceOf(MoveFile::class.java))
+        val moveFile = nextOperation as MoveFile
+        assertThat("Move file source should be file", moveFile.sourceFile.file, equalTo(file))
+        assertThat("Destination file source should be file", moveFile.destinationFile, equalTo(File(destinationDir, file.name)))
     }
 
     @Test
@@ -43,7 +48,11 @@ class MoveFileOrDirectoryTest {
         val directory = createTransientDirectory()
         val nextOperations = execute(directory)
         assertThat("Only one operation should be next", nextOperations, hasSize(1))
-        assertThat("A file as input should return a file operation", nextOperations.single(), instanceOf(MoveDirectory::class.java))
+        val nextOperation = nextOperations[0]
+        assertThat("A file as input should return a file operation", nextOperation, instanceOf(MoveDirectory::class.java))
+        val moveDirectory = nextOperation as MoveDirectory
+        assertThat("Move file source should be file", moveDirectory.source.directory, equalTo(directory))
+        assertThat("Destination file source should be file", moveDirectory.destination, equalTo(File(destinationDir, directory.name)))
     }
 
     @Test


### PR DESCRIPTION
I know explicitly state that in MoveFile and MoveDirectory, the destination is
the actual new path of the file/directory. (And not the directory where the
copied element will be)

For the sake of consistency, I change MoveFileOrDirectory so that its
destination is also the new path (and not the path of the directory containing
the copied file).

I discovered it while trying to make more specific test, where the
source/destination of elements were asserted. Those test are now committed too.
