### PR TITLE
MoveFile deal with destination which is a directory

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/scopedstorage/MigrateUserData.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/scopedstorage/MigrateUserData.kt
@@ -42,6 +42,11 @@ class MigrateUserData {
     class FileConflictException(val source: DiskFile, val destination: DiskFile) : RuntimeException()
 
     /**
+     * If [destination] is a folder. In this case, move `source/filename` to `source/conflict/filename`.
+     */
+    class FileDirectoryConflictException(val source: DiskFile, val destination: Directory) : RuntimeException()
+
+    /**
      * If one or more required directories were missing
      */
     class MissingDirectoryException(val directories: List<File>) : RuntimeException() {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/scopedstorage/MigrateUserData.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/scopedstorage/MigrateUserData.kt
@@ -39,12 +39,12 @@ class MigrateUserData {
      *
      * If a file named `filename` exists in [destination] and in [source] with different content, move `source/filename` to `source/conflict/filename`.
      */
-    class FileConflictException(val source: DiskFile, val destination: DiskFile) : RuntimeException()
+    class FileConflictException(val source: DiskFile, val destination: DiskFile) : RuntimeException("File $source can not be copied to $destination, destination exists and differs.")
 
     /**
      * If [destination] is a folder. In this case, move `source/filename` to `source/conflict/filename`.
      */
-    class FileDirectoryConflictException(val source: DiskFile, val destination: Directory) : RuntimeException()
+    class FileDirectoryConflictException(val source: DiskFile, val destination: Directory) : RuntimeException("File $source can not be copied to $destination, as destination is a directory.")
 
     /**
      * If one or more required directories were missing

--- a/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/scopedstorage/MoveFile.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/scopedstorage/MoveFile.kt
@@ -17,6 +17,7 @@
 package com.ichi2.anki.servicelayer.scopedstorage
 
 import androidx.annotation.VisibleForTesting
+import com.ichi2.anki.model.Directory
 import com.ichi2.anki.model.DiskFile
 import com.ichi2.anki.servicelayer.scopedstorage.MigrateUserData.EquivalentFileException
 import com.ichi2.anki.servicelayer.scopedstorage.MigrateUserData.Operation
@@ -38,6 +39,11 @@ import java.io.File
 internal data class MoveFile(val sourceFile: DiskFile, val destinationFile: File) : Operation() {
     override fun execute(context: MigrateUserData.MigrationContext): List<Operation> {
         val destinationExists = destinationFile.exists()
+
+        if (destinationExists && destinationFile.isDirectory) {
+            context.reportError(this, MigrateUserData.FileDirectoryConflictException(sourceFile, Directory.createInstanceUnsafe(destinationFile)))
+            return operationCompleted()
+        }
 
         if (handledEquivalentFileContent(destinationExists, context)) {
             return operationCompleted()

--- a/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/MoveFileTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/MoveFileTest.kt
@@ -265,6 +265,22 @@ class MoveFileTest(private val attemptRename: Boolean) : RobolectricTest() {
         assertProgressReported(size)
     }
 
+    @Test
+    fun move_file_to_dir_fail() {
+        val source = addUntrackedMediaFile("hello", listOf("hello.txt"))
+        val destination = createTransientDirectory()
+        executionContext.logExceptions = true
+        MoveFile(source, destination).execute()
+
+        assertThat("An exception should be logged", executionContext.exceptions, hasSize(1))
+        val exception = executionContext.exceptions[0]
+        assertThat("An exception should be of the correct type", exception, instanceOf(FileDirectoryConflictException::class.java))
+
+        assertThat("source file should still exist", source.file.exists(), equalTo(true))
+        assertThat("destination file should exist", destination.exists(), equalTo(true))
+        assertThat("content should not have changed", getContent(source.file), equalTo("hello"))
+    }
+
     /** Asserts that 1 element of progress of the provided size was reported */
     private fun assertProgressReported(expectedSize: Long) {
         val progress = executionContext.progress


### PR DESCRIPTION
That used to crash the app/test, because contentEquals require both files to be
either null or actual files (and not directory)
