### PR TITLE
Operation: Move content of a directory

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/scopedstorage/MoveDirectoryContent.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/scopedstorage/MoveDirectoryContent.kt
@@ -1,0 +1,75 @@
+/*
+ *  Copyright (c) 2022 Arthur Milchior <Arthur@milchior.fr>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.servicelayer.scopedstorage
+
+import androidx.annotation.VisibleForTesting
+import com.ichi2.anki.model.Directory
+import com.ichi2.compat.CompatHelper
+import com.ichi2.compat.FileStream
+import java.io.File
+import java.io.IOException
+
+/**
+ * This operation moves content of source to destination. This Operation is called one time for each file in the directory, and one last time. Unless an exception occurs. Use the [createInstance] to instantiate the object.  It will convert the given Directory source to a FileStream. This conversion is a potentially long-running operation.
+ * @param [source]: an iterator over File content, [source] will be closed in [execute] once the source is empty or if accessing its content raise an exception.
+ * @param [destination]: a folder to copy the source content.
+ * This is different than [MoveFile], [MoveDirectory] and [MoveFileOrDirectory] where destination is the new path of the copied element.
+ * Because in this case, there is not a single destination path.
+ */
+class MoveDirectoryContent private constructor(val source: FileStream, val destination: File) : MigrateUserData.Operation() {
+    companion object {
+        /**
+         * Return a [MoveDirectoryContent], moving the content of [source] to [destination].
+         * Its running time is potentially proportional to the number of files in [source].
+         * @param [source] a directory that should be moved
+         * @param [destination] a directory, assumed to exists, to which [source] content will be transferred.
+         * @throws [NoSuchFileException] if the file do not exists (starting at API 26)
+         * @throws [java.nio.file.NotDirectoryException] if the file exists and is not a directory (starting at API 26)
+         * @throws [FileNotFoundException] if the file do not exists (up to API 25)
+         * @throws [IOException] if files can not be listed. On non existing or non-directory file up to API 25. This also occurred on an existing directory because of permission issue
+         * that we could not reproduce. See https://github.com/ankidroid/Anki-Android/issues/10358
+         * @throws [SecurityException] – If a security manager exists and its SecurityManager.checkRead(String) method denies read access to the directory
+         */
+        fun createInstance(source: Directory, destination: File): MoveDirectoryContent =
+            MoveDirectoryContent(CompatHelper.getCompat().contentOfDirectory(source.directory), destination)
+    }
+
+    override fun execute(context: MigrateUserData.MigrationContext): List<MigrateUserData.Operation> {
+        try {
+            val hasNext = source.hasNext() // can throw an IOException
+            if (!hasNext) {
+                source.close()
+                return operationCompleted()
+            }
+        } catch (e: IOException) {
+            source.close()
+            throw e
+        }
+        val nextFile = source.next() // Guaranteed not to throw since hasNext returned true.
+        val moveNextFile = toMoveOperation(nextFile)
+        val moveRemainingDirectoryContent = this
+        return listOf(moveNextFile, moveRemainingDirectoryContent)
+    }
+
+    /**
+     * @returns An operation to move file or directory [sourceFile] to [destination]
+     */
+    @VisibleForTesting
+    internal fun toMoveOperation(sourceFile: File): MigrateUserData.Operation {
+        return MoveFileOrDirectory(sourceFile, File(destination, sourceFile.name))
+    }
+}

--- a/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/MoveDirectoryContentTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/MoveDirectoryContentTest.kt
@@ -16,83 +16,69 @@
 
 package com.ichi2.anki.servicelayer.scopedstorage
 
+import android.os.Build
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.ichi2.anki.model.Directory
 import com.ichi2.anki.servicelayer.scopedstorage.MigrateUserData.Operation
 import com.ichi2.testutils.*
-import org.hamcrest.CoreMatchers.equalTo
-import org.hamcrest.CoreMatchers.instanceOf
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.*
 import org.junit.Test
+import org.junit.runner.RunWith
 import org.mockito.kotlin.any
 import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.spy
+import org.robolectric.annotation.Config
 import java.io.File
+import java.io.FileNotFoundException
+import java.io.IOException
+import java.nio.file.NotDirectoryException
 
 /**
- * Test for [MoveDirectory]
+ * Test for [MoveDirectoryContent]
  */
-class MoveDirectoryTest : OperationTest {
-    override val executionContext: MockMigrationContext = MockMigrationContext()
+@RunWith(AndroidJUnit4::class)
+@Config(sdk = [21, 26])
+class MoveDirectoryContentTest : OperationTest {
+
+    override val executionContext = MockMigrationContext()
+
+    @Test
+    fun test_one_operation() {
+        val source = createDirectory()
+            .withTempFile("foo.txt")
+        val destinationDirectory = createTransientDirectory()
+
+        val moveOperation = moveDirectoryContent(source, destinationDirectory)
+        val result1 = moveOperation.execute()
+        assertThat("First result should have two operations", result1, hasSize(2))
+        assertThat("First result's first operation should be MoveFileOrDirectory", result1[0], instanceOf(MoveFileOrDirectory::class.java))
+        val moveFoo = result1[0] as MoveFileOrDirectory
+        assertThat("First result's second operation should have source foo.txt", moveFoo.sourceFile.name, equalTo("foo.txt"))
+        assertThat("First result's second operation should be move_operation", result1[1], equalTo(moveOperation))
+
+        val result2 = moveOperation.execute()
+        assertThat("Second result should have no operation", result2, hasSize(0))
+    }
 
     @Test
     fun test_success_integration_test_recursive() {
         val source = createDirectory().withTempFile("tmp.txt")
-        source.createTransientDirectory("more files").withTempFile("tmp-2.txt")
-        val destinationFile = generateDestinationDirectoryRef()
-        executionContext.attemptRename = false
+        val moreFiles = source.createTransientDirectory("more files").withTempFile("tmp-2.txt")
+        val destinationDirectory = createTransientDirectory()
 
-        executeAll(MoveDirectory(source, destinationFile))
+        executeAll(moveDirectoryContent(source, destinationDirectory))
 
-        assertThat("source directory should not exist", source.exists(), equalTo(false))
-        assertThat("destination directory should exist", destinationFile.exists(), equalTo(true))
-        assertThat("file should be copied", File(destinationFile, "tmp.txt").exists(), equalTo(true))
+        assertThat("source directory should exist", source.exists(), equalTo(true))
+        assertThat("destination directory should exist", destinationDirectory.exists(), equalTo(true))
+        assertThat("tmp.txt should be deleted at source", File(source.directory, "tmp.txt").exists(), equalTo(false))
+        assertThat("tmp.txt should be copied", File(destinationDirectory, "tmp.txt").exists(), equalTo(true))
 
-        val subdirectory = File(destinationFile, "more files")
+        val subdirectory = File(destinationDirectory, "more files")
+        assertThat("'more file' should be deleted at source", moreFiles.exists(), equalTo(false))
         assertThat("subdir was copied", subdirectory.exists(), equalTo(true))
-        assertThat("subdir file was copied", File(subdirectory, "tmp-2.txt").exists(), equalTo(true))
-    }
-
-    @Test
-    fun test_fast_rename() {
-        val source = createDirectory().withTempFile("tmp.txt")
-        val destinationFile = generateDestinationDirectoryRef()
-        executionContext.attemptRename = true
-
-        val ret = MoveDirectory(source, destinationFile).execute()
-
-        assertThat("fast rename returns no operations", ret, empty())
-        assertThat("source directory should not exist", source.exists(), equalTo(false))
-        assertThat("destination directory should exist", destinationFile.exists(), equalTo(true))
-        assertThat("file should be copied", File(destinationFile, "tmp.txt").exists(), equalTo(true))
-    }
-
-    @Test
-    fun failed_rename_avoids_further_renames() {
-        // This is a performance optimization,
-        val source = createDirectory().withTempFile("tmp.txt")
-        val destinationFile = generateDestinationDirectoryRef()
-        var renameCalled = 0
-
-        executionContext.logExceptions = true
-        // don't actually move the directory, or we'd have a problem
-        val moveDirectory = spy(MoveDirectory(source, destinationFile)) {
-            doAnswer { renameCalled++; return@doAnswer false }.`when`(it).rename(any(), any())
-        }
-
-        assertThat("rename was true", executionContext.attemptRename, equalTo(true))
-
-        moveDirectory.execute()
-
-        assertThat("rename is now false", executionContext.attemptRename, equalTo(false))
-        assertThat("rename was called", renameCalled, equalTo(1))
-
-        moveDirectory.execute()
-
-        assertThat("rename was not called again", renameCalled, equalTo(1))
-
-        assertThat(executionContext.exceptions, hasSize(0))
-        assertThat("source was not copied", File(source.directory, "tmp.txt").exists(), equalTo(true))
+        assertThat("tmp-2.txt file was deleted at source", File(moreFiles.directory, "tmp-2.txt").exists(), equalTo(false))
+        assertThat("tmp-2.txt file was copied", File(subdirectory, "tmp-2.txt").exists(), equalTo(true))
     }
 
     @Test
@@ -102,16 +88,16 @@ class MoveDirectoryTest : OperationTest {
             .withTempFile("bar.txt")
             .withTempFile("baz.txt")
 
-        val destinationDirectory = generateDestinationDirectoryRef()
+        assertThat("foo should exists", File(source.directory, "foo.txt").exists(), equalTo(true))
+        val destinationDirectory = createTransientDirectory()
 
         // Use variables as we don't know which file will be returned in the middle from listFiles()
         var beforeFile: File? = null
         var failedFile: File? = null // ensure the second file fails
         var afterFile: File? = null
-        executionContext.attemptRename = false
         executionContext.logExceptions = true
         var movesProcessed = 0
-        val operation = spy(MoveDirectory(source, destinationDirectory)) {
+        val operation = spy(moveDirectoryContent(source, destinationDirectory)) {
             doAnswer { op ->
                 val sourceFile = op.arguments[0] as File
                 when (movesProcessed++) {
@@ -128,17 +114,15 @@ class MoveDirectoryTest : OperationTest {
             }.`when`(it).toMoveOperation(any())
         }
         executeAll(operation)
+        assertThat("Should have done three moves", movesProcessed, equalTo(3))
 
-        assertThat(executionContext.exceptions, hasSize(2))
+        assertThat(executionContext.exceptions, hasSize(1))
         executionContext.exceptions[0].run {
             assertThat(this, instanceOf(TestException::class.java))
         }
-        executionContext.exceptions[1].run {
-            assertThat(this.message, containsString("directory was not empty"))
-        }
 
         assertThat("source directory should not be deleted", source.exists(), equalTo(true))
-        assertThat("fail was not copied", failedFile!!.exists(), equalTo(true))
+        assertThat("fail (${failedFile!!.absolutePath}) was not copied", failedFile!!.exists(), equalTo(true))
         assertThat("file before failure was copied", beforeFile!!.exists(), equalTo(false))
         assertThat("file after failure was copied", afterFile!!.exists(), equalTo(false))
     }
@@ -176,7 +160,7 @@ class MoveDirectoryTest : OperationTest {
         executionContext.attemptRename = false
         executionContext.logExceptions = true
         var movesProcessed = 0
-        val operation = spy(MoveDirectory(source, destinationDirectory)) {
+        val operation = spy(MoveDirectoryContent.createInstance(source, destinationDirectory)) {
             doAnswer { op ->
                 val operation = op.callRealMethod() as Operation
                 if (movesProcessed++ == 1) {
@@ -200,34 +184,40 @@ class MoveDirectoryTest : OperationTest {
         )
     }
 
+    /**
+     * Checking that `MoveDirectoryContent` don't delete the source directory.
+     * Deleting the source directory is the responsability of `MoveDirectory`
+     */
     @Test
-    fun empty_directory_is_deleted() {
+    fun empty_directory_is_not_deleted() {
         val source = createDirectory()
-        val destinationFile = generateDestinationDirectoryRef()
+        val destinationDirectory = generateDestinationDirectoryRef()
 
-        executionContext.attemptRename = false
+        executeAll(moveDirectoryContent(source, destinationDirectory))
 
-        executeAll(MoveDirectory(source, destinationFile))
-
-        assertThat("source was deleted", source.directory.exists(), equalTo(false))
+        assertThat("source directory should not be deleted", source.directory.exists(), equalTo(true))
     }
 
     @Test
-    fun empty_directory_is_deleted_rename() {
+    fun factory_on_missing_directory_throw() {
         val source = createDirectory()
-        val destinationFile = generateDestinationDirectoryRef()
-
-        executionContext.attemptRename = true
-
-        executeAll(MoveDirectory(source, destinationFile))
-
-        assertThat("source was deleted", source.directory.exists(), equalTo(false))
+        val destinationDirectory = generateDestinationDirectoryRef()
+        source.directory.delete()
+        assertThrows<FileNotFoundException> { moveDirectoryContent(source, destinationDirectory) }
     }
-}
 
-/** A move operation which fails */
-class FailMove : Operation() {
-    override fun execute(context: MigrateUserData.MigrationContext): List<Operation> {
-        throw TestException("should fail but not crash")
+    @Test
+    fun factory_on_file_throw() {
+        val source_file = createTransientFile()
+        val dir = Directory.createInstanceUnsafe(source_file)
+        val destinationDirectory = generateDestinationDirectoryRef()
+        val ex = assertThrowsSubclass<IOException> { moveDirectoryContent(dir, destinationDirectory) }
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            assertThat("Starting at API 26, this should be a NotDirectoryException", ex, instanceOf(NotDirectoryException::class.java))
+        }
+    }
+
+    private fun moveDirectoryContent(source: Directory, destinationDirectory: File): MoveDirectoryContent {
+        return MoveDirectoryContent.createInstance(source, destinationDirectory)
     }
 }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/MoveDirectoryTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/MoveDirectoryTest.kt
@@ -226,19 +226,6 @@ class MoveDirectoryTest : OperationTest {
         assertThat("source was deleted", source.directory.exists(), equalTo(false))
     }
 
-    /** Helper function: executes an [Operation] and all sub-operations */
-    private fun executeAll(op: MoveDirectory) {
-        val l = ArrayDeque<Operation>()
-        l.addFirst(op)
-        while (l.any()) {
-            val head = l.removeFirst()
-            Timber.d("executing $head")
-            this.executionContext.execSafe(head) {
-                l.addAll(0, head.execute())
-            }
-        }
-    }
-
     /** Creates an empty TMP directory to place the output files in */
     private fun generateDestinationDirectoryRef(): File {
         val createDirectory = createDirectory()

--- a/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/MoveDirectoryTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/MoveDirectoryTest.kt
@@ -233,9 +233,6 @@ class MoveDirectoryTest : OperationTest {
         CompatHelper.getCompat().deleteFile(createDirectory.directory)
         return createDirectory.directory
     }
-
-    private fun createDirectory(): Directory =
-        Directory.createInstance(createTransientDirectory())!!
 }
 
 /** A move operation which fails */

--- a/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/MoveDirectoryTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/MoveDirectoryTest.kt
@@ -28,7 +28,6 @@ import org.junit.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.spy
-import timber.log.Timber
 import java.io.File
 
 /**
@@ -224,14 +223,6 @@ class MoveDirectoryTest : OperationTest {
         executeAll(MoveDirectory(source, destinationFile))
 
         assertThat("source was deleted", source.directory.exists(), equalTo(false))
-    }
-
-    /** Creates an empty TMP directory to place the output files in */
-    private fun generateDestinationDirectoryRef(): File {
-        val createDirectory = createDirectory()
-        Timber.d("test: deleting $createDirectory")
-        CompatHelper.getCompat().deleteFile(createDirectory.directory)
-        return createDirectory.directory
     }
 }
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/OperationTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/OperationTest.kt
@@ -17,7 +17,9 @@
 
 package com.ichi2.anki.servicelayer.scopedstorage
 
+import com.ichi2.anki.model.Directory
 import com.ichi2.anki.servicelayer.scopedstorage.MigrateUserData.Operation
+import com.ichi2.testutils.createTransientDirectory
 import timber.log.Timber
 
 interface OperationTest {
@@ -40,5 +42,10 @@ interface OperationTest {
      * Executes an [Operation] without executing the sub-operations
      * @return the sub-operations returned from the execution of the operation
      */
+
     fun Operation.execute(): List<Operation> = this.execute(executionContext)
+
+    /** Return a new empty Directory, which will be deleted after the test. */
+    fun createDirectory(): Directory =
+        Directory.createInstance(createTransientDirectory())!!
 }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/OperationTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/OperationTest.kt
@@ -19,8 +19,10 @@ package com.ichi2.anki.servicelayer.scopedstorage
 
 import com.ichi2.anki.model.Directory
 import com.ichi2.anki.servicelayer.scopedstorage.MigrateUserData.Operation
+import com.ichi2.compat.CompatHelper
 import com.ichi2.testutils.createTransientDirectory
 import timber.log.Timber
+import java.io.File
 
 interface OperationTest {
     val executionContext: MockMigrationContext
@@ -48,4 +50,12 @@ interface OperationTest {
     /** Return a new empty Directory, which will be deleted after the test. */
     fun createDirectory(): Directory =
         Directory.createInstance(createTransientDirectory())!!
+
+    /** Creates an empty TMP directory to place the output files in */
+    fun generateDestinationDirectoryRef(): File {
+        val createDirectory = createDirectory()
+        Timber.d("test: deleting $createDirectory")
+        CompatHelper.getCompat().deleteFile(createDirectory.directory)
+        return createDirectory.directory
+    }
 }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/OperationTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/OperationTest.kt
@@ -18,9 +18,23 @@
 package com.ichi2.anki.servicelayer.scopedstorage
 
 import com.ichi2.anki.servicelayer.scopedstorage.MigrateUserData.Operation
+import timber.log.Timber
 
 interface OperationTest {
     val executionContext: MockMigrationContext
+
+    /** Helper function: executes an [Operation] and all sub-operations */
+    fun executeAll(op: Operation) {
+        val ops = ArrayDeque<Operation>()
+        ops.addFirst(op)
+        while (ops.any()) {
+            val head = ops.removeFirst()
+            Timber.d("executing $head")
+            this.executionContext.execSafe(head) {
+                ops.addAll(0, head.execute())
+            }
+        }
+    }
 
     /**
      * Executes an [Operation] without executing the sub-operations


### PR DESCRIPTION
This PR adds an operation that allow to move the content of a directory.

It's a step toward creating "MoveDirectory" with atomic operations starting on API O. It requires PR ~~#10369, #10372, #10373, #10374~~ (all merged) and #10376