### PR TITLE
Factorize execute

### DIFF
--- a/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/DeleteEmptyDirectoryTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/DeleteEmptyDirectoryTest.kt
@@ -70,6 +70,4 @@ class DeleteEmptyDirectoryTest : OperationTest {
 
     private fun createEmptyDirectory() =
         Directory.createInstance(File(createTempDirectory().pathString))!!
-
-    fun MigrateUserData.Operation.execute() = this.execute(executionContext)
 }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/DeleteEmptyDirectoryTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/DeleteEmptyDirectoryTest.kt
@@ -28,9 +28,9 @@ import kotlin.io.path.pathString
 /**
  * Tests for [DeleteEmptyDirectory]
  */
-class DeleteEmptyDirectoryTest {
+class DeleteEmptyDirectoryTest : OperationTest {
 
-    val executionContext = MockMigrationContext()
+    override val executionContext = MockMigrationContext()
 
     @Test
     fun succeeds_if_directory_is_empty() {

--- a/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/MoveDirectoryTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/MoveDirectoryTest.kt
@@ -34,9 +34,8 @@ import java.io.File
 /**
  * Test for [MoveDirectory]
  */
-class MoveDirectoryTest {
-
-    private val executionContext: MockMigrationContext = MockMigrationContext()
+class MoveDirectoryTest : OperationTest {
+    override val executionContext: MockMigrationContext = MockMigrationContext()
 
     @Test
     fun test_success_integration_test_recursive() {

--- a/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/MoveDirectoryTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/MoveDirectoryTest.kt
@@ -249,12 +249,6 @@ class MoveDirectoryTest : OperationTest {
 
     private fun createDirectory(): Directory =
         Directory.createInstance(createTransientDirectory())!!
-
-    /**
-     * Executes an [Operation] without executing the sub-operations
-     * @return the sub-operations returned from the execution of the operation
-     */
-    private fun Operation.execute(): List<Operation> = this.execute(executionContext)
 }
 
 /** A move operation which fails */

--- a/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/MoveFileOrDirectoryTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/MoveFileOrDirectoryTest.kt
@@ -63,5 +63,5 @@ class MoveFileOrDirectoryTest : OperationTest {
         assertThat("No operations should be next as file is deleted", nextOperations, hasSize(0))
     }
 
-    private fun moveFromAndExecute(file: File) = MoveFileOrDirectory(file, File(destinationDir, file.name)).execute(executionContext)
+    private fun moveFromAndExecute(file: File) = MoveFileOrDirectory(file, File(destinationDir, file.name)).execute()
 }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/MoveFileOrDirectoryTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/MoveFileOrDirectoryTest.kt
@@ -26,9 +26,9 @@ import org.junit.Test
 import java.io.File
 
 /** Tests for [MoveFileOrDirectory] */
-class MoveFileOrDirectoryTest {
+class MoveFileOrDirectoryTest : OperationTest {
 
-    private val executionContext = MockMigrationContext()
+    override val executionContext = MockMigrationContext()
     private val destinationDir = createTransientDirectory()
 
     @Test

--- a/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/MoveFileTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/MoveFileTest.kt
@@ -35,7 +35,7 @@ import timber.log.Timber
 import java.io.File
 
 @RunWith(ParameterizedRobolectricTestRunner::class)
-class MoveFileTest(private val attemptRename: Boolean) : RobolectricTest() {
+class MoveFileTest(private val attemptRename: Boolean) : RobolectricTest(), OperationTest {
     companion object {
         @Suppress("unused")
         @Parameters(name = "attemptRename = {0}")
@@ -45,7 +45,7 @@ class MoveFileTest(private val attemptRename: Boolean) : RobolectricTest() {
         }
     }
 
-    private val executionContext: MockMigrationContext = MockMigrationContext()
+    override val executionContext: MockMigrationContext = MockMigrationContext()
 
     @Test
     fun move_file_is_success() {

--- a/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/OperationTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/OperationTest.kt
@@ -17,6 +17,14 @@
 
 package com.ichi2.anki.servicelayer.scopedstorage
 
+import com.ichi2.anki.servicelayer.scopedstorage.MigrateUserData.Operation
+
 interface OperationTest {
     val executionContext: MockMigrationContext
+
+    /**
+     * Executes an [Operation] without executing the sub-operations
+     * @return the sub-operations returned from the execution of the operation
+     */
+    fun Operation.execute(): List<Operation> = this.execute(executionContext)
 }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/OperationTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/OperationTest.kt
@@ -1,0 +1,22 @@
+/*
+ *  Copyright (c) 2022 David Allison <davidallisongithub@gmail.com>
+ *  Copyright (c) 2022 Arthur Milchior <arthur@milchior.fr>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.servicelayer.scopedstorage
+
+interface OperationTest {
+    val executionContext: MockMigrationContext
+}


### PR DESCRIPTION
It depends on #10382 and #10383 and was originally a part of #10376
It ensures that we have a single implementation for `execute` and that all methods called `execute` do the same thing (at least in this test package)