### PR TITLE
"Deck Search" display now same as the Deck Viewer

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckSelectionDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckSelectionDialog.kt
@@ -226,13 +226,6 @@ open class DeckSelectionDialog : AnalyticsDialogFragment() {
                 deckTextView.text = deck.displayName
             }
 
-            /*
-            deckName and deckTextView.text are different, so that
-            even though the displayName will be used for display in
-            the recyclerView, the deckName(which is the entire deck path)
-            will be used in the below init functions (which require the path)
-             */
-
             init {
                 deckTextView.setOnClickListener {
                     selectDeckByNameAndClose(deckName)
@@ -321,14 +314,20 @@ open class DeckSelectionDialog : AnalyticsDialogFragment() {
          */
         val name: String
 
-        var displayName: String = ""
-        // The name to be displayed in the Recycler View
-        // contains only subdeck name, not "deck::subdeck"
+        /**
+         * The name to be displayed to the user. Contains
+         * only the sub-deck name with proper indentation
+         * rather than the entire deck name.
+         * Eg: foo::bar -> \t\tbar
+         */
+        val displayName: String // TODO should be a lazy value
+            get() {
+                return getDisplayName(name)
+            }
 
         constructor(deckId: Long, name: String) {
             this.deckId = deckId
             this.name = name
-            this.displayName = getDisplayName(name)
         }
 
         protected constructor(d: Deck) : this(d.getLong("id"), d.getString("name"))
@@ -337,20 +336,14 @@ open class DeckSelectionDialog : AnalyticsDialogFragment() {
             name = `in`.readString()!!
         }
 
-        /*
-        The getDisplayName function takes the entire deck path as input,
-        and returns only the name of the deck/subdeck
+        /**
+         * @param name the entire name(path) of the deck
+         * @return the deck/subdeck name to be displayed to the user
          */
-
         private fun getDisplayName(name: String): String {
-            var displayName = name
-            var subDeckLevel: Int = name.count { "::".contains(it) } / 2
-
-            while (subDeckLevel > 0) {
-                displayName = displayName.slice(displayName.indexOf("::") + 2 until displayName.length)
-                subDeckLevel--
-            }
-            displayName = "\t\t".repeat(name.count { "::".contains(it) } / 2) + displayName
+            var nameArr = name.split("::")
+            var displayName = nameArr[nameArr.size - 1]
+            displayName = "\t\t".repeat(nameArr.size - 1) + displayName
 
             return displayName
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckSelectionDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckSelectionDialog.kt
@@ -321,9 +321,7 @@ open class DeckSelectionDialog : AnalyticsDialogFragment() {
          * Eg: foo::bar -> \t\tbar
          */
         val displayName: String // TODO should be a lazy value
-            get() {
-                return getDisplayName(name)
-            }
+            get() = getDisplayName(name)
 
         constructor(deckId: Long, name: String) {
             this.deckId = deckId
@@ -342,10 +340,7 @@ open class DeckSelectionDialog : AnalyticsDialogFragment() {
          */
         private fun getDisplayName(name: String): String {
             var nameArr = name.split("::")
-            var displayName = nameArr[nameArr.size - 1]
-            displayName = "\t\t".repeat(nameArr.size - 1) + displayName
-
-            return displayName
+            return "\t\t".repeat(nameArr.size - 1) + nameArr[nameArr.size - 1]
         }
 
         /** "All decks" comes first. Then usual deck name order.  */

--- a/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/DeckSelectionDialogTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/DeckSelectionDialogTest.kt
@@ -1,0 +1,36 @@
+/*
+ *  Copyright (c) 2022 Akshit Sinha <akshitsinha3@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.dialogs
+
+import com.ichi2.anki.dialogs.DeckSelectionDialog.SelectableDeck
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers
+import org.junit.Test
+
+class DeckSelectionDialogTest {
+
+    @Test
+    fun verifyDeckDisplayName() {
+        val input = "deck::sub-deck::sub-deck2::sub-deck3"
+        val expected = "\t\t\t\t\t\tsub-deck3"
+
+        val deck = SelectableDeck(1234, input)
+        val actual: String = deck.displayName
+
+        assertThat(actual, Matchers.equalTo(expected))
+    }
+}


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
As described in #10378, the way decks are currently displayed in the "Deck Search" subscreen is not intuitive nor easy to understand, especially with multiple subdeck levels. This PR aims to make it more user friendly by indenting decks the same way as the main "Deck Viewer" screen.

EDIT: Also added a test for the same. 

I feel the code can be better formatted and commented.

## Fixes
Fixes #10378 

## Approach
instead of displaying the entire deck path, now only the subdeck name is displayed along with appropriate indentation. Deck and subdeck creation works just like before.

### Before
![image](https://user-images.githubusercontent.com/86671025/155477017-9d49348b-3b9f-4ffb-a703-c11f49e414be.png)

### After
![image](https://user-images.githubusercontent.com/86671025/155477034-571d8ca7-34d7-4198-88e1-cc91de3ae103.png)

Video showing creation of subdecks:
<img src="https://user-images.githubusercontent.com/86671025/155477447-830af4bd-16de-452e-a9ca-1d7584240f03.gif" width="300" inline = "true" >

Video showing search capability:

https://user-images.githubusercontent.com/86671025/155478620-26e90d7c-cab6-4425-93a3-55ee93fd7405.mp4

## How Has This Been Tested?

Emulator:
Pixel 5 API 32

Device:
Xaomi Redmi Note 8 Pro API 28 (Android 9)

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
