### PR TITLE
`contentOfDirectory` may throw

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/compat/Compat.java
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/Compat.java
@@ -261,7 +261,12 @@ public interface Compat {
      * @param directory A directory.
      * @return a FileStream over file and folder of this directory.
      *         null in case of trouble. This stream must be closed explicitly when done with it.
+     * @throws java.nio.file.NoSuchFileException if the file do not exists (starting at API 26)
+     * @throws java.nio.file.NotDirectoryException if the file exists and is not a directory (starting at API 26)
+     * @throws IOException if files can not be listed. On non existing or non-directory file up to API 25. This also occurred on an existing directory because of permission issue
+     * that we could not reproduce. See https://github.com/ankidroid/Anki-Android/issues/10358
+     * @throws SecurityException – If a security manager exists and its SecurityManager.checkRead(String) method denies read access to the directory
      */
-    @Nullable FileStream contentOfDirectory(File directory);
+    @NonNull FileStream contentOfDirectory(File directory) throws IOException  ;
 }
 

--- a/AnkiDroid/src/main/java/com/ichi2/compat/CompatV21.java
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/CompatV21.java
@@ -279,10 +279,10 @@ public class CompatV21 implements Compat {
     * It is linear in time and space in the number of file and folder in the directory.
     * However, hasNext and next should be constant in time and space. */
     @Override
-    public @Nullable FileStream contentOfDirectory(@NonNull File directory) {
+    public @NonNull FileStream contentOfDirectory(@NonNull File directory) throws IOException {
         File[] paths = directory.listFiles();
         if (paths == null) {
-            return null;
+            throw new IOException("Directory " + directory.getPath() + "'s file can not be listed. Probable cause are that it's not a directory (which violate the method's assumption) or a permission issue.");
         }
         int length = paths.length;
         return new FileStream() {

--- a/AnkiDroid/src/main/java/com/ichi2/compat/CompatV26.java
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/CompatV26.java
@@ -192,14 +192,8 @@ public class CompatV26 extends CompatV23 implements Compat {
      * Hence this method, hasNext and next should be constant in time and space.
      */
     @Override
-    public @Nullable FileStream contentOfDirectory(File directory) {
-        DirectoryStream<Path> paths_stream;
-        try {
-            paths_stream = Files.newDirectoryStream(directory.toPath());
-        } catch (IOException e) {
-            Timber.w(e);
-            return null;
-        }
+    public @NonNull FileStream contentOfDirectory(File directory) throws IOException {
+        DirectoryStream<Path> paths_stream = Files.newDirectoryStream(directory.toPath());
         Iterator<Path> paths = paths_stream.iterator();
         return new FileStream() {
             @Override


### PR DESCRIPTION
This was the case in #10358 due to a permission issue with newDirectoryStream.
In this case, `listFiles` returned null. In this case, throwing makes more sens,
as it indicates that something was wrong.

UI will need to catch it eventually and ask to contact AnkiDroid developer for
help, because when this occurs there is nothing the app can do anymore.