### PR TITLE
Localize backups date and add Choose another button

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/BackupManager.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/BackupManager.kt
@@ -227,7 +227,8 @@ open class BackupManager {
             get() = true
 
         @KotlinCleanup("make non-null - requires fixing unit tests - they accidentally use empty string as the path")
-        private fun getBackupDirectory(ankidroidDir: File?): File {
+        @JvmStatic
+        fun getBackupDirectory(ankidroidDir: File?): File {
             val directory = File(ankidroidDir, BACKUP_SUFFIX)
             if (!directory.isDirectory && !directory.mkdirs()) {
                 Timber.w("getBackupDirectory() mkdirs on %s failed", ankidroidDir)
@@ -392,7 +393,8 @@ open class BackupManager {
          * @param colPath Path of collection file whose backups should be deleted
          * @param keepNumber How many files to keep
          */
-        private fun deleteDeckBackups(colPath: String, keepNumber: Int): Boolean {
+        @JvmStatic
+        fun deleteDeckBackups(colPath: String, keepNumber: Int): Boolean {
             return deleteDeckBackups(getBackups(File(colPath)).sortedArray(), keepNumber)
         }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/BackupManager.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/BackupManager.kt
@@ -80,7 +80,7 @@ open class BackupManager {
             Timber.d("performBackup: No backup created. Last backup younger than 5 hours")
             return false
         }
-        val backupFilename = getNewBackupName(time) ?: return false
+        val backupFilename = getNameForNewBackup(time) ?: return false
 
         // Abort backup if destination already exists (extremely unlikely)
         val backupFile = getBackupFile(colFile, backupFilename)
@@ -126,7 +126,7 @@ open class BackupManager {
     /**
      * @return filename with pattern collection-yyyy-MM-dd-HH-mm based on given time parameter
      */
-    fun getNewBackupName(time: Time): String? {
+    fun getNameForNewBackup(time: Time): String? {
         /** Changes in the file name pattern should be updated as well in
          * [getBackupTimeStrings] and [com.ichi2.anki.dialogs.DatabaseErrorDialog.onCreateDialog] */
         val cal: Calendar = time.gregorianCalendar()

--- a/AnkiDroid/src/main/java/com/ichi2/anki/BackupManager.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/BackupManager.kt
@@ -212,6 +212,7 @@ open class BackupManager {
         private const val MIN_BACKUP_COL_SIZE = 10000 // threshold in bytes to backup a col file
         private const val BACKUP_SUFFIX = "backup"
         const val BROKEN_DECKS_SUFFIX = "broken"
+        private val backupNameRegex = Regex("collection-((\\d{4})-(\\d{2})-(\\d{2})-(\\d{2})-(\\d{2})).colpkg")
 
         /** Number of hours after which a backup new backup is created  */
         private const val BACKUP_INTERVAL = 5
@@ -357,9 +358,7 @@ open class BackupManager {
          */
         @JvmStatic
         fun getBackupTimeStrings(fileName: String): List<String>? {
-            val m = "collection-((\\d{4})-(\\d{2})-(\\d{2})-(\\d{2})-(\\d{2})).colpkg"
-                .toRegex()
-                .matchEntire(fileName)
+            val m = backupNameRegex.matchEntire(fileName)
             return m?.groupValues?.subList(1, 7)
         }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/BackupManager.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/BackupManager.kt
@@ -400,9 +400,9 @@ open class BackupManager {
         private fun deleteDeckBackups(backups: Array<File>, keepNumber: Int): Boolean {
             for (i in 0 until backups.size - keepNumber) {
                 if (!backups[i].delete()) {
-                    Timber.e("deleteBackups() failed to delete %s", backups[i].absolutePath)
+                    Timber.e("deleteDeckBackups() failed to delete %s", backups[i].absolutePath)
                 } else {
-                    Timber.i("deleteBackups: backup file %s deleted.", backups[i].absolutePath)
+                    Timber.i("deleteDeckBackups: backup file %s deleted.", backups[i].absolutePath)
                 }
             }
             return true

--- a/AnkiDroid/src/main/java/com/ichi2/anki/BackupManager.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/BackupManager.kt
@@ -31,7 +31,6 @@ import java.io.BufferedOutputStream
 import java.io.File
 import java.io.FileOutputStream
 import java.io.IOException
-import java.text.ParseException
 import java.text.SimpleDateFormat
 import java.util.*
 import java.util.Collections.sort
@@ -145,18 +144,11 @@ open class BackupManager {
      * In order to get the latest date, the given files array must be sorted
      */
     fun getLastBackupDate(files: Array<File>): Date? {
-        if (files.isEmpty()) {
-            return null
-        }
-        for (file in files.reversed()) {
-            val ts = getBackupTimeStrings(file.name)
-            if (ts != null) {
-                try {
-                    return df.parse(ts[0])
-                } catch (e: ParseException) {}
-            }
-        }
-        return null
+        return files
+            .reversed()
+            .mapNotNull { getBackupTimeStrings(it.name) }
+            .mapNotNull { df.parse(it[0]) }
+            .firstOrNull()
     }
 
     @KotlinCleanup("make backupFilename non-null")

--- a/AnkiDroid/src/main/java/com/ichi2/anki/BackupManager.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/BackupManager.kt
@@ -381,7 +381,7 @@ open class BackupManager {
             }
             val backups = mutableListOf<File>()
             for (aktFile in files) {
-                if (getBackupTimeStrings(aktFile.name) != null) {
+                if (backupNameRegex.matchEntire(aktFile.name) != null) {
                     backups.add(aktFile)
                 }
             }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/BackupManager.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/BackupManager.kt
@@ -149,14 +149,13 @@ open class BackupManager {
     }
 
     /**
-     * @return last date in parseable file names or null if all file names can't be parsed
+     * @return last date in parseable file names or null if all names can't be parsed
      */
     fun getLastBackupDate(files: Array<File>): Date? {
-        return files
-            .sortedDescending()
-            .mapNotNull { getBackupTimeStrings(it.name) }
-            .mapNotNull { getBackupDate(it[0]) }
-            .firstOrNull()
+        for (file in files.sortedDescending()) {
+            getBackupTimeStrings(file.name)?.let { return getBackupDate(it[0]) }
+        }
+        return null
     }
 
     @KotlinCleanup("make backupFilename non-null")

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DatabaseErrorDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DatabaseErrorDialog.kt
@@ -181,9 +181,6 @@ class DatabaseErrorDialog : AsyncDialogFragment() {
                 // Allow user to restore one of the backups
                 val path = CollectionHelper.getCollectionPath(activity)
                 mBackups = BackupManager.getBackups(File(path))
-                // Since backups are sorted ascendingly at getBackups(),
-                // revert it to show latest backups at top
-                mBackups.reverse()
                 if (mBackups.isEmpty()) {
                     builder.title(res.getString(R.string.backup_restore))
                         .contentNullable(message)
@@ -193,6 +190,8 @@ class DatabaseErrorDialog : AsyncDialogFragment() {
                                 ?.showDatabaseErrorDialog(DIALOG_ERROR_HANDLING)
                         }
                 } else {
+                    // Show backups sorted with latest on top
+                    mBackups.sortDescending()
                     val dates = mutableListOf<String>()
                     /** Backups name pattern is defined at [BackupManager.getNameForNewBackup] */
                     for (backup in mBackups) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DatabaseErrorDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DatabaseErrorDialog.kt
@@ -19,6 +19,7 @@ package com.ichi2.anki.dialogs
 import android.content.DialogInterface
 import android.os.Bundle
 import android.os.Message
+import android.text.format.DateFormat.getBestDateTimePattern
 import android.view.KeyEvent
 import android.view.View
 import com.afollestad.materialdialogs.DialogAction
@@ -31,6 +32,7 @@ import com.ichi2.utils.contentNullable
 import timber.log.Timber
 import java.io.File
 import java.io.IOException
+import java.text.SimpleDateFormat
 import java.util.*
 
 class DatabaseErrorDialog : AsyncDialogFragment() {
@@ -192,14 +194,15 @@ class DatabaseErrorDialog : AsyncDialogFragment() {
                 } else {
                     // Show backups sorted with latest on top
                     mBackups.sortDescending()
+                    val localDf = SimpleDateFormat(getBestDateTimePattern(Locale.getDefault(), "yyyy-MM-dd HH:mm:ss"))
                     val dates = mutableListOf<String>()
+                    val bm = BackupManager()
                     /** Backups name pattern is defined at [BackupManager.getNameForNewBackup] */
                     for (backup in mBackups) {
                         val ts = BackupManager.getBackupTimeStrings(backup.name)
                         if (ts != null) {
-                            // "00" seconds member is hardcoded until #10388 is fixed
-                            // and backup naming scheme is updated to be compatible with Anki Desktop
-                            dates.add(res.getString(R.string.restore_backup_date_pattern, ts[1], ts[2], ts[3], ts[4], ts[5], "00"))
+                            val date = bm.getBackupDate(ts[0])
+                            dates.add(localDf.format(date!!))
                         } else {
                             Timber.w("backup name '%s' couldn't be parsed", backup.name)
                         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DatabaseErrorDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DatabaseErrorDialog.kt
@@ -194,7 +194,7 @@ class DatabaseErrorDialog : AsyncDialogFragment() {
                 } else {
                     // Show backups sorted with latest on top
                     mBackups.sortDescending()
-                    val localDf = SimpleDateFormat(getBestDateTimePattern(Locale.getDefault(), "yyyy-MM-dd HH:mm:ss"))
+                    val localDf = SimpleDateFormat(getBestDateTimePattern(Locale.getDefault(), "dd MMM yyyy HH:mm"))
                     val dates = mutableListOf<String>()
                     /** Backups name pattern is defined at [BackupManager.getNameForNewBackup] */
                     for (backup in mBackups) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DatabaseErrorDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DatabaseErrorDialog.kt
@@ -196,13 +196,11 @@ class DatabaseErrorDialog : AsyncDialogFragment() {
                     mBackups.sortDescending()
                     val localDf = SimpleDateFormat(getBestDateTimePattern(Locale.getDefault(), "yyyy-MM-dd HH:mm:ss"))
                     val dates = mutableListOf<String>()
-                    val bm = BackupManager()
                     /** Backups name pattern is defined at [BackupManager.getNameForNewBackup] */
                     for (backup in mBackups) {
-                        val ts = BackupManager.getBackupTimeStrings(backup.name)
-                        if (ts != null) {
-                            val date = bm.getBackupDate(ts[0])
-                            dates.add(localDf.format(date!!))
+                        val date = BackupManager.getBackupDate(backup.name)
+                        if (date != null) {
+                            dates.add(localDf.format(date))
                         } else {
                             Timber.w("backup name '%s' couldn't be parsed", backup.name)
                         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DatabaseErrorDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DatabaseErrorDialog.kt
@@ -194,7 +194,7 @@ class DatabaseErrorDialog : AsyncDialogFragment() {
                         }
                 } else {
                     val dates = mutableListOf<String>()
-                    /** Backups name pattern is defined at [BackupManager.getNewBackupName] */
+                    /** Backups name pattern is defined at [BackupManager.getNameForNewBackup] */
                     for (backup in mBackups) {
                         val ts = BackupManager.getBackupTimeStrings(backup.name)
                         if (ts != null) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DatabaseErrorDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DatabaseErrorDialog.kt
@@ -35,7 +35,7 @@ import java.util.*
 
 class DatabaseErrorDialog : AsyncDialogFragment() {
     private lateinit var mRepairValues: IntArray
-    private lateinit var mBackups: Array<File?>
+    private lateinit var mBackups: Array<File>
     override fun onCreateDialog(savedInstanceState: Bundle?): MaterialDialog {
         super.onCreate(savedInstanceState)
         val type = requireArguments().getInt("dialogType")
@@ -180,13 +180,10 @@ class DatabaseErrorDialog : AsyncDialogFragment() {
 
                 // Allow user to restore one of the backups
                 val path = CollectionHelper.getCollectionPath(activity)
-                val files = BackupManager.getBackups(File(path))
-                mBackups = arrayOfNulls(files.size)
-                var i = 0
-                while (i < files.size) {
-                    mBackups[i] = files[files.size - 1 - i]
-                    i++
-                }
+                mBackups = BackupManager.getBackups(File(path))
+                // Since backups are sorted ascendingly at getBackups(),
+                // revert it to show latest backups at top
+                mBackups.reverse()
                 if (mBackups.isEmpty()) {
                     builder.title(res.getString(R.string.backup_restore))
                         .contentNullable(message)
@@ -196,27 +193,32 @@ class DatabaseErrorDialog : AsyncDialogFragment() {
                                 ?.showDatabaseErrorDialog(DIALOG_ERROR_HANDLING)
                         }
                 } else {
-                    val dates = arrayOfNulls<String>(mBackups.size)
-                    var j = 0
-                    while (j < mBackups.size) {
-                        dates[j] = mBackups[j]!!.name.replace(
-                            ".*-(\\d{4}-\\d{2}-\\d{2})-(\\d{2})-(\\d{2}).apkg".toRegex(), "$1 ($2:$3 h)"
-                        )
-                        j++
+                    val dates = mutableListOf<String>()
+                    /** Backups name pattern is defined at [BackupManager.getNewBackupName] */
+                    for (backup in mBackups) {
+                        val ts = BackupManager.getBackupTimeStrings(backup.name)
+                        if (ts != null) {
+                            // "00" seconds member is hardcoded until #10388 is fixed
+                            // and backup naming scheme is updated to be compatible with Anki Desktop
+                            dates.add(res.getString(R.string.restore_backup_date_pattern, ts[1], ts[2], ts[3], ts[4], ts[5], "00"))
+                        } else {
+                            Timber.w("backup name '%s' couldn't be parsed", backup.name)
+                        }
                     }
                     builder.title(res.getString(R.string.backup_restore_select_title))
+                        .positiveText(R.string.restore_backup_choose_another)
                         .negativeText(R.string.dialog_cancel)
-                        .items(*dates)
-                        .itemsCallbackSingleChoice(
-                            dates.size
-                        ) { _: MaterialDialog?, _: View?, which: Int, _: CharSequence? ->
-                            if (mBackups[which]!!.length() > 0) {
+                        .items(*dates.toTypedArray())
+                        .onPositive { _: MaterialDialog?, _: DialogAction? ->
+                            ImportFileSelectionFragment.openImportFilePicker(activity as AnkiActivity)
+                        }
+                        .itemsCallbackSingleChoice(-1) {
+                            _: MaterialDialog?, _: View?, which: Int, _: CharSequence? ->
+                            if (mBackups[which].length() > 0) {
                                 // restore the backup if it's valid
                                 (activity as DeckPicker?)
                                     ?.restoreFromBackup(
-                                        mBackups[which]
-
-                                            ?.path
+                                        mBackups[which].path
                                     )
                                 dismissAllDialogFragments()
                             } else {
@@ -229,6 +231,7 @@ class DatabaseErrorDialog : AsyncDialogFragment() {
                             }
                             true
                         }
+                        .alwaysCallSingleChoiceCallback()
                 }
                 val materialDialog = builder.build()
                 materialDialog.setOnKeyListener { _: DialogInterface?, keyCode: Int, _: KeyEvent? ->

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ImportFileSelectionFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ImportFileSelectionFragment.kt
@@ -58,7 +58,7 @@ class ImportFileSelectionFragment {
 
         // needs to be static for serialization
         @JvmStatic
-        private fun openImportFilePicker(activity: AnkiActivity) {
+        fun openImportFilePicker(activity: AnkiActivity) {
             Timber.d("openImportFilePicker() delegating to file picker intent")
             val intent = Intent(Intent.ACTION_OPEN_DOCUMENT)
             intent.addCategory(Intent.CATEGORY_OPENABLE)

--- a/AnkiDroid/src/main/res/values/03-dialogs.xml
+++ b/AnkiDroid/src/main/res/values/03-dialogs.xml
@@ -106,7 +106,6 @@
 
     <string name="restore_backup_title">Restore backup?</string>
     <string name="restore_backup">Your collection will be replaced with an older copy. Any unsaved progress will be lost.</string>
-    <string name="restore_backup_date_pattern">%2$s-%3$s-%1$s, %4$s:%5$s:%6$s</string>
     <string name="restore_backup_choose_another">Choose another</string>
 
     <string name="dialog_cancel">Cancel</string>

--- a/AnkiDroid/src/main/res/values/03-dialogs.xml
+++ b/AnkiDroid/src/main/res/values/03-dialogs.xml
@@ -106,6 +106,8 @@
 
     <string name="restore_backup_title">Restore backup?</string>
     <string name="restore_backup">Your collection will be replaced with an older copy. Any unsaved progress will be lost.</string>
+    <string name="restore_backup_date_pattern">%2$s-%3$s-%1$s, %4$s:%5$s:%6$s</string>
+    <string name="restore_backup_choose_another">Choose another</string>
 
     <string name="dialog_cancel">Cancel</string>
     <string name="dialog_ok">OK</string>

--- a/AnkiDroid/src/test/java/com/ichi2/anki/BackupManagerTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/BackupManagerTest.java
@@ -26,12 +26,12 @@ import org.junit.runner.RunWith;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Date;
 
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
 import static com.ichi2.utils.StrictMock.strictMock;
-import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertNull;
@@ -140,7 +140,10 @@ public class BackupManagerTest {
         File[] backups = BackupManager.getBackups(colFile);
 
         assertNotNull(backups);
-        assertArrayEquals("Only the valid backup names should have been kept", new File[] {f1, f3}, backups);
+        assertEquals("Only the valid backup names should have been kept", 2, backups.length);
+        Arrays.sort(backups);
+        assertEquals("collection-2000-12-31-23-04.colpkg", backups[0].getName());
+        assertEquals("collection-2010-12-06-13-04.colpkg", backups[1].getName());
     }
 
     @Test

--- a/AnkiDroid/src/test/java/com/ichi2/anki/BackupManagerTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/BackupManagerTest.java
@@ -24,9 +24,7 @@ import org.junit.runner.RunWith;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.Arrays;
 import java.util.Date;
-import java.util.List;
 
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
@@ -53,46 +51,41 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 public class BackupManagerTest extends RobolectricTest {
 
     @Test
+    public void getBackupTimeStringTest() {
+        String ts = BackupManager.getBackupTimeString("collection-1999-12-31-23-59.colpkg");
+        assertEquals("1999-12-31-23-59", ts);
+    }
+    
+    @Test
+    public void parseBackupTimeStringTest() {
+        assertNotNull(BackupManager.parseBackupTimeString("1970-01-02-00-46"));
+        assertNull(BackupManager.parseBackupTimeString("123456"));
+    }
+
+    @Test
     public void getBackupDateTest() {
-        BackupManager bm = BackupManager.createInstance();
-        assertNotNull(bm.getBackupDate("1970-01-02-00-46"));
-        assertNull(bm.getBackupDate("123456"));
+        assertNotNull(BackupManager.getBackupDate("collection-1970-01-02-00-46.colpkg"));
+        assertNull(BackupManager.getBackupDate("foo"));
     }
 
     @Test
     public void getNameForNewBackupTest() {
-        BackupManager bm = BackupManager.createInstance();
         // Using a timestamp number directly as MockTime parameter may
         // have different results on other computers and GitHub CI
-        Date date = bm.getBackupDate("1970-01-02-00-46");
+        Date date = BackupManager.parseBackupTimeString("1970-01-02-00-46");
         assertNotNull(date);
         long timestamp = date.getTime();
-        String backupName = bm.getNameForNewBackup(new MockTime(timestamp));
+        String backupName = BackupManager.getNameForNewBackup(new MockTime(timestamp));
 
         assertEquals("Backup name doesn't match naming pattern","collection-1970-01-02-00-46.colpkg", backupName);
     }
 
     @Test
-    public void getBackupTimeStringsTest() {
-        List<String> ts = BackupManager.getBackupTimeStrings("collection-1999-12-31-23-59.colpkg");
-        List<String> expected = Arrays.asList(
-                "1999-12-31-23-59", // dateformat
-                "1999", // year
-                "12", // month
-                "31", // day
-                "23", // hours
-                "59" // minutes
-        );
-        assertEquals(expected, ts);
-    }
-
-    @Test
     public void nameOfNewBackupsCanBeParsed() {
-        BackupManager bm = BackupManager.createInstance();
-        String backupName = bm.getNameForNewBackup(new MockTime(100000000));
+        String backupName = BackupManager.getNameForNewBackup(new MockTime(100000000));
         assertNotNull(backupName);
 
-        List<String> ts = BackupManager.getBackupTimeStrings(backupName);
+        Date ts = BackupManager.getBackupDate(backupName);
         assertNotNull("New backup name couldn't be parsed by getBackupTimeStrings()", ts);
     }
 
@@ -113,8 +106,8 @@ public class BackupManagerTest extends RobolectricTest {
                 new File ("bar.colpkg"),
         };
 
-        Date expected = bm.getBackupDate("2010-01-02-03-04");
-        Date expected2 = bm.getBackupDate("2000-12-31-23-04");
+        Date expected = BackupManager.parseBackupTimeString("2010-01-02-03-04");
+        Date expected2 = BackupManager.parseBackupTimeString("2000-12-31-23-04");
 
         assertNull(bm.getLastBackupDate(new File[]{}));
         assertNotNull(bm.getLastBackupDate(backups));

--- a/AnkiDroid/src/test/java/com/ichi2/anki/BackupManagerTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/BackupManagerTest.java
@@ -50,12 +50,12 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 public class BackupManagerTest {
 
     @Test
-    public void getNewBackupNameTest() throws ParseException {
+    public void getNameForNewBackupTest() throws ParseException {
         BackupManager bm = BackupManager.createInstance();
         // Using a timestamp number directly as MockTime parameter may
         // have different results on other computers and GitHub CI
         long timestamp = bm.getDf().parse("1970-01-02-00-46").getTime();
-        String backupName = bm.getNewBackupName(new MockTime(timestamp));
+        String backupName = bm.getNameForNewBackup(new MockTime(timestamp));
 
         assertEquals("Backup name doesn't match naming scheme","collection-1970-01-02-00-46.colpkg", backupName);
     }
@@ -75,9 +75,9 @@ public class BackupManagerTest {
     }
 
     @Test
-    public void newBackupNameCanBeParsed() {
+    public void nameOfNewBackupsCanBeParsed() {
         BackupManager bm = BackupManager.createInstance();
-        String backupName = bm.getNewBackupName(new MockTime(100000000));
+        String backupName = bm.getNameForNewBackup(new MockTime(100000000));
         assertNotNull(backupName);
 
         List<String> ts = BackupManager.getBackupTimeStrings(backupName);

--- a/AnkiDroid/src/test/java/com/ichi2/anki/BackupManagerTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/BackupManagerTest.java
@@ -113,6 +113,7 @@ public class BackupManagerTest {
         Date expected2 = bm.getBackupDate("2000-12-31-23-04");
 
         assertNull(bm.getLastBackupDate(new File[]{}));
+        assertNotNull(bm.getLastBackupDate(backups));
         assertEquals(expected, bm.getLastBackupDate(backups));
         assertEquals("getLastBackupDate() should return the last valid date", expected2, bm.getLastBackupDate(backups2));
         assertNull("getLastBackupDate() should return null when all files aren't parseable", bm.getLastBackupDate(backups3));

--- a/AnkiDroid/src/test/java/com/ichi2/anki/BackupManagerTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/BackupManagerTest.java
@@ -19,7 +19,9 @@ package com.ichi2.anki;
 import com.ichi2.libanki.utils.Time;
 import com.ichi2.testutils.MockTime;
 
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 
 import java.io.File;
@@ -48,7 +50,10 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 @RunWith(AndroidJUnit4.class)
-public class BackupManagerTest extends RobolectricTest {
+public class BackupManagerTest {
+
+    @Rule
+    public TemporaryFolder tempFolder = new TemporaryFolder();
 
     @Test
     public void getBackupTimeStringTest() {
@@ -120,10 +125,12 @@ public class BackupManagerTest extends RobolectricTest {
     @Test
     @SuppressWarnings("ResultOfMethodCallIgnored")
     public void getBackupsTest() throws IOException {
-        File colFile = new File(getCol().getPath());
+        // getBackups() doesn't require a proper collection file
+        // because it is only used to get its parent
+        File colFile = tempFolder.newFile();
         assertEquals(0, BackupManager.getBackups(colFile).length);
 
-        File backupDir = BackupManager.getBackupDirectory(colFile.getParentFile());
+        File backupDir = BackupManager.getBackupDirectory(tempFolder.getRoot());
         File f1 = new File (backupDir, "collection-2000-12-31-23-04.colpkg");
         File f2 = new File (backupDir, "foo");
         File f3 = new File (backupDir, "collection-2010-12-06-13-04.colpkg");
@@ -139,8 +146,8 @@ public class BackupManagerTest extends RobolectricTest {
     @Test
     @SuppressWarnings("ResultOfMethodCallIgnored")
     public void deleteDeckBackupsTest() throws IOException {
-        File colFile = new File(getCol().getPath());
-        File backupDir = BackupManager.getBackupDirectory(colFile.getParentFile());
+        File colFile = tempFolder.newFile();
+        File backupDir = BackupManager.getBackupDirectory(tempFolder.getRoot());
 
         File f1 = new File (backupDir, "collection-2000-12-31-23-04.colpkg");
         File f2 = new File (backupDir, "collection-1990-08-31-45-04.colpkg");

--- a/AnkiDroid/src/test/java/com/ichi2/anki/BackupManagerTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/BackupManagerTest.java
@@ -23,7 +23,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import java.io.File;
-import java.text.ParseException;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
@@ -50,14 +49,23 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 public class BackupManagerTest {
 
     @Test
-    public void getNameForNewBackupTest() throws ParseException {
+    public void getBackupDateTest() {
+        BackupManager bm = BackupManager.createInstance();
+        assertNotNull(bm.getBackupDate("1970-01-02-00-46"));
+        assertNull(bm.getBackupDate("123456"));
+    }
+
+    @Test
+    public void getNameForNewBackupTest() {
         BackupManager bm = BackupManager.createInstance();
         // Using a timestamp number directly as MockTime parameter may
         // have different results on other computers and GitHub CI
-        long timestamp = bm.getDf().parse("1970-01-02-00-46").getTime();
+        Date date = bm.getBackupDate("1970-01-02-00-46");
+        assertNotNull(date);
+        long timestamp = date.getTime();
         String backupName = bm.getNameForNewBackup(new MockTime(timestamp));
 
-        assertEquals("Backup name doesn't match naming scheme","collection-1970-01-02-00-46.colpkg", backupName);
+        assertEquals("Backup name doesn't match naming pattern","collection-1970-01-02-00-46.colpkg", backupName);
     }
 
     @Test
@@ -84,9 +92,8 @@ public class BackupManagerTest {
         assertNotNull("New backup name couldn't be parsed by getBackupTimeStrings()", ts);
     }
 
-    /** Should get date of item at last position on list */
     @Test
-    public void getLastBackupDateTest() throws ParseException {
+    public void getLastBackupDateTest() {
         BackupManager bm = BackupManager.createInstance();
         File[] backups = {
                 new File ("collection-2000-12-31-23-04.colpkg"),
@@ -102,8 +109,8 @@ public class BackupManagerTest {
                 new File ("bar.colpkg"),
         };
 
-        Date expected = bm.getDf().parse("1999-12-31-23-59");
-        Date expected2 = bm.getDf().parse("2000-12-31-23-04");
+        Date expected = bm.getBackupDate("2010-01-02-03-04");
+        Date expected2 = bm.getBackupDate("2000-12-31-23-04");
 
         assertNull(bm.getLastBackupDate(new File[]{}));
         assertEquals(expected, bm.getLastBackupDate(backups));


### PR DESCRIPTION
## Purpose / Description
Backup options were backup name files, which isn't human-readable

## Fixes
Fixes #10362

## Approach
- Refactor part of `BackupManager.kt` in order to work properly and be more clear
    - Other parts of it still need refactoring, but probably are best suited in another PR
- Parse the backup filenames as localizable time strings
- Add a `Choose another` button, so the user can import backups which are not on backups folder

## How Has This Been Tested?

### Human-readable options
https://user-images.githubusercontent.com/69634269/155613612-830cabeb-343f-4b88-8950-8aa5db3062a1.mp4

### Choose another button
https://user-images.githubusercontent.com/69634269/155613828-7c6fca48-3db0-4808-ae91-b8af973e73a6.mp4

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [X] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
