### PR TITLE
`hasFiles` raises exception

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/model/Directory.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/model/Directory.kt
@@ -18,6 +18,9 @@ package com.ichi2.anki.model
 
 import com.ichi2.compat.CompatHelper
 import java.io.File
+import java.io.IOException
+import java.nio.file.NotDirectoryException
+import kotlin.jvm.Throws
 
 /**
  * A directory which is assumed to exist (existed when class was instantiated)
@@ -32,9 +35,18 @@ class Directory private constructor(val directory: File) {
     fun listFiles(): Array<out File> = directory.listFiles() ?: emptyArray()
 
     /**
-     * Whether a directory has files
-     * @return false if supplied argument is not a directory, or has no files. True if directory has files
+     * Whether this directory has at least files
+     * @return Whether the directory has file.
+     * @throws [SecurityException] If a security manager exists and its SecurityManager.checkRead(String)
+     * method denies read access to the directory
+     * @throws [FileNotFoundException] if the file do not exists
+     * @throws [NotDirectoryException] if the file could not otherwise be opened because it is not
+     * a directory (optional specific exception), (starting at API 26)
+     * @throws [IOException] – if an I/O error occurs.
+     * This also occurred on an existing directory because of permission issue
+     * that we could not reproduce. See https://github.com/ankidroid/Anki-Android/issues/10358
      */
+    @Throws(IOException::class, SecurityException::class, NotDirectoryException::class)
     fun hasFiles(): Boolean = CompatHelper.getCompat().hasFiles(directory)
 
     /** The [canonical path][java.io.File.getCanonicalPath] for the file */

--- a/AnkiDroid/src/main/java/com/ichi2/compat/Compat.java
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/Compat.java
@@ -156,10 +156,20 @@ public interface Compat {
     void moveDirectory(File srcDir, File destDir, ProgressSenderAndCancelListener<Integer> ioTask) throws IOException;
 
     /**
-     * Returns whether the directory has one or more file
-     * @return false if the directory is not a directory, does not exist, or has no files
+     * Whether a directory has at least one files
+     * @return Whether the directory has file.
+     * @throws [SecurityException] If a security manager exists and its SecurityManager.checkRead(String)
+     * method denies read access to the directory
+     * @throws [FileNotFoundException] if the file do not exists
+     * @throws [NotDirectoryException] if the file could not otherwise be opened because it is not
+     * a directory (optional specific exception), (starting at API 26)
+     * @throws [IOException] – if an I/O error occurs
      */
-    boolean hasFiles(@NonNull File directory) throws IOException;
+    default boolean hasFiles(@NonNull File directory) throws IOException {
+        try(FileStream stream = contentOfDirectory(directory)) {
+            return stream.hasNext();
+        }
+    }
 
     boolean hasVideoThumbnail(@NonNull String path);
     void requestAudioFocus(AudioManager audioManager, AudioManager.OnAudioFocusChangeListener audioFocusChangeListener, @Nullable AudioFocusRequest audioFocusRequest);
@@ -263,7 +273,7 @@ public interface Compat {
      * @return a FileStream over file and folder of this directory.
      *         null in case of trouble. This stream must be closed explicitly when done with it.
      * @throws NotDirectoryException if the file exists and is not a directory (starting at API 26)
-     * @throws FileNotFoundException if the file do not exists (up to API 25)
+     * @throws FileNotFoundException if the file do not exists
      * @throws IOException if files can not be listed. On non existing or non-directory file up to API 25. This also occurred on an existing directory because of permission issue
      * that we could not reproduce. See https://github.com/ankidroid/Anki-Android/issues/10358
      * @throws SecurityException – If a security manager exists and its SecurityManager.checkRead(String) method denies read access to the directory

--- a/AnkiDroid/src/main/java/com/ichi2/compat/CompatV21.java
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/CompatV21.java
@@ -208,15 +208,6 @@ public class CompatV21 implements Compat {
         }
     }
 
-    @Override
-    public boolean hasFiles(@NonNull File directory) throws IOException {
-        File[] files = directory.listFiles();
-        if (files == null) {
-            return false;
-        }
-        return files.length > 0;
-    }
-
 
     // Until API 23 the methods have "current" in the name
     @Override

--- a/AnkiDroid/src/main/java/com/ichi2/compat/CompatV26.java
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/CompatV26.java
@@ -159,15 +159,6 @@ public class CompatV26 extends CompatV23 implements Compat {
         });
     }
 
-    @Override
-    public boolean hasFiles(@NonNull File directory) throws IOException {
-        try (DirectoryStream<Path> paths = Files.newDirectoryStream(directory.toPath())) {
-            return paths.iterator().hasNext();
-        } catch (NotDirectoryException | NoSuchFileException ex) {
-            return false;
-        }
-    }
-
 
     @Override
     public void requestAudioFocus(AudioManager audioManager, AudioManager.OnAudioFocusChangeListener audioFocusChangeListener,

--- a/AnkiDroid/src/main/java/com/ichi2/compat/FileStream.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/FileStream.kt
@@ -46,4 +46,7 @@ interface FileStream : AutoCloseable {
      */
     @Throws(IOException::class)
     fun next(): File
+
+    @Throws(IOException::class)
+    override fun close()
 }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/model/DirectoryTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/model/DirectoryTest.kt
@@ -17,12 +17,15 @@
 package com.ichi2.anki.model
 
 import com.ichi2.testutils.HamcrestUtils.containsInAnyOrder
+import com.ichi2.testutils.assertThrows
 import com.ichi2.testutils.withTempFile
 import org.acra.util.IOUtils
 import org.hamcrest.CoreMatchers.*
 import org.hamcrest.MatcherAssert
+import org.hamcrest.MatcherAssert.assertThat
 import org.junit.Test
 import java.io.File
+import java.io.FileNotFoundException
 import kotlin.io.path.createTempDirectory
 import kotlin.io.path.pathString
 
@@ -87,14 +90,10 @@ class DirectoryTest {
     }
 
     @Test
-    fun has_files_is_false_if_no_longer_exists() {
+    fun has_files_throws_if_file_no_longer_exists() {
         val dir = createValidTempDir()
         dir.directory.delete()
-        MatcherAssert.assertThat(
-            "deleted directory should not have files",
-            dir.hasFiles(),
-            equalTo(false)
-        )
+        assertThrows<FileNotFoundException> { dir.hasFiles() }
     }
 
     @Test


### PR DESCRIPTION
The primary goal how this commit is to have a clear way to catch #10358.
This PR depends on #10400 and #10418

It changes the way the method behaves when method assumption are not satisfied;
and raising an exception seems at least as acceptable than returning null. Plus
it will lead to more specific error cause if we care about them.
