### PR TITLE
`contentOfDirectory` throws FileNotFoundException

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/compat/Compat.java
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/Compat.java
@@ -36,6 +36,8 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
+import java.nio.file.NoSuchFileException;
+import java.nio.file.NotDirectoryException;
 import java.nio.file.Path;
 
 import androidx.annotation.IntDef;
@@ -261,8 +263,9 @@ public interface Compat {
      * @param directory A directory.
      * @return a FileStream over file and folder of this directory.
      *         null in case of trouble. This stream must be closed explicitly when done with it.
-     * @throws java.nio.file.NoSuchFileException if the file do not exists (starting at API 26)
-     * @throws java.nio.file.NotDirectoryException if the file exists and is not a directory (starting at API 26)
+     * @throws NoSuchFileException if the file do not exists (starting at API 26)
+     * @throws NotDirectoryException if the file exists and is not a directory (starting at API 26)
+     * @throws FileNotFoundException if the file do not exists (up to API 25)
      * @throws IOException if files can not be listed. On non existing or non-directory file up to API 25. This also occurred on an existing directory because of permission issue
      * that we could not reproduce. See https://github.com/ankidroid/Anki-Android/issues/10358
      * @throws SecurityException – If a security manager exists and its SecurityManager.checkRead(String) method denies read access to the directory

--- a/AnkiDroid/src/main/java/com/ichi2/compat/CompatV21.java
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/CompatV21.java
@@ -42,6 +42,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.nio.file.NoSuchFileException;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -282,6 +283,9 @@ public class CompatV21 implements Compat {
     public @NonNull FileStream contentOfDirectory(@NonNull File directory) throws IOException {
         File[] paths = directory.listFiles();
         if (paths == null) {
+            if (!directory.exists()) {
+                throw new FileNotFoundException(directory.getPath());
+            }
             throw new IOException("Directory " + directory.getPath() + "'s file can not be listed. Probable cause are that it's not a directory (which violate the method's assumption) or a permission issue.");
         }
         int length = paths.length;

--- a/AnkiDroid/src/test/java/com/ichi2/compat/DirectoryContentTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/compat/DirectoryContentTest.kt
@@ -24,6 +24,7 @@ import org.hamcrest.MatcherAssert.assertThat
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.annotation.Config
+import java.io.FileNotFoundException
 import java.io.IOException
 import java.nio.file.NoSuchFileException
 import java.nio.file.NotDirectoryException
@@ -82,9 +83,8 @@ class DirectoryContentTest {
             CompatHelper.getCompat().contentOfDirectory(directory)
         }
         )
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            assertThat("Starting at API 26, this should be a NotDirectoryException", exception, instanceOf(NoSuchFileException::class.java))
-        }
+        val expectedException = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) NoSuchFileException::class else FileNotFoundException::class
+        assertThat("this should be a FileNotFound or NoSuchFile exception depending on API", exception, instanceOf(expectedException.java))
     }
 
     @Test


### PR DESCRIPTION
I discovered this exception lately, and thought it might be more specific that
IOException.

Admittedly, there is no semantic difference between FileNotFoundException and
NoSuchFileException here, so unifying may be better; but probably not worth
catching the later to transform it into the former
