### PR TITLE
Additional answer button tweaks (useful for e-ink)

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -1180,11 +1180,16 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
                 answerAreaParams.addRule(RelativeLayout.BELOW, R.id.mic_tool_bar_layer);
                 answerArea.removeView(mAnswerField);
                 answerArea.addView(mAnswerField, 1);
+                answerArea.setVisibility(View.VISIBLE);
                 break;
             case "bottom":
                 cardContainerParams.addRule(RelativeLayout.ABOVE, R.id.bottom_area_layout);
                 cardContainerParams.addRule(RelativeLayout.BELOW, R.id.mic_tool_bar_layer);
                 answerAreaParams.addRule(RelativeLayout.ALIGN_PARENT_BOTTOM);
+                answerArea.setVisibility(View.VISIBLE);
+                break;
+            case "none":
+                answerArea.setVisibility(View.GONE);
                 break;
             default:
                 Timber.w("Unknown answerButtonsPosition: %s", answerButtonsPosition);
@@ -1422,7 +1427,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
         mDoubleTapTimeInterval = preferences.getInt(DOUBLE_TAP_TIME_INTERVAL, DEFAULT_DOUBLE_TAP_TIME_INTERVAL);
         mExitViaDoubleTapBack = preferences.getBoolean("exitViaDoubleTapBack", false);
 
-        mGesturesEnabled = preferences.getBoolean("gestures", false);
+        mGesturesEnabled = preferences.getBoolean(GestureProcessor.PREF_KEY, false);
         if (mGesturesEnabled) {
             mGestureProcessor.init(preferences);
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
@@ -43,6 +43,7 @@ import android.webkit.URLUtil;
 import com.afollestad.materialdialogs.MaterialDialog;
 import com.ichi2.anim.ActivityTransitionAnimation;
 import com.ichi2.anki.analytics.Acra;
+import com.ichi2.anki.cardviewer.GestureProcessor;
 import com.ichi2.anki.contextmenu.AnkiCardContextMenu;
 import com.ichi2.anki.contextmenu.CardBrowserContextMenu;
 import com.ichi2.anki.debug.DatabaseLock;
@@ -933,10 +934,22 @@ public class Preferences extends AnkiActivity {
         protected void initSubscreen() {
             addPreferencesFromResource(R.xml.preferences_reviewing);
             // Show error toast if the user tries to disable answer button without gestures on
+            Preference buttonsPreference = requirePreference(getString(R.string.answer_buttons_position_preference));
+            buttonsPreference.setOnPreferenceChangeListener((preference, newValue) -> {
+                SharedPreferences prefs = AnkiDroidApp.getSharedPrefs(requireContext());
+                if (prefs.getBoolean(GestureProcessor.PREF_KEY, false) || !newValue.equals("none")) {
+                    return true;
+                } else {
+                    UIUtils.showThemedToast(requireContext(),
+                            R.string.full_screen_error_gestures, false);
+                    return false;
+                }
+            });
+
             ListPreference fullscreenPreference = requirePreference(FullScreenMode.PREF_KEY);
             fullscreenPreference.setOnPreferenceChangeListener((preference, newValue) -> {
                 SharedPreferences prefs = AnkiDroidApp.getSharedPrefs(requireContext());
-                if (prefs.getBoolean("gestures", false) || !FullScreenMode.FULLSCREEN_ALL_GONE.getPreferenceValue().equals(newValue)) {
+                if (prefs.getBoolean(GestureProcessor.PREF_KEY, false) || !FullScreenMode.FULLSCREEN_ALL_GONE.getPreferenceValue().equals(newValue)) {
                     return true;
                 } else {
                     UIUtils.showThemedToast(requireContext(),

--- a/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/GestureProcessor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/GestureProcessor.kt
@@ -20,6 +20,9 @@ import com.ichi2.anki.cardviewer.ViewerCommand.COMMAND_NOTHING
 import com.ichi2.anki.reviewer.GestureMapper
 
 class GestureProcessor(private val processor: ViewerCommand.CommandProcessor?) {
+    companion object {
+        const val PREF_KEY = "gestures"
+    }
     private var gestureDoubleTap: ViewerCommand? = null
     private var gestureLongclick: ViewerCommand? = null
     private var gestureSwipeUp: ViewerCommand? = null
@@ -46,7 +49,7 @@ class GestureProcessor(private val processor: ViewerCommand.CommandProcessor?) {
         private set
 
     fun init(preferences: SharedPreferences) {
-        isEnabled = preferences.getBoolean("gestures", false)
+        isEnabled = preferences.getBoolean(PREF_KEY, false)
         gestureDoubleTap = Gesture.DOUBLE_TAP.fromPreference(preferences)
         gestureLongclick = Gesture.LONG_TAP.fromPreference(preferences)
         gestureSwipeUp = Gesture.SWIPE_UP.fromPreference(preferences)

--- a/AnkiDroid/src/main/res/values/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values/10-preferences.xml
@@ -69,6 +69,7 @@
     <string-array name="answer_buttons_position_labels">
         <item>Top</item>
         <item>Bottom</item>
+        <item>None</item>
     </string-array>
     <string name="gestures" maxLength="41">Enable gestures</string>
     <string name="gestures_summ">Assign gestures to actions such as answering and editing cards.</string>

--- a/AnkiDroid/src/main/res/values/constants.xml
+++ b/AnkiDroid/src/main/res/values/constants.xml
@@ -268,6 +268,7 @@
     <string-array name="answer_buttons_position" translatable="false">
         <item>top</item>
         <item>bottom</item>
+        <item>none</item>
     </string-array>
     <string-array name="html_size_codes">
         <item>xx-small</item>

--- a/AnkiDroid/src/main/res/xml/preferences_reviewing.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_reviewing.xml
@@ -117,7 +117,7 @@
             android:text=" %"
             android:title="@string/button_size"
             app:interval="10"
-            app:min="100" />
+            app:min="10" />
         <ListPreference
             android:defaultValue="bottom"
             android:entries="@array/answer_buttons_position_labels"

--- a/AnkiDroid/src/test/java/com/ichi2/anki/ReviewerNoParamTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/ReviewerNoParamTest.java
@@ -288,7 +288,7 @@ public class ReviewerNoParamTest extends RobolectricTest {
 
     private void setGestureSetting(boolean value) {
         Editor settings = AnkiDroidApp.getSharedPrefs(getTargetContext()).edit();
-        settings.putBoolean("gestures", value);
+        settings.putBoolean(GestureProcessor.PREF_KEY, value);
         settings.apply();
     }
 


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
Add two options reduce flicker on e-ink devices:
1) Shrink answers bar (50%, 25%, etc)
2) Hide answers bar completely (but keep review count, toolbar, etc. enabled)

## Approach
1) A smaller bar causes less noticeable flashing (less screen to refresh)
2) No white->black->white flashing at all

## How Has This Been Tested?

Hardware used:
 - android emulator (api 31) 
 - Onyx Boox Leaf

Tested reducing button height.
Tested hiding answer buttons.
Tested unable to hide buttons if gestures are disabled.

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
