### PR TITLE
Don't show `Full sync` option if not logged on database error dialog

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/utils/SyncStatus.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/SyncStatus.kt
@@ -63,7 +63,7 @@ enum class SyncStatus {
                 val preferences = AnkiDroidApp.getSharedPrefs(AnkiDroidApp.getInstance())
                 return !preferences.getBoolean("showSyncStatusBadge", true)
             }
-        private val isLoggedIn: Boolean
+        val isLoggedIn: Boolean
             get() {
                 val preferences = AnkiDroidApp.getSharedPrefs(AnkiDroidApp.getInstance())
                 val hkey = preferences.getString("hkey", "")


### PR DESCRIPTION
## Fixes
Fixes #7326, Fixes #10394

## Approach
- Only add the option if the user is logged in

## How Has This Been Tested?

### Incompatible database
- Be unlogged
- Use a collection.anki2 with a scheme newer than 11 (from Anki desktop)
- Open the app
Result:
![Screenshot_20220228-201206_AnkiDroid](https://user-images.githubusercontent.com/69634269/156079321-51e15e28-ef98-4170-bcb6-5c23bebc1b28.png)

### Error handling dialog
With no backups on backups folder, did the following:
https://user-images.githubusercontent.com/69634269/156079204-ed1e84ef-edde-4204-a429-a1d68ad11428.mp4

Did the same processes logged and the `Full sync from server` option shows accordingly

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [X] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
