### PR TITLE
feat(scoped-storage): Prefs & Construct MigrateUserData

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/ScopedStorageService.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/ScopedStorageService.kt
@@ -18,9 +18,9 @@ package com.ichi2.anki.servicelayer
 
 import android.content.Context
 import android.content.SharedPreferences
-import androidx.annotation.VisibleForTesting
 import com.ichi2.anki.AnkiDroidApp
 import com.ichi2.anki.servicelayer.scopedstorage.MigrateUserData
+import java.io.File
 
 /** A path to the AnkiDroid folder, named "AnkiDroid" by default */
 typealias AnkiDroidDirectory = String
@@ -69,8 +69,7 @@ object ScopedStorageService {
      * @throws IllegalStateException If either [PREF_MIGRATION_SOURCE] or [PREF_MIGRATION_DESTINATION] is set (but not both)
      * It is a logic bug if only one is set
      */
-    @VisibleForTesting
-    internal fun userMigrationIsInProgress(preferences: SharedPreferences) =
+    fun userMigrationIsInProgress(preferences: SharedPreferences) =
         UserDataMigrationPreferences.createInstance(preferences).migrationInProgress
 
     /**
@@ -83,6 +82,8 @@ object ScopedStorageService {
     class UserDataMigrationPreferences private constructor(val source: String, val destination: String) {
         /**  Whether a scoped storage migration is in progress */
         val migrationInProgress = source.isNotEmpty()
+        val sourceFile get() = File(source)
+        val destinationFile get() = File(destination)
         companion object {
             /**
              * @throws IllegalStateException If either [PREF_MIGRATION_SOURCE] or [PREF_MIGRATION_DESTINATION] is set (but not both)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/ScopedStorageService.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/ScopedStorageService.kt
@@ -1,0 +1,110 @@
+/*
+ *  Copyright (c) 2022 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.servicelayer
+
+import android.content.Context
+import android.content.SharedPreferences
+import androidx.annotation.VisibleForTesting
+import com.ichi2.anki.AnkiDroidApp
+import com.ichi2.anki.servicelayer.scopedstorage.MigrateUserData
+
+/** A path to the AnkiDroid folder, named "AnkiDroid" by default */
+typealias AnkiDroidDirectory = String
+
+object ScopedStorageService {
+    /**
+     * Preference listing the [AnkiDroidDirectory] where a scoped storage migration is occurring from
+     *
+     * This directory should exist if the preference is set
+     *
+     * If this preference is set and non-empty, then a [migration of user data][MigrateUserData] should be occurring
+     * @see userMigrationIsInProgress
+     * @see UserDataMigrationPreferences
+     */
+    const val PREF_MIGRATION_SOURCE = "migrationSourcePath"
+
+    /**
+     * Preference listing the [AnkiDroidDirectory] where a scoped storage migration is migrating to.
+     *
+     * This directory should exist if the preference is set
+     *
+     * This preference exists to decouple scoped storage migration from the `deckPath` variable: there are a number
+     * of reasons that `deckPath` could change, and it's a long-term risk to couple the two operations
+     *
+     * If this preference is set and non-empty, then a [migration of user data][MigrateUserData] should be occurring
+     * @see userMigrationIsInProgress
+     * @see UserDataMigrationPreferences
+     */
+    const val PREF_MIGRATION_DESTINATION = "migrationDestinationPath"
+
+    /**
+     * Whether a user data scoped storage migration is taking place
+     * This refers to the [MigrateUserData] operation of copying media which can take a long time.
+     *
+     * @throws IllegalStateException If either [PREF_MIGRATION_SOURCE] or [PREF_MIGRATION_DESTINATION] is set (but not both)
+     * It is a logic bug if only one is set
+     */
+    fun userMigrationIsInProgress(context: Context): Boolean =
+        userMigrationIsInProgress(AnkiDroidApp.getSharedPrefs(context))
+
+    /**
+     * Whether a user data scoped storage migration is taking place
+     * This refers to the [MigrateUserData] operation of copying media which can take a long time.
+     *
+     * @see userMigrationIsInProgress[Context]
+     * @throws IllegalStateException If either [PREF_MIGRATION_SOURCE] or [PREF_MIGRATION_DESTINATION] is set (but not both)
+     * It is a logic bug if only one is set
+     */
+    @VisibleForTesting
+    internal fun userMigrationIsInProgress(preferences: SharedPreferences) =
+        UserDataMigrationPreferences.createInstance(preferences).migrationInProgress
+
+    /**
+     * Preferences relating to whether a user data scoped storage migration is taking place
+     * This refers to the [MigrateUserData] operation of copying media which can take a long time.
+     *
+     * @param source The path of the source directory. Check [migrationInProgress] before use.
+     * @param destination The path of the destination directory. Check [migrationInProgress] before use.
+     */
+    class UserDataMigrationPreferences private constructor(val source: String, val destination: String) {
+        /**  Whether a scoped storage migration is in progress */
+        val migrationInProgress = source.isNotEmpty()
+        companion object {
+            /**
+             * @throws IllegalStateException If either [PREF_MIGRATION_SOURCE] or [PREF_MIGRATION_DESTINATION] is set (but not both)
+             * It is a logic bug if only one is set
+             */
+            fun createInstance(preferences: SharedPreferences): UserDataMigrationPreferences {
+                fun getValue(key: String) = preferences.getString(key, "")!!
+
+                return UserDataMigrationPreferences(
+                    source = getValue(PREF_MIGRATION_SOURCE),
+                    destination = getValue(PREF_MIGRATION_DESTINATION)
+                ).also {
+                    // ensure that both are set, or both are empty
+                    if (it.source.isEmpty() != it.destination.isEmpty()) {
+                        // throw if there's a mismatch + list the key -> value pairs
+                        val message =
+                            "'$PREF_MIGRATION_SOURCE': '${getValue(PREF_MIGRATION_SOURCE)}'; " +
+                                "'$PREF_MIGRATION_DESTINATION': '${getValue(PREF_MIGRATION_DESTINATION)}'"
+                        throw IllegalStateException("Expected either all or no migration directories set. $message")
+                    }
+                }
+            }
+        }
+    }
+}

--- a/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/scopedstorage/MoveFile.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/scopedstorage/MoveFile.kt
@@ -133,12 +133,10 @@ internal data class MoveFile(val sourceFile: DiskFile, val destinationFile: File
      * @throws MigrateUserData.MissingDirectoryException if source or destination's directory is missing
      */
     private fun ensureParentDirectoriesExist() {
-        val deletedDirectories = listOf(sourceFile.file, destinationFile)
-            .map { it.parentFile!! }
-            .filter { !it.exists() }
-        if (deletedDirectories.any()) {
-            throw MigrateUserData.MissingDirectoryException(deletedDirectories)
-        }
+        val exceptionBuilder = MigrateUserData.DirectoryValidator()
+        exceptionBuilder.tryCreate("source - parent dir", sourceFile.file.parentFile!!)
+        exceptionBuilder.tryCreate("destination - parent dir", destinationFile.parentFile!!)
+        exceptionBuilder.throwIfNecessary()
     }
 
     @VisibleForTesting

--- a/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/ScopedStorageServiceTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/ScopedStorageServiceTest.kt
@@ -1,0 +1,81 @@
+/*
+ *  Copyright (c) 2022 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.servicelayer
+
+import android.content.SharedPreferences
+import com.ichi2.anki.servicelayer.ScopedStorageService.PREF_MIGRATION_DESTINATION
+import com.ichi2.anki.servicelayer.ScopedStorageService.PREF_MIGRATION_SOURCE
+import com.ichi2.anki.servicelayer.ScopedStorageService.userMigrationIsInProgress
+import com.ichi2.testutils.assertThrows
+import org.hamcrest.CoreMatchers.equalTo
+import org.hamcrest.MatcherAssert.assertThat
+import org.junit.Test
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+
+class ScopedStorageServiceTest {
+    @Test
+    fun no_migration_by_default() {
+        val preferences = getScopedStorageMigrationPreferences(setSource = false, setDestination = false)
+
+        assertThat("migration is not in progress if neither preference set", userMigrationIsInProgress(preferences), equalTo(false))
+    }
+
+    @Test
+    fun error_if_only_source_set() {
+        val preferences = getScopedStorageMigrationPreferences(setSource = true, setDestination = false)
+
+        val exception = assertThrows<IllegalStateException> { userMigrationIsInProgress(preferences) }
+        assertThat(
+            exception.message,
+            equalTo(
+                "Expected either all or no migration directories set. " +
+                    "'migrationSourcePath': 'sample_source_path'; " +
+                    "'migrationDestinationPath': ''"
+            )
+        )
+    }
+
+    @Test
+    fun error_if_only_destination_set() {
+        val preferences = getScopedStorageMigrationPreferences(setSource = false, setDestination = true)
+
+        val exception = assertThrows<IllegalStateException> { userMigrationIsInProgress(preferences) }
+        assertThat(
+            exception.message,
+            equalTo(
+                "Expected either all or no migration directories set. " +
+                    "'migrationSourcePath': ''; " +
+                    "'migrationDestinationPath': 'sample_dest_path'"
+            )
+        )
+    }
+
+    @Test
+    fun migration_if_both_set() {
+        val preferences = getScopedStorageMigrationPreferences(setSource = true, setDestination = true)
+
+        assertThat("migration is in progress if both preferences set", userMigrationIsInProgress(preferences), equalTo(true))
+    }
+
+    private fun getScopedStorageMigrationPreferences(setSource: Boolean, setDestination: Boolean): SharedPreferences {
+        return mock {
+            on { getString(PREF_MIGRATION_SOURCE, "") } doReturn if (setSource) "sample_source_path" else ""
+            on { getString(PREF_MIGRATION_DESTINATION, "") } doReturn if (setDestination) "sample_dest_path" else ""
+        }
+    }
+}

--- a/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/MigrateUserDataJvmTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/MigrateUserDataJvmTest.kt
@@ -1,0 +1,113 @@
+/*
+ *  Copyright (c) 2022 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.servicelayer.scopedstorage
+
+import android.content.SharedPreferences
+import com.ichi2.anki.servicelayer.ScopedStorageService
+import com.ichi2.anki.servicelayer.scopedstorage.MigrateUserData.MissingDirectoryException
+import com.ichi2.anki.servicelayer.scopedstorage.MigrateUserDataJvmTest.SourceType.*
+import com.ichi2.testutils.assertThrows
+import com.ichi2.testutils.createTransientDirectory
+import org.hamcrest.CoreMatchers.*
+import org.hamcrest.MatcherAssert.assertThat
+import org.junit.BeforeClass
+import org.junit.Test
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+
+/**
+ * A test for [MigrateUserData] which does not require Robolectric
+ */
+class MigrateUserDataJvmTest {
+
+    companion object {
+        private lateinit var sourceDir: String
+        private lateinit var destDir: String
+        private lateinit var missingDir: String
+
+        @BeforeClass
+        @JvmStatic
+        fun initClass() {
+            sourceDir = createTransientDirectory().canonicalPath
+            destDir = createTransientDirectory().canonicalPath
+            missingDir = createTransientDirectory().also { it.delete() }.canonicalPath
+        }
+    }
+
+    @Test
+    fun valid_instance_if_directories_exist() {
+        val preferences = getScopedStorageMigrationPreferences(source = VALID_DIR, destination = VALID_DIR)
+        val data = MigrateUserData.createInstance(preferences)
+
+        assertThat("a valid task instance should be created", data, notNullValue())
+
+        assertThat(data!!.source.directory.canonicalPath, equalTo(sourceDir))
+        assertThat(data.destination.directory.canonicalPath, equalTo(destDir))
+    }
+
+    @Test
+    fun no_instance_if_not_migrating() {
+        val preferences = getScopedStorageMigrationPreferences(source = NOT_SET, destination = NOT_SET)
+        val data = MigrateUserData.createInstance(preferences)
+        assertThat("a valid task instance should not be created as we are not migrating", data, nullValue())
+    }
+
+    @Test
+    fun error_if_settings_are_bad() {
+        val preferences = getScopedStorageMigrationPreferences(source = NOT_SET, destination = VALID_DIR)
+        val exception = assertThrows<IllegalStateException> { MigrateUserData.createInstance(preferences) }
+
+        assertThat(exception.message, equalTo("Expected either all or no migration directories set. 'migrationSourcePath': ''; 'migrationDestinationPath': '$destDir'"))
+    }
+
+    @Test
+    fun error_if_source_does_not_exist() {
+        val preferences = getScopedStorageMigrationPreferences(source = MISSING_DIR, destination = VALID_DIR)
+        val exception = assertThrows<MissingDirectoryException> { MigrateUserData.createInstance(preferences) }
+        assertThat(exception.directories.single().file.canonicalPath, equalTo(missingDir))
+    }
+
+    @Test
+    fun error_if_destination_does_not_exist() {
+        val preferences = getScopedStorageMigrationPreferences(source = VALID_DIR, destination = MISSING_DIR)
+        val exception = assertThrows<MissingDirectoryException> { MigrateUserData.createInstance(preferences) }
+        assertThat(exception.directories.single().file.canonicalPath, equalTo(missingDir))
+    }
+
+    private fun getScopedStorageMigrationPreferences(source: SourceType, destination: SourceType): SharedPreferences {
+        return mock {
+            on { getString(ScopedStorageService.PREF_MIGRATION_SOURCE, "") } doReturn
+                when (source) {
+                    VALID_DIR -> sourceDir
+                    MISSING_DIR -> missingDir
+                    NOT_SET -> ""
+                }
+            on { getString(ScopedStorageService.PREF_MIGRATION_DESTINATION, "") } doReturn
+                when (destination) {
+                    VALID_DIR -> destDir
+                    MISSING_DIR -> missingDir
+                    NOT_SET -> ""
+                }
+        }
+    }
+
+    enum class SourceType {
+        NOT_SET,
+        MISSING_DIR,
+        VALID_DIR
+    }
+}

--- a/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/MoveFileTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/MoveFileTest.kt
@@ -19,6 +19,7 @@ package com.ichi2.anki.servicelayer.scopedstorage
 import com.ichi2.anki.RobolectricTest
 import com.ichi2.anki.model.DiskFile
 import com.ichi2.anki.servicelayer.scopedstorage.MigrateUserData.*
+import com.ichi2.anki.servicelayer.scopedstorage.MigrateUserData.MissingDirectoryException.MissingFile
 import com.ichi2.testutils.*
 import org.hamcrest.CoreMatchers.*
 import org.hamcrest.MatcherAssert.assertThat
@@ -229,8 +230,8 @@ class MoveFileTest(private val attemptRename: Boolean) : RobolectricTest(), Oper
         }
 
         assertThat("2 missing directories expected", exception.directories, hasSize(2))
-        assertThat("source was logged", exception.directories[0], equalTo(sourceDirectoryToDelete))
-        assertThat("destination was logged", exception.directories[1], equalTo(destinationDirectoryToDelete))
+        assertThat("source was logged", exception.directories[0], equalTo(MissingFile("source - parent dir", sourceDirectoryToDelete)))
+        assertThat("destination was logged", exception.directories[1], equalTo(MissingFile("destination - parent dir", destinationDirectoryToDelete)))
     }
 
     @Test


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
Pushing things forward more, this adds:

* Preferences which will be stored when a scoped storage background migration is in progress
* Failure cases for these preferences
* Preparing to have `MigrateUserData` inherit from `TaskDelegate - allowing it to be run in the background

## Issue
#5304 

## How Has This Been Tested?

Unit tested

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)