### PR TITLE
Added `Try Anyway` button for login screen

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -1369,11 +1369,11 @@ public class DeckPicker extends NavigationDrawerActivity implements
                     NotificationChannels.Channel.SYNC);
         } else {
             if (syncMessage == null || syncMessage.length() == 0) {
-                if (messageResource == R.string.youre_offline && !Connection.getAllowSyncOnNoConnection()) {
+                if (messageResource == R.string.youre_offline && !Connection.getAllowLoginSyncOnNoConnection()) {
                     //#6396 - Add a temporary "Try Anyway" button until we sort out `isOnline`
                     View root = this.findViewById(R.id.root_layout);
                     UIUtils.showSnackbar(this, messageResource, false, R.string.sync_even_if_offline, (v) -> {
-                        Connection.setAllowSyncOnNoConnection(true);
+                        Connection.setAllowLoginSyncOnNoConnection(true);
                         sync();
                     }, null);
                 } else {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/MyAccount.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/MyAccount.java
@@ -19,11 +19,13 @@ import android.content.Intent;
 import android.content.SharedPreferences;
 import android.content.SharedPreferences.Editor;
 import android.content.res.Configuration;
+import android.content.res.Resources;
 import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.StringRes;
 import androidx.appcompat.widget.Toolbar;
 
 import android.view.KeyEvent;
@@ -248,6 +250,26 @@ public class MyAccount extends AnkiActivity {
         }
     }
 
+    private void showLoginLogMessage(@StringRes int messageResource, String loginMessage) {
+        {
+            if (loginMessage == null || loginMessage.length() == 0) {
+                if (messageResource == R.string.youre_offline && !Connection.getAllowLoginSyncOnNoConnection()) {
+                    //#6396 - Add a temporary "Try Anyway" button until we sort out `isOnline`
+                    View root = this.findViewById(R.id.root_layout);
+                    UIUtils.showSnackbar(this, messageResource, false, R.string.sync_even_if_offline, (v) -> {
+                        Connection.setAllowLoginSyncOnNoConnection(true);
+                        login();
+                    }, null);
+                } else {
+                    UIUtils.showSimpleSnackbar(this, messageResource, false);
+                }
+            } else {
+                Resources res = AnkiDroidApp.getAppResources();
+                showSimpleMessageDialog(res.getString(messageResource), loginMessage, false);
+            }
+        }
+    }
+
 
     /**
      * Listeners
@@ -308,7 +330,7 @@ public class MyAccount extends AnkiActivity {
 
         @Override
         public void onDisconnected() {
-            UIUtils.showSimpleSnackbar(MyAccount.this, R.string.youre_offline, true);
+            showLoginLogMessage(R.string.youre_offline, "");
         }
     };
 

--- a/AnkiDroid/src/main/java/com/ichi2/async/Connection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/Connection.java
@@ -69,7 +69,7 @@ public class Connection extends BaseAsyncTask<Connection.Payload, Object, Connec
     private static boolean sIsCancelled;
     private static boolean sIsCancellable;
 
-    private static boolean sAllowSyncOnNoConnection;
+    private static boolean sAllowLoginSyncOnNoConnection;
 
     /**
      * Before syncing, we acquire a wake lock and then release it once the sync is complete.
@@ -116,13 +116,13 @@ public class Connection extends BaseAsyncTask<Connection.Payload, Object, Connec
     }
 
 
-    public static boolean getAllowSyncOnNoConnection() {
-        return sAllowSyncOnNoConnection;
+    public static boolean getAllowLoginSyncOnNoConnection() {
+        return sAllowLoginSyncOnNoConnection;
     }
 
 
-    public static void setAllowSyncOnNoConnection(boolean value) {
-        sAllowSyncOnNoConnection = value;
+    public static void setAllowLoginSyncOnNoConnection(boolean value) {
+        sAllowLoginSyncOnNoConnection = value;
     }
 
 
@@ -588,7 +588,7 @@ public class Connection extends BaseAsyncTask<Connection.Payload, Object, Connec
 
     @SuppressWarnings("deprecation")
     public static boolean isOnline() {
-        if (sAllowSyncOnNoConnection) {
+        if (sAllowLoginSyncOnNoConnection) {
             return true;
         }
         ConnectivityManager cm = (ConnectivityManager) AnkiDroidApp.getInstance().getApplicationContext()


### PR DESCRIPTION

## Pull Request template

## Purpose / Description
In some cases, even if user has access to the AnkiDroid server, AnkiDroid says "You are offline" and doesn't allow to connect to the server at all.

## Fixes
Fixes #9961 

## Approach
Added the `Try Anyway` button just like the one present for syncing, so that AnkiDroid tries to attempt to connect before reporting any failure. 
Also changed variable name from `setAllowSyncOnNoConnection` to `setAllowLoginSyncOnNoConnection` in accordance with the updated implementation. 

https://user-images.githubusercontent.com/86671025/156182520-47d7b10c-98bd-4c94-abbd-d2200990bd85.mp4

## How Has This Been Tested?
Emulator:
Pixel 5 API 32

Device:
Xaomi Redmi Note 8 Pro API 28 (Android 9)

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
