### PR TITLE
`hasFile` throw FileNotFoundException instead of NoSuchFile

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/compat/Compat.java
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/Compat.java
@@ -36,7 +36,6 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
-import java.nio.file.NoSuchFileException;
 import java.nio.file.NotDirectoryException;
 import java.nio.file.Path;
 
@@ -263,7 +262,6 @@ public interface Compat {
      * @param directory A directory.
      * @return a FileStream over file and folder of this directory.
      *         null in case of trouble. This stream must be closed explicitly when done with it.
-     * @throws NoSuchFileException if the file do not exists (starting at API 26)
      * @throws NotDirectoryException if the file exists and is not a directory (starting at API 26)
      * @throws FileNotFoundException if the file do not exists (up to API 25)
      * @throws IOException if files can not be listed. On non existing or non-directory file up to API 25. This also occurred on an existing directory because of permission issue

--- a/AnkiDroid/src/main/java/com/ichi2/compat/CompatV21.java
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/CompatV21.java
@@ -42,7 +42,6 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.nio.file.NoSuchFileException;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;

--- a/AnkiDroid/src/main/java/com/ichi2/compat/CompatV26.java
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/CompatV26.java
@@ -193,7 +193,16 @@ public class CompatV26 extends CompatV23 implements Compat {
      */
     @Override
     public @NonNull FileStream contentOfDirectory(File directory) throws IOException {
-        DirectoryStream<Path> paths_stream = Files.newDirectoryStream(directory.toPath());
+        final DirectoryStream<Path> paths_stream;
+        try {
+            paths_stream = Files.newDirectoryStream(directory.toPath());
+        } catch (IOException e) {
+            if (e instanceof NoSuchFileException) {
+                NoSuchFileException nsfe = (NoSuchFileException) e;
+                throw new FileNotFoundException(nsfe.getFile() + "\n" + nsfe.getCause() + "\n" + nsfe.getStackTrace());
+            }
+            throw e;
+        }
         Iterator<Path> paths = paths_stream.iterator();
         return new FileStream() {
             @Override


### PR DESCRIPTION
I wanted to ensure that there is a method that check whether we use the expected
exception for absent file depending on the API. So I decided to extend Compat
and CompatHelper for tests and use it to simplify a test. It'll be used again in
other PR which need to deal with missing files, in particular ensuring hasFile raises
