### PR TITLE
Add option to show all deck stats by default

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/Statistics.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Statistics.java
@@ -128,7 +128,20 @@ public class Statistics extends NavigationDrawerActivity implements
         // Prepare options menu only after loading everything
         supportInvalidateOptionsMenu();
 //        StatisticFragment.updateAllFragments();
-        mStatsDeckId = getCol().getDecks().selected();
+
+        String defaultDeck = AnkiDroidApp.getSharedPrefs(this).getString("stats_default_deck", "current");
+        switch (defaultDeck) {
+            case "current":
+                mStatsDeckId = getCol().getDecks().selected();
+                break;
+            case "all":
+                mStatsDeckId = Stats.ALL_DECKS_ID;
+                break;
+            default:
+                Timber.w("Unknown defaultDeck: %s", defaultDeck);
+                break;
+        }
+
         mDeckSpinnerSelection = new DeckSpinnerSelection(this, col, this.findViewById(R.id.toolbar_spinner), true, true);
         mDeckSpinnerSelection.initializeActionBarDeckSpinner(this.getSupportActionBar());
         mDeckSpinnerSelection.selectDeckById(mStatsDeckId, false);

--- a/AnkiDroid/src/main/res/values/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values/10-preferences.xml
@@ -197,6 +197,10 @@
     <!-- Allow all files in media imports -->
     <string name="media_import_allow_all_files" maxLength="41">Allow all files in media imports</string>
     <string name="media_import_allow_all_files_summ">If Android doesn’t recognize a media file</string>
+    <!-- Statistics settings -->
+    <string name="stats_default_deck_title" maxLength="41">Default deck when opening statistics</string>
+    <string name="stats_default_deck_current">Show stats for most recent deck</string>
+    <string name="stats_default_deck_all">Show stats for all decks</string>
     <!-- Advanced statistics settings -->
     <string name="advanced_statistics_title" maxLength="41">Advanced statistics</string>
     <string name="enable_advanced_statistics_title" maxLength="41">Enable advanced statistics</string>

--- a/AnkiDroid/src/main/res/values/constants.xml
+++ b/AnkiDroid/src/main/res/values/constants.xml
@@ -285,4 +285,14 @@
     <string name="show_onboarding" maxLength="41">Show onboarding walkthrough</string>
     <string name="show_onboarding_desc">Display feature tutorial to learn more about the app</string>
     <string name="reset_onboarding_desc">Show all tutorials again</string>
+
+    <!-- Stats -->
+    <string-array name="stats_default_deck_labels">
+        <item>@string/stats_default_deck_current</item>
+        <item>@string/stats_default_deck_all</item>
+    </string-array>
+    <string-array name="stats_default_deck_values">
+        <item>current</item>
+        <item>all</item>
+    </string-array>
 </resources>

--- a/AnkiDroid/src/main/res/xml/preferences_advanced.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_advanced.xml
@@ -155,6 +155,12 @@
                 android:key="double_scrolling"
                 android:summary="@string/double_scrolling_gap_summ"
                 android:title="@string/double_scrolling_gap" />
+            <ListPreference
+                android:entries="@array/stats_default_deck_labels"
+                android:entryValues="@array/stats_default_deck_values"
+                android:key="stats_default_deck"
+                android:title="@string/stats_default_deck_title"
+                android:defaultValue="current" />
             <Preference
                 android:key="advanced_statistics_link"
                 android:title="@string/advanced_statistics_title"


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
This option is useful to anyone who wants to know "how many cards did I
study today (in total), and how many cards are due tomorrow (in total)".
In this situation it can save a few clicks and scrolls which can be slow
on e-ink displays.

## Fixes
If using a single "To Review" filtered deck then stats are pretty
meaningless. For instance "Studied 3 cards in 0 minutes today". To
find the real statistics after studying with a filtered deck I have
to select "All decks" and then I correctly see "Studied 491 cards in
25 minutes today".

## Approach
This option lets you bypass the empty filtered deck stats and go directly to the stats you are interested in (this new behavior is opt-in)

## How Has This Been Tested?

Deploy to android emulator:
 - Review a deck, open nav drawer, click stats, see last deck stats
 - Enable new "Show statistics for all decks by default" advanced setting
 - Review a deck, open nav drawer, click stats, see all decks stats

## Learning (optional, can help others)
Search strings for existing setting name

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
