### PR TITLE
Do not make a copy when reattaching the same audio or video file

### DIFF
--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/libanki/MediaTest.java
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/libanki/MediaTest.java
@@ -245,8 +245,8 @@ public class MediaTest extends InstrumentedTest {
 
     @Test
     public void testIllegal() {
-        String aString = "a:b|cd\\e/f\0g*h";
-        String good = "abcdefgh";
+        String aString = "a:b|cd\\e/f\0g*h\\[i\\]j";
+        String good = "abcdefghij";
         assertEquals(good, mTestCol.getMedia().stripIllegal(aString));
         for (int i = 0; i < aString.length(); i++) {
             char c = aString.charAt(i);

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicImageFieldController.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicImageFieldController.java
@@ -298,7 +298,9 @@ public class BasicImageFieldController extends FieldControllerBase implements IF
     }
 
     private File createCachedFile(@NonNull String filename) throws IOException {
-        return new File(mAnkiCacheDirectory, filename);
+        File file = new File(mAnkiCacheDirectory, filename);
+        file.deleteOnExit();
+        return file;
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicMediaClipFieldController.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicMediaClipFieldController.kt
@@ -25,7 +25,6 @@ import android.view.ViewGroup
 import android.widget.Button
 import android.widget.LinearLayout
 import androidx.annotation.StringRes
-import androidx.annotation.VisibleForTesting
 import com.ichi2.anki.AnkiDroidApp
 import com.ichi2.anki.R
 import com.ichi2.anki.UIUtils.showThemedToast
@@ -201,17 +200,5 @@ class BasicMediaClipFieldController : FieldControllerBase(), IFieldController {
     companion object {
         private const val ACTIVITY_SELECT_AUDIO_CLIP = 1
         private const val ACTIVITY_SELECT_VIDEO_CLIP = 2
-
-        /**
-         * This method replaces any character that isn't a number, letter or underscore with underscore in file name.
-         * This method doesn't check that file name is valid or not it simply operates on all file name.
-         * @param mediaClipFullName name of the file.
-         * @return file name which is valid.
-         */
-        @JvmStatic
-        @VisibleForTesting
-        fun checkFileName(mediaClipFullName: String): String {
-            return mediaClipFullName.replace("[^\\w.]+".toRegex(), "_")
-        }
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicMediaClipFieldController.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicMediaClipFieldController.kt
@@ -167,7 +167,7 @@ class BasicMediaClipFieldController : FieldControllerBase(), IFieldController {
                 // If everything worked, hand off the information
                 mField.setHasTemporaryMedia(true)
                 mField.audioPath = clipCopy.absolutePath
-                tvAudioClip.text = mField.formattedValue
+                tvAudioClip.text = clipCopy.name
                 tvAudioClip.visibility = View.VISIBLE
             }
         } catch (e: Exception) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/MediaClipField.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/MediaClipField.kt
@@ -19,7 +19,7 @@ class MediaClipField : AudioField() {
     }
 
     override fun hasTemporaryMedia(): Boolean {
-        return false
+        return currentHasTemporaryMedia
     }
 
     override fun getName(): String? {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/NoteService.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/NoteService.kt
@@ -111,41 +111,6 @@ object NoteService {
     }
 
     /**
-     * Saves the multimedia associated with this card to proper path inside anki folder. For each field associated with
-     * the note it checks for the following condition a. The field content should have changed b. The field content does
-     * not already point to a media inside anki media path If both condition satisfies then it copies the file inside
-     * the media path and deletes the file referenced by the note
-     *
-     * @param noteNew
-     */
-    @JvmStatic
-    fun saveMedia(col: com.ichi2.libanki.Collection, noteNew: MultimediaEditableNote) {
-        // if (noteNew.getModelId() == noteOld.getModelId())
-        // {
-        // int fieldCount = noteNew.getNumberOfFields();
-        // for (int i = 0; i < fieldCount; i++)
-        // {
-        // IField newField = noteNew.getField(i);
-        // IField oldField = noteOld.getField(i);
-        // if
-        // (newField.getFormattedValue().equals(oldField.getFormattedValue()))
-        // {
-        // continue;
-        // }
-        // importMediaToDirectory(newField);
-        // }
-        // }
-        // else
-        // {
-        val fieldCount: Int = noteNew.numberOfFields
-        for (i in 0 until fieldCount) {
-            val newField = noteNew.getField(i)
-            importMediaToDirectory(col, newField)
-        }
-        // }
-    }
-
-    /**
      * Considering the field is new, if it has media handle it
      *
      * @param field
@@ -167,8 +132,6 @@ object NoteService {
                 if (inFile.exists() && inFile.length() > 0) {
                     val fname = col.media.addFile(inFile)
                     val outFile = File(col.media.dir(), fname)
-                    // Update imagePath in case the file name wasn't unique
-                    field.imagePath = fname
                     if (field.hasTemporaryMedia() && outFile.absolutePath != tmpMediaPath) {
                         // Delete original
                         inFile.delete()

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Media.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Media.java
@@ -83,7 +83,9 @@ import static java.lang.Math.min;
         "PMD.SwitchStmtsShouldHaveDefault","PMD.EmptyIfStmt","PMD.SimplifyBooleanReturns","PMD.CollapsibleIfStatements"})
 public class Media {
 
-    private static final Pattern fIllegalCharReg = Pattern.compile("[><:\"/?*^\\\\|\\x00\\r\\n]");
+    // Upstream illegal chars defined on disallowed_char()
+    // in https://github.com/ankitects/anki/blob/main/rslib/src/media/files.rs
+    private static final Pattern fIllegalCharReg = Pattern.compile("[\\[\\]><:\"/?*^\\\\|\\x00\\r\\n]");
     private static final Pattern fRemotePattern  = Pattern.compile("(https?|ftp)://");
 
     /*

--- a/AnkiDroid/src/test/java/com/ichi2/anki/multimediacard/fields/BasicMediaClipFieldControllerTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/multimediacard/fields/BasicMediaClipFieldControllerTest.java
@@ -18,21 +18,9 @@ package com.ichi2.anki.multimediacard.fields;
 
 import org.junit.Test;
 
-import static com.ichi2.anki.multimediacard.fields.BasicMediaClipFieldController.checkFileName;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
 public class BasicMediaClipFieldControllerTest {
-
-
-    @Test
-    public void test_bad_chars_stripped() {
-        assertThat(checkFileName("There's a good film on the day <b>after</b> tomorrow.mp3"), is("There_s_a_good_film_on_the_day_b_after_b_tomorrow.mp3"));
-    }
-
-    @Test
-    public void test_extension_is_not_stripped() {
-        assertThat(checkFileName("file_example_MP3_700KB.mp3"), is("file_example_MP3_700KB.mp3"));
-    }
 
 }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/services/NoteServiceTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/services/NoteServiceTest.java
@@ -141,6 +141,55 @@ public class NoteServiceTest extends RobolectricTest {
         assertEquals("path should be equal to the new file made in NoteService.saveMedia", outFile.getAbsolutePath(), imgField.getImagePath());
     }
 
+
+    /**
+     * Tests if after importing:
+     *
+     * * New file keeps its name
+     * * File with same name, but different content, has its name changed
+     * * File with same name and content don't have its name changed
+     *
+     * @throws IOException if new created files already exist on temp folder
+     */
+    @Test
+    public void importAudioWithSameNameTest() throws IOException {
+        File f1 = folder.newFile("audio.mp3");
+        File f2 = folder2.newFile("audio.mp3");
+
+        // write a line in the file so the file's length isn't 0
+        try (FileWriter fileWriter = new FileWriter(f1)) {
+            fileWriter.write("1");
+        }
+        // do the same to the second file, but with different data
+        try (FileWriter fileWriter = new FileWriter(f2)) {
+            fileWriter.write("2");
+        }
+
+        MediaClipField fld1 = new MediaClipField();
+        fld1.setAudioPath(f1.getAbsolutePath());
+
+        MediaClipField fld2 = new MediaClipField();
+        fld2.setAudioPath(f2.getAbsolutePath());
+
+        // third field to test if name is kept after reimporting the same file
+        MediaClipField fld3 = new MediaClipField();
+        fld3.setAudioPath(f1.getAbsolutePath());
+
+        NoteService.importMediaToDirectory(mTestCol, fld1);
+        File o1 = new File(mTestCol.getMedia().dir(), f1.getName());
+
+        NoteService.importMediaToDirectory(mTestCol, fld2);
+        File o2 = new File(mTestCol.getMedia().dir(), f2.getName());
+
+        NoteService.importMediaToDirectory(mTestCol, fld3);
+        // creating a third outfile isn't necessary because it should be equal to the first one
+
+        assertEquals("path should be equal to the new file made in NoteService.importMediaToDirectory", o1.getAbsolutePath(), fld1.getAudioPath());
+        assertNotEquals("path should be different to the new file made in NoteService.importMediaToDirectory", o2.getAbsolutePath(), fld2.getAudioPath());
+        assertEquals("path should be equal to the new file made in NoteService.importMediaToDirectory", o1.getAbsolutePath(), fld3.getAudioPath());
+    }
+
+    // Similar test like above, but with an ImageField instead of a MediaClipField
     @Test
     public void importImageWithSameNameTest() throws IOException {
         File f1 = folder.newFile("img.png");

--- a/AnkiDroid/src/test/java/com/ichi2/anki/services/NoteServiceTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/services/NoteServiceTest.java
@@ -20,7 +20,6 @@ import com.ichi2.anki.RobolectricTest;
 import com.ichi2.anki.multimediacard.IMultimediaEditableNote;
 import com.ichi2.anki.multimediacard.fields.MediaClipField;
 import com.ichi2.anki.multimediacard.fields.ImageField;
-import com.ichi2.anki.multimediacard.impl.MultimediaEditableNote;
 import com.ichi2.anki.servicelayer.NoteService;
 import com.ichi2.libanki.Collection;
 import com.ichi2.libanki.Model;
@@ -98,49 +97,41 @@ public class NoteServiceTest extends RobolectricTest {
 
         File fileAudio = folder.newFile("testaudio.wav");
 
-        //writes a line in the file so the file's length isn't 0
-        try(FileWriter fileWriter = new FileWriter(fileAudio)) {
+        // writes a line in the file so the file's length isn't 0
+        try (FileWriter fileWriter = new FileWriter(fileAudio)) {
             fileWriter.write("line1");
         }
 
-        MultimediaEditableNote testAudioClip = new MultimediaEditableNote();
-        testAudioClip.setNumFields(1);
-
         MediaClipField audioField = new MediaClipField();
         audioField.setAudioPath(fileAudio.getAbsolutePath());
-        testAudioClip.setField(0, audioField);
 
-        NoteService.saveMedia(mTestCol, testAudioClip);
+        NoteService.importMediaToDirectory(mTestCol, audioField);
 
         File outFile = new File(mTestCol.getMedia().dir(), fileAudio.getName());
 
-        assertEquals("path should be equal to the new file made in NoteService.saveMedia", outFile.getAbsolutePath(), audioField.getAudioPath());
+        assertEquals("path should be equal to the new file made in NoteService.importMediaToDirectory", outFile.getAbsolutePath(), audioField.getAudioPath());
 
     }
 
-    //similar test like above, but with an imagefield instead of an audioclipfield
+    // Similar test like above, but with an ImageField instead of a MediaClipField
     @Test
     public void importImageToDirectoryTest() throws IOException {
 
         File fileImage = folder.newFile("testimage.png");
 
-        //writes a line in the file so the file's length isn't 0
-        try(FileWriter fileWriter = new FileWriter(fileImage)) {
+        // writes a line in the file so the file's length isn't 0
+        try (FileWriter fileWriter = new FileWriter(fileImage)) {
             fileWriter.write("line1");
         }
 
-        MultimediaEditableNote testImage = new MultimediaEditableNote();
-        testImage.setNumFields(1);
-
         ImageField imgField = new ImageField();
         imgField.setImagePath(fileImage.getAbsolutePath());
-        testImage.setField(0, imgField);
 
-        NoteService.saveMedia(mTestCol, testImage);
+        NoteService.importMediaToDirectory(mTestCol, imgField);
 
         File outFile = new File(mTestCol.getMedia().dir(), fileImage.getName());
 
-        assertEquals("path should be equal to the new file made in NoteService.saveMedia", outFile.getAbsolutePath(), imgField.getImagePath());
+        assertEquals("path should be equal to the new file made in NoteService.importMediaToDirectory", outFile.getAbsolutePath(), imgField.getImagePath());
     }
 
 
@@ -206,21 +197,15 @@ public class NoteServiceTest extends RobolectricTest {
             fileWriter.write("2");
         }
 
-        MultimediaEditableNote testImage = new MultimediaEditableNote();
-        testImage.setNumFields(3);
-
         ImageField fld1 = new ImageField();
         fld1.setImagePath(f1.getAbsolutePath());
-        testImage.setField(0, fld1);
 
         ImageField fld2 = new ImageField();
         fld2.setImagePath(f2.getAbsolutePath());
-        testImage.setField(1, fld2);
 
         // third field to test if name is kept after reimporting the same file
         ImageField fld3 = new ImageField();
         fld3.setImagePath(f1.getAbsolutePath());
-        testImage.setField(0, fld3);
 
         NoteService.importMediaToDirectory(mTestCol, fld1);
         File o1 = new File(mTestCol.getMedia().dir(), f1.getName());

--- a/AnkiDroid/src/test/java/com/ichi2/anki/services/NoteServiceTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/services/NoteServiceTest.java
@@ -41,6 +41,8 @@ import androidx.test.ext.junit.runners.AndroidJUnit4;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertFalse;
+import static com.ichi2.testutils.FileSystemUtilsKt.createTransientFile;
 
 @RunWith(AndroidJUnit4.class)
 public class NoteServiceTest extends RobolectricTest {
@@ -232,6 +234,38 @@ public class NoteServiceTest extends RobolectricTest {
         assertEquals("path should be equal to the new file made in NoteService.importMediaToDirectory", o1.getAbsolutePath(), fld1.getImagePath());
         assertNotEquals("path should be different to the new file made in NoteService.importMediaToDirectory", o2.getAbsolutePath(), fld2.getImagePath());
         assertEquals("path should be equal to the new file made in NoteService.importMediaToDirectory", o1.getAbsolutePath(), fld3.getImagePath());
+    }
+
+    /**
+     * Sometimes media files cannot be imported directly to the media directory,
+     * so they are copied to cache then imported and deleted.
+     * This tests if cached media are properly deleted after import.
+     */
+    @Test
+    public void tempAudioIsDeletedAfterImport() {
+        File file = createTransientFile("foo");
+
+        MediaClipField field = new MediaClipField();
+        field.setAudioPath(file.getAbsolutePath());
+        field.setHasTemporaryMedia(true);
+
+        NoteService.importMediaToDirectory(mTestCol, field);
+
+        assertFalse("Audio temporary file should have been deleted after importing", file.exists());
+    }
+
+    // Similar test like above, but with an ImageField instead of a MediaClipField
+    @Test
+    public void tempImageIsDeletedAfterImport() {
+        File file = createTransientFile("foo");
+
+        ImageField field = new ImageField();
+        field.setImagePath(file.getAbsolutePath());
+        field.setHasTemporaryMedia(true);
+
+        NoteService.importMediaToDirectory(mTestCol, field);
+
+        assertFalse("Image temporary file should have been deleted after importing", file.exists());
     }
 
 }


### PR DESCRIPTION
## Purpose / Description
_Describe the problem or feature and motivation_

## Fixes
Fixes #10419

## Approach
1. Fix outdated/broken behaviors
    - MediaClipField files weren't being deleted
    - The illegal chars on media names were outdated
2. Cache temporary audio files (like the ImageField behavior) and keep their names
3. Updated the field preview
    - i.e. the text added after confirming the file selection, below the `AUDIO` and `VIDEO` buttons (0:06 on the procedure video)
5. Make tests to guarantee cached temporary files deletion and audio importing with same name
6. Cleaned unused functions/variables

## How Has This Been Tested?

Tested on my phone (Samsung Galaxy Note 10 Lite SM-N770F/DS, API 30)

Procedure:

https://user-images.githubusercontent.com/69634269/156594640-dc006633-a7da-4943-9c17-b3a292687a9d.mp4



## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
