### PR TITLE
feat(kotlin-test): assertNotNull

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -355,6 +355,8 @@ dependencies {
     testImplementation 'androidx.test:core:1.4.0'
     testImplementation 'androidx.test.ext:junit:1.1.3'
     testImplementation "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
+    testImplementation "org.jetbrains.kotlin:kotlin-test:$kotlin_version"
+
     // debugImplementation required vs testImplementation: https://issuetracker.google.com/issues/128612536
     debugImplementation 'androidx.fragment:fragment-testing:1.4.1'
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/CardTemplateEditorTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/CardTemplateEditorTest.kt
@@ -27,7 +27,7 @@ import com.ichi2.libanki.Model
 import com.ichi2.utils.JSONObject
 import org.hamcrest.MatcherAssert
 import org.hamcrest.Matchers
-import org.junit.Assert
+import org.junit.Assert.*
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.Robolectric
@@ -49,15 +49,15 @@ class CardTemplateEditorTest : RobolectricTest() {
         var templateEditorController = Robolectric.buildActivity(CardTemplateEditor::class.java, intent).create().start().resume().visible()
         saveControllerForCleanup(templateEditorController)
         var testEditor = templateEditorController.get()
-        Assert.assertFalse("Model should not have changed yet", testEditor.modelHasChanged())
+        assertFalse("Model should not have changed yet", testEditor.modelHasChanged())
 
         // Change the model and make sure it registers as changed, but the database is unchanged
         var templateFront = testEditor.findViewById<EditText>(R.id.editor_editText)
         val testModelQfmtEdit = "!@#$%^&*TEST*&^%$#@!"
         templateFront.text.append(testModelQfmtEdit)
         advanceRobolectricLooperWithSleep()
-        Assert.assertTrue("Model did not change after edit?", testEditor.modelHasChanged())
-        Assert.assertEquals("Change already in database?", collectionBasicModelOriginal.toString().trim { it <= ' ' }, getCurrentDatabaseModelCopy(modelName).toString().trim { it <= ' ' })
+        assertTrue("Model did not change after edit?", testEditor.modelHasChanged())
+        assertEquals("Change already in database?", collectionBasicModelOriginal.toString().trim { it <= ' ' }, getCurrentDatabaseModelCopy(modelName).toString().trim { it <= ' ' })
 
         // Kill and restart the Activity, make sure model edit is preserved
         val outBundle = Bundle()
@@ -67,23 +67,23 @@ class CardTemplateEditorTest : RobolectricTest() {
         saveControllerForCleanup(templateEditorController)
         testEditor = templateEditorController.get()
         var shadowTestEditor = shadowOf(testEditor)
-        Assert.assertTrue("model change not preserved across activity lifecycle?", testEditor.modelHasChanged())
-        Assert.assertEquals("Change already in database?", collectionBasicModelOriginal.toString().trim { it <= ' ' }, getCurrentDatabaseModelCopy(modelName).toString().trim { it <= ' ' })
+        assertTrue("model change not preserved across activity lifecycle?", testEditor.modelHasChanged())
+        assertEquals("Change already in database?", collectionBasicModelOriginal.toString().trim { it <= ' ' }, getCurrentDatabaseModelCopy(modelName).toString().trim { it <= ' ' })
 
         // Make sure we get a confirmation dialog if we hit the back button
-        Assert.assertTrue("Unable to click?", shadowTestEditor.clickMenuItem(android.R.id.home))
+        assertTrue("Unable to click?", shadowTestEditor.clickMenuItem(android.R.id.home))
         advanceRobolectricLooperWithSleep()
-        Assert.assertEquals("Wrong dialog shown?", getDialogText(true), getResourceString(R.string.discard_unsaved_changes))
+        assertEquals("Wrong dialog shown?", getDialogText(true), getResourceString(R.string.discard_unsaved_changes))
         clickDialogButton(DialogAction.NEGATIVE, true)
         advanceRobolectricLooperWithSleep()
-        Assert.assertTrue("model change not preserved despite canceling back button?", testEditor.modelHasChanged())
+        assertTrue("model change not preserved despite canceling back button?", testEditor.modelHasChanged())
 
         // Make sure we things are cleared out after a cancel
-        Assert.assertTrue("Unable to click?", shadowTestEditor.clickMenuItem(android.R.id.home))
-        Assert.assertEquals("Wrong dialog shown?", getDialogText(true), getResourceString(R.string.discard_unsaved_changes))
+        assertTrue("Unable to click?", shadowTestEditor.clickMenuItem(android.R.id.home))
+        assertEquals("Wrong dialog shown?", getDialogText(true), getResourceString(R.string.discard_unsaved_changes))
         clickDialogButton(DialogAction.POSITIVE, true)
         advanceRobolectricLooperWithSleep()
-        Assert.assertFalse("model change not cleared despite discarding changes?", testEditor.modelHasChanged())
+        assertFalse("model change not cleared despite discarding changes?", testEditor.modelHasChanged())
 
         // Get going for content edit assertions again...
         templateEditorController = Robolectric.buildActivity(CardTemplateEditor::class.java, intent).create().start().resume().visible()
@@ -93,29 +93,29 @@ class CardTemplateEditorTest : RobolectricTest() {
         templateFront = testEditor.findViewById(R.id.editor_editText)
         templateFront.text.append(testModelQfmtEdit)
         advanceRobolectricLooperWithSleep()
-        Assert.assertTrue("Model did not change after edit?", testEditor.modelHasChanged())
+        assertTrue("Model did not change after edit?", testEditor.modelHasChanged())
 
         // Make sure we pass the edit to the Previewer
-        Assert.assertTrue("Unable to click?", shadowTestEditor.clickMenuItem(R.id.action_preview))
+        assertTrue("Unable to click?", shadowTestEditor.clickMenuItem(R.id.action_preview))
         advanceRobolectricLooperWithSleep()
         val startedIntent = shadowTestEditor.nextStartedActivity
         val shadowIntent = shadowOf(startedIntent)
         advanceRobolectricLooperWithSleep()
-        Assert.assertEquals("Previewer not started?", CardTemplatePreviewer::class.java.name, shadowIntent.intentClass.name)
-        Assert.assertNotNull("intent did not have model JSON filename?", startedIntent.getStringExtra(TemporaryModel.INTENT_MODEL_FILENAME))
-        Assert.assertNotEquals("Model sent to Previewer is unchanged?", testEditor.tempModel.model, TemporaryModel.getTempModel(startedIntent.getStringExtra(TemporaryModel.INTENT_MODEL_FILENAME)!!))
-        Assert.assertEquals("Change already in database?", collectionBasicModelOriginal.toString().trim { it <= ' ' }, getCurrentDatabaseModelCopy(modelName).toString().trim { it <= ' ' })
+        assertEquals("Previewer not started?", CardTemplatePreviewer::class.java.name, shadowIntent.intentClass.name)
+        assertNotNull("intent did not have model JSON filename?", startedIntent.getStringExtra(TemporaryModel.INTENT_MODEL_FILENAME))
+        assertNotEquals("Model sent to Previewer is unchanged?", testEditor.tempModel.model, TemporaryModel.getTempModel(startedIntent.getStringExtra(TemporaryModel.INTENT_MODEL_FILENAME)!!))
+        assertEquals("Change already in database?", collectionBasicModelOriginal.toString().trim { it <= ' ' }, getCurrentDatabaseModelCopy(modelName).toString().trim { it <= ' ' })
         shadowTestEditor.receiveResult(startedIntent, Activity.RESULT_OK, Intent())
 
         // Save the template then fetch it from the collection to see if it was saved correctly
         val testEditorModelEdited = testEditor.tempModel.model
         advanceRobolectricLooperWithSleep()
-        Assert.assertTrue("Unable to click?", shadowTestEditor.clickMenuItem(R.id.action_confirm))
+        assertTrue("Unable to click?", shadowTestEditor.clickMenuItem(R.id.action_confirm))
         advanceRobolectricLooperWithSleep()
         val collectionBasicModelCopyEdited = getCurrentDatabaseModelCopy(modelName)
-        Assert.assertNotEquals("model is unchanged?", collectionBasicModelOriginal, collectionBasicModelCopyEdited)
-        Assert.assertEquals("model did not save?", testEditorModelEdited.toString().trim { it <= ' ' }, collectionBasicModelCopyEdited.toString().trim { it <= ' ' })
-        Assert.assertTrue("model does not have our change?", collectionBasicModelCopyEdited.toString().contains(testModelQfmtEdit))
+        assertNotEquals("model is unchanged?", collectionBasicModelOriginal, collectionBasicModelCopyEdited)
+        assertEquals("model did not save?", testEditorModelEdited.toString().trim { it <= ' ' }, collectionBasicModelCopyEdited.toString().trim { it <= ' ' })
+        assertTrue("model does not have our change?", collectionBasicModelCopyEdited.toString().contains(testModelQfmtEdit))
     }
 
     @Test
@@ -129,36 +129,36 @@ class CardTemplateEditorTest : RobolectricTest() {
         val templateEditorController = Robolectric.buildActivity(CardTemplateEditor::class.java, intent).create().start().resume().visible()
         saveControllerForCleanup(templateEditorController)
         val testEditor = templateEditorController.get()
-        Assert.assertFalse("Model should not have changed yet", testEditor.modelHasChanged())
-        Assert.assertEquals("Model should have 2 templates now", 2, testEditor.tempModel.templateCount.toLong())
+        assertFalse("Model should not have changed yet", testEditor.modelHasChanged())
+        assertEquals("Model should have 2 templates now", 2, testEditor.tempModel.templateCount.toLong())
 
         // Try to delete the template - click delete, click confirm for card delete, click confirm again for full sync
         val shadowTestEditor = shadowOf(testEditor)
-        Assert.assertTrue("Unable to click?", shadowTestEditor.clickMenuItem(R.id.action_delete))
+        assertTrue("Unable to click?", shadowTestEditor.clickMenuItem(R.id.action_delete))
         advanceRobolectricLooperWithSleep()
-        Assert.assertEquals("Wrong dialog shown?", "Delete the “Card 1” card type, and its 0 cards?", getDialogText(true))
+        assertEquals("Wrong dialog shown?", "Delete the “Card 1” card type, and its 0 cards?", getDialogText(true))
         clickDialogButton(DialogAction.POSITIVE, true)
         advanceRobolectricLooperWithSleep()
-        Assert.assertTrue("Model should have changed", testEditor.modelHasChanged())
-        Assert.assertEquals("Model should have 1 template now", 1, testEditor.tempModel.templateCount.toLong())
+        assertTrue("Model should have changed", testEditor.modelHasChanged())
+        assertEquals("Model should have 1 template now", 1, testEditor.tempModel.templateCount.toLong())
 
         // Try to delete the template again, but there's only one
-        Assert.assertTrue("Unable to click?", shadowTestEditor.clickMenuItem(R.id.action_delete))
+        assertTrue("Unable to click?", shadowTestEditor.clickMenuItem(R.id.action_delete))
         advanceRobolectricLooperWithSleep()
-        Assert.assertEquals(
+        assertEquals(
             "Did not show dialog about deleting only card?",
             getResourceString(R.string.card_template_editor_cant_delete),
             getDialogText(true)
         )
-        Assert.assertEquals("Change already in database?", collectionBasicModelOriginal.toString().trim { it <= ' ' }, getCurrentDatabaseModelCopy(modelName).toString().trim { it <= ' ' })
+        assertEquals("Change already in database?", collectionBasicModelOriginal.toString().trim { it <= ' ' }, getCurrentDatabaseModelCopy(modelName).toString().trim { it <= ' ' })
 
         // Save the change to the database and make sure there's only one template after
         val testEditorModelEdited = testEditor.tempModel.model
-        Assert.assertTrue("Unable to click?", shadowTestEditor.clickMenuItem(R.id.action_confirm))
+        assertTrue("Unable to click?", shadowTestEditor.clickMenuItem(R.id.action_confirm))
         advanceRobolectricLooperWithSleep()
         val collectionBasicModelCopyEdited = getCurrentDatabaseModelCopy(modelName)
-        Assert.assertNotEquals("model is unchanged?", collectionBasicModelOriginal, collectionBasicModelCopyEdited)
-        Assert.assertEquals("model did not save?", testEditorModelEdited.toString().trim { it <= ' ' }, collectionBasicModelCopyEdited.toString().trim { it <= ' ' })
+        assertNotEquals("model is unchanged?", collectionBasicModelOriginal, collectionBasicModelCopyEdited)
+        assertEquals("model did not save?", testEditorModelEdited.toString().trim { it <= ' ' }, collectionBasicModelCopyEdited.toString().trim { it <= ' ' })
     }
 
     @Test
@@ -173,7 +173,7 @@ class CardTemplateEditorTest : RobolectricTest() {
         val templateEditorController = Robolectric.buildActivity(CardTemplateEditor::class.java, intent).create().start().resume().visible()
         saveControllerForCleanup(templateEditorController)
         val testEditor = templateEditorController.get()
-        Assert.assertFalse("Ordinal pending add?", TemporaryModel.isOrdinalPendingAdd(testEditor.tempModel, 0))
+        assertFalse("Ordinal pending add?", TemporaryModel.isOrdinalPendingAdd(testEditor.tempModel, 0))
 
         // Try to add a template - click add, click confirm for card add, click confirm again for full sync
         val shadowTestEditor = shadowOf(testEditor)
@@ -181,29 +181,29 @@ class CardTemplateEditorTest : RobolectricTest() {
         // if AnkiDroid moves to match AnkiDesktop it will pop a dialog to confirm card create
         // Assert.assertEquals("Wrong dialog shown?", "This will create NN cards. Proceed?", getDialogText());
         // clickDialogButton(DialogAction.POSITIVE);
-        Assert.assertTrue("Model should have changed", testEditor.modelHasChanged())
-        Assert.assertEquals("Change not pending add?", 1, TemporaryModel.getAdjustedAddOrdinalAtChangeIndex(testEditor.tempModel, 0).toLong())
-        Assert.assertFalse("Ordinal pending add?", TemporaryModel.isOrdinalPendingAdd(testEditor.tempModel, 0))
-        Assert.assertTrue("Ordinal not pending add?", TemporaryModel.isOrdinalPendingAdd(testEditor.tempModel, 1))
-        Assert.assertEquals("Model should have 2 templates now", 2, testEditor.tempModel.templateCount.toLong())
+        assertTrue("Model should have changed", testEditor.modelHasChanged())
+        assertEquals("Change not pending add?", 1, TemporaryModel.getAdjustedAddOrdinalAtChangeIndex(testEditor.tempModel, 0).toLong())
+        assertFalse("Ordinal pending add?", TemporaryModel.isOrdinalPendingAdd(testEditor.tempModel, 0))
+        assertTrue("Ordinal not pending add?", TemporaryModel.isOrdinalPendingAdd(testEditor.tempModel, 1))
+        assertEquals("Model should have 2 templates now", 2, testEditor.tempModel.templateCount.toLong())
 
         // Make sure we pass the new template to the Previewer
-        Assert.assertTrue("Unable to click?", shadowTestEditor.clickMenuItem(R.id.action_preview))
+        assertTrue("Unable to click?", shadowTestEditor.clickMenuItem(R.id.action_preview))
         val startedIntent = shadowTestEditor.nextStartedActivity
         val shadowIntent = shadowOf(startedIntent)
-        Assert.assertEquals("Previewer not started?", CardTemplatePreviewer::class.java.name, shadowIntent.intentClass.name)
-        Assert.assertNotNull("intent did not have model JSON filename?", startedIntent.getStringExtra(TemporaryModel.INTENT_MODEL_FILENAME))
-        Assert.assertEquals("intent did not have ordinal?", 1, startedIntent.getIntExtra("ordinal", -1).toLong())
-        Assert.assertNotEquals("Model sent to Previewer is unchanged?", testEditor.tempModel.model, TemporaryModel.getTempModel(startedIntent.getStringExtra(TemporaryModel.INTENT_MODEL_FILENAME)!!))
-        Assert.assertEquals("Change already in database?", collectionBasicModelOriginal.toString().trim { it <= ' ' }, getCurrentDatabaseModelCopy(modelName).toString().trim { it <= ' ' })
+        assertEquals("Previewer not started?", CardTemplatePreviewer::class.java.name, shadowIntent.intentClass.name)
+        assertNotNull("intent did not have model JSON filename?", startedIntent.getStringExtra(TemporaryModel.INTENT_MODEL_FILENAME))
+        assertEquals("intent did not have ordinal?", 1, startedIntent.getIntExtra("ordinal", -1).toLong())
+        assertNotEquals("Model sent to Previewer is unchanged?", testEditor.tempModel.model, TemporaryModel.getTempModel(startedIntent.getStringExtra(TemporaryModel.INTENT_MODEL_FILENAME)!!))
+        assertEquals("Change already in database?", collectionBasicModelOriginal.toString().trim { it <= ' ' }, getCurrentDatabaseModelCopy(modelName).toString().trim { it <= ' ' })
 
         // Save the change to the database and make sure there are two templates after
         val testEditorModelEdited = testEditor.tempModel.model
-        Assert.assertTrue("Unable to click?", shadowTestEditor.clickMenuItem(R.id.action_confirm))
+        assertTrue("Unable to click?", shadowTestEditor.clickMenuItem(R.id.action_confirm))
         advanceRobolectricLooperWithSleep()
         val collectionBasicModelCopyEdited = getCurrentDatabaseModelCopy(modelName)
-        Assert.assertNotEquals("model is unchanged?", collectionBasicModelOriginal, collectionBasicModelCopyEdited)
-        Assert.assertEquals("model did not save?", testEditorModelEdited.toString().trim { it <= ' ' }, collectionBasicModelCopyEdited.toString().trim { it <= ' ' })
+        assertNotEquals("model is unchanged?", collectionBasicModelOriginal, collectionBasicModelCopyEdited)
+        assertEquals("model did not save?", testEditorModelEdited.toString().trim { it <= ' ' }, collectionBasicModelCopyEdited.toString().trim { it <= ' ' })
     }
 
     /**
@@ -235,19 +235,19 @@ class CardTemplateEditorTest : RobolectricTest() {
         val templateEditorController = Robolectric.buildActivity(CardTemplateEditor::class.java, intent).create().start().resume().visible()
         saveControllerForCleanup(templateEditorController)
         val testEditor = templateEditorController.get()
-        Assert.assertFalse("Model should not have changed yet", testEditor.modelHasChanged())
-        Assert.assertEquals("Model should have 2 templates now", 2, testEditor.tempModel.templateCount.toLong())
-        Assert.assertFalse("Ordinal pending add?", TemporaryModel.isOrdinalPendingAdd(testEditor.tempModel, 0))
-        Assert.assertFalse("Ordinal pending add?", TemporaryModel.isOrdinalPendingAdd(testEditor.tempModel, 1))
+        assertFalse("Model should not have changed yet", testEditor.modelHasChanged())
+        assertEquals("Model should have 2 templates now", 2, testEditor.tempModel.templateCount.toLong())
+        assertFalse("Ordinal pending add?", TemporaryModel.isOrdinalPendingAdd(testEditor.tempModel, 0))
+        assertFalse("Ordinal pending add?", TemporaryModel.isOrdinalPendingAdd(testEditor.tempModel, 1))
 
         // Try to delete Card 1 template - click delete, check confirm for card delete popup indicating it was possible, then dismiss it
         val shadowTestEditor = shadowOf(testEditor)
-        Assert.assertTrue("Unable to click?", shadowTestEditor.clickMenuItem(R.id.action_delete))
+        assertTrue("Unable to click?", shadowTestEditor.clickMenuItem(R.id.action_delete))
         advanceRobolectricLooperWithSleep()
-        Assert.assertEquals("Wrong dialog shown?", "Delete the “Card 1” card type, and its 0 cards?", getDialogText(true))
+        assertEquals("Wrong dialog shown?", "Delete the “Card 1” card type, and its 0 cards?", getDialogText(true))
         clickDialogButton(DialogAction.NEGATIVE, true)
         advanceRobolectricLooperWithSleep()
-        Assert.assertFalse("Model should not have changed", testEditor.modelHasChanged())
+        assertFalse("Model should not have changed", testEditor.modelHasChanged())
 
         // Create note with forward and back info, Add Reverse is empty, so should only be one card
         val selectiveGeneratedNote = col.newNote(collectionBasicModelOriginal)
@@ -258,37 +258,37 @@ class CardTemplateEditorTest : RobolectricTest() {
             Timber.d("Got a field: %s", field)
         }
         col.addNote(selectiveGeneratedNote)
-        Assert.assertEquals("selective generation should result in one card", 1, getModelCardCount(collectionBasicModelOriginal).toLong())
+        assertEquals("selective generation should result in one card", 1, getModelCardCount(collectionBasicModelOriginal).toLong())
 
         // Try to delete the template again, but there's selective generation means it would orphan the note
-        Assert.assertTrue("Unable to click?", shadowTestEditor.clickMenuItem(R.id.action_delete))
+        assertTrue("Unable to click?", shadowTestEditor.clickMenuItem(R.id.action_delete))
         advanceRobolectricLooperWithSleep()
-        Assert.assertEquals(
+        assertEquals(
             "Did not show dialog about deleting only card?",
             getResourceString(R.string.card_template_editor_would_delete_note),
             getDialogText(true)
         )
         clickDialogButton(DialogAction.POSITIVE, true)
         advanceRobolectricLooperWithSleep()
-        Assert.assertNull("Can delete used template?", col.models.getCardIdsForModel(collectionBasicModelOriginal.getLong("id"), intArrayOf(0)))
-        Assert.assertEquals("Change already in database?", collectionBasicModelOriginal.toString().trim { it <= ' ' }, getCurrentDatabaseModelCopy(modelName).toString().trim { it <= ' ' })
-        Assert.assertFalse("Ordinal pending add?", TemporaryModel.isOrdinalPendingAdd(testEditor.tempModel, 0))
-        Assert.assertEquals("Change incorrectly added to list?", 0, testEditor.tempModel.templateChanges.size.toLong())
+        assertNull("Can delete used template?", col.models.getCardIdsForModel(collectionBasicModelOriginal.getLong("id"), intArrayOf(0)))
+        assertEquals("Change already in database?", collectionBasicModelOriginal.toString().trim { it <= ' ' }, getCurrentDatabaseModelCopy(modelName).toString().trim { it <= ' ' })
+        assertFalse("Ordinal pending add?", TemporaryModel.isOrdinalPendingAdd(testEditor.tempModel, 0))
+        assertEquals("Change incorrectly added to list?", 0, testEditor.tempModel.templateChanges.size.toLong())
 
         // Assert can delete 'Card 2'
-        Assert.assertNotNull("Cannot delete unused template?", col.models.getCardIdsForModel(collectionBasicModelOriginal.getLong("id"), intArrayOf(1)))
+        assertNotNull("Cannot delete unused template?", col.models.getCardIdsForModel(collectionBasicModelOriginal.getLong("id"), intArrayOf(1)))
 
         // Edit note to have Add Reverse set to 'y' so we get a second card
         selectiveGeneratedNote.setField(2, "y")
         selectiveGeneratedNote.flush()
 
         // - assert two cards
-        Assert.assertEquals("should be two cards now", 2, getModelCardCount(collectionBasicModelOriginal).toLong())
+        assertEquals("should be two cards now", 2, getModelCardCount(collectionBasicModelOriginal).toLong())
 
         // - assert can delete either Card template but not both
-        Assert.assertNotNull("Cannot delete template?", col.models.getCardIdsForModel(collectionBasicModelOriginal.getLong("id"), intArrayOf(0)))
-        Assert.assertNotNull("Cannot delete template?", col.models.getCardIdsForModel(collectionBasicModelOriginal.getLong("id"), intArrayOf(1)))
-        Assert.assertNull("Can delete both templates?", col.models.getCardIdsForModel(collectionBasicModelOriginal.getLong("id"), intArrayOf(0, 1)))
+        assertNotNull("Cannot delete template?", col.models.getCardIdsForModel(collectionBasicModelOriginal.getLong("id"), intArrayOf(0)))
+        assertNotNull("Cannot delete template?", col.models.getCardIdsForModel(collectionBasicModelOriginal.getLong("id"), intArrayOf(1)))
+        assertNull("Can delete both templates?", col.models.getCardIdsForModel(collectionBasicModelOriginal.getLong("id"), intArrayOf(0, 1)))
 
         // A couple more notes to make sure things are okay
         val secondNote = col.newNote(collectionBasicModelOriginal)
@@ -298,9 +298,9 @@ class CardTemplateEditorTest : RobolectricTest() {
         col.addNote(secondNote)
 
         // - assert can delete either Card template but not both
-        Assert.assertNotNull("Cannot delete template?", col.models.getCardIdsForModel(collectionBasicModelOriginal.getLong("id"), intArrayOf(0)))
-        Assert.assertNotNull("Cannot delete template?", col.models.getCardIdsForModel(collectionBasicModelOriginal.getLong("id"), intArrayOf(1)))
-        Assert.assertNull("Can delete both templates?", col.models.getCardIdsForModel(collectionBasicModelOriginal.getLong("id"), intArrayOf(0, 1)))
+        assertNotNull("Cannot delete template?", col.models.getCardIdsForModel(collectionBasicModelOriginal.getLong("id"), intArrayOf(0)))
+        assertNotNull("Cannot delete template?", col.models.getCardIdsForModel(collectionBasicModelOriginal.getLong("id"), intArrayOf(1)))
+        assertNull("Can delete both templates?", col.models.getCardIdsForModel(collectionBasicModelOriginal.getLong("id"), intArrayOf(0, 1)))
     }
 
     /**
@@ -317,46 +317,46 @@ class CardTemplateEditorTest : RobolectricTest() {
         var templateEditorController = Robolectric.buildActivity(CardTemplateEditor::class.java, intent).create().start().resume().visible()
         saveControllerForCleanup(templateEditorController)
         var testEditor = templateEditorController.get()
-        Assert.assertFalse("Model should not have changed yet", testEditor.modelHasChanged())
-        Assert.assertEquals("Model should have 2 templates now", 2, testEditor.tempModel.templateCount.toLong())
-        Assert.assertFalse("Ordinal pending add?", TemporaryModel.isOrdinalPendingAdd(testEditor.tempModel, 0))
-        Assert.assertFalse("Ordinal pending add?", TemporaryModel.isOrdinalPendingAdd(testEditor.tempModel, 1))
+        assertFalse("Model should not have changed yet", testEditor.modelHasChanged())
+        assertEquals("Model should have 2 templates now", 2, testEditor.tempModel.templateCount.toLong())
+        assertFalse("Ordinal pending add?", TemporaryModel.isOrdinalPendingAdd(testEditor.tempModel, 0))
+        assertFalse("Ordinal pending add?", TemporaryModel.isOrdinalPendingAdd(testEditor.tempModel, 1))
 
         // Create note with forward and back info
         val selectiveGeneratedNote = col.newNote(collectionBasicModelOriginal)
         selectiveGeneratedNote.setField(0, "TestFront")
         selectiveGeneratedNote.setField(1, "TestBack")
         col.addNote(selectiveGeneratedNote)
-        Assert.assertEquals("card generation should result in two cards", 2, getModelCardCount(collectionBasicModelOriginal).toLong())
+        assertEquals("card generation should result in two cards", 2, getModelCardCount(collectionBasicModelOriginal).toLong())
 
         // Test if we can delete the template - should be possible - but cancel the delete
         var shadowTestEditor = shadowOf(testEditor)
-        Assert.assertTrue("Unable to click?", shadowTestEditor.clickMenuItem(R.id.action_delete))
+        assertTrue("Unable to click?", shadowTestEditor.clickMenuItem(R.id.action_delete))
         advanceRobolectricLooperWithSleep()
-        Assert.assertEquals(
+        assertEquals(
             "Did not show dialog about deleting template and it's card?",
             getQuantityString(R.plurals.card_template_editor_confirm_delete, 1, 1, "Card 1"),
             getDialogText(true)
         )
         clickDialogButton(DialogAction.NEGATIVE, true)
         advanceRobolectricLooperWithSleep()
-        Assert.assertNotNull("Cannot delete template?", col.models.getCardIdsForModel(collectionBasicModelOriginal.getLong("id"), intArrayOf(0)))
-        Assert.assertNotNull("Cannot delete template?", col.models.getCardIdsForModel(collectionBasicModelOriginal.getLong("id"), intArrayOf(1)))
-        Assert.assertNull("Can delete both templates?", col.models.getCardIdsForModel(collectionBasicModelOriginal.getLong("id"), intArrayOf(0, 1)))
-        Assert.assertEquals("Change in database despite no change?", collectionBasicModelOriginal.toString().trim { it <= ' ' }, getCurrentDatabaseModelCopy(modelName).toString().trim { it <= ' ' })
-        Assert.assertEquals("Model should have 2 templates still", 2, testEditor.tempModel.templateCount.toLong())
+        assertNotNull("Cannot delete template?", col.models.getCardIdsForModel(collectionBasicModelOriginal.getLong("id"), intArrayOf(0)))
+        assertNotNull("Cannot delete template?", col.models.getCardIdsForModel(collectionBasicModelOriginal.getLong("id"), intArrayOf(1)))
+        assertNull("Can delete both templates?", col.models.getCardIdsForModel(collectionBasicModelOriginal.getLong("id"), intArrayOf(0, 1)))
+        assertEquals("Change in database despite no change?", collectionBasicModelOriginal.toString().trim { it <= ' ' }, getCurrentDatabaseModelCopy(modelName).toString().trim { it <= ' ' })
+        assertEquals("Model should have 2 templates still", 2, testEditor.tempModel.templateCount.toLong())
 
         // Add a template - click add, click confirm for card add, click confirm again for full sync
         addCardType(testEditor, shadowTestEditor)
-        Assert.assertTrue("Model should have changed", testEditor.modelHasChanged())
-        Assert.assertEquals("Change added but not adjusted correctly?", 2, TemporaryModel.getAdjustedAddOrdinalAtChangeIndex(testEditor.tempModel, 0).toLong())
-        Assert.assertFalse("Ordinal pending add?", TemporaryModel.isOrdinalPendingAdd(testEditor.tempModel, 0))
-        Assert.assertFalse("Ordinal pending add?", TemporaryModel.isOrdinalPendingAdd(testEditor.tempModel, 1))
-        Assert.assertTrue("Ordinal not pending add?", TemporaryModel.isOrdinalPendingAdd(testEditor.tempModel, 2))
-        Assert.assertTrue("Unable to click?", shadowTestEditor.clickMenuItem(R.id.action_confirm))
+        assertTrue("Model should have changed", testEditor.modelHasChanged())
+        assertEquals("Change added but not adjusted correctly?", 2, TemporaryModel.getAdjustedAddOrdinalAtChangeIndex(testEditor.tempModel, 0).toLong())
+        assertFalse("Ordinal pending add?", TemporaryModel.isOrdinalPendingAdd(testEditor.tempModel, 0))
+        assertFalse("Ordinal pending add?", TemporaryModel.isOrdinalPendingAdd(testEditor.tempModel, 1))
+        assertTrue("Ordinal not pending add?", TemporaryModel.isOrdinalPendingAdd(testEditor.tempModel, 2))
+        assertTrue("Unable to click?", shadowTestEditor.clickMenuItem(R.id.action_confirm))
         advanceRobolectricLooperWithSleep()
-        Assert.assertFalse("Model should now be unchanged", testEditor.modelHasChanged())
-        Assert.assertEquals("card generation should result in three cards", 3, getModelCardCount(collectionBasicModelOriginal).toLong())
+        assertFalse("Model should now be unchanged", testEditor.modelHasChanged())
+        assertEquals("card generation should result in three cards", 3, getModelCardCount(collectionBasicModelOriginal).toLong())
         collectionBasicModelOriginal = getCurrentDatabaseModelCopy(modelName) // reload the model for future comparison after saving the edit
 
         // Start the CardTemplateEditor back up after saving (which closes the thing...)
@@ -365,29 +365,29 @@ class CardTemplateEditorTest : RobolectricTest() {
         templateEditorController = Robolectric.buildActivity(CardTemplateEditor::class.java, intent).create().start().resume().visible()
         testEditor = templateEditorController.get()
         shadowTestEditor = shadowOf(testEditor)
-        Assert.assertFalse("Model should not have changed yet", testEditor.modelHasChanged())
-        Assert.assertFalse("Ordinal pending add?", TemporaryModel.isOrdinalPendingAdd(testEditor.tempModel, 0))
-        Assert.assertFalse("Ordinal pending add?", TemporaryModel.isOrdinalPendingAdd(testEditor.tempModel, 1))
-        Assert.assertFalse("Ordinal pending add?", TemporaryModel.isOrdinalPendingAdd(testEditor.tempModel, 2))
-        Assert.assertEquals("Model should have 3 templates now", 3, testEditor.tempModel.templateCount.toLong())
+        assertFalse("Model should not have changed yet", testEditor.modelHasChanged())
+        assertFalse("Ordinal pending add?", TemporaryModel.isOrdinalPendingAdd(testEditor.tempModel, 0))
+        assertFalse("Ordinal pending add?", TemporaryModel.isOrdinalPendingAdd(testEditor.tempModel, 1))
+        assertFalse("Ordinal pending add?", TemporaryModel.isOrdinalPendingAdd(testEditor.tempModel, 2))
+        assertEquals("Model should have 3 templates now", 3, testEditor.tempModel.templateCount.toLong())
 
         // Add another template - but we work in memory for a while before saving
         addCardType(testEditor, shadowTestEditor)
-        Assert.assertEquals("Change added but not adjusted correctly?", 3, TemporaryModel.getAdjustedAddOrdinalAtChangeIndex(testEditor.tempModel, 0).toLong())
-        Assert.assertTrue("Model should have changed", testEditor.modelHasChanged())
-        Assert.assertEquals("Model should have 4 templates now", 4, testEditor.tempModel.templateCount.toLong())
-        Assert.assertFalse("Ordinal pending add?", TemporaryModel.isOrdinalPendingAdd(testEditor.tempModel, 0))
-        Assert.assertFalse("Ordinal pending add?", TemporaryModel.isOrdinalPendingAdd(testEditor.tempModel, 1))
-        Assert.assertFalse("Ordinal pending add?", TemporaryModel.isOrdinalPendingAdd(testEditor.tempModel, 2))
-        Assert.assertTrue("Ordinal not pending add?", TemporaryModel.isOrdinalPendingAdd(testEditor.tempModel, 3))
-        Assert.assertEquals("Change added but not adjusted correctly?", 3, TemporaryModel.getAdjustedAddOrdinalAtChangeIndex(testEditor.tempModel, 0).toLong())
+        assertEquals("Change added but not adjusted correctly?", 3, TemporaryModel.getAdjustedAddOrdinalAtChangeIndex(testEditor.tempModel, 0).toLong())
+        assertTrue("Model should have changed", testEditor.modelHasChanged())
+        assertEquals("Model should have 4 templates now", 4, testEditor.tempModel.templateCount.toLong())
+        assertFalse("Ordinal pending add?", TemporaryModel.isOrdinalPendingAdd(testEditor.tempModel, 0))
+        assertFalse("Ordinal pending add?", TemporaryModel.isOrdinalPendingAdd(testEditor.tempModel, 1))
+        assertFalse("Ordinal pending add?", TemporaryModel.isOrdinalPendingAdd(testEditor.tempModel, 2))
+        assertTrue("Ordinal not pending add?", TemporaryModel.isOrdinalPendingAdd(testEditor.tempModel, 3))
+        assertEquals("Change added but not adjusted correctly?", 3, TemporaryModel.getAdjustedAddOrdinalAtChangeIndex(testEditor.tempModel, 0).toLong())
 
         // Delete two pre-existing templates for real now - but still without saving it out, should work fine
         advanceRobolectricLooperWithSleep()
         testEditor.mViewPager.currentItem = 0
-        Assert.assertTrue("Unable to click?", shadowTestEditor.clickMenuItem(R.id.action_delete))
+        assertTrue("Unable to click?", shadowTestEditor.clickMenuItem(R.id.action_delete))
         advanceRobolectricLooperWithSleep()
-        Assert.assertEquals(
+        assertEquals(
             "Did not show dialog about deleting template and it's card?",
             getQuantityString(R.plurals.card_template_editor_confirm_delete, 1, 1, "Card 1"),
             getDialogText(true)
@@ -396,9 +396,9 @@ class CardTemplateEditorTest : RobolectricTest() {
         advanceRobolectricLooperWithSleep()
         advanceRobolectricLooperWithSleep()
         testEditor.mViewPager.currentItem = 0
-        Assert.assertTrue("Unable to click?", shadowTestEditor.clickMenuItem(R.id.action_delete))
+        assertTrue("Unable to click?", shadowTestEditor.clickMenuItem(R.id.action_delete))
         advanceRobolectricLooperWithSleep()
-        Assert.assertEquals(
+        assertEquals(
             "Did not show dialog about deleting template and it's card?",
             getQuantityString(R.plurals.card_template_editor_confirm_delete, 1, 1, "Card 2"),
             getDialogText(true)
@@ -407,25 +407,25 @@ class CardTemplateEditorTest : RobolectricTest() {
         advanceRobolectricLooperWithSleep()
 
         // - assert can delete any 1 or 2 Card templates but not all
-        Assert.assertNotNull("Cannot delete template?", col.models.getCardIdsForModel(collectionBasicModelOriginal.getLong("id"), intArrayOf(0)))
-        Assert.assertNotNull("Cannot delete template?", col.models.getCardIdsForModel(collectionBasicModelOriginal.getLong("id"), intArrayOf(1)))
-        Assert.assertNotNull("Cannot delete template?", col.models.getCardIdsForModel(collectionBasicModelOriginal.getLong("id"), intArrayOf(2)))
-        Assert.assertNotNull("Cannot delete two templates?", col.models.getCardIdsForModel(collectionBasicModelOriginal.getLong("id"), intArrayOf(0, 1)))
-        Assert.assertNotNull("Cannot delete two templates?", col.models.getCardIdsForModel(collectionBasicModelOriginal.getLong("id"), intArrayOf(0, 2)))
-        Assert.assertNotNull("Cannot delete two templates?", col.models.getCardIdsForModel(collectionBasicModelOriginal.getLong("id"), intArrayOf(1, 2)))
-        Assert.assertNull("Can delete all templates?", col.models.getCardIdsForModel(collectionBasicModelOriginal.getLong("id"), intArrayOf(0, 1, 2)))
-        Assert.assertEquals("Change already in database?", collectionBasicModelOriginal.toString().trim { it <= ' ' }, getCurrentDatabaseModelCopy(modelName).toString().trim { it <= ' ' })
-        Assert.assertEquals("Change added but not adjusted correctly?", 1, TemporaryModel.getAdjustedAddOrdinalAtChangeIndex(testEditor.tempModel, 0).toLong())
-        Assert.assertEquals("Change incorrectly pending add?", -1, TemporaryModel.getAdjustedAddOrdinalAtChangeIndex(testEditor.tempModel, 1).toLong())
-        Assert.assertEquals("Change incorrectly pending add?", -1, TemporaryModel.getAdjustedAddOrdinalAtChangeIndex(testEditor.tempModel, 2).toLong())
+        assertNotNull("Cannot delete template?", col.models.getCardIdsForModel(collectionBasicModelOriginal.getLong("id"), intArrayOf(0)))
+        assertNotNull("Cannot delete template?", col.models.getCardIdsForModel(collectionBasicModelOriginal.getLong("id"), intArrayOf(1)))
+        assertNotNull("Cannot delete template?", col.models.getCardIdsForModel(collectionBasicModelOriginal.getLong("id"), intArrayOf(2)))
+        assertNotNull("Cannot delete two templates?", col.models.getCardIdsForModel(collectionBasicModelOriginal.getLong("id"), intArrayOf(0, 1)))
+        assertNotNull("Cannot delete two templates?", col.models.getCardIdsForModel(collectionBasicModelOriginal.getLong("id"), intArrayOf(0, 2)))
+        assertNotNull("Cannot delete two templates?", col.models.getCardIdsForModel(collectionBasicModelOriginal.getLong("id"), intArrayOf(1, 2)))
+        assertNull("Can delete all templates?", col.models.getCardIdsForModel(collectionBasicModelOriginal.getLong("id"), intArrayOf(0, 1, 2)))
+        assertEquals("Change already in database?", collectionBasicModelOriginal.toString().trim { it <= ' ' }, getCurrentDatabaseModelCopy(modelName).toString().trim { it <= ' ' })
+        assertEquals("Change added but not adjusted correctly?", 1, TemporaryModel.getAdjustedAddOrdinalAtChangeIndex(testEditor.tempModel, 0).toLong())
+        assertEquals("Change incorrectly pending add?", -1, TemporaryModel.getAdjustedAddOrdinalAtChangeIndex(testEditor.tempModel, 1).toLong())
+        assertEquals("Change incorrectly pending add?", -1, TemporaryModel.getAdjustedAddOrdinalAtChangeIndex(testEditor.tempModel, 2).toLong())
 
         // Now confirm everything to persist it to the database
-        Assert.assertTrue("Unable to click?", shadowTestEditor.clickMenuItem(R.id.action_confirm))
+        assertTrue("Unable to click?", shadowTestEditor.clickMenuItem(R.id.action_confirm))
         advanceRobolectricLooperWithSleep()
         advanceRobolectricLooperWithSleep()
-        Assert.assertNotEquals("Change not in database?", collectionBasicModelOriginal.toString().trim { it <= ' ' }, getCurrentDatabaseModelCopy(modelName).toString().trim { it <= ' ' })
-        Assert.assertEquals("Model should have 2 templates now", 2, getCurrentDatabaseModelCopy(modelName).getJSONArray("tmpls").length().toLong())
-        Assert.assertEquals("should be two cards", 2, getModelCardCount(collectionBasicModelOriginal).toLong())
+        assertNotEquals("Change not in database?", collectionBasicModelOriginal.toString().trim { it <= ' ' }, getCurrentDatabaseModelCopy(modelName).toString().trim { it <= ' ' })
+        assertEquals("Model should have 2 templates now", 2, getCurrentDatabaseModelCopy(modelName).getJSONArray("tmpls").length().toLong())
+        assertEquals("should be two cards", 2, getModelCardCount(collectionBasicModelOriginal).toLong())
     }
 
     /**
@@ -442,10 +442,10 @@ class CardTemplateEditorTest : RobolectricTest() {
         val templateEditorController = Robolectric.buildActivity(CardTemplateEditor::class.java, intent).create().start().resume().visible()
         saveControllerForCleanup(templateEditorController)
         val testEditor = templateEditorController.get()
-        Assert.assertFalse("Model should not have changed yet", testEditor.modelHasChanged())
-        Assert.assertEquals("Model should have 2 templates now", 2, testEditor.tempModel.templateCount.toLong())
-        Assert.assertFalse("Ordinal pending add?", TemporaryModel.isOrdinalPendingAdd(testEditor.tempModel, 0))
-        Assert.assertFalse("Ordinal pending add?", TemporaryModel.isOrdinalPendingAdd(testEditor.tempModel, 1))
+        assertFalse("Model should not have changed yet", testEditor.modelHasChanged())
+        assertEquals("Model should have 2 templates now", 2, testEditor.tempModel.templateCount.toLong())
+        assertFalse("Ordinal pending add?", TemporaryModel.isOrdinalPendingAdd(testEditor.tempModel, 0))
+        assertFalse("Ordinal pending add?", TemporaryModel.isOrdinalPendingAdd(testEditor.tempModel, 1))
 
         // Create note with forward and back info
         val selectiveGeneratedNote = col.newNote(collectionBasicModelOriginal)
@@ -453,58 +453,58 @@ class CardTemplateEditorTest : RobolectricTest() {
         selectiveGeneratedNote.setField(1, "TestBack")
         selectiveGeneratedNote.setField(2, "y")
         col.addNote(selectiveGeneratedNote)
-        Assert.assertEquals("card generation should result in two cards", 2, getModelCardCount(collectionBasicModelOriginal).toLong())
+        assertEquals("card generation should result in two cards", 2, getModelCardCount(collectionBasicModelOriginal).toLong())
 
         // Delete ord 1 / 'Card 2' and check the message
         val shadowTestEditor = shadowOf(testEditor)
         testEditor.mViewPager.currentItem = 1
-        Assert.assertTrue("Unable to click?", shadowTestEditor.clickMenuItem(R.id.action_delete))
+        assertTrue("Unable to click?", shadowTestEditor.clickMenuItem(R.id.action_delete))
         advanceRobolectricLooperWithSleep()
-        Assert.assertEquals(
+        assertEquals(
             "Did not show dialog about deleting template and it's card?",
             getQuantityString(R.plurals.card_template_editor_confirm_delete, 1, 1, "Card 2"),
             getDialogText(true)
         )
         clickDialogButton(DialogAction.POSITIVE, true)
         advanceRobolectricLooperWithSleep()
-        Assert.assertTrue("Model should have changed", testEditor.modelHasChanged())
-        Assert.assertNotNull("Cannot delete template?", col.models.getCardIdsForModel(collectionBasicModelOriginal.getLong("id"), intArrayOf(0)))
-        Assert.assertNotNull("Cannot delete template?", col.models.getCardIdsForModel(collectionBasicModelOriginal.getLong("id"), intArrayOf(1)))
-        Assert.assertNull("Can delete both templates?", col.models.getCardIdsForModel(collectionBasicModelOriginal.getLong("id"), intArrayOf(0, 1)))
-        Assert.assertEquals("Change in database despite no save?", collectionBasicModelOriginal.toString().trim { it <= ' ' }, getCurrentDatabaseModelCopy(modelName).toString().trim { it <= ' ' })
-        Assert.assertEquals("Model should have 1 template", 1, testEditor.tempModel.templateCount.toLong())
+        assertTrue("Model should have changed", testEditor.modelHasChanged())
+        assertNotNull("Cannot delete template?", col.models.getCardIdsForModel(collectionBasicModelOriginal.getLong("id"), intArrayOf(0)))
+        assertNotNull("Cannot delete template?", col.models.getCardIdsForModel(collectionBasicModelOriginal.getLong("id"), intArrayOf(1)))
+        assertNull("Can delete both templates?", col.models.getCardIdsForModel(collectionBasicModelOriginal.getLong("id"), intArrayOf(0, 1)))
+        assertEquals("Change in database despite no save?", collectionBasicModelOriginal.toString().trim { it <= ' ' }, getCurrentDatabaseModelCopy(modelName).toString().trim { it <= ' ' })
+        assertEquals("Model should have 1 template", 1, testEditor.tempModel.templateCount.toLong())
 
         // Add a template - click add, click confirm for card add, click confirm again for full sync
         addCardType(testEditor, shadowTestEditor)
-        Assert.assertTrue("Model should have changed", testEditor.modelHasChanged())
-        Assert.assertEquals("Change added but not adjusted correctly?", 1, TemporaryModel.getAdjustedAddOrdinalAtChangeIndex(testEditor.tempModel, 1).toLong())
-        Assert.assertFalse("Ordinal pending add?", TemporaryModel.isOrdinalPendingAdd(testEditor.tempModel, 0))
-        Assert.assertTrue("Ordinal not pending add?", TemporaryModel.isOrdinalPendingAdd(testEditor.tempModel, 1))
-        Assert.assertEquals("Model should have 2 templates", 2, testEditor.tempModel.templateCount.toLong())
+        assertTrue("Model should have changed", testEditor.modelHasChanged())
+        assertEquals("Change added but not adjusted correctly?", 1, TemporaryModel.getAdjustedAddOrdinalAtChangeIndex(testEditor.tempModel, 1).toLong())
+        assertFalse("Ordinal pending add?", TemporaryModel.isOrdinalPendingAdd(testEditor.tempModel, 0))
+        assertTrue("Ordinal not pending add?", TemporaryModel.isOrdinalPendingAdd(testEditor.tempModel, 1))
+        assertEquals("Model should have 2 templates", 2, testEditor.tempModel.templateCount.toLong())
 
         // Delete ord 1 / 'Card 2' again and check the message - it's in the same spot as the pre-existing template but there are no cards actually associated
         testEditor.mViewPager.currentItem = 1
-        Assert.assertTrue("Unable to click?", shadowTestEditor.clickMenuItem(R.id.action_delete))
+        assertTrue("Unable to click?", shadowTestEditor.clickMenuItem(R.id.action_delete))
         advanceRobolectricLooperWithSleep()
-        Assert.assertEquals(
+        assertEquals(
             "Did not show dialog about deleting template and it's card?",
             getQuantityString(R.plurals.card_template_editor_confirm_delete, 0, 0, "Card 2"),
             getDialogText(true)
         )
         clickDialogButton(DialogAction.POSITIVE, true)
         advanceRobolectricLooperWithSleep()
-        Assert.assertTrue("Model should have changed", testEditor.modelHasChanged())
-        Assert.assertNotNull("Cannot delete template?", col.models.getCardIdsForModel(collectionBasicModelOriginal.getLong("id"), intArrayOf(0)))
-        Assert.assertNotNull("Cannot delete template?", col.models.getCardIdsForModel(collectionBasicModelOriginal.getLong("id"), intArrayOf(1)))
-        Assert.assertNull("Can delete both templates?", col.models.getCardIdsForModel(collectionBasicModelOriginal.getLong("id"), intArrayOf(0, 1)))
-        Assert.assertEquals("Change in database despite no save?", collectionBasicModelOriginal.toString().trim { it <= ' ' }, getCurrentDatabaseModelCopy(modelName).toString().trim { it <= ' ' })
-        Assert.assertEquals("Model should have 1 template", 1, testEditor.tempModel.templateCount.toLong())
+        assertTrue("Model should have changed", testEditor.modelHasChanged())
+        assertNotNull("Cannot delete template?", col.models.getCardIdsForModel(collectionBasicModelOriginal.getLong("id"), intArrayOf(0)))
+        assertNotNull("Cannot delete template?", col.models.getCardIdsForModel(collectionBasicModelOriginal.getLong("id"), intArrayOf(1)))
+        assertNull("Can delete both templates?", col.models.getCardIdsForModel(collectionBasicModelOriginal.getLong("id"), intArrayOf(0, 1)))
+        assertEquals("Change in database despite no save?", collectionBasicModelOriginal.toString().trim { it <= ' ' }, getCurrentDatabaseModelCopy(modelName).toString().trim { it <= ' ' })
+        assertEquals("Model should have 1 template", 1, testEditor.tempModel.templateCount.toLong())
 
         // Save it out and make some assertions
-        Assert.assertTrue("Unable to click?", shadowTestEditor.clickMenuItem(R.id.action_confirm))
+        assertTrue("Unable to click?", shadowTestEditor.clickMenuItem(R.id.action_confirm))
         advanceRobolectricLooperWithSleep()
-        Assert.assertFalse("Model should now be unchanged", testEditor.modelHasChanged())
-        Assert.assertEquals("card generation should result in 1 card", 1, getModelCardCount(collectionBasicModelOriginal).toLong())
+        assertFalse("Model should now be unchanged", testEditor.modelHasChanged())
+        assertEquals("card generation should result in 1 card", 1, getModelCardCount(collectionBasicModelOriginal).toLong())
     }
 
     @Test
@@ -584,14 +584,14 @@ class CardTemplateEditorTest : RobolectricTest() {
     }
 
     private fun addCardType(testEditor: CardTemplateEditor, shadowTestEditor: ShadowActivity) {
-        Assert.assertTrue("Unable to click?", shadowTestEditor.clickMenuItem(R.id.action_add))
+        assertTrue("Unable to click?", shadowTestEditor.clickMenuItem(R.id.action_add))
         advanceRobolectricLooperWithSleep()
         val ordinal = testEditor.mViewPager.currentItem
         var numAffectedCards = 0
         if (!TemporaryModel.isOrdinalPendingAdd(testEditor.tempModel, ordinal)) {
             numAffectedCards = col.models.tmplUseCount(testEditor.tempModel.model, ordinal)
         }
-        Assert.assertEquals(
+        assertEquals(
             "Did not show dialog about adding template and it's card?",
             getQuantityString(R.plurals.card_template_editor_confirm_add, numAffectedCards, numAffectedCards),
             getDialogText(true)

--- a/AnkiDroid/src/test/java/com/ichi2/anki/CardTemplateEditorTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/CardTemplateEditorTest.kt
@@ -24,16 +24,21 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.afollestad.materialdialogs.DialogAction
 import com.ichi2.anki.dialogs.DeckSelectionDialog.SelectableDeck
 import com.ichi2.libanki.Model
+import com.ichi2.testutils.assertFalse
 import com.ichi2.utils.JSONObject
 import org.hamcrest.MatcherAssert
 import org.hamcrest.Matchers
-import org.junit.Assert.*
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.Robolectric
 import org.robolectric.Shadows.shadowOf
 import org.robolectric.shadows.ShadowActivity
 import timber.log.Timber
+import kotlin.test.junit.JUnitAsserter.assertEquals
+import kotlin.test.junit.JUnitAsserter.assertNotEquals
+import kotlin.test.junit.JUnitAsserter.assertNotNull
+import kotlin.test.junit.JUnitAsserter.assertNull
+import kotlin.test.junit.JUnitAsserter.assertTrue
 
 @RunWith(AndroidJUnit4::class)
 class CardTemplateEditorTest : RobolectricTest() {
@@ -130,7 +135,7 @@ class CardTemplateEditorTest : RobolectricTest() {
         saveControllerForCleanup(templateEditorController)
         val testEditor = templateEditorController.get()
         assertFalse("Model should not have changed yet", testEditor.modelHasChanged())
-        assertEquals("Model should have 2 templates now", 2, testEditor.tempModel.templateCount.toLong())
+        assertEquals("Model should have 2 templates now", 2, testEditor.tempModel.templateCount)
 
         // Try to delete the template - click delete, click confirm for card delete, click confirm again for full sync
         val shadowTestEditor = shadowOf(testEditor)
@@ -140,7 +145,7 @@ class CardTemplateEditorTest : RobolectricTest() {
         clickDialogButton(DialogAction.POSITIVE, true)
         advanceRobolectricLooperWithSleep()
         assertTrue("Model should have changed", testEditor.modelHasChanged())
-        assertEquals("Model should have 1 template now", 1, testEditor.tempModel.templateCount.toLong())
+        assertEquals("Model should have 1 template now", 1, testEditor.tempModel.templateCount)
 
         // Try to delete the template again, but there's only one
         assertTrue("Unable to click?", shadowTestEditor.clickMenuItem(R.id.action_delete))
@@ -182,10 +187,10 @@ class CardTemplateEditorTest : RobolectricTest() {
         // Assert.assertEquals("Wrong dialog shown?", "This will create NN cards. Proceed?", getDialogText());
         // clickDialogButton(DialogAction.POSITIVE);
         assertTrue("Model should have changed", testEditor.modelHasChanged())
-        assertEquals("Change not pending add?", 1, TemporaryModel.getAdjustedAddOrdinalAtChangeIndex(testEditor.tempModel, 0).toLong())
+        assertEquals("Change not pending add?", 1, TemporaryModel.getAdjustedAddOrdinalAtChangeIndex(testEditor.tempModel, 0))
         assertFalse("Ordinal pending add?", TemporaryModel.isOrdinalPendingAdd(testEditor.tempModel, 0))
         assertTrue("Ordinal not pending add?", TemporaryModel.isOrdinalPendingAdd(testEditor.tempModel, 1))
-        assertEquals("Model should have 2 templates now", 2, testEditor.tempModel.templateCount.toLong())
+        assertEquals("Model should have 2 templates now", 2, testEditor.tempModel.templateCount)
 
         // Make sure we pass the new template to the Previewer
         assertTrue("Unable to click?", shadowTestEditor.clickMenuItem(R.id.action_preview))
@@ -193,7 +198,7 @@ class CardTemplateEditorTest : RobolectricTest() {
         val shadowIntent = shadowOf(startedIntent)
         assertEquals("Previewer not started?", CardTemplatePreviewer::class.java.name, shadowIntent.intentClass.name)
         assertNotNull("intent did not have model JSON filename?", startedIntent.getStringExtra(TemporaryModel.INTENT_MODEL_FILENAME))
-        assertEquals("intent did not have ordinal?", 1, startedIntent.getIntExtra("ordinal", -1).toLong())
+        assertEquals("intent did not have ordinal?", 1, startedIntent.getIntExtra("ordinal", -1))
         assertNotEquals("Model sent to Previewer is unchanged?", testEditor.tempModel.model, TemporaryModel.getTempModel(startedIntent.getStringExtra(TemporaryModel.INTENT_MODEL_FILENAME)!!))
         assertEquals("Change already in database?", collectionBasicModelOriginal.toString().trim { it <= ' ' }, getCurrentDatabaseModelCopy(modelName).toString().trim { it <= ' ' })
 
@@ -236,7 +241,7 @@ class CardTemplateEditorTest : RobolectricTest() {
         saveControllerForCleanup(templateEditorController)
         val testEditor = templateEditorController.get()
         assertFalse("Model should not have changed yet", testEditor.modelHasChanged())
-        assertEquals("Model should have 2 templates now", 2, testEditor.tempModel.templateCount.toLong())
+        assertEquals("Model should have 2 templates now", 2, testEditor.tempModel.templateCount)
         assertFalse("Ordinal pending add?", TemporaryModel.isOrdinalPendingAdd(testEditor.tempModel, 0))
         assertFalse("Ordinal pending add?", TemporaryModel.isOrdinalPendingAdd(testEditor.tempModel, 1))
 
@@ -258,7 +263,7 @@ class CardTemplateEditorTest : RobolectricTest() {
             Timber.d("Got a field: %s", field)
         }
         col.addNote(selectiveGeneratedNote)
-        assertEquals("selective generation should result in one card", 1, getModelCardCount(collectionBasicModelOriginal).toLong())
+        assertEquals("selective generation should result in one card", 1, getModelCardCount(collectionBasicModelOriginal))
 
         // Try to delete the template again, but there's selective generation means it would orphan the note
         assertTrue("Unable to click?", shadowTestEditor.clickMenuItem(R.id.action_delete))
@@ -273,7 +278,7 @@ class CardTemplateEditorTest : RobolectricTest() {
         assertNull("Can delete used template?", col.models.getCardIdsForModel(collectionBasicModelOriginal.getLong("id"), intArrayOf(0)))
         assertEquals("Change already in database?", collectionBasicModelOriginal.toString().trim { it <= ' ' }, getCurrentDatabaseModelCopy(modelName).toString().trim { it <= ' ' })
         assertFalse("Ordinal pending add?", TemporaryModel.isOrdinalPendingAdd(testEditor.tempModel, 0))
-        assertEquals("Change incorrectly added to list?", 0, testEditor.tempModel.templateChanges.size.toLong())
+        assertEquals("Change incorrectly added to list?", 0, testEditor.tempModel.templateChanges.size)
 
         // Assert can delete 'Card 2'
         assertNotNull("Cannot delete unused template?", col.models.getCardIdsForModel(collectionBasicModelOriginal.getLong("id"), intArrayOf(1)))
@@ -283,7 +288,7 @@ class CardTemplateEditorTest : RobolectricTest() {
         selectiveGeneratedNote.flush()
 
         // - assert two cards
-        assertEquals("should be two cards now", 2, getModelCardCount(collectionBasicModelOriginal).toLong())
+        assertEquals("should be two cards now", 2, getModelCardCount(collectionBasicModelOriginal))
 
         // - assert can delete either Card template but not both
         assertNotNull("Cannot delete template?", col.models.getCardIdsForModel(collectionBasicModelOriginal.getLong("id"), intArrayOf(0)))
@@ -318,7 +323,7 @@ class CardTemplateEditorTest : RobolectricTest() {
         saveControllerForCleanup(templateEditorController)
         var testEditor = templateEditorController.get()
         assertFalse("Model should not have changed yet", testEditor.modelHasChanged())
-        assertEquals("Model should have 2 templates now", 2, testEditor.tempModel.templateCount.toLong())
+        assertEquals("Model should have 2 templates now", 2, testEditor.tempModel.templateCount)
         assertFalse("Ordinal pending add?", TemporaryModel.isOrdinalPendingAdd(testEditor.tempModel, 0))
         assertFalse("Ordinal pending add?", TemporaryModel.isOrdinalPendingAdd(testEditor.tempModel, 1))
 
@@ -327,7 +332,7 @@ class CardTemplateEditorTest : RobolectricTest() {
         selectiveGeneratedNote.setField(0, "TestFront")
         selectiveGeneratedNote.setField(1, "TestBack")
         col.addNote(selectiveGeneratedNote)
-        assertEquals("card generation should result in two cards", 2, getModelCardCount(collectionBasicModelOriginal).toLong())
+        assertEquals("card generation should result in two cards", 2, getModelCardCount(collectionBasicModelOriginal))
 
         // Test if we can delete the template - should be possible - but cancel the delete
         var shadowTestEditor = shadowOf(testEditor)
@@ -344,19 +349,19 @@ class CardTemplateEditorTest : RobolectricTest() {
         assertNotNull("Cannot delete template?", col.models.getCardIdsForModel(collectionBasicModelOriginal.getLong("id"), intArrayOf(1)))
         assertNull("Can delete both templates?", col.models.getCardIdsForModel(collectionBasicModelOriginal.getLong("id"), intArrayOf(0, 1)))
         assertEquals("Change in database despite no change?", collectionBasicModelOriginal.toString().trim { it <= ' ' }, getCurrentDatabaseModelCopy(modelName).toString().trim { it <= ' ' })
-        assertEquals("Model should have 2 templates still", 2, testEditor.tempModel.templateCount.toLong())
+        assertEquals("Model should have 2 templates still", 2, testEditor.tempModel.templateCount)
 
         // Add a template - click add, click confirm for card add, click confirm again for full sync
         addCardType(testEditor, shadowTestEditor)
         assertTrue("Model should have changed", testEditor.modelHasChanged())
-        assertEquals("Change added but not adjusted correctly?", 2, TemporaryModel.getAdjustedAddOrdinalAtChangeIndex(testEditor.tempModel, 0).toLong())
+        assertEquals("Change added but not adjusted correctly?", 2, TemporaryModel.getAdjustedAddOrdinalAtChangeIndex(testEditor.tempModel, 0))
         assertFalse("Ordinal pending add?", TemporaryModel.isOrdinalPendingAdd(testEditor.tempModel, 0))
         assertFalse("Ordinal pending add?", TemporaryModel.isOrdinalPendingAdd(testEditor.tempModel, 1))
         assertTrue("Ordinal not pending add?", TemporaryModel.isOrdinalPendingAdd(testEditor.tempModel, 2))
         assertTrue("Unable to click?", shadowTestEditor.clickMenuItem(R.id.action_confirm))
         advanceRobolectricLooperWithSleep()
         assertFalse("Model should now be unchanged", testEditor.modelHasChanged())
-        assertEquals("card generation should result in three cards", 3, getModelCardCount(collectionBasicModelOriginal).toLong())
+        assertEquals("card generation should result in three cards", 3, getModelCardCount(collectionBasicModelOriginal))
         collectionBasicModelOriginal = getCurrentDatabaseModelCopy(modelName) // reload the model for future comparison after saving the edit
 
         // Start the CardTemplateEditor back up after saving (which closes the thing...)
@@ -369,18 +374,18 @@ class CardTemplateEditorTest : RobolectricTest() {
         assertFalse("Ordinal pending add?", TemporaryModel.isOrdinalPendingAdd(testEditor.tempModel, 0))
         assertFalse("Ordinal pending add?", TemporaryModel.isOrdinalPendingAdd(testEditor.tempModel, 1))
         assertFalse("Ordinal pending add?", TemporaryModel.isOrdinalPendingAdd(testEditor.tempModel, 2))
-        assertEquals("Model should have 3 templates now", 3, testEditor.tempModel.templateCount.toLong())
+        assertEquals("Model should have 3 templates now", 3, testEditor.tempModel.templateCount)
 
         // Add another template - but we work in memory for a while before saving
         addCardType(testEditor, shadowTestEditor)
-        assertEquals("Change added but not adjusted correctly?", 3, TemporaryModel.getAdjustedAddOrdinalAtChangeIndex(testEditor.tempModel, 0).toLong())
+        assertEquals("Change added but not adjusted correctly?", 3, TemporaryModel.getAdjustedAddOrdinalAtChangeIndex(testEditor.tempModel, 0))
         assertTrue("Model should have changed", testEditor.modelHasChanged())
-        assertEquals("Model should have 4 templates now", 4, testEditor.tempModel.templateCount.toLong())
+        assertEquals("Model should have 4 templates now", 4, testEditor.tempModel.templateCount)
         assertFalse("Ordinal pending add?", TemporaryModel.isOrdinalPendingAdd(testEditor.tempModel, 0))
         assertFalse("Ordinal pending add?", TemporaryModel.isOrdinalPendingAdd(testEditor.tempModel, 1))
         assertFalse("Ordinal pending add?", TemporaryModel.isOrdinalPendingAdd(testEditor.tempModel, 2))
         assertTrue("Ordinal not pending add?", TemporaryModel.isOrdinalPendingAdd(testEditor.tempModel, 3))
-        assertEquals("Change added but not adjusted correctly?", 3, TemporaryModel.getAdjustedAddOrdinalAtChangeIndex(testEditor.tempModel, 0).toLong())
+        assertEquals("Change added but not adjusted correctly?", 3, TemporaryModel.getAdjustedAddOrdinalAtChangeIndex(testEditor.tempModel, 0))
 
         // Delete two pre-existing templates for real now - but still without saving it out, should work fine
         advanceRobolectricLooperWithSleep()
@@ -415,17 +420,17 @@ class CardTemplateEditorTest : RobolectricTest() {
         assertNotNull("Cannot delete two templates?", col.models.getCardIdsForModel(collectionBasicModelOriginal.getLong("id"), intArrayOf(1, 2)))
         assertNull("Can delete all templates?", col.models.getCardIdsForModel(collectionBasicModelOriginal.getLong("id"), intArrayOf(0, 1, 2)))
         assertEquals("Change already in database?", collectionBasicModelOriginal.toString().trim { it <= ' ' }, getCurrentDatabaseModelCopy(modelName).toString().trim { it <= ' ' })
-        assertEquals("Change added but not adjusted correctly?", 1, TemporaryModel.getAdjustedAddOrdinalAtChangeIndex(testEditor.tempModel, 0).toLong())
-        assertEquals("Change incorrectly pending add?", -1, TemporaryModel.getAdjustedAddOrdinalAtChangeIndex(testEditor.tempModel, 1).toLong())
-        assertEquals("Change incorrectly pending add?", -1, TemporaryModel.getAdjustedAddOrdinalAtChangeIndex(testEditor.tempModel, 2).toLong())
+        assertEquals("Change added but not adjusted correctly?", 1, TemporaryModel.getAdjustedAddOrdinalAtChangeIndex(testEditor.tempModel, 0))
+        assertEquals("Change incorrectly pending add?", -1, TemporaryModel.getAdjustedAddOrdinalAtChangeIndex(testEditor.tempModel, 1))
+        assertEquals("Change incorrectly pending add?", -1, TemporaryModel.getAdjustedAddOrdinalAtChangeIndex(testEditor.tempModel, 2))
 
         // Now confirm everything to persist it to the database
         assertTrue("Unable to click?", shadowTestEditor.clickMenuItem(R.id.action_confirm))
         advanceRobolectricLooperWithSleep()
         advanceRobolectricLooperWithSleep()
         assertNotEquals("Change not in database?", collectionBasicModelOriginal.toString().trim { it <= ' ' }, getCurrentDatabaseModelCopy(modelName).toString().trim { it <= ' ' })
-        assertEquals("Model should have 2 templates now", 2, getCurrentDatabaseModelCopy(modelName).getJSONArray("tmpls").length().toLong())
-        assertEquals("should be two cards", 2, getModelCardCount(collectionBasicModelOriginal).toLong())
+        assertEquals("Model should have 2 templates now", 2, getCurrentDatabaseModelCopy(modelName).getJSONArray("tmpls").length())
+        assertEquals("should be two cards", 2, getModelCardCount(collectionBasicModelOriginal))
     }
 
     /**
@@ -443,7 +448,7 @@ class CardTemplateEditorTest : RobolectricTest() {
         saveControllerForCleanup(templateEditorController)
         val testEditor = templateEditorController.get()
         assertFalse("Model should not have changed yet", testEditor.modelHasChanged())
-        assertEquals("Model should have 2 templates now", 2, testEditor.tempModel.templateCount.toLong())
+        assertEquals("Model should have 2 templates now", 2, testEditor.tempModel.templateCount)
         assertFalse("Ordinal pending add?", TemporaryModel.isOrdinalPendingAdd(testEditor.tempModel, 0))
         assertFalse("Ordinal pending add?", TemporaryModel.isOrdinalPendingAdd(testEditor.tempModel, 1))
 
@@ -453,7 +458,7 @@ class CardTemplateEditorTest : RobolectricTest() {
         selectiveGeneratedNote.setField(1, "TestBack")
         selectiveGeneratedNote.setField(2, "y")
         col.addNote(selectiveGeneratedNote)
-        assertEquals("card generation should result in two cards", 2, getModelCardCount(collectionBasicModelOriginal).toLong())
+        assertEquals("card generation should result in two cards", 2, getModelCardCount(collectionBasicModelOriginal))
 
         // Delete ord 1 / 'Card 2' and check the message
         val shadowTestEditor = shadowOf(testEditor)
@@ -472,15 +477,15 @@ class CardTemplateEditorTest : RobolectricTest() {
         assertNotNull("Cannot delete template?", col.models.getCardIdsForModel(collectionBasicModelOriginal.getLong("id"), intArrayOf(1)))
         assertNull("Can delete both templates?", col.models.getCardIdsForModel(collectionBasicModelOriginal.getLong("id"), intArrayOf(0, 1)))
         assertEquals("Change in database despite no save?", collectionBasicModelOriginal.toString().trim { it <= ' ' }, getCurrentDatabaseModelCopy(modelName).toString().trim { it <= ' ' })
-        assertEquals("Model should have 1 template", 1, testEditor.tempModel.templateCount.toLong())
+        assertEquals("Model should have 1 template", 1, testEditor.tempModel.templateCount)
 
         // Add a template - click add, click confirm for card add, click confirm again for full sync
         addCardType(testEditor, shadowTestEditor)
         assertTrue("Model should have changed", testEditor.modelHasChanged())
-        assertEquals("Change added but not adjusted correctly?", 1, TemporaryModel.getAdjustedAddOrdinalAtChangeIndex(testEditor.tempModel, 1).toLong())
+        assertEquals("Change added but not adjusted correctly?", 1, TemporaryModel.getAdjustedAddOrdinalAtChangeIndex(testEditor.tempModel, 1))
         assertFalse("Ordinal pending add?", TemporaryModel.isOrdinalPendingAdd(testEditor.tempModel, 0))
         assertTrue("Ordinal not pending add?", TemporaryModel.isOrdinalPendingAdd(testEditor.tempModel, 1))
-        assertEquals("Model should have 2 templates", 2, testEditor.tempModel.templateCount.toLong())
+        assertEquals("Model should have 2 templates", 2, testEditor.tempModel.templateCount)
 
         // Delete ord 1 / 'Card 2' again and check the message - it's in the same spot as the pre-existing template but there are no cards actually associated
         testEditor.mViewPager.currentItem = 1
@@ -498,13 +503,13 @@ class CardTemplateEditorTest : RobolectricTest() {
         assertNotNull("Cannot delete template?", col.models.getCardIdsForModel(collectionBasicModelOriginal.getLong("id"), intArrayOf(1)))
         assertNull("Can delete both templates?", col.models.getCardIdsForModel(collectionBasicModelOriginal.getLong("id"), intArrayOf(0, 1)))
         assertEquals("Change in database despite no save?", collectionBasicModelOriginal.toString().trim { it <= ' ' }, getCurrentDatabaseModelCopy(modelName).toString().trim { it <= ' ' })
-        assertEquals("Model should have 1 template", 1, testEditor.tempModel.templateCount.toLong())
+        assertEquals("Model should have 1 template", 1, testEditor.tempModel.templateCount)
 
         // Save it out and make some assertions
         assertTrue("Unable to click?", shadowTestEditor.clickMenuItem(R.id.action_confirm))
         advanceRobolectricLooperWithSleep()
         assertFalse("Model should now be unchanged", testEditor.modelHasChanged())
-        assertEquals("card generation should result in 1 card", 1, getModelCardCount(collectionBasicModelOriginal).toLong())
+        assertEquals("card generation should result in 1 card", 1, getModelCardCount(collectionBasicModelOriginal))
     }
 
     @Test

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/CardTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/CardTest.kt
@@ -21,13 +21,14 @@ import com.ichi2.anki.RobolectricTest
 import com.ichi2.anki.exception.ConfirmModSchemaException
 import com.ichi2.libanki.backend.exception.DeckRenameException
 import com.ichi2.utils.JSONObject
-import org.hamcrest.Matchers.*
+import org.hamcrest.Matchers.equalTo
+import org.hamcrest.Matchers.hasItemInArray
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertNotNull
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.annotation.Config
 import java.util.*
+import kotlin.test.assertNotNull
 
 @RunWith(AndroidJUnit4::class)
 class CardTest : RobolectricTest() {
@@ -134,7 +135,7 @@ class CardTest : RobolectricTest() {
         val models = col.models
         val model = models.byName("Basic")
         assertNotNull(model)
-        models.renameField(model!!, model.getJSONArray("flds").getJSONObject(0), "A")
+        models.renameField(model, model.getJSONArray("flds").getJSONObject(0), "A")
         models.renameField(model, model.getJSONArray("flds").getJSONObject(1), "B")
         val fld2 = models.newField("C")
         fld2.put("ord", JSONObject.NULL)
@@ -184,7 +185,7 @@ class CardTest : RobolectricTest() {
         val models = col.models
         val model = models.byName("Basic")
         assertNotNull(model)
-        val tmpls = model!!.getJSONArray("tmpls")
+        val tmpls = model.getJSONArray("tmpls")
         models.renameField(model, model.getJSONArray("flds").getJSONObject(0), "First")
         models.renameField(model, model.getJSONArray("flds").getJSONObject(1), "Front")
         val fld2 = models.newField("AddIfEmpty")

--- a/AnkiDroid/src/test/java/com/ichi2/testutils/AnkiAssertKt.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/testutils/AnkiAssertKt.kt
@@ -17,6 +17,7 @@
 package com.ichi2.testutils
 
 import org.junit.Assert
+import kotlin.test.junit.JUnitAsserter
 
 /** assertThrows, allowing for lambda shorthand
  *
@@ -56,4 +57,12 @@ inline fun <reified T : Throwable> assertThrowsSubclass(r: Runnable): T {
 
     Assert.fail("Expected exception: " + T::class.simpleName + ". No exception thrown.")
     throw IllegalStateException("shouldn't reach here")
+}
+
+/** Asserts that the expression is `false` with an optional [message]. */
+fun assertFalse(message: String? = null, actual: Boolean) {
+    // This exists in JUnit, but we want to avoid JUnit as their `assertNotNull` does not use contracts
+    // So, we want a method in a different namespace for `assertFalse`
+    // JUnitAsserter doesn't contain it, so we add it in
+    JUnitAsserter.assertTrue(message, !actual)
 }

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/IssueRegistry.java
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/IssueRegistry.java
@@ -11,6 +11,7 @@ import com.ichi2.anki.lint.rules.DirectSystemCurrentTimeMillisUsage;
 import com.ichi2.anki.lint.rules.DirectDateInstantiation;
 import com.ichi2.anki.lint.rules.DirectGregorianInstantiation;
 import com.ichi2.anki.lint.rules.DirectToastMakeTextUsage;
+import com.ichi2.anki.lint.rules.JUnitNullAssertionDetector;
 import com.ichi2.anki.lint.rules.DuplicateCrowdInStrings;
 import com.ichi2.anki.lint.rules.DuplicateTextInPreferencesXml;
 import com.ichi2.anki.lint.rules.FixedPreferencesTitleLength;
@@ -45,6 +46,7 @@ public class IssueRegistry extends com.android.tools.lint.client.api.IssueRegist
         issues.add(DuplicateCrowdInStrings.ISSUE);
         issues.add(DuplicateTextInPreferencesXml.ISSUE);
         issues.add(InconsistentAnnotationUsage.ISSUE);
+        issues.add(JUnitNullAssertionDetector.ISSUE);
         issues.add(KotlinMigrationBrokenEmails.ISSUE);
         issues.add(KotlinMigrationFixLineBreaks.ISSUE);
         issues.add(PreferIsEmptyOverSizeCheck.ISSUE);

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/rules/JUnitNullAssertionDetector.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/JUnitNullAssertionDetector.kt
@@ -1,0 +1,73 @@
+/*
+ *  Copyright (c) 2022 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.lint.rules
+
+import com.android.tools.lint.detector.api.*
+import com.android.tools.lint.detector.api.Scope.Companion.JAVA_FILE_SCOPE
+import com.google.common.annotations.VisibleForTesting
+import com.ichi2.anki.lint.utils.Constants
+import com.intellij.psi.PsiMethod
+import org.jetbrains.uast.UCallExpression
+
+/**
+ * This custom Lint rules will raise an error if a developer uses JUnit's `assert(Not)Null`
+ * methods instead of using the methods from `kotlin-test`
+ *
+ * `kotlin-test` methods use contracts, reducing the need for `!!` in the code
+ *
+ * TODO/PERF: Only run this in tests, there's no JUnit in /src/
+ */
+class JUnitNullAssertionDetector : Detector(), SourceCodeScanner {
+    /** Detect both assertNotNull and assertNull: assertNotNull is the most likely to cause improvements */
+    override fun getApplicableMethodNames(): List<String> = arrayListOf("assertNotNull", "assertNull")
+
+    override fun visitMethodCall(context: JavaContext, node: UCallExpression, method: PsiMethod) {
+        super.visitMethodCall(context, node, method)
+        // only for kotlin files
+        if (!context.file.path.endsWith(".kt")) return
+        // only for org.junit.Assert.assert[Not]Null
+        if (!context.evaluator.isMemberInClass(method, "org.junit.Assert")) return
+
+        context.report(
+            ISSUE,
+            context.getCallLocation(node, includeReceiver = true, includeArguments = true),
+            DESCRIPTION
+        )
+    }
+
+    companion object {
+        @VisibleForTesting
+        val ID = "LegacyNullAssertionDetector"
+
+        @VisibleForTesting
+        val DESCRIPTION = "Use kotlin.test.junit.JUnitAsserter instead of JUnit in Kotlin"
+        private const val EXPLANATION = "JUnitAsserter's methods use contracts, removing the need for `!!` " +
+            "afterwards"
+        private val implementation = Implementation(JUnitNullAssertionDetector::class.java, JAVA_FILE_SCOPE)
+
+        @JvmField
+        val ISSUE: Issue = Issue.create(
+            ID,
+            DESCRIPTION,
+            EXPLANATION,
+            Constants.ANKI_CODE_STYLE_CATEGORY,
+            Constants.ANKI_CODE_STYLE_PRIORITY,
+            Constants.ANKI_CODE_STYLE_SEVERITY,
+            implementation
+        )
+    }
+}


### PR DESCRIPTION
## Purpose / Description
It was mentioned that we could improve `assertNotNull` to enforce non-nullability in the Kotlin type system via use of contracts.

## Fixes
Fixes #10427

## Approach

* Depend on `kotlin-test`
* Use either a bare `assertNotNull` or `JUnitAsserter` if there is a `message` argument
* Fix up changes with `JUnitAsserter`
  * removed `toLong` calls

## How Has This Been Tested?
Test Only + lint works

## Learning (optional, can help others)

https://kotlinlang.org/api/latest/kotlin.test/
* args are in the other order (assertion, THEN the message)

https://kotlinlang.org/api/latest/kotlin.test/kotlin.test.junit/-j-unit-asserter/

* no `AssertFalse`
* `assertEquals` doesn't work between int and longs 

https://www.baeldung.com/kotlin/contracts - unstable, but in use in some libraries, and interesting. I expect it'll be another incremental improvement when stable.

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
