### PR TITLE
Fix `setDid()` when did is null

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -1819,7 +1819,7 @@ public class NoteEditor extends AnkiActivity implements
             return;
         }
         if (note == null || mAddNote || mCurrentEditedCard == null) {
-            JSONObject model = getCol().getModels().current();
+            Model model = getCol().getModels().current();
             if (getCol().get_config("addToCur", true)) {
                 mCurrentDid = getCol().get_config_long(CURRENT_DECK);
                 if (getCol().getDecks().isDyn(mCurrentDid)) {
@@ -1831,7 +1831,7 @@ public class NoteEditor extends AnkiActivity implements
                     mCurrentDid = 1;
                 }
             } else {
-                mCurrentDid = model.getLong("did");
+                mCurrentDid = model.getDid();
             }
         } else {
             mCurrentDid = mCurrentEditedCard.getDid();

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
@@ -870,7 +870,7 @@ public class Collection implements CollectionGetter {
                     due = (long) nextID("pos");
                 }
                 if (did == null || did == 0L) {
-                    did = model.getLong("did");
+                    did = model.getDid();
                 }
                 // add any missing cards
                 ArrayList<JSONObject> tmpls = _tmplsFromOrds(model, avail);

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Model.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Model.java
@@ -80,6 +80,11 @@ public class Model extends JSONObject {
         return getJSONArray("flds").getJSONObject(pos);
     }
 
+    /**
+     * @return model did or default deck id (1) if null
+     */
+    public Long getDid() { return isNull("did") ? 1L : getLong("did"); }
+
     public List<String> getTemplatesNames() {
         return getJSONArray("tmpls").toStringList("name");
     }

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/ModelTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/ModelTest.java
@@ -673,4 +673,24 @@ public class ModelTest extends RobolectricTest {
         assertListEquals(Arrays.asList(0, 1), Models.availOrds(reverse, new String[]{"Foo", "Bar"}, Models.AllowEmpty.TRUE));
         assertListEquals(Arrays.asList(1), Models.availOrds(reverse, new String[]{"  \t ", "Bar"}, Models.AllowEmpty.TRUE));
     }
+
+    /**
+     * tests if Model.getDid() returns model did
+     * or default deck id (1) if null
+     */
+    @Test
+    public void getDid_test() {
+        Collection col = getCol();
+        ModelManager mm = col.getModels();
+        Model basic = mm.byName("Basic");
+        basic.put("did", 999L);
+
+        Long expected = 999L;
+        assertEquals("getDid() should return the model did", expected, basic.getDid());
+
+        // Check if returns default deck id (1) when did is null
+        basic.put("did", null);
+        Long expected2 = 1L;
+        assertEquals("getDid() should return 1 (default deck id) if model did is null", expected2, basic.getDid());
+    }
 }


### PR DESCRIPTION
## Fixes
Fixes #10434

## Approach
Check if "did" property in model is not null before trying to get its value

## How Has This Been Tested?

Tested on my device (where the problem first happened) (Samsung Galaxy Note 10 Lite SM-N770F/DS, API 30)

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [X] You have performed a self-review of your own code
- [X] You have commented your code, particularly in hard-to-understand areas
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
