### PR TITLE
Permission exception for `hasFile`

### DIFF
--- a/AnkiDroid/src/test/java/com/ichi2/compat/CompatHasFilesTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/compat/CompatHasFilesTest.kt
@@ -78,5 +78,16 @@ class CompatHasFilesTest(
         }
     }
 
+    /**
+     * Reproduces https://github.com/ankidroid/Anki-Android/issues/10358
+     * Where for some reason, `listFiles` returned null on an existing directory and
+     * newDirectoryStream returned `AccessDeniedException`.
+     */
+    @Test
+    fun reproduce_10358() {
+        val permissionDenied = CompatDirectoryContentTest.PermissionDenied.createInstance(createTransientDirectory(), CompatHelper.getCompat())
+        assertThrowsSubclass<IOException> { permissionDenied.compat.hasFiles(permissionDenied.directory) }
+    }
+
     private fun hasFiles(dir: File) = compat.hasFiles(dir)
 }


### PR DESCRIPTION
It depends on #10438
It can already be merged. I plan to do similar test with MoveDirectoryContent once I know how to deal with the fact that it uses compat from compat helper