### PR TITLE
DirectoryTest for API 21 and 26

### DIFF
--- a/AnkiDroid/src/test/java/com/ichi2/compat/CompatDirectoryContentTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/compat/CompatDirectoryContentTest.kt
@@ -17,23 +17,32 @@
 package com.ichi2.compat
 
 import android.os.Build
-import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.ichi2.testutils.*
 import org.hamcrest.CoreMatchers.*
 import org.hamcrest.MatcherAssert.assertThat
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
 import org.mockito.kotlin.*
-import org.robolectric.annotation.Config
 import java.io.File
 import java.io.FileNotFoundException
 import java.io.IOException
 import java.nio.file.NotDirectoryException
 
-@RunWith(AndroidJUnit4::class)
-@Config(sdk = [21, 26])
-class CompatDirectoryContentTest {
-    val compat = CompatHelper.getCompat()
+@RunWith(Parameterized::class)
+class CompatDirectoryContentTest(
+    val compat: Compat,
+    /** Used in the "Test Results" Window */
+    @Suppress("unused") private val unitTestDescription: String
+) {
+    companion object {
+        @JvmStatic
+        @Parameterized.Parameters(name = "{1}")
+        fun data(): Iterable<Array<Any>> = sequence {
+            yield(arrayOf(CompatV21(), "CompatV21"))
+            yield(arrayOf(CompatV26(), "CompatV26"))
+        }.asIterable()
+    }
 
     @Test
     fun empty_dir_test() {


### PR DESCRIPTION
Indeed, multiple of those tests uses `hasFile` which require to be tested on
both API