### PR TITLE
Permission exception operation

### DIFF
--- a/AnkiDroid/src/test/java/com/ichi2/anki/model/DirectoryTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/model/DirectoryTest.kt
@@ -16,14 +16,19 @@
 
 package com.ichi2.anki.model
 
+import android.os.Build
+import androidx.annotation.RequiresApi
+import com.ichi2.compat.Compat
+import com.ichi2.compat.CompatHelper
+import com.ichi2.compat.Test21And26
+import com.ichi2.testutils.*
 import com.ichi2.testutils.HamcrestUtils.containsInAnyOrder
-import com.ichi2.testutils.assertThrows
-import com.ichi2.testutils.withTempFile
 import org.acra.util.IOUtils
 import org.hamcrest.CoreMatchers.*
 import org.hamcrest.MatcherAssert
-import org.hamcrest.MatcherAssert.assertThat
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
 import java.io.File
 import java.io.FileNotFoundException
 import kotlin.io.path.createTempDirectory
@@ -32,7 +37,13 @@ import kotlin.io.path.pathString
 /**
  * Tests for [Directory]
  */
-class DirectoryTest {
+@RequiresApi(Build.VERSION_CODES.O) // This requirement is necessary for compilation. However, it still allows to test CompatV21
+@RunWith(Parameterized::class)
+class DirectoryTest(
+    override val compat: Compat,
+    /** Used in the "Test Results" Window */
+    @Suppress("unused") private val unitTestDescription: String
+) : Test21And26(compat, unitTestDescription) {
     @Test
     fun passes_if_existing_directory() {
         val path = createTempDirectory().pathString
@@ -105,6 +116,17 @@ class DirectoryTest {
             dir.hasFiles(),
             equalTo(true)
         )
+    }
+
+    /**
+     * Reproduces https://github.com/ankidroid/Anki-Android/issues/10358
+     * Where for some reason, `listFiles` returned null on an existing directory and
+     * newDirectoryStream returned `AccessDeniedException`.
+     */
+    @Test
+    fun reproduce_10358() {
+        val permissionDenied = createPermissionDenied(createTransientDirectory(), CompatHelper.getCompat())
+        permissionDenied.assertThrowsWhenPermissionDenied { permissionDenied.directory.hasFiles() }
     }
 
     private fun createValidTempDir(): Directory {

--- a/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/DeleteEmptyDirectoryTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/DeleteEmptyDirectoryTest.kt
@@ -16,11 +16,19 @@
 
 package com.ichi2.anki.servicelayer.scopedstorage
 
+import android.os.Build
+import androidx.annotation.RequiresApi
 import com.ichi2.anki.model.Directory
+import com.ichi2.compat.Compat
+import com.ichi2.compat.CompatHelper
+import com.ichi2.compat.Test21And26
+import com.ichi2.testutils.createTransientDirectory
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.hasSize
 import org.hamcrest.Matchers.instanceOf
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
 import java.io.File
 import kotlin.io.path.createTempDirectory
 import kotlin.io.path.pathString
@@ -28,7 +36,13 @@ import kotlin.io.path.pathString
 /**
  * Tests for [DeleteEmptyDirectory]
  */
-class DeleteEmptyDirectoryTest : OperationTest {
+@RequiresApi(Build.VERSION_CODES.O) // This requirement is necessary for compilation. However, it still allows to test CompatV21
+@RunWith(Parameterized::class)
+class DeleteEmptyDirectoryTest(
+    override val compat: Compat,
+    /** Used in the "Test Results" Window */
+    @Suppress("unused") private val unitTestDescription: String
+) : Test21And26(compat, unitTestDescription), OperationTest {
 
     override val executionContext = MockMigrationContext()
 
@@ -66,6 +80,17 @@ class DeleteEmptyDirectoryTest : OperationTest {
 
         assertThat("no exceptions", executionContext.exceptions, hasSize(0))
         assertThat("no more operations", next, hasSize(0))
+    }
+
+    /**
+     * Reproduces https://github.com/ankidroid/Anki-Android/issues/10358
+     * Where for some reason, `listFiles` returned null on an existing directory and
+     * newDirectoryStream returned `AccessDeniedException`.
+     */
+    @Test
+    fun reproduce_10358() {
+        val permissionDenied = createPermissionDenied(createTransientDirectory(), CompatHelper.getCompat())
+        permissionDenied.assertThrowsWhenPermissionDenied { DeleteEmptyDirectory(permissionDenied.directory).execute(executionContext) }
     }
 
     private fun createEmptyDirectory() =

--- a/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/MoveDirectoryContentTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/MoveDirectoryContentTest.kt
@@ -21,6 +21,7 @@ import androidx.annotation.RequiresApi
 import com.ichi2.anki.model.Directory
 import com.ichi2.anki.servicelayer.scopedstorage.MigrateUserData.Operation
 import com.ichi2.compat.Compat
+import com.ichi2.compat.Test21And26
 import com.ichi2.testutils.*
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.*

--- a/AnkiDroid/src/test/java/com/ichi2/compat/CompatCopyFileTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/compat/CompatCopyFileTest.java
@@ -17,13 +17,11 @@
 package com.ichi2.compat;
 
 import com.ichi2.anki.TestUtils;
-import com.ichi2.testutils.Test21And26;
 
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-import org.robolectric.annotation.Config;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -32,8 +30,6 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
-
-import androidx.test.ext.junit.runners.AndroidJUnit4;
 
 import static com.ichi2.utils.FileOperation.getFileResource;
 

--- a/AnkiDroid/src/test/java/com/ichi2/compat/CompatCopyFileTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/compat/CompatCopyFileTest.java
@@ -16,6 +16,8 @@
 
 package com.ichi2.compat;
 
+import android.os.Build;
+
 import com.ichi2.anki.TestUtils;
 
 import org.junit.Assert;
@@ -31,8 +33,11 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
 
+import androidx.annotation.RequiresApi;
+
 import static com.ichi2.utils.FileOperation.getFileResource;
 
+@RequiresApi(api = Build.VERSION_CODES.O) // This requirement is necessary for compilation. However, it still allows to test CompatV21
 @RunWith(Parameterized.class)
 public class CompatCopyFileTest extends Test21And26 {
     public CompatCopyFileTest(Compat compat, String unitTestDescription) {

--- a/AnkiDroid/src/test/java/com/ichi2/compat/CompatHasFilesTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/compat/CompatHasFilesTest.kt
@@ -34,7 +34,7 @@ import java.nio.file.NotDirectoryException
 
 /** Tests for [Compat.hasFiles] */
 @RunWith(Parameterized::class)
-@RequiresApi(Build.VERSION_CODES.O) // ALlows code to compile, but we still test with [CompatV21]
+@RequiresApi(Build.VERSION_CODES.O) // Allows code to compile, but we still test with [CompatV21]
 class CompatHasFilesTest(
     override val compat: Compat,
     /** Used in the "Test Results" Window */
@@ -78,8 +78,8 @@ class CompatHasFilesTest(
      */
     @Test
     fun reproduce_10358() {
-        val permissionDenied = CompatDirectoryContentTest.PermissionDenied.createInstance(createTransientDirectory(), CompatHelper.getCompat())
-        assertThrowsSubclass<IOException> { permissionDenied.compat.hasFiles(permissionDenied.directory) }
+        val permissionDenied = createPermissionDenied(createTransientDirectory(), CompatHelper.getCompat())
+        assertThrowsSubclass<IOException> { permissionDenied.compat.hasFiles(permissionDenied.directory.directory) }
     }
 
     private fun hasFiles(dir: File) = compat.hasFiles(dir)

--- a/AnkiDroid/src/test/java/com/ichi2/compat/Test21And26.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/compat/Test21And26.kt
@@ -14,12 +14,8 @@
  *  this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package com.ichi2.testutils
+package com.ichi2.compat
 
-import com.ichi2.compat.Compat
-import com.ichi2.compat.CompatHelper
-import com.ichi2.compat.CompatV21
-import com.ichi2.compat.CompatV26
 import org.junit.After
 import org.junit.Before
 import org.junit.runners.Parameterized

--- a/AnkiDroid/src/test/java/com/ichi2/compat/Test21And26.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/compat/Test21And26.kt
@@ -16,18 +16,25 @@
 
 package com.ichi2.compat
 
+import android.os.Build
+import androidx.annotation.RequiresApi
+import com.ichi2.anki.model.Directory
+import com.ichi2.testutils.assertThrowsSubclass
 import org.junit.After
 import org.junit.Before
 import org.junit.runners.Parameterized
 import org.mockito.MockedStatic
 import org.mockito.Mockito
-import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.*
+import java.io.File
+import java.io.IOException
 
 /**
  * Allows to test with CompatV21 and V26.
  * In particular it allows to test version of the code that uses [Files] and [Path] classes.
  * And versions that must restrict themselves to [File].
  */
+@RequiresApi(Build.VERSION_CODES.O) // This requirement is necessary for compilation. However, it still allows to test CompatV21
 open class Test21And26(
     open val compat: Compat,
     /** Used in the "Test Results" Window */
@@ -56,8 +63,58 @@ open class Test21And26(
         mocked.`when`<Compat> { CompatHelper.getCompat() }.doReturn(compat)
     }
 
+    // Allow to cancel every static mock, appart from the setup's one.
+    // Required because individual method can't be unregistered.
+    fun restart() {
+        tearDown()
+        setup()
+    }
+
     @After
     fun tearDown() {
         mocked.close()
+    }
+
+    /**
+     * Represents structure and compat required to simulate https://github.com/ankidroid/Anki-Android/issues/10358
+     * This is a bug that occurred in a smartphone, where listFiles returned `null` on an existing directory.
+     */
+    inner class PermissionDenied constructor(val directory: Directory, val compat: Compat) {
+        /**
+         * This run test, ensuring that [newDirectoryStream] throws on [directory].
+         * This is useful in the case where we can't directly access the directory or compat
+         */
+        fun <T> runWithPermissionDenied(test: () -> T): T {
+            mocked.`when`<Compat> { CompatHelper.getCompat() }.doReturn(compat)
+            val result = test()
+            restart()
+            return result
+        }
+
+        /**
+         * Allow to ensure that [test] throw an IOException.
+         * We plan to use it to ensure that if we don't have permission to read the directory
+         * the exception is not catched.
+         */
+        fun assertThrowsWhenPermissionDenied(test: () -> Unit): IOException =
+            runWithPermissionDenied { assertThrowsSubclass(test) }
+    }
+
+    fun createPermissionDenied(directory: File, compat: Compat): PermissionDenied {
+        val directoryWithPermissionDenied =
+            spy(directory) {
+                on { listFiles() } doReturn null
+            }
+        val compatWithPermissionDenied =
+            if (compat is CompatV26) {
+                // Closest to simulate [newDirectoryStream] throwing [AccessDeniedException]
+                // since this method calls toPath.
+                spy(compat) {
+                    doThrow(AccessDeniedException(directory)).whenever(it).newDirectoryStream(eq(directory.toPath()))
+                }
+            } else {
+                compat
+            }
+        return PermissionDenied(Directory.createInstance(directoryWithPermissionDenied)!!, compatWithPermissionDenied)
     }
 }


### PR DESCRIPTION
This begins with #10439.
It checks that if there is no permission to list directory content, then the exception is not catched in:
* creation of MoveDirectoryContent
* execution of DeleteDirectory
* entire execution of MoveDirectory
* Directory's hasFile