### PR TITLE
NF: remove `val col = col`

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/DeckDueTreeNode.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/DeckDueTreeNode.kt
@@ -128,7 +128,6 @@ class DeckDueTreeNode(col: Collection?, name: String?, did: Long, private var re
     }
 
     override fun withChildren(children: MutableList<DeckDueTreeNode?>): DeckDueTreeNode {
-        val col = col
         val name = fullDeckName
         val did = did
         val node = DeckDueTreeNode(col, name, did, revCount, lrnCount, newCount)

--- a/AnkiDroid/src/test/java/com/ichi2/anki/AnkiDroidJsAPITest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/AnkiDroidJsAPITest.kt
@@ -30,7 +30,6 @@ class AnkiDroidJsAPITest : RobolectricTest() {
 
     @Test
     fun initTest() {
-        val col = col
         val models = col.models
         val decks = col.decks
         val didA = addDeck("Test")
@@ -55,7 +54,6 @@ class AnkiDroidJsAPITest : RobolectricTest() {
 
     @Test
     fun ankiGetNextTimeTest() {
-        val col = col
         val models = col.models
         val decks = col.decks
         val didA = addDeck("Test")
@@ -79,7 +77,6 @@ class AnkiDroidJsAPITest : RobolectricTest() {
 
     @Test
     fun ankiTestCurrentCard() {
-        val col = col
         val models = col.models
         val decks = col.decks
         val didA = addDeck("Test")
@@ -138,7 +135,6 @@ class AnkiDroidJsAPITest : RobolectricTest() {
 
     @Test
     fun ankiJsUiTest() {
-        val col = col
         val models = col.models
         val decks = col.decks
         val didA = addDeck("Test")
@@ -168,7 +164,6 @@ class AnkiDroidJsAPITest : RobolectricTest() {
     @Test
     fun ankiMarkAndFlagCardTest() {
         // js api test for marking and flagging card
-        val col = col
         val models = col.models
         val decks = col.decks
         val didA = addDeck("Test")
@@ -236,7 +231,6 @@ class AnkiDroidJsAPITest : RobolectricTest() {
         // add five notes, four will be buried and suspended
         // count number of notes, if buried or suspended then
         // in scheduling the count will be less than previous scheduling
-        val col = col
         val models = col.models
         val decks = col.decks
         val didA = addDeck("Test")

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/CardTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/CardTest.kt
@@ -37,7 +37,6 @@ class CardTest : RobolectricTest() {
      ******************/
     @Test
     fun test_delete() {
-        val col = col
         val note = col.newNote()
         note.setItem("Front", "1")
         note.setItem("Back", "2")
@@ -55,7 +54,6 @@ class CardTest : RobolectricTest() {
 
     @Test
     fun test_misc_cards() {
-        val col = col
         val note = col.newNote()
         note.setItem("Front", "1")
         note.setItem("Back", "2")
@@ -67,7 +65,6 @@ class CardTest : RobolectricTest() {
 
     @Test
     fun test_genrem() {
-        val col = col
         val note = col.newNote()
         note.setItem("Front", "1")
         note.setItem("Back", "")
@@ -98,7 +95,6 @@ class CardTest : RobolectricTest() {
 
     @Test
     fun test_gendeck() {
-        val col = col
         val cloze = col.models.byName("Cloze")
         col.models.setCurrent(cloze!!)
         val note = col.newNote()
@@ -131,7 +127,6 @@ class CardTest : RobolectricTest() {
     @Test
     @Throws(ConfirmModSchemaException::class)
     fun test_gen_or() {
-        val col = col
         val models = col.models
         val model = models.byName("Basic")
         assertNotNull(model)
@@ -181,7 +176,6 @@ class CardTest : RobolectricTest() {
     @Test
     @Throws(ConfirmModSchemaException::class)
     fun test_gen_not() {
-        val col = col
         val models = col.models
         val model = models.byName("Basic")
         assertNotNull(model)
@@ -236,7 +230,6 @@ class CardTest : RobolectricTest() {
     @Config(qualifiers = "en")
     @Throws(DeckRenameException::class)
     fun nextDueTest() {
-        val col = col
         // Test runs as the 7th of august 2020, 9h00
         val n = addNoteUsingBasicModel("Front", "Back")
         val c = n.firstCard()

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/CollectionPersistentTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/CollectionPersistentTest.kt
@@ -32,7 +32,6 @@ class CollectionPersistentTest : RobolectricTest() {
 
     @Test
     fun beforeUploadDbIsV11() {
-        val col = col
         assumeThat(col.queryVer(), not(equalTo(11)))
         col.beforeUpload()
         assumeThat(Storage.getDatabaseVersion(col.path), equalTo(11))

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/StorageTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/StorageTest.kt
@@ -60,7 +60,6 @@ open class StorageTest : RobolectricTest() {
     private val results: CollectionData
         get() {
             val results = CollectionData()
-            val col = col
             results.loadFromCollection(col)
             return results
         }


### PR DESCRIPTION
That was due to porting from java, as previously  it was `getCol`
