### PR TITLE
Remove android when possible

### DIFF
--- a/AnkiDroid/src/test/java/com/ichi2/anki/HandlerUtilsTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/HandlerUtilsTest.kt
@@ -28,7 +28,7 @@ import org.junit.runner.RunWith
 import org.robolectric.shadows.ShadowLooper.runUiThreadTasksIncludingDelayedTasks
 
 @RunWith(AndroidJUnit4::class)
-class HandlerUtilsTest : RobolectricTest() {
+class HandlerUtilsTest {
 
     @Test
     fun checkHandlerFunctionExecution() {

--- a/AnkiDroid/src/test/java/com/ichi2/anki/OnboardingUtilsTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/OnboardingUtilsTest.kt
@@ -16,22 +16,18 @@
 
 package com.ichi2.anki
 
-import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.ichi2.testutils.HamcrestUtils.containsInAnyOrder
 import com.ichi2.testutils.isType
 import org.hamcrest.MatcherAssert.assertThat
 import org.junit.Before
 import org.junit.Test
-import org.junit.runner.RunWith
 import kotlin.reflect.KCallable
 import kotlin.reflect.full.companionObject
 
-@RunWith(AndroidJUnit4::class)
-class OnboardingUtilsTest : RobolectricTest() {
+class OnboardingUtilsTest {
 
     @Before
-    override fun setUp() {
-        super.setUp()
+    fun setUp() {
         Onboarding.resetOnboardingForTesting() // #9597 - global needs resetting
     }
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/DeckPickerContextMenuAndroidTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/DeckPickerContextMenuAndroidTest.kt
@@ -1,0 +1,67 @@
+/*
+ *  Copyright (c) 2022 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.dialogs
+
+import androidx.fragment.app.testing.FragmentScenario
+import androidx.lifecycle.Lifecycle
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.afollestad.materialdialogs.MaterialDialog
+import com.ichi2.anki.R
+import com.ichi2.anki.RobolectricTest
+import com.ichi2.libanki.Consts
+import org.hamcrest.CoreMatchers
+import org.hamcrest.MatcherAssert
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class DeckPickerContextMenuAndroidTest : RobolectricTest() {
+    @Test
+    fun delete_deck_is_last_in_menu_issue_10283() {
+        // "Delete deck" was previously close to "Custom study" which caused misclicks.
+        // This is less likely at the bottom of the list
+        testDialog(Consts.DEFAULT_DECK_ID) { dialog ->
+            val lastItem = dialog.items!!.last()
+            MatcherAssert.assertThat(
+                "'Delete deck' should be last item in the menu",
+                lastItem,
+                CoreMatchers.equalTo(getResourceString(R.string.contextmenu_deckpicker_delete_deck))
+            )
+        }
+    }
+
+    /**
+     * Allows testing the [MaterialDialog] returned from the [DeckPickerContextMenu]
+     *
+     * @param deckId The deck ID to test
+     * @param execAssertions the assertions to perform on the [MaterialDialog] under test
+     */
+    private fun testDialog(@Suppress("SameParameterValue") deckId: Long, execAssertions: (MaterialDialog) -> Unit) {
+        val args = DeckPickerContextMenu(col)
+            .withArguments(deckId)
+            .arguments
+
+        val factory = DeckPickerContextMenu.Factory { col }
+        FragmentScenario.launch(DeckPickerContextMenu::class.java, args, R.style.Theme_AppCompat, factory)
+            .use { scenario ->
+                scenario.moveToState(Lifecycle.State.STARTED)
+                scenario.onFragment { f: DeckPickerContextMenu ->
+                    execAssertions(f.dialog as MaterialDialog)
+                }
+            }
+    }
+}

--- a/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/DeckPickerContextMenuTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/DeckPickerContextMenuTest.kt
@@ -16,58 +16,13 @@
 
 package com.ichi2.anki.dialogs
 
-import androidx.fragment.app.testing.FragmentScenario
-import androidx.lifecycle.Lifecycle
-import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.afollestad.materialdialogs.MaterialDialog
-import com.ichi2.anki.R
 import com.ichi2.anki.RobolectricTest
-import com.ichi2.libanki.Consts
 import com.ichi2.testutils.assertThrows
-import org.hamcrest.CoreMatchers.equalTo
-import org.hamcrest.MatcherAssert.assertThat
 import org.junit.Test
-import org.junit.runner.RunWith
 
-@RunWith(AndroidJUnit4::class)
 class DeckPickerContextMenuTest : RobolectricTest() {
-    @Test
-    fun delete_deck_is_last_in_menu_issue_10283() {
-        // "Delete deck" was previously close to "Custom study" which caused misclicks.
-        // This is less likely at the bottom of the list
-        testDialog(Consts.DEFAULT_DECK_ID) { dialog ->
-            val lastItem = dialog.items!!.last()
-            assertThat(
-                "'Delete deck' should be last item in the menu",
-                lastItem,
-                equalTo(getResourceString(R.string.contextmenu_deckpicker_delete_deck))
-            )
-        }
-    }
-
     @Test
     fun ensure_cannot_be_instantiated_without_arguments() {
         assertThrows<IllegalStateException> { DeckPickerContextMenu(col).deckId }
-    }
-
-    /**
-     * Allows testing the [MaterialDialog] returned from the [DeckPickerContextMenu]
-     *
-     * @param deckId The deck ID to test
-     * @param execAssertions the assertions to perform on the [MaterialDialog] under test
-     */
-    private fun testDialog(@Suppress("SameParameterValue") deckId: Long, execAssertions: (MaterialDialog) -> Unit) {
-        val args = DeckPickerContextMenu(col)
-            .withArguments(deckId)
-            .arguments
-
-        val factory = DeckPickerContextMenu.Factory { col }
-        FragmentScenario.launch(DeckPickerContextMenu::class.java, args, R.style.Theme_AppCompat, factory)
-            .use { scenario ->
-                scenario.moveToState(Lifecycle.State.STARTED)
-                scenario.onFragment { f: DeckPickerContextMenu ->
-                    execAssertions(f.dialog as MaterialDialog)
-                }
-            }
     }
 }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/RecursivePictureMenuAndroidTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/RecursivePictureMenuAndroidTest.kt
@@ -1,0 +1,62 @@
+/*
+ *  Copyright (c) 2020 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.dialogs
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.ichi2.anki.R
+import com.ichi2.anki.RunInBackground
+import com.ichi2.anki.dialogs.utils.RecursivePictureMenuUtil
+import com.ichi2.utils.ArrayUtil
+import org.hamcrest.MatcherAssert
+import org.hamcrest.Matchers
+import org.junit.Ignore
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class RecursivePictureMenuAndroidTest : RecursivePictureMenuUtilTest() {
+    @Test
+    @RunInBackground
+    fun testNormalStartupSelectingItem() {
+        val linkedItem = getItemLinkingTo(R.string.link_anki)
+        val v = getRecyclerViewFor(linkedItem)
+        clickChildAtIndex(v, 0)
+        MatcherAssert.assertThat(activity!!.lastUrlOpened, Matchers.`is`(getResourceString(R.string.link_anki)))
+    }
+
+    @Test
+    @RunInBackground
+    fun testSelectingHeader() {
+        val numberOfChildItems = 2
+        val header: RecursivePictureMenu.Item = getHeaderWithSubItems(numberOfChildItems)
+        val v = getRecyclerViewFor(header)
+        clickChildAtIndex(v, 0)
+        val currentMenu = activity!!.lastShownDialogFragment as RecursivePictureMenu
+        val rv = RecursivePictureMenuUtil.getRecyclerViewFor(currentMenu)
+        MatcherAssert.assertThat("Unexpected number of items - check the adapter", rv.childCount, Matchers.`is`(numberOfChildItems))
+    }
+
+    @Test
+    @Ignore("Not implemented")
+    fun removeFromRoot() {
+        val header: RecursivePictureMenu.Item = getHeaderWithSubItems(1)
+        val allItems = ArrayUtil.toArrayList(arrayOf(header))
+        RecursivePictureMenu.removeFrom(allItems, header)
+
+        // Do we return, or check to see if the list is mutated?
+    }
+}

--- a/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/RecursivePictureMenuTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/RecursivePictureMenuTest.kt
@@ -15,59 +15,15 @@
  */
 package com.ichi2.anki.dialogs
 
-import androidx.recyclerview.widget.RecyclerView
-import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.ichi2.anki.R
-import com.ichi2.anki.RobolectricTest
-import com.ichi2.anki.RunInBackground
-import com.ichi2.anki.analytics.UsageAnalytics
-import com.ichi2.anki.dialogs.HelpDialog.LinkItem
-import com.ichi2.anki.dialogs.RecursivePictureMenu.ItemHeader
-import com.ichi2.anki.dialogs.utils.FragmentTestActivity
-import com.ichi2.anki.dialogs.utils.RecursivePictureMenuUtil
 import com.ichi2.testutils.AnkiAssert
 import com.ichi2.utils.ArrayUtil.toArrayList
 import org.hamcrest.MatcherAssert
 import org.hamcrest.Matchers
-import org.junit.Ignore
 import org.junit.Test
-import org.junit.runner.RunWith
 import java.util.*
 
-@RunWith(AndroidJUnit4::class)
-class RecursivePictureMenuTest : RobolectricTest() {
-    private var mActivity: FragmentTestActivity? = null
-    @Test
-    @RunInBackground
-    fun testNormalStartupSelectingItem() {
-        val linkedItem = getItemLinkingTo(R.string.link_anki)
-        val v = getRecyclerViewFor(linkedItem)
-        clickChildAtIndex(v, 0)
-        MatcherAssert.assertThat(mActivity!!.lastUrlOpened, Matchers.`is`(getResourceString(R.string.link_anki)))
-    }
-
-    @Test
-    @RunInBackground
-    fun testSelectingHeader() {
-        val numberOfChildItems = 2
-        val header: RecursivePictureMenu.Item = getHeaderWithSubItems(numberOfChildItems)
-        val v = getRecyclerViewFor(header)
-        clickChildAtIndex(v, 0)
-        val currentMenu = mActivity!!.lastShownDialogFragment as RecursivePictureMenu
-        val rv = RecursivePictureMenuUtil.getRecyclerViewFor(currentMenu)
-        MatcherAssert.assertThat("Unexpected number of items - check the adapter", rv.childCount, Matchers.`is`(numberOfChildItems))
-    }
-
-    @Test
-    @Ignore("Not implemented")
-    fun removeFromRoot() {
-        val header: RecursivePictureMenu.Item = getHeaderWithSubItems(1)
-        val allItems = toArrayList(arrayOf(header))
-        RecursivePictureMenu.removeFrom(allItems, header)
-
-        // Do we return, or check to see if the list is mutated?
-    }
-
+class RecursivePictureMenuTest : RecursivePictureMenuUtilTest() {
     @Test
     fun removeChild() {
         val header = getHeaderWithSubItems(1)
@@ -82,30 +38,5 @@ class RecursivePictureMenuTest : RobolectricTest() {
         val header = getHeaderWithSubItems(1)
         val allItems = toArrayList(arrayOf<RecursivePictureMenu.Item>(header))
         AnkiAssert.assertDoesNotThrow { RecursivePictureMenu.removeFrom(allItems, getItemLinkingTo(R.string.link_anki_manual)) }
-    }
-
-    private fun getRecyclerViewFor(vararg items: RecursivePictureMenu.Item): RecyclerView {
-        val itemList = ArrayList(listOf(*items))
-        val menu = RecursivePictureMenu.createInstance(itemList, R.string.help)
-        mActivity = openDialogFragmentUsingActivity(menu)
-        return RecursivePictureMenuUtil.getRecyclerViewFor(menu)
-    }
-
-    private fun clickChildAtIndex(v: RecyclerView, index: Int) {
-        advanceRobolectricLooperWithSleep()
-        val childAt = v.getChildAt(index) // This is null without appropriate looper calls
-        childAt.performClick()
-    }
-
-    private fun getItemLinkingTo(linkLocation: Int): RecursivePictureMenu.Item {
-        return LinkItem(R.string.help_item_ankidroid_manual, R.drawable.ic_manual_black_24dp, UsageAnalytics.Actions.OPENED_ANKIDROID_MANUAL, linkLocation)
-    }
-
-    private fun getHeaderWithSubItems(count: Int): ItemHeader {
-        val items = arrayOfNulls<RecursivePictureMenu.Item>(count)
-        for (i in 0 until count) {
-            items[i] = getItemLinkingTo(R.string.link_anki)
-        }
-        return ItemHeader(R.string.help_item_ankidroid_manual, R.drawable.ic_manual_black_24dp, UsageAnalytics.Actions.OPENED_ANKIDROID_MANUAL, *items)
     }
 }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/RecursivePictureMenuUtilTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/RecursivePictureMenuUtilTest.kt
@@ -1,0 +1,54 @@
+/*
+ *  Copyright (c) 2020 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.dialogs
+
+import androidx.recyclerview.widget.RecyclerView
+import com.ichi2.anki.R
+import com.ichi2.anki.RobolectricTest
+import com.ichi2.anki.analytics.UsageAnalytics
+import com.ichi2.anki.dialogs.utils.FragmentTestActivity
+import com.ichi2.anki.dialogs.utils.RecursivePictureMenuUtil
+import java.util.ArrayList
+
+open class RecursivePictureMenuUtilTest : RobolectricTest() {
+    var activity: FragmentTestActivity? = null
+
+    fun getRecyclerViewFor(vararg items: RecursivePictureMenu.Item): RecyclerView {
+        val itemList = ArrayList(listOf(*items))
+        val menu = RecursivePictureMenu.createInstance(itemList, R.string.help)
+        activity = openDialogFragmentUsingActivity(menu)
+        return RecursivePictureMenuUtil.getRecyclerViewFor(menu)
+    }
+
+    fun clickChildAtIndex(v: RecyclerView, index: Int) {
+        RobolectricTest.advanceRobolectricLooperWithSleep()
+        val childAt = v.getChildAt(index) // This is null without appropriate looper calls
+        childAt.performClick()
+    }
+
+    fun getItemLinkingTo(linkLocation: Int): RecursivePictureMenu.Item {
+        return HelpDialog.LinkItem(R.string.help_item_ankidroid_manual, R.drawable.ic_manual_black_24dp, UsageAnalytics.Actions.OPENED_ANKIDROID_MANUAL, linkLocation)
+    }
+
+    fun getHeaderWithSubItems(count: Int): RecursivePictureMenu.ItemHeader {
+        val items = arrayOfNulls<RecursivePictureMenu.Item>(count)
+        for (i in 0 until count) {
+            items[i] = getItemLinkingTo(R.string.link_anki)
+        }
+        return RecursivePictureMenu.ItemHeader(R.string.help_item_ankidroid_manual, R.drawable.ic_manual_black_24dp, UsageAnalytics.Actions.OPENED_ANKIDROID_MANUAL, *items)
+    }
+}

--- a/AnkiDroid/src/test/java/com/ichi2/anki/multimediacard/AudioRecorderAndroidTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/multimediacard/AudioRecorderAndroidTest.kt
@@ -1,0 +1,79 @@
+/*
+ *  Copyright (c) 2021 Kael Madar <itsybitsyspider@madarhome.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.ichi2.anki.multimediacard
+
+import android.media.MediaRecorder
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.ichi2.anki.RobolectricTest
+import org.junit.Assert
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.Mockito
+import org.mockito.MockitoAnnotations
+import java.io.IOException
+
+@RunWith(AndroidJUnit4::class)
+class AudioRecorderAndroidTest : RobolectricTest() {
+
+    private lateinit var mAudioRecorder: AudioRecorder
+
+    @Mock(name = "mRecorder")
+    private val mMockedMediaRecorder: MediaRecorder? = null
+
+    @InjectMocks
+    private lateinit var mInjectedRecorder: AudioRecorder
+    @Before
+    fun before() {
+        MockitoAnnotations.openMocks(this)
+        mAudioRecorder = AudioRecorder()
+    }
+
+    // verify that the audio recorder is initialized in high sampling mode
+    @Test
+    @Throws(IOException::class)
+    fun testStartRecordingHighSampling() {
+        val recordingHandler = Mockito.mock(Runnable::class.java)
+        mAudioRecorder.setOnRecordingInitializedHandler(recordingHandler)
+        mAudioRecorder.startRecording(targetContext, "testpath")
+        Mockito.verify(recordingHandler, Mockito.times(1)).run()
+    }
+
+    // verify that the audio recorder is initialized in low sampling mode
+    @Test
+    @Throws(IOException::class)
+    fun testRecordingLowSampling() {
+        class InitHandlerWithError : Runnable {
+            var timesRun = 0
+                private set
+            private var mHasThrown = false
+            override fun run() {
+                timesRun++
+                if (!mHasThrown) {
+                    mHasThrown = true
+                    throw RuntimeException()
+                }
+            }
+        }
+
+        val recordingHandler = InitHandlerWithError()
+        mAudioRecorder.setOnRecordingInitializedHandler(recordingHandler)
+        mAudioRecorder.startRecording(targetContext, "testpath")
+        Assert.assertEquals("Initialization handler should run twice", 2, recordingHandler.timesRun.toLong())
+    }
+}

--- a/AnkiDroid/src/test/java/com/ichi2/anki/multimediacard/AudioRecorderTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/multimediacard/AudioRecorderTest.kt
@@ -16,20 +16,14 @@
 package com.ichi2.anki.multimediacard
 
 import android.media.MediaRecorder
-import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.ichi2.anki.RobolectricTest
-import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
-import org.junit.runner.RunWith
 import org.mockito.InjectMocks
 import org.mockito.Mock
 import org.mockito.Mockito.*
 import org.mockito.MockitoAnnotations
-import java.io.IOException
 
-@RunWith(AndroidJUnit4::class)
-class AudioRecorderTest : RobolectricTest() {
+class AudioRecorderTest {
     private lateinit var mAudioRecorder: AudioRecorder
 
     @Mock(name = "mRecorder")
@@ -50,38 +44,5 @@ class AudioRecorderTest : RobolectricTest() {
         mInjectedRecorder.release()
         verify(mMockedMediaRecorder, times(1))?.stop()
         verify(mMockedMediaRecorder, times(1))?.release()
-    }
-
-    // verify that the audio recorder is initialized in high sampling mode
-    @Test
-    @Throws(IOException::class)
-    fun testStartRecordingHighSampling() {
-        val recordingHandler = mock(Runnable::class.java)
-        mAudioRecorder.setOnRecordingInitializedHandler(recordingHandler)
-        mAudioRecorder.startRecording(targetContext, "testpath")
-        verify(recordingHandler, times(1)).run()
-    }
-
-    // verify that the audio recorder is initialized in low sampling mode
-    @Test
-    @Throws(IOException::class)
-    fun testRecordingLowSampling() {
-        class InitHandlerWithError : Runnable {
-            var timesRun = 0
-                private set
-            private var mHasThrown = false
-            override fun run() {
-                timesRun++
-                if (!mHasThrown) {
-                    mHasThrown = true
-                    throw RuntimeException()
-                }
-            }
-        }
-
-        val recordingHandler = InitHandlerWithError()
-        mAudioRecorder.setOnRecordingInitializedHandler(recordingHandler)
-        mAudioRecorder.startRecording(targetContext, "testpath")
-        assertEquals("Initialization handler should run twice", 2, recordingHandler.timesRun.toLong())
     }
 }


### PR DESCRIPTION
I check for each robolectric and RunWith AndroidTest which are required and splitted classes when it is possible so that some tests are shorter

I still need to work out the case where AndroidTest can be removed by mocking the compat instead