### PR TITLE
NF: introduce Test21And26

### DIFF
--- a/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/MoveDirectoryContentTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/MoveDirectoryContentTest.kt
@@ -17,19 +17,20 @@
 package com.ichi2.anki.servicelayer.scopedstorage
 
 import android.os.Build
-import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.annotation.RequiresApi
 import com.ichi2.anki.model.Directory
 import com.ichi2.anki.servicelayer.scopedstorage.MigrateUserData.Operation
+import com.ichi2.compat.Compat
 import com.ichi2.testutils.*
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.*
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
 import org.mockito.kotlin.any
 import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.spy
 import org.mockito.kotlin.whenever
-import org.robolectric.annotation.Config
 import java.io.File
 import java.io.FileNotFoundException
 import java.io.IOException
@@ -38,9 +39,13 @@ import java.nio.file.NotDirectoryException
 /**
  * Test for [MoveDirectoryContent]
  */
-@RunWith(AndroidJUnit4::class)
-@Config(sdk = [21, 26])
-class MoveDirectoryContentTest : OperationTest {
+@RequiresApi(Build.VERSION_CODES.O) // ALlows code to compile, but we still test with [CompatV21]
+@RunWith(Parameterized::class)
+class MoveDirectoryContentTest(
+    override val compat: Compat,
+    /** Used in the "Test Results" Window */
+    @Suppress("unused") private val unitTestDescription: String
+) : Test21And26(compat, unitTestDescription), OperationTest {
 
     override val executionContext = MockMigrationContext()
 
@@ -195,7 +200,7 @@ class MoveDirectoryContentTest : OperationTest {
         val dir = Directory.createInstanceUnsafe(source_file)
         val destinationDirectory = generateDestinationDirectoryRef()
         val ex = assertThrowsSubclass<IOException> { moveDirectoryContent(dir, destinationDirectory) }
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+        if (isV26) {
             assertThat("Starting at API 26, this should be a NotDirectoryException", ex, instanceOf(NotDirectoryException::class.java))
         }
     }

--- a/AnkiDroid/src/test/java/com/ichi2/compat/CompatCopyFileTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/compat/CompatCopyFileTest.java
@@ -17,10 +17,12 @@
 package com.ichi2.compat;
 
 import com.ichi2.anki.TestUtils;
+import com.ichi2.testutils.Test21And26;
 
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 import org.robolectric.annotation.Config;
 
 import java.io.File;
@@ -35,9 +37,11 @@ import androidx.test.ext.junit.runners.AndroidJUnit4;
 
 import static com.ichi2.utils.FileOperation.getFileResource;
 
-@RunWith(AndroidJUnit4.class)
-@Config(sdk = { 21, 26 })
-public class CompatCopyFileTest {
+@RunWith(Parameterized.class)
+public class CompatCopyFileTest extends Test21And26 {
+    public CompatCopyFileTest(Compat compat, String unitTestDescription) {
+        super(compat, unitTestDescription);
+    }
 
     @Test
     public void testCopyFileToStream() throws Exception {

--- a/AnkiDroid/src/test/java/com/ichi2/compat/CompatHasFilesTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/compat/CompatHasFilesTest.kt
@@ -17,6 +17,7 @@
 package com.ichi2.compat
 
 import android.os.Build
+import androidx.annotation.RequiresApi
 import com.ichi2.testutils.*
 import com.ichi2.testutils.createTransientDirectory
 import com.ichi2.testutils.withTempFile
@@ -33,20 +34,12 @@ import java.nio.file.NotDirectoryException
 
 /** Tests for [Compat.hasFiles] */
 @RunWith(Parameterized::class)
+@RequiresApi(Build.VERSION_CODES.O) // ALlows code to compile, but we still test with [CompatV21]
 class CompatHasFilesTest(
-    val compat: Compat,
+    override val compat: Compat,
     /** Used in the "Test Results" Window */
     @Suppress("unused") private val unitTestDescription: String
-) {
-
-    companion object {
-        @JvmStatic
-        @Parameterized.Parameters(name = "{1}")
-        fun data(): Iterable<Array<Any>> = sequence {
-            yield(arrayOf(CompatV21(), "CompatV21"))
-            yield(arrayOf(CompatV26(), "CompatV26"))
-        }.asIterable()
-    }
+) : Test21And26(compat, unitTestDescription) {
 
     @Test
     fun has_files_with_file() {

--- a/AnkiDroid/src/test/java/com/ichi2/testutils/Test21And26.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/testutils/Test21And26.kt
@@ -1,0 +1,67 @@
+/*
+ *  Copyright (c) 2022 Arthur Milchior <arthur@milchior.fr>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.testutils
+
+import com.ichi2.compat.Compat
+import com.ichi2.compat.CompatHelper
+import com.ichi2.compat.CompatV21
+import com.ichi2.compat.CompatV26
+import org.junit.After
+import org.junit.Before
+import org.junit.runners.Parameterized
+import org.mockito.MockedStatic
+import org.mockito.Mockito
+import org.mockito.kotlin.doReturn
+
+/**
+ * Allows to test with CompatV21 and V26.
+ * In particular it allows to test version of the code that uses [Files] and [Path] classes.
+ * And versions that must restrict themselves to [File].
+ */
+open class Test21And26(
+    open val compat: Compat,
+    /** Used in the "Test Results" Window */
+    @Suppress("unused") private val unitTestDescription: String
+) {
+    companion object {
+        @JvmStatic
+        @Parameterized.Parameters(name = "{1}")
+
+        fun data(): Iterable<Array<Any>> = sequence {
+            yield(arrayOf(CompatV21(), "CompatV21"))
+            yield(arrayOf(CompatV26(), "CompatV26"))
+        }.asIterable()
+    }
+
+    val isV21: Boolean
+        get() = compat is CompatV21
+    val isV26: Boolean
+        get() = compat is CompatV26
+
+    lateinit var mocked: MockedStatic<CompatHelper>
+
+    @Before
+    open fun setup() {
+        mocked = Mockito.mockStatic(CompatHelper::class.java)
+        mocked.`when`<Compat> { CompatHelper.getCompat() }.doReturn(compat)
+    }
+
+    @After
+    fun tearDown() {
+        mocked.close()
+    }
+}


### PR DESCRIPTION
This allow CompatHelper to return V21 and V26. Useful for cases where the only
difference between version is only in Compat.