### PR TITLE
Show toast after undo

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -1011,7 +1011,17 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
 
     protected void undo() {
         if (isUndoAvailable()) {
-            new UndoService.Undo().runWithHandler(answerCardHandler(false));
+            Resources res = getResources();
+            String undoName = getCol().undoName(res);
+
+            new UndoService.Undo().runWithHandler(
+                    answerCardHandler(false)
+                    .alsoExecuteAfter(computation -> UIUtils.showThemedToast(
+                            AbstractFlashcardViewer.this,
+                            res.getString(R.string.undo_succeeded, undoName),
+                            false)
+                )
+            );
         }
     }
 

--- a/AnkiDroid/src/main/res/values/03-dialogs.xml
+++ b/AnkiDroid/src/main/res/values/03-dialogs.xml
@@ -185,6 +185,7 @@
     <string name="card_browser_deck_change_error">Could not change deck</string>
     <!-- AbstractFlashCardViewer -->
     <string name="card_viewer_url_decode_error">Error decoding data from card</string>
+    <string name="undo_succeeded">Undone \"%s\"</string>
 
     <!-- Deck Options -->
     <string name="deck_options_corrupt">Failed to process deck options: %s</string>


### PR DESCRIPTION
## Fixes
Fixes #9192

## Approach
Add toast after undone action showing its name.

I haven't gone the extra miles of showing a message if the computation takes too long because I think this behavior should have its own issue, since, for consistency, it should apply to all toasts in the reviewer (suspend card, bury, etc)

The undone message is open to discussion

## How Has This Been Tested?

On my phone (Samsung Galaxy Note 10 Lite SM-N770F/DS, API 30)
Procedure:

https://user-images.githubusercontent.com/69634269/157095312-1a8bb2e4-0bda-4e57-86dc-7ba3b98e7b82.mp4

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [X] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
