### PR TITLE
#10442 Preferences title isn't reupdated after opening a screen optio…

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.kt
@@ -94,8 +94,9 @@ class Preferences : AnkiActivity() {
     /** The collection path when Preferences was opened   */
     private var mOldCollectionPath: String? = null
 
-    private lateinit var mOnBackStackChangedListener: FragmentManager.OnBackStackChangedListener
-
+    private val mOnBackStackChangedListener: FragmentManager.OnBackStackChangedListener = FragmentManager.OnBackStackChangedListener {
+        updateActionBarTitle(supportFragmentManager, supportActionBar)
+    }
     // ----------------------------------------------------------------------------
     // Overridden methods
     // ----------------------------------------------------------------------------
@@ -120,9 +121,6 @@ class Preferences : AnkiActivity() {
             .replace(R.id.settings_container, fragment)
             .commit()
 
-        mOnBackStackChangedListener = FragmentManager.OnBackStackChangedListener {
-            updateActionBarTitle(supportFragmentManager, supportActionBar)
-        }
         supportFragmentManager.addOnBackStackChangedListener(mOnBackStackChangedListener)
     }
 
@@ -134,11 +132,14 @@ class Preferences : AnkiActivity() {
     private fun updateActionBarTitle(fragmentManager: FragmentManager, actionBar: ActionBar?) {
         val fragment = fragmentManager.findFragmentById(R.id.settings_container)
 
-        when (fragment) {
-            is AdvancedStatisticsSettingsFragment -> actionBar?.title = resources.getString(R.string.advanced_statistics_title)
-            is CustomSyncServerSettingsFragment -> actionBar?.title = resources.getString(R.string.custom_sync_server_title)
-            is CustomButtonsSettingsFragment -> actionBar?.title = resources.getString(R.string.custom_buttons)
-            else -> actionBar?.title = resources.getString(R.string.preferences_title)
+        if (actionBar == null)
+            return
+
+        actionBar.title = when (fragment) {
+            is AdvancedStatisticsSettingsFragment -> resources.getString(R.string.advanced_statistics_title)
+            is CustomSyncServerSettingsFragment -> resources.getString(R.string.custom_sync_server_title)
+            is CustomButtonsSettingsFragment -> resources.getString(R.string.custom_buttons)
+            else -> resources.getString(R.string.preferences_title)
         }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.kt
@@ -39,6 +39,7 @@ import androidx.appcompat.app.ActionBar
 import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.FragmentManager
 import androidx.preference.*
 import com.afollestad.materialdialogs.MaterialDialog
 import com.ichi2.anim.ActivityTransitionAnimation
@@ -93,6 +94,8 @@ class Preferences : AnkiActivity() {
     /** The collection path when Preferences was opened   */
     private var mOldCollectionPath: String? = null
 
+    private lateinit var mOnBackStackChangedListener: FragmentManager.OnBackStackChangedListener
+
     // ----------------------------------------------------------------------------
     // Overridden methods
     // ----------------------------------------------------------------------------
@@ -116,6 +119,27 @@ class Preferences : AnkiActivity() {
             .beginTransaction()
             .replace(R.id.settings_container, fragment)
             .commit()
+
+        mOnBackStackChangedListener = FragmentManager.OnBackStackChangedListener {
+            updateActionBarTitle(supportFragmentManager, supportActionBar)
+        }
+        supportFragmentManager.addOnBackStackChangedListener(mOnBackStackChangedListener)
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        supportFragmentManager.removeOnBackStackChangedListener(mOnBackStackChangedListener)
+    }
+
+    private fun updateActionBarTitle(fragmentManager: FragmentManager, actionBar: ActionBar?) {
+        val fragment = fragmentManager.findFragmentById(R.id.settings_container)
+
+        when (fragment) {
+            is AdvancedStatisticsSettingsFragment -> actionBar?.title = resources.getString(R.string.advanced_statistics_title)
+            is CustomSyncServerSettingsFragment -> actionBar?.title = resources.getString(R.string.custom_sync_server_title)
+            is CustomButtonsSettingsFragment -> actionBar?.title = resources.getString(R.string.custom_buttons)
+            else -> actionBar?.title = resources.getString(R.string.preferences_title)
+        }
     }
 
     private fun getInitialFragment(intent: Intent?): Fragment {


### PR DESCRIPTION
1 bug fixed

## Pull Request template

## Purpose / Description
Preferences title isn't reupdated after navigating back from any of the inner fragments(like AdvancedStatisticsSettingsFragment), bug is fixed in this commit.

## Fixes
Fixes #10442

## Approach
Added onBackStackChangedListener to supportFragmentManager and based on the type of current fragment visible to user changed the title on its action bar.

## How Has This Been Tested?

Previous automated tests should be enough. Also manually tested by going back and forth between affected fragments.

## Learning (optional, can help others)
_Describe the research stage_

_Links to blog posts, patterns, libraries or addons used to solve this problem_

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [x] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

https://user-images.githubusercontent.com/54733471/157274683-6a0045b0-fc90-40ac-9499-170e5714d45a.mp4


