### PR TITLE
refactor(preferences): Post-Kotlin Cleanup

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.kt
@@ -1348,9 +1348,7 @@ class Preferences : AnkiActivity() {
         }
 
         /** Whether the user is logged on to AnkiWeb  */
-        fun hasAnkiWebAccount(preferences: SharedPreferences): Boolean {
-            val userName = preferences.getString("username", "")
-            return !TextUtils.isEmpty(userName)
-        }
+        fun hasAnkiWebAccount(preferences: SharedPreferences): Boolean =
+            preferences.getString("username", "")!!.isNotEmpty()
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.kt
@@ -266,7 +266,6 @@ class Preferences : AnkiActivity() {
         listpref.summary = listpref.entry.toString()
     }
 
-    @KotlinCleanup("make value non-null")
     private fun updateSummary(pref: Preference?) {
         if (pref == null || pref.key == null) {
             return
@@ -289,19 +288,15 @@ class Preferences : AnkiActivity() {
             }
         }
         // Get value text
-        val value: String? = try {
-            when (pref) {
-                is NumberRangePreferenceCompat -> pref.getValue().toString()
-                is SeekBarPreferenceCompat -> pref.value.toString()
-                is ListPreference -> pref.entry.toString()
-                is EditTextPreference -> pref.text
-                is ControlPreference -> return
-                else -> return
-            }
-        } catch (e: NullPointerException) {
-            Timber.w(e)
-            ""
+        val value: String = when (pref) {
+            is NumberRangePreferenceCompat -> pref.getValue().toString()
+            is SeekBarPreferenceCompat -> pref.value.toString()
+            is ListPreference -> pref.entry?.toString() ?: ""
+            is EditTextPreference -> pref.text ?: ""
+            is ControlPreference -> return
+            else -> return
         }
+
         // Get summary text
         val oldSummary = mOriginalSummaries[pref.key]
         // Replace summary text with value according to some rules

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.kt
@@ -298,7 +298,7 @@ class Preferences : AnkiActivity() {
         }
 
         // Get summary text
-        val oldSummary = mOriginalSummaries[pref.key]
+        val oldSummary = mOriginalSummaries[pref.key] ?: ""
         // Replace summary text with value according to some rules
         pref.summary = when {
             oldSummary == "" -> value
@@ -308,18 +308,28 @@ class Preferences : AnkiActivity() {
         }
     }
 
-    @KotlinCleanup("str & value: non-null")
-    private fun replaceString(str: String?, value: String?): String {
-        return if (str!!.contains("XXX")) {
-            str.replace("XXX", value!!)
+    /**
+     * Replace "XXX" in [str] with [value]
+     *
+     * This exists to enable formatting the summary of a preference with data
+     * As summary is set via XML, this cannot have format strings, so we use "XXX" later on.
+     */
+    private fun replaceString(str: String, value: String): String {
+        return if (str.contains("XXX")) {
+            str.replace("XXX", value)
         } else {
             str
         }
     }
 
-    private fun replaceStringIfNumeric(str: String?, value: String?): String? {
+    /**
+     * If [value] is convertible to a double, replace "XXX" in [str] with the value
+     * @param str A string which may have "XXX", if so, this may be replaced
+     * @param value If this is a double, the "XXX" string in [str] is replaced with [value]
+     */
+    private fun replaceStringIfNumeric(str: String, value: String): String? {
         return try {
-            value!!.toDouble()
+            value.toDouble()
             replaceString(str, value)
         } catch (e: NumberFormatException) {
             Timber.w(e)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.kt
@@ -1284,8 +1284,6 @@ class Preferences : AnkiActivity() {
         /**
          * Represents in Android preferences the collections configuration "newSpread": i.e.
          * whether the new cards are added at the end of the queue or randomly in it.
-         * It seems not to be implemented in Ankidroid and only used in anki.
-         * TODO: port sched v2 from upstream
          */
         private const val NEW_SPREAD = "newSpread"
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.kt
@@ -1333,15 +1333,9 @@ class Preferences : AnkiActivity() {
         @JvmStatic
         fun getDayOffset(col: Collection): Int {
             return when (col.schedVer()) {
-                1 -> {
-                    val calendar: Calendar = col.crtGregorianCalendar()
-                    calendar[Calendar.HOUR_OF_DAY]
-                }
                 2 -> col.get_config("rollover", 4.toInt())!!
-                else -> {
-                    val calendar: Calendar = col.crtGregorianCalendar()
-                    calendar[Calendar.HOUR_OF_DAY]
-                }
+                // 1, or otherwise:
+                else -> col.crtGregorianCalendar()[Calendar.HOUR_OF_DAY]
             }
         }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.kt
@@ -88,7 +88,7 @@ import java.util.*
 class Preferences : AnkiActivity() {
     // Other variables
     @KotlinCleanup("we use string? as some keys were null")
-    private val mOriginalSumarries = HashMap<String?, String>()
+    private val mOriginalSummaries = HashMap<String?, String>()
 
     /** The collection path when Preferences was opened   */
     private var mOldCollectionPath: String? = null
@@ -234,7 +234,7 @@ class Preferences : AnkiActivity() {
         }
         // Set the value from the summary cache
         val s = pref.summary
-        mOriginalSumarries[pref.key] = s?.toString() ?: ""
+        mOriginalSummaries[pref.key] = s?.toString() ?: ""
         // Update summary
         updateSummary(pref)
     }
@@ -314,7 +314,7 @@ class Preferences : AnkiActivity() {
             ""
         }
         // Get summary text
-        val oldSummary = mOriginalSumarries[pref.key]
+        val oldSummary = mOriginalSummaries[pref.key]
         // Replace summary text with value according to some rules
         if ("" == oldSummary) {
             pref.summary = value
@@ -358,7 +358,7 @@ class Preferences : AnkiActivity() {
     /** This is not fit for purpose (other than testing a single screen)  */
     @get:VisibleForTesting(otherwise = VisibleForTesting.NONE)
     val loadedPreferenceKeys: Set<String>
-        get() = mOriginalSumarries.keys.filterNotNull().toSet()
+        get() = mOriginalSummaries.keys.filterNotNull().toSet()
 
     // ----------------------------------------------------------------------------
     // Inner classes


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
I mentioned some issues via `KotlinCleanup` in: https://github.com/ankidroid/Anki-Android/pull/10456

This fixes most of the `@KotlinCleanup` annotations, and starts the "proper" refactor to idiomatic Kotlin.

Not massive, but I wanted to make a commit today.

## Approach
Lint on:

* rename variable 
* 'protected' visibility is effectively 'private' in a final class
* Variable is same as 'X' and can be inlined
* Cascade if should be replaced with when
* Fix variable names
* Always returns null type

Then some manual work

## How Has This Been Tested?
Untested, mostly automated refactorings

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
