### PR TITLE
searchdeck button appearing issue fix

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -690,10 +690,9 @@ public class DeckPicker extends NavigationDrawerActivity implements
                 String undo = res.getString(R.string.studyoptions_congrats_undo, getCol().undoName(res));
                 menu.findItem(R.id.action_undo).setTitle(undo);
             }
-
-            // Remove the filter - not necessary and search has other implications for new users.
-            menu.findItem(R.id.deck_picker_action_filter).setVisible(getCol().getDecks().count() >= 10);
         }
+        // Remove the filter - not necessary and search has other implications for new users.
+        menu.findItem(R.id.deck_picker_action_filter).setVisible(getCol().getDecks().count()>=10);
 
 
         return super.onCreateOptionsMenu(menu);


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
issue - search deck button appearing even when decks >= 10

## Fixes
Just removed the setVisibility line outside an if else block

## Approach
because of the if else block the logic wasn't working 

## How Has This Been Tested?
Did manual testing and it is working as expected.

## Learning (optional, can help others)
I debugged the whole block of code in which that line was there and checked if the count of decks is wrong, but when I found out that the count is coming correct, I checked the reason why is this line not being executed. Thats where I found it was in a if else block.

