### PR TITLE
searchdeck button appearing issue fix

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -690,10 +690,9 @@ public class DeckPicker extends NavigationDrawerActivity implements
                 String undo = res.getString(R.string.studyoptions_congrats_undo, getCol().undoName(res));
                 menu.findItem(R.id.action_undo).setTitle(undo);
             }
-
-            // Remove the filter - not necessary and search has other implications for new users.
-            menu.findItem(R.id.deck_picker_action_filter).setVisible(getCol().getDecks().count() >= 10);
         }
+        // Remove the filter - not necessary and search has other implications for new users.
+        menu.findItem(R.id.deck_picker_action_filter).setVisible(getCol().getDecks().count() >= 10);
 
 
         return super.onCreateOptionsMenu(menu);


### PR DESCRIPTION
## Pull Request template

## Issue
fixes #10445

## Purpose / Description
search deck button was showing even when decks count >= 10

## Fixes
Removed the icons setVisibility property outside a if else block

## Approach
Debugged the deck counts, after debugging got to know that the count is correct. Then I found out because it was inside if else bock the particular line of code wasnt being executed

## How Has This Been Tested?
Have manually tested this bug, and its working as expected


