### PR TITLE
Update hamcrest-all:1.3 to hamcrest:2.2

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -348,7 +348,7 @@ dependencies {
     testImplementation 'org.junit.vintage:junit-vintage-engine:5.8.2'
     testImplementation 'org.mockito:mockito-inline:4.3.1'
     testImplementation "org.mockito.kotlin:mockito-kotlin:4.0.0"
-    testImplementation 'org.hamcrest:hamcrest-all:1.3'
+    testImplementation 'org.hamcrest:hamcrest:2.2'
     testImplementation 'net.lachlanmckee:timber-junit-rule:1.0.1'
     // robolectricDownloader.gradle *may* need a new SDK jar entry if they release one or if we change targetSdk. Instructions in that gradle file.
     testImplementation "org.robolectric:robolectric:4.7.3"

--- a/AnkiDroid/src/test/java/com/ichi2/anki/ReviewerTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/ReviewerTest.java
@@ -56,7 +56,7 @@ import static com.ichi2.anki.AbstractFlashcardViewer.RESULT_DEFAULT;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.isEmptyString;
+import static org.hamcrest.Matchers.emptyString;
 import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
@@ -146,7 +146,7 @@ public class ReviewerTest extends RobolectricTest {
         assertThat("4 buttons should be displayed", reviewer.getAnswerButtonCount(), is(4));
 
         String nextTime = javaScriptFunction.ankiGetNextTime4();
-        assertThat(nextTime, not(isEmptyString()));
+        assertThat(nextTime, not(emptyString()));
 
         // Display the next answer
         reviewer.answerCard(Consts.BUTTON_FOUR);
@@ -156,7 +156,7 @@ public class ReviewerTest extends RobolectricTest {
         if (schedVersion == 1) {
             assertThat("The 4th button should not be visible", reviewer.getAnswerButtonCount(), is(3));
             String learnTime = javaScriptFunction.ankiGetNextTime4();
-            assertThat("If the 4th button is not visible, there should be no time4 in JS", learnTime, isEmptyString());
+            assertThat("If the 4th button is not visible, there should be no time4 in JS", learnTime, emptyString());
         }
     }
 

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/StorageTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/StorageTest.kt
@@ -109,7 +109,7 @@ open class StorageTest : RobolectricTest() {
                 c.moveToFirst()
                 for (i in 0 until c.columnCount) {
                     if (M_V_11_ONLY_COLUMNS.contains(i)) {
-                        MatcherAssert.assertThat(c.getString(i), Matchers.isEmptyOrNullString())
+                        MatcherAssert.assertThat(c.getString(i), Matchers.emptyOrNullString())
                         continue
                     }
                     loadV11(i, c.getString(i))

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/template/TemplateTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/template/TemplateTest.java
@@ -81,7 +81,7 @@ public class TemplateTest extends RobolectricTest {
 
         HashMap<String, String> context = new HashMap<>();
 
-        assertThat(render(maybeBad, context), Matchers.isEmptyString());
+        assertThat(render(maybeBad, context), Matchers.emptyString());
     }
 
     @Test

--- a/AnkiDroid/src/test/java/com/ichi2/utils/LanguageUtilsTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/utils/LanguageUtilsTest.java
@@ -35,7 +35,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.isOneOf;
+import static org.hamcrest.Matchers.oneOf;
 
 @RunWith(AndroidJUnit4.class)
 public class LanguageUtilsTest extends RobolectricTest {
@@ -120,10 +120,10 @@ public class LanguageUtilsTest extends RobolectricTest {
     public void localeThreeLetterRegionalVariantResolves() {
         assertThat("A locale with a 2-letter code and regional variant resolves correctly",
                 LanguageUtil.getLocale("yue-TW").getDisplayName(),
-                isOneOf("yue (Taiwan)", "Cantonese (Taiwan)"));
+                oneOf("yue (Taiwan)", "Cantonese (Taiwan)"));
         
         assertThat("A locale with a 2-letter code and regional variant resolves correctly",
                 LanguageUtil.getLocale("yue_TW").getDisplayName(),
-                isOneOf("yue (Taiwan)", "Cantonese (Taiwan)"));
+                oneOf("yue (Taiwan)", "Cantonese (Taiwan)"));
     }
 }


### PR DESCRIPTION
## Purpose / Description
The package name `hamcrest-all` is not used for newer releases of hamcrest.
`hamcrest` 2.x+ packages all classes by default. Because of the name changing, dependabot could not have updated this.

Some relevant new features: [FileMatchers](http://hamcrest.org/JavaHamcrest/javadoc/2.2/) and [ComparatorMatcherBuilder](http://hamcrest.org/JavaHamcrest/javadoc/2.2/org/hamcrest/comparator/ComparatorMatcherBuilder.html)

Useful to #10387

## Approach
Change the package name and version in build.gradle

Handled deprecations:
- isOneOf -> oneOf
- isEmptyString -> emptyString
- isEmptyOrNullString -> emptyOrNullString

## How Has This Been Tested?

Ran the automated tests

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
