### PR TITLE
feat(scoped-storage): Retry DeleteEmptyDirectory 

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/scopedstorage/MigrateUserData.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/scopedstorage/MigrateUserData.kt
@@ -126,7 +126,7 @@ class MigrateUserData private constructor(val source: Directory, val destination
      * a large mutable queue of tasks
      */
     abstract class MigrationContext {
-        abstract fun reportError(context: Operation, ex: Exception)
+        abstract fun reportError(throwingOperation: Operation, ex: Exception)
         abstract fun reportProgress(transferred: NumberOfBytes)
         /**
          * Whether [File#renameTo] should be attempted

--- a/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/scopedstorage/MigrateUserData.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/scopedstorage/MigrateUserData.kt
@@ -20,6 +20,8 @@ import android.content.SharedPreferences
 import com.ichi2.anki.model.Directory
 import com.ichi2.anki.model.DiskFile
 import com.ichi2.anki.servicelayer.ScopedStorageService.UserDataMigrationPreferences
+import com.ichi2.anki.servicelayer.scopedstorage.MigrateUserData.Operation
+import com.ichi2.anki.servicelayer.scopedstorage.MigrateUserData.SingleRetryDecorator
 import timber.log.Timber
 import java.io.File
 
@@ -233,8 +235,42 @@ class MigrateUserData private constructor(val source: Directory, val destination
          * * deleting the original folder.
          */
         abstract fun execute(context: MigrationContext): List<Operation>
+
+        /** A list of operations to perform if the operation should be retried */
+        open val retryOperations get() = emptyList<Operation>()
+    }
+
+    /**
+     * A decorator for [Operation] which executes [standardOperation].
+     * When retried, executes [retryOperation].
+     * Ignores [retryOperations] defined in [standardOperation]
+     */
+    class SingleRetryDecorator(
+        private val standardOperation: Operation,
+        private val retryOperation: Operation
+    ) : Operation() {
+        override fun execute(context: MigrationContext) = standardOperation.execute(context)
+        override val retryOperations get() = listOf(retryOperation)
     }
 }
 
+/**
+ * Wraps an [Operation] with functionality to allow for retries
+ *
+ * Useful if you want to call a different operation when an operation is being retried.
+ *
+ * Example: call MoveDirectory again if DeleteEmptyDirectory fails
+ *
+ * @receiver The operation to be decorated with a retry action
+ * @param operationOnRetry The action to perform is [Operation.retryOperations] is called
+ */
+internal fun Operation.onRetryExecute(operationOnRetry: Operation): Operation {
+    val operationToBeDecorated = this
+    return SingleRetryDecorator(
+        standardOperation = operationToBeDecorated,
+        retryOperation = operationOnRetry
+    )
+}
+
 /** The operation was completed (not necessarily successfully) and no additional operations are required */
-internal fun operationCompleted() = emptyList<MigrateUserData.Operation>()
+internal fun operationCompleted() = emptyList<Operation>()

--- a/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/scopedstorage/MoveDirectory.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/scopedstorage/MoveDirectory.kt
@@ -50,7 +50,8 @@ data class MoveDirectory(val source: Directory, val destination: File) : Migrate
         }
 
         val moveContentOperations = MoveDirectoryContent.createInstance(source, destination)
-        val deleteOperation = DeleteEmptyDirectory(source)
+        // If DeleteEmptyDirectory fails, retrying is executing the MoveDirectory that spawned it
+        val deleteOperation = DeleteEmptyDirectory(source).onRetryExecute(this)
         return listOf(moveContentOperations, deleteOperation)
     }
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/MockExecutor.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/MockExecutor.kt
@@ -1,0 +1,51 @@
+/*
+ *  Copyright (c) 2022 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.servicelayer.scopedstorage
+
+import com.ichi2.anki.servicelayer.scopedstorage.MigrateUserData.MigrationContext
+import com.ichi2.anki.servicelayer.scopedstorage.MigrateUserData.Operation
+
+/**
+ * Functionality:
+ *
+ * * Execution of recursive tasks (folder copying etc..)
+ *
+ * This is a mock as it's not tested, but will eventually be moved to a real class with a slightly different API
+ *
+ * @param operations A collection of operations to be executed, to allow direct access in tests
+ * @param contextSupplier A function providing context, used so [execute] only requires operations
+ */
+class MockExecutor(
+    val operations: ArrayDeque<Operation> = ArrayDeque(),
+    val contextSupplier: (() -> MigrationContext)
+) {
+    /**
+     * Executes one, or a number of [operations][Operation].
+     * Each operation in [operations] is executed after all previous operations
+     * (and the operation they span) are completed.
+     */
+    fun execute(vararg operations: Operation) {
+        this.operations.addAll(operations)
+        val context = contextSupplier()
+        while (this.operations.any()) {
+            context.execSafe(this.operations.removeFirst()) {
+                val replacements = it.execute(context)
+                this.operations.addAll(0, replacements)
+            }
+        }
+    }
+}

--- a/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/MockMigrationContext.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/MockMigrationContext.kt
@@ -16,7 +16,7 @@
 
 package com.ichi2.anki.servicelayer.scopedstorage
 
-class MockMigrationContext : MigrateUserData.MigrationContext() {
+open class MockMigrationContext : MigrateUserData.MigrationContext() {
     /** set [logExceptions] to populate this property */
     val exceptions = mutableListOf<Exception>()
     var logExceptions: Boolean = false
@@ -31,5 +31,30 @@ class MockMigrationContext : MigrateUserData.MigrationContext() {
 
     override fun reportProgress(transferred: NumberOfBytes) {
         progress.add(transferred)
+    }
+}
+
+/**
+ * A [MockMigrationContext] which will call [MigrateUserData.Operation.retryOperations] once on
+ * a failed operation, if any `retryOperations` are available.
+ *
+ * If a second failure occurs, or if no `retryOperations` are available, it will throw
+ */
+class RetryMigrationContext(val retry: (List<MigrateUserData.Operation>) -> Unit) : MockMigrationContext() {
+    var retryCount = 0
+
+    override fun reportError(context: MigrateUserData.Operation, ex: Exception) {
+        val opsForRetry = context.retryOperations
+        if (!opsForRetry.any()) {
+            throw ex
+        }
+        retryCount++
+        if (retryCount > 1) {
+            throw ex
+        }
+        retry(opsForRetry)
+    }
+
+    override fun reportProgress(transferred: NumberOfBytes) {
     }
 }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/MockMigrationContext.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/MockMigrationContext.kt
@@ -22,7 +22,7 @@ open class MockMigrationContext : MigrateUserData.MigrationContext() {
     var logExceptions: Boolean = false
     val progress = mutableListOf<NumberOfBytes>()
 
-    override fun reportError(context: MigrateUserData.Operation, ex: Exception) {
+    override fun reportError(throwingOperation: MigrateUserData.Operation, ex: Exception) {
         if (!logExceptions) {
             throw ex
         }
@@ -43,8 +43,8 @@ open class MockMigrationContext : MigrateUserData.MigrationContext() {
 class RetryMigrationContext(val retry: (List<MigrateUserData.Operation>) -> Unit) : MockMigrationContext() {
     var retryCount = 0
 
-    override fun reportError(context: MigrateUserData.Operation, ex: Exception) {
-        val opsForRetry = context.retryOperations
+    override fun reportError(throwingOperation: MigrateUserData.Operation, ex: Exception) {
+        val opsForRetry = throwingOperation.retryOperations
         if (!opsForRetry.any()) {
             throw ex
         }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/MockMigrationContextTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/MockMigrationContextTest.kt
@@ -1,0 +1,49 @@
+/*
+ *  Copyright (c) 2022 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.servicelayer.scopedstorage
+
+import com.ichi2.anki.servicelayer.scopedstorage.MigrateUserData.Operation
+import com.ichi2.testutils.TestException
+import com.ichi2.testutils.assertThrows
+import org.hamcrest.CoreMatchers.equalTo
+import org.hamcrest.MatcherAssert.assertThat
+import org.junit.Test
+
+class MockMigrationContextTest {
+    @Test
+    fun retry_migration_context_test_retry() {
+        // if the lambda assigned to "retry" is called
+        var retryCalled = 0
+        val context = RetryMigrationContext { retryCalled++ }
+        val throwIfUsed = OperationWhichThrowsIfUsed()
+
+        fun reportError() = context.reportError(throwIfUsed, TestException("test ex"))
+
+        reportError() // retryCount is 0 during test. It increments to 1
+        assertThrows<TestException> { reportError() }
+
+        assertThat("retry should be called", retryCalled, equalTo(1))
+    }
+
+    class OperationWhichThrowsIfUsed : Operation() {
+        override fun execute(context: MigrateUserData.MigrationContext): List<Operation> =
+            throw TestException("should not be called")
+
+        override val retryOperations: List<Operation>
+            get() = listOf(OperationWhichThrowsIfUsed())
+    }
+}

--- a/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/OperationTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/OperationTest.kt
@@ -34,16 +34,9 @@ interface OperationTest {
     val executionContext: MockMigrationContext
 
     /** Helper function: executes an [Operation] and all sub-operations */
-    fun executeAll(vararg ops: Operation) {
-        val opsTodo = ArrayDeque(ops.toList())
-        while (opsTodo.any()) {
-            val head = opsTodo.removeFirst()
-            Timber.d("executing $head")
-            this.executionContext.execSafe(head) {
-                opsTodo.addAll(0, head.execute())
-            }
-        }
-    }
+    fun executeAll(vararg ops: Operation) =
+        MockExecutor(ArrayDeque(ops.toList())) { executionContext }
+            .execute()
 
     /**
      * Executes an [Operation] without executing the sub-operations


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
If `DeleteEmptyDirectory` fails, we want to perform the `MoveDirectory` that spawned it

This could happen for many reasons, such as a failed file move, or adding a file to `AnkiDroid` during the process

In the real world, this will all be handled in the `ExecutionContext`, we start this off with a mock.

## Approach
* Mock `ExecutionContext`
* add `retry()`
* Use a decorator to implement `retry()` on an arbitrary `Operation`

## How Has This Been Tested?
Unit tested. Had a bad rebase operation, so small potential for issues.

## Learning
I need to allocate more time specifically in blocks for scoped storage. Really close to completion now.

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)