### PR TITLE
Enable  LogConditional lint

### DIFF
--- a/AnkiDroid/src/test/java/com/ichi2/anki/ProductionCrashReportingTreeTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/ProductionCrashReportingTreeTest.java
@@ -34,7 +34,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
 
-@SuppressLint("LogNotTimber")
+@SuppressLint( {"LogNotTimber", "LogConditional"})
 public class ProductionCrashReportingTreeTest {
 
 

--- a/lint-release.xml
+++ b/lint-release.xml
@@ -51,6 +51,9 @@
     <issue id="RtlEnabled" severity="fatal" />
     <issue id="RtlHardcoded" severity="fatal" />
 
+    <issue id="LogConditional" severity="fatal" />
+
+
     <!-- this is new with AGP7.1+, does not appear to create value -->
     <issue id="IntentFilterUniqueDataAttributes" severity="ignore" />
 
@@ -221,7 +224,6 @@
     <issue id="InvalidResourceFolder" severity="ignore" />
     <issue id="WrongRegion" severity="ignore" />
     <issue id="UseAlpha2" severity="ignore" />
-    <issue id="LogConditional" severity="ignore" />
     <issue id="LongLogTag" severity="ignore" />
     <issue id="LogTagMismatch" severity="ignore" />
     <issue id="AllowBackup" severity="ignore" />


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
Enable  LogConditional lint

## Fixes
Fixes #10478

## Approach
1.Changed the severity value of the `LogConditional` lint from ignore to fatal
2.Fixed the following problems appearing on running gradlew lint
3.Fixed the problems by adding `@SuppressLint("LogConditional")` on top
<img width="919" alt="Screenshot 2022-03-12 085519" src="https://user-images.githubusercontent.com/65972015/158002489-7ae0973e-833a-42b2-ad3a-2cececee9db3.png">

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [x] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
