### PR TITLE
Enabled lint check "ObsoleteLayoutParam"

### DIFF
--- a/AnkiDroid/src/main/res/layout/activity_drawing.xml
+++ b/AnkiDroid/src/main/res/layout/activity_drawing.xml
@@ -9,16 +9,20 @@
 
     <include layout="@layout/toolbar"
         android:id="@id/toolbar"
+        android:layout_alignParentTop="true"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         />
     <include
         layout="@layout/reviewer_whiteboard_editor"
         android:layout_width="wrap_content"
-        android:layout_height="wrap_content" />
+        android:layout_height="wrap_content"
+        android:layout_centerHorizontal="true"
+        android:layout_above="@+id/bottom_area_layout"/>
     <FrameLayout
         android:layout_gravity="center"
         android:id="@+id/whiteboard"
+        android:layout_below="@id/whiteboard_editor"
         android:layout_margin="0dip"
         android:layout_width="fill_parent"
         android:layout_height="fill_parent" />

--- a/AnkiDroid/src/main/res/layout/activity_drawing.xml
+++ b/AnkiDroid/src/main/res/layout/activity_drawing.xml
@@ -9,20 +9,16 @@
 
     <include layout="@layout/toolbar"
         android:id="@id/toolbar"
-        android:layout_alignParentTop="true"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         />
     <include
         layout="@layout/reviewer_whiteboard_editor"
         android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_centerHorizontal="true"
-        android:layout_above="@+id/bottom_area_layout"/>
+        android:layout_height="wrap_content" />
     <FrameLayout
         android:layout_gravity="center"
         android:id="@+id/whiteboard"
-        android:layout_below="@id/whiteboard_editor"
         android:layout_margin="0dip"
         android:layout_width="fill_parent"
         android:layout_height="fill_parent" />

--- a/lint-release.xml
+++ b/lint-release.xml
@@ -45,6 +45,7 @@
     <issue id="WrongConstant" severity="fatal" />
     <issue id="WrongViewCast" severity="fatal" />
     <issue id="UnknownId" severity="fatal" />
+    <issue id="ObsoleteLayoutParam" severity="fatal" />
 
     <!--           RTL Rules               -->
     <issue id="RtlCompat" severity="fatal" />
@@ -263,7 +264,6 @@
     <issue id="UnlocalizedSms" severity="ignore" />
     <issue id="ObjectAnimatorBinding" severity="ignore" />
     <issue id="AnimatorKeep" severity="ignore" />
-    <issue id="ObsoleteLayoutParam" severity="ignore" />
     <issue id="OnClick" severity="ignore" />
     <issue id="Overdraw" severity="ignore" />
     <issue id="DalvikOverride" severity="ignore" />


### PR DESCRIPTION
## Purpose / Description
Enabled lint check for "ObsoleteLayouParam", changed "ignore" to "fatal" and took the line above.

## Fixes
Fixes  #10482 

## How Has This Been Tested?

Ran ./gradlew lint and resolved errros in activity_drawing.xml

