### PR TITLE
Enable ObsoleteSdkInt lint

### DIFF
--- a/lint-release.xml
+++ b/lint-release.xml
@@ -51,6 +51,7 @@
     <issue id="RtlEnabled" severity="fatal" />
     <issue id="RtlHardcoded" severity="fatal" />
 
+    <issue id="ObsoleteSdkInt" severity="fatal" />
     <!-- this is new with AGP7.1+, does not appear to create value -->
     <issue id="IntentFilterUniqueDataAttributes" severity="ignore" />
 


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
Enable ObsoleteSdkInt lint

## Fixes
Fixes #10501
## Approach
1.Changed the severity value of the  ObsoleteSdkInt lint from ignore to fatal
2.And run gradlew lint and their are no issue with this lint



## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [x] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
