### PR TITLE
NF: rename folder to directory

### DIFF
--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/libanki/ImportTest.java
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/libanki/ImportTest.java
@@ -101,7 +101,7 @@ public class ImportTest extends InstrumentedTest {
         n.setField(0, "[sound:foo.mp3]");
         long mid = n.model().getLong("id");
         mTestCol.addNote(n);
-        // add that sound to the media folder
+        // add that sound to the media directory
         FileOutputStream os = new FileOutputStream(new File(mTestCol.getMedia().dir(), "foo.mp3"), false);
         os.write("foo".getBytes());
         os.close();

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -2719,7 +2719,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
                     return true;
                 /*
                  *  Call displayCardAnswer() and answerCard() from anki deck template using javascript
-                 *  See card.js in assets/scripts folder
+                 *  See card.js in assets/scripts directory
                  */
                 case WebViewSignalParserUtils.SHOW_ANSWER:
                     // display answer when showAnswer() called from card.js

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.java
@@ -162,7 +162,7 @@ import static timber.log.Timber.DebugTree;
 )
 public class AnkiDroidApp extends Application {
 
-    /** Running under instrumentation. a "/androidTest" folder will be created which contains a test collection */
+    /** Running under instrumentation. a "/androidTest" directory will be created which contains a test collection */
     public static boolean INSTRUMENTATION_TESTING = false;
 
     /**

--- a/AnkiDroid/src/main/java/com/ichi2/anki/BackupManager.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/BackupManager.kt
@@ -284,11 +284,11 @@ open class BackupManager {
                     Timber.e("repairCollection - dump to %s.tmp failed", deckPath)
                     return false
                 }
-                if (!moveDatabaseToBrokenFolder(deckPath, false, time)) {
-                    Timber.e("repairCollection - could not move corrupt file to broken folder")
+                if (!moveDatabaseToBrokenDirectory(deckPath, false, time)) {
+                    Timber.e("repairCollection - could not move corrupt file to broken directory")
                     return false
                 }
-                Timber.i("repairCollection - moved corrupt file to broken folder")
+                Timber.i("repairCollection - moved corrupt file to broken directory")
                 val repairedFile = File("$deckPath.tmp")
                 return repairedFile.renameTo(deckFile)
             } catch (e: IOException) {
@@ -299,7 +299,7 @@ open class BackupManager {
             return false
         }
 
-        fun moveDatabaseToBrokenFolder(colPath: String, moveConnectedFilesToo: Boolean, time: Time): Boolean {
+        fun moveDatabaseToBrokenDirectory(colPath: String, moveConnectedFilesToo: Boolean, time: Time): Boolean {
             val colFile = File(colPath)
 
             // move file

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CollectionHelper.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CollectionHelper.java
@@ -56,9 +56,9 @@ public class CollectionHelper {
     public static final String COLLECTION_FILENAME = "collection.anki2";
 
     /**
-     * The preference key for the path to the current AnkiDroid folder
+     * The preference key for the path to the current AnkiDroid directory
      * <br>
-     * This folder contains all AnkiDroid data and media for a given collection
+     * This directory contains all AnkiDroid data and media for a given collection
      * Except the Android preferences, cached files and {@link MetaDB}
      * <br>
      * This can be changed by the {@link Preferences} screen
@@ -288,15 +288,15 @@ public class CollectionHelper {
 
     /**
      * Get the absolute path to a directory that is suitable to be the default starting location
-     * for the AnkiDroid folder.
+     * for the AnkiDroid directory.
      * <p>
-     * Currently, this is a folder named "AnkiDroid" at the top level of the non-app-specific external storage directory.
+     * Currently, this is a directory named "AnkiDroid" at the top level of the non-app-specific external storage directory.
      * <p><br>
      * When targeting API > 29, AnkiDroid will have to use Scoped Storage on any device of any API level.
      * Scoped Storage only allows access to App-Specific directories (without permissions).
      * Hence, AnkiDroid won't be able to access the directory used currently on all devices,
      * regardless of their API level, once AnkiDroid targets API > 29.
-     * Instead, AnkiDroid will have to use an App-Specific directory to store the AnkiDroid folder.
+     * Instead, AnkiDroid will have to use an App-Specific directory to store the AnkiDroid directory.
      * This applies to the entire AnkiDroid userbase.
      * <p><br>
      * Currently, if <code>TESTING_SCOPED_STORAGE</code> is set to <code>true</code>, AnkiDroid uses its External
@@ -340,7 +340,7 @@ public class CollectionHelper {
      * very different things as explained above.
      * <p><br>
      *
-     * @return Absolute Path to the default location starting location for the AnkiDroid folder
+     * @return Absolute Path to the default location starting location for the AnkiDroid directory
      */
     @SuppressWarnings("deprecation") // TODO Tracked in https://github.com/ankidroid/Anki-Android/issues/5304
     @CheckResult
@@ -414,7 +414,7 @@ public class CollectionHelper {
     public static String getCurrentAnkiDroidDirectory(Context context) {
         SharedPreferences preferences = AnkiDroidApp.getSharedPrefs(context);
         if (AnkiDroidApp.INSTRUMENTATION_TESTING) {
-            // create an "androidTest" folder inside the current collection folder which contains the test data
+            // create an "androidTest" directory inside the current collection directory which contains the test data
             // "/AnkiDroid/androidTest" would be a new collection path
             return new File(getDefaultAnkiDroidDirectory(context), "androidTest").getAbsolutePath();
         }
@@ -427,7 +427,7 @@ public class CollectionHelper {
     /**
      * Get parent directory given the {@link Collection} path.
      * @param path path to AnkiDroid collection
-     * @return path to AnkiDroid folder
+     * @return path to AnkiDroid directory
      */
     private static String getParentDirectory(String path) {
         return new File(path).getParentFile().getAbsolutePath();

--- a/AnkiDroid/src/main/java/com/ichi2/anki/MediaRegistration.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/MediaRegistration.kt
@@ -43,7 +43,7 @@ class MediaRegistration(private val context: Context) {
     private val mPastedImageCache = HashMap<String, String?>()
 
     /**
-     * Loads an image into the collection.media folder and returns a HTML reference
+     * Loads an image into the collection.media directory and returns a HTML reference
      * @param uri The uri of the image to load
      * @return HTML referring to the loaded image
      */

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.kt
@@ -840,7 +840,7 @@ class Preferences : AnkiActivity() {
                         val currentAnkiDroidDirectory = CollectionHelper.getCurrentAnkiDroidDirectory(requireContext())
                         val imageName = "DeckPickerBackground.png"
                         val destFile = File(currentAnkiDroidDirectory, imageName)
-                        // Image size less than 10 MB copied to AnkiDroid folder
+                        // Image size less than 10 MB copied to AnkiDroid directory
                         if (fileLength < 10) {
                             (requireContext().contentResolver.openInputStream(selectedImage) as FileInputStream?)!!.channel.use { sourceChannel ->
                                 FileOutputStream(destFile).channel.use { destChannel ->

--- a/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/SoundPlayer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/SoundPlayer.kt
@@ -31,7 +31,7 @@ import com.ichi2.libanki.TTSTag
  *
  * https://docs.ankiweb.net/templates/fields.html?highlight=tts#text-to-speech
  * No manual reference for [sound:], but this handles Sound or Video with a reference to the file
- * in the media folder.
+ * in the media directory.
  *
  * AnkiDroid also introduced a "tts" setting, which existed before Anki Desktop TTS.
  * This only allowed TTS if a setting was enabled,

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DatabaseErrorDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DatabaseErrorDialog.kt
@@ -259,7 +259,7 @@ class DatabaseErrorDialog : AsyncDialogFragment() {
                         val time = ch.getTimeSafe(context)
                         ch.closeCollection(false, "DatabaseErrorDialog: Before Create New Collection")
                         val path1 = CollectionHelper.getCollectionPath(activity)
-                        if (BackupManager.moveDatabaseToBrokenFolder(path1, false, time)) {
+                        if (BackupManager.moveDatabaseToBrokenDirectory(path1, false, time)) {
                             (activity as DeckPicker?)!!.restartActivity()
                         } else {
                             (activity as DeckPicker?)!!.showDatabaseErrorDialog(DIALOG_LOAD_FAILED)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/ScopedStorageService.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/ScopedStorageService.kt
@@ -22,7 +22,7 @@ import com.ichi2.anki.AnkiDroidApp
 import com.ichi2.anki.servicelayer.scopedstorage.MigrateUserData
 import java.io.File
 
-/** A path to the AnkiDroid folder, named "AnkiDroid" by default */
+/** A path to the AnkiDroid directory, named "AnkiDroid" by default */
 typealias AnkiDroidDirectory = String
 
 object ScopedStorageService {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/scopedstorage/MigrateUserData.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/scopedstorage/MigrateUserData.kt
@@ -32,7 +32,7 @@ typealias NumberOfBytes = Long
  * This needs to be performed in the background to allow users to use AnkiDroid
  *
  * If this were performed in the foreground, users would be encouraged to uninstall the app
- * which means the app permanently loses access to the AnkiDroid folder.
+ * which means the app permanently loses access to the AnkiDroid directory.
  *
  * This also handles preemption, allowing media files to skip the queue
  * (if they're required for review)
@@ -87,7 +87,7 @@ class MigrateUserData private constructor(val source: Directory, val destination
     class FileConflictException(val source: DiskFile, val destination: DiskFile) : RuntimeException("File $source can not be copied to $destination, destination exists and differs.")
 
     /**
-     * If [destination] is a folder. In this case, move `source/filename` to `source/conflict/filename`.
+     * If [destination] is a directory. In this case, move `source/filename` to `source/conflict/filename`.
      */
     class FileDirectoryConflictException(val source: DiskFile, val destination: Directory) : RuntimeException("File $source can not be copied to $destination, as destination is a directory.")
 
@@ -229,10 +229,10 @@ class MigrateUserData private constructor(val source: Directory, val destination
          * Starts to execute the current operation. Only do as little non-trivial work as possible to start the operation, such as listing a directory content or moving a single file.
          * Returns the list of operations remaining to end this operation.
          *
-         * E.g. for "move a folder", this method would simply compute the folder content and then retuns the following list of operations:
-         * * creating the destination folder
-         * * moving each file and subfolder individually
-         * * deleting the original folder.
+         * E.g. for "move a directory", this method would simply compute the directory content and then retuns the following list of operations:
+         * * creating the destination directory
+         * * moving each file and subdirectory individually
+         * * deleting the original directory.
          */
         abstract fun execute(context: MigrationContext): List<Operation>
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/scopedstorage/MoveDirectory.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/scopedstorage/MoveDirectory.kt
@@ -60,7 +60,7 @@ data class MoveDirectory(val source: Directory, val destination: File) : Migrate
      * Return whether it was successful.
      */
     internal fun createDirectory(context: MigrateUserData.MigrationContext): Boolean {
-        Timber.d("creating folder '$destination'")
+        Timber.d("creating directory '$destination'")
         if (!createDirectory(destination)) {
             context.reportError(this, IllegalStateException("Could not create '$destination'"))
             return false

--- a/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/scopedstorage/MoveDirectoryContent.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/scopedstorage/MoveDirectoryContent.kt
@@ -26,7 +26,7 @@ import java.io.IOException
 /**
  * This operation moves content of source to destination. This Operation is called one time for each file in the directory, and one last time. Unless an exception occurs. Use the [createInstance] to instantiate the object.  It will convert the given Directory source to a FileStream. This conversion is a potentially long-running operation.
  * @param [source]: an iterator over File content, [source] will be closed in [execute] once the source is empty or if accessing its content raise an exception.
- * @param [destination]: a folder to copy the source content.
+ * @param [destination]: a directory to copy the source content.
  * This is different than [MoveFile], [MoveDirectory] and [MoveFileOrDirectory] where destination is the new path of the copied element.
  * Because in this case, there is not a single destination path.
  */

--- a/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/scopedstorage/MoveFile.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/scopedstorage/MoveFile.kt
@@ -50,7 +50,7 @@ internal data class MoveFile(val sourceFile: DiskFile, val destinationFile: File
         }
 
         // destination exists, and does NOT match content: throw an exception
-        // this is intended to be handled by moving the file to a "conflict" folder
+        // this is intended to be handled by moving the file to a "conflict" directory
         if (destinationExists) {
             // if the source file doesn't exist, but the destination does, we assume that the move
             // took place outside this "MoveFile" instance - possibly preempted by the

--- a/AnkiDroid/src/main/java/com/ichi2/compat/Compat.java
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/Compat.java
@@ -251,7 +251,7 @@ public interface Compat {
     PendingIntent getImmutableBroadcastIntent(Context context, int requestCode, Intent intent, @PendingIntentFlags int flags);
 
     /**
-     * Writes an image represented by bitmap to the Pictures/AnkiDroid folder under the primary
+     * Writes an image represented by bitmap to the Pictures/AnkiDroid directory under the primary
      * external storage directory. Requires the WRITE_EXTERNAL_STORAGE permission to be obtained on devices running
      * API <= 28. If this condition isn't satisfied, this method will throw a {@link FileNotFoundException}.
      *
@@ -270,7 +270,7 @@ public interface Compat {
     /**
      *
      * @param directory A directory.
-     * @return a FileStream over file and folder of this directory.
+     * @return a FileStream over file and directory of this directory.
      *         null in case of trouble. This stream must be closed explicitly when done with it.
      * @throws NotDirectoryException if the file exists and is not a directory (starting at API 26)
      * @throws FileNotFoundException if the file do not exists

--- a/AnkiDroid/src/main/java/com/ichi2/compat/CompatV21.java
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/CompatV21.java
@@ -256,18 +256,18 @@ public class CompatV21 implements Compat {
     @SuppressWarnings({"deprecation", "RedundantSuppression"})
     public Uri saveImage(Context context, Bitmap bitmap, String baseFileName, String extension, Bitmap.CompressFormat format, int quality) throws FileNotFoundException {
         File pictures = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_PICTURES);
-        File ankiDroidFolder = new File(pictures, "AnkiDroid");
-        if (!ankiDroidFolder.exists()) {
+        File ankiDroidDirectory = new File(pictures, "AnkiDroid");
+        if (!ankiDroidDirectory.exists()) {
             //noinspection ResultOfMethodCallIgnored
-            ankiDroidFolder.mkdirs();
+            ankiDroidDirectory.mkdirs();
         }
-        File imageFile = new File(ankiDroidFolder, baseFileName + "." + extension);
+        File imageFile = new File(ankiDroidDirectory, baseFileName + "." + extension);
         bitmap.compress(format, quality, new FileOutputStream(imageFile));
         return Uri.fromFile(imageFile);
     }
 
     /* This method actually read the full content of the directory.
-    * It is linear in time and space in the number of file and folder in the directory.
+    * It is linear in time and space in the number of file and directory in the directory.
     * However, hasNext and next should be constant in time and space. */
     @Override
     public @NonNull FileStream contentOfDirectory(@NonNull File directory) throws IOException {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Media.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Media.java
@@ -452,7 +452,7 @@ public class Media {
                 allRefs.addAll(noteRefs);
             }
         }
-        // loop through media folder
+        // loop through media directory
         List<String> unused = new ArrayList<>();
         List<String> invalid = new ArrayList<>();
         File[] files;
@@ -615,7 +615,7 @@ public class Media {
      */
 
     /**
-     * Scan the media folder if it's changed, and note any changes.
+     * Scan the media directory if it's changed, and note any changes.
      */
     public void findChanges() {
         findChanges(false);
@@ -623,7 +623,7 @@ public class Media {
 
 
     /**
-     * @param force Unconditionally scan the media folder for changes (i.e., ignore differences in recorded and current
+     * @param force Unconditionally scan the media directory for changes (i.e., ignore differences in recorded and current
      *            directory mod times). Use this when rebuilding the media database.
      */
     public void findChanges(boolean force) {
@@ -709,7 +709,7 @@ public class Media {
         List<String> removed = new ArrayList<>();
         // loop through on-disk files
         for (File f : new File(dir()).listFiles()) {
-            // ignore folders and thumbs.db
+            // ignore directories and thumbs.db
             if (f.isDirectory()) {
                 continue;
             }
@@ -848,7 +848,7 @@ public class Media {
      * - This method will be repeatedly called from MediaSyncer until there are no more files (marked "dirty" in the DB)
      * to send.
      * <p>
-     * - Since AnkiDroid avoids scanning the media folder on every sync, it is possible for a file to be marked as a
+     * - Since AnkiDroid avoids scanning the media directory on every sync, it is possible for a file to be marked as a
      * new addition but actually have been deleted (e.g., with a file manager). In this case we skip over the file
      * and mark it as removed in the database. (This behaviour differs from the desktop client).
      * <p>

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Utils.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Utils.java
@@ -700,7 +700,7 @@ public class Utils {
     /**
      * @param zipFile A zip file
      * @param targetDirectory Directory in which to unzip some of the zipped field
-     * @param zipEntries files of the zip folder to unzip
+     * @param zipEntries files of the zip directory to unzip
      * @param zipEntryToFilenameMap Renaming rules from name in zip file to name in the device
      * @throws IOException if the directory can't be created
      */

--- a/AnkiDroid/src/test/java/com/ichi2/anki/BackupManagerSimpleTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/BackupManagerSimpleTest.kt
@@ -40,7 +40,7 @@ import kotlin.test.junit.JUnitAsserter.assertTrue
  */
 class BackupManagerSimpleTest {
     @get:Rule
-    var tempFolder = TemporaryFolder()
+    var tempDirectory = TemporaryFolder()
 
     @Test
     fun getBackupTimeStringTest() {
@@ -111,9 +111,9 @@ class BackupManagerSimpleTest {
     fun getBackupsTest() {
         // getBackups() doesn't require a proper collection file
         // because it is only used to get its parent
-        val colFile = tempFolder.newFile()
+        val colFile = tempDirectory.newFile()
         assertEquals(0, BackupManager.getBackups(colFile).size)
-        val backupDir = BackupManager.getBackupDirectory(tempFolder.root)
+        val backupDir = BackupManager.getBackupDirectory(tempDirectory.root)
         val f1 = File(backupDir, "collection-2000-12-31-23-04.colpkg")
         val f2 = File(backupDir, "foo")
         val f3 = File(backupDir, "collection-2010-12-06-13-04.colpkg")
@@ -131,8 +131,8 @@ class BackupManagerSimpleTest {
 
     @Test
     fun deleteDeckBackupsTest() {
-        val colFile = tempFolder.newFile()
-        val backupDir = BackupManager.getBackupDirectory(tempFolder.root)
+        val colFile = tempDirectory.newFile()
+        val backupDir = BackupManager.getBackupDirectory(tempDirectory.root)
 
         val f1 = File(backupDir, "collection-2000-12-31-23-04.colpkg")
         val f2 = File(backupDir, "collection-1990-08-31-45-04.colpkg")
@@ -152,22 +152,22 @@ class BackupManagerSimpleTest {
 
     @Test
     fun latest_backup_returns_null_on_no_backups() {
-        val colFile = tempFolder.newFile()
+        val colFile = tempDirectory.newFile()
         assertThat(getLatestBackup(colFile), nullValue())
     }
 
     @Test
     fun latest_backup_returns_null_on_invalid() {
-        val colFile = tempFolder.newFile()
-        val backupDir = BackupManager.getBackupDirectory(tempFolder.root)
+        val colFile = tempDirectory.newFile()
+        val backupDir = BackupManager.getBackupDirectory(tempDirectory.root)
         File(backupDir, "blah.colpkg").createNewFile()
         assertThat(getLatestBackup(colFile), nullValue())
     }
 
     @Test
     fun latest_backup_returns_latest() {
-        val colFile = tempFolder.newFile()
-        val backupDir = BackupManager.getBackupDirectory(tempFolder.root)
+        val colFile = tempDirectory.newFile()
+        val backupDir = BackupManager.getBackupDirectory(tempDirectory.root)
         File(backupDir, "collection-1990-08-31-45-04.colpkg").createNewFile()
         File(backupDir, "collection-2010-12-06-13-04.colpkg").createNewFile()
         File(backupDir, "blah.colpkg").createNewFile()

--- a/AnkiDroid/src/test/java/com/ichi2/anki/multimediacard/AudioPlayerTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/multimediacard/AudioPlayerTest.java
@@ -45,12 +45,12 @@ public class AudioPlayerTest extends RobolectricTest {
     private File mFile;
 
     @Rule
-    public TemporaryFolder tempFolder = new TemporaryFolder();
+    public TemporaryFolder tempDirectory = new TemporaryFolder();
 
     @Before
     public void before() throws IOException {
         mAudioPlayer = new AudioPlayer();
-        mFile = tempFolder.newFile("testaudio.wav");
+        mFile = tempDirectory.newFile("testaudio.wav");
 
         ShadowMediaPlayer testPlayer = new ShadowMediaPlayer();
         DataSource fileSource = DataSource.toDataSource(mFile.getAbsolutePath());

--- a/AnkiDroid/src/test/java/com/ichi2/anki/multimediacard/fields/ImageFieldTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/multimediacard/fields/ImageFieldTest.java
@@ -94,7 +94,7 @@ public class ImageFieldTest {
     @Test
     public void testNoImagePathIsNothing() {
         String knownBadImage = "<br />";
-        Collection col = collectionWithMediaFolder("media");
+        Collection col = collectionWithMediaDirectory("media");
 
         String imageSrc = ImageField.getImageFullPath(col, knownBadImage);
 
@@ -104,7 +104,7 @@ public class ImageFieldTest {
     @Test
     public void testNoImagePathConcat() {
         String goodImage = "<img src='1.png'/>";
-        Collection col = collectionWithMediaFolder("media");
+        Collection col = collectionWithMediaDirectory("media");
 
         String imageSrc = ImageField.getImageFullPath(col, goodImage);
 
@@ -112,7 +112,7 @@ public class ImageFieldTest {
     }
 
     @CheckResult
-    protected Collection collectionWithMediaFolder(String dir) {
+    protected Collection collectionWithMediaDirectory(String dir) {
         Media media = mock(Media.class);
         when(media.dir()).thenReturn(dir);
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/MoveDirectoryContentTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/MoveDirectoryContentTest.kt
@@ -135,7 +135,7 @@ class MoveDirectoryContentTest(
     }
 
     /**
-     * Test moving a directory with two files. [toDoBetweenTwoFilesMove] is executed before moving the second file and return a new file/directory it generated in source directly (not in a subfolder).
+     * Test moving a directory with two files. [toDoBetweenTwoFilesMove] is executed before moving the second file and return a new file/directory it generated in source directly (not in a subdirectory).
      * This new file/directory must be present in source or destination.
      *
      */

--- a/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/MoveDirectoryTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/MoveDirectoryTest.kt
@@ -200,7 +200,7 @@ class MoveDirectoryTest(
     }
 
     /**
-     * Test moving a directory with two files. [toDoBetweenTwoFilesMove] is executed before moving the second file and return a new file/directory it generated in source directly (not in a subfolder).
+     * Test moving a directory with two files. [toDoBetweenTwoFilesMove] is executed before moving the second file and return a new file/directory it generated in source directly (not in a subdirectory).
      * This new file/directory must be present in source or destination.
      *
      * @return The [MoveDirectory] which was executed

--- a/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/MoveFileTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/MoveFileTest.kt
@@ -52,7 +52,7 @@ class MoveFileTest(private val attemptRename: Boolean) : RobolectricTest(), Oper
     @Test
     fun move_file_is_success() {
         val source = addUntrackedMediaFile("hello-world", listOf("hello.txt"))
-        val destinationFile = File(ankiDroidFolder(), "hello.txt")
+        val destinationFile = File(ankiDroidDirectory(), "hello.txt")
         val size = source.length()
 
         MoveFile(source, destinationFile)
@@ -69,7 +69,7 @@ class MoveFileTest(private val attemptRename: Boolean) : RobolectricTest(), Oper
     fun move_file_twice_throws_no_exception() {
         // For example: if an operation was preempted by a file transfer for the Reviewer
         val source = addUntrackedMediaFile("hello-world", listOf("hello.txt"))
-        val destinationFile = File(ankiDroidFolder(), "hello.txt")
+        val destinationFile = File(ankiDroidDirectory(), "hello.txt")
         val size = source.length()
 
         MoveFile(source, destinationFile).execute()
@@ -87,7 +87,7 @@ class MoveFileTest(private val attemptRename: Boolean) : RobolectricTest(), Oper
         if (attemptRename) return // not relevant
         // if the move doesn't work, do not delete the source file
         val source = addUntrackedMediaFile("hello-world", listOf("hello.txt"))
-        val destinationFile = File(ankiDroidFolder(), "hello.txt")
+        val destinationFile = File(ankiDroidDirectory(), "hello.txt")
 
         executionContext.logExceptions = true
         spy(MoveFile(source, destinationFile)) {
@@ -107,7 +107,7 @@ class MoveFileTest(private val attemptRename: Boolean) : RobolectricTest(), Oper
         if (attemptRename) return // not relevant
         // if the move doesn't work, do not delete the source file
         val source = addUntrackedMediaFile("hello-world", listOf("hello.txt"))
-        val destinationFile = File(ankiDroidFolder(), "hello.txt")
+        val destinationFile = File(ankiDroidDirectory(), "hello.txt")
 
         // this is correct - exception is not in a logged context
         executionContext.logExceptions = true
@@ -127,7 +127,7 @@ class MoveFileTest(private val attemptRename: Boolean) : RobolectricTest(), Oper
     fun no_op_if_both_files_deleted_but_directory_exists() {
         // if the move doesn't work, do not delete the source file
         val source = addUntrackedMediaFile("hello-world", listOf("hello.txt"))
-        val destinationFile = File(ankiDroidFolder(), "hello.txt")
+        val destinationFile = File(ankiDroidDirectory(), "hello.txt")
         // we make a `DiskFile` which doesn't exist - class is in a bad state
         source.file.delete()
         assertThat("destination should not exist", destinationFile.exists(), equalTo(false))
@@ -144,7 +144,7 @@ class MoveFileTest(private val attemptRename: Boolean) : RobolectricTest(), Oper
     fun source_is_deleted_if_both_files_are_the_same() {
         // This can happen if a power off occurs between copying the file, and cleaning up the source
         val source = addUntrackedMediaFile("hello-world", listOf("hello.txt"))
-        val destinationFile = File(ankiDroidFolder(), "hello.txt")
+        val destinationFile = File(ankiDroidDirectory(), "hello.txt")
         source.file.copyTo(destinationFile, overwrite = false)
 
         val size = source.length()
@@ -163,7 +163,7 @@ class MoveFileTest(private val attemptRename: Boolean) : RobolectricTest(), Oper
     @Test
     fun if_both_files_same_and_delete_throws_exception() {
         val source = addUntrackedMediaFile("hello-world", listOf("hello.txt"))
-        val destinationFile = File(ankiDroidFolder(), "hello.txt")
+        val destinationFile = File(ankiDroidDirectory(), "hello.txt")
         source.file.copyTo(destinationFile, overwrite = false)
 
         executionContext.logExceptions = true
@@ -217,8 +217,8 @@ class MoveFileTest(private val attemptRename: Boolean) : RobolectricTest(), Oper
     fun error_if_both_files_do_not_exist_but_no_directory() {
         val sourceDirectoryToDelete = createTransientDirectory("toDelete")
         val destinationDirectoryToDelete = createTransientDirectory("toDelete")
-        val sourceNotExist = DiskFile.createInstanceUnsafe(File(sourceDirectoryToDelete, "deletedFolder-in.txt"))
-        val destinationFileNotExist = File(destinationDirectoryToDelete, "deletedFolder-out.txt")
+        val sourceNotExist = DiskFile.createInstanceUnsafe(File(sourceDirectoryToDelete, "deletedDirectory-in.txt"))
+        val destinationFileNotExist = File(destinationDirectoryToDelete, "deletedDirectory-out.txt")
         assertThat(
             "deletion should work",
             sourceDirectoryToDelete.delete() && destinationDirectoryToDelete.delete(),
@@ -240,7 +240,7 @@ class MoveFileTest(private val attemptRename: Boolean) : RobolectricTest(), Oper
         if (attemptRename) return // not relevant
         // if a crash/"delete" fails, we want to ensure the duplicate file is cleaned up
         val source = addUntrackedMediaFile("hello-world", listOf("hello.txt"))
-        val destinationFile = File(ankiDroidFolder(), "hello.txt")
+        val destinationFile = File(ankiDroidDirectory(), "hello.txt")
         val size = source.length()
 
         executionContext.logExceptions = true

--- a/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/Utils.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/Utils.kt
@@ -42,7 +42,7 @@ private fun convertPathToMediaFile(media: Media, path: List<String>): File {
 }
 
 /** A [File] reference to the AnkiDroid directory of the current collection */
-internal fun RobolectricTest.ankiDroidFolder() = File(col.path).parentFile!!
+internal fun RobolectricTest.ankiDroidDirectory() = File(col.path).parentFile!!
 
 /** Adds a file to collection.media which [Media] is not aware of */
 @CheckResult

--- a/AnkiDroid/src/test/java/com/ichi2/anki/services/NoteServiceTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/services/NoteServiceTest.java
@@ -52,11 +52,11 @@ public class NoteServiceTest extends RobolectricTest {
         mTestCol = getCol();
     }
 
-    //temporary folder to test importMediaToDirectory function
+    //temporary directory to test importMediaToDirectory function
     @Rule
-    public TemporaryFolder folder = new TemporaryFolder();
+    public TemporaryFolder directory = new TemporaryFolder();
     @Rule
-    public TemporaryFolder folder2 = new TemporaryFolder();
+    public TemporaryFolder directory2 = new TemporaryFolder();
 
     //tests if the text fields of the notes are the same after calling updateJsonNoteFromMultimediaNote
     @Test
@@ -95,7 +95,7 @@ public class NoteServiceTest extends RobolectricTest {
     @Test
     public void importAudioClipToDirectoryTest() throws IOException {
 
-        File fileAudio = folder.newFile("testaudio.wav");
+        File fileAudio = directory.newFile("testaudio.wav");
 
         // writes a line in the file so the file's length isn't 0
         try (FileWriter fileWriter = new FileWriter(fileAudio)) {
@@ -117,7 +117,7 @@ public class NoteServiceTest extends RobolectricTest {
     @Test
     public void importImageToDirectoryTest() throws IOException {
 
-        File fileImage = folder.newFile("testimage.png");
+        File fileImage = directory.newFile("testimage.png");
 
         // writes a line in the file so the file's length isn't 0
         try (FileWriter fileWriter = new FileWriter(fileImage)) {
@@ -142,12 +142,12 @@ public class NoteServiceTest extends RobolectricTest {
      * * File with same name, but different content, has its name changed
      * * File with same name and content don't have its name changed
      *
-     * @throws IOException if new created files already exist on temp folder
+     * @throws IOException if new created files already exist on temp directory
      */
     @Test
     public void importAudioWithSameNameTest() throws IOException {
-        File f1 = folder.newFile("audio.mp3");
-        File f2 = folder2.newFile("audio.mp3");
+        File f1 = directory.newFile("audio.mp3");
+        File f2 = directory2.newFile("audio.mp3");
 
         // write a line in the file so the file's length isn't 0
         try (FileWriter fileWriter = new FileWriter(f1)) {
@@ -185,8 +185,8 @@ public class NoteServiceTest extends RobolectricTest {
     // Similar test like above, but with an ImageField instead of a MediaClipField
     @Test
     public void importImageWithSameNameTest() throws IOException {
-        File f1 = folder.newFile("img.png");
-        File f2 = folder2.newFile("img.png");
+        File f1 = directory.newFile("img.png");
+        File f2 = directory2.newFile("img.png");
 
         // write a line in the file so the file's length isn't 0
         try (FileWriter fileWriter = new FileWriter(f1)) {

--- a/AnkiDroid/src/test/java/com/ichi2/compat/CompatDeleteFileTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/compat/CompatDeleteFileTest.kt
@@ -51,7 +51,7 @@ class CompatDeleteFileTest(
     }
 
     @Test
-    fun delete_folder_which_exists() {
+    fun delete_directory_which_exists() {
         val dir = createTransientDirectory()
         assertDoesNotThrow { deleteFile(dir) }
         assertThat("directory should no longer exist", dir.exists(), equalTo(false))

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/ExportingTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/ExportingTest.java
@@ -98,7 +98,7 @@ public class ExportingTest extends RobolectricTest {
 
        @Test
        public void test_export_ankipkg(){
-       // add a test file to the media folder
+       // add a test file to the media directory
        with open(os.path.join(col.getMedia().dir(), "今日.mp3"), "w") as note:
        note.write("test");
        Note n = col.newNote();

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/ImportingTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/ImportingTest.java
@@ -52,7 +52,7 @@ public class ImportingTest extends RobolectricTest {
       n.setItem("Front", "[sound:foo.mp3]");
       mid = n.model().getLong("id");
       col.addNote(n);
-      // add that sound to media folder
+      // add that sound to media directory
       with open(os.path.join(col.getMedia().dir(), "foo.mp3"), "w") as note:
       note.write("foo");
       col.close();

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/MediaTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/MediaTest.java
@@ -31,7 +31,7 @@ public class MediaTest extends RobolectricTest {
     /*****************
      ** Media        *
      *****************/
-    // copying files to media folder
+    // copying files to media directory
 
     /* TODO: media
        @Test

--- a/AnkiDroid/src/test/java/com/ichi2/testutils/FileSystemUtils.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/testutils/FileSystemUtils.kt
@@ -41,7 +41,7 @@ object FileSystemUtils {
      * |  +--backup/
      * |  |  +--collection-2020-08-07-08-00.colpkg
      * |  +--collection.media/
-     * |  |  +--folder/
+     * |  |  +--directory/
      * |  |  |  +--test.txt
      * |  |  +--test.txt
      * ```
@@ -52,27 +52,27 @@ object FileSystemUtils {
 
     /** from https://stackoverflow.com/a/13130974/ */
     @CheckResult
-    private fun printDirectoryTree(folder: File): String {
-        require(folder.isDirectory) { "folder is not a Directory" }
+    private fun printDirectoryTree(directory: File): String {
+        require(directory.isDirectory) { "directory is not a Directory" }
         val indent = 0
         val sb = StringBuilder()
-        printDirectoryTree(folder, indent, sb)
+        printDirectoryTree(directory, indent, sb)
         return sb.toString()
     }
 
     /** from https://stackoverflow.com/a/13130974/ */
     private fun printDirectoryTree(
-        folder: File,
+        directory: File,
         indent: Int,
         sb: StringBuilder
     ) {
-        require(folder.isDirectory) { "folder is not a Directory" }
+        require(directory.isDirectory) { "directory is not a Directory" }
         sb.append(getIndentString(indent))
         sb.append("+--")
-        sb.append(folder.name)
+        sb.append(directory.name)
         sb.append("/")
         sb.append("\n")
-        for (file in folder.listFiles() ?: emptyArray()) {
+        for (file in directory.listFiles() ?: emptyArray()) {
             if (file.isDirectory) {
                 printDirectoryTree(file, indent + 1, sb)
             } else {

--- a/AnkiDroid/src/test/java/com/ichi2/utils/FileUtilTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/utils/FileUtilTest.java
@@ -43,8 +43,8 @@ import static org.junit.Assert.assertTrue;
 public class FileUtilTest {
 
     @Rule
-    public TemporaryFolder temporaryFolder = new TemporaryFolder();
-    long mTestFolderSize;
+    public TemporaryFolder temporaryDirectory = new TemporaryFolder();
+    long mTestDirectorySize;
 
     private static class DummyListener implements ProgressSenderAndCancelListener<Integer> {
         @Override
@@ -95,7 +95,7 @@ public class FileUtilTest {
         for (int i = 0; i < files.size(); ++i) {
             final File file = files.get(i);
             writeStringToFile(file, "File " + (i + 1) + " called " + file.getName());
-            mTestFolderSize += file.length();
+            mTestDirectorySize += file.length();
         }
 
         return grandParentDir;
@@ -105,7 +105,7 @@ public class FileUtilTest {
     @Test
     public void testCopyDirectory() throws Exception {
         // Create temporary root directory for holding test directories
-        File temporaryRootDir = temporaryFolder.newFolder("tempRootDir");
+        File temporaryRootDir = temporaryDirectory.newFolder("tempRootDir");
 
         // Test for successful copy directory operation
         File srcDir = createSrcFilesForTest(temporaryRootDir, "srcDir");
@@ -131,7 +131,7 @@ public class FileUtilTest {
     @Test
     public void testMoveDirectory() throws Exception {
         // Create temporary root directory for holding test directories
-        File temporaryRootDir = temporaryFolder.newFolder("tempRootDir");
+        File temporaryRootDir = temporaryDirectory.newFolder("tempRootDir");
 
         // Test for successful move directory operation
         File srcDirToBeMovedSuccessfully = createSrcFilesForTest(temporaryRootDir, "srcDirToBeMovedSuccessfully");
@@ -178,11 +178,11 @@ public class FileUtilTest {
     @Test
     public void testDirectorySize() throws Exception {
         // Create temporary root directory for holding test directories
-        File temporaryRootDir = temporaryFolder.newFolder("tempRootDir");
+        File temporaryRootDir = temporaryDirectory.newFolder("tempRootDir");
 
         // Test for success scenario
         File dir = createSrcFilesForTest(temporaryRootDir, "dir");
-        assertEquals(FileUtil.getDirectorySize(dir), mTestFolderSize);
+        assertEquals(FileUtil.getDirectorySize(dir), mTestDirectorySize);
 
         // Test for failure scenario by passing a file as an argument instead of a directory
         assertThrows(IOException.class, () -> FileUtil.getDirectorySize(new File(dir, "file1.txt")));
@@ -191,7 +191,7 @@ public class FileUtilTest {
     @Test
     public void ensureFileIsDirectoryTest() throws Exception {
         // Create temporary root directory for holding test directories
-        File temporaryRootDir = temporaryFolder.newFolder("tempRootDir");
+        File temporaryRootDir = temporaryDirectory.newFolder("tempRootDir");
 
         // Create test data
         File testDir = createSrcFilesForTest(temporaryRootDir, "testDir");
@@ -214,7 +214,7 @@ public class FileUtilTest {
     @Test
     public void listFilesTest() throws Exception {
         // Create temporary root directory for holding test directories
-        File temporaryRootDir = temporaryFolder.newFolder("tempRootDir");
+        File temporaryRootDir = temporaryDirectory.newFolder("tempRootDir");
 
         // Create valid input
         File testDir = createSrcFilesForTest(temporaryRootDir ,"testDir");

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/rules/DuplicateCrowdInStrings.java
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/DuplicateCrowdInStrings.java
@@ -98,8 +98,8 @@ public class DuplicateCrowdInStrings extends ResourceXmlDetector {
 
 
     @Override
-    public boolean appliesTo(ResourceFolderType folderType) {
-        return folderType == ResourceFolderType.VALUES;
+    public boolean appliesTo(ResourceFolderType directoryType) {
+        return directoryType == ResourceFolderType.VALUES;
     }
 
 

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/rules/DuplicateTextInPreferencesXml.java
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/DuplicateTextInPreferencesXml.java
@@ -64,7 +64,7 @@ public class DuplicateTextInPreferencesXml extends ResourceXmlDetector {
 
 
     @Override
-    public boolean appliesTo(ResourceFolderType folderType) {
-        return folderType == ResourceFolderType.XML;
+    public boolean appliesTo(ResourceFolderType directoryType) {
+        return directoryType == ResourceFolderType.XML;
     }
 }

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/rules/FixedPreferencesTitleLength.java
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/FixedPreferencesTitleLength.java
@@ -127,8 +127,8 @@ public class FixedPreferencesTitleLength extends ResourceXmlDetector implements 
 
 
     @Override
-    public boolean appliesTo(ResourceFolderType folderType) {
-        return (folderType == ResourceFolderType.XML || folderType == ResourceFolderType.VALUES);
+    public boolean appliesTo(ResourceFolderType directoryType) {
+        return (directoryType == ResourceFolderType.XML || directoryType == ResourceFolderType.VALUES);
     }
 
 

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/rules/NonPositionalFormatSubstitutions.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/NonPositionalFormatSubstitutions.kt
@@ -54,12 +54,12 @@ class NonPositionalFormatSubstitutions : ResourceXmlDetector() {
         )
     }
 
-    override fun appliesTo(folderType: ResourceFolderType): Boolean = folderType == ResourceFolderType.VALUES
+    override fun appliesTo(directoryType: ResourceFolderType): Boolean = directoryType == ResourceFolderType.VALUES
 
     override fun getApplicableElements() = listOf(SdkConstants.TAG_STRING)
 
     override fun visitElement(context: XmlContext, element: Element) {
-        // Check both the translated text and the "values" folder.
+        // Check both the translated text and the "values" directory.
 
         val childNodes = element.childNodes
         if (childNodes.length <= 0) return


### PR DESCRIPTION
Simply for the sake of consistency. It will ensure that when searching for a
method, function or variable name, I have a single word to look for

This was done by a simple search and replace in .java and .kt files, preserving
case.

The only exception being org.junit.rules.TemporaryFolder, which obviously was
not renamed