### PR TITLE
NF: remove `createDirectory`

### DIFF
--- a/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/MoveDirectoryContentTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/MoveDirectoryContentTest.kt
@@ -52,7 +52,7 @@ class MoveDirectoryContentTest(
 
     @Test
     fun test_one_operation() {
-        val source = createDirectory()
+        val source = createTransientDirectory()
             .withTempFile("foo.txt")
         val destinationDirectory = createTransientDirectory()
 
@@ -70,7 +70,7 @@ class MoveDirectoryContentTest(
 
     @Test
     fun test_success_integration_test_recursive() {
-        val source = createDirectory().withTempFile("tmp.txt")
+        val source = createTransientDirectory().withTempFile("tmp.txt")
         val moreFiles = source.createTransientDirectory("more files").withTempFile("tmp-2.txt")
         val destinationDirectory = createTransientDirectory()
 
@@ -78,7 +78,7 @@ class MoveDirectoryContentTest(
 
         assertThat("source directory should exist", source.exists(), equalTo(true))
         assertThat("destination directory should exist", destinationDirectory.exists(), equalTo(true))
-        assertThat("tmp.txt should be deleted at source", File(source.directory, "tmp.txt").exists(), equalTo(false))
+        assertThat("tmp.txt should be deleted at source", File(source, "tmp.txt").exists(), equalTo(false))
         assertThat("tmp.txt should be copied", File(destinationDirectory, "tmp.txt").exists(), equalTo(true))
 
         val subdirectory = File(destinationDirectory, "more files")
@@ -90,12 +90,12 @@ class MoveDirectoryContentTest(
 
     @Test
     fun a_move_failure_is_not_fatal() {
-        val source = createDirectory()
+        val source = createTransientDirectory()
             .withTempFile("foo.txt")
             .withTempFile("bar.txt")
             .withTempFile("baz.txt")
 
-        assertThat("foo should exists", File(source.directory, "foo.txt").exists(), equalTo(true))
+        assertThat("foo should exists", File(source, "foo.txt").exists(), equalTo(true))
         val destinationDirectory = createTransientDirectory()
 
         // Use variables as we don't know which file will be returned in the middle from listFiles()
@@ -118,15 +118,15 @@ class MoveDirectoryContentTest(
 
     @Test
     fun adding_file_during_move_is_not_fatal() {
-        adding_during_move_helper() {
-            return@adding_during_move_helper it.directory.addTempFile("new_file.txt", "new file")
+        adding_during_move_helper {
+            return@adding_during_move_helper it.addTempFile("new_file.txt", "new file")
         }
     }
 
     @Test
     fun adding_directory_during_move_is_not_fatal() {
-        adding_during_move_helper() {
-            val new_directory = File(it.directory, "subdirectory")
+        adding_during_move_helper {
+            val new_directory = File(it, "subdirectory")
             assertThat("Subdirectory is created", new_directory.mkdir())
             new_directory.deleteOnExit()
             return@adding_during_move_helper new_directory
@@ -138,8 +138,8 @@ class MoveDirectoryContentTest(
      * This new file/directory must be present in source or destination.
      *
      */
-    fun adding_during_move_helper(toDoBetweenTwoFilesMove: (source: Directory) -> File) {
-        val source = createDirectory()
+    fun adding_during_move_helper(toDoBetweenTwoFilesMove: (source: File) -> File) {
+        val source = createTransientDirectory()
             .withTempFile("foo.txt")
             .withTempFile("bar.txt")
 
@@ -149,7 +149,7 @@ class MoveDirectoryContentTest(
         executionContext.attemptRename = false
         executionContext.logExceptions = true
         var movesProcessed = 0
-        val operation = spy(MoveDirectoryContent.createInstance(source, destinationDirectory)) {
+        val operation = spy(MoveDirectoryContent.createInstance(Directory.createInstance(source)!!, destinationDirectory)) {
             doAnswer { op ->
                 val operation = op.callRealMethod() as Operation
                 if (movesProcessed++ == 1) {
@@ -169,7 +169,7 @@ class MoveDirectoryContentTest(
 
         assertThat(
             "new_file should be present in source or directory",
-            File(source.directory, new_file_name!!).exists() || File(destinationDirectory, new_file_name!!).exists()
+            File(source, new_file_name!!).exists() || File(destinationDirectory, new_file_name!!).exists()
         )
     }
 
@@ -179,20 +179,21 @@ class MoveDirectoryContentTest(
      */
     @Test
     fun empty_directory_is_not_deleted() {
-        val source = createDirectory()
+        val source = createTransientDirectory()
         val destinationDirectory = generateDestinationDirectoryRef()
 
         executeAll(moveDirectoryContent(source, destinationDirectory))
 
-        assertThat("source directory should not be deleted", source.directory.exists(), equalTo(true))
+        assertThat("source directory should not be deleted", source.exists(), equalTo(true))
     }
 
     @Test
     fun factory_on_missing_directory_throw() {
-        val source = createDirectory()
+        val source = createTransientDirectory()
+        val sourceDirectory = Directory.createInstance(source)!!
         val destinationDirectory = generateDestinationDirectoryRef()
-        source.directory.delete()
-        assertThrows<FileNotFoundException> { moveDirectoryContent(source, destinationDirectory) }
+        source.delete()
+        assertThrows<FileNotFoundException> { moveDirectoryContent(sourceDirectory, destinationDirectory) }
     }
 
     @Test
@@ -219,5 +220,9 @@ class MoveDirectoryContentTest(
 
     private fun moveDirectoryContent(source: Directory, destinationDirectory: File): MoveDirectoryContent {
         return MoveDirectoryContent.createInstance(source, destinationDirectory)
+    }
+
+    private fun moveDirectoryContent(source: File, destinationDirectory: File): MoveDirectoryContent {
+        return moveDirectoryContent(Directory.createInstance(source)!!, destinationDirectory)
     }
 }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/MoveDirectoryTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/MoveDirectoryTest.kt
@@ -57,12 +57,12 @@ class MoveDirectoryTest(
 
     @Test
     fun test_success_integration_test_recursive() {
-        val source = createDirectory().withTempFile("tmp.txt")
+        val source = createTransientDirectory().withTempFile("tmp.txt")
         source.createTransientDirectory("more files").withTempFile("tmp-2.txt")
         val destinationFile = generateDestinationDirectoryRef()
         executionContext.attemptRename = false
 
-        executeAll(MoveDirectory(source, destinationFile))
+        executeAll(moveDirectory(source, destinationFile))
 
         assertThat("source directory should not exist", source.exists(), equalTo(false))
         assertThat("destination directory should exist", destinationFile.exists(), equalTo(true))
@@ -75,11 +75,11 @@ class MoveDirectoryTest(
 
     @Test
     fun test_fast_rename() {
-        val source = createDirectory().withTempFile("tmp.txt")
+        val source = createTransientDirectory().withTempFile("tmp.txt")
         val destinationFile = generateDestinationDirectoryRef()
         executionContext.attemptRename = true
 
-        val ret = MoveDirectory(source, destinationFile).execute()
+        val ret = moveDirectory(source, destinationFile).execute()
 
         assertThat("fast rename returns no operations", ret, empty())
         assertThat("source directory should not exist", source.exists(), equalTo(false))
@@ -90,13 +90,13 @@ class MoveDirectoryTest(
     @Test
     fun failed_rename_avoids_further_renames() {
         // This is a performance optimization,
-        val source = createDirectory().withTempFile("tmp.txt")
+        val source = createTransientDirectory().withTempFile("tmp.txt")
         val destinationFile = generateDestinationDirectoryRef()
         var renameCalled = 0
 
         executionContext.logExceptions = true
         // don't actually move the directory, or we'd have a problem
-        val moveDirectory = spy(MoveDirectory(source, destinationFile)) {
+        val moveDirectory = spy(moveDirectory(source, destinationFile)) {
             doAnswer { renameCalled++; return@doAnswer false }.whenever(it).rename(any(), any())
         }
 
@@ -112,12 +112,12 @@ class MoveDirectoryTest(
         assertThat("rename was not called again", renameCalled, equalTo(1))
 
         assertThat(executionContext.exceptions, hasSize(0))
-        assertThat("source was not copied", File(source.directory, "tmp.txt").exists(), equalTo(true))
+        assertThat("source was not copied", File(source, "tmp.txt").exists(), equalTo(true))
     }
 
     @Test
     fun a_move_failure_is_not_fatal() {
-        val source = createDirectory()
+        val source = createTransientDirectory()
             .withTempFile("foo.txt")
             .withTempFile("bar.txt")
             .withTempFile("baz.txt")
@@ -126,7 +126,7 @@ class MoveDirectoryTest(
 
         executionContext.attemptRename = false
         executionContext.logExceptions = true
-        val moveDirectory = MoveDirectory(source, destinationDirectory)
+        val moveDirectory = moveDirectory(source, destinationDirectory)
         val subOperations = moveDirectory.execute()
         val moveDirectoryContent = subOperations[0] as MoveDirectoryContent
         val deleteDirectory = subOperations[1]
@@ -151,7 +151,7 @@ class MoveDirectoryTest(
     @Test
     fun adding_file_during_move_is_not_fatal() {
         val operation = adding_during_move_helper {
-            return@adding_during_move_helper it.directory.addTempFile("new_file.txt", "new file")
+            return@adding_during_move_helper it.addTempFile("new_file.txt", "new file")
         }
 
         assertThat("source should not be deleted on retry", operation.source.exists(), equalTo(true))
@@ -161,7 +161,7 @@ class MoveDirectoryTest(
     @Test
     fun adding_directory_during_move_is_not_fatal() {
         val operation = adding_during_move_helper {
-            val new_directory = File(it.directory, "subdirectory")
+            val new_directory = File(it, "subdirectory")
             assertThat("Subdirectory is created", new_directory.mkdir())
             new_directory.deleteOnExit()
             return@adding_during_move_helper new_directory
@@ -176,7 +176,7 @@ class MoveDirectoryTest(
         executionContext = RetryMigrationContext { l -> executor.operations.addAll(0, l) }
 
         val operation = adding_during_move_helper {
-            return@adding_during_move_helper it.directory.addTempFile("new_file.txt", "new file")
+            return@adding_during_move_helper it.addTempFile("new_file.txt", "new file")
         }
 
         assertThat("source should be deleted on retry", operation.source.exists(), equalTo(false))
@@ -188,7 +188,7 @@ class MoveDirectoryTest(
         executionContext = RetryMigrationContext { l -> executor.operations.addAll(0, l) }
 
         val operation = adding_during_move_helper {
-            val newDirectory = File(it.directory, "subdirectory")
+            val newDirectory = File(it, "subdirectory")
             assertThat("Subdirectory is created", newDirectory.mkdir())
             newDirectory.deleteOnExit()
             return@adding_during_move_helper newDirectory
@@ -204,8 +204,8 @@ class MoveDirectoryTest(
      *
      * @return The [MoveDirectory] which was executed
      */
-    fun adding_during_move_helper(toDoBetweenTwoFilesMove: (source: Directory) -> File): MoveDirectory {
-        val source = createDirectory()
+    fun adding_during_move_helper(toDoBetweenTwoFilesMove: (source: File) -> File): MoveDirectory {
+        val source = createTransientDirectory()
             .withTempFile("foo.txt")
             .withTempFile("bar.txt")
 
@@ -215,7 +215,7 @@ class MoveDirectoryTest(
         executionContext.attemptRename = false
         executionContext.logExceptions = true
         var movesProcessed = 0
-        val moveDirectory = MoveDirectory(source, destinationDirectory)
+        val moveDirectory = moveDirectory(source, destinationDirectory)
         val suboperations = moveDirectory.execute()
         val moveDirectoryContent = suboperations[0] as MoveDirectoryContent
         val deleteDirectory = suboperations[1]
@@ -240,33 +240,33 @@ class MoveDirectoryTest(
 
         assertThat(
             "new_file should be present in source or directory",
-            File(source.directory, new_file_name!!).exists() || File(destinationDirectory, new_file_name!!).exists()
+            File(source, new_file_name!!).exists() || File(destinationDirectory, new_file_name!!).exists()
         )
         return moveDirectory
     }
 
     @Test
     fun empty_directory_is_deleted() {
-        val source = createDirectory()
+        val source = createTransientDirectory()
         val destinationFile = generateDestinationDirectoryRef()
 
         executionContext.attemptRename = false
 
-        executeAll(MoveDirectory(source, destinationFile))
+        executeAll(moveDirectory(source, destinationFile))
 
-        assertThat("source was deleted", source.directory.exists(), equalTo(false))
+        assertThat("source was deleted", source.exists(), equalTo(false))
     }
 
     @Test
     fun empty_directory_is_deleted_rename() {
-        val source = createDirectory()
+        val source = createTransientDirectory()
         val destinationFile = generateDestinationDirectoryRef()
 
         executionContext.attemptRename = true
 
-        executeAll(MoveDirectory(source, destinationFile))
+        executeAll(moveDirectory(source, destinationFile))
 
-        assertThat("source was deleted", source.directory.exists(), equalTo(false))
+        assertThat("source was deleted", source.exists(), equalTo(false))
     }
 
     /**
@@ -278,6 +278,10 @@ class MoveDirectoryTest(
     fun reproduce_10358() {
         val sourceWithPermissionDenied = createPermissionDenied()
         val destination = createTransientDirectory()
-        sourceWithPermissionDenied.assertThrowsWhenPermissionDenied { executeAll(MoveDirectory(sourceWithPermissionDenied.directory, destination)) }
+        sourceWithPermissionDenied.assertThrowsWhenPermissionDenied { executeAll(moveDirectory(sourceWithPermissionDenied.directory.directory, destination)) }
+    }
+
+    fun moveDirectory(source: File, destination: File): MoveDirectory {
+        return MoveDirectory(Directory.createInstance(source)!!, destination)
     }
 }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/OperationTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/OperationTest.kt
@@ -17,7 +17,6 @@
 
 package com.ichi2.anki.servicelayer.scopedstorage
 
-import com.ichi2.anki.model.Directory
 import com.ichi2.anki.servicelayer.scopedstorage.MigrateUserData.Operation
 import com.ichi2.compat.CompatHelper
 import com.ichi2.testutils.TestException
@@ -45,16 +44,12 @@ interface OperationTest {
 
     fun Operation.execute(): List<Operation> = this.execute(executionContext)
 
-    /** Return a new empty Directory, which will be deleted after the test. */
-    fun createDirectory(): Directory =
-        Directory.createInstance(createTransientDirectory())!!
-
     /** Creates an empty TMP directory to place the output files in */
     fun generateDestinationDirectoryRef(): File {
-        val createDirectory = createDirectory()
+        val createDirectory = createTransientDirectory()
         Timber.d("test: deleting $createDirectory")
-        CompatHelper.getCompat().deleteFile(createDirectory.directory)
-        return createDirectory.directory
+        CompatHelper.getCompat().deleteFile(createDirectory)
+        return createDirectory
     }
 
     /**

--- a/AnkiDroid/src/test/java/com/ichi2/testutils/FileSystemUtils.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/testutils/FileSystemUtils.kt
@@ -17,7 +17,6 @@
 package com.ichi2.testutils
 
 import androidx.annotation.CheckResult
-import com.ichi2.anki.model.Directory
 import org.acra.util.IOUtils
 import org.hamcrest.CoreMatchers
 import org.hamcrest.MatcherAssert
@@ -118,8 +117,8 @@ fun createTransientFile(content: String = ""): File =
     }
 
 /** Creates a sub-directory with the given name which is deleted on exit */
-fun Directory.createTransientDirectory(name: String): File {
-    File(this.directory, name).also { directory ->
+fun File.createTransientDirectory(name: String): File {
+    File(this, name).also { directory ->
         directory.deleteOnExit()
         Timber.d("test: creating $directory")
         MatcherAssert.assertThat("directory should have been created", directory.mkdirs(), CoreMatchers.equalTo(true))


### PR DESCRIPTION
It was confusing to have both `createDirectory` and
`createTransientDirectory`. Plus, we almost never really need a `Directory` but
its underlying `File`.

This remove confusion in which method to use, what are the difference between
them, and it remove even some `.direction`, at the cost of two helpers methods
that encapsulate File in Direction when required