### PR TITLE
replaced deprecated startActivityForResult() in AnkiActivity.java with newer API

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiActivity.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiActivity.java
@@ -15,6 +15,7 @@ import android.net.Uri;
 import android.os.Bundle;
 
 import androidx.activity.result.ActivityResultLauncher;
+import androidx.activity.result.contract.ActivityResultContracts;
 import androidx.annotation.LayoutRes;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -261,12 +262,13 @@ public class AnkiActivity extends AppCompatActivity implements SimpleMessageDial
         enableActivityAnimation(animation);
     }
 
-
-    @Deprecated
-    @Override
-    public void startActivityForResult(Intent intent, int requestCode) {
+    ActivityResultLauncher<Intent> mActivityResultLauncher = registerForActivityResult(
+            new ActivityResultContracts.StartActivityForResult(),
+            result -> { }
+    );
+    public void launchActivityForResult(Intent intent) {
         try {
-            super.startActivityForResult(intent, requestCode);
+            mActivityResultLauncher.launch(intent);
         } catch (ActivityNotFoundException e) {
             Timber.w(e);
             UIUtils.showSimpleSnackbar(this, R.string.activity_start_failed,true);
@@ -276,14 +278,14 @@ public class AnkiActivity extends AppCompatActivity implements SimpleMessageDial
 
     public void startActivityForResultWithoutAnimation(Intent intent, int requestCode) {
         disableIntentAnimation(intent);
-        startActivityForResult(intent, requestCode);
+        launchActivityForResult(intent);
         disableActivityAnimation();
     }
 
 
     public void startActivityForResultWithAnimation(Intent intent, int requestCode, Direction animation) {
         enableIntentAnimation(intent);
-        startActivityForResult(intent, requestCode);
+        launchActivityForResult(intent);
         enableActivityAnimation(animation);
     }
 


### PR DESCRIPTION
## Purpose / Description
replaced deprecated startActivityForResult() in AnkiActivity.java with newer API

## Fixes
Fixes #8602


## Approach
Since the AnkiActivity didn't override the onActivityResult(), it completely ignores the result of intent. The only task done by startActivityForResult() was to catch the NoActivityFoundException and display a snack bar to users with an appropriate message. I have replaced it with the suggested way by Android Team.

## How Has This Been Tested?
It has passed all the unit tests and runs as expected on Pixel 4 Emulator API 27,31 and physical device Realme 6i API 30

## Learning (optional, can help others)
Learned how Android handles activity results 
https://developer.android.com/training/basics/intents/result


## Checklist

- [✓] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [✓] You have a descriptive commit message with a short title (first line, max 50 chars).
- [✓] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [✓] You have commented your code, particularly in hard-to-understand areas
- [✓] You have performed a self-review of your own code
- [✕] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [✕] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
