### PR TITLE
removed redundant @KotlinCleanup from Preferences.kt

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.kt
@@ -435,7 +435,6 @@ class Preferences : AnkiActivity() {
         }
 
         @Suppress("deprecation") // setTargetFragment
-        @KotlinCleanup("use when")
         override fun onDisplayPreferenceDialog(preference: Preference) {
             val dialogFragment = when (preference) {
                 is IncrementerNumberRangePreferenceCompat -> IncrementerNumberRangePreferenceCompat.IncrementerNumberRangeDialogFragmentCompat.newInstance(preference.getKey())


### PR DESCRIPTION
## Purpose / Description
As the method already used when(), `@KotlinCleanup` was redundant there.

## Fixes
Fixes  a part of [#10489](https://github.com/ankidroid/Anki-Android/issues/10489)

## How Has This Been Tested?
Runs as expected on physical device and emulator.


## Checklist
- [✓] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [✓] You have a descriptive commit message with a short title (first line, max 50 chars).
- [✓] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [✓] You have commented your code, particularly in hard-to-understand areas
- [✓] You have performed a self-review of your own code
- [✕] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [✕] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
