### PR TITLE
Removed copyDirectory and inheritors

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/compat/Compat.java
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/Compat.java
@@ -99,63 +99,6 @@ public interface Compat {
     void deleteFile(@NonNull File file) throws IOException;
 
     /**
-     * Copies the directory represented by srcDir to the directory represented by destDir, and optionally makes a
-     * best-effort to delete srcDir if the deleteAfterCopy param is set to <code>true</code>. The source must be a
-     * directory. If the destination exists, it must be a directory. If it doesn't exist, then the destination directory
-     * and any necessary parent directories are created recursively (see {@link File#mkdirs()} for details).
-     * It is assumed that srcDir and destDir contain no symbolic links.
-     * <p><br>
-     * For instance, if the source directory, sdcard/AnkiDroid directory, contains 3 files, and
-     * com.ichi2.Anki/files is the destination directory, the 3 files will be copied inside the com.ichi2.Anki/files
-     * directory.
-     * <p><br>
-     * The destination may be empty or it may contain (partially or completely) content that is <em>probably</em> the
-     * same as the source. A file isn't copied to the destination if it already exists at the destination according to a
-     * simple heuristic.
-     * <p><br>
-     * This operation takes linear time - is proportional to the number of files in srcDir and its subdirectories
-     * @param srcDir Abstract representation of source file/directory
-     * @param destDir Abstract representation of destination directory
-     * @param ioTask Listener used to send how many kilobytes of data have been copied since the last update
-     * @param deleteAfterCopy If set to <code>true</code>, makes a best-effort to delete srcDir after it has been copied
-     * @throws IOException if an error occurs
-     */
-    void copyDirectory(File srcDir, File destDir, ProgressSenderAndCancelListener<Integer> ioTask, boolean deleteAfterCopy) throws IOException;
-
-    /**
-     * Moves the directory represented by source to the directory represented by destination.
-     * After completion, destDir will exist and will contain the contents of srcDir, and srcDir will not exist since it
-     * will have been moved.
-     * <p><br>
-     * srcDir must be a directory. If destDir exists, it must be a directory. If it doesn't exist, then the destination
-     * directory and any necessary parent directories are created recursively (see {@link File#mkdirs()} for details).
-     * It is assumed that srcDir and destDir contain no symbolic links.
-     * <p><br>
-     * For instance, if the source directory, sdcard/AnkiDroid directory, contains 3 files, and com.ichi2.Anki/files is
-     * the destination directory, the 3 files will be moved inside the com.ichi2.Anki/files directory.
-     * The source directory, sdcard/AnkiDroid will often be deleted after a successful operation.
-     * However, this method provides no guarantee that the entire srcDir will be deleted.
-     * <p><br>
-     * In case this operation is interrupted, srDir & destDir should satisfy the following properties:
-     * <ul>
-     *     <li>A subset of the srcDir files and directories have been moved to destDir</li>
-     *     <li>All the files/directories that have been moved to destDir have been deleted,
-     *     except for at most one file</li>
-     * </ul>
-     * The destination may be empty or it may contain (partially or completely) content that is <em>probably</em> the
-     * same as the source. A file isn't moved to the destination if it already exists at the destination according to a
-     * simple heuristic.
-     * <p><br>
-     * This operation takes constant time if srcDir and destDir are on the same partition. If not, it takes linear time
-     *  - is proportional to the number of files in srcDir and its subdirectories.
-     * @param srcDir Abstract representation of source file/directory
-     * @param destDir Abstract representation of destination directory
-     * @param ioTask Listener used to send how many kilobytes of data have been moved since the last update
-     * @throws IOException if an error occurs
-     */
-    void moveDirectory(File srcDir, File destDir, ProgressSenderAndCancelListener<Integer> ioTask) throws IOException;
-
-    /**
      * Whether a directory has at least one files
      * @return Whether the directory has file.
      * @throws SecurityException If a security manager exists and its SecurityManager.checkRead(String)

--- a/AnkiDroid/src/main/java/com/ichi2/compat/CompatV26.java
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/CompatV26.java
@@ -114,53 +114,6 @@ public class CompatV26 extends CompatV23 implements Compat {
         }
     }
 
-    // Explores the source directory tree recursively and copies each directory and each file inside each directory
-    @Override
-    public void copyDirectory(@NonNull File srcDir, @NonNull File destDir, @NonNull ProgressSenderAndCancelListener<Integer> ioTask, boolean deleteAfterCopy) throws IOException {
-        // If destDir exists, it must be a directory. If not, create it
-        FileUtil.ensureFileIsDirectory(destDir);
-
-        Path sourceDirPath = srcDir.toPath();
-        Path destinationDirPath = destDir.toPath();
-
-        Files.walkFileTree(sourceDirPath, new SimpleFileVisitor<Path>() {
-
-            @Override
-            public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) throws IOException {
-                Files.createDirectories(destinationDirPath.resolve(sourceDirPath.relativize(dir)));
-                return FileVisitResult.CONTINUE;
-            }
-
-
-            @Override
-            public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
-                File destFile = destinationDirPath.resolve(sourceDirPath.relativize(file)).toFile();
-
-                // Copy if source file and destination file aren't of the same length
-                // i.e., copy if destination file wasn't copied completely
-                if (file.toFile().length() != destFile.length()) {
-                    OutputStream outputStream = new FileOutputStream(destFile, false);
-                    long bytesCopied = copyFile(file.toString(), outputStream);
-                    ioTask.doProgress((int) bytesCopied / 1024);
-                    outputStream.close();
-                }
-                if (deleteAfterCopy) {
-                    Files.delete(file);
-                }
-                return FileVisitResult.CONTINUE;
-            }
-
-            @Override
-            public FileVisitResult postVisitDirectory(Path dir, IOException exc) throws IOException {
-                if (deleteAfterCopy) {
-                    Files.delete(dir);
-                }
-                return FileVisitResult.CONTINUE;
-            }
-        });
-    }
-
-
     @Override
     public void requestAudioFocus(AudioManager audioManager, AudioManager.OnAudioFocusChangeListener audioFocusChangeListener,
                                   @Nullable AudioFocusRequest audioFocusRequest) {

--- a/AnkiDroid/src/test/java/com/ichi2/utils/FileUtilTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/utils/FileUtilTest.java
@@ -110,21 +110,16 @@ public class FileUtilTest {
         // Test for successful copy directory operation
         File srcDir = createSrcFilesForTest(temporaryRootDir, "srcDir");
         File successfulDestDir = new File(temporaryRootDir, "successfulDest");
-        CompatHelper.getCompat().copyDirectory(srcDir, successfulDestDir, new DummyListener(), false);
         compareDirs(srcDir, successfulDestDir);
 
 
         // Test for unsuccessful copy directory operation
         File unsuccessfulDestDir = new File(temporaryRootDir, "failedDest");
         File unexpectedFile = addUnexpectedFileToDestination(unsuccessfulDestDir);
-        org.junit.Assert.assertThrows(IOException.class, () -> CompatHelper.getCompat().copyDirectory(srcDir,
-                unsuccessfulDestDir, new DummyListener(), false));
 
         // Test for successful copy directory operation after partial operation
         // by removing the unexpected file from the destination directory and trying again
         Assert.assertTrue(unexpectedFile.delete());
-        CompatHelper.getCompat().copyDirectory(srcDir, unsuccessfulDestDir, new DummyListener() ,false);
-        compareDirs(srcDir, unsuccessfulDestDir);
     }
 
     @Config(sdk = { 21, 26 })
@@ -137,20 +132,16 @@ public class FileUtilTest {
         File srcDirToBeMovedSuccessfully = createSrcFilesForTest(temporaryRootDir, "srcDirToBeMovedSuccessfully");
         File srcDirForComparison = createSrcFilesForTest(temporaryRootDir, "srcDirForComparison");
         File successfulDestDir = new File(temporaryRootDir, "successfulDestDir");
-        CompatHelper.getCompat().moveDirectory(srcDirToBeMovedSuccessfully, successfulDestDir, new DummyListener());
         compareDirs(srcDirForComparison, successfulDestDir);
 
         // Test for unsuccessful move directory operation
         File srcDirToBeMovedUnsuccessfully = createSrcFilesForTest(temporaryRootDir, "srcDirToBeMovedUnsuccessfully");
         File unsuccessfulDestDir = new File(temporaryRootDir, "unsuccessfulDestDir");
         File unexpectedFile = addUnexpectedFileToDestination(unsuccessfulDestDir);
-        org.junit.Assert.assertThrows(IOException.class, () -> CompatHelper.getCompat().moveDirectory(srcDirToBeMovedUnsuccessfully,
-                unsuccessfulDestDir, new DummyListener()));
 
         // Test for successful move directory operation after partial operation
         // by removing the unexpected file from the destination directory and trying again
         Assert.assertTrue(unexpectedFile.delete());
-        CompatHelper.getCompat().moveDirectory(srcDirToBeMovedUnsuccessfully, unsuccessfulDestDir, new DummyListener());
         compareDirs(srcDirForComparison, unsuccessfulDestDir);
     }
 


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
Removing the function copyDirectory

## Fixes
Fixes #10458

## Approach
Removes copyDirectory in Compat interface and its inheritors
