### PR TITLE
Kotlin cleanup for CardTemplatePreviewer.kt

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplatePreviewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplatePreviewer.kt
@@ -244,8 +244,8 @@ open class CardTemplatePreviewer : AbstractFlashcardViewer() {
             // loading from the card template editor
             mAllFieldsNull = true
             // card template with associated card due to opening from note editor
-            if (mCardListIndex >= 0 && mCardListIndex < mCardList.size) {
-                currentCard = PreviewerCard(col, mCardList[mCardListIndex])
+            if (mCardList != null && mCardListIndex >= 0 && mCardListIndex < mCardList!!.size) {
+                currentCard = PreviewerCard(col, mCardList!![mCardListIndex])
             } else if (mEditedModel != null) { // bare note type (not coming from note editor), or new card template
                 Timber.d("onCreate() CardTemplatePreviewer started with edited model and template index, displaying blank to preview formatting")
                 currentCard = getDummyCard(mEditedModel!!, mOrdinal)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplatePreviewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplatePreviewer.kt
@@ -49,7 +49,7 @@ open class CardTemplatePreviewer : AbstractFlashcardViewer() {
     /** The list (currently singular) of cards to be previewed
      * A single template was selected, and there was an associated card which exists
      */
-    private lateinit var mCardList: LongArray
+    private var mCardList: LongArray? = null
     private var mNoteEditorBundle: Bundle? = null
     private var mShowingAnswer = false
 
@@ -79,7 +79,7 @@ open class CardTemplatePreviewer : AbstractFlashcardViewer() {
         if (parameters != null) {
             mNoteEditorBundle = parameters.getBundle("noteEditorBundle")
             mEditedModelFileName = parameters.getString(TemporaryModel.INTENT_MODEL_FILENAME)
-            mCardList = parameters.getLongArray("cardList") ?: longArrayOf()
+            mCardList = parameters.getLongArray("cardList")
             mOrdinal = parameters.getInt("ordinal")
             mCardListIndex = parameters.getInt("cardListIndex")
             mShowingAnswer = parameters.getBoolean("showingAnswer", mShowingAnswer)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplatePreviewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplatePreviewer.kt
@@ -28,7 +28,6 @@ import com.ichi2.libanki.Model
 import com.ichi2.libanki.Note
 import com.ichi2.libanki.TemplateManager.TemplateRenderContext.TemplateRenderOutput
 import com.ichi2.libanki.utils.NoteUtils
-import com.ichi2.utils.KotlinCleanup
 import net.ankiweb.rsdroid.RustCleanup
 import timber.log.Timber
 import java.io.IOException
@@ -50,8 +49,7 @@ open class CardTemplatePreviewer : AbstractFlashcardViewer() {
     /** The list (currently singular) of cards to be previewed
      * A single template was selected, and there was an associated card which exists
      */
-    @KotlinCleanup("make lateinit")
-    private var mCardList: LongArray? = null
+    private lateinit var mCardList: LongArray
     private var mNoteEditorBundle: Bundle? = null
     private var mShowingAnswer = false
 
@@ -81,7 +79,7 @@ open class CardTemplatePreviewer : AbstractFlashcardViewer() {
         if (parameters != null) {
             mNoteEditorBundle = parameters.getBundle("noteEditorBundle")
             mEditedModelFileName = parameters.getString(TemporaryModel.INTENT_MODEL_FILENAME)
-            mCardList = parameters.getLongArray("cardList")
+            mCardList = parameters.getLongArray("cardList") ?: longArrayOf()
             mOrdinal = parameters.getInt("ordinal")
             mCardListIndex = parameters.getInt("cardListIndex")
             mShowingAnswer = parameters.getBoolean("showingAnswer", mShowingAnswer)
@@ -246,8 +244,8 @@ open class CardTemplatePreviewer : AbstractFlashcardViewer() {
             // loading from the card template editor
             mAllFieldsNull = true
             // card template with associated card due to opening from note editor
-            if (mCardList != null && mCardListIndex >= 0 && mCardListIndex < mCardList!!.size) {
-                currentCard = PreviewerCard(col, mCardList!![mCardListIndex])
+            if (mCardListIndex >= 0 && mCardListIndex < mCardList.size) {
+                currentCard = PreviewerCard(col, mCardList[mCardListIndex])
             } else if (mEditedModel != null) { // bare note type (not coming from note editor), or new card template
                 Timber.d("onCreate() CardTemplatePreviewer started with edited model and template index, displaying blank to preview formatting")
                 currentCard = getDummyCard(mEditedModel!!, mOrdinal)


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
Made mCardList lateinit as per KotlinCleanup and removed the annotation.

## Fixes
#10489

## Approach
Made mCardList lateinit variable and initialized it to empty array if the value derived from parameters is null.

## How Has This Been Tested?

Runs as expected on physical device and emulator.

## Learning (optional, can help others)
_Describe the research stage_

_Links to blog posts, patterns, libraries or addons used to solve this problem_

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
