### PR TITLE
startActivityForResult migration in Preferences.kt

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -50,27 +50,6 @@
         </value>
       </option>
     </JavaCodeStyleSettings>
-    <JetCodeStyleSettings>
-      <option name="PACKAGES_TO_USE_STAR_IMPORTS">
-        <value>
-          <package name="java.util" alias="false" withSubpackages="false" />
-          <package name="kotlinx.android.synthetic" alias="false" withSubpackages="true" />
-          <package name="io.ktor" alias="false" withSubpackages="true" />
-        </value>
-      </option>
-      <option name="PACKAGES_IMPORT_LAYOUT">
-        <value>
-          <package name="" alias="false" withSubpackages="true" />
-          <package name="java" alias="false" withSubpackages="true" />
-          <package name="javax" alias="false" withSubpackages="true" />
-          <package name="kotlin" alias="false" withSubpackages="true" />
-          <package name="" alias="true" withSubpackages="true" />
-        </value>
-      </option>
-    </JetCodeStyleSettings>
-    <XML>
-      <option name="XML_LEGACY_SETTINGS_IMPORTED" value="true" />
-    </XML>
     <codeStyleSettings language="JAVA">
       <option name="RIGHT_MARGIN" value="120" />
       <option name="BLANK_LINES_AROUND_CLASS" value="3" />

--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -50,6 +50,27 @@
         </value>
       </option>
     </JavaCodeStyleSettings>
+    <JetCodeStyleSettings>
+      <option name="PACKAGES_TO_USE_STAR_IMPORTS">
+        <value>
+          <package name="java.util" alias="false" withSubpackages="false" />
+          <package name="kotlinx.android.synthetic" alias="false" withSubpackages="true" />
+          <package name="io.ktor" alias="false" withSubpackages="true" />
+        </value>
+      </option>
+      <option name="PACKAGES_IMPORT_LAYOUT">
+        <value>
+          <package name="" alias="false" withSubpackages="true" />
+          <package name="java" alias="false" withSubpackages="true" />
+          <package name="javax" alias="false" withSubpackages="true" />
+          <package name="kotlin" alias="false" withSubpackages="true" />
+          <package name="" alias="true" withSubpackages="true" />
+        </value>
+      </option>
+    </JetCodeStyleSettings>
+    <XML>
+      <option name="XML_LEGACY_SETTINGS_IMPORTED" value="true" />
+    </XML>
     <codeStyleSettings language="JAVA">
       <option name="RIGHT_MARGIN" value="120" />
       <option name="BLANK_LINES_AROUND_CLASS" value="3" />

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.kt
@@ -32,6 +32,7 @@ import android.text.TextUtils
 import android.view.MenuItem
 import android.view.WindowManager.BadTokenException
 import android.webkit.URLUtil
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.annotation.StringRes
 import androidx.annotation.VisibleForTesting
 import androidx.annotation.XmlRes
@@ -764,8 +765,7 @@ class Preferences : AnkiActivity() {
             mBackgroundImage!!.onPreferenceClickListener = Preference.OnPreferenceClickListener {
                 if (mBackgroundImage!!.isChecked) {
                     try {
-                        val galleryIntent = Intent(Intent.ACTION_PICK, MediaStore.Images.Media.EXTERNAL_CONTENT_URI)
-                        startActivityForResult(galleryIntent, RESULT_LOAD_IMG)
+                        mBackgroundImageResultLauncher.launch("image/*")
                         mBackgroundImage!!.isChecked = true
                     } catch (ex: Exception) {
                         Timber.e("%s", ex.localizedMessage)
@@ -824,15 +824,12 @@ class Preferences : AnkiActivity() {
             return names
         }
 
-        @Suppress("deprecation") // super.onActivityResult
-        override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
-            super.onActivityResult(requestCode, resultCode, data)
-            // DEFECT #5973: Does not handle Google Drive downloads
-            try {
-                if (requestCode == RESULT_LOAD_IMG && resultCode == RESULT_OK && null != data) {
-                    val selectedImage = data.data
+        private val mBackgroundImageResultLauncher = registerForActivityResult(ActivityResultContracts.GetContent()) { selectedImage ->
+            if (selectedImage != null) {
+                // handling file may result in exception
+                try {
                     val filePathColumn = arrayOf(MediaStore.MediaColumns.SIZE)
-                    requireContext().contentResolver.query(selectedImage!!, filePathColumn, null, null, null).use { cursor ->
+                    requireContext().contentResolver.query(selectedImage, filePathColumn, null, null, null).use { cursor ->
                         cursor!!.moveToFirst()
                         // file size in MB
                         val fileLength = cursor.getLong(0) / (1024 * 1024)
@@ -852,21 +849,17 @@ class Preferences : AnkiActivity() {
                             showThemedToast(requireContext(), getString(R.string.image_max_size_allowed, 10), false)
                         }
                     }
-                } else {
-                    mBackgroundImage!!.isChecked = false
-                    showThemedToast(requireContext(), getString(R.string.no_image_selected), false)
+                } catch (e: OutOfMemoryError) {
+                    Timber.w(e)
+                    showThemedToast(requireContext(), getString(R.string.error_selecting_image, e.localizedMessage), false)
+                } catch (e: Exception) {
+                    Timber.w(e)
+                    showThemedToast(requireContext(), getString(R.string.error_selecting_image, e.localizedMessage), false)
                 }
-            } catch (e: OutOfMemoryError) {
-                Timber.w(e)
-                showThemedToast(requireContext(), getString(R.string.error_selecting_image, e.localizedMessage), false)
-            } catch (e: Exception) {
-                Timber.w(e)
-                showThemedToast(requireContext(), getString(R.string.error_selecting_image, e.localizedMessage), false)
+            } else {
+                mBackgroundImage!!.isChecked = false
+                showThemedToast(requireContext(), getString(R.string.no_image_selected), false)
             }
-        }
-
-        companion object {
-            private const val RESULT_LOAD_IMG = 111
         }
     }
 


### PR DESCRIPTION
## Purpose / Description
Remove usage of depricated startActivityForResult()

## Fixes
Fixes a part of #8602

## Approach
1. Remove the `onActivityResult()` method and create an equivalent `ActivityResultLauncher`
2. Replace call to `startActivityForResult()`, call `activityLancher.launch()`

# How Has This Been Tested?
Passes all unit tests and runs as expected on Realme 6i 


https://user-images.githubusercontent.com/69595691/158453132-932f1969-abb2-4f19-9334-aa203f4f47a7.mp4

https://user-images.githubusercontent.com/69595691/158445981-16e8bf8b-5cb7-4b9d-8383-d9ee5730ef9a.mp4

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
