### PR TITLE
Added `delete note` button in the  Previewer (Help Wanted)

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -1068,7 +1068,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
     }
 
     /** Consumers should use {@link #showDeleteNoteDialog()}  */
-    private void deleteNoteWithoutConfirmation() {
+    protected void deleteNoteWithoutConfirmation() {
         dismiss(new SchedulerService.DeleteNote(mCurrentCard), () -> UIUtils.showThemedToast(this, R.string.deleted_note, true));
     }
 

--- a/AnkiDroid/src/main/res/menu/previewer.xml
+++ b/AnkiDroid/src/main/res/menu/previewer.xml
@@ -22,4 +22,9 @@
         android:icon="@drawable/ic_mode_edit_white"
         android:title="@string/cardeditor_title_edit_card"
         ankidroid:showAsAction="ifRoom"/>
+    <item
+        android:id="@+id/action_delete"
+        android:icon="@drawable/ic_delete_white"
+        android:title="@string/delete_card_title"
+        ankidroid:showAsAction="ifRoom"/>
 </menu>


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
To add a delete note button in the previewer for deleting notes/cards quicker.

## Fixes
Fixes  #10321 

## Approach
Now, cards can be directly deleted from the Previewer. Progress bar updates every time a card is deleted. If no cards remain, Deck Picker is opened. Indexing still needs more work, need help with that. Navigating back leads to the Card Browser.

As shown in the video, the correct card is sometimes not shown when a card is deleted unless we navigate back to it from another card. I suspect it is a flaw in my logic, would be grateful for help in improving the `mIndex` logic.

Till the Indexing logic is fixed, not ready to merge. (Will convert to draft till fixed if needed)

https://user-images.githubusercontent.com/86671025/158470842-fbb78434-84a1-463b-9c1a-9c509c0f6932.mp4

## How Has This Been Tested?

Tested on emulator and my phone. Happy to add suggested Unit Tests. None added as of now.

Emulator:
Pixel 5 API 32

Device:
Xaomi Redmi Note 8 Pro API 28 (Android 9)

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
