### PR TITLE
fix(prettier): Ignore 'build' folder

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,2 +1,3 @@
 AnkiDroid/src/main/assets/mathjax
 AnkiDroid/src/main/assets/jquery.min.js
+AnkiDroid/build/


### PR DESCRIPTION
Sample file picked up:

```
AnkiDroid\build\intermediates\assets\amazonDebug\mergeAmazonDebugAssets\jquery.min.js 1203ms
AnkiDroid\build\intermediates\assets\amazonDebug\mergeAmazonDebugAssets\mathjax\a11y\assistive-mml.js 77ms
AnkiDroid\build\intermediates\assets\amazonDebug\mergeAmazonDebugAssets\mathjax\a11y\complexity.js 165ms
AnkiDroid\build\intermediates\assets\amazonDebug\mergeAmazonDebugAssets\mathjax\a11y\explorer.js 213ms
AnkiDroid\build\intermediates\assets\amazonDebug\mergeAmazonDebugAssets\mathjax\a11y\semantic-enrich.js 48ms
AnkiDroid\build\intermediates\assets\amazonDebug\mergeAmazonDebugAssets\mathjax\conf.js 5ms
AnkiDroid\build\intermediates\assets\amazonDebug\mergeAmazonDebugAssets\mathjax\input\tex\extensions\action.js 26ms
AnkiDroid\build\intermediates\assets\amazonDebug\mergeAmazonDebugAssets\mathjax\input\tex\extensions\all-packages.js 883ms
...
```