### PR TITLE
Allow KotlinCleanup annotation on properties

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/utils/KotlinCleanup.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/KotlinCleanup.kt
@@ -19,7 +19,8 @@ package com.ichi2.utils
 /** Use when code can be changed after further conversion to Kotlin */
 @Target(
     AnnotationTarget.CLASS, AnnotationTarget.FUNCTION,
-    AnnotationTarget.VALUE_PARAMETER, AnnotationTarget.EXPRESSION, AnnotationTarget.FIELD
+    AnnotationTarget.VALUE_PARAMETER, AnnotationTarget.EXPRESSION,
+    AnnotationTarget.FIELD, AnnotationTarget.PROPERTY
 )
 @Retention(AnnotationRetention.SOURCE)
 @MustBeDocumented


### PR DESCRIPTION
Allow `KotlinCleanup` annotationto be used on properties.