### PR TITLE
Made MergeRootFrame Fatal

### DIFF
--- a/AnkiDroid/src/main/res/layout/activity_load_pronounciation.xml
+++ b/AnkiDroid/src/main/res/layout/activity_load_pronounciation.xml
@@ -1,4 +1,4 @@
-<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<merge xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
@@ -18,4 +18,4 @@
 
     <include layout="@layout/progress_bar_layout" />
 
-</FrameLayout>
+</merge>

--- a/AnkiDroid/src/main/res/layout/activity_translation.xml
+++ b/AnkiDroid/src/main/res/layout/activity_translation.xml
@@ -1,4 +1,4 @@
-<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<merge xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
@@ -10,4 +10,4 @@
 
     <include layout="@layout/progress_bar_layout"/>
 
-</FrameLayout>
+</merge>

--- a/AnkiDroid/src/main/res/layout/reviewer_flashcard.xml
+++ b/AnkiDroid/src/main/res/layout/reviewer_flashcard.xml
@@ -21,7 +21,7 @@
 ~ this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
 
-<FrameLayout
+<merge
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_gravity="center"
     android:id="@+id/flashcard_frame"
@@ -47,4 +47,4 @@
         android:layout_margin="0dip"
         android:layout_width="match_parent"
         android:layout_height="match_parent" />
-</FrameLayout>
+</merge>

--- a/AnkiDroid/src/main/res/layout/reviewer_flashcard_fullscreen.xml
+++ b/AnkiDroid/src/main/res/layout/reviewer_flashcard_fullscreen.xml
@@ -15,7 +15,7 @@
 ~ this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
 
-<FrameLayout
+<merge
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_gravity="center"
     android:id="@+id/flashcard_frame"
@@ -37,4 +37,4 @@
         android:id="@+id/whiteboard"
         android:layout_width="match_parent"
         android:layout_height="match_parent" />
-</FrameLayout>
+</merge>

--- a/AnkiDroid/src/main/res/layout/reviewer_flashcard_fullscreen_noanswers.xml
+++ b/AnkiDroid/src/main/res/layout/reviewer_flashcard_fullscreen_noanswers.xml
@@ -15,7 +15,7 @@
 ~ this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
 
-<FrameLayout
+<merge
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_gravity="center"
     android:id="@+id/flashcard_frame"
@@ -38,4 +38,4 @@
         android:id="@+id/whiteboard"
         android:layout_width="match_parent"
         android:layout_height="match_parent" />
-</FrameLayout>
+</merge>

--- a/lint-release.xml
+++ b/lint-release.xml
@@ -45,6 +45,7 @@
     <issue id="WrongConstant" severity="fatal" />
     <issue id="WrongViewCast" severity="fatal" />
     <issue id="UnknownId" severity="fatal" />
+    <issue id="MergeRootFrame" severity="fatal" />
 
     <!--           RTL Rules               -->
     <issue id="RtlCompat" severity="fatal" />
@@ -247,7 +248,6 @@
     <issue id="ManifestResource" severity="ignore" />
     <issue id="ManifestTypo" severity="ignore" />
     <issue id="MergeMarker" severity="ignore" />
-    <issue id="MergeRootFrame" severity="ignore" />
     <issue id="IncompatibleMediaBrowserServiceCompatVersion" severity="ignore" />
     <issue id="InnerclassSeparator" severity="ignore" />
     <issue id="Instantiatable" severity="ignore" />


### PR DESCRIPTION
## Purpose / Description
Enabled lint check for "ObsoleteLayouParam", changed "ignore" to "fatal" and took the line above.

## Fixes
Fixes #10502 

## How Has This Been Tested?
Ran ./gradlew lint and resolved errros in 5 xml fies
