### PR TITLE
fix(translations): make arrays constant

### DIFF
--- a/AnkiDroid/src/main/res/values/11-arrays.xml
+++ b/AnkiDroid/src/main/res/values/11-arrays.xml
@@ -14,65 +14,67 @@
 ~ You should have received a copy of the GNU General Public License along with
 ~ this program.  If not, see <http://www.gnu.org/licenses/>.
 --><resources>
-    <string-array name="error_reporting_choice_labels">
-        <item>Always report</item>
-        <item>Never report</item>
-        <item>Ask me</item>
-    </string-array>
-    <string-array name="leech_action_labels">
-        <item>Suspend card</item>
-        <item>Tag only</item>
-    </string-array>
-    <string-array name="new_order_labels">
-        <item>New cards in random order</item>
-        <item>New cards in order added</item>
-    </string-array>
-    <string-array name="cram_deck_conf_order_labels">
-        <item>Oldest seen first</item>
-        <item>Random</item>
-        <item>Increasing intervals</item>
-        <item>Decreasing intervals</item>
-        <item>Most lapsed</item>
-        <item>Order added</item>
-        <item>Order due</item>
-        <item>Latest added first</item>
-        <item>Relative overdueness</item>
-    </string-array>
-    <string-array name="add_to_cur_labels">
-        <item>Use current deck</item>
-        <item>Decide by note type</item>
-    </string-array>
-    <string-array name="new_spread_labels">
-        <item>Mix new cards and reviews</item>
-        <item>New cards after reviews</item>
-        <item>New cards before reviews</item>
-    </string-array>
-    <string-array name="override_font_labels">
-        <item>When no font specified on flashcards</item>
-        <item>Always</item>
-    </string-array>
-    <string-array name="day_theme_labels">
-        <item>Light</item>
-        <item>Plain</item>
-    </string-array>
-    <string-array name="night_theme_labels">
-        <item>Black</item>
-        <item>Dark</item>
-    </string-array>
-    <string-array name="html_size_code_labels">
-        <item>xx-small</item>
-        <item>x-small</item>
-        <item>small</item>
-        <item>medium</item>
-        <item>large</item>
-        <item>x-large</item>
-        <item>xx-large</item>
-    </string-array>
 
-    <!--
-    #7794 - it's better to use @string references in non-translated arrays as this handles
-    changes in the array ordering better
-     -->
+    <!-- 11-arrays.xml used to contain arrays. This caused problems when changing the ordering.
+    Now arrays are defined in constants.xml, and the strings are here -->
+
+    <!-- error_reporting_choice_labels -->
+    <string name="error_reporting_choice_always_report">Always report</string>
+    <string name="error_reporting_choice_never_report">Never report</string>
+    <string name="error_reporting_choice_ask_user">Ask me</string>
+
+    <!-- leech_action_labels -->
+    <!-- 01-core:menu_suspend_card -->
+    <string name="leech_action_tag_only">Tag only</string>
+
+
+    <!-- new_order_labels -->
+    <string name="new_order_random">New cards in random order</string>
+    <string name="new_order_order_added">New cards in order added</string>
+
+    <!-- cram_deck_conf_order_labels -->
+    <string name="cram_deck_conf_order_oldest_seen_first">Oldest seen first</string>
+    <string name="cram_deck_conf_order_random">Random</string>
+    <string name="cram_deck_conf_order_increasing_intervals">Increasing intervals</string>
+    <string name="cram_deck_conf_order_decreasing_intervals">Decreasing intervals</string>
+    <string name="cram_deck_conf_order_most_lapsed">Most lapsed</string>
+    <string name="cram_deck_conf_order_order_added">Order added</string>
+    <string name="cram_deck_conf_order_order_due">Order due</string>
+    <string name="cram_deck_conf_order_latest_added_first">Latest added first</string>
+    <string name="cram_deck_conf_order_relative_overdueness">Relative overdueness</string>
+
+    <!-- add_to_cur_labels -->
+    <string name="add_to_deck_use_current_deck">Use current deck</string>
+    <string name="add_to_deck_decide_by_note_type">Decide by note type</string>
+
+    <!-- html_size_code_labels -->
+    <string name="html_size_code_xx_small">xx-small</string>
+    <string name="html_size_code_x_small">x-small</string>
+    <string name="html_size_code_small">small</string>
+    <string name="html_size_code_medium">medium</string>
+    <string name="html_size_code_large">large</string>
+    <string name="html_size_code_x_large">x-large</string>
+    <string name="html_size_code_xx_large">xx-large</string>
+
+    <!-- day_theme_labels -->
+    <string name="day_theme_light">Light</string>
+    <string name="day_theme_plain">Plain</string>
+
+    <!-- night_theme_labels -->
+    <string name="night_theme_black">Black</string>
+    <string name="night_theme_dark">Dark</string>
+
+
+    <!-- override_font_labels -->
+    <string name="override_font_if_missing">When no font specified on flashcards</string>
+    <string name="override_font_always">Always</string>
+
+    <!-- new_spread_labels -->
+    <string name="new_spread_mix_new_and_review">Mix new cards and reviews</string>
+    <string name="new_spread_new_after_review">New cards after reviews</string>
+    <string name="new_spread_new_before_review">New cards before reviews</string>
+
+    <!-- gestures_labels -->
     <string name="gesture_no_action">No action</string>
     <string name="gesture_answer_1">Answer button 1</string>
     <string name="gesture_answer_2">Answer button 2</string>

--- a/AnkiDroid/src/main/res/values/constants.xml
+++ b/AnkiDroid/src/main/res/values/constants.xml
@@ -153,6 +153,62 @@
         <item>0</item>
         <item>3</item>
     </string-array>
+
+    <string-array name="error_reporting_choice_labels">
+        <item>@string/error_reporting_choice_always_report</item>
+        <item>@string/error_reporting_choice_never_report</item>
+        <item>@string/error_reporting_choice_ask_user</item>
+    </string-array>
+    <string-array name="leech_action_labels">
+        <item>@string/menu_suspend_card</item>
+        <item>@string/leech_action_tag_only</item>
+    </string-array>
+    <string-array name="new_order_labels">
+        <item>@string/new_order_random</item>
+        <item>@string/new_order_order_added</item>
+    </string-array>
+    <string-array name="cram_deck_conf_order_labels">
+        <item>@string/cram_deck_conf_order_oldest_seen_first</item>
+        <item>@string/cram_deck_conf_order_random</item>
+        <item>@string/cram_deck_conf_order_increasing_intervals</item>
+        <item>@string/cram_deck_conf_order_decreasing_intervals</item>
+        <item>@string/cram_deck_conf_order_most_lapsed</item>
+        <item>@string/cram_deck_conf_order_order_added</item>
+        <item>@string/cram_deck_conf_order_order_due</item>
+        <item>@string/cram_deck_conf_order_latest_added_first</item>
+        <item>@string/cram_deck_conf_order_relative_overdueness</item>
+    </string-array>
+    <string-array name="add_to_cur_labels">
+        <item>@string/add_to_deck_use_current_deck</item>
+        <item>@string/add_to_deck_decide_by_note_type</item>
+    </string-array>
+    <string-array name="new_spread_labels">
+        <item>@string/new_spread_mix_new_and_review</item>
+        <item>@string/new_spread_new_after_review</item>
+        <item>@string/new_spread_new_before_review</item>
+    </string-array>
+    <string-array name="override_font_labels">
+        <item>@string/override_font_if_missing</item>
+        <item>@string/override_font_always</item>
+    </string-array>
+    <string-array name="day_theme_labels">
+        <item>@string/day_theme_light</item>
+        <item>@string/day_theme_plain</item>
+    </string-array>
+    <string-array name="night_theme_labels">
+        <item>@string/night_theme_black</item>
+        <item>@string/night_theme_dark</item>
+    </string-array>
+    <string-array name="html_size_code_labels">
+        <item>@string/html_size_code_xx_small</item>
+        <item>@string/html_size_code_x_small</item>
+        <item>@string/html_size_code_small</item>
+        <item>@string/html_size_code_medium</item>
+        <item>@string/html_size_code_large</item>
+        <item>@string/html_size_code_x_large</item>
+        <item>@string/html_size_code_xx_large</item>
+    </string-array>
+
     <string name="link_anki">https://ankisrs.net</string>
     <string name="link_anki_manual">https://docs.ankiweb.net/#/</string>
     <string name="link_anki_forum">https://forums.ankiweb.net/</string>


### PR DESCRIPTION
If we changed array ordering, CrowdIn corrupted the ordering of strings

To fix this: define a fixed order in constants.xml, and use
translatable strings from `11-arrays`

Fixes #7794
Fixes #10554 

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
