### PR TITLE
Fixing deck ordering #8397

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
@@ -598,16 +598,8 @@ public class SchedV2 extends AbstractSched {
         return _groupChildren(deckDueTree, true);
     }
 
-    private @NonNull <T extends AbstractDeckTreeNode<T>> List<T> _groupChildren(@NonNull List<T> decks, boolean checkDone) {
-        // sort based on name's components
-        Collections.sort(decks);
-        // then run main function
-        return _groupChildrenMain(decks, checkDone);
-    }
-
-
-    protected @NonNull  <T extends AbstractDeckTreeNode<T>> List<T> _groupChildrenMain(@NonNull List<T> decks, boolean checkDone) {
-        return _groupChildrenMain(decks, 0, checkDone);
+    protected @NonNull  <T extends AbstractDeckTreeNode<T>> List<T> _groupChildren(@NonNull List<T> decks, boolean checkDone) {
+        return _groupChildren(decks, 0, checkDone);
     }
 
     /**
@@ -621,7 +613,7 @@ public class SchedV2 extends AbstractSched {
         false, we can't assume all decks have parents and that there
         is no duplicate. Instead, we'll ignore problems.
      */
-    protected @NonNull <T extends AbstractDeckTreeNode<T>> List<T> _groupChildrenMain(@NonNull List<T> descendants, int depth, boolean checkDone) {
+    protected @NonNull <T extends AbstractDeckTreeNode<T>> List<T> _groupChildren(@NonNull List<T> descendants, int depth, boolean checkDone) {
         List<T> children = new ArrayList<>();
         // group and recurse
         ListIterator<T> it = descendants.listIterator();
@@ -658,7 +650,7 @@ public class SchedV2 extends AbstractSched {
                 }
             }
             // the children_sDescendant set contains direct children_sDescendant but not the children_sDescendant of children_sDescendant...
-            List<T> childrenNode = _groupChildrenMain(descendantsOfChild, depth + 1, checkDone);
+            List<T> childrenNode = _groupChildren(descendantsOfChild, depth + 1, checkDone);
             child.setChildren(childrenNode, "std".equals(getName()));
             children.add(child);
         }

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/sched/SchedV2Test.java
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/sched/SchedV2Test.java
@@ -103,12 +103,12 @@ public class SchedV2Test extends RobolectricTest {
         DeckDueTreeNode ci = new DeckDueTreeNode(col, "cmxieunwoogyxsctnjmv::INSBGDS", 1, 0, 0, 0);
         ci.setChildren(new ArrayList<>(), addRev);
         DeckDueTreeNode c = new DeckDueTreeNode(col, "cmxieunwoogyxsctnjmv", 1, 0, 0, 0);
-        c.setChildren(Arrays.asList(ci, ca), addRev);
+        c.setChildren(Arrays.asList(ca, ci), addRev);
         DeckDueTreeNode defaul = new DeckDueTreeNode(col, "Default", 1, 0, 0, 0);
         defaul.setChildren(new ArrayList<>(), addRev);
         DeckDueTreeNode s = new DeckDueTreeNode(col, "scxipjiyozczaaczoawo", 1, 0, 0, 0);
         s.setChildren(new ArrayList<>(), addRev);
-        return Arrays.asList(defaul, c, s); // Default is first, because start by an Upper case
+        return Arrays.asList(c, defaul, s);
     }
 
 


### PR DESCRIPTION
## Description
Deck ordering in AnkiDroid respected differences in case, unlike the ordering found in the desktop version. This pull request  brings AnkiDroid's ordering in line with the desktop version.

## Fixes
Fixes https://github.com/ankidroid/Anki-Android/issues/8397
Before: 
![SmartSelect_20220317-123906_AnkiDroid](https://user-images.githubusercontent.com/94284954/158756031-65a4510c-fed8-4d45-ac68-9df1105790f0.jpg)
After:
![SmartSelect_20220317-124149_AnkiDroid](https://user-images.githubusercontent.com/94284954/158756061-ede21fca-b0d2-4038-869d-ae08b5b4aa6a.jpg)


## Approach
While debugging, I found a discrepancy between the ordering in the Scheduler (SchedV2.java) and the actual ordering displayed on the DeckPicker activity. Both the DeckNameComparator and it's associated test followed Desktop Anki's ordering and could be excluded as the root cause of the issue.

I tracked down the cause to a _Collections.sort_ call in the groupChildren method of SchedV2 which reordered the deck without using a DeckNameComparator. I have removed this call since the deck has _already_ been ordered at that point.
I have performed some refactoring to remove the now superfluous _groupChildren method. 

I have also modified the Test deck used in SchedV2Test to mirror the desktop ordering.

## How Has This Been Tested?
On a Galaxy A31. 

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
