### PR TITLE
Change .prettierrc endOfLine to auto

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -6,5 +6,6 @@
   "bracketSpacing": true,
   "bracketSameLine": false,
   "tabWidth": 4,
-  "printWidth": 100
+  "printWidth": 100,
+  "endOfLine": "auto"
 }


### PR DESCRIPTION
## Purpose / Description
On Windows, conflict between git's CRLF normalization and prettier's was generating EOL diff
To solve it, this changes `endOfLine` to `auto`, which does:
`Maintain existing line endings (mixed values within one file are normalised by looking at what’s used after the first line)`

## Fixes
Fixes _Link to the issues._

## Approach
Add `endOfLine: "auto"` to .prettierrc

## How Has This Been Tested?

Made a commit and checked if there was EOL diffs

## Learning (optional, can help others)
Prettier EOL options: https://prettier.io/docs/en/options.html#end-of-line

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
