### PR TITLE
fix: Crash opening Deck Options

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.kt
@@ -838,7 +838,7 @@ class Preferences : AnkiActivity() {
                 appThemePref.entryValues = appThemesValues.sliceArray(1..appThemesValues.lastIndex)
             }
 
-            val followSystem = Themes.themeFollowsSystem(context)
+            val followSystem = Themes.themeFollowsSystem(requireContext())
             dayThemePref.isEnabled = followSystem
             nightThemePref.isEnabled = followSystem
 

--- a/AnkiDroid/src/main/java/com/ichi2/themes/Themes.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/themes/Themes.kt
@@ -223,7 +223,7 @@ object Themes {
      * @return if user current selected theme is "Follow system"
      */
     @JvmStatic
-    fun themeFollowsSystem(context: Context?): Boolean {
+    fun themeFollowsSystem(context: Context): Boolean {
         val prefs = AnkiDroidApp.getSharedPrefs(context)
         val selectedAppTheme = prefs.getString(APP_THEME_KEY, FOLLOW_SYSTEM_MODE)
         return selectedAppTheme == FOLLOW_SYSTEM_MODE

--- a/AnkiDroid/src/main/java/com/ichi2/themes/Themes.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/themes/Themes.kt
@@ -105,9 +105,12 @@ object Themes {
 
     @JvmStatic
     fun setThemeLegacy(context: Context) {
-        val prefs = AnkiDroidApp.getSharedPrefs(context.applicationContext)
-        if (themeFollowsSystem(context)) {
-            if (systemIsInNightMode(context)) {
+        // we need the applicationContext to obtain preferences, we can't do this with a regular
+        // Activity context since this is called before super.onCreate()
+        val applicationContext = context.applicationContext
+        val prefs = AnkiDroidApp.getSharedPrefs(applicationContext)
+        if (themeFollowsSystem(applicationContext)) {
+            if (systemIsInNightMode(applicationContext)) {
                 when (prefs.getString(NIGHT_THEME_KEY, NIGHT_BLACK_THEME)) {
                     NIGHT_BLACK_THEME -> context.setTheme(R.style.LegacyActionBarBlack)
                     NIGHT_DARK_THEME -> context.setTheme(R.style.LegacyActionBarDark)


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
We were using the `Activity` context before `super.onCreate()` was called
This meant that `AnkiDroidApp.getSharedPrefs(context)` returns null

## Fixes
Fixes #10584

## Approach
* Use Application Context
* Then a refactoring commit I noticed

## How Has This Been Tested?
Manually - Google Pixel 3A, Android 11

## Learning (optional, can help others)
We have 2 usages of setting the legacy theme, this requires upgrading the Preferences library: #5019


## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
