### PR TITLE
open keyboard when rescheduling a card

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/IntegerDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/IntegerDialog.kt
@@ -19,6 +19,7 @@ package com.ichi2.anki.dialogs
 import android.os.Bundle
 import android.text.InputType
 import com.afollestad.materialdialogs.MaterialDialog
+import com.ichi2.anki.MaterialEditTextDialog.Companion.displayKeyboard
 import com.ichi2.anki.R
 import com.ichi2.anki.analytics.AnalyticsDialogFragment
 import com.ichi2.utils.contentNullable
@@ -43,16 +44,18 @@ open class IntegerDialog : AnalyticsDialogFragment() {
 
     override fun onCreateDialog(savedInstanceState: Bundle?): MaterialDialog {
         super.onCreate(savedInstanceState)
-        return MaterialDialog.Builder(requireActivity())
-            .title(requireArguments().getString("title")!!)
-            .positiveText(resources.getString(R.string.dialog_ok))
-            .negativeText(R.string.dialog_cancel)
-            .inputType(InputType.TYPE_CLASS_NUMBER)
-            .inputRange(1, requireArguments().getInt("digits"))
-            .input(
-                requireArguments().getString("prompt"), ""
-            ) { _: MaterialDialog?, text: CharSequence -> mConsumer!!.accept(text.toString().toInt()) }
-            .contentNullable(requireArguments().getString("content"))
-            .show()
+        val show = MaterialDialog.Builder(requireActivity())
+                .title(requireArguments().getString("title")!!)
+                .positiveText(resources.getString(R.string.dialog_ok))
+                .negativeText(R.string.dialog_cancel)
+                .inputType(InputType.TYPE_CLASS_NUMBER)
+                .inputRange(1, requireArguments().getInt("digits"))
+                .input(
+                        requireArguments().getString("prompt"), ""
+                ) { _: MaterialDialog?, text: CharSequence -> mConsumer!!.accept(text.toString().toInt()) }
+                .contentNullable(requireArguments().getString("content"))
+                .show()
+        displayKeyboard(show.inputEditText!!, show)
+        return show
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/IntegerDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/IntegerDialog.kt
@@ -45,16 +45,16 @@ open class IntegerDialog : AnalyticsDialogFragment() {
     override fun onCreateDialog(savedInstanceState: Bundle?): MaterialDialog {
         super.onCreate(savedInstanceState)
         val show = MaterialDialog.Builder(requireActivity())
-                .title(requireArguments().getString("title")!!)
-                .positiveText(resources.getString(R.string.dialog_ok))
-                .negativeText(R.string.dialog_cancel)
-                .inputType(InputType.TYPE_CLASS_NUMBER)
-                .inputRange(1, requireArguments().getInt("digits"))
-                .input(
-                        requireArguments().getString("prompt"), ""
-                ) { _: MaterialDialog?, text: CharSequence -> mConsumer!!.accept(text.toString().toInt()) }
-                .contentNullable(requireArguments().getString("content"))
-                .show()
+            .title(requireArguments().getString("title")!!)
+            .positiveText(resources.getString(R.string.dialog_ok))
+            .negativeText(R.string.dialog_cancel)
+            .inputType(InputType.TYPE_CLASS_NUMBER)
+            .inputRange(1, requireArguments().getInt("digits"))
+            .input(
+                requireArguments().getString("prompt"), ""
+            ) { _: MaterialDialog?, text: CharSequence -> mConsumer!!.accept(text.toString().toInt()) }
+            .contentNullable(requireArguments().getString("content"))
+            .show()
         displayKeyboard(show.inputEditText!!, show)
         return show
     }


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
Open keyboard when Rescheduling a Card

## Fixes
Fixes Issue #10476

## Approach
Made the use of _displayKeyboard()_ function from **MaterialEditTextDialog.kt** and instead of directly returning the **MaterialDialog** to the _onCreateDialog()_ function of **IntegerDialog.kt** , I passed the variable `show` as a parameter to the _displayKeybaord()_ function

## How Has This Been Tested?

This feature has been tested on Physical Android Device and Android Studio emulator.
Device Model : Asus Zenfone Max Pro M2 (X01BDA)
Android Version : 9

## Learning (optional, can help others)

_Links to blog posts, patterns, libraries or addons used to solve this problem_

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [ ] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner]

https://user-images.githubusercontent.com/40427461/159292389-2db1e009-6262-4dfa-8f8b-074a670309f8.mp4

(https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
