### PR TITLE
chore(tests): Cleanup Test21And26

### DIFF
--- a/AnkiDroid/src/test/java/com/ichi2/anki/model/DirectoryTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/model/DirectoryTest.kt
@@ -18,10 +18,10 @@ package com.ichi2.anki.model
 
 import android.os.Build
 import androidx.annotation.RequiresApi
-import com.ichi2.compat.Compat
 import com.ichi2.compat.Test21And26
-import com.ichi2.testutils.*
 import com.ichi2.testutils.HamcrestUtils.containsInAnyOrder
+import com.ichi2.testutils.assertThrows
+import com.ichi2.testutils.withTempFile
 import org.acra.util.IOUtils
 import org.hamcrest.CoreMatchers.*
 import org.hamcrest.MatcherAssert
@@ -38,11 +38,7 @@ import kotlin.io.path.pathString
  */
 @RequiresApi(Build.VERSION_CODES.O) // This requirement is necessary for compilation. However, it still allows to test CompatV21
 @RunWith(Parameterized::class)
-class DirectoryTest(
-    override val compat: Compat,
-    /** Used in the "Test Results" Window */
-    @Suppress("unused") private val unitTestDescription: String
-) : Test21And26(compat, unitTestDescription) {
+class DirectoryTest : Test21And26() {
     @Test
     fun passes_if_existing_directory() {
         val path = createTempDirectory().pathString

--- a/AnkiDroid/src/test/java/com/ichi2/anki/model/DirectoryTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/model/DirectoryTest.kt
@@ -16,8 +16,6 @@
 
 package com.ichi2.anki.model
 
-import android.os.Build
-import androidx.annotation.RequiresApi
 import com.ichi2.compat.Test21And26
 import com.ichi2.testutils.HamcrestUtils.containsInAnyOrder
 import com.ichi2.testutils.assertThrows
@@ -36,7 +34,6 @@ import kotlin.io.path.pathString
 /**
  * Tests for [Directory]
  */
-@RequiresApi(Build.VERSION_CODES.O) // This requirement is necessary for compilation. However, it still allows to test CompatV21
 @RunWith(Parameterized::class)
 class DirectoryTest : Test21And26() {
     @Test

--- a/AnkiDroid/src/test/java/com/ichi2/anki/model/DirectoryTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/model/DirectoryTest.kt
@@ -24,8 +24,6 @@ import org.acra.util.IOUtils
 import org.hamcrest.CoreMatchers.*
 import org.hamcrest.MatcherAssert
 import org.junit.Test
-import org.junit.runner.RunWith
-import org.junit.runners.Parameterized
 import java.io.File
 import java.io.FileNotFoundException
 import kotlin.io.path.createTempDirectory
@@ -34,7 +32,6 @@ import kotlin.io.path.pathString
 /**
  * Tests for [Directory]
  */
-@RunWith(Parameterized::class)
 class DirectoryTest : Test21And26() {
     @Test
     fun passes_if_existing_directory() {

--- a/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/DeleteEmptyDirectoryTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/DeleteEmptyDirectoryTest.kt
@@ -19,7 +19,6 @@ package com.ichi2.anki.servicelayer.scopedstorage
 import android.os.Build
 import androidx.annotation.RequiresApi
 import com.ichi2.anki.model.Directory
-import com.ichi2.compat.Compat
 import com.ichi2.compat.Test21And26
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.hasSize
@@ -36,11 +35,7 @@ import kotlin.io.path.pathString
  */
 @RequiresApi(Build.VERSION_CODES.O) // This requirement is necessary for compilation. However, it still allows to test CompatV21
 @RunWith(Parameterized::class)
-class DeleteEmptyDirectoryTest(
-    override val compat: Compat,
-    /** Used in the "Test Results" Window */
-    @Suppress("unused") private val unitTestDescription: String
-) : Test21And26(compat, unitTestDescription), OperationTest {
+class DeleteEmptyDirectoryTest : Test21And26(), OperationTest {
 
     override val executionContext = MockMigrationContext()
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/DeleteEmptyDirectoryTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/DeleteEmptyDirectoryTest.kt
@@ -22,8 +22,6 @@ import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.hasSize
 import org.hamcrest.Matchers.instanceOf
 import org.junit.Test
-import org.junit.runner.RunWith
-import org.junit.runners.Parameterized
 import java.io.File
 import kotlin.io.path.createTempDirectory
 import kotlin.io.path.pathString
@@ -31,7 +29,6 @@ import kotlin.io.path.pathString
 /**
  * Tests for [DeleteEmptyDirectory]
  */
-@RunWith(Parameterized::class)
 class DeleteEmptyDirectoryTest : Test21And26(), OperationTest {
 
     override val executionContext = MockMigrationContext()

--- a/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/DeleteEmptyDirectoryTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/DeleteEmptyDirectoryTest.kt
@@ -16,8 +16,6 @@
 
 package com.ichi2.anki.servicelayer.scopedstorage
 
-import android.os.Build
-import androidx.annotation.RequiresApi
 import com.ichi2.anki.model.Directory
 import com.ichi2.compat.Test21And26
 import org.hamcrest.MatcherAssert.assertThat
@@ -33,7 +31,6 @@ import kotlin.io.path.pathString
 /**
  * Tests for [DeleteEmptyDirectory]
  */
-@RequiresApi(Build.VERSION_CODES.O) // This requirement is necessary for compilation. However, it still allows to test CompatV21
 @RunWith(Parameterized::class)
 class DeleteEmptyDirectoryTest : Test21And26(), OperationTest {
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/MoveDirectoryContentTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/MoveDirectoryContentTest.kt
@@ -24,8 +24,6 @@ import com.ichi2.testutils.*
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.*
 import org.junit.Test
-import org.junit.runner.RunWith
-import org.junit.runners.Parameterized
 import org.mockito.kotlin.any
 import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.spy
@@ -38,7 +36,6 @@ import java.nio.file.NotDirectoryException
 /**
  * Test for [MoveDirectoryContent]
  */
-@RunWith(Parameterized::class)
 class MoveDirectoryContentTest : Test21And26(), OperationTest {
 
     override val executionContext = MockMigrationContext()

--- a/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/MoveDirectoryContentTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/MoveDirectoryContentTest.kt
@@ -20,7 +20,6 @@ import android.os.Build
 import androidx.annotation.RequiresApi
 import com.ichi2.anki.model.Directory
 import com.ichi2.anki.servicelayer.scopedstorage.MigrateUserData.Operation
-import com.ichi2.compat.Compat
 import com.ichi2.compat.Test21And26
 import com.ichi2.testutils.*
 import org.hamcrest.MatcherAssert.assertThat
@@ -42,11 +41,7 @@ import java.nio.file.NotDirectoryException
  */
 @RequiresApi(Build.VERSION_CODES.O) // Allows code to compile, but we still test with [CompatV21]
 @RunWith(Parameterized::class)
-class MoveDirectoryContentTest(
-    override val compat: Compat,
-    /** Used in the "Test Results" Window */
-    @Suppress("unused") private val unitTestDescription: String
-) : Test21And26(compat, unitTestDescription), OperationTest {
+class MoveDirectoryContentTest : Test21And26(), OperationTest {
 
     override val executionContext = MockMigrationContext()
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/MoveDirectoryContentTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/MoveDirectoryContentTest.kt
@@ -16,8 +16,7 @@
 
 package com.ichi2.anki.servicelayer.scopedstorage
 
-import android.os.Build
-import androidx.annotation.RequiresApi
+import android.annotation.SuppressLint
 import com.ichi2.anki.model.Directory
 import com.ichi2.anki.servicelayer.scopedstorage.MigrateUserData.Operation
 import com.ichi2.compat.Test21And26
@@ -39,7 +38,6 @@ import java.nio.file.NotDirectoryException
 /**
  * Test for [MoveDirectoryContent]
  */
-@RequiresApi(Build.VERSION_CODES.O) // Allows code to compile, but we still test with [CompatV21]
 @RunWith(Parameterized::class)
 class MoveDirectoryContentTest : Test21And26(), OperationTest {
 
@@ -191,6 +189,7 @@ class MoveDirectoryContentTest : Test21And26(), OperationTest {
         assertThrows<FileNotFoundException> { moveDirectoryContent(sourceDirectory, destinationDirectory) }
     }
 
+    @SuppressLint("NewApi") // NotDirectoryException
     @Test
     fun factory_on_file_throw() {
         val source_file = createTransientFile()

--- a/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/MoveDirectoryTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/MoveDirectoryTest.kt
@@ -16,8 +16,6 @@
 
 package com.ichi2.anki.servicelayer.scopedstorage
 
-import android.os.Build
-import androidx.annotation.RequiresApi
 import com.ichi2.anki.model.Directory
 import com.ichi2.anki.servicelayer.scopedstorage.MigrateUserData.Operation
 import com.ichi2.compat.Test21And26
@@ -39,7 +37,6 @@ import java.io.File
 /**
  * Test for [MoveDirectory]
  */
-@RequiresApi(Build.VERSION_CODES.O) // This requirement is necessary for compilation. However, it still allows to test CompatV21
 @RunWith(Parameterized::class)
 class MoveDirectoryTest : Test21And26(), OperationTest {
     override lateinit var executionContext: MockMigrationContext

--- a/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/MoveDirectoryTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/MoveDirectoryTest.kt
@@ -26,8 +26,6 @@ import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.*
 import org.junit.Before
 import org.junit.Test
-import org.junit.runner.RunWith
-import org.junit.runners.Parameterized
 import org.mockito.kotlin.any
 import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.spy
@@ -37,7 +35,6 @@ import java.io.File
 /**
  * Test for [MoveDirectory]
  */
-@RunWith(Parameterized::class)
 class MoveDirectoryTest : Test21And26(), OperationTest {
     override lateinit var executionContext: MockMigrationContext
     private val executor = MockExecutor { executionContext }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/MoveDirectoryTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/MoveDirectoryTest.kt
@@ -20,7 +20,6 @@ import android.os.Build
 import androidx.annotation.RequiresApi
 import com.ichi2.anki.model.Directory
 import com.ichi2.anki.servicelayer.scopedstorage.MigrateUserData.Operation
-import com.ichi2.compat.Compat
 import com.ichi2.compat.Test21And26
 import com.ichi2.testutils.*
 import org.hamcrest.CoreMatchers.equalTo
@@ -42,11 +41,7 @@ import java.io.File
  */
 @RequiresApi(Build.VERSION_CODES.O) // This requirement is necessary for compilation. However, it still allows to test CompatV21
 @RunWith(Parameterized::class)
-class MoveDirectoryTest(
-    override val compat: Compat,
-    /** Used in the "Test Results" Window */
-    @Suppress("unused") private val unitTestDescription: String
-) : Test21And26(compat, unitTestDescription), OperationTest {
+class MoveDirectoryTest : Test21And26(), OperationTest {
     override lateinit var executionContext: MockMigrationContext
     private val executor = MockExecutor { executionContext }
 

--- a/AnkiDroid/src/test/java/com/ichi2/compat/CompatCopyFileTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/compat/CompatCopyFileTest.java
@@ -40,9 +40,6 @@ import static com.ichi2.utils.FileOperation.getFileResource;
 @RequiresApi(api = Build.VERSION_CODES.O) // This requirement is necessary for compilation. However, it still allows to test CompatV21
 @RunWith(Parameterized.class)
 public class CompatCopyFileTest extends Test21And26 {
-    public CompatCopyFileTest(Compat compat, String unitTestDescription) {
-        super(compat, unitTestDescription);
-    }
 
     @Test
     public void testCopyFileToStream() throws Exception {

--- a/AnkiDroid/src/test/java/com/ichi2/compat/CompatCopyFileTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/compat/CompatCopyFileTest.java
@@ -20,8 +20,6 @@ import com.ichi2.anki.TestUtils;
 
 import org.junit.Assert;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -33,7 +31,6 @@ import java.net.URL;
 
 import static com.ichi2.utils.FileOperation.getFileResource;
 
-@RunWith(Parameterized.class)
 public class CompatCopyFileTest extends Test21And26 {
 
     @Test

--- a/AnkiDroid/src/test/java/com/ichi2/compat/CompatCopyFileTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/compat/CompatCopyFileTest.java
@@ -16,8 +16,6 @@
 
 package com.ichi2.compat;
 
-import android.os.Build;
-
 import com.ichi2.anki.TestUtils;
 
 import org.junit.Assert;
@@ -33,11 +31,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
 
-import androidx.annotation.RequiresApi;
-
 import static com.ichi2.utils.FileOperation.getFileResource;
 
-@RequiresApi(api = Build.VERSION_CODES.O) // This requirement is necessary for compilation. However, it still allows to test CompatV21
 @RunWith(Parameterized.class)
 public class CompatCopyFileTest extends Test21And26 {
 

--- a/AnkiDroid/src/test/java/com/ichi2/compat/CompatDirectoryContentTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/compat/CompatDirectoryContentTest.kt
@@ -16,8 +16,7 @@
 
 package com.ichi2.compat
 
-import android.os.Build
-import androidx.annotation.RequiresApi
+import android.annotation.SuppressLint
 import com.ichi2.testutils.*
 import org.hamcrest.CoreMatchers.*
 import org.hamcrest.MatcherAssert.assertThat
@@ -28,7 +27,6 @@ import java.io.FileNotFoundException
 import java.io.IOException
 import java.nio.file.NotDirectoryException
 
-@RequiresApi(Build.VERSION_CODES.O) // This requirement is necessary for compilation. However, it still allows to test CompatV21
 @RunWith(Parameterized::class)
 class CompatDirectoryContentTest : Test21And26() {
 
@@ -85,6 +83,7 @@ class CompatDirectoryContentTest : Test21And26() {
         )
     }
 
+    @SuppressLint("NewApi")
     @Test
     fun file_test() {
         val file = createTransientFile("foo")

--- a/AnkiDroid/src/test/java/com/ichi2/compat/CompatDirectoryContentTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/compat/CompatDirectoryContentTest.kt
@@ -24,18 +24,13 @@ import org.hamcrest.MatcherAssert.assertThat
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
-import org.mockito.kotlin.*
 import java.io.FileNotFoundException
 import java.io.IOException
 import java.nio.file.NotDirectoryException
 
 @RequiresApi(Build.VERSION_CODES.O) // This requirement is necessary for compilation. However, it still allows to test CompatV21
 @RunWith(Parameterized::class)
-class CompatDirectoryContentTest(
-    override val compat: Compat,
-    /** Used in the "Test Results" Window */
-    @Suppress("unused") private val unitTestDescription: String
-) : Test21And26(compat, unitTestDescription) {
+class CompatDirectoryContentTest : Test21And26() {
 
     @Test
     fun empty_dir_test() {

--- a/AnkiDroid/src/test/java/com/ichi2/compat/CompatDirectoryContentTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/compat/CompatDirectoryContentTest.kt
@@ -21,13 +21,10 @@ import com.ichi2.testutils.*
 import org.hamcrest.CoreMatchers.*
 import org.hamcrest.MatcherAssert.assertThat
 import org.junit.Test
-import org.junit.runner.RunWith
-import org.junit.runners.Parameterized
 import java.io.FileNotFoundException
 import java.io.IOException
 import java.nio.file.NotDirectoryException
 
-@RunWith(Parameterized::class)
 class CompatDirectoryContentTest : Test21And26() {
 
     @Test

--- a/AnkiDroid/src/test/java/com/ichi2/compat/CompatHasFilesTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/compat/CompatHasFilesTest.kt
@@ -22,15 +22,12 @@ import org.hamcrest.CoreMatchers
 import org.hamcrest.CoreMatchers.equalTo
 import org.hamcrest.MatcherAssert.assertThat
 import org.junit.Test
-import org.junit.runner.RunWith
-import org.junit.runners.Parameterized
 import java.io.File
 import java.io.FileNotFoundException
 import java.io.IOException
 import java.nio.file.NotDirectoryException
 
 /** Tests for [Compat.hasFiles] */
-@RunWith(Parameterized::class)
 class CompatHasFilesTest : Test21And26() {
 
     @Test

--- a/AnkiDroid/src/test/java/com/ichi2/compat/CompatHasFilesTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/compat/CompatHasFilesTest.kt
@@ -17,7 +17,6 @@
 package com.ichi2.compat
 
 import android.os.Build
-import androidx.annotation.RequiresApi
 import com.ichi2.testutils.*
 import org.hamcrest.CoreMatchers
 import org.hamcrest.CoreMatchers.equalTo
@@ -32,7 +31,6 @@ import java.nio.file.NotDirectoryException
 
 /** Tests for [Compat.hasFiles] */
 @RunWith(Parameterized::class)
-@RequiresApi(Build.VERSION_CODES.O) // Allows code to compile, but we still test with [CompatV21]
 class CompatHasFilesTest : Test21And26() {
 
     @Test

--- a/AnkiDroid/src/test/java/com/ichi2/compat/CompatHasFilesTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/compat/CompatHasFilesTest.kt
@@ -19,8 +19,6 @@ package com.ichi2.compat
 import android.os.Build
 import androidx.annotation.RequiresApi
 import com.ichi2.testutils.*
-import com.ichi2.testutils.createTransientDirectory
-import com.ichi2.testutils.withTempFile
 import org.hamcrest.CoreMatchers
 import org.hamcrest.CoreMatchers.equalTo
 import org.hamcrest.MatcherAssert.assertThat
@@ -35,11 +33,7 @@ import java.nio.file.NotDirectoryException
 /** Tests for [Compat.hasFiles] */
 @RunWith(Parameterized::class)
 @RequiresApi(Build.VERSION_CODES.O) // Allows code to compile, but we still test with [CompatV21]
-class CompatHasFilesTest(
-    override val compat: Compat,
-    /** Used in the "Test Results" Window */
-    @Suppress("unused") private val unitTestDescription: String
-) : Test21And26(compat, unitTestDescription) {
+class CompatHasFilesTest : Test21And26() {
 
     @Test
     fun has_files_with_file() {

--- a/AnkiDroid/src/test/java/com/ichi2/compat/Test21And26.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/compat/Test21And26.kt
@@ -35,11 +35,7 @@ import java.io.IOException
  * And versions that must restrict themselves to [File].
  */
 @RequiresApi(Build.VERSION_CODES.O) // This requirement is necessary for compilation. However, it still allows to test CompatV21
-open class Test21And26(
-    open val compat: Compat,
-    /** Used in the "Test Results" Window */
-    @Suppress("unused") private val unitTestDescription: String
-) {
+open class Test21And26 {
     companion object {
         @JvmStatic
         @Parameterized.Parameters(name = "{1}")
@@ -49,6 +45,14 @@ open class Test21And26(
             yield(arrayOf(CompatV26(), "CompatV26"))
         }.asIterable()
     }
+
+    @Parameterized.Parameter(0)
+    lateinit var compat: Compat
+
+    @Parameterized.Parameter(1)
+    @Suppress("unused")
+    /** Used in the "Test Results" Window */
+    lateinit var unitTestDescription: String
 
     val isV21: Boolean
         get() = compat is CompatV21

--- a/AnkiDroid/src/test/java/com/ichi2/compat/Test21And26.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/compat/Test21And26.kt
@@ -23,6 +23,7 @@ import com.ichi2.testutils.createTransientDirectory
 import io.mockk.*
 import org.junit.After
 import org.junit.Before
+import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
 import org.mockito.kotlin.*
 import java.io.File
@@ -33,7 +34,8 @@ import java.io.IOException
  * In particular it allows to test version of the code that uses [Files] and [Path] classes.
  * And versions that must restrict themselves to [File].
  */
-open class Test21And26 {
+@RunWith(Parameterized::class)
+abstract class Test21And26 {
     companion object {
         @JvmStatic
         @Parameterized.Parameters(name = "{1}")

--- a/AnkiDroid/src/test/java/com/ichi2/compat/Test21And26.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/compat/Test21And26.kt
@@ -16,8 +16,7 @@
 
 package com.ichi2.compat
 
-import android.os.Build
-import androidx.annotation.RequiresApi
+import android.annotation.SuppressLint
 import com.ichi2.anki.model.Directory
 import com.ichi2.testutils.assertThrowsSubclass
 import com.ichi2.testutils.createTransientDirectory
@@ -34,7 +33,6 @@ import java.io.IOException
  * In particular it allows to test version of the code that uses [Files] and [Path] classes.
  * And versions that must restrict themselves to [File].
  */
-@RequiresApi(Build.VERSION_CODES.O) // This requirement is necessary for compilation. However, it still allows to test CompatV21
 open class Test21And26 {
     companion object {
         @JvmStatic
@@ -107,6 +105,7 @@ open class Test21And26 {
      * which simulates to simulate https://github.com/ankidroid/Anki-Android/issues/10358.
      * Also ensure that [Files.newDirectoryStream] fails on this directory.
      */
+    @SuppressLint("NewApi") // File.toPath = only called if sending API 26
     fun createPermissionDenied(): PermissionDenied {
         val directory = createTransientDirectory()
         val compat = CompatHelper.compat


### PR DESCRIPTION
## Purpose / Description
I wanted to use the tests, but didn't feel the structure was ideal, and tests took 100ms longer than expected to execute (**each**), so I fixed them

## Approach
* Use `@Parameterized.Parameter`
* Use `@SuppressLint`
* Move the mocking to `.cctor`, rather than `.ctor`, 

## How Has This Been Tested?
It is tests

## Learning (optional, can help others)
See approach

* `abstract` stops a test class being attempted to be run

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
