### PR TITLE
fix: translation of "Card Info" Title

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardInfo.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardInfo.java
@@ -74,7 +74,7 @@ public class CardInfo extends AnkiActivity {
             return;
         }
         super.onCreate(savedInstanceState);
-
+        setTitle(R.string.card_info_title);
         setContentView(R.layout.card_info);
 
         mCardId = getCardId(savedInstanceState);


### PR DESCRIPTION
Window title was not translated

Fixes #10591

![image](https://user-images.githubusercontent.com/62114487/159366199-d50ffa14-b78f-4abb-9bc6-a6a8523aa04f.png)

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
