### PR TITLE
Fix translation of MultimediaEditFieldActivity title

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/activity/MultimediaEditFieldActivity.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/activity/MultimediaEditFieldActivity.java
@@ -101,6 +101,7 @@ public class MultimediaEditFieldActivity extends AnkiActivity
             }
         }
 
+        setTitle(R.string.title_activity_edit_text);
         setContentView(R.layout.multimedia_edit_field_activity);
         View mainView = findViewById(android.R.id.content);
         enableToolbar(mainView);


### PR DESCRIPTION
## Fixes
Fixes #10598

## Approach
Sets title on activity creation

## How Has This Been Tested?

Manually on my device (Samsung Galaxy Note 10 Lite SM-N770F/DS, API 30)

System in portuguese, anki in japanese
![Screenshot_20220321-193937_AnkiDroid](https://user-images.githubusercontent.com/69634269/159375556-f03515f6-61ec-4ac1-8e88-061ccfe762d7.png)

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
