### PR TITLE
chore(ktlint): bump ktlint to 0.45.1 / spacing changes w/new version

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -205,6 +205,7 @@ android {
     ndkVersion "22.0.7026061"
 
     ktlint {
+        version = "0.45.1"
         disabledRules = ["no-wildcard-imports"]
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/SharedDecksDownloadFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/SharedDecksDownloadFragment.kt
@@ -134,7 +134,7 @@ class SharedDecksDownloadFragment : Fragment() {
      * the download progress checker.
      */
     private fun downloadFile(fileToBeDownloaded: DownloadFile) {
-        // Register broadcast receiver for download completion. 
+        // Register broadcast receiver for download completion.
         Timber.d("Registering broadcast receiver for download completion")
         activity?.registerReceiver(mOnComplete, IntentFilter(DownloadManager.ACTION_DOWNLOAD_COMPLETE))
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/AsyncDialogFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/AsyncDialogFragment.kt
@@ -25,7 +25,7 @@ import timber.log.Timber
 abstract class AsyncDialogFragment : AnalyticsDialogFragment() {
     /* provide methods for text to show in notification bar when the DialogFragment
        can't be shown due to the host activity being in stopped state.
-       This can happen when the DialogFragment is shown from 
+       This can happen when the DialogFragment is shown from
        the onPostExecute() method of an AsyncTask */
     @KotlinCleanup("convert these back to properties")
     abstract fun getNotificationMessage(): String?

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DatabaseErrorDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DatabaseErrorDialog.kt
@@ -217,7 +217,7 @@ class DatabaseErrorDialog : AsyncDialogFragment() {
                             ImportFileSelectionFragment.openImportFilePicker(activity as AnkiActivity)
                         }
                         .itemsCallbackSingleChoice(-1) {
-                            _: MaterialDialog?, _: View?, which: Int, _: CharSequence? ->
+                                _: MaterialDialog?, _: View?, which: Int, _: CharSequence? ->
                             if (mBackups[which].length() > 0) {
                                 // restore the backup if it's valid
                                 (activity as DeckPicker?)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/PeripheralKeymap.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/PeripheralKeymap.kt
@@ -1,17 +1,17 @@
 /*
- Copyright (c) 2020 David Allison <davidallisongithub@gmail.com>                     
-                                                                                     
- This program is free software; you can redistribute it and/or modify it under       
- the terms of the GNU General Public License as published by the Free Software       
- Foundation; either version 3 of the License, or (at your option) any later          
- version.                                                                            
-                                                                                     
- This program is distributed in the hope that it will be useful, but WITHOUT ANY     
- WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A     
- PARTICULAR PURPOSE. See the GNU General Public License for more details.            
-                                                                                     
- You should have received a copy of the GNU General Public License along with        
- this program.  If not, see <http://www.gnu.org/licenses/>.                          
+ Copyright (c) 2020 David Allison <davidallisongithub@gmail.com>
+
+ This program is free software; you can redistribute it and/or modify it under
+ the terms of the GNU General Public License as published by the Free Software
+ Foundation; either version 3 of the License, or (at your option) any later
+ version.
+
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License along with
+ this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
 package com.ichi2.anki.reviewer

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/DecksV16.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/DecksV16.kt
@@ -311,7 +311,7 @@ class DecksV16(private val col: Collection, private val decksBackend: DecksBacke
         return this.all_names_and_ids(
             skip_empty_default = !force_default, include_filtered = dyn
         ).map {
-            x ->
+                x ->
             x.name
         }.toMutableList()
     }
@@ -704,10 +704,10 @@ class DecksV16(private val col: Collection, private val decksBackend: DecksBacke
     fun child_ids(parent_name: str): Iterable<did> {
         val prefix = parent_name + "::"
         return all_names_and_ids().filter {
-            x ->
+                x ->
             x.name.startsWith(prefix)
         }.map {
-            d ->
+                d ->
             d.id
         }.toMutableList()
     }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/ModelsV16.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/ModelsV16.kt
@@ -371,7 +371,7 @@ class ModelsV16(col: Collection, backend: BackendV1) : ModelManager(col) {
     /** Mapping of field name : (ord, field). */
     fun fieldMap(m: NoteType): Map<str, Tuple<int, Field>> {
         return m.flds.jsonObjectIterable().map {
-            f ->
+                f ->
             Pair(f.getString("name"), Pair(f.getLong("ord"), f))
         }.toMap()
     }
@@ -594,7 +594,7 @@ and notes.mid = ? and cards.ord = ?""",
                 }
                 flds = Array(flds.size) { "" }
                 newflds.forEach {
-                    (i, fld) ->
+                        (i, fld) ->
                     flds[i] = fld
                 }
                 val fldsAsString = joinFields(flds)

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/backend/DecksBackend.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/backend/DecksBackend.kt
@@ -147,7 +147,7 @@ class RustDroidDeckBackend(private val backend: BackendV1) : DecksBackend {
 
     override fun all_names_and_ids(skip_empty_default: Boolean, include_filtered: Boolean): List<DeckNameId> {
         return backend.getDeckNames(skip_empty_default, include_filtered).entriesList.map {
-            entry ->
+                entry ->
             DeckNameId(entry.name, entry.id)
         }
     }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/utils/PythonExtensions.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/utils/PythonExtensions.kt
@@ -94,7 +94,7 @@ fun JSONArray.remove(jsonObject: JSONObject) {
 
 fun JSONArray.index(jsonObject: JSONObject): Optional<Int> {
     this.jsonObjectIterable().forEachIndexed {
-        i, value ->
+            i, value ->
         run {
             if (jsonObject == value) {
                 return Optional.of(i)

--- a/AnkiDroid/src/main/java/com/ichi2/utils/JSONException.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/JSONException.kt
@@ -1,34 +1,34 @@
-/*  
+/*
  *  Copyright (c) 2020 Arthur Milchior <arthur@milchior.fr>
- *  
- *  This file is free software: you may copy, redistribute and/or modify it  
- *  under the terms of the GNU General Public License as published by the  
- *  Free Software Foundation, either version 3 of the License, or (at your  
- *  option) any later version.  
- *  
- *  This file is distributed in the hope that it will be useful, but  
- *  WITHOUT ANY WARRANTY; without even the implied warranty of  
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU  
- *  General Public License for more details.  
- *  
- *  You should have received a copy of the GNU General Public License  
+ *
+ *  This file is free software: you may copy, redistribute and/or modify it
+ *  under the terms of the GNU General Public License as published by the
+ *  Free Software Foundation, either version 3 of the License, or (at your
+ *  option) any later version.
+ *
+ *  This file is distributed in the hope that it will be useful, but
+ *  WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
- *  
- *  This file incorporates work covered by the following copyright and  
- *  permission notice:  
- *  
+ *
+ *  This file incorporates work covered by the following copyright and
+ *  permission notice:
+ *
  *    Copyright (c) 2002 JSON.org
- *    
+ *
  *    Permission is hereby granted, free of charge, to any person obtaining a copy
  *    of this software and associated documentation files (the "Software"), to deal
  *    in the Software without restriction, including without limitation the rights
  *    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  *    copies of the Software, and to permit persons to whom the Software is
  *    furnished to do so, subject to the following conditions:
- *   
+ *
  *    The above copyright notice and this permission notice shall be included in all
  *    copies or substantial portions of the Software.
- *   
+ *
  *    The Software shall be used for Good, not Evil.
  *
  *    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
@@ -37,7 +37,7 @@
  *    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
  *    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  *    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
- *    SOFTWARE. 
+ *    SOFTWARE.
  */
 
 package com.ichi2.utils

--- a/AnkiDroid/src/main/java/com/ichi2/utils/JSONTokener.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/JSONTokener.kt
@@ -1,34 +1,34 @@
-/*  
+/*
  *  Copyright (c) 2020 Arthur Milchior <arthur@milchior.fr>
- *  
- *  This file is free software: you may copy, redistribute and/or modify it  
- *  under the terms of the GNU General Public License as published by the  
- *  Free Software Foundation, either version 3 of the License, or (at your  
- *  option) any later version.  
- *  
- *  This file is distributed in the hope that it will be useful, but  
- *  WITHOUT ANY WARRANTY; without even the implied warranty of  
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU  
- *  General Public License for more details.  
- *  
- *  You should have received a copy of the GNU General Public License  
+ *
+ *  This file is free software: you may copy, redistribute and/or modify it
+ *  under the terms of the GNU General Public License as published by the
+ *  Free Software Foundation, either version 3 of the License, or (at your
+ *  option) any later version.
+ *
+ *  This file is distributed in the hope that it will be useful, but
+ *  WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
- *  
- *  This file incorporates work covered by the following copyright and  
- *  permission notice:  
- *  
+ *
+ *  This file incorporates work covered by the following copyright and
+ *  permission notice:
+ *
  *    Copyright (c) 2002 JSON.org
- *    
+ *
  *    Permission is hereby granted, free of charge, to any person obtaining a copy
  *    of this software and associated documentation files (the "Software"), to deal
  *    in the Software without restriction, including without limitation the rights
  *    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  *    copies of the Software, and to permit persons to whom the Software is
  *    furnished to do so, subject to the following conditions:
- *   
+ *
  *    The above copyright notice and this permission notice shall be included in all
  *    copies or substantial portions of the Software.
- *   
+ *
  *    The Software shall be used for Good, not Evil.
  *
  *    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
@@ -37,7 +37,7 @@
  *    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
  *    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  *    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
- *    SOFTWARE. 
+ *    SOFTWARE.
  */
 package com.ichi2.utils
 

--- a/lint-rules/build.gradle
+++ b/lint-rules/build.gradle
@@ -7,6 +7,7 @@ java {
 }
 
 ktlint {
+    version = "0.45.1"
     disabledRules = ["no-wildcard-imports"]
 }
 


### PR DESCRIPTION
## Pull Request template

## Purpose / Description

Bump underlying version of ktlint in order to access this memory fix: https://github.com/pinterest/ktlint/issues/1216

## Fixes
Fixes #10242 (well, should fix it for real, can reopen I guess, if not)

## Approach

spacing changes were produced automatically using the new version on the
command line with `-F` argument to auto-fix spacing to conform with new
version of the tool. 

It has to be changed at same time as the version since ktlint actually changed it's behavior

## How Has This Been Tested?

I ran ktlint a few times from the command line and it seemed fine?

I verified via `./gradlew :AnkiDroid:dependencies |grep ktlint` that it was pullingn 0.42.1 before this change and is getting 0.45.1 now.


## Learning (optional, can help others)

Allowing version overrides on transitive dependencies is really helpful if you make things transitively dependent on consumers of your project. Thanks gradle ktlint plugin :-)

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
