### PR TITLE
[Deprecation] create wrapper deprecation api change

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/FieldEditText.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/FieldEditText.kt
@@ -23,13 +23,16 @@ import android.net.Uri
 import android.os.*
 import android.text.InputType
 import android.util.AttributeSet
+import android.view.View
 import android.view.inputmethod.EditorInfo
 import android.view.inputmethod.InputConnection
 import android.widget.EditText
 import androidx.annotation.RequiresApi
+import androidx.core.view.ContentInfoCompat
+import androidx.core.view.OnReceiveContentListener
+import androidx.core.view.ViewCompat
 import androidx.core.view.inputmethod.EditorInfoCompat
 import androidx.core.view.inputmethod.InputConnectionCompat
-import androidx.core.view.inputmethod.InputContentInfoCompat
 import com.ichi2.anki.servicelayer.NoteService
 import com.ichi2.themes.Themes.getColorFromAttr
 import com.ichi2.ui.FixedEditText
@@ -95,42 +98,46 @@ class FieldEditText : FixedEditText, NoteService.NoteField {
         mImageListener = imageListener
     }
 
-    // Tracked in #9775
-    @Suppress("deprecation")
+    @KotlinCleanup("add extension method to iterate clip items")
     override fun onCreateInputConnection(editorInfo: EditorInfo): InputConnection? {
         val inputConnection = super.onCreateInputConnection(editorInfo) ?: return null
         EditorInfoCompat.setContentMimeTypes(editorInfo, IMAGE_MIME_TYPES)
-        return InputConnectionCompat.createWrapper(inputConnection, editorInfo) { contentInfo: InputContentInfoCompat, flags: Int, opts: Bundle? ->
-            if (mImageListener == null) {
-                return@createWrapper false
-            }
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N_MR1 && flags and
-                InputConnection.INPUT_CONTENT_GRANT_READ_URI_PERMISSION != 0
-            ) {
-                try {
-                    contentInfo.requestPermission()
-                } catch (e: Exception) {
-                    return@createWrapper false
+        ViewCompat.setOnReceiveContentListener(
+            this, IMAGE_MIME_TYPES,
+            object : OnReceiveContentListener {
+                override fun onReceiveContent(view: View, payload: ContentInfoCompat): ContentInfoCompat? {
+                    val pair = payload.partition { item -> item.uri != null }
+                    val uriContent = pair.first
+                    val remaining = pair.second
+
+                    if (mImageListener == null || uriContent == null) {
+                        return remaining
+                    }
+
+                    val clip = uriContent.clip
+                    val description = clip.description
+
+                    if (!hasImage(description)) {
+                        return remaining
+                    }
+
+                    for (i in 0 until clip.itemCount) {
+                        val uri = clip.getItemAt(i).uri
+                        try {
+                            onImagePaste(uri)
+                        } catch (e: Exception) {
+                            Timber.w(e)
+                            AnkiDroidApp.sendExceptionReport(e, "NoteEditor::onImage")
+                            return remaining
+                        }
+                    }
+
+                    return remaining
                 }
             }
-            val description = contentInfo.description
-            if (!hasImage(description)) {
-                return@createWrapper false
-            }
-            try {
-                if (!onImagePaste(contentInfo.contentUri)) {
-                    return@createWrapper false
-                }
-                // There is a timeout on this line which occurs even if we're stopped in the debugger, if we take too long we get
-                // "Ankidroid doesn't support image insertion here"
-                InputConnectionCompat.commitContent(inputConnection, editorInfo, contentInfo, flags, opts)
-                return@createWrapper true
-            } catch (e: Exception) {
-                Timber.w(e)
-                AnkiDroidApp.sendExceptionReport(e, "NoteEditor::onImage")
-                return@createWrapper false
-            }
-        }
+        )
+
+        return InputConnectionCompat.createWrapper(this, inputConnection, editorInfo)
     }
 
     override fun onSelectionChanged(selStart: Int, selEnd: Int) {


### PR DESCRIPTION
## Purpose / Description
 Input connection createWrapper current implementation is deprecated in function onCreateInputConnection in AnkiDroid/Anki-Android/AnkiDroid/src/main/java/com/ichi2/anki/FieldEditText.kt.

## Fixes
Fixes #9775 

## Approach

As suggested in [documentation](https://developer.android.com/reference/androidx/core/view/inputmethod/InputConnectionCompat#createWrapper(android.view.inputmethod.InputConnection,%20android.view.inputmethod.EditorInfo,%20androidx.core.view.inputmethod.InputConnectionCompat.OnCommitContentListener)), i have used createWrapper(View,InputConnection,EditorInfo) and ViewCompat.setOnReceiveContentListener with implementation of OnReceiveContentListener interface.

I have not reimplemented the request read uri permission part alone because its documentation states read uri permission is granted by default [here](https://developer.android.com/reference/androidx/core/view/OnReceiveContentListener#uri-permissions).

reference [implementation](https://developer.android.com/reference/androidx/core/view/OnReceiveContentListener) of onReceiveContentListener

## How Has This Been Tested?

manual test on android 11(oneui 3.1) of image and text paste works

## Checklist

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [ ] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
