### PR TITLE
Fix ModelBrowser Activity title

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/ModelBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ModelBrowser.java
@@ -187,6 +187,7 @@ public class ModelBrowser extends AnkiActivity {
             return;
         }
         super.onCreate(savedInstanceState);
+        setTitle(R.string.model_browser_label);
         setContentView(R.layout.model_browser);
         mModelListView = findViewById(R.id.note_type_browser_list);
         enableToolbar();


### PR DESCRIPTION
## Purpose / Description
It defaulted to system language instead of Anki's

## Fixes
Fixes #10623

## Approach
Sets title on ModelBrowser activity creation

## How Has This Been Tested?

Manually on my phone (Samsung Galaxy Note 10 Lite SM-N770F/DS, API 30)

### Before

![Screenshot_20220325-102755_AnkiDroid](https://user-images.githubusercontent.com/69634269/160132684-d379a57b-3f7a-452d-a02c-9f05cfb6cc56.png)

### After

![Screenshot_20220325-103442_AnkiDroid](https://user-images.githubusercontent.com/69634269/160132693-a8202b55-0d04-4814-b9d3-cc04053c8d18.png)


## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [X] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
