### PR TITLE
feat(tests): Apple Silicon Support

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -77,7 +77,7 @@ android {
             // Check Crash Reports page on developer wiki for info on ACRA testing
             buildConfigField "String", "ACRA_URL", '"https://ankidroid.org/acra/report"'
 //            buildConfigField "String", "ACRA_URL", '"https://918f7f55-f238-436c-b34f-c8b5f1331fe5-bluemix.cloudant.com/acra-ankidroid/_design/acra-storage/_update/report"'
-
+            buildConfigField "String", "BACKEND_VERSION", "\"$ankidroid_backend_version\""
             // #6009 Allow optional disabling of JaCoCo for general build (assembleDebug).
             // jacocoDebug task was slow, hung, and wasn't required unless I wanted coverage
             if (project.rootProject.file('local.properties').exists()) {
@@ -102,6 +102,7 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
             signingConfig signingConfigs.release
             buildConfigField "String", "ACRA_URL", '"https://ankidroid.org/acra/report"'
+            buildConfigField "String", "BACKEND_VERSION", "\"$ankidroid_backend_version\""
             resValue 'color', 'anki_foreground_icon_color_0', "#FF29B6F6"
             resValue 'color', 'anki_foreground_icon_color_1', "#FF0288D1"
         }
@@ -302,18 +303,15 @@ dependencies {
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.13.2'
     implementation 'com.github.CanHub:Android-Image-Cropper:3.1.3'
 
-
-    // == Rust conversion (from Anki-Android-Backend on GitHub) ==
-    String backendVersion = "0.1.10" // We want both testing and implementation on the same version
     // build with ./gradlew rsdroid:assembleRelease
-    // In my experience, using `files()` currently requires a reindex operation, which is slow.
+    // In my experience, using `files()` currently requires a reindex operation.
     // implementation files("C:\\GitHub\\Rust-Test\\rsdroid\\build\\outputs\\aar\\rsdroid-release.aar")
     implementation 'com.google.protobuf:protobuf-java:3.19.4' // This is required when loading from a file
-    implementation "io.github.david-allison-1:anki-android-backend:$backendVersion"
+    implementation "io.github.david-allison-1:anki-android-backend:$ankidroid_backend_version"
     // build with ./gradlew rsdroid-testing:assembleRelease
     // RobolectricTest.java: replace RustBackendLoader.init(); with RustBackendLoader.loadRsdroid(path);
     // A path for a testing library is typically under rsdroid-testing/assets
-    testImplementation "io.github.david-allison-1:anki-android-backend-testing:$backendVersion"
+    testImplementation "io.github.david-allison-1:anki-android-backend-testing:$ankidroid_backend_version"
 
     // May need a resolution strategy for support libs to our versions
     implementation "ch.acra:acra-http:$acra_version"

--- a/build.gradle
+++ b/build.gradle
@@ -7,6 +7,7 @@ buildscript {
     ext.kotlin_version = '1.6.10'
     ext.lint_version = '30.1.2'
     ext.acra_version = '5.7.0'
+    ext.ankidroid_backend_version = '0.1.10'
 
     repositories {
         google()


### PR DESCRIPTION
## Pull Request template

## Purpose / Description

`anki-android-backend-testing` contains pre-compiled Rust code so Robolectric can load it and run natively.

We can't currently include an Apple Silicon (AS) dylib inside `anki-android-backend-testing `(`cross` doesn't compile AS code yet)

## Fixes
Fixes https://github.com/ankidroid/Anki-Android-Backend/issues/164

## Approach




But, we can compile an AS dylib on an AS Mac and reference it.

So we include the `dylib` in the releases folder of `Anki-Android-Backend` and add functionality to specify an environment variable to load this `dylib` from disk, instead of from the `.jar`

**Instructions (for 0.1.10):**

Download librsdroid-arm64.dylib from https://github.com/ankidroid/Anki-Android-Backend/releases/tag/0.1.10

And add the following environment variables:
one to the path and one for the version

```
export ANKIDROID_BACKEND_PATH="/Users/davidallison/StudioProjects/Anki-Android-Backend/rslib-bridge/target/aarch64-apple-darwin/release/librsdroid-arm64.dylib"
export ANKIDROID_BACKEND_VERSION="0.1.10"
```

Library generated from:
```
davidallison@Davids-MBP rslib-bridge % pwd
/Users/davidallison/StudioProjects/Anki-Android-Backend/rslib-bridge
rustup install 1.54.0
rustup default 1.54.0
cross build --release --features no-android --verbose --target aarch64-apple
```
on an AS MacBook

## How Has This Been Tested?

Tested the version mismatch case and the valid case

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
