### PR TITLE
added New Lint rule for Detecting invalid string formats.

### DIFF
--- a/lint-rules/src/main/java/com/ichi2/anki/lint/IssueRegistry.java
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/IssueRegistry.java
@@ -11,6 +11,7 @@ import com.ichi2.anki.lint.rules.DirectSystemCurrentTimeMillisUsage;
 import com.ichi2.anki.lint.rules.DirectDateInstantiation;
 import com.ichi2.anki.lint.rules.DirectGregorianInstantiation;
 import com.ichi2.anki.lint.rules.DirectToastMakeTextUsage;
+import com.ichi2.anki.lint.rules.InvalidStringFormatDetector;
 import com.ichi2.anki.lint.rules.JUnitNullAssertionDetector;
 import com.ichi2.anki.lint.rules.DuplicateCrowdInStrings;
 import com.ichi2.anki.lint.rules.DuplicateTextInPreferencesXml;
@@ -57,6 +58,7 @@ public class IssueRegistry extends com.android.tools.lint.client.api.IssueRegist
         issues.add(FixedPreferencesTitleLength.ISSUE_MAX_LENGTH);
         issues.add(FixedPreferencesTitleLength.ISSUE_TITLE_LENGTH);
         issues.add(VariableNamingDetector.ISSUE);
+        issues.add(InvalidStringFormatDetector.ISSUE);
         return issues;
     }
 

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/rules/InvalidStringFormatDetector.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/InvalidStringFormatDetector.kt
@@ -55,7 +55,7 @@ class InvalidStringFormatDetector : ResourceXmlDetector() {
         )
     }
 
-    private val INVALID_FORMAT_PATTERN = Pattern.compile("[^%]+%")
+    private val INVALID_FORMAT_PATTERN = Pattern.compile("[^%]+%").toRegex()
 
     override fun appliesTo(folderType: ResourceFolderType): Boolean =
         EnumSet.of(ResourceFolderType.VALUES).contains(folderType)
@@ -89,9 +89,8 @@ class InvalidStringFormatDetector : ResourceXmlDetector() {
     }
 
     private fun checkText(context: XmlContext, element: Element, text: String) {
-        println(text)
         text.split(" ").forEach {
-            if (it.matches(INVALID_FORMAT_PATTERN.toRegex())) {
+            if (it.matches(INVALID_FORMAT_PATTERN) && it != "XXX%") {
                 val location = context.createLocationHandle(element).resolve()
                 context.report(
                     ISSUE, location,

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/rules/InvalidStringFormatDetector.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/InvalidStringFormatDetector.kt
@@ -1,0 +1,106 @@
+/*
+ *  Copyright (c) 2022 Divyansh Dwivedi <justdvnsh2208@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.lint.rules
+
+import com.android.SdkConstants.*
+import com.android.resources.ResourceFolderType
+import com.android.tools.lint.detector.api.Implementation
+import com.android.tools.lint.detector.api.Issue
+import com.android.tools.lint.detector.api.ResourceXmlDetector
+import com.android.tools.lint.detector.api.Scope.Companion.ALL_RESOURCES_SCOPE
+import com.android.tools.lint.detector.api.XmlContext
+import com.android.utils.forEach
+import com.ichi2.anki.lint.utils.Constants.*
+import com.ichi2.anki.lint.utils.StringFormatDetector
+import org.w3c.dom.Element
+import org.w3c.dom.Node
+import java.util.*
+import java.util.regex.Pattern
+
+/**
+ * Fix for "Linting Error - String format should be valid."
+ * [https://github.com/ankidroid/Anki-Android/issues/10604](https://github.com/ankidroid/Anki-Android/issues/10604)
+ */
+class InvalidStringFormatDetector : ResourceXmlDetector() {
+    companion object {
+        private val IMPLEMENTATION_XML =
+            Implementation(InvalidStringFormatDetector::class.java, ALL_RESOURCES_SCOPE)
+
+        /**
+         * Whether the string or plural resource that is being used has all the translations
+         * **/
+        @JvmField
+        val ISSUE = Issue.create(
+            "InvalidStringFormat",
+            "The String format is invalid",
+            "The String format used is invalid, Make sure to use a valid string format",
+            ANKI_XML_CATEGORY,
+            ANKI_XML_PRIORITY,
+            ANKI_XML_SEVERITY,
+            IMPLEMENTATION_XML
+        )
+    }
+
+    private val INVALID_FORMAT_PATTERN = Pattern.compile("[^%]+%")
+
+    override fun appliesTo(folderType: ResourceFolderType): Boolean =
+        EnumSet.of(ResourceFolderType.VALUES).contains(folderType)
+
+    override fun getApplicableElements() = listOf(TAG_STRING, TAG_PLURALS)
+
+    override fun visitElement(context: XmlContext, element: Element) {
+        val childNodes = element.childNodes
+        if (childNodes.length <= 0) return
+
+        element.childNodes
+            .forEach { child ->
+                val isStringResource = child.nodeType == Node.TEXT_NODE &&
+                    TAG_STRING == element.localName
+                val isStringArrayOrPlurals = child.nodeType == Node.ELEMENT_NODE &&
+                    (
+                        TAG_STRING_ARRAY == element.localName ||
+                            TAG_PLURALS == element.localName
+                        )
+
+                if (isStringResource) {
+                    checkText(context, element, child.nodeValue)
+                } else if (isStringArrayOrPlurals) {
+                    val sb = StringBuilder()
+                    StringFormatDetector.addText(sb, element)
+                    if (sb.isNotEmpty()) {
+                        checkText(context, element, sb.toString())
+                    }
+                }
+            }
+    }
+
+    private fun checkText(context: XmlContext, element: Element, text: String) {
+        println(text)
+        text.split(" ").forEach {
+            if (it.matches(INVALID_FORMAT_PATTERN.toRegex())) {
+                val location = context.createLocationHandle(element).resolve()
+                context.report(
+                    ISSUE, location,
+                    "You have specified the string in wrong format" +
+                        "Please check that '%' sign been applied only to valid parameters. " +
+                        "Your string might be having a regular word with '%' sign after it. " +
+                        "eg: 'I have completed% %s cards.' "
+                )
+            }
+        }
+    }
+}

--- a/lint-rules/src/test/java/com/ichi2/anki/lint/rules/InvalidStringFormatDetectorTest.kt
+++ b/lint-rules/src/test/java/com/ichi2/anki/lint/rules/InvalidStringFormatDetectorTest.kt
@@ -1,0 +1,78 @@
+/*
+ *  Copyright (c) 2022 Divyansh Dwivedi <justdvnsh2208@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.lint.rules
+
+import com.android.tools.lint.checks.infrastructure.TestFiles
+import com.android.tools.lint.checks.infrastructure.TestLintTask
+import org.intellij.lang.annotations.Language
+import org.junit.Test
+
+/** Test for [InvalidStringFormatDetectorTest] */
+class InvalidStringFormatDetectorTest {
+
+    @Language("XML")
+    private val invalid = """<resources>
+        |<string name="testString">I am a test% String</string>
+        |<string name="testString2">test%</string>
+        |<string name="testString3">test% string</string>
+        |<plurals name="pluralTestString1">
+            <item quantity="other">आज%  %1${'$'}'d' मध्ये% %2${'$'}'s' कार्डांचा अभ्यास केला</item>
+        </plurals>
+        |</resources>
+    """.trimMargin()
+
+    @Language("XML")
+    private val valid = """<resources>
+        |<string name="testString">I am a test String</string>
+        |<string name="testString2">test</string>
+        |<string name="testString3">test string</string>
+        ||<string name="testString4">test string %s</string>
+        |<string name="testString5">%%</string>
+        |<string name="testString6">%1\$'d' is expected</string>
+        |<plurals name="PluralTestString1">
+            <item quantity="one">%1$'d' card (0 due)</item>
+            <item quantity="other">%1$'d' cards (0 due)</item>
+        </plurals>
+        |<plurals name="pluralTestString2">
+            <item quantity="one">आज %1${'$'}'d' मध्ये %2${'$'}'s' कार्डचा अभ्यास केला</item>
+        </plurals>
+        |</resources>
+    """.trimMargin()
+
+    @Test
+    fun error_if_string_format_invalid() {
+        TestLintTask.lint()
+            .allowMissingSdk()
+            .allowCompilationErrors()
+            .allowDuplicates()
+            .files(TestFiles.xml("res/values/string.xml", invalid))
+            .issues(InvalidStringFormatDetector.ISSUE)
+            .run()
+            .expectErrorCount(4)
+    }
+
+    @Test
+    fun no_error_if_string_format_valid() {
+        TestLintTask.lint()
+            .allowMissingSdk()
+            .allowCompilationErrors()
+            .files(TestFiles.xml("res/values/string.xml", valid))
+            .issues(InvalidStringFormatDetector.ISSUE)
+            .run()
+            .expectClean()
+    }
+}

--- a/lint-rules/src/test/java/com/ichi2/anki/lint/rules/InvalidStringFormatDetectorTest.kt
+++ b/lint-rules/src/test/java/com/ichi2/anki/lint/rules/InvalidStringFormatDetectorTest.kt
@@ -50,6 +50,7 @@ class InvalidStringFormatDetectorTest {
         |<plurals name="pluralTestString2">
             <item quantity="one">आज %1${'$'}'d' मध्ये %2${'$'}'s' कार्डचा अभ्यास केला</item>
         </plurals>
+        |<string name="testString7">XXX%</string>
         |</resources>
     """.trimMargin()
 


### PR DESCRIPTION
## Purpose / Description
The main issue was an invalid format string: https://github.com/ankidroid/Anki-Android/pull/10548/files which caused a crash.

We want to ensure that a string on the left is caught by the lint-rules project, and fails the CI. We want this both for plurals and standard strings (this may be a plural only issue).

## Fixes
Fixes #10604 

## Approach
Added a new lint rule to check for such errors. 

## How Has This Been Tested?
Added a test for the rule as well.

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
