### PR TITLE
fix(tests): Fix tests on Apple Silicon

### DIFF
--- a/AnkiDroid/src/test/java/com/ichi2/compat/CompatDirectoryContentTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/compat/CompatDirectoryContentTest.kt
@@ -42,7 +42,7 @@ class CompatDirectoryContentTest : Test21And26() {
             .withTempFile("zero")
         val iterator = compat.contentOfDirectory(directory)
         val file = iterator.next()
-        assertThat("Paths should be canonical", file.path, equalTo(file.canonicalPath))
+        assertThat("Paths should be absolute", file.path, equalTo(file.absolutePath))
     }
 
     @Test


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
Error:

```
com.ichi2.compat.DirectoryContentTest > ensure_absolute_path[21] FAILED
    java.lang.AssertionError: Paths should be canonical
    Expected: "/private/var/folders/tq/7kbhnvh9675drxzzyvpk0n840000gq/T/13587878100631967865/zero"
         but: was "/var/folders/tq/7kbhnvh9675drxzzyvpk0n840000gq/T/13587878100631967865/zero"
        at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:20)
        at com.ichi2.compat.DirectoryContentTest.ensure_absolute_path(DirectoryContentTest.kt:49)

com.ichi2.compat.DirectoryContentTest > ensure_absolute_path FAILED
    java.lang.AssertionError: Paths should be canonical
    Expected: "/private/var/folders/tq/7kbhnvh9675drxzzyvpk0n840000gq/T/8221483500880813673/zero"
         but: was "/var/folders/tq/7kbhnvh9675drxzzyvpk0n840000gq/T/8221483500880813673/zero"
        at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:20)
        at com.ichi2.compat.DirectoryContentTest.ensure_absolute_path(DirectoryContentTest.kt:49)
com.ichi2.async.CollectionTaskSearchCardsTest > searchCardsNumberOfResultCount FAILED
```

## Fixes
Fixes #10403

## Approach
I was wrong in https://github.com/ankidroid/Anki-Android/pull/10369#discussion_r811758601

we did not want canonical paths as the path returned from listFiles()
is not canonical.

## How Has This Been Tested?
Test only

## Learning (optional, can help others)
`listFiles()` doesn't return a canonical path

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)