### PR TITLE
feat(compat): createDirectories

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/scopedstorage/MoveDirectory.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/scopedstorage/MoveDirectory.kt
@@ -19,6 +19,7 @@ package com.ichi2.anki.servicelayer.scopedstorage
 import androidx.annotation.VisibleForTesting
 import com.ichi2.anki.model.Directory
 import com.ichi2.anki.servicelayer.scopedstorage.MigrateUserData.Operation
+import com.ichi2.compat.CompatHelper
 import timber.log.Timber
 import java.io.File
 
@@ -61,10 +62,7 @@ data class MoveDirectory(val source: Directory, val destination: File) : Migrate
      */
     internal fun createDirectory(context: MigrateUserData.MigrationContext): Boolean {
         Timber.d("creating directory '$destination'")
-        if (!createDirectory(destination)) {
-            context.reportError(this, IllegalStateException("Could not create '$destination'"))
-            return false
-        }
+        createDirectory(destination)
 
         val destinationDirectory = Directory.createInstance(destination)
         if (destinationDirectory == null) {
@@ -76,7 +74,7 @@ data class MoveDirectory(val source: Directory, val destination: File) : Migrate
 
     /** Creates a directory if it doesn't already exist */
     @VisibleForTesting
-    internal fun createDirectory(directory: File) = directory.exists() || directory.mkdirs()
+    internal fun createDirectory(directory: File) = CompatHelper.compat.createDirectories(directory)
 
     @VisibleForTesting
     internal fun rename(source: Directory, destination: File) = source.renameTo(destination)

--- a/AnkiDroid/src/main/java/com/ichi2/compat/Compat.java
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/Compat.java
@@ -27,8 +27,6 @@ import android.media.MediaRecorder;
 import android.net.Uri;
 import android.widget.TimePicker;
 
-import com.ichi2.async.ProgressSenderAndCancelListener;
-
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -114,6 +112,12 @@ public interface Compat {
         }
     }
 
+    /**
+     * Same as [File::createDirectories]. Does not throw if directory already exists
+     * @param directory a directory to create. Create parents if necessary
+     * @throws IOException
+     */
+    void createDirectories(@NonNull File directory) throws IOException;
     boolean hasVideoThumbnail(@NonNull String path);
     void requestAudioFocus(AudioManager audioManager, AudioManager.OnAudioFocusChangeListener audioFocusChangeListener, @Nullable AudioFocusRequest audioFocusRequest);
     void abandonAudioFocus(AudioManager audioManager, AudioManager.OnAudioFocusChangeListener audioFocusChangeListener, @Nullable AudioFocusRequest audioFocusRequest);

--- a/AnkiDroid/src/main/java/com/ichi2/compat/CompatV21.java
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/CompatV21.java
@@ -31,8 +31,6 @@ import android.os.Vibrator;
 import android.provider.MediaStore;
 import android.widget.TimePicker;
 
-import com.ichi2.async.ProgressSenderAndCancelListener;
-import com.ichi2.utils.FileUtil;
 import com.ichi2.utils.KotlinCleanup;
 
 import java.io.File;
@@ -147,6 +145,21 @@ public class CompatV21 implements Compat {
             throw new IOException("Unable to delete: " + file.getCanonicalPath());
         }
     }
+
+
+    @Override
+    public void createDirectories(@NonNull File directory) throws IOException {
+        if (directory.exists()) {
+            if (!directory.isDirectory()) {
+                throw new IOException(directory + " is not a directory");
+            }
+            return;
+        }
+        if (!directory.mkdirs()) {
+            throw new IOException("Failed to create " + directory);
+        }
+    }
+
 
     // Until API 23 the methods have "current" in the name
     @Override

--- a/AnkiDroid/src/main/java/com/ichi2/compat/CompatV26.java
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/CompatV26.java
@@ -26,33 +26,24 @@ import android.media.AudioManager;
 import android.os.VibrationEffect;
 import android.os.Vibrator;
 
-import com.ichi2.async.ProgressSenderAndCancelListener;
-import com.ichi2.utils.FileUtil;
-
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-import androidx.annotation.VisibleForTesting;
-import androidx.core.app.NotificationCompat;
-
 import java.io.File;
 import java.io.FileNotFoundException;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.file.DirectoryIteratorException;
 import java.nio.file.DirectoryStream;
-import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
 import java.nio.file.NoSuchFileException;
-import java.nio.file.NotDirectoryException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.nio.file.SimpleFileVisitor;
 import java.nio.file.StandardCopyOption;
-import java.nio.file.attribute.BasicFileAttributes;
 import java.util.Iterator;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.annotation.VisibleForTesting;
+import androidx.core.app.NotificationCompat;
 import timber.log.Timber;
 
 /** Implementation of {@link Compat} for SDK level 26 and higher. Check  {@link Compat}'s for more detail. */
@@ -113,6 +104,12 @@ public class CompatV26 extends CompatV23 implements Compat {
             throw new FileNotFoundException(file.getCanonicalPath());
         }
     }
+
+    @Override
+    public void createDirectories(@NonNull File directory) throws IOException {
+        Files.createDirectories(directory.toPath());
+    }
+
 
     @Override
     public void requestAudioFocus(AudioManager audioManager, AudioManager.OnAudioFocusChangeListener audioFocusChangeListener,

--- a/AnkiDroid/src/test/java/com/ichi2/compat/CreateDirectoriesTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/compat/CreateDirectoriesTest.kt
@@ -1,0 +1,63 @@
+/*
+ *  Copyright (c) 2022 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.compat
+
+import com.ichi2.testutils.AnkiAssert.assertDoesNotThrow
+import com.ichi2.testutils.assertThrowsSubclass
+import com.ichi2.testutils.createTransientDirectory
+import org.hamcrest.CoreMatchers.not
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.io.FileMatchers.anExistingDirectory
+import org.junit.Test
+import java.io.File
+import java.io.IOException
+
+class CreateDirectoriesTest : Test21And26() {
+
+    private val rootDirectory = createTransientDirectory()
+
+    @Test
+    fun if_directory_does_not_exist_it_is_created() {
+        val parent = rootDirectory.createTransientDirectory("1")
+        val child = parent.createTransientDirectory("2").also { it.delete() }
+        parent.delete()
+
+        assertThat("parent should not exist", parent, not(anExistingDirectory()))
+        assertThat("child should not exist", child, not(anExistingDirectory()))
+
+        compat.createDirectories(child)
+
+        assertThat("parent should be created", parent, anExistingDirectory())
+        assertThat("child should be created", child, anExistingDirectory())
+    }
+
+    @Test
+    fun if_directory_exists_nothing_happens() {
+        val existing = rootDirectory.createTransientDirectory("2")
+        assertDoesNotThrow { compat.createDirectories(existing) }
+    }
+
+    @Test
+    fun exception_if_directory_cannot_be_created() {
+        val file = File(rootDirectory, "a").apply {
+            createNewFile()
+            deleteOnExit()
+        }
+        // We fail as it's a file
+        assertThrowsSubclass<IOException> { compat.createDirectories(file) }
+    }
+}


### PR DESCRIPTION
This allows a "human readable" exception when creating a directory
And a fast result if the directory already exists.

mkdirs() is nice, but:
* The return value only gives us a boolean pass/fail
* It "fails" if the directory already exists

This will be used in MoveConflictedFile

Supersedes #10571

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
