### PR TITLE
[Bug] After creating a subdeck, the parent deck's menu is displayed again

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -2656,6 +2656,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
         CreateDeckDialog createDeckDialog = new CreateDeckDialog(DeckPicker.this, R.string.create_subdeck, CreateDeckDialog.DeckDialogType.SUB_DECK, did);
         createDeckDialog.setOnNewDeckCreated((i) -> {
             // a deck was created
+            dismissAllDialogFragments();
             mDeckListAdapter.notifyDataSetChanged();
             updateDeckList();
             if (mFragmented) {


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
_Describe the problem or feature and motivation_

After creating a subdeck, the parent deck's menu is displayed again

## Fixes
Fixes #10632 

## How Has This Been Tested?
Android Device:Redmi y3


## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [x] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
