### PR TITLE
test(robolectric): update robolectric jars list to match currently used

### DIFF
--- a/.github/workflows/tests_emulator.yml
+++ b/.github/workflows/tests_emulator.yml
@@ -70,7 +70,7 @@ jobs:
           timeout_minutes: 10
           retry_wait_seconds: 60
           max_attempts: 3
-          command: ./gradlew assembleDebug assembleAndroidTest
+          command: ./gradlew assembleDebug assembleAndroidTest robolectricSdkDownload
 
       - name: Download Emulator Image
         # This can fail on network request, wrap with retry

--- a/AnkiDroid/robolectricDownloader.gradle
+++ b/AnkiDroid/robolectricDownloader.gradle
@@ -19,11 +19,13 @@ def robolectricAndroidSdkVersions = [
 //        [androidVersion: "6.0.1_r3", frameworkSdkBuildVersion: "r1"],
 //        [androidVersion: "7.0.0_r1", frameworkSdkBuildVersion: "r1"],
 //        [androidVersion: "7.1.0_r7", frameworkSdkBuildVersion: "r1"],
-        [androidVersion: "8.0.0_r4", frameworkSdkBuildVersion: "r1"],
+//        [androidVersion: "8.0.0_r4", frameworkSdkBuildVersion: "r1"],
 //        [androidVersion: "8.1.0", frameworkSdkBuildVersion: "4611349"],
 //        [androidVersion: "9", frameworkSdkBuildVersion: "4913185-2"],
         [androidVersion: "10", frameworkSdkBuildVersion:  "5803371"],
-        [androidVersion: "11", frameworkSdkBuildVersion:  "6757853"],
+//        [androidVersion: "11", frameworkSdkBuildVersion:  "6757853"],
+        [androidVersion: "12", frameworkSdkBuildVersion:  "7732740"],
+//        [androidVersion: "12.1", frameworkSdkBuildVersion:  "8229987"],
 ]
 
 // Base, public task - will be displayed in ./gradlew robolectricDownloader:tasks


### PR DESCRIPTION
## Pull Request template

## Purpose / Description

Make sure we only download the bits we need in CI via the robolectric pre-downloader (which itself is just there to do the download in a retry loop to avoid flaky network failures during tests if the jars are downloaded on-demand during testing)

Also it turns out that the task that runs this `robolectricSdkDownload` was not actually called in CI, so no de-flaking was happening. Haven't seen this flake in a while but it definitely used to happen, and the code works (or should - CI will bear it out)

## Fixes

No issue logged

## Approach

## How Has This Been Tested?

Here is the output from my diagnostic jar search to detect current versions:

```

mike@bistromath:/mnt/c/Users/micro/.m2$ find . |grep android-all |grep '.jar$'
./repository/org/robolectric/android-all-instrumented/10-robolectric-5803371-i3/android-all-instrumented-10-robolectric-5803371-i3.jar
./repository/org/robolectric/android-all-instrumented/12-robolectric-7732740-i3/android-all-instrumented-12-robolectric-7732740-i3.jar
./repository/org/robolectric/android-all-instrumented/5.0.2_r3-robolectric-r0-i3/android-all-instrumented-5.0.2_r3-robolectric-r0-i3.jar
./repository/org/robolectric/android-all-instrumented/5.1.1_r9-robolectric-r2-i3/android-all-instrumented-5.1.1_r9-robolectric-r2-i3.jar
```

Here is where I pulled the rest of the jar names https://github.com/robolectric/robolectric/blob/3fd918ca3411b1e84d44c8d1b39e16c2cd81efd1/robolectric/src/main/java/org/robolectric/plugins/DefaultSdkProvider.java#L66-L83

Examining the `warm gradle cache` action in CI emulator run should show the robolectric download task running

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
