### PR TITLE
fix(NoteEditor): MIUI Android 12 Crash

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -2229,7 +2229,8 @@ public class NoteEditor extends AnkiActivity implements
             int initialSize = menu.size();
 
             if (isClozeType()) {
-                menu.add(Menu.NONE, mClozeMenuId, 0, R.string.multimedia_editor_popup_cloze);
+                // 10644: Do not pass in a R.string as the final parameter as MIUI on Android 12 crashes.
+                menu.add(Menu.NONE, mClozeMenuId, 0, getString(R.string.multimedia_editor_popup_cloze));
             }
 
             return initialSize != menu.size();


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
`menu.add` crashes if a resource identifier is passed in.

## Fixes
Hopefully fixes #10644

## Approach
Pass in a string instead

## How Has This Been Tested?

Untested

## Learning (optional, can help others)

https://github.com/K1rakishou/Kuroba-Experimental/commit/bcaf2d5f55e7f3bf5f3ffc7e0148a2060c69e6c3

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
