### PR TITLE
Added instructions for failure of .init() in M1 Mac

### DIFF
--- a/AnkiDroid/src/test/java/com/ichi2/anki/RobolectricTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/RobolectricTest.kt
@@ -105,7 +105,11 @@ open class RobolectricTest : CollectionGetter {
             RustBackendLoader.loadRsdroid(backendPath)
         } else {
             // default (no env variable): Extract the backend testing lib from the jar
-            RustBackendLoader.init()
+            try {
+                RustBackendLoader.init()
+            } catch (e: UnsatisfiedLinkError) {
+                Timber.e("Please update the environment variables with following commands : export ANKIDROID_BACKEND_PATH=\"{path-to-directory}/Anki-Android-Backend/rslib-bridge/target/aarch64-apple-darwin/release/librsdroid-arm64.dylib\" export ANKIDROID_BACKEND_VERSION=\"0.1.10\"")
+            }
         }
 
         // If you want to see the Android logging (from Timber), you need to set it up here


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
Added instructions for failure of .init() in M1 Mac

## Fixes
https://github.com/ankidroid/Anki-Android/issues/10626

## Approach
Added try catch statement and if it fails it would give instructions to solve the issue

## How Has This Been Tested?
Not tested as I was not able to replicate the error on my M1 Mac


## Checklist

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
