### PR TITLE
feat(scoped-storage): Move conflicted file

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/model/RelativeFilePath.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/model/RelativeFilePath.kt
@@ -18,6 +18,7 @@
 package com.ichi2.anki.model
 
 import java.io.File
+import java.nio.file.Path
 
 /**
  * A relative path, with the final component representing the filename.
@@ -46,7 +47,7 @@ class RelativeFilePath private constructor(
 
         /**
          * Return the relative path from Folder [baseDir] to file [file]. If [file]
-         * is contained in [baseDir], return [null].
+         * is contained in [baseDir], return `null`.
          * Similar to [Path.relativize], but available in all APIs.
          */
         fun fromPaths(baseDir: Directory, file: DiskFile): RelativeFilePath? =
@@ -56,7 +57,7 @@ class RelativeFilePath private constructor(
 
         /**
          * Return the relative path from Folder [baseDir] to file [file]. If [file]
-         * is contained in [baseDir], return [null].
+         * is contained in [baseDir], return `null`.
          * Assumes that [file] is actually a file and [baseDir] a directory, hence distinct.
          * Similar to [Path.relativize], but available in all APIs.
          * @param baseDir A directory.

--- a/AnkiDroid/src/main/java/com/ichi2/anki/model/RelativeFilePath.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/model/RelativeFilePath.kt
@@ -43,6 +43,21 @@ class RelativeFilePath private constructor(
         return File(directory, fileName)
     }
 
+    /**
+     * Adds a directory named [directoryName] to the start of [path]
+     *
+     * This is unsafe as it does not check for directory escapes or invalid characters.
+     * Should only be supplied with constants
+     *
+     * Sample:
+     * ```
+     * "/foo/bar/baz.txt".unsafePrependDirectory("quz") = "/quz/foo/bar/baz.txt"
+     * ```
+     */
+    fun unsafePrependDirectory(directoryName: String): RelativeFilePath {
+        return RelativeFilePath(listOf(directoryName) + path, fileName)
+    }
+
     companion object {
 
         /**

--- a/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/scopedstorage/MigrateUserData.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/scopedstorage/MigrateUserData.kt
@@ -116,9 +116,15 @@ class MigrateUserData private constructor(val source: Directory, val destination
     class EquivalentFileException(val source: File, val destination: File) : RuntimeException("Source and destination path are the same")
 
     /**
-     * If a directory could not be deleted as it still contained files
+     * If a directory could not be deleted as it still contained files.
      */
     class DirectoryNotEmptyException(val directory: Directory) : RuntimeException("directory was not empty: $directory")
+
+    /**
+     * If the number of retries was exceeded when resolving a file conflict via moving it to the
+     * /conflict/ folder.
+     */
+    class FileConflictResolutionFailedException(val sourceFile: DiskFile, val attemptedDestination: File) : RuntimeException("Failed to move $sourceFile to $attemptedDestination")
 
     /**
      * Context for an [Operation], allowing a change of execution behavior and

--- a/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/scopedstorage/MoveConflictedFile.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/scopedstorage/MoveConflictedFile.kt
@@ -1,0 +1,168 @@
+/*
+ *  Copyright (c) 2022 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.servicelayer.scopedstorage
+
+import androidx.annotation.CheckResult
+import androidx.annotation.VisibleForTesting
+import com.ichi2.anki.model.Directory
+import com.ichi2.anki.model.DiskFile
+import com.ichi2.anki.model.RelativeFilePath
+import com.ichi2.anki.servicelayer.scopedstorage.MigrateUserData.*
+import com.ichi2.compat.CompatHelper
+import java.io.File
+import java.lang.IllegalStateException
+
+/**
+ * Moves a file from [sourceFile] to [proposedDestinationFile].
+ *
+ * Ensures that the folder underneath [proposedDestinationFile] exists, and renames the destination file.
+ * if the file at [proposedDestinationFile] exists and has a distinct content, it will increment the filename, attempting to find a filename which is not in use.
+ * if the file at [proposedDestinationFile] exists and has the same content, [sourceFile] is deleted and move is assumed to be succesful.
+ *
+ * This does not handle other exceptions, such as a file existing as a directory in the relative path.
+ *
+ * Throws [FileConflictResolutionFailedException] if [proposedDestinationFile] exists, as do all
+ * the other candidate destination files for conflict resolution.
+ * This is unlikely to occur, and is expected to represent an application logic error.
+ *
+ * @see MoveFile for the definition of move
+ */
+/* In AnkiDroid planned use, proposedDestinationFile is assumed to be topLevel/conflict/relativePathOfSourceFile */
+class MoveConflictedFile private constructor(
+    val sourceFile: DiskFile,
+    val proposedDestinationFile: File
+) : Operation() {
+
+    override fun execute(context: MigrationContext): List<Operation> {
+
+        // create the "conflict" folder if it didn't exist, and the relative path to the file
+        // example: "AnkiDroid/conflict/collection.media/subfolder"
+        createDirectory(proposedDestinationFile.parentFile!!)
+
+        // wrap the context so we can handle internal file conflict exceptions, and set the correct
+        // 'operation' if an error occurs.
+        val wrappedContext = ContextHandlingFileConflictException(context, this)
+        // loop from "filename.ext", then "filename (1).ext" to "filename (${MAX_RENAMES - 1}).ext" to ensure we transfer the file
+        for (potentialDestinationFile in queryCandidateFilenames(proposedDestinationFile)) {
+            return try {
+                moveFile(potentialDestinationFile, wrappedContext)
+                if (wrappedContext.handledFileConflictSinceLastReset) {
+                    wrappedContext.reset()
+                    continue // we had a conflict, try the next name
+                }
+                // the operation completed, with or without an error report. Don't try again
+                operationCompleted()
+            } catch (ex: Exception) {
+                // We had an exception not handled by Operation,
+                // or one that ContextHandlingFileConflictException decided to re-throw.
+                // Don't try a different name
+                wrappedContext.reportError(this, ex)
+                operationCompleted()
+            }
+        }
+
+        throw FileConflictResolutionFailedException(sourceFile, proposedDestinationFile)
+    }
+
+    @VisibleForTesting
+    internal fun moveFile(potentialDestinationFile: File, wrappedContext: ContextHandlingFileConflictException) {
+        MoveFile(sourceFile, potentialDestinationFile).execute(wrappedContext)
+    }
+
+    private fun createDirectory(folder: File) = CompatHelper.compat.createDirectories(folder)
+
+    companion object {
+        const val CONFLICT_DIRECTORY = "conflict"
+        /**
+         * @param sourceFile The file to move from
+         * @param destinationTopLevel The top level directory to move to (non-relative path). "/storage/emulated/0/AnkiDroid/"
+         * @param sourceRelativePath The relative path of the file. Does not start with /conflict/.
+         * Is a suffix of [sourceFile]'s path: "/collection.media/image.jpg"
+         */
+        fun createInstance(
+            sourceFile: DiskFile,
+            destinationTopLevel: Directory,
+            sourceRelativePath: RelativeFilePath
+        ): MoveConflictedFile {
+
+            // we add /conflict/ to the path inside this method. If this already occurred, something was wrong
+            if (sourceRelativePath.path.firstOrNull() == CONFLICT_DIRECTORY) {
+                throw IllegalStateException("can't move from a root path of 'conflict': $sourceRelativePath")
+            }
+
+            val conflictedPath = sourceRelativePath.unsafePrependDirectory(CONFLICT_DIRECTORY)
+
+            val destinationFile = conflictedPath.toFile(baseDir = destinationTopLevel)
+
+            return MoveConflictedFile(sourceFile, destinationFile)
+        }
+
+        @VisibleForTesting
+        @CheckResult
+        internal fun queryCandidateFilenames(templateFile: File) = sequence {
+            yield(templateFile)
+
+            // examples from a file named: "helloWorld.tmp". the dot between name and extension isn't included
+            val filename = templateFile.nameWithoutExtension // 'helloWorld'
+            val extension = templateFile.extension // 'tmp'
+            for (i in 1 until MAX_DESTINATION_NAMES) { // 1..4
+                val newFileName = "$filename ($i).$extension" // 'helloWorld (1).tmp'
+                yield(File(templateFile.parent, newFileName))
+            }
+        }
+
+        /**
+         * The max number of attempts to rename a file
+         *
+         * "filename.ext", then "filename (1).ext" ... "filename (4).ext"
+         * where 4 = MAX_DESTINATION_NAMES - 1
+         */
+        const val MAX_DESTINATION_NAMES = 5
+    }
+
+    /**
+     * Wrapper around [MigrateUserData.MigrationContext].
+     * Ignores [FileConflictException], behaves as [MigrateUserData.MigrationContext] otherwise.
+     * Reports errors using the provided [operation]
+     */
+    class ContextHandlingFileConflictException(
+        private val wrappedContext: MigrationContext,
+        private val operation: Operation
+    ) : MigrationContext() {
+
+        /** Whether at least one [FileConflictException] was handled and ignored */
+        var handledFileConflictSinceLastReset = false
+
+        /** Resets the status of [handledFileConflictSinceLastReset] */
+        fun reset() {
+            handledFileConflictSinceLastReset = false
+        }
+
+        override fun reportError(throwingOperation: Operation, ex: Exception) {
+            if (ex is FileConflictException || ex is FileDirectoryConflictException) {
+                handledFileConflictSinceLastReset = true
+                return
+            }
+
+            // report error using the operation passed into the ContextHandlingFileConflictException
+            // (MoveConflictedFile)
+            wrappedContext.reportError(operation, ex)
+        }
+
+        override fun reportProgress(transferred: NumberOfBytes) = wrappedContext.reportProgress(transferred)
+    }
+}

--- a/AnkiDroid/src/test/java/com/ichi2/anki/model/RelativeFilePathTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/model/RelativeFilePathTest.kt
@@ -56,6 +56,21 @@ class RelativeFilePathTest {
         checkBasePlusRelativeEqualsExpected(destination, relative, File(File(destination, "sub"), "fileName"))
     }
 
+    @Test
+    fun test_prepend_directory() {
+        val source = createTransientDirectory()
+        val destination = createTransientDirectory()
+        val subDir = source.createTransientDirectory("sub")
+        val file = subDir.addTempFile("fileName")
+        val relative = RelativeFilePath.fromPaths(source, file)!!
+        val prepended = relative.unsafePrependDirectory("testing")
+        assertThat(prepended.fileName, equalTo("fileName"))
+        assertThat(prepended.path, hasSize(2))
+        assertThat(prepended.path[0], equalTo("testing"))
+        assertThat(prepended.path[1], equalTo("sub"))
+        checkBasePlusRelativeEqualsExpected(destination, prepended, File(File(File(destination, "testing"), "sub"), "fileName"))
+    }
+
     companion object {
         fun checkBasePlusRelativeEqualsExpected(baseDir: File, relative: RelativeFilePath, expected: File) {
             assertThat(relative.toFile(Directory.createInstance(baseDir)!!), equalTo(expected))

--- a/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/MockMigrationContext.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/MockMigrationContext.kt
@@ -18,7 +18,8 @@ package com.ichi2.anki.servicelayer.scopedstorage
 
 open class MockMigrationContext : MigrateUserData.MigrationContext() {
     /** set [logExceptions] to populate this property */
-    val exceptions = mutableListOf<Exception>()
+    val errors = mutableListOf<ReportedError>()
+    val exceptions get() = errors.map { it.exception }
     var logExceptions: Boolean = false
     val progress = mutableListOf<NumberOfBytes>()
 
@@ -26,12 +27,14 @@ open class MockMigrationContext : MigrateUserData.MigrationContext() {
         if (!logExceptions) {
             throw ex
         }
-        exceptions.add(ex)
+        errors.add(ReportedError(throwingOperation, ex))
     }
 
     override fun reportProgress(transferred: NumberOfBytes) {
         progress.add(transferred)
     }
+
+    data class ReportedError(val operation: MigrateUserData.Operation, val exception: Exception)
 }
 
 /**

--- a/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/MoveConflictedFileTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/MoveConflictedFileTest.kt
@@ -1,0 +1,278 @@
+/*
+ *  Copyright (c) 2022 David Allison <davidallisongithub@gmail.com>
+ *  Copyright (c) 2022 Arthur Milchior <arthur@milchior.fr>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.servicelayer.scopedstorage
+
+import com.ichi2.anki.model.Directory
+import com.ichi2.anki.model.DiskFile
+import com.ichi2.anki.model.RelativeFilePath
+import com.ichi2.anki.servicelayer.scopedstorage.MigrateUserData.FileConflictResolutionFailedException
+import com.ichi2.compat.Test21And26
+import com.ichi2.testutils.*
+import org.hamcrest.CoreMatchers.*
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.hasSize
+import org.hamcrest.io.FileMatchers
+import org.junit.Test
+import org.mockito.kotlin.*
+import java.io.File
+import java.io.IOException
+import java.lang.IllegalStateException
+
+class MoveConflictedFileTest : Test21And26(), OperationTest {
+
+    override val executionContext: MockMigrationContext by lazy {
+        MockMigrationContext()
+    }
+
+    /**
+     * Comprehensive test of the function to query candidate filenames given a "template" file
+     *
+     * @see [MoveConflictedFile.queryCandidateFilenames]
+     */
+    @Test
+    fun test_queryCandidateFilenames() {
+        val testFile = createTransientFile()
+
+        val sequence = MoveConflictedFile.queryCandidateFilenames(testFile).toList()
+
+        assertThat("5 attempts should be made to find a valid file", sequence.size, equalTo(EXPECTED_ATTEMPTS))
+
+        // Test and production uses different method to extract the base name for extra test safety
+        val filename = testFile.name.substringBefore(".")
+
+        assertThat("first element has no brackets", sequence.first().name, not(containsString("(")))
+        assertThat("second element has brackets", sequence[1].name, endsWith(" (1).tmp"))
+        assertThat("last element has brackets", sequence.last().name, equalTo("$filename (${EXPECTED_ATTEMPTS - 1}).tmp"))
+
+        val final = sequence.last()
+
+        assertThat("final file is in same directory as original file", final.parent!!, equalTo(testFile.parent))
+    }
+
+    @Test
+    fun creation_fails_if_path_starts_with_conflict() {
+        // the method adds /conflict/, so don't do this outside the function call
+        val params = InputParameters("conflict", sourceFileName = "tmp.txt")
+
+        val illegalStateException = assertThrows<IllegalStateException> { params.createOperation() }
+
+        assertThat(illegalStateException.message, startsWith("can't move from a root path of 'conflict': "))
+    }
+
+    @Test
+    fun creation_prepends_conflict_to_path() {
+        val params = InputParameters("collection.media", sourceFileName = "tmp.txt")
+
+        val operation = params.createOperation()
+
+        assertThat("provided 'sourceFile' parameter is unchanged", operation.sourceFile.file, equalTo(params.sourceFile))
+
+        // this is "path", but with a "conflict" subfolder.
+        assertThat("'conflict' is prepended to the path", operation.proposedDestinationFile, equalTo(params.intendedDestinationFilePath))
+    }
+
+    @Test
+    fun failing_to_create_directory_fails() {
+        val params = InputParameters("collection.media", sourceFileName = "tmp.txt")
+
+        // this will fail to create a directory, as we have a file named conflict.
+        File(params.destinationTopLevel, "conflict").apply {
+            createNewFile()
+            deleteOnExit()
+        }
+
+        assertThrowsSubclass<IOException> { params.createOperation().execute() }
+
+        assertThat("should be no progress", executionContext.progress, hasSize(0))
+    }
+
+    @Test
+    fun valid() {
+        val params = InputParameters("collection.media", sourceFileName = "tmp.txt")
+        assertThat("source file exists", params.sourceFile, FileMatchers.anExistingFile())
+        val moveConflictedFile = params.createOperation()
+        moveConflictedFile.execute()
+
+        assertThat("source file should be removed", params.sourceFile, not(FileMatchers.anExistingFile()))
+        assertThat("destination should exist", moveConflictedFile.proposedDestinationFile, FileMatchers.anExistingFile())
+
+        assertThat("1 instance of progress", executionContext.progress, hasSize(1))
+        assertThat("1 instance of progress: 0 bytes", executionContext.progress.single(), equalTo(params.contentLength))
+    }
+
+    @Test
+    fun single_rename() {
+        val params = InputParameters("collection.media", sourceFileName = "tmp.txt")
+
+        params.intendedDestinationFilePath.apply {
+            parentFile!!.mkdirs()
+            createNewFile()
+            writeText("hello") // we can't have the contents be identical
+        }
+
+        val moveConflictedFile = params.createOperation()
+        moveConflictedFile.execute()
+
+        val expectedFile = File(moveConflictedFile.proposedDestinationFile.parentFile, "tmp (1).txt")
+
+        assertThat("source file should be removed", params.sourceFile, not(FileMatchers.anExistingFile()))
+        assertThat("destination should exist with (1) in the name", expectedFile, FileMatchers.anExistingFile())
+
+        assertThat("1 instance of progress", executionContext.progress, hasSize(1))
+        assertThat("1 instance of progress: 0 bytes", executionContext.progress.single(), equalTo(params.contentLength))
+
+        assertThat("1 instance of progress", executionContext.progress, hasSize(1))
+        assertThat("1 instance of progress: 0 bytes", executionContext.progress.single(), equalTo(params.contentLength))
+    }
+
+    @Test
+    fun maxed_out_rename_fails() {
+        val params = InputParameters("collection.media", sourceFileName = "tmp.txt")
+
+        // use up all the paths
+        for (path in MoveConflictedFile.queryCandidateFilenames(params.intendedDestinationFilePath)) {
+            path.apply {
+                parentFile!!.mkdirs()
+                createNewFile()
+                writeText(path.nameWithoutExtension) // we can't have the contents be identical
+            }
+        }
+
+        assertThrows<FileConflictResolutionFailedException> { params.createOperation().execute() }
+
+        assertThat("should be no progress", executionContext.progress, hasSize(0))
+    }
+
+    @Test
+    fun operation_failed_via_report() {
+        // arrange
+        val params = InputParameters("collection.media", sourceFileName = "tmp.txt")
+
+        var op = params.createOperation()
+        op = spy(op) {
+            doAnswer<List<MigrateUserData.Operation>> { answer ->
+                val context = answer.arguments[1] as MigrateUserData.MigrationContext
+                context.reportError(this.mock, TestException("testing"))
+                emptyList()
+            }.whenever(it).moveFile(any(), any())
+        }
+
+        executionContext.logExceptions = true
+
+        // act
+        op.execute()
+
+        // assert
+        assertThat("source file should not be moved", params.sourceFile, FileMatchers.anExistingFile())
+        assertThat("an error should be logged", executionContext.errors, hasSize(1))
+        val error = executionContext.errors.single()
+
+        assertThat("operation should be the wrapping operation", error.operation, instanceOf(MoveConflictedFile::class.java))
+        assertThat("Exception should be thrown", error.exception, instanceOf(TestException::class.java))
+
+        assertThat("should be no progress", executionContext.progress, hasSize(0))
+    }
+
+    @Test
+    fun operation_failed_via_exception() {
+        // arrange
+        val params = InputParameters("collection.media", sourceFileName = "tmp.txt")
+
+        var op = params.createOperation()
+        op = spy(op) {
+            doThrow(TestException("operation_failed_via_exception")).whenever(it).moveFile(any(), any())
+        }
+
+        executionContext.logExceptions = true
+
+        // act
+        op.execute()
+
+        // assert
+        assertThat("source file should not be moved", params.sourceFile, FileMatchers.anExistingFile())
+        assertThat("an error should be logged", executionContext.errors, hasSize(1))
+        val error = executionContext.errors.single()
+
+        assertThat("operation should be the wrapping operation", error.operation, instanceOf(MoveConflictedFile::class.java))
+        assertThat("Exception should be thrown", error.exception, instanceOf(TestException::class.java))
+
+        assertThat("should be no progress", executionContext.progress, hasSize(0))
+    }
+
+    /**
+     * Encapsulates the variables required to create a [MoveConflictedFile] instance for testing
+     *
+     * Generates a temporary directory for the source and destination, and sets up the file defined by
+     * [directoryComponents]/[sourceFileName]
+     *
+     * [createOperation] returns the operation to move this source file to [destinationTopLevel]
+     *
+     * @param directoryComponents components to the folder holding the source file ["collection.media"]
+     * @param sourceFileName The name of the source file: "file.ext"
+     * @param content The content of the source file
+     */
+    private class InputParameters constructor(
+        private vararg val directoryComponents: String,
+        val sourceFileName: String,
+        val content: String = "source content"
+    ) {
+        val sourceTopLevel: File by lazy { createTransientDirectory() }
+        val sourceFile: File by lazy {
+            var directory: File = sourceTopLevel
+            for (component in directoryComponents) {
+                directory = File(directory, component)
+            }
+            directory.mkdirs()
+            directory.addTempFile(sourceFileName, content)
+        }
+        val destinationTopLevel by lazy { createTransientDirectory() }
+        val destinationTopLevelDirectory get() = Directory.createInstance(destinationTopLevel)!!
+        val contentLength = content.length.toLong()
+
+        /** A [RelativeFilePath] created from [directoryComponents] and [sourceFileName]  */
+        private val relativePath
+            get() = RelativeFilePath.Companion.fromPaths(sourceTopLevel, sourceFile)!!
+
+        /**
+         * The intended destination of the file (assumed it did not have to be renamed due to conflict in the "conflict"'s subdirectory)
+         *
+         * File [destinationTopLevel]/"conflict"/[directoryComponents]/[sourceFileName]
+         */
+        val intendedDestinationFilePath: File get() =
+            relativePath.unsafePrependDirectory("conflict").toFile(baseDir = destinationTopLevelDirectory)
+
+        /**
+         * Operation to move conflicted file [sourceFileName] from [sourceTopLevel] to [destinationTopLevel]/"conflict"/[directoryComponents]/[sourceFileName].
+         */
+        fun createOperation(): MoveConflictedFile {
+            return MoveConflictedFile.createInstance(
+                sourceFile = DiskFile.createInstance(this.sourceFile)!!,
+                destinationTopLevel = destinationTopLevelDirectory,
+                sourceRelativePath = relativePath
+            )
+        }
+    }
+
+    companion object {
+        /**
+         * Equal to [MoveConflictedFile.MAX_DESTINATION_NAMES]
+         * Copied to tests to ensure unexpected changes cause test changes
+         */
+        const val EXPECTED_ATTEMPTS = 5
+    }
+}


### PR DESCRIPTION
## Purpose / Description
This handled the 'conflicted file' edge case when performing a scoped storage migration:

A file `AnkiDroid/A.txt` is wanted to be moved to `scoped directory/A.txt`, but `A.txt` already exists in the destination AND is different.

## Fixes
Related: #5304

## Approach
Move the file to `AnkiDroid/conflict/A.txt` or ... `AnkiDroid/conflict/A (99).txt` if there are internal conflicts.

* Fail if (99) is also a conflict (too many conflicts)
* Fail if the move fails on an exception other than a file conflict

## How Has This Been Tested?
Unit tested

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)