### PR TITLE
Fix tests on macOS+ refactoring

### DIFF
--- a/AnkiDroid/src/test/java/com/ichi2/anki/jsaddons/TgzPackageExtractTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/jsaddons/TgzPackageExtractTest.kt
@@ -40,14 +40,11 @@ class TgzPackageExtractTest : RobolectricTest() {
     override fun setUp() {
         super.setUp()
 
-        var currentAnkiDroidDirectory = CollectionHelper.getCurrentAnkiDroidDirectory(targetContext)
-        val path = File(currentAnkiDroidDirectory, "addons").parentFile!!
-        ShadowStatFs.registerStats(path, 100, 20, 10000)
-
+        val currentAnkiDroidDirectory = CollectionHelper.getCurrentAnkiDroidDirectory(targetContext)
+        ShadowStatFs.registerStats(File(currentAnkiDroidDirectory), 100, 20, 10000)
         addonPackage = TgzPackageExtract(targetContext)
-        tarballPath = getFileResource("valid-ankidroid-js-addon-test-1.0.0.tgz")
-        currentAnkiDroidDirectory = CollectionHelper.getCurrentAnkiDroidDirectory(targetContext)
         addonDir = File(currentAnkiDroidDirectory, "addons")
+        tarballPath = getFileResource("valid-ankidroid-js-addon-test-1.0.0.tgz")
         if (!addonDir.exists()) {
             addonDir.mkdirs()
         }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/jsaddons/TgzPackageExtractTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/jsaddons/TgzPackageExtractTest.kt
@@ -41,7 +41,7 @@ class TgzPackageExtractTest : RobolectricTest() {
         super.setUp()
 
         val currentAnkiDroidDirectory = CollectionHelper.getCurrentAnkiDroidDirectory(targetContext)
-        ShadowStatFs.registerStats(File(currentAnkiDroidDirectory), 100, 20, 10000)
+        ShadowStatFs.markAsNonEmpty(File(currentAnkiDroidDirectory))
         addonPackage = TgzPackageExtract(targetContext)
         addonDir = File(currentAnkiDroidDirectory, "addons")
         tarballPath = getFileResource("valid-ankidroid-js-addon-test-1.0.0.tgz")

--- a/AnkiDroid/src/test/java/com/ichi2/anki/jsaddons/TgzPackageExtractTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/jsaddons/TgzPackageExtractTest.kt
@@ -23,6 +23,7 @@ import com.ichi2.testutils.ShadowStatFs
 import com.ichi2.utils.FileOperation.Companion.getFileResource
 import junit.framework.TestCase.assertTrue
 import org.apache.commons.compress.archivers.ArchiveException
+import org.junit.After
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -50,6 +51,12 @@ class TgzPackageExtractTest : RobolectricTest() {
         if (!addonDir.exists()) {
             addonDir.mkdirs()
         }
+    }
+
+    @After
+    override fun tearDown() {
+        super.tearDown()
+        ShadowStatFs.reset()
     }
 
     /**

--- a/AnkiDroid/src/test/java/com/ichi2/anki/jsaddons/TgzPackageExtractTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/jsaddons/TgzPackageExtractTest.kt
@@ -19,13 +19,13 @@ package com.ichi2.anki.jsaddons
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.ichi2.anki.CollectionHelper
 import com.ichi2.anki.RobolectricTest
+import com.ichi2.testutils.ShadowStatFs
 import com.ichi2.utils.FileOperation.Companion.getFileResource
 import junit.framework.TestCase.assertTrue
 import org.apache.commons.compress.archivers.ArchiveException
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.robolectric.shadows.ShadowStatFs
 import java.io.File
 import java.io.IOException
 
@@ -40,7 +40,7 @@ class TgzPackageExtractTest : RobolectricTest() {
         super.setUp()
 
         var currentAnkiDroidDirectory = CollectionHelper.getCurrentAnkiDroidDirectory(targetContext)
-        val path = File(currentAnkiDroidDirectory, "addons").parentFile?.path
+        val path = File(currentAnkiDroidDirectory, "addons").parentFile!!
         ShadowStatFs.registerStats(path, 100, 20, 10000)
 
         addonPackage = TgzPackageExtract(targetContext)

--- a/AnkiDroid/src/test/java/com/ichi2/testutils/BackupManagerTestUtilities.java
+++ b/AnkiDroid/src/test/java/com/ichi2/testutils/BackupManagerTestUtilities.java
@@ -33,7 +33,7 @@ public class BackupManagerTestUtilities {
         if (path == null) {
             throw new IllegalStateException("currentAnkiDroidDirectory had no parent");
         }
-        ShadowStatFs.registerStats(path, 100, 20, 10000);
+        ShadowStatFs.markAsNonEmpty(path);
 
         assertTrue(BackupManager.enoughDiscSpace(currentAnkiDroidDirectory));
     }

--- a/AnkiDroid/src/test/java/com/ichi2/testutils/BackupManagerTestUtilities.java
+++ b/AnkiDroid/src/test/java/com/ichi2/testutils/BackupManagerTestUtilities.java
@@ -21,8 +21,6 @@ import android.content.Context;
 import com.ichi2.anki.BackupManager;
 import com.ichi2.anki.CollectionHelper;
 
-import org.robolectric.shadows.ShadowStatFs;
-
 import java.io.File;
 
 import static org.junit.Assert.assertTrue;
@@ -31,7 +29,10 @@ public class BackupManagerTestUtilities {
     public static void setupSpaceForBackup(Context context) {
         String currentAnkiDroidDirectory = CollectionHelper.getCurrentAnkiDroidDirectory(context);
 
-        String path = new File(currentAnkiDroidDirectory).getParentFile().getPath();
+        File path = new File(currentAnkiDroidDirectory).getParentFile();
+        if (path == null) {
+            throw new IllegalStateException("currentAnkiDroidDirectory had no parent");
+        }
         ShadowStatFs.registerStats(path, 100, 20, 10000);
 
         assertTrue(BackupManager.enoughDiscSpace(currentAnkiDroidDirectory));

--- a/AnkiDroid/src/test/java/com/ichi2/testutils/ShadowStatFs.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/testutils/ShadowStatFs.kt
@@ -33,6 +33,8 @@ object ShadowStatFs {
      * @param blockCount number of blocks
      * @param freeBlocks number of free blocks
      * @param availableBlocks number of available blocks
+     *
+     * @see [markAsNonEmpty]
      */
     @JvmStatic
     fun registerStats(path: File, blockCount: Int, freeBlocks: Int, availableBlocks: Int) {
@@ -40,6 +42,17 @@ object ShadowStatFs {
         // call canonicalFile so this works on macOS
         RobolectricStats.registerStats(path.canonicalFile, blockCount, freeBlocks, availableBlocks)
     }
+
+    /**
+     * Marks the provided path in Robolectric as non-empty, therefore [android.os.StatFs] will work
+     * and operations such as backups will succeed
+     *
+     * Call [reset] when this is completed.
+     *
+     * @param path path to the file
+     */
+    @JvmStatic
+    fun markAsNonEmpty(path: File) = registerStats(path, 100, 20, 10000)
 
     @Resetter
     @JvmStatic

--- a/AnkiDroid/src/test/java/com/ichi2/testutils/ShadowStatFs.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/testutils/ShadowStatFs.kt
@@ -1,0 +1,47 @@
+/*
+ *  Copyright (c) 2022 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.testutils
+
+import org.robolectric.annotation.Resetter
+import java.io.File
+import org.robolectric.shadows.ShadowStatFs as RobolectricStats
+
+/**
+ * Workaround to fix [org.robolectric.shadows.ShadowStatFs] failing on macOS
+ */
+object ShadowStatFs {
+
+    /**
+     * Register stats for a path, which will be used when a matching [android.os.StatFs] instance is
+     * created.
+     *
+     * @param path path to the file
+     * @param blockCount number of blocks
+     * @param freeBlocks number of free blocks
+     * @param availableBlocks number of available blocks
+     */
+    @JvmStatic
+    fun registerStats(path: File, blockCount: Int, freeBlocks: Int, availableBlocks: Int) {
+        RobolectricStats.registerStats(path, blockCount, freeBlocks, availableBlocks)
+        // call canonicalFile so this works on macOS
+        RobolectricStats.registerStats(path.canonicalFile, blockCount, freeBlocks, availableBlocks)
+    }
+
+    @Resetter
+    @JvmStatic
+    fun reset() = RobolectricStats.reset()
+}


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
`IOException: There is not enough space to import the package.`

Cause: `TgzPackageExtractTest` - `ShadowStatsFs` fails to use the canonical path

But: The non-canonical path is required by `BackupManagerTestUtilities`

## Fixes
Fixes #10651

## Approach
* define a method which uses both canonical and regular paths `registerStats`

## How Has This Been Tested?

Ran tests - now pass

## Learning (optional, can help others)
* Macs are hard yo, but it's nice to be able to reasonably run tests locally
* ShadowStatFs needs BOTH canonical and non-canonical path 

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
