### PR TITLE
Finish switch to Kotlin for StorageAccessException.kt

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/exception/StorageAccessException.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/exception/StorageAccessException.kt
@@ -16,11 +16,7 @@
 
 package com.ichi2.anki.exception
 
-import com.ichi2.utils.KotlinCleanup
-import java.lang.Exception
-
-@KotlinCleanup("Combine constructors")
-class StorageAccessException : Exception {
-    constructor(msg: String?, e: Throwable?) : super(msg, e) {}
-    constructor(msg: String?) : super(msg) {}
-}
+class StorageAccessException @JvmOverloads constructor(
+    msg: String? = null,
+    e: Throwable? = null
+) : Exception(msg, e)


### PR DESCRIPTION
## Purpose / Description

Implements the requested changes for `StorageAccessException.kt` by switching to a main constructor with default parameters and adding the `@JvmOverloads` annotation which will generate the actual constructors used by the app. To remove all imports I also used the Kotlin provided exception which is an alias for the Java based `Exception` class.

## Fixes
Code related to issue #10489

## How Has This Been Tested?

Not much to test as the change is mostly cosmetic.

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [x] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
