### PR TITLE
fix crash opening FIlteredDeckOptions

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/FilteredDeckOptions.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/FilteredDeckOptions.kt
@@ -27,6 +27,7 @@ import com.ichi2.anim.ActivityTransitionAnimation
 import com.ichi2.anim.ActivityTransitionAnimation.slide
 import com.ichi2.anki.analytics.UsageAnalytics
 import com.ichi2.anki.receiver.SdCardReceiver
+import com.ichi2.annotations.NeedsTest
 import com.ichi2.libanki.Collection
 import com.ichi2.libanki.Deck
 import com.ichi2.preferences.StepsPreference.Companion.convertFromJSON
@@ -40,6 +41,7 @@ import com.ichi2.utils.KotlinCleanup
 import timber.log.Timber
 import java.util.*
 
+@NeedsTest("construction + onCreate - do this after converting to fragment-based preferences.")
 class FilteredDeckOptions : AppCompatPreferenceActivity(), OnSharedPreferenceChangeListener {
     @KotlinCleanup("try to make mDeck non-null / use lateinit")
     private var mDeck: Deck? = null

--- a/AnkiDroid/src/main/java/com/ichi2/anki/FilteredDeckOptions.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/FilteredDeckOptions.kt
@@ -359,7 +359,8 @@ class FilteredDeckOptions : AppCompatPreferenceActivity(), OnSharedPreferenceCha
         return false
     }
 
-    override fun onSharedPreferenceChanged(sharedPreferences: SharedPreferences, key: String) {
+    @KotlinCleanup("Find a different method rather than providing a null key in a caller")
+    override fun onSharedPreferenceChanged(sharedPreferences: SharedPreferences, key: String?) {
         // update values on changed preference
         updateSummaries()
         mPrefChanged = true

--- a/AnkiDroid/src/main/java/com/ichi2/annotations/NeedsTest.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/annotations/NeedsTest.kt
@@ -1,0 +1,32 @@
+/*
+ *  Copyright (c) 2022 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.annotations
+
+/**
+ * Use when code needs unit tests
+ *
+ * To ensure the reminder isn't forgotten about or left to go stale in a GitHub issue
+ */
+@Target(
+    AnnotationTarget.CLASS, AnnotationTarget.FUNCTION,
+    AnnotationTarget.VALUE_PARAMETER, AnnotationTarget.EXPRESSION,
+    AnnotationTarget.FIELD, AnnotationTarget.PROPERTY
+)
+@Repeatable
+@Retention(AnnotationRetention.SOURCE)
+@MustBeDocumented
+annotation class NeedsTest(val value: String)


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
`commit` called `listener.onSharedPreferenceChanged(this@DeckPreferenceHack, null)` which crashed due to the null 'key'

## Fixes
Fixes #10661

## Approach
Make parameter nullable

## How Has This Been Tested?
On device - no longer crashes

## Learning
Added a `NeedsTest` annotation, as otherwise this information would be lost


## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
