### PR TITLE
Strings format for size and number of files in tar archive

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/jsaddons/TgzPackageExtract.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/jsaddons/TgzPackageExtract.kt
@@ -234,7 +234,7 @@ class TgzPackageExtract(private val context: Context) {
             }
         } catch (e: IOException) {
             outputDir.deleteRecursively()
-            throw ArchiveException(context.getString(R.string.malicious_archive_exceeds_limit))
+            throw ArchiveException(context.getString(R.string.malicious_archive_exceeds_limit, Formatter.formatFileSize(context, TOO_BIG_SIZE), TOO_MANY_FILES))
         }
     }
 

--- a/AnkiDroid/src/main/res/values/02-strings.xml
+++ b/AnkiDroid/src/main/res/values/02-strings.xml
@@ -434,6 +434,6 @@
     <string name="not_valid_js_addon">%s is not a valid javascript addon package</string>
     <string name="could_not_create_dir">Could not create directory %s</string>
     <string name="malicious_archive_entry_outside">Malicious archive. Contains entry outside of the target dir: %s</string>
-    <string name="malicious_archive_exceeds_limit">Malicious archive. Size exceeds 100MB or contains more than 1024 files</string>
+    <string name="malicious_archive_exceeds_limit">Malicious archive. Size exceeds %1$s or contains more than %2$d files</string>
     <string name="file_extract_exceeds_storage_space">File extract exceeds storage space</string>
 </resources>


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
Strings format for size and number of files in tar archive

## Fixes
Fixes #10451

## Approach
Used `%1$s` and `%2$d` instead of hardcoded values

## How Has This Been Tested?
JUnit test

## Learning (optional, can help others)


## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
