### PR TITLE
Add merged PR to milestone and remove specific labels

### DIFF
--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -1,0 +1,15 @@
+name: Remove Labels
+
+on:
+  pull_request:
+    types: [ closed ]
+
+jobs:
+  merge_job:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+    - uses: andymckay/labeler@master
+      with:
+        remove-labels: "Pending Merge, Waiting For Feedback, Needs Review, Review High Priority, Needs Second Approval"
+        

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -11,5 +11,14 @@ jobs:
     steps:
     - uses: andymckay/labeler@master
       with:
-        remove-labels: "Pending Merge, Waiting For Feedback, Needs Review, Review High Priority, Needs Second Approval"
-        
+        remove-labels: > 
+          Pending Merge, 
+          Waiting For Feedback, 
+          Needs Review, 
+          Review High Priority, 
+          Needs Second Approval,
+          Blocked by dependency, 
+          Needs a new dev, 
+          squash-merge, 
+          Keep Open, 
+          Stable

--- a/.github/workflows/milestone.yml
+++ b/.github/workflows/milestone.yml
@@ -1,0 +1,16 @@
+name: PR Milestone
+
+on:
+  pull_request:
+    types: [ closed ]
+
+jobs:
+  milestone:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - uses: zoispag/action-assign-milestone@v1
+        with:
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"
+          milestone: "2.16 release"
+    


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
For each merged PR, it needs to manually add milestone and remove labels. So, this PR will help in adding milestone to PR and removing all labels using GitHub actions.

Removes following labels for merged PR
```
Pending Merge
Waiting For Feedback
Needs Review
Review High Priority
Needs Second Approval
```

Currently it adds to `2.16 release` milestone

## Fixes
Fixes #10410

## Approach
I have used this two GitHub actions repository
- https://github.com/zoispag/action-assign-milestone
- https://github.com/andymckay/labeler

For milestone, release milestone string is hardcoded. 


## How Has This Been Tested?
Tested in private repository
<img src="https://user-images.githubusercontent.com/12841290/161202834-d64601c8-850a-458e-a0f4-131f0357d2f9.png" width=450></img>


## Learning (optional, can help others)
https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
