### PR TITLE
Setting the time constraint in double back press to exit/return feature of DeckPicker and AbstractFlashCardViewer

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
@@ -28,9 +28,7 @@ import android.content.res.Resources
 import android.graphics.Color
 import android.media.MediaPlayer
 import android.net.Uri
-import android.os.Build
-import android.os.Bundle
-import android.os.SystemClock
+import android.os.*
 import android.text.TextUtils
 import android.view.*
 import android.view.GestureDetector.SimpleOnGestureListener
@@ -632,6 +630,12 @@ abstract class AbstractFlashcardViewer : NavigationDrawerActivity(), ReviewerUi,
                 showThemedToast(this, getString(R.string.back_pressed_once_reviewer), true)
             }
             mBackButtonPressedToReturn = true
+            Handler(Looper.getMainLooper()).postDelayed(
+                Runnable {
+                    mBackButtonPressedToReturn = false
+                },
+                2000
+            )
         }
     }
 
@@ -2520,7 +2524,7 @@ abstract class AbstractFlashcardViewer : NavigationDrawerActivity(), ReviewerUi,
     }
 
     open fun javaScriptFunction(): AnkiDroidJsAPI? {
-        return AnkiDroidJsAPI(this)
+        return com.ichi2.anki.AnkiDroidJsAPI(this)
     }
 
     companion object {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
@@ -634,7 +634,7 @@ abstract class AbstractFlashcardViewer : NavigationDrawerActivity(), ReviewerUi,
                 Runnable {
                     mBackButtonPressedToReturn = false
                 },
-                Consts.LENGTH_SHORT
+                Consts.SHORT_TOAST_DURATION
             )
         }
     }
@@ -2524,7 +2524,7 @@ abstract class AbstractFlashcardViewer : NavigationDrawerActivity(), ReviewerUi,
     }
 
     open fun javaScriptFunction(): AnkiDroidJsAPI? {
-        return com.ichi2.anki.AnkiDroidJsAPI(this)
+        return AnkiDroidJsAPI(this)
     }
 
     companion object {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
@@ -634,7 +634,7 @@ abstract class AbstractFlashcardViewer : NavigationDrawerActivity(), ReviewerUi,
                 Runnable {
                     mBackButtonPressedToReturn = false
                 },
-                2000
+                Consts.LENGTH_SHORT
             )
         }
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -38,6 +38,8 @@ import android.graphics.drawable.Drawable;
 import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
+import android.os.Handler;
+import android.os.Looper;
 import android.os.Message;
 import android.provider.Settings;
 
@@ -61,6 +63,7 @@ import androidx.recyclerview.widget.DividerItemDecoration;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 
+import android.provider.SyncStateContract;
 import android.text.TextUtils;
 import android.util.Pair;
 import android.util.TypedValue;
@@ -77,6 +80,7 @@ import android.widget.Filterable;
 import android.widget.LinearLayout;
 import android.widget.RelativeLayout;
 import android.widget.TextView;
+import android.widget.Toast;
 
 import com.afollestad.materialdialogs.MaterialDialog;
 import com.ichi2.anki.CollectionHelper.CollectionIntegrityStorageCheck;
@@ -970,6 +974,12 @@ public class DeckPicker extends NavigationDrawerActivity implements
                     UIUtils.showThemedToast(this, getString(R.string.back_pressed_once), true);
                 }
                 mBackButtonPressedToExit = true;
+                new Handler(Looper.getMainLooper()).postDelayed(new Runnable() {
+                    @Override
+                    public void run() {
+                        mBackButtonPressedToExit = false;
+                    }
+                }, 2000);
             }
         }
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -63,7 +63,6 @@ import androidx.recyclerview.widget.DividerItemDecoration;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 
-import android.provider.SyncStateContract;
 import android.text.TextUtils;
 import android.util.Pair;
 import android.util.TypedValue;
@@ -80,7 +79,6 @@ import android.widget.Filterable;
 import android.widget.LinearLayout;
 import android.widget.RelativeLayout;
 import android.widget.TextView;
-import android.widget.Toast;
 
 import com.afollestad.materialdialogs.MaterialDialog;
 import com.ichi2.anki.CollectionHelper.CollectionIntegrityStorageCheck;
@@ -150,7 +148,6 @@ import java.io.File;
 import java.util.List;
 
 import kotlin.Unit;
-import kotlin.io.ConstantsKt;
 import timber.log.Timber;
 
 import static com.ichi2.async.Connection.ConflictResolution.FULL_DOWNLOAD;
@@ -981,7 +978,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
                     public void run() {
                         mBackButtonPressedToExit = false;
                     }
-                }, Consts.LENGTH_SHORT);
+                }, Consts.SHORT_TOAST_DURATION);
             }
         }
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -123,6 +123,7 @@ import com.ichi2.async.TaskListenerWithContext;
 import com.ichi2.async.TaskManager;
 import com.ichi2.compat.CompatHelper;
 import com.ichi2.libanki.Collection;
+import com.ichi2.libanki.Consts;
 import com.ichi2.libanki.Decks;
 import com.ichi2.libanki.Model;
 import com.ichi2.libanki.ModelManager;
@@ -149,6 +150,7 @@ import java.io.File;
 import java.util.List;
 
 import kotlin.Unit;
+import kotlin.io.ConstantsKt;
 import timber.log.Timber;
 
 import static com.ichi2.async.Connection.ConflictResolution.FULL_DOWNLOAD;
@@ -979,7 +981,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
                     public void run() {
                         mBackButtonPressedToExit = false;
                     }
-                }, 2000);
+                }, Consts.LENGTH_SHORT);
             }
         }
     }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Consts.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Consts.kt
@@ -152,4 +152,7 @@ object Consts {
     const val DEFAULT_DECK_CONFIG_ID: Long = 1
     @JvmField
     val FIELD_SEPARATOR = Character.toString('\u001f')
+
+    /** Time duration for toasy **/
+    const val LENGTH_SHORT: Long = 2000
 }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Consts.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Consts.kt
@@ -153,6 +153,6 @@ object Consts {
     @JvmField
     val FIELD_SEPARATOR = Character.toString('\u001f')
 
-    /** Time duration for toasy **/
-    const val LENGTH_SHORT: Long = 2000
+    /** Time duration for toast **/
+    const val SHORT_TOAST_DURATION: Long = 2000
 }


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
Double back pressed to exit feature wasn't working properly.

## Fixes
Fixes #10638 

## Approach
The variable storing the number of back pressed wasn't getting reset when we were moving to the next activity. So I reset the variable in the onPause function of the activity.

## How Has This Been Tested?

Physical Device: Realme 8i


## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [ ] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [ ] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

In the video, I have demonstrated that it requires two back presses to exit the app and then in the next turn I went to a different activity and came back to the original and still it took two back presses not one which was the issue I resolved

https://user-images.githubusercontent.com/73571511/161382224-d1eadb3a-ad47-40ed-b989-58b47da6c197.mp4


