### PR TITLE
Use `DeckSelectionDialog` on change deck

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiActivity.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiActivity.java
@@ -67,6 +67,8 @@ public class AnkiActivity extends AppCompatActivity implements SimpleMessageDial
 
     public final int SIMPLE_NOTIFICATION_ID = 0;
     public static final int REQUEST_REVIEW = 901;
+    public static final String DIALOG_FRAGMENT_TAG = "dialog";
+
     /** The name of the parent class (Reviewer) */
     private final String mActivityName;
 
@@ -496,13 +498,13 @@ public class AnkiActivity extends AppCompatActivity implements SimpleMessageDial
         // in a transaction. We also want to remove any currently showing
         // dialog, so make our own transaction and take care of that here.
         FragmentTransaction ft = manager.beginTransaction();
-        Fragment prev = manager.findFragmentByTag("dialog");
+        Fragment prev = manager.findFragmentByTag(DIALOG_FRAGMENT_TAG);
         if (prev != null) {
             ft.remove(prev);
         }
         // save transaction to the back stack
-        ft.addToBackStack("dialog");
-        newFragment.show(ft, "dialog");
+        ft.addToBackStack(DIALOG_FRAGMENT_TAG);
+        newFragment.show(ft, DIALOG_FRAGMENT_TAG);
         manager.executePendingTransactions();
     }
 
@@ -633,7 +635,7 @@ public class AnkiActivity extends AppCompatActivity implements SimpleMessageDial
 
     // Dismiss whatever dialog is showing
     public void dismissAllDialogFragments() {
-        getSupportFragmentManager().popBackStack("dialog", FragmentManager.POP_BACK_STACK_INCLUSIVE);
+        getSupportFragmentManager().popBackStack(DIALOG_FRAGMENT_TAG, FragmentManager.POP_BACK_STACK_INCLUSIVE);
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -18,7 +18,6 @@
 
 package com.ichi2.anki;
 
-import android.app.AlertDialog;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
@@ -62,6 +61,7 @@ import com.ichi2.anki.dialogs.CardBrowserMySearchesDialog;
 import com.ichi2.anki.dialogs.CardBrowserOrderDialog;
 import com.ichi2.anki.dialogs.ConfirmationDialog;
 import com.ichi2.anki.dialogs.DeckSelectionDialog;
+import com.ichi2.anki.dialogs.DeckSelectionDialog.SelectableDeck;
 import com.ichi2.anki.dialogs.IntegerDialog;
 import com.ichi2.anki.dialogs.RescheduleDialog;
 import com.ichi2.anki.dialogs.SimpleMessageDialog;
@@ -120,6 +120,7 @@ import java.util.Set;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
+import androidx.fragment.app.Fragment;
 import kotlin.Unit;
 import timber.log.Timber;
 
@@ -212,6 +213,13 @@ public class CardBrowser extends NavigationDrawerActivity implements
 
     /** The query which is currently in the search box, potentially null. Only set when search box was open */
     private String mTempSearchQuery;
+
+    /**
+     * Argument key to add on change deck dialog,
+     * so it can be dismissed on activity recreation,
+     * since the cards are unselected when this happens
+     */
+    private static final String CHANGE_DECK_KEY = "CHANGE_DECK";
 
     ActivityResultLauncher<Intent> mOnEditCardActivityResult = registerForActivityResult(new ActivityResultContracts.StartActivityForResult(), result -> {
         Timber.d("onEditCardActivityResult: resultCode=%d", result.getResultCode());
@@ -538,15 +546,12 @@ public class CardBrowser extends NavigationDrawerActivity implements
 
     /**
      * Change Deck
-     * @param deckPosition NOT the did. The index in the DISPLAYED Deck list to change the decks to.
-     * grep: changeDeck
+     * @param did Id of the deck
      */
     @VisibleForTesting
-    void moveSelectedCardsToDeck(int deckPosition) {
+    void moveSelectedCardsToDeck(long did) {
         List<Long> ids = getSelectedCardIds();
-
-        Deck selectedDeck = getValidDecksForChangeDeck().get(deckPosition);
-
+        Deck selectedDeck = getCol().getDecks().get(did);
         try {
             //#5932 - can't be dynamic
             if (Decks.isDynamic(selectedDeck)) {
@@ -629,6 +634,17 @@ public class CardBrowser extends NavigationDrawerActivity implements
             searchCards();
         }
 
+        // Selected cards aren't restored on activity recreation,
+        // so it is necessary to dismiss the change deck dialog
+        Fragment dialogFragment = getSupportFragmentManager().findFragmentByTag(DIALOG_FRAGMENT_TAG);
+        if (dialogFragment instanceof DeckSelectionDialog) {
+            DeckSelectionDialog deckDialog = (DeckSelectionDialog) dialogFragment;
+
+            if (deckDialog.getArguments().getBoolean(CHANGE_DECK_KEY, false)) {
+                Timber.d("onCreate(): Change deck dialog dismissed");
+                deckDialog.dismiss();
+            }
+        }
         mOnboarding.onCreate();
     }
 
@@ -1441,29 +1457,31 @@ public class CardBrowser extends NavigationDrawerActivity implements
             rescheduleCardHandler());
     }
 
+    public DeckSelectionDialog getChangeDeckDialog(ArrayList<SelectableDeck> selectableDecks) {
+        DeckSelectionDialog dialog = DeckSelectionDialog.newInstance(
+                getString(R.string.move_all_to_deck),
+                null,
+                false,
+                selectableDecks
+        );
+        // Add change deck argument so the dialog can be dismissed
+        // after activity recreation, since the selected cards will be gone with it
+        dialog.getArguments().putBoolean(CHANGE_DECK_KEY, true);
+        dialog.setDeckSelectionListener(deck -> moveSelectedCardsToDeck(deck.getDeckId()));
+        return dialog;
+    }
 
     private void showChangeDeckDialog() {
         if (!hasSelectedCards()) {
             Timber.i("Not showing Change Deck - No Cards");
             return;
         }
-
-        AlertDialog.Builder builderSingle = new AlertDialog.Builder(this);
-        builderSingle.setTitle(getString(R.string.move_all_to_deck));
-
-        //WARNING: changeDeck depends on this index, so any changes should be reflected there.
-        final ArrayAdapter<String> arrayAdapter = new ArrayAdapter<>(this, R.layout.dropdown_deck_item);
-        for (Deck deck : getValidDecksForChangeDeck()) {
-            try {
-                arrayAdapter.add(deck.getString("name"));
-            } catch (JSONException e) {
-                Timber.w(e);
-            }
+        ArrayList<SelectableDeck> selectableDecks = new ArrayList<>();
+        for (Deck deck: getValidDecksForChangeDeck()) {
+            selectableDecks.add(new SelectableDeck(deck));
         }
-
-        builderSingle.setNegativeButton(getString(R.string.dialog_cancel), (dialog, which) -> dialog.dismiss());
-        builderSingle.setAdapter(arrayAdapter, (dialog, which) -> moveSelectedCardsToDeck(which));
-        builderSingle.show();
+        DeckSelectionDialog dialog = getChangeDeckDialog(selectableDecks);
+        showDialogFragment(dialog);
     }
 
 
@@ -3019,18 +3037,6 @@ public class CardBrowser extends NavigationDrawerActivity implements
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)
     boolean hasCheckedCardAtPosition(int i) {
         return mCheckedCards.contains(getCards().get(i));
-    }
-
-    @VisibleForTesting(otherwise = VisibleForTesting.NONE)
-    public int getChangeDeckPositionFromId(long deckId) {
-        List<Deck> decks = getValidDecksForChangeDeck();
-        for (int i = 0; i < decks.size(); i++) {
-            Deck deck = decks.get(i);
-            if (deck.getLong("id") == deckId) {
-                return i;
-            }
-        }
-        throw new IllegalStateException(String.format(Locale.US, "Deck %d not found", deckId));
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckSelectionDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckSelectionDialog.kt
@@ -328,7 +328,7 @@ open class DeckSelectionDialog : AnalyticsDialogFragment() {
             "\t\t".repeat(nameArr.size - 1) + nameArr[nameArr.size - 1]
         }
 
-        protected constructor(d: Deck) : this(d.getLong("id"), d.getString("name"))
+        constructor(d: Deck) : this(d.getLong("id"), d.getString("name"))
 
         /** "All decks" comes first. Then usual deck name order.  */
         override fun compareTo(other: SelectableDeck): Int {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckSelectionDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckSelectionDialog.kt
@@ -47,6 +47,7 @@ import com.ichi2.libanki.stats.Stats
 import com.ichi2.utils.DeckNameComparator
 import com.ichi2.utils.FilterResultsUtils
 import com.ichi2.utils.FunctionalInterfaces
+import com.ichi2.utils.KotlinCleanup
 import kotlinx.parcelize.IgnoredOnParcel
 import kotlinx.parcelize.Parcelize
 import timber.log.Timber
@@ -191,11 +192,15 @@ open class DeckSelectionDialog : AnalyticsDialogFragment() {
      * @param deck deck sent to the listener.
      */
     protected fun onDeckSelected(deck: SelectableDeck?) {
-        deckSelectionListener.onDeckSelected(deck)
+        deckSelectionListener!!.onDeckSelected(deck)
     }
 
-    private val deckSelectionListener: DeckSelectionListener
+    @KotlinCleanup("Use a factory here")
+    var deckSelectionListener: DeckSelectionListener? = null
         get() {
+            if (field != null) {
+                return field
+            }
             val activity: Activity = requireActivity()
             if (activity is DeckSelectionListener) {
                 return activity

--- a/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.java
@@ -27,6 +27,7 @@ import android.view.View;
 import android.widget.AdapterView;
 import android.widget.ListView;
 
+import com.ichi2.anki.dialogs.DeckSelectionDialog;
 import com.ichi2.async.CollectionTask;
 import com.ichi2.async.TaskManager;
 import com.ichi2.libanki.Card;
@@ -35,6 +36,7 @@ import com.ichi2.libanki.Deck;
 import com.ichi2.libanki.Note;
 import com.ichi2.libanki.SortOrder;
 import com.ichi2.testutils.AnkiAssert;
+import com.ichi2.testutils.AnkiActivityUtils;
 import com.ichi2.testutils.IntentAssert;
 
 import org.junit.Assert;
@@ -47,6 +49,7 @@ import org.robolectric.annotation.Config;
 import org.robolectric.shadows.ShadowActivity;
 import org.robolectric.shadows.ShadowApplication;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -57,6 +60,7 @@ import java.util.Random;
 import javax.annotation.CheckReturnValue;
 
 import androidx.annotation.StringRes;
+import androidx.fragment.app.Fragment;
 import androidx.test.core.app.ApplicationProvider;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import timber.log.Timber;
@@ -72,6 +76,8 @@ import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.robolectric.Shadows.shadowOf;
 
@@ -257,10 +263,8 @@ public class CardBrowserTest extends RobolectricTest {
             assertThat("Deck should have been changed yet", getCol().getCard(cardId).getDid(), not(deckIdToChangeTo));
         }
 
-        final int deckPosition = b.getChangeDeckPositionFromId(deckIdToChangeTo);
-
         //act
-        AnkiAssert.assertDoesNotThrow(() -> b.moveSelectedCardsToDeck(deckPosition));
+        AnkiAssert.assertDoesNotThrow(() -> b.moveSelectedCardsToDeck(deckIdToChangeTo));
 
         //assert
         advanceRobolectricLooperWithSleep();
@@ -583,6 +587,21 @@ public class CardBrowserTest extends RobolectricTest {
         advanceRobolectricLooperWithSleep();
 
         assertUndoContains(b, R.string.deck_conf_cram_reschedule);
+    }
+
+    @Test
+    public void change_deck_dialog_is_dismissed_on_activity_recreation() {
+        CardBrowser cardBrowser = getBrowserWithNoNewCards();
+
+        DeckSelectionDialog dialog = cardBrowser.getChangeDeckDialog(new ArrayList<>());
+        cardBrowser.showDialogFragment(dialog);
+
+        Fragment shownDialog = AnkiActivityUtils.getDialogFragment(cardBrowser);
+        assertNotNull(shownDialog);
+
+        cardBrowser.recreate();
+        Fragment dialogAfterRecreate = AnkiActivityUtils.getDialogFragment(cardBrowser);
+        assertNull(dialogAfterRecreate);
     }
 
     /** 8027 */

--- a/AnkiDroid/src/test/java/com/ichi2/testutils/AnkiActivityUtils.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/testutils/AnkiActivityUtils.kt
@@ -24,11 +24,11 @@ object AnkiActivityUtils {
     @Suppress("unused")
     @KotlinCleanup("replace getDialogFragment with this")
     inline fun <reified T : DialogFragment> AnkiActivity.getDialogFragmentKt(): T? {
-        return supportFragmentManager.findFragmentByTag("dialog") as T?
+        return supportFragmentManager.findFragmentByTag(AnkiActivity.DIALOG_FRAGMENT_TAG) as T?
     }
 
     @JvmStatic
     fun getDialogFragment(activity: AnkiActivity): DialogFragment? {
-        return activity.supportFragmentManager.findFragmentByTag("dialog") as DialogFragment?
+        return activity.supportFragmentManager.findFragmentByTag(AnkiActivity.DIALOG_FRAGMENT_TAG) as DialogFragment?
     }
 }


### PR DESCRIPTION
## Fixes
Fixes #10674 and closes #10681

## Approach
1. Made deckSelectionListener variable instead of val, so it can be set on other places
2. Reused deckSelectionDialog on changeDeckDialog
3. Fixed tests

## How Has This Been Tested?

On my device (Samsung Galaxy Note 10 Lite SM-N770F/DS, API 30)

https://user-images.githubusercontent.com/69634269/161401513-36b30335-8c17-42ea-9df1-638d07f65b56.mp4


## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [X] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)