### PR TITLE
Do not match unrelated classes on `hasUserDefinedNightMode()`

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/CardAppearance.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/CardAppearance.kt
@@ -24,14 +24,6 @@ import com.ichi2.themes.Themes.AppTheme
 
 /** Responsible for calculating CSS and element styles and modifying content on a flashcard  */
 class CardAppearance(private val customFonts: ReviewerCustomFonts, private val cardZoom: Int, private val imageZoom: Int, val isNightMode: Boolean, private val centerVertically: Boolean) {
-    /**
-     * hasUserDefinedNightMode finds out if the user has included class .night_mode in card's stylesheet
-     */
-    fun hasUserDefinedNightMode(card: Card): Boolean {
-        // TODO: find more robust solution that won't match unrelated classes like "night_mode_old"
-        return card.css().contains(".night_mode") || card.css().contains(".nightMode")
-    }
-
     /** Below could be in a better abstraction.  */
     fun appendCssStyle(style: StringBuilder) {
         // Zoom cards
@@ -83,6 +75,8 @@ class CardAppearance(private val customFonts: ReviewerCustomFonts, private val c
     }
 
     companion object {
+        private val nightModeClassRegex = Regex("\\.night(?:_m|M)ode\\b")
+
         @JvmStatic
         fun create(customFonts: ReviewerCustomFonts, preferences: SharedPreferences): CardAppearance {
             val cardZoom = preferences.getInt("cardZoom", 100)
@@ -102,6 +96,12 @@ class CardAppearance(private val customFonts: ReviewerCustomFonts, private val c
             // In order to display the bold style correctly, we have to change
             // font-weight to 700
             return content.replace("font-weight:600;", "font-weight:700;")
+        }
+        /**
+         * hasUserDefinedNightMode finds out if the user has included class .night_mode in card's stylesheet
+         */
+        fun hasUserDefinedNightMode(card: Card): Boolean {
+            return card.css().contains(nightModeClassRegex)
         }
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/CardHtml.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/CardHtml.kt
@@ -19,6 +19,7 @@ package com.ichi2.anki.cardviewer
 import android.content.Context
 import com.ichi2.anki.R
 import com.ichi2.anki.TtsParser
+import com.ichi2.anki.cardviewer.CardAppearance.Companion.hasUserDefinedNightMode
 import com.ichi2.libanki.*
 import com.ichi2.libanki.template.MathJax
 import com.ichi2.themes.HtmlColors
@@ -129,7 +130,7 @@ class CardHtml(
         fun createInstance(card: Card, reload: Boolean, side: Side, context: HtmlGenerator): CardHtml {
             val content = displayString(card, reload, side, context)
 
-            val nightModeInversion = context.cardAppearance.isNightMode && !context.cardAppearance.hasUserDefinedNightMode(card)
+            val nightModeInversion = context.cardAppearance.isNightMode && !hasUserDefinedNightMode(card)
 
             val renderOutput = card.render_output()
             val questionAv = renderOutput.question_av_tags

--- a/AnkiDroid/src/test/java/com/ichi2/anki/cardviewer/CardAppearanceTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/cardviewer/CardAppearanceTest.kt
@@ -1,0 +1,42 @@
+/*
+ *  Copyright (c) 2022 Brayan Oliveira <brayandso.dev@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.cardviewer
+
+import com.ichi2.anki.cardviewer.CardAppearance.Companion.hasUserDefinedNightMode
+import com.ichi2.libanki.Card
+import com.ichi2.testutils.assertFalse
+import org.junit.Test
+import org.mockito.Mockito
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.whenever
+import kotlin.test.junit.JUnitAsserter.assertTrue
+
+class CardAppearanceTest {
+
+    @Test
+    fun hasUserDefinedNightModeTest() {
+        val mockCard = Mockito.mock(Card::class.java)
+        doReturn(".night_mode {}").whenever(mockCard).css()
+        assertTrue("CSS should have a night mode class", hasUserDefinedNightMode(mockCard))
+
+        doReturn(".nightMode{}").whenever(mockCard).css()
+        assertTrue("CSS should have a night mode class", hasUserDefinedNightMode(mockCard))
+
+        doReturn(".night_mode_old {}").whenever(mockCard).css()
+        assertFalse("CSS should not have a night mode class", hasUserDefinedNightMode(mockCard))
+    }
+}


### PR DESCRIPTION
## Purpose / Description
Clean out a [TODO](https://github.com/ankidroid/Anki-Android/blob/cadcc3ddf7d277f350a04c5fc44f5a238317c619/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/CardAppearance.kt#L31) on CardAppearance. 

Before, `hasUserDefinedNightModeTest()` was returning true if card css had a class like `.night_mode_old`

## Approach
1. Used a regex to match night mode classes
    - It can be tested on https://regex101.com/r/iQtXKo/3
    - Note: commented classes are still being matched. Haven't covered because it would need a overkill regex/function and wasn't sure if it would be accepted
2. Built a unit test
    - Moved `hasUserDefinedNightModeTest()` to companion object in order to test it with more ease

## How Has This Been Tested?

Unit tests and on my device (Samsung Galaxy Note 10 Lite SM-N770F/DS, API 30)

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
