### PR TITLE
fix: crash opening DeckOptions

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckOptions.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckOptions.java
@@ -39,6 +39,7 @@ import com.ichi2.anim.ActivityTransitionAnimation;
 import com.ichi2.anki.exception.ConfirmModSchemaException;
 import com.ichi2.anki.receiver.SdCardReceiver;
 import com.ichi2.anki.services.ReminderService;
+import com.ichi2.annotations.NeedsTest;
 import com.ichi2.async.CollectionTask;
 import com.ichi2.async.TaskListenerWithContext;
 import com.ichi2.async.TaskManager;
@@ -80,6 +81,7 @@ import static com.ichi2.anim.ActivityTransitionAnimation.Direction.FADE;
 /**
  * Preferences for the current deck.
  */
+@NeedsTest("onCreate - to be done after preference migration (5019)")
 public class DeckOptions extends AppCompatPreferenceActivity implements OnSharedPreferenceChangeListener {
 
     private DeckConfig mOptions;

--- a/AnkiDroid/src/main/java/com/ichi2/ui/SeekBarPreference.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/ui/SeekBarPreference.kt
@@ -102,7 +102,7 @@ class SeekBarPreference(context: Context, attrs: AttributeSet) : android.prefere
         mSeekBar!!.progress = (mValue - mMin) / mInterval
     }
 
-    override fun onSetInitialValue(restore: Boolean, defaultValue: Any) {
+    override fun onSetInitialValue(restore: Boolean, defaultValue: Any?) {
         super.onSetInitialValue(restore, defaultValue)
         mValue = getPersistedInt(mDefault)
         mValue = if (restore) {


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
Opening DeckOptions Crashes

Cause:
Kotlin Migration
49907c76e7fd800c3109b385bd1911f3898a014c

## Fixes
Fixes #10687

## Approach
Fix crash

## How Has This Been Tested?

Android 11 - no longer crashes

## Learning (optional, can help others)
#5019 would be useful here

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
