### PR TITLE
Add missing inputType flag for crash reporting dialog

### DIFF
--- a/AnkiDroid/src/main/res/layout/feedback.xml
+++ b/AnkiDroid/src/main/res/layout/feedback.xml
@@ -22,7 +22,7 @@
             android:gravity="top"
             android:hint="@string/feedback_default_text"
             android:minLines="2"
-            android:inputType="text" />
+            android:inputType="text|textMultiLine" />
     </ScrollView>
 
     <CheckBox


### PR DESCRIPTION
## Purpose / Description
This small PR adds the missing `inputType` flag as mentioned in the [documentation](https://developer.android.com/reference/android/widget/TextView#attr_android:minLines).

## Fixes
Fixes #10688 

## Checklist

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [x] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
