### PR TITLE
feat: sort list in DeckPicker using NaturalSort

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -141,7 +141,10 @@ import com.ichi2.widget.WidgetStatus;
 
 import com.ichi2.utils.JSONException;
 
+import net.greypanther.natsort.CaseInsensitiveSimpleNaturalComparator;
+
 import java.io.File;
+import java.util.Collections;
 import java.util.List;
 
 import kotlin.Unit;
@@ -2168,6 +2171,12 @@ public class DeckPicker extends NavigationDrawerActivity implements
                 deckPicker.showCollectionErrorDialog();
                 return;
             }
+
+            // Sort entries using natural sorting order ("Lesson 2" before "Lesson 11")
+            Collections.sort(dueTree,
+                    (T a, T b) -> CaseInsensitiveSimpleNaturalComparator
+                            .<String>getInstance()
+                            .compare(a.getLastDeckNameComponent(), b.getLastDeckNameComponent()));
             deckPicker.mDueTree = dueTree;
 
             deckPicker.__renderPage();

--- a/AnkiDroid/src/main/java/net/greypanther/natsort/AbstractSimpleNaturalComparator.java
+++ b/AnkiDroid/src/main/java/net/greypanther/natsort/AbstractSimpleNaturalComparator.java
@@ -1,0 +1,82 @@
+package net.greypanther.natsort;
+
+import java.util.Comparator;
+
+abstract class AbstractSimpleNaturalComparator<T extends CharSequence> implements Comparator<T> {
+  @Override
+  public int compare(T sequence1, T sequence2) {
+    int len1 = sequence1.length(), len2 = sequence2.length();
+    int idx1 = 0, idx2 = 0;
+
+    while (idx1 < len1 && idx2 < len2) {
+      char c1 = sequence1.charAt(idx1++);
+      char c2 = sequence2.charAt(idx2++);
+
+      boolean isDigit1 = isDigit(c1);
+      boolean isDigit2 = isDigit(c2);
+
+      if (isDigit1 && !isDigit2) {
+        return -1;
+      } else if (!isDigit1 && isDigit2) {
+        return 1;
+      } else if (!isDigit1 && !isDigit2) {
+        int c = compareChars(c1, c2);
+        if (c != 0) {
+          return c;
+        }
+      } else {
+        long num1 = parse(c1);
+        while (idx1 < len1) {
+          char digit = sequence1.charAt(idx1++);
+          if (isDigit(digit)) {
+            num1 = num1 * 10 + parse(digit);
+          } else {
+            idx1--;
+            break;
+          }
+        }
+
+        long num2 = parse(c2);
+        while (idx2 < len2) {
+          char digit = sequence2.charAt(idx2++);
+          if (isDigit(digit)) {
+            num2 = num2 * 10 + parse(digit);
+          } else {
+            idx2--;
+            break;
+          }
+        }
+
+        if (num1 != num2) {
+          return compareUnsigned(num1, num2);
+        }
+      }
+    }
+
+    if (idx1 < len1) {
+      return 1;
+    } else if (idx2 < len2) {
+      return -1;
+    } else {
+      return 0;
+    }
+  }
+
+  abstract int compareChars(char c1, char c2);
+
+  private static int compareUnsigned(long num1, long num2) {
+    return compare(num1 + Long.MIN_VALUE, num2 + Long.MIN_VALUE);
+  }
+
+  private static int compare(long x, long y) {
+    return (x < y) ? -1 : ((x == y) ? 0 : 1);
+  }
+
+  private static long parse(char c1) {
+    return c1 - '0';
+  }
+
+  private static boolean isDigit(char c) {
+    return '0' <= c & c <= '9';
+  }
+}

--- a/AnkiDroid/src/main/java/net/greypanther/natsort/CaseInsensitiveSimpleNaturalComparator.java
+++ b/AnkiDroid/src/main/java/net/greypanther/natsort/CaseInsensitiveSimpleNaturalComparator.java
@@ -1,0 +1,27 @@
+package net.greypanther.natsort;
+
+import java.util.Comparator;
+
+/**
+ * The same as {@link SimpleNaturalComparator} but comparison is done after converting each
+ * character to lower case.
+ */
+public final class CaseInsensitiveSimpleNaturalComparator<T extends CharSequence>
+    extends AbstractSimpleNaturalComparator<T> implements Comparator<T> {
+  @SuppressWarnings("rawtypes")
+  private static final Comparator INSTANCE = new CaseInsensitiveSimpleNaturalComparator();
+
+  private CaseInsensitiveSimpleNaturalComparator() {
+    // to be instantiated only internally
+  }
+
+  @Override
+  int compareChars(char c1, char c2) {
+    return Character.toLowerCase(c1) - Character.toLowerCase(c2);
+  }
+
+  @SuppressWarnings("unchecked")
+  public static <T extends CharSequence> Comparator<T> getInstance() {
+    return INSTANCE;
+  }
+}


### PR DESCRIPTION
## Pull Request template

## Purpose / Description

`DeckPicker` currently doesn't seem to solve the list of decks and displays them in the order the DB returns them. It would be nice if they were sorted using natural sorting (https://en.wikipedia.org/wiki/Natural_sort_order). This is a draft on how natural would change the UI

I understand the `dueList` is sorted in the order I ought to do them. A sorting option would be nice though when I want to find them by name and not in the order I should work on the text. This is just a draft. The final PR should guard this by an option.

With natural sorting:
![anki_with_natsort](https://user-images.githubusercontent.com/7189118/161443360-0f2938eb-6b05-41e9-93b9-cd0afc481a47.png)

Before:
![anki_before](https://user-images.githubusercontent.com/7189118/161443363-b3a0f148-00cc-4b87-85ed-fc0abf035dcc.png)


## Fixes
Fixes #10695

## Approach
When the UI refreshes it's view using a list imported from the DB, I apply `sort` before setting the deck list to the UI class. I have introduced a vendored dependency (https://github.com/gpanther/java-nat-sort/ Apache License) since I didn't not know how to add a Maven dependency to the gradle build (Android Studio was complaining that it can't mix non-Android gradle builds with Android gradle builds when I added `    implementation 'net.grey-panther:natural-comparator:1.1' to `Anki-Droid/build.gradle`).

Ideally this feature should be guarded by a setting.

Disclaimer: I have never worked with any Android app so advice is appreciated on how the dependency can be built using `build.gradle` only

## How Has This Been Tested?

I would like to get initial feedback whether this patch is applicable. It could be easily tested by checking the order of `mDueList` after refreshing the view.

## Learning (optional, can help others)
N/A

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
