### PR TITLE
fix(deck-selection): don't keep activities crash

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckSelectionDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckSelectionDialog.kt
@@ -47,6 +47,7 @@ import com.ichi2.libanki.stats.Stats
 import com.ichi2.utils.DeckNameComparator
 import com.ichi2.utils.FilterResultsUtils
 import com.ichi2.utils.FunctionalInterfaces
+import kotlinx.parcelize.IgnoredOnParcel
 import kotlinx.parcelize.Parcelize
 import timber.log.Timber
 import java.util.*
@@ -316,19 +317,13 @@ open class DeckSelectionDialog : AnalyticsDialogFragment() {
          * rather than the entire deck name.
          * Eg: foo::bar -> \t\tbar
          */
-        val displayName: String // TODO should be a lazy value
-            get() = getDisplayName(name)
+        @IgnoredOnParcel
+        val displayName: String by lazy {
+            val nameArr = name.split("::")
+            "\t\t".repeat(nameArr.size - 1) + nameArr[nameArr.size - 1]
+        }
 
         protected constructor(d: Deck) : this(d.getLong("id"), d.getString("name"))
-
-        /**
-         * @param name the entire name(path) of the deck
-         * @return the deck/subdeck name to be displayed to the user
-         */
-        private fun getDisplayName(name: String): String {
-            val nameArr = name.split("::")
-            return "\t\t".repeat(nameArr.size - 1) + nameArr[nameArr.size - 1]
-        }
 
         /** "All decks" comes first. Then usual deck name order.  */
         override fun compareTo(other: SelectableDeck): Int {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckSelectionDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckSelectionDialog.kt
@@ -18,7 +18,6 @@ package com.ichi2.anki.dialogs
 import android.app.Activity
 import android.app.Dialog
 import android.os.Bundle
-import android.os.Parcel
 import android.os.Parcelable
 import android.view.LayoutInflater
 import android.view.View
@@ -38,6 +37,7 @@ import com.ichi2.anki.UIUtils.showThemedToast
 import com.ichi2.anki.analytics.AnalyticsDialogFragment
 import com.ichi2.anki.dialogs.DeckSelectionDialog.DecksArrayAdapter.DecksFilter
 import com.ichi2.anki.dialogs.DeckSelectionDialog.SelectableDeck
+import com.ichi2.annotations.NeedsTest
 import com.ichi2.libanki.Collection
 import com.ichi2.libanki.CollectionGetter
 import com.ichi2.libanki.Deck
@@ -47,7 +47,7 @@ import com.ichi2.libanki.stats.Stats
 import com.ichi2.utils.DeckNameComparator
 import com.ichi2.utils.FilterResultsUtils
 import com.ichi2.utils.FunctionalInterfaces
-import com.ichi2.utils.KotlinCleanup
+import kotlinx.parcelize.Parcelize
 import timber.log.Timber
 import java.util.*
 import java.util.Objects.requireNonNull
@@ -63,6 +63,7 @@ import java.util.Objects.requireNonNull
  *
  * @see SelectableDeck The data that is displayed
  */
+@NeedsTest("simulate 'don't keep activities'")
 open class DeckSelectionDialog : AnalyticsDialogFragment() {
     private var mDialog: MaterialDialog? = null
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -302,18 +303,13 @@ open class DeckSelectionDialog : AnalyticsDialogFragment() {
             mCurrentlyDisplayedDecks.sort()
         }
     }
-    @KotlinCleanup("auto parcel is needed")
-    open class SelectableDeck : Comparable<SelectableDeck>, Parcelable {
-        /**
-         * Either a deck id or ALL_DECKS_ID
-         */
-        val deckId: Long
 
-        /**
-         * Name of the deck, or localization of "all decks"
-         */
-        val name: String
-
+    /**
+     * @param deckId Either a deck id or ALL_DECKS_ID
+     * @param name Name of the deck, or localization of "all decks"
+     */
+    @Parcelize
+    class SelectableDeck(val deckId: Long, val name: String) : Comparable<SelectableDeck>, Parcelable {
         /**
          * The name to be displayed to the user. Contains
          * only the sub-deck name with proper indentation
@@ -323,23 +319,14 @@ open class DeckSelectionDialog : AnalyticsDialogFragment() {
         val displayName: String // TODO should be a lazy value
             get() = getDisplayName(name)
 
-        constructor(deckId: Long, name: String) {
-            this.deckId = deckId
-            this.name = name
-        }
-
         protected constructor(d: Deck) : this(d.getLong("id"), d.getString("name"))
-        protected constructor(`in`: Parcel) {
-            deckId = `in`.readLong()
-            name = `in`.readString()!!
-        }
 
         /**
          * @param name the entire name(path) of the deck
          * @return the deck/subdeck name to be displayed to the user
          */
         private fun getDisplayName(name: String): String {
-            var nameArr = name.split("::")
+            val nameArr = name.split("::")
             return "\t\t".repeat(nameArr.size - 1) + nameArr[nameArr.size - 1]
         }
 
@@ -353,15 +340,6 @@ open class DeckSelectionDialog : AnalyticsDialogFragment() {
             return if (other.deckId == Stats.ALL_DECKS_ID) {
                 1
             } else DeckNameComparator.INSTANCE.compare(name, other.name)
-        }
-
-        override fun describeContents(): Int {
-            return 0
-        }
-
-        override fun writeToParcel(dest: Parcel, flags: Int) {
-            dest.writeLong(deckId)
-            dest.writeString(name)
         }
 
         companion object {
@@ -381,16 +359,6 @@ open class DeckSelectionDialog : AnalyticsDialogFragment() {
                     ret.add(SelectableDeck(d))
                 }
                 return ret
-            }
-
-            val CREATOR: Parcelable.Creator<SelectableDeck?> = object : Parcelable.Creator<SelectableDeck?> {
-                override fun createFromParcel(`in`: Parcel): SelectableDeck {
-                    return SelectableDeck(`in`)
-                }
-
-                override fun newArray(size: Int): Array<SelectableDeck?> {
-                    return arrayOfNulls(size)
-                }
             }
         }
     }


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
Crash Fix


## Fixes
Fixes #10698

## Approach
`@Parcelize`

## How Has This Been Tested?

On my Android 11 - no longer crashes

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
