### PR TITLE
Solved double ripple effect.

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/widgets/DeckAdapter.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/widgets/DeckAdapter.java
@@ -223,6 +223,7 @@ public class DeckAdapter<T extends AbstractDeckTreeNode<T>> extends RecyclerView
             holder.deckExpander.setOnClickListener(mDeckExpanderClickListener);
         } else {
             holder.deckExpander.setClickable(false);
+            holder.deckExpander.setOnClickListener(null);
         }
         holder.deckLayout.setBackgroundResource(mRowCurrentDrawable);
         // Set background colour. The current deck has its own color


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
Double ripple effect was occurring in Deck screen.
## Fixes
Fixes [#10634](https://github.com/ankidroid/Anki-Android/issues/10634)

## Approach
Setting the listener for deckExpander to null in DeckAdapter.onBindViewHolder() solved this issue:

## How Has This Been Tested?
Emulator: Pixel 4 XL API 27
Physical Device: Xiaomi Poco x2.

## Learning (optional, can help others)
It is my first pull request on github. The issue which I fixed was not very complex. 
But the feeling is really great. And much excited in journey of open source, contribution.

## Checklist
_Please, go through these checks before submitting the PR._


- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [ ] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner]

## Before
https://user-images.githubusercontent.com/63647613/161525750-6bfc4793-33a3-4ce5-a180-aeac927a65b6.mp4

## After

https://user-images.githubusercontent.com/63647613/161524531-c624a7c0-b7af-4d6c-a854-b7518795b4e0.mp4

(https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
