### PR TITLE
refactor: Use file matchers on BackupManagerSimpleTest and NoteServiceTest

### DIFF
--- a/AnkiDroid/src/test/java/com/ichi2/anki/BackupManagerSimpleTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/BackupManagerSimpleTest.kt
@@ -18,22 +18,20 @@ package com.ichi2.anki
 
 import com.ichi2.anki.BackupManager.Companion.getLatestBackup
 import com.ichi2.testutils.MockTime
-import com.ichi2.testutils.assertFalse
-import org.hamcrest.CoreMatchers.equalTo
-import org.hamcrest.CoreMatchers.nullValue
+import org.hamcrest.CoreMatchers.*
 import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.collection.ArrayMatching.arrayContainingInAnyOrder
+import org.hamcrest.io.FileMatchers.anExistingFile
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
 import java.io.File
-import java.util.*
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.junit.JUnitAsserter.assertEquals
 import kotlin.test.junit.JUnitAsserter.assertNotNull
 import kotlin.test.junit.JUnitAsserter.assertNull
-import kotlin.test.junit.JUnitAsserter.assertTrue
 
 /**
  * Test for [BackupManager] without [RobolectricTest]. For performance
@@ -124,9 +122,7 @@ class BackupManagerSimpleTest {
 
         assertNotNull(backups)
         assertEquals("Only the valid backup names should have been kept", 2, backups.size)
-        Arrays.sort(backups)
-        assertEquals("collection-2000-12-31-23-04.colpkg", backups[0].name)
-        assertEquals("collection-2010-12-06-13-04.colpkg", backups[1].name)
+        assertThat(backups, arrayContainingInAnyOrder(f1, f3))
     }
 
     @Test
@@ -144,10 +140,10 @@ class BackupManagerSimpleTest {
         f4.createNewFile()
 
         BackupManager.deleteDeckBackups(colFile.path, 2)
-        assertFalse("Older backups should have been deleted", f2.exists())
-        assertFalse("Older backups should have been deleted", f4.exists())
-        assertTrue("Newer backups should have been kept", f1.exists())
-        assertTrue("Newer backups should have been kept", f3.exists())
+        assertThat("Older backups should have been deleted", f2, not(anExistingFile()))
+        assertThat("Older backups should have been deleted", f4, not(anExistingFile()))
+        assertThat("Newer backups should have been kept", f1, anExistingFile())
+        assertThat("Newer backups should have been kept", f3, anExistingFile())
     }
 
     @Test

--- a/AnkiDroid/src/test/java/com/ichi2/anki/services/NoteServiceTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/services/NoteServiceTest.java
@@ -24,7 +24,6 @@ import com.ichi2.anki.servicelayer.NoteService;
 import com.ichi2.libanki.Collection;
 import com.ichi2.libanki.Model;
 import com.ichi2.libanki.Note;
-
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -37,10 +36,13 @@ import java.io.IOException;
 
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.io.FileMatchers.aFileWithAbsolutePath;
+import static org.hamcrest.io.FileMatchers.anExistingFile;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertFalse;
 import static com.ichi2.testutils.FileSystemUtilsKt.createTransientFile;
 
 @RunWith(AndroidJUnit4.class)
@@ -109,7 +111,7 @@ public class NoteServiceTest extends RobolectricTest {
 
         File outFile = new File(mTestCol.getMedia().dir(), fileAudio.getName());
 
-        assertEquals("path should be equal to the new file made in NoteService.importMediaToDirectory", outFile.getAbsolutePath(), audioField.getAudioPath());
+        assertThat("path should be equal to new file made in NoteService.importMediaToDirectory", outFile, aFileWithAbsolutePath(equalTo(audioField.getAudioPath())));
 
     }
 
@@ -131,7 +133,7 @@ public class NoteServiceTest extends RobolectricTest {
 
         File outFile = new File(mTestCol.getMedia().dir(), fileImage.getName());
 
-        assertEquals("path should be equal to the new file made in NoteService.importMediaToDirectory", outFile.getAbsolutePath(), imgField.getImagePath());
+        assertThat("path should be equal to new file made in NoteService.importMediaToDirectory", outFile, aFileWithAbsolutePath(equalTo(imgField.getImagePath())));
     }
 
 
@@ -177,9 +179,9 @@ public class NoteServiceTest extends RobolectricTest {
         NoteService.importMediaToDirectory(mTestCol, fld3);
         // creating a third outfile isn't necessary because it should be equal to the first one
 
-        assertEquals("path should be equal to the new file made in NoteService.importMediaToDirectory", o1.getAbsolutePath(), fld1.getAudioPath());
-        assertNotEquals("path should be different to the new file made in NoteService.importMediaToDirectory", o2.getAbsolutePath(), fld2.getAudioPath());
-        assertEquals("path should be equal to the new file made in NoteService.importMediaToDirectory", o1.getAbsolutePath(), fld3.getAudioPath());
+        assertThat("path should be equal to new file made in NoteService.importMediaToDirectory", o1, aFileWithAbsolutePath(equalTo(fld1.getAudioPath())));
+        assertThat("path should be different to new file made in NoteService.importMediaToDirectory", o2, aFileWithAbsolutePath(not(fld2.getAudioPath())));
+        assertThat("path should be equal to new file made in NoteService.importMediaToDirectory", o1, aFileWithAbsolutePath(equalTo(fld3.getAudioPath())));
     }
 
     // Similar test like above, but with an ImageField instead of a MediaClipField
@@ -216,9 +218,9 @@ public class NoteServiceTest extends RobolectricTest {
         NoteService.importMediaToDirectory(mTestCol, fld3);
         // creating a third outfile isn't necessary because it should be equal to the first one
 
-        assertEquals("path should be equal to the new file made in NoteService.importMediaToDirectory", o1.getAbsolutePath(), fld1.getImagePath());
-        assertNotEquals("path should be different to the new file made in NoteService.importMediaToDirectory", o2.getAbsolutePath(), fld2.getImagePath());
-        assertEquals("path should be equal to the new file made in NoteService.importMediaToDirectory", o1.getAbsolutePath(), fld3.getImagePath());
+        assertThat("path should be equal to new file made in NoteService.importMediaToDirectory", o1, aFileWithAbsolutePath(equalTo(fld1.getImagePath())));
+        assertThat("path should be different to new file made in NoteService.importMediaToDirectory", o2, aFileWithAbsolutePath(not(fld2.getImagePath())));
+        assertThat("path should be equal to new file made in NoteService.importMediaToDirectory", o1, aFileWithAbsolutePath(equalTo(fld3.getImagePath())));
     }
 
     /**
@@ -236,7 +238,7 @@ public class NoteServiceTest extends RobolectricTest {
 
         NoteService.importMediaToDirectory(mTestCol, field);
 
-        assertFalse("Audio temporary file should have been deleted after importing", file.exists());
+        assertThat("Audio temporary file should have been deleted after importing", file, not(anExistingFile()));
     }
 
     // Similar test like above, but with an ImageField instead of a MediaClipField
@@ -250,7 +252,7 @@ public class NoteServiceTest extends RobolectricTest {
 
         NoteService.importMediaToDirectory(mTestCol, field);
 
-        assertFalse("Image temporary file should have been deleted after importing", file.exists());
+        assertThat("Image temporary file should have been deleted after importing", file, not(anExistingFile()));
     }
 
 }


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
My body itched when I saw a PR which used io.Filematchers and I remembered some tests I built before the matchers introduction could use them

## Fixes
Helps #10387

## Approach
Use hamcrest filematchers instead of junit asserts

## How Has This Been Tested?

Unit tests

## Learning (optional, can help others)
Hamcrest docs: http://hamcrest.org/JavaHamcrest/javadoc/2.2/

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
