### PR TITLE
refactor: Toolbar

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -50,7 +50,6 @@ import android.text.TextWatcher;
 import android.util.Pair;
 import android.view.ActionMode;
 import android.view.KeyEvent;
-import android.view.LayoutInflater;
 import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.MenuItem;
@@ -59,7 +58,6 @@ import android.view.ViewGroup.MarginLayoutParams;
 import android.view.WindowManager;
 import android.widget.AdapterView;
 import android.widget.AdapterView.OnItemSelectedListener;
-import android.widget.Button;
 import android.widget.EditText;
 import android.widget.ImageButton;
 import android.widget.LinearLayout;
@@ -659,7 +657,7 @@ public class NoteEditor extends AnkiActivity implements
         String selectedText = text.substring(start, end);
         String afterText = text.substring(end);
 
-        Toolbar.TextWrapper.StringFormat formatResult = formatter.format(selectedText);
+        Toolbar.StringFormat formatResult = formatter.format(selectedText);
         String newText = formatResult.result;
 
         // Update text field with updated text and selection
@@ -667,8 +665,8 @@ public class NoteEditor extends AnkiActivity implements
         StringBuilder newFieldContent = new StringBuilder(length).append(beforeText).append(newText).append(afterText);
         textBox.setText(newFieldContent);
 
-        int newStart = formatResult.start;
-        int newEnd = formatResult.end;
+        int newStart = formatResult.selectionStart;
+        int newEnd = formatResult.selectionEnd;
         textBox.setSelection(start + newStart, start + newEnd);
     }
 
@@ -1893,15 +1891,15 @@ public class NoteEditor extends AnkiActivity implements
         View clozeIcon = mToolbar.getClozeIcon();
         if (mEditorNote.model().isCloze()) {
             Toolbar.TextFormatter clozeFormatter = s -> {
-                Toolbar.TextWrapper.StringFormat stringFormat = new Toolbar.TextWrapper.StringFormat();
+                Toolbar.StringFormat stringFormat = new Toolbar.StringFormat();
                 String prefix = "{{c" + getNextClozeIndex() + "::";
                 stringFormat.result = prefix + s + "}}";
                 if (s.length() == 0) {
-                    stringFormat.start = prefix.length();
-                    stringFormat.end = prefix.length();
+                    stringFormat.selectionStart = prefix.length();
+                    stringFormat.selectionEnd = prefix.length();
                 } else {
-                    stringFormat.start = 0;
-                    stringFormat.end = stringFormat.result.length();
+                    stringFormat.selectionStart = 0;
+                    stringFormat.selectionEnd = stringFormat.result.length();
                 }
                 return stringFormat;
             };

--- a/AnkiDroid/src/main/java/com/ichi2/anki/noteeditor/Toolbar.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/noteeditor/Toolbar.kt
@@ -133,7 +133,7 @@ class Toolbar : FrameLayout {
     }
 
     fun insertItem(id: Int, drawable: Drawable?, formatter: TextFormatter?): View {
-        return insertItem(id, drawable) { onFormat(formatter) }
+        return insertItem(id, drawable, Runnable { onFormat(formatter) })
     }
 
     fun insertItem(@IdRes id: Int, drawable: Drawable?, runnable: Runnable): AppCompatImageButton {
@@ -295,11 +295,11 @@ class Toolbar : FrameLayout {
         mStringPaint!!.color = color
     }
 
-    interface TextFormatListener {
+    fun interface TextFormatListener {
         fun performFormat(formatter: TextFormatter?)
     }
 
-    interface TextFormatter {
+    fun interface TextFormatter {
         fun format(s: String): TextWrapper.StringFormat
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/noteeditor/Toolbar.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/noteeditor/Toolbar.kt
@@ -38,58 +38,80 @@ import com.afollestad.materialdialogs.MaterialDialog
 import com.ichi2.anki.AnkiDroidApp
 import com.ichi2.anki.R
 import com.ichi2.libanki.Utils
+import com.ichi2.utils.ViewGroupUtils
 import com.ichi2.utils.ViewGroupUtils.getAllChildrenRecursive
 import timber.log.Timber
 import java.util.*
 import kotlin.math.ceil
 
+/**
+ * Handles the toolbar inside [com.ichi2.anki.NoteEditor]
+ *
+ * * Handles a number of buttons which arbitrarily format selected text, or insert an item at the cursor
+ *    * Text is formatted as HTML
+ *    * if a tag with an empty body is inserted, we want the cursor in the middle: `<b>|</b>`
+ * * Handles the "default" buttons: [setupDefaultButtons], [displayFontSizeDialog], [displayInsertHeadingDialog]
+ * * Handles custom buttons with arbitrary prefixes and suffixes: [mCustomButtons]
+ *    * Handles generating the 'icon' for these custom buttons: [createDrawableForString]
+ *    * Handles CTRL+ the tag of the button: [onKeyUp]. Allows for Ctrl+1..9 shortcuts
+ * * Handles adding a dynamic number of buttons and aligning them into rows: [insertItem]
+ *    * And handles whether these should be stacked or scrollable: [shouldScrollToolbar]
+ */
 class Toolbar : FrameLayout {
-    private var mFormatCallback: TextFormatListener? = null
-    private var mToolbar: LinearLayout? = null
-    private var mToolbarLayout: LinearLayout? = null
+    var formatListener: TextFormatListener? = null
+    private val mToolbar: LinearLayout
+    private val mToolbarLayout: LinearLayout
+    /** A list of buttons, typically user-defined which modify text + selection */
     private val mCustomButtons: MutableList<View> = ArrayList()
     private val mRows: MutableList<LinearLayout> = ArrayList()
 
-    // HACK until API 21 FIXME can this be altered now?
+    /**
+     * TODO HACK until API 21 - can be removed once tested.
+     *
+     * inside NoteEditor: use [insertItem] instead of accessing this
+     * and remove [R.id.note_editor_toolbar_button_cloze] from [R.layout.note_editor_toolbar]
+     */
     var clozeIcon: View? = null
         private set
     private var mStringPaint: Paint? = null
 
-    constructor(context: Context) : super(context) {
-        init()
-    }
+    constructor(context: Context) : super(context)
+    constructor(context: Context, attrs: AttributeSet?) : super(context, attrs)
+    constructor(context: Context, attrs: AttributeSet?, defStyleAttr: Int) : super(context, attrs, defStyleAttr)
+    constructor(context: Context, attrs: AttributeSet?, defStyleAttr: Int, defStyleRes: Int) : super(context, attrs, defStyleAttr, defStyleRes)
 
-    constructor(context: Context, attrs: AttributeSet?) : super(context, attrs) {
-        init()
-    }
-
-    constructor(context: Context, attrs: AttributeSet?, defStyleAttr: Int) : super(context, attrs, defStyleAttr) {
-        init()
-    }
-
-    constructor(context: Context, attrs: AttributeSet?, defStyleAttr: Int, defStyleRes: Int) : super(context, attrs, defStyleAttr, defStyleRes) {
-        init()
-    }
-
-    private fun init() {
+    init {
         LayoutInflater.from(context).inflate(R.layout.note_editor_toolbar, this, true)
-        val paintSize = dpToPixels(24)
-        mStringPaint = Paint(Paint.ANTI_ALIAS_FLAG)
-        mStringPaint!!.textSize = paintSize.toFloat()
-        mStringPaint!!.color = Color.BLACK
-        mStringPaint!!.textAlign = Paint.Align.CENTER
+        mStringPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+            textSize = dpToPixels(24).toFloat()
+            color = Color.BLACK
+            textAlign = Paint.Align.CENTER
+        }
         mToolbar = findViewById(R.id.editor_toolbar_internal)
         mToolbarLayout = findViewById(R.id.toolbar_layout)
-        setClick(R.id.note_editor_toolbar_button_bold, "<b>", "</b>")
-        setClick(R.id.note_editor_toolbar_button_italic, "<em>", "</em>")
-        setClick(R.id.note_editor_toolbar_button_underline, "<u>", "</u>")
-        setClick(R.id.note_editor_toolbar_button_insert_mathjax, "\\(", "\\)")
-        setClick(R.id.note_editor_toolbar_button_horizontal_rule, "<hr>", "")
-        findViewById<View>(R.id.note_editor_toolbar_button_font_size).setOnClickListener { displayFontSizeDialog() }
-        findViewById<View>(R.id.note_editor_toolbar_button_title).setOnClickListener { displayInsertHeadingDialog() }
         clozeIcon = findViewById(R.id.note_editor_toolbar_button_cloze)
+        setupDefaultButtons()
     }
 
+    /** Sets up the "standard" buttons to insert bold, italics etc... */
+    private fun setupDefaultButtons() {
+        // sets up a button click to wrap text with the prefix/suffix. So "aa" becomes "<b>aa</b>"
+        fun setupButtonWrappingText(@IdRes id: Int, prefix: String, suffix: String) =
+            findViewById<View>(id).setOnClickListener { onFormat(TextWrapper(prefix, suffix)) }
+
+        setupButtonWrappingText(R.id.note_editor_toolbar_button_bold, "<b>", "</b>")
+        setupButtonWrappingText(R.id.note_editor_toolbar_button_italic, "<em>", "</em>")
+        setupButtonWrappingText(R.id.note_editor_toolbar_button_underline, "<u>", "</u>")
+        setupButtonWrappingText(R.id.note_editor_toolbar_button_insert_mathjax, "\\(", "\\)")
+        setupButtonWrappingText(R.id.note_editor_toolbar_button_horizontal_rule, "<hr>", "")
+        findViewById<View>(R.id.note_editor_toolbar_button_font_size).setOnClickListener { displayFontSizeDialog() }
+        findViewById<View>(R.id.note_editor_toolbar_button_title).setOnClickListener { displayInsertHeadingDialog() }
+    }
+
+    /**
+     * If a button is assigned a tag, Ctrl+Tag will invoke the button
+     * Typically used for Ctrl + 1..9 with custom buttons
+     */
     override fun onKeyUp(keyCode: Int, event: KeyEvent): Boolean {
         // hack to see if only CTRL is pressed - might not be perfect.
         // I'll avoid checking "function" here as it may be required to press Ctrl
@@ -132,7 +154,7 @@ class Toolbar : FrameLayout {
         return insertItem(id, d, runnable)
     }
 
-    fun insertItem(id: Int, drawable: Drawable?, formatter: TextFormatter?): View {
+    fun insertItem(id: Int, drawable: Drawable?, formatter: TextFormatter): View {
         return insertItem(id, drawable, Runnable { onFormat(formatter) })
     }
 
@@ -159,7 +181,7 @@ class Toolbar : FrameLayout {
         button.setPadding(twoDp, twoDp, twoDp, twoDp)
         // end apply style
         if (shouldScrollToolbar()) {
-            mToolbar!!.addView(button, mToolbar!!.childCount)
+            mToolbar.addView(button, mToolbar.childCount)
         } else {
             addViewToToolbar(button)
         }
@@ -186,6 +208,7 @@ class Toolbar : FrameLayout {
             return displayMetrics.widthPixels
         }
 
+    /** Clears all items added by [insertItem] */
     fun clearCustomItems() {
         for (v in mCustomButtons) {
             (v.parent as ViewGroup).removeView(v)
@@ -193,10 +216,11 @@ class Toolbar : FrameLayout {
         mCustomButtons.clear()
     }
 
-    fun setFormatListener(formatter: TextFormatListener?) {
-        mFormatCallback = formatter
-    }
-
+    /**
+     * Displays a dialog which allows the HTML size codes to be inserted around text (xx-small to xx-large)
+     *
+     * @see [R.array.html_size_codes]
+     */
     private fun displayFontSizeDialog() {
         val results = resources.getStringArray(R.array.html_size_codes)
 
@@ -204,57 +228,54 @@ class Toolbar : FrameLayout {
         MaterialDialog.Builder(context)
             .items(R.array.html_size_code_labels)
             .itemsCallback { _: MaterialDialog?, _: View?, pos: Int, _: CharSequence? ->
-                val prefix = "<span style=\"font-size:" + results[pos] + "\">"
-                val suffix = "</span>"
-                val formatter = TextWrapper(prefix, suffix)
+                val formatter = TextWrapper(
+                    prefix = "<span style=\"font-size:${results[pos]}\">",
+                    suffix = "</span>"
+                )
                 onFormat(formatter)
             }
             .title(R.string.menu_font_size)
             .show()
     }
 
+    /**
+     * Displays a dialog which allows `<h1>` to `<h6>` to be inserted
+     */
     private fun displayInsertHeadingDialog() {
         MaterialDialog.Builder(context)
             .items("h1", "h2", "h3", "h4", "h5")
             .itemsCallback { _: MaterialDialog?, _: View?, _: Int, string: CharSequence ->
-                val prefix = "<$string>"
-                val suffix = "</$string>"
-                val formatter = TextWrapper(prefix, suffix)
+                val formatter = TextWrapper(prefix = "<$string>", suffix = "</$string>")
                 onFormat(formatter)
             }
             .title(R.string.insert_heading)
             .show()
     }
 
-    fun createDrawableForString(text: String?): Drawable {
+    /** Given a string [text], generates a [Drawable] which can be used as a button icon */
+    fun createDrawableForString(text: String): Drawable {
         val baseline = -mStringPaint!!.ascent()
         val size = (baseline + mStringPaint!!.descent() + 0.5f).toInt()
         val image = Bitmap.createBitmap(size, size, Bitmap.Config.ARGB_8888)
         val canvas = Canvas(image)
-        canvas.drawText(text!!, size / 2f, baseline, mStringPaint!!)
+        canvas.drawText(text, size / 2f, baseline, mStringPaint!!)
         return BitmapDrawable(resources, image)
     }
 
-    private fun getVisibleItemCount(layout: LinearLayout?): Int {
-        var count = 0
-        for (i in 0 until layout!!.childCount) {
-            if (layout.getChildAt(i).visibility == VISIBLE) {
-                count++
-            }
-        }
-        return count
-    }
+    /** Returns the number of top-level children of [layout] that are visible */
+    private fun getVisibleItemCount(layout: LinearLayout): Int =
+        ViewGroupUtils.getAllChildren(layout).count { it.visibility == VISIBLE }
 
     private fun addViewToToolbar(button: AppCompatImageButton) {
         val expectedWidth = getVisibleItemCount(mToolbar) * dpToPixels(48)
         val width = screenWidth
         if (expectedWidth <= width) {
-            mToolbar!!.addView(button, mToolbar!!.childCount)
+            mToolbar.addView(button, mToolbar.childCount)
             return
         }
         var spaceLeft = false
         if (mRows.isNotEmpty()) {
-            val row = mRows[mRows.size - 1]
+            val row = mRows.last()
             val expectedRowWidth = getVisibleItemCount(row) * dpToPixels(48)
             if (expectedRowWidth <= width) {
                 row.addView(button, row.childCount)
@@ -268,66 +289,94 @@ class Toolbar : FrameLayout {
             row.orientation = LinearLayout.HORIZONTAL
             row.addView(button)
             mRows.add(row)
-            mToolbarLayout!!.addView(mRows[mRows.size - 1])
+            mToolbarLayout.addView(mRows.last())
         }
     }
 
-    private fun setClick(@IdRes id: Int, prefix: String, suffix: String) {
-        setClick(id, TextWrapper(prefix, suffix))
-    }
-
-    private fun setClick(id: Int, textWrapper: TextFormatter) {
-        findViewById<View>(id).setOnClickListener { onFormat(textWrapper) }
-    }
-
-    fun onFormat(formatter: TextFormatter?) {
-        if (mFormatCallback == null) {
-            return
-        }
-        mFormatCallback!!.performFormat(formatter)
+    /**
+     * If a [formatListener] is attached, supply it with the provided [TextFormatter] so that
+     * the current selection of text can be formatted, and the selection can be changed.
+     *
+     * The listener determines the appropriate selection of text to be formatted and handles
+     * selection changes
+     */
+    fun onFormat(formatter: TextFormatter) {
+        formatListener?.performFormat(formatter)
     }
 
     fun setIconColor(@ColorInt color: Int) {
-        for (i in 0 until mToolbar!!.childCount) {
-            val button = mToolbar!!.getChildAt(i) as AppCompatImageButton
-            button.setColorFilter(color)
-        }
+        ViewGroupUtils.getAllChildren(mToolbar)
+            .forEach { (it as AppCompatImageButton).setColorFilter(color) }
         mStringPaint!!.color = color
     }
 
+    /** @see performFormat */
     fun interface TextFormatListener {
-        fun performFormat(formatter: TextFormatter?)
+        /**
+         * A function which accepts a [TextFormatter] and performs some formatting, handling selection changes
+         * In the note editor: this takes the [TextFormatter], determines the correct EditText and selection,
+         * applies the [TextFormatter] to the selection, and ensures the selection is valid
+         *
+         * We use a [TextFormatter] to ensure that the selection is correct after the modification
+         */
+        fun performFormat(formatter: TextFormatter)
     }
 
+    /**
+     * A function which takes and returns a [StringFormat] structure
+     * Providing a method of inserting text and knowledge of how the selection should change
+     */
     fun interface TextFormatter {
-        fun format(s: String): TextWrapper.StringFormat
+        /**
+         * A function which takes and returns a [StringFormat] structure
+         * Providing a method of inserting text and knowledge of how the selection should change
+         */
+        fun format(s: String): StringFormat
     }
 
+    /**
+     * A [TextFormatter] which wraps the selected string with [prefix] and [suffix]
+     * If there's no selected, the cursor is in the middle of the prefix and suffix
+     * If there is text selected, the whole string is selected
+     */
     class TextWrapper(private val prefix: String, private val suffix: String) : TextFormatter {
         override fun format(s: String): StringFormat {
-            val stringFormat = StringFormat()
-            stringFormat.result = prefix + s + suffix
-            if (s.isEmpty()) {
-                stringFormat.start = prefix.length
-                stringFormat.end = prefix.length
-            } else {
-                stringFormat.start = 0
-                stringFormat.end = stringFormat.result!!.length
+            return StringFormat(result = prefix + s + suffix).apply {
+                if (s.isEmpty()) {
+                    // if there's no selection: place the cursor between the start and end tag
+                    selectionStart = prefix.length
+                    selectionEnd = prefix.length
+                } else {
+                    // otherwise, wrap the newly formatted context
+                    selectionStart = 0
+                    selectionEnd = result.length
+                }
             }
-            return stringFormat
-        }
-
-        class StringFormat {
-            @JvmField
-            var result: String? = null
-            @JvmField
-            var start = 0
-            @JvmField
-            var end = 0
         }
     }
 
+    /**
+     * Defines a string insertion, and the selection which should occur once the string is inserted
+     *
+     * @param result The string which should be inserted
+     *
+     * @param selectionStart
+     * The number of characters inside [result] where the selection should start
+     * For example: in {{c1::}}, we should set this to 6, to start after the ::
+     *
+     * @param selectionEnd
+     * The number of character inside [result] where the selection should end
+     * If the input was empty, we typically want this between the start and end tags
+     * If not, at the end of the string
+     */
+    data class StringFormat(
+        @JvmField var result: String = "",
+        @JvmField var selectionStart: Int = 0,
+        @JvmField var selectionEnd: Int = 0
+    )
+
     companion object {
+        /** @return true: toolbar should scroll horizontally. false: toolbar should be stacked vertically */
         fun shouldScrollToolbar(): Boolean {
             return AnkiDroidApp.getSharedPrefs(AnkiDroidApp.getInstance()).getBoolean("noteEditorScrollToolbar", true)
         }


### PR DESCRIPTION
I wanted to convert `NoteEditor`, but first we needed some functional interfaces.

After that, I went through and documented `Toolbar`.

## Approach
Documented, renamed a few fields
Used streams and scope functions
Moved `StringFormat` to the top level

## How Has This Been Tested?
Unit tests + had a quick test on Android 11

## Learning (optional, can help others)
I can't get lowerAPI emulators working, so I couldn't fix the one TODO which drew me to the class in the first place. Hopefully documented it a little better

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
