### PR TITLE
[Bug] reschedule icon color isn't same as one of other icons

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
@@ -633,7 +633,7 @@ open class Reviewer : AbstractFlashcardViewer() {
      */
     private fun shouldUseDefaultColor(menuItem: MenuItem) {
         val drawable = menuItem.icon
-        if (drawable != null && !menuItem.hasSubMenu() && !isFlagResource(menuItem.itemId)) {
+        if (drawable != null && !isFlagResource(menuItem.itemId)) {
             drawable.mutate()
             drawable.setTint(ResourcesCompat.getColor(resources, R.color.material_blue_600, null))
         }


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
The color of "Reschedule" icon on "︙"  menu in Review actiivity isn't same as one of other icons

## Fixes
Fixes #10703

## Approach
Change the color of reschedule icon

## How Has This Been Tested?
Android Device:Redmi y3
![WhatsApp Image 2022-04-06 at 5 08 48 PM](https://user-images.githubusercontent.com/65972015/161966656-0fe96a57-e138-46a0-a300-14e521512f06.jpeg)

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [x] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
