### PR TITLE
fix: add merged pr to milestone

### DIFF
--- a/.github/workflows/milestone.yml
+++ b/.github/workflows/milestone.yml
@@ -1,19 +1,18 @@
 name: PR Milestone
 
 on:
-  pull_request_target:
+  pull_request:
     types: [ closed ]
 
 jobs:
   milestone:
-    if: github.event.pull_request.merged == true
-    permissions:
-      contents: read
-      pull-requests: write    
+    if: ${{ github.event.pull_request.merged == true && github.event.pull_request.milestone == null }}
     runs-on: ubuntu-latest
     steps:
-      - uses: zoispag/action-assign-milestone@v1
-        with:
-          repo-token: "${{ secrets.GITHUB_TOKEN }}"
-          milestone: "2.16 release"
-    
+    - uses: actions/checkout@v2
+    - name: Add to milestone
+      run: |
+        curl --request PATCH \
+        --url ${{ github.event.pull_request.issue_url }} \
+        --header 'authorization: token ${{ secrets.GITHUB_TOKEN }}' \
+        --data '{"milestone": 42}'


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
Fix, add merged PR to milestone. 

## Fixes
Fixes #10410 

## Approach
I have tried many implementation and only implementation in this PR works. I have used `curl` to send POST request using GITHUB_TOKEN to assign milestone to merged PR. I have used `pull_request` instead of `pull_request_target` because only that work. 

## How Has This Been Tested?
It works on my repository but it needs to tested here. 

## Learning (optional, can help others)
https://docs.github.com/en/rest/guides/getting-started-with-the-rest-api

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
