### PR TITLE
Kotlin Cleanup #1048 : Use listOf() instead of Java's Arrays.asList() in Count.kt

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Counts.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Counts.kt
@@ -16,8 +16,7 @@
 
 package com.ichi2.libanki.sched
 
-import com.ichi2.utils.KotlinCleanup
-import java.util.*
+
 
 /**
  * Represents the three counts shown in deck picker and reviewer. Semantically more meaningful than int[]

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Counts.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Counts.kt
@@ -72,8 +72,7 @@ class Counts @JvmOverloads constructor(var new: Int = 0, var lrn: Int = 0, var r
     }
 
     override fun hashCode(): Int {
-        @KotlinCleanup("Kotlin listOf instead of Java Arrays.asList")
-        return Arrays.asList(new, rev, lrn).hashCode()
+        return listOf(new, rev, lrn).hashCode()
     }
 
     override fun toString(): String {


### PR DESCRIPTION
## Purpose / Description 

#### Problem: Count.kt file required a Kotlin cleanup, successfully cleaned.

Issue : Kotlin Cleanup #10489
File effected(s) : Count.kt 
File link : https://github.com/ankidroid/Anki-Android/blob/main/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Counts.kt


## Fixes 
 
#### It required replacing Java's method for returning immutable lists with Kotlin's method for returning immutable lists.

## Approach

#### Replacing Arrays.asList()  to Kotlin's listOf() solved the problem.

## How Has This Been Tested?

#### Passed all the unit tests and runs as expected on Redmi MiA2 API 31, as well as the android emulator (Pixel 3A).

## Learning (optional, can help others)

#### Kotlin provide two methods for returning a list : 

1. Returning mutable lists whose elements can be changed.
> Method :  mutableListOf(i1,i2,i3..iN);

2. Returning immutable lists whose elements can't be altered.
> Method : listOf(i1,i2,i3...iN);

## Checklist

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in if statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)