### PR TITLE
[Bug] Review activity Menu item icon get hidden after one or two time screen rotation

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
@@ -618,16 +618,6 @@ open class Reviewer : AbstractFlashcardViewer() {
         startActivityForResultWithAnimation(intent, ADD_NOTE, ActivityTransitionAnimation.Direction.START)
     }
 
-    override fun onMenuOpened(featureId: Int, menu: Menu): Boolean {
-        postOnNewHandler {
-            for (i in 0 until menu.size()) {
-                val menuItem = menu.getItem(i)
-                shouldUseDefaultColor(menuItem)
-            }
-        }
-        return super.onMenuOpened(featureId, menu)
-    }
-
     /**
      * This Method changes the color of icon if user taps in overflow button.
      */
@@ -771,7 +761,17 @@ open class Reviewer : AbstractFlashcardViewer() {
         suspend_icon.icon.mutate().alpha = alpha
         setupSubMenu(menu, R.id.action_schedule, ScheduleProvider(this))
         mOnboarding.onCreate()
+        setMenuIconsColor(menu)
         return super.onCreateOptionsMenu(menu)
+    }
+
+    private fun setMenuIconsColor(menu: Menu) {
+        postOnNewHandler {
+            for (i in 0 until menu.size()) {
+                val menuItem = menu.getItem(i)
+                shouldUseDefaultColor(menuItem)
+            }
+        }
     }
 
     @SuppressLint("RestrictedApi")


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
Menu item icon of Review activity get hidden after one or two time screen rotation

## Fixes
Fixes #10732

## Approach
We set the color of Menu icon when `onMenuOpened` function is called  is wrong 
In below image it is soon how `onCreateOptionsMenu` and `onMenuOpened`  function  is called 

<img width="641" alt="Screenshot 2022-04-07 085209" src="https://user-images.githubusercontent.com/65972015/162191867-d15c988b-8fc8-477c-b095-98f18658d37f.png">

 

## How Has This Been Tested?
Android Device :Redmi y3

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration (SDK version(s), emulator or physical, etc)

## Learning (optional, can help others)

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [x] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
