### PR TITLE
 CardTemplateBrowserAppearanceEditor follows system language instead of app [Solved]

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateBrowserAppearanceEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateBrowserAppearanceEditor.java
@@ -145,11 +145,6 @@ public class CardTemplateBrowserAppearanceEditor extends AnkiActivity {
         mAnswerEditText.setText(bundle.getString(INTENT_ANSWER_FORMAT));
 
         enableToolbar();
-
-        // Set activity title
-        if (getSupportActionBar() != null) {
-            getSupportActionBar().setTitle(R.string.card_template_browser_appearance_title);
-        }
     }
 
     private boolean answerHasChanged(Intent intent) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateBrowserAppearanceEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateBrowserAppearanceEditor.java
@@ -145,6 +145,11 @@ public class CardTemplateBrowserAppearanceEditor extends AnkiActivity {
         mAnswerEditText.setText(bundle.getString(INTENT_ANSWER_FORMAT));
 
         enableToolbar();
+
+        // Set activity title
+        if (getSupportActionBar() != null) {
+            getSupportActionBar().setTitle(R.string.card_template_browser_appearance_title);
+        }
     }
 
     private boolean answerHasChanged(Intent intent) {

--- a/AnkiDroid/src/main/res/drawable/ic_tune_white.xml
+++ b/AnkiDroid/src/main/res/drawable/ic_tune_white.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M3,17v2h6v-2L3,17zM3,5v2h10L13,5L3,5zM13,21v-2h8v-2h-8v-2h-2v6h2zM7,9v2L3,11v2h4v2h2L9,9L7,9zM21,13v-2L11,11v2h10zM15,9h2L17,7h4L21,5h-4L17,3h-2v6z"/>
+</vector>

--- a/AnkiDroid/src/main/res/menu-television/reviewer.xml
+++ b/AnkiDroid/src/main/res/menu-television/reviewer.xml
@@ -138,6 +138,7 @@
     </item>
     <item
         android:id="@+id/action_open_deck_options"
+        android:icon="@drawable/ic_tune_white"
         android:title="@string/menu__deck_options" />
     <item
         android:id="@+id/action_select_tts"

--- a/AnkiDroid/src/main/res/menu/reviewer.xml
+++ b/AnkiDroid/src/main/res/menu/reviewer.xml
@@ -131,6 +131,7 @@
     </item>
     <item
         android:id="@+id/action_open_deck_options"
+        android:icon="@drawable/ic_tune_white"
         android:title="@string/menu__deck_options" />
     <item
         android:id="@+id/action_select_tts"


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
Actually "CardTemplateBrowserAppearanceEditor" activity's title follows system language instead of app language (i.e. if app language is "English" & system language is "Hindi" then only this activity's title showed in "Hindi" language.

## Fixes
Fixes #10737 

## Approach
Just go to CardTemplateBrowserAppearanceEditor.java file & set title.

<img src="https://user-images.githubusercontent.com/39590581/162225306-e6a086a3-e904-45b2-ae10-f86c9cc392bc.jpg" height="600">

## How Has This Been Tested?

Tested via real device: Samsung Galaxy M51 (Android Version: 11)