### PR TITLE
CardTemplateBrowserAppearanceEditor follows system language instead of app language [Solved]

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateBrowserAppearanceEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateBrowserAppearanceEditor.java
@@ -145,6 +145,11 @@ public class CardTemplateBrowserAppearanceEditor extends AnkiActivity {
         mAnswerEditText.setText(bundle.getString(INTENT_ANSWER_FORMAT));
 
         enableToolbar();
+     
+        // Set activity title
+        if (getSupportActionBar() != null) {
+            getSupportActionBar().setTitle(R.string.card_template_browser_appearance_title);
+        }
     }
 
     private boolean answerHasChanged(Intent intent) {


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
Actually "CardTemplateBrowserAppearanceEditor" activity's title follows system language instead of app language (i.e. if app language is "English" & system language is "Hindi" then only this activity's title showed in "Hindi" language.

## Fixes
Fixes #10737 

## Approach
Just go to CardTemplateBrowserAppearanceEditor.java file & set title.

<img src="https://user-images.githubusercontent.com/39590581/162225306-e6a086a3-e904-45b2-ae10-f86c9cc392bc.jpg" height="600">

## How Has This Been Tested?

Tested via real device: Samsung Galaxy M51 (Android Version: 11)