### PR TITLE
Close the Nav Drawer if same screen selected which was already opened

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/NavigationDrawerActivity.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NavigationDrawerActivity.java
@@ -359,6 +359,7 @@ public abstract class NavigationDrawerActivity extends AnkiActivity implements N
     public boolean onNavigationItemSelected(final MenuItem item) {
         // Don't do anything if user selects already selected position
         if (item.isChecked()) {
+            closeDrawer();
             return true;
         }
 


### PR DESCRIPTION
## Purpose / Description
Whenever we used to select the screen which we were used to be already on through Nav Drawer. The Nav Drawer used to remain inactive and no interaction used to be observed.
Now, The Nav drawer closes in case you select the same screen you are already on
## Fixes
#10738 

## Approach
called the closeDrawer() function on item.isChecked true condition

## How Has This Been Tested?
Instrumental testing on device : Realme 8i


https://user-images.githubusercontent.com/73571511/162423384-35dce5a1-a78e-41df-a968-315868b55fcf.mp4



## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [ ] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
