### PR TITLE
Rename 'Reviews' on app shortcuts menu to 'Study now'

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/NavigationDrawerActivity.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NavigationDrawerActivity.java
@@ -188,8 +188,8 @@ public abstract class NavigationDrawerActivity extends AnkiActivity implements N
         intentReviewCards.setAction(Intent.ACTION_VIEW);
         intentReviewCards.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK);
         ShortcutInfo reviewCardsShortcut = new ShortcutInfo.Builder(context, "reviewCardsShortcutId")
-                .setShortLabel(context.getString(R.string.card_info_reviews))
-                .setLongLabel(context.getString(R.string.card_info_reviews))
+                .setShortLabel(context.getString(R.string.study_now))
+                .setLongLabel(context.getString(R.string.study_now))
                 .setIcon(Icon.createWithResource(context, R.drawable.ankidroid_logo))
                 .setIntent(intentReviewCards)
                 .build();

--- a/AnkiDroid/src/main/res/values/01-core.xml
+++ b/AnkiDroid/src/main/res/values/01-core.xml
@@ -34,6 +34,9 @@
     <string name="studyoptions_eta">Estimated time (min):</string>
     <string name="studyoptions_start">Study</string>
 
+    <!-- App shortcuts menu label -->
+    <string name="study_now" comments="Label of the app shortcut which reopens the study screen of the last opened deck" >Study now</string>
+
     <!-- DeckPicker.java -->
     <string name="expand">Expand</string>
     <string name="collapse">Collapse</string>


### PR DESCRIPTION
Signed-off-by: Abhiram-DLVSS

## Purpose / Description
Rename "Reviews" on app shortcuts menu to "Study now", based on the suggestions from #10728.

## Fixes
Fixes #10728 

## Approach
- Added a new string in `AnkiDroid/src/main/res/values/01-core.xml` with name `study_now` with value `Study now`
- Edited `AnkiDroid/src/main/java/com/ichi2/anki/NavigationDrawerActivity.java` to change the required app shortcut label from `Reviews` to `Study now`

## How Has This Been Tested?

I verified the changes by installing the application on an emulator (Android 11).

## Changes
Screenshot of the app shortcuts (Before vs After)

![image](https://user-images.githubusercontent.com/58914306/162434847-034a8c07-6bfa-4f9a-ad41-b38f094a6b3e.png)


## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [x] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
