### PR TITLE
Rename the Reviews shortcut option to Study for clarity

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/NavigationDrawerActivity.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NavigationDrawerActivity.java
@@ -188,8 +188,8 @@ public abstract class NavigationDrawerActivity extends AnkiActivity implements N
         intentReviewCards.setAction(Intent.ACTION_VIEW);
         intentReviewCards.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK);
         ShortcutInfo reviewCardsShortcut = new ShortcutInfo.Builder(context, "reviewCardsShortcutId")
-                .setShortLabel(context.getString(R.string.card_info_reviews))
-                .setLongLabel(context.getString(R.string.card_info_reviews))
+                .setShortLabel(context.getString(R.string.studyoptions_start))
+                .setLongLabel(context.getString(R.string.studyoptions_start))
                 .setIcon(Icon.createWithResource(context, R.drawable.ankidroid_logo))
                 .setIntent(intentReviewCards)
                 .build();


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
The shortcut for studying cards used a slightly misleading word, `Reviews,` which has been changed to use the existing `Study` string.

## Fixes
Fixes #10728.

## Approach
Updated the wording to `Study,` which matches the `Study` button used elsewhere.

## How Has This Been Tested?
Hold down on the app icon to launch the shortcut and note that the `Reviews` option now says `Study` and still launches the study option successfully.

## Learning (optional, can help others)
n/a

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [ ] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [x] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

![image](https://user-images.githubusercontent.com/71997294/162463467-6e957057-79ee-4292-ab8d-47452f6783b0.png)
