### PR TITLE
Feat: Delete Downloaded Deck after successful import

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -351,9 +351,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
                 AnkiPackageImporter imp = result.first;
                 deckPicker.showSimpleMessageDialog(TextUtils.join("\n", imp.getLog()));
                 deckPicker.updateDeckList();
-                Uri cleanupUri = deckPicker.getDeckDownloadedUri(mImportPath);
-                Timber.i("Cleaning up %s", cleanupUri);
-                deckPicker.getBaseContext().getContentResolver().delete(cleanupUri, null, null);
+                deckPicker.cleanupDownloadedDeck(mImportPath);
             }
         }
 
@@ -372,9 +370,10 @@ public class DeckPicker extends NavigationDrawerActivity implements
         }
     }
 
-    private Uri getDeckDownloadedUri(String importPath) {
+    private void cleanupDownloadedDeck(String importPath) {
         String filename = ImportUtils.fileNameFromPath(importPath);
-        return ImportUtils.getApkgDownloadUriFor(getBaseContext(), filename);
+        Uri cleanupUri = ImportUtils.getApkgDownloadUriFor(getBaseContext(), filename);
+        getContentResolver().delete(cleanupUri, null, null);
     }
 
     private ImportReplaceListener importReplaceListener(String importPath) {
@@ -399,9 +398,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
             Resources res = deckPicker.getResources();
             if (result.succeeded()) {
                 deckPicker.updateDeckList();
-                Uri cleanupUri = deckPicker.getDeckDownloadedUri(mImportPath);
-                Timber.i("Cleaning up %s", cleanupUri);
-                deckPicker.getBaseContext().getContentResolver().delete(cleanupUri, null, null);
+                deckPicker.cleanupDownloadedDeck(mImportPath);
             } else {
                 deckPicker.showSimpleMessageDialog(res.getString(R.string.import_log_no_apkg), true);
             }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/SharedDecksDownloadFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/SharedDecksDownloadFragment.kt
@@ -32,13 +32,11 @@ import android.webkit.URLUtil
 import android.widget.Button
 import android.widget.ProgressBar
 import android.widget.TextView
-import androidx.core.content.FileProvider
 import androidx.fragment.app.Fragment
 import com.afollestad.materialdialogs.MaterialDialog
 import com.ichi2.anki.SharedDecksActivity.Companion.DOWNLOAD_FILE
 import com.ichi2.utils.ImportUtils
 import timber.log.Timber
-import java.io.File
 import java.net.URLConnection
 import kotlin.math.abs
 
@@ -376,13 +374,7 @@ class SharedDecksDownloadFragment : Fragment() {
         val fileIntent = Intent(context, IntentHandler::class.java)
         fileIntent.action = Intent.ACTION_VIEW
 
-        val fileUri = context?.let {
-            FileProvider.getUriForFile(
-                it,
-                it.applicationContext?.packageName + ".apkgfileprovider",
-                File(it.getExternalFilesDir(Environment.DIRECTORY_DOWNLOADS), mFileName.toString())
-            )
-        }
+        val fileUri = context?.let { ImportUtils.getApkgDownloadUriFor(it, mFileName.toString()) }
         Timber.d("File URI -> $fileUri")
         fileIntent.setDataAndType(fileUri, mimeType)
         fileIntent.flags = Intent.FLAG_ACTIVITY_NEW_TASK

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ImportDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ImportDialog.kt
@@ -20,6 +20,7 @@ import android.os.Bundle
 import com.afollestad.materialdialogs.DialogAction
 import com.afollestad.materialdialogs.MaterialDialog
 import com.ichi2.anki.R
+import com.ichi2.utils.ImportUtils
 import timber.log.Timber
 import java.net.URLDecoder
 
@@ -41,7 +42,7 @@ class ImportDialog : AsyncDialogFragment() {
             DIALOG_IMPORT_ADD_CONFIRM -> {
                 val displayFileName = convertToDisplayName(dialogMessage)
                 builder.title(res.getString(R.string.import_title))
-                    .content(res.getString(R.string.import_message_add_confirm, filenameFromPath(displayFileName)))
+                    .content(res.getString(R.string.import_message_add_confirm, ImportUtils.fileNameFromPath(displayFileName)))
                     .positiveText(R.string.import_message_add)
                     .negativeText(R.string.dialog_cancel)
                     .onPositive { _: MaterialDialog?, _: DialogAction? ->
@@ -108,10 +109,6 @@ class ImportDialog : AsyncDialogFragment() {
             args.putString("dialogMessage", dialogMessage)
             f.arguments = args
             return f
-        }
-
-        private fun filenameFromPath(path: String): String {
-            return path.split("/").toTypedArray()[path.split("/").toTypedArray().size - 1]
         }
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/utils/ImportUtils.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/ImportUtils.kt
@@ -75,6 +75,11 @@ object ImportUtils {
     }
 
     @JvmStatic
+    fun fileNameFromPath(path: String): String {
+        return path.split("/").last()
+    }
+
+    @JvmStatic
     fun showImportUnsuccessfulDialog(
         activity: Activity,
         errorMessage: String?,

--- a/AnkiDroid/src/main/java/com/ichi2/utils/ImportUtils.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/ImportUtils.kt
@@ -22,11 +22,13 @@ import android.content.Context
 import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
+import android.os.Environment
 import android.os.Message
 import android.provider.OpenableColumns
 import android.text.TextUtils
 import android.webkit.MimeTypeMap
 import androidx.annotation.CheckResult
+import androidx.core.content.FileProvider
 import com.afollestad.materialdialogs.DialogAction
 import com.afollestad.materialdialogs.MaterialDialog
 import com.ichi2.anki.AnkiActivity
@@ -64,12 +66,28 @@ object ImportUtils {
     }
 
     @JvmStatic
-    fun showImportUnsuccessfulDialog(activity: Activity, errorMessage: String?, exitActivity: Boolean) {
+    fun getApkgDownloadUriFor(context: Context, filename: String): Uri {
+        return FileProvider.getUriForFile(
+            context,
+            context.applicationContext?.packageName + ".apkgfileprovider",
+            File(context.getExternalFilesDir(Environment.DIRECTORY_DOWNLOADS), filename)
+        )
+    }
+
+    @JvmStatic
+    fun showImportUnsuccessfulDialog(
+        activity: Activity,
+        errorMessage: String?,
+        exitActivity: Boolean
+    ) {
         FileImporter().showImportUnsuccessfulDialog(activity, errorMessage, exitActivity)
     }
 
     fun isCollectionPackage(filename: String?): Boolean {
-        return filename != null && (filename.lowercase(Locale.ROOT).endsWith(".colpkg") || "collection.apkg" == filename)
+        return filename != null && (
+            filename.lowercase(Locale.ROOT)
+                .endsWith(".colpkg") || "collection.apkg" == filename
+            )
     }
 
     /** @return Whether the file is either a deck, or a collection package */


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
As briefly discussed in #10663, Shared Decks are downloaded to the app-specific Download directory (`Android/data/com.ichi2.anki/files/Download`). After successful import, these files remain in there, adding to App's Storage and not required by any Use Case as well. This PR adds cleanup implementation at callback receiving 'Import Successful'.

## Fixes
Fixes #10663

## Approach
After downloading the deck file, the same is copied to cache directory and all the further import operations are implemented using this version. As a result, on the UI site, we only get access to cache file which we're not supposed to clean up. This PR adds an implementation that derives Downloaded Uri from the cache FileName and makes the required `delete(Uri..)` call on the `ContentResolver`
## How Has This Been Tested?
Tested on Pixel 4a running Android 12 (API 31)

## Learning (optional, can help others)
How to delete files using ContentResolver ([stackoverflow](https://stackoverflow.com/a/43563972))

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [X] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [X] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
