### PR TITLE
feat(scoped-storage): Refactorings and Storage Locking

### DIFF
--- a/.idea/dictionaries/davidallison.xml
+++ b/.idea/dictionaries/davidallison.xml
@@ -81,6 +81,7 @@
       <w>unbury</w>
       <w>unflag</w>
       <w>unmark</w>
+      <w>unopenable</w>
       <w>unsuspend</w>
       <w>untriggered</w>
       <w>userbase</w>

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CollectionHelper.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CollectionHelper.java
@@ -247,44 +247,6 @@ public class CollectionHelper {
         }
     }
 
-    /**
-     * Checks if current directory being used by AnkiDroid to store user data is a Legacy Storage Directory.
-     * This directory is stored under {@link #PREF_DECK_PATH}
-     * @return <code>true</code> if AnkiDroid is storing user data in a Legacy Storage Directory.
-     */
-    public static boolean isLegacyStorage(Context context) {
-        String currentDirPath = CollectionHelper.getCurrentAnkiDroidDirectory(context);
-        String externalScopedDirPath = CollectionHelper.getAppSpecificExternalAnkiDroidDirectory(context);
-        String internalScopedDirPath = CollectionHelper.getAppSpecificInternalAnkiDroidDirectory(context);
-
-        File currentDir = new File(currentDirPath);
-        File[] externalScopedDirs = context.getExternalFilesDirs(null);
-        File internalScopedDir = new File(internalScopedDirPath);
-
-        Timber.i("isLegacyStorage(): current dir: %s\nscoped external dir: %s\nscoped internal dir: %s",
-                currentDirPath, externalScopedDirPath, internalScopedDirPath);
-
-        // Loop to check if the current AnkiDroid directory or any of its parents are the same as the root directories
-        // for app-specific external or internal storage - the only directories which will be accessible without
-        // permissions under scoped storage
-        File currentDirParent = currentDir;
-        while (currentDirParent != null) {
-            if (currentDirParent.compareTo(internalScopedDir) == 0) {
-                return false;
-            }
-            for (File externalScopedDir : externalScopedDirs) {
-                if (currentDirParent.compareTo(externalScopedDir) == 0) {
-                    return false;
-                }
-            }
-            currentDirParent = currentDirParent.getParentFile();
-        }
-
-        // If the current AnkiDroid directory isn't a sub directory of the app-specific external or internal storage
-        // directories, then it must be in a legacy storage directory
-        return true;
-    }
-
 
     /**
      * Get the absolute path to a directory that is suitable to be the default starting location

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CollectionHelper.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CollectionHelper.java
@@ -349,6 +349,15 @@ public class CollectionHelper {
 
 
     /**
+     * @return Returns an array of {@link File}s reflecting the directories that AnkiDroid can access without storage permissions
+     * @see android.content.Context#getExternalFilesDirs(String)
+     */
+    @NonNull
+    public static File[] getAppSpecificExternalDirectories(@NonNull Context context) {
+        return context.getExternalFilesDirs(null);
+    }
+
+    /**
      * Returns the absolute path to the private AnkiDroid directory under the app-specific, internal storage directory.
      * <p>
      * AnkiDroid can access this directory without permissions, even under Scoped Storage

--- a/AnkiDroid/src/main/java/com/ichi2/anki/IntentHandler.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/IntentHandler.kt
@@ -26,6 +26,7 @@ import androidx.annotation.VisibleForTesting
 import com.ichi2.anki.UIUtils.showThemedToast
 import com.ichi2.anki.dialogs.DialogHandler
 import com.ichi2.anki.dialogs.DialogHandler.Companion.storeMessage
+import com.ichi2.anki.servicelayer.ScopedStorageService
 import com.ichi2.anki.services.ReminderService
 import com.ichi2.themes.Themes.disableXiaomiForceDarkMode
 import com.ichi2.utils.ImportUtils.handleFileImport
@@ -77,7 +78,7 @@ class IntentHandler : Activity() {
      *
      */
     private fun performActionIfStorageAccessible(runnable: Runnable, reloadIntent: Intent, action: String?) {
-        if (!CollectionHelper.isLegacyStorage(this) ||
+        if (!ScopedStorageService.isLegacyStorage(this) ||
             applicationInfo.targetSdkVersion < Build.VERSION_CODES.R && hasStorageAccessPermission(this)
         ) {
             Timber.i("User has storage permissions. Running intent: %s", action)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/model/Directory.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/model/Directory.kt
@@ -53,6 +53,11 @@ class Directory private constructor(val directory: File) {
     override fun toString(): String = directory.canonicalPath
     companion object {
         /**
+         * Returns a [Directory] from [path] if `Directory` precondition holds; i.e. [path] is an existing directory.
+         * Otherwise returns `null`.
+         */
+        fun createInstance(path: String): Directory? = createInstance(File(path))
+        /**
          * Returns a [Directory] from [file] if `Directory` precondition holds; i.e. [file] is an existing directory.
          * Otherwise returns `null`.
          */

--- a/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/ScopedStorageService.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/ScopedStorageService.kt
@@ -25,7 +25,6 @@ import com.ichi2.anki.model.Directory
 import com.ichi2.anki.model.DiskFile
 import com.ichi2.anki.model.RelativeFilePath
 import com.ichi2.anki.servicelayer.scopedstorage.MigrateUserData
-import com.ichi2.annotations.NeedsTest
 import timber.log.Timber
 import java.io.File
 
@@ -94,9 +93,14 @@ object ScopedStorageService {
      * This directory is stored under [CollectionHelper.PREF_DECK_PATH] in SharedPreferences
      * @return `true` if AnkiDroid is storing user data in a Legacy Storage Directory.
      */
-    @NeedsTest("may want unit testing")
     fun isLegacyStorage(context: Context): Boolean {
-        val currentDirPath = CollectionHelper.getCurrentAnkiDroidDirectory(context)
+        return isLegacyStorage(CollectionHelper.getCurrentAnkiDroidDirectory(context), context)
+    }
+
+    /**
+     * @return `true` if [currentDirPath] is a Legacy Storage Directory.
+     */
+    fun isLegacyStorage(currentDirPath: String, context: Context): Boolean {
         val internalScopedDirPath = CollectionHelper.getAppSpecificInternalAnkiDroidDirectory(context)
         val currentDir = File(currentDirPath).canonicalFile
         val externalScopedDirs = CollectionHelper.getAppSpecificExternalDirectories(context).map { it.canonicalFile }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/model/DirectoryTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/model/DirectoryTest.kt
@@ -38,7 +38,7 @@ class DirectoryTest : Test21And26() {
         val path = createTempDirectory().pathString
         MatcherAssert.assertThat(
             "Directory should work with valid directory",
-            Directory.createInstance(File(path)),
+            Directory.createInstance(path),
             not(nullValue())
         )
     }
@@ -58,7 +58,7 @@ class DirectoryTest : Test21And26() {
         val dir = kotlin.io.path.createTempFile().pathString
         MatcherAssert.assertThat(
             "file should not become a Directory",
-            Directory.createInstance(File(dir)),
+            Directory.createInstance(dir),
             nullValue()
         )
     }
@@ -107,6 +107,16 @@ class DirectoryTest : Test21And26() {
         )
     }
 
+    @Test
+    fun test_create_from_string() {
+        val path = File(createTempDirectory().pathString)
+
+        val fromPath = Directory.createInstance(path.path)!!
+        val fromFile = Directory.createInstance(path)!!
+
+        MatcherAssert.assertThat("Equal result constructing from file or path", fromFile.directory, equalTo(fromPath.directory))
+    }
+
     /**
      * Reproduces https://github.com/ankidroid/Anki-Android/issues/10358
      * Where for some reason, `listFiles` returned null on an existing directory and
@@ -119,6 +129,6 @@ class DirectoryTest : Test21And26() {
     }
 
     private fun createValidTempDir(): Directory {
-        return Directory.createInstance(File(createTempDirectory().pathString))!!
+        return Directory.createInstance(createTempDirectory().pathString)!!
     }
 }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/DeleteEmptyDirectoryTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/DeleteEmptyDirectoryTest.kt
@@ -81,5 +81,5 @@ class DeleteEmptyDirectoryTest : Test21And26(), OperationTest {
     }
 
     private fun createEmptyDirectory() =
-        Directory.createInstance(File(createTempDirectory().pathString))!!
+        Directory.createInstance(createTempDirectory().pathString)!!
 }

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/StorageLockingTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/StorageLockingTest.kt
@@ -1,0 +1,85 @@
+/*
+ *  Copyright (c) 2022 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.libanki
+
+import android.database.sqlite.SQLiteDatabaseLockedException
+import androidx.test.core.app.ApplicationProvider.getApplicationContext
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.ichi2.anki.RobolectricTest
+import com.ichi2.testutils.AnkiAssert.assertDoesNotThrow
+import com.ichi2.testutils.assertThrows
+import com.ichi2.testutils.createTransientFile
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.equalTo
+import org.junit.After
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class StorageLockingTest : RobolectricTest() {
+
+    private var toCleanup: Collection? = null
+    @After
+    fun after() {
+        toCleanup?.close()
+        Storage.unlockCollection()
+    }
+
+    @Test
+    fun test_normal_open() {
+        assertDoesNotThrow { successfulOpen() }
+    }
+
+    @Test
+    fun open_fails_if_locked() {
+        Storage.lockCollection()
+        assertThrows<SQLiteDatabaseLockedException> { successfulOpen() }
+    }
+
+    @Test
+    fun lock_sets_value() {
+        Storage.lockCollection()
+        assertThat("locking the collection sets isLocked", Storage.isLocked(), equalTo(true))
+        Storage.unlockCollection()
+        assertThat("unlocking the collection sets isLocked", Storage.isLocked(), equalTo(false))
+    }
+
+    @Test
+    fun unlock_works() {
+        open_fails_if_locked()
+        Storage.unlockCollection()
+        test_normal_open()
+    }
+
+    @Test
+    fun lock_does_nothing_if_open() {
+        assertDoesNotThrow {
+            successfulOpen()
+            Storage.lockCollection()
+        }
+    }
+
+    @Test
+    fun collection_unlocked_by_default() {
+        assertThat("by default, collection should be unlocked", Storage.isLocked(), equalTo(false))
+    }
+
+    /** Opens a valid collection */
+    private fun successfulOpen() {
+        toCleanup = Storage.Collection(getApplicationContext(), createTransientFile(extension = "anki2").path)
+    }
+}

--- a/AnkiDroid/src/test/java/com/ichi2/testutils/FileSystemUtils.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/testutils/FileSystemUtils.kt
@@ -17,6 +17,7 @@
 package com.ichi2.testutils
 
 import androidx.annotation.CheckResult
+import com.ichi2.utils.KotlinCleanup
 import org.acra.util.IOUtils
 import org.hamcrest.CoreMatchers
 import org.hamcrest.MatcherAssert
@@ -109,9 +110,14 @@ fun createTransientDirectory(prefix: String? = null): File =
         return@let file
     }
 
-/** Returns a temp file with [content]. The file is deleted on exit. */
-fun createTransientFile(content: String = ""): File =
-    File(kotlin.io.path.createTempFile().pathString).also {
+/**
+ * Returns a temp file with [content]. The file is deleted on exit.
+ * @param extension The file extension. Do not include a "."
+ */
+@JvmOverloads
+@KotlinCleanup("remove JvmOverloads after NoteServiceTest is converted")
+fun createTransientFile(content: String = "", extension: String? = null): File =
+    File(kotlin.io.path.createTempFile(suffix = if (extension == null) null else ".$extension").pathString).also {
         it.deleteOnExit()
         IOUtils.writeStringToFile(it, content)
     }


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
I want to add a "Migrate Essential Files" PR, and smaller refactorings and Storage locking makes this a smaller PR when it goes in.

## Fixes
Associated with #5304

## Approach
* `isLegacySotrage`: move to ScopedStorageService, fix & refactor
* Add `Storage.lockCollection`
* Make it easier to create a `Directory`

## How Has This Been Tested?
Unit Tested, the end result is tested on my Android 11

## Learning (optional, can help others)
FileChannel.lock did not lock an Anki Database on macOS

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
