### PR TITLE
Minor Fix for DeckPicker Translation/String Resource Issue

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -2273,7 +2273,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
             if (getCol().cardCount() != -1) {
                 String time = "-";
                 if (eta != -1 && eta != null) {
-                    time = Utils.timeQuantityTopDeckPicker(AnkiDroidApp.getInstance(), eta*60);
+                    time = Utils.timeQuantityTopDeckPicker(this, eta*60);
                 }
                 if (due != null && getSupportActionBar() != null) {
                     String subTitle;


### PR DESCRIPTION
## Purpose / Description
There exists a resource string/translation issue on the current builds of AnkiDroid such that when the user switches between 2 languages, the time indicator of the action bar does not translate over. This can be alleviated by restarting AnkiDroid.

## Fixes
Fixes #10772.

## Approach
Switching the context passed into the Util method from Application to Activity context seemed to resolve the issue.

## How Has This Been Tested?

This was manually tested on my OnePlus 8T, running Android 11. Switching between English and Japanese (and vice-versa) now produces the correct behavior. Attached is a video of the new, expected behavior.

https://user-images.githubusercontent.com/13594022/162661738-779693e5-00df-41ee-b12e-5e517edb6a9c.mp4


In addition to the manual testing, the suite of unit tests that exists for DeckPicker.java was run to ensure that no regressions occurred from this change. This returned a 100% pass rate, though 1 test was ignored:
![image](https://user-images.githubusercontent.com/13594022/162659783-deaa474f-4c9f-4394-a772-55a5bc099b4f.png)

## Learning (optional, can help others)
Honestly, this one's a headscratcher. After finding the method, I quickly tested out calling the resource string from within the method that ultimately set the action bar subtitle, and that seemed to produce the correct result. Naively copy-pasting the implementation of the utility function seemed to show that it wasn't an error in implementation and moving the method call to later into the method also seemed to show that it wasn't an issue with timing. 

I decided to give a shot of passing in the Activity context rather than grabbing the application context, and lo and behold, it works. If anyone has an explanation on why the activity would update quicker than the application, I'm all ears.

Also funnily enough, in the course of fixing this error, I found another one related to the "system default" option (seems like selecting the option after a restart fails to translate the app in its entirety until another restart, perhaps a similar issue?). I'll have to run through the issue process to make sure it isn't a duplicate or has been fixed and hope to have it up soon.

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
