### PR TITLE
fix: MIUI on Android 12 crash

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.java
@@ -514,7 +514,8 @@ public class CardTemplateEditor extends AnkiActivity implements DeckSelectionDia
                 int initialSize = menu.size();
 
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N && mCurrentEditorViewId != R.id.styling_edit) {
-                    menu.add(Menu.FIRST, mInsertFieldId, 0, R.string.card_template_editor_insert_field);
+                    // 10644: Do not pass in a R.string as the final parameter as MIUI on Android 12 crashes.
+                    menu.add(Menu.FIRST, mInsertFieldId, 0, getString(R.string.card_template_editor_insert_field));
                 }
 
                 return initialSize != menu.size();


### PR DESCRIPTION
They broke `menu.add`

Caught this in ACRA

Reference: Issue #10644
Untested 

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
