### PR TITLE
feat(scoped-storage): Migrate Essential Files

### DIFF
--- a/.idea/dictionaries/davidallison.xml
+++ b/.idea/dictionaries/davidallison.xml
@@ -82,6 +82,7 @@
       <w>replayq</w>
       <w>rerender</w>
       <w>resync</w>
+      <w>retryable</w>
       <w>servicelayer</w>
       <w>sinh</w>
       <w>spacebar</w>

--- a/AnkiDroid/src/main/java/com/ichi2/anki/exception/RetryableException.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/exception/RetryableException.kt
@@ -1,0 +1,44 @@
+/*
+ *  Copyright (c) 2022 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.exception
+
+import timber.log.Timber
+
+/**
+ * An exception wrapper signifying that the operation throwing the wrapped exception may be retried
+ * @param inner wrapped exception
+ */
+class RetryableException(private val inner: Throwable) : java.lang.RuntimeException(inner) {
+    companion object {
+        /**
+         * Retries the provided action if a [RetryableException] is thrown
+         */
+        fun retryOnce(action: (() -> Unit)) {
+            try {
+                action.invoke()
+            } catch (e: RetryableException) {
+                Timber.w(e, "Found retryable exception, retrying")
+                try {
+                    action.invoke()
+                } catch (e: RetryableException) {
+                    Timber.w(e, "action was retried once, throwing")
+                    throw e.inner
+                }
+            }
+        }
+    }
+}

--- a/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/ScopedStorageService.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/ScopedStorageService.kt
@@ -24,12 +24,20 @@ import com.ichi2.anki.CollectionHelper
 import com.ichi2.anki.model.Directory
 import com.ichi2.anki.model.DiskFile
 import com.ichi2.anki.model.RelativeFilePath
+import com.ichi2.anki.servicelayer.ScopedStorageService.isLegacyStorage
 import com.ichi2.anki.servicelayer.scopedstorage.MigrateUserData
 import timber.log.Timber
 import java.io.File
 
 /** A path to the AnkiDroid directory, named "AnkiDroid" by default */
 typealias AnkiDroidDirectory = Directory
+
+/** A path to collection.anki2 */
+typealias CollectionFilePath = String
+
+/** The collection.anki2 CollectionFilePath of [this] AnkiDroid directory */
+fun AnkiDroidDirectory.getCollectionAnki2Path(): CollectionFilePath =
+    File(this.directory, CollectionHelper.COLLECTION_FILENAME).canonicalPath
 
 /**
  * Returns the relative file path from a given [AnkiDroidDirectory]
@@ -40,6 +48,37 @@ fun AnkiDroidDirectory.getRelativeFilePath(file: DiskFile): RelativeFilePath? =
         baseDir = this,
         file = file
     )
+
+/**
+ * An [AnkiDroidDirectory] for an AnkiDroid collection which is under scoped storage
+ * This storage directory is accessible without permissions after scoped storage changes,
+ * and is much faster to access
+ *
+ * When uninstalling: A user will be asked if they want to delete this folder
+ * A folder here may be modifiable via USB. In AnkiDroid's case, all collection folders should
+ * be modifiable
+ *
+ * @see [isLegacyStorage]
+ */
+class ScopedAnkiDroidDirectory private constructor(val path: AnkiDroidDirectory) {
+    companion object {
+        /**
+         * Creates an instance of [ScopedAnkiDroidDirectory] from [directory]
+         * @param directory The [AnkiDroidDirectory] which should contain the AnkiDroid collection.
+         * This should not be a directory which is under the legacy (non-scoped storage) model
+         *
+         * @return The directory, or `null` if the provided [directory] was a [legacy directory][isLegacyStorage]
+         * @see [isLegacyStorage]
+         */
+        fun createInstance(directory: Directory, context: Context): ScopedAnkiDroidDirectory? {
+            if (isLegacyStorage(directory.directory.absolutePath, context)) {
+                return null
+            }
+
+            return ScopedAnkiDroidDirectory(directory)
+        }
+    }
+}
 
 object ScopedStorageService {
     /**

--- a/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/scopedstorage/MigrateEssentialFiles.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/scopedstorage/MigrateEssentialFiles.kt
@@ -1,0 +1,458 @@
+/*
+ *  Copyright (c) 2022 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.servicelayer.scopedstorage
+
+import android.content.Context
+import androidx.annotation.VisibleForTesting
+import androidx.core.content.edit
+import com.ichi2.anki.AnkiDroidApp
+import com.ichi2.anki.CollectionHelper
+import com.ichi2.anki.exception.RetryableException
+import com.ichi2.anki.servicelayer.*
+import com.ichi2.anki.servicelayer.ScopedStorageService.PREF_MIGRATION_DESTINATION
+import com.ichi2.anki.servicelayer.ScopedStorageService.PREF_MIGRATION_SOURCE
+import com.ichi2.anki.servicelayer.scopedstorage.MigrateEssentialFiles.UserActionRequiredException
+import com.ichi2.annotations.NeedsTest
+import com.ichi2.compat.CompatHelper
+import com.ichi2.libanki.Collection
+import com.ichi2.libanki.Storage
+import org.apache.commons.io.FileUtils
+import timber.log.Timber
+import java.io.Closeable
+import java.io.File
+
+/**
+ * Algorithm class which represents copying the essential files (collection and media SQL-related
+ * files, and .nomedia/collection logs) to a location under scoped storage: [PRIORITY_FILES]
+ * This exists as a class to allow overriding operations for fault injection testing
+ *
+ * Our main concerns here are ensuring that there are no errors, and the graceful handling of issues.
+ * One primary concern is whether the failure case leaves files in the destination (scoped) directory.
+ *
+ * Many of our users are low on space, and leaving "difficult to delete" files in the app private
+ * directory is user-hostile.
+ *
+ * See: [execute]
+ *
+ * Preconditions (verified inside class - exceptions thrown if not met):
+ * * Collection is not corrupt and can be opened
+ * * Collection basic check passes [UserActionRequiredException.CheckDatabaseException]
+ * * Collection can be closed and locked
+ * * A migration is not currently taking place
+ */
+open class MigrateEssentialFiles(
+    private val context: Context,
+    private val sourceDirectory: AnkiDroidDirectory,
+    private val destinationDirectory: ScopedAnkiDroidDirectory
+) {
+    /**
+     * Copies (not moves) the [essential files][PRIORITY_FILES] to [destinationDirectory]
+     *
+     * Then opens a collection at the new location, and updates [CollectionHelper.PREF_DECK_PATH] there.
+     *
+     * After:
+     *
+     * [PREF_MIGRATION_SOURCE] contains the [AnkiDroidDirectory] with the remaining items to move ([sourceDirectory])
+     * [PREF_MIGRATION_DESTINATION] contains an [AnkiDroidDirectory] with the copied collection.anki2/media ([destinationDirectory])
+     * [CollectionHelper.PREF_DECK_PATH] now points to the new location of the collection in private storage
+     * [ScopedStorageService.UserDataMigrationPreferences.migrationInProgress] returns `true`
+     *
+     * @throws IllegalStateException Migration in progress
+     * @throws IllegalStateException [destinationDirectory] is not empty
+     * @throws UserActionRequiredException.MissingEssentialFileException if an essential file does not exist
+     * @throws UserActionRequiredException.CheckDatabaseException if 'Check Database' needs to be done first
+     * @throws IllegalStateException If a lock cannot be acquired on the collection
+     */
+    fun execute() {
+        if (ScopedStorageService.userMigrationIsInProgress(context)) {
+            throw IllegalStateException("Migration is already in progress")
+        }
+
+        val destinationPath = destinationDirectory.path
+
+        ensureFolderIsEmpty(destinationPath)
+
+        // ensure the current collection is the one in sourcePath
+        ensurePathIsCurrentCollectionPath(sourceDirectory)
+
+        // Throws MissingEssentialFileException if the files we need to copy don't exist
+        throwIfEssentialFilesDoNotExistInDestination(sourceDirectory)
+
+        // Close the collection before we lock the files.
+        // ensureCollectionNotCorrupted is not compatible with an already open collection
+        closeCollection()
+
+        // Race Condition! - The collection could be opened here before locking (maybe by API?).
+        // This is resolved as a RetryableException is thrown if the collection is open
+
+        // open the collection directly and ensure it's not corrupted (must be closed and not locked)
+        throwIfCollectionIsCorrupted(sourceDirectory.getCollectionAnki2Path())
+
+        // Lock the collection & journal, to ensure that nobody can open/corrupt it
+        // Also ensures the collection may not be opened
+        lockCollection().use {
+            // Copy essential files to new location. Guaranteed to be empty
+            for (file in iterateEssentialFiles(sourceDirectory)) {
+                copyTopLevelFile(file, destinationPath)
+            }
+        }
+
+        val destinationCollectionAnki2Path = destinationPath.getCollectionAnki2Path()
+
+        throwIfEssentialFilesAreMutated(sourceDirectory, destinationDirectory)
+
+        // Open the collection in the new location, checking for corruption
+        throwIfCollectionIsCorrupted(destinationCollectionAnki2Path)
+
+        // set the preferences to the new deck path + checks CollectionHelper
+        // sets migration variables (migrationIsInProgress will be true)
+        updatePreferences(destinationPath)
+    }
+
+    /**
+     * Ensures that [directory] is empty
+     * @throws IllegalStateException if [directory] is not empty
+     */
+    private fun ensureFolderIsEmpty(directory: AnkiDroidDirectory) {
+        val listFiles = directory.listFiles()
+
+        if (listFiles.any()) {
+            throw IllegalStateException("destination was non-empty '$directory'")
+        }
+    }
+
+    /**
+     * Ensures that the provided [path] represents the current AnkiDroid collection ([CollectionHelper.getCol])
+     */
+    private fun ensurePathIsCurrentCollectionPath(path: AnkiDroidDirectory) {
+        val currentCollectionFilePath = getCurrentCollectionPath()
+        if (path.directory.canonicalPath != currentCollectionFilePath.directory.canonicalPath) {
+            throw IllegalStateException("paths did not match: '$path' and '$currentCollectionFilePath' (Collection)")
+        }
+    }
+
+    @NeedsTest("untested, needs documentation")
+    private fun throwIfEssentialFilesAreMutated(sourceDirectory: AnkiDroidDirectory, destinationDirectory: ScopedAnkiDroidDirectory) {
+        // TODO: For Arthur to improve
+        for ((source, destination) in iterateEssentialFiles(sourceDirectory).zip(iterateEssentialFiles(destinationDirectory.path))) {
+            if (!FileUtils.contentEquals(source, destination)) {
+                throw IllegalStateException("files not equal: $source, $destination")
+            }
+        }
+    }
+
+    /**
+     * Ensures that all files in [PRIORITY_FILES] and that are in the source exists in the destination.
+     * @throws UserActionRequiredException.MissingEssentialFileException if a file does not exist
+     */
+    private fun throwIfEssentialFilesDoNotExistInDestination(sourcePath: AnkiDroidDirectory) {
+        for (file in iterateEssentialFiles(sourcePath)) {
+            if (!file.exists()) {
+                throw UserActionRequiredException.MissingEssentialFileException(file)
+            }
+        }
+    }
+
+    /**
+     * Copies [file] to [destinationDirectory], retaining the same filename
+     */
+    fun copyTopLevelFile(file: File, destinationDirectory: AnkiDroidDirectory) {
+        val destinationPath = File(destinationDirectory.directory, file.name).path
+        Timber.i("Migrating essential file: '${file.name}'")
+        Timber.d("Copying '$file' to '$destinationPath'")
+        CompatHelper.compat.copyFile(file.path, destinationPath)
+    }
+
+    /**
+     * Updates preferences after a successful "essential files" migration.
+     * The collection is opened with this new preference.
+     * Any error in opening the collection are thrown, and the preference change is reverted.
+     */
+    private fun updatePreferences(destinationDirectory: AnkiDroidDirectory) {
+        val prefs = AnkiDroidApp.getSharedPrefs(context)
+
+        // keep the old values in case we need to restore them
+        val oldPrefValues = listOf(PREF_MIGRATION_SOURCE, PREF_MIGRATION_DESTINATION, CollectionHelper.PREF_DECK_PATH)
+            .associateWith { prefs.getString(it, null) }
+
+        prefs.edit {
+            // specify that a migration is in progress
+            putString(PREF_MIGRATION_SOURCE, sourceDirectory.directory.absolutePath)
+            putString(PREF_MIGRATION_DESTINATION, destinationDirectory.directory.absolutePath)
+            putString(CollectionHelper.PREF_DECK_PATH, destinationDirectory.directory.absolutePath)
+        }
+
+        // open the collection in the new location - data is now migrated
+        try {
+            throwIfCollectionCannotBeOpened()
+        } catch (e: Throwable) {
+            // if we can't open the migrated collection, revert the preference change so the user
+            // can still use their collection.
+            Timber.w("error opening new collection, restoring old values")
+            prefs.edit {
+                oldPrefValues.forEach {
+                    putString(it.key, it.value)
+                }
+            }
+            throw e
+        }
+    }
+
+    /**
+     * Checks that the default collection (from [CollectionHelper.getCol]) can be opened
+     * @throws IllegalStateException If collection can't be opened
+     */
+    @VisibleForTesting
+    open fun throwIfCollectionCannotBeOpened() {
+        CollectionHelper.getInstance().getCol(context) ?: throw IllegalStateException("collection could not be opened")
+    }
+
+    /**
+     * Ensures that the collection is closed.
+     * This will temporarily open the collection during the operation if it was already closed
+     */
+    private fun closeCollection() {
+        val instance = CollectionHelper.getInstance()
+        // this opens col if it wasn't closed
+        val col = instance.getCol(context)
+        col.close()
+    }
+
+    /** Converts the current AnkiDroid collection path to an [AnkiDroidDirectory] instance */
+    private fun getCurrentCollectionPath(): AnkiDroidDirectory {
+        val collectionAnki2Path = File(CollectionHelper.getCollectionPath(context))
+        // happy with the !! here: the parent of the AnkiDroid file is a directory
+        return AnkiDroidDirectory.createInstance(File(collectionAnki2Path.canonicalPath).parent!!)!!
+    }
+
+    /**
+     * Locks the collection and returns a [Closeable] when the closeable is closed, the collection is unlocked
+     *
+     * @throws IllegalStateException Collection is openable after lock acquired
+     */
+    private fun lockCollection(): Closeable {
+        return createLockedCollection().also {
+            // Since we locked the files, we want to ensure that the collection can no longer be opened
+            try {
+                ensureCollectionNotOpenable()
+            } catch (e: Exception) {
+                Timber.w(e, "collection was openable")
+                it.close()
+                throw e
+            }
+        }
+    }
+
+    /**
+     * Locks the collection and returns a [LockedCollection] which allows the collection to be unlocked
+     */
+    @VisibleForTesting
+    fun createLockedCollection() = LockedCollection.createLockedInstance()
+
+    /**
+     * Check that the collection is not openable. This is expected to be called after the collection is locked, to check whether it was correctly locked.
+     * We must check it because improperly locked collections may lead to database corruption. (copying may mean the DB is out of sync with the journal)
+     * If the collection is openable or open, close it.
+     * @throws RetryableException ([IllegalStateException]) if the collection was openable
+     */
+    private fun ensureCollectionNotOpenable() {
+        val lockedCollection: Collection?
+        try {
+            lockedCollection = CollectionHelper.getInstance().getCol(context)
+        } catch (e: Exception) {
+            Timber.i("Expected exception thrown: ", e)
+            return
+        }
+
+        // Unexpected: collection was opened. Close it and report an error.
+        // Note: it shouldn't be null - a null value infers a new collection can't be created
+        // or if the storage media is removed
+        try {
+            lockedCollection?.close()
+        } catch (e: Exception) {
+        }
+
+        throw RetryableException(IllegalStateException("Collection not locked correctly"))
+    }
+
+    /**
+     * Given the path to a `collection.anki2` which is not open, ensures the collection is usable
+     *
+     * Otherwise: throws an exception
+     *
+     * @throws UserActionRequiredException.CheckDatabaseException If "check database" is required
+     *
+     * This may also fail for the following, less likely reasons:
+     * * Collection is already open
+     * * Collection directory does not exist
+     * * Collection directory is not writable
+     * * Error opening collection
+     */
+    open fun throwIfCollectionIsCorrupted(path: CollectionFilePath) {
+        var result: Collection? = null
+        var firstException: Throwable? = null
+        try {
+            // Store the collection in `result` so we can close it in the `finally`
+            // this can throw [StorageAccessException]: locked or invalid
+            result = CollectionHelper.getInstance().getColFromPath(path, context)
+            if (!result.basicCheck()) {
+                throw UserActionRequiredException.CheckDatabaseException()
+            }
+        } catch (e: Throwable) {
+            firstException = e
+        }
+        // this can throw, which ruins the stack trace if the above block threw
+        try {
+            result?.close()
+        } catch (ex: Exception) {
+            Timber.w("exception thrown closing database", ex)
+            firstException = firstException ?: ex
+        }
+
+        // If close() threw in the finally {}, we want to abort.
+        if (firstException != null) {
+            throw firstException
+        }
+    }
+
+    /**
+     * Represents a locked collection. Unlocks the collection when [close] is called.
+     *
+     * Note that collection locking is related to being unable to open the collection.
+     * An open collection may still exist after this lock is taken.
+     *
+     * Usage:
+     * ```kotlin
+     * LockedCollection.createLockedInstance().use {
+     *      // do something requiring the collection to be closed
+     * } // collection is unlocked here
+     * ```
+     */
+    class LockedCollection private constructor() : Closeable {
+        companion object {
+            /**
+             * Locks the collection and creates an instance of [LockedCollection]
+             * @see Storage.lockCollection
+             */
+            fun createLockedInstance(): LockedCollection {
+                // Ideally, we would want to lock the files.
+                // However, on macOS, file locking is only advisor and not mandatory to follow,
+                // meaning that even if the lock succeed, another thread can still open the file.
+                // This is why we instead decided to lock with static variable.
+                // Locked using the static lock in [Storage]
+                Storage.lockCollection()
+                return LockedCollection()
+            }
+        }
+
+        /** Unlocks the collection */
+        override fun close() {
+            Storage.unlockCollection()
+        }
+    }
+
+    /**
+     * A file, or group of files which must be migrated synchronously while the collection is closed
+     * This is either because the file is vital for when a collection is reopened in a new location
+     * Or because it is immediately created and may cause a conflict
+     */
+    abstract class PriorityFile {
+        /**
+         * A list of essential files.
+         * The returned files are assumed to exists at the time when [getEssentialFiles] is called.
+         * It is the caller responsibility to ensure that those files are not created nor deleted
+         * between the time when `getFiles` is called and the time when the result is used.
+         */
+        abstract fun getEssentialFiles(sourceDirectory: String): List<File>
+
+        fun spaceRequired(sourceDirectory: String): NumberOfBytes {
+            return getEssentialFiles(sourceDirectory).sumOf { it.length() }
+        }
+    }
+
+    /**
+     * A SQLite database, which contains both a database and a journal
+     * @see PriorityFile
+     */
+    internal class SQLiteDBFiles(val fileName: String) : PriorityFile() {
+        override fun getEssentialFiles(sourceDirectory: String): List<File> {
+            val list = mutableListOf(File(sourceDirectory, fileName))
+            val journal = File(sourceDirectory, journalName)
+            if (journal.exists()) {
+                list.add(journal)
+            }
+            return list
+        }
+
+        // guaranteed to be + "-journal": https://www.sqlite.org/tempfiles.html
+        private val journalName = "$fileName-journal"
+    }
+
+    /**
+     * The file at [fileName] if it exists, no file otherwise.
+     *
+     * The existence test is delayed until the list of files is needed.
+     * This means that the list of files may vary with time depending on file creation or deletion
+     */
+    class OptionalFile(val fileName: String) : PriorityFile() {
+        override fun getEssentialFiles(sourceDirectory: String): List<File> {
+            val file = File(sourceDirectory, fileName)
+            return if (!file.exists()) {
+                emptyList()
+            } else {
+                listOf(file)
+            }
+        }
+    }
+
+    /**
+     * An exception which requires user action to resolve
+     */
+    abstract class UserActionRequiredException(message: String) : RuntimeException(message) {
+        constructor() : this("")
+
+        /**
+         * The user must perform 'Check Database'
+         */
+        class CheckDatabaseException : UserActionRequiredException()
+
+        /**
+         * The user must determine why essential files don't exist
+         */
+        class MissingEssentialFileException(val file: File) : UserActionRequiredException("missing essential file: ${file.name}")
+    }
+
+    companion object {
+        /**
+         * Lists the files to be moved by [MigrateEssentialFiles]
+         * Priority files are files to be moved if they exist.
+         * Essential files are files which MUST be moved
+         */
+        val PRIORITY_FILES = listOf(
+            SQLiteDBFiles("collection.anki2"), // Anki collection
+            SQLiteDBFiles("collection.media.ad.db2"), // media database + journal
+            OptionalFile(".nomedia"), // written immediately
+            OptionalFile("collection.log") // written immediately and conflicts
+        )
+
+        /**
+         * A collection of [File] objects to be moved by [MigrateEssentialFiles]
+         */
+        private fun iterateEssentialFiles(sourcePath: AnkiDroidDirectory) =
+            PRIORITY_FILES.flatMap { it.getEssentialFiles(sourcePath.directory.canonicalPath) }
+    }
+}

--- a/AnkiDroid/src/test/java/com/ichi2/anki/exception/RetryableExceptionTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/exception/RetryableExceptionTest.kt
@@ -1,0 +1,49 @@
+/*
+ *  Copyright (c) 2022 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.exception
+
+import com.ichi2.testutils.TestException
+import com.ichi2.testutils.assertThrows
+import org.hamcrest.CoreMatchers.equalTo
+import org.hamcrest.MatcherAssert.assertThat
+import org.junit.Test
+
+/** Tests [RetryableException] */
+class RetryableExceptionTest {
+    var called = 0
+
+    @Test
+    fun non_throwing_function_works() {
+        RetryableException.retryOnce { called++ }
+        assertThat("function should only be called once", called, equalTo(1))
+    }
+
+    @Test
+    fun conditionally_throwing_function_retries() {
+        RetryableException.retryOnce { called++; if (called == 1) { throw RetryableException(TestException("throwing_function_retries")) } }
+        assertThat("function should be called twice", called, equalTo(2))
+    }
+
+    @Test
+    fun throwing_function_fails_with_inner() {
+        val exception = assertThrows<TestException> {
+            RetryableException.retryOnce { called++; throw RetryableException(TestException("throwing_function_retries")) }
+        }
+        assertThat("exception message is retained", exception.message, equalTo("throwing_function_retries"))
+        assertThat("function should be called twice", called, equalTo(2))
+    }
+}

--- a/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/MigrateEssentialFilesIntegrationTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/MigrateEssentialFilesIntegrationTest.kt
@@ -1,0 +1,175 @@
+/*
+ *  Copyright (c) 2022 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.servicelayer.scopedstorage
+
+import androidx.core.content.edit
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.ichi2.anki.CollectionHelper
+import com.ichi2.anki.RobolectricTest
+import com.ichi2.anki.servicelayer.ScopedStorageService
+import com.ichi2.annotations.NeedsTest
+import com.ichi2.testutils.AnkiAssert.assertDoesNotThrow
+import com.ichi2.testutils.assertThrows
+import org.hamcrest.CoreMatchers.containsString
+import org.hamcrest.CoreMatchers.equalTo
+import org.hamcrest.MatcherAssert.assertThat
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.ArgumentMatchers
+import org.mockito.Mockito
+import org.mockito.kotlin.KStubbing
+import org.mockito.kotlin.spy
+import org.robolectric.shadows.ShadowStatFs
+import java.io.File
+import java.io.FileOutputStream
+import kotlin.io.path.Path
+import kotlin.io.path.pathString
+
+/**
+ * Test for [MigrateEssentialFiles.migrateEssentialFiles]
+ */
+@RunWith(AndroidJUnit4::class)
+@NeedsTest("fails when you can't create the destination directory")
+class MigrateEssentialFilesIntegrationTest : RobolectricTest() {
+    /**
+     * A directory in scoped storage.
+     * Non existing in the file system, but with available space
+     */
+    private lateinit var destinationPath: File
+
+    override fun useInMemoryDatabase(): Boolean = false
+
+    @Before
+    override fun setUp() {
+        super.setUp()
+
+        // we need to access 'col' before we start
+        col.basicCheck()
+        destinationPath = File(Path(targetContext.getExternalFilesDir(null)!!.canonicalPath, "AnkiDroid-1").pathString)
+
+        // arbitrary large values
+        ShadowStatFs.registerStats(destinationPath, 100, 20, 10000)
+    }
+
+    @After
+    override fun tearDown() {
+        super.tearDown()
+        ShadowStatFs.reset()
+    }
+
+    @Test
+    fun migrate_essential_files_success() {
+        assertMigrationNotInProgress()
+
+        val oldDeckPath = getPreferences().getString("deckPath", "")
+
+        migrateEssentialFiles()
+
+        // assert the collection is open, working, and has been moved to the outPath
+        assertThat(col.basicCheck(), equalTo(true))
+        assertThat(col.path, equalTo(File(destinationPath, "collection.anki2").canonicalPath))
+
+        assertMigrationInProgress()
+
+        // assert that the preferences are updated
+        val prefs = getPreferences()
+        assertThat("The deck path is updated", prefs.getString("deckPath", ""), equalTo(destinationPath.canonicalPath))
+        assertThat("The migration source is the original deck path", prefs.getString(ScopedStorageService.PREF_MIGRATION_SOURCE, ""), equalTo(oldDeckPath))
+        assertThat("The migration destination is the deck path", prefs.getString(ScopedStorageService.PREF_MIGRATION_DESTINATION, ""), equalTo(destinationPath.canonicalPath))
+    }
+
+    @Test
+    fun exception_if_not_enough_free_space_migrate_essential_files() {
+        ShadowStatFs.reset()
+
+        val ex = assertThrows<MigrateEssentialFiles.UserActionRequiredException.OutOfSpaceException> {
+            migrateEssentialFiles()
+        }
+
+        assertThat(ex.message, containsString("More free space is required"))
+    }
+
+    @Test
+    fun exception_if_source_already_scoped() {
+        getPreferences().edit { putString(DECK_PATH, destinationPath.canonicalPath) }
+        CollectionHelper.getInstance().setColForTests(null)
+
+        val newDestination = File(destinationPath, "again")
+
+        val ex = assertThrows<IllegalStateException> {
+            MigrateEssentialFiles.migrateEssentialFiles(targetContext, newDestination)
+        }
+
+        assertThat(ex.message, containsString("Directory is already under scoped storage"))
+    }
+
+    @Test
+    fun no_exception_if_directory_is_empty_directory_migrate_essential_files() {
+        assertThat("destination should not exist ($destinationPath)", destinationPath.exists(), equalTo(false))
+
+        assertDoesNotThrow { migrateEssentialFiles() }
+    }
+
+    @Test
+    fun fails_if_destination_is_not_empty() {
+        destinationPath.mkdirs()
+        assertThat("destination should exist ($destinationPath)", destinationPath.exists(), equalTo(true))
+
+        FileOutputStream(File(destinationPath, "hello.txt")).use {
+            it.write(1)
+        }
+
+        val ex = assertThrows<IllegalStateException> {
+            migrateEssentialFiles()
+        }
+
+        assertThat(ex.message, containsString("Target directory was not empty"))
+    }
+
+    /**
+     * A race condition can occur between closing and locking the collection.
+     *
+     * We add a retry mechanism to confirm that this works
+     */
+    @Test
+    fun retry_succeeds_if_race_condition_occurs() {
+        var timesCalled = 0
+
+        migrateEssentialFiles {
+            Mockito.doAnswer {
+                // if it's the first time, open the collection instead of checking for corruption
+                // on the retry this is not true
+                if (timesCalled == 0) {
+                    col.basicCheck()
+                }
+                timesCalled++
+            }.`when`(it).throwIfCollectionIsCorrupted(ArgumentMatchers.anyString())
+        }
+
+        assertThat(timesCalled, equalTo(3))
+    }
+
+    private fun migrateEssentialFiles(stubbing: (KStubbing<MigrateEssentialFiles>.(MigrateEssentialFiles) -> Unit)? = null) {
+
+        fun mock(e: MigrateEssentialFiles): MigrateEssentialFiles {
+            return if (stubbing == null) e else spy(e, stubbing)
+        }
+        MigrateEssentialFiles.migrateEssentialFiles(targetContext, destinationPath, ::mock)
+    }
+}

--- a/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/MigrateEssentialFilesTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/MigrateEssentialFilesTest.kt
@@ -1,0 +1,264 @@
+/*
+ *  Copyright (c) 2022 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.servicelayer.scopedstorage
+
+import android.database.sqlite.SQLiteDatabaseCorruptException
+import androidx.annotation.CheckResult
+import androidx.core.content.edit
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.ichi2.anki.CollectionHelper
+import com.ichi2.anki.RobolectricTest
+import com.ichi2.anki.exception.RetryableException
+import com.ichi2.anki.model.Directory
+import com.ichi2.anki.servicelayer.ScopedAnkiDroidDirectory
+import com.ichi2.anki.servicelayer.ScopedStorageService
+import com.ichi2.anki.servicelayer.scopedstorage.MigrateEssentialFiles.LockedCollection
+import com.ichi2.anki.servicelayer.scopedstorage.MigrateEssentialFiles.UserActionRequiredException.MissingEssentialFileException
+import com.ichi2.compat.CompatHelper
+import com.ichi2.libanki.Storage
+import com.ichi2.testutils.CollectionDBCorruption
+import com.ichi2.testutils.TestException
+import com.ichi2.testutils.assertThrows
+import com.ichi2.testutils.createTransientDirectory
+import org.hamcrest.CoreMatchers.*
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.io.FileMatchers
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mockito
+import org.mockito.kotlin.*
+import java.io.File
+import kotlin.io.path.Path
+import kotlin.io.path.pathString
+
+const val DECK_PATH = "deckPath"
+
+/**
+ * Test for [MigrateEssentialFiles]
+ */
+@RunWith(AndroidJUnit4::class)
+class MigrateEssentialFilesTest : RobolectricTest() {
+
+    override fun useInMemoryDatabase(): Boolean = false
+    private lateinit var defaultCollectionSourcePath: String
+
+    /** Whether to check the collection to ensure it's still openable */
+    private var checkCollectionAfter = true
+
+    @Before
+    override fun setUp() {
+        // had interference between two tests
+        CollectionHelper.getInstance().setColForTests(null)
+        super.setUp()
+        defaultCollectionSourcePath = getMigrationSourcePath()
+    }
+
+    @After
+    override fun tearDown() {
+        super.tearDown()
+        if (checkCollectionAfter) {
+            assertThat("col is still valid", col.basicCheck())
+        }
+    }
+
+    @Test
+    fun successful_migration() {
+        assertMigrationNotInProgress()
+
+        this.addNoteUsingBasicModel("Hello", "World")
+
+        val collectionSourcePath = getMigrationSourcePath()
+
+        val oldDeckPath = getPreferences().getString(DECK_PATH, "")
+
+        val outPath = executeAlgorithmSuccessfully(collectionSourcePath)
+
+        // assert the collection is open, working, and has been moved to the outPath
+        assertThat(col.basicCheck(), equalTo(true))
+        assertThat(col.path, equalTo(File(outPath, "collection.anki2").canonicalPath))
+
+        assertMigrationInProgress()
+
+        // assert that the preferences are updated
+        val prefs = getPreferences()
+        assertThat("The deck path should be updated", prefs.getString(DECK_PATH, ""), equalTo(outPath.canonicalPath))
+        assertThat("The migration source should be the original deck path", prefs.getString(ScopedStorageService.PREF_MIGRATION_SOURCE, ""), equalTo(oldDeckPath))
+        assertThat("The migration destination should be the deck path", prefs.getString(ScopedStorageService.PREF_MIGRATION_DESTINATION, ""), equalTo(outPath.canonicalPath))
+
+        assertThat(".nomedia should be copied", File(outPath.canonicalPath, ".nomedia"), FileMatchers.anExistingFile())
+
+        assertThat("The added card should still exists", col.cardCount(), equalTo(1))
+    }
+
+    @Test
+    fun exception_thrown_if_migration_is_started_while_in_process() {
+        getPreferences().edit {
+            putString(ScopedStorageService.PREF_MIGRATION_SOURCE, defaultCollectionSourcePath)
+            putString(ScopedStorageService.PREF_MIGRATION_DESTINATION, createTransientDirectory().path)
+        }
+        assertMigrationInProgress()
+
+        val ex = assertThrows<IllegalStateException> { executeAlgorithmSuccessfully(defaultCollectionSourcePath) }
+
+        assertThat(ex.message, containsString("Migration is already in progress"))
+    }
+
+    @Test
+    fun exception_thrown_if_destination_is_not_empty() {
+        // This is not handled upstream as it's a logic error - the directory passed in should be created
+        val nonEmptyDestination = getMigrationDestinationPath().also {
+            File(it, "tmp.txt").createNewFile()
+        }
+
+        val exception = assertThrows<IllegalStateException> { executeAlgorithmSuccessfully(getMigrationSourcePath(), optionalDestinationPath = nonEmptyDestination) }
+        assertThat(exception.message, startsWith("destination was non-empty"))
+    }
+
+    @Test
+    fun fails_if_source_path_is_not_current_ankiDroid_collection() {
+        val invalidSourcePath = createTransientDirectory().absolutePath
+        // preliminary check, not part of the test assertion.
+        assertThat("source path should be invalid", invalidSourcePath, not(equalTo(col.path)))
+        assertThat(Directory.createInstance(invalidSourcePath), notNullValue())
+        val algo = getAlgorithm(invalidSourcePath, getMigrationDestinationPath())
+        val exception = assertThrows<IllegalStateException> { algo.execute() }
+        assertThat(exception.message, containsString("paths did not match"))
+    }
+
+    @Test
+    fun exception_thrown_if_database_corrupt() {
+        checkCollectionAfter = false
+        val collectionAnki2Path = CollectionDBCorruption.closeAndCorrupt(targetContext)
+
+        val collectionSourcePath = File(collectionAnki2Path).parent!!
+
+        assertThrows<SQLiteDatabaseCorruptException> { executeAlgorithmSuccessfully(collectionSourcePath) }
+
+        assertMigrationNotInProgress()
+    }
+
+    @Test
+    fun collection_is_not_locked_if_copy_fails() {
+        var called = false
+
+        assertThrows<TestException> {
+            executeAlgorithmSuccessfully(defaultCollectionSourcePath) {
+                Mockito
+                    .doAnswer {
+                        called = true
+                        assertThat("collection should be locked", Storage.isLocked(), equalTo(true))
+                        throw TestException("")
+                    }
+                    .whenever(it)
+                    .copyTopLevelFile(any(), any())
+            }
+        }
+
+        assertThat("mock was unused", called, equalTo(true))
+        assertThat("the collection is no longer locked", Storage.isLocked(), equalTo(false))
+    }
+
+    @Test
+    fun fails_if_collection_can_still_be_opened() {
+        val ex = assertThrows<RetryableException> {
+            executeAlgorithmSuccessfully(defaultCollectionSourcePath) {
+                Mockito.doReturn(Mockito.mock(LockedCollection::class.java)).whenever(it).createLockedCollection()
+            }
+        }
+
+        assertThat(ex.message, containsString("Collection not locked correctly"))
+    }
+
+    @Test
+    fun prefs_are_restored_if_reopening_fails() {
+        // after preferences are set, we make one final check with these new preferences
+        // if this check fails, we want to revert the changes to preferences that we made
+        val collectionSourcePath = getMigrationSourcePath()
+
+        val prefKeys = listOf(ScopedStorageService.PREF_MIGRATION_SOURCE, ScopedStorageService.PREF_MIGRATION_DESTINATION, DECK_PATH)
+        val oldPrefValues = prefKeys
+            .associateWith { getPreferences().getString(it, null) }
+
+        assertThrows<TestException> {
+            executeAlgorithmSuccessfully(collectionSourcePath) {
+                Mockito.doThrow(TestException("simulating final collection open failure")).whenever(it).throwIfCollectionCannotBeOpened()
+            }
+        }
+
+        oldPrefValues.forEach {
+            assertThat("Pref ${it.key} should be unchanged", getPreferences().getString(it.key, null), equalTo(it.value))
+        }
+
+        assertMigrationNotInProgress()
+    }
+
+    @Test
+    @Suppress("UNUSED_VARIABLE")
+    fun fails_if_missing_essential_file() {
+        val unused = col.usnForSync
+
+        col.close() // required for Windows, can't delete if locked.
+
+        CompatHelper.compat.deleteFile(File(defaultCollectionSourcePath, "collection.media.ad.db2"))
+
+        val ex = assertThrows<MissingEssentialFileException> {
+            executeAlgorithmSuccessfully(defaultCollectionSourcePath) {
+                Mockito.doReturn(Mockito.mock(LockedCollection::class.java)).whenever(it).createLockedCollection()
+            }
+        }
+
+        assertThat(ex.file.name, equalTo("collection.media.ad.db2"))
+    }
+
+    /**
+     * Executes the collection migration algorithm, moving from the local test directory /AnkiDroid, to /migration
+     * This is only the initial stage which does not delete data
+     */
+    private fun executeAlgorithmSuccessfully(
+        ankiDroidFolder: String,
+        optionalDestinationPath: File? = null,
+        stubbing: (KStubbing<MigrateEssentialFiles>.(MigrateEssentialFiles) -> Unit)? = null
+    ): File {
+        val destinationPath = optionalDestinationPath ?: getMigrationDestinationPath()
+
+        var algo = getAlgorithm(ankiDroidFolder, destinationPath)
+
+        if (stubbing != null) {
+            algo = spy(algo, stubbing)
+        }
+        algo.execute()
+
+        return destinationPath
+    }
+
+    private fun getMigrationDestinationPath(): File {
+        return File(Path(targetContext.getExternalFilesDir(null)!!.canonicalPath, "AnkiDroid-1").pathString).also {
+            it.mkdirs()
+        }
+    }
+
+    private fun getMigrationSourcePath() = File(col.path).parent!!
+
+    @CheckResult
+    private fun getAlgorithm(sourcePath: String, destinationPath: File): MigrateEssentialFiles {
+        val destinationDir = Directory.createInstance(destinationPath) ?: throw IllegalStateException("'$destinationPath' was not a directory")
+        val destinationDirectory = ScopedAnkiDroidDirectory.createInstance(destinationDir, targetContext) ?: throw IllegalStateException("'$destinationPath' was not under scoped storage")
+        return MigrateEssentialFiles(targetContext, Directory.createInstance(sourcePath)!!, destinationDirectory)
+    }
+}

--- a/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/Utils.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/Utils.kt
@@ -19,8 +19,11 @@ package com.ichi2.anki.servicelayer.scopedstorage
 import androidx.annotation.CheckResult
 import com.ichi2.anki.RobolectricTest
 import com.ichi2.anki.model.DiskFile
+import com.ichi2.anki.servicelayer.ScopedStorageService
 import com.ichi2.libanki.Media
 import org.acra.util.IOUtils
+import org.hamcrest.CoreMatchers.*
+import org.hamcrest.MatcherAssert.*
 import java.io.File
 
 /** Adds a media file to collection.media which [Media] is not aware of */
@@ -48,3 +51,11 @@ internal fun RobolectricTest.ankiDroidDirectory() = File(col.path).parentFile!!
 @CheckResult
 internal fun RobolectricTest.addUntrackedMediaFile(content: String, path: List<String>): DiskFile =
     addUntrackedMediaFile(col.media, content, path)
+
+fun RobolectricTest.assertMigrationInProgress() {
+    assertThat("the migration should be in progress", ScopedStorageService.userMigrationIsInProgress(this.targetContext), equalTo(true))
+}
+
+fun RobolectricTest.assertMigrationNotInProgress() {
+    assertThat("the migration should not be in progress", ScopedStorageService.userMigrationIsInProgress(this.targetContext), equalTo(false))
+}

--- a/AnkiDroid/src/test/java/com/ichi2/testutils/CollectionDBCorruption.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/testutils/CollectionDBCorruption.kt
@@ -1,0 +1,57 @@
+/*
+ *  Copyright (c) 2022 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.testutils
+
+import android.content.Context
+import com.ichi2.anki.CollectionHelper
+import com.ichi2.annotations.NeedsTest
+import com.ichi2.utils.KotlinCleanup
+import timber.log.Timber
+import java.io.File
+import java.io.RandomAccessFile
+import kotlin.random.Random
+
+/**
+ * Corrupt the file at `path`.
+ * Assumes the File at pas exists, is readable, writable, and at least 100 bytes.
+ */
+@KotlinCleanup("androidTest/DBTest has corruption but wasn't sufficient. Combine this with that")
+@NeedsTest("test corruption")
+object CollectionDBCorruption {
+    // It writes 100 bytes at position 100 to 199
+    private fun corrupt(path: String) {
+        RandomAccessFile(File(path), "rw").use { col ->
+            col.seek(100)
+            col.write(Random.nextBytes(100))
+        }
+
+        assert(File(path).length() != 0L)
+        Timber.w("Explicitly corrupted database file: $path")
+    }
+
+    @NeedsTest("test with a new collection")
+    /**
+     * Closes and corrupts [CollectionHelper]'s collection
+     */
+    fun closeAndCorrupt(context: Context): String {
+        val col = CollectionHelper.getInstance().getCol(context)
+        val path = col.path
+        col.close()
+        corrupt(path)
+        return path
+    }
+}


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
We want to get the user up and running in a scoped storage directory as soon as possible

## Fixes
Related: #5304

## Approach
COPIES essential files to a scoped location. Locking the collection
to prevent corruption.

This is a fast operation, and is designed to block the foreground with
a spinner while it occurs.

This exists to move 'deckPath' quickly, so a user can continue under a
scoped location while a 'MoveUserData' executes in the background

This only copies:
* collection.anki2 + journal
* collection.media.ad.db2 + journal
* collection.log
* .nomedia


## How Has This Been Tested?
Unit Tested

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
