### PR TITLE
migration of countModules() asyncTask to coroutines

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
@@ -1550,36 +1550,6 @@ public class CollectionTask<Progress, Result> extends BaseAsyncTask<Void, Progre
         }
     }
 
-
-    /*
-     * Async task for the ModelBrowser Class
-     * Returns an ArrayList of all models alphabetically ordered and the number of notes
-     * associated with each model.
-     *
-     * @return {ArrayList<JSONObject> models, ArrayList<Integer> cardCount}
-     */
-    public static class CountModels extends TaskDelegate<Void, Pair<List<Model>, ArrayList<Integer>>> {
-        protected Pair<List<Model>, ArrayList<Integer>> task(@NonNull Collection col, @NonNull ProgressSenderAndCancelListener<Void> collectionTask) {
-            Timber.d("doInBackgroundLoadModels");
-
-            List<Model> models = col.getModels().all();
-            ArrayList<Integer> cardCount = new ArrayList<>();
-            Collections.sort(models, (Comparator<JSONObject>) (a, b) -> a.getString("name").compareTo(b.getString("name")));
-
-            for (Model n : models) {
-                if (collectionTask.isCancelled()) {
-                    Timber.e("doInBackgroundLoadModels :: Cancelled");
-                    // onPostExecute not executed if cancelled. Return value not used.
-                    return null;
-                }
-                cardCount.add(col.getModels().useCount(n));
-            }
-
-            return new Pair<>(models, cardCount);
-        }
-    }
-
-
     /**
      * Deletes the given model
      * and all notes associated with it

--- a/AnkiDroid/src/main/java/com/ichi2/suspend/CollectionTaskMig.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/suspend/CollectionTaskMig.kt
@@ -1,0 +1,53 @@
+/****************************************************************************************
+ * Copyright (c) 2022 Saurav Rao <sauravrao637@gmail.com>                               *
+ *                                                                                      *
+ * This program is free software; you can redistribute it and/or modify it under        *
+ * the terms of the GNU General Public License as published by the Free Software        *
+ * Foundation; either version 3 of the License, or (at your option) any later           *
+ * version.                                                                             *
+ *                                                                                      *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *                                                                                      *
+ * You should have received a copy of the GNU General Public License along with         *
+ * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ ****************************************************************************************/
+
+package com.ichi2.suspend
+
+import android.util.Pair
+import com.ichi2.libanki.Collection
+import com.ichi2.libanki.Model
+import com.ichi2.utils.JSONObject
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.withContext
+import timber.log.Timber
+import java.util.*
+
+/*
+ * This is responsible for handling asynchronous tasks related to notes, Decks and Collections
+ * This file is part of migration for asyncTask to coroutines for CollectionTask.java
+ * After successful migration this will be renamed to CollectionTask
+ */
+object CollectionTaskMig {
+    // TODO add tests for this
+    suspend fun countModels(col: Collection, dispatcher: CoroutineDispatcher = Dispatchers.IO): Pair<List<Model>, ArrayList<Int>>? {
+        return withContext(dispatcher) {
+            Timber.d("counting models in background")
+            val models = col.models.all()
+            val cardCount = ArrayList<Int>()
+            Collections.sort(models, Comparator { a: JSONObject, b: JSONObject -> a.getString("name").compareTo(b.getString("name")) } as Comparator<JSONObject>)
+            for (n in models) {
+                if (!isActive) {
+                    Timber.e("countModels :: Cancelled")
+                    return@withContext null
+                }
+                cardCount.add(col.models.useCount(n))
+            }
+            Pair(models, cardCount)
+        }
+    }
+}


### PR DESCRIPTION
## Purpose / Description
part of fix for #7108
This PR is part of migration of asyncTask to coroutines

## Fixes
countModules() async task successfully migrated to coroutines

## Approach
currently I have used 

        launchWhenCreated{} 
in loadModules() according to my learnings so far and maybe it needs to be changed to other (please let me know the same as I am still learning )

## How Has This Been Tested?

Have been tested manually on RedmiNote 5 Pro (with LineageOS android version 10) and also tested with all the written tests.


[reason](https://stackoverflow.com/questions/3200551/unable-to-modify-arrayadapter-in-listview-unsupportedoperationexception) for avoiding toList() for items in DisplayPairAdapter
[resource 1](https://www.marcogomiero.com/posts/2019/asynctask-to-coroutines/?utm_source=medium)
[resource 2](https://medium.com/androiddevelopers/a-safer-way-to-collect-flows-from-android-uis-23080b1f8bda)
## Checklist

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
