### PR TITLE
Add missing argument for the `onPageFinishedCallback`

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
@@ -1018,7 +1018,7 @@ abstract class AbstractFlashcardViewer :
         webView.isFocusableInTouchMode = typeAnswer!!.useInputTag
         webView.isScrollbarFadingEnabled = true
         Timber.d("Focusable = %s, Focusable in touch mode = %s", webView.isFocusable, webView.isFocusableInTouchMode)
-        webView.webViewClient = CardViewerWebClient(mAssetLoader)
+        webView.webViewClient = CardViewerWebClient(mAssetLoader, this)
         // Set transparent color to prevent flashing white when night mode enabled
         webView.setBackgroundColor(Color.argb(1, 0, 0, 0))
 


### PR DESCRIPTION
Signed-off-by: Kshitij Patil <kshitijpatil98@gmail.com>

## Pull Request template

## Purpose / Description
Recently, in #10720, we added `OnPageFinishedCallback` to be used by a `WebViewClient` indicating the load is finished. This is currently used by `CardViewerWebClient` and is expected to provide a hook for all the subclasses of `AbstractFlashcardViewer`. Currently, we're not using this callback as there's is a missing `this` parameter here
Android/blob/bcae6dc760bc981c7c74ce77490d1445849577b2/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt#L1021

## Approach
Added `this` parameter while constructing the instance of `CardViewerWebClient`

## How Has This Been Tested?
By manually running it on a physical device (Pixel 4a)

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
