### PR TITLE
Replace the string, 'Add note', of Decks-screen's-add-button-menu item with 'Add' #10773

### DIFF
--- a/AnkiDroid/src/main/res/values/01-core.xml
+++ b/AnkiDroid/src/main/res/values/01-core.xml
@@ -83,7 +83,7 @@
     <string name="create_shortcut">Create shortcut</string>
     <string name="browse_cards">Browse cards</string>
     <string name="menu_add" comment="A generic add button - Main Deck Picker and card templates. Please inform us if you need more specific strings">Add</string>
-    <string name="menu_add_note">Add note</string>
+    <string name="menu_add_note">Add</string>
     <string name="menu_my_account" comment="Label of the window in which the user should enter their account. This text can't be found in AnkiDroid directly.">Sync account</string>
     <string name="menu_dismiss_note">Hide / delete</string>
     <string name="menu_bury_card">Bury card</string>


### PR DESCRIPTION

## Purpose / Description

Replaced the string, "Add note", of Decks-screen's-add-button-menu item with "Add". This is a topic of open discussion and we simply made a PR for the proposed change. 

## Fixes
Fixes [#10773](https://github.com/ankidroid/Anki-Android/issues/10773)

![#10773](https://i.imgur.com/v7PkSAj.png)

## Approach
Changed the value of the "menu_add_note" string resource to "Add".

## How Has This Been Tested?

Manually verified correct output rendered emulator. 

## Checklist

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner]
