### PR TITLE
Update when FAB should close or hide while navigating the app

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -2700,14 +2700,14 @@ public class DeckPicker extends NavigationDrawerActivity implements
     }
 
     public void hideFab() {
-        if (mFloatingActionMenu.isFabVisible()) {
+        if (mFloatingActionMenu.isFloatingActionButtonVisible()) {
             Timber.i("DeckPicker:: hideFab()");
             mFloatingActionMenu.hideFloatingActionButton();
         }
     }
 
     public void showFab() {
-        if (!mFloatingActionMenu.isFabVisible()) {
+        if (!mFloatingActionMenu.isFloatingActionButtonVisible()) {
             Timber.i("DeckPicker:: showFab()");
             mFloatingActionMenu.showFloatingActionButton();
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -652,6 +652,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
     @Override
     public boolean onCreateOptionsMenu(Menu menu) {
         Timber.d("onCreateOptionsMenu()");
+        mFloatingActionMenu.closeFloatingActionMenu();
         getMenuInflater().inflate(R.menu.deck_picker, menu);
         boolean sdCardAvailable = AnkiDroidApp.isSdCardMounted();
         menu.findItem(R.id.action_sync).setEnabled(sdCardAvailable);
@@ -666,7 +667,6 @@ public class DeckPicker extends NavigationDrawerActivity implements
             // When SearchItem is expanded
             public boolean onMenuItemActionExpand(MenuItem item) {
                 Timber.i("DeckPicker:: SearchItem opened");
-                mFloatingActionMenu.closeFloatingActionMenu();
                 // Hide the floating action button if it is visible
                 mFloatingActionMenu.hideFloatingActionButton();
                 return true;
@@ -763,6 +763,8 @@ public class DeckPicker extends NavigationDrawerActivity implements
 
     @Override
     public boolean onOptionsItemSelected(MenuItem item) {
+        mFloatingActionMenu.closeFloatingActionMenu();
+
         Resources res = getResources();
         if (getDrawerToggle().onOptionsItemSelected(item)) {
             return true;

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -664,6 +664,29 @@ public class DeckPicker extends NavigationDrawerActivity implements
         menu.findItem(R.id.action_empty_cards).setEnabled(sdCardAvailable);
 
         MenuItem toolbarSearchItem = menu.findItem(R.id.deck_picker_action_filter);
+        toolbarSearchItem.setOnActionExpandListener(new MenuItem.OnActionExpandListener() {
+            @Override
+            public boolean onMenuItemActionExpand(MenuItem item) {
+                Timber.i("DeckPicker:: hide FAB");
+                // When the keyboard is expanded, hide the floating action button if it is visible
+                if (mFloatingActionMenu.isFabVisible()) {
+                    mFloatingActionMenu.hideFloatingActionButton();
+                }
+                return true;
+            }
+
+
+            @Override
+            public boolean onMenuItemActionCollapse(MenuItem item) {
+                Timber.i("DeckPicker:: show FAB");
+                // When the keyboard is collapsed, show the floating action button if it is hidden
+                if (!mFloatingActionMenu.isFabVisible()) {
+                    mFloatingActionMenu.showFloatingActionButton();
+                }
+                return true;
+            }
+        });
+
         mToolbarSearchView = (SearchView) toolbarSearchItem.getActionView();
 
         mToolbarSearchView.setQueryHint(getString(R.string.search_decks));
@@ -753,6 +776,9 @@ public class DeckPicker extends NavigationDrawerActivity implements
         if (itemId == R.id.action_undo) {
             Timber.i("DeckPicker:: Undo button pressed");
             undo();
+            return true;
+        } else if (itemId == R.id.deck_picker_action_filter) {
+            Timber.i("DeckPicker:: Search button pressed");
             return true;
         } else if (itemId == R.id.action_sync) {
             Timber.i("DeckPicker:: Sync button pressed");
@@ -960,6 +986,11 @@ public class DeckPicker extends NavigationDrawerActivity implements
     @Override
     @KotlinCleanup("once in Kotlin: use HandlerUtils.executeFunctionWithDelay")
     public void onBackPressed() {
+        // If floating action button is not visible, make it visible
+        if (!mFloatingActionMenu.isFabVisible()) {
+            mFloatingActionMenu.showFloatingActionButton();
+        }
+
         SharedPreferences preferences = AnkiDroidApp.getSharedPrefs(getBaseContext());
         if (isDrawerOpen()) {
             super.onBackPressed();

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -278,7 +278,6 @@ public class DeckPicker extends NavigationDrawerActivity implements
     private void onDeckClick(View v, DeckSelectionType selectionType) {
         long deckId = (long) v.getTag();
         Timber.i("DeckPicker:: Selected deck with id %d", deckId);
-        closeFloatingActionMenu();
 
         boolean collectionIsOpen = false;
         try {
@@ -667,9 +666,9 @@ public class DeckPicker extends NavigationDrawerActivity implements
             // When SearchItem is expanded
             public boolean onMenuItemActionExpand(MenuItem item) {
                 Timber.i("DeckPicker:: SearchItem opened");
-                closeFloatingActionMenu();
+                mFloatingActionMenu.closeFloatingActionMenu();
                 // Hide the floating action button if it is visible
-                hideFab();
+                mFloatingActionMenu.hideFloatingActionButton();
                 return true;
             }
 
@@ -678,7 +677,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
             public boolean onMenuItemActionCollapse(MenuItem item) {
                 Timber.i("DeckPicker:: SearchItem closed");
                 // Show the floating action button if it is hidden
-                showFab();
+                mFloatingActionMenu.showFloatingActionButton();
                 return true;
             }
         });
@@ -2685,27 +2684,6 @@ public class DeckPicker extends NavigationDrawerActivity implements
             }
         });
         createDeckDialog.showDialog();
-    }
-
-    public void closeFloatingActionMenu() {
-        if (mFloatingActionMenu.isFABOpen()) {
-            Timber.i("DeckPicker:: closeFloatingActionMenu()");
-            mFloatingActionMenu.closeFloatingActionMenu();
-        }
-    }
-
-    public void hideFab() {
-        if (mFloatingActionMenu.isFloatingActionButtonVisible()) {
-            Timber.i("DeckPicker:: hideFab()");
-            mFloatingActionMenu.hideFloatingActionButton();
-        }
-    }
-
-    public void showFab() {
-        if (!mFloatingActionMenu.isFloatingActionButtonVisible()) {
-            Timber.i("DeckPicker:: showFab()");
-            mFloatingActionMenu.showFloatingActionButton();
-        }
     }
 
     @VisibleForTesting

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -278,9 +278,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
     private void onDeckClick(View v, DeckSelectionType selectionType) {
         long deckId = (long) v.getTag();
         Timber.i("DeckPicker:: Selected deck with id %d", deckId);
-        if (mFloatingActionMenu.isFABOpen()) {
-            mFloatingActionMenu.closeFloatingActionMenu();
-        }
+        closeFloatingActionMenu();
 
         boolean collectionIsOpen = false;
         try {
@@ -666,23 +664,21 @@ public class DeckPicker extends NavigationDrawerActivity implements
         MenuItem toolbarSearchItem = menu.findItem(R.id.deck_picker_action_filter);
         toolbarSearchItem.setOnActionExpandListener(new MenuItem.OnActionExpandListener() {
             @Override
+            // When SearchItem is expanded
             public boolean onMenuItemActionExpand(MenuItem item) {
-                Timber.i("DeckPicker:: hide FAB");
-                // When the keyboard is expanded, hide the floating action button if it is visible
-                if (mFloatingActionMenu.isFabVisible()) {
-                    mFloatingActionMenu.hideFloatingActionButton();
-                }
+                Timber.i("DeckPicker:: SearchItem opened");
+                closeFloatingActionMenu();
+                // Hide the floating action button if it is visible
+                hideFab();
                 return true;
             }
 
-
             @Override
+            // When SearchItem is collapsed
             public boolean onMenuItemActionCollapse(MenuItem item) {
-                Timber.i("DeckPicker:: show FAB");
-                // When the keyboard is collapsed, show the floating action button if it is hidden
-                if (!mFloatingActionMenu.isFabVisible()) {
-                    mFloatingActionMenu.showFloatingActionButton();
-                }
+                Timber.i("DeckPicker:: SearchItem closed");
+                // Show the floating action button if it is hidden
+                showFab();
                 return true;
             }
         });
@@ -692,15 +688,15 @@ public class DeckPicker extends NavigationDrawerActivity implements
         mToolbarSearchView.setQueryHint(getString(R.string.search_decks));
         mToolbarSearchView.setOnQueryTextListener(new SearchView.OnQueryTextListener() {
             @Override
-            public boolean onQueryTextSubmit(String query) {
-                mToolbarSearchView.clearFocus();
+            public boolean onQueryTextChange(String newText) {
+                Filterable adapter = (Filterable) mRecyclerView.getAdapter();
+                adapter.getFilter().filter(newText);
                 return true;
             }
 
             @Override
-            public boolean onQueryTextChange(String newText) {
-                Filterable adapter = (Filterable) mRecyclerView.getAdapter();
-                adapter.getFilter().filter(newText);
+            public boolean onQueryTextSubmit(String query) {
+                mToolbarSearchView.clearFocus();
                 return true;
             }
         });
@@ -2694,6 +2690,27 @@ public class DeckPicker extends NavigationDrawerActivity implements
             }
         });
         createDeckDialog.showDialog();
+    }
+
+    public void closeFloatingActionMenu() {
+        if (mFloatingActionMenu.isFABOpen()) {
+            Timber.i("DeckPicker:: closeFloatingActionMenu()");
+            mFloatingActionMenu.closeFloatingActionMenu();
+        }
+    }
+
+    public void hideFab() {
+        if (mFloatingActionMenu.isFabVisible()) {
+            Timber.i("DeckPicker:: hideFab()");
+            mFloatingActionMenu.hideFloatingActionButton();
+        }
+    }
+
+    public void showFab() {
+        if (!mFloatingActionMenu.isFabVisible()) {
+            Timber.i("DeckPicker:: showFab()");
+            mFloatingActionMenu.showFloatingActionButton();
+        }
     }
 
     @VisibleForTesting

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -982,11 +982,6 @@ public class DeckPicker extends NavigationDrawerActivity implements
     @Override
     @KotlinCleanup("once in Kotlin: use HandlerUtils.executeFunctionWithDelay")
     public void onBackPressed() {
-        // If floating action button is not visible, make it visible
-        if (!mFloatingActionMenu.isFabVisible()) {
-            mFloatingActionMenu.showFloatingActionButton();
-        }
-
         SharedPreferences preferences = AnkiDroidApp.getSharedPrefs(getBaseContext());
         if (isDrawerOpen()) {
             super.onBackPressed();

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPickerFloatingActionMenu.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPickerFloatingActionMenu.kt
@@ -19,6 +19,7 @@ import android.animation.Animator
 import android.view.View
 import android.widget.LinearLayout
 import android.widget.TextView
+import androidx.core.view.isVisible
 import com.google.android.material.floatingactionbutton.FloatingActionButton
 import com.ichi2.anki.dialogs.CreateDeckDialog
 import timber.log.Timber
@@ -106,6 +107,18 @@ class DeckPickerFloatingActionMenu(view: View, private val deckPicker: DeckPicke
             mAddSharedLayout.visibility = View.GONE
             mAddDeckLayout.visibility = View.GONE
         }
+    }
+
+    fun showFloatingActionButton() {
+        mFabMain.show()
+    }
+
+    fun hideFloatingActionButton() {
+        mFabMain.hide()
+    }
+
+    fun isFabVisible(): Boolean {
+        return mFabMain.isVisible
     }
 
     init {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPickerFloatingActionMenu.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPickerFloatingActionMenu.kt
@@ -109,15 +109,17 @@ class DeckPickerFloatingActionMenu(view: View, private val deckPicker: DeckPicke
     }
 
     fun showFloatingActionButton() {
-        mFabMain.show()
+        if (!mFabMain.isShown) {
+            Timber.i("DeckPicker:: showFloatingActionButton()")
+            mFabMain.visibility = View.VISIBLE
+        }
     }
 
     fun hideFloatingActionButton() {
-        mFabMain.hide()
-    }
-
-    fun isFloatingActionButtonVisible(): Boolean {
-        return mFabMain.isShown
+        if (mFabMain.isShown) {
+            Timber.i("DeckPicker:: hideFloatingActionButton()")
+            mFabMain.visibility = View.GONE
+        }
     }
 
     init {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPickerFloatingActionMenu.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPickerFloatingActionMenu.kt
@@ -117,7 +117,7 @@ class DeckPickerFloatingActionMenu(view: View, private val deckPicker: DeckPicke
         mFabMain.hide()
     }
 
-    fun isFabVisible(): Boolean {
+    fun isFloatingActionButtonVisible(): Boolean {
         return mFabMain.isVisible
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPickerFloatingActionMenu.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPickerFloatingActionMenu.kt
@@ -19,7 +19,6 @@ import android.animation.Animator
 import android.view.View
 import android.widget.LinearLayout
 import android.widget.TextView
-import androidx.core.view.isVisible
 import com.google.android.material.floatingactionbutton.FloatingActionButton
 import com.ichi2.anki.dialogs.CreateDeckDialog
 import timber.log.Timber
@@ -118,7 +117,7 @@ class DeckPickerFloatingActionMenu(view: View, private val deckPicker: DeckPicke
     }
 
     fun isFloatingActionButtonVisible(): Boolean {
-        return mFabMain.isVisible
+        return mFabMain.isShown
     }
 
     init {


### PR DESCRIPTION
## Purpose / Description
When pulling up the keyboard to search, the FAB did not disappear, which resulted in unexpected behavior when interacted with.

## Fixes
Fix #10797 

## Approach
I set the fab to disappear when the SearchItem toolbar is opened and reappear when it is closed.

## How Has This Been Tested?

This was manually tested on the latest alpha using the emulator for Pixel 5 API 31.
I looked into a unit test, but I faced the following issue: https://stackoverflow.com/questions/36793404/checking-android-fab-visibility-always-returns-visible-from-robolectric-test-cas

## Learning
This SO post can be applied to converting the code to kotlin when the time comes: https://stackoverflow.com/questions/57712498/how-to-hide-fab-when-user-click-on-searchview-and-keyboard-opens

## Checklist

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [x] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)


https://user-images.githubusercontent.com/71997294/163465158-6dd476f0-8837-46c2-b820-628e62b18609.mp4

