### PR TITLE
Fix: androidTest/DeckPickerTest

### DIFF
--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/DeckPickerTest.java
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/DeckPickerTest.java
@@ -59,7 +59,6 @@ public class DeckPickerTest {
     public GrantPermissionRule mRuntimePermissionRule =
             GrantPermissionRule.grant(Manifest.permission.WRITE_EXTERNAL_STORAGE);
 
-    @Ignore("This test appears to be flaky everywhere")
     @Test
     public void checkIfClickOnCountsLayoutOpensStudyOptionsOnMobile() {
         // Run the test only on emulator.

--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/DeckPickerTest.java
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/DeckPickerTest.java
@@ -126,5 +126,8 @@ public class DeckPickerTest {
 
         // Go back to Deck Picker
         pressBack();
+        // It appears first attempt of `pressBack()` always fails,
+        // calling it for the second time makes it work
+        pressBack();
     }
 }

--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/DeckPickerTest.java
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/DeckPickerTest.java
@@ -103,7 +103,7 @@ public class DeckPickerTest {
         // Create a new deck
         onView(withId(R.id.fab_main)).perform(click());
         onView(withId(R.id.add_deck_action)).perform(click());
-        onView(withId(R.id.action_edit)).perform(typeText("TestDeck" + testString));
+        onView(withId(android.R.id.input)).perform(typeText("TestDeck" + testString));
         onView(withId(R.id.md_buttonDefaultPositive)).perform(click());
 
         // The deck is currently empty, so if we tap on it, it becomes the selected deck but doesn't enter


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
DeckPickerTest expecting the `StudyOptionsFragment` after adding a new card to a deck and pressing back is failing on both Mobile as well as Tablet. Reason:
* Incorrect viewId for Dialog's EditText
* pressBack at the first attempt is not working

## Approach
* As per the `afollestad/material-dialogs` (v0.9.6.0)

    https://github.com/afollestad/material-dialogs/blob/03fed5b82196063a983a986128cc64ec98a321f7/core/src/main/java/com/afollestad/materialdialogs/DialogInit.java#L514

    The EditText within a Dialog has id `android.R.id.input`. Doing the required id change fixed the first part of the issue. 

* As per the observations, `pressBack()` is not working on the first attempt. Calling it twice fixes the 2nd part of the issue.

## How Has This Been Tested?

Running tests on Mobile and Tablet emulator (API 32)

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
