### PR TITLE
Added more choices for customButtonDeckOption Preference

### DIFF
--- a/AnkiDroid/src/main/res/xml/preferences_custom_buttons.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_custom_buttons.xml
@@ -86,8 +86,8 @@ TODO: Add a unit test
             android:title="@string/select_tts" />
         <ListPreference
             android:defaultValue="0"
-            android:entries="@array/custom_button_labels_menu_and_disabled"
-            android:entryValues="@array/custom_button_values_menu_and_disabled"
+            android:entries="@array/custom_button_labels"
+            android:entryValues="@array/custom_button_values"
             android:key="customButtonDeckOptions"
             android:title="@string/menu__deck_options" />
         <ListPreference


### PR DESCRIPTION
## Purpose / Description
This added two additional choices of 'Always Show' and 'Show if room' for deck options

## Fixes
Fixes #10815 

## Approach
I used the 

    @array/custom_button_labels and @array/custom_button_values
instead of

    @array/custom_button_labels_menu_and_disabled and @array/custom_button_values_menu_and_disabled
for entry and values array of customButtonDeckOption List Preference

## How Has This Been Tested?
I have tested this on my device

UI changes is as described in images of #10815 
## Checklist

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [x] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
