### PR TITLE
Converting all the Checkbox in Preference section into Toggle Switches

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.kt
@@ -259,21 +259,21 @@ class Preferences : AnkiActivity() {
             if (col != null) {
                 try {
                     when (pref.key) {
-                        SHOW_ESTIMATE -> (pref as CheckBoxPreference).isChecked = col.get_config_boolean("estTimes")
-                        SHOW_PROGRESS -> (pref as CheckBoxPreference).isChecked = col.get_config_boolean("dueCounts")
+                        SHOW_ESTIMATE -> (pref as SwitchPreference).isChecked = col.get_config_boolean("estTimes")
+                        SHOW_PROGRESS -> (pref as SwitchPreference).isChecked = col.get_config_boolean("dueCounts")
                         LEARN_CUTOFF -> (pref as NumberRangePreferenceCompat).setValue(col.get_config_int("collapseTime") / 60)
                         TIME_LIMIT -> (pref as NumberRangePreferenceCompat).setValue(col.get_config_int("timeLim") / 60)
                         USE_CURRENT -> (pref as ListPreference).setValueIndex(if (col.get_config("addToCur", true)!!) 0 else 1)
                         AUTOMATIC_ANSWER_ACTION -> (pref as ListPreference).setValueIndex(col.get_config(AutomaticAnswerAction.CONFIG_KEY, 0.toInt())!!)
                         NEW_SPREAD -> (pref as ListPreference).setValueIndex(col.get_config_int("newSpread"))
                         DAY_OFFSET -> (pref as SeekBarPreferenceCompat).value = getDayOffset(col)
-                        PASTE_PNG -> (pref as CheckBoxPreference).isChecked = col.get_config("pastePNG", false)!!
+                        PASTE_PNG -> (pref as SwitchPreference).isChecked = col.get_config("pastePNG", false)!!
                         NEW_TIMEZONE_HANDLING -> {
-                            val checkBox = pref as CheckBoxPreference
-                            checkBox.isChecked = col.sched._new_timezone_enabled()
+                            val Switch = pref as SwitchPreference
+                            Switch.isChecked = col.sched._new_timezone_enabled()
                             if (col.schedVer() <= 1 || !col.isUsingRustBackend) {
                                 Timber.d("Disabled 'newTimezoneHandling' box")
-                                checkBox.isEnabled = false
+                                Switch.isEnabled = false
                             }
                         }
                     }
@@ -507,16 +507,16 @@ class Preferences : AnkiActivity() {
                     CustomSyncServer.PREFERENCE_CUSTOM_MEDIA_SYNC_URL, CustomSyncServer.PREFERENCE_CUSTOM_SYNC_BASE, CustomSyncServer.PREFERENCE_ENABLE_CUSTOM_SYNC_SERVER -> // This may be a tad hasty - performed before "back" is pressed.
                         handleSyncServerPreferenceChange(preferencesActivity!!.baseContext)
                     "timeoutAnswer" -> {
-                        val keepScreenOn = screen.findPreference<CheckBoxPreference>("keepScreenOn")
-                        keepScreenOn!!.isChecked = (pref as CheckBoxPreference).isChecked
+                        val keepScreenOn = screen.findPreference<SwitchPreference>("keepScreenOn")
+                        keepScreenOn!!.isChecked = (pref as SwitchPreference).isChecked
                     }
                     LANGUAGE -> preferencesActivity!!.closePreferences()
                     SHOW_PROGRESS -> {
-                        preferencesActivity!!.col.set_config("dueCounts", (pref as CheckBoxPreference).isChecked)
+                        preferencesActivity!!.col.set_config("dueCounts", (pref as SwitchPreference).isChecked)
                         preferencesActivity.col.setMod()
                     }
                     SHOW_ESTIMATE -> {
-                        preferencesActivity!!.col.set_config("estTimes", (pref as CheckBoxPreference).isChecked)
+                        preferencesActivity!!.col.set_config("estTimes", (pref as SwitchPreference).isChecked)
                         preferencesActivity.col.setMod()
                     }
                     NEW_SPREAD -> {
@@ -543,7 +543,7 @@ class Preferences : AnkiActivity() {
                         preferencesActivity!!.setDayOffset((pref as SeekBarPreferenceCompat).value)
                     }
                     PASTE_PNG -> {
-                        preferencesActivity!!.col.set_config("pastePNG", (pref as CheckBoxPreference).isChecked)
+                        preferencesActivity!!.col.set_config("pastePNG", (pref as SwitchPreference).isChecked)
                         preferencesActivity.col.setMod()
                     }
                     MINIMUM_CARDS_DUE_FOR_NOTIFICATION -> {
@@ -582,7 +582,7 @@ class Preferences : AnkiActivity() {
                         val providerName = ComponentName(preferencesActivity!!, "com.ichi2.anki.provider.CardContentProvider")
                         val pm = preferencesActivity.packageManager
                         val state: Int
-                        if ((pref as CheckBoxPreference).isChecked) {
+                        if ((pref as SwitchPreference).isChecked) {
                             state = PackageManager.COMPONENT_ENABLED_STATE_ENABLED
                             Timber.i("AnkiDroid ContentProvider enabled by user")
                         } else {
@@ -595,7 +595,7 @@ class Preferences : AnkiActivity() {
                         if (preferencesActivity!!.col.schedVer() != 1 && preferencesActivity.col.isUsingRustBackend) {
                             val sched = preferencesActivity.col.sched
                             val wasEnabled = sched._new_timezone_enabled()
-                            val isEnabled = (pref as CheckBoxPreference).isChecked
+                            val isEnabled = (pref as SwitchPreference).isChecked
                             if (wasEnabled != isEnabled) {
                                 if (isEnabled) {
                                     try {
@@ -710,11 +710,11 @@ class Preferences : AnkiActivity() {
             addPreferencesFromResource(R.xml.preferences_general)
             val screen = preferenceScreen
             if (isRestrictedLearningDevice) {
-                val checkBoxPrefVibrate = requirePreference<CheckBoxPreference>("widgetVibrate")
-                val checkBoxPrefBlink = requirePreference<CheckBoxPreference>("widgetBlink")
+                val switchPrefVibrate = requirePreference<SwitchPreference>("widgetVibrate")
+                val switchPrefBlink = requirePreference<SwitchPreference>("widgetBlink")
                 val category = requirePreference<PreferenceCategory>("category_general_notification_pref")
-                category.removePreference(checkBoxPrefVibrate)
-                category.removePreference(checkBoxPrefBlink)
+                category.removePreference(switchPrefVibrate)
+                category.removePreference(switchPrefBlink)
             }
             // Build languages
             initializeLanguageDialog(screen)
@@ -783,7 +783,7 @@ class Preferences : AnkiActivity() {
     }
 
     class AppearanceSettingsFragment : SpecificSettingsFragment() {
-        private var mBackgroundImage: CheckBoxPreference? = null
+        private var mBackgroundImage: SwitchPreference? = null
         override val preferenceResource: Int
             get() = R.xml.preferences_appearance
         override val analyticsScreenNameConstant: String
@@ -792,7 +792,7 @@ class Preferences : AnkiActivity() {
         @Suppress("deprecation") // startActivityForResult
         override fun initSubscreen() {
             addPreferencesFromResource(R.xml.preferences_appearance)
-            mBackgroundImage = requirePreference<CheckBoxPreference>("deckPickerBackground")
+            mBackgroundImage = requirePreference<SwitchPreference>("deckPickerBackground")
             mBackgroundImage!!.onPreferenceClickListener = Preference.OnPreferenceClickListener {
                 if (mBackgroundImage!!.isChecked) {
                     try {
@@ -1020,7 +1020,7 @@ class Preferences : AnkiActivity() {
             setupContextMenuPreference(AnkiCardContextMenu.ANKI_CARD_CONTEXT_MENU_PREF_KEY, R.string.context_menu_anki_card_label)
             if (col!!.schedVer() == 1) {
                 Timber.i("Displaying V1-to-V2 scheduler preference")
-                val schedVerPreference = CheckBoxPreference(requireContext())
+                val schedVerPreference = SwitchPreference(requireContext())
                 schedVerPreference.setTitle(R.string.sched_v2)
                 schedVerPreference.setSummary(R.string.sched_v2_summ)
                 schedVerPreference.onPreferenceChangeListener = Preference.OnPreferenceChangeListener { _, _ ->
@@ -1101,7 +1101,7 @@ class Preferences : AnkiActivity() {
             }
             if (BuildConfig.DEBUG) {
                 Timber.i("Debug mode, option for showing onboarding walkthrough")
-                val onboardingPreference = CheckBoxPreference(requireContext())
+                val onboardingPreference = SwitchPreference(requireContext())
                 onboardingPreference.key = "showOnboarding"
                 onboardingPreference.setTitle(R.string.show_onboarding)
                 onboardingPreference.setSummary(R.string.show_onboarding_desc)
@@ -1177,7 +1177,7 @@ class Preferences : AnkiActivity() {
         private fun setupContextMenuPreference(key: String, @StringRes contextMenuName: Int) {
             // FIXME: The menu is named in the system language (as it's defined in the manifest which may be
             //  different than the app language
-            val cardBrowserContextMenuPreference = requirePreference<CheckBoxPreference>(key)
+            val cardBrowserContextMenuPreference = requirePreference<SwitchPreference>(key)
             val menuName = getString(contextMenuName)
             // Note: The below format strings are generic, not card browser specific despite the name
             cardBrowserContextMenuPreference.title = getString(R.string.card_browser_enable_external_context_menu, menuName)
@@ -1188,14 +1188,14 @@ class Preferences : AnkiActivity() {
             val plugins = findPreference<PreferenceCategory>("category_plugins")
             // Disable the emoji/kana buttons to scroll preference if those keys don't exist
             if (!CompatHelper.hasKanaAndEmojiKeys()) {
-                val emojiScrolling = findPreference<CheckBoxPreference>("scrolling_buttons")
+                val emojiScrolling = findPreference<SwitchPreference>("scrolling_buttons")
                 if (emojiScrolling != null && plugins != null) {
                     plugins.removePreference(emojiScrolling)
                 }
             }
             // Disable the double scroll preference if no scrolling keys
             if (!CompatHelper.hasScrollKeys() && !CompatHelper.hasKanaAndEmojiKeys()) {
-                val doubleScrolling = findPreference<CheckBoxPreference>("double_scrolling")
+                val doubleScrolling = findPreference<SwitchPreference>("double_scrolling")
                 if (doubleScrolling != null && plugins != null) {
                     plugins.removePreference(doubleScrolling)
                 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.kt
@@ -269,11 +269,11 @@ class Preferences : AnkiActivity() {
                         DAY_OFFSET -> (pref as SeekBarPreferenceCompat).value = getDayOffset(col)
                         PASTE_PNG -> (pref as SwitchPreference).isChecked = col.get_config("pastePNG", false)!!
                         NEW_TIMEZONE_HANDLING -> {
-                            val Switch = pref as SwitchPreference
-                            Switch.isChecked = col.sched._new_timezone_enabled()
+                            val switch = pref as SwitchPreference
+                            switch.isChecked = col.sched._new_timezone_enabled()
                             if (col.schedVer() <= 1 || !col.isUsingRustBackend) {
                                 Timber.d("Disabled 'newTimezoneHandling' box")
-                                Switch.isEnabled = false
+                                switch.isEnabled = false
                             }
                         }
                     }

--- a/AnkiDroid/src/main/res/xml/preferences_advanced.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_advanced.xml
@@ -144,13 +144,11 @@
                 android:summary="@string/convert_fen_text_summ"
                 android:title="@string/convert_fen_text" />
             <SwitchPreference
-                android:id="@+id/scrolling_buttons_Switch"
                 android:defaultValue="false"
                 android:key="scrolling_buttons"
                 android:summary="@string/more_scrolling_buttons_summ"
                 android:title="@string/more_scrolling_buttons" />
             <SwitchPreference
-                android:id="@+id/double_scrolling_Switch"
                 android:defaultValue="false"
                 android:key="double_scrolling"
                 android:summary="@string/double_scrolling_gap_summ"

--- a/AnkiDroid/src/main/res/xml/preferences_advanced.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_advanced.xml
@@ -51,29 +51,29 @@
         <PreferenceCategory
             android:key="category_workarounds"
             android:title="@string/pref_cat_workarounds" >
-            <CheckBoxPreference
+            <SwitchPreference
                 android:defaultValue="false"
                 android:key="softwareRender"
                 android:summary="@string/software_render_summ"
                 android:title="@string/software_render" />
-            <CheckBoxPreference
+            <SwitchPreference
                 android:defaultValue="false"
                 android:key="safeDisplay"
                 android:summary="@string/safe_display_summ"
                 android:title="@string/safe_display" />
-            <CheckBoxPreference
+            <SwitchPreference
                 android:defaultValue="false"
                 android:key="useInputTag"
                 android:disableDependentsState="true"
                 android:summary="@string/use_input_tag_summ"
                 android:title="@string/use_input_tag" />
             <!-- Workaround for #5533 -->
-            <CheckBoxPreference
+            <SwitchPreference
                 android:defaultValue="false"
                 android:key="disableExtendedTextUi"
                 android:summary="@string/disable_extended_text_ui_summ"
                 android:title="@string/disable_extended_text_ui" />
-            <CheckBoxPreference
+            <SwitchPreference
                 android:defaultValue="true"
                 android:key="noteEditorNewlineReplace"
                 android:summary="@string/note_editor_replace_newlines_summ"
@@ -81,7 +81,7 @@
                 />
             <!-- #7896 - Workaround for old webviews which could not render some characters in a <code> block
             due to problems with the default monospace font handling -->
-            <CheckBoxPreference
+            <SwitchPreference
                 android:defaultValue="false"
                 android:key="noCodeFormatting"
                 android:summary="@string/no_code_formatting_summ"
@@ -91,13 +91,13 @@
                 UseInputTag: has had `disableDependentsState` set, so this is disabled
                 if useInputTag is true
              -->
-            <CheckBoxPreference
+            <SwitchPreference
                 android:defaultValue="true"
                 android:key="autoFocusTypeInAnswer"
                 android:summary="@string/type_in_answer_focus_summ"
                 android:dependency="useInputTag"
                 android:title="@string/type_in_answer_focus" />
-            <CheckBoxPreference
+            <SwitchPreference
                 android:defaultValue="false"
                 android:key="exitViaDoubleTapBack"
                 android:summary="@string/exit_via_double_tap_back_summ"
@@ -105,7 +105,7 @@
             <!-- #9639 - allow all files in media selection dialog - .opus is application/octet-stream
             in older versions of Android (fixed between API 26 and API 30)
              We don't want to allow this by default, but we want an override -->
-            <CheckBoxPreference
+            <SwitchPreference
                 android:defaultValue="false"
                 android:key="mediaImportAllowAllFiles"
                 android:summary="@string/media_import_allow_all_files_summ"
@@ -114,7 +114,7 @@
         <PreferenceCategory
             android:key="category_plugins"
             android:title="@string/pref_cat_plugins" >
-            <CheckBoxPreference
+            <SwitchPreference
                 android:defaultValue="true"
                 android:key="providerEnabled"
                 android:summary="@string/enable_api_summary"
@@ -124,7 +124,7 @@
                 android:summary="@string/thirdparty_apps_summary"
                 android:title="@string/thirdparty_apps_title">
             </Preference>
-            <CheckBoxPreference
+            <SwitchPreference
                 android:defaultValue="false"
                 android:key="tts"
                 android:summary="@string/tts_summ"
@@ -138,19 +138,19 @@
                 android:summary="@string/reset_languages_summ"
                 android:title="@string/reset_languages"
                 android:key="resetLanguages" />
-            <CheckBoxPreference
+            <SwitchPreference
                 android:defaultValue="false"
                 android:key="convertFenText"
                 android:summary="@string/convert_fen_text_summ"
                 android:title="@string/convert_fen_text" />
-            <CheckBoxPreference
-                android:id="@+id/scrolling_buttons_checkbox"
+            <SwitchPreference
+                android:id="@+id/scrolling_buttons_Switch"
                 android:defaultValue="false"
                 android:key="scrolling_buttons"
                 android:summary="@string/more_scrolling_buttons_summ"
                 android:title="@string/more_scrolling_buttons" />
-            <CheckBoxPreference
-                android:id="@+id/double_scrolling_checkbox"
+            <SwitchPreference
+                android:id="@+id/double_scrolling_Switch"
                 android:defaultValue="false"
                 android:key="double_scrolling"
                 android:summary="@string/double_scrolling_gap_summ"
@@ -165,18 +165,18 @@
                 android:key="advanced_statistics_link"
                 android:title="@string/advanced_statistics_title"
                 android:fragment="com.ichi2.anki.Preferences$AdvancedStatisticsSettingsFragment" />
-            <CheckBoxPreference
+            <SwitchPreference
                 android:defaultValue="false"
                 android:key="html_javascript_debugging"
                 android:summary="@string/html_javascript_debugging_summ"
                 android:title="@string/html_javascript_debugging"/>
             <!-- Title and summary are variable, handled in string:
             card_browser_enable_external_context_menu -->
-            <CheckBoxPreference
+            <SwitchPreference
                 android:id="@+id/card_browser_external_context_menu"
                 android:defaultValue="false"
                 android:key="card_browser_enable_external_context_menu"/>
-            <CheckBoxPreference
+            <SwitchPreference
                 android:id="@+id/anki_card_external_context_menu"
                 android:defaultValue="true"
                 android:key="anki_card_enable_external_context_menu"/>

--- a/AnkiDroid/src/main/res/xml/preferences_advanced_statistics.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_advanced_statistics.xml
@@ -5,7 +5,7 @@
 <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://arbitrary.app.namespace/com.ichi2.anki">
 
-    <CheckBoxPreference
+    <SwitchPreference
         android:defaultValue="false"
         android:key="advanced_statistics_enabled"
         android:summary="@string/enable_advanced_statistics_summ"

--- a/AnkiDroid/src/main/res/xml/preferences_appearance.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_appearance.xml
@@ -49,7 +49,7 @@
             android:title="@string/night_theme" />
     </PreferenceCategory>
     <PreferenceCategory android:title="@string/background_image_title" >
-        <CheckBoxPreference
+        <SwitchPreference
             android:checked="false"
             android:defaultValue="0"
             android:key="deckPickerBackground"
@@ -83,7 +83,7 @@
                 app:min="10" />
         </PreferenceCategory>
     <PreferenceCategory android:title="@string/card_browser">
-        <CheckBoxPreference
+        <SwitchPreference
             android:checked="false"
             android:defaultValue="false"
             android:key="card_browser_show_media_filenames"

--- a/AnkiDroid/src/main/res/xml/preferences_custom_sync_server.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_custom_sync_server.xml
@@ -3,7 +3,7 @@
 
 <!-- Advanced Preferences -->
 <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
-    <CheckBoxPreference
+    <SwitchPreference
         android:key="useCustomSyncServer"
         android:title="@string/custom_sync_server_enable_title"
         android:summary="@string/custom_sync_server_enable_summary"

--- a/AnkiDroid/src/main/res/xml/preferences_general.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_general.xml
@@ -22,8 +22,9 @@
 
 <!--  General Preferences -->
 <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:title="@string/app_name"
-    android:summary="@string/pref_cat_general_summ" >
+    android:summary="@string/pref_cat_general_summ">
     <PreferenceCategory android:title="@string/button_sync" >
         <Preference
             android:dialogTitle="@string/sync_account"
@@ -34,17 +35,17 @@
                 android:targetClass="com.ichi2.anki.MyAccount"
                 android:targetPackage="com.ichi2.anki" />
         </Preference>
-        <CheckBoxPreference
+        <SwitchPreference
             android:defaultValue="true"
             android:key="syncFetchesMedia"
             android:summary="@string/sync_fetch_missing_media_summ"
             android:title="@string/sync_fetch_missing_media" />
-        <CheckBoxPreference
+        <SwitchPreference
             android:defaultValue="false"
             android:key="automaticSyncMode"
             android:summary="@string/automatic_sync_choice_summ"
             android:title="@string/automatic_sync_choice" />
-        <CheckBoxPreference
+        <SwitchPreference
             android:defaultValue="true"
             android:key="showSyncStatusBadge"
             android:summary="@string/sync_status_badge_summ"
@@ -61,12 +62,12 @@
             android:key="language"
             android:icon="@drawable/ic_language_black_24dp"
             android:title="@string/language" />
-        <CheckBoxPreference
+        <SwitchPreference
             android:defaultValue="false"
             android:key="analyticsOptIn"
             android:summary="@string/analytics_summ"
             android:title="@string/analytics_title" />
-        <CheckBoxPreference
+        <SwitchPreference
             android:defaultValue="false"
             android:title="@string/paste_as_png"
             android:summary="@string/paste_as_png_summary"
@@ -87,11 +88,11 @@
             android:entryValues="@array/notification_minimum_cards_due_values"
             android:key="minimumCardsDueForNotification"
             android:title="@string/notification_pref_title" />
-        <CheckBoxPreference
+        <SwitchPreference
             android:defaultValue="false"
             android:key="widgetVibrate"
             android:title="@string/notification_minimum_cards_due_vibrate" />
-        <CheckBoxPreference
+        <SwitchPreference
             android:defaultValue="false"
             android:key="widgetBlink"
             android:title="@string/notification_minimum_cards_due_blink" />

--- a/AnkiDroid/src/main/res/xml/preferences_general.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_general.xml
@@ -22,7 +22,6 @@
 
 <!--  General Preferences -->
 <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:title="@string/app_name"
     android:summary="@string/pref_cat_general_summ">
     <PreferenceCategory android:title="@string/button_sync" >

--- a/AnkiDroid/src/main/res/xml/preferences_gestures.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_gestures.xml
@@ -25,20 +25,20 @@
     xmlns:app="http://arbitrary.app.namespace/com.ichi2.anki"
     android:title="@string/pref_cat_gestures"
     android:summary="@string/pref_cat_gestures_summ" >
-    <CheckBoxPreference
+    <SwitchPreference
         android:defaultValue="false"
         android:disableDependentsState="false"
         android:key="gestures"
         android:summary="@string/gestures_summ"
         android:title="@string/gestures" />
-    <CheckBoxPreference
+    <SwitchPreference
         android:defaultValue="false"
         android:dependency="gestures"
         android:disableDependentsState="false"
         android:key="gestureCornerTouch"
         android:summary="@string/gestures_corner_touch_summary"
         android:title="@string/gestures_corner_touch" />
-    <CheckBoxPreference
+    <SwitchPreference
         android:defaultValue="false"
         android:dependency="gestures"
         android:disableDependentsState="false"

--- a/AnkiDroid/src/main/res/xml/preferences_reviewing.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_reviewing.xml
@@ -52,7 +52,7 @@
             android:title="@string/time_limit"
             app:max="9999"
             app:min="0" />
-        <CheckBoxPreference
+        <SwitchPreference
             android:key="@string/new_timezone_handling_preference"
             android:title="@string/new_timezone"
             android:defaultValue="false" />
@@ -71,7 +71,7 @@
             android:title="@string/custom_buttons"
             android:key="@string/custom_buttons_link_preference"
             android:fragment="com.ichi2.anki.Preferences$CustomButtonsSettingsFragment" />
-        <CheckBoxPreference
+        <SwitchPreference
             android:defaultValue="false"
             android:key="@string/keep_screen_on_preference"
             android:summary="@string/pref_keep_screen_on_summ"
@@ -82,12 +82,12 @@
             android:entries="@array/full_screen_mode_labels"
             android:entryValues="@array/full_screen_mode_values"
             android:title="@string/fullscreen_review" />
-        <CheckBoxPreference
+        <SwitchPreference
             android:defaultValue="false"
             android:key="@string/center_vertically_preference"
             android:summary="@string/vertical_centering_summ"
             android:title="@string/vertical_centering" />
-        <CheckBoxPreference
+        <SwitchPreference
             android:key="@string/show_estimates_preference"
             android:summary="@string/show_estimates_summ"
             android:title="@string/show_estimates" />
@@ -124,21 +124,21 @@
             android:entryValues="@array/answer_buttons_position"
             android:key="@string/answer_buttons_position_preference"
             android:title="@string/answer_buttons_position" />
-        <CheckBoxPreference
+        <SwitchPreference
             android:key="@string/show_topbar_preference"
             android:defaultValue="true"
             android:summary="@string/show_top_bar_summ"
             android:title="@string/show_top_bar" />
-        <CheckBoxPreference
+        <SwitchPreference
             android:key="@string/show_progress_preference"
             android:summary="@string/show_progress_summ"
             android:title="@string/show_progress" />
-        <CheckBoxPreference
+        <SwitchPreference
             android:key="@string/show_eta_preference"
             android:defaultValue="true"
             android:summary="@string/show_eta_summ"
             android:title="@string/show_eta" />
-        <CheckBoxPreference
+        <SwitchPreference
             android:key="@string/show_large_answer_buttons_preference"
             android:defaultValue="false"
             android:summary="@string/show_large_answer_buttons_summ"
@@ -154,7 +154,7 @@
             android:title="@string/whiteboard_stroke_width" />
     </PreferenceCategory>
     <PreferenceCategory android:title="@string/timeout_answer_text" >
-        <CheckBoxPreference
+        <SwitchPreference
             android:defaultValue="false"
             android:disableDependentsState="false"
             android:key="@string/timeout_answer_preference"

--- a/AnkiDroid/src/test/java/com/ichi2/anki/PreferencesTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/PreferencesTest.kt
@@ -18,7 +18,6 @@ package com.ichi2.anki
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.ichi2.anki.Preferences.Companion.getDayOffset
 import com.ichi2.anki.exception.ConfirmModSchemaException
-import com.ichi2.utils.KotlinCleanup
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
 import org.junit.Test
@@ -57,11 +56,9 @@ class PreferencesTest : RobolectricTest() {
         assertThat("rollover config should be set to new value", col.get_config("rollover", 4.toInt()), equalTo(2))
     }
 
-    @KotlinCleanup("use scope function")
-    val instance: Preferences
-        get() {
-            val preferences = Preferences()
-            preferences.attachBaseContext(targetContext)
-            return preferences
+    val instance by lazy {
+        Preferences().apply {
+            attachBaseContext(targetContext)
         }
+    }
 }


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
Converting all the Checkbox in the Preference section into Toggle Switches

## Fixes
Fixes #10776 

## Approach
CheckBox and Switch are two custom selection elements provided by the preference library and they have an identical implementation, its just CheckBox has CheckBoxPreferences and Switch has SwitchPreferences, and the two elements being two-option having elements have identical possible states as well.


## How Has This Been Tested?

Tested by my physical device: Realme 8i

https://user-images.githubusercontent.com/73571511/163495066-f607e85e-0278-4d1f-bd82-3ce3b31104df.mp4



## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [ ] You have commented your code, particularly in hard-to-understand areas
- [ ] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
