### PR TITLE
Add note', of Decks-screen's-add-button-menu item with 'Add' #10773

### DIFF
--- a/AnkiDroid/src/main/res/layout/floating_add_button.xml
+++ b/AnkiDroid/src/main/res/layout/floating_add_button.xml
@@ -123,7 +123,7 @@
                 android:textColor="@color/white"
                 android:layout_marginEnd="5dp"
                 android:layout_height="wrap_content"
-                android:text="@string/menu_add_note"
+                android:text="@string/menu_add"
                 />
             <com.google.android.material.floatingactionbutton.FloatingActionButton
                 android:id="@+id/add_note_action"


### PR DESCRIPTION
## Purpose / Description

Replaced the string, "Add note", of Decks-screen's-add-button-menu item with "Add". This is a topic of open discussion and we simply made a PR for the proposed change. 

## Fixes
Fixes [#10773](https://github.com/ankidroid/Anki-Android/issues/10773)

![#10773](https://i.imgur.com/v7PkSAj.png)

## Approach
Changed the value of the "menu_add_note" string resource to `@string/menu_add`.

## How Has This Been Tested?

Manually verified correct output rendered emulator. 

## Checklist

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner]