### PR TITLE
Fix: app name now shows parallel name for parallel packages

### DIFF
--- a/tools/parallel-package-name.sh
+++ b/tools/parallel-package-name.sh
@@ -11,9 +11,8 @@ MANIFEST="AndroidManifest.xml"
 CONSTANTS="res/values/constants.xml"
 
 OLD_ID=com.ichi2.anki
-OLD_NAME=AnkiDroid
 
-perl -pi -e "s/name=\"app_name\">$OLD_NAME/name=\"app_name\">$NEW_NAME/g" $ROOT$CONSTANTS
+perl -pi -e "s/name=\"app_name\"(.*?)>.*?<\/string>/name=\"app_name\"\1>$NEW_NAME<\/string>/g" $ROOT$CONSTANTS
 perl -pi -e "s/applicationId \"$OLD_ID/applicationId \"$NEW_ID/g" AnkiDroid/build.gradle
 perl -pi -e "s/android:authorities=\"$OLD_ID/android:authorities=\"$NEW_ID/g" $ROOT$MANIFEST
 perl -pi -e "s/permission android:name=\"$OLD_ID.permission/permission android:name=\"$NEW_ID.permission/g" $ROOT$MANIFEST


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
Parallel Builds are not identifiable at all after install

## Fixes
Fixes #10188

## Approach

https://github.com/ankidroid/Anki-Android/commit/50de2d21bd4a9061150e9cd16354cb364794877e#diff-90245b3aabb697f90a867f2dfd56e526ff1167b17b9c66b414e4ac044a55259aR24  added a comment to the `app_name` constant which broke the following line:

https://github.com/ankidroid/Anki-Android/blob/f7cf613c6e126941396c1a6fc8d18e9a99f8eb80/tools/parallel-package-name.sh#L16

This fixes it by changing the Regex. Removed `OLD_NAME`variable because it wasn't necessary anymore

## How Has This Been Tested?
Running the script then compiling the app
![Screenshot_20220415-060204_One UI Home](https://user-images.githubusercontent.com/69634269/163550781-0f0450aa-aa48-4565-84a0-8527fc082aca.png)

## Learning (optional, can help others)
I didn't know anything about PERL
https://www.tutorialspoint.com/perl/perl_regular_expressions.htm


## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
