### PR TITLE
refactor: extract TreeNode from AbstractDeckTreeNode

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/services/ReminderService.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/services/ReminderService.kt
@@ -141,7 +141,7 @@ class ReminderService : BroadcastReceiver() {
             return null
         }
         try {
-            val dues = col.sched.deckDueTree()
+            val dues = col.sched.deckDueTree().map { it.value }
             val decks: MutableList<DeckDueTreeNode> = ArrayList(dues.size)
             // This loop over top level deck only. No notification will ever occur for subdecks.
             for (node in dues) {

--- a/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
@@ -60,6 +60,7 @@ import com.ichi2.libanki.importer.AnkiPackageImporter;
 import com.ichi2.libanki.sched.Counts;
 import com.ichi2.libanki.sched.DeckDueTreeNode;
 import com.ichi2.libanki.sched.DeckTreeNode;
+import com.ichi2.libanki.sched.TreeNode;
 import com.ichi2.libanki.utils.Time;
 import com.ichi2.utils.Computation;
 import com.ichi2.utils.JSONArray;
@@ -360,8 +361,8 @@ public class CollectionTask<Progress, Result> extends BaseAsyncTask<Void, Progre
         }
     }
 
-    public static class LoadDeck extends TaskDelegate<Void, List<DeckTreeNode>> {
-        protected List<DeckTreeNode> task(@NonNull Collection col, @NonNull ProgressSenderAndCancelListener<Void> collectionTask) {
+    public static class LoadDeck extends TaskDelegate<Void, List<TreeNode<DeckTreeNode>>> {
+        protected List<TreeNode<DeckTreeNode>> task(@NonNull Collection col, @NonNull ProgressSenderAndCancelListener<Void> collectionTask) {
             Timber.d("doInBackgroundLoadDeckCounts");
             try {
                 // Get due tree
@@ -374,8 +375,8 @@ public class CollectionTask<Progress, Result> extends BaseAsyncTask<Void, Progre
     }
 
 
-    public static class LoadDeckCounts extends TaskDelegate<Void, List<DeckDueTreeNode>> {
-        protected List<DeckDueTreeNode> task(@NonNull Collection col, @NonNull ProgressSenderAndCancelListener<Void> collectionTask) {
+    public static class LoadDeckCounts extends TaskDelegate<Void, List<TreeNode<DeckDueTreeNode>>> {
+        protected List<TreeNode<DeckDueTreeNode>> task(@NonNull Collection col, @NonNull ProgressSenderAndCancelListener<Void> collectionTask) {
             Timber.d("doInBackgroundLoadDeckCounts");
             try {
                 // Get due tree

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/AbstractSched.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/AbstractSched.kt
@@ -187,17 +187,17 @@ abstract class AbstractSched {
      * @param cancelListener A task that is potentially cancelled
      * @return the due tree. null if task is cancelled
      */
-    abstract fun deckDueTree(cancelListener: CancelListener?): List<DeckDueTreeNode?>?
+    abstract fun deckDueTree(cancelListener: CancelListener?): List<TreeNode<DeckDueTreeNode>>?
 
     /**
      * @return the due tree. null if task is cancelled.
      */
-    abstract fun deckDueTree(): List<DeckDueTreeNode>
+    abstract fun deckDueTree(): List<TreeNode<DeckDueTreeNode>>
 
     /**
      * @return The tree of decks, without numbers
      */
-    abstract fun quickDeckDueTree(): List<DeckTreeNode?>
+    abstract fun quickDeckDueTree(): List<TreeNode<DeckTreeNode>>
 
     /** New count for a single deck.
      * @param did The deck to consider (descendants and ancestors are ignored)

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/DeckTreeNode.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/DeckTreeNode.java
@@ -22,19 +22,13 @@ import java.util.List;
 
 import androidx.annotation.NonNull;
 
-public class DeckTreeNode extends AbstractDeckTreeNode<DeckTreeNode> {
+public class DeckTreeNode extends AbstractDeckTreeNode {
     public DeckTreeNode(Collection col, String name, long did) {
         super(col, name, did);
     }
 
-
     @Override
-    public DeckTreeNode withChildren(@NonNull List<? extends DeckTreeNode> children) {
-        Collection col = getCol();
-        String name = getFullDeckName();
-        long did = getDid();
-        DeckTreeNode node = new DeckTreeNode(col, name, did);
-        node.setChildren(children, false);
-        return node;
+    public void processChildren(@NonNull List<? extends AbstractDeckTreeNode> children, boolean addRev) {
+        // intentionally blank
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
@@ -67,6 +67,7 @@ import java.util.List;
 import java.util.ListIterator;
 import java.util.Locale;
 import java.util.Random;
+import java.util.stream.Collectors;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -571,7 +572,7 @@ public class SchedV2 extends AbstractSched {
      requires multiple database access by deck.  Ignoring this number
      lead to the creation of a tree more quickly.*/
     @Override
-    public @NonNull List<DeckTreeNode> quickDeckDueTree() {
+    public @NonNull List<TreeNode<DeckTreeNode>> quickDeckDueTree() {
         // Similar to deckDueTree, ignoring the numbers
 
         // Similar to deckDueList
@@ -586,12 +587,12 @@ public class SchedV2 extends AbstractSched {
     }
 
 
-    public @NonNull List<DeckDueTreeNode> deckDueTree() {
+    public @NonNull List<TreeNode<DeckDueTreeNode>> deckDueTree() {
         return deckDueTree(null);
     }
 
     @Nullable
-    public List<DeckDueTreeNode> deckDueTree(@Nullable CancelListener cancelListener) {
+    public List<TreeNode<DeckDueTreeNode>> deckDueTree(@Nullable CancelListener cancelListener) {
         List<DeckDueTreeNode> allDecksSorted = deckDueList(cancelListener);
         if (allDecksSorted == null) {
             return null;
@@ -604,7 +605,7 @@ public class SchedV2 extends AbstractSched {
      * @param allDecksSorted the set of all decks of the collection. Sorted.
      * @param checkDone Whether the set of deck was checked. If false, we can't assume all decks have parents
      * and that there is no duplicate. Instead, we'll ignore problems.*/
-    protected @NonNull  <T extends AbstractDeckTreeNode<T>> List<T> _groupChildren(@NonNull List<T> allDecksSorted, boolean checkDone) {
+    protected @NonNull <T extends AbstractDeckTreeNode> List<TreeNode<T>> _groupChildren(@NonNull List<T> allDecksSorted, boolean checkDone) {
         return _groupChildren(allDecksSorted, 0, checkDone);
     }
 
@@ -619,8 +620,8 @@ public class SchedV2 extends AbstractSched {
         false, we can't assume all decks have parents and that there
         is no duplicate. Instead, we'll ignore problems.
      */
-    protected @NonNull <T extends AbstractDeckTreeNode<T>> List<T> _groupChildren(@NonNull List<T> sortedDescendants, int depth, boolean checkDone) {
-        List<T> sortedChildren = new ArrayList<>();
+    protected @NonNull <T extends AbstractDeckTreeNode> List<TreeNode<T>> _groupChildren(@NonNull List<T> sortedDescendants, int depth, boolean checkDone) {
+        List<TreeNode<T>> sortedChildren = new ArrayList<>();
         // group and recurse
         ListIterator<T> it = sortedDescendants.listIterator();
         while (it.hasNext()) {
@@ -657,9 +658,15 @@ public class SchedV2 extends AbstractSched {
             }
             // the childrenNode set contains direct child of `child`, but not
             // any descendants of the children of `child`...
-            List<T> childrenNode = _groupChildren(sortedDescendantsOfChild, depth + 1, checkDone);
-            child.setChildren(childrenNode, "std".equals(getName()));
-            sortedChildren.add(child);
+            List<TreeNode<T>> childrenNode = _groupChildren(sortedDescendantsOfChild, depth + 1, checkDone);
+
+            // Add the child nodes, and process the addition
+            TreeNode<T> toAdd = new TreeNode<>(child);
+            toAdd.getChildren().addAll(childrenNode);
+            List<T> childValues = childrenNode.stream().map(TreeNode::getValue).collect(Collectors.toList());
+            child.processChildren(childValues, "std".equals(getName()));
+
+            sortedChildren.add(toAdd);
         }
         return sortedChildren;
     }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/TreeNode.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/TreeNode.kt
@@ -1,0 +1,46 @@
+/*
+ *  Copyright (c) 2022 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.libanki.sched
+
+import com.ichi2.utils.KotlinCleanup
+
+/**
+ * Defines a node in a tree with a known, non-null value: [value].
+ * [children] contain the children (may be empty, but non-null)
+ */
+data class TreeNode<T : Any>(val value: T) {
+    fun hasChildren(): Boolean = children.any()
+    val children: MutableList<TreeNode<T>> = mutableListOf()
+
+    /** UNSAFE. Casts the tree to [U] */
+    @KotlinCleanup("should be removable after DeckPicker is converted")
+    @Suppress("UNCHECKED_CAST")
+    fun <U : Any> unsafeCastToType(): TreeNode<U> {
+        return TreeNode(this.value as U).also {
+            it.children.addAll(this.children.map { child -> child.unsafeCastToType() })
+        }
+    }
+
+    /** UNSAFE. Casts the tree to [U] */
+    @KotlinCleanup("should be removable after DeckPicker is converted")
+    @Suppress("UNUSED_PARAMETER")
+    fun <U : Any> unsafeCastToType(unused: Class<U>): TreeNode<U> {
+        return unsafeCastToType()
+    }
+
+    override fun toString(): String = "$value, $children"
+}

--- a/AnkiDroid/src/main/java/com/ichi2/widget/WidgetStatus.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/widget/WidgetStatus.kt
@@ -106,7 +106,7 @@ object WidgetStatus {
             col.sched._checkDay()
 
             // Only count the top-level decks in the total
-            val nodes = col.sched.deckDueTree()
+            val nodes = col.sched.deckDueTree().map { it.value }
             for (node in nodes) {
                 total.addNew(node.newCount)
                 total.addLrn(node.lrnCount)

--- a/AnkiDroid/src/test/java/com/ichi2/anki/DeckPickerTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/DeckPickerTest.java
@@ -223,7 +223,7 @@ public class DeckPickerTest extends RobolectricTest {
         ensureCollectionLoadIsSynchronous();
         DeckPicker deckPicker = super.startActivityNormallyOpenCollectionWithIntent(DeckPicker.class, new Intent());
 
-        assertEquals(10, deckPicker.mDueTree.get(0).getNewCount());
+        assertEquals(10, deckPicker.mDueTree.get(0).getValue().getNewCount());
     }
 
     @Test

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/sched/SchedTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/sched/SchedTest.java
@@ -137,11 +137,11 @@ public class SchedTest extends RobolectricTest {
 
     @NonNull
     private DeckDueTreeNode getCountsForDid(double didToFind) {
-        List<DeckDueTreeNode> tree = getCol().getSched().deckDueTree();
+        List<TreeNode<DeckDueTreeNode>> tree = getCol().getSched().deckDueTree();
 
-        for (DeckDueTreeNode node : tree) {
-            if (node.getDid() == didToFind) {
-                return node;
+        for (TreeNode<DeckDueTreeNode> node : tree) {
+            if (node.getValue().getDid() == didToFind) {
+                return node.getValue();
             }
         }
 
@@ -179,7 +179,7 @@ public class SchedTest extends RobolectricTest {
         }
         getCol().getSched().deckDueTree();
         AbstractSched sched = getCol().getSched();
-        List<DeckDueTreeNode> tree = sched.deckDueTree();
+        List<TreeNode<DeckDueTreeNode>> tree = sched.deckDueTree();
         Assert.assertEquals("Tree has not the expected structure", SchedV2Test.expectedTree(getCol(), false), tree);
 
     }
@@ -1252,18 +1252,18 @@ public class SchedTest extends RobolectricTest {
         col.addNote(note);
         col.reset();
         assertEquals(5, col.getDecks().allSortedNames().size());
-        DeckDueTreeNode tree = col.getSched().deckDueTree().get(0);
-        assertEquals("Default", tree.getLastDeckNameComponent());
+        TreeNode<DeckDueTreeNode> tree = col.getSched().deckDueTree().get(0);
+        assertEquals("Default", tree.getValue().getLastDeckNameComponent());
         // sum of child and parent
-        assertEquals(1, tree.getDid());
-        assertEquals(1, tree.getRevCount());
-        assertEquals(1, tree.getNewCount());
+        assertEquals(1, tree.getValue().getDid());
+        assertEquals(1, tree.getValue().getRevCount());
+        assertEquals(1, tree.getValue().getNewCount());
         // child count is just review
-        DeckDueTreeNode child = tree.getChildren().get(0);
-        assertEquals("1", child.getLastDeckNameComponent());
-        assertEquals(default1, child.getDid());
-        assertEquals(1, child.getRevCount());
-        assertEquals(0, child.getNewCount());
+        TreeNode<DeckDueTreeNode> child = tree.getChildren().get(0);
+        assertEquals("1", child.getValue().getLastDeckNameComponent());
+        assertEquals(default1, child.getValue().getDid());
+        assertEquals(1, child.getValue().getRevCount());
+        assertEquals(0, child.getValue().getNewCount());
         // code should not fail if a card has an invalid deck
         c.setDid(12345);
         c.flush();


### PR DESCRIPTION
I'm sorry this is so big. There is a lot of coupling and it's difficult to reduce this.

I'm open to additional commits to change the name of:

* TreeNode (added by this PR)
* AbstractDeckTreeNode (no longer a TreeNode)
* DeckTreeNode (no longer a TreeNode)
* DeckDueTreeNode (no longer a TreeNode)


## Pull Request template

## Purpose / Description
I needed to convert `DeckPicker` for the Kotlin migration, and the recursive + inherited nature of `AbstractDeckTreeNode` seemed infeasible to pass through the type system after some trying.

AbstractDeckTreeNode has two responsibilities: as a base class for deck display data, and as a tree.

The combination of the two led to the recursive structure:

```kotlin
AbstractDeckTreeNode<T : AbstractDeckTreeNode<T>?>
```

which is difficult to express in Kotlin.

As well as breaking the SRP, and being a single-use implementation of a tree.


## Approach
See: `AbstractDeckTreeNode` and `TreeNode `for most of the changes.

* define `TreeNode<T>`
* Switch `List<AbstractDeckTreeNode>` for either
  * `List<AbstractDeckTreeNode>` when a list was desired
  * `List<TreeNode<AbstractDeckTreeNode>>` when a tree was desired
* Fix all references to the structure
* Fix two creation patterns: filtering and creation in `Sched`
Filtering is easy - just filter the deck structures as we did previously with `withChildren`
 and create a new instance of the TreeNode with different children
 as all calculations were completed

Creation is less easy:
* define [processChildren] on `AbstractDeckTreeNode`
* call this with the children which will be added to the node


## How Has This Been Tested?
Unit tests pass

* one was rewritten, because the output deck Ids were not the inputs into the test. The test relied on hidden functionality to change the deck IDS, which no longer occurred 

```
Java output (before this PR):

[cmxieunwoogyxsctnjmv, 1596783600440, 0, 0, 0, [cmxieunwoogyxsctnjmv::abcdefgh, 1596783600460, 0, 0, 0, [cmxieunwoogyxsctnjmv::abcdefgh::ZYXW, 1596783600480, 0, 0, 0, []], cmxieunwoogyxsctnjmv::INSBGDS, 1596783600500, 0, 0, 0, []], Default, 1, 0, 0, 0, [], scxipjiyozczaaczoawo, 1596783600420, 0, 0, 0, []]
```

I briefly tested on my phone, both filtering and the counts, but it's hard to know for certain

## Learning 
I added `withChildren` to the recursive structure (f2831f8dd7e6df149aaf6c8630a28e93611c75bf) and shouldn't. I should have tacked the architectural debt at the time.


## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
