### PR TITLE
Don't hide flag and marked icons from minibar on fullscreen

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
@@ -71,6 +71,7 @@ import com.ichi2.anki.servicelayer.NoteService.toggleMark
 import com.ichi2.anki.servicelayer.SchedulerService.*
 import com.ichi2.anki.servicelayer.TaskListenerBuilder
 import com.ichi2.anki.workarounds.FirefoxSnackbarWorkaround.handledLaunchFromWebBrowser
+import com.ichi2.annotations.NeedsTest
 import com.ichi2.libanki.*
 import com.ichi2.libanki.Collection
 import com.ichi2.libanki.sched.Counts
@@ -183,6 +184,9 @@ open class Reviewer : AbstractFlashcardViewer() {
         super.onResume()
     }
 
+    @NeedsTest("is hidden if flag is on app bar")
+    @NeedsTest("is not hidden if flag is not on app bar")
+    @NeedsTest("is not hidden if flag is on app bar and fullscreen is enabled")
     protected val flagToDisplay: Int
         get() {
             val actualValue = mCurrentCard!!.userFlag()
@@ -190,7 +194,7 @@ open class Reviewer : AbstractFlashcardViewer() {
                 return CardMarker.FLAG_NONE
             }
             val isShownInActionBar = mActionButtons.isShownInActionBar(ActionButtons.RES_FLAG)
-            return if (isShownInActionBar != null && isShownInActionBar) {
+            return if (isShownInActionBar != null && isShownInActionBar && !mPrefFullscreenReview) {
                 CardMarker.FLAG_NONE
             } else actualValue
         }
@@ -208,6 +212,9 @@ open class Reviewer : AbstractFlashcardViewer() {
         setRenderWorkaround(this)
     }
 
+    @NeedsTest("is hidden if marked is on app bar")
+    @NeedsTest("is not hidden if marked is not on app bar")
+    @NeedsTest("is not hidden if marked is on app bar and fullscreen is enabled")
     override fun shouldDisplayMark(): Boolean {
         val markValue = super.shouldDisplayMark()
         if (!markValue) {
@@ -216,7 +223,7 @@ open class Reviewer : AbstractFlashcardViewer() {
         val isShownInActionBar = mActionButtons.isShownInActionBar(ActionButtons.RES_MARK)
         // If we don't know, show it.
         // Otherwise, if it's in the action bar, don't show it again.
-        return isShownInActionBar == null || !isShownInActionBar
+        return isShownInActionBar == null || !isShownInActionBar || mPrefFullscreenReview
     }
 
     protected open fun onMark(card: Card?) {


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
Don't hide minibar flags/marked icon on fullscreen mode

## Fixes
Fixes #10882

## Approach
Add a check for fullscreen mode on flag and marked minibar methods

## How Has This Been Tested?

On my phone (Samsung Galaxy Note 10 Lite SM-N770F/DS, API 31, One UI 4.0)

https://user-images.githubusercontent.com/69634269/163674889-80c4080f-4a9f-44a5-b08a-d72ad9875cd0.mp4

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
