### PR TITLE
Android: enable `preserveLegacyExternalStorage`

### DIFF
--- a/AnkiDroid/src/main/AndroidManifest.xml
+++ b/AnkiDroid/src/main/AndroidManifest.xml
@@ -72,6 +72,7 @@
         android:networkSecurityConfig="@xml/network_security_config"
         android:banner="@drawable/tv_banner"
         android:requestLegacyExternalStorage="true"
+        android:preserveLegacyExternalStorage="true"
         android:resizeableActivity="true"
         android:supportsRtl="true"
         >


### PR DESCRIPTION
https://developer.android.com/reference/android/R.attr#preserveLegacyExternalStorage
https://developer.android.com/training/data-storage/use-cases

Note: If you set `preserveLegacyExternalStorage` to true, the legacy
storage model remains in effect only until the user uninstalls your
app.

If the user installs or reinstalls your app on a device that runs
Android 11, then your app cannot opt out the scoped storage model,
regardless of the value of preserveLegacyExternalStorage.

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
