### PR TITLE
NF: rename PREF_DECK_PATH to PREF_COLLECTION_PATH

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CollectionHelper.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CollectionHelper.java
@@ -66,7 +66,7 @@ public class CollectionHelper {
      * <br>
      * The path also defines the collection that the AnkiDroid API accesses
      */
-    public static final String PREF_DECK_PATH = "deckPath";
+    public static final String PREF_COLLECTION_PATH = "deckPath";
 
     /**
      * Prevents {@link com.ichi2.async.CollectionLoader} from spuriously re-opening the {@link Collection}.
@@ -200,7 +200,7 @@ public class CollectionHelper {
     /**
      * Create the AnkiDroid directory if it doesn't exist and add a .nomedia file to it if needed.
      *
-     * The AnkiDroid directory is a user preference stored under {@link #PREF_DECK_PATH}, and a sensible
+     * The AnkiDroid directory is a user preference stored under {@link #PREF_COLLECTION_PATH}, and a sensible
      * default is chosen if the preference hasn't been created yet (i.e., on the first run).
      *
      * The presence of a .nomedia file indicates to media scanners that the directory must be
@@ -391,7 +391,7 @@ public class CollectionHelper {
         }
         return PreferenceExtensions.getOrSetString(
                 preferences,
-                PREF_DECK_PATH,
+                PREF_COLLECTION_PATH,
                 () -> getDefaultAnkiDroidDirectory(context));
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.kt
@@ -998,7 +998,7 @@ class Preferences : AnkiActivity() {
             addPreferencesFromResource(R.xml.preferences_advanced)
             val screen = preferenceScreen
             // Check that input is valid before committing change in the collection path
-            val collectionPathPreference = requirePreference<EditTextPreference>(CollectionHelper.PREF_DECK_PATH)
+            val collectionPathPreference = requirePreference<EditTextPreference>(CollectionHelper.PREF_COLLECTION_PATH)
             collectionPathPreference.onPreferenceChangeListener = Preference.OnPreferenceChangeListener { _, newValue: Any? ->
                 val newPath = newValue as String?
                 try {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/ScopedStorageService.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/ScopedStorageService.kt
@@ -90,7 +90,7 @@ object ScopedStorageService {
 
     /**
      * Checks if current directory being used by AnkiDroid to store user data is a Legacy Storage Directory.
-     * This directory is stored under [CollectionHelper.PREF_DECK_PATH] in SharedPreferences
+     * This directory is stored under [CollectionHelper.PREF_COLLECTION_PATH] in SharedPreferences
      * @return `true` if AnkiDroid is storing user data in a Legacy Storage Directory.
      */
     fun isLegacyStorage(context: Context): Boolean {

--- a/AnkiDroid/src/test/java/com/ichi2/anki/DeckPickerTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/DeckPickerTest.java
@@ -494,7 +494,7 @@ public class DeckPickerTest extends RobolectricTest {
 
         // set collection path
         SharedPreferences preferences = AnkiDroidApp.getSharedPrefs(getTargetContext());
-        preferences.edit().putString(CollectionHelper.PREF_DECK_PATH, collectionDirectory).apply();
+        preferences.edit().putString(CollectionHelper.PREF_COLLECTION_PATH, collectionDirectory).apply();
 
         // ensure collection not loaded yet
         assertThat("collection should not be loaded", CollectionHelper.getInstance().colIsOpen(), is(false));


### PR DESCRIPTION
For the context, long ago "deck" were called "collection" in anki. Then a
collection could have many decks, and the difference became important.

I don't want to change the value, because it would be hard to do properly and
have no interest. But I clearly want to change the constant name because "DECK"
makes no sens today
