### PR TITLE
fix: eagerly push release version / fix 2.16alpha58

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -53,8 +53,8 @@ android {
         //
         // This ensures the correct ordering between the various types of releases (dev < alpha < beta < release) which is
         // needed for upgrades to be offered correctly.
-        versionCode=21600157
-        versionName="2.16alpha57"
+        versionCode=21600158
+        versionName="2.16alpha58"
         minSdkVersion 21
         //noinspection OldTargetApi - also performed in api/build.fradle
         targetSdkVersion 29 // change .travis.yml platform download at same time

--- a/tools/release.sh
+++ b/tools/release.sh
@@ -89,6 +89,18 @@ if [ "$PUBLIC" != "public" ]; then
   sed -i -e s/versionCode="$PREVIOUS_CODE"/versionCode="$GUESSED_CODE"/g $GRADLEFILE
 fi
 
+# If any changes go in during the release process, pushing fails, so push immediately.
+# Worst case this burns a version number despite a failure later, and we have a version/tag
+# that never launched. That's better than having to manually patch up build.gradle and push a tag
+# for a release that did launch, but the push failed
+git add $GRADLEFILE $CHANGELOG
+git commit -m "Bumped version to $VERSION"
+git tag v"$VERSION"
+
+# Push both commits and tag
+git push
+git push --tags
+
 # Read the key passwords if needed
 if [ "$KSTOREPWD" == "" ]; then
   read -rsp "Enter keystore password: " KSTOREPWD; echo
@@ -109,16 +121,6 @@ then
 #else  #API30
   echo "Google has rejected the APK upload. Likely because targetSdkVersion < 30. Continuing..."  #API30
 fi  #API30
-  # Play store is irreversible, so now commit modified AndroidManifest.xml (and changelog.html if it changed)
-  git add $GRADLEFILE $CHANGELOG
-  git commit -m "Bumped version to $VERSION"
-
-  # Tag the release
-  git tag v"$VERSION"
-
-  # Push both commits and tag
-  git push
-  git push --tags
 #fi  #API30
 
 # Now build the universal release also


### PR DESCRIPTION
## Pull Request template

## Purpose / Description

As noted in the commits, sometimes I (as main release engineer) am all eagerly running a release while merging PRs, and if you merge a PR while releasing then the release script fails to push the version increment and the tag.

So now I'm eagerly pushing them, before the build succeeds even. Balance of risks is tilted towards burning more version numbers than actually release vs not pushing the build increment that really did release.

## Approach
Just move the git commit / tag / push to before the build step, to minimize the window where something else may merge

## How Has This Been Tested?

Untested but I'm about to run a release...that'll test it.

## Learning (optional, can help others)
If you do something long enough, you hit corner cases frequently. 3rd time this has happened to me

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
