### PR TITLE
[Need Feedback/Help] Draft Fix for Study Shortcut Bug

### DIFF
--- a/AnkiDroid/src/main/AndroidManifest.xml
+++ b/AnkiDroid/src/main/AndroidManifest.xml
@@ -72,6 +72,7 @@
         android:networkSecurityConfig="@xml/network_security_config"
         android:banner="@drawable/tv_banner"
         android:requestLegacyExternalStorage="true"
+        android:preserveLegacyExternalStorage="true"
         android:resizeableActivity="true"
         android:supportsRtl="true"
         >

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -505,6 +505,12 @@ public class DeckPicker extends NavigationDrawerActivity implements
         mShortAnimDuration = getResources().getInteger(android.R.integer.config_shortAnimTime);
 
         new Onboarding.DeckPicker(this, mRecyclerViewLayoutManager).onCreate();
+
+        //"Navigate" to review if coming from an intent.
+        if(Intent.ACTION_VIEW.equals(getIntent().getAction())) {
+            Timber.d("Called from shortcut, launching review!");
+            openReviewer();
+        }
     }
 
     /**

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -506,11 +506,6 @@ public class DeckPicker extends NavigationDrawerActivity implements
 
         new Onboarding.DeckPicker(this, mRecyclerViewLayoutManager).onCreate();
 
-        //"Navigate" to review if coming from an intent.
-        if(Intent.ACTION_VIEW.equals(getIntent().getAction())) {
-            Timber.d("Called from shortcut, launching review!");
-            openReviewer();
-        }
     }
 
     /**

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NavigationDrawerActivity.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NavigationDrawerActivity.java
@@ -184,14 +184,14 @@ public abstract class NavigationDrawerActivity extends AnkiActivity implements N
         ShortcutManager shortcutManager = context.getSystemService(ShortcutManager.class);
 
         // Review Cards Shortcut
-        Intent intentReviewCards = new Intent(context, DeckPicker.class);
+        Intent intentReviewCards = new Intent(context, Reviewer.class);
         intentReviewCards.setAction(Intent.ACTION_VIEW);
         intentReviewCards.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK);
         ShortcutInfo reviewCardsShortcut = new ShortcutInfo.Builder(context, "reviewCardsShortcutId")
                 .setShortLabel(context.getString(R.string.studyoptions_start))
                 .setLongLabel(context.getString(R.string.studyoptions_start))
                 .setIcon(Icon.createWithResource(context, R.drawable.ankidroid_logo))
-                .setIntent(intentReviewCards)
+                .setIntents(addIntentToBase(context, intentReviewCards))
                 .build();
 
         // Add Note Shortcut
@@ -203,7 +203,7 @@ public abstract class NavigationDrawerActivity extends AnkiActivity implements N
                 .setShortLabel(context.getString(R.string.menu_add_note))
                 .setLongLabel(context.getString(R.string.menu_add_note))
                 .setIcon(Icon.createWithResource(context, R.drawable.ankidroid_logo))
-                .setIntent(intentAddNote)
+                .setIntents(addIntentToBase(context, intentAddNote))
                 .build();
 
         // CardBrowser Shortcut
@@ -214,11 +214,26 @@ public abstract class NavigationDrawerActivity extends AnkiActivity implements N
                 .setShortLabel(context.getString(R.string.card_browser))
                 .setLongLabel(context.getString(R.string.card_browser))
                 .setIcon(Icon.createWithResource(context, R.drawable.ankidroid_logo))
-                .setIntent(intentCardBrowser)
+                .setIntents(addIntentToBase(context, intentCardBrowser))
                 .build();
 
         shortcutManager.addDynamicShortcuts(Arrays.asList(reviewCardsShortcut, NoteEditorShortcut, cardBrowserShortcut));
 
+    }
+
+
+    /**
+     * Adds an additional intent on top of the "base" DeckPicker.
+     */
+    private static Intent[] addIntentToBase(Context context, Intent intent) {
+        Intent deckPickerIntent = new Intent(context, DeckPicker.class);
+        deckPickerIntent.setAction(Intent.ACTION_VIEW);
+        deckPickerIntent.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK);
+        TaskStackBuilder taskStackBuilder =
+                TaskStackBuilder.create(AnkiDroidApp.getInstance())
+                        .addNextIntent(deckPickerIntent)
+                        .addNextIntent(intent);
+        return taskStackBuilder.getIntents();
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NavigationDrawerActivity.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NavigationDrawerActivity.java
@@ -184,7 +184,7 @@ public abstract class NavigationDrawerActivity extends AnkiActivity implements N
         ShortcutManager shortcutManager = context.getSystemService(ShortcutManager.class);
 
         // Review Cards Shortcut
-        Intent intentReviewCards = new Intent(context, Reviewer.class);
+        Intent intentReviewCards = new Intent(context, DeckPicker.class);
         intentReviewCards.setAction(Intent.ACTION_VIEW);
         intentReviewCards.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK);
         ShortcutInfo reviewCardsShortcut = new ShortcutInfo.Builder(context, "reviewCardsShortcutId")

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
@@ -161,10 +161,6 @@ open class Reviewer : AbstractFlashcardViewer() {
             finishWithAnimation(ActivityTransitionAnimation.Direction.END)
             return
         }
-        if (Intent.ACTION_VIEW == intent.action) {
-            Timber.d("onCreate() :: received Intent with action = %s", intent.action)
-            selectDeckFromExtra()
-        }
         mColorPalette = findViewById(R.id.whiteboard_editor)
         answerTimer = AnswerTimer(findViewById(R.id.card_time))
         mTextBarNew = findViewById(R.id.new_number)


### PR DESCRIPTION
## Purpose / Description
This PR was intended to fix a pair of bugs that occur as a result of the current app behavior associated with the "Study" shortcut. 

I took a swing for about a day or so, and have _a_ solution, but unfortunately, it introduces a bug of its own. So I'm leaving it as a draft to solicit feedback or advice from others for now.

## Fixes
This PR fixes #10840 and fixes #10841.

## Approach
I decided to switch the shortcut to open DeckPicker rather than the Reviewer, and then have the DeckPicker launch a review using the selected deck.

## How Has This Been Tested?

This was manually tested on my OnePlus 8T, running Android 11.

The suite of DeckPicker tests was also run to ensure no regressions were introduced.
![image](https://user-images.githubusercontent.com/13594022/163695072-a958dd0a-a97d-4db0-a5aa-08ca3245aa5a.png)


https://user-images.githubusercontent.com/13594022/163695272-eb16b23b-7622-4cfb-944f-e8ebf1a19d81.mp4


https://user-images.githubusercontent.com/13594022/163695276-fc494435-c92b-43fe-9619-63796bb7e734.mp4



## Learning + Current Issue
Navigation is a strange beast and a part of the Android API that I don't have much experience in. Following @BrayanDSO's advice, I tried to find some way to manually push an Activity onto the backstack, but a search didn't seem to pull up anything worthwhile (though that may still be the better approach, let me know!)

My current workaround is to open DeckPicker first, then navigate to Reviewer. However, my approach introduces a new issue, in that on decks with no cards, it will still return the "Congrats!" snack bar despite not having studied anything.

An attempt was made to utilize _handleDeckSelection()_ to show the appropriate snackbar without launching to the reviewer, but this caused a NPE as the collection list/tree is not initialized. I tried to use _\_\_renderPage()_ to populate the structure, but I was unsuccessful in handling this. Any advice on this front (or if a better approach can be implemented) would be appreciated.

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
