### PR TITLE
CI: ignore flaky test on Windows [version16CollectionOpen]

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -357,6 +357,7 @@ dependencies {
     testImplementation "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
     testImplementation "org.jetbrains.kotlin:kotlin-test:$kotlin_version"
     testImplementation "io.mockk:mockk:1.12.3"
+    testImplementation 'org.apache.commons:commons-exec:1.3' // obtaining the OS
 
     // debugImplementation required vs testImplementation: https://issuetracker.google.com/issues/128612536
     debugImplementation 'androidx.fragment:fragment-testing:1.4.1'

--- a/AnkiDroid/src/test/java/com/ichi2/anki/DeckPickerTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/DeckPickerTest.java
@@ -11,6 +11,7 @@ import android.view.Menu;
 
 import com.ichi2.anki.dialogs.DatabaseErrorDialog;
 import com.ichi2.anki.dialogs.DeckPickerConfirmDeleteDeckDialog;
+import com.ichi2.annotations.NeedsTest;
 import com.ichi2.libanki.Collection;
 import com.ichi2.libanki.DB;
 import com.ichi2.libanki.DeckConfig;
@@ -22,6 +23,7 @@ import com.ichi2.testutils.BackupManagerTestUtilities;
 import com.ichi2.testutils.DbUtils;
 import com.ichi2.utils.ResourceLoader;
 
+import org.apache.commons.exec.OS;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -399,7 +401,12 @@ public class DeckPickerTest extends RobolectricTest {
 
     @Test
     @RunInBackground
+    @NeedsTest("fix this on Windows")
     public void version16CollectionOpens() {
+        if (OS.isFamilyWindows()) {
+            assumeTrue("test is flaky on Windows", false);
+        }
+
         try {
             setupColV16();
 


### PR DESCRIPTION
This is causing a lot of test failures. Best to ignore for now.

I like the addition of the `NeedsTest` annotation, it removes the chance of an issue to add tests going stale, and adds good 'TODOs' for onboarding.

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
