### PR TITLE
refactor: SyncErrorDialogListener: collection access

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/SyncErrorDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/SyncErrorDialog.kt
@@ -25,17 +25,16 @@ import com.ichi2.anki.AnkiActivity
 import com.ichi2.anki.DeckPicker
 import com.ichi2.anki.R
 import com.ichi2.async.Connection.ConflictResolution
-import com.ichi2.libanki.Collection
+import com.ichi2.libanki.CollectionGetter
 import com.ichi2.utils.contentNullable
 
 class SyncErrorDialog : AsyncDialogFragment() {
-    interface SyncErrorDialogListener {
+    interface SyncErrorDialogListener : CollectionGetter {
         fun showSyncErrorDialog(dialogType: Int)
         fun showSyncErrorDialog(dialogType: Int, message: String?)
         fun loginToSyncServer()
         fun sync()
         fun sync(conflict: ConflictResolution?)
-        val col: Collection?
         fun mediaCheck()
         fun dismissAllDialogFragments()
         fun integrityCheck()


### PR DESCRIPTION
Using `CollectionGetter` allows `DeckPicker` to be converted to Kotlin

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
