### PR TITLE
refactor: IField - add nullability annotations

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicTextFieldController.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicTextFieldController.kt
@@ -152,6 +152,7 @@ class BasicTextFieldController : FieldControllerBase(), IFieldController, Dialog
      *            one, and use it's value in the current one.
      * @param p layout params
      */
+    @KotlinCleanup("remove !! from curField.text access")
     private fun createCloneButton(layoutTools: LinearLayout, p: LinearLayout.LayoutParams) {
         // Makes sense only for two and more fields
         if (mNote.numberOfFields > 1) {
@@ -178,7 +179,7 @@ class BasicTextFieldController : FieldControllerBase(), IFieldController, Dialog
                 }
 
                 // collect clone sources
-                mPossibleClones!!.add(curField.text)
+                mPossibleClones!!.add(curField.text!!)
                 ++numTextFields
             }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/IField.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/IField.java
@@ -39,6 +39,7 @@ public interface IField extends Serializable {
 
 
     // For mixed type
+    @Nullable
     String getHtml();
 
 
@@ -62,6 +63,7 @@ public interface IField extends Serializable {
 
 
     // For Text type
+    @Nullable
     String getText();
 
 


### PR DESCRIPTION
`ImageField` overrides `getText` and `getHtml` to return null

Don't change the setters: non-null params are always used

Untested

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
