### PR TITLE
Fix ModelBrowser activity title

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/ModelBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ModelBrowser.kt
@@ -35,6 +35,7 @@ import com.ichi2.anki.UIUtils.showThemedToast
 import com.ichi2.anki.dialogs.ConfirmationDialog
 import com.ichi2.anki.dialogs.ModelBrowserContextMenu
 import com.ichi2.anki.exception.ConfirmModSchemaException
+import com.ichi2.annotations.NeedsTest
 import com.ichi2.async.CollectionTask.CountModels
 import com.ichi2.async.CollectionTask.DeleteModel
 import com.ichi2.async.TaskListenerWithContext
@@ -144,11 +145,13 @@ class ModelBrowser : AnkiActivity() {
     // ----------------------------------------------------------------------------
     // ANDROID METHODS
     // ----------------------------------------------------------------------------
+    @NeedsTest("Title follows AnkiDroid's language instead of system's")
     public override fun onCreate(savedInstanceState: Bundle?) {
         if (showedActivityFailedScreen(savedInstanceState)) {
             return
         }
         super.onCreate(savedInstanceState)
+        setTitle(R.string.model_browser_label)
         setContentView(R.layout.model_browser)
         mModelListView = findViewById(R.id.note_type_browser_list)
         enableToolbar()


### PR DESCRIPTION
It was broke on the file migration to Kotlin. Hence the title was using system language instead of AnkiDroid's

## Pull Request template

## Purpose / Description
#10623 was fixed by #10624, but it was broken on migration to Kotlin
https://github.com/ankidroid/Anki-Android/pull/10642/commits/981838fe6c7fa70638a935ef4e416f0343391ec1#diff-68fad64039cfc6325306bc878f94f2f247e7974ff69b57db4e37fab0d4871ee1L190
## Fixes
Fixes #10623

## Approach
Sets the activity title
## How Has This Been Tested?

On my phone (Samsung Galaxy Note 10 Lite SM-N770F/DS, API 31, One UI 4.0)

![Screenshot_20220418-135352_AnkiDroid](https://user-images.githubusercontent.com/69634269/163843107-5893d85a-b0f0-4517-9422-410c1968d6f9.png)

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [X] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
