### PR TITLE
Fixed "don't keep activities" crash on HelpDialog

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/HelpDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/HelpDialog.kt
@@ -147,7 +147,7 @@ object HelpDialog {
         private constructor(`in`: Parcel?) : super(`in`!!)
 
         companion object {
-            val CREATOR: Parcelable.Creator<RateAppItem?> = object : Parcelable.Creator<RateAppItem?> {
+            @JvmField val CREATOR: Parcelable.Creator<RateAppItem?> = object : Parcelable.Creator<RateAppItem?> {
                 override fun createFromParcel(`in`: Parcel): RateAppItem {
                     return RateAppItem(`in`)
                 }
@@ -189,7 +189,7 @@ object HelpDialog {
         }
 
         companion object {
-            val CREATOR: Parcelable.Creator<LinkItem?> = object : Parcelable.Creator<LinkItem?> {
+            @JvmField val CREATOR: Parcelable.Creator<LinkItem?> = object : Parcelable.Creator<LinkItem?> {
                 override fun createFromParcel(`in`: Parcel): LinkItem {
                     return LinkItem(`in`)
                 }
@@ -231,7 +231,7 @@ object HelpDialog {
         }
 
         companion object {
-            val CREATOR: Parcelable.Creator<FunctionItem?> = object : Parcelable.Creator<FunctionItem?> {
+            @JvmField val CREATOR: Parcelable.Creator<FunctionItem?> = object : Parcelable.Creator<FunctionItem?> {
                 override fun createFromParcel(`in`: Parcel): FunctionItem {
                     return FunctionItem(`in`)
                 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/HelpDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/HelpDialog.kt
@@ -35,6 +35,7 @@ import com.ichi2.anki.exception.UserSubmittedException
 import com.ichi2.utils.AdaptionUtil.isUserATestClient
 import com.ichi2.utils.IntentUtil.canOpenIntent
 import com.ichi2.utils.IntentUtil.tryOpenIntent
+import com.ichi2.utils.KotlinCleanup
 import org.acra.ACRA
 import org.acra.config.DialogConfigurationBuilder
 import org.acra.config.LimiterData
@@ -133,6 +134,7 @@ object HelpDialog {
         return createInstance(itemList, R.string.help_title_support_ankidroid)
     }
 
+    @KotlinCleanup("Convert to @Parcelize")
     class RateAppItem : RecursivePictureMenu.Item, Parcelable {
         constructor(@StringRes titleRes: Int, @DrawableRes iconRes: Int, analyticsRes: String?) : super(titleRes, iconRes, analyticsRes)
 
@@ -159,6 +161,7 @@ object HelpDialog {
         }
     }
 
+    @KotlinCleanup("Convert to @Parcelize")
     class LinkItem : RecursivePictureMenu.Item, Parcelable {
         @StringRes
         private val mUrlLocationRes: Int
@@ -201,6 +204,7 @@ object HelpDialog {
         }
     }
 
+    @KotlinCleanup("Convert to @Parcelize")
     class FunctionItem : RecursivePictureMenu.Item, Parcelable {
 
         private val mFunc: ActivityConsumer


### PR DESCRIPTION
## Purpose / Description
App would crash if "Don't keep Activities" was ON and you did as [this video](https://github.com/ankidroid/Anki-Android/issues/10944#issuecomment-1101689732) shows

## Fixes
Fixes #10944 

## Approach
Added `@JvmField` for all `CREATOR`s in `HelpDialog`

## How Has This Been Tested?

https://user-images.githubusercontent.com/59933477/164052808-151a285b-ef92-4c64-a035-ef7ab9403b7a.mov




## Checklist

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [x] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
