### PR TITLE
refactor: Introduce 'UnsafeTaskDelegate'

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
@@ -1011,8 +1011,9 @@ public class CollectionTask<Progress, Result> extends BaseAsyncTask<Void, Progre
     }
 
 
-    public static class RepairCollection extends TaskDelegate<Void, Boolean> {
-        protected Boolean task(@NonNull Collection col, @NonNull ProgressSenderAndCancelListener<Void> collectionTask) {
+    @KotlinCleanup("doesn't work on null collection - only on non-openable")
+    public static class RepairCollection extends UnsafeTaskDelegate<Void, Boolean> {
+        protected Boolean task(@Nullable Collection col, @NonNull ProgressSenderAndCancelListener<Void> collectionTask) {
             Timber.d("doInBackgroundRepairCollection");
             if (col != null) {
                 Timber.i("RepairCollection: Closing collection");
@@ -1112,7 +1113,7 @@ public class CollectionTask<Progress, Result> extends BaseAsyncTask<Void, Progre
 
 
     @KotlinCleanup("needs to handle null collection")
-    public static class ImportReplace extends TaskDelegate<String, Computation<?>> {
+    public static class ImportReplace extends UnsafeTaskDelegate<String, Computation<?>> {
         private final String mPath;
 
 
@@ -1121,7 +1122,7 @@ public class CollectionTask<Progress, Result> extends BaseAsyncTask<Void, Progre
         }
 
 
-        protected Computation<?> task(@NonNull Collection col, @NonNull ProgressSenderAndCancelListener<String> collectionTask) {
+        protected Computation<?> task(@Nullable Collection col, @NonNull ProgressSenderAndCancelListener<String> collectionTask) {
             Timber.d("doInBackgroundImportReplace");
             Resources res = AnkiDroidApp.getInstance().getBaseContext().getResources();
             Context context = col.getContext();

--- a/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
@@ -61,11 +61,11 @@ import com.ichi2.libanki.sched.Counts;
 import com.ichi2.libanki.sched.DeckDueTreeNode;
 import com.ichi2.libanki.sched.DeckTreeNode;
 import com.ichi2.libanki.sched.TreeNode;
-import com.ichi2.libanki.utils.Time;
 import com.ichi2.utils.Computation;
 import com.ichi2.utils.JSONArray;
 import com.ichi2.utils.JSONException;
 import com.ichi2.utils.JSONObject;
+import com.ichi2.utils.KotlinCleanup;
 import com.ichi2.utils.SyncStatus;
 import com.ichi2.utils.Triple;
 
@@ -141,15 +141,15 @@ public class CollectionTask<Progress, Result> extends BaseAsyncTask<Void, Progre
         return mContext;
     }
 
-    private final TaskDelegate<Progress, Result> mTask;
-    public TaskDelegate<Progress, Result> getTask() {
+    private final TaskDelegateBase<Progress, Result> mTask;
+    public TaskDelegateBase<Progress, Result> getTask() {
         return mTask;
     }
     private final TaskListener<? super Progress, ? super Result> mListener;
     private CollectionTask mPreviousTask;
 
 
-    protected CollectionTask(TaskDelegate<Progress, Result> task, TaskListener<? super Progress, ? super Result> listener, CollectionTask previousTask) {
+    protected CollectionTask(TaskDelegateBase<Progress, Result> task, TaskListener<? super Progress, ? super Result> listener, CollectionTask previousTask) {
         mTask = task;
         mListener = listener;
         mPreviousTask = previousTask;
@@ -197,7 +197,7 @@ public class CollectionTask<Progress, Result> extends BaseAsyncTask<Void, Progre
             return null;
         }
         // Actually execute the task now that we are at the front of the queue.
-        return mTask.task(getCol(), this);
+        return mTask.execTask(getCol(), this);
     }
 
 
@@ -1020,11 +1020,6 @@ public class CollectionTask<Progress, Result> extends BaseAsyncTask<Void, Progre
             }
             return BackupManager.repairCollection(col);
         }
-
-        @Override
-        protected boolean requiresOpenCollection() {
-            return false;
-        }
     }
 
 
@@ -1116,6 +1111,7 @@ public class CollectionTask<Progress, Result> extends BaseAsyncTask<Void, Progre
     }
 
 
+    @KotlinCleanup("needs to handle null collection")
     public static class ImportReplace extends TaskDelegate<String, Computation<?>> {
         private final String mPath;
 
@@ -1257,11 +1253,6 @@ public class CollectionTask<Progress, Result> extends BaseAsyncTask<Void, Progre
                 AnkiDroidApp.sendExceptionReport(e, "doInBackgroundImportReplace3");
                 return ERR;
             }
-        }
-
-        @Override
-        protected boolean requiresOpenCollection() {
-            return false;
         }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/async/SingleTaskManager.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/SingleTaskManager.java
@@ -73,7 +73,7 @@ public class SingleTaskManager extends TaskManager {
      * @return the newly created task
      */
     @Override
-    public <Progress, Result> Cancellable launchCollectionTaskConcrete(TaskDelegate<Progress, Result> task) {
+    public <Progress, Result> Cancellable launchCollectionTaskConcrete(TaskDelegateBase<Progress, Result> task) {
         return launchCollectionTask(task, null);
     }
 
@@ -92,7 +92,7 @@ public class SingleTaskManager extends TaskManager {
      */
     @SuppressWarnings("deprecation") // #7108: AsyncTask
     public <Progress, Result> Cancellable
-    launchCollectionTaskConcrete(@NonNull TaskDelegate<Progress, Result> task,
+    launchCollectionTaskConcrete(@NonNull TaskDelegateBase<Progress, Result> task,
                          @Nullable TaskListener<? super Progress, ? super Result> listener) {
         // Start new task
         CollectionTask<Progress, Result> newTask = new CollectionTask<>(task, listener, mLatestInstance);

--- a/AnkiDroid/src/main/java/com/ichi2/async/TaskDelegate.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/async/TaskDelegate.kt
@@ -18,6 +18,12 @@ package com.ichi2.async
 
 import com.ichi2.libanki.Collection
 
+/** @see [TaskDelegate] */
+abstract class TaskDelegateBase<Progress, Result> {
+    protected abstract fun execTask(col: Collection?, collectionTask: ProgressSenderAndCancelListener<Progress>): Result
+    protected abstract fun requiresOpenCollection(): Boolean
+}
+
 /**
  * TaskDelegate contains the business logic of background tasks.
  * While CollectionTask deals with all general task features, such as ensuring that no two tasks runs simultaneously
@@ -39,9 +45,11 @@ import com.ichi2.libanki.Collection
  * @param <Progress> The type of values that the task can send to indicates its progress. E.g. a card to display while remaining work is done; the progression of a counter.
  * @param <Result>   The type of result returned by the task at the end. E.g. the tree of decks, counts for a particular deck
  */
-abstract class TaskDelegate<Progress, Result> {
+abstract class TaskDelegate<Progress, Result> : TaskDelegateBase<Progress, Result>() {
+    final override fun execTask(col: Collection?, collectionTask: ProgressSenderAndCancelListener<Progress>): Result =
+        task(col!!, collectionTask)
     protected abstract fun task(col: Collection, collectionTask: ProgressSenderAndCancelListener<Progress>): Result
-    protected open fun requiresOpenCollection(): Boolean {
+    override fun requiresOpenCollection(): Boolean {
         return true
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/async/TaskDelegate.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/async/TaskDelegate.kt
@@ -49,7 +49,19 @@ abstract class TaskDelegate<Progress, Result> : TaskDelegateBase<Progress, Resul
     final override fun execTask(col: Collection?, collectionTask: ProgressSenderAndCancelListener<Progress>): Result =
         task(col!!, collectionTask)
     protected abstract fun task(col: Collection, collectionTask: ProgressSenderAndCancelListener<Progress>): Result
-    override fun requiresOpenCollection(): Boolean {
-        return true
-    }
+    final override fun requiresOpenCollection(): Boolean = true
+}
+
+/**
+ * A [TaskDelegate] which allows the collection to be null, or when `getCol` can fail (for example if it can't be opened)
+ *
+ * @param <Progress> The type of values that the task can send to indicates its progress. E.g. a card to display while remaining work is done; the progression of a counter.
+ * @param <Result>   The type of result returned by the task at the end. E.g. the tree of decks, counts for a particular deck
+ * @see [TaskDelegate]
+ */
+abstract class UnsafeTaskDelegate<Progress, Result> : TaskDelegateBase<Progress, Result>() {
+    final override fun execTask(col: Collection?, collectionTask: ProgressSenderAndCancelListener<Progress>): Result =
+        task(col, collectionTask)
+    protected abstract fun task(col: Collection?, collectionTask: ProgressSenderAndCancelListener<Progress>): Result
+    final override fun requiresOpenCollection(): Boolean = false
 }

--- a/AnkiDroid/src/main/java/com/ichi2/async/TaskManager.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/TaskManager.java
@@ -67,11 +67,11 @@ public abstract class TaskManager {
         sTaskManager.setLatestInstanceConcrete(task);
     }
 
-    public static <Progress, Result> Cancellable launchCollectionTask(TaskDelegate<Progress, Result> task) {
+    public static <Progress, Result> Cancellable launchCollectionTask(TaskDelegateBase<Progress, Result> task) {
         return sTaskManager.launchCollectionTaskConcrete(task);
     }
 
-    public abstract <Progress, Result> Cancellable launchCollectionTaskConcrete(TaskDelegate<Progress, Result> task);
+    public abstract <Progress, Result> Cancellable launchCollectionTaskConcrete(TaskDelegateBase<Progress, Result> task);
 
 
     protected abstract void setLatestInstanceConcrete(CollectionTask task);
@@ -88,13 +88,13 @@ public abstract class TaskManager {
      * @return the newly created task
      */
     public static <Progress, Result> Cancellable
-    launchCollectionTask(@NonNull TaskDelegate<Progress, Result> task,
+    launchCollectionTask(@NonNull TaskDelegateBase<Progress, Result> task,
                          @Nullable TaskListener<? super Progress, ? super Result> listener) {
         return sTaskManager.launchCollectionTaskConcrete(task, listener);
     }
 
     public abstract <Progress, Result> Cancellable
-    launchCollectionTaskConcrete(@NonNull TaskDelegate<Progress, Result> task,
+    launchCollectionTaskConcrete(@NonNull TaskDelegateBase<Progress, Result> task,
                          @Nullable TaskListener<? super Progress, ? super Result> listener);
 
     /**

--- a/AnkiDroid/src/test/java/com/ichi2/anki/RobolectricTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/RobolectricTest.kt
@@ -443,7 +443,7 @@ open class RobolectricTest : CollectionGetter {
 
     @Synchronized
     @Throws(InterruptedException::class)
-    protected fun <Progress, Result : Computation<*>?> waitForTask(task: TaskDelegate<Progress, Result>, timeoutMs: Int) {
+    protected fun <Progress, Result : Computation<*>?> waitForTask(task: TaskDelegateBase<Progress, Result>, timeoutMs: Int) {
         val completed = booleanArrayOf(false)
         val listener: TaskListener<Progress, Result> = object : TaskListener<Progress, Result>() {
             override fun onPreExecute() {}

--- a/AnkiDroid/src/test/java/com/ichi2/async/ForegroundTaskManager.java
+++ b/AnkiDroid/src/test/java/com/ichi2/async/ForegroundTaskManager.java
@@ -17,6 +17,7 @@
 package com.ichi2.async;
 
 import com.ichi2.libanki.CollectionGetter;
+import com.ichi2.utils.KotlinCleanup;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -37,7 +38,7 @@ public class ForegroundTaskManager extends TaskManager {
 
 
     @Override
-    public <Progress, Result> Cancellable launchCollectionTaskConcrete(TaskDelegate<Progress, Result> task) {
+    public <Progress, Result> Cancellable launchCollectionTaskConcrete(TaskDelegateBase<Progress, Result> task) {
         return launchCollectionTaskConcrete(task, null);
     }
 
@@ -49,20 +50,21 @@ public class ForegroundTaskManager extends TaskManager {
 
     @Override
     public <Progress, Result> Cancellable launchCollectionTaskConcrete(
-            @NonNull TaskDelegate<Progress, Result> task,
+            @NonNull TaskDelegateBase<Progress, Result> task,
             @Nullable TaskListener<? super Progress, ? super Result> listener) {
         return executeTaskWithListener(task, listener, mColGetter);
     }
 
+    @KotlinCleanup("getCol should be allowed to return null: maybe getColSafe here?")
     public static <Progress, Result> Cancellable executeTaskWithListener(
-            @NonNull TaskDelegate<Progress, Result> task,
+            @NonNull TaskDelegateBase<Progress, Result> task,
             @Nullable TaskListener<? super Progress, ? super Result> listener, CollectionGetter colGetter) {
         if (listener != null) {
             listener.onPreExecute();
         }
         final Result res;
         try {
-            res = task.task(colGetter.getCol(), new MockTaskManager<>(listener));
+            res = task.execTask(colGetter.getCol(), new MockTaskManager<>(listener));
         } catch (Exception e) {
             Timber.w(e, "A new failure may have something to do with running in the foreground.");
             throw e;
@@ -125,7 +127,7 @@ public class ForegroundTaskManager extends TaskManager {
     public static class EmptyTask<Progress, Result> extends
             CollectionTask<Progress, Result> {
 
-        protected EmptyTask(TaskDelegate<Progress, Result> task, TaskListener<? super Progress, ? super Result> listener) {
+        protected EmptyTask(TaskDelegateBase<Progress, Result> task, TaskListener<? super Progress, ? super Result> listener) {
             super(task, listener, null);
         }
     }


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
When moving to Kotlin, we have a large number of tasks which require a non-null collection, and a small number which require a nullable collection.

We use the type system to split these out, which will allow an easier, and more correct conversion to Kotlin.


## Approach

This splits out TaskDelegate into:
* TaskDelegateBase - what TaskDelegate was
  * `task()` is renamed to `execTask()`
  * `execTask` accepts a Collection?

Move all task executions to use `TaskDelegateBase` in preparation for a `UnsafeTaskDelegate`

* Use `UnsafeTaskDelegate` to allow a null collection in the type system
* Remove overrides of `requiresOpenCollection`
  * Handle this in the base class

## How Has This Been Tested?

Unit tests only

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
