### PR TITLE
Implement `Add note` gesture

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
@@ -1142,6 +1142,10 @@ open class Reviewer : AbstractFlashcardViewer() {
                 onMark(mCurrentCard)
                 return true
             }
+            ViewerCommand.COMMAND_ADD_NOTE -> {
+                addNote()
+                return true
+            }
             else -> return super.executeCommand(which)
         }
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/ViewerCommand.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/ViewerCommand.kt
@@ -68,7 +68,8 @@ enum class ViewerCommand(val resourceId: Int, private val preferenceValue: Int) 
     COMMAND_REPLAY_VOICE(R.string.replay_voice, 36),
     COMMAND_TOGGLE_WHITEBOARD(R.string.gesture_toggle_whiteboard, 37),
     COMMAND_SHOW_HINT(R.string.gesture_show_hint, 41),
-    COMMAND_SHOW_ALL_HINTS(R.string.gesture_show_all_hints, 42);
+    COMMAND_SHOW_ALL_HINTS(R.string.gesture_show_all_hints, 42),
+    COMMAND_ADD_NOTE(R.string.menu_add_note, 43);
 
     companion object {
         fun fromString(value: String): ViewerCommand? {
@@ -169,6 +170,7 @@ enum class ViewerCommand(val resourceId: Int, private val preferenceValue: Int) 
                 COMMAND_TOGGLE_FLAG_PURPLE -> from(keyCode(KeyEvent.KEYCODE_7, CardSide.BOTH, ctrl()), keyCode(KeyEvent.KEYCODE_NUMPAD_7, CardSide.BOTH, ctrl()))
                 COMMAND_SHOW_HINT -> from(keyCode(KeyEvent.KEYCODE_H, CardSide.BOTH))
                 COMMAND_SHOW_ALL_HINTS -> from(keyCode(KeyEvent.KEYCODE_G, CardSide.BOTH))
+                COMMAND_ADD_NOTE -> from(keyCode(KeyEvent.KEYCODE_A, CardSide.BOTH))
                 else -> ArrayList()
             }
 

--- a/AnkiDroid/src/main/res/values/constants.xml
+++ b/AnkiDroid/src/main/res/values/constants.xml
@@ -102,6 +102,7 @@
         <item>@string/gesture_toggle_whiteboard</item>
         <item>@string/gesture_show_hint</item>
         <item>@string/gesture_show_all_hints</item>
+        <item>@string/menu_add_note</item>
     </string-array>
     <string-array name="gestures_values">
         <item>0</item>
@@ -142,6 +143,7 @@
         <item>37</item> <!-- Toggle whiteboard -->
         <item>41</item> <!-- Show hint -->
         <item>42</item> <!-- Show all hints -->
+        <item>43</item> <!-- Add note -->
     </string-array>
     <string-array name="custom_button_values">
         <item>2</item>

--- a/AnkiDroid/src/test/java/com/ichi2/anki/cardviewer/ViewerCommandTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/cardviewer/ViewerCommandTest.kt
@@ -40,7 +40,8 @@ class ViewerCommandTest {
                 "binding_TOGGLE_FLAG_ORANGE, binding_TOGGLE_FLAG_GREEN, binding_TOGGLE_FLAG_BLUE, " +
                 "binding_TOGGLE_FLAG_PINK, binding_TOGGLE_FLAG_TURQUOISE, binding_TOGGLE_FLAG_PURPLE, " +
                 "binding_UNSET_FLAG, binding_PAGE_UP, binding_PAGE_DOWN, binding_TAG, binding_CARD_INFO, binding_ABORT_AND_SYNC, " +
-                "binding_RECORD_VOICE, binding_REPLAY_VOICE, binding_TOGGLE_WHITEBOARD, binding_SHOW_HINT, binding_SHOW_ALL_HINTS",
+                "binding_RECORD_VOICE, binding_REPLAY_VOICE, binding_TOGGLE_WHITEBOARD, binding_SHOW_HINT, " +
+                "binding_SHOW_ALL_HINTS, binding_ADD_NOTE",
             names
         )
     }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/reviewer/MappableBindingTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/reviewer/MappableBindingTest.kt
@@ -35,8 +35,8 @@ class MappableBindingTest {
     fun inequalityTest() {
         val allBindings = getAllBindings()
         // pick an arbitrary key which is not mapped
-        assertThat(allBindings, not(hasItem(unicodeCharacter('a'))))
-        assertThat(allBindings, not(hasItem(keyCode(KeyEvent.KEYCODE_A))))
+        assertThat(allBindings, not(hasItem(unicodeCharacter('l'))))
+        assertThat(allBindings, not(hasItem(keyCode(KeyEvent.KEYCODE_L))))
     }
 
     private fun getAllBindings() = ViewerCommand.allDefaultBindings


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
There was a Add Note app bar button, but not a gesture

## Fixes
Fixes #10976

## Approach
Hook the gesture and command with the appropriate methods

Note: `A` is the default hotkey for adding notes on Anki, so reused here
![image](https://user-images.githubusercontent.com/69634269/164120749-cccb9124-b956-4978-8680-15941326a2a3.png)


## How Has This Been Tested?

On my phone (Samsung Galaxy Note 10 Lite SM-N770F/DS, API 31, One UI 4.0)

<details><summary>Screenshot</summary>

![Screenshot_20220419-205645_AnkiDroid](https://user-images.githubusercontent.com/69634269/164120039-912aff01-afe9-4e0b-943c-945ebd0c613a.png)

</details>

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
