### PR TITLE
build(deps): kotlin stdlib deps are implicit now

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -334,8 +334,6 @@ dependencies {
     implementation 'org.jsoup:jsoup:1.14.3'
     implementation "com.github.zafarkhaja:java-semver:0.9.0" // For AnkiDroid JS API Versioning
     implementation 'com.drakeet.drawer:drawer:1.0.3'
-    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation 'uk.co.samuelwall:material-tap-target-prompt:3.3.2'
 
     // Cannot use debugImplementation since classes need to be imported in AnkiDroidApp

--- a/lint-rules/build.gradle
+++ b/lint-rules/build.gradle
@@ -20,8 +20,6 @@ dependencies {
     compileOnly "com.android.tools.lint:lint-api:$lint_version"
     compileOnly "com.android.tools.lint:lint:$lint_version"
 
-    compileOnly "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-
     testImplementation "junit:junit:4.13.2"
     testImplementation "com.android.tools.lint:lint:$lint_version"
     testImplementation "com.android.tools.lint:lint-api:$lint_version"


### PR DESCRIPTION
## Pull Request template

## Purpose / Description

these do not need to be included by themselves, and if they are
Android Studio actually emits a warning (which prompted the investigation)

https://kotlinlang.org/docs/gradle.html#dependency-on-the-standard-library
from https://stackoverflow.com/questions/49956051/warning-kotlin-plugin-version-is-not-the-same-as-library-version-but-it-is

## Approach

Just remove the dependencies

## How Has This Been Tested?

API21 / API24 / API31 emulators up, run `./gradlew jacocoTestReport ktlintCheck lint` it all passes

## Learning (optional, can help others)
Kotlin moves a bit faster than it appears...in DX as well as language features

## Checklist

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
