### PR TITLE
chore(lint): fix lint compile warning re: missing Vendor

### DIFF
--- a/lint-rules/src/main/java/com/ichi2/anki/lint/IssueRegistry.java
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/IssueRegistry.java
@@ -1,5 +1,7 @@
 package com.ichi2.anki.lint;
 
+import com.android.annotations.Nullable;
+import com.android.tools.lint.client.api.Vendor;
 import com.android.tools.lint.detector.api.ApiKt;
 import com.android.tools.lint.detector.api.Issue;
 import com.ichi2.anki.lint.rules.ConstantJavaFieldDetector;
@@ -65,5 +67,16 @@ public class IssueRegistry extends com.android.tools.lint.client.api.IssueRegist
     @Override
     public int getApi() {
         return ApiKt.CURRENT_API;
+    }
+
+    @Nullable
+    @Override
+    public Vendor getVendor() {
+        return new Vendor(
+                "AnkiDroid",
+                "com.ichi2.anki:lint-rules",
+                "https://github.com/ankidroid/Anki-Android/issues",
+                "https://github.com/ankidroid/Anki-Android"
+        );
     }
 }


### PR DESCRIPTION
## Pull Request template

## Purpose / Description

I saw this compile warning and I don't like warnings.

```
> Task :api:lintAnalyzeDebug
com.ichi2.anki.lint.IssueRegistry in /home/mike/work/AnkiDroid/Anki-Android-Upstream/lint-rules/build/libs/lint-rules.jar does not specify a vendor; see IssueRegistry#vendor
```

So I fixed it

## Approach
Implement required method override

## How Has This Been Tested?

`./gradlew lint` should compile without this warning, it does now

## Learning (optional, can help others)
The lint stuff for custom rules is pretty terribly documented but it's also not that hard to manage

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
