### PR TITLE
fix: forward-port to non-deprecated APIs in DuplicateCrowdInStrings rule

### DIFF
--- a/lint-rules/src/main/java/com/ichi2/anki/lint/rules/DuplicateCrowdInStrings.java
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/DuplicateCrowdInStrings.java
@@ -42,7 +42,7 @@ import com.android.tools.lint.checks.StringCasingDetector.StringDeclaration;
 import com.android.tools.lint.detector.api.Context;
 import com.android.tools.lint.detector.api.Implementation;
 import com.android.tools.lint.detector.api.Issue;
-import com.android.tools.lint.detector.api.LintUtils;
+import com.android.tools.lint.detector.api.Lint;
 import com.android.tools.lint.detector.api.Location;
 import com.android.tools.lint.detector.api.ResourceXmlDetector;
 import com.android.tools.lint.detector.api.Scope;
@@ -144,7 +144,7 @@ public class DuplicateCrowdInStrings extends ResourceXmlDetector {
             return;
         }
 
-        LocaleQualifier locale = LintUtils.getLocale(context);
+        LocaleQualifier locale = Lint.getLocale(context);
         Pair<String, String> key = locale != null ?
                 Pair.of(locale.getFull(), text.toLowerCase(Locale.forLanguageTag(locale.getTag()))) :
                 Pair.of("default", text.toLowerCase(Locale.US));
@@ -204,7 +204,7 @@ public class DuplicateCrowdInStrings extends ResourceXmlDetector {
             }
 
 
-            String nameList = LintUtils.formatList(nameValues, nameValues.size(),true);
+            String nameList = Lint.formatList(nameValues, nameValues.size(), true, false);
             // we use both quotes and code styling here so it appears in the console quoted
             String message = String.format("Duplicate string value \"`%s`\", used in %s", prevString, nameList);
             if (caseVaries) {


### PR DESCRIPTION
## Pull Request template

## Purpose / Description

Cleans up a deprecation warning on compile

## Approach
Trawl through kotlin source etc and trial and error

## How Has This Been Tested?
Compile with and without this, errors are gone with this

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
