### PR TITLE
fix: nonPositionalFormatSubstitution rule should use same param name as super

### DIFF
--- a/lint-rules/src/main/java/com/ichi2/anki/lint/rules/NonPositionalFormatSubstitutions.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/NonPositionalFormatSubstitutions.kt
@@ -54,7 +54,7 @@ class NonPositionalFormatSubstitutions : ResourceXmlDetector() {
         )
     }
 
-    override fun appliesTo(directoryType: ResourceFolderType): Boolean = directoryType == ResourceFolderType.VALUES
+    override fun appliesTo(folderType: ResourceFolderType): Boolean = folderType == ResourceFolderType.VALUES
 
     override fun getApplicableElements() = listOf(SdkConstants.TAG_STRING)
 


### PR DESCRIPTION

quiets a build warning

Tested by compiling with it and without it