### PR TITLE
fix: forward-port to non-deprecated gradle properties

### DIFF
--- a/AnkiDroid/jacoco.gradle
+++ b/AnkiDroid/jacoco.gradle
@@ -68,7 +68,7 @@ task jacocoTestReport(type: JacocoReport, dependsOn: ['testPlayDebugUnitTest', '
     }
 
     reports {
-        xml.enabled = true
+        xml.required = true
         html.destination htmlOutDir
     }
 
@@ -93,7 +93,7 @@ task jacocoUnitTestReport(type: JacocoReport, dependsOn: ['testPlayDebugUnitTest
     }
 
     reports {
-        xml.enabled = true
+        xml.required = true
         html.destination htmlOutDir
     }
 
@@ -118,7 +118,7 @@ task jacocoAndroidTestReport(type: JacocoReport, dependsOn: ['connectedPlayDebug
     }
 
     reports {
-        xml.enabled = true
+        xml.required = true
         html.destination htmlOutDir
     }
 

--- a/api/build.gradle
+++ b/api/build.gradle
@@ -129,8 +129,8 @@ publishing {
 
 task zipRelease(type: Zip) {
     from layout.buildDirectory.dir('repos/releases')
-    destinationDir buildDir
-    archiveName "${buildDir}/release-${archiveVersion.get()}.zip"
+    destinationDirectory = buildDir
+    archiveFileName = "${buildDir}/release-${archiveVersion.get()}.zip"
 }
 
 // Use this task to make a release you can send to someone


### PR DESCRIPTION
## Pull Request template

## Purpose / Description

I want `./gradlew clean jacocoTestReport ktlintCheck lint` to run as clean as possible

## Fixes

Several gradle deprecation errors (if you turn on `--warning-mode all` on the gradle command line you see them)

## Approach
Following instructions to use new APIs, fairly easy

## How Has This Been Tested?
Lots of command line runs of the above gradle command

## Learning (optional, can help others)
In groovy, `destinationDirectory <something>` is not the same as `destinationDirectory = <something>`

The `=` is important

## Checklist

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
