### PR TITLE
refactor: Use constants on some preferences keys

### DIFF
--- a/AnkiDroid/src/main/res/values/preferences.xml
+++ b/AnkiDroid/src/main/res/values/preferences.xml
@@ -27,4 +27,5 @@
     <string name="day_theme_key">dayTheme</string>
     <string name="night_theme_key">nightTheme</string>
     <string name="gestures_preference">gestures</string>
+    <string name="gestures_corner_touch_preference">gestureCornerTouch</string>
 </resources>

--- a/AnkiDroid/src/main/res/values/preferences.xml
+++ b/AnkiDroid/src/main/res/values/preferences.xml
@@ -26,4 +26,5 @@
     <string name="app_theme_key">appTheme</string>
     <string name="day_theme_key">dayTheme</string>
     <string name="night_theme_key">nightTheme</string>
+    <string name="gestures_preference">gestures</string>
 </resources>

--- a/AnkiDroid/src/main/res/xml/preferences_gestures.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_gestures.xml
@@ -28,26 +28,26 @@
     <SwitchPreference
         android:defaultValue="false"
         android:disableDependentsState="false"
-        android:key="gestures"
+        android:key="@string/gestures_preference"
         android:summary="@string/gestures_summ"
         android:title="@string/gestures" />
     <SwitchPreference
         android:defaultValue="false"
-        android:dependency="gestures"
+        android:dependency="@string/gestures_preference"
         android:disableDependentsState="false"
         android:key="gestureCornerTouch"
         android:summary="@string/gestures_corner_touch_summary"
         android:title="@string/gestures_corner_touch" />
     <SwitchPreference
         android:defaultValue="false"
-        android:dependency="gestures"
+        android:dependency="@string/gestures_preference"
         android:disableDependentsState="false"
         android:key="gestureFullScreenNavigationDrawer"
         android:summary="@string/gestures_fullscreen_nav_drawer_summary"
         android:title="@string/gestures_full_screen_nav_drawer" />
     <com.ichi2.preferences.SeekBarPreferenceCompat
         android:defaultValue="100"
-        android:dependency="gestures"
+        android:dependency="@string/gestures_preference"
         android:dialogMessage="@string/preference_summary_literal"
         android:key="swipeSensitivity"
         android:max="180"
@@ -59,35 +59,35 @@
     <PreferenceCategory android:title="@string/pref_cat_actions" >
         <ListPreference
             android:defaultValue="0"
-            android:dependency="gestures"
+            android:dependency="@string/gestures_preference"
             android:entries="@array/gestures_labels"
             android:entryValues="@array/gestures_values"
             android:key="gestureSwipeUp"
             android:title="@string/gestures_swipe_up" />
         <ListPreference
             android:defaultValue="0"
-            android:dependency="gestures"
+            android:dependency="@string/gestures_preference"
             android:entries="@array/gestures_labels"
             android:entryValues="@array/gestures_values"
             android:key="gestureSwipeDown"
             android:title="@string/gestures_swipe_down" />
         <ListPreference
             android:defaultValue="6"
-            android:dependency="gestures"
+            android:dependency="@string/gestures_preference"
             android:entries="@array/gestures_labels"
             android:entryValues="@array/gestures_values"
             android:key="gestureSwipeLeft"
             android:title="@string/gestures_swipe_left" />
         <ListPreference
             android:defaultValue="2"
-            android:dependency="gestures"
+            android:dependency="@string/gestures_preference"
             android:entries="@array/gestures_labels"
             android:entryValues="@array/gestures_values"
             android:key="gestureSwipeRight"
             android:title="@string/gestures_swipe_right" />
         <ListPreference
             android:defaultValue="0"
-            android:dependency="gestures"
+            android:dependency="@string/gestures_preference"
             android:entries="@array/gestures_labels"
             android:entryValues="@array/gestures_values"
             android:key="gestureDoubleTap"
@@ -101,7 +101,7 @@
             android:title="@string/gestures_corner_tap_top_left" />
         <ListPreference
             android:defaultValue="1"
-            android:dependency="gestures"
+            android:dependency="@string/gestures_preference"
             android:entries="@array/gestures_labels"
             android:entryValues="@array/gestures_values"
             android:key="gestureTapTop"
@@ -115,7 +115,7 @@
             android:title="@string/gestures_corner_tap_top_right" />
         <ListPreference
             android:defaultValue="1"
-            android:dependency="gestures"
+            android:dependency="@string/gestures_preference"
             android:entries="@array/gestures_labels"
             android:entryValues="@array/gestures_values"
             android:key="gestureTapLeft"
@@ -129,7 +129,7 @@
             android:title="@string/gestures_corner_tap_middle_center" />
         <ListPreference
             android:defaultValue="1"
-            android:dependency="gestures"
+            android:dependency="@string/gestures_preference"
             android:entries="@array/gestures_labels"
             android:entryValues="@array/gestures_values"
             android:key="gestureTapRight"
@@ -143,7 +143,7 @@
             android:title="@string/gestures_corner_tap_bottom_left" />
         <ListPreference
             android:defaultValue="1"
-            android:dependency="gestures"
+            android:dependency="@string/gestures_preference"
             android:entries="@array/gestures_labels"
             android:entryValues="@array/gestures_values"
             android:key="gestureTapBottom"

--- a/AnkiDroid/src/main/res/xml/preferences_gestures.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_gestures.xml
@@ -35,7 +35,7 @@
         android:defaultValue="false"
         android:dependency="@string/gestures_preference"
         android:disableDependentsState="false"
-        android:key="gestureCornerTouch"
+        android:key="@string/gestures_corner_touch_preference"
         android:summary="@string/gestures_corner_touch_summary"
         android:title="@string/gestures_corner_touch" />
     <SwitchPreference
@@ -94,7 +94,7 @@
             android:title="@string/gestures_double_tap" />
         <ListPreference
             android:defaultValue="0"
-            android:dependency="gestureCornerTouch"
+            android:dependency="@string/gestures_corner_touch_preference"
             android:entries="@array/gestures_labels"
             android:entryValues="@array/gestures_values"
             android:key="gestureTapTopLeft"
@@ -108,7 +108,7 @@
             android:title="@string/gestures_tap_top" />
         <ListPreference
             android:defaultValue="0"
-            android:dependency="gestureCornerTouch"
+            android:dependency="@string/gestures_corner_touch_preference"
             android:entries="@array/gestures_labels"
             android:entryValues="@array/gestures_values"
             android:key="gestureTapTopRight"
@@ -122,7 +122,7 @@
             android:title="@string/gestures_tap_left" />
         <ListPreference
             android:defaultValue="0"
-            android:dependency="gestureCornerTouch"
+            android:dependency="@string/gestures_corner_touch_preference"
             android:entries="@array/gestures_labels"
             android:entryValues="@array/gestures_values"
             android:key="gestureTapCenter"
@@ -136,7 +136,7 @@
             android:title="@string/gestures_tap_right" />
         <ListPreference
             android:defaultValue="0"
-            android:dependency="gestureCornerTouch"
+            android:dependency="@string/gestures_corner_touch_preference"
             android:entries="@array/gestures_labels"
             android:entryValues="@array/gestures_values"
             android:key="gestureTapBottomLeft"
@@ -150,7 +150,7 @@
             android:title="@string/gestures_tap_bottom" />
         <ListPreference
             android:defaultValue="0"
-            android:dependency="gestureCornerTouch"
+            android:dependency="@string/gestures_corner_touch_preference"
             android:entries="@array/gestures_labels"
             android:entryValues="@array/gestures_values"
             android:key="gestureTapBottomRight"

--- a/AnkiDroid/src/main/res/xml/preferences_reviewing.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_reviewing.xml
@@ -162,21 +162,21 @@
             android:title="@string/timeout_answer_text" />
         <ListPreference
             android:entries="@array/automatic_answer_options"
-            android:dependency="timeoutAnswer"
+            android:dependency="@string/timeout_answer_preference"
             android:entryValues="@array/automatic_answer_values"
             android:defaultValue="0"
             android:key="@string/automatic_answer_action_preference"
             android:title="@string/timeout_answer" />
         <com.ichi2.preferences.SeekBarPreferenceCompat
             android:defaultValue="20"
-            android:dependency="timeoutAnswer"
+            android:dependency="@string/timeout_answer_preference"
             android:key="@string/timeout_answer_seconds_preference"
             android:max="30"
             android:summary="@string/timeout_answer_seconds_summ"
             android:title="@string/timeout_answer_seconds" />
         <com.ichi2.preferences.SeekBarPreferenceCompat
             android:defaultValue="60"
-            android:dependency="timeoutAnswer"
+            android:dependency="@string/timeout_answer_preference"
             android:key="@string/timeout_question_seconds_preference"
             android:max="60"
             android:summary="@string/timeout_answer_seconds_summ"


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
I wanted more safety on dealing with some preferences keys

## Fixes
Helps #10423

## Approach
Add constants to `gestures` and `gestureCornerTouch` and add some uses of the existing `timeoutAnswer` constant

## How Has This Been Tested?

Lint passes

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
