### PR TITLE
Move code related to LeakCanary outside of AnkiDroidApp

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.java
@@ -38,7 +38,6 @@ import androidx.core.content.pm.PackageInfoCompat;
 import androidx.localbroadcastmanager.content.LocalBroadcastManager;
 
 import android.util.Log;
-import android.view.ViewConfiguration;
 import android.webkit.CookieManager;
 
 import com.ichi2.anki.analytics.AnkiDroidCrashReportDialog;
@@ -51,7 +50,6 @@ import com.ichi2.anki.services.NotificationService;
 import com.ichi2.compat.CompatHelper;
 import com.ichi2.utils.AdaptionUtil;
 import com.ichi2.utils.ExceptionUtil;
-import com.ichi2.utils.KotlinCleanup;
 import com.ichi2.utils.LanguageUtil;
 import com.ichi2.anki.analytics.UsageAnalytics;
 import com.ichi2.utils.Permissions;
@@ -68,22 +66,12 @@ import org.acra.config.ToastConfigurationBuilder;
 import org.acra.sender.HttpSender;
 
 import java.io.InputStream;
-import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Locale;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import androidx.webkit.WebViewCompat;
-import leakcanary.AppWatcher;
-import leakcanary.DefaultOnHeapAnalyzedListener;
-import leakcanary.LeakCanary;
-import shark.AndroidMetadataExtractor;
-import shark.AndroidObjectInspectors;
-import shark.AndroidReferenceMatchers;
-import shark.KeyedWeakReferenceFinder;
-import shark.ReferenceMatcher;
 import timber.log.Timber;
 import static timber.log.Timber.DebugTree;
 
@@ -285,22 +273,11 @@ public class AnkiDroidApp extends Application {
             // Enable verbose error logging and do method tracing to put the Class name as log tag
             Timber.plant(new DebugTree());
             setDebugACRAConfig(preferences);
-
-            List<ReferenceMatcher> referenceMatchers = new ArrayList<>();
-            // Add known memory leaks to 'referenceMatchers'
-            matchKnownMemoryLeaks(referenceMatchers);
-
-            // AppWatcher manual install if not already installed
-            if (!AppWatcher.INSTANCE.isInstalled()) {
-                AppWatcher.INSTANCE.manualInstall(this);
-            }
-
-            // Show 'Leaks' app launcher. It has been removed by default via constants.xml.
-            LeakCanary.INSTANCE.showLeakDisplayActivityLauncherIcon(true);
+            LeakCanaryConfiguration.setInitialConfigFor(this);
         } else {
             Timber.plant(new ProductionCrashReportingTree());
             setProductionACRAConfig(preferences);
-            disableLeakCanary();
+            LeakCanaryConfiguration.disable();
         }
         Timber.tag(TAG);
 
@@ -749,51 +726,5 @@ public class AnkiDroidApp extends Application {
             Timber.w(e);
         }
         return webViewInfo;
-    }
-
-    /**
-     * Matching known library leaks or leaks which have been already reported previously.
-     */
-    @KotlinCleanup("Only pass referenceMatchers to copy() method after conversion to Kotlin")
-    private void matchKnownMemoryLeaks(List<ReferenceMatcher> knownLeaks) {
-        List<ReferenceMatcher> referenceMatchers = AndroidReferenceMatchers.Companion.getAppDefaults();
-        referenceMatchers.addAll(knownLeaks);
-
-        // Passing default values will not be required after migration to Kotlin.
-        LeakCanary.setConfig(LeakCanary.getConfig().copy(
-                true,
-                false,
-                5,
-                referenceMatchers,
-                AndroidObjectInspectors.Companion.getAppDefaults(),
-                DefaultOnHeapAnalyzedListener.Companion.create(),
-                AndroidMetadataExtractor.INSTANCE,
-                true,
-                7,
-                false,
-                KeyedWeakReferenceFinder.INSTANCE,
-                false
-        ));
-    }
-
-    /**
-     * Disable LeakCanary
-     */
-    @KotlinCleanup("Only pass relevant arguments to copy() method after conversion to Kotlin")
-    private void disableLeakCanary() {
-        LeakCanary.setConfig(LeakCanary.getConfig().copy(
-                false,
-                false,
-                0,
-                AndroidReferenceMatchers.Companion.getAppDefaults(),
-                AndroidObjectInspectors.Companion.getAppDefaults(),
-                DefaultOnHeapAnalyzedListener.Companion.create(),
-                AndroidMetadataExtractor.INSTANCE,
-                false,
-                0,
-                false,
-                KeyedWeakReferenceFinder.INSTANCE,
-                false
-        ));
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/LeakCanaryConfiguration.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/LeakCanaryConfiguration.kt
@@ -1,0 +1,56 @@
+/****************************************************************************************
+ * Copyright (c) 2022 lukstbit <lukstbit@users.noreply.github.com>                      *
+ *                                                                                      *
+ * This program is free software; you can redistribute it and/or modify it under        *
+ * the terms of the GNU General Public License as published by the Free Software        *
+ * Foundation; either version 3 of the License, or (at your option) any later           *
+ * version.                                                                             *
+ *                                                                                      *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *                                                                                      *
+ * You should have received a copy of the GNU General Public License along with         *
+ * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ ****************************************************************************************/
+package com.ichi2.anki
+
+import android.app.Application
+import leakcanary.AppWatcher.isInstalled
+import leakcanary.AppWatcher.manualInstall
+import leakcanary.LeakCanary.config
+import leakcanary.LeakCanary.showLeakDisplayActivityLauncherIcon
+import shark.AndroidReferenceMatchers
+import shark.ReferenceMatcher
+
+object LeakCanaryConfiguration {
+    /**
+     * Disable LeakCanary.
+     */
+    @JvmStatic
+    fun disable() {
+        config = config.copy(
+            dumpHeap = false,
+            retainedVisibleThreshold = 0,
+            referenceMatchers = AndroidReferenceMatchers.appDefaults,
+            computeRetainedHeapSize = false,
+            maxStoredHeapDumps = 0,
+        )
+    }
+
+    /**
+     * Sets the initial configuration for LeakCanary. This method can be used to match known library
+     * leaks or leaks which have been already reported previously.
+     */
+    @JvmStatic
+    @JvmOverloads
+    fun setInitialConfigFor(application: Application, knownMemoryLeaks: List<ReferenceMatcher> = emptyList()) {
+        config = config.copy(referenceMatchers = AndroidReferenceMatchers.appDefaults + knownMemoryLeaks)
+        // AppWatcher manual install if not already installed
+        if (!isInstalled) {
+            manualInstall(application)
+        }
+        // Show 'Leaks' app launcher. It has been removed by default via constants.xml.
+        showLeakDisplayActivityLauncherIcon(true)
+    }
+}


### PR DESCRIPTION
## Purpose / Description

This PR creates a helper object to hold the code related to initialization of Leakcanary happening inside of AnkiDroidApp. I've taken the liberty of simplifying the code a bit, for example by removing the empty list that was being passed in and replacing it with a todo for when the class is migrated to kotlin. 

I can migrate the class directly to kotlin if needed.

## Fixes
Fixes #11006 

## How Has This Been Tested?

Ran the usual tests.

## Checklist

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
