### PR TITLE
refactor(ci): use built-in concurrency features

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -28,16 +28,16 @@ on:
       - '**/*.gradle'
       - 'gradle/**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lintDebug:
     name: Lint Debug
     timeout-minutes: 15
     runs-on: ubuntu-latest
     steps:
-      - uses: styfle/cancel-workflow-action@0.9.1
-        with:
-          all_but_latest: true
-
       - uses: actions/checkout@v3
         with:
           fetch-depth: 1

--- a/.github/workflows/tests_emulator.yml
+++ b/.github/workflows/tests_emulator.yml
@@ -28,6 +28,10 @@ on:
       - '**/*.gradle'
       - 'gradle/**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   emulator_test:
     name: Android Emulator Test
@@ -37,10 +41,6 @@ jobs:
       EMULATOR_COMMAND: "-avd TestingAVD -noaudio -gpu swiftshader_indirect -camera-back none -no-snapshot -no-window -no-boot-anim -nojni -memory 2048 -timezone 'Europe/London' -cores 2"
       EMULATOR_EXECUTABLE: qemu-system-x86_64-headless
     steps:
-      - uses: styfle/cancel-workflow-action@0.9.1
-        with:
-          all_but_latest: true
-
       - uses: actions/checkout@v3
         with:
           fetch-depth: 50

--- a/.github/workflows/tests_unit.yml
+++ b/.github/workflows/tests_unit.yml
@@ -28,6 +28,10 @@ on:
       - '**/*.gradle'
       - 'gradle/**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   unit:
     name: JUnit Tests
@@ -40,10 +44,6 @@ jobs:
     #env:
     #  CODACY_TOKEN: ${{ secrets.CODACY_TOKEN }}
     steps:
-      - uses: styfle/cancel-workflow-action@0.9.1
-        with:
-          all_but_latest: true
-
       - uses: actions/checkout@v3
         with:
           fetch-depth: 50


### PR DESCRIPTION

## Pull Request template

## Purpose / Description

these did not exist prior, and cancel-workflow has worked well for us,
but built-in is better when it is available

## Approach

Determined via trial and error what the best naming was for the concurrency group, via work in Anki-Android-Backend

## How Has This Been Tested?

Tested on Anki-Android-Backend - it works! But only on the second-or-after runs because the name has to be stable starting with the first one

## Learning (optional, can help others)


_Links to blog posts, patterns, libraries or addons used to solve this problem_

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
