### PR TITLE
feat: Allow Kotlin Migration on lint-rules

### DIFF
--- a/lint-rules/build.gradle
+++ b/lint-rules/build.gradle
@@ -28,3 +28,4 @@ dependencies {
     testImplementation "com.android.tools.lint:lint-tests:$lint_version"
     testImplementation 'org.hamcrest:hamcrest-all:1.3'
 }
+apply from: "./kotlinMigration-lint.gradle"

--- a/lint-rules/kotlinMigration-lint.gradle
+++ b/lint-rules/kotlinMigration-lint.gradle
@@ -1,0 +1,121 @@
+/*
+Copyright (c) 2021 David Allison <davidallisongithub@gmail.com>
+Copyright (c) 2021 Shridhar Goel <shridhar.goel@gmail.com>
+
+This program is free software; you can redistribute it and/or modify it under
+the terms of the GNU General Public License as published by the Free Software
+Foundation; either version 3 of the License, or (at your option) any later
+version.
+
+This program is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with
+this program.  If not, see <http://www.gnu.org/licenses/>.
+
+This file incorporates work covered by the following copyright and
+permission notice:
+
+    Copyright 2021 David Allison <davidallisongithub@gmail.com>
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included
+    in all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+    OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+// This file is documented: docs/kotlin-migration.md
+
+// Example of class name: "/com/ichi2/anki/UIUtils.kt"
+// Ensure that it starts with '/' (slash)
+def source = Source.MAIN
+def className = ""
+
+enum Source {
+    MAIN("/src/main/java"),
+    TEST("/src/test/java"),
+    ANDROID_TEST("/src/androidTest/java") // untested
+    public String path
+    private Source(String pathSubset) {
+        this.path = pathSubset
+    }
+}
+
+static def isKotlinCompile(Object t) {
+    def clazz = t.class
+    while (clazz.superclass != null) {
+        // importing caused a different class to be used
+        if (clazz.name == "org.jetbrains.kotlin.gradle.tasks.KotlinCompile") {
+            return true
+        }
+        clazz = clazz.superclass
+
+    }
+    return false
+}
+
+allprojects {
+    afterEvaluate {
+        tasks.all {
+            if (!className.isEmpty() && isKotlinCompile(it)) {
+                it.exclude('**' + className)
+            }
+        }
+    }
+}
+
+
+
+ktlint {
+    filter {
+        if (!className.isEmpty()) {
+            exclude('**' + className)
+        }
+    }
+}
+
+task copySingleFileInGradle {
+    if (className.isEmpty()) return
+
+    doFirst {
+        def path = projectDir.absolutePath + source.path + className
+        def newPath = path.replace(".kt", ".java")
+
+        def src = new File(path)
+        def dst = new File(newPath)
+        dst.write(src.text)
+    }
+}
+
+task deleteSingleFileInGradle {
+    if (className.isEmpty()) return
+
+    doFirst {
+        def path = projectDir.absolutePath + source.path + className
+        def newPath = path.replace(".kt", ".java")
+        def dst = new File(newPath)
+        if (dst.directory) {
+            throw IllegalStateException("should be a file")
+        }
+        dst.delete()
+    }
+}
+
+tasks.withType(JavaCompile).configureEach {
+    it.dependsOn copySingleFileInGradle
+    it.finalizedBy deleteSingleFileInGradle
+}

--- a/lint-rules/kotlinMigration-lint.gradle
+++ b/lint-rules/kotlinMigration-lint.gradle
@@ -48,7 +48,6 @@ def className = ""
 enum Source {
     MAIN("/src/main/java"),
     TEST("/src/test/java"),
-    ANDROID_TEST("/src/androidTest/java") // untested
     public String path
     private Source(String pathSubset) {
         this.path = pathSubset


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
I want to migrate `DuplicateCrowdInStrings`, because https://github.com/ankidroid/Anki-Android/pull/11015 raised an issue with it, and I want to use Kotlin to resolve it.

## Approach
changes from `AnkiDroid/kotlinMigration`:

* remove `android { }` wrapper around `ktlint { }`

Due to this change, we use a new file
We use the -lint suffix to imply to reviewers that this is a different file type


## How Has This Been Tested?
I tested this before the file rename to `-lint` on `DuplicateCrowdInStrings`, and it compiled on the 'rename' commit.

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
