### PR TITLE
Changing the colorAccent of theme_light to material_light_blue_800

### DIFF
--- a/AnkiDroid/src/main/res/values/theme_light.xml
+++ b/AnkiDroid/src/main/res/values/theme_light.xml
@@ -13,7 +13,7 @@ APIs. It's visible when there aren't enough decks to fill the screen.
 -->
 <resources>
     <color name="theme_light_primary">@color/material_light_blue_500</color>
-    <color name="theme_light_primary_dark">@color/material_light_blue_700</color>
+    <color name="theme_light_primary_dark">@color/material_light_blue_600</color>
     <color name="theme_light_primary_light">@color/material_light_blue_100</color>
     <color name="theme_light_accent">@color/material_light_blue_600</color>
     <color name="theme_light_primary_text">@color/black</color>
@@ -136,6 +136,13 @@ APIs. It's visible when there aren't enough decks to fill the screen.
         <item name="popupBackgroundColor">@android:color/white</item>
 
         <item name="editTextDisabled">@color/material_grey_500</item>
+
+<!--        Preference category title color-->
+        <item name="preferenceCategoryTitleTextColor">@color/black</item>
+    </style>
+
+    <style name="toggle_buttos_style" parent="Preference.SwitchPreferenceCompat">
+        <item name="colorAccent">@color/black</item>
     </style>
 
     <!-- Preferences screens -->

--- a/AnkiDroid/src/main/res/values/theme_light.xml
+++ b/AnkiDroid/src/main/res/values/theme_light.xml
@@ -15,7 +15,7 @@ APIs. It's visible when there aren't enough decks to fill the screen.
     <color name="theme_light_primary">@color/material_light_blue_500</color>
     <color name="theme_light_primary_dark">@color/material_light_blue_700</color>
     <color name="theme_light_primary_light">@color/material_light_blue_100</color>
-    <color name="theme_light_accent">@color/material_light_blue_800</color>
+    <color name="theme_light_accent">@color/material_light_blue_600</color>
     <color name="theme_light_primary_text">@color/black</color>
     <color name="theme_light_secondary_text">#de000000</color>  <!-- 87 percent black -->
     <color name="theme_light_row_current">#ececec</color>

--- a/AnkiDroid/src/main/res/values/theme_light.xml
+++ b/AnkiDroid/src/main/res/values/theme_light.xml
@@ -137,15 +137,10 @@ APIs. It's visible when there aren't enough decks to fill the screen.
 
         <item name="editTextDisabled">@color/material_grey_500</item>
 
-<!--        Preference category title color-->
+        <!--Preference category title color-->
         <item name="preferenceCategoryTitleTextColor">@color/black</item>
     </style>
 
-    <style name="toggle_buttos_style" parent="Preference.SwitchPreferenceCompat">
-        <item name="colorAccent">@color/black</item>
-    </style>
-
-    <!-- Preferences screens -->
     <!-- Theme for showing legacy ActionBar without explicitly including a toolbar -->
     <style name="LegacyActionBarLight" parent="Theme_Light">
         <item name="windowActionBar">true</item>

--- a/AnkiDroid/src/main/res/values/theme_light.xml
+++ b/AnkiDroid/src/main/res/values/theme_light.xml
@@ -15,7 +15,7 @@ APIs. It's visible when there aren't enough decks to fill the screen.
     <color name="theme_light_primary">@color/material_light_blue_500</color>
     <color name="theme_light_primary_dark">@color/material_light_blue_700</color>
     <color name="theme_light_primary_light">@color/material_light_blue_100</color>
-    <color name="theme_light_accent">@color/material_blue_grey_700</color>
+    <color name="theme_light_accent">@color/material_light_blue_800</color>
     <color name="theme_light_primary_text">@color/black</color>
     <color name="theme_light_secondary_text">#de000000</color>  <!-- 87 percent black -->
     <color name="theme_light_row_current">#ececec</color>


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
To change the default toggle switch color of preferences screens.

## Fixes
Fixes #10909

## Approach
changing the colorAccent of theme

## How Has This Been Tested?

My physical device : Realme 8i

colorAccent : material_light_blue_800
<img src="https://user-images.githubusercontent.com/73571511/164883188-e76d34b7-06c1-4348-8780-c401fe3bcf9a.jpeg" width="200" height="400" />

colorAccent : material_light_blue_600
<img src="https://user-images.githubusercontent.com/73571511/164912524-217f30d3-dbd2-4b32-b6c8-965543f6ae09.jpeg" width="200" height="400" />


## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [ ] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [ ] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
