### PR TITLE
Fix a bug about multiple decks created when tapping `::xxx` on deck's name

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
@@ -697,6 +697,11 @@ public class Decks extends DeckManager {
         }
         for(int i = 0; i < path.length - 1; i++) {
             String p = path[i];
+            // Fix bugs in issue #11026
+            // Extra check if the parent name was blank when deck is created
+            if ("".equals(p)) {
+                p = "blank";
+            }
             if (TextUtils.isEmpty(s)) {
                 s += p;
             } else {

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/DecksTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/DecksTest.java
@@ -48,6 +48,7 @@ public class DecksTest extends RobolectricTest {
             "scxipjiyozczaaczoawo",
             "cmxieunwoogyxsctnjmv::abcdefgh::ZYXW",
             "cmxieunwoogyxsctnjmv::INSBGDS",
+            "::foobar", // Addition test for issue #11026
     };
     @Test
     public void ensureDeckList() {

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/sched/SchedV2Test.java
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/sched/SchedV2Test.java
@@ -96,6 +96,12 @@ import static org.junit.platform.commons.util.CollectionUtils.getOnlyElement;
 @RunWith(AndroidJUnit4.class)
 public class SchedV2Test extends RobolectricTest {
 
+    /***
+     * Creating a {@code DeckDueTreeNode} tree for subsequent tests.
+     * @param col The deck's id is depend on the collection time.
+     * @param addRev Determines whether to count the identifier of {@code revCount}.
+     * @return
+     */
     @KotlinCleanup("reduce code")
     protected static List<TreeNode<DeckDueTreeNode>> expectedTree(Collection col, boolean addRev) {
         AbstractSched sched = col.getSched();
@@ -110,12 +116,16 @@ public class SchedV2Test extends RobolectricTest {
         DeckDueTreeNode c = new DeckDueTreeNode(col, "cmxieunwoogyxsctnjmv", 1596783600440L, 0, 0, 0);
         DeckDueTreeNode defaul = new DeckDueTreeNode(col, "Default", 1, 0, 0, 0);
         DeckDueTreeNode s = new DeckDueTreeNode(col, "scxipjiyozczaaczoawo", 1596783600420L, 0, 0, 0);
+        DeckDueTreeNode f = new DeckDueTreeNode(col, "blank::foobar", 1596783600540L, 0, 0, 0);
+        DeckDueTreeNode b = new DeckDueTreeNode(col, "blank", 1596783600520L, 0, 0, 0);
 
 
         TreeNode<DeckDueTreeNode> cazNode = new TreeNode<>(caz);
         TreeNode<DeckDueTreeNode> caNode = new TreeNode<>(ca);
         TreeNode<DeckDueTreeNode> ciNode = new TreeNode<>(ci);
         TreeNode<DeckDueTreeNode> cNode = new TreeNode<>((c));
+        TreeNode<DeckDueTreeNode> fNode = new TreeNode<>(f);
+        TreeNode<DeckDueTreeNode> bNode = new TreeNode<>(b);
 
         // add "caz" to "ca"
         caNode.getChildren().add(cazNode);
@@ -129,6 +139,11 @@ public class SchedV2Test extends RobolectricTest {
         cChildren.add(ciNode.getValue());
         cNode.getValue().processChildren(cChildren, addRev);
 
+        // add "f" to "b"
+        bNode.getChildren().add(fNode);
+        bNode.getValue().processChildren(Collections.singletonList(fNode.getValue()), addRev);
+
+        expected.add(bNode);
         expected.add(cNode);
         expected.add(new TreeNode(defaul));
         expected.add(new TreeNode(s));


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
When create a deck with empty parents name will cause a bug, which make multiple "blank" decks created.

## Fixes
Fixes #11026

## Approach
Check whether the parents' name is blank, and replace them to "blank" if so.

## How Has This Been Tested?

Run the automated tests through `./gradlew jacocoTestReport`. And manually test it simulator.

## Learning (optional, can help others)
Think things through. In this issue I learned the basic process of deck creation.

_Links to blog posts, patterns, libraries or addons used to solve this problem_

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
