### PR TITLE
First update of issue.

### DIFF
--- a/lint-rules/src/main/java/com/ichi2/anki/lint/rules/DirectSDK_INTUsage.java
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/DirectSDK_INTUsage.java
@@ -1,0 +1,77 @@
+package com.ichi2.anki.lint.rules;
+
+import com.android.annotations.NonNull;
+import com.android.annotations.Nullable;
+import com.android.tools.lint.client.api.JavaEvaluator;
+import com.android.tools.lint.detector.api.Detector;
+import com.android.tools.lint.detector.api.Implementation;
+import com.android.tools.lint.detector.api.Issue;
+import com.android.tools.lint.detector.api.JavaContext;
+import com.android.tools.lint.detector.api.Scope;
+import com.android.tools.lint.detector.api.SourceCodeScanner;
+import com.google.common.annotations.VisibleForTesting;
+import com.ichi2.anki.lint.utils.Constants;
+import com.ichi2.anki.lint.utils.LintUtils;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiMethod;
+
+import org.jetbrains.uast.UCallExpression;
+import org.jetbrains.uast.UClass;
+import org.jetbrains.uast.UReferenceExpression;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class DirectSDK_INTUsage extends Detector implements SourceCodeScanner {
+
+    @VisibleForTesting
+    static final String ID = "DirectSDK_INTUsage";
+
+    @VisibleForTesting
+    static final String DESCRIPTION = "Check whether SDK_INT is directly used.";
+
+    private static final String EXPLANATION = "Check whether SDK_INT is directly used.";
+    private static Implementation implementation = new Implementation(DirectSDK_INTUsage.class, Scope.JAVA_FILE_SCOPE);
+    public static final Issue ISSUE = Issue.create(
+            ID,
+            DESCRIPTION,
+            EXPLANATION,
+            Constants.ANKI_CODE_STYLE_CATEGORY,
+            Constants.ANKI_CODE_STYLE_PRIORITY,
+            Constants.ANKI_CODE_STYLE_SEVERITY,
+            implementation
+    );
+
+    public DirectSDK_INTUsage(){
+
+    }
+
+    @Nullable
+    @Override
+    public List<String> getApplicableReferenceNames() {
+        List<String> forbiddenReferenceNames = new ArrayList<>();
+        forbiddenReferenceNames.add("SDK_INT");
+        return forbiddenReferenceNames;
+    }
+
+    @Override
+    public void visitReference(@NonNull JavaContext context, @NonNull UReferenceExpression reference, @NonNull PsiElement referenced){
+        super.visitReference(context,reference,referenced);
+        //JavaEvaluator evaluator = context.getEvaluator();
+        //!LintUtils.isAnAllowedClass(foundClasses, "CompatHelper")
+        UClass topClass = context.getUastFile().getClasses().get(0);
+        PsiElement parent=referenced.getParent();
+        PsiElement pParent=parent.getParent();
+
+        if (parent.toString().contains("VERSION") && pParent.toString().contains("Build") && !topClass.toString().contains("CompatHelper")) {
+            context.report(
+                    ISSUE,
+                    reference,
+                    context.getLocation(referenced),
+                    DESCRIPTION
+            );
+        }
+    }
+
+
+}

--- a/lint-rules/src/test/java/com/ichi2/anki/lint/rules/DirectSDK_INTUsageTest.java
+++ b/lint-rules/src/test/java/com/ichi2/anki/lint/rules/DirectSDK_INTUsageTest.java
@@ -1,0 +1,66 @@
+package com.ichi2.anki.lint.rules;
+
+import org.intellij.lang.annotations.Language;
+import org.junit.Test;
+
+import static com.android.tools.lint.checks.infrastructure.TestLintTask.lint;
+import static org.junit.Assert.assertTrue;
+import static com.android.tools.lint.checks.infrastructure.TestFile.JavaTestFile.create;
+
+public class DirectSDK_INTUsageTest {
+    @Language("JAVA")
+    private final String stubBuild = "package android.os;\n" +
+            "public class Build {                         \n" +
+            "public static class VERSION {                \n" +
+            "public static final int SDK_INT = 0;         \n" +
+            "}                                            \n"+
+            "}";
+
+    @Language("JAVA")
+    private final String JavaTestIllegal = "" +
+            "package com.ichi2.anki.lint.rules;                             \n" +
+            "import android.os.Build;          \n" +
+            "public class TestJavaClass {                                   \n" +
+            "    public static void main(String[] args) {                   \n" +
+            "        int sdk=Build.VERSION.SDK_INT;                \n" +
+            "    }                                                          \n" +
+            "}                                                              \n";
+
+    @Language("JAVA")
+    private final String TestWithCompat = "" +
+            "package com.ichi2.anki.lint.rules;\n" +
+            "import android.os.Build;\n" +
+            "public class CompatHelper {\n" +
+            "public static int getSdkVersion() {\n" +
+            "        return Build.VERSION.SDK_INT;\n" +
+            "    }\n" +
+            "}";
+
+
+    @Test
+    public void showsErrorsForInvalidUsage() {
+        lint()
+                .allowMissingSdk()
+                .allowCompilationErrors()
+                .files(create(stubBuild), create(JavaTestIllegal))
+                .issues(DirectSDK_INTUsage.ISSUE)
+                .run()
+                .expectErrorCount(1)
+                .check(output -> {
+                    assertTrue(output.contains(DirectSDK_INTUsage.ID));
+                    assertTrue(output.contains(DirectSDK_INTUsage.DESCRIPTION));
+                });
+    }
+
+
+    @Test
+    public void allowsUsageForCompat() {
+        lint()
+                .allowMissingSdk()
+                .allowCompilationErrors()
+                .files(create(stubBuild), create(TestWithCompat))
+                .issues(DirectSDK_INTUsage.ISSUE)
+                .run()
+                .expectClean();
+    }
+}


### PR DESCRIPTION
## Purpose / Description
In this issue, we need to use lint to specify which codes **can** use `Build.VERSION.SDK_INT` and which **cannot**. 

In this update, we have created two new files, `DirectSDK_INTUsage.java` and `DirectSDK_INTUsageTest.java`. In `DirectSDK_INTUsage.java`, we have designed a set of principles: direct use of `Build.VERSION.SDK_INT` is not allowed, while `Build.VERSION.SDK_INT` defined in `CompatHelper` is allowed. `DirectSDK_INTUsageTest.java` is designed for the above two cases

