### PR TITLE
Fix Overflow Icon Color Change on Config Change (Orientation Change)

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
@@ -81,7 +81,6 @@ import com.ichi2.utils.AndroidUiUtils.isRunningOnTv
 import com.ichi2.utils.Computation
 import com.ichi2.utils.HandlerUtils.getDefaultLooper
 import com.ichi2.utils.HandlerUtils.postDelayedOnNewHandler
-import com.ichi2.utils.HandlerUtils.postOnNewHandler
 import com.ichi2.utils.KotlinCleanup
 import com.ichi2.utils.Permissions.canRecordAudio
 import com.ichi2.utils.ViewGroupUtils.setRenderWorkaround
@@ -134,6 +133,7 @@ open class Reviewer : AbstractFlashcardViewer() {
     // Preferences from the collection
     private var mShowRemainingCardCount = false
     private val mActionButtons = ActionButtons(this)
+    private var mOverflowMenuIsOpen = false
 
     @JvmField
     @VisibleForTesting
@@ -172,6 +172,18 @@ open class Reviewer : AbstractFlashcardViewer() {
         mTextBarLearn = findViewById(R.id.learn_number)
         mTextBarReview = findViewById(R.id.review_number)
         startLoadingCollection()
+    }
+
+    override fun onSaveInstanceState(savedInstanceState: Bundle) {
+        super.onSaveInstanceState(savedInstanceState)
+
+        savedInstanceState.putBoolean("mOverflowMenuIsOpen", mOverflowMenuIsOpen)
+    }
+
+    override fun onRestoreInstanceState(savedInstanceState: Bundle) {
+        super.onRestoreInstanceState(savedInstanceState)
+
+        mOverflowMenuIsOpen = savedInstanceState.getBoolean("mOverflowMenuIsOpen", false)
     }
 
     override fun onPause() {
@@ -656,11 +668,11 @@ open class Reviewer : AbstractFlashcardViewer() {
     }
 
     override fun onMenuOpened(featureId: Int, menu: Menu): Boolean {
-        postOnNewHandler {
-            for (i in 0 until menu.size()) {
-                val menuItem = menu.getItem(i)
-                shouldUseDefaultColor(menuItem)
-            }
+        Timber.d("onMenuOpened()")
+        mOverflowMenuIsOpen = true
+        for (i in 0 until menu.size()) {
+            val menuItem = menu.getItem(i)
+            shouldUseDefaultColor(menuItem)
         }
         return super.onMenuOpened(featureId, menu)
     }
@@ -677,10 +689,13 @@ open class Reviewer : AbstractFlashcardViewer() {
     }
 
     override fun onPanelClosed(featureId: Int, menu: Menu) {
+        Timber.d("onPanelClosed()")
+        mOverflowMenuIsOpen = false
         postDelayedOnNewHandler({ refreshActionBar() }, 100)
     }
 
     override fun onCreateOptionsMenu(menu: Menu): Boolean {
+        Timber.d("onCreateOptionsMenu()")
         // NOTE: This is called every time a new question is shown via invalidate options menu
         menuInflater.inflate(R.menu.reviewer, menu)
         displayIconsOnTv(menu)
@@ -808,6 +823,9 @@ open class Reviewer : AbstractFlashcardViewer() {
         suspend_icon.icon.mutate().alpha = alpha
         setupSubMenu(menu, R.id.action_schedule, ScheduleProvider(this))
         mOnboarding.onCreate()
+        if (mOverflowMenuIsOpen)
+            for (i in 0 until menu.size())
+                shouldUseDefaultColor(menu.getItem(i))
         return super.onCreateOptionsMenu(menu)
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
@@ -41,6 +41,7 @@ import android.widget.LinearLayout
 import android.widget.TextView
 import androidx.annotation.*
 import androidx.appcompat.view.menu.MenuBuilder
+import androidx.appcompat.widget.Toolbar
 import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
 import androidx.core.content.res.ResourcesCompat
@@ -134,6 +135,7 @@ open class Reviewer : AbstractFlashcardViewer() {
     private var mShowRemainingCardCount = false
     private val mActionButtons = ActionButtons(this)
     private var mOverflowMenuIsOpen = false
+    private lateinit var mToolbar: Toolbar
 
     @JvmField
     @VisibleForTesting
@@ -171,6 +173,7 @@ open class Reviewer : AbstractFlashcardViewer() {
         mTextBarNew = findViewById(R.id.new_number)
         mTextBarLearn = findViewById(R.id.learn_number)
         mTextBarReview = findViewById(R.id.review_number)
+        mToolbar = findViewById(R.id.toolbar)
         startLoadingCollection()
     }
 
@@ -683,8 +686,11 @@ open class Reviewer : AbstractFlashcardViewer() {
     private fun shouldUseDefaultColor(menuItem: MenuItem) {
         val drawable = menuItem.icon
         if (drawable != null && !isFlagResource(menuItem.itemId)) {
-            drawable.mutate()
-            drawable.setTint(ResourcesCompat.getColor(resources, R.color.material_blue_600, null))
+            val itemIsOverflowing = mToolbar.findViewById<View>(menuItem.itemId) == null
+            if (itemIsOverflowing) {
+                drawable.mutate()
+                drawable.setTint(ResourcesCompat.getColor(resources, R.color.material_blue_600, null))
+            }
         }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
@@ -694,6 +694,8 @@ open class Reviewer : AbstractFlashcardViewer() {
         postDelayedOnNewHandler({ refreshActionBar() }, 100)
     }
 
+    // Related to https://github.com/ankidroid/Anki-Android/pull/11061#issuecomment-1107868455
+    @NeedsTest("Order of operations needs Testing around Menu (Overflow) Icons and their colors.")
     override fun onCreateOptionsMenu(menu: Menu): Boolean {
         Timber.d("onCreateOptionsMenu()")
         // NOTE: This is called every time a new question is shown via invalidate options menu


### PR DESCRIPTION
## Purpose / Description
Fixed Change in overflow menu icon colors if screen orientation changed

## Fixes
Fixes #11060 
Fixes #11017 

## How Has This Been Tested?
Tested on Emulator

https://user-images.githubusercontent.com/59933477/164968847-3578e565-d8b0-43ac-ab7c-b5634576bd37.mov




## Checklist

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [x] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
