### PR TITLE
Second update of issue.

### DIFF
--- a/lint-rules/src/main/java/com/ichi2/anki/lint/IssueRegistry.java
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/IssueRegistry.java
@@ -7,6 +7,7 @@ import com.android.tools.lint.detector.api.Issue;
 import com.ichi2.anki.lint.rules.ConstantJavaFieldDetector;
 import com.ichi2.anki.lint.rules.CopyrightHeaderExists;
 import com.ichi2.anki.lint.rules.DirectCalendarInstanceUsage;
+import com.ichi2.anki.lint.rules.DirectSdkIntUsage;
 import com.ichi2.anki.lint.rules.DirectSnackbarMakeUsage;
 import com.ichi2.anki.lint.rules.DirectSystemTimeInstantiation;
 import com.ichi2.anki.lint.rules.DirectSystemCurrentTimeMillisUsage;
@@ -61,6 +62,7 @@ public class IssueRegistry extends com.android.tools.lint.client.api.IssueRegist
         issues.add(FixedPreferencesTitleLength.ISSUE_TITLE_LENGTH);
         issues.add(VariableNamingDetector.ISSUE);
         issues.add(InvalidStringFormatDetector.ISSUE);
+        issues.add(DirectSdkIntUsage.ISSUE);
         return issues;
     }
 

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/rules/DirectSdkIntUsage.java
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/DirectSdkIntUsage.java
@@ -1,0 +1,92 @@
+/*
+ *  Copyright (c) 2021 Almas Ahmad <ahmadalmas.786.aa@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.lint.rules;
+
+import com.android.annotations.NonNull;
+import com.android.annotations.Nullable;
+import com.android.tools.lint.detector.api.Detector;
+import com.android.tools.lint.detector.api.Implementation;
+import com.android.tools.lint.detector.api.Issue;
+import com.android.tools.lint.detector.api.JavaContext;
+import com.android.tools.lint.detector.api.Scope;
+import com.android.tools.lint.detector.api.SourceCodeScanner;
+import com.google.common.annotations.VisibleForTesting;
+import com.ichi2.anki.lint.utils.Constants;
+import com.intellij.psi.PsiElement;
+
+import org.jetbrains.uast.UClass;
+import org.jetbrains.uast.UReferenceExpression;
+
+import java.util.ArrayList;
+import java.util.List;
+
+
+public class DirectSdkIntUsage extends Detector implements SourceCodeScanner {
+
+    @VisibleForTesting
+    static final String ID = "DirectSdkIntUsage";
+
+    @VisibleForTesting
+    static final String DESCRIPTION = "Check whether SdkInt is directly used";
+
+    private static final String EXPLANATION = "To improve code consistency within the codebase you should use CompatHelper.getSdkVersion() "+
+            "instead of Build.VERSION.SDK_INT";
+    private static Implementation implementation = new Implementation(DirectSdkIntUsage.class, Scope.JAVA_FILE_SCOPE);
+    public static final Issue ISSUE = Issue.create(
+            ID,
+            DESCRIPTION,
+            EXPLANATION,
+            Constants.ANKI_CODE_STYLE_CATEGORY,
+            Constants.ANKI_CODE_STYLE_PRIORITY,
+            Constants.ANKI_CODE_STYLE_SEVERITY,
+            implementation
+    );
+
+
+    public DirectSdkIntUsage() {
+
+    }
+
+
+    @Nullable
+    @Override
+    public List<String> getApplicableReferenceNames() {
+        List<String> forbiddenReferenceNames = new ArrayList<>();
+        forbiddenReferenceNames.add("SDK_INT");
+        return forbiddenReferenceNames;
+    }
+
+
+    @Override
+    public void visitReference(@NonNull JavaContext context, @NonNull UReferenceExpression reference, @NonNull PsiElement referenced) {
+        super.visitReference(context, reference, referenced);
+        UClass topClass = context.getUastFile().getClasses().get(0);
+        PsiElement parent = referenced.getParent();
+        PsiElement grandParent = parent.getParent();
+
+        if (parent.toString().contains("VERSION") && grandParent.toString().contains("Build") && !topClass.toString().contains("CompatHelper")) {
+            context.report(
+                    ISSUE,
+                    reference,
+                    context.getLocation(referenced),
+                    DESCRIPTION
+            );
+        }
+    }
+
+
+}

--- a/lint-rules/src/test/java/com/ichi2/anki/lint/rules/DirectSdkIntUsageTest.java
+++ b/lint-rules/src/test/java/com/ichi2/anki/lint/rules/DirectSdkIntUsageTest.java
@@ -1,0 +1,83 @@
+/*
+ *  Copyright (c) 2021 Almas Ahmad <ahmadalmas.786.aa@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.lint.rules;
+
+import org.intellij.lang.annotations.Language;
+import org.junit.Test;
+
+import static com.android.tools.lint.checks.infrastructure.TestLintTask.lint;
+import static org.junit.Assert.assertTrue;
+import static com.android.tools.lint.checks.infrastructure.TestFile.JavaTestFile.create;
+
+public class DirectSdkIntUsageTest {
+    @Language("JAVA")
+    private final String stubBuild = "                                      \n" +
+            "package android.os;                                            \n" +
+            "public class Build {                                           \n" +
+            "    public static class VERSION {                              \n" +
+            "        public static final int SDK_INT = 0;                   \n" +
+            "    }                                                          \n" +
+            "}";
+
+    @Language("JAVA")
+    private final String JavaTestIllegal = "                                \n" +
+            "package com.ichi2.anki.lint.rules;                             \n" +
+            "import android.os.Build;                                       \n" +
+            "public class TestJavaClass {                                   \n" +
+            "    public static void main(String[] args) {                   \n" +
+            "        int sdk=Build.VERSION.SDK_INT;                         \n" +
+            "    }                                                          \n" +
+            "}                                                              \n";
+
+    @Language("JAVA")
+    private final String TestWithCompat = "                                 \n" +
+            "package com.ichi2.anki.lint.rules;                             \n" +
+            "import android.os.Build;                                       \n" +
+            "public class CompatHelper {                                    \n" +
+            "    public static int getSdkVersion() {                        \n" +
+            "        return Build.VERSION.SDK_INT;                          \n" +
+            "    }                                                          \n" +
+            "}";
+
+
+    @Test
+    public void showsErrorsForInvalidUsage() {
+        lint()
+                .allowMissingSdk()
+                .allowCompilationErrors()
+                .files(create(stubBuild), create(JavaTestIllegal))
+                .issues(DirectSdkIntUsage.ISSUE)
+                .run()
+                .expectErrorCount(1)
+                .check(output -> {
+                    assertTrue(output.contains(DirectSdkIntUsage.ID));
+                    assertTrue(output.contains(DirectSdkIntUsage.DESCRIPTION));
+                });
+    }
+
+
+    @Test
+    public void allowsUsageForCompat() {
+        lint()
+                .allowMissingSdk()
+                .allowCompilationErrors()
+                .files(create(stubBuild), create(TestWithCompat))
+                .issues(DirectSdkIntUsage.ISSUE)
+                .run()
+                .expectClean();
+    }
+}


### PR DESCRIPTION
## Purpose / Description
In the first update of issue,we made a mistake and cause a irreparable bug.So we discard the first version and make a new update.

In this issue, we need to use lint to specify which codes can use Build.VERSION.SDK_INT and which cannot.

In this update, we have created two new files, DirectSDK_INTUsage.java and DirectSDK_INTUsageTest.java. In DirectSDK_INTUsage.java, we have designed a set of principles: direct use of Build.VERSION.SDK_INT is not allowed, while Build.VERSION.SDK_INT defined in CompatHelper is allowed. DirectSDK_INTUsageTest.java is designed for the above two cases

## Fixes
Fixes https://github.com/ankidroid/Anki-Android/issues/10416
