### PR TITLE
Fix: preferenceKeys detected as duplicate strings

### DIFF
--- a/AnkiDroid/src/main/res/values/attrs.xml
+++ b/AnkiDroid/src/main/res/values/attrs.xml
@@ -15,7 +15,7 @@
 ~ this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
 
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="DuplicateCrowdInStrings">
 
     <!-- Android provides a straightforward way to control action bar styles; an additional color attribute
      specifically for action bar text color isn't necessary, but it simplifies the color setting

--- a/AnkiDroid/src/main/res/values/colors.xml
+++ b/AnkiDroid/src/main/res/values/colors.xml
@@ -12,7 +12,7 @@
 		License along with ~ this program. If not, see
 		<http://www.gnu.org/licenses/>.
 -->
-<resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="UnusedResources">
+<resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="UnusedResources,DuplicateCrowdInStrings">
 
     <color name="wb_fg_color">#B00000FF</color>
     <color name="wb_fg_color_inv">#0099FF</color>

--- a/AnkiDroid/src/main/res/values/constants.xml
+++ b/AnkiDroid/src/main/res/values/constants.xml
@@ -14,7 +14,7 @@
 ~ You should have received a copy of the GNU General Public License along with
 ~ this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
-<resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="MissingTranslation">
+<resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="MissingTranslation,DuplicateCrowdInStrings">
 
     <!--
         WARNING: These values here match static values defined in Deck.java DO

--- a/AnkiDroid/src/main/res/values/dimens.xml
+++ b/AnkiDroid/src/main/res/values/dimens.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="UnusedResources">
+<resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="UnusedResources,DuplicateCrowdInStrings">
     <!-- Material UI side margin: http://web.archive.org/web/20180105203433if_/https://material.io/guidelines/layout/metrics-keylines.html#metrics-keylines-keylines-spacing -->
     <dimen name="side_margin">16dp</dimen>
     <dimen name="touch_target">48dp</dimen>

--- a/AnkiDroid/src/main/res/values/fonts.xml
+++ b/AnkiDroid/src/main/res/values/fonts.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="DuplicateCrowdInStrings">
     <string name="font_fontFamily_medium">sans-serif-medium</string>
 </resources>

--- a/AnkiDroid/src/main/res/values/leakcanary.xml
+++ b/AnkiDroid/src/main/res/values/leakcanary.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="UnusedResources">
+<resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="UnusedResources,DuplicateCrowdInStrings">
     <bool name="leak_canary_allow_in_non_debuggable_build">true</bool>
     <bool name="leak_canary_add_launcher_icon">false</bool>
     <bool name="leak_canary_watcher_auto_install">false</bool>

--- a/AnkiDroid/src/main/res/values/preferences.xml
+++ b/AnkiDroid/src/main/res/values/preferences.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="MissingTranslation">
+<resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="MissingTranslation,DuplicateCrowdInStrings">
     <string name="new_spread_preference">newSpread</string>
     <string name="day_offset_preference">dayOffset</string>
     <string name="learn_cutoff_preference">learnCutoff</string>

--- a/AnkiDroid/src/main/res/values/strings.xml
+++ b/AnkiDroid/src/main/res/values/strings.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="DuplicateCrowdInStrings">
     <string name="ga_trackingId" translatable="false">UA-125800786-1</string>
     <!-- If you go over limits, further hits are dropped, setting a sampling percentage can help -->
     <!-- Current limits: 10MM/month globally, 200K/user && 500/session, 1 ever 2s + 60 in a session -->

--- a/AnkiDroid/src/main/res/values/styles.xml
+++ b/AnkiDroid/src/main/res/values/styles.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="UnusedResources">
+<resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="UnusedResources,DuplicateCrowdInStrings">
 
     <!-- App themes
         These compat themes are just copies of the parent themes here, but some attributes are

--- a/AnkiDroid/src/main/res/values/theme_black.xml
+++ b/AnkiDroid/src/main/res/values/theme_black.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="DuplicateCrowdInStrings">
     <color name="theme_black_primary">#000000</color>
     <color name="theme_black_primary_dark">#000000</color>
     <color name="theme_black_primary_light">#151515</color>

--- a/AnkiDroid/src/main/res/values/theme_dark.xml
+++ b/AnkiDroid/src/main/res/values/theme_dark.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="DuplicateCrowdInStrings">
     <color name="theme_dark_primary">#3d3d3d</color>
     <color name="theme_dark_primary_dark">@color/material_grey_900</color>
     <color name="theme_dark_primary_light">@color/material_grey_800</color>

--- a/AnkiDroid/src/main/res/values/theme_light.xml
+++ b/AnkiDroid/src/main/res/values/theme_light.xml
@@ -11,7 +11,7 @@ See Android bug https://code.google.com/p/android/issues/detail?id=26251
 - windowBackground colors the area under the decklist (and possibly other things) on older
 APIs. It's visible when there aren't enough decks to fill the screen.
 -->
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="DuplicateCrowdInStrings">
     <color name="theme_light_primary">@color/material_light_blue_500</color>
     <color name="theme_light_primary_dark">@color/material_light_blue_700</color>
     <color name="theme_light_primary_light">@color/material_light_blue_100</color>

--- a/AnkiDroid/src/main/res/values/theme_plain.xml
+++ b/AnkiDroid/src/main/res/values/theme_plain.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="DuplicateCrowdInStrings">
     <color name="theme_plain_primary">#9E9E9E</color>
     <color name="theme_plain_primary_dark">#616161</color>
     <color name="theme_plain_primary_light">#F5F5F5</color>

--- a/AnkiDroid/src/main/res/values/xiaomi-theme-overlay.xml
+++ b/AnkiDroid/src/main/res/values/xiaomi-theme-overlay.xml
@@ -14,6 +14,6 @@
   ~  this program.  If not, see <http://www.gnu.org/licenses/>.
   -->
 
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="DuplicateCrowdInStrings">
     <style name="ThemeOverlay.Xiaomi" parent="" />
 </resources>

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/rules/DuplicateCrowdInStrings.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/DuplicateCrowdInStrings.kt
@@ -32,6 +32,7 @@
  *
  *  https://android.googlesource.com/platform/tools/base/+/studio-master-dev/lint/libs/lint-checks/src/main/java/com/android/tools/lint/checks/StringCasingDetector.kt?autodive=0%2F
  */
+@file:Suppress("UnstableApiUsage")
 package com.ichi2.anki.lint.rules
 
 import com.android.SdkConstants.*
@@ -41,30 +42,28 @@ import com.android.tools.lint.detector.api.*
 import com.android.tools.lint.detector.api.Scope.Companion.ALL_RESOURCES_SCOPE
 import com.android.utils.Pair
 import com.ichi2.anki.lint.utils.Constants
-import com.ichi2.anki.lint.utils.KotlinCleanup
 import com.ichi2.anki.lint.utils.StringFormatDetector
 import org.w3c.dom.Element
 import org.w3c.dom.Node
 import java.util.*
 
-@KotlinCleanup("replace java streams")
-@KotlinCleanup("Fix IDE lint")
 class DuplicateCrowdInStrings : ResourceXmlDetector() {
     /*
      * Map of all locale,strings in lower case, to their raw elements to ensure that there are no
      * duplicate strings.
      */
     private val allStrings: HashMap<Pair<String, String>, MutableList<StringDeclaration>> = HashMap<Pair<String, String>, MutableList<StringDeclaration>>()
-    override fun appliesTo(directoryType: ResourceFolderType): Boolean {
-        return directoryType == ResourceFolderType.VALUES
+    override fun appliesTo(folderType: ResourceFolderType): Boolean {
+        return folderType == ResourceFolderType.VALUES
     }
 
-    override fun getApplicableElements(): Collection<String>? {
+    override fun getApplicableElements(): Collection<String> {
         return listOf(TAG_STRING)
     }
 
     override fun visitElement(context: XmlContext, element: Element) {
         // Only check the golden copy - not the translated sources.
+        // We currently do not have the ability to do a 'per file'
         if ("values" != context.file.parentFile.name) {
             return
         }
@@ -82,7 +81,7 @@ class DuplicateCrowdInStrings : ResourceXmlDetector() {
             } else {
                 val sb = StringBuilder()
                 StringFormatDetector.addText(sb, element)
-                if (sb.length != 0) {
+                if (sb.isNotEmpty()) {
                     checkTextNode(context, element, sb.toString())
                 }
             }
@@ -94,7 +93,7 @@ class DuplicateCrowdInStrings : ResourceXmlDetector() {
             return
         }
         val locale = getLocale(context)
-        val key = if (locale != null) Pair.of(locale.full, text.toLowerCase(Locale.forLanguageTag(locale.tag))) else Pair.of("default", text.toLowerCase(Locale.US))
+        val key = if (locale != null) Pair.of(locale.full, text.lowercase(Locale.forLanguageTag(locale.tag))) else Pair.of("default", text.lowercase(Locale.US))
         val handle: Location.Handle = context.createLocationHandle(element)
         handle.clientData = element
         val handleList: MutableList<StringDeclaration> = allStrings.getOrDefault(key, ArrayList<StringDeclaration>())
@@ -112,12 +111,10 @@ class DuplicateCrowdInStrings : ResourceXmlDetector() {
             var prevString = ""
             var caseVaries = false
             val names: MutableList<String> = ArrayList()
-            if (duplicates.stream().allMatch(
-                    { x: StringDeclaration ->
-                        val el = x.location.clientData as Element
-                        el.hasAttribute("comment")
-                    }
-                )
+            if (duplicates.all { x: StringDeclaration ->
+                val el = x.location.clientData as Element
+                el.hasAttribute("comment")
+            }
             ) {
                 // skipping as all instances have a comment
                 continue
@@ -146,7 +143,7 @@ class DuplicateCrowdInStrings : ResourceXmlDetector() {
             for (name in names) {
                 nameValues.add(String.format("`%s`", name))
             }
-            val nameList = formatList(nameValues, nameValues.size, true, false)
+            val nameList = formatList(nameValues, nameValues.size, sort = true, useConjunction = false)
             // we use both quotes and code styling here so it appears in the console quoted
             var message = String.format("Duplicate string value \"`%s`\", used in %s", prevString, nameList)
             if (caseVaries) {

--- a/lint-rules/src/test/java/com/ichi2/anki/lint/rules/DuplicateCrowdInStringsTest.java
+++ b/lint-rules/src/test/java/com/ichi2/anki/lint/rules/DuplicateCrowdInStringsTest.java
@@ -49,6 +49,12 @@ public class DuplicateCrowdInStringsTest {
             "   <string name=\"hello2\" comment=\"hello\">a</string>\n" +
             "</resources>";
 
+    @Language("XML")
+    private final String mIgnoredFile = "<resources tools:ignore=\"AAA,DuplicateCrowdInStrings\">\n" +
+            "   <string name=\"hello\">a</string>\n" +
+            "   <string name=\"hello2\">a</string>\n" +
+            "</resources>";
+
     @Test
     public void duplicateStringsInSameFileDetected() {
         // This appears to be a bug in StringCasingDetector - string is self-referential.
@@ -102,6 +108,17 @@ public class DuplicateCrowdInStringsTest {
         .allowMissingSdk()
         .allowCompilationErrors()
         .files(xml("res/values/string.xml", mDuplicateBothValid))
+        .issues(DuplicateCrowdInStrings.ISSUE)
+        .run()
+        .expectErrorCount(0);
+    }
+
+    @Test
+    public void ignoredFilePasses() {
+        lint()
+        .allowMissingSdk()
+        .allowCompilationErrors()
+        .files(xml("res/values/string.xml", mIgnoredFile))
         .issues(DuplicateCrowdInStrings.ISSUE)
         .run()
         .expectErrorCount(0);


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
fix: Don't apply strings lint to non-strings file

`DuplicateCrowdInStrings` applies to only the /values/ folder but there are other files in the values folder aside from translatable strings (resources, constants, etc...)

## Approach
Refactor

As lint does not currently have a good way to exclude files from linting
So instead we use `tools:ignore` to do this


## How Has This Been Tested?

Unit tested

## Learning (optional, can help others)
We need a guide to teach someone how to 'refresh' a lint rule so `gradlew lint` picks it up

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
