### PR TITLE
fix: Don't apply lint to ignored file

### DIFF
--- a/lint-rules/src/main/java/com/ichi2/anki/lint/rules/DuplicateCrowdInStrings.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/DuplicateCrowdInStrings.kt
@@ -67,6 +67,14 @@ class DuplicateCrowdInStrings : ResourceXmlDetector() {
         if ("values" != context.file.parentFile.name) {
             return
         }
+
+        // parentNode == resources, as we only apply this to <string>
+        element.parentNode.attributes.getNamedItem("tools:ignore")?.let {
+            if (it.nodeValue.contains(ID)) {
+                return
+            }
+        }
+
         val childNodes = element.childNodes
         if (childNodes.length > 0) {
             if (childNodes.length == 1) {
@@ -157,12 +165,14 @@ class DuplicateCrowdInStrings : ResourceXmlDetector() {
     companion object {
         private val IMPLEMENTATION_XML = Implementation(DuplicateCrowdInStrings::class.java, ALL_RESOURCES_SCOPE)
 
+        const val ID = "DuplicateCrowdInStrings"
+
         /**
          * Whether there are any duplicate strings, including capitalization adjustments.
          */
         @JvmField
         var ISSUE: Issue = Issue.create(
-            "DuplicateCrowdInStrings",
+            ID,
             "Duplicate Strings (CrowdIn)",
             "Duplicate strings are ambiguous for translators." +
                 "This lint check looks for duplicate strings, including differences for strings" +

--- a/lint-rules/src/test/java/com/ichi2/anki/lint/rules/DuplicateCrowdInStringsTest.java
+++ b/lint-rules/src/test/java/com/ichi2/anki/lint/rules/DuplicateCrowdInStringsTest.java
@@ -50,9 +50,14 @@ public class DuplicateCrowdInStringsTest {
             "</resources>";
 
     @Language("XML")
-    private final String mIgnoredFile = "<resources tools:ignore=\"AAA,DuplicateCrowdInStrings\">\n" +
+    private final String mIgnoredFile = "<resources xmlns:tools=\"http://schemas.android.com/tools\" tools:ignore=\"AAA,DuplicateCrowdInStrings\">\n" +
             "   <string name=\"hello\">a</string>\n" +
             "   <string name=\"hello2\">a</string>\n" +
+            "</resources>";
+
+    @Language("XML")
+    private final String mNotIgnored = "<resources>\n" +
+            "   <string name=\"hello3\">a</string>\n" +
             "</resources>";
 
     @Test
@@ -115,10 +120,11 @@ public class DuplicateCrowdInStringsTest {
 
     @Test
     public void ignoredFilePasses() {
+        // TODO: this doesn't work over two files. If the tools:ignore is removed, only the single file fails
         lint()
         .allowMissingSdk()
         .allowCompilationErrors()
-        .files(xml("res/values/string.xml", mIgnoredFile))
+        .files(xml("res/values/constants.xml", mIgnoredFile), xml("res/values/strings.xml", mNotIgnored))
         .issues(DuplicateCrowdInStrings.ISSUE)
         .run()
         .expectErrorCount(0);


### PR DESCRIPTION
tools:ignore ignores the outcome, but still processed the file

This caused a bug as it found a duplicate key in an ignored file

and flagged it as an error on the non-ignored file

## Testing

Pulled https://github.com/ankidroid/Anki-Android/pull/11015 and made it pass

## Learning

* tools:ignore only ignores the outcome, it doesn't stop the processing
* Issues with the unit test framework

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
