### PR TITLE
fix: Sync Badge status after editing Custom Study options

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/customstudy/CustomStudyDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/customstudy/CustomStudyDialog.kt
@@ -214,7 +214,7 @@ class CustomStudyDialog(private val collection: Collection, private val customSt
                         deck.put("extendNew", n)
                         collection.decks.save(deck)
                         collection.sched.extendLimits(n, 0)
-                        onLimitsExtended(jumpToReviewer)
+                        onLimitsExtended(true)
                         // Check if new card limit modified
                         if (oldNewValue != n) {
                             // Mark the status as hasChanged
@@ -229,7 +229,7 @@ class CustomStudyDialog(private val collection: Collection, private val customSt
                         deck.put("extendRev", n)
                         collection.decks.save(deck)
                         collection.sched.extendLimits(0, n)
-                        onLimitsExtended(jumpToReviewer)
+                        onLimitsExtended(true)
                         // Check if review card limit modified
                         if (oldRevValue != n) {
                             // Mark the status as hasChanged

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/customstudy/CustomStudyDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/customstudy/CustomStudyDialog.kt
@@ -208,18 +208,26 @@ class CustomStudyDialog(private val collection: Collection, private val customSt
                     STUDY_NEW -> {
                         AnkiDroidApp.getSharedPrefs(requireActivity()).edit().putInt("extendNew", n).apply()
                         val deck = collection.decks.get(did)
+                        val oldNewValue = deck.get("extendNew")
                         deck.put("extendNew", n)
                         collection.decks.save(deck)
                         collection.sched.extendLimits(n, 0)
                         onLimitsExtended(jumpToReviewer)
+                        if (oldNewValue != n) {
+                            SyncStatus.markDataAsChanged()
+                        }
                     }
                     STUDY_REV -> {
                         AnkiDroidApp.getSharedPrefs(requireActivity()).edit().putInt("extendRev", n).apply()
                         val deck = collection.decks.get(did)
+                        val oldRevValue = deck.get("extendRev")
                         deck.put("extendRev", n)
                         collection.decks.save(deck)
                         collection.sched.extendLimits(0, n)
                         onLimitsExtended(jumpToReviewer)
+                        if (oldRevValue != n) {
+                            SyncStatus.markDataAsChanged()
+                        }
                     }
                     STUDY_FORGOT -> {
                         val ar = JSONArray()

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/customstudy/CustomStudyDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/customstudy/CustomStudyDialog.kt
@@ -229,7 +229,7 @@ class CustomStudyDialog(private val collection: Collection, private val customSt
                         deck.put("extendRev", n)
                         collection.decks.save(deck)
                         collection.sched.extendLimits(0, n)
-                        onLimitsExtended(true)
+                        onLimitsExtended(jumpToReviewer)
                         // Check if review card limit modified
                         if (oldRevValue != n) {
                             // Mark the status as hasChanged

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/customstudy/CustomStudyDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/customstudy/CustomStudyDialog.kt
@@ -208,24 +208,30 @@ class CustomStudyDialog(private val collection: Collection, private val customSt
                     STUDY_NEW -> {
                         AnkiDroidApp.getSharedPrefs(requireActivity()).edit().putInt("extendNew", n).apply()
                         val deck = collection.decks.get(did)
+                        // Get old value of new card limit
                         val oldNewValue = deck.get("extendNew")
                         deck.put("extendNew", n)
                         collection.decks.save(deck)
                         collection.sched.extendLimits(n, 0)
                         onLimitsExtended(jumpToReviewer)
+                        // Check if new card limit modified
                         if (oldNewValue != n) {
+                            // Mark the status as hasChanged
                             SyncStatus.markDataAsChanged()
                         }
                     }
                     STUDY_REV -> {
                         AnkiDroidApp.getSharedPrefs(requireActivity()).edit().putInt("extendRev", n).apply()
                         val deck = collection.decks.get(did)
+                        // Get old value of review card limit
                         val oldRevValue = deck.get("extendRev")
                         deck.put("extendRev", n)
                         collection.decks.save(deck)
                         collection.sched.extendLimits(0, n)
                         onLimitsExtended(jumpToReviewer)
+                        // Check if review card limit modified
                         if (oldRevValue != n) {
+                            // Mark the status as hasChanged
                             SyncStatus.markDataAsChanged()
                         }
                     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/customstudy/CustomStudyDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/customstudy/CustomStudyDialog.kt
@@ -189,8 +189,8 @@ class CustomStudyDialog(private val collection: Collection, private val customSt
         }
         // deck id
         val did = requireArguments().getLong("did")
-        // Whether or not to jump straight to the reviewer
-        val jumpToReviewer = requireArguments().getBoolean("jumpToReviewer")
+        // Whether or not to jump straight to the reviewer, default true.
+        val jumpToReviewer = true
         // Set builder parameters
         val builder = MaterialDialog.Builder(requireActivity())
             .customView(v, true)
@@ -214,7 +214,7 @@ class CustomStudyDialog(private val collection: Collection, private val customSt
                         deck.put("extendNew", n)
                         collection.decks.save(deck)
                         collection.sched.extendLimits(n, 0)
-                        onLimitsExtended(true)
+                        onLimitsExtended(jumpToReviewer)
                         // Check if new card limit modified
                         if (oldNewValue != n) {
                             // Mark the status as hasChanged

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/customstudy/CustomStudyDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/customstudy/CustomStudyDialog.kt
@@ -50,6 +50,7 @@ import com.ichi2.utils.HashUtil.HashMapInit
 import com.ichi2.utils.JSONArray
 import com.ichi2.utils.JSONObject
 import com.ichi2.utils.KotlinCleanup
+import com.ichi2.utils.SyncStatus
 import timber.log.Timber
 import java.util.*
 

--- a/lint-rules/src/test/java/com/ichi2/anki/lint/rules/NonPositionalFormatSubstitutionsTest.kt
+++ b/lint-rules/src/test/java/com/ichi2/anki/lint/rules/NonPositionalFormatSubstitutionsTest.kt
@@ -43,8 +43,56 @@ class NonPositionalFormatSubstitutionsTest {
     @Language("XML")
     private val encoded = "<resources><string name=\"hello\">%%</string></resources>"
 
+    @Language("XML")
+    private val pluralPass = """
+        <resources>
+            <plurals name="import_complete_message">
+                <item quantity="one">Cards imported: %1${'$'}d</item>
+                <item quantity="other">Files imported :%1${'$'}d" Total cards imported: %2${'$'}d</item>
+            </plurals>
+        </resources>
+    """.trimIndent()
+
+    @Language("XML")
+    private val pluralPartial = """
+        <resources>
+            <plurals name="import_complete_message">
+                <item quantity="one">Cards imported: %d</item>
+                <item quantity="other">Files imported :%1${'$'}d" Total cards imported: %2${'$'}d</item>
+            </plurals>
+        </resources>
+    """.trimIndent()
+
+    @Language("XML")
+    private val pluralFail = """
+        <resources>
+            <plurals name="import_complete_message">
+                <item quantity="one">Cards imported: %d</item>
+                <item quantity="other">Files imported: %d\nTotal cards imported: %d</item>
+            </plurals>
+        </resources>
+    """.trimIndent()
+
+    @Language("XML")
+    private val pluralMultiple = """
+            <plurals name="reschedule_card_dialog_interval">
+                <item quantity="one">Current interval: %d day</item>
+                <item quantity="few">Keisti Kortelių mokymosi dieną</item>
+                <item quantity="many">Current interval: %d days</item>
+                <item quantity="other">Current interval: %d days</item>
+            </plurals>
+    """.trimIndent()
+
+    @Language("XML")
+    private val pluralMultipleTwo = """
+            <plurals name="in_minutes">
+                <item quantity="one">%1${'$'}d मिनट</item>
+                <item quantity="other">मिनट</item>
+            </plurals>
+    """.trimIndent()
+
     @Test
-    fun errors_if_ambiguous() {
+    fun errorsIfAmbiguous() {
         TestLintTask.lint()
             .allowMissingSdk()
             .allowCompilationErrors()
@@ -55,7 +103,7 @@ class NonPositionalFormatSubstitutionsTest {
     }
 
     @Test
-    fun no_errors_if_valid() {
+    fun `No Errors If Valid`() {
         TestLintTask.lint()
             .allowMissingSdk()
             .allowCompilationErrors()
@@ -66,7 +114,7 @@ class NonPositionalFormatSubstitutionsTest {
     }
 
     @Test
-    fun no_errors_if_unambiguous() {
+    fun `No Errors If Unambiguous`() {
         TestLintTask.lint()
             .allowMissingSdk()
             .allowCompilationErrors()
@@ -77,11 +125,67 @@ class NonPositionalFormatSubstitutionsTest {
     }
 
     @Test
-    fun no_errors_if_encoded() {
+    fun `No Errors If Encoded`() {
         TestLintTask.lint()
             .allowMissingSdk()
             .allowCompilationErrors()
             .files(TestFiles.xml("res/values/string.xml", encoded))
+            .issues(NonPositionalFormatSubstitutions.ISSUE)
+            .run()
+            .expectClean()
+    }
+
+    @Test
+    fun validPluralPassed() {
+        TestLintTask.lint()
+            .allowMissingSdk()
+            .allowCompilationErrors()
+            .files(TestFiles.xml("res/values/string.xml", pluralPass))
+            .issues(NonPositionalFormatSubstitutions.ISSUE)
+            .run()
+            .expectClean()
+    }
+
+    @Test
+    fun pluralPartialFlags() {
+        // If one plural has $1, $2 etc... the other should as well
+        TestLintTask.lint()
+            .allowMissingSdk()
+            .allowCompilationErrors()
+            .files(TestFiles.xml("res/values/string.xml", pluralPartial))
+            .issues(NonPositionalFormatSubstitutions.ISSUE)
+            .run()
+            .expectErrorCount(1)
+    }
+
+    @Test
+    fun `Errors On Plural Issue`() {
+        TestLintTask.lint()
+            .allowMissingSdk()
+            .allowCompilationErrors()
+            .files(TestFiles.xml("res/values/string.xml", pluralFail))
+            .issues(NonPositionalFormatSubstitutions.ISSUE)
+            .run()
+            .expectErrorCount(1)
+    }
+
+    @Test
+    fun pluralIntegrationTest() {
+        TestLintTask.lint()
+            .allowMissingSdk()
+            .allowCompilationErrors()
+            .files(TestFiles.xml("res/values/string.xml", pluralMultiple))
+            .issues(NonPositionalFormatSubstitutions.ISSUE)
+            .run()
+            .expectClean()
+    }
+
+    @Test
+    fun `Plural Integration Test Positional And Nothing`() {
+        TestLintTask.lint()
+            .allowMissingSdk()
+            .allowCompilationErrors()
+            .files(TestFiles.xml("res/values/string.xml", pluralMultipleTwo))
             .issues(NonPositionalFormatSubstitutions.ISSUE)
             .run()
             .expectClean()


### PR DESCRIPTION
Half Fixed, need to add a refresh function after pressing OK button

## Pull Request

## Purpose / Description
Change  the syncStatus properly for correctly presenting sync badge.

## Fixes
Fixes #9978 

## Approach
Call `SyncStatus.markDataAsChanged()` to change the FSN so when page refresh happens (`onCreateOptionsMenu()`), the badge will show up as expected.

## How Has This Been Tested?

Tested on emulator in Android Studio.

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [ ] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [ ] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
