### PR TITLE
lint: verify plural positional format strings

### DIFF
--- a/lint-rules/src/main/java/com/ichi2/anki/lint/rules/NonPositionalFormatSubstitutions.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/NonPositionalFormatSubstitutions.kt
@@ -24,14 +24,18 @@ import com.android.tools.lint.detector.api.ResourceXmlDetector
 import com.android.tools.lint.detector.api.Scope.Companion.ALL_RESOURCES_SCOPE
 import com.android.tools.lint.detector.api.XmlContext
 import com.ichi2.anki.lint.utils.Aapt2Util
+import com.ichi2.anki.lint.utils.Aapt2Util.FormatData
 import com.ichi2.anki.lint.utils.Constants
 import com.ichi2.anki.lint.utils.StringFormatDetector
+import com.ichi2.anki.lint.utils.childrenSequence
 import org.w3c.dom.Element
 import org.w3c.dom.Node
+import java.lang.IllegalStateException
 
 /**
  * Fix for "Multiple substitutions specified in non-positional format"
- * [https://github.com/ankidroid/Anki-Android/issues/10347](https://github.com/ankidroid/Anki-Android/issues/10347)
+ * [Issue 10347](https://github.com/ankidroid/Anki-Android/issues/10347)
+ * [Issue 11072: Plurals](https://github.com/ankidroid/Anki-Android/issues/11072)
  */
 class NonPositionalFormatSubstitutions : ResourceXmlDetector() {
     companion object {
@@ -56,35 +60,75 @@ class NonPositionalFormatSubstitutions : ResourceXmlDetector() {
 
     override fun appliesTo(folderType: ResourceFolderType): Boolean = folderType == ResourceFolderType.VALUES
 
-    override fun getApplicableElements() = listOf(SdkConstants.TAG_STRING)
+    override fun getApplicableElements() = listOf(SdkConstants.TAG_STRING, SdkConstants.TAG_PLURALS)
 
     override fun visitElement(context: XmlContext, element: Element) {
-        // Check both the translated text and the "values" directory.
 
-        val childNodes = element.childNodes
-        if (childNodes.length <= 0) return
+        val elementsToCheck = when (element.tagName) {
+            SdkConstants.TAG_PLURALS -> element.childrenSequence()
+                // skip if the item was not a plural (style, etc...)
+                .filter { it.nodeName == SdkConstants.TAG_ITEM }
+                .filter { it.nodeType == Node.ELEMENT_NODE }
+                .map { it as Element }
+                .toList()
+            SdkConstants.TAG_STRING -> listOf(element)
+            else -> throw IllegalStateException("Unsupported tag: ${element.tagName}")
+        }
 
-        if (childNodes.length == 1) {
-            val child = childNodes.item(0)
-            if (child.nodeType == Node.TEXT_NODE) {
-                checkTextNode(
-                    context,
-                    element,
-                    StringFormatDetector.stripQuotes(child.nodeValue)
-                )
+        val validFormatData =
+            elementsToCheck.mapNotNull { getStringFromElement(it) }
+                .filter { it.isNotEmpty() }
+                // Filter to only string format data
+                .mapNotNull {
+                    Aapt2Util.verifyJavaStringFormat(it).let { formatData ->
+                        when (formatData) {
+                            is FormatData.DateFormatData -> null
+                            is FormatData.StringFormatData -> formatData
+                        }
+                    }
+                }
+
+        validFormatData.filter { it.argCount > 0 }.also { formatData ->
+            // for plurals: report if some have positional args, but not others.
+            // This may not trigger the second check, see unit tests
+            if (formatData.any { !it.hasNonPositionalArguments } && !formatData.all { !it.hasNonPositionalArguments }) {
+                reportPositionalArgumentMismatch(context, element)
             }
-        } else {
-            val sb = StringBuilder()
-            StringFormatDetector.addText(sb, element)
-            if (sb.isNotEmpty()) {
-                checkTextNode(context, element, sb.toString())
-            }
+        }
+
+        // report the invalid nodes
+        for (unused in validFormatData.filter { it.isInvalid }) {
+            reportInvalidPositionalArguments(context, element)
         }
     }
 
-    private fun checkTextNode(context: XmlContext, element: Element, text: String) {
-        if (Aapt2Util.verifyJavaStringFormat(text)) return
+    private fun getStringFromElement(element: Element): String? {
+        // Check both the translated text and the "values" directory.
+        val childNodes = element.childNodes
+        if (childNodes.length <= 0) return null
 
+        if (childNodes.length == 1) {
+            val child = childNodes.item(0)
+            return if (child.nodeType != Node.TEXT_NODE) {
+                null
+            } else {
+                StringFormatDetector.stripQuotes(child.nodeValue)
+            }
+        }
+
+        val sb = StringBuilder()
+        StringFormatDetector.addText(sb, element)
+        return sb.toString()
+    }
+
+    private fun reportPositionalArgumentMismatch(context: XmlContext, element: Element) {
+        val location = context.createLocationHandle(element).resolve()
+
+        // For clarity, the unescaped string is: "%s to %1$s"
+        context.report(ISSUE, location, "Some, but not all plurals have positional arguments. Convert \"%s\" to \"%1\$s\"")
+    }
+
+    private fun reportInvalidPositionalArguments(context: XmlContext, element: Element) {
         val location = context.createLocationHandle(element).resolve()
 
         // For clarity, the unescaped string is: "%s to %1$s"

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/utils/DomExtensions.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/utils/DomExtensions.kt
@@ -1,0 +1,28 @@
+/*
+ *  Copyright (c) 2022 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.lint.utils
+
+import org.w3c.dom.Node
+
+fun Node.childrenSequence() = sequence {
+    var current = firstChild
+
+    while (current != null) {
+        yield(current)
+        current = current.nextSibling
+    }
+}

--- a/lint-rules/src/test/java/com/ichi2/anki/lint/rules/NonPositionalFormatSubstitutionsTest.kt
+++ b/lint-rules/src/test/java/com/ichi2/anki/lint/rules/NonPositionalFormatSubstitutionsTest.kt
@@ -43,6 +43,54 @@ class NonPositionalFormatSubstitutionsTest {
     @Language("XML")
     private val encoded = "<resources><string name=\"hello\">%%</string></resources>"
 
+    @Language("XML")
+    private val pluralPass = """
+        <resources>
+            <plurals name="import_complete_message">
+                <item quantity="one">Cards imported: %1${'$'}d</item>
+                <item quantity="other">Files imported :%1${'$'}d" Total cards imported: %2${'$'}d</item>
+            </plurals>
+        </resources>
+    """.trimIndent()
+
+    @Language("XML")
+    private val pluralPartial = """
+        <resources>
+            <plurals name="import_complete_message">
+                <item quantity="one">Cards imported: %d</item>
+                <item quantity="other">Files imported :%1${'$'}d" Total cards imported: %2${'$'}d</item>
+            </plurals>
+        </resources>
+    """.trimIndent()
+
+    @Language("XML")
+    private val pluralFail = """
+        <resources>
+            <plurals name="import_complete_message">
+                <item quantity="one">Cards imported: %d</item>
+                <item quantity="other">Files imported: %d\nTotal cards imported: %d</item>
+            </plurals>
+        </resources>
+    """.trimIndent()
+
+    @Language("XML")
+    private val pluralMultiple = """
+            <plurals name="reschedule_card_dialog_interval">
+                <item quantity="one">Current interval: %d day</item>
+                <item quantity="few">Keisti Kortelių mokymosi dieną</item>
+                <item quantity="many">Current interval: %d days</item>
+                <item quantity="other">Current interval: %d days</item>
+            </plurals>
+    """.trimIndent()
+
+    @Language("XML")
+    private val pluralMultipleTwo = """
+            <plurals name="in_minutes">
+                <item quantity="one">%1${'$'}d मिनट</item>
+                <item quantity="other">मिनट</item>
+            </plurals>
+    """.trimIndent()
+
     @Test
     fun errors_if_ambiguous() {
         TestLintTask.lint()
@@ -82,6 +130,62 @@ class NonPositionalFormatSubstitutionsTest {
             .allowMissingSdk()
             .allowCompilationErrors()
             .files(TestFiles.xml("res/values/string.xml", encoded))
+            .issues(NonPositionalFormatSubstitutions.ISSUE)
+            .run()
+            .expectClean()
+    }
+
+    @Test
+    fun valid_plural_passed() {
+        TestLintTask.lint()
+            .allowMissingSdk()
+            .allowCompilationErrors()
+            .files(TestFiles.xml("res/values/string.xml", pluralPass))
+            .issues(NonPositionalFormatSubstitutions.ISSUE)
+            .run()
+            .expectClean()
+    }
+
+    @Test
+    fun plural_partial_flags() {
+        // If one plural has $1, $2 etc... the other should as well
+        TestLintTask.lint()
+            .allowMissingSdk()
+            .allowCompilationErrors()
+            .files(TestFiles.xml("res/values/string.xml", pluralPartial))
+            .issues(NonPositionalFormatSubstitutions.ISSUE)
+            .run()
+            .expectErrorCount(1)
+    }
+
+    @Test
+    fun errors_on_plural_issue() {
+        TestLintTask.lint()
+            .allowMissingSdk()
+            .allowCompilationErrors()
+            .files(TestFiles.xml("res/values/string.xml", pluralFail))
+            .issues(NonPositionalFormatSubstitutions.ISSUE)
+            .run()
+            .expectErrorCount(1)
+    }
+
+    @Test
+    fun plural_integration_test() {
+        TestLintTask.lint()
+            .allowMissingSdk()
+            .allowCompilationErrors()
+            .files(TestFiles.xml("res/values/string.xml", pluralMultiple))
+            .issues(NonPositionalFormatSubstitutions.ISSUE)
+            .run()
+            .expectClean()
+    }
+
+    @Test
+    fun plural_integration_test_positional_and_nothing() {
+        TestLintTask.lint()
+            .allowMissingSdk()
+            .allowCompilationErrors()
+            .files(TestFiles.xml("res/values/string.xml", pluralMultipleTwo))
             .issues(NonPositionalFormatSubstitutions.ISSUE)
             .run()
             .expectClean()


### PR DESCRIPTION
`%d Total cards imported: %d`

should be

`%1$d Total cards imported: %2$d`

We already had the code, just apply it to plurals -> item elements

We also have a more complex case:
  * one (valid) plural with one non-positional element: "%s"
  * one (valid) plural with two positional elements: "%1$s, %2$s"

But together, this implies that the plural is given two strings
so the first should be positional

Fixes #11072

## Approach
* extend `verifyJavaStringFormat` to return more information
* extend `NonPositionalFormatSubstitutions` to accept plurals 
* extract obtaining string from `visitElement` + handle plurals
* filter for two issues:
  * The original:  where `verifyJavaStringFormat` returns false
  * A second (plural only): where some format strings are not positional inside the `<plurals>` element

## How Has This Been Tested?

Unit tested, this will have lots of failures

## Learning (optional, can help others)
Kotlin is nice

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
