### PR TITLE
fix(strings): missing positional string args

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Utils.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Utils.java
@@ -202,13 +202,13 @@ public class Utils {
             time_x = (int) (time_s / TIME_HOUR_LONG);
             remaining_seconds = (int) (time_s % TIME_HOUR_LONG);
             remaining = (int) Math.round((float) remaining_seconds / TIME_MINUTE);
-            return res.getQuantityString(R.plurals.reviewer_window_title_hours, time_x, time_x, remaining);
+            return res.getQuantityString(R.plurals.reviewer_window_title_hours_new, time_x, time_x, remaining);
 
         } else {
             time_x = (int) (time_s / TIME_DAY_LONG);
             remaining_seconds = (int) ((float) time_s % TIME_DAY_LONG);
             remaining = (int) Math.round(remaining_seconds / TIME_HOUR);
-            return res.getQuantityString(R.plurals.reviewer_window_title_days, time_x, time_x, remaining);
+            return res.getQuantityString(R.plurals.reviewer_window_title_days_new, time_x, time_x, remaining);
         }
     }
 

--- a/AnkiDroid/src/main/res/values-af/01-core.xml
+++ b/AnkiDroid/src/main/res/values-af/01-core.xml
@@ -70,11 +70,11 @@
         <item quantity="one">%d minuut oor</item>
         <item quantity="other">%d minute oor</item>
     </plurals>
-    <plurals name="reviewer_window_title_hours">
+    <plurals name="reviewer_window_title_hours_new">
         <item quantity="one">%d hour %d left</item>
         <item quantity="other">Ure Oor</item>
     </plurals>
-    <plurals name="reviewer_window_title_days">
+    <plurals name="reviewer_window_title_days_new">
         <item quantity="one">%d day %d left</item>
         <item quantity="other">Dae oor</item>
     </plurals>

--- a/AnkiDroid/src/main/res/values-am/01-core.xml
+++ b/AnkiDroid/src/main/res/values-am/01-core.xml
@@ -70,11 +70,11 @@
         <item quantity="one">%d minute left</item>
         <item quantity="other">%d minutes left</item>
     </plurals>
-    <plurals name="reviewer_window_title_hours">
+    <plurals name="reviewer_window_title_hours_new">
         <item quantity="one">%d hour %d left</item>
         <item quantity="other">%d hours %d left</item>
     </plurals>
-    <plurals name="reviewer_window_title_days">
+    <plurals name="reviewer_window_title_days_new">
         <item quantity="one">%d day %d left</item>
         <item quantity="other">%d days %d left</item>
     </plurals>

--- a/AnkiDroid/src/main/res/values-ar/01-core.xml
+++ b/AnkiDroid/src/main/res/values-ar/01-core.xml
@@ -78,7 +78,7 @@
         <item quantity="many">%d دقيقة متبقية</item>
         <item quantity="other">%d دقيقة متبقية</item>
     </plurals>
-    <plurals name="reviewer_window_title_hours">
+    <plurals name="reviewer_window_title_hours_new">
         <item quantity="zero">تبقى %d ساعة و%d دقيقة</item>
         <item quantity="one">تبقى %d ساعة و%d دقيقة</item>
         <item quantity="two">تبقى %d ساعة و%d دقيقة</item>
@@ -86,7 +86,7 @@
         <item quantity="many">تبقى %d ساعة و%d دقيقة</item>
         <item quantity="other">تبقى %d ساعة و%d دقيقة</item>
     </plurals>
-    <plurals name="reviewer_window_title_days">
+    <plurals name="reviewer_window_title_days_new">
         <item quantity="zero">تبقى %d يوم و%d ساعة</item>
         <item quantity="one">تبقى %d يوم و%d ساعة</item>
         <item quantity="two">تبقى %d يوم و%d ساعة</item>

--- a/AnkiDroid/src/main/res/values-az/01-core.xml
+++ b/AnkiDroid/src/main/res/values-az/01-core.xml
@@ -70,11 +70,11 @@
         <item quantity="one">%d dəqiqə qaldı</item>
         <item quantity="other">%d dəqiqə qaldı</item>
     </plurals>
-    <plurals name="reviewer_window_title_hours">
+    <plurals name="reviewer_window_title_hours_new">
         <item quantity="one">%d hour %d left</item>
         <item quantity="other">%d hours %d left</item>
     </plurals>
-    <plurals name="reviewer_window_title_days">
+    <plurals name="reviewer_window_title_days_new">
         <item quantity="one">%d day %d left</item>
         <item quantity="other">%d days %d left</item>
     </plurals>

--- a/AnkiDroid/src/main/res/values-be/01-core.xml
+++ b/AnkiDroid/src/main/res/values-be/01-core.xml
@@ -74,13 +74,13 @@
         <item quantity="many">Засталося %d хвілін</item>
         <item quantity="other">Засталося %d хвіліны</item>
     </plurals>
-    <plurals name="reviewer_window_title_hours">
+    <plurals name="reviewer_window_title_hours_new">
         <item quantity="one">%d гадзіна %d засталася</item>
         <item quantity="few">%d гадзіны %d засталося</item>
         <item quantity="many">%d гадзін %d засталося</item>
         <item quantity="other">%d гадзін %d засталося</item>
     </plurals>
-    <plurals name="reviewer_window_title_days">
+    <plurals name="reviewer_window_title_days_new">
         <item quantity="one">%d дзень %d засталося</item>
         <item quantity="few">%d дні %d засталіся</item>
         <item quantity="many">%d дзён %d засталося</item>

--- a/AnkiDroid/src/main/res/values-bg/01-core.xml
+++ b/AnkiDroid/src/main/res/values-bg/01-core.xml
@@ -70,11 +70,11 @@
         <item quantity="one">%d минута остава</item>
         <item quantity="other">%d минути остава</item>
     </plurals>
-    <plurals name="reviewer_window_title_hours">
+    <plurals name="reviewer_window_title_hours_new">
         <item quantity="one">%d час %d остава</item>
         <item quantity="other">%d часа %d остават</item>
     </plurals>
-    <plurals name="reviewer_window_title_days">
+    <plurals name="reviewer_window_title_days_new">
         <item quantity="one">%d ден %d остава</item>
         <item quantity="other">%d дни %d остават</item>
     </plurals>

--- a/AnkiDroid/src/main/res/values-bn/01-core.xml
+++ b/AnkiDroid/src/main/res/values-bn/01-core.xml
@@ -70,11 +70,11 @@
         <item quantity="one">%d মিনিট বাকি আছে</item>
         <item quantity="other">%d মিনিট বাকি আছে</item>
     </plurals>
-    <plurals name="reviewer_window_title_hours">
+    <plurals name="reviewer_window_title_hours_new">
         <item quantity="one">%d ঘণ্টা %d বাকি</item>
         <item quantity="other">%d ঘণ্টা %d বাকি</item>
     </plurals>
-    <plurals name="reviewer_window_title_days">
+    <plurals name="reviewer_window_title_days_new">
         <item quantity="one">%d দিন %d বাকি</item>
         <item quantity="other">%d দিন %d বাকি</item>
     </plurals>

--- a/AnkiDroid/src/main/res/values-ca/01-core.xml
+++ b/AnkiDroid/src/main/res/values-ca/01-core.xml
@@ -70,11 +70,11 @@
         <item quantity="one">%d minut restant</item>
         <item quantity="other">%d minuts restants</item>
     </plurals>
-    <plurals name="reviewer_window_title_hours">
+    <plurals name="reviewer_window_title_hours_new">
         <item quantity="one">%d hores %d restants</item>
         <item quantity="other">%s hores %d restants</item>
     </plurals>
-    <plurals name="reviewer_window_title_days">
+    <plurals name="reviewer_window_title_days_new">
         <item quantity="one">%d minuts restants</item>
         <item quantity="other">%d dies %d hores restants</item>
     </plurals>

--- a/AnkiDroid/src/main/res/values-ckb/01-core.xml
+++ b/AnkiDroid/src/main/res/values-ckb/01-core.xml
@@ -70,11 +70,11 @@
         <item quantity="one">%d minute left</item>
         <item quantity="other">%d minutes left</item>
     </plurals>
-    <plurals name="reviewer_window_title_hours">
+    <plurals name="reviewer_window_title_hours_new">
         <item quantity="one">%d hour %d left</item>
         <item quantity="other">%d hours %d left</item>
     </plurals>
-    <plurals name="reviewer_window_title_days">
+    <plurals name="reviewer_window_title_days_new">
         <item quantity="one">%d day %d left</item>
         <item quantity="other">%d days %d left</item>
     </plurals>

--- a/AnkiDroid/src/main/res/values-cs/01-core.xml
+++ b/AnkiDroid/src/main/res/values-cs/01-core.xml
@@ -74,13 +74,13 @@
         <item quantity="many">zbývá %d minuty</item>
         <item quantity="other">zbývá %d minut</item>
     </plurals>
-    <plurals name="reviewer_window_title_hours">
+    <plurals name="reviewer_window_title_hours_new">
         <item quantity="one">Zbývá %d hodina %d</item>
         <item quantity="few">Zbývají %d hodiny %d</item>
         <item quantity="many">Zbývá %d hodiny %d</item>
         <item quantity="other">Zbývá %d hodin %d</item>
     </plurals>
-    <plurals name="reviewer_window_title_days">
+    <plurals name="reviewer_window_title_days_new">
         <item quantity="one">Zbývá %d den %d</item>
         <item quantity="few">Zbývají %d dny %d</item>
         <item quantity="many">Zbývá %d dne %d</item>

--- a/AnkiDroid/src/main/res/values-da/01-core.xml
+++ b/AnkiDroid/src/main/res/values-da/01-core.xml
@@ -70,11 +70,11 @@
         <item quantity="one">%d minutter tilbage</item>
         <item quantity="other">%d minutter tilbage</item>
     </plurals>
-    <plurals name="reviewer_window_title_hours">
+    <plurals name="reviewer_window_title_hours_new">
         <item quantity="one">%d time %d tilbage</item>
         <item quantity="other">%d timer %d tilbage</item>
     </plurals>
-    <plurals name="reviewer_window_title_days">
+    <plurals name="reviewer_window_title_days_new">
         <item quantity="one">%d dag %d tilbage</item>
         <item quantity="other">%d dage %d tilbage</item>
     </plurals>

--- a/AnkiDroid/src/main/res/values-de/01-core.xml
+++ b/AnkiDroid/src/main/res/values-de/01-core.xml
@@ -70,11 +70,11 @@
         <item quantity="one">noch %d Minute</item>
         <item quantity="other">noch %d Minuten</item>
     </plurals>
-    <plurals name="reviewer_window_title_hours">
+    <plurals name="reviewer_window_title_hours_new">
         <item quantity="one">%d Stunde %d übrig</item>
         <item quantity="other">%d Stunden %d verbleiben</item>
     </plurals>
-    <plurals name="reviewer_window_title_days">
+    <plurals name="reviewer_window_title_days_new">
         <item quantity="one">%d Tag %d verbleibt</item>
         <item quantity="other">%d Tage %d verbleiben</item>
     </plurals>

--- a/AnkiDroid/src/main/res/values-el/01-core.xml
+++ b/AnkiDroid/src/main/res/values-el/01-core.xml
@@ -70,11 +70,11 @@
         <item quantity="one">Απέμεινε %d λεπτό</item>
         <item quantity="other">Απόμειναν %d λεπτά</item>
     </plurals>
-    <plurals name="reviewer_window_title_hours">
+    <plurals name="reviewer_window_title_hours_new">
         <item quantity="one">Απομένει %d ώρα %d</item>
         <item quantity="other">Απομένουν %d ώρες %d</item>
     </plurals>
-    <plurals name="reviewer_window_title_days">
+    <plurals name="reviewer_window_title_days_new">
         <item quantity="one">Απομένει %d ημέρα %d</item>
         <item quantity="other">Απομένουν %d ημέρες %d</item>
     </plurals>

--- a/AnkiDroid/src/main/res/values-eo/01-core.xml
+++ b/AnkiDroid/src/main/res/values-eo/01-core.xml
@@ -70,11 +70,11 @@
         <item quantity="one">ankoraŭ %d minuto</item>
         <item quantity="other">ankoraŭ %d minutoj</item>
     </plurals>
-    <plurals name="reviewer_window_title_hours">
+    <plurals name="reviewer_window_title_hours_new">
         <item quantity="one">ankoraŭ %d horo %d</item>
         <item quantity="other">ankoraŭ %d horoj %d</item>
     </plurals>
-    <plurals name="reviewer_window_title_days">
+    <plurals name="reviewer_window_title_days_new">
         <item quantity="one">ankoraŭ %d tago %d</item>
         <item quantity="other">ankoraŭ %d tagoj %d</item>
     </plurals>

--- a/AnkiDroid/src/main/res/values-es-rAR/01-core.xml
+++ b/AnkiDroid/src/main/res/values-es-rAR/01-core.xml
@@ -70,11 +70,11 @@
         <item quantity="one">%d minuto restante</item>
         <item quantity="other">%d minutos restantes</item>
     </plurals>
-    <plurals name="reviewer_window_title_hours">
+    <plurals name="reviewer_window_title_hours_new">
         <item quantity="one">%d hora %d restante</item>
         <item quantity="other">%d horas %d restantes</item>
     </plurals>
-    <plurals name="reviewer_window_title_days">
+    <plurals name="reviewer_window_title_days_new">
         <item quantity="one">%d día %d restante</item>
         <item quantity="other">%d días %d restantes</item>
     </plurals>

--- a/AnkiDroid/src/main/res/values-es-rES/01-core.xml
+++ b/AnkiDroid/src/main/res/values-es-rES/01-core.xml
@@ -70,11 +70,11 @@
         <item quantity="one">%d minuto restante</item>
         <item quantity="other">%d minutos restantes</item>
     </plurals>
-    <plurals name="reviewer_window_title_hours">
+    <plurals name="reviewer_window_title_hours_new">
         <item quantity="one">%d hora %d restante</item>
         <item quantity="other">%d horas %d restantes</item>
     </plurals>
-    <plurals name="reviewer_window_title_days">
+    <plurals name="reviewer_window_title_days_new">
         <item quantity="one">%d día %d restante</item>
         <item quantity="other">%d días %d restantes</item>
     </plurals>

--- a/AnkiDroid/src/main/res/values-et/01-core.xml
+++ b/AnkiDroid/src/main/res/values-et/01-core.xml
@@ -70,11 +70,11 @@
         <item quantity="one">%d minutit jäänud</item>
         <item quantity="other">%d minutit jäänud</item>
     </plurals>
-    <plurals name="reviewer_window_title_hours">
+    <plurals name="reviewer_window_title_hours_new">
         <item quantity="one">%d tund %d jäänud</item>
         <item quantity="other">%d tundi %d jäänud</item>
     </plurals>
-    <plurals name="reviewer_window_title_days">
+    <plurals name="reviewer_window_title_days_new">
         <item quantity="one">%d päev %d jäänud</item>
         <item quantity="other">%d päeva %d jäänud</item>
     </plurals>

--- a/AnkiDroid/src/main/res/values-eu/01-core.xml
+++ b/AnkiDroid/src/main/res/values-eu/01-core.xml
@@ -70,11 +70,11 @@
         <item quantity="one">Minutu %d geratzen da</item>
         <item quantity="other">%d minutu geratzen dira</item>
     </plurals>
-    <plurals name="reviewer_window_title_hours">
+    <plurals name="reviewer_window_title_hours_new">
         <item quantity="one">%d hour %d left</item>
         <item quantity="other">%d hours %d left</item>
     </plurals>
-    <plurals name="reviewer_window_title_days">
+    <plurals name="reviewer_window_title_days_new">
         <item quantity="one">%d day %d left</item>
         <item quantity="other">%d days %d left</item>
     </plurals>

--- a/AnkiDroid/src/main/res/values-fa/01-core.xml
+++ b/AnkiDroid/src/main/res/values-fa/01-core.xml
@@ -70,11 +70,11 @@
         <item quantity="one">%d دقیقه باقیمانده</item>
         <item quantity="other">%d دقیقه باقیمانده</item>
     </plurals>
-    <plurals name="reviewer_window_title_hours">
+    <plurals name="reviewer_window_title_hours_new">
         <item quantity="one">%d ساعت %d باقیمانده است</item>
         <item quantity="other">%d ساعت %d باقیمانده است</item>
     </plurals>
-    <plurals name="reviewer_window_title_days">
+    <plurals name="reviewer_window_title_days_new">
         <item quantity="one">%d روز %d باقیمانده است</item>
         <item quantity="other">%d روز %d باقیمانده است</item>
     </plurals>

--- a/AnkiDroid/src/main/res/values-fi/01-core.xml
+++ b/AnkiDroid/src/main/res/values-fi/01-core.xml
@@ -70,11 +70,11 @@
         <item quantity="one">%d minuutti jäljellä</item>
         <item quantity="other">%d minuuttia jäljellä</item>
     </plurals>
-    <plurals name="reviewer_window_title_hours">
+    <plurals name="reviewer_window_title_hours_new">
         <item quantity="one">%d tunti %d jäljellä</item>
         <item quantity="other">%d tuntia %d jäljellä</item>
     </plurals>
-    <plurals name="reviewer_window_title_days">
+    <plurals name="reviewer_window_title_days_new">
         <item quantity="one">%d päivä %d jäljellä</item>
         <item quantity="other">%d päivää %d jäljellä</item>
     </plurals>

--- a/AnkiDroid/src/main/res/values-fil/01-core.xml
+++ b/AnkiDroid/src/main/res/values-fil/01-core.xml
@@ -71,11 +71,11 @@
 mga natitirang minuto</item>
         <item quantity="other">%d minutong natitira</item>
     </plurals>
-    <plurals name="reviewer_window_title_hours">
+    <plurals name="reviewer_window_title_hours_new">
         <item quantity="one">%d hour %d left</item>
         <item quantity="other">%d hours %d left</item>
     </plurals>
-    <plurals name="reviewer_window_title_days">
+    <plurals name="reviewer_window_title_days_new">
         <item quantity="one">%d day %d left</item>
         <item quantity="other">%d days %d left</item>
     </plurals>

--- a/AnkiDroid/src/main/res/values-fr/01-core.xml
+++ b/AnkiDroid/src/main/res/values-fr/01-core.xml
@@ -70,11 +70,11 @@
         <item quantity="one">%d minute restante</item>
         <item quantity="other">%d minutes restantes</item>
     </plurals>
-    <plurals name="reviewer_window_title_hours">
+    <plurals name="reviewer_window_title_hours_new">
         <item quantity="one">%d heure %d restante</item>
         <item quantity="other">%d heures %d restantes</item>
     </plurals>
-    <plurals name="reviewer_window_title_days">
+    <plurals name="reviewer_window_title_days_new">
         <item quantity="one">%d jour %d restant</item>
         <item quantity="other">%d jours %d restants</item>
     </plurals>

--- a/AnkiDroid/src/main/res/values-fy/01-core.xml
+++ b/AnkiDroid/src/main/res/values-fy/01-core.xml
@@ -70,11 +70,11 @@
         <item quantity="one">%d minute left</item>
         <item quantity="other">%d minutes left</item>
     </plurals>
-    <plurals name="reviewer_window_title_hours">
+    <plurals name="reviewer_window_title_hours_new">
         <item quantity="one">%d hour %d left</item>
         <item quantity="other">%d hours %d left</item>
     </plurals>
-    <plurals name="reviewer_window_title_days">
+    <plurals name="reviewer_window_title_days_new">
         <item quantity="one">%d day %d left</item>
         <item quantity="other">%d days %d left</item>
     </plurals>

--- a/AnkiDroid/src/main/res/values-ga/01-core.xml
+++ b/AnkiDroid/src/main/res/values-ga/01-core.xml
@@ -76,14 +76,14 @@
         <item quantity="many">%d minutes left</item>
         <item quantity="other">%d minutes left</item>
     </plurals>
-    <plurals name="reviewer_window_title_hours">
+    <plurals name="reviewer_window_title_hours_new">
         <item quantity="one">%d hour %d left</item>
         <item quantity="two">%d hours %d left</item>
         <item quantity="few">%d hours %d left</item>
         <item quantity="many">%d hours %d left</item>
         <item quantity="other">%d hours %d left</item>
     </plurals>
-    <plurals name="reviewer_window_title_days">
+    <plurals name="reviewer_window_title_days_new">
         <item quantity="one">%d day %d left</item>
         <item quantity="two">%d days %d left</item>
         <item quantity="few">%d days %d left</item>

--- a/AnkiDroid/src/main/res/values-gl/01-core.xml
+++ b/AnkiDroid/src/main/res/values-gl/01-core.xml
@@ -70,11 +70,11 @@
         <item quantity="one">%d minuto restante</item>
         <item quantity="other">%d minutos restantes</item>
     </plurals>
-    <plurals name="reviewer_window_title_hours">
+    <plurals name="reviewer_window_title_hours_new">
         <item quantity="one">%d hour %d left</item>
         <item quantity="other">%d hours %d left</item>
     </plurals>
-    <plurals name="reviewer_window_title_days">
+    <plurals name="reviewer_window_title_days_new">
         <item quantity="one">%d day %d left</item>
         <item quantity="other">%d days %d left</item>
     </plurals>

--- a/AnkiDroid/src/main/res/values-got/01-core.xml
+++ b/AnkiDroid/src/main/res/values-got/01-core.xml
@@ -70,11 +70,11 @@
         <item quantity="one">Nauh %d minutus</item>
         <item quantity="other">Nauh %d minutjus</item>
     </plurals>
-    <plurals name="reviewer_window_title_hours">
+    <plurals name="reviewer_window_title_hours_new">
         <item quantity="one">%d hour %d left</item>
         <item quantity="other">%d hours %d left</item>
     </plurals>
-    <plurals name="reviewer_window_title_days">
+    <plurals name="reviewer_window_title_days_new">
         <item quantity="one">%d day %d left</item>
         <item quantity="other">%d days %d left</item>
     </plurals>

--- a/AnkiDroid/src/main/res/values-gu/01-core.xml
+++ b/AnkiDroid/src/main/res/values-gu/01-core.xml
@@ -70,11 +70,11 @@
         <item quantity="one">%d minute left</item>
         <item quantity="other">%d minutes left</item>
     </plurals>
-    <plurals name="reviewer_window_title_hours">
+    <plurals name="reviewer_window_title_hours_new">
         <item quantity="one">%d hour %d left</item>
         <item quantity="other">%d hours %d left</item>
     </plurals>
-    <plurals name="reviewer_window_title_days">
+    <plurals name="reviewer_window_title_days_new">
         <item quantity="one">%d day %d left</item>
         <item quantity="other">%d days %d left</item>
     </plurals>

--- a/AnkiDroid/src/main/res/values-heb/01-core.xml
+++ b/AnkiDroid/src/main/res/values-heb/01-core.xml
@@ -74,13 +74,13 @@
         <item quantity="many">נותרו %d דקות</item>
         <item quantity="other">נותרו %d דקות</item>
     </plurals>
-    <plurals name="reviewer_window_title_hours">
+    <plurals name="reviewer_window_title_hours_new">
         <item quantity="one">%d שעה %d נותרה </item>
         <item quantity="two">%d שעות %d נותרו</item>
         <item quantity="many">%d שעות %d נותרו</item>
         <item quantity="other">%d שעות %d נותרו</item>
     </plurals>
-    <plurals name="reviewer_window_title_days">
+    <plurals name="reviewer_window_title_days_new">
         <item quantity="one">נותרו %d ימים ו %d שעות</item>
         <item quantity="two">נותרו %d ימים ו %d שעות</item>
         <item quantity="many">נותרו %d ימים ו %d שעות</item>

--- a/AnkiDroid/src/main/res/values-hi/01-core.xml
+++ b/AnkiDroid/src/main/res/values-hi/01-core.xml
@@ -70,11 +70,11 @@
         <item quantity="one">%d मिनट शेष</item>
         <item quantity="other">%d मिनट बचे हैं</item>
     </plurals>
-    <plurals name="reviewer_window_title_hours">
+    <plurals name="reviewer_window_title_hours_new">
         <item quantity="one">%d घंटे %d बचे हैं</item>
         <item quantity="other">%d घंटे %d बचे हैं</item>
     </plurals>
-    <plurals name="reviewer_window_title_days">
+    <plurals name="reviewer_window_title_days_new">
         <item quantity="one">%d दिन %d बचे हैं</item>
         <item quantity="other">%d दिन %d बचे हैं</item>
     </plurals>

--- a/AnkiDroid/src/main/res/values-hr/01-core.xml
+++ b/AnkiDroid/src/main/res/values-hr/01-core.xml
@@ -72,12 +72,12 @@
         <item quantity="few">%d minute preostale</item>
         <item quantity="other">%d minuta preostalo</item>
     </plurals>
-    <plurals name="reviewer_window_title_hours">
+    <plurals name="reviewer_window_title_hours_new">
         <item quantity="one">%d sat %d preostalo</item>
         <item quantity="few">%d sati %d preostalo</item>
         <item quantity="other">%d sati %d preostalo</item>
     </plurals>
-    <plurals name="reviewer_window_title_days">
+    <plurals name="reviewer_window_title_days_new">
         <item quantity="one">%d dan %d preostalo</item>
         <item quantity="few">%d dana %d preostalo</item>
         <item quantity="other">%d dana %d preostalo</item>

--- a/AnkiDroid/src/main/res/values-hu/01-core.xml
+++ b/AnkiDroid/src/main/res/values-hu/01-core.xml
@@ -70,11 +70,11 @@
         <item quantity="one">%d perc van hátra</item>
         <item quantity="other">%d perc van hátra</item>
     </plurals>
-    <plurals name="reviewer_window_title_hours">
+    <plurals name="reviewer_window_title_hours_new">
         <item quantity="one">%d óra %d maradt</item>
         <item quantity="other">%d óra maradt</item>
     </plurals>
-    <plurals name="reviewer_window_title_days">
+    <plurals name="reviewer_window_title_days_new">
         <item quantity="one">%d nap %d van hátra</item>
         <item quantity="other">%d napok %d vannak hátra</item>
     </plurals>

--- a/AnkiDroid/src/main/res/values-hy/01-core.xml
+++ b/AnkiDroid/src/main/res/values-hy/01-core.xml
@@ -70,11 +70,11 @@
         <item quantity="one">%d րոպե է մնացել</item>
         <item quantity="other">%d րոպե է մնացել</item>
     </plurals>
-    <plurals name="reviewer_window_title_hours">
+    <plurals name="reviewer_window_title_hours_new">
         <item quantity="one">%d hour %d left</item>
         <item quantity="other">%d hours %d left</item>
     </plurals>
-    <plurals name="reviewer_window_title_days">
+    <plurals name="reviewer_window_title_days_new">
         <item quantity="one">%d day %d left</item>
         <item quantity="other">%d days %d left</item>
     </plurals>

--- a/AnkiDroid/src/main/res/values-ind/01-core.xml
+++ b/AnkiDroid/src/main/res/values-ind/01-core.xml
@@ -68,10 +68,10 @@
     <plurals name="reviewer_window_title">
         <item quantity="other">%d menit lagi</item>
     </plurals>
-    <plurals name="reviewer_window_title_hours">
+    <plurals name="reviewer_window_title_hours_new">
         <item quantity="other">%d jam %d mnt lagi</item>
     </plurals>
-    <plurals name="reviewer_window_title_days">
+    <plurals name="reviewer_window_title_days_new">
         <item quantity="other">%d hari %d jam lagi</item>
     </plurals>
     <string name="no_cards_placeholder_title">Koleksi kosong</string>

--- a/AnkiDroid/src/main/res/values-is/01-core.xml
+++ b/AnkiDroid/src/main/res/values-is/01-core.xml
@@ -70,11 +70,11 @@
         <item quantity="one">%d mínuta enn</item>
         <item quantity="other">%d mínutur enn</item>
     </plurals>
-    <plurals name="reviewer_window_title_hours">
+    <plurals name="reviewer_window_title_hours_new">
         <item quantity="one">%d klúkkutími %d enn</item>
         <item quantity="other">%d klúkkutímar %d enn</item>
     </plurals>
-    <plurals name="reviewer_window_title_days">
+    <plurals name="reviewer_window_title_days_new">
         <item quantity="one">%d dagur %d enn</item>
         <item quantity="other">%d dagar %d enn</item>
     </plurals>

--- a/AnkiDroid/src/main/res/values-it/01-core.xml
+++ b/AnkiDroid/src/main/res/values-it/01-core.xml
@@ -70,11 +70,11 @@
         <item quantity="one">Resta %d minuto</item>
         <item quantity="other">Restano %d minuti</item>
     </plurals>
-    <plurals name="reviewer_window_title_hours">
+    <plurals name="reviewer_window_title_hours_new">
         <item quantity="one">%d ora %d rimanente</item>
         <item quantity="other">%d ore %d rimanenti</item>
     </plurals>
-    <plurals name="reviewer_window_title_days">
+    <plurals name="reviewer_window_title_days_new">
         <item quantity="one">%d giorno %d rimanente</item>
         <item quantity="other">%d giorni %d rimanenti</item>
     </plurals>

--- a/AnkiDroid/src/main/res/values-ja/01-core.xml
+++ b/AnkiDroid/src/main/res/values-ja/01-core.xml
@@ -68,10 +68,10 @@
     <plurals name="reviewer_window_title">
         <item quantity="other">残り約 %d 分</item>
     </plurals>
-    <plurals name="reviewer_window_title_hours">
+    <plurals name="reviewer_window_title_hours_new">
         <item quantity="other">残り約 %d 時間 %d 分</item>
     </plurals>
-    <plurals name="reviewer_window_title_days">
+    <plurals name="reviewer_window_title_days_new">
         <item quantity="other">残り約 %d 日と %d 時間</item>
     </plurals>
     <string name="no_cards_placeholder_title">まだデッキがありません</string>

--- a/AnkiDroid/src/main/res/values-jv/01-core.xml
+++ b/AnkiDroid/src/main/res/values-jv/01-core.xml
@@ -68,10 +68,10 @@
     <plurals name="reviewer_window_title">
         <item quantity="other">%d minutes left</item>
     </plurals>
-    <plurals name="reviewer_window_title_hours">
+    <plurals name="reviewer_window_title_hours_new">
         <item quantity="other">%d hours %d left</item>
     </plurals>
-    <plurals name="reviewer_window_title_days">
+    <plurals name="reviewer_window_title_days_new">
         <item quantity="other">%d days %d left</item>
     </plurals>
     <string name="no_cards_placeholder_title">Collection is empty</string>

--- a/AnkiDroid/src/main/res/values-ka/01-core.xml
+++ b/AnkiDroid/src/main/res/values-ka/01-core.xml
@@ -70,11 +70,11 @@
         <item quantity="one">დარჩა %d წუთი</item>
         <item quantity="other">დარჩა %d წუთი</item>
     </plurals>
-    <plurals name="reviewer_window_title_hours">
+    <plurals name="reviewer_window_title_hours_new">
         <item quantity="one">დარჩა %d საათი %d</item>
         <item quantity="other">დარჩა %d საათი %d</item>
     </plurals>
-    <plurals name="reviewer_window_title_days">
+    <plurals name="reviewer_window_title_days_new">
         <item quantity="one">დარჩა %d დღე %d</item>
         <item quantity="other">დარჩა %d დღე %d</item>
     </plurals>

--- a/AnkiDroid/src/main/res/values-kk/01-core.xml
+++ b/AnkiDroid/src/main/res/values-kk/01-core.xml
@@ -70,11 +70,11 @@
         <item quantity="one">%d minute left</item>
         <item quantity="other">%d минута қалды</item>
     </plurals>
-    <plurals name="reviewer_window_title_hours">
+    <plurals name="reviewer_window_title_hours_new">
         <item quantity="one">%d hour %d left</item>
         <item quantity="other">%d сағат %d қалды</item>
     </plurals>
-    <plurals name="reviewer_window_title_days">
+    <plurals name="reviewer_window_title_days_new">
         <item quantity="one">%d күн %d қалды</item>
         <item quantity="other">%d days %d left</item>
     </plurals>

--- a/AnkiDroid/src/main/res/values-km/01-core.xml
+++ b/AnkiDroid/src/main/res/values-km/01-core.xml
@@ -68,10 +68,10 @@
     <plurals name="reviewer_window_title">
         <item quantity="other">នៅសល់​ %d​ នាទី</item>
     </plurals>
-    <plurals name="reviewer_window_title_hours">
+    <plurals name="reviewer_window_title_hours_new">
         <item quantity="other">នៅ​សល់​ %d ម៉ោង</item>
     </plurals>
-    <plurals name="reviewer_window_title_days">
+    <plurals name="reviewer_window_title_days_new">
         <item quantity="other">នៅសល់​ %d ថ្ងៃ</item>
     </plurals>
     <string name="no_cards_placeholder_title">Collection is empty</string>

--- a/AnkiDroid/src/main/res/values-kn/01-core.xml
+++ b/AnkiDroid/src/main/res/values-kn/01-core.xml
@@ -70,11 +70,11 @@
         <item quantity="one">%d ನಿಮಿಷ ಉಳಿದಿದೆ</item>
         <item quantity="other">%d ನಿಮಿಷಗಳು ಉಳಿದಿವೆ</item>
     </plurals>
-    <plurals name="reviewer_window_title_hours">
+    <plurals name="reviewer_window_title_hours_new">
         <item quantity="one">%d ಗಂಟೆ %d ಉಳಿದಿದೆ</item>
         <item quantity="other">%d ಗಂಟೆಗಳು %d ಉಳಿದಿವೆ</item>
     </plurals>
-    <plurals name="reviewer_window_title_days">
+    <plurals name="reviewer_window_title_days_new">
         <item quantity="one">%d ದಿನ %d ಉಳಿದಿದೆ </item>
         <item quantity="other">%d ದಿನಗಳು %d ಉಳಿದಿವೆ</item>
     </plurals>

--- a/AnkiDroid/src/main/res/values-ko/01-core.xml
+++ b/AnkiDroid/src/main/res/values-ko/01-core.xml
@@ -68,10 +68,10 @@
     <plurals name="reviewer_window_title">
         <item quantity="other">%d분 남음</item>
     </plurals>
-    <plurals name="reviewer_window_title_hours">
+    <plurals name="reviewer_window_title_hours_new">
         <item quantity="other">%d 시간 남음</item>
     </plurals>
-    <plurals name="reviewer_window_title_days">
+    <plurals name="reviewer_window_title_days_new">
         <item quantity="other">%d일 %d시간 남음</item>
     </plurals>
     <string name="no_cards_placeholder_title">이 컬렉션은 비어 있습니다</string>

--- a/AnkiDroid/src/main/res/values-ku/01-core.xml
+++ b/AnkiDroid/src/main/res/values-ku/01-core.xml
@@ -70,11 +70,11 @@
         <item quantity="one">%d minute left</item>
         <item quantity="other">%d minutes left</item>
     </plurals>
-    <plurals name="reviewer_window_title_hours">
+    <plurals name="reviewer_window_title_hours_new">
         <item quantity="one">%d hour %d left</item>
         <item quantity="other">%d hours %d left</item>
     </plurals>
-    <plurals name="reviewer_window_title_days">
+    <plurals name="reviewer_window_title_days_new">
         <item quantity="one">%d day %d left</item>
         <item quantity="other">%d days %d left</item>
     </plurals>

--- a/AnkiDroid/src/main/res/values-ky/01-core.xml
+++ b/AnkiDroid/src/main/res/values-ky/01-core.xml
@@ -70,11 +70,11 @@
         <item quantity="one">%d minute left</item>
         <item quantity="other">%d minutes left</item>
     </plurals>
-    <plurals name="reviewer_window_title_hours">
+    <plurals name="reviewer_window_title_hours_new">
         <item quantity="one">%d hour %d left</item>
         <item quantity="other">%d hours %d left</item>
     </plurals>
-    <plurals name="reviewer_window_title_days">
+    <plurals name="reviewer_window_title_days_new">
         <item quantity="one">%d day %d left</item>
         <item quantity="other">%d days %d left</item>
     </plurals>

--- a/AnkiDroid/src/main/res/values-lt/01-core.xml
+++ b/AnkiDroid/src/main/res/values-lt/01-core.xml
@@ -74,13 +74,13 @@
         <item quantity="many">Liko %d minučių</item>
         <item quantity="other">Liko %d min.</item>
     </plurals>
-    <plurals name="reviewer_window_title_hours">
+    <plurals name="reviewer_window_title_hours_new">
         <item quantity="one">%d hour %d left</item>
         <item quantity="few">%d hours %d left</item>
         <item quantity="many">%d hours %d left</item>
         <item quantity="other">%d hours %d left</item>
     </plurals>
-    <plurals name="reviewer_window_title_days">
+    <plurals name="reviewer_window_title_days_new">
         <item quantity="one">%d day %d left</item>
         <item quantity="few">%d days %d left</item>
         <item quantity="many">%d days %d left</item>

--- a/AnkiDroid/src/main/res/values-lv/01-core.xml
+++ b/AnkiDroid/src/main/res/values-lv/01-core.xml
@@ -72,12 +72,12 @@
         <item quantity="one">%d minute left</item>
         <item quantity="other">%d minutes left</item>
     </plurals>
-    <plurals name="reviewer_window_title_hours">
+    <plurals name="reviewer_window_title_hours_new">
         <item quantity="zero">%d hours %d left</item>
         <item quantity="one">%d hour %d left</item>
         <item quantity="other">%d hours %d left</item>
     </plurals>
-    <plurals name="reviewer_window_title_days">
+    <plurals name="reviewer_window_title_days_new">
         <item quantity="zero">%d days %d left</item>
         <item quantity="one">%d day %d left</item>
         <item quantity="other">%d days %d left</item>

--- a/AnkiDroid/src/main/res/values-mk/01-core.xml
+++ b/AnkiDroid/src/main/res/values-mk/01-core.xml
@@ -70,11 +70,11 @@
         <item quantity="one">остана %d минута</item>
         <item quantity="other">останаа %d минути</item>
     </plurals>
-    <plurals name="reviewer_window_title_hours">
+    <plurals name="reviewer_window_title_hours_new">
         <item quantity="one">%d саат %d останат</item>
         <item quantity="other">%d hours %d left</item>
     </plurals>
-    <plurals name="reviewer_window_title_days">
+    <plurals name="reviewer_window_title_days_new">
         <item quantity="one">%d ден %d останат</item>
         <item quantity="other">%d days %d left</item>
     </plurals>

--- a/AnkiDroid/src/main/res/values-ml/01-core.xml
+++ b/AnkiDroid/src/main/res/values-ml/01-core.xml
@@ -70,11 +70,11 @@
         <item quantity="one">%d മിനിറ്റ് ശേഷിക്കുന്നു</item>
         <item quantity="other">%d മിനിറ്റ് ശേഷിക്കുന്നു</item>
     </plurals>
-    <plurals name="reviewer_window_title_hours">
+    <plurals name="reviewer_window_title_hours_new">
         <item quantity="one">മണിക്കൂർ</item>
         <item quantity="other">മണിക്കൂറുകൾ</item>
     </plurals>
-    <plurals name="reviewer_window_title_days">
+    <plurals name="reviewer_window_title_days_new">
         <item quantity="one">ദിവസങ്ങളിൽ</item>
         <item quantity="other">%d ദിവസം %d ശേഷിക്കുന്നു</item>
     </plurals>

--- a/AnkiDroid/src/main/res/values-mn/01-core.xml
+++ b/AnkiDroid/src/main/res/values-mn/01-core.xml
@@ -70,11 +70,11 @@
         <item quantity="one">%d minute left</item>
         <item quantity="other">%d minutes left</item>
     </plurals>
-    <plurals name="reviewer_window_title_hours">
+    <plurals name="reviewer_window_title_hours_new">
         <item quantity="one">%d hour %d left</item>
         <item quantity="other">%d hours %d left</item>
     </plurals>
-    <plurals name="reviewer_window_title_days">
+    <plurals name="reviewer_window_title_days_new">
         <item quantity="one">%d day %d left</item>
         <item quantity="other">%d days %d left</item>
     </plurals>

--- a/AnkiDroid/src/main/res/values-mr/01-core.xml
+++ b/AnkiDroid/src/main/res/values-mr/01-core.xml
@@ -70,11 +70,11 @@
         <item quantity="one">%d मिनिट शिल्लक आहे</item>
         <item quantity="other">%d मिनिटे शिल्लक आहेत</item>
     </plurals>
-    <plurals name="reviewer_window_title_hours">
+    <plurals name="reviewer_window_title_hours_new">
         <item quantity="one">%d तास %d शिल्लक</item>
         <item quantity="other">%d तास %d शिल्लक</item>
     </plurals>
-    <plurals name="reviewer_window_title_days">
+    <plurals name="reviewer_window_title_days_new">
         <item quantity="one">%d दिवस %d तास बाकी आहे</item>
         <item quantity="other">%d दिवस %d तास बाकी आहेत</item>
     </plurals>

--- a/AnkiDroid/src/main/res/values-ms/01-core.xml
+++ b/AnkiDroid/src/main/res/values-ms/01-core.xml
@@ -68,10 +68,10 @@
     <plurals name="reviewer_window_title">
         <item quantity="other">%d minit tinggal</item>
     </plurals>
-    <plurals name="reviewer_window_title_hours">
+    <plurals name="reviewer_window_title_hours_new">
         <item quantity="other">%d jam %d minit tinggal</item>
     </plurals>
-    <plurals name="reviewer_window_title_days">
+    <plurals name="reviewer_window_title_days_new">
         <item quantity="other">%d hari %d jam tinggal</item>
     </plurals>
     <string name="no_cards_placeholder_title">Koleksi kosong</string>

--- a/AnkiDroid/src/main/res/values-my/01-core.xml
+++ b/AnkiDroid/src/main/res/values-my/01-core.xml
@@ -68,10 +68,10 @@
     <plurals name="reviewer_window_title">
         <item quantity="other">%d minutes left</item>
     </plurals>
-    <plurals name="reviewer_window_title_hours">
+    <plurals name="reviewer_window_title_hours_new">
         <item quantity="other">%d hours %d left</item>
     </plurals>
-    <plurals name="reviewer_window_title_days">
+    <plurals name="reviewer_window_title_days_new">
         <item quantity="other">%d days %d left</item>
     </plurals>
     <string name="no_cards_placeholder_title">Collection is empty</string>

--- a/AnkiDroid/src/main/res/values-nl/01-core.xml
+++ b/AnkiDroid/src/main/res/values-nl/01-core.xml
@@ -70,11 +70,11 @@
         <item quantity="one">%d minuut over</item>
         <item quantity="other">%d minuten over</item>
     </plurals>
-    <plurals name="reviewer_window_title_hours">
+    <plurals name="reviewer_window_title_hours_new">
         <item quantity="one">%d uur %d over</item>
         <item quantity="other">%d uur %d over</item>
     </plurals>
-    <plurals name="reviewer_window_title_days">
+    <plurals name="reviewer_window_title_days_new">
         <item quantity="one">%d dag %d over</item>
         <item quantity="other">%d dagen %d over</item>
     </plurals>

--- a/AnkiDroid/src/main/res/values-nn/01-core.xml
+++ b/AnkiDroid/src/main/res/values-nn/01-core.xml
@@ -70,11 +70,11 @@
         <item quantity="one">%d minutt igjen</item>
         <item quantity="other">%d minutter igjen</item>
     </plurals>
-    <plurals name="reviewer_window_title_hours">
+    <plurals name="reviewer_window_title_hours_new">
         <item quantity="one">%d hour %d left</item>
         <item quantity="other">%d hours %d left</item>
     </plurals>
-    <plurals name="reviewer_window_title_days">
+    <plurals name="reviewer_window_title_days_new">
         <item quantity="one">%d day %d left</item>
         <item quantity="other">%d days %d left</item>
     </plurals>

--- a/AnkiDroid/src/main/res/values-no/01-core.xml
+++ b/AnkiDroid/src/main/res/values-no/01-core.xml
@@ -70,11 +70,11 @@
         <item quantity="one">%d minutt igjen</item>
         <item quantity="other">%d minutter igjen</item>
     </plurals>
-    <plurals name="reviewer_window_title_hours">
+    <plurals name="reviewer_window_title_hours_new">
         <item quantity="one">%d hour %d left</item>
         <item quantity="other">%d hours %d left</item>
     </plurals>
-    <plurals name="reviewer_window_title_days">
+    <plurals name="reviewer_window_title_days_new">
         <item quantity="one">%d day %d left</item>
         <item quantity="other">%d days %d left</item>
     </plurals>

--- a/AnkiDroid/src/main/res/values-or/01-core.xml
+++ b/AnkiDroid/src/main/res/values-or/01-core.xml
@@ -70,11 +70,11 @@
         <item quantity="one">%d ମିନିଟ୍ ବାକି ଅଛି</item>
         <item quantity="other">%d ମିନିଟ୍ ବାକି ଅଛି</item>
     </plurals>
-    <plurals name="reviewer_window_title_hours">
+    <plurals name="reviewer_window_title_hours_new">
         <item quantity="one">%d ଘଣ୍ଟା %d ବାକି ଅଛି</item>
         <item quantity="other">%d ଘଣ୍ଟା %d ବାକି ଅଛି</item>
     </plurals>
-    <plurals name="reviewer_window_title_days">
+    <plurals name="reviewer_window_title_days_new">
         <item quantity="one">%d ଦିନ %d ବାକି ଅଛି</item>
         <item quantity="other">%d ଦିନ %d ବାକି ଅଛି</item>
     </plurals>

--- a/AnkiDroid/src/main/res/values-pa/01-core.xml
+++ b/AnkiDroid/src/main/res/values-pa/01-core.xml
@@ -70,11 +70,11 @@
         <item quantity="one">%d minute left</item>
         <item quantity="other">%d ਮਿੰਟ ਬਾਕੀ</item>
     </plurals>
-    <plurals name="reviewer_window_title_hours">
+    <plurals name="reviewer_window_title_hours_new">
         <item quantity="one">%d hour %d left</item>
         <item quantity="other">%d ਘੰਟੇ ਬਾਕੀ</item>
     </plurals>
-    <plurals name="reviewer_window_title_days">
+    <plurals name="reviewer_window_title_days_new">
         <item quantity="one">%d day %d left</item>
         <item quantity="other">%d ਦਿਨ%d ਬਾਕੀ</item>
     </plurals>

--- a/AnkiDroid/src/main/res/values-pl/01-core.xml
+++ b/AnkiDroid/src/main/res/values-pl/01-core.xml
@@ -74,13 +74,13 @@
         <item quantity="many">Zostało %d minut</item>
         <item quantity="other">Zostało %d minut</item>
     </plurals>
-    <plurals name="reviewer_window_title_hours">
+    <plurals name="reviewer_window_title_hours_new">
         <item quantity="one">Została %d godzina %d</item>
         <item quantity="few">Zostały %d godziny %d</item>
         <item quantity="many">Zostało %d godzin %d</item>
         <item quantity="other">Zostało %d godzin %d</item>
     </plurals>
-    <plurals name="reviewer_window_title_days">
+    <plurals name="reviewer_window_title_days_new">
         <item quantity="one">Został %d dzień %d</item>
         <item quantity="few">Zostały %d dni %d</item>
         <item quantity="many">Zostało %d dni %d</item>

--- a/AnkiDroid/src/main/res/values-pt-rBR/01-core.xml
+++ b/AnkiDroid/src/main/res/values-pt-rBR/01-core.xml
@@ -70,11 +70,11 @@
         <item quantity="one">%d minuto restante</item>
         <item quantity="other">%d minutos restantes</item>
     </plurals>
-    <plurals name="reviewer_window_title_hours">
+    <plurals name="reviewer_window_title_hours_new">
         <item quantity="one">%d hora %d restante</item>
         <item quantity="other">%d horas %d restantes</item>
     </plurals>
-    <plurals name="reviewer_window_title_days">
+    <plurals name="reviewer_window_title_days_new">
         <item quantity="one">%d dia %d restante</item>
         <item quantity="other">%d dias %d restantes</item>
     </plurals>

--- a/AnkiDroid/src/main/res/values-pt-rPT/01-core.xml
+++ b/AnkiDroid/src/main/res/values-pt-rPT/01-core.xml
@@ -70,11 +70,11 @@
         <item quantity="one">%d minuto restante</item>
         <item quantity="other">%d minutos restantes</item>
     </plurals>
-    <plurals name="reviewer_window_title_hours">
+    <plurals name="reviewer_window_title_hours_new">
         <item quantity="one">%d hora restante</item>
         <item quantity="other">%d horas restantes</item>
     </plurals>
-    <plurals name="reviewer_window_title_days">
+    <plurals name="reviewer_window_title_days_new">
         <item quantity="one">%d dia %d restante</item>
         <item quantity="other">%d dias %d restantes</item>
     </plurals>

--- a/AnkiDroid/src/main/res/values-ro/01-core.xml
+++ b/AnkiDroid/src/main/res/values-ro/01-core.xml
@@ -72,12 +72,12 @@
         <item quantity="few">%d minutes left</item>
         <item quantity="other">%d minutes left</item>
     </plurals>
-    <plurals name="reviewer_window_title_hours">
+    <plurals name="reviewer_window_title_hours_new">
         <item quantity="one">%d hour %d left</item>
         <item quantity="few">%d hours %d left</item>
         <item quantity="other">%d hours %d left</item>
     </plurals>
-    <plurals name="reviewer_window_title_days">
+    <plurals name="reviewer_window_title_days_new">
         <item quantity="one">%d day %d left</item>
         <item quantity="few">%d days %d left</item>
         <item quantity="other">%d days %d left</item>

--- a/AnkiDroid/src/main/res/values-ru/01-core.xml
+++ b/AnkiDroid/src/main/res/values-ru/01-core.xml
@@ -74,13 +74,13 @@
         <item quantity="many">Осталось %d минут</item>
         <item quantity="other">Осталось %d минут</item>
     </plurals>
-    <plurals name="reviewer_window_title_hours">
+    <plurals name="reviewer_window_title_hours_new">
         <item quantity="one">%d час %d остался</item>
         <item quantity="few">%d час %d остались</item>
         <item quantity="many">%d час %d остались</item>
         <item quantity="other">%d час %d осталось</item>
     </plurals>
-    <plurals name="reviewer_window_title_days">
+    <plurals name="reviewer_window_title_days_new">
         <item quantity="one">%d день %d остался</item>
         <item quantity="few">%d дня %d остались</item>
         <item quantity="many">%d дней %d остались</item>

--- a/AnkiDroid/src/main/res/values-sat/01-core.xml
+++ b/AnkiDroid/src/main/res/values-sat/01-core.xml
@@ -70,11 +70,11 @@
         <item quantity="one">%d ᱴᱤᱯᱤᱡ ᱥᱟᱨᱟᱡ ᱟᱠᱟᱱᱟ</item>
         <item quantity="other">%d ᱴᱤᱯᱤᱡ ᱥᱟᱨᱟᱡ ᱟᱠᱟᱱᱟ</item>
     </plurals>
-    <plurals name="reviewer_window_title_hours">
+    <plurals name="reviewer_window_title_hours_new">
         <item quantity="one">%d ᱴᱚᱲᱚᱝ %d ᱥᱟᱨᱮᱡ ᱟᱠᱟᱱᱟ</item>
         <item quantity="other">%d ᱴᱚᱲᱚᱝ %d ᱥᱟᱨᱮᱡ ᱟᱠᱟᱱᱟ</item>
     </plurals>
-    <plurals name="reviewer_window_title_days">
+    <plurals name="reviewer_window_title_days_new">
         <item quantity="one">%d ᱫᱤᱱ %d ᱥᱟᱨᱮᱡ ᱟᱠᱟᱱᱟ</item>
         <item quantity="other">%d ᱫᱤᱱ %d ᱥᱟᱨᱮᱡ ᱟᱠᱟᱱᱟ</item>
     </plurals>

--- a/AnkiDroid/src/main/res/values-sc/01-core.xml
+++ b/AnkiDroid/src/main/res/values-sc/01-core.xml
@@ -70,11 +70,11 @@
         <item quantity="one">Mancat %d minutu</item>
         <item quantity="other">Mancant %d minutos</item>
     </plurals>
-    <plurals name="reviewer_window_title_hours">
+    <plurals name="reviewer_window_title_hours_new">
         <item quantity="one">Mancat %d ora %d</item>
         <item quantity="other">Mancant %d oras %d</item>
     </plurals>
-    <plurals name="reviewer_window_title_days">
+    <plurals name="reviewer_window_title_days_new">
         <item quantity="one">Mancat %d die %d</item>
         <item quantity="other">Mancant %d dies %d</item>
     </plurals>

--- a/AnkiDroid/src/main/res/values-sk/01-core.xml
+++ b/AnkiDroid/src/main/res/values-sk/01-core.xml
@@ -74,13 +74,13 @@
         <item quantity="many">zostáva %d minút</item>
         <item quantity="other">zostáva %d minút</item>
     </plurals>
-    <plurals name="reviewer_window_title_hours">
+    <plurals name="reviewer_window_title_hours_new">
         <item quantity="one">%d hodina %d zostáva</item>
         <item quantity="few">%d hodiny %d zostávajú</item>
         <item quantity="many">%d hodín %d zostáva</item>
         <item quantity="other">%d hodín %d zostáva</item>
     </plurals>
-    <plurals name="reviewer_window_title_days">
+    <plurals name="reviewer_window_title_days_new">
         <item quantity="one">%d deň %d zostáva</item>
         <item quantity="few">%d dni %d zostávajú</item>
         <item quantity="many">%d dní %d zostáva</item>

--- a/AnkiDroid/src/main/res/values-sl/01-core.xml
+++ b/AnkiDroid/src/main/res/values-sl/01-core.xml
@@ -74,13 +74,13 @@
         <item quantity="few">Še %d min.</item>
         <item quantity="other">Še %d min.</item>
     </plurals>
-    <plurals name="reviewer_window_title_hours">
+    <plurals name="reviewer_window_title_hours_new">
         <item quantity="one">%d hour %d left</item>
         <item quantity="two">%d hours %d left</item>
         <item quantity="few">%d hours %d left</item>
         <item quantity="other">%d hours %d left</item>
     </plurals>
-    <plurals name="reviewer_window_title_days">
+    <plurals name="reviewer_window_title_days_new">
         <item quantity="one">%d day %d left</item>
         <item quantity="two">%d days %d left</item>
         <item quantity="few">%d days %d left</item>

--- a/AnkiDroid/src/main/res/values-sq/01-core.xml
+++ b/AnkiDroid/src/main/res/values-sq/01-core.xml
@@ -70,11 +70,11 @@
         <item quantity="one">%d minute left</item>
         <item quantity="other">%d minutes left</item>
     </plurals>
-    <plurals name="reviewer_window_title_hours">
+    <plurals name="reviewer_window_title_hours_new">
         <item quantity="one">%d hour %d left</item>
         <item quantity="other">%d hours %d left</item>
     </plurals>
-    <plurals name="reviewer_window_title_days">
+    <plurals name="reviewer_window_title_days_new">
         <item quantity="one">%d day %d left</item>
         <item quantity="other">%d days %d left</item>
     </plurals>

--- a/AnkiDroid/src/main/res/values-sr/01-core.xml
+++ b/AnkiDroid/src/main/res/values-sr/01-core.xml
@@ -72,12 +72,12 @@
         <item quantity="few">%d minutes left</item>
         <item quantity="other">%d минута остало</item>
     </plurals>
-    <plurals name="reviewer_window_title_hours">
+    <plurals name="reviewer_window_title_hours_new">
         <item quantity="one">%d сати %d преостало</item>
         <item quantity="few">%d hours %d left</item>
         <item quantity="other">%d сати %d преостало</item>
     </plurals>
-    <plurals name="reviewer_window_title_days">
+    <plurals name="reviewer_window_title_days_new">
         <item quantity="one">Остао је још %d дан</item>
         <item quantity="few">Остало је још %d дана</item>
         <item quantity="other">%d days %d left</item>

--- a/AnkiDroid/src/main/res/values-ss/01-core.xml
+++ b/AnkiDroid/src/main/res/values-ss/01-core.xml
@@ -70,11 +70,11 @@
         <item quantity="one">%d minute left</item>
         <item quantity="other">%d minutes left</item>
     </plurals>
-    <plurals name="reviewer_window_title_hours">
+    <plurals name="reviewer_window_title_hours_new">
         <item quantity="one">%d hour %d left</item>
         <item quantity="other">%d hours %d left</item>
     </plurals>
-    <plurals name="reviewer_window_title_days">
+    <plurals name="reviewer_window_title_days_new">
         <item quantity="one">%d day %d left</item>
         <item quantity="other">%d days %d left</item>
     </plurals>

--- a/AnkiDroid/src/main/res/values-sv/01-core.xml
+++ b/AnkiDroid/src/main/res/values-sv/01-core.xml
@@ -70,11 +70,11 @@
         <item quantity="one">%d minut kvar</item>
         <item quantity="other">%d minuter kvar</item>
     </plurals>
-    <plurals name="reviewer_window_title_hours">
+    <plurals name="reviewer_window_title_hours_new">
         <item quantity="one">%d timme %d kvar</item>
         <item quantity="other">%d timmar %d kvar</item>
     </plurals>
-    <plurals name="reviewer_window_title_days">
+    <plurals name="reviewer_window_title_days_new">
         <item quantity="one">%d dag %d kvar</item>
         <item quantity="other">%d dagar %d kvar</item>
     </plurals>

--- a/AnkiDroid/src/main/res/values-sw/01-core.xml
+++ b/AnkiDroid/src/main/res/values-sw/01-core.xml
@@ -70,11 +70,11 @@
         <item quantity="one">%d minute left</item>
         <item quantity="other">%d minutes left</item>
     </plurals>
-    <plurals name="reviewer_window_title_hours">
+    <plurals name="reviewer_window_title_hours_new">
         <item quantity="one">%d hour %d left</item>
         <item quantity="other">%d hours %d left</item>
     </plurals>
-    <plurals name="reviewer_window_title_days">
+    <plurals name="reviewer_window_title_days_new">
         <item quantity="one">%d day %d left</item>
         <item quantity="other">%d days %d left</item>
     </plurals>

--- a/AnkiDroid/src/main/res/values-ta/01-core.xml
+++ b/AnkiDroid/src/main/res/values-ta/01-core.xml
@@ -70,11 +70,11 @@
         <item quantity="one">%d நிமிடம் விட்டுவிட்டது</item>
         <item quantity="other">%d நிமிடம் விட்டுவிட்டது</item>
     </plurals>
-    <plurals name="reviewer_window_title_hours">
+    <plurals name="reviewer_window_title_hours_new">
         <item quantity="one">%d hour %d left</item>
         <item quantity="other">%d மணி %d மீதம்</item>
     </plurals>
-    <plurals name="reviewer_window_title_days">
+    <plurals name="reviewer_window_title_days_new">
         <item quantity="one">%d day %d left</item>
         <item quantity="other">%d நாட்கள் %d மீதம்</item>
     </plurals>

--- a/AnkiDroid/src/main/res/values-te/01-core.xml
+++ b/AnkiDroid/src/main/res/values-te/01-core.xml
@@ -70,11 +70,11 @@
         <item quantity="one">%d minute left</item>
         <item quantity="other">%d నిమిషాలు మిగిలి ఉన్నాయి</item>
     </plurals>
-    <plurals name="reviewer_window_title_hours">
+    <plurals name="reviewer_window_title_hours_new">
         <item quantity="one">%d నిమిషం %d మిగిలి ఉంది</item>
         <item quantity="other">%d నిమిషాలు %d మిగిలి ఉన్నాయి</item>
     </plurals>
-    <plurals name="reviewer_window_title_days">
+    <plurals name="reviewer_window_title_days_new">
         <item quantity="one">%d రోజు %d మిగిలి ఉంది </item>
         <item quantity="other">%d రోజులు %d మిగిలి ఉన్నాయి</item>
     </plurals>

--- a/AnkiDroid/src/main/res/values-tg/01-core.xml
+++ b/AnkiDroid/src/main/res/values-tg/01-core.xml
@@ -70,11 +70,11 @@
         <item quantity="one">%d minute left</item>
         <item quantity="other">%d minutes left</item>
     </plurals>
-    <plurals name="reviewer_window_title_hours">
+    <plurals name="reviewer_window_title_hours_new">
         <item quantity="one">%d hour %d left</item>
         <item quantity="other">%d hours %d left</item>
     </plurals>
-    <plurals name="reviewer_window_title_days">
+    <plurals name="reviewer_window_title_days_new">
         <item quantity="one">%d day %d left</item>
         <item quantity="other">%d days %d left</item>
     </plurals>

--- a/AnkiDroid/src/main/res/values-tgl/01-core.xml
+++ b/AnkiDroid/src/main/res/values-tgl/01-core.xml
@@ -76,11 +76,11 @@
 
 %d natitirang mga minuto</item>
     </plurals>
-    <plurals name="reviewer_window_title_hours">
+    <plurals name="reviewer_window_title_hours_new">
         <item quantity="one">%d hour %d left</item>
         <item quantity="other">%d hours %d left</item>
     </plurals>
-    <plurals name="reviewer_window_title_days">
+    <plurals name="reviewer_window_title_days_new">
         <item quantity="one">%d day %d left</item>
         <item quantity="other">%d days %d left</item>
     </plurals>

--- a/AnkiDroid/src/main/res/values-th/01-core.xml
+++ b/AnkiDroid/src/main/res/values-th/01-core.xml
@@ -69,10 +69,10 @@
     <plurals name="reviewer_window_title">
         <item quantity="other">เหลืออีก %d นาที</item>
     </plurals>
-    <plurals name="reviewer_window_title_hours">
+    <plurals name="reviewer_window_title_hours_new">
         <item quantity="other">เหลืออีก %d ชั่วโมง %d</item>
     </plurals>
-    <plurals name="reviewer_window_title_days">
+    <plurals name="reviewer_window_title_days_new">
         <item quantity="other">เหลืออีก %d day %d </item>
     </plurals>
     <string name="no_cards_placeholder_title">Collection is empty</string>

--- a/AnkiDroid/src/main/res/values-ti/01-core.xml
+++ b/AnkiDroid/src/main/res/values-ti/01-core.xml
@@ -70,11 +70,11 @@
         <item quantity="one">ተሪፉካ ዘሎ ደቒቕ %d</item>
         <item quantity="other">%d ተሪፊካ ዘሎ ደቓይቕ</item>
     </plurals>
-    <plurals name="reviewer_window_title_hours">
+    <plurals name="reviewer_window_title_hours_new">
         <item quantity="one">%d hour %d left</item>
         <item quantity="other">%d hours %d left</item>
     </plurals>
-    <plurals name="reviewer_window_title_days">
+    <plurals name="reviewer_window_title_days_new">
         <item quantity="one">%d day %d left</item>
         <item quantity="other">%d days %d left</item>
     </plurals>

--- a/AnkiDroid/src/main/res/values-tn/01-core.xml
+++ b/AnkiDroid/src/main/res/values-tn/01-core.xml
@@ -70,11 +70,11 @@
         <item quantity="one">%d minute left</item>
         <item quantity="other">%d minutes left</item>
     </plurals>
-    <plurals name="reviewer_window_title_hours">
+    <plurals name="reviewer_window_title_hours_new">
         <item quantity="one">%d hour %d left</item>
         <item quantity="other">%d hours %d left</item>
     </plurals>
-    <plurals name="reviewer_window_title_days">
+    <plurals name="reviewer_window_title_days_new">
         <item quantity="one">%d day %d left</item>
         <item quantity="other">%d days %d left</item>
     </plurals>

--- a/AnkiDroid/src/main/res/values-tr/01-core.xml
+++ b/AnkiDroid/src/main/res/values-tr/01-core.xml
@@ -70,11 +70,11 @@
         <item quantity="one">%d dakika kaldı</item>
         <item quantity="other">%d dakika kaldı</item>
     </plurals>
-    <plurals name="reviewer_window_title_hours">
+    <plurals name="reviewer_window_title_hours_new">
         <item quantity="one">%d saat kaldı</item>
         <item quantity="other">%d saat kaldı</item>
     </plurals>
-    <plurals name="reviewer_window_title_days">
+    <plurals name="reviewer_window_title_days_new">
         <item quantity="one">%d gün kaldı</item>
         <item quantity="other">%d gün kaldı</item>
     </plurals>

--- a/AnkiDroid/src/main/res/values-ts/01-core.xml
+++ b/AnkiDroid/src/main/res/values-ts/01-core.xml
@@ -70,11 +70,11 @@
         <item quantity="one">%d minute left</item>
         <item quantity="other">%d minutes left</item>
     </plurals>
-    <plurals name="reviewer_window_title_hours">
+    <plurals name="reviewer_window_title_hours_new">
         <item quantity="one">%d hour %d left</item>
         <item quantity="other">%d hours %d left</item>
     </plurals>
-    <plurals name="reviewer_window_title_days">
+    <plurals name="reviewer_window_title_days_new">
         <item quantity="one">%d day %d left</item>
         <item quantity="other">%d days %d left</item>
     </plurals>

--- a/AnkiDroid/src/main/res/values-tt/01-core.xml
+++ b/AnkiDroid/src/main/res/values-tt/01-core.xml
@@ -68,10 +68,10 @@
     <plurals name="reviewer_window_title">
         <item quantity="other">%d минут калды</item>
     </plurals>
-    <plurals name="reviewer_window_title_hours">
+    <plurals name="reviewer_window_title_hours_new">
         <item quantity="other">%d сәгатъ %d калды</item>
     </plurals>
-    <plurals name="reviewer_window_title_days">
+    <plurals name="reviewer_window_title_days_new">
         <item quantity="other">%d көн %d калды</item>
     </plurals>
     <string name="no_cards_placeholder_title">Коллекция буш</string>

--- a/AnkiDroid/src/main/res/values-uk/01-core.xml
+++ b/AnkiDroid/src/main/res/values-uk/01-core.xml
@@ -74,13 +74,13 @@
         <item quantity="many">Залишилося %d хвилин</item>
         <item quantity="other">Залишилося %d хвилини</item>
     </plurals>
-    <plurals name="reviewer_window_title_hours">
+    <plurals name="reviewer_window_title_hours_new">
         <item quantity="one">залишилася %d година %d</item>
         <item quantity="few">залишилося %d години %d </item>
         <item quantity="many">залишилося %d годин %d </item>
         <item quantity="other">залишилося %d годин %d</item>
     </plurals>
-    <plurals name="reviewer_window_title_days">
+    <plurals name="reviewer_window_title_days_new">
         <item quantity="one">залишився %d день, %d </item>
         <item quantity="few">залишилося %d дні %d</item>
         <item quantity="many">залишилося %d днів %d</item>

--- a/AnkiDroid/src/main/res/values-ur/01-core.xml
+++ b/AnkiDroid/src/main/res/values-ur/01-core.xml
@@ -70,11 +70,11 @@
         <item quantity="one">%d منٹ باقی</item>
         <item quantity="other">%d منٹ باقی</item>
     </plurals>
-    <plurals name="reviewer_window_title_hours">
+    <plurals name="reviewer_window_title_hours_new">
         <item quantity="one">%d hour %d left</item>
         <item quantity="other">%d hours %d left</item>
     </plurals>
-    <plurals name="reviewer_window_title_days">
+    <plurals name="reviewer_window_title_days_new">
         <item quantity="one">%d day %d left</item>
         <item quantity="other">%d days %d left</item>
     </plurals>

--- a/AnkiDroid/src/main/res/values-uz/01-core.xml
+++ b/AnkiDroid/src/main/res/values-uz/01-core.xml
@@ -71,11 +71,11 @@
         <item quantity="one">%d minut qoldi</item>
         <item quantity="other">%d minutes left</item>
     </plurals>
-    <plurals name="reviewer_window_title_hours">
+    <plurals name="reviewer_window_title_hours_new">
         <item quantity="one">%d soat %d qoldi</item>
         <item quantity="other">%d hours %d left</item>
     </plurals>
-    <plurals name="reviewer_window_title_days">
+    <plurals name="reviewer_window_title_days_new">
         <item quantity="one">%d kun %d qoldi</item>
         <item quantity="other">%d days %d left</item>
     </plurals>

--- a/AnkiDroid/src/main/res/values-ve/01-core.xml
+++ b/AnkiDroid/src/main/res/values-ve/01-core.xml
@@ -70,11 +70,11 @@
         <item quantity="one">%d minute left</item>
         <item quantity="other">%d minutes left</item>
     </plurals>
-    <plurals name="reviewer_window_title_hours">
+    <plurals name="reviewer_window_title_hours_new">
         <item quantity="one">%d hour %d left</item>
         <item quantity="other">%d hours %d left</item>
     </plurals>
-    <plurals name="reviewer_window_title_days">
+    <plurals name="reviewer_window_title_days_new">
         <item quantity="one">%d day %d left</item>
         <item quantity="other">%d days %d left</item>
     </plurals>

--- a/AnkiDroid/src/main/res/values-vi/01-core.xml
+++ b/AnkiDroid/src/main/res/values-vi/01-core.xml
@@ -68,10 +68,10 @@
     <plurals name="reviewer_window_title">
         <item quantity="other">còn %d phút</item>
     </plurals>
-    <plurals name="reviewer_window_title_hours">
+    <plurals name="reviewer_window_title_hours_new">
         <item quantity="other">Còn %d giờ %d</item>
     </plurals>
-    <plurals name="reviewer_window_title_days">
+    <plurals name="reviewer_window_title_days_new">
         <item quantity="other">Còn %d ngày %d</item>
     </plurals>
     <string name="no_cards_placeholder_title">Bộ sưu tập trống</string>

--- a/AnkiDroid/src/main/res/values-wo/01-core.xml
+++ b/AnkiDroid/src/main/res/values-wo/01-core.xml
@@ -68,10 +68,10 @@
     <plurals name="reviewer_window_title">
         <item quantity="other">%d minutes left</item>
     </plurals>
-    <plurals name="reviewer_window_title_hours">
+    <plurals name="reviewer_window_title_hours_new">
         <item quantity="other">%d hours %d left</item>
     </plurals>
-    <plurals name="reviewer_window_title_days">
+    <plurals name="reviewer_window_title_days_new">
         <item quantity="other">%d days %d left</item>
     </plurals>
     <string name="no_cards_placeholder_title">Collection is empty</string>

--- a/AnkiDroid/src/main/res/values-xh/01-core.xml
+++ b/AnkiDroid/src/main/res/values-xh/01-core.xml
@@ -70,11 +70,11 @@
         <item quantity="one">%d minute left</item>
         <item quantity="other">%d minutes left</item>
     </plurals>
-    <plurals name="reviewer_window_title_hours">
+    <plurals name="reviewer_window_title_hours_new">
         <item quantity="one">%d hour %d left</item>
         <item quantity="other">%d hours %d left</item>
     </plurals>
-    <plurals name="reviewer_window_title_days">
+    <plurals name="reviewer_window_title_days_new">
         <item quantity="one">%d day %d left</item>
         <item quantity="other">%d days %d left</item>
     </plurals>

--- a/AnkiDroid/src/main/res/values-yue/01-core.xml
+++ b/AnkiDroid/src/main/res/values-yue/01-core.xml
@@ -68,10 +68,10 @@
     <plurals name="reviewer_window_title">
         <item quantity="other">剩低 %d 分鐘</item>
     </plurals>
-    <plurals name="reviewer_window_title_hours">
+    <plurals name="reviewer_window_title_hours_new">
         <item quantity="other">%d hours %d left</item>
     </plurals>
-    <plurals name="reviewer_window_title_days">
+    <plurals name="reviewer_window_title_days_new">
         <item quantity="other">%d days %d left</item>
     </plurals>
     <string name="no_cards_placeholder_title">Collection is empty</string>

--- a/AnkiDroid/src/main/res/values-zh-rCN/01-core.xml
+++ b/AnkiDroid/src/main/res/values-zh-rCN/01-core.xml
@@ -68,10 +68,10 @@
     <plurals name="reviewer_window_title">
         <item quantity="other">剩余%d分钟</item>
     </plurals>
-    <plurals name="reviewer_window_title_hours">
+    <plurals name="reviewer_window_title_hours_new">
         <item quantity="other">剩余 %d 小时 %d</item>
     </plurals>
-    <plurals name="reviewer_window_title_days">
+    <plurals name="reviewer_window_title_days_new">
         <item quantity="other">剩余 %d 天 %d</item>
     </plurals>
     <string name="no_cards_placeholder_title">收藏为空</string>

--- a/AnkiDroid/src/main/res/values-zh-rTW/01-core.xml
+++ b/AnkiDroid/src/main/res/values-zh-rTW/01-core.xml
@@ -68,10 +68,10 @@
     <plurals name="reviewer_window_title">
         <item quantity="other">還有%d分鐘</item>
     </plurals>
-    <plurals name="reviewer_window_title_hours">
+    <plurals name="reviewer_window_title_hours_new">
         <item quantity="other">剩餘 %d 小時 %d 分鐘</item>
     </plurals>
-    <plurals name="reviewer_window_title_days">
+    <plurals name="reviewer_window_title_days_new">
         <item quantity="other">剩餘 %d 天 %d 小時</item>
     </plurals>
     <string name="no_cards_placeholder_title">牌組是空的</string>

--- a/AnkiDroid/src/main/res/values-zu/01-core.xml
+++ b/AnkiDroid/src/main/res/values-zu/01-core.xml
@@ -70,11 +70,11 @@
         <item quantity="one">%d minute left</item>
         <item quantity="other">%d minutes left</item>
     </plurals>
-    <plurals name="reviewer_window_title_hours">
+    <plurals name="reviewer_window_title_hours_new">
         <item quantity="one">%d hour %d left</item>
         <item quantity="other">%d hours %d left</item>
     </plurals>
-    <plurals name="reviewer_window_title_days">
+    <plurals name="reviewer_window_title_days_new">
         <item quantity="one">%d day %d left</item>
         <item quantity="other">%d days %d left</item>
     </plurals>

--- a/AnkiDroid/src/main/res/values/01-core.xml
+++ b/AnkiDroid/src/main/res/values/01-core.xml
@@ -46,13 +46,13 @@
         <item quantity="one">%d minute left</item>
         <item quantity="other">%d minutes left</item>
     </plurals>
-    <plurals name="reviewer_window_title_hours">
-        <item quantity="one">%d hour %d left</item>
-        <item quantity="other">%d hours %d left</item>
+    <plurals name="reviewer_window_title_hours_new">
+        <item quantity="one">%1$d hour %2$d left</item>
+        <item quantity="other">%1$d hours %2$d left</item>
     </plurals>
-    <plurals name="reviewer_window_title_days">
-        <item quantity="one">%d day %d left</item>
-        <item quantity="other">%d days %d left</item>
+    <plurals name="reviewer_window_title_days_new">
+        <item quantity="one">%1$d day %2$d left</item>
+        <item quantity="other">%1$d days %2$d left</item>
     </plurals>
     <string name="no_cards_placeholder_title">Collection is empty</string>
     <string name="no_cards_placeholder_description">Start adding cards\nusing the + icon.</string>


### PR DESCRIPTION
Plurals missing positional string args were previously not detected by either lint or AAPT2. We're about to change that and need to fix issues

the strings in question:
```xml
    <plurals name="reviewer_window_title_hours">
        <item quantity="one">%d hour %d left</item>
        <item quantity="other">%d hours %d left</item>
    </plurals>
    <plurals name="reviewer_window_title_days">
        <item quantity="one">%d day %d left</item>
        <item quantity="other">%d days %d left</item>
    </plurals>
```

## Fixes
* Improves the situation with  #11072
* Mostly unblocks #11081

## Approach

To fix: rename:
`reviewer_window_title_days` -> `reviewer_window_title_days_new`
`reviewer_window_title_hours` -> `reviewer_window_title_hours_new`
and fix the strings: `%d` -> `%1$d`

I renamed the strings as:
* This was easier to do in the IDE, rather than deleting them
* They'll be overwritten on the next translation sync
  * and with less of a 'line change'

## How Has This Been Tested?
Letting our test suite do its thing

## Learning 
* I think this is the best way to deal with string changes when handling the error:

```
/Users/davidallison/StudioProjects/Anki-Android/AnkiDroid/src/main/res/values-ar/01-core.xml:89: Error: The plurals "reviewer_window_title_days" in values-ar has no declaration in the base values folder; this can lead to crashes when the resource is queried in a configuration that does not match this qualifier [MissingDefaultResource]
    <plurals name="reviewer_window_title_days">
             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
184 errors, 0 warnings
```

But it does mean I'm not adding negative lines to my code deletion stats 😜 

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
