### PR TITLE
feat: Double tap FAB to add note 

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -372,7 +372,7 @@ open class DeckPicker : NavigationDrawerActivity(), StudyOptionsListener, SyncEr
         mPullToSyncWrapper.viewTreeObserver.addOnScrollChangedListener { mPullToSyncWrapper.isEnabled = mRecyclerViewLayoutManager.findFirstCompletelyVisibleItemPosition() == 0 }
 
         // Setup the FloatingActionButtons, should work everywhere with min API >= 15
-        mFloatingActionMenu = DeckPickerFloatingActionMenu(view, this)
+        mFloatingActionMenu = DeckPickerFloatingActionMenu(this, view, this)
 
         mReviewSummaryTextView = findViewById(R.id.today_stats_text_view)
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPickerFloatingActionMenu.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPickerFloatingActionMenu.kt
@@ -17,11 +17,13 @@ package com.ichi2.anki
 
 import android.animation.Animator
 import android.content.Context
+import android.view.MotionEvent
 import android.view.View
 import android.widget.LinearLayout
 import android.widget.TextView
 import com.google.android.material.floatingactionbutton.FloatingActionButton
 import com.ichi2.anki.dialogs.CreateDeckDialog
+import com.ichi2.anki.ui.DoubleTapListener
 import timber.log.Timber
 
 class DeckPickerFloatingActionMenu(private val context: Context, view: View, private val deckPicker: DeckPicker) {
@@ -130,13 +132,21 @@ class DeckPickerFloatingActionMenu(private val context: Context, view: View, pri
         val addNoteLabel: TextView = view.findViewById(R.id.add_note_label)
         val addSharedLabel: TextView = view.findViewById(R.id.add_shared_label)
         val addDeckLabel: TextView = view.findViewById(R.id.add_deck_label)
-        mFabMain.setOnClickListener {
-            if (!isFABOpen) {
-                showFloatingActionMenu()
-            } else {
-                closeFloatingActionMenu()
+        mFabMain.setOnTouchListener(object : DoubleTapListener(context) {
+            override fun onDoubleTap(e: MotionEvent?) {
+                addNote()
             }
-        }
+
+            override fun onUnconfirmedSingleTap(e: MotionEvent?) {
+                // we use an unconfirmed tap as we don't want any visual delay in tapping the +
+                // and opening the menu.
+                if (!isFABOpen) {
+                    showFloatingActionMenu()
+                } else {
+                    closeFloatingActionMenu()
+                }
+            }
+        })
         mFabBGLayout.setOnClickListener { closeFloatingActionMenu() }
         val addDeckListener = View.OnClickListener {
             if (isFABOpen) {
@@ -157,10 +167,18 @@ class DeckPickerFloatingActionMenu(private val context: Context, view: View, pri
         addSharedLabel.setOnClickListener(addSharedListener)
         val addNoteListener = View.OnClickListener {
             Timber.d("configureFloatingActionsMenu::addNoteButton::onClickListener - Adding Note")
-            closeFloatingActionMenu()
-            deckPicker.addNote()
+            addNote()
         }
         addNoteButton.setOnClickListener(addNoteListener)
         addNoteLabel.setOnClickListener(addNoteListener)
+    }
+
+    /**
+     * Closes the FAB menu and opens the [NoteEditor]
+     * @see DeckPicker.addNote
+     */
+    private fun addNote() {
+        closeFloatingActionMenu()
+        deckPicker.addNote()
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPickerFloatingActionMenu.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPickerFloatingActionMenu.kt
@@ -16,6 +16,7 @@
 package com.ichi2.anki
 
 import android.animation.Animator
+import android.content.Context
 import android.view.View
 import android.widget.LinearLayout
 import android.widget.TextView
@@ -23,7 +24,7 @@ import com.google.android.material.floatingactionbutton.FloatingActionButton
 import com.ichi2.anki.dialogs.CreateDeckDialog
 import timber.log.Timber
 
-class DeckPickerFloatingActionMenu(view: View, private val deckPicker: DeckPicker) {
+class DeckPickerFloatingActionMenu(private val context: Context, view: View, private val deckPicker: DeckPicker) {
     private val mFabMain: FloatingActionButton = view.findViewById(R.id.fab_main)
     private val mAddSharedLayout: LinearLayout = view.findViewById(R.id.add_shared_layout)
     private val mAddDeckLayout: LinearLayout = view.findViewById(R.id.add_deck_layout)
@@ -38,7 +39,7 @@ class DeckPickerFloatingActionMenu(view: View, private val deckPicker: DeckPicke
         get() = mStudyOptionsFrame != null
 
     private fun animationEnabled(): Boolean {
-        val preferences = AnkiDroidApp.getSharedPrefs(deckPicker)
+        val preferences = AnkiDroidApp.getSharedPrefs(context)
         return !preferences.getBoolean("safeDisplay", false)
     }
 
@@ -140,7 +141,7 @@ class DeckPickerFloatingActionMenu(view: View, private val deckPicker: DeckPicke
         val addDeckListener = View.OnClickListener {
             if (isFABOpen) {
                 closeFloatingActionMenu()
-                val createDeckDialog = CreateDeckDialog(deckPicker, R.string.new_deck, CreateDeckDialog.DeckDialogType.DECK, null)
+                val createDeckDialog = CreateDeckDialog(context, R.string.new_deck, CreateDeckDialog.DeckDialogType.DECK, null)
                 createDeckDialog.setOnNewDeckCreated { deckPicker.updateDeckList() }
                 createDeckDialog.showDialog()
             }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/DoubleTapListener.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/DoubleTapListener.kt
@@ -1,0 +1,103 @@
+/*
+ *  Copyright (c) 2022 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.ui
+
+import android.content.Context
+import android.view.GestureDetector
+import android.view.MotionEvent
+import android.view.View
+
+/**
+ * Adapter handling the case of needing to handle both single and double taps on a control
+ * To be used in [View.setOnTouchListener]
+ *
+ * ```kotlin
+ * view.setOnTouchListener(object: DoubleTapListener(context) {
+ *     override fun onDoubleTap(e: MotionEvent?) {
+ *     }
+ *
+ *     // either of the below, likely not both:
+ *     override fun onConfirmedSingleTap(e: MotionEvent?) {
+ *     override fun onUnconfirmedSingleTap(e: MotionEvent?) {
+ *     }
+ * })
+ * ```
+ *
+ * Source: modified from https://stackoverflow.com/a/19629851
+ */
+abstract class DoubleTapListener(context: Context) : View.OnTouchListener {
+    /**
+     * When a single-tap occurs. this is not certain to be a double-tap.
+     *
+     * Use this if you want a tap action immediately regardless of whether the double tap occurs.
+     *
+     * Use [onConfirmedSingleTap] if you want to wait.
+     *
+     * @param e The down motion event of the single-tap.
+     * @return true if the event is consumed, else false
+     */
+    open fun onUnconfirmedSingleTap(e: MotionEvent?) {
+        // intentionally blank - a maximum of one of the single taps should be overridden
+    }
+
+    /**
+     * When a single-tap occurs. this is certain to be a double-tap.
+     * Uses [android.view.ViewConfiguration.getDoubleTapTimeout] for the timeout
+     *
+     * @param e The down motion event of the single-tap.
+     * @return true if the event is consumed, else false
+     */
+    open fun onConfirmedSingleTap(e: MotionEvent?) {
+        // intentionally blank - a maximum of one of the single taps should be overridden
+    }
+
+    /**
+     * Notified when a double-tap occurs. Triggered on the down event of second tap.
+     * Uses [android.view.ViewConfiguration.getDoubleTapTimeout] for the timeout
+     *
+     * @param e The down motion event of the first tap of the double-tap.
+     * @return true if the event is consumed, else false
+     */
+    abstract fun onDoubleTap(e: MotionEvent?)
+
+    private val detector = object : GestureDetector(
+        context,
+        object : SimpleOnGestureListener() {
+            override fun onDoubleTap(e: MotionEvent?): Boolean {
+                this@DoubleTapListener.onDoubleTap(e)
+                return super.onDoubleTap(e)
+            }
+
+            override fun onSingleTapUp(e: MotionEvent?): Boolean {
+                this@DoubleTapListener.onUnconfirmedSingleTap(e)
+                return super.onSingleTapUp(e)
+            }
+
+            override fun onSingleTapConfirmed(e: MotionEvent?): Boolean {
+                this@DoubleTapListener.onConfirmedSingleTap(e)
+                return super.onSingleTapConfirmed(e)
+            }
+
+            override fun onDown(e: MotionEvent?): Boolean {
+                super.onDown(e)
+                return true
+            }
+        }
+    ) {}
+
+    override fun onTouch(v: View?, event: MotionEvent?): Boolean = detector.onTouchEvent(event)
+}

--- a/AnkiDroid/src/test/java/com/ichi2/anki/DeckPickerFloatingActionMenuTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/DeckPickerFloatingActionMenuTest.kt
@@ -1,0 +1,113 @@
+/*
+ *  Copyright (c) 2022 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki
+
+import android.content.Intent
+import android.view.View
+import android.widget.LinearLayout
+import android.widget.TextView
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.google.android.material.floatingactionbutton.FloatingActionButton
+import com.ichi2.testutils.EmptyApplication
+import com.ichi2.testutils.simulateDoubleTap
+import com.ichi2.testutils.simulateUnconfirmedSingleTap
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Answers
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.kotlin.*
+import org.robolectric.Robolectric
+import org.robolectric.annotation.Config
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Test for [DeckPickerFloatingActionMenu]
+ */
+@RunWith(AndroidJUnit4::class)
+@Config(application = EmptyApplication::class)
+class DeckPickerFloatingActionMenuTest {
+
+    @Mock private val deckPicker: DeckPicker = mock()
+    @Mock private lateinit var mFabMain: FloatingActionButton
+    @Mock private val mAddSharedLayout: LinearLayout = mock(defaultAnswer = Answers.RETURNS_MOCKS)
+    @Mock private val mAddDeckLayout: LinearLayout = mock(defaultAnswer = Answers.RETURNS_MOCKS)
+    @Mock private val mAddNoteLayout: LinearLayout = mock(defaultAnswer = Answers.RETURNS_MOCKS)
+    @Mock private val mFabBGLayout: View = mock()
+    @Mock private val mLinearLayout: LinearLayout = mock()
+    @Mock private val mStudyOptionsFrame: View = mock()
+    @Mock private lateinit var view: View
+
+    @Mock private val addNoteButton: FloatingActionButton = mock()
+    @Mock private val addSharedButton: FloatingActionButton = mock()
+    @Mock private val addDeckButton: FloatingActionButton = mock()
+    @Mock private val addNoteLabel: TextView = mock()
+    @Mock private val addSharedLabel: TextView = mock()
+    @Mock private val addDeckLabel: TextView = mock()
+
+    @InjectMocks
+    private lateinit var menu: DeckPickerFloatingActionMenu
+
+    @Before
+    fun before() {
+        val ankiActivity = Robolectric.buildActivity(AnkiActivity::class.java, Intent()).get()
+        ankiActivity.setTheme(R.style.Theme_Light_Compat)
+        mFabMain = spy(FloatingActionButton(ankiActivity))
+
+        // TODO: Figure out a nicer way of mocking
+        view = mock {
+            on { findViewById<FloatingActionButton>(R.id.fab_main) } doReturn mFabMain
+            on { findViewById<LinearLayout>(R.id.add_shared_layout) } doReturn mAddSharedLayout
+            on { findViewById<LinearLayout>(R.id.add_deck_layout) } doReturn mAddDeckLayout
+            on { findViewById<LinearLayout>(R.id.add_note_layout) } doReturn mAddNoteLayout
+            on { findViewById<View>(R.id.fabBGLayout) } doReturn mFabBGLayout
+            on { findViewById<LinearLayout>(R.id.deckpicker_view) } doReturn mLinearLayout
+            on { findViewById<View>(R.id.studyoptions_fragment) } doReturn mStudyOptionsFrame
+
+            on { findViewById<FloatingActionButton>(R.id.add_note_action) } doReturn addNoteButton
+            on { findViewById<FloatingActionButton>(R.id.add_shared_action) } doReturn addSharedButton
+            on { findViewById<FloatingActionButton>(R.id.add_deck_action) } doReturn addDeckButton
+            on { findViewById<TextView>(R.id.add_note_label) } doReturn addNoteLabel
+            on { findViewById<TextView>(R.id.add_shared_label) } doReturn addSharedLabel
+            on { findViewById<TextView>(R.id.add_deck_label) } doReturn addDeckLabel
+        }
+        menu = DeckPickerFloatingActionMenu(ApplicationProvider.getApplicationContext(), view, deckPicker)
+    }
+
+    @Test
+    fun doubleTapAddsNote() {
+        mFabMain.simulateDoubleTap()
+
+        verify(deckPicker, times(1)).addNote()
+    }
+
+    @Test
+    fun singleTapTogglesFab() {
+        assertFalse("before a tap, menu should not be open") { menu.isFABOpen }
+
+        mFabMain.simulateUnconfirmedSingleTap()
+
+        assertTrue("after a tap, menu should be open") { menu.isFABOpen }
+
+        mFabMain.simulateUnconfirmedSingleTap()
+
+        assertFalse("after a second tap, menu should not be open") { menu.isFABOpen }
+    }
+}

--- a/AnkiDroid/src/test/java/com/ichi2/testutils/ViewUtils.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/testutils/ViewUtils.kt
@@ -1,0 +1,87 @@
+/*
+ *  Copyright (c) 2022 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.testutils
+
+import android.os.SystemClock
+import android.view.MotionEvent
+import android.view.View
+import com.ichi2.anki.ui.DoubleTapListener
+import org.robolectric.Shadows
+
+/**
+ * Constant to be used - extracted from StackOverflow code
+ */
+private val uptime = SystemClock.uptimeMillis()
+
+/** Simulates a double tap for a [DoubleTapListener] */
+fun View.simulateDoubleTap() {
+    fun simulateEvent(action: Int, delta: Int = 0) = simulateEvent(this, action, delta)
+    simulateEvent(MotionEvent.ACTION_DOWN)
+    simulateEvent(MotionEvent.ACTION_UP)
+    // delta needs to be > 30 in Robolectric. GestureDetector: DOUBLE_TAP_MIN_TIME
+    simulateEvent(MotionEvent.ACTION_DOWN, 50)
+    simulateEvent(MotionEvent.ACTION_UP, 50)
+}
+
+/**
+ * Simulates an unconfirmed single tap for a [DoubleTapListener].
+ * Calling this twice will not result in a double-tap
+ */
+fun View.simulateUnconfirmedSingleTap() {
+    fun simulateEvent(action: Int) = simulateEvent(this, action)
+    simulateEvent(MotionEvent.ACTION_DOWN)
+    simulateEvent(MotionEvent.ACTION_UP)
+}
+
+/**
+ * https://stackoverflow.com/a/10124199
+ */
+private fun simulateEvent(target: View, action: Int, delta: Int = 0) {
+    val event = obtainMotionEvent(
+        downTime = uptime + delta,
+        eventTime = uptime + 100 + delta,
+        action = action,
+        x = 0.0f,
+        y = 0.0f,
+        metaState = 0
+    )
+
+    Shadows.shadowOf(target).onTouchListener.onTouch(target, event)
+}
+
+/**
+ * Kotlin wrapper for [MotionEvent.obtain] allowing named arguments
+ * @see MotionEvent.obtain
+ */
+@Suppress("SameParameterValue")
+private fun obtainMotionEvent(
+    downTime: Long,
+    eventTime: Long,
+    action: Int,
+    x: Float,
+    y: Float,
+    metaState: Int
+): MotionEvent {
+    return MotionEvent.obtain(
+        downTime,
+        eventTime,
+        action,
+        x,
+        y,
+        metaState
+    )!!
+}


### PR DESCRIPTION
## Purpose / Description
I liked the UX concept in Discord's "upload file" - a fast path for the common action

## Fixes
Fixes #11084

## Approach
* Create `DoubleTapListener`
* use `DoubleTapListener`
* Extract `context` to allow for testing
* Test

## How Has This Been Tested?
Unit test and tested on my device, bit sluggish under a debugger (as the note editor takes 1 second to open). This was the same as the normal method, but the single 'double tap' made me more latency sensitive.

Outside a debugger: I love it

## Learning (optional, can help others)
* Double tapping: Awesome, 
* Unit tests... UGH
  * My approach was 'just get it working' then refactor, it's still a bit of a mess, it was a lot worse before
* I went through ~5 methods of how to double-tap a button in a test, the final result was a combination of all of them, then giving up and writing my own (with the `MotionEvent` method modified from StackOverflow)
* Testing here really just feels useful in getting our 'base coverage' up: once a class has tests, it's much easier to test in the future (broken windows and all that)

https://stackoverflow.com/a/10124199
https://stackoverflow.com/a/19629851

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
