### PR TITLE
Made Focusable DeckOptions Preferences Auto-Focus

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/preferences/AutoFocusEditTextPreference.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/preferences/AutoFocusEditTextPreference.kt
@@ -1,3 +1,19 @@
+/*
+ *  Copyright (c) 2022 Dorrin Sotoudeh <dorrinsotoudeh123@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package com.ichi2.preferences
 
 import android.content.Context

--- a/AnkiDroid/src/main/java/com/ichi2/preferences/AutoFocusEditTextPreference.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/preferences/AutoFocusEditTextPreference.kt
@@ -20,22 +20,19 @@ import android.content.Context
 import android.util.AttributeSet
 import android.view.View
 import android.widget.EditText
+import com.ichi2.utils.AndroidUiUtils.setFocusAndOpenKeyboard
 
 interface AutoFocusable {
-    fun autoFocus(editText: EditText) {
-        editText.requestFocus()
-        editText.setSelection(editText.text.length)
+    fun autoFocusAndMoveCursorToEnd(editText: EditText) {
+        // focus EditText and place cursor at the end of text
+        setFocusAndOpenKeyboard(editText) { editText.setSelection(editText.text.length) }
     }
 }
 
 @Suppress("deprecation")
-open class AutoFocusEditTextPreference : android.preference.EditTextPreference, AutoFocusable {
-    constructor(context: Context?, attrs: AttributeSet?, defStyleAttr: Int) : super(context, attrs, defStyleAttr)
-    constructor(context: Context?, attrs: AttributeSet?) : super(context, attrs)
-    constructor(context: Context?) : super(context)
-
+open class AutoFocusEditTextPreference(context: Context?, attrs: AttributeSet?) : android.preference.EditTextPreference(context, attrs), AutoFocusable {
     override fun onBindView(view: View?) {
         super.onBindView(view)
-        autoFocus(editText)
+        autoFocusAndMoveCursorToEnd(editText)
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/preferences/AutoFocusEditTextPreference.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/preferences/AutoFocusEditTextPreference.kt
@@ -1,0 +1,25 @@
+package com.ichi2.preferences
+
+import android.content.Context
+import android.util.AttributeSet
+import android.view.View
+import android.widget.EditText
+
+interface AutoFocusable {
+    fun autoFocus(editText: EditText) {
+        editText.requestFocus()
+        editText.selectAll() // todo may change
+    }
+}
+
+@Suppress("deprecation")
+open class AutoFocusEditTextPreference : android.preference.EditTextPreference, AutoFocusable {
+    constructor(context: Context?, attrs: AttributeSet?, defStyleAttr: Int) : super(context, attrs, defStyleAttr)
+    constructor(context: Context?, attrs: AttributeSet?) : super(context, attrs)
+    constructor(context: Context?) : super(context)
+
+    override fun onBindView(view: View?) {
+        super.onBindView(view)
+        autoFocus(editText)
+    }
+}

--- a/AnkiDroid/src/main/java/com/ichi2/preferences/AutoFocusEditTextPreference.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/preferences/AutoFocusEditTextPreference.kt
@@ -8,7 +8,7 @@ import android.widget.EditText
 interface AutoFocusable {
     fun autoFocus(editText: EditText) {
         editText.requestFocus()
-        editText.selectAll() // todo may change
+        editText.setSelection(editText.text.length)
     }
 }
 

--- a/AnkiDroid/src/main/java/com/ichi2/preferences/IncrementerNumberRangePreference.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/preferences/IncrementerNumberRangePreference.kt
@@ -28,7 +28,7 @@ import java.lang.NumberFormatException
 
 // TODO Tracked in https://github.com/ankidroid/Anki-Android/issues/5019 : use IncrementerNumberRangePreferenceCompat
 @Suppress("deprecation")
-class IncrementerNumberRangePreference : NumberRangePreference, AutoFocusable {
+class IncrementerNumberRangePreference : NumberRangePreference {
     private val mLinearLayout = LinearLayout(context)
     private val mEditText = editText // Get default EditText from parent
     private val mIncrementButton = Button(context)
@@ -52,11 +52,6 @@ class IncrementerNumberRangePreference : NumberRangePreference, AutoFocusable {
         mLinearLayout.addView(mEditText)
         mLinearLayout.addView(mIncrementButton)
         return mLinearLayout
-    }
-
-    override fun onBindView(view: View?) {
-        super.onBindView(view)
-        autoFocusAndMoveCursorToEnd(editText)
     }
 
     override fun onDialogClosed(positiveResult: Boolean) {

--- a/AnkiDroid/src/main/java/com/ichi2/preferences/IncrementerNumberRangePreference.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/preferences/IncrementerNumberRangePreference.kt
@@ -56,7 +56,7 @@ class IncrementerNumberRangePreference : NumberRangePreference, AutoFocusable {
 
     override fun onBindView(view: View?) {
         super.onBindView(view)
-        autoFocus(editText)
+        autoFocusAndMoveCursorToEnd(editText)
     }
 
     override fun onDialogClosed(positiveResult: Boolean) {

--- a/AnkiDroid/src/main/java/com/ichi2/preferences/IncrementerNumberRangePreference.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/preferences/IncrementerNumberRangePreference.kt
@@ -28,7 +28,7 @@ import java.lang.NumberFormatException
 
 // TODO Tracked in https://github.com/ankidroid/Anki-Android/issues/5019 : use IncrementerNumberRangePreferenceCompat
 @Suppress("deprecation")
-class IncrementerNumberRangePreference : NumberRangePreference {
+class IncrementerNumberRangePreference : NumberRangePreference, AutoFocusable {
     private val mLinearLayout = LinearLayout(context)
     private val mEditText = editText // Get default EditText from parent
     private val mIncrementButton = Button(context)
@@ -52,6 +52,11 @@ class IncrementerNumberRangePreference : NumberRangePreference {
         mLinearLayout.addView(mEditText)
         mLinearLayout.addView(mIncrementButton)
         return mLinearLayout
+    }
+
+    override fun onBindView(view: View?) {
+        super.onBindView(view)
+        autoFocus(editText)
     }
 
     override fun onDialogClosed(positiveResult: Boolean) {

--- a/AnkiDroid/src/main/java/com/ichi2/preferences/NumberRangePreference.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/preferences/NumberRangePreference.kt
@@ -25,7 +25,7 @@ import com.ichi2.anki.AnkiDroidApp
 import timber.log.Timber
 
 @Suppress("deprecation") // TODO Tracked in https://github.com/ankidroid/Anki-Android/issues/5019 : use NumberRangePreferenceCompat
-open class NumberRangePreference : android.preference.EditTextPreference {
+open class NumberRangePreference : AutoFocusEditTextPreference {
     protected val mMin: Int
     private val mMax: Int
 

--- a/AnkiDroid/src/main/java/com/ichi2/preferences/NumberRangePreference.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/preferences/NumberRangePreference.kt
@@ -21,11 +21,12 @@ import android.text.InputFilter.LengthFilter
 import android.text.InputType
 import android.text.TextUtils
 import android.util.AttributeSet
+import android.view.View
 import com.ichi2.anki.AnkiDroidApp
 import timber.log.Timber
 
 @Suppress("deprecation") // TODO Tracked in https://github.com/ankidroid/Anki-Android/issues/5019 : use NumberRangePreferenceCompat
-open class NumberRangePreference : AutoFocusEditTextPreference {
+open class NumberRangePreference : android.preference.EditTextPreference, AutoFocusable {
     protected val mMin: Int
     private val mMax: Int
 
@@ -45,6 +46,11 @@ open class NumberRangePreference : AutoFocusEditTextPreference {
         mMin = getMinFromAttributes(null)
         mMax = getMaxFromAttributes(null)
         updateSettings()
+    }
+
+    override fun onBindView(view: View?) {
+        super.onBindView(view)
+        autoFocusAndMoveCursorToEnd(editText)
     }
 
     override fun onDialogClosed(positiveResult: Boolean) {

--- a/AnkiDroid/src/main/java/com/ichi2/preferences/StepsPreference.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/preferences/StepsPreference.kt
@@ -28,7 +28,7 @@ import com.ichi2.utils.JSONException
 import timber.log.Timber
 
 @Suppress("deprecation") // TODO Tracked in https://github.com/ankidroid/Anki-Android/issues/5019
-class StepsPreference : android.preference.EditTextPreference {
+class StepsPreference : AutoFocusEditTextPreference {
     private val mAllowEmpty: Boolean
 
     @Suppress("unused")

--- a/AnkiDroid/src/main/java/com/ichi2/preferences/StepsPreference.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/preferences/StepsPreference.kt
@@ -20,6 +20,7 @@ import android.content.Context
 import android.text.InputType
 import android.text.TextUtils
 import android.util.AttributeSet
+import android.view.View
 import com.ichi2.anki.AnkiDroidApp
 import com.ichi2.anki.R
 import com.ichi2.anki.UIUtils.showThemedToast
@@ -28,7 +29,7 @@ import com.ichi2.utils.JSONException
 import timber.log.Timber
 
 @Suppress("deprecation") // TODO Tracked in https://github.com/ankidroid/Anki-Android/issues/5019
-class StepsPreference : AutoFocusEditTextPreference {
+class StepsPreference : android.preference.EditTextPreference, AutoFocusable {
     private val mAllowEmpty: Boolean
 
     @Suppress("unused")
@@ -47,6 +48,11 @@ class StepsPreference : AutoFocusEditTextPreference {
     constructor(context: Context?) : super(context) {
         mAllowEmpty = getAllowEmptyFromAttributes(null)
         updateSettings()
+    }
+
+    override fun onBindView(view: View?) {
+        super.onBindView(view)
+        autoFocusAndMoveCursorToEnd(editText)
     }
 
     /**

--- a/AnkiDroid/src/main/java/com/ichi2/utils/AndroidUiUtils.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/AndroidUiUtils.kt
@@ -47,14 +47,16 @@ object AndroidUiUtils {
     /**
      * Focuses on View and opens the soft keyboard.
      * @param view The View which requires the focus to be set (typically an EditText).
+     * @param runnable The Optional Runnable that will be executed at the end.
      */
     @JvmStatic
-    fun setFocusAndOpenKeyboard(view: View) {
+    fun setFocusAndOpenKeyboard(view: View, runnable: Runnable? = null) {
         //  Required on some Android 9, 10 devices to show keyboard: https://stackoverflow.com/a/7784904
         view.postDelayed({
             view.requestFocus()
             val imm = view.context.getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
             imm.showSoftInput(view, InputMethodManager.SHOW_IMPLICIT)
+            runnable?.run()
         }, 200)
     }
 }

--- a/AnkiDroid/src/main/res/xml/deck_options.xml
+++ b/AnkiDroid/src/main/res/xml/deck_options.xml
@@ -29,7 +29,7 @@
                 android:key="currentConf"
                 android:title="@string/deck_conf_current_group" />
 
-            <EditTextPreference
+            <com.ichi2.preferences.AutoFocusEditTextPreference
                 android:key="confAdd"
                 android:summary="@string/deck_conf_add_summ"
                 android:title="@string/deck_conf_add" />
@@ -43,7 +43,7 @@
                 android:positiveButtonText="@string/dialog_positive_remove"
                 android:title="@string/dialog_positive_remove" />
 
-            <EditTextPreference
+            <com.ichi2.preferences.AutoFocusEditTextPreference
                 android:key="confRename"
                 android:title="@string/deck_conf_rename" />
 
@@ -229,7 +229,7 @@
                 android:title="@string/deck_conf_reminders_time"
                 android:dependency="reminderEnabled" />
         </PreferenceScreen>
-        <EditTextPreference
+        <com.ichi2.preferences.AutoFocusEditTextPreference
             android:key="desc"
             android:title="@string/deck_conf_deck_description" />
 </PreferenceScreen>


### PR DESCRIPTION


## Purpose / Description
Made All Focusable DeckOptions Classes AutoFocus

## Fixes
Fixes #11053 

## Approach
Added an AutoFocusable interface and a AutoFocusEditTextPreference and extended all focusable preferences from them.

## How Has This Been Tested?
Tested by running on emulator

https://user-images.githubusercontent.com/59933477/165082712-8b6eb6c9-72bd-47e0-93a0-5565609fff17.mov



## Checklist

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [x] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
