### PR TITLE
Make animation transitions use the same direction of used swipe gesture

### DIFF
--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/reviewer/PeripheralKeymapTest.java
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/reviewer/PeripheralKeymapTest.java
@@ -18,6 +18,7 @@ package com.ichi2.anki.reviewer;
 
 import android.view.KeyEvent;
 
+import com.ichi2.anki.cardviewer.Gesture;
 import com.ichi2.anki.cardviewer.ViewerCommand;
 import com.ichi2.anki.testutil.MockReviewerUi;
 
@@ -42,7 +43,7 @@ public class PeripheralKeymapTest {
         // #7736 Ensures that a numpad key is passed through (mostly testing num lock)
         List<ViewerCommand> processed = new ArrayList<>();
 
-        PeripheralKeymap peripheralKeymap = new PeripheralKeymap(MockReviewerUi.displayingAnswer(), processed::add);
+        PeripheralKeymap peripheralKeymap = new PeripheralKeymap(MockReviewerUi.displayingAnswer(), (ViewerCommand e, Gesture i) -> processed.add(e) );
         peripheralKeymap.setup();
 
         peripheralKeymap.onKeyDown(KeyEvent.KEYCODE_NUMPAD_1, getNumpadEvent(KeyEvent.KEYCODE_NUMPAD_1));

--- a/AnkiDroid/src/main/java/com/ichi2/anim/ActivityTransitionAnimation.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anim/ActivityTransitionAnimation.kt
@@ -26,7 +26,7 @@ object ActivityTransitionAnimation {
             Direction.UP -> activity.overridePendingTransition(R.anim.slide_up_in, R.anim.slide_up_out)
             Direction.DIALOG_EXIT -> activity.overridePendingTransition(R.anim.none, R.anim.dialog_exit)
             Direction.NONE -> activity.overridePendingTransition(R.anim.none, R.anim.none)
-            Direction.DOWN -> {
+            Direction.DEFAULT -> {
             }
             else -> {
             }
@@ -42,7 +42,7 @@ object ActivityTransitionAnimation {
             Direction.UP -> ActivityOptionsCompat.makeCustomAnimation(activity, R.anim.slide_up_in, R.anim.slide_up_out)
             Direction.DIALOG_EXIT -> ActivityOptionsCompat.makeCustomAnimation(activity, R.anim.none, R.anim.dialog_exit)
             Direction.NONE -> ActivityOptionsCompat.makeCustomAnimation(activity, R.anim.none, R.anim.none)
-            Direction.DOWN -> // this is the default animation, we shouldn't try to override it
+            Direction.DEFAULT -> // this is the default animation, we shouldn't try to override it
                 ActivityOptionsCompat.makeBasic()
             else -> ActivityOptionsCompat.makeBasic()
         }
@@ -53,6 +53,6 @@ object ActivityTransitionAnimation {
     }
 
     enum class Direction {
-        START, END, FADE, UP, DOWN, DIALOG_EXIT, NONE
+        START, END, FADE, UP, DEFAULT, DIALOG_EXIT, NONE
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anim/ActivityTransitionAnimation.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anim/ActivityTransitionAnimation.kt
@@ -22,6 +22,8 @@ object ActivityTransitionAnimation {
             } else {
                 activity.overridePendingTransition(R.anim.slide_right_in, R.anim.slide_right_out)
             }
+            Direction.RIGHT -> activity.overridePendingTransition(R.anim.slide_right_in, R.anim.slide_right_out)
+            Direction.LEFT -> activity.overridePendingTransition(R.anim.slide_left_in, R.anim.slide_left_out)
             Direction.FADE -> activity.overridePendingTransition(R.anim.fade_out, R.anim.fade_in)
             Direction.UP -> activity.overridePendingTransition(R.anim.slide_up_in, R.anim.slide_up_out)
             Direction.DIALOG_EXIT -> activity.overridePendingTransition(R.anim.none, R.anim.dialog_exit)
@@ -38,6 +40,8 @@ object ActivityTransitionAnimation {
         return when (direction) {
             Direction.START -> if (isRightToLeft(activity)) ActivityOptionsCompat.makeCustomAnimation(activity, R.anim.slide_right_in, R.anim.slide_right_out) else ActivityOptionsCompat.makeCustomAnimation(activity, R.anim.slide_left_in, R.anim.slide_left_out)
             Direction.END -> if (isRightToLeft(activity)) ActivityOptionsCompat.makeCustomAnimation(activity, R.anim.slide_left_in, R.anim.slide_left_out) else ActivityOptionsCompat.makeCustomAnimation(activity, R.anim.slide_right_in, R.anim.slide_right_out)
+            Direction.RIGHT -> ActivityOptionsCompat.makeCustomAnimation(activity, R.anim.slide_right_in, R.anim.slide_right_out)
+            Direction.LEFT -> ActivityOptionsCompat.makeCustomAnimation(activity, R.anim.slide_left_in, R.anim.slide_left_out)
             Direction.FADE -> ActivityOptionsCompat.makeCustomAnimation(activity, R.anim.fade_out, R.anim.fade_in)
             Direction.UP -> ActivityOptionsCompat.makeCustomAnimation(activity, R.anim.slide_up_in, R.anim.slide_up_out)
             Direction.DIALOG_EXIT -> ActivityOptionsCompat.makeCustomAnimation(activity, R.anim.none, R.anim.dialog_exit)
@@ -53,6 +57,6 @@ object ActivityTransitionAnimation {
     }
 
     enum class Direction {
-        START, END, FADE, UP, DEFAULT, DIALOG_EXIT, NONE
+        START, END, FADE, UP, RIGHT, LEFT, DEFAULT, DIALOG_EXIT, NONE
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anim/ActivityTransitionAnimation.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anim/ActivityTransitionAnimation.kt
@@ -26,6 +26,7 @@ object ActivityTransitionAnimation {
             Direction.LEFT -> activity.overridePendingTransition(R.anim.slide_left_in, R.anim.slide_left_out)
             Direction.FADE -> activity.overridePendingTransition(R.anim.fade_out, R.anim.fade_in)
             Direction.UP -> activity.overridePendingTransition(R.anim.slide_up_in, R.anim.slide_up_out)
+            Direction.DOWN -> activity.overridePendingTransition(R.anim.slide_down_in, R.anim.slide_down_out)
             Direction.DIALOG_EXIT -> activity.overridePendingTransition(R.anim.none, R.anim.dialog_exit)
             Direction.NONE -> activity.overridePendingTransition(R.anim.none, R.anim.none)
             Direction.DEFAULT -> {
@@ -44,6 +45,7 @@ object ActivityTransitionAnimation {
             Direction.LEFT -> ActivityOptionsCompat.makeCustomAnimation(activity, R.anim.slide_left_in, R.anim.slide_left_out)
             Direction.FADE -> ActivityOptionsCompat.makeCustomAnimation(activity, R.anim.fade_out, R.anim.fade_in)
             Direction.UP -> ActivityOptionsCompat.makeCustomAnimation(activity, R.anim.slide_up_in, R.anim.slide_up_out)
+            Direction.DOWN -> ActivityOptionsCompat.makeCustomAnimation(activity, R.anim.slide_down_in, R.anim.slide_down_out)
             Direction.DIALOG_EXIT -> ActivityOptionsCompat.makeCustomAnimation(activity, R.anim.none, R.anim.dialog_exit)
             Direction.NONE -> ActivityOptionsCompat.makeCustomAnimation(activity, R.anim.none, R.anim.none)
             Direction.DEFAULT -> // this is the default animation, we shouldn't try to override it
@@ -57,6 +59,6 @@ object ActivityTransitionAnimation {
     }
 
     enum class Direction {
-        START, END, FADE, UP, RIGHT, LEFT, DEFAULT, DIALOG_EXIT, NONE
+        START, END, FADE, UP, DOWN, RIGHT, LEFT, DEFAULT, DIALOG_EXIT, NONE
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
@@ -1664,7 +1664,7 @@ abstract class AbstractFlashcardViewer :
                 true
             }
             ViewerCommand.COMMAND_CARD_INFO -> {
-                openCardInfo()
+                openCardInfo(fromGesture)
                 true
             }
             ViewerCommand.COMMAND_TAG -> {
@@ -1742,14 +1742,15 @@ abstract class AbstractFlashcardViewer :
         closeReviewer(RESULT_ABORT_AND_SYNC, true)
     }
 
-    protected fun openCardInfo() {
+    @JvmOverloads
+    protected fun openCardInfo(fromGesture: Gesture? = null) {
         if (mCurrentCard == null) {
             showThemedToast(this, getString(R.string.multimedia_editor_something_wrong), true)
             return
         }
         val intent = Intent(this, CardInfo::class.java)
         intent.putExtra("cardId", mCurrentCard!!.id)
-        startActivityWithAnimation(intent, ActivityTransitionAnimation.Direction.FADE)
+        startActivityWithAnimation(intent, getAnimationTransitionFromGesture(fromGesture))
     }
 
     /** Displays a snackbar which does not obscure the answer buttons  */

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
@@ -1611,7 +1611,7 @@ abstract class AbstractFlashcardViewer :
         return dismiss(BuryNote(mCurrentCard!!)) { showThemedToast(this, R.string.buried_note, true) }
     }
 
-    override fun executeCommand(which: ViewerCommand): Boolean {
+    override fun executeCommand(which: ViewerCommand, fromGesture: Gesture?): Boolean {
         return if (isControlBlocked() && which !== ViewerCommand.COMMAND_EXIT) {
             false
         } else when (which) {
@@ -1719,6 +1719,10 @@ abstract class AbstractFlashcardViewer :
                 false
             }
         }
+    }
+
+    fun executeCommand(which: ViewerCommand): Boolean {
+        return executeCommand(which, fromGesture = null)
     }
 
     protected open fun replayVoice() {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
@@ -2591,5 +2591,19 @@ abstract class AbstractFlashcardViewer :
         @KotlinCleanup("moved from SelectEaseHandler")
         // maximum screen distance from initial touch where we will consider a click related to the touch
         private const val CLICK_ACTION_THRESHOLD = 200
+
+        /**
+         * @return if [gesture] is a swipe, a transition to the same direction of the swipe
+         * else return [ActivityTransitionAnimation.Direction.FADE]
+         */
+        fun getAnimationTransitionFromGesture(gesture: Gesture?): ActivityTransitionAnimation.Direction {
+            return when (gesture) {
+                Gesture.SWIPE_UP -> ActivityTransitionAnimation.Direction.UP
+                Gesture.SWIPE_DOWN -> ActivityTransitionAnimation.Direction.DOWN
+                Gesture.SWIPE_RIGHT -> ActivityTransitionAnimation.Direction.RIGHT
+                Gesture.SWIPE_LEFT -> ActivityTransitionAnimation.Direction.LEFT
+                else -> ActivityTransitionAnimation.Direction.FADE
+            }
+        }
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
@@ -840,7 +840,8 @@ abstract class AbstractFlashcardViewer :
         finishWithoutAnimation()
     }
 
-    protected open fun editCard() {
+    @JvmOverloads
+    protected open fun editCard(fromGesture: Gesture? = null) {
         if (mCurrentCard == null) {
             // This should never occurs. It means the review button was pressed while there is no more card in the reviewer.
             return
@@ -848,7 +849,7 @@ abstract class AbstractFlashcardViewer :
         val editCard = Intent(this@AbstractFlashcardViewer, NoteEditor::class.java)
         editCard.putExtra(NoteEditor.EXTRA_CALLER, NoteEditor.CALLER_REVIEWER)
         editorCard = mCurrentCard
-        startActivityForResultWithAnimation(editCard, EDIT_CURRENT_CARD, ActivityTransitionAnimation.Direction.START)
+        startActivityForResultWithAnimation(editCard, EDIT_CURRENT_CARD, getAnimationTransitionFromGesture(fromGesture))
     }
 
     fun generateQuestionSoundList() {
@@ -1659,7 +1660,7 @@ abstract class AbstractFlashcardViewer :
                 true
             }
             ViewerCommand.COMMAND_EDIT -> {
-                editCard()
+                editCard(fromGesture)
                 true
             }
             ViewerCommand.COMMAND_CARD_INFO -> {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -835,7 +835,7 @@ open class DeckPicker : NavigationDrawerActivity(), StudyOptionsListener, SyncEr
     }
 
     private fun finishWithAnimation() {
-        super.finishWithAnimation(DOWN)
+        super.finishWithAnimation(DEFAULT)
     }
 
     override fun onKeyUp(keyCode: Int, event: KeyEvent): Boolean {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Previewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Previewer.java
@@ -28,6 +28,7 @@ import android.widget.LinearLayout;
 import android.widget.SeekBar;
 import android.widget.TextView;
 
+import com.ichi2.anki.cardviewer.Gesture;
 import com.ichi2.anki.cardviewer.PreviewLayout;
 import com.ichi2.anki.cardviewer.ViewerCommand;
 import com.ichi2.libanki.Collection;
@@ -266,7 +267,7 @@ public class Previewer extends AbstractFlashcardViewer {
 
 
     @Override
-    public boolean executeCommand(@NonNull ViewerCommand which) {
+    public boolean executeCommand(@NonNull ViewerCommand which, Gesture fromGesture) {
         /* do nothing */
         return false;
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
@@ -1104,7 +1104,7 @@ open class Reviewer : AbstractFlashcardViewer() {
         }
     }
 
-    override fun executeCommand(which: ViewerCommand): Boolean {
+    override fun executeCommand(which: ViewerCommand, fromGesture: Gesture?): Boolean {
         if (isControlBlocked() && which !== ViewerCommand.COMMAND_EXIT) {
             return false
         }
@@ -1149,7 +1149,7 @@ open class Reviewer : AbstractFlashcardViewer() {
                 addNote()
                 return true
             }
-            else -> return super.executeCommand(which)
+            else -> return super.executeCommand(which, fromGesture)
         }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
@@ -652,10 +652,10 @@ open class Reviewer : AbstractFlashcardViewer() {
         showDialogFragment(dialog)
     }
 
-    private fun addNote() {
+    private fun addNote(fromGesture: Gesture? = null) {
         val intent = Intent(this, NoteEditor::class.java)
         intent.putExtra(NoteEditor.EXTRA_CALLER, NoteEditor.CALLER_REVIEWER_ADD)
-        startActivityForResultWithAnimation(intent, ADD_NOTE, ActivityTransitionAnimation.Direction.START)
+        startActivityForResultWithAnimation(intent, ADD_NOTE, getAnimationTransitionFromGesture(fromGesture))
     }
 
     override fun onMenuOpened(featureId: Int, menu: Menu): Boolean {
@@ -1146,7 +1146,7 @@ open class Reviewer : AbstractFlashcardViewer() {
                 return true
             }
             ViewerCommand.COMMAND_ADD_NOTE -> {
-                addNote()
+                addNote(fromGesture)
                 return true
             }
             else -> return super.executeCommand(which, fromGesture)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/GestureProcessor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/GestureProcessor.kt
@@ -92,7 +92,7 @@ class GestureProcessor(private val processor: ViewerCommand.CommandProcessor?) {
     private fun execute(gesture: Gesture?): Boolean? {
         val command = mapGestureToCommand(gesture)
         return if (command != null) {
-            processor?.executeCommand(command)
+            processor?.executeCommand(command, gesture)
         } else {
             false
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/ViewerCommand.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/ViewerCommand.kt
@@ -195,6 +195,6 @@ enum class ViewerCommand(val resourceId: Int, private val preferenceValue: Int) 
          *
          * example failure: answering an ease on the front of the card
          */
-        fun executeCommand(which: ViewerCommand): Boolean
+        fun executeCommand(which: ViewerCommand, fromGesture: Gesture?): Boolean
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/PeripheralKeymap.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/PeripheralKeymap.kt
@@ -74,7 +74,7 @@ class PeripheralKeymap(reviewerUi: ReviewerUi, commandProcessor: ViewerCommand.C
             for (b in bindings) {
                 val binding = MappableBinding(b, MappableBinding.Screen.Reviewer(side))
                 val command = mBindingMap[binding] ?: continue
-                ret = ret or processor.executeCommand(command)
+                ret = ret or processor.executeCommand(command, fromGesture = null)
             }
             return ret
         }

--- a/AnkiDroid/src/main/res/anim/slide_down_in.xml
+++ b/AnkiDroid/src/main/res/anim/slide_down_in.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<set xmlns:android="http://schemas.android.com/apk/res/android" >
+<translate
+    android:duration="300"
+    android:fromYDelta="-100%p"
+    android:toYDelta="0" />
+</set>

--- a/AnkiDroid/src/main/res/anim/slide_down_out.xml
+++ b/AnkiDroid/src/main/res/anim/slide_down_out.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<set xmlns:android="http://schemas.android.com/apk/res/android" >
+<translate
+    android:duration="300"
+    android:fromYDelta="0"
+    android:toYDelta="100%p" />
+</set>

--- a/AnkiDroid/src/test/java/com/ichi2/anki/ReviewerKeyboardInputTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/ReviewerKeyboardInputTest.kt
@@ -382,7 +382,7 @@ class ReviewerKeyboardInputTest : RobolectricTest() {
             return true
         }
 
-        override fun editCard() {
+        override fun editCard(fromGesture: Gesture?) {
             editCardCalled = true
         }
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/ReviewerKeyboardInputTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/ReviewerKeyboardInputTest.kt
@@ -24,6 +24,7 @@ import com.ichi2.anki.AbstractFlashcardViewer.Companion.EASE_1
 import com.ichi2.anki.AbstractFlashcardViewer.Companion.EASE_2
 import com.ichi2.anki.AbstractFlashcardViewer.Companion.EASE_3
 import com.ichi2.anki.AbstractFlashcardViewer.Companion.EASE_4
+import com.ichi2.anki.cardviewer.Gesture
 import com.ichi2.anki.reviewer.ReviewerUi.ControlBlock
 import com.ichi2.anki.servicelayer.AnkiMethod
 import com.ichi2.anki.servicelayer.SchedulerService.BuryNote

--- a/AnkiDroid/src/test/java/com/ichi2/anki/cardviewer/GestureProcessorTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/cardviewer/GestureProcessorTest.kt
@@ -35,7 +35,7 @@ import org.mockito.kotlin.eq
 class GestureProcessorTest : ViewerCommand.CommandProcessor {
     private val mSut = GestureProcessor(this)
     private val mExecutedCommands: MutableList<ViewerCommand> = ArrayList()
-    override fun executeCommand(which: ViewerCommand): Boolean {
+    override fun executeCommand(which: ViewerCommand, fromGesture: Gesture?): Boolean {
         mExecutedCommands.add(which)
         return true
     }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/reviewer/PeripheralKeymapTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/reviewer/PeripheralKeymapTest.kt
@@ -35,7 +35,7 @@ class PeripheralKeymapTest {
     fun flagAndAnswerDoNotConflict() {
         val processed: MutableList<ViewerCommand> = ArrayList()
 
-        val peripheralKeymap = PeripheralKeymap(MockReviewerUi(), { e: ViewerCommand -> processed.add(e) })
+        val peripheralKeymap = PeripheralKeymap(MockReviewerUi()) { e: ViewerCommand, _ -> processed.add(e) }
         peripheralKeymap.setup(mock(SharedPreferences::class.java))
         val event = mock(KeyEvent::class.java)
         `when`(event.unicodeChar).thenReturn(0)


### PR DESCRIPTION
## Fixes
Fixes #11094

## Approach
1. Rename the `DOWN` direction to `DEFAULT` since it was meant to follow the default animation and the default animation (at least on my phone) doesn't come from down
2. Add right and left transitions
3. Created a new down transition (equivalent inverse of the current UP transition)
4. Pass the used gesture to `executeCommand()`
5. Map swipe gestures to animations with `FADE` as default
6. Pass the mapped animation transitions to the gestures which opens other activities (i.e. Edit card, Card Info and Add Note)

## How Has This Been Tested?

On my phone (Samsung Galaxy Note 10 Lite SM-N770F/DS, API 31, One UI 4.0)

https://user-images.githubusercontent.com/69634269/165154680-fcea43ee-6447-4bf7-a836-7e6e2242083b.mp4

## Learning (optional, can help others)

- Learned a little about android XML animations by reading the existing ones

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
