### PR TITLE
build(deps): fix build issues

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -54,11 +54,13 @@ jobs:
         run: java -fullversion 2>&1 | grep '11.0'
         shell: bash
 
-      - name: Gradle Cache
-        uses: actions/cache@v3
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2
         with:
-          path: ~/.gradle/caches
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*') }}-v1
+          # Only write to the cache for builds on the 'main' branches, stops branches evicting main cache
+          # Builds on other branches will only read from main branch cache writes
+          # Comment this and the with: above out for performance testing on a branch
+          cache-read-only: ${{ github.ref != 'refs/heads/main' }}
 
       - name: Warm Gradle Cache
         # This makes sure we fetch gradle network resources with a retry
@@ -67,19 +69,15 @@ jobs:
           timeout_minutes: 10
           retry_wait_seconds: 60
           max_attempts: 3
-          command: ./gradlew :AnkiDroid:compilePlayDebugJavaWithJavac compileLint lint-rules:compileTestJava
+          command: ./gradlew :AnkiDroid:compilePlayDebugJavaWithJavac compileLint lint-rules:compileTestJava --daemon
 
       - name: Run Lint Debug
-        # "lint" is run under the 'Amazon' flavor, so slow in CI
-        # "lintPlayRelease" doesn't test androidTest
-        # "lintPlayDebug" doesn't test the API
-        run: ./gradlew lintPlayDebug :api:lintDebug
-
-      - name: Test Lint Rules
-        run: ./gradlew lint-rules:test
-
-      - name: Ktlint Check
-        run: ./gradlew ktlintCheck
+        uses: gradle/gradle-build-action@v2
+        with:
+          # "lint" is run under the 'Amazon' flavor, so slow in CI
+          # "lintPlayRelease" doesn't test androidTest
+          # "lintPlayDebug" doesn't test the API
+          arguments: lintPlayDebug :api:lintDebug ktLintCheck lint-rules:test --daemon
 
       - name: Prettify code
         uses: creyD/prettier_action@v4.2

--- a/.github/workflows/tests_emulator.yml
+++ b/.github/workflows/tests_emulator.yml
@@ -74,7 +74,7 @@ jobs:
           timeout_minutes: 15
           retry_wait_seconds: 60
           max_attempts: 3
-          command: ./gradlew packagePlayDebug packagePlayDebugAndroidTest
+          command: ./gradlew packagePlayDebug packagePlayDebugAndroidTest --daemon
 
         # This appears to be 'Cache Size: ~1230 MB (1290026823 B)' based on watching action logs
         # Repo limit is 10GB; branch caches are independent; branches may read default branch cache.
@@ -141,7 +141,7 @@ jobs:
           disable-animations: true
           script: |
             $ANDROID_HOME/platform-tools/adb logcat '*:D' > adb-log.txt &
-            ./gradlew uninstallAll jacocoAndroidTestReport
+            ./gradlew uninstallAll jacocoAndroidTestReport --daemon
 
       - name: Compress Emulator Log
         if: always()

--- a/.github/workflows/tests_unit.yml
+++ b/.github/workflows/tests_unit.yml
@@ -60,11 +60,13 @@ jobs:
         run: java -fullversion 2>&1 | grep '11.0'
         shell: bash
 
-      - name: Gradle Cache
-        uses: actions/cache@v3
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2
         with:
-          path: ~/.gradle/caches
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*') }}-v2
+          # Only write to the cache for builds on the 'main' branches, stops branches evicting main cache
+          # Builds on other branches will only read from main branch cache writes
+          # Comment this and the with: above out for performance testing on a branch
+          cache-read-only: ${{ github.ref != 'refs/heads/main' }}
 
       - name: Gradle Dependency Download
         uses: nick-invision/retry@v2
@@ -72,10 +74,12 @@ jobs:
           timeout_minutes: 10
           retry_wait_seconds: 60
           max_attempts: 3
-          command: ./gradlew robolectricSdkDownload
+          command: ./gradlew robolectricSdkDownload --daemon
 
       - name: Run Unit Tests
-        run: ./gradlew jacocoUnitTestReport
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: jacocoUnitTestReport --daemon
 
       - name: Submit Coverage
         # This can fail on timeouts etc, wrap with retry

--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -348,7 +348,7 @@ dependencies {
     testImplementation 'org.junit.vintage:junit-vintage-engine:5.8.2'
     testImplementation 'org.mockito:mockito-inline:4.5.1'
     testImplementation "org.mockito.kotlin:mockito-kotlin:4.0.0"
-    testImplementation 'org.hamcrest:hamcrest:2.2'
+    testImplementation "org.hamcrest:hamcrest:$hamcrest_version"
     testImplementation 'net.lachlanmckee:timber-junit-rule:1.0.1'
     // robolectricDownloader.gradle *may* need a new SDK jar entry if they release one or if we change targetSdk. Instructions in that gradle file.
     testImplementation "org.robolectric:robolectric:4.7.3"

--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -172,10 +172,6 @@ android {
 
     testOptions {
         animationsDisabled true
-
-        unitTests {
-            includeAndroidResources = true
-        }
     }
 
     compileOptions {
@@ -184,31 +180,12 @@ android {
     packagingOptions {
         exclude 'META-INF/DEPENDENCIES'
     }
-    testOptions.unitTests.all {
-        testLogging {
-            events "failed", "skipped"
-            showStackTraces = true
-            exceptionFormat = "full"
-        }
-
-        maxParallelForks = gradleTestMaxParallelForks
-        forkEvery = 40
-        maxHeapSize = "2048m"
-        minHeapSize = "1024m"
-        systemProperties['junit.jupiter.execution.parallel.enabled'] = true
-        systemProperties['junit.jupiter.execution.parallel.mode.default'] = "concurrent"
-    }
     sourceSets {
         debug {
             manifest.srcFile 'src/test/AndroidManifest.xml'
         }
     }
     ndkVersion "22.0.7026061"
-
-    ktlint {
-        version = "0.45.1"
-        disabledRules = ["no-wildcard-imports"]
-    }
 }
 
 play {
@@ -222,17 +199,6 @@ amazon {
     replaceEdit = true
 }
 
-// Deprecation is an error. Use @SuppressWarnings("deprecation") and justify in the PR if you must
-tasks.withType(JavaCompile) {
-    options.compilerArgs << "-Xlint:deprecation" << "-Xlint:fallthrough" << "-Xmaxwarns" << "1000" << "-Werror"
-
-    // https://guides.gradle.org/performance/#compiling_java
-    // 1- fork improves things over time with repeated builds, doesn't harm CI single builds
-    options.fork = true
-    // 2- incremental will be the default in the future and can help now
-    options.incremental = true
-}
-
 // Install Git pre-commit hook for Ktlint
 task installGitHook(type: Copy) {
     from new File(rootProject.rootDir, 'pre-commit')
@@ -240,29 +206,6 @@ task installGitHook(type: Copy) {
     fileMode 0755
 }
 tasks.getByPath(':AnkiDroid:preBuild').dependsOn installGitHook
-
-/**
-Kotlin allows concrete function implementations inside interfaces.
-For those to work when Kotlin compilation targets the JVM backend, you have to enable the interoperability via
-'freeCompilerArgs' in your gradle file, and you have to choose one of the appropriate '-Xjvm-default' modes.
-
-https://kotlinlang.org/docs/java-to-kotlin-interop.html#default-methods-in-interfaces
-
-    and we used "all" because we don't have downstream consumers
-    https://docs.gradle.org/current/userguide/task_configuration_avoidance.html
- */
-tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
-    kotlinOptions {
-        allWarningsAsErrors = true
-        freeCompilerArgs = ['-Xjvm-default=all'] 
-    }
-}
-
-//Workaround for: https://github.com/pinterest/ktlint/issues/1216
-//To be removed when upstream gets patched
-tasks.withType(org.jlleitschuh.gradle.ktlint.worker.KtLintWorkAction) {
-    workerMaxHeapSize = "2048m"
-}
 
 apply from: "./robolectricDownloader.gradle"
 apply from: "./jacoco.gradle"

--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -207,6 +207,28 @@ task installGitHook(type: Copy) {
 }
 tasks.getByPath(':AnkiDroid:preBuild').dependsOn installGitHook
 
+// Issue 11078 - some emulators run, but run zero tests, and still report success
+task assertNonzeroAndroidTests() {
+    doLast {
+        // androidTest currently creates one .xml file per emulator with aggregate results in this dir
+        File folder = file("./build/outputs/androidTest-results/connected/flavors/play")
+        File[] listOfFiles = folder.listFiles({ d, f -> f ==~ /.*.xml/ } as FilenameFilter)
+        for (File file : listOfFiles) {
+            // The aggregate results file currently contains a line with this pattern holding test count
+            String[] matches = file.readLines().findAll { it.contains('<testsuite') }
+            if (matches.length != 1) {
+                throw new GradleScriptException("Unable to determine count of tests executed for " + file.name + ". Regex pattern out of date?", null)
+            }
+            if (!(matches[0] ==~ /.* tests="\d+" .*/) || matches[0].contains('tests="0"')) {
+                throw new GradleScriptException("androidTest executed 0 tests for " + file.name + " - Probably a bug with the emulator. Try another image.", null)
+            }
+        }
+    }
+}
+afterEvaluate {
+    tasks.getByPath(':AnkiDroid:connectedPlayDebugAndroidTest').finalizedBy(assertNonzeroAndroidTests)
+}
+
 apply from: "./robolectricDownloader.gradle"
 apply from: "./jacoco.gradle"
 apply from: "../lint.gradle"

--- a/AnkiDroid/jacoco.gradle
+++ b/AnkiDroid/jacoco.gradle
@@ -3,13 +3,13 @@ import groovy.transform.Memoized
 apply plugin: 'jacoco'
 
 jacoco {
-    toolVersion = "0.8.7"
+    toolVersion = "0.8.8"
 
 }
 
 android {
     jacoco {
-        version = "0.8.7"
+        version = "0.8.8"
     }
 }
 

--- a/api/build.gradle
+++ b/api/build.gradle
@@ -25,25 +25,9 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
-    testOptions {
-        unitTests {
-            includeAndroidResources = true
-        }
-    }
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
-    }
-    testOptions.unitTests.all {
-        testLogging {
-            events "failed", "skipped"
-            showStackTraces = true
-            exceptionFormat = "full"
-        }
-
-        maxParallelForks = gradleTestMaxParallelForks
-        systemProperties['junit.jupiter.execution.parallel.enabled'] = true
-        systemProperties['junit.jupiter.execution.parallel.mode.default'] = "concurrent"
     }
 }
 
@@ -146,14 +130,3 @@ publishMavenJavaPublicationToMavenRepository.dependsOn(assemble)
 publish.dependsOn(assemble)
 generateRelease.dependsOn(publish)
 generateRelease.dependsOn(zipRelease)
-
-// Deprecation is an error. Use @SuppressWarnings("deprecation") and justify in the PR if you must
-tasks.withType(JavaCompile) {
-    options.compilerArgs << "-Xlint:deprecation" << "-Xmaxwarns" << "1000" << "-Werror"
-
-    // https://guides.gradle.org/performance/#compiling_java
-    // 1- fork improves things over time with repeated builds, doesn't harm CI single builds
-    options.fork = true
-    // 2- incremental will be the default in the future and can help now
-    options.incremental = true
-}

--- a/build.gradle
+++ b/build.gradle
@@ -71,7 +71,9 @@ subprojects {
         }
 
         ktlint {
-            version = "0.45.1"
+            // remove version override when ktlint gradle plugin releases with 0.45+ transitive
+            // check here https://github.com/JLLeitschuh/ktlint-gradle/blob/ddd465e28d77b879384886e1eef5666ebe518b4d/plugin/gradle/libs.versions.toml#L3
+            version = "0.45.2"
             disabledRules = ["no-wildcard-imports"]
         }
 
@@ -90,12 +92,6 @@ subprojects {
                 allWarningsAsErrors = true
                 freeCompilerArgs = ['-Xjvm-default=all']
             }
-        }
-
-        // Workaround for: https://github.com/pinterest/ktlint/issues/1216
-        // To be removed when upstream gets patched
-        tasks.withType(org.jlleitschuh.gradle.ktlint.worker.KtLintWorkAction) {
-            workerMaxHeapSize = "2048m"
         }
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,71 @@ allprojects {
     apply plugin: "org.jlleitschuh.gradle.ktlint"
 }
 
+// Here we extract per-module "best practices" settings to a single top-level evaluation
+subprojects {
+    afterEvaluate { project ->
+
+        if (project.hasProperty('android')) {
+            project.android.testOptions.unitTests {
+                includeAndroidResources = true
+            }
+            project.android.testOptions.unitTests.all {
+                testLogging {
+                    events "failed", "skipped"
+                    showStackTraces = true
+                    exceptionFormat = "full"
+                }
+
+                maxParallelForks = gradleTestMaxParallelForks
+                forkEvery = 40
+                maxHeapSize = "2048m"
+                minHeapSize = "1024m"
+                systemProperties['junit.jupiter.execution.parallel.enabled'] = true
+                systemProperties['junit.jupiter.execution.parallel.mode.default'] = "concurrent"
+            }
+        }
+
+        // Deprecation is an error. Use @SuppressWarnings("deprecation") and justify in the PR if you must
+        project.tasks.withType(JavaCompile) {
+            options.compilerArgs << "-Xlint:deprecation" << "-Xlint:fallthrough" << "-Xmaxwarns" << "1000" << "-Werror"
+
+            // https://guides.gradle.org/performance/#compiling_java
+            // 1- fork improves things over time with repeated builds, doesn't harm CI single builds
+            options.fork = true
+            // 2- incremental will be the default in the future and can help now
+            options.incremental = true
+        }
+
+        ktlint {
+            version = "0.45.1"
+            disabledRules = ["no-wildcard-imports"]
+        }
+
+        /**
+         Kotlin allows concrete function implementations inside interfaces.
+         For those to work when Kotlin compilation targets the JVM backend, you have to enable the interoperability via
+         'freeCompilerArgs' in your gradle file, and you have to choose one of the appropriate '-Xjvm-default' modes.
+
+         https://kotlinlang.org/docs/java-to-kotlin-interop.html#default-methods-in-interfaces
+
+         and we used "all" because we don't have downstream consumers
+         https://docs.gradle.org/current/userguide/task_configuration_avoidance.html
+        */
+        tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
+            kotlinOptions {
+                allWarningsAsErrors = true
+                freeCompilerArgs = ['-Xjvm-default=all']
+            }
+        }
+
+        // Workaround for: https://github.com/pinterest/ktlint/issues/1216
+        // To be removed when upstream gets patched
+        tasks.withType(org.jlleitschuh.gradle.ktlint.worker.KtLintWorkAction) {
+            workerMaxHeapSize = "2048m"
+        }
+    }
+}
+
 ext {
 
     jvmVersion = Jvm.current().javaVersion.majorVersion

--- a/build.gradle
+++ b/build.gradle
@@ -8,6 +8,7 @@ buildscript {
     ext.lint_version = '30.1.3'
     ext.acra_version = '5.7.0'
     ext.ankidroid_backend_version = '0.1.10'
+    ext.hamcrest_version = '2.2'
 
     repositories {
         google()

--- a/lint-rules/build.gradle
+++ b/lint-rules/build.gradle
@@ -20,10 +20,11 @@ dependencies {
     compileOnly "com.android.tools.lint:lint-api:$lint_version"
     compileOnly "com.android.tools.lint:lint:$lint_version"
 
-    testImplementation "junit:junit:4.13.2"
+    testImplementation "org.hamcrest:hamcrest:$hamcrest_version"
+    testImplementation "org.hamcrest:hamcrest-library:$hamcrest_version"
+    testImplementation 'junit:junit:4.13.2'
     testImplementation "com.android.tools.lint:lint:$lint_version"
     testImplementation "com.android.tools.lint:lint-api:$lint_version"
     testImplementation "com.android.tools.lint:lint-tests:$lint_version"
-    testImplementation 'org.hamcrest:hamcrest-all:1.3'
 }
 apply from: "./kotlinMigration-lint.gradle"

--- a/lint-rules/build.gradle
+++ b/lint-rules/build.gradle
@@ -6,11 +6,6 @@ java {
     targetCompatibility = JavaVersion.VERSION_1_8
 }
 
-ktlint {
-    version = "0.45.1"
-    disabledRules = ["no-wildcard-imports"]
-}
-
 repositories {
     google()
     mavenCentral()


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
Each commit here does a thing in our build scripts - 

1- a simple jacoco version update (dependabot doesn't see these for whatever reason)
2- using gradle-build-action in all our workflows (I trialed it in emulator tests, works well, Fixes #11080)
3- hamcrest is used in multiple modules, extract version, update it in lagging module
4- extract our build best practices so lint-rules gets `-Werror` compiler arg "for free" (Fixes #11083)
5- post-process androidTest XML to make sure non-zero # of tests ran (Fixes #11078)


## Fixes
Linked above

## Approach


## How Has This Been Tested?

I tested the -Werror / "extract build common practices" by doing `git revert a70c0f6a381b31ad205388d4b5e3d6e1f3198f15` then running the build - :heavy_check_mark: got the expected error 

```
mike@bistromath:~/work/AnkiDroid/Anki-Android (batch-of-build-work) % !2142
./gradlew clean jacocoTestReport ktlintCheck lint lint-rules:test --rerun-tasks

> Task :AnkiDroid:processPlayDebugMainManifest
/home/mike/work/AnkiDroid/Anki-Android/AnkiDroid/src/test/AndroidManifest.xml:39:9-45:51 Warning:
        provider#org.acra.attachment.AcraContentProvider@android:authorities was tagged at AndroidManifest.xml:39 to replace other declarations but no other declaration present

> Task :lint-rules:compileKotlin FAILED
e: warnings found and -Werror specified
w: /home/mike/work/AnkiDroid/Anki-Android/lint-rules/src/main/java/com/ichi2/anki/lint/rules/NonPositionalFormatSubstitutions.kt: (57, 28): The corresponding parameter in the supertype 'ResourceXmlDetector' is named 'folderType'. This may cause problems when calling this function with named arguments.

FAILURE: Build failed with an exception.
```

I tested the zero tests by starting android API21 locally by itself, API21 + API31, and API31 by itself. 31 by itself passes (:heavy_check_mark:) but any time 21 is in - by itself or in combo with others - :heavy_check_mark:  get the expected error:

```
> Task :AnkiDroid:assertNonzeroAndroidTests FAILED

FAILURE: Build failed with an exception.

* Where:
Build file '/home/mike/work/AnkiDroid/Anki-Android/AnkiDroid/build.gradle' line: 216

* What went wrong:
androidTest executed 0 tests for TEST-TestingAVD_API-31_TAG-PLAY(AVD) - 12-AnkiDroid-play.xml - Probably a bug with the emulator. Try another image.
```

## Learning (optional, can help others)

- Groovy is pretty powerful
- Project-level "afterEvaluate" is pretty powerful to extract common build elements
- Gradle lifecycle task dependency features always have what you need
