### PR TITLE
refactor: simplify enabling toolbar

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiActivity.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiActivity.java
@@ -18,6 +18,7 @@ import androidx.activity.result.ActivityResultLauncher;
 import androidx.annotation.LayoutRes;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.appcompat.app.ActionBar;
 import androidx.appcompat.app.AppCompatDelegate;
 import androidx.appcompat.widget.Toolbar;
 import androidx.browser.customtabs.CustomTabColorSchemeParams;
@@ -53,6 +54,8 @@ import com.ichi2.libanki.CollectionGetter;
 import com.ichi2.themes.Themes;
 import com.ichi2.utils.AdaptionUtil;
 import com.ichi2.utils.AndroidUiUtils;
+
+import java.util.Objects;
 
 import timber.log.Timber;
 
@@ -649,25 +652,38 @@ public class AnkiActivity extends AppCompatActivity implements SimpleMessageDial
         this.finishWithoutAnimation();
     }
 
-    protected void enableToolbar() {
+    /**
+     * sets {@link #getSupportActionBar} and returns the action bar
+     * @return The action bar which was created
+     * @throws IllegalStateException if the bar could not be enabled
+     */
+    @NonNull
+    protected ActionBar enableToolbar() {
         Toolbar toolbar = findViewById(R.id.toolbar);
-        if (toolbar != null) {
-            setSupportActionBar(toolbar);
-        } else {
+        if (toolbar == null) {
             // likely missing "<include layout="@layout/toolbar" />"
-            Timber.w("Could not find toolbar");
+            throw new IllegalStateException("Unable to find toolbar");
         }
+        setSupportActionBar(toolbar);
+        return Objects.requireNonNull(getSupportActionBar());
     }
 
-    protected void enableToolbar(@Nullable View view) {
-        if (view == null) {
-            Timber.w("Unable to enable toolbar - invalid view supplied");
-            return;
-        }
+
+    /**
+     * sets {@link #getSupportActionBar} and returns the action bar
+     * @param view the view which contains a toolbar element:
+     * @return The action bar which was created
+     * @throws IllegalStateException if the bar could not be enabled
+     */
+    @NonNull
+    protected ActionBar enableToolbar(@NonNull View view) {
         Toolbar toolbar = view.findViewById(R.id.toolbar);
-        if (toolbar != null) {
-            setSupportActionBar(toolbar);
+        if (toolbar == null) {
+            // likely missing "<include layout="@layout/toolbar" />"
+            throw new IllegalStateException("Unable to find toolbar: " + view);
         }
+        setSupportActionBar(toolbar);
+        return Objects.requireNonNull(getSupportActionBar());
     }
 
     protected boolean showedActivityFailedScreen(Bundle savedInstanceState) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ModelBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ModelBrowser.kt
@@ -154,8 +154,7 @@ class ModelBrowser : AnkiActivity() {
         setTitle(R.string.model_browser_label)
         setContentView(R.layout.model_browser)
         mModelListView = findViewById(R.id.note_type_browser_list)
-        enableToolbar()
-        mActionBar = supportActionBar
+        mActionBar = enableToolbar()
         startLoadingCollection()
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ModelFieldEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ModelFieldEditor.kt
@@ -88,11 +88,9 @@ class ModelFieldEditor : AnkiActivity(), LocaleSelectionDialogHandler {
         setContentView(R.layout.model_field_editor)
 
         fieldLabelView = findViewById(R.id.note_type_editor_fields)
-        enableToolbar()
-
-        supportActionBar?.let {
-            it.setTitle(R.string.model_field_editor_title)
-            it.subtitle = intent.getStringExtra("title")
+        enableToolbar().apply {
+            setTitle(R.string.model_field_editor_title)
+            subtitle = intent.getStringExtra("title")
         }
         startLoadingCollection()
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NavigationDrawerActivity.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NavigationDrawerActivity.java
@@ -33,6 +33,7 @@ import com.google.android.material.navigation.NavigationView;
 import androidx.annotation.LayoutRes;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.appcompat.app.ActionBar;
 import androidx.coordinatorlayout.widget.CoordinatorLayout;
 import androidx.core.app.TaskStackBuilder;
 import androidx.core.content.ContextCompat;
@@ -50,6 +51,7 @@ import android.view.View;
 import com.ichi2.anki.dialogs.HelpDialog;
 import com.ichi2.themes.Themes;
 import com.ichi2.utils.HandlerUtils;
+import com.ichi2.utils.KotlinCleanup;
 
 import java.util.Arrays;
 
@@ -116,6 +118,7 @@ public abstract class NavigationDrawerActivity extends AnkiActivity implements N
     }
 
     // Navigation drawer initialisation
+    @KotlinCleanup("use .apply on enableToolbar")
     protected void initNavigationDrawer(View mainView) {
         // Create inherited navigation drawer layout here so that it can be used by parent class
         mDrawerLayout = mainView.findViewById(R.id.drawer_layout);

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.kt
@@ -107,11 +107,11 @@ class Preferences : AnkiActivity() {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.preferences)
         setThemeLegacy(this)
-        enableToolbar()
-
-        // Add a home button to the actionbar
-        supportActionBar!!.setHomeButtonEnabled(true)
-        supportActionBar!!.setDisplayHomeAsUpEnabled(true)
+        enableToolbar().apply {
+            // Add a home button to the actionbar
+            setHomeButtonEnabled(true)
+            setDisplayHomeAsUpEnabled(true)
+        }
         title = resources.getText(R.string.preferences_title)
 
         val fragment = getInitialFragment(intent)


### PR DESCRIPTION
It was asked if it was possible to remove the `!!`s on` supportActionBar`

## How Has This Been Tested?
Manually

## Approach

enableToolbar:
* returns the ActionBar which is created
* now throws if provided an invalid view
* Does not accept a `null` view


## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
