### PR TITLE
Fixed SearchDecks Icon visibility not updating if DeckCount changed

### DIFF
--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/DeckPickerTest.java
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/DeckPickerTest.java
@@ -63,9 +63,8 @@ import static com.ichi2.anki.TestUtils.clickChildViewWithId;
 import static com.ichi2.anki.TestUtils.getActivityInstance;
 import static com.ichi2.anki.TestUtils.isScreenSw600dp;
 import static org.hamcrest.Matchers.instanceOf;
-import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
 import static org.junit.Assume.assumeFalse;
 import static org.junit.Assume.assumeTrue;
 
@@ -210,26 +209,28 @@ public class DeckPickerTest {
 
 
     private void ensureIsGone(int iconId) {
-        boolean searchDeckIconIsVisible = true;
-        try {
-            ViewInteraction icon = onView(withId(iconId));
-            icon.check(isGone());
-        } catch (NoMatchingViewException e) {
-            searchDeckIconIsVisible = false;
-        }
-        assertFalse("Icon should be invisible", searchDeckIconIsVisible);
+        checkVisibility(iconId, false);
     }
 
 
     private void ensureIsVisible(int iconId) {
+        checkVisibility(iconId, true);
+    }
+
+
+    private void checkVisibility(int iconId, boolean expectedVisibility) {
         boolean searchDeckIconIsVisible = true;
         try {
             ViewInteraction icon = onView(withId(iconId));
-            icon.check(isVisible());
+            if (expectedVisibility) {
+                icon.check(isVisible());
+            } else {
+                icon.check(isGone());
+            }
         } catch (NoMatchingViewException e) {
             searchDeckIconIsVisible = false;
         }
-        assertTrue("Icon should be visible", searchDeckIconIsVisible);
+        assertEquals("Icon should be " + (expectedVisibility ? "" : "in") + "visible", searchDeckIconIsVisible, expectedVisibility);
     }
 
 

--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/DeckPickerTest.java
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/DeckPickerTest.java
@@ -23,35 +23,96 @@ import android.annotation.SuppressLint;
 import com.ichi2.anki.tests.InstrumentedTest;
 import com.ichi2.anki.testutil.ThreadUtils;
 
+import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 
+import java.util.Arrays;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import androidx.test.espresso.NoMatchingViewException;
+import androidx.test.espresso.PerformException;
+import androidx.test.espresso.ViewAssertion;
+import androidx.test.espresso.ViewInteraction;
 import androidx.test.espresso.contrib.RecyclerViewActions;
+import androidx.test.espresso.matcher.ViewMatchers.Visibility;
 import androidx.test.ext.junit.rules.ActivityScenarioRule;
 import androidx.test.rule.GrantPermissionRule;
 
 import static androidx.test.espresso.Espresso.onView;
+import static androidx.test.espresso.Espresso.openActionBarOverflowOrOptionsMenu;
 import static androidx.test.espresso.Espresso.pressBack;
 import static androidx.test.espresso.action.ViewActions.click;
 import static androidx.test.espresso.action.ViewActions.closeSoftKeyboard;
+import static androidx.test.espresso.action.ViewActions.longClick;
 import static androidx.test.espresso.action.ViewActions.typeText;
 import static androidx.test.espresso.assertion.ViewAssertions.matches;
+import static androidx.test.espresso.matcher.ViewMatchers.Visibility.GONE;
+import static androidx.test.espresso.matcher.ViewMatchers.Visibility.VISIBLE;
 import static androidx.test.espresso.matcher.ViewMatchers.hasDescendant;
 import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
 import static androidx.test.espresso.matcher.ViewMatchers.withContentDescription;
+import static androidx.test.espresso.matcher.ViewMatchers.withEffectiveVisibility;
 import static androidx.test.espresso.matcher.ViewMatchers.withId;
 import static androidx.test.espresso.matcher.ViewMatchers.withText;
+import static androidx.test.platform.app.InstrumentationRegistry.getInstrumentation;
+import static com.ichi2.anki.AnkiDroidApp.INSTRUMENTATION_TESTING;
 import static com.ichi2.anki.TestUtils.clickChildViewWithId;
 import static com.ichi2.anki.TestUtils.getActivityInstance;
 import static com.ichi2.anki.TestUtils.isScreenSw600dp;
 import static org.hamcrest.Matchers.instanceOf;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assume.assumeFalse;
 import static org.junit.Assume.assumeTrue;
 
 @SuppressLint("DirectSystemCurrentTimeMillisUsage")
 public class DeckPickerTest {
+    @Before
+    public void setup() {
+        INSTRUMENTATION_TESTING = true;
+        deleteAllDecks();
+    }
+
+
+    private void deleteAllDecks() {
+        deleteAllNotes();
+
+        while (true) {
+            try {
+                deleteDeck(0);
+            } catch (PerformException e) {
+                break; // no more decks left
+            }
+        }
+    }
+
+
+    private void deleteAllNotes() {
+        onView(withContentDescription(R.string.drawer_open)).perform(click());
+        onView(withText(R.string.card_browser)).perform(click());
+        onView(withText(R.string.card_browser_all_decks)).perform(click());
+        try {
+            openActionBarOverflowOrOptionsMenu(getInstrumentation().getTargetContext());
+            onView(withText(R.string.card_browser_select_all)).perform(click());
+            openActionBarOverflowOrOptionsMenu(getInstrumentation().getTargetContext());
+            onView(withText(R.string.card_browser_delete_card)).perform(click());
+        } catch (NoMatchingViewException ignored) {
+            pressBack(); // close overflow menu
+        }
+        pressBack();
+    }
+
+
+    private void deleteDeck(int position) {
+        onView(withId(R.id.files)).perform(RecyclerViewActions.actionOnItemAtPosition(position, longClick()));
+        onView(withText(R.string.contextmenu_deckpicker_delete_deck)).perform(click());
+    }
+
+
     @Rule
     public ActivityScenarioRule<DeckPicker> mActivityRule = new ActivityScenarioRule<>(DeckPicker.class);
 
@@ -99,12 +160,81 @@ public class DeckPickerTest {
         onView(withId(R.id.studyoptions_fragment)).check(matches(isDisplayed()));
     }
 
+
+    @Test
+    public void deckNormalCreationAndDeletionMakesSearchDecksIconVisible() {
+        int iconId = R.id.deck_picker_action_filter;
+        ensureIsGone(iconId);
+
+        for (int count = 1; count < 9; count++) {
+            createEmptyDeck("Deck" + count);
+            ensureIsGone(iconId);
+        }
+        createEmptyDeck("Deck9");
+        ensureIsVisible(iconId);
+
+        deleteDeck(0);
+        ensureIsGone(iconId);
+    }
+
+
+    @Test
+    public void subdeckCreationAndDeletionMakesSearchDecksIconVisible() {
+        int iconId = R.id.deck_picker_action_filter;
+        ensureIsGone(iconId);
+
+        createEmptyDeck(deckTreeName(1, 9, "Deck"));
+        ensureIsVisible(iconId);
+
+        deleteAllDecks();
+        ensureIsGone(iconId);
+
+        createEmptyDeck(deckTreeName(1, 11, "Deck"));
+        ensureIsVisible(iconId);
+
+        deleteAllDecks();
+        ensureIsGone(iconId);
+
+        createEmptyDeck(deckTreeName(1, 5, "Deck"));
+        ensureIsGone(iconId);
+        createEmptyDeck(deckTreeName(6, 11, "Deck"));
+        ensureIsVisible(iconId);
+    }
+
+
+    String deckTreeName(int startInclusive, int endInclusive, String prefix) {
+        return Arrays.stream(IntStream.rangeClosed(startInclusive, endInclusive).toArray())
+                .mapToObj(i -> prefix + i)
+                .collect(Collectors.joining("::"));
+    }
+
+
+    private void ensureIsGone(int iconId) {
+        boolean searchDeckIconIsVisible = true;
+        try {
+            ViewInteraction icon = onView(withId(iconId));
+            icon.check(isGone());
+        } catch (NoMatchingViewException e) {
+            searchDeckIconIsVisible = false;
+        }
+        assertFalse("Icon should be invisible", searchDeckIconIsVisible);
+    }
+
+
+    private void ensureIsVisible(int iconId) {
+        boolean searchDeckIconIsVisible = true;
+        try {
+            ViewInteraction icon = onView(withId(iconId));
+            icon.check(isVisible());
+        } catch (NoMatchingViewException e) {
+            searchDeckIconIsVisible = false;
+        }
+        assertTrue("Icon should be visible", searchDeckIconIsVisible);
+    }
+
+
     private void createDeckWithCard(String testString) {
-        // Create a new deck
-        onView(withId(R.id.fab_main)).perform(click());
-        onView(withId(R.id.add_deck_action)).perform(click());
-        onView(withId(R.id.action_edit)).perform(typeText("TestDeck" + testString));
-        onView(withId(R.id.md_buttonDefaultPositive)).perform(click());
+        createEmptyDeck("TestDeck" + testString);
 
         // The deck is currently empty, so if we tap on it, it becomes the selected deck but doesn't enter
         onView(withId(R.id.files)).perform(RecyclerViewActions.actionOnItem(hasDescendant(withText("TestDeck" + testString)), clickChildViewWithId(R.id.counts_layout)));
@@ -126,5 +256,35 @@ public class DeckPickerTest {
 
         // Go back to Deck Picker
         pressBack();
+    }
+
+
+    private void createEmptyDeck(String deckName) {
+        onView(withId(R.id.fab_main)).perform(click());
+        onView(withId(R.id.add_deck_action)).perform(click());
+        createDeckDialog(deckName);
+    }
+
+
+    private void createDeckDialog(String deckName) {
+        int editTextId = 16908297;
+        onView(withId(editTextId)).perform(typeText(deckName));
+        onView(withId(R.id.md_buttonDefaultPositive)).perform(click());
+
+    }
+
+
+    private ViewAssertion isGone() {
+        return getViewAssertion(GONE);
+    }
+
+
+    private ViewAssertion isVisible() {
+        return getViewAssertion(VISIBLE);
+    }
+
+
+    private ViewAssertion getViewAssertion(Visibility visibility) {
+        return matches(withEffectiveVisibility(visibility));
     }
 }

--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/DeckPickerTest.java
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/DeckPickerTest.java
@@ -27,82 +27,31 @@ import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 
-import java.util.Arrays;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
-
-import androidx.test.espresso.NoMatchingViewException;
-import androidx.test.espresso.PerformException;
-import androidx.test.espresso.ViewAssertion;
-import androidx.test.espresso.ViewInteraction;
 import androidx.test.espresso.contrib.RecyclerViewActions;
-import androidx.test.espresso.matcher.ViewMatchers.Visibility;
 import androidx.test.ext.junit.rules.ActivityScenarioRule;
 import androidx.test.rule.GrantPermissionRule;
 
 import static androidx.test.espresso.Espresso.onView;
-import static androidx.test.espresso.Espresso.openActionBarOverflowOrOptionsMenu;
 import static androidx.test.espresso.Espresso.pressBack;
 import static androidx.test.espresso.action.ViewActions.click;
 import static androidx.test.espresso.action.ViewActions.closeSoftKeyboard;
-import static androidx.test.espresso.action.ViewActions.longClick;
 import static androidx.test.espresso.action.ViewActions.typeText;
 import static androidx.test.espresso.assertion.ViewAssertions.matches;
-import static androidx.test.espresso.matcher.ViewMatchers.Visibility.GONE;
-import static androidx.test.espresso.matcher.ViewMatchers.Visibility.VISIBLE;
 import static androidx.test.espresso.matcher.ViewMatchers.hasDescendant;
 import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
 import static androidx.test.espresso.matcher.ViewMatchers.withContentDescription;
-import static androidx.test.espresso.matcher.ViewMatchers.withEffectiveVisibility;
 import static androidx.test.espresso.matcher.ViewMatchers.withId;
 import static androidx.test.espresso.matcher.ViewMatchers.withText;
-import static androidx.test.platform.app.InstrumentationRegistry.getInstrumentation;
 import static com.ichi2.anki.TestUtils.clickChildViewWithId;
 import static com.ichi2.anki.TestUtils.getActivityInstance;
 import static com.ichi2.anki.TestUtils.isScreenSw600dp;
 import static org.hamcrest.Matchers.instanceOf;
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assume.assumeFalse;
 import static org.junit.Assume.assumeTrue;
 
 @SuppressLint("DirectSystemCurrentTimeMillisUsage")
 public class DeckPickerTest {
-    private void deleteAllDecks() {
-        deleteAllNotes();
-
-        while (true) {
-            try {
-                deleteDeck(0);
-            } catch (PerformException e) {
-                break; // no more decks left
-            }
-        }
-    }
-
-
-    private void deleteAllNotes() {
-        onView(withContentDescription(R.string.drawer_open)).perform(click());
-        onView(withText(R.string.card_browser)).perform(click());
-        onView(withText(R.string.card_browser_all_decks)).perform(click());
-        try {
-            openActionBarOverflowOrOptionsMenu(getInstrumentation().getTargetContext());
-            onView(withText(R.string.card_browser_select_all)).perform(click());
-            openActionBarOverflowOrOptionsMenu(getInstrumentation().getTargetContext());
-            onView(withText(R.string.card_browser_delete_card)).perform(click());
-        } catch (NoMatchingViewException ignored) {
-            pressBack(); // close overflow menu
-        }
-        pressBack();
-    }
-
-
-    private void deleteDeck(int position) {
-        onView(withId(R.id.files)).perform(RecyclerViewActions.actionOnItemAtPosition(position, longClick()));
-        onView(withText(R.string.contextmenu_deckpicker_delete_deck)).perform(click());
-    }
-
-
     @Rule
     public ActivityScenarioRule<DeckPicker> mActivityRule = new ActivityScenarioRule<>(DeckPicker.class);
 
@@ -150,93 +99,12 @@ public class DeckPickerTest {
         onView(withId(R.id.studyoptions_fragment)).check(matches(isDisplayed()));
     }
 
-
-    @Test
-    public void deckNormalCreationAndDeletionMakesSearchDecksIconVisible() {
-        // Run the test only on emulator.
-        assumeTrue(InstrumentedTest.isEmulator());
-        assumeFalse("Test flaky in CI - #9282, skipping", TestUtils.wasBuiltOnCI());
-        deleteAllDecks();
-
-        int iconId = R.id.deck_picker_action_filter;
-        ensureIsGone(iconId);
-
-        for (int count = 1; count < 9; count++) {
-            createEmptyDeck("Deck" + count);
-            ensureIsGone(iconId);
-        }
-        createEmptyDeck("Deck9");
-        ensureIsVisible(iconId);
-
-        deleteDeck(0);
-        ensureIsGone(iconId);
-    }
-
-
-    @Test
-    public void subdeckCreationAndDeletionMakesSearchDecksIconVisible() {
-        // Run the test only on emulator.
-        assumeTrue(InstrumentedTest.isEmulator());
-        assumeFalse("Test flaky in CI - #9282, skipping", TestUtils.wasBuiltOnCI());
-        deleteAllDecks();
-
-        int iconId = R.id.deck_picker_action_filter;
-        ensureIsGone(iconId);
-
-        createEmptyDeck(deckTreeName(1, 9, "Deck"));
-        ensureIsVisible(iconId);
-
-        deleteAllDecks();
-        ensureIsGone(iconId);
-
-        createEmptyDeck(deckTreeName(1, 11, "Deck"));
-        ensureIsVisible(iconId);
-
-        deleteAllDecks();
-        ensureIsGone(iconId);
-
-        createEmptyDeck(deckTreeName(1, 5, "Deck"));
-        ensureIsGone(iconId);
-        createEmptyDeck(deckTreeName(6, 11, "Deck"));
-        ensureIsVisible(iconId);
-    }
-
-
-    String deckTreeName(int startInclusive, int endInclusive, String prefix) {
-        return Arrays.stream(IntStream.rangeClosed(startInclusive, endInclusive).toArray())
-                .mapToObj(i -> prefix + i)
-                .collect(Collectors.joining("::"));
-    }
-
-
-    private void ensureIsGone(int iconId) {
-        checkVisibility(iconId, false);
-    }
-
-
-    private void ensureIsVisible(int iconId) {
-        checkVisibility(iconId, true);
-    }
-
-
-    private void checkVisibility(int iconId, boolean expectedVisibility) {
-        boolean searchDeckIconIsVisible = true;
-        try {
-            ViewInteraction icon = onView(withId(iconId));
-            if (expectedVisibility) {
-                icon.check(isVisible());
-            } else {
-                icon.check(isGone());
-            }
-        } catch (NoMatchingViewException e) {
-            searchDeckIconIsVisible = false;
-        }
-        assertEquals("Icon should be " + (expectedVisibility ? "" : "in") + "visible", searchDeckIconIsVisible, expectedVisibility);
-    }
-
-
     private void createDeckWithCard(String testString) {
-        createEmptyDeck("TestDeck" + testString);
+        // Create a new deck
+        onView(withId(R.id.fab_main)).perform(click());
+        onView(withId(R.id.add_deck_action)).perform(click());
+        onView(withId(R.id.action_edit)).perform(typeText("TestDeck" + testString));
+        onView(withId(R.id.md_buttonDefaultPositive)).perform(click());
 
         // The deck is currently empty, so if we tap on it, it becomes the selected deck but doesn't enter
         onView(withId(R.id.files)).perform(RecyclerViewActions.actionOnItem(hasDescendant(withText("TestDeck" + testString)), clickChildViewWithId(R.id.counts_layout)));
@@ -258,35 +126,5 @@ public class DeckPickerTest {
 
         // Go back to Deck Picker
         pressBack();
-    }
-
-
-    private void createEmptyDeck(String deckName) {
-        onView(withId(R.id.fab_main)).perform(click());
-        onView(withId(R.id.add_deck_action)).perform(click());
-        createDeckDialog(deckName);
-    }
-
-
-    private void createDeckDialog(String deckName) {
-        int editTextId = 16908297;
-        onView(withId(editTextId)).perform(typeText(deckName));
-        onView(withId(R.id.md_buttonDefaultPositive)).perform(click());
-
-    }
-
-
-    private ViewAssertion isGone() {
-        return getViewAssertion(GONE);
-    }
-
-
-    private ViewAssertion isVisible() {
-        return getViewAssertion(VISIBLE);
-    }
-
-
-    private ViewAssertion getViewAssertion(Visibility visibility) {
-        return matches(withEffectiveVisibility(visibility));
     }
 }

--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/DeckPickerTest.java
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/DeckPickerTest.java
@@ -155,6 +155,7 @@ public class DeckPickerTest {
     public void deckNormalCreationAndDeletionMakesSearchDecksIconVisible() {
         // Run the test only on emulator.
         assumeTrue(InstrumentedTest.isEmulator());
+        assumeFalse("Test flaky in CI - #9282, skipping", TestUtils.wasBuiltOnCI());
         deleteAllDecks();
 
         int iconId = R.id.deck_picker_action_filter;
@@ -176,6 +177,7 @@ public class DeckPickerTest {
     public void subdeckCreationAndDeletionMakesSearchDecksIconVisible() {
         // Run the test only on emulator.
         assumeTrue(InstrumentedTest.isEmulator());
+        assumeFalse("Test flaky in CI - #9282, skipping", TestUtils.wasBuiltOnCI());
         deleteAllDecks();
 
         int iconId = R.id.deck_picker_action_filter;

--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/DeckPickerTest.java
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/DeckPickerTest.java
@@ -23,7 +23,6 @@ import android.annotation.SuppressLint;
 import com.ichi2.anki.tests.InstrumentedTest;
 import com.ichi2.anki.testutil.ThreadUtils;
 
-import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
@@ -58,7 +57,6 @@ import static androidx.test.espresso.matcher.ViewMatchers.withEffectiveVisibilit
 import static androidx.test.espresso.matcher.ViewMatchers.withId;
 import static androidx.test.espresso.matcher.ViewMatchers.withText;
 import static androidx.test.platform.app.InstrumentationRegistry.getInstrumentation;
-import static com.ichi2.anki.AnkiDroidApp.INSTRUMENTATION_TESTING;
 import static com.ichi2.anki.TestUtils.clickChildViewWithId;
 import static com.ichi2.anki.TestUtils.getActivityInstance;
 import static com.ichi2.anki.TestUtils.isScreenSw600dp;
@@ -70,13 +68,6 @@ import static org.junit.Assume.assumeTrue;
 
 @SuppressLint("DirectSystemCurrentTimeMillisUsage")
 public class DeckPickerTest {
-    @Before
-    public void setup() {
-        INSTRUMENTATION_TESTING = true;
-        deleteAllDecks();
-    }
-
-
     private void deleteAllDecks() {
         deleteAllNotes();
 
@@ -162,6 +153,10 @@ public class DeckPickerTest {
 
     @Test
     public void deckNormalCreationAndDeletionMakesSearchDecksIconVisible() {
+        // Run the test only on emulator.
+        assumeTrue(InstrumentedTest.isEmulator());
+        deleteAllDecks();
+
         int iconId = R.id.deck_picker_action_filter;
         ensureIsGone(iconId);
 
@@ -179,6 +174,10 @@ public class DeckPickerTest {
 
     @Test
     public void subdeckCreationAndDeletionMakesSearchDecksIconVisible() {
+        // Run the test only on emulator.
+        assumeTrue(InstrumentedTest.isEmulator());
+        deleteAllDecks();
+
         int iconId = R.id.deck_picker_action_filter;
         ensureIsGone(iconId);
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -168,7 +168,7 @@ open class DeckPicker : NavigationDrawerActivity(), StudyOptionsListener, SyncEr
         val did = view.tag as Long
         if (!col.decks.children(did).isEmpty()) {
             col.decks.collapse(did)
-            renderPage()
+            renderPage(deckCount) // no change in deck count
             dismissAllDialogFragments()
         }
     }
@@ -566,7 +566,7 @@ open class DeckPicker : NavigationDrawerActivity(), StudyOptionsListener, SyncEr
     }
 
     private fun updateSearchDecksIconVisibility(menu: Menu) {
-        menu.findItem(R.id.deck_picker_action_filter).isVisible = col.decks.count() >= 10
+        menu.findItem(R.id.deck_picker_action_filter).isVisible = deckCount >= 10
     }
 
     @VisibleForTesting
@@ -1940,7 +1940,7 @@ open class DeckPicker : NavigationDrawerActivity(), StudyOptionsListener, SyncEr
                 return
             }
             context.mDueTree = result.map { x -> x.unsafeCastToType(AbstractDeckTreeNode::class.java) }
-            context.renderPage()
+            context.renderPage(context.deckCount)
             // Update the mini statistics bar as well
             AnkiStatsTaskHandler.createReviewSummaryStatistics(context.col, context.mReviewSummaryTextView)
             Timber.d("Startup - Deck List UI Completed")
@@ -1966,7 +1966,7 @@ open class DeckPicker : NavigationDrawerActivity(), StudyOptionsListener, SyncEr
         }
     }
 
-    fun renderPage() {
+    fun renderPage(deckCountBeforeChange: Int) {
         if (mDueTree == null) {
             // mDueTree may be set back to null when the activity restart.
             // We may need to recompute it.
@@ -2044,9 +2044,8 @@ open class DeckPicker : NavigationDrawerActivity(), StudyOptionsListener, SyncEr
             mFocusedDeck = current
         }
 
-        // if Deck Count may have changed, update SearchDeck icon Visibility
-        val deckCount = col.decks.count()
-        if (deckCount == 9 || deckCount == 10) {
+        if (deckCountBeforeChange != deckCount) {
+            // update SearchDeck Icon visibility
             invalidateOptionsMenu()
         }
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -566,7 +566,7 @@ open class DeckPicker : NavigationDrawerActivity(), StudyOptionsListener, SyncEr
     }
 
     private fun updateSearchDecksIconVisibility(menu: Menu) {
-        menu.findItem(R.id.deck_picker_action_filter).isVisible = deckCount >= 10
+        menu.findItem(R.id.deck_picker_action_filter).isVisible = colIsOpen() && col.decks.count() >= 10
     }
 
     @VisibleForTesting

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -495,6 +495,7 @@ open class DeckPicker : NavigationDrawerActivity(), StudyOptionsListener, SyncEr
     }
 
     override fun onPrepareOptionsMenu(menu: Menu): Boolean {
+        updateSearchDecksIconVisibility(menu)
         // Null check to prevent crash when col inaccessible
         // #9081: sync leaves the collection closed, thus colIsOpen() is insufficient, carefully open the collection if possible
         return if (CollectionHelper.getInstance().getColSafe(this) == null) {
@@ -559,10 +560,13 @@ open class DeckPicker : NavigationDrawerActivity(), StudyOptionsListener, SyncEr
                 menu.findItem(R.id.action_undo).title = undo
             }
 
-            // Remove the filter - not necessary and search has other implications for new users.
-            menu.findItem(R.id.deck_picker_action_filter).isVisible = col.decks.count() >= 10
+            updateSearchDecksIconVisibility(menu)
         }
         return super.onCreateOptionsMenu(menu)
+    }
+
+    private fun updateSearchDecksIconVisibility(menu: Menu) {
+        menu.findItem(R.id.deck_picker_action_filter).isVisible = col.decks.count() >= 10
     }
 
     @VisibleForTesting
@@ -2038,6 +2042,12 @@ open class DeckPicker : NavigationDrawerActivity(), StudyOptionsListener, SyncEr
         if (mFocusedDeck != current) {
             scrollDecklistToDeck(current)
             mFocusedDeck = current
+        }
+
+        // if Deck Count may have changed, update SearchDeck icon Visibility
+        val deckCount = col.decks.count()
+        if (deckCount == 9 || deckCount == 10) {
+            invalidateOptionsMenu()
         }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -566,7 +566,7 @@ open class DeckPicker : NavigationDrawerActivity(), StudyOptionsListener, SyncEr
     }
 
     private fun updateSearchDecksIconVisibility() {
-        mSearchDecksIcon!!.isVisible = deckCount >= 10
+        mSearchDecksIcon?.isVisible = deckCount >= 10
     }
 
     @VisibleForTesting

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -168,7 +168,7 @@ open class DeckPicker : NavigationDrawerActivity(), StudyOptionsListener, SyncEr
         val did = view.tag as Long
         if (!col.decks.children(did).isEmpty()) {
             col.decks.collapse(did)
-            renderPage(deckCount) // no change in deck count
+            renderPage()
             dismissAllDialogFragments()
         }
     }
@@ -1940,7 +1940,7 @@ open class DeckPicker : NavigationDrawerActivity(), StudyOptionsListener, SyncEr
                 return
             }
             context.mDueTree = result.map { x -> x.unsafeCastToType(AbstractDeckTreeNode::class.java) }
-            context.renderPage(context.deckCount)
+            context.renderPage()
             // Update the mini statistics bar as well
             AnkiStatsTaskHandler.createReviewSummaryStatistics(context.col, context.mReviewSummaryTextView)
             Timber.d("Startup - Deck List UI Completed")
@@ -1966,7 +1966,7 @@ open class DeckPicker : NavigationDrawerActivity(), StudyOptionsListener, SyncEr
         }
     }
 
-    fun renderPage(deckCountBeforeChange: Int) {
+    fun renderPage() {
         if (mDueTree == null) {
             // mDueTree may be set back to null when the activity restart.
             // We may need to recompute it.
@@ -2044,10 +2044,8 @@ open class DeckPicker : NavigationDrawerActivity(), StudyOptionsListener, SyncEr
             mFocusedDeck = current
         }
 
-        if (deckCountBeforeChange != deckCount) {
-            // update SearchDeck Icon visibility
-            invalidateOptionsMenu()
-        }
+        // update SearchDeck Icon visibility
+        invalidateOptionsMenu()
     }
 
     // Callback to show study options for currently selected deck

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -143,7 +143,8 @@ open class DeckPicker : NavigationDrawerActivity(), StudyOptionsListener, SyncEr
     @VisibleForTesting
     var mDueTree: List<TreeNode<AbstractDeckTreeNode>>? = null
 
-    var mSearchDecksIcon: MenuItem? = null
+    @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+    var searchDecksIcon: MenuItem? = null
 
     /**
      * Flag to indicate whether the activity will perform a sync in its onResume.
@@ -515,8 +516,8 @@ open class DeckPicker : NavigationDrawerActivity(), StudyOptionsListener, SyncEr
         menu.findItem(R.id.action_check_media).isEnabled = sdCardAvailable
         menu.findItem(R.id.action_empty_cards).isEnabled = sdCardAvailable
 
-        mSearchDecksIcon = menu.findItem(R.id.deck_picker_action_filter)
-        mSearchDecksIcon!!.setOnActionExpandListener(object : MenuItem.OnActionExpandListener {
+        searchDecksIcon = menu.findItem(R.id.deck_picker_action_filter)
+        searchDecksIcon!!.setOnActionExpandListener(object : MenuItem.OnActionExpandListener {
             // When SearchItem is expanded
             override fun onMenuItemActionExpand(item: MenuItem?): Boolean {
                 Timber.i("DeckPicker:: SearchItem opened")
@@ -534,7 +535,7 @@ open class DeckPicker : NavigationDrawerActivity(), StudyOptionsListener, SyncEr
             }
         })
 
-        mToolbarSearchView = mSearchDecksIcon!!.actionView as SearchView
+        mToolbarSearchView = searchDecksIcon!!.actionView as SearchView
         mToolbarSearchView!!.queryHint = getString(R.string.search_decks)
         mToolbarSearchView!!.setOnQueryTextListener(object : SearchView.OnQueryTextListener {
             override fun onQueryTextSubmit(query: String): Boolean {
@@ -566,7 +567,7 @@ open class DeckPicker : NavigationDrawerActivity(), StudyOptionsListener, SyncEr
     }
 
     private fun updateSearchDecksIconVisibility() {
-        mSearchDecksIcon?.isVisible = deckCount >= 10
+        searchDecksIcon?.isVisible = deckCount >= 10
     }
 
     @VisibleForTesting

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -562,7 +562,7 @@ open class DeckPicker : NavigationDrawerActivity(), StudyOptionsListener, SyncEr
     }
 
     private fun updateSearchDecksIconVisibility() {
-        searchDecksIcon?.isVisible = deckCount >= 10
+        searchDecksIcon?.isVisible = colIsOpen() && col.decks.count() >= 10
     }
 
     @VisibleForTesting

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -168,12 +168,7 @@ open class DeckPicker : NavigationDrawerActivity(), StudyOptionsListener, SyncEr
     // LISTENERS
     // ----------------------------------------------------------------------------
     private val mDeckExpanderClickListener = View.OnClickListener { view: View ->
-        val did = view.tag as Long
-        if (!col.decks.children(did).isEmpty()) {
-            col.decks.collapse(did)
-            renderPage()
-            dismissAllDialogFragments()
-        }
+        toggleDeckExpand(view.tag as Long)
     }
     private val mDeckClickListener = View.OnClickListener { v: View -> onDeckClick(v, DeckSelectionType.DEFAULT) }
     private val mCountsClickListener = View.OnClickListener { v: View -> onDeckClick(v, DeckSelectionType.SHOW_STUDY_OPTIONS) }
@@ -908,6 +903,15 @@ open class DeckPicker : NavigationDrawerActivity(), StudyOptionsListener, SyncEr
 
     private fun showCollectionErrorDialog() {
         dialogHandler.sendEmptyMessage(DialogHandler.MSG_SHOW_COLLECTION_LOADING_ERROR_DIALOG)
+    }
+
+    @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+    fun toggleDeckExpand(did: Long) {
+        if (!col.decks.children(did).isEmpty()) {
+            col.decks.collapse(did)
+            renderPage()
+            dismissAllDialogFragments()
+        }
     }
 
     fun addNote() {

--- a/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/CreateDeckDialogTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/CreateDeckDialogTest.kt
@@ -159,7 +159,7 @@ class CreateDeckDialogTest : RobolectricTest() {
                     deckPicker.updateDeckList()
                     assertEquals(deckCounter.get() - 1, deckPicker.deckCount)
 
-                    assertEquals(deckPicker.mSearchDecksIcon!!.isVisible, deckPicker.deckCount >= 10)
+                    assertEquals(deckPicker.searchDecksIcon!!.isVisible, deckPicker.deckCount >= 10)
 
                     // After the last deck was created, delete a deck
                     if (deckPicker.deckCount >= 10) {
@@ -169,7 +169,7 @@ class CreateDeckDialogTest : RobolectricTest() {
                         deckPicker.updateDeckList()
                         assertEquals(deckCounter.get() - 1, deckPicker.deckCount)
 
-                        assertFalse(deckPicker.mSearchDecksIcon!!.isVisible)
+                        assertFalse(deckPicker.searchDecksIcon!!.isVisible)
                     }
                 }
                 createDeckDialog.createDeck("Deck$i")
@@ -186,13 +186,13 @@ class CreateDeckDialogTest : RobolectricTest() {
                 assertEquals(11, decks.count())
                 deckPicker.updateDeckList()
                 assertEquals(10, deckPicker.deckCount)
-                assertTrue(deckPicker.mSearchDecksIcon!!.isVisible)
+                assertTrue(deckPicker.searchDecksIcon!!.isVisible)
 
                 deckPicker.confirmDeckDeletion(decks.id("Deck0::Deck1"))
                 assertEquals(2, decks.count())
                 deckPicker.updateDeckList()
                 assertEquals(1, deckPicker.deckCount)
-                assertFalse(deckPicker.mSearchDecksIcon!!.isVisible)
+                assertFalse(deckPicker.searchDecksIcon!!.isVisible)
             }
             createDeckDialog.createDeck(deckTreeName(0, 9, "Deck"))
 
@@ -201,13 +201,13 @@ class CreateDeckDialogTest : RobolectricTest() {
                 assertEquals(13, decks.count())
                 deckPicker.updateDeckList()
                 assertEquals(12, deckPicker.deckCount)
-                assertTrue(deckPicker.mSearchDecksIcon!!.isVisible)
+                assertTrue(deckPicker.searchDecksIcon!!.isVisible)
 
                 deckPicker.confirmDeckDeletion(decks.id("Deck0::Deck1"))
                 assertEquals(2, decks.count())
                 deckPicker.updateDeckList()
                 assertEquals(1, deckPicker.deckCount)
-                assertFalse(deckPicker.mSearchDecksIcon!!.isVisible)
+                assertFalse(deckPicker.searchDecksIcon!!.isVisible)
             }
             createDeckDialog.createDeck(deckTreeName(0, 11, "Deck"))
 
@@ -216,7 +216,7 @@ class CreateDeckDialogTest : RobolectricTest() {
                 assertEquals(7, decks.count())
                 deckPicker.updateDeckList()
                 assertEquals(6, deckPicker.deckCount)
-                assertFalse(deckPicker.mSearchDecksIcon!!.isVisible)
+                assertFalse(deckPicker.searchDecksIcon!!.isVisible)
             }
             createDeckDialog.createDeck(deckTreeName(0, 5, "Deck"))
 
@@ -225,7 +225,7 @@ class CreateDeckDialogTest : RobolectricTest() {
                 assertEquals(13, decks.count())
                 deckPicker.updateDeckList()
                 assertEquals(12, deckPicker.deckCount)
-                assertTrue(deckPicker.mSearchDecksIcon!!.isVisible)
+                assertTrue(deckPicker.searchDecksIcon!!.isVisible)
             }
             createDeckDialog.createDeck(deckTreeName(6, 11, "Deck"))
         }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/CreateDeckDialogTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/CreateDeckDialogTest.kt
@@ -148,25 +148,26 @@ class CreateDeckDialogTest : RobolectricTest() {
     @Test
     fun searchDecksIconVisibilityDeckCreationTest() {
         mActivityScenario!!.onActivity { deckPicker ->
+            val decks = deckPicker.col.decks
             val deckCounter = AtomicInteger(1)
             for (i in 0 until 10) {
                 val createDeckDialog = CreateDeckDialog(deckPicker, R.string.new_deck, CreateDeckDialog.DeckDialogType.DECK, null)
                 createDeckDialog.setOnNewDeckCreated { did ->
-                    assertEquals(deckCounter.incrementAndGet(), deckPicker.col.decks.count())
+                    assertEquals(deckCounter.incrementAndGet(), decks.count())
+
+                    assertEquals(deckCounter.get(), decks.count())
 
                     deckPicker.updateDeckList()
-                    assertEquals(deckCounter.get() - 1, deckPicker.deckCount)
-
-                    assertEquals(deckPicker.searchDecksIcon!!.isVisible, deckPicker.deckCount >= 10)
+                    assertEquals(deckPicker.searchDecksIcon!!.isVisible, decks.count() >= 10)
 
                     // After the last deck was created, delete a deck
-                    if (deckPicker.deckCount >= 10) {
+                    if (decks.count() >= 10) {
                         deckPicker.confirmDeckDeletion(did)
-                        assertEquals(deckCounter.decrementAndGet(), deckPicker.col.decks.count())
+                        assertEquals(deckCounter.decrementAndGet(), decks.count())
+
+                        assertEquals(deckCounter.get(), decks.count())
 
                         deckPicker.updateDeckList()
-                        assertEquals(deckCounter.get() - 1, deckPicker.deckCount)
-
                         assertFalse(deckPicker.searchDecksIcon!!.isVisible)
                     }
                 }
@@ -181,76 +182,45 @@ class CreateDeckDialogTest : RobolectricTest() {
             var createDeckDialog = CreateDeckDialog(deckPicker, R.string.new_deck, CreateDeckDialog.DeckDialogType.DECK, null)
             val decks = deckPicker.col.decks
             createDeckDialog.setOnNewDeckCreated {
-                assertEquals(11, decks.count())
+                assertEquals(10, decks.count())
                 deckPicker.updateDeckList()
-                assertEquals(10, deckPicker.deckCount)
                 assertTrue(deckPicker.searchDecksIcon!!.isVisible)
 
                 deckPicker.confirmDeckDeletion(decks.id("Deck0::Deck1"))
                 assertEquals(2, decks.count())
                 deckPicker.updateDeckList()
-                assertEquals(1, deckPicker.deckCount)
                 assertFalse(deckPicker.searchDecksIcon!!.isVisible)
             }
-            createDeckDialog.createDeck(deckTreeName(0, 9, "Deck"))
+            createDeckDialog.createDeck(deckTreeName(0, 8, "Deck"))
 
             createDeckDialog = CreateDeckDialog(deckPicker, R.string.new_deck, CreateDeckDialog.DeckDialogType.DECK, null)
             createDeckDialog.setOnNewDeckCreated {
-                assertEquals(13, decks.count())
+                assertEquals(12, decks.count())
                 deckPicker.updateDeckList()
-                assertEquals(12, deckPicker.deckCount)
                 assertTrue(deckPicker.searchDecksIcon!!.isVisible)
 
                 deckPicker.confirmDeckDeletion(decks.id("Deck0::Deck1"))
                 assertEquals(2, decks.count())
                 deckPicker.updateDeckList()
-                assertEquals(1, deckPicker.deckCount)
                 assertFalse(deckPicker.searchDecksIcon!!.isVisible)
             }
-            createDeckDialog.createDeck(deckTreeName(0, 11, "Deck"))
+            createDeckDialog.createDeck(deckTreeName(0, 10, "Deck"))
 
             createDeckDialog = CreateDeckDialog(deckPicker, R.string.new_deck, CreateDeckDialog.DeckDialogType.DECK, null)
             createDeckDialog.setOnNewDeckCreated {
-                assertEquals(7, decks.count())
+                assertEquals(6, decks.count())
                 deckPicker.updateDeckList()
-                assertEquals(6, deckPicker.deckCount)
                 assertFalse(deckPicker.searchDecksIcon!!.isVisible)
             }
-            createDeckDialog.createDeck(deckTreeName(0, 5, "Deck"))
+            createDeckDialog.createDeck(deckTreeName(0, 4, "Deck"))
 
             createDeckDialog = CreateDeckDialog(deckPicker, R.string.new_deck, CreateDeckDialog.DeckDialogType.DECK, null)
             createDeckDialog.setOnNewDeckCreated {
-                assertEquals(13, decks.count())
+                assertEquals(12, decks.count())
                 deckPicker.updateDeckList()
-                assertEquals(12, deckPicker.deckCount)
                 assertTrue(deckPicker.searchDecksIcon!!.isVisible)
             }
             createDeckDialog.createDeck(deckTreeName(6, 11, "Deck"))
-        }
-    }
-
-    @Test
-    fun searchDecksIconVisibilityExpandCollapseTest() {
-        mActivityScenario?.onActivity { deckPicker ->
-            val decks = deckPicker.col.decks
-            val createDeckDialog = CreateDeckDialog(deckPicker, R.string.new_deck, CreateDeckDialog.DeckDialogType.DECK, null)
-            createDeckDialog.setOnNewDeckCreated {
-                assertEquals(11, decks.count())
-                deckPicker.updateDeckList()
-                assertEquals(10, deckPicker.deckCount)
-                assertTrue(deckPicker.searchDecksIcon!!.isVisible)
-
-                val did = decks.id(deckTreeName(0, 6, "Deck"))
-                deckPicker.toggleDeckExpand(did)
-                deckPicker.updateDeckList()
-                assertEquals(7, deckPicker.deckCount)
-                assertFalse(deckPicker.searchDecksIcon!!.isVisible)
-                deckPicker.toggleDeckExpand(did)
-                deckPicker.updateDeckList()
-                assertEquals(10, deckPicker.deckCount)
-                assertTrue(deckPicker.searchDecksIcon!!.isVisible)
-            }
-            createDeckDialog.createDeck(deckTreeName(0, 9, "Deck"))
         }
     }
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/CreateDeckDialogTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/CreateDeckDialogTest.kt
@@ -33,8 +33,6 @@ import org.robolectric.RobolectricTestRunner
 import java.util.*
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.atomic.AtomicReference
-import java.util.stream.Collectors
-import java.util.stream.IntStream
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
@@ -231,9 +229,33 @@ class CreateDeckDialogTest : RobolectricTest() {
         }
     }
 
-    private fun deckTreeName(startInclusive: Int, endInclusive: Int, prefix: String): String {
-        return Arrays.stream(IntStream.rangeClosed(startInclusive, endInclusive).toArray())
-            .mapToObj { i: Int -> prefix + i }
-            .collect(Collectors.joining("::"))
+    @Test
+    fun searchDecksIconVisibilityExpandCollapseTest() {
+        mActivityScenario?.onActivity { deckPicker ->
+            val decks = deckPicker.col.decks
+            val createDeckDialog = CreateDeckDialog(deckPicker, R.string.new_deck, CreateDeckDialog.DeckDialogType.DECK, null)
+            createDeckDialog.setOnNewDeckCreated {
+                assertEquals(11, decks.count())
+                deckPicker.updateDeckList()
+                assertEquals(10, deckPicker.deckCount)
+                assertTrue(deckPicker.searchDecksIcon!!.isVisible)
+
+                val did = decks.id(deckTreeName(0, 6, "Deck"))
+                deckPicker.toggleDeckExpand(did)
+                deckPicker.updateDeckList()
+                assertEquals(7, deckPicker.deckCount)
+                assertFalse(deckPicker.searchDecksIcon!!.isVisible)
+                deckPicker.toggleDeckExpand(did)
+                deckPicker.updateDeckList()
+                assertEquals(10, deckPicker.deckCount)
+                assertTrue(deckPicker.searchDecksIcon!!.isVisible)
+            }
+            createDeckDialog.createDeck(deckTreeName(0, 9, "Deck"))
+        }
+    }
+
+    private fun deckTreeName(start: Int, end: Int, prefix: String): String {
+        return List(end - start + 1) { "${prefix}${it + start}" }
+            .joinToString("::")
     }
 }


### PR DESCRIPTION
## Purpose / Description
Search Decks Icon would not change (show or unshow) if deck count was changed (added or deleted) unless app was restarted

## Fixes
Fixes #11112

## Approach
Since after DeckList was changed, `renderPage()` will be called, added a deckcount check there and if deckcount was 9 or 10 it would invalidate options menu. Also added the visibility update to `onPrepareOptionsMenu`.

## How Has This Been Tested?
Tested on emulator

https://user-images.githubusercontent.com/59933477/165406059-c0a6c3d9-4da0-483b-9534-1747f4baee35.mov



## Checklist

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [x] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
