### PR TITLE
Fix @KotlinCleanup for IFieldController

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/activity/MultimediaEditFieldActivity.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/activity/MultimediaEditFieldActivity.java
@@ -438,6 +438,7 @@ public class MultimediaEditFieldActivity extends AnkiActivity
 
     /** Intermediate class to hold state for the onRequestPermissionsResult callback */
     private final static class ChangeUIRequest {
+        @NonNull
         private final IField mNewField;
         private final int mState;
         private boolean mRequiresPermissionCheck = true;
@@ -449,11 +450,12 @@ public class MultimediaEditFieldActivity extends AnkiActivity
         /** A change in UI via access to the activity. Not (yet) cancellable */
         public static final int EXTERNAL_FIELD_CHANGE = 2;
 
-        private ChangeUIRequest(IField field, int state) {
+        private ChangeUIRequest(@NonNull IField field, int state) {
             this.mNewField = field;
             this.mState = state;
         }
 
+        @NonNull
         private IField getField() {
             return mNewField;
         }
@@ -462,11 +464,11 @@ public class MultimediaEditFieldActivity extends AnkiActivity
             return new ChangeUIRequest(field, ACTIVITY_LOAD);
         }
 
-        private static ChangeUIRequest uiChange(IField field) {
+        private static ChangeUIRequest uiChange(@NonNull IField field) {
             return new ChangeUIRequest(field, UI_CHANGE);
         }
 
-        private static ChangeUIRequest fieldChange(IField field) {
+        private static ChangeUIRequest fieldChange(@NonNull IField field) {
             return new ChangeUIRequest(field, EXTERNAL_FIELD_CHANGE);
         }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicAudioRecordingFieldController.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicAudioRecordingFieldController.kt
@@ -41,7 +41,7 @@ class BasicAudioRecordingFieldController : FieldControllerBase(), IFieldControll
     private var mTempAudioPath: String? = null
     private var mAudioView: AudioView? = null
 
-    override fun createUI(context: Context, layout: LinearLayout?) {
+    override fun createUI(context: Context, layout: LinearLayout) {
         val origAudioPath = mField.audioPath
         var bExist = false
         if (origAudioPath != null) {
@@ -73,7 +73,7 @@ class BasicAudioRecordingFieldController : FieldControllerBase(), IFieldControll
                 mField.setHasTemporaryMedia(true)
             }
         })
-        layout!!.addView(mAudioView, LinearLayout.LayoutParams.MATCH_PARENT)
+        layout.addView(mAudioView, LinearLayout.LayoutParams.MATCH_PARENT)
 
         context.apply {
             // add preview of the field data to provide context to the user

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicMediaClipFieldController.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicMediaClipFieldController.kt
@@ -40,7 +40,7 @@ class BasicMediaClipFieldController : FieldControllerBase(), IFieldController {
 
     private lateinit var tvAudioClip: FixedTextView
 
-    override fun createUI(context: Context, layout: LinearLayout?) {
+    override fun createUI(context: Context, layout: LinearLayout) {
         ankiCacheDirectory = context.externalCacheDir?.absolutePath
         // #9639: .opus is application/octet-stream in API 26,
         // requires a workaround as we don't want to enable application/octet-stream by default
@@ -54,7 +54,7 @@ class BasicMediaClipFieldController : FieldControllerBase(), IFieldController {
                 ACTIVITY_SELECT_AUDIO_CLIP
             )
         }
-        layout!!.addView(btnLibrary, ViewGroup.LayoutParams.MATCH_PARENT)
+        layout.addView(btnLibrary, ViewGroup.LayoutParams.MATCH_PARENT)
         val btnVideo = Button(mActivity).apply {
             text = mActivity.getText(R.string.multimedia_editor_import_video)
             setOnClickListener {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicTextFieldController.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicTextFieldController.kt
@@ -52,11 +52,11 @@ class BasicTextFieldController : FieldControllerBase(), IFieldController, Dialog
 
     // This is used to copy from another field value to this field
     private var mPossibleClones: ArrayList<String>? = null
-    override fun createUI(context: Context, layout: LinearLayout?) {
+    override fun createUI(context: Context, layout: LinearLayout) {
         mEditText = FixedEditText(mActivity)
         mEditText!!.minLines = 3
         mEditText!!.setText(mField.text)
-        layout!!.addView(mEditText, LinearLayout.LayoutParams.MATCH_PARENT)
+        layout.addView(mEditText, LinearLayout.LayoutParams.MATCH_PARENT)
         val layoutTools = LinearLayout(mActivity)
         layoutTools.orientation = LinearLayout.HORIZONTAL
         layout.addView(layoutTools)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/FieldControllerBase.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/FieldControllerBase.java
@@ -24,6 +24,7 @@ import android.os.Bundle;
 import com.ichi2.anki.multimediacard.IMultimediaEditableNote;
 import com.ichi2.anki.multimediacard.activity.MultimediaEditFieldActivity;
 
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 public abstract class FieldControllerBase implements IFieldController {
@@ -35,12 +36,13 @@ public abstract class FieldControllerBase implements IFieldController {
 
 
     @Override
-    public void setField(IField field) {
+    public void setField(@NonNull IField field) {
         mField = field;
     }
 
 
     @Override
+    // current code seems to require note to be nullable!
     public void setNote(IMultimediaEditableNote note) {
         mNote = note;
     }
@@ -53,13 +55,13 @@ public abstract class FieldControllerBase implements IFieldController {
 
 
     @Override
-    public void setEditingActivity(MultimediaEditFieldActivity activity) {
+    public void setEditingActivity(@NonNull MultimediaEditFieldActivity activity) {
         mActivity = activity;
     }
 
 
     @Override
-    public void loadInstanceState(Bundle savedInstancedState) { /* Default implementation does nothing */ }
+    public void loadInstanceState(@Nullable Bundle savedInstancedState) { /* Default implementation does nothing */ }
 
 
     @Override

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/IFieldController.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/IFieldController.kt
@@ -25,7 +25,6 @@ import android.os.Bundle
 import android.widget.LinearLayout
 import com.ichi2.anki.multimediacard.IMultimediaEditableNote
 import com.ichi2.anki.multimediacard.activity.MultimediaEditFieldActivity
-import com.ichi2.utils.KotlinCleanup
 
 /**
  * A note in anki has fields. Each of the fields can be edited.
@@ -36,10 +35,10 @@ import com.ichi2.utils.KotlinCleanup
  * MultimediaEditFieldActivity calls controller's set methods by protocol before it works on UI creation.
  */
 interface IFieldController {
-    @KotlinCleanup("make field non-null")
+
     // This is guaranteed to be called before create UI, so that the controller
     // is aware of the field, including type an content.
-    fun setField(field: IField?)
+    fun setField(field: IField)
 
     // This is guaranteed to be called before create UI, so that the controller
     // is aware of the note.
@@ -50,7 +49,7 @@ interface IFieldController {
     fun setFieldIndex(index: Int)
 
     // Called before other
-    fun setEditingActivity(activity: MultimediaEditFieldActivity?)
+    fun setEditingActivity(activity: MultimediaEditFieldActivity)
 
     // Called after setting field/note/index/activity, allows state persistence across Activity restarts
     fun loadInstanceState(savedInstanceState: Bundle?)
@@ -58,9 +57,8 @@ interface IFieldController {
     // Called during editing Activity pause, allows state persistence across Activity restarts
     fun saveInstanceState(): Bundle?
 
-    @KotlinCleanup("make layout non-null")
     // Layout is vertical inside a scroll view already
-    fun createUI(context: Context, layout: LinearLayout?)
+    fun createUI(context: Context, layout: LinearLayout)
 
     // If the controller ever starts an activity for result, this is going to be
     // called back on result.


### PR DESCRIPTION
## Purpose / Description

This fixes the @KotlinCleanup for the IFieldController.kt file. Based on the research I've done for the cleanup I also improved the nullability for other classes related to IFieldController. This will make the transition to kotlin smoother for java files in the `com.ichi2.anki.multimediacard` package.

## How Has This Been Tested?

Ran the usual tests.

## Checklist

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
