### PR TITLE
Fixed `A::` last deck not being escaped to "blank"

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
@@ -716,7 +716,8 @@ public class Decks extends DeckManager {
                 throw DeckRenameException.filteredAncestor(name, s);
             }
         }
-        name = s + "::" + path[path.length - 1];
+        String lastDeck = path[path.length - 1];
+        name = s + "::" + (lastDeck.isEmpty() ? "blank" : lastDeck);
         return name;
     }
 

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/DecksTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/DecksTest.java
@@ -22,9 +22,14 @@ import com.ichi2.utils.JSONObject;
 
 import org.apache.http.util.Asserts;
 import org.junit.Test;
+import org.junit.jupiter.api.Nested;
 import org.junit.runner.RunWith;
+import org.robolectric.ParameterizedRobolectricTestRunner;
+import org.robolectric.ParameterizedRobolectricTestRunner.Parameters;
 
+import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
@@ -283,5 +288,39 @@ public class DecksTest extends RobolectricTest {
         DeckConfig config = decks.confForDid(d.getLong("id"));
 
         assertThat("If a config is not found, return the default", config.getLong("id"), is(1L));
+    }
+
+    @Nested
+    @RunWith(ParameterizedRobolectricTestRunner.class)
+    public static class EmptyStringDeckTreeTest extends RobolectricTest {
+        @Parameters(name = "\"{0}\"")
+        public static Iterable<String> deckNames() {
+            return Arrays.asList("A::", "::A", "::", "::A::", "::::", "A::B::", "::A::B", "::A::B::");
+        }
+
+
+        private final String mDeckName;
+
+
+        public EmptyStringDeckTreeTest(String deckName) {
+            this.mDeckName = deckName;
+        }
+
+
+        @Test
+        public void ensureEmptyStringsGetRenamedToBlank() {
+            DeckManager decks = getCol().getDecks();
+
+            String escapedPath = decks.name(addDeck(mDeckName));
+            assertThat("Decks should be added", decks.count(), is(1 + mDeckName.split("::", -1).length));
+            assertThat("Deck Hierarchy created correctly", escapedPath, is(escapeEmptyDeckNames(mDeckName)));
+        }
+
+
+        private String escapeEmptyDeckNames(String deckName) {
+            return Arrays.stream(deckName.split("::", -1))
+                    .map(dn -> dn.isEmpty() ? "blank" : dn)
+                    .collect(Collectors.joining("::"));
+        }
     }
 }


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
_Describe the problem or feature and motivation_

## Fixes
Fixes #11120 

## Approach
_How does this change address the problem?_

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration (SDK version(s), emulator or physical, etc)

## Learning (optional, can help others)
_Describe the research stage_

_Links to blog posts, patterns, libraries or addons used to solve this problem_

## Checklist
_Please, go through these checks before submitting the PR._

- [ ] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [ ] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [ ] You have commented your code, particularly in hard-to-understand areas
- [ ] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
