### PR TITLE
(feat:js-api) reset card progress js api and enhance set due js api

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidJsAPI.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidJsAPI.kt
@@ -525,4 +525,11 @@ open class AnkiDroidJsAPI(private val activity: AbstractFlashcardViewer) {
         // it may be called in previewer so just return true value here
         return true
     }
+
+    @JavascriptInterface
+    open fun ankiResetProgress(): Boolean {
+        // the function is overridden in Reviewer.kt
+        // it may be called in previewer so just return true value here
+        return true
+    }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidJsAPIConstants.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidJsAPIConstants.kt
@@ -42,6 +42,7 @@ object AnkiDroidJsAPIConstants {
     const val SUSPEND_CARD = "suspendCard"
     const val SUSPEND_NOTE = "suspendNote"
     const val SET_CARD_DUE = "setCardDue"
+    const val RESET_PROGRESS = "setCardDue"
 
     fun initApiMap(): HashMap<String, Boolean> {
         val jsApiListMap = HashMap<String, Boolean>()
@@ -53,6 +54,7 @@ object AnkiDroidJsAPIConstants {
         jsApiListMap[SUSPEND_CARD] = false
         jsApiListMap[SUSPEND_NOTE] = false
         jsApiListMap[SET_CARD_DUE] = false
+        jsApiListMap[RESET_PROGRESS] = false
 
         return jsApiListMap
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
@@ -1544,7 +1544,7 @@ open class Reviewer : AbstractFlashcardViewer() {
                 return false
             }
 
-            if (days < 1 || days > 9999) {
+            if (days < 0 || days > 9999) {
                 showDeveloperContact(ankiJsErrorCodeSetDue)
                 return false
             }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
@@ -48,6 +48,7 @@ import androidx.core.view.ActionProvider
 import androidx.core.view.MenuItemCompat
 import androidx.vectordrawable.graphics.drawable.VectorDrawableCompat
 import com.ichi2.anim.ActivityTransitionAnimation
+import com.ichi2.anki.AnkiDroidJsAPIConstants.RESET_PROGRESS
 import com.ichi2.anki.AnkiDroidJsAPIConstants.SET_CARD_DUE
 import com.ichi2.anki.AnkiDroidJsAPIConstants.ankiJsErrorCodeDefault
 import com.ichi2.anki.AnkiDroidJsAPIConstants.ankiJsErrorCodeSetDue
@@ -1550,6 +1551,18 @@ open class Reviewer : AbstractFlashcardViewer() {
 
             val cardIds = listOf(currentCard!!.id)
             RescheduleCards(cardIds, days).runWithHandler(scheduleCollectionTaskHandler(R.plurals.reschedule_cards_dialog_acknowledge))
+            return true
+        }
+
+        @JavascriptInterface
+        override fun ankiResetProgress(): Boolean {
+            val apiList = getJsApiListMap()!!
+            if (!apiList[RESET_PROGRESS]!!) {
+                showDeveloperContact(ankiJsErrorCodeDefault)
+                return false
+            }
+            val cardIds = listOf(currentCard!!.id)
+            ResetCards(cardIds).runWithHandler(scheduleCollectionTaskHandler(R.plurals.reset_cards_dialog_acknowledge))
             return true
         }
     }


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
In Anki there is option to add `!` to reset card due. So, I have enhanced the implemented JS API to do the same. Also the JS API will have input 0 for due setting for current day.

![image](https://user-images.githubusercontent.com/12841290/165806216-8f8042f4-d831-46c5-b34a-540a8dc6a231.png)

## Fixes
Fixes

## Approach
1. First used boolean in JS API function parameters
2. Using the boolean reset card using existing function
```
ResetCards(cardIds).runWithHandler(scheduleCollectionTaskHandler(R.plurals.reset_cards_dialog_acknowledge))
```

## How Has This Been Tested?
1. Added unit test 
2. Tested on device using chrome dev tools

## Learning (optional, can help others)
_Describe the research stage_

_Links to blog posts, patterns, libraries or addons used to solve this problem_

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)