### PR TITLE
Fix NoteEditor crash when restoring state

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/FieldEditText.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/FieldEditText.kt
@@ -269,6 +269,7 @@ class FieldEditText : FixedEditText, NoteService.NoteField {
         }
 
         companion object {
+            @JvmField
             val CREATOR: Parcelable.Creator<SavedState> = object : Parcelable.Creator<SavedState> {
                 override fun createFromParcel(source: Parcel): SavedState {
                     return SavedState(source)


### PR DESCRIPTION
## Purpose / Description

This PR fixes the `Parcelable.Creator` implementation for `FieldEditText.SavedState` by appending the @JvmField annotation. This makes the implementation to match the expected contract.

At the moment there are two other classes which are written in kotlin and have a CREATOR field without @JvmField: `RecursivePictureMenu.ItemHeader` and` HelpDialog.ExceptionReportItem`. They are most likely responsible for #10942 .

## Fixes

Fixes #10939 

## How Has This Been Tested?

Ran the usual tests

## Checklist

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
