### PR TITLE
Fix translation of `SharedDecksActivity`'s title

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/SharedDecksActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/SharedDecksActivity.kt
@@ -77,6 +77,7 @@ class SharedDecksActivity : AnkiActivity() {
 
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_shared_decks)
+        setTitle(R.string.download_deck)
 
         val webviewToolbar: Toolbar = findViewById(R.id.webview_toolbar)
         webviewToolbar.setTitleTextColor(ContextCompat.getColor(this, R.color.white))


### PR DESCRIPTION
## Purpose / Description
Fixes the problem of using system's language instead of AnkiDroid's

## Approach
Set title on SharedDecksActivity creation 

## How Has This Been Tested?

On my phone (Samsung Galaxy Note 10 Lite SM-N770F/DS, API 31, One UI 4.0)

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
