### PR TITLE
Implement the long-click feature.

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/tags/TagsArrayAdapter.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/tags/TagsArrayAdapter.kt
@@ -216,19 +216,12 @@ class TagsArrayAdapter(private val tags: TagsList, private val resources: Resour
 
     /**
      * Long click listener for each tag item. Used to add a subtag for the clicked tag.
+     * The full tag is passed through View.tag
      */
-    private var mTagLongClickListener: View.OnLongClickListener? = null
+    var tagLongClickListener: View.OnLongClickListener? = null
 
     fun sortData() {
         tags.sort()
-    }
-
-    /**
-     * Set the long click listener for each tag item.
-     * View.tag is bound with the actual tag.
-     */
-    fun setTagLongClickListener(listener: View.OnLongClickListener?) {
-        mTagLongClickListener = listener
     }
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
@@ -264,7 +257,7 @@ class TagsArrayAdapter(private val tags: TagsList, private val resources: Resour
             }
         }
         // long clicking a tag opens the add tag dialog with the current tag as the prefix
-        vh.itemView.setOnLongClickListener(mTagLongClickListener)
+        vh.itemView.setOnLongClickListener(tagLongClickListener)
         return vh
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/tags/TagsArrayAdapter.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/tags/TagsArrayAdapter.kt
@@ -214,8 +214,21 @@ class TagsArrayAdapter(private val tags: TagsList, private val resources: Resour
      */
     private val mTagToIsExpanded: HashMap<String, Boolean>
 
+    /**
+     * Long click listener for each tag item. Used to add a subtag for the clicked tag.
+     */
+    private var mTagLongClickListener: View.OnLongClickListener? = null
+
     fun sortData() {
         tags.sort()
+    }
+
+    /**
+     * Set the long click listener for each tag item.
+     * View.tag is bound with the actual tag.
+     */
+    fun setTagLongClickListener(listener: View.OnLongClickListener?) {
+        mTagLongClickListener = listener
     }
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
@@ -250,12 +263,15 @@ class TagsArrayAdapter(private val tags: TagsList, private val resources: Resour
                 vh.mCheckBoxView.performClick()
             }
         }
+        // long clicking a tag opens the add tag dialog with the current tag as the prefix
+        vh.itemView.setOnLongClickListener(mTagLongClickListener)
         return vh
     }
 
     override fun onBindViewHolder(holder: ViewHolder, position: Int) {
         holder.node = getVisibleTagTreeNode(position)!!
         holder.node.vh = holder
+        holder.itemView.tag = holder.node.tag
 
         if (mHasVisibleNestedTag) {
             holder.mExpandButton.visibility = if (holder.node.isNotLeaf()) View.VISIBLE else View.INVISIBLE

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/tags/TagsDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/tags/TagsDialog.kt
@@ -130,7 +130,10 @@ class TagsDialog : AnalyticsDialogFragment {
         get() = mListener
             ?: TagsDialogListener.createFragmentResultSender(parentFragmentManager)!!
 
-    @NeedsTest("All checked tags should be visible when the dialog opens (paths to them should be expanded).")
+    @NeedsTest(
+        "In EDIT_TAGS dialog, long-clicking a tag should open the add tag dialog with the clicked tag" +
+            "filled as prefix properly. In other dialog types, long-clicking a tag behaves like a short click."
+    )
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
         @SuppressLint("InflateParams") val tagsDialogView = LayoutInflater.from(activity).inflate(R.layout.tags_dialog, null, false)
         mTagsListRecyclerView = tagsDialogView.findViewById(R.id.tags_dialog_tags_list)
@@ -156,14 +159,14 @@ class TagsDialog : AnalyticsDialogFragment {
             mDialogTitle = resources.getString(R.string.card_details_tags)
             optionsGroup.visibility = View.GONE
             mPositiveText = getString(R.string.dialog_ok)
-            mTagsArrayAdapter!!.setTagLongClickListener { v ->
+            mTagsArrayAdapter!!.tagLongClickListener = View.OnLongClickListener { v ->
                 createAddTagDialog(v.tag as String)
                 true
             }
         } else {
             mDialogTitle = resources.getString(R.string.studyoptions_limit_select_tags)
             mPositiveText = getString(R.string.select)
-            mTagsArrayAdapter!!.setTagLongClickListener { false }
+            mTagsArrayAdapter!!.tagLongClickListener = View.OnLongClickListener { false }
         }
         adjustToolbar(tagsDialogView)
         val builder = MaterialDialog.Builder(requireActivity())
@@ -236,8 +239,10 @@ class TagsDialog : AnalyticsDialogFragment {
 
     /**
      * Create an add tag dialog.
+     *
      * @param prefixTag: The tag to be prefilled into the EditText section. A trailing '::' will be appended.
      */
+    @NeedsTest("The prefixTag should be prefilled properly")
     private fun createAddTagDialog(prefixTag: String?) {
         val addTagBuilder = MaterialDialog.Builder(requireActivity())
             .title(getString(R.string.add_tag))


### PR DESCRIPTION
## Purpose / Description
Long-click a tag in the tag picker dialog now opens the add tag dialog with `$current_tag + ::` as the prefilled input.

* Long-click a tag in `FILTER_BY_TAG` dialog does nothing.
* Long-click a tag in `EDIT_TAGS` dialog opens the add tag dialog.

## Fixes
Fixes #11138 

## Approach
* Set `onLongClickListener` to open the add tag dialog for each tag item in `TagsArrayAdapter`.
* The real tag content is passed by setting `View.tag`.
* Prefill the prefix tag by `EditText.setText()`.

## How Has This Been Tested?

Tested on a physical device, Huawei P40 Pro.
* Long-click a tag in `EDIT_TAGS` dialog opens the add tag dialog:
  1. In note editor, open the tag dialog.
  2. Long-click an existing tag `root`.
  3. The add tag dialog shows up, with `root::` prefilled.
* Long-click a tag in `FILTER_BY_TAG` dialog does nothing:
  1. In Card browser, choose "Filter by tag" to open the tag dialog.
  2. Long-click an existing tag `root`.
  3. No add tag dialog jumps up. The clicked item acts as if it is short clicked (toggle between expanded/collapsed or checked / unchecked)

## Checklist

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
