### PR TITLE
NF: Use same param names on NavigationDrawerActivity inheritors

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
@@ -546,9 +546,9 @@ abstract class AbstractFlashcardViewer :
     val isFullscreen: Boolean
         get() = !supportActionBar!!.isShowing
 
-    override fun onConfigurationChanged(config: Configuration) {
+    override fun onConfigurationChanged(newConfig: Configuration) {
         // called when screen rotated, etc, since recreating the Webview is too expensive
-        super.onConfigurationChanged(config)
+        super.onConfigurationChanged(newConfig)
         refreshActionBar()
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -668,8 +668,8 @@ open class DeckPicker : NavigationDrawerActivity(), StudyOptionsListener, SyncEr
 
     @Deprecated("Deprecated in Java")
     @Suppress("deprecation") // onActivityResult
-    override fun onActivityResult(requestCode: Int, resultCode: Int, intent: Intent?) {
-        super.onActivityResult(requestCode, resultCode, intent)
+    override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
+        super.onActivityResult(requestCode, resultCode, data)
         if (resultCode == RESULT_MEDIA_EJECTED) {
             onSdCardNotMounted()
             return
@@ -698,7 +698,7 @@ open class DeckPicker : NavigationDrawerActivity(), StudyOptionsListener, SyncEr
             // The collection path was inaccessible on startup so just close the activity and let user restart
             finishWithoutAnimation()
         } else if (requestCode == PICK_APKG_FILE && resultCode == RESULT_OK) {
-            val importResult = ImportUtils.handleFileImport(this, intent!!)
+            val importResult = ImportUtils.handleFileImport(this, data!!)
             if (!importResult.isSuccess) {
                 ImportUtils.showImportUnsuccessfulDialog(this, importResult.humanReadableMessage, false)
             }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsActivity.kt
@@ -67,8 +67,8 @@ class StudyOptionsActivity : NavigationDrawerActivity(), StudyOptionsListener, C
     }
 
     @Suppress("deprecation") // #10086
-    public override fun onActivityResult(requestCode: Int, resultCode: Int, intent: Intent?) {
-        super.onActivityResult(requestCode, resultCode, intent)
+    public override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
+        super.onActivityResult(requestCode, resultCode, data)
         Timber.d("onActivityResult (requestCode = %d, resultCode = %d)", requestCode, resultCode)
     }
 


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
This is necessary to kotlin migration of NavigationDrawerActivity

## Approach
Rename params to be the same name of NavigationDrawerActivity

## How Has This Been Tested?

Lint

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
