### PR TITLE
Fix CardTemplateBrowserAppearanceEditor title

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateBrowserAppearanceEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateBrowserAppearanceEditor.kt
@@ -123,6 +123,7 @@ class CardTemplateBrowserAppearanceEditor : AnkiActivity() {
         mAnswerEditText.setText(bundle.getString(INTENT_ANSWER_FORMAT))
 
         enableToolbar()
+        setTitle(R.string.card_template_browser_appearance_title)
     }
 
     private fun answerHasChanged(intent: Intent): Boolean {


### PR DESCRIPTION
It wasn't being set before, so it defaulted to system's language instead of AnkiDroid's

## Fixes
Fixes #10737 and Closes #10748

## Approach
Set title on activity creation

## How Has This Been Tested?

On my phone (Samsung Galaxy Note 10 Lite SM-N770F/DS, API 31, One UI 4.1)

![Screenshot_20220504-104112_AnkiDroid](https://user-images.githubusercontent.com/69634269/166693941-74f615c0-9e99-488f-a87d-2541daa9a0a3.png)

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
