### PR TITLE
Update general category title

### DIFF
--- a/AnkiDroid/src/main/res/values/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values/10-preferences.xml
@@ -22,7 +22,7 @@
     <string name="disabled">Disabled</string>
     <string name="enabled">Enabled</string>
     <!-- preferences.xml categories-->
-    <string name="pref_cat_general" comment="name of the general preference category">General</string>
+    <string name="pref_cat_general" comment="name of the general preference category" maxLength="41">General</string>
     <string name="pref_cat_general_summ">General settings</string>
     <string name="pref_cat_reviewing" maxLength="41">Reviewing</string>
     <string name="pref_cat_reviewing_summ">Non-deck-specific reviewer settings</string>

--- a/AnkiDroid/src/main/res/xml/preference_headers.xml
+++ b/AnkiDroid/src/main/res/xml/preference_headers.xml
@@ -21,7 +21,7 @@
     <Preference
         android:fragment="com.ichi2.anki.Preferences$GeneralSettingsFragment"
         android:summary="@string/pref_cat_general_summ"
-        android:title="@string/app_name">
+        android:title="@string/pref_cat_general">
     </Preference>
 
     <!-- Reviewing Preferences -->


### PR DESCRIPTION
## Purpose / Description

#11165 introduced a new name for the first preferences category and added it to the appBar, but not to the category title, so it kept using the app name as title. So it should be updated to be coherent with the appBar title

## Approach
Use the correct string for the category

## How Has This Been Tested?

Went to the preferences initial screen on my device (Samsung Galaxy Note 10 Lite SM-N770F/DS, API 31, One UI 4.1)


## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [X] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

## Screenshots

<details><summary>Before</summary>
_See the difference between the category name and the app bar after opening it_

![Screenshot_20220504-105702_AnkiDroidA](https://user-images.githubusercontent.com/69634269/166698202-14f6e31c-7fde-4f80-950c-920e2ea90030.png)
![Screenshot_20220504-105645_AnkiDroid](https://user-images.githubusercontent.com/69634269/166698347-81baf481-42bc-4100-a2fc-ecaa960941d4.png)

</details>

<details><summary>After</summary>

![Screenshot_20220504-105638_AnkiDroid](https://user-images.githubusercontent.com/69634269/166698497-99d0ef30-3b6a-42d2-9409-3c14105a61d6.png)

</details>