### PR TITLE
Fixed no splash screen in shortcuts.

### DIFF
--- a/AnkiDroid/src/main/AndroidManifest.xml
+++ b/AnkiDroid/src/main/AndroidManifest.xml
@@ -206,6 +206,7 @@
         <activity
             android:name="com.ichi2.anki.CardBrowser"
             android:label="@string/card_browser"
+            android:theme="@style/Theme_Dark_Compat.Launcher"
             android:exported="true"
             android:configChanges="keyboardHidden|orientation|locale|screenSize"
             android:parentActivityName=".DeckPicker"
@@ -230,6 +231,7 @@
         <activity
             android:name="com.ichi2.anki.Reviewer"
             android:exported="true"
+            android:theme="@style/Theme_Dark_Compat.Launcher"
             android:configChanges="keyboardHidden|orientation|locale|screenSize"
             android:windowSoftInputMode="adjustResize"
             android:parentActivityName=".DeckPicker">
@@ -302,6 +304,7 @@
         <activity
             android:name="com.ichi2.anki.NoteEditor"
             android:label="@string/fact_adder_intent_title"
+            android:theme="@style/Theme_Dark_Compat.Launcher"
             android:exported="true"
             android:configChanges="keyboardHidden|orientation|locale|screenSize"
             >


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
The splash screen did not in shortcuts on cold start.

## Fixes
Fixed issue #10792

## How Has This Been Tested?

- Test on Android 10 virtual device.
- Tested on Physical device with android 12

## Learning (optional, can help others)
_Describe the research stage_

_Links to blog posts, patterns, libraries or addons used to solve this problem_

## Checklist
_Please, go through these checks before submitting the PR._

- [ x ] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [ x ] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ x ] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [ x ] You have commented your code, particularly in hard-to-understand areas
- [ x ] You have performed a self-review of your own code
- [ x ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [  ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
