### PR TITLE
Removed metadata elements from AndroidManifest.xml

### DIFF
--- a/AnkiDroid/src/main/AndroidManifest.xml
+++ b/AnkiDroid/src/main/AndroidManifest.xml
@@ -182,11 +182,6 @@
             android:configChanges="keyboardHidden|locale|orientation|screenSize"
             android:parentActivityName=".DeckPicker"
             >
-            <!-- The meta-data element is needed for versions lower than 4.1 -->
-            <meta-data
-                android:name="android.support.PARENT_ACTIVITY"
-                android:value="com.ichi2.anki.DeckPicker"
-                />
         </activity>
 
         <!-- Context menu item name is the label, context is the system language -->
@@ -210,11 +205,6 @@
             android:configChanges="keyboardHidden|orientation|locale|screenSize"
             android:parentActivityName=".DeckPicker"
             >
-            <!-- The meta-data element is needed for versions lower than 4.1 -->
-            <meta-data
-                android:name="android.support.PARENT_ACTIVITY"
-                android:value="com.ichi2.anki.DeckPicker"
-                />
         </activity>
         <activity
             android:name=".ModelBrowser"
@@ -233,11 +223,6 @@
             android:configChanges="keyboardHidden|orientation|locale|screenSize"
             android:windowSoftInputMode="adjustResize"
             android:parentActivityName=".DeckPicker">
-            <!-- The meta-data element is needed for versions lower than 4.1 -->
-            <meta-data
-                android:name="android.support.PARENT_ACTIVITY"
-                android:value="com.ichi2.anki.DeckPicker"
-                />
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
                 <category android:name="android.intent.category.DEFAULT" />
@@ -334,11 +319,6 @@
             android:configChanges="keyboardHidden|orientation|locale|screenSize"
             android:parentActivityName=".DeckPicker"
             >
-            <!-- The meta-data element is needed for versions lower than 4.1 -->
-            <meta-data
-                android:name="android.support.PARENT_ACTIVITY"
-                android:value="com.ichi2.anki.DeckPicker"
-                />
         </activity>
         <activity
             android:name="com.ichi2.anki.Previewer"


### PR DESCRIPTION
## Purpose / Description

Meta-data elements are only needed for versions lower than 4.1. As we don't support Android 4.1 there is no need for these meta-data elements.

## How Has This Been Tested?

Tested on 

- Android 6.0 virtual device.
- Android 12 physical device.

## Checklist
_Please, go through these checks before submitting the PR._

- [ x ] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [ x ] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ x ] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [ x ] You have commented on your code, particularly in hard-to-understand areas
- [ x ] You have performed a self-review of your own code
- [ x ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [  ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
