### PR TITLE
Update the material library dependency to 1.6.0

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -264,7 +264,7 @@ dependencies {
     implementation 'androidx.constraintlayout:constraintlayout:2.1.3'
     implementation 'androidx.webkit:webkit:1.4.0'
     // Note: the design support library can be quite buggy, so test everything thoroughly before updating it
-    implementation 'com.google.android.material:material:1.3.0'
+    implementation 'com.google.android.material:material:1.6.0'
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.13.2.2'
     implementation 'com.github.CanHub:Android-Image-Cropper:3.1.3'
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.java
@@ -438,7 +438,7 @@ public class CardTemplateEditor extends AnkiActivity implements DeckSelectionDia
 
 
             BottomNavigationView bottomNavigation = mainView.findViewById(R.id.card_template_editor_bottom_navigation);
-            bottomNavigation.setOnNavigationItemSelectedListener(item -> {
+            bottomNavigation.setOnItemSelectedListener(item -> {
                 int currentSelectedId = item.getItemId();
                 mTemplateEditor.mEditorViewId.put(position, currentSelectedId);
                 if (currentSelectedId == R.id.styling_edit) {


### PR DESCRIPTION
## Purpose / Description

Updates the material library dependency to the lastest version, 1.6.0. The update saw the deprecation of one of the methods used which I replaced in the PR with a call to the proper method.

## Fixes

Closes [dependabot's update PR](https://github.com/ankidroid/Anki-Android/pull/11240)

## How Has This Been Tested?

Ran the tests.
Also ran the application on several emulators with different API levels and manually used the app to check for issues.

## Checklist

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
