### PR TITLE
Fix note renaming not working in ModelBrowser

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/ModelBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ModelBrowser.kt
@@ -496,7 +496,10 @@ class ModelBrowser : AnkiActivity() {
     /*
      * For display in the main list via an ArrayAdapter
      */
-    inner class DisplayPairAdapter(context: Context?, items: ArrayList<DisplayPair>?) : ArrayAdapter<DisplayPair?>(context!!, R.layout.model_browser_list_item, R.id.model_list_item_1, items!!.toList()) {
+    inner class DisplayPairAdapter(
+        context: Context,
+        items: ArrayList<DisplayPair>?
+    ) : ArrayAdapter<DisplayPair>(context, R.layout.model_browser_list_item, R.id.model_list_item_1, items!!) {
         override fun getView(position: Int, convertView: View?, parent: ViewGroup): View {
             val _convertView = convertView ?: LayoutInflater.from(context).inflate(R.layout.model_browser_list_item, parent, false)
             val item = getItem(position)


### PR DESCRIPTION
## Purpose / Description

At the moment there's a bug in ModelBrowser:

_from DeckPicker's toolbar menu -> "Manage note types" -> Long click on a note type -> Choose "Rename" -> Enter a different name -> the new name should appear in the list, instead there's no change until we leave the host activity ModelBrowser_

This is happening because the adapter that display the lists of notes uses `items!!.toList()` which creates a new list containing the items. So, although the activity list of does get updated when renaming, the adapter which uses a new list doesn't see the changes so it doesn't update.

## How Has This Been Tested?

Ran the usual tests.

## Checklist

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
