### PR TITLE
Removed undo in study options fragment

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsFragment.kt
@@ -38,7 +38,6 @@ import com.ichi2.anim.ActivityTransitionAnimation.slide
 import com.ichi2.anki.UIUtils.showSnackbar
 import com.ichi2.anki.dialogs.customstudy.CustomStudyDialog
 import com.ichi2.anki.servicelayer.ComputeResult
-import com.ichi2.anki.servicelayer.UndoService.Undo
 import com.ichi2.async.CollectionTask.*
 import com.ichi2.async.TaskListener
 import com.ichi2.async.TaskManager
@@ -252,11 +251,11 @@ class StudyOptionsFragment : Fragment(), Toolbar.OnMenuItemClickListener {
 
     override fun onMenuItemClick(item: MenuItem): Boolean {
         when (item.itemId) {
-            R.id.action_undo -> {
-                Timber.i("StudyOptionsFragment:: Undo button pressed")
-                Undo().runWithHandler(mUndoListener)
-                return true
-            }
+//            R.id.action_undo -> {
+//                Timber.i("StudyOptionsFragment:: Undo button pressed")
+//                Undo().runWithHandler(mUndoListener)
+//                return true
+//            }
             R.id.action_deck_or_study_options -> {
                 Timber.i("StudyOptionsFragment:: Deck or study options button pressed")
                 if (col!!.decks.isDyn(col!!.decks.selected())) {
@@ -355,13 +354,13 @@ class StudyOptionsFragment : Fragment(), Toolbar.OnMenuItemClickListener {
             // Switch on or off unbury depending on if there are cards to unbury
             menu.findItem(R.id.action_unbury).isVisible = col != null && col!!.sched.haveBuried()
             // Switch on or off undo depending on whether undo is available
-            if (col == null || !col!!.undoAvailable()) {
-                menu.findItem(R.id.action_undo).isVisible = false
-            } else {
-                menu.findItem(R.id.action_undo).isVisible = true
-                val res = AnkiDroidApp.getAppResources()
-                menu.findItem(R.id.action_undo).title = res.getString(R.string.studyoptions_congrats_undo, col!!.undoName(res))
-            }
+//            if (col == null || !col!!.undoAvailable()) {
+//                menu.findItem(R.id.action_undo).isVisible = false
+//            } else {
+//                menu.findItem(R.id.action_undo).isVisible = true
+//                val res = AnkiDroidApp.getAppResources()
+//                menu.findItem(R.id.action_undo).title = res.getString(R.string.studyoptions_congrats_undo, col!!.undoName(res))
+//            }
             // Set the back button listener
             if (!mFragmented) {
                 val icon = AppCompatResources.getDrawable(requireContext(), R.drawable.ic_arrow_back_white)

--- a/AnkiDroid/src/main/res/menu/study_options_fragment.xml
+++ b/AnkiDroid/src/main/res/menu/study_options_fragment.xml
@@ -1,12 +1,12 @@
 <menu xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:ankidroid="http://schemas.android.com/apk/res-auto" >
-    <item
-        android:id="@+id/action_undo"
-        android:enabled="true"
-        android:icon="@drawable/ic_undo_white"
-        android:title="@string/undo"
-        ankidroid:actionProviderClass="com.ichi2.ui.RtlCompliantActionProvider"
-        ankidroid:showAsAction="always"/>
+<!--    <item-->
+<!--        android:id="@+id/action_undo"-->
+<!--        android:enabled="true"-->
+<!--        android:icon="@drawable/ic_undo_white"-->
+<!--        android:title="@string/undo"-->
+<!--        ankidroid:actionProviderClass="com.ichi2.ui.RtlCompliantActionProvider"-->
+<!--        ankidroid:showAsAction="always"/>-->
     <item
         android:id="@+id/action_rebuild"
         android:title="@string/rebuild_cram_label"


### PR DESCRIPTION
This is a possible solution towards fixing #11220 
(Undo was showing up unnecessarily in Study Options Fragment. See the issue for details on when exactly the problem occurs)

Before:
<img src="https://user-images.githubusercontent.com/26631482/167305817-9b922791-277e-495d-a464-0b6aed476a96.png" width=30% height=30%>
After:
<img src="https://user-images.githubusercontent.com/26631482/167305914-3c2b5b15-3b74-443c-8a99-847ab6d049b3.png" width=30% height=30%>

The idea was to simply remove the undo element from the layout file for the study options fragment menu and related code in the fragment. I want to confirm that this wouldn't be a problem though - I am definitely not sure about this. 

The other option would be to examine why `undoAvailable()` returns true when unnecessary. 


## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
