### PR TITLE
Fix crash if no video or audio is selected on NoteEditor

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
@@ -1149,8 +1149,11 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
                     val col = col
                     val extras = data!!.extras ?: return
                     val index = extras.getInt(MultimediaEditFieldActivity.EXTRA_RESULT_FIELD_INDEX)
-                    val field =
-                        extras[MultimediaEditFieldActivity.EXTRA_RESULT_FIELD] as IField? ?: return
+                    val field = extras[MultimediaEditFieldActivity.EXTRA_RESULT_FIELD] as IField? ?: return
+                    if (field.imagePath == null && field.audioPath == null) {
+                        Timber.i("field imagePath and audioPath are both null")
+                        return
+                    }
                     val note = getCurrentMultimediaEditableNote(col)
                     note!!.setField(index, field)
                     val fieldEditText = mEditFields!![index]

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/AudioField.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/AudioField.kt
@@ -77,12 +77,12 @@ abstract class AudioField : FieldBase(), IField {
     abstract override fun getName(): String?
     abstract override fun setName(name: String)
     override fun getFormattedValue(): String {
-        var formattedValue = ""
-        val file = File(audioPath!!)
-        if (file.exists()) {
-            formattedValue = String.format("[sound:%s]", file.name)
+        if (audioPath == null) {
+            return ""
         }
-        return formattedValue
+        val file = File(audioPath!!)
+
+        return if (file.exists()) String.format("[sound:%s]", file.name) else ""
     }
 
     override fun setFormattedString(col: Collection, value: String) {

--- a/AnkiDroid/src/test/java/com/ichi2/anki/multimediacard/fields/MediaClipTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/multimediacard/fields/MediaClipTest.kt
@@ -1,0 +1,42 @@
+/*
+ *  Copyright (c) 2022 Brayan Oliveira <brayandso.dev@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.ichi2.anki.multimediacard.fields
+
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.equalTo
+import org.junit.jupiter.api.Test
+import java.io.File
+
+class MediaClipTest {
+
+    @Test
+    fun formattedValue_returns_an_empty_string_if_path_is_null() {
+        val mediaClipField = MediaClipField()
+        assertThat(mediaClipField.formattedValue.isEmpty(), equalTo(true))
+    }
+
+    @Test
+    fun formattedValue_test() {
+        val mediaClipField = MediaClipField()
+        val mediaFile = File("foo").also {
+            it.createNewFile()
+            it.deleteOnExit()
+        }
+        mediaClipField.audioPath = mediaFile.path
+
+        assertThat(mediaClipField.formattedValue, equalTo("[sound:foo]"))
+    }
+}


### PR DESCRIPTION
## Fixes
Fixes #11280

## Approach
Fixes handling of `audioPath` nullability and add tests

## How Has This Been Tested?

On my phone (Samsung Galaxy Note 10 Lite SM-N770F/DS, API 31, One UI 4.1)

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
