### PR TITLE
fix: Lint handling of CDATA elements

### DIFF
--- a/lint-rules/src/main/java/com/ichi2/anki/lint/rules/DuplicateCrowdInStrings.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/DuplicateCrowdInStrings.kt
@@ -79,7 +79,7 @@ class DuplicateCrowdInStrings : ResourceXmlDetector() {
         if (childNodes.length > 0) {
             if (childNodes.length == 1) {
                 val child = childNodes.item(0)
-                if (child.nodeType == Node.TEXT_NODE) {
+                if (child.nodeType == Node.TEXT_NODE || child.nodeType == Node.CDATA_SECTION_NODE) {
                     checkTextNode(
                         context,
                         element,

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/rules/InvalidStringFormatDetector.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/InvalidStringFormatDetector.kt
@@ -68,7 +68,7 @@ class InvalidStringFormatDetector : ResourceXmlDetector() {
 
         element.childNodes
             .forEach { child ->
-                val isStringResource = child.nodeType == Node.TEXT_NODE &&
+                val isStringResource = (child.nodeType == Node.TEXT_NODE || child.nodeType == Node.CDATA_SECTION_NODE) &&
                     TAG_STRING == element.localName
                 val isStringArrayOrPlurals = child.nodeType == Node.ELEMENT_NODE &&
                     (

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/rules/NonPositionalFormatSubstitutions.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/NonPositionalFormatSubstitutions.kt
@@ -109,7 +109,7 @@ class NonPositionalFormatSubstitutions : ResourceXmlDetector() {
 
         if (childNodes.length == 1) {
             val child = childNodes.item(0)
-            return if (child.nodeType != Node.TEXT_NODE) {
+            return if (child.nodeType != Node.TEXT_NODE && child.nodeType != Node.CDATA_SECTION_NODE) {
                 null
             } else {
                 StringFormatDetector.stripQuotes(child.nodeValue)


### PR DESCRIPTION
lint 30.2.0 auto-converts XML text nodes to CDATA

This uncovered a few bugs in our lint checks where we did not check
CDATA nodes

Unblocks #11298


## How Has This Been Tested?
Unit tested on #11298

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
