### PR TITLE
Allow only single imports on the .colpkg option.

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ImportFileSelectionFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ImportFileSelectionFragment.kt
@@ -33,9 +33,9 @@ class ImportFileSelectionFragment {
             // this needs a deckPicker for now. See use of PICK_APKG_FILE
 
             // This is required for serialization of the lambda
-            val openFilePicker = object : FunctionItem.ActivityConsumer {
+            class OpenFilePicker(var multiple: Boolean = false) : FunctionItem.ActivityConsumer {
                 override fun consume(activity: AnkiActivity) {
-                    openImportFilePicker(activity)
+                    openImportFilePicker(activity, multiple)
                 }
             }
 
@@ -44,13 +44,13 @@ class ImportFileSelectionFragment {
                     R.string.import_deck_package,
                     R.drawable.ic_manual_black_24dp,
                     UsageAnalytics.Actions.IMPORT_APKG_FILE,
-                    openFilePicker
+                    OpenFilePicker(true)
                 ),
                 FunctionItem(
                     R.string.import_collection_package,
                     R.drawable.ic_manual_black_24dp,
                     UsageAnalytics.Actions.IMPORT_COLPKG_FILE,
-                    openFilePicker
+                    OpenFilePicker()
                 ),
             )
             return RecursivePictureMenu.createInstance(ArrayList(importItems), R.string.menu_import)
@@ -58,7 +58,7 @@ class ImportFileSelectionFragment {
 
         // needs to be static for serialization
         @JvmStatic
-        fun openImportFilePicker(activity: AnkiActivity) {
+        fun openImportFilePicker(activity: AnkiActivity, multiple: Boolean = false) {
             Timber.d("openImportFilePicker() delegating to file picker intent")
             val intent = Intent(Intent.ACTION_OPEN_DOCUMENT)
             intent.addCategory(Intent.CATEGORY_OPENABLE)
@@ -66,7 +66,7 @@ class ImportFileSelectionFragment {
             intent.putExtra("android.content.extra.SHOW_ADVANCED", true)
             intent.putExtra("android.content.extra.FANCY", true)
             intent.putExtra("android.content.extra.SHOW_FILESIZE", true)
-            intent.putExtra(Intent.EXTRA_ALLOW_MULTIPLE, true)
+            intent.putExtra(Intent.EXTRA_ALLOW_MULTIPLE, multiple)
             activity.startActivityForResultWithoutAnimation(intent, DeckPicker.PICK_APKG_FILE)
         }
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ImportFileSelectionFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ImportFileSelectionFragment.kt
@@ -22,9 +22,13 @@ import com.ichi2.anki.DeckPicker
 import com.ichi2.anki.R
 import com.ichi2.anki.analytics.UsageAnalytics
 import com.ichi2.anki.dialogs.HelpDialog.FunctionItem
+import com.ichi2.annotations.NeedsTest
 import com.ichi2.utils.KotlinCleanup
 import timber.log.Timber
 
+@NeedsTest("Selecting APKG allows multiple files")
+@NeedsTest("Selecting COLPKG does not allow multiple files")
+@NeedsTest("Restore backup dialog does not allow multiple files")
 class ImportFileSelectionFragment {
     companion object {
         @JvmStatic


### PR DESCRIPTION
## Purpose / Description
Allow only importing single files when .colpkg option is selected in the import dialog as mentioned [here](https://github.com/ankidroid/Anki-Android/pull/10851#pullrequestreview-965378466).

## Approach
Added an optional flag to ImportFileSelectionFragment to enable or disable multiple file selection. 

## How Has This Been Tested?
Tested on: 
- A physical device with Android 12
- Virtual Device with Android 7.0

## Checklist

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
