### PR TITLE
[Coroutines Migration] LoadPronunciationActivity

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/activity/LoadPronunciationActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/activity/LoadPronunciationActivity.kt
@@ -36,6 +36,9 @@ import com.ichi2.anki.web.HttpFetcher.fetchThroughHttp
 import com.ichi2.async.Connection
 import com.ichi2.themes.Themes.disableXiaomiForceDarkMode
 import com.ichi2.utils.AdaptionUtil.isUserATestClient
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 import org.intellij.lang.annotations.Language
 import timber.log.Timber
 import java.io.UnsupportedEncodingException
@@ -131,8 +134,7 @@ open class LoadPronunciationActivity : Activity(), DialogInterface.OnCancelListe
     /**
      * @param v Start of the story.
      */
-    @Suppress("deprecation") // #7108: AsyncTask
-    private fun onLoadPronunciation(@Suppress("UNUSED_PARAMETER") v: View?) {
+    private fun onLoadPronunciation(@Suppress("UNUSED_PARAMETER")v: View?) {
         if (!Connection.isOnline()) {
             showToast(gtxt(R.string.network_no_connection))
             return
@@ -140,15 +142,15 @@ open class LoadPronunciationActivity : Activity(), DialogInterface.OnCancelListe
         val message = gtxt(R.string.multimedia_editor_searching_word)
         showProgressBar(message)
         mTranslationAddress = computeAddressOfTranslationPage()
-        try {
-            mPostTranslation = BackgroundPost()
-            mPostTranslation!!.address = mTranslationAddress
-            // post.setStopper(PRONUNC_STOPPER);
-            mPostTranslation!!.execute()
-        } catch (e: Exception) {
-            Timber.w(e)
-            hideProgressBar()
-            showToast(gtxt(R.string.multimedia_editor_something_wrong))
+        CoroutineScope(Dispatchers.Main).launch {
+            try {
+                mPostTranslation = BackgroundPost()
+                mPostTranslation!!.address = mTranslationAddress
+            } catch (e: Exception) {
+                Timber.w(e)
+                hideProgressBar()
+                showToast(gtxt(R.string.multimedia_editor_something_wrong))
+            }
         }
     }
 


### PR DESCRIPTION
## Purpose / Description
Migration of LoadPronunciationActivity from AsyncTask to Coroutines

## Fixes
partially fixes https://github.com/ankidroid/Anki-Android/issues/7108

## Approach
Migrate the inner classes `BackgroundPost` and `DownloadFileTask` from AsyncTask to Coroutines. Instead of directly returning the values as in case of AsyncTask I created suspending function and return the different values using withContext coroutine function. 
Initialized a job keyword and used it to cancel the coroutine.
For onLoadPronunciation method I used CoroutineScope with Main Dispatchers .

## How Has This Been Tested?
Tested manually on device ASUS_X01BDA running on Android 9

## Learning (optional, can help others)
1. https://www.bollyinside.com/articles/how-you-can-replace-asynctask-with-kotlins-coroutines/
2. https://www.xda-developers.com/asynctask-to-coroutines/

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
