### PR TITLE
test(ci): add tight timeout to gradle setup step

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -56,6 +56,7 @@ jobs:
 
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v2
+        timeout-minutes: 5
         with:
           # Only write to the cache for builds on the 'main' branches, stops branches evicting main cache
           # Builds on other branches will only read from main branch cache writes

--- a/.github/workflows/tests_emulator.yml
+++ b/.github/workflows/tests_emulator.yml
@@ -61,6 +61,7 @@ jobs:
 
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v2
+        timeout-minutes: 5
         with:
           # Only write to the cache for builds on the 'main' branches, stops branches evicting main cache
           # Builds on other branches will only read from main branch cache writes

--- a/.github/workflows/tests_unit.yml
+++ b/.github/workflows/tests_unit.yml
@@ -62,6 +62,7 @@ jobs:
 
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v2
+        timeout-minutes: 5
         with:
           # Only write to the cache for builds on the 'main' branches, stops branches evicting main cache
           # Builds on other branches will only read from main branch cache writes


### PR DESCRIPTION
## Pull Request template

## Purpose / Description

Just fail fast if setup fails while fetching external resources (cache etc)
That's a simple solution that match the observed low frequency of the flake (so far)

## Fixes

Fixes #11301

## How Has This Been Tested?

Checked on my fork, did not corrupt the yaml, so I think it works...

## Learning (optional, can help others)

If it runs often enough, and relies on external resources, it will fail in CI.

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
