### PR TITLE
Fix `supportInvalidateOptionsMenu` deprecation

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
@@ -557,7 +557,6 @@ abstract class AbstractFlashcardViewer :
     protected abstract fun setTitle()
 
     // Finish initializing the activity after the collection has been correctly loaded
-    @Suppress("deprecation") // supportInvalidateOptionsMenu
     public override fun onCollectionLoaded(col: Collection) {
         super.onCollectionLoaded(col)
         sched = col.sched
@@ -590,7 +589,7 @@ abstract class AbstractFlashcardViewer :
         // Initialize text-to-speech. This is an asynchronous operation.
         mTTS.initialize(this, ReadTextListener())
         updateActionBar()
-        supportInvalidateOptionsMenu()
+        invalidateOptionsMenu()
     }
 
     // Saves deck each time Reviewer activity loses focus
@@ -1818,9 +1817,8 @@ abstract class AbstractFlashcardViewer :
         finishWithAnimation(ActivityTransitionAnimation.Direction.END)
     }
 
-    @Suppress("deprecation") // supportInvalidateOptionsMenu
     protected fun refreshActionBar() {
-        supportInvalidateOptionsMenu()
+        invalidateOptionsMenu()
     }
 
     /** Fixing bug 720: <input></input> focus, thanks to pablomouzo on android issue 7189  */

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -298,7 +298,6 @@ open class CardBrowser : NavigationDrawerActivity(), SubtitleListener, DeckSelec
             Timber.d("CardBrowser::RepositionCardHandler() onPreExecute")
         }
 
-        @Suppress("deprecation") // super.supportInvalidateOptionsMenu
         override fun actualOnPostExecute(context: CardBrowser, result: Computation<NextCard<Array<Card>>>) {
             Timber.d("CardBrowser::RepositionCardHandler() onPostExecute")
             context.mReloadRequired = true
@@ -308,7 +307,7 @@ open class CardBrowser : NavigationDrawerActivity(), SubtitleListener, DeckSelec
                 context.resources.getQuantityString(R.plurals.reposition_card_dialog_acknowledge, cardCount, cardCount), true
             )
             context.reloadCards(result.value.result)
-            context.supportInvalidateOptionsMenu()
+            context.invalidateOptionsMenu()
         }
     }
 
@@ -321,7 +320,6 @@ open class CardBrowser : NavigationDrawerActivity(), SubtitleListener, DeckSelec
             Timber.d("CardBrowser::ResetProgressCardHandler() onPreExecute")
         }
 
-        @Suppress("deprecation") // supportInvalidateOptionsMenu
         override fun actualOnPostExecute(context: CardBrowser, result: Computation<NextCard<Array<Card>>>) {
             Timber.d("CardBrowser::ResetProgressCardHandler() onPostExecute")
             context.mReloadRequired = true
@@ -331,7 +329,7 @@ open class CardBrowser : NavigationDrawerActivity(), SubtitleListener, DeckSelec
                 context.resources.getQuantityString(R.plurals.reset_cards_dialog_acknowledge, cardCount, cardCount), true
             )
             context.reloadCards(result.value.result)
-            context.supportInvalidateOptionsMenu()
+            context.invalidateOptionsMenu()
         }
     }
 
@@ -344,7 +342,6 @@ open class CardBrowser : NavigationDrawerActivity(), SubtitleListener, DeckSelec
             Timber.d("CardBrowser::RescheduleCardHandler() onPreExecute")
         }
 
-        @Suppress("deprecation") // supportInvalidateOptionsMenu
         override fun actualOnPostExecute(context: CardBrowser, result: Computation<NextCard<Array<Card>>>) {
             Timber.d("CardBrowser::RescheduleCardHandler() onPostExecute")
             context.mReloadRequired = true
@@ -354,7 +351,7 @@ open class CardBrowser : NavigationDrawerActivity(), SubtitleListener, DeckSelec
                 context.resources.getQuantityString(R.plurals.reschedule_cards_dialog_acknowledge, cardCount, cardCount), true
             )
             context.reloadCards(result.value.result)
-            context.supportInvalidateOptionsMenu()
+            context.invalidateOptionsMenu()
         }
     }
 
@@ -855,7 +852,6 @@ open class CardBrowser : NavigationDrawerActivity(), SubtitleListener, DeckSelec
     }
 
     @KotlinCleanup("Add a few variables to get rid of the !!")
-    @Suppress("deprecation") // supportInvalidateOptionsMenu
     override fun onCreateOptionsMenu(menu: Menu): Boolean {
         Timber.d("onCreateOptionsMenu()")
         mActionBarMenu = menu
@@ -880,7 +876,7 @@ open class CardBrowser : NavigationDrawerActivity(), SubtitleListener, DeckSelec
                     mSearchView!!.setQuery(mSearchTerms!!, false)
                     searchCards()
                     // invalidate options menu so that disappeared icons would appear again
-                    supportInvalidateOptionsMenu()
+                    invalidateOptionsMenu()
                     mTempSearchQuery = null
                     return true
                 }
@@ -903,7 +899,7 @@ open class CardBrowser : NavigationDrawerActivity(), SubtitleListener, DeckSelec
                 }
             })
             // Fixes #6500 - keep the search consistent if coming back from note editor
-            // Fixes #9010 - consistent search after drawer change calls supportInvalidateOptionsMenu (mTempSearchQuery)
+            // Fixes #9010 - consistent search after drawer change calls invalidateOptionsMenu (mTempSearchQuery)
             if (!TextUtils.isEmpty(mTempSearchQuery) || !TextUtils.isEmpty(mSearchTerms)) {
                 mSearchItem!!.expandActionView() // This calls mSearchView.setOnSearchClickListener
                 val toUse = if (!TextUtils.isEmpty(mTempSearchQuery)) mTempSearchQuery else mSearchTerms
@@ -2590,7 +2586,6 @@ open class CardBrowser : NavigationDrawerActivity(), SubtitleListener, DeckSelec
     /**
      * Turn on Multi-Select Mode so that the user can select multiple cards at once.
      */
-    @Suppress("deprecation") // supportInvalidateOptionsMenu
     private fun loadMultiSelectMode() {
         if (isInMultiSelectMode) {
             return
@@ -2603,13 +2598,12 @@ open class CardBrowser : NavigationDrawerActivity(), SubtitleListener, DeckSelec
         mActionBarTitle!!.text = checkedCardCount().toString()
         mDeckSpinnerSelection!!.setSpinnerVisibility(View.GONE)
         // reload the actionbar using the multi-select mode actionbar
-        supportInvalidateOptionsMenu()
+        invalidateOptionsMenu()
     }
 
     /**
      * Turn off Multi-Select Mode and return to normal state
      */
-    @Suppress("deprecation") // supportInvalidateOptionsMenu
     private fun endMultiSelectMode() {
         Timber.d("endMultiSelectMode()")
         mCheckedCards.clear()
@@ -2620,7 +2614,7 @@ open class CardBrowser : NavigationDrawerActivity(), SubtitleListener, DeckSelec
         // update adapter to remove check boxes
         mCardsAdapter!!.notifyDataSetChanged()
         // update action bar
-        supportInvalidateOptionsMenu()
+        invalidateOptionsMenu()
         mDeckSpinnerSelection!!.setSpinnerVisibility(View.VISIBLE)
         mActionBarTitle!!.visibility = View.GONE
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.kt
@@ -209,7 +209,6 @@ open class CardTemplateEditor : AnkiActivity(), DeckSelectionListener {
     }
 
     /** When a deck is selected via Deck Override  */
-    @Suppress("deprecation") // supportInvalidateOptionsMenu()
     override fun onDeckSelected(deck: SelectableDeck?) {
         if (tempModel!!.model.isCloze) {
             Timber.w("Attempted to set deck for cloze model")
@@ -240,7 +239,7 @@ open class CardTemplateEditor : AnkiActivity(), DeckSelectionListener {
         UIUtils.showThemedToast(this, message, true)
 
         // Deck Override can change from "on" <-> "off"
-        supportInvalidateOptionsMenu()
+        invalidateOptionsMenu()
     }
 
     override fun onKeyUp(keyCode: Int, event: KeyEvent): Boolean {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -757,7 +757,6 @@ open class DeckPicker : NavigationDrawerActivity(), StudyOptionsListener, SyncEr
         refreshState()
     }
 
-    @Suppress("deprecation") // supportInvalidateOptionsMenu: deprecated in Java
     fun refreshState() {
         mActivityPaused = false
         if (mSyncOnResume) {
@@ -778,7 +777,7 @@ open class DeckPicker : NavigationDrawerActivity(), StudyOptionsListener, SyncEr
             TaskManager.launchCollectionTask(LoadCollectionComplete())
         }
         // Update sync status (if we've come back from a screen)
-        supportInvalidateOptionsMenu()
+        invalidateOptionsMenu()
     }
 
     public override fun onSaveInstanceState(savedInstanceState: Bundle) {
@@ -1719,8 +1718,7 @@ open class DeckPicker : NavigationDrawerActivity(), StudyOptionsListener, SyncEr
                 }
                 // Mark sync as completed - then refresh the sync icon
                 SyncStatus.markSyncCompleted()
-                @Suppress("deprecation")
-                supportInvalidateOptionsMenu()
+                invalidateOptionsMenu()
                 updateDeckList()
                 WidgetStatus.update(this@DeckPicker)
                 if (fragmented) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/MyAccount.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/MyAccount.kt
@@ -73,8 +73,6 @@ class MyAccount : AnkiActivity() {
                 setContentView(mLoginToMyAccountView)
             }
         }
-        @Suppress("deprecation")
-        supportInvalidateOptionsMenu() // Needed?
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NavigationDrawerActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NavigationDrawerActivity.kt
@@ -104,7 +104,6 @@ abstract class NavigationDrawerActivity :
 
     // Navigation drawer initialisation
     @KotlinCleanup("use .apply on enableToolbar")
-    @Suppress("deprecation") // supportInvalidateOptionsMenu(
     protected fun initNavigationDrawer(mainView: View) {
         // Create inherited navigation drawer layout here so that it can be used by parent class
         mDrawerLayout = mainView.findViewById(R.id.drawer_layout)
@@ -132,7 +131,7 @@ abstract class NavigationDrawerActivity :
 
             override fun onDrawerClosed(drawerView: View) {
                 super.onDrawerClosed(drawerView)
-                supportInvalidateOptionsMenu()
+                invalidateOptionsMenu()
 
                 // If animations are disabled, this is executed before onNavigationItemSelected is called
                 // PERF: May be able to reduce this delay
@@ -146,7 +145,7 @@ abstract class NavigationDrawerActivity :
 
             override fun onDrawerOpened(drawerView: View) {
                 super.onDrawerOpened(drawerView)
-                supportInvalidateOptionsMenu()
+                invalidateOptionsMenu()
             }
         }
         if (mDrawerLayout is ClosableDrawerLayout) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/activity/MultimediaEditFieldActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/activity/MultimediaEditFieldActivity.kt
@@ -262,14 +262,14 @@ class MultimediaEditFieldActivity : AnkiActivity(), OnRequestPermissionsResultCa
         }
     }
 
-    @Suppress("deprecation") // onActivityResult + supportInvalidateOptionsMenu
+    @Suppress("deprecation") // onActivityResult
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
         Timber.d("onActivityResult()")
         if (fieldController != null) {
             fieldController!!.onActivityResult(requestCode, resultCode, data)
         }
         super.onActivityResult(requestCode, resultCode, data)
-        supportInvalidateOptionsMenu()
+        invalidateOptionsMenu()
     }
 
     private fun recreateEditingUIUsingCachedRequest() {
@@ -430,11 +430,10 @@ class MultimediaEditFieldActivity : AnkiActivity(), OnRequestPermissionsResultCa
             }
         }
 
-        @Suppress("deprecation") // supportInvalidateOptionsMenu
         fun onPostUICreation(request: ChangeUIRequest, activity: MultimediaEditFieldActivity) {
             Timber.d("onPostUICreation. State: %d", request.state)
             when (request.state) {
-                ChangeUIRequest.UI_CHANGE, ChangeUIRequest.EXTERNAL_FIELD_CHANGE -> activity.supportInvalidateOptionsMenu()
+                ChangeUIRequest.UI_CHANGE, ChangeUIRequest.EXTERNAL_FIELD_CHANGE -> activity.invalidateOptionsMenu()
                 ChangeUIRequest.ACTIVITY_LOAD -> {}
                 else -> Timber.e("onPostUICreation: Unhandled state: %s", request.state)
             }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.kt
@@ -551,7 +551,7 @@ class CardBrowserTest : RobolectricTest() {
     }
 
     @Test
-    @Ignore("FLAKY: Robolectric getOptionsMenu does not require supportInvalidateOptionsMenu - so would not fail")
+    @Ignore("FLAKY: Robolectric getOptionsMenu does not require invalidateOptionsMenu - so would not fail")
     fun rescheduleUndoTest() {
         val b = getBrowserWithNotes(1)
 


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
supportInvalidateOptionsMenu is deprecated

## Approach
- Change it to equivalent `invalidateOptionsMenu`.
- Removed it from `MyAccount` because it isn't necessary there

## Learning (optional, can help others)

AppCompatActivity source code:
```java
    @Override
    public void supportInvalidateOptionsMenu() {
        getDelegate().invalidateOptionsMenu();
    }

    @Override
    public void invalidateOptionsMenu() {
        getDelegate().invalidateOptionsMenu();
    }
```

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
