### PR TITLE
refactor(lint-rules): Kotlin Cleanup

### DIFF
--- a/lint-rules/src/main/java/com/ichi2/anki/lint/IssueRegistry.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/IssueRegistry.kt
@@ -1,3 +1,4 @@
+@file:Suppress("UnstableApiUsage")
 package com.ichi2.anki.lint
 
 import com.android.tools.lint.client.api.IssueRegistry

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/IssueRegistry.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/IssueRegistry.kt
@@ -64,7 +64,7 @@ class IssueRegistry : IssueRegistry() {
         }
     override val api: Int
         get() = CURRENT_API
-    override val vendor: Vendor?
+    override val vendor: Vendor
         get() = Vendor(
             "AnkiDroid",
             "com.ichi2.anki:lint-rules",

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/IssueRegistry.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/IssueRegistry.kt
@@ -27,40 +27,37 @@ import com.ichi2.anki.lint.rules.NonPublicNonStaticJavaFieldDetector
 import com.ichi2.anki.lint.rules.PreferIsEmptyOverSizeCheck
 import com.ichi2.anki.lint.rules.PrintStackTraceUsage
 import com.ichi2.anki.lint.rules.VariableNamingDetector
-import com.ichi2.anki.lint.utils.KotlinCleanup
-import java.util.ArrayList
 
-@KotlinCleanup("listOf")
 class IssueRegistry : IssueRegistry() {
     // Keep this list lexicographically ordered.
     override val issues: List<Issue>
         get() {
             // Keep this list lexicographically ordered.
-            val issues: MutableList<Issue> = ArrayList()
-            issues.add(CopyrightHeaderExists.ISSUE)
-            issues.add(DirectCalendarInstanceUsage.ISSUE)
-            issues.add(DirectDateInstantiation.ISSUE)
-            issues.add(DirectGregorianInstantiation.ISSUE)
-            issues.add(DirectSnackbarMakeUsage.ISSUE)
-            issues.add(DirectSystemCurrentTimeMillisUsage.ISSUE)
-            issues.add(DirectSystemTimeInstantiation.ISSUE)
-            issues.add(DirectToastMakeTextUsage.ISSUE)
-            issues.add(DuplicateCrowdInStrings.ISSUE)
-            issues.add(DuplicateTextInPreferencesXml.ISSUE)
-            issues.add(InconsistentAnnotationUsage.ISSUE)
-            issues.add(JUnitNullAssertionDetector.ISSUE)
-            issues.add(KotlinMigrationBrokenEmails.ISSUE)
-            issues.add(KotlinMigrationFixLineBreaks.ISSUE)
-            issues.add(PreferIsEmptyOverSizeCheck.ISSUE)
-            issues.add(PrintStackTraceUsage.ISSUE)
-            issues.add(NonPositionalFormatSubstitutions.ISSUE)
-            issues.add(NonPublicNonStaticJavaFieldDetector.ISSUE)
-            issues.add(ConstantJavaFieldDetector.ISSUE)
-            issues.add(FixedPreferencesTitleLength.ISSUE_MAX_LENGTH)
-            issues.add(FixedPreferencesTitleLength.ISSUE_TITLE_LENGTH)
-            issues.add(VariableNamingDetector.ISSUE)
-            issues.add(InvalidStringFormatDetector.ISSUE)
-            return issues
+            return listOf(
+                CopyrightHeaderExists.ISSUE,
+                DirectCalendarInstanceUsage.ISSUE,
+                DirectDateInstantiation.ISSUE,
+                DirectGregorianInstantiation.ISSUE,
+                DirectSnackbarMakeUsage.ISSUE,
+                DirectSystemCurrentTimeMillisUsage.ISSUE,
+                DirectSystemTimeInstantiation.ISSUE,
+                DirectToastMakeTextUsage.ISSUE,
+                DuplicateCrowdInStrings.ISSUE,
+                DuplicateTextInPreferencesXml.ISSUE,
+                InconsistentAnnotationUsage.ISSUE,
+                JUnitNullAssertionDetector.ISSUE,
+                KotlinMigrationBrokenEmails.ISSUE,
+                KotlinMigrationFixLineBreaks.ISSUE,
+                PreferIsEmptyOverSizeCheck.ISSUE,
+                PrintStackTraceUsage.ISSUE,
+                NonPositionalFormatSubstitutions.ISSUE,
+                NonPublicNonStaticJavaFieldDetector.ISSUE,
+                ConstantJavaFieldDetector.ISSUE,
+                FixedPreferencesTitleLength.ISSUE_MAX_LENGTH,
+                FixedPreferencesTitleLength.ISSUE_TITLE_LENGTH,
+                VariableNamingDetector.ISSUE,
+                InvalidStringFormatDetector.ISSUE
+            )
         }
     override val api: Int
         get() = CURRENT_API

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/rules/ConstantJavaFieldDetector.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/ConstantJavaFieldDetector.kt
@@ -31,7 +31,7 @@ import java.util.*
  * https://github.com/ankidroid/Anki-Android/wiki/Code-style#constant-final-variables-names-must-be-all-uppercase-using-underscore-to-separate-words
  * Constant (final variables) names must be all uppercase using underscore to separate words.
  */
-@KotlinCleanup("Remove after all are converted")
+@KotlinCleanup("Remove this class once there's no Java in AnkiDroid")
 class ConstantJavaFieldDetector : JavaFieldNamingPatternDetector() {
     override fun isApplicable(variable: UVariable): Boolean {
         // TODO: The code style here is ambiguous - we'll only flag public static final for now

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/rules/ConstantJavaFieldDetector.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/ConstantJavaFieldDetector.kt
@@ -46,19 +46,11 @@ class ConstantJavaFieldDetector : JavaFieldNamingPatternDetector() {
             )
     }
 
-    @KotlinCleanup("use filter/any")
-    override fun meetsNamingStandards(variableName: String): Boolean {
-        var foundLower = false
-        for (c in variableName.toCharArray()) {
-            if (Character.isLowerCase(c)) {
-                foundLower = true
-                break
-            }
-        }
-
-        // if 0-length, or no lowercase letters - should be OK
-        return !foundLower
-    }
+    /**
+     * @return `true` if 0-length, or no lowercase letters
+     */
+    override fun meetsNamingStandards(variableName: String) =
+        variableName.all { it.isUpperCase() }
 
     @KotlinCleanup("extract method: setting 'variableWithoutPrefix'")
     @KotlinCleanup("define replacement after setting 'variableWithoutPrefix'")

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/rules/ConstantJavaFieldDetector.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/ConstantJavaFieldDetector.kt
@@ -13,6 +13,7 @@
  *  You should have received a copy of the GNU General Public License along with
  *  this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+@file:Suppress("UnstableApiUsage")
 package com.ichi2.anki.lint.rules
 
 import com.android.tools.lint.detector.api.Implementation
@@ -30,8 +31,6 @@ import java.util.*
  * https://github.com/ankidroid/Anki-Android/wiki/Code-style#constant-final-variables-names-must-be-all-uppercase-using-underscore-to-separate-words
  * Constant (final variables) names must be all uppercase using underscore to separate words.
  */
-@KotlinCleanup("IDE warnings")
-@KotlinCleanup("Ignore unstable API warning")
 @KotlinCleanup("Remove after all are converted")
 class ConstantJavaFieldDetector : JavaFieldNamingPatternDetector() {
     override fun isApplicable(variable: UVariable): Boolean {

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/rules/DirectGregorianInstantiation.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/DirectGregorianInstantiation.kt
@@ -37,13 +37,9 @@ class DirectGregorianInstantiation : Detector(), SourceCodeScanner {
         )
     }
 
-    override fun getApplicableMethodNames(): List<String> {
-        return mutableListOf("from")
-    }
+    override fun getApplicableMethodNames() = mutableListOf("from")
 
-    override fun getApplicableConstructorTypes(): List<String> {
-        return mutableListOf("java.util.GregorianCalendar")
-    }
+    override fun getApplicableConstructorTypes() = mutableListOf("java.util.GregorianCalendar")
 
     override fun visitMethodCall(context: JavaContext, node: UCallExpression, method: PsiMethod) {
         super.visitMethodCall(context, node, method)

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/rules/DirectSnackbarMakeUsage.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/DirectSnackbarMakeUsage.kt
@@ -13,6 +13,7 @@
  *  You should have received a copy of the GNU General Public License along with
  *  this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+@file:Suppress("UnstableApiUsage")
 package com.ichi2.anki.lint.rules
 
 import com.android.tools.lint.detector.api.*

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/rules/DirectSnackbarMakeUsage.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/DirectSnackbarMakeUsage.kt
@@ -29,18 +29,15 @@ import org.jetbrains.uast.UCallExpression
  * instead of using the method provided by the UIUtils class {com.ichi2.anki.UIUtils#showSimpleSnackbar(...)}
  * or {com.ichi2.anki.UIUtils#showSnackbar(...)}.
  */
-@KotlinCleanup("IDE lint")
 @KotlinCleanup("mutableListOf")
 class DirectSnackbarMakeUsage : Detector(), SourceCodeScanner {
 
     companion object {
-        @JvmField
         @VisibleForTesting
-        val ID = "DirectSnackbarMakeUsage"
+        const val ID = "DirectSnackbarMakeUsage"
 
-        @JvmField
         @VisibleForTesting
-        val DESCRIPTION = "Use UIUtils.showSimpleSnackbar or UIUtils.showSnackbar instead of Snackbar.make"
+        const val DESCRIPTION = "Use UIUtils.showSimpleSnackbar or UIUtils.showSnackbar instead of Snackbar.make"
         private const val EXPLANATION = "To improve code consistency within the codebase you should use UIUtils.showSimpleSnackbar or UIUtils.showSnackbar " +
             "in place of the library Snackbar.make(...).show()"
         private val implementation = Implementation(DirectSnackbarMakeUsage::class.java, Scope.JAVA_FILE_SCOPE)
@@ -56,7 +53,7 @@ class DirectSnackbarMakeUsage : Detector(), SourceCodeScanner {
         )
     }
 
-    override fun getApplicableMethodNames(): List<String>? {
+    override fun getApplicableMethodNames(): List<String> {
         val forbiddenMethods: MutableList<String> = ArrayList()
         forbiddenMethods.add("make")
         return forbiddenMethods
@@ -72,7 +69,7 @@ class DirectSnackbarMakeUsage : Detector(), SourceCodeScanner {
             context.report(
                 ISSUE,
                 node,
-                context.getCallLocation(node, true, true),
+                context.getCallLocation(node, includeReceiver = true, includeArguments = true),
                 DESCRIPTION
             )
         }

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/rules/DirectSnackbarMakeUsage.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/DirectSnackbarMakeUsage.kt
@@ -19,7 +19,6 @@ package com.ichi2.anki.lint.rules
 import com.android.tools.lint.detector.api.*
 import com.google.common.annotations.VisibleForTesting
 import com.ichi2.anki.lint.utils.Constants
-import com.ichi2.anki.lint.utils.KotlinCleanup
 import com.ichi2.anki.lint.utils.LintUtils
 import com.intellij.psi.PsiMethod
 import org.jetbrains.uast.UCallExpression
@@ -29,7 +28,6 @@ import org.jetbrains.uast.UCallExpression
  * instead of using the method provided by the UIUtils class {com.ichi2.anki.UIUtils#showSimpleSnackbar(...)}
  * or {com.ichi2.anki.UIUtils#showSnackbar(...)}.
  */
-@KotlinCleanup("mutableListOf")
 class DirectSnackbarMakeUsage : Detector(), SourceCodeScanner {
 
     companion object {
@@ -53,11 +51,7 @@ class DirectSnackbarMakeUsage : Detector(), SourceCodeScanner {
         )
     }
 
-    override fun getApplicableMethodNames(): List<String> {
-        val forbiddenMethods: MutableList<String> = ArrayList()
-        forbiddenMethods.add("make")
-        return forbiddenMethods
-    }
+    override fun getApplicableMethodNames() = mutableListOf("make")
 
     override fun visitMethodCall(context: JavaContext, node: UCallExpression, method: PsiMethod) {
         super.visitMethodCall(context, node, method)

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/rules/DirectSystemCurrentTimeMillisUsage.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/DirectSystemCurrentTimeMillisUsage.kt
@@ -1,3 +1,4 @@
+@file:Suppress("UnstableApiUsage")
 package com.ichi2.anki.lint.rules
 
 import com.android.tools.lint.detector.api.*

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/rules/DirectSystemCurrentTimeMillisUsage.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/DirectSystemCurrentTimeMillisUsage.kt
@@ -13,18 +13,15 @@ import org.jetbrains.uast.UCallExpression
  * This custom Lint rules will raise an error if a developer uses the [System.currentTimeMillis] method instead
  * of using the time provided by the new Time class.
  */
-@KotlinCleanup("IDE lint")
 @KotlinCleanup("mutableListOf")
 class DirectSystemCurrentTimeMillisUsage : Detector(), SourceCodeScanner {
 
     companion object {
-        @JvmField
         @VisibleForTesting
-        val ID = "DirectSystemCurrentTimeMillisUsage"
+        const val ID = "DirectSystemCurrentTimeMillisUsage"
 
-        @JvmField
         @VisibleForTesting
-        val DESCRIPTION = "Use the collection's getTime() method instead of System.currentTimeMillis()"
+        const val DESCRIPTION = "Use the collection's getTime() method instead of System.currentTimeMillis()"
         private const val EXPLANATION = "Using time directly means time values cannot be controlled during testing. " +
             "Time values like System.currentTimeMillis() must be obtained through the Time obtained from a Collection"
         private val implementation = Implementation(DirectSystemCurrentTimeMillisUsage::class.java, Scope.JAVA_FILE_SCOPE)
@@ -40,7 +37,7 @@ class DirectSystemCurrentTimeMillisUsage : Detector(), SourceCodeScanner {
         )
     }
 
-    override fun getApplicableMethodNames(): List<String>? {
+    override fun getApplicableMethodNames(): List<String> {
         val forbiddenSystemMethods: MutableList<String> = ArrayList()
         forbiddenSystemMethods.add("currentTimeMillis")
         return forbiddenSystemMethods
@@ -53,7 +50,7 @@ class DirectSystemCurrentTimeMillisUsage : Detector(), SourceCodeScanner {
         if (!LintUtils.isAnAllowedClass(foundClasses, "SystemTime") && evaluator.isMemberInClass(method, "java.lang.System")) {
             context.report(
                 ISSUE,
-                context.getCallLocation(node, true, true),
+                context.getCallLocation(node, includeReceiver = true, includeArguments = true),
                 DESCRIPTION
             )
         }

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/rules/DirectSystemCurrentTimeMillisUsage.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/DirectSystemCurrentTimeMillisUsage.kt
@@ -4,7 +4,6 @@ package com.ichi2.anki.lint.rules
 import com.android.tools.lint.detector.api.*
 import com.google.common.annotations.VisibleForTesting
 import com.ichi2.anki.lint.utils.Constants
-import com.ichi2.anki.lint.utils.KotlinCleanup
 import com.ichi2.anki.lint.utils.LintUtils
 import com.intellij.psi.PsiMethod
 import org.jetbrains.uast.UCallExpression
@@ -13,7 +12,6 @@ import org.jetbrains.uast.UCallExpression
  * This custom Lint rules will raise an error if a developer uses the [System.currentTimeMillis] method instead
  * of using the time provided by the new Time class.
  */
-@KotlinCleanup("mutableListOf")
 class DirectSystemCurrentTimeMillisUsage : Detector(), SourceCodeScanner {
 
     companion object {
@@ -37,11 +35,7 @@ class DirectSystemCurrentTimeMillisUsage : Detector(), SourceCodeScanner {
         )
     }
 
-    override fun getApplicableMethodNames(): List<String> {
-        val forbiddenSystemMethods: MutableList<String> = ArrayList()
-        forbiddenSystemMethods.add("currentTimeMillis")
-        return forbiddenSystemMethods
-    }
+    override fun getApplicableMethodNames() = mutableListOf("currentTimeMillis")
 
     override fun visitMethodCall(context: JavaContext, node: UCallExpression, method: PsiMethod) {
         super.visitMethodCall(context, node, method)

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/rules/DirectSystemTimeInstantiation.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/DirectSystemTimeInstantiation.kt
@@ -42,11 +42,7 @@ class DirectSystemTimeInstantiation : Detector(), SourceCodeScanner {
         )
     }
 
-    override fun getApplicableConstructorTypes(): List<String> {
-        val forbiddenConstructors: MutableList<String> = ArrayList()
-        forbiddenConstructors.add("com.ichi2.libanki.utils.SystemTime")
-        return forbiddenConstructors
-    }
+    override fun getApplicableConstructorTypes() = listOf("com.ichi2.libanki.utils.SystemTime")
 
     override fun visitConstructor(
         context: JavaContext,

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/rules/DirectSystemTimeInstantiation.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/DirectSystemTimeInstantiation.kt
@@ -1,3 +1,4 @@
+@file:Suppress("UnstableApiUsage")
 package com.ichi2.anki.lint.rules
 
 import com.android.tools.lint.detector.api.*

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/rules/DirectSystemTimeInstantiation.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/DirectSystemTimeInstantiation.kt
@@ -4,7 +4,6 @@ package com.ichi2.anki.lint.rules
 import com.android.tools.lint.detector.api.*
 import com.google.common.annotations.VisibleForTesting
 import com.ichi2.anki.lint.utils.Constants
-import com.ichi2.anki.lint.utils.KotlinCleanup
 import com.ichi2.anki.lint.utils.LintUtils.isAnAllowedClass
 import com.intellij.psi.PsiMethod
 import org.jetbrains.uast.UCallExpression
@@ -16,17 +15,14 @@ import org.jetbrains.uast.UCallExpression
  * NOTE: For future reference, if you plan on creating a Lint rule which looks for a constructor invocation, make sure
  * that the target class has a constructor defined in its source code!
  */
-@KotlinCleanup("IDE lint")
 class DirectSystemTimeInstantiation : Detector(), SourceCodeScanner {
 
     companion object {
-        @JvmField
         @VisibleForTesting
-        val ID = "DirectSystemTimeInstantiation"
+        const val ID = "DirectSystemTimeInstantiation"
 
-        @JvmField
         @VisibleForTesting
-        val DESCRIPTION =
+        const val DESCRIPTION =
             "Use the collection's getTime() method instead of instantiating SystemTime"
         private const val EXPLANATION =
             "Creating SystemTime instances directly means time cannot be controlled during" +
@@ -46,7 +42,7 @@ class DirectSystemTimeInstantiation : Detector(), SourceCodeScanner {
         )
     }
 
-    override fun getApplicableConstructorTypes(): List<String>? {
+    override fun getApplicableConstructorTypes(): List<String> {
         val forbiddenConstructors: MutableList<String> = ArrayList()
         forbiddenConstructors.add("com.ichi2.libanki.utils.SystemTime")
         return forbiddenConstructors

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/rules/DirectToastMakeTextUsage.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/DirectToastMakeTextUsage.kt
@@ -28,18 +28,15 @@ import org.jetbrains.uast.UCallExpression
  * This custom Lint rules will raise an error if a developer uses the {android.widget.Toast#makeText(...)} method instead
  * of using the method provided by the UIUtils class {com.ichi2.anki.UIUtils#showThemedToast(...)}.
  */
-@KotlinCleanup("IDE lint")
 @KotlinCleanup("mutableListOf")
 class DirectToastMakeTextUsage : Detector(), SourceCodeScanner {
 
     companion object {
-        @JvmField
         @VisibleForTesting
-        val ID = "DirectToastMakeTextUsage"
+        const val ID = "DirectToastMakeTextUsage"
 
-        @JvmField
         @VisibleForTesting
-        val DESCRIPTION = "Use UIUtils.showThemedToast instead of Toast.makeText"
+        const val DESCRIPTION = "Use UIUtils.showThemedToast instead of Toast.makeText"
         private const val EXPLANATION = "To improve code consistency within the codebase you should use UIUtils.showThemedToast in place" +
             " of the library Toast.makeText(...).show(). This ensures also that the toast is actually displayed after being created"
         private val implementation = Implementation(DirectToastMakeTextUsage::class.java, Scope.JAVA_FILE_SCOPE)
@@ -55,7 +52,7 @@ class DirectToastMakeTextUsage : Detector(), SourceCodeScanner {
         )
     }
 
-    override fun getApplicableMethodNames(): List<String>? {
+    override fun getApplicableMethodNames(): List<String> {
         val forbiddenToastMethods: MutableList<String> = ArrayList()
         forbiddenToastMethods.add("makeText")
         return forbiddenToastMethods
@@ -69,7 +66,7 @@ class DirectToastMakeTextUsage : Detector(), SourceCodeScanner {
             context.report(
                 ISSUE,
                 node,
-                context.getCallLocation(node, true, true),
+                context.getCallLocation(node, includeReceiver = true, includeArguments = true),
                 DESCRIPTION
             )
         }

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/rules/DirectToastMakeTextUsage.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/DirectToastMakeTextUsage.kt
@@ -13,6 +13,7 @@
  *  You should have received a copy of the GNU General Public License along with
  *  this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+@file:Suppress("UnstableApiUsage")
 package com.ichi2.anki.lint.rules
 
 import com.android.tools.lint.detector.api.*

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/rules/DirectToastMakeTextUsage.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/DirectToastMakeTextUsage.kt
@@ -19,7 +19,6 @@ package com.ichi2.anki.lint.rules
 import com.android.tools.lint.detector.api.*
 import com.google.common.annotations.VisibleForTesting
 import com.ichi2.anki.lint.utils.Constants
-import com.ichi2.anki.lint.utils.KotlinCleanup
 import com.ichi2.anki.lint.utils.LintUtils
 import com.intellij.psi.PsiMethod
 import org.jetbrains.uast.UCallExpression
@@ -28,7 +27,6 @@ import org.jetbrains.uast.UCallExpression
  * This custom Lint rules will raise an error if a developer uses the {android.widget.Toast#makeText(...)} method instead
  * of using the method provided by the UIUtils class {com.ichi2.anki.UIUtils#showThemedToast(...)}.
  */
-@KotlinCleanup("mutableListOf")
 class DirectToastMakeTextUsage : Detector(), SourceCodeScanner {
 
     companion object {
@@ -52,11 +50,7 @@ class DirectToastMakeTextUsage : Detector(), SourceCodeScanner {
         )
     }
 
-    override fun getApplicableMethodNames(): List<String> {
-        val forbiddenToastMethods: MutableList<String> = ArrayList()
-        forbiddenToastMethods.add("makeText")
-        return forbiddenToastMethods
-    }
+    override fun getApplicableMethodNames() = mutableListOf("makeText")
 
     override fun visitMethodCall(context: JavaContext, node: UCallExpression, method: PsiMethod) {
         super.visitMethodCall(context, node, method)

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/rules/DuplicateCrowdInStrings.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/DuplicateCrowdInStrings.kt
@@ -57,9 +57,7 @@ class DuplicateCrowdInStrings : ResourceXmlDetector() {
         return folderType == ResourceFolderType.VALUES
     }
 
-    override fun getApplicableElements(): Collection<String> {
-        return listOf(TAG_STRING)
-    }
+    override fun getApplicableElements() = listOf(TAG_STRING)
 
     override fun visitElement(context: XmlContext, element: Element) {
         // Only check the golden copy - not the translated sources.

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/rules/DuplicateTextInPreferencesXml.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/DuplicateTextInPreferencesXml.kt
@@ -1,16 +1,15 @@
+@file:Suppress("UnstableApiUsage")
 package com.ichi2.anki.lint.rules
 
 import com.android.resources.ResourceFolderType
 import com.android.tools.lint.detector.api.*
 import com.google.common.annotations.VisibleForTesting
 import com.ichi2.anki.lint.utils.Constants
-import com.ichi2.anki.lint.utils.KotlinCleanup
 import org.w3c.dom.Element
 
 /**
  * A Lint check to prevent using the same string for the title and summary of a preference.
  */
-@KotlinCleanup("IDe lint")
 class DuplicateTextInPreferencesXml : ResourceXmlDetector() {
 
     companion object {

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/rules/FixedPreferencesTitleLength.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/FixedPreferencesTitleLength.kt
@@ -22,11 +22,9 @@ import com.android.tools.lint.detector.api.Location.Handle
 import com.android.utils.Pair
 import com.google.common.annotations.VisibleForTesting
 import com.ichi2.anki.lint.utils.Constants
-import com.ichi2.anki.lint.utils.KotlinCleanup
 import org.w3c.dom.Element
 import java.util.*
 
-@KotlinCleanup("IDE lint")
 class FixedPreferencesTitleLength : ResourceXmlDetector(), XmlScanner {
     companion object {
         @VisibleForTesting
@@ -43,7 +41,8 @@ class FixedPreferencesTitleLength : ResourceXmlDetector(), XmlScanner {
         val DESCRIPTION_MAX_LENGTH = String.format("Preference titles should contain maxLength=\"%d\" attribute", PREFERENCE_TITLE_MAX_LENGTH)
 
         // Around 42 is a hard max on emulators, likely smaller in reality, so use a buffer
-        private const val EXPLANATION_TITLE_LENGTH = "A title with more than " + PREFERENCE_TITLE_MAX_LENGTH + " characters may fail to display on smaller screens"
+        private const val EXPLANATION_TITLE_LENGTH =
+            "A title with more than $PREFERENCE_TITLE_MAX_LENGTH characters may fail to display on smaller screens"
 
         // Read More: https://support.crowdin.com/file-formats/android-xml/
         private const val EXPLANATION_MAX_LENGTH = "Preference Title should contain maxLength attribute " +
@@ -101,7 +100,7 @@ class FixedPreferencesTitleLength : ResourceXmlDetector(), XmlScanner {
         }
         val handle: Handle = context.createLocationHandle(element)
         handle.clientData = element
-        valuesData[element.getAttribute(ATTR_NAME)] = Pair.of<Element, Handle>(element, handle)
+        valuesData[element.getAttribute(ATTR_NAME)] = Pair.of(element, handle)
     }
 
     override fun appliesTo(folderType: ResourceFolderType): Boolean {
@@ -114,17 +113,17 @@ class FixedPreferencesTitleLength : ResourceXmlDetector(), XmlScanner {
                 continue
             }
             val stringData: Pair<Element, Handle> = valuesData[title]!!
-            val element = stringData.getFirst()
+            val element = stringData.first
             if (!element.hasAttribute(ATTR_MAX_LENGTH)) {
                 val message = String.format(Locale.ENGLISH, "Preference title '%s' is missing \"maxLength=%d\" attribute", title, PREFERENCE_TITLE_MAX_LENGTH)
-                context.report(ISSUE_MAX_LENGTH, stringData.getSecond().resolve(), message)
-            } else if (element.getAttribute(ATTR_MAX_LENGTH) != Integer.toString(PREFERENCE_TITLE_MAX_LENGTH)) {
+                context.report(ISSUE_MAX_LENGTH, stringData.second.resolve(), message)
+            } else if (element.getAttribute(ATTR_MAX_LENGTH) != PREFERENCE_TITLE_MAX_LENGTH.toString()) {
                 val message = String.format(Locale.ENGLISH, "Preference title '%s' is having maxLength=%s it should contain maxLength=%d", title, element.getAttribute(ATTR_MAX_LENGTH), PREFERENCE_TITLE_MAX_LENGTH)
-                context.report(ISSUE_MAX_LENGTH, stringData.getSecond().resolve(), message)
+                context.report(ISSUE_MAX_LENGTH, stringData.second.resolve(), message)
             }
             if (element.textContent.length > PREFERENCE_TITLE_MAX_LENGTH) {
                 val message = String.format(Locale.ENGLISH, "Preference title '%s' must be less than %d characters (currently %d)", title, PREFERENCE_TITLE_MAX_LENGTH, element.textContent.length)
-                context.report(ISSUE_TITLE_LENGTH, stringData.getSecond().resolve(), message)
+                context.report(ISSUE_TITLE_LENGTH, stringData.second.resolve(), message)
             }
         }
     }

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/rules/FixedPreferencesTitleLength.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/FixedPreferencesTitleLength.kt
@@ -13,6 +13,7 @@
  *  You should have received a copy of the GNU General Public License along with
  *  this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+@file:Suppress("UnstableApiUsage")
 package com.ichi2.anki.lint.rules
 
 import com.android.resources.ResourceFolderType

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/rules/InconsistentAnnotationUsage.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/InconsistentAnnotationUsage.kt
@@ -13,6 +13,7 @@
  *  You should have received a copy of the GNU General Public License along with
  *  this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+@file:Suppress("UnstableApiUsage")
 package com.ichi2.anki.lint.rules
 
 import com.android.tools.lint.detector.api.*
@@ -22,7 +23,7 @@ import com.ichi2.anki.lint.utils.ImportStatementDetector
 import com.ichi2.anki.lint.utils.KotlinCleanup
 import org.jetbrains.uast.UImportStatement
 
-@KotlinCleanup("IDE lint - ignore 'Beta'")
+@KotlinCleanup("IDE lint")
 class InconsistentAnnotationUsage : ImportStatementDetector(), SourceCodeScanner {
 
     companion object {

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/rules/InconsistentAnnotationUsage.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/InconsistentAnnotationUsage.kt
@@ -20,20 +20,16 @@ import com.android.tools.lint.detector.api.*
 import com.google.common.annotations.VisibleForTesting
 import com.ichi2.anki.lint.utils.Constants
 import com.ichi2.anki.lint.utils.ImportStatementDetector
-import com.ichi2.anki.lint.utils.KotlinCleanup
 import org.jetbrains.uast.UImportStatement
 
-@KotlinCleanup("IDE lint")
 class InconsistentAnnotationUsage : ImportStatementDetector(), SourceCodeScanner {
 
     companion object {
-        @JvmField
         @VisibleForTesting
-        val ID = "InconsistentAnnotationUsage"
+        const val ID = "InconsistentAnnotationUsage"
 
-        @JvmField
         @VisibleForTesting
-        val DESCRIPTION = "Use androidx.annotation.NonNull and androidx.annotation.Nullable. See explanation for IDE-level fix"
+        const val DESCRIPTION = "Use androidx.annotation.NonNull and androidx.annotation.Nullable. See explanation for IDE-level fix"
         private const val EXPLANATION = "AnkiDroid uses androidx nullability annotations over JetBrains for nullability. " +
             "The annotations library can be specified in Settings - Inspections - Java - Probable Bugs - Nullability Problems - @NonNull/@Nullable problems. " +
             "Search in Settings for '@Nullable problems'"

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/rules/InvalidStringFormatDetector.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/InvalidStringFormatDetector.kt
@@ -14,6 +14,7 @@
  *  this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+@file:Suppress("UnstableApiUsage")
 package com.ichi2.anki.lint.rules
 
 import com.android.SdkConstants.*

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/rules/InvalidStringFormatDetector.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/InvalidStringFormatDetector.kt
@@ -56,9 +56,9 @@ class InvalidStringFormatDetector : ResourceXmlDetector() {
             ANKI_XML_SEVERITY,
             IMPLEMENTATION_XML
         )
-    }
 
-    private val INVALID_FORMAT_PATTERN = Pattern.compile("[^%]+%").toRegex()
+        private val INVALID_FORMAT_PATTERN = Pattern.compile("[^%]+%").toRegex()
+    }
 
     override fun appliesTo(folderType: ResourceFolderType): Boolean =
         EnumSet.of(ResourceFolderType.VALUES).contains(folderType)

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/rules/JUnitNullAssertionDetector.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/JUnitNullAssertionDetector.kt
@@ -14,6 +14,7 @@
  *  this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+@file:Suppress("UnstableApiUsage")
 package com.ichi2.anki.lint.rules
 
 import com.android.tools.lint.detector.api.*

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/rules/JavaFieldNamingPatternDetector.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/JavaFieldNamingPatternDetector.kt
@@ -13,17 +13,16 @@
  *  You should have received a copy of the GNU General Public License along with
  *  this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+@file:Suppress("UnstableApiUsage")
 package com.ichi2.anki.lint.rules
 
 import com.android.tools.lint.client.api.UElementHandler
 import com.android.tools.lint.detector.api.Detector
 import com.android.tools.lint.detector.api.JavaContext
-import com.ichi2.anki.lint.utils.KotlinCleanup
 import org.jetbrains.uast.UElement
 import org.jetbrains.uast.UField
 import org.jetbrains.uast.UVariable
 
-@KotlinCleanup("IDE Lint")
 abstract class JavaFieldNamingPatternDetector : Detector(), Detector.UastScanner {
     override fun createUastHandler(context: JavaContext): UElementHandler? {
         return VariableNamingHandler(context)

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/rules/JavaFieldNamingPatternDetector.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/JavaFieldNamingPatternDetector.kt
@@ -19,7 +19,6 @@ package com.ichi2.anki.lint.rules
 import com.android.tools.lint.client.api.UElementHandler
 import com.android.tools.lint.detector.api.Detector
 import com.android.tools.lint.detector.api.JavaContext
-import org.jetbrains.uast.UElement
 import org.jetbrains.uast.UField
 import org.jetbrains.uast.UVariable
 
@@ -28,9 +27,7 @@ abstract class JavaFieldNamingPatternDetector : Detector(), Detector.UastScanner
         return VariableNamingHandler(context)
     }
 
-    override fun getApplicableUastTypes(): List<Class<out UElement?>>? {
-        return listOf(UVariable::class.java)
-    }
+    override fun getApplicableUastTypes() = listOf(UVariable::class.java)
 
     private inner class VariableNamingHandler(private val mContext: JavaContext) :
         UElementHandler() {

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/rules/KotlinMigrationBrokenEmails.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/KotlinMigrationBrokenEmails.kt
@@ -14,6 +14,7 @@
  *  this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+@file:Suppress("UnstableApiUsage")
 package com.ichi2.anki.lint.rules
 
 import com.android.tools.lint.detector.api.*

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/rules/KotlinMigrationBrokenEmails.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/KotlinMigrationBrokenEmails.kt
@@ -28,7 +28,7 @@ import java.util.regex.Pattern
 
 @Beta
 class KotlinMigrationBrokenEmails : Detector(), SourceCodeScanner {
-    override fun getApplicableUastTypes(): List<Class<out UElement?>>? {
+    override fun getApplicableUastTypes(): List<Class<out UElement?>> {
         return listOf(UClass::class.java)
     }
 

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/rules/KotlinMigrationBrokenEmails.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/KotlinMigrationBrokenEmails.kt
@@ -22,15 +22,12 @@ import com.google.common.annotations.Beta
 import com.google.common.annotations.VisibleForTesting
 import com.ichi2.anki.lint.utils.Constants
 import org.jetbrains.uast.UClass
-import org.jetbrains.uast.UElement
 import java.util.*
 import java.util.regex.Pattern
 
 @Beta
 class KotlinMigrationBrokenEmails : Detector(), SourceCodeScanner {
-    override fun getApplicableUastTypes(): List<Class<out UElement?>> {
-        return listOf(UClass::class.java)
-    }
+    override fun getApplicableUastTypes() = listOf(UClass::class.java)
 
     override fun afterCheckFile(context: Context) {
         val contents = context.getContents()

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/rules/KotlinMigrationFixLineBreaks.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/KotlinMigrationFixLineBreaks.kt
@@ -23,15 +23,12 @@ import com.google.common.annotations.Beta
 import com.google.common.annotations.VisibleForTesting
 import com.ichi2.anki.lint.utils.Constants
 import org.jetbrains.uast.UClass
-import org.jetbrains.uast.UElement
 import java.util.*
 import java.util.regex.Pattern
 
 @Beta
 class KotlinMigrationFixLineBreaks : Detector(), SourceCodeScanner {
-    override fun getApplicableUastTypes(): List<Class<out UElement?>> {
-        return listOf(UClass::class.java)
-    }
+    override fun getApplicableUastTypes() = listOf(UClass::class.java)
 
     override fun afterCheckFile(context: Context) {
         val contents = context.getContents()

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/rules/KotlinMigrationFixLineBreaks.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/KotlinMigrationFixLineBreaks.kt
@@ -29,7 +29,7 @@ import java.util.regex.Pattern
 
 @Beta
 class KotlinMigrationFixLineBreaks : Detector(), SourceCodeScanner {
-    override fun getApplicableUastTypes(): List<Class<out UElement?>>? {
+    override fun getApplicableUastTypes(): List<Class<out UElement?>> {
         return listOf(UClass::class.java)
     }
 

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/rules/KotlinMigrationFixLineBreaks.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/KotlinMigrationFixLineBreaks.kt
@@ -15,6 +15,7 @@
  *  this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+@file:Suppress("UnstableApiUsage")
 package com.ichi2.anki.lint.rules
 
 import com.android.tools.lint.detector.api.*

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/rules/NonPositionalFormatSubstitutions.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/NonPositionalFormatSubstitutions.kt
@@ -14,6 +14,7 @@
  *  this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+@file:Suppress("UnstableApiUsage")
 package com.ichi2.anki.lint.rules
 
 import com.android.SdkConstants

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/rules/NonPublicNonStaticJavaFieldDetector.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/NonPublicNonStaticJavaFieldDetector.kt
@@ -13,6 +13,7 @@
  *  You should have received a copy of the GNU General Public License along with
  *  this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+@file:Suppress("UnstableApiUsage")
 package com.ichi2.anki.lint.rules
 
 import com.android.tools.lint.detector.api.Implementation

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/rules/NonPublicNonStaticJavaFieldDetector.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/NonPublicNonStaticJavaFieldDetector.kt
@@ -21,7 +21,6 @@ import com.android.tools.lint.detector.api.Issue
 import com.android.tools.lint.detector.api.JavaContext
 import com.android.tools.lint.detector.api.Scope
 import com.ichi2.anki.lint.utils.Constants
-import com.ichi2.anki.lint.utils.KotlinCleanup
 import org.jetbrains.uast.UElement
 import org.jetbrains.uast.UVariable
 import org.jetbrains.uast.UastVisibility
@@ -30,7 +29,6 @@ import java.util.*
 /**
  * https://github.com/ankidroid/Anki-Android/wiki/Code-style#non-public-non-static-field-names-should-start-with-m
  */
-@KotlinCleanup("IDE Lint")
 class NonPublicNonStaticJavaFieldDetector : JavaFieldNamingPatternDetector() {
 
     companion object {
@@ -50,9 +48,7 @@ class NonPublicNonStaticJavaFieldDetector : JavaFieldNamingPatternDetector() {
         if (variable.isStatic) {
             return false
         }
-        return if (variable.visibility == UastVisibility.PUBLIC) {
-            false
-        } else true
+        return variable.visibility != UastVisibility.PUBLIC
     }
 
     override fun meetsNamingStandards(variableName: String): Boolean {

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/rules/PreferIsEmptyOverSizeCheck.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/PreferIsEmptyOverSizeCheck.kt
@@ -28,7 +28,7 @@ import org.jetbrains.uast.*
 import java.util.*
 import java.util.regex.Pattern
 
-@KotlinCleanup("remove after all converted")
+@KotlinCleanup("Remove this class once there's no Java in AnkiDroid")
 class PreferIsEmptyOverSizeCheck : Detector(), UastScanner {
 
     companion object {

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/rules/PreferIsEmptyOverSizeCheck.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/PreferIsEmptyOverSizeCheck.kt
@@ -29,7 +29,6 @@ import java.util.*
 import java.util.regex.Pattern
 
 @KotlinCleanup("remove after all converted")
-@KotlinCleanup("requireNonNull")
 class PreferIsEmptyOverSizeCheck : Detector(), UastScanner {
 
     companion object {
@@ -112,10 +111,7 @@ class PreferIsEmptyOverSizeCheck : Detector(), UastScanner {
                 isAffirmative = null
                 return
             }
-            val methods = Objects.requireNonNull(
-                mJavaContext.evaluator
-                    .getTypeClass(node.receiverType)
-            )!!.allMethods
+            val methods = mJavaContext.evaluator.getTypeClass(node.receiverType)!!.allMethods
             if (Arrays.stream(methods).anyMatch { m: PsiMethod -> "isEmpty" == m.name && m.hasModifier(JvmModifier.PUBLIC) }) {
                 reportVariable(mJavaContext, parentNode!!, isAffirmative!!)
                 parentNode = null

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/rules/PreferIsEmptyOverSizeCheck.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/PreferIsEmptyOverSizeCheck.kt
@@ -29,7 +29,6 @@ import java.util.*
 import java.util.regex.Pattern
 
 @KotlinCleanup("remove after all converted")
-@KotlinCleanup("IDE lint")
 @KotlinCleanup("requireNonNull")
 class PreferIsEmptyOverSizeCheck : Detector(), UastScanner {
 
@@ -55,11 +54,11 @@ class PreferIsEmptyOverSizeCheck : Detector(), UastScanner {
         private val pattern = Pattern.compile("\\.size\\(\\)([^=]*)(==|>|<|>=|<=).*\\z")
     }
 
-    override fun createUastHandler(context: JavaContext): UElementHandler? {
+    override fun createUastHandler(context: JavaContext): UElementHandler {
         return BinaryExpressionHandler(context)
     }
 
-    override fun getApplicableUastTypes(): List<Class<out UElement>>? {
+    override fun getApplicableUastTypes(): List<Class<out UElement>> {
         val allowed: MutableList<Class<out UElement>> = ArrayList(2)
         allowed.add(UBinaryExpression::class.java)
         allowed.add(UCallExpression::class.java)
@@ -120,7 +119,7 @@ class PreferIsEmptyOverSizeCheck : Detector(), UastScanner {
             val methods = Objects.requireNonNull(
                 mJavaContext.evaluator
                     .getTypeClass(node.receiverType)
-            )!!.getAllMethods()
+            )!!.allMethods
             if (Arrays.stream(methods).anyMatch { m: PsiMethod -> "isEmpty" == m.name && m.hasModifier(JvmModifier.PUBLIC) }) {
                 reportVariable(mJavaContext, parentNode!!, isAffirmative!!)
                 parentNode = null

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/rules/PreferIsEmptyOverSizeCheck.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/PreferIsEmptyOverSizeCheck.kt
@@ -13,6 +13,7 @@
  *  You should have received a copy of the GNU General Public License along with
  *  this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+@file:Suppress("UnstableApiUsage")
 package com.ichi2.anki.lint.rules
 
 import com.android.tools.lint.client.api.UElementHandler

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/rules/PreferIsEmptyOverSizeCheck.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/PreferIsEmptyOverSizeCheck.kt
@@ -58,12 +58,8 @@ class PreferIsEmptyOverSizeCheck : Detector(), UastScanner {
         return BinaryExpressionHandler(context)
     }
 
-    override fun getApplicableUastTypes(): List<Class<out UElement>> {
-        val allowed: MutableList<Class<out UElement>> = ArrayList(2)
-        allowed.add(UBinaryExpression::class.java)
-        allowed.add(UCallExpression::class.java)
-        return allowed
-    }
+    override fun getApplicableUastTypes() =
+        mutableListOf(UBinaryExpression::class.java, UCallExpression::class.java)
 
     /**
      * Report the problematic comparison expression to the lint checker and compute the fix to apply

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/rules/PrintStackTraceUsage.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/PrintStackTraceUsage.kt
@@ -13,6 +13,7 @@
  *  You should have received a copy of the GNU General Public License along with
  *  this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+@file:Suppress("UnstableApiUsage")
 package com.ichi2.anki.lint.rules
 
 import com.android.tools.lint.detector.api.*

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/rules/PrintStackTraceUsage.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/PrintStackTraceUsage.kt
@@ -19,7 +19,6 @@ package com.ichi2.anki.lint.rules
 import com.android.tools.lint.detector.api.*
 import com.google.common.annotations.VisibleForTesting
 import com.ichi2.anki.lint.utils.Constants
-import com.ichi2.anki.lint.utils.KotlinCleanup
 import com.intellij.psi.PsiMethod
 import org.jetbrains.uast.UCallExpression
 
@@ -47,7 +46,6 @@ class PrintStackTraceUsage : Detector(), SourceCodeScanner {
 
     override fun getApplicableMethodNames() = mutableListOf("printStackTrace")
 
-    @KotlinCleanup("remove comment about semicolon")
     override fun visitMethodCall(context: JavaContext, node: UCallExpression, method: PsiMethod) {
         super.visitMethodCall(context, node, method)
         val evaluator = context.evaluator
@@ -60,7 +58,6 @@ class PrintStackTraceUsage : Detector(), SourceCodeScanner {
         val fix = LintFix.create()
             .replace()
             .select(node.asSourceString())
-            // We don't need a semicolon here
             .with("Timber.w(" + node.receiver!!.asSourceString() + ")")
             .autoFix()
             .build()

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/rules/PrintStackTraceUsage.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/PrintStackTraceUsage.kt
@@ -23,14 +23,12 @@ import com.ichi2.anki.lint.utils.KotlinCleanup
 import com.intellij.psi.PsiMethod
 import org.jetbrains.uast.UCallExpression
 
-@KotlinCleanup("IDE Lint")
 @KotlinCleanup("mutableListOf")
 class PrintStackTraceUsage : Detector(), SourceCodeScanner {
 
     companion object {
-        @JvmField
         @VisibleForTesting
-        val ID = "PrintStackTraceUsage"
+        const val ID = "PrintStackTraceUsage"
 
         @VisibleForTesting
         val DESCRIPTION = "Use Timber to log exceptions (typically Timber.w if non-fatal)"
@@ -48,7 +46,7 @@ class PrintStackTraceUsage : Detector(), SourceCodeScanner {
         )
     }
 
-    override fun getApplicableMethodNames(): List<String>? {
+    override fun getApplicableMethodNames(): List<String> {
         val forbiddenMethods: MutableList<String> = ArrayList()
         forbiddenMethods.add("printStackTrace")
         return forbiddenMethods
@@ -73,7 +71,7 @@ class PrintStackTraceUsage : Detector(), SourceCodeScanner {
             .build()
         context.report(
             ISSUE,
-            context.getCallLocation(node, true, true),
+            context.getCallLocation(node, includeReceiver = true, includeArguments = true),
             DESCRIPTION,
             fix
         )

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/rules/PrintStackTraceUsage.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/PrintStackTraceUsage.kt
@@ -23,7 +23,6 @@ import com.ichi2.anki.lint.utils.KotlinCleanup
 import com.intellij.psi.PsiMethod
 import org.jetbrains.uast.UCallExpression
 
-@KotlinCleanup("mutableListOf")
 class PrintStackTraceUsage : Detector(), SourceCodeScanner {
 
     companion object {
@@ -46,11 +45,7 @@ class PrintStackTraceUsage : Detector(), SourceCodeScanner {
         )
     }
 
-    override fun getApplicableMethodNames(): List<String> {
-        val forbiddenMethods: MutableList<String> = ArrayList()
-        forbiddenMethods.add("printStackTrace")
-        return forbiddenMethods
-    }
+    override fun getApplicableMethodNames() = mutableListOf("printStackTrace")
 
     @KotlinCleanup("remove comment about semicolon")
     override fun visitMethodCall(context: JavaContext, node: UCallExpression, method: PsiMethod) {

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/rules/VariableNamingDetector.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/VariableNamingDetector.kt
@@ -31,7 +31,7 @@ import org.jetbrains.uast.UVariable
 
 class VariableNamingDetector : Detector(), Detector.UastScanner {
 
-    override fun getApplicableUastTypes(): List<Class<out UElement>>? {
+    override fun getApplicableUastTypes(): List<Class<out UElement>> {
         return listOf(UVariable::class.java)
     }
 

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/rules/VariableNamingDetector.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/VariableNamingDetector.kt
@@ -14,6 +14,7 @@
  *  this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+@file:Suppress("UnstableApiUsage")
 package com.ichi2.anki.lint.rules
 
 import com.android.tools.lint.client.api.UElementHandler

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/rules/VariableNamingDetector.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/VariableNamingDetector.kt
@@ -31,9 +31,7 @@ import org.jetbrains.uast.UVariable
 
 class VariableNamingDetector : Detector(), Detector.UastScanner {
 
-    override fun getApplicableUastTypes(): List<Class<out UElement>> {
-        return listOf(UVariable::class.java)
-    }
+    override fun getApplicableUastTypes() = listOf(UVariable::class.java)
 
     private fun reportVariable(context: JavaContext, node: UVariable) {
         context.report(

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/utils/Constants.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/utils/Constants.kt
@@ -1,3 +1,4 @@
+@file:Suppress("UnstableApiUsage")
 package com.ichi2.anki.lint.utils
 
 import com.android.tools.lint.detector.api.Category
@@ -7,7 +8,6 @@ import com.android.tools.lint.detector.api.Severity
 /**
  * Hold some constants applicable to all lint issues.
  */
-@KotlinCleanup("IDE Lint")
 object Constants {
     /**
      * A special [Category] which groups the Lint issues related to the usage of the new SystemTime class as a

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/utils/ImportStatementDetector.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/utils/ImportStatementDetector.kt
@@ -13,6 +13,7 @@
  *  You should have received a copy of the GNU General Public License along with
  *  this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+@file:Suppress("UnstableApiUsage")
 package com.ichi2.anki.lint.utils
 
 import com.android.tools.lint.client.api.UElementHandler
@@ -21,7 +22,6 @@ import com.android.tools.lint.detector.api.JavaContext
 import org.jetbrains.uast.UElement
 import org.jetbrains.uast.UImportStatement
 
-@KotlinCleanup("IDE lint")
 abstract class ImportStatementDetector : Detector() {
     abstract fun visitImportStatement(context: JavaContext, node: UImportStatement)
     override fun getApplicableUastTypes(): List<Class<out UElement?>>? {


### PR DESCRIPTION
Fixes all `@KotlinCleanup` but the 'Remove this rule once there's no more Java' cleanups

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
