### PR TITLE
Ignore image and audio paths check for text based fields

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
@@ -77,6 +77,7 @@ import com.ichi2.anki.servicelayer.NoteService
 import com.ichi2.anki.ui.NoteTypeSpinnerUtils
 import com.ichi2.anki.widgets.DeckDropDownAdapter.SubtitleListener
 import com.ichi2.anki.widgets.PopupMenuWithIcons
+import com.ichi2.annotations.NeedsTest
 import com.ichi2.async.CollectionTask.AddNote
 import com.ichi2.async.TaskListenerWithContext
 import com.ichi2.async.TaskManager
@@ -1157,13 +1158,14 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
                     mChanged = true
                 }
             }
+            @NeedsTest("test to guard against changes in the REQUEST_MULTIMEDIA_EDIT clause preventing text fields to be updated")
             REQUEST_MULTIMEDIA_EDIT -> {
                 if (resultCode != RESULT_CANCELED) {
                     val col = col
                     val extras = data!!.extras ?: return
                     val index = extras.getInt(MultimediaEditFieldActivity.EXTRA_RESULT_FIELD_INDEX)
                     val field = extras[MultimediaEditFieldActivity.EXTRA_RESULT_FIELD] as IField? ?: return
-                    if (field.imagePath == null && field.audioPath == null) {
+                    if (field.type != EFieldType.TEXT && (field.imagePath == null && field.audioPath == null)) {
                         Timber.i("field imagePath and audioPath are both null")
                         return
                     }


### PR DESCRIPTION
## Purpose / Description

Commit c33e7ea8a introduced a regression:

_From DeckPicker, select a deck -> from the toolbar menu, select edit note -> select multimedia(the clip icon) edit for a text field -> use one of the options there like clear or clone -> select done menu item from the toolbar -> expected to see the changes in the note editor, instead the change is ignored._

This is happening because, when returning to NoteEditor, there's a check if the media references are null which shouldn't happen for text fields.

## How Has This Been Tested?

Ran the usual tests.

## Checklist

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
