### PR TITLE
fix: invalid sourceSets for Android Chipmunk

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -180,11 +180,6 @@ android {
     packagingOptions {
         exclude 'META-INF/DEPENDENCIES'
     }
-    sourceSets {
-        debug {
-            manifest.srcFile 'src/test/AndroidManifest.xml'
-        }
-    }
     ndkVersion "22.0.7026061"
 }
 

--- a/AnkiDroid/src/test/AndroidManifest.xml
+++ b/AnkiDroid/src/test/AndroidManifest.xml
@@ -3,12 +3,7 @@
     <application tools:ignore="AllowBackup,GoogleAppIndexingWarning">
 
         <!-- To use AndroidX Test APIs on Activity sub-classes, you must have valid
-             Activity entries in your AndroidManifest. Manifest merger only happens with
-             build variants, and tests always run with the debug build variant, so test-only
-             Activity subclasses are defined here, and this file is included in debug.sourceSet
-             https://developer.android.com/studio/build/manifest-merge
-             https://issuetracker.google.com/issues/37001185
-             -->
+             Activity entries in your AndroidManifest -->
         <activity
             android:name="com.ichi2.anki.TestCardTemplatePreviewer">
         </activity>


### PR DESCRIPTION
Due to https://issuetracker.google.com/issues/37001185 we were defining`manifest.srcFile` for `debug` instead of for `test`. This is because manifest merging previously occurred only with build variants

Was required for robolectric. Apparently fixed in AGP 0.13.0: https://issuetracker.google.com/issues/37001185

It seems we can manifest merge based on `test` and `androidTest`, so remove the `debug` sourceSet.

This caused a bug on Android Chipmunk, as we included `test` in the `main` source set due to a change in how sourceSets were processed

## Fixes
Fixes #11291

## Approach
Remove `debug` sourceSet

## How Has This Been Tested?
Robolectric passes on Bumblebee and Chipmunk

## Learning (optional, can help others)

Main comments: https://issuetracker.google.com/issues/232007221

https://issuetracker.google.com/issues/220326930

https://issuetracker.google.com/issues/37001185


## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
