### PR TITLE
Fix AutoFocus EditText Preferences Back/Return Button Bug

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/preferences/AutoFocusEditTextPreference.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/preferences/AutoFocusEditTextPreference.kt
@@ -31,8 +31,8 @@ interface AutoFocusable {
 
 @Suppress("deprecation")
 open class AutoFocusEditTextPreference(context: Context?, attrs: AttributeSet?) : android.preference.EditTextPreference(context, attrs), AutoFocusable {
-    override fun onBindView(view: View?) {
-        super.onBindView(view)
+    override fun onBindDialogView(view: View?) {
+        super.onBindDialogView(view)
         autoFocusAndMoveCursorToEnd(editText)
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/preferences/NumberRangePreference.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/preferences/NumberRangePreference.kt
@@ -48,8 +48,8 @@ open class NumberRangePreference : android.preference.EditTextPreference, AutoFo
         updateSettings()
     }
 
-    override fun onBindView(view: View?) {
-        super.onBindView(view)
+    override fun onBindDialogView(view: View?) {
+        super.onBindDialogView(view)
         autoFocusAndMoveCursorToEnd(editText)
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/preferences/StepsPreference.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/preferences/StepsPreference.kt
@@ -50,8 +50,8 @@ class StepsPreference : android.preference.EditTextPreference, AutoFocusable {
         updateSettings()
     }
 
-    override fun onBindView(view: View?) {
-        super.onBindView(view)
+    override fun onBindDialogView(view: View?) {
+        super.onBindDialogView(view)
         autoFocusAndMoveCursorToEnd(editText)
     }
 


### PR DESCRIPTION
## Purpose / Description
Fix bug

## Fixes
Fixes #11332 

## Approach
as `onBindView` would be called when Back button was pressed, changed `onBindView` to `onBindDialogView` which wasn't

## How Has This Been Tested?
Tested on emulator

https://user-images.githubusercontent.com/59933477/168155147-18a62245-59ca-4697-b9fe-9c4cfc045c0a.mov



## Checklist

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [x] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
