### PR TITLE
feat: Speed up tests on Apple Silicon and CI

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -121,7 +121,11 @@ ext {
     // Virtualized Environment like CI may report host CPU counts vs guest, but runs 2 cores
     // everyone else gets 50% of cores to account for SMT which doesn't help this workload
     gradleTestMaxParallelForks = 1
-    if (!ciBuild) {
+    if (System.getProperty("os.name") == "Mac OS X") {
+        // macOS reports hardware cores. This is accurate for CI, Intel (halved due to SMT) and Apple Silicon
+        gradleTestMaxParallelForks = "sysctl -n hw.physicalcpu".execute().text.toInteger()
+    } else if (!ciBuild) {
+        // Use 50% of cores to account for SMT which doesn't help this workload
         gradleTestMaxParallelForks = Runtime.runtime.availableProcessors().intdiv(2) ?: 1
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -118,15 +118,17 @@ ext {
     // allows for universal APKs to be generated
     universalApkEnabled = "true" == System.getProperty("universal-apk", "false")
 
-    // Virtualized Environment like CI may report host CPU counts vs guest, but runs 2 cores
-    // everyone else gets 50% of cores to account for SMT which doesn't help this workload
-    gradleTestMaxParallelForks = 1
     if (System.getProperty("os.name") == "Mac OS X") {
         // macOS reports hardware cores. This is accurate for CI, Intel (halved due to SMT) and Apple Silicon
         gradleTestMaxParallelForks = "sysctl -n hw.physicalcpu".execute().text.toInteger()
-    } else if (!ciBuild) {
+    } else if (ciBuild) {
+        // GitHub Actions (Standard_DS2_v2) are 1:1 on Linux/Windows with two vCPU cores
+        // Sources:
+        // Standard_DS2_v2 https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#cloud-hosts-for-github-hosted-runners
+        // Which is 1:1 https://docs.microsoft.com/en-gb/azure/virtual-machines/acu : DS1_v2 - DS15_v2 | 1:1
+        gradleTestMaxParallelForks = 2
+    } else {
         // Use 50% of cores to account for SMT which doesn't help this workload
         gradleTestMaxParallelForks = Runtime.runtime.availableProcessors().intdiv(2) ?: 1
     }
 }
-


### PR DESCRIPTION
M1 Macs don't have SMT, so there's no need to halve the processors when running tests

Before:
BUILD SUCCESSFUL in 3m 1s
BUILD SUCCESSFUL in 2m 57s

After:
BUILD SUCCESSFUL in 2m 08s
BUILD SUCCESSFUL in 1m 53s

Note: Scenario was unit test runs inside Android Studio, had similar speedup with `./gradlew clean jacocoUnitTestReport --rerun-tasks`

## How Has This Been Tested?

All tests
## Learning (optional, can help others)

We may want to do this based on physical CPUs if there is a good platform-agnostic method.

```
davidallison@Davids-MBP optilingo_mobile_app_v2 % sysctl -n hw.physicalcpu                                         
10
davidallison@Davids-MBP optilingo_mobile_app_v2 % sysctl -n hw.ncpu                                 
10
```


## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
