### PR TITLE
Fix ModelBrowser leaking its ModelBrowserContextMenu reference

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ModelBrowserContextMenu.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ModelBrowserContextMenu.kt
@@ -3,38 +3,41 @@ package com.ichi2.anki.dialogs
 
 import android.app.Dialog
 import android.os.Bundle
+import androidx.annotation.StringRes
+import androidx.core.os.bundleOf
 import com.afollestad.materialdialogs.MaterialDialog
-import com.afollestad.materialdialogs.MaterialDialog.ListCallback
+import com.ichi2.anki.ModelBrowser
 import com.ichi2.anki.R
 import com.ichi2.anki.analytics.AnalyticsDialogFragment
+import timber.log.Timber
 
 class ModelBrowserContextMenu : AnalyticsDialogFragment() {
+
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
         super.onCreate(savedInstanceState)
-        val entries = arrayOfNulls<String>(3)
-        entries[MODEL_TEMPLATE] = resources.getString(R.string.model_browser_template)
-        entries[MODEL_RENAME] = resources.getString(R.string.model_browser_rename)
-        entries[MODEL_DELETE] = resources.getString(R.string.model_browser_delete)
+        val items = ModelBrowserContextMenuAction.values().sortedBy { it.order }
         return MaterialDialog.Builder(requireActivity())
-            .title(requireArguments().getString("label")!!)
-            .items(*entries)
-            .itemsCallback(mContextMenuListener!!)
+            .title(requireArguments().getString(KEY_LABEL)!!)
+            .items(items.map { resources.getString(it.actionTextResId) })
+            .itemsCallback { _, _, position, _ ->
+                (requireActivity() as? ModelBrowser)?.run { handleAction(items[position]) }
+                    ?: Timber.e("ContextMenu used from outside of its target activity!")
+            }
             .build()
     }
 
     companion object {
-        const val MODEL_TEMPLATE = 0
-        const val MODEL_RENAME = 1
-        const val MODEL_DELETE = 2
-        private var mContextMenuListener: ListCallback? = null
+        private const val KEY_LABEL = "key_label"
+
         @JvmStatic
-        fun newInstance(label: String?, contextMenuListener: ListCallback?): ModelBrowserContextMenu {
-            mContextMenuListener = contextMenuListener
-            val n = ModelBrowserContextMenu()
-            val b = Bundle()
-            b.putString("label", label)
-            n.arguments = b
-            return n
+        fun newInstance(label: String?): ModelBrowserContextMenu = ModelBrowserContextMenu().apply {
+            arguments = bundleOf(KEY_LABEL to label)
         }
     }
+}
+
+enum class ModelBrowserContextMenuAction(val order: Int, @StringRes val actionTextResId: Int) {
+    Template(0, R.string.model_browser_template),
+    Rename(1, R.string.model_browser_rename),
+    Delete(2, R.string.model_browser_delete),
 }


### PR DESCRIPTION
## Purpose / Description

Fix a leak reported by LeakCanary for ModelBrowser. It was happening because ModelBrowser was holding a reference to its ModelBrowserContextMenu to dismiss it. 

Instead I used the FragmentManager to dismiss the context menu and I removed its reference.

## How Has This Been Tested?

Ran the usual tests.

## Checklist

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
