### PR TITLE
Fix ModelFieldEditor leaking ModelEditorContextMenu

### DIFF
--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/dialogs/ModelEditorContextMenuTest.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/dialogs/ModelEditorContextMenuTest.kt
@@ -1,0 +1,70 @@
+/****************************************************************************************
+ * Copyright (c) 2022 lukstbit <lukstbit@users.noreply.github.com>                      *
+ *                                                                                      *
+ * This program is free software; you can redistribute it and/or modify it under        *
+ * the terms of the GNU General Public License as published by the Free Software        *
+ * Foundation; either version 3 of the License, or (at your option) any later           *
+ * version.                                                                             *
+ *                                                                                      *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *                                                                                      *
+ * You should have received a copy of the GNU General Public License along with         *
+ * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ ****************************************************************************************/
+package com.ichi2.anki.dialogs
+
+import androidx.core.os.bundleOf
+import androidx.fragment.app.testing.launchFragment
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.assertion.ViewAssertions.doesNotExist
+import androidx.test.espresso.assertion.ViewAssertions.matches
+import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
+import androidx.test.espresso.matcher.ViewMatchers.withText
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.ichi2.anki.R
+import com.ichi2.anki.dialogs.ModelEditorContextMenu.ModelEditorContextMenuAction
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class ModelEditorContextMenuTest {
+    private val testDialogTitle = "test editor title"
+
+    @Test
+    fun showsAllOptionsIfAboveN() {
+        launchFragment(
+            fragmentArgs = bundleOf(ModelEditorContextMenu.KEY_LABEL to testDialogTitle),
+            themeResId = R.style.Theme_Light
+        ) { MockModelEditorContextMenu(isAtLeastAtN = true) }
+        onView(withText(testDialogTitle)).check(matches(isDisplayed()))
+        ModelEditorContextMenuAction.values().forEach {
+            onView(withText(it.actionTextId)).check(matches(isDisplayed()))
+        }
+    }
+
+    @Test
+    fun doesNotShowLanguageHintOptionIfBelowN() {
+        launchFragment(
+            fragmentArgs = bundleOf(ModelEditorContextMenu.KEY_LABEL to testDialogTitle),
+            themeResId = R.style.Theme_Light
+        ) { MockModelEditorContextMenu(isAtLeastAtN = false) }
+        onView(withText(testDialogTitle)).check(matches(isDisplayed()))
+        // ModelEditorContextMenuAction.AddLanguageHint shouldn't be available
+        onView(withText(ModelEditorContextMenuAction.AddLanguageHint.actionTextId)).check(
+            doesNotExist()
+        )
+        // make sure we aren't losing other items besides ModelEditorContextMenuAction.AddLanguageHint
+        ModelEditorContextMenuAction.values()
+            .filterNot { it == ModelEditorContextMenuAction.AddLanguageHint }.forEach {
+                onView(withText(it.actionTextId)).check(matches(isDisplayed()))
+            }
+    }
+
+    class MockModelEditorContextMenu(
+        private val isAtLeastAtN: Boolean
+    ) : ModelEditorContextMenu() {
+        override fun isAtLeastAtN(): Boolean = isAtLeastAtN
+    }
+}


### PR DESCRIPTION
## Purpose / Description

Fix a leak reported by LeakCanary for ModelFieldEditor. It was happening because ModelFieldEditor was holding a reference to its ModelEditorContextMenu to dismiss it. Instead I used the FragmentManager to dismiss the context menu and I removed its reference from ModelFieldEditor. Also, I removed the @RequiresApi for AddLanguageHint, the rationale behind this is that ModelEditorContextMenu will trigger this action only when the current API level matches the requirement(added a test for this).

## How Has This Been Tested?

Ran the usual tests.

## Checklist

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
