### PR TITLE
Fix onActivityResult deprecation for StudyOptionsActivity

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsActivity.kt
@@ -15,7 +15,6 @@
  ****************************************************************************************/
 package com.ichi2.anki
 
-import android.content.Intent
 import android.os.Bundle
 import android.view.MenuItem
 import com.ichi2.anim.ActivityTransitionAnimation
@@ -64,12 +63,6 @@ class StudyOptionsActivity : NavigationDrawerActivity(), StudyOptionsListener, C
             return true
         }
         return super.onOptionsItemSelected(item)
-    }
-
-    @Suppress("deprecation") // #10086
-    public override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
-        super.onActivityResult(requestCode, resultCode, data)
-        Timber.d("onActivityResult (requestCode = %d, resultCode = %d)", requestCode, resultCode)
     }
 
     private fun closeStudyOptions(result: Int = RESULT_OK) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsFragment.kt
@@ -389,6 +389,7 @@ class StudyOptionsFragment : Fragment(), Toolbar.OnMenuItemClickListener {
 
     var onRequestReviewActivityResult = registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result: ActivityResult ->
         Timber.i("StudyOptionsFragment::mOnRequestReviewActivityResult")
+        Timber.d("Handling onActivityResult for StudyOptionsFragment (openReview, resultCode = %d)", result.resultCode)
         if (mToolbar != null) {
             configureToolbar() // FIXME we were crashing here because mToolbar is null #8913
         } else {
@@ -408,6 +409,7 @@ class StudyOptionsFragment : Fragment(), Toolbar.OnMenuItemClickListener {
     }
     private var onDeckOptionsActivityResult = registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result: ActivityResult ->
         Timber.i("StudyOptionsFragment::mOnDeckOptionsActivityResult")
+        Timber.d("Handling onActivityResult for StudyOptionsFragment (deckOptions/filteredDeckOptions, resultCode = %d)", result.resultCode)
         configureToolbar()
         if (result.resultCode == DeckPicker.RESULT_DB_ERROR || result.resultCode == DeckPicker.RESULT_MEDIA_EJECTED) {
             closeStudyOptions(result.resultCode)


### PR DESCRIPTION
## Purpose / Description

This PR removes the deprecated  onActivityResult from StudyOptionsActivity. The method was only used to log calls so I moved the logging call to the places from this activity where a result is expected from another activity, which are found in StudyOptionsFragment.

## How Has This Been Tested?

Ran the usual tests.

## Checklist

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
