### PR TITLE
test(ci, windows): stop gradle daemon to unlock files for caching

### DIFF
--- a/.github/workflows/tests_unit.yml
+++ b/.github/workflows/tests_unit.yml
@@ -82,6 +82,12 @@ jobs:
         with:
           arguments: jacocoUnitTestReport --daemon
 
+      - name: Stop Gradle
+        if: matrix.os == 'windows-latest'
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: --stop
+
       - name: Submit Coverage
         # This can fail on timeouts etc, wrap with retry
         uses: nick-invision/retry@v2


### PR DESCRIPTION

## Pull Request template

## Purpose / Description

looks like windows file locking strikes again, with the gradle daemon
locking files in a way that makes caching them not work, leading to
persistent underperformance on windows runners


https://github.com/ankidroid/Anki-Android/runs/6476348351?check_suite_focus=true#step:16:17

## Approach

Stopping the gradle daemon will release the file locks

## How Has This Been Tested?

I'm not sure I can even test this until it's merged into main since cache is read only on all branches

## Learning (optional, can help others)

Gradle-related issues turned up via search described the locks getting in the way, and people reported that either turning off the daemon or stopping it at the end released locks

Also, the windows filesystem is lame and always has been. 
