### PR TITLE
Fixes #11365 - Beolingus Search spacing issue

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/beolingus/parsing/BeolingusParser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/beolingus/parsing/BeolingusParser.kt
@@ -45,10 +45,11 @@ object BeolingusParser {
         while (m.find()) {
             // Perform .contains() due to #5376 (a "%20{noun}" suffix).
             // Perform .toLowerCase() due to #5810 ("hello" should match "Hello").
+            // Perform .trim() due to #11365 (" Hello " should match "Hello")
             // See #5810 for discussion on Locale complexities. Currently unhandled.
             @Suppress("DEPRECATION")
             @KotlinCleanup("improve null handling of m.group() possibly returning null")
-            if (m.group(2)!!.toLowerCase(Locale.ROOT).contains(wordToSearchFor!!.toLowerCase(Locale.ROOT))) {
+            if (m.group(2)!!.toLowerCase(Locale.ROOT).contains(wordToSearchFor!!.toLowerCase(Locale.ROOT).trim())) {
                 Timber.d("pronunciation URL is https://dict.tu-chemnitz.de%s", m.group(1))
                 return "https://dict.tu-chemnitz.de" + m.group(1)
             }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/multimediacard/beolingus/parsing/BeolingusParserTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/multimediacard/beolingus/parsing/BeolingusParserTest.kt
@@ -71,4 +71,18 @@ class BeolingusParserTest {
         val mp3 = BeolingusParser.getMp3AddressFromPronunciation(html)
         assertEquals("https://dict.tu-chemnitz.de/speak-de/0/7/52qA5FttGIU.mp3", mp3)
     }
+
+    @Test
+    fun `Test to check trimming of extra spaces`() {
+        // #11365 - confirm " Hello " matches "Hello"
+        @Language("HTML")
+        val html = "" +
+            "<a href=\"/dings.cgi?speak=en/2/0/zQbP7qZh_u2;text=Hello\" " +
+            "onclick=\"return s(this)\" onmouseover=\"return u('Hello')\">" +
+            "<img src=\"/pics/s1.png\" width=\"16\" height=\"16\" " +
+            "alt=\"[listen]\" title=\"Hello\" border=\"0\" align=\"top\" /></a>"
+
+        val pronunciationUrl = BeolingusParser.getPronunciationAddressFromTranslation(html, " Hello ")
+        assertEquals("https://dict.tu-chemnitz.de/dings.cgi?speak=en/2/0/zQbP7qZh_u2;text=Hello", pronunciationUrl)
+    }
 }


### PR DESCRIPTION
## Purpose / Description
Earlier a search of " Hello " failed to find the pronunciation on Beolingus named "Hello".  This fixes that issue. 

## Fixes
Fixes #11365
 
## Approach
Make use of the `trim()` to trim the extra spaces present in the word.

## How Has This Been Tested?
It has been tested with a Unit Test.

It has also been manually tested on Android Device : 
Model : Asus Max Pro M2, Android Version - 9

## Checklist

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
