### PR TITLE
LoadPronunciationActivity now extends AnkiActivity

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/activity/LoadPronunciationActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/activity/LoadPronunciationActivity.kt
@@ -103,6 +103,7 @@ open class LoadPronunciationActivity : AnkiActivity(), DialogInterface.OnCancelL
         saveButton.setOnClickListener { }
         mActivity = this
         mStopped = false
+        enableToolbar()
     }
 
     override fun onCreateOptionsMenu(menu: Menu): Boolean {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/activity/LoadPronunciationActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/activity/LoadPronunciationActivity.kt
@@ -19,13 +19,13 @@
 
 package com.ichi2.anki.multimediacard.activity
 
-import android.app.Activity
 import android.content.DialogInterface
 import android.content.Intent
 import android.os.Bundle
 import android.view.Menu
 import android.view.View
 import android.widget.*
+import com.ichi2.anki.AnkiActivity
 import com.ichi2.anki.R
 import com.ichi2.anki.UIUtils.showThemedToast
 import com.ichi2.anki.multimediacard.beolingus.parsing.BeolingusParser
@@ -48,9 +48,8 @@ import java.util.*
  * User picks a source language and the source is passed as extra.
  * <p>
  * When activity finished, it passes the filepath as another extra to the caller.
- * FIXME why isn't this extending AnkiActivity?
  */
-open class LoadPronunciationActivity : Activity(), DialogInterface.OnCancelListener {
+open class LoadPronunciationActivity : AnkiActivity(), DialogInterface.OnCancelListener {
     private var mStopped = false
     private lateinit var source: String
     private lateinit var mTranslationAddress: String
@@ -123,7 +122,7 @@ open class LoadPronunciationActivity : Activity(), DialogInterface.OnCancelListe
         mLoadingLayoutMessage.text = message
     }
 
-    private fun hideProgressBar() {
+    override fun hideProgressBar() {
         mLoadingLayout.visibility = View.GONE
         mMainLayout.visibility = View.VISIBLE
     }
@@ -288,13 +287,13 @@ open class LoadPronunciationActivity : Activity(), DialogInterface.OnCancelListe
         val resultData = Intent()
         resultData.putExtra(EXTRA_PRONUNCIATION_FILE_PATH, result)
         setResult(RESULT_OK, resultData)
-        finish()
+        finishWithoutAnimation()
     }
 
     private fun finishCancel() {
         val resultData = Intent()
         setResult(RESULT_CANCELED, resultData)
-        finish()
+        finishWithoutAnimation()
     }
 
     private fun failNoPronunciation() {
@@ -343,7 +342,7 @@ open class LoadPronunciationActivity : Activity(), DialogInterface.OnCancelListe
         stopAllTasks()
         val resultData = Intent()
         setResult(RESULT_CANCELED, resultData)
-        finish()
+        finishWithoutAnimation()
     }
 
     @Suppress("deprecation") // #7108: AsyncTask

--- a/AnkiDroid/src/main/res/layout/activity_load_pronounciation.xml
+++ b/AnkiDroid/src/main/res/layout/activity_load_pronounciation.xml
@@ -8,6 +8,8 @@
         android:layout_height="match_parent"
         android:orientation="vertical">
 
+        <include layout="@layout/toolbar" />
+
         <com.ichi2.ui.FixedTextView
             android:id="@+id/textViewPoweredBy"
             android:layout_width="wrap_content"


### PR DESCRIPTION
## Purpose / Description
LoadPronunciationActivity was extending Activity before & I don't really see why it should not be using AnkiActivity.

## Checklist

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented on your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
