### PR TITLE
Refactor to use Collection parameter in onCollectionLoaded callback

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -539,7 +539,7 @@ open class CardBrowser : NavigationDrawerActivity(), SubtitleListener, DeckSelec
         // Load reference to action bar title
         mActionBarTitle = findViewById(R.id.toolbar_title)
         mOrder = CARD_ORDER_NONE
-        val colOrder = getCol().get_config_string("sortType")
+        val colOrder = col.get_config_string("sortType")
         for (c in fSortTypes.indices) {
             if (fSortTypes[c] == colOrder) {
                 mOrder = c
@@ -553,7 +553,7 @@ open class CardBrowser : NavigationDrawerActivity(), SubtitleListener, DeckSelec
         // setConf. However older version of AnkiDroid didn't call
         // upgradeJSONIfNecessary during setConf, which means the
         // conf saved may still have this bug.
-        mOrderAsc = upgradeJSONIfNecessary(getCol(), "sortBackwards", false)
+        mOrderAsc = upgradeJSONIfNecessary(col, "sortBackwards", false)
         mCards.reset()
         mCardsListView = findViewById(R.id.card_browser_list)
         // Create a spinner for column1
@@ -675,7 +675,7 @@ open class CardBrowser : NavigationDrawerActivity(), SubtitleListener, DeckSelec
             true
         }
         window.setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_ALWAYS_HIDDEN)
-        val deckId = getCol().decks.selected()
+        val deckId = col.decks.selected()
         mDeckSpinnerSelection = DeckSpinnerSelection(
             this, col, findViewById(R.id.toolbar_spinner),
             showAllDecks = true, alwaysShowDefault = false
@@ -698,7 +698,7 @@ open class CardBrowser : NavigationDrawerActivity(), SubtitleListener, DeckSelec
         mRestrictOnDeck = if (deckId == ALL_DECKS_ID) {
             ""
         } else {
-            val deckName = col.decks.name(deckId)
+            val deckName = col!!.decks.name(deckId)
             "deck:\"$deckName\" "
         }
         saveLastDeckId(deckId)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplatePreviewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplatePreviewer.kt
@@ -235,7 +235,7 @@ open class CardTemplatePreviewer : AbstractFlashcardViewer() {
             // loading from the note editor
             val toPreview = setCurrentCardFromNoteEditorBundle(col)
             if (toPreview != null) {
-                mTemplateCount = getCol().findTemplates(toPreview.note()).size
+                mTemplateCount = col.findTemplates(toPreview.note()).size
                 if (mTemplateCount >= 2) {
                     mPreviewLayout!!.showNavigationButtons()
                 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
@@ -348,7 +348,7 @@ open class Reviewer : AbstractFlashcardViewer() {
             setWhiteboardVisibility(whiteboardVisibility)
         }
         col.sched.deferReset() // Reset schedule in case card was previously loaded
-        getCol().startTimebox()
+        col.startTimebox()
         GetCard().runWithHandler(answerCardHandler(false))
         disableDrawerSwipeOnConflicts()
         // Add a weak reference to current activity so that scheduler can talk to to Activity

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Statistics.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Statistics.kt
@@ -108,7 +108,7 @@ class Statistics : NavigationDrawerActivity(), DeckSelectionListener, SubtitleLi
         invalidateOptionsMenu()
         //        StatisticFragment.updateAllFragments();
         when (val defaultDeck = AnkiDroidApp.getSharedPrefs(this).getString("stats_default_deck", "current")) {
-            "current" -> mStatsDeckId = getCol().decks.selected()
+            "current" -> mStatsDeckId = col.decks.selected()
             "all" -> mStatsDeckId = Stats.ALL_DECKS_ID
             else -> Timber.w("Unknown defaultDeck: %s", defaultDeck)
         }


### PR DESCRIPTION
## Purpose / Description

To improve type safety this PR refactors code in the onCollectionLoaded() callbacks to use the non null Collection received as a parameter instead of the getCol() method call from the super class which can be nullable. There's a also a `!!` addition which is safe because the method where it happens it's called from onCollectionLoaded() where we know that the Collection is valid.

## How Has This Been Tested?

Ran the usual tests.

## Checklist

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
