### PR TITLE
Update image cropper library dependency to 4.2.1

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -261,7 +261,7 @@ dependencies {
     // Note: the design support library can be quite buggy, so test everything thoroughly before updating it
     implementation 'com.google.android.material:material:1.6.0'
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.13.2.2'
-    implementation 'com.github.CanHub:Android-Image-Cropper:3.1.3'
+    implementation 'com.github.CanHub:Android-Image-Cropper:4.2.1'
 
     // build with ./gradlew rsdroid:assembleRelease
     // In my experience, using `files()` currently requires a reindex operation.

--- a/AnkiDroid/src/main/AndroidManifest.xml
+++ b/AnkiDroid/src/main/AndroidManifest.xml
@@ -305,7 +305,7 @@
         </activity>
         <activity
             android:name="com.canhub.cropper.CropImageActivity"
-            android:exported="false"
+            android:exported="true"
             android:configChanges="keyboardHidden|orientation|locale|screenSize"
             android:theme="@style/Base.Theme.AppCompat" />
         <activity

--- a/AnkiDroid/src/test/java/com/ichi2/anki/multimediacard/fields/BasicImageFieldControllerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/multimediacard/fields/BasicImageFieldControllerTest.kt
@@ -17,7 +17,10 @@ package com.ichi2.anki.multimediacard.fields
 
 import android.app.Activity
 import android.content.Intent
+import androidx.activity.result.ActivityResultRegistry
+import androidx.activity.result.contract.ActivityResultContract
 import androidx.annotation.CheckResult
+import androidx.core.app.ActivityOptionsCompat
 import com.ichi2.anki.R
 import com.ichi2.anki.multimediacard.activity.MultimediaEditFieldActivityTestBase
 import com.ichi2.testutils.AnkiAssert
@@ -31,6 +34,7 @@ import org.mockito.kotlin.whenever
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.shadows.ShadowToast
 import java.io.File
+import kotlin.test.fail
 
 @RunWith(RobolectricTestRunner::class)
 open class BasicImageFieldControllerTest : MultimediaEditFieldActivityTestBase() {
@@ -90,6 +94,16 @@ open class BasicImageFieldControllerTest : MultimediaEditFieldActivityTestBase()
     @Test
     fun invalidImageResultDoesNotCrashController() {
         val controller = validControllerNoImage
+        controller.registryToUse = object : ActivityResultRegistry() {
+            override fun <I, O> onLaunch(
+                requestCode: Int,
+                contract: ActivityResultContract<I, O>,
+                input: I,
+                options: ActivityOptionsCompat?
+            ) {
+                fail("Unexpected access to the activity result registry!")
+            }
+        }
         val activity = setupActivityMock(controller, controller.getActivity())
         val mock = MockContentResolver.returningEmptyCursor()
         whenever(activity.contentResolver).thenReturn(mock)


### PR DESCRIPTION
## Purpose / Description

This PR updates the Android-Image-Cropper dependency to its latest version(4.2.1 at this time). The code related to cropping was migrated to the newer ActivityResultLauncher apis used by the library in its newer versions.

## Fixes

Closes #10710 

## How Has This Been Tested?

Ran the usual tests.

## Checklist

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
