### PR TITLE
Fixed Reviewer not updating after changing card in Browser

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -1794,6 +1794,9 @@ open class CardBrowser : NavigationDrawerActivity(), SubtitleListener, DeckSelec
             browser.updateCardsInList(result.value.toList())
             browser.hideProgressBar()
             browser.invalidateOptionsMenu() // maybe the availability of undo changed
+            if (result.value.map { it.id }.contains(browser.reviewerCardId)) {
+                browser.mReloadRequired = true
+            }
         }
     }
 
@@ -1812,6 +1815,9 @@ open class CardBrowser : NavigationDrawerActivity(), SubtitleListener, DeckSelec
             browser.updateCardsInList(getAllCards(getNotes(result.value.toList())))
             browser.hideProgressBar()
             browser.invalidateOptionsMenu() // maybe the availability of undo changed
+            if (result.value.map { it.id }.contains(browser.reviewerCardId)) {
+                browser.mReloadRequired = true
+            }
         }
     }
 


### PR DESCRIPTION
## Purpose / Description
If a card is open in reviewer, its flag and mark should be updated if we change them by navigating to card browser and going back

## Fixes
Fixes #11396 

## Approach
Set `reloadRequired` in `CardBrowser` to true if `reviewerCardId` is in the list of selected cards to set Flag or Mark of

## How Has This Been Tested?
Emulator:

https://user-images.githubusercontent.com/59933477/169697989-4a1834e0-06dc-4004-aa3c-cc8d46eddeac.mov



## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [x] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
