### PR TITLE
NF: remove redundant nullity check

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckOptions.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckOptions.kt
@@ -774,21 +774,21 @@ class DeckOptions :
         }
 
     /**
-     * finish when sd card is ejected
+     * Call exactly once, during creation
+     * to ensure that if the SD card is ejected
+     * this activity finish.
      */
     private fun registerExternalStorageListener() {
-        if (mUnmountReceiver == null) {
-            mUnmountReceiver = object : BroadcastReceiver() {
-                override fun onReceive(context: Context, intent: Intent) {
-                    if (SdCardReceiver.MEDIA_EJECT == intent.action) {
-                        finish()
-                    }
+        mUnmountReceiver = object : BroadcastReceiver() {
+            override fun onReceive(context: Context, intent: Intent) {
+                if (SdCardReceiver.MEDIA_EJECT == intent.action) {
+                    finish()
                 }
             }
-            val iFilter = IntentFilter()
-            iFilter.addAction(SdCardReceiver.MEDIA_EJECT)
-            registerReceiver(mUnmountReceiver, iFilter)
         }
+        val iFilter = IntentFilter()
+        iFilter.addAction(SdCardReceiver.MEDIA_EJECT)
+        registerReceiver(mUnmountReceiver, iFilter)
     }
 
     private fun restartActivity() {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/FilteredDeckOptions.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/FilteredDeckOptions.kt
@@ -452,22 +452,23 @@ class FilteredDeckOptions : AppCompatPreferenceActivity(), OnSharedPreferenceCha
     }
 
     /**
-     * finish when sd card is ejected
+     * Call exactly once, during creation
+     * to ensure that if the SD card is ejected
+     * this activity finish.
      */
     private fun registerExternalStorageListener() {
-        if (mUnmountReceiver == null) {
-            mUnmountReceiver = object : BroadcastReceiver() {
-                override fun onReceive(context: Context, intent: Intent) {
-                    if (intent.action == SdCardReceiver.MEDIA_EJECT) {
-                        finish()
-                    }
+        mUnmountReceiver = object : BroadcastReceiver() {
+            override fun onReceive(context: Context, intent: Intent) {
+                if (intent.action == SdCardReceiver.MEDIA_EJECT) {
+                    finish()
                 }
             }
-            val iFilter = IntentFilter()
-            iFilter.addAction(SdCardReceiver.MEDIA_EJECT)
-            registerReceiver(mUnmountReceiver, iFilter)
         }
+        val iFilter = IntentFilter()
+        iFilter.addAction(SdCardReceiver.MEDIA_EJECT)
+        registerReceiver(mUnmountReceiver, iFilter)
     }
+
     @Suppress("deprecation")
     private fun setupSecondFilterListener() {
         val secondFilterSign = findPreference("filterSecond") as CheckBoxPreference


### PR DESCRIPTION
this method can only be called once, during the only creation, and the
unmontReceiver is necessarily null at this step.

Part of #11418