### PR TITLE
Solving issue #11275, like AnkiDesktop, do not reset the interval when rescheduling a card.

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/RescheduleDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/RescheduleDialog.kt
@@ -76,6 +76,7 @@ object RescheduleDialog : IntegerDialog() {
      $message
      
      ${resources.getQuantityString(R.plurals.reschedule_card_dialog_interval, currentCard.ivl, currentCard.ivl)}
+     ${"Interval won't change by default."}
         """.trimIndent()
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/SchedulerService.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/SchedulerService.kt
@@ -163,7 +163,7 @@ class SchedulerService {
         override fun execute(): RepositionResetResult {
             val inputCards = dismissNotes(cardIds) { cards ->
                 return@dismissNotes rescheduleRepositionReset(cards, R.string.card_editor_reschedule_card) {
-                    col.sched.reschedCards(cardIds, interval, interval)
+                    col.sched.reschedCards(cardIds, interval, interval, false)
                 }
             }
             return inputCards.map { x -> NextCard(x.first.orElse(null), x.second) }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/AbstractSched.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/AbstractSched.kt
@@ -331,13 +331,14 @@ abstract class AbstractSched {
     abstract fun forgetCards(ids: List<Long?>)
 
     /**
-     * Put cards in review queue with a new interval in days (min, max).
+     * Put cards in review queue in days (min, max).
      *
      * @param ids The list of card ids to be affected
      * @param imin the minimum interval (inclusive)
      * @param imax The maximum interval (inclusive)
+     * @param civl The boolean indicate if changing the interval
      */
-    abstract fun reschedCards(ids: List<Long?>, imin: Int, imax: Int)
+    abstract fun reschedCards(ids: List<Long?>, imin: Int, imax: Int, civl: Boolean)
 
     /**
      * @param ids Ids of cards to reset for export

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
@@ -2713,7 +2713,7 @@ public class SchedV2 extends AbstractSched {
         Random rnd = new Random();
         for (long id : ids) {
             int r = rnd.nextInt(imax - imin + 1) + imin;
-            d.add(civl ? new Object[] {r,  r + t, mCol.usn(), mod, RESCHEDULE_FACTOR, id }:
+            d.add(civl ? new Object[] {Math.max(1, r),  r + t, mCol.usn(), mod, RESCHEDULE_FACTOR, id }:
                     new Object[] {r + t, mCol.usn(), mod, RESCHEDULE_FACTOR, id });
         }
         remFromDyn(ids);

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
@@ -2699,24 +2699,27 @@ public class SchedV2 extends AbstractSched {
 
 
     /**
-     * Put cards in review queue with a new interval in days (min, max).
+     * Put cards in review queue in days (min, max).
      *
      * @param ids The list of card ids to be affected
      * @param imin the minimum interval (inclusive)
      * @param imax The maximum interval (inclusive)
+     * @param civl The boolean indicate if changing the interval
      */
-    public void reschedCards(@NonNull List<Long> ids, int imin, int imax) {
+    public void reschedCards(@NonNull List<Long> ids, int imin, int imax, boolean civl) {
         ArrayList<Object[]> d = new ArrayList<>(ids.size());
         int t = mToday;
         long mod = getTime().intTime();
         Random rnd = new Random();
         for (long id : ids) {
             int r = rnd.nextInt(imax - imin + 1) + imin;
-            d.add(new Object[] { Math.max(1, r), r + t, mCol.usn(), mod, RESCHEDULE_FACTOR, id });
+            d.add(civl ? new Object[] {r,  r + t, mCol.usn(), mod, RESCHEDULE_FACTOR, id }:
+                    new Object[] {r + t, mCol.usn(), mod, RESCHEDULE_FACTOR, id });
         }
         remFromDyn(ids);
+        String ivlQ = civl ? ",ivl=?" : "";
         mCol.getDb().executeMany(
-                "update cards set type=" + Consts.CARD_TYPE_REV + ",queue=" + Consts.QUEUE_TYPE_REV + ",ivl=?,due=?,odue=0, " +
+                "update cards set type=" + Consts.CARD_TYPE_REV + ",queue=" + Consts.QUEUE_TYPE_REV + ivlQ +",due=?,odue=0, " +
                         "usn=?,mod=?,factor=? where id=?", d);
         mCol.log(ids);
     }

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/sched/SchedTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/sched/SchedTest.java
@@ -1370,13 +1370,13 @@ public class SchedTest extends RobolectricTest {
         note.setItem("Front", "one");
         col.addNote(note);
         Card c = note.cards().get(0);
-        col.getSched().reschedCards(Collections.singletonList(c.getId()), 0, 0);
+        col.getSched().reschedCards(Collections.singletonList(c.getId()), 0, 0, true);
         c.load();
         assertEquals(col.getSched().getToday(), c.getDue());
         assertEquals(1, c.getIvl());
         assertEquals(CARD_TYPE_REV, c.getType());
         assertEquals(QUEUE_TYPE_REV, c.getQueue());
-        col.getSched().reschedCards(Collections.singletonList(c.getId()), 1, 1);
+        col.getSched().reschedCards(Collections.singletonList(c.getId()), 1, 1, true);
         c.load();
         assertEquals(col.getSched().getToday() + 1, c.getDue());
         assertEquals(+1, c.getIvl());

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/sched/SchedV2Test.java
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/sched/SchedV2Test.java
@@ -1595,13 +1595,13 @@ public class SchedV2Test extends RobolectricTest {
         note.setItem("Front", "one");
         col.addNote(note);
         Card c = note.cards().get(0);
-        col.getSched().reschedCards(Collections.singletonList(c.getId()), 0, 0);
+        col.getSched().reschedCards(Collections.singletonList(c.getId()), 0, 0, true);
         c.load();
         assertEquals(col.getSched().getToday(), c.getDue());
         assertEquals(1, c.getIvl());
         assertEquals(QUEUE_TYPE_REV, c.getType());
         assertEquals(CARD_TYPE_REV, c.getQueue());
-        col.getSched().reschedCards(Collections.singletonList(c.getId()), 1, 1);
+        col.getSched().reschedCards(Collections.singletonList(c.getId()), 1, 1, true);
         c.load();
         assertEquals(col.getSched().getToday() + 1, c.getDue());
         assertEquals(+1, c.getIvl());
@@ -1706,7 +1706,7 @@ public class SchedV2Test extends RobolectricTest {
         // make sure relearning cards transition correctly to v1
         col.changeSchedulerVer(2);
         // card with 100 day interval, answering again
-        col.getSched().reschedCards(Collections.singletonList(c.getId()), 100, 100);
+        col.getSched().reschedCards(Collections.singletonList(c.getId()), 100, 100, true);
         c.load();
         c.setDue(0);
         c.flush();


### PR DESCRIPTION
## Purpose / Description
Like AnkiDesktop, I make the interval never be reseted when rescheduling, with prompt. But unfortunately I fail to add the checkbox in the dialog, to completely add the feature to choose to reset the interval or not. However, change the relevant method for preparation.

## Fixes
Fixes [[#11275]()](https://github.com/ankidroid/Anki-Android/issues/11275)

## Approach
By changing `reschedCards` in `AbstractSched.kt` and `SchedV2.java,  I enable the option of choosing whether change the interval. And I change the args for relevant test file.

## How Has This Been Tested?
Through manual multiple tests, this scheme is verified to be feasible. <br/>
Before: <br/>
![image](https://user-images.githubusercontent.com/67989850/170664147-d44fadf8-102b-4209-8b1b-407d1aa55536.png)
Scheduling: <br/>
![image](https://user-images.githubusercontent.com/67989850/170664366-b7ef8b60-ea97-4fbc-a15d-3d90eb4ef1cc.png)
![image](https://user-images.githubusercontent.com/67989850/170664456-03581518-1be8-4c62-b0a3-578946d1fbfb.png)
After: <br/>
![image](https://user-images.githubusercontent.com/67989850/170665028-5394d1f3-d42e-4b13-8f9a-ecabc4ddbe6e.png)
