### PR TITLE
Attempt to solve: Option to disable auto sync with metered connection…

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/async/Connection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/Connection.java
@@ -617,6 +617,35 @@ public class Connection extends BaseAsyncTask<Connection.Payload, Object, Connec
         }
     }
 
+    @SuppressWarnings("deprecation")
+    public static boolean isWifiConnected(){
+        if (!isOnline()) return false;
+        ConnectivityManager cm = (ConnectivityManager) AnkiDroidApp.getInstance().getApplicationContext()
+                .getSystemService(Context.CONNECTIVITY_SERVICE);
+        if (cm == null) {
+            return false;
+        }
+        /* NetworkInfo is deprecated in API 29 so we have to check separately for higher API Levels */
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+            Network network = cm.getActiveNetwork();
+            if (network == null) {
+                return false;
+            }
+            NetworkCapabilities networkCapabilities = cm.getNetworkCapabilities(network);
+            if (networkCapabilities == null) {
+                return false;
+            }
+            return networkCapabilities.hasTransport(NetworkCapabilities.TRANSPORT_WIFI);
+        } else {
+            android.net.NetworkInfo info = cm.getNetworkInfo(ConnectivityManager.TYPE_WIFI);
+            android.net.NetworkInfo.State state = info.getState();
+            if (android.net.NetworkInfo.State.CONNECTED==state) {
+                return true;
+            }
+            return false;
+        }
+    }
+
 
     public interface TaskListener {
         void onPreExecute();


### PR DESCRIPTION
## Purpose / Description
I add a method which can be helpful to the feature: add an option to whether do sync in mobile data. 

## Fixes
Fixes https://github.com/ankidroid/Anki-Android/issues/10706

## Approach
I add a new method isWifiConnected() in async.Connection. But I haven't add an option to it, hope others can do that. The method can be called in anki.DeckPicker to decide whether to  sync during auto-sync, only in WIFI environment can anki process auto sync. 

## How Has This Been Tested?

The method has not been called yet so it does not have to be tested.

## Learning (optional, can help others)
_Describe the research stage_

_Links to blog posts, patterns, libraries or addons used to solve this problem_

## Checklist
_Please, go through these checks before submitting the PR._

- [ ] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [ ] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [ ] You have commented your code, particularly in hard-to-understand areas
- [ ] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
