### PR TITLE
feat: enable dom storage in webview for localStorage

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
@@ -1030,6 +1030,10 @@ abstract class AbstractFlashcardViewer :
         // Javascript interface for calling AnkiDroid functions in webview, see card.js
         mAnkiDroidJsAPI = javaScriptFunction()
         webView.addJavascriptInterface(mAnkiDroidJsAPI!!, "AnkiDroidJS")
+
+        // enable dom storage so that sessionStorage & localStorage can be used in webview
+        webView.settings.domStorageEnabled = true
+
         return webView
     }
 


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
`localStorage` is implemented in Anki 2.1.50 and later version. So using webview settings the dom storage enabled for AnkiDroid also. 

It is not required to enable dom storage for `sessionStorage`, but it does not persist data during review or after restarting of app so `localStorage` will be helpful here.

## Fixes
Fixes #11268
Fixes #6971

## Approach
Enabled dom storage in webview
```kotlin
webView.settings.domStorageEnabled = true
```

## How Has This Been Tested?
Tested on device
1. Add js script to front side of card
```html
<script>
localStorage.setItem("Anki", "Droid");
</script>
```
2. Check the set value in back side of card
```html
<script>
console.log( localStorage.getItem("Anki") );
</script>
```

## Learning (optional, can help others)
https://developer.android.com/reference/android/webkit/WebSettings?hl=en#setDomStorageEnabled(boolean)
https://developer.mozilla.org/en-US/docs/web/api/web_storage_api

_Links to blog posts, patterns, libraries or addons used to solve this problem_

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
