### PR TITLE
NF: browser use two columns explicitly

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -573,9 +573,7 @@ open class CardBrowser : NavigationDrawerActivity(), SubtitleListener, DeckSelec
                     mColumn1Index = pos
                     AnkiDroidApp.getSharedPrefs(AnkiDroidApp.getInstance().baseContext).edit()
                         .putInt("cardBrowserColumn1", mColumn1Index).apply()
-                    val fromMap = mCardsAdapter!!.fromMapping
-                    fromMap[0] = COLUMN1_KEYS[mColumn1Index]
-                    mCardsAdapter!!.fromMapping = fromMap
+                    mCardsAdapter!!.setColumnOne(COLUMN1_KEYS[mColumn1Index])
                 }
             }
 
@@ -601,9 +599,7 @@ open class CardBrowser : NavigationDrawerActivity(), SubtitleListener, DeckSelec
                     mColumn2Index = pos
                     AnkiDroidApp.getSharedPrefs(AnkiDroidApp.getInstance().baseContext).edit()
                         .putInt("cardBrowserColumn2", mColumn2Index).apply()
-                    val fromMap = mCardsAdapter!!.fromMapping
-                    fromMap[1] = COLUMN2_KEYS[mColumn2Index]
-                    mCardsAdapter!!.fromMapping = fromMap
+                    mCardsAdapter!!.setColumnTwo(COLUMN2_KEYS[mColumn2Index])
                 }
             }
 
@@ -614,12 +610,14 @@ open class CardBrowser : NavigationDrawerActivity(), SubtitleListener, DeckSelec
         // get the font and font size from the preferences
         val sflRelativeFontSize = preferences.getInt("relativeCardBrowserFontSize", DEFAULT_FONT_SIZE_RATIO)
         val sflCustomFont = preferences.getString("browserEditorFont", "")
-        val columnsContent = arrayOf(COLUMN1_KEYS[mColumn1Index], COLUMN2_KEYS[mColumn2Index])
         // make a new list adapter mapping the data in mCards to column1 and column2 of R.layout.card_item_browser
         mCardsAdapter = MultiColumnListAdapter(
             this,
             R.layout.card_item_browser,
-            columnsContent, intArrayOf(R.id.card_sfld, R.id.card_column2),
+            COLUMN1_KEYS[mColumn1Index],
+            COLUMN1_KEYS[mColumn2Index],
+            R.id.card_sfld,
+            R.id.card_column2,
             sflRelativeFontSize,
             sflCustomFont
         )
@@ -2149,11 +2147,22 @@ open class CardBrowser : NavigationDrawerActivity(), SubtitleListener, DeckSelec
     inner class MultiColumnListAdapter(
         context: Context?,
         private val resource: Int,
-        private var fromKeys: Array<Column>,
-        private val toIds: IntArray,
+        private var columnOne: Column,
+        private var columnTwo: Column,
+        private val idColumnOne: Int,
+        private val idColumnTwo: Int,
         private val fontSizeScalePcent: Int,
         customFont: String?
     ) : BaseAdapter() {
+
+        fun setColumnOne(from: Column) {
+            columnOne = from
+            notifyDataSetChanged()
+        }
+        fun setColumnTwo(from: Column) {
+            columnTwo = from
+            notifyDataSetChanged()
+        }
         private var mOriginalTextSize = -1.0f
         private var mCustomTypeface: Typeface? = null
         private val mInflater: LayoutInflater
@@ -2162,12 +2171,7 @@ open class CardBrowser : NavigationDrawerActivity(), SubtitleListener, DeckSelec
             val v: View
             if (convertView == null) {
                 v = mInflater.inflate(resource, parent, false)
-                val count = toIds.size
-                val columns = arrayOfNulls<View>(count)
-                for (i in 0 until count) {
-                    columns[i] = v.findViewById(toIds[i])
-                }
-                v.tag = columns
+                v.tag = kotlin.Pair<TextView, TextView>(v.findViewById(idColumnOne), v.findViewById(idColumnTwo))
             } else {
                 v = convertView
             }
@@ -2179,15 +2183,14 @@ open class CardBrowser : NavigationDrawerActivity(), SubtitleListener, DeckSelec
         @KotlinCleanup("Unchecked cast")
         private fun bindView(position: Int, v: View) {
             // Draw the content in the columns
-            val columns = v.tag as Array<View>
+            val columns = v.tag as kotlin.Pair<TextView, TextView>
+            val columnOneView = columns.first
+            val columnTwoView = columns.second
             val card = mCards[position]
-            for (i in toIds.indices) {
-                val col = columns[i] as TextView
-                // set font for column
-                setFont(col)
-                // set text for column
-                col.text = card.getColumnHeaderText(fromKeys[i])
-            }
+            setFont(columnOneView)
+            columnOneView.text = card.getColumnHeaderText(columnOne)
+            setFont(columnTwoView)
+            columnOneView.text = card.getColumnHeaderText(columnTwo)
             // set card's background color
             val backgroundColor: Int = getColorFromAttr(this@CardBrowser, card.color)
             v.setBackgroundColor(backgroundColor)
@@ -2235,13 +2238,6 @@ open class CardBrowser : NavigationDrawerActivity(), SubtitleListener, DeckSelec
                 v.typeface = mCustomTypeface
             }
         }
-
-        var fromMapping: Array<Column>
-            get() = fromKeys
-            set(from) {
-                fromKeys = from
-                notifyDataSetChanged()
-            }
 
         override fun getCount(): Int {
             return cardCount


### PR DESCRIPTION
This should help https://github.com/ankidroid/Anki-Android/pull/11460. Since there is exactly two occurrences, most of the
time, arrays obfuscate instead of improving readability. I believe this version
is more readable.