### PR TITLE
[Kotlin Cleanup] AnkiStatsTaskHandlerTest

### DIFF
--- a/AnkiDroid/src/test/java/com/ichi2/anki/stats/AnkiStatsTaskHandlerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/stats/AnkiStatsTaskHandlerTest.kt
@@ -21,29 +21,28 @@ import com.ichi2.anki.RobolectricTest
 import com.ichi2.anki.stats.AnkiStatsTaskHandler.Companion.createReviewSummaryStatistics
 import com.ichi2.annotations.NeedsTest
 import com.ichi2.libanki.Collection
-import com.ichi2.utils.KotlinCleanup
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mock
 import org.mockito.Mockito.*
 import org.mockito.MockitoAnnotations
+import org.mockito.kotlin.whenever
 import java.util.concurrent.ExecutionException
 
 @RunWith(AndroidJUnit4::class)
-@KotlinCleanup("make mocks lateinit")
-@KotlinCleanup("`when` -> whenever")
 class AnkiStatsTaskHandlerTest : RobolectricTest() {
     @Mock
-    private val mCol: Collection? = null
+    private lateinit var mCol: Collection
 
     @Mock
-    private val mView: TextView? = null
+    private lateinit var mView: TextView
+
     @Before
     override fun setUp() {
         MockitoAnnotations.openMocks(this)
-        `when`(mCol!!.db).thenReturn(null)
-        `when`(mCol.dbClosed).thenReturn(true)
+        whenever(mCol.db).thenReturn(null)
+        whenever(mCol.dbClosed).thenReturn(true)
     }
 
     @Test
@@ -52,7 +51,7 @@ class AnkiStatsTaskHandlerTest : RobolectricTest() {
     @Suppress("deprecation") // #7108: AsyncTask
     fun testCreateReviewSummaryStatistics() {
         verify(mCol, atMost(0))!!.db
-        val result = createReviewSummaryStatistics(mCol!!, mView!!)
+        val result = createReviewSummaryStatistics(mCol, mView)
         result.get()
         advanceRobolectricLooper()
         verify(mCol, atLeast(0))!!.db


### PR DESCRIPTION

## Purpose / Description
Kotlin Cleanup

## Approach
replace `when` -> `whenever()`
made mocks lateinit

## How Has This Been Tested?
Test runs as expected


## Checklist

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [ ] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
