### PR TITLE
currentSearchTerms

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/CardBrowserMySearchesDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/CardBrowserMySearchesDialog.kt
@@ -19,7 +19,6 @@ class CardBrowserMySearchesDialog : AnalyticsDialogFragment() {
     private var buttonItemAdapter: ButtonItemAdapter? = null
     private var savedFilters: HashMap<String, String>? = null
     private var savedFilterKeys: ArrayList<String>? = null
-    private var currentSearchTerms: String? = null
 
     interface MySearchesDialogListener {
         fun onSelection(searchName: String?)
@@ -60,7 +59,7 @@ class CardBrowserMySearchesDialog : AnalyticsDialogFragment() {
                     .adapter(this, null)
             }
         } else if (type == CARD_BROWSER_MY_SEARCHES_TYPE_SAVE) {
-            currentSearchTerms = requireArguments().getString("currentSearchTerms")
+            val currentSearchTerms = requireArguments().getString("currentSearchTerms")
             builder.title(getString(R.string.card_browser_list_my_searches_save))
                 .positiveText(getString(android.R.string.ok))
                 .negativeText(getString(R.string.dialog_cancel))


### PR DESCRIPTION
- fix: forward-port to non-deprecated gradle properties
- fix: forward-port to non-deprecated APIs in DuplicateCrowdInStrings rule
- Enable @KotlinCleanup for local variables
- Rename BeolingusParser.java to .kt
- Migrate BeolingusParser.java to Kotlin
- Rename Compat.java to .kt
- [Kotlin Migration] Compat
- Move code related to LeakCanary outside of AnkiDroidApp
- refactor(ci): use built-in concurrency features
- refactor: Rename CollectionTask.java to .kt
- refactor: Convert CollectionTask to Kotlin
- refactor: prepare CollectionUtils for removal
- fix: nonPositionalFormatSubstitution rule should use same param name as super
- Rename .java to .kt
- Migrate AssetHelperTest to Kotlin
- Rename .java to .kt
- Migrate CollectionUtilsTest to Kotlin
- Add a tools/migrate.sh file for Kotlin migration (#10779)
- Rename .java to .kt
- Migrate ContentResolverUtilTest to Kotlin
- Rename .java to .kt
- Migrate DeckNameComparatorTest to Kotlin
- Rename .java to .kt
- Migrate NamedJSONComparatorTest to Kotlin
- feat: Allow Kotlin Migration on lint-rules (#11037)
- Rename .java to .kt
- Migrate MaxExecFunctionTest to Kotlin
- Rename LanguageUtilsTest.java to .kt com.ichi2.utils.LanguageUtilsTest
- Convert LanguageUtilsTest.kt to Kotlin com.ichi2.utils.LanguageUtilsTest
- Rename ReviewerNoParamTest.java to .kt com.ichi2.anki.ReviewerNoParamTest
- Convert ReviewerNoParamTest.kt to Kotlin com.ichi2.anki.ReviewerNoParamTest
- Rename MediaTest.java to MediaTest.kt
- Migrate MediaTest.java to Kotlin
- Rename BeolingusParserTest.java to .kt com.ichi2.anki.multimediacard.beolingus.parsing.BeolingusParserTest
- Convert BeolingusParserTest.kt to Kotlin com.ichi2.anki.multimediacard.beolingus.parsing.BeolingusParserTest
- Rename AudioPlayerTest.java to .kt com.ichi2.anki.multimediacard.AudioPlayerTest
- Convert AudioPlayerTest.kt to Kotlin com.ichi2.anki.multimediacard.AudioPlayerTest
- refactor: Rename DuplicateCrowdInStrings.java to .kt
- refactor: Convert DuplicateCrowdInStrings to Kotlin
- [Kotlin Cleanup] Statistics.kt (#10943)
- Rename ImportUtilsTest.java to .kt com.ichi2.utils.ImportUtilsTest
- Convert ImportUtilsTest.kt to Kotlin com.ichi2.utils.ImportUtilsTest
- Rename .java to .kt
- Migrate ResourceLoader to Kotlin
- Rename .java to .kt
- Migrate UniqueArrayListTest to Kotlin
- Rename .java to .kt
- Migrate ExtendedFragmentFactoryTest to Kotlin
- Rename CompatV26.java to .kt
- Migrate CompatV26.java to Kotlin
- Rename MetaTest.java to MetaTest.kt
- Migrate MetaTest.java to Kotlin
- Rename .java to .kt
- Migrate MockTimeTest to Kotlin
- refactor: Rename ImageField.java to .kt
- refactor: Convert ImageField.kt to Kotlin
- Rename .java to .kt
- Migrate DBTest to Kotlin
- add the explaination for the addition test
- kotlin migration: Enable ANDROID_TEST migration
- Added Unit Tests for ```StepsPreference.kt``` (#11058)
- Rename MockReviewerUi.java to .kt
- [Kotlin Migration] MockReviewerUi
- Rename TestEnvironment.java to .kt
- [Kotlin Migration] TestEnvironment
- Rename ClozeTest.java to ClozeTest.kt
- Migrate ClozeTest.java to Kotlin
- Rename .java to .kt
- Migrate JSONArrayTest to Kotlin
- Rename MathJaxClozeTest.java to MathJaxClozeTest.kt
- Migrate MathJaxClozeTest.java to Kotlin
- refactor: Kotlin Cleanup: DuplicateCrowdInStrings
- fix: Don't apply strings lint to non-strings file
- feat(scoped-storage): let dialog execute migration
- Rename ReviewerTest.java to .kt
- Convert ReviewerTest.kt to Kotlin
- Rename DatabaseUtils.java to .kt
- [Kotlin Migration] DatabaseUtils
- Rename InstrumentedTest.java to .kt
- [Kotlin Migration] InstrumentedTest
- Rename ThreadUtils.java to .kt
- [Kotlin Migration] ThreadUtils
- feat: get list of addons model from json containing array of addons data (#11023)
- perf(ci, emulator): community emulator action / AVD caching / gradle cachine
- [JS API] Reschedule card with x days (#11071)
- Rename AnkiDroidAppTest.java to AnkiDroidAppTest.kt
- Migrate AnkiDroidAppTest.java to Kotlin
- fix: Don't apply lint to ignored file
- refactor: Rename CompatV21.java to .kt
- refactor: Convert CompatV21.kt to Kotlin
- Kotlin Cleanup: AbstractFlashcardViewerTest.kt
- fix(strings): missing positional string args
- build(deps): dependency updates 20220425
- build(deps): bump jacoco from 0.8.7 to 0.8.8
- perf(ci): use gradle-build-action w/main cache only on all workflows
- build(deps): lint-rules hamcrest use 2.2, extract hamcrest version
- fix(build): lint-rules project should use common best build practices
- fix(build): assert that more than zero androidTests executed
- build(deps): remove ktlint memory leak workaround
- Updated strings from Crowdin
- [KotlinCleanup] LoadPronunciationActivity.kt
- Rename CardInfoModelTest.java to CardInfoModelTest.kt
- Migrate CardInfoModelTest.java to Kotlin
- Rename DeckTreeNode.java to .kt
- Migrate DeckTreeNode.java to Kotlin
- Rename Direction.DOWN to DEFAULT
- Add RIGHT and LEFT animation transitions
- Add DOWN animation transition
- Add fromGesture param to executeCommand()
- Add method to get same animation direction of a swipe gesture
- Use same transition direction of swipe on `Edit card` command
- Use same transition direction of swipe on `Card info` command
- Use same transition direction of swipe on `Add note` command
- Rename UtilsTest.java to UtilsTest.kt
- Migrate UtilsTest.java to Kotlin
- refactor: Rename CardTemplatePreviewerTest.java to .kt
- refactor: Convert CardTemplatePreviewerTest.java to Kotlin
- [Kotlin Cleanup] MockTimeTest.kt
- [Kotlin Cleanup] HtmlUtilsTest.kt
- Made Focusable DeckOptions Preferences Auto-Focus (#11087)
- [Kotlin Cleanup] ExtendedFragmentFactoryTest.kt
- Fix #11100 : migrate.sh should give changed commit msg
- refactor: simplify enabling toolbar
- Fixed "CheckMedia" causing crash (#10931)
- Use constants on `gestures` key
- Use constants on `gesturesCornerTouch` key
- Use constants on `timeoutAnswer` preference
- Rename CardContentProvider.java to .kt
- Migrate CardContentProvider.java to Kotlin
- refactor: Rename AbstractFlashcardViewerCommandTest.java to .kt
- refactor: Convert AbstractFlashcardViewerCommandTest.java to Kotlin
- Bumped version to 2.16alpha62
- Centralize all ACRA related code in CrashReportService (#11109)
- Reformat with shell script formatter
- Remove ShellCheck Warnings
- chore: use recommended Kotlin code style settings
- Fix @KotlinCleanup for IFieldController
- refactor: Rename DiffEngineTest.java to .kt
- refactor: Convert DiffEngineTest to Kotlin
- added test coverage for the login method of `MyAccount.kt` without server side mocking
- Manual renaming of CardBrowserTest.java to Kotlin
- Manual migration of CardBrowserTest to Kotlin
- [Kotlin Cleanup] StringUtilTest
- [Kotlin Cleanup] ContentResolverUtilTest
- [Kotlin Cleanup] BundleUtilsTest
- [Kotlin Cleanup] AssertHelperTest
- [Kotlin Cleanup] MapUtilTest
- [Kotlin Cleanup] TestCardTemplatePreviewer
- Add support for hierarchy tag (#10966)
- Rename UndoTest.java to .kt
- Migrate UndoTest.java to Kotlin
- Added test message explanations
- [Kotlin Cleanup] OnRenderProcessGoneDelegateTest
- [Kotlin Cleanup] UniqueArrayListTest
- [KotlinCleanup] OverviewStatsBuilder.kt
- refactor: Rename PieChartTestParametersBuilder.java to .kt
- refactor: Convert PieChartTestParametersBuilder to Kotlin
- [Kotlin Cleanup] ExceptionUtilTest
- [KotlinCleanup] AnkiDroidJsAPI.kt
- [Kotlin Cleanup] CollectionUtilsTest
- refactor: Rename InfoTestNoOnCreate.java to .kt
- refactor: Convert InfoTestNoOnCreate to Kotlin
- lint: verify plural positional format strings
- refactor: Rename DeckPickerImportTest.java to .kt
- refactor: Convert DeckPickerImportTest to Kotlin
- refactor: Rename CustomTabActivityHelperTest.java to .kt
- refactor: Convert CustomTabActivityHelperTest to Kotlin
- Rename TextCardExporterTest.java to TextCardExporterTest.kt
- Migrate TextCardExporterTest.java to Kotlin
- Rename FieldEditLine.java to .kt
- Migrate FieldEditLine.java to Kotlin
- refactor: add `Context` to FAB constructor
- feat: Double tap FAB to add node
- [Kotlin Cleanup] DeckNameComparatorTest
- [Kotlin Cleanup] FileUtilTest
- [Kotlin Cleanup] ResourceLoader
- [Kotlin Cleanup] FragmentFactoryUtilsTest
- refactor: Rename ConstantJavaFieldDetector.java to .kt
- refactor: convert ConstantJavaFieldDetector to Kotlin
- refactor: Rename CopyrightHeaderExists.java to .kt
- refactor: convert CopyrightHeaderExists to Kotlin
- [Kotlin Cleanup] IntentHandlerTest
- refactor: Rename DirectCalendarInstanceUsage.java to .kt
- refactor: convert DirectCalendarInstanceUsage to Kotlin
- Fix Parcelable.Creator implementation for FieldEditText
- [Kotlin Cleanup] CardTemplateTest
- refactor: Rename DirectDateInstantiation.java to .kt
- refactor: convert DirectDateInstantiation to Kotlin
- [Kotlin Cleanup] DBTest
- refactor: Rename DirectGregorianInstantiation.java to .kt
- refactor: convert DirectGregorianInstantiation to Kotlin
- [Kotlin Cleanup] MissingImageHandlerTest
- [Kotlin Cleanup] MockContentResolver
- [Kotlin Cleanup] LanguageUtilsTest
- reset progress
- enhance reschedule js api
- Updated strings from Crowdin
- Bumped version to 2.16alpha63
- Rename RustTest.java to RustTest.kt
- [Kotlin Migration] RustTest
- [Kotlin Cleanup] RustTest
- Set title on `SharedDecksActivity` creation
- Use JUnit5 on tests
- Category heading on the toolbar of settings section
- refactor: Fix lint warnings
- refactor: Fix lint weak warnings
- NF: Use same param names on NavigationDrawerActivity inheritors
- Rename TemplateTest.java to TemplateTest.kt
- Migrate TemplateTest.java to Kotlin
- Rename StringUtilsTest.java to StringUtilsTest.kt
- Migrate StringUtilsTest.java to Kotlin
- refactor: Rename PieChartParameterizedTest.java to .kt
- refactor: Convert PieChartParameterizedTest to Kotlin
- Update the material library dependency to 1.6.0
- [Kotlin Cleanup] DirectDateInstantiation
-  DeckOverview screen Overflow menu icon changed #10868 error solved (#10906)
- Add the 'Always Show' and 'Show if room' to "Set TTS language" (#10941)
- Fix CardTemplateBrowserAppearanceEditor title
- refactor: Rename DuplicateTextInPreferencesXml.java to .kt
- refactor: convert DuplicateTextInPreferencesXml to Kotlin
- Removed meta data elements from AndroidManifest.xml
- [Kotlin Cleanup] PieChartParameterizedTest
- [Kotlin Cleanup] GestureProcessorTest
- Add 'Any' constraint for 'CTX' (#11188)
- long-click on tag allows you to add sub-tag (#11199)
- Rename TemplateError.java to .kt
- Migrate TemplateError.java to Kotlin
- Rename NoteUtils.java to .kt
- Migrate NoteUtils.java to Kotlin
- refactor: Rename MetaDB.java to .kt
- refactor: Convert MetaDB to Kotlin
- refactor: Rename Previewer.java to .kt
- refactor: Convert Previewer to Kotlin
- Renamed files extension to .kt extension in string xmls (#11239)
- refactor: Rename PieChartTest.java to .kt
- refactor: Convert PieChartTest to Kotlin
- Updated strings from Crowdin
- Bumped version to 2.16alpha64
- [Kotlin Cleanup] CopyrightHeaderExists
- [Kotlin Cleanup] MetaTest
- [Kotlin Cleanup] PieChartTestParametersBuilder
- [Kotlin Cleanup] ImageFieldTest
- [Kotlin Cleanup] InitialActivityWithConflictTest
- [Kotlin Cleanup] CardInfoModelTest
- [Kotlin Cleanup] PreviewerTest
- [Kotlin Cleanup] HtmlColorsTest
- [Kotlin Cleanup] IntentAssert
- [Kotlin Cleanup] LaTeXTest
- [Kotlin Cleanup] DirectCalendarInstanceUsage
- [Kotlin Cleanup] PeripheralKeymapTest
- [Kotlin Cleanup] DirectGregorianInstantiation
- [Kotlin Cleanup] ReviewerNoParamTest
- [Kotlin Cleanup] BackupManagerIntegrationTest
- [Kotlin Cleanup] CardBrowserTest
- refactor: Rename NavigationDrawerActivity.java to .kt
- refactor: Convert NavigationDrawerActivity to Kotlin
- Rename MathJax.java to .kt
- Migrate MathJax.java to Kotlin
- Rename PreferenceExtensionsTest.java to PreferenceExtensionsTest.kt
- Migrate PreferenceExtensionsTest.java to Kotlin
- Rename FuriganaFilters.java to .kt
- Migrate FuriganaFilters.java to Kotlin
- refactor: Rename BasicImageFieldController.java to .kt
- refactor: Convert BasicImageFieldController to Kotlin
- [Kotlin Cleanup] ReadTextTest (#11262)
- Rename .java to .kt
- Migrate NumberAtom to Kotlin
- refactor: Rename NoteEditor.java to .kt
- refactor: Convert NoteEditor to Kotlin
- kotlin cleanup : CheckBoxTriState.kt (#11164)
- Rename TemporaryModel.java to .kt
- Migrate TemporaryModel.java to Kotlin
- [KotlinCleanup] BasicTextFieldController (#11234)
- Rename CsvProcessIntegrationTest.java to CsvProcessIntegrationTest.kt
- Migrate CsvProcessIntegrationTest.java to Kotlin
- kotlinMigration.gradle for api project.
- Update general category title
- Rename SchedUpgradeTest.java to SchedUpgradeTest.kt
- Migrate SchedUpgradeTest.java to Kotlin
- Rename ParserTest.java to ParserTest.kt
- Migrate ParserTest.java to Kotlin
- refactor: Rename DeckOptions.java to .kt
- refactor: Convert DeckOptions to Kotlin
- Rename CsvSniffer.java to .kt
- Migrate CsvSniffer.java to kotlin
- Rename CsvReaderIterator.java to .kt
- Migrate CsvReaderIterator.java to kotlin
- Fix crash if no video or audio is selected on NoteEditor
- [KotlinCleanup] Previewer.kt
- refactor: Rename CardTemplateEditor.java to .kt
- refactor: Convert CardTemplateEditor to Kotlin
- Fixed no splash screen in shortcuts.
- Make adapter in ModelBrowser to use the proper backing list
- Add NeedTest note for changes to list of note types
- Make possible to pass a finish animation on a intent
- Add method to return the inverse transition of an animation direction
- Rename CALLER_REVIEWER to CALLER_REVIEWER_EDIT
- Move openCardInfo() to Reviewer.kt
- Add inverse finish transitions on `Add note` and `Edit note` commands
- Add inverse finish transitions on `Card info` command
- Truncate Option in Card Browser (#10863)
- Added test message explanations
- feat: import multiple files (#10851)
- Fixed `A::` last deck not being escaped to "blank" (#11131)
- [KotlinCleanup] ActivityExportingDelegate.kt (#11289)
- fix: Overflow Icon Color Change on Config Change (Orientation Change) (#11061)
- Rename TokenizerTest.java to TokenizerTest.kt
- Migrate TokenizerTest.java to Kotlin
- fix: Lint handling of CDATA elements
- test(ci): add tight timeout to gradle setup setup
- refactor: Rename MultimediaEditFieldActivity.java to .kt
- refactor: Convert MultimediaEditFieldActivity to Kotlin
- [KotlinCleanup] TranslationActivity.kt
- refactor: Rename DirectSnackbarMakeUsage.java to .kt
- refactor: convert DirectSnackbarMakeUsage to Kotlin
- refactor: Rename DirectSystemCurrentTimeMillisUsage.java to .kt
- refactor: convert DirectSystemCurrentTimeMillisUsage to Kotlin
- refactor: Rename DirectToastMakeTextUsage.java to .kt
- refactor: convert DirectToastMakeTextUsage to Kotlin
- refactor: Rename FixedPreferencesTitleLength.java to .kt
- refactor: convert FixedPreferencesTitleLength to Kotlin
- refactor: Rename InconsistentAnnotationUsage.java to .kt
- refactor: convert InconsistentAnnotationUsage to Kotlin
- refactor: Rename NonPublicNonStaticJavaFieldDetector.java to .kt
- refactor: convert NonPublicNonStaticJavaFieldDetector to Kotlin
- refactor: Rename PreferIsEmptyOverSizeCheck.java to .kt
- refactor: convert PreferIsEmptyOverSizeCheck to Kotlin
- refactor: Rename PrintStackTraceUsage.java to .kt
- refactor: convert PrintStackTraceUsage to Kotlin
- refactor: Rename IssueRegistry.java to .kt
- refactor: convert IssueRegistry to Kotlin
- Refactor ArgumentUtils into BundleUtils
- build(deps): Dependency updates 20220510
- Fix `supportInvalidateOptionsMenu` deprecation (#11312)
- Updated strings from Crowdin
- refactor: Rename ImportStatementDetector.java to .kt
- refactor: Convert ImportStatementDetector to Kotlin
- refactor: Rename LintUtils.java to .kt
- refactor: Convert LintUtils to Kotlin
- refactor: Rename StringFormatDetector.java to .kt
- refactor: Convert StringFormatDetector to Kotlin
- refactor: Rename JavaFieldNamingPatternDetector.java to .kt
- refactor: Convert JavaFieldNamingPatternDetector to Kotlin
- refactor: Rename Constants.java to .kt
- refactor: Convert Constants to Kotlin
- Rename RemoteMediaServer.java to .kt
- Migrate RemoteMediaServer.java to Kotlin
- Rename TagsList.java to .kt
- Migrate TagsList.java to Kotlin
- refactor: Rename DirectSystemTimeInstantiation.java to .kt
- refactor: Convert DirectSystemTimeInstantiation to Kotlin
- Bumped version to 2.16alpha65
- refactor: ignore "UnstableApiUsage" lint warnings
- refactor(lint-rules): fix IDE lint
- refactor: Kotlin Cleanup: use listOf
- refactor: remove requireNonNull
- refactor: kotlin cleanup - shorten method
- refactor: kotlin cleanup - improve readability
- refactor: kotlin cleanup - documentation fix
- docs: better explain cleanup annotation
- [Unit Test] ThreadUtilTest.kt
- Rename FieldControllerBase.java to .kt
- Migrate FieldControllerBase.java to kotlin
- Remove code related to translation from project
- [Kotlin Cleanup] CollectionTaskCheckDatabaseTest
- Allow only single imports on the .colpkg option. (#11303)
- [Kotlin Cleanup] Various
- [Kotlin Cleanup] ListUtil
- [KotlinCleanup] AsyncDialogFragment.kt (#11287)
- docs: Rationale for `@NeedsTest`
- Remove useless abstraction for IControllerFactory
- refactor: Kotlin Cleanup: nullability
- refactor: Kotlin Cleanup: nullability
- refactor: Kotlin Cleanup: nullability
- refactor: IDE Lint
- refactor: Kotlin Cleanup
- Ignore image and audio paths check for text based fields
- fix(test): shorten time and use greaterThanOrEqualTo for sleep test
- Rename .java to .kt
- Migrate BasicModel to Kotlin
- Bumped API version due to kotlin visibility change on package protected
- fix: invalid sourceSets for Android Chipmunk
- feat(scoped-storage): complete migrateEssentialFiles (#11049)
- Fix ModelBrowser leaking its ModelBrowserContextMenu reference
- Fix AutoFocus EditText Preferences Back/Return Button Bug
- [Kotlin Cleanup] ReminderServiceTest
- Refactor IField to prepare for its migration to java
- [Kotlin Cleanup] MockCursor
- [Kotlin Cleanup] CollectionUtils
- feat: Speed up tests on M1 Macs
- ci: Use two CPUs when building on CI
- [Kotlin Cleanup] JSONArrayTest
- [Kotlin Cleanup] Various Files
- added test for CountModels
- added test for CountModels
- Rename IField.java to .kt
- Migrate IField.java to kotlin
- refactor: Rename Collection.java to .kt
- refactor: Convert Collection to Kotlin
- Rename FunctionalInterfaces.java to .kt
- Migrate FunctionalInterfaces.java to kotlin
- build(deps): bump mockk from 1.12.3 to 1.12.4
- lint: fix rule for constant detection
- lint: suppress naming check here for AGP7.2 compat
- build: cut memory usage for gradle daemons
- test(windows, ci): increase available paging space
- Bump gradle from 7.1.3 to 7.2.0
- test(ci): give lint / unit test a bit more time to complete
- test(ci, windows): stop gradle daemon to unlock files for caching
- Fixed a bug about NavigateUp Button on DeckOverview screen (#11005)
- Rename TextNoteExporter.java to .kt
- Migrate TextNoteExporter.java to kotlin
- Rename .java to .kt
- Migrate CopyrightHeaderExistsTest [Lint Test] to Kotlin
- Rename DiffEngineTest.java to DiffEngineTest.kt
- Migrate DiffEngineTest.java to Kotlin
- Rename CheckMediaTest.java to CheckMediaTest.kt
- Migrate CheckMediaTest.java to Kotlin
- Rename .java to .kt
- Migrate NoteInfo to Kotlin
- Fix ModelFieldEditor leaking ModelEditorContextMenu
- Rename .java to .kt
- Migrate Basic2Model to Kotlin
- Rename Tags.java to .kt
- Migrate Tags.java to kotlin
- Refactor code around DatabaseLock
- Add support to `<audio>` and `<object>`
- Rename ActionBarOverflowTest.java to ActionBarOverflow.kt
- Migrate ActionBarOverflowTest.java to Kotlin
- Rename PeripheralKeymapTest.java to PeripheralKeymapTest.kt
- Migrate PeripheralKeymapTest.java to Kotlin
- Rename .java to .kt
- Migrate Utils to Kotlin
- Refactor to use Collection parameter in onCollectionLoaded callback
- Cleanup for file RemoteServer.kt
- Rename .java to .kt
- Converted DirectCalendarInstanceUsageTest [Lint Test] to Kotlin
- Fixed Reviewer not updating after changing card in Browser
- Include Edgecases in kotlin migration script + Touch ups
- Rename LaTeX.java to .kt
- Migrate LaTeX.java to .kt
- enable dom storage in webview for sessionStorage & localStorage
- NF: remove duplicate nullability tests
- NF: factorize collection in deck options
- NF: remove redundant nullity check
- NF: rename mEditorPosition
- NF: uses constant for key "position"
- NF: rename position in cardIndex
- NF: nonNullable arg in getAboutAnkiDroidHtml
- NF: remove chaining of append
- NF: move function result in values
- NF: replace append by a template
- Mention migrate.sh in documentation (#11394)
- [Kotlin Cleanup] Tags
- NF: info use scoped function
- [Kotlin Cleanup] ParserTest
- Update image cropper library dependency to 4.2.1
- [Automation] Remove assignees on merged Pull Request (#11432)
- NF: Ensure searchTerm is non null
- NF: make currentSearchTerms local

## Pull Request template

## Purpose / Description
_Describe the problem or feature and motivation_

## Fixes
Fixes _Link to the issues._

## Approach
_How does this change address the problem?_

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration (SDK version(s), emulator or physical, etc)

## Learning (optional, can help others)
_Describe the research stage_

_Links to blog posts, patterns, libraries or addons used to solve this problem_

## Checklist
_Please, go through these checks before submitting the PR._

- [ ] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [ ] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [ ] You have commented your code, particularly in hard-to-understand areas
- [ ] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
