### PR TITLE
[GSoC] Add `Developer options` category

### DIFF
--- a/AnkiDroid/src/main/res/values/preferences.xml
+++ b/AnkiDroid/src/main/res/values/preferences.xml
@@ -28,4 +28,13 @@
     <string name="night_theme_key">nightTheme</string>
     <string name="gestures_preference">gestures</string>
     <string name="gestures_corner_touch_preference">gestureCornerTouch</string>
+    <!-- Developer options -->
+    <string name="pref_cat_dev_options" maxLength="41">Developer options</string>
+    <string name="pref_trigger_crash_key">trigger_crash_preference</string>
+    <string name="pref_analytics_debug_key">analytics_debug_preference</string>
+    <string name="pref_lock_database_key">debug_lock_database</string>
+    <string name="pref_show_onboarding_key">showOnboarding</string>
+    <string name="pref_reset_onboarding_key">resetOnboarding</string>
+    <string name="pref_rust_backend_key">useRustBackend</string>
+    <string name="pref_scoped_storage_key">useScopedStorage</string>
 </resources>

--- a/AnkiDroid/src/main/res/xml/preferences_dev_options.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_dev_options.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~  Copyright (c) 2022 Brayan Oliveira <brayandso.dev@gmail.com>
+  ~
+  ~  This program is free software; you can redistribute it and/or modify it under
+  ~  the terms of the GNU General Public License as published by the Free Software
+  ~  Foundation; either version 3 of the License, or (at your option) any later
+  ~  version.
+  ~
+  ~  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+  ~  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+  ~  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+  ~
+  ~  You should have received a copy of the GNU General Public License along with
+  ~  this program.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
+    android:title="@string/pref_cat_dev_options">
+    <Preference
+        android:title="Trigger test crash"
+        android:summary="Touch here for an immediate test crash"
+        android:key="@string/pref_trigger_crash_key"/>
+    <Preference
+        android:title="Switch Analytics to dev mode"
+        android:summary="Touch here to use Analytics dev tag and 100% sample rate"
+        android:key="@string/pref_analytics_debug_key"/>
+    <Preference
+        android:title="Lock Database"
+        android:summary="Touch here to lock the database (all threads block in-process, exception if using second process)"
+        android:key="@string/pref_lock_database_key"/>
+    <SwitchPreference
+        android:title="@string/show_onboarding"
+        android:summary="@string/show_onboarding_desc"
+        android:key="@string/pref_show_onboarding_key"
+        android:defaultValue="false"/>
+    <Preference
+        android:title="@string/reset_onboarding"
+        android:summary="@string/reset_onboarding_desc"
+        android:key="@string/pref_reset_onboarding_key"/>
+    <Preference
+        android:title="Use V16 Backend"
+        android:summary="UNSTABLE. DO NOT USE ON A COLLECTION YOU CARE ABOUT. REVERTED ON APP CLOSE"
+        android:key="@string/pref_rust_backend_key"/>
+    <Preference
+        android:title="Enable Scoped Storage"
+        android:summary="UNSTABLE. DO NOT USE ON A COLLECTION YOU CARE ABOUT. REVERTED ON APP CLOSE"
+        android:key="@string/pref_scoped_storage_key"/>
+</PreferenceScreen>


### PR DESCRIPTION
## Purpose / Description
Move options exclusive to debug builds to its own category from the bottom of advanced category. 

## Approach
1. Create a XML layout with the previous debug options
2. Extract the debug options from the advanced category to the new one

## How Has This Been Tested?

https://user-images.githubusercontent.com/69634269/171644357-8adf8cf9-bd03-4f4d-b124-ffcb66fd3286.mp4

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
