### PR TITLE
Update androidx.core:core-ktx dependency to 1.8.0

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -246,7 +246,7 @@ dependencies {
     implementation 'androidx.annotation:annotation:1.3.0'
     implementation 'androidx.appcompat:appcompat:1.4.1'
     implementation 'androidx.browser:browser:1.4.0'
-    implementation "androidx.core:core-ktx:1.7.0"
+    implementation "androidx.core:core-ktx:1.8.0"
     implementation 'androidx.exifinterface:exifinterface:1.3.3'
     implementation 'androidx.fragment:fragment-ktx:1.4.1'
     implementation 'androidx.localbroadcastmanager:localbroadcastmanager:1.0.0'

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ActionProviderCompat.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ActionProviderCompat.kt
@@ -1,0 +1,37 @@
+/****************************************************************************************
+ * Copyright (c) 2022 lukstbit <52494258+lukstbit@users.noreply.github.com>             *
+ *                                                                                      *
+ * This program is free software; you can redistribute it and/or modify it under        *
+ * the terms of the GNU General Public License as published by the Free Software        *
+ * Foundation; either version 3 of the License, or (at your option) any later           *
+ * version.                                                                             *
+ *                                                                                      *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *                                                                                      *
+ * You should have received a copy of the GNU General Public License along with         *
+ * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ ****************************************************************************************/
+package com.ichi2.anki
+
+import android.content.Context
+import android.view.View
+import androidx.core.view.ActionProvider
+
+/**
+ * Fix for [ActionProvider.onCreateActionView] deprecation on API 16+. This class should be used
+ * instead of the library [ActionProvider].
+ *
+ * @see ActionProvider
+ */
+abstract class ActionProviderCompat(context: Context) : ActionProvider(context) {
+
+    @Deprecated("Override onCreateActionView(MenuItem)")
+    override fun onCreateActionView(): View {
+        // The previous code returned null from this method but updates to the core-ktx library
+        // forced with an annotation the return of a non null View. Throwing an exception is safe
+        // because the system doesn't use this method anymore.
+        throw UnsupportedOperationException("This should no longer be called. onCreateActionView(MenuItem) should be used")
+    }
+}

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardInfo.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardInfo.kt
@@ -168,7 +168,7 @@ class CardInfo : AnkiActivity() {
         return String.format(locale, formatSpecifier, number)
     }
 
-    private val locale: Locale
+    private val locale: Locale?
         get() = LanguageUtil.getLocaleCompat(resources)
 
     private fun setText(@IdRes id: Int, text: String?) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -2087,7 +2087,7 @@ open class DeckPicker : NavigationDrawerActivity(), StudyOptionsListener, SyncEr
         mExportingDelegate.showExportDialog(msg, did)
     }
 
-    fun createIcon(context: Context?, did: Long) {
+    fun createIcon(context: Context, did: Long) {
         // This code should not be reachable with lower versions
         val shortcut = ShortcutInfoCompat.Builder(this, did.toString())
             .setIntent(

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
@@ -408,17 +408,21 @@ open class Reviewer : AbstractFlashcardViewer() {
             }
             R.id.action_bury -> {
                 Timber.i("Reviewer:: Bury button pressed")
-                if (!MenuItemCompat.getActionProvider(item).hasSubMenu()) {
-                    Timber.d("Bury card due to no submenu")
-                    buryCard()
-                }
+                MenuItemCompat.getActionProvider(item)?.hasSubMenu()?.let { isAvailable ->
+                    if (!isAvailable) {
+                        Timber.d("Bury card due to no submenu")
+                        buryCard()
+                    }
+                } ?: Timber.w("Null ActionProvider for bury menu item in Reviewer!")
             }
             R.id.action_suspend -> {
                 Timber.i("Reviewer:: Suspend button pressed")
-                if (!MenuItemCompat.getActionProvider(item).hasSubMenu()) {
-                    Timber.d("Suspend card due to no submenu")
-                    suspendCard()
-                }
+                MenuItemCompat.getActionProvider(item)?.hasSubMenu()?.let { isAvailable ->
+                    if (!isAvailable) {
+                        Timber.d("Suspend card due to no submenu")
+                        suspendCard()
+                    }
+                } ?: Timber.w("Null ActionProvider for suspend menu item in Reviewer!")
             }
             R.id.action_delete -> {
                 Timber.i("Reviewer:: Delete note button pressed")
@@ -1431,10 +1435,7 @@ open class Reviewer : AbstractFlashcardViewer() {
     /**
      * Inner class which implements the submenu for the Suspend button
      */
-    internal inner class SuspendProvider(context: Context?) : ActionProvider(context), SubMenuProvider {
-        override fun onCreateActionView(): View? {
-            return null // Just return null for a simple dropdown menu
-        }
+    internal inner class SuspendProvider(context: Context) : ActionProviderCompat(context), SubMenuProvider {
 
         override val subMenu: Int
             get() = R.menu.reviewer_suspend
@@ -1465,10 +1466,7 @@ open class Reviewer : AbstractFlashcardViewer() {
     /**
      * Inner class which implements the submenu for the Bury button
      */
-    internal inner class BuryProvider(context: Context?) : ActionProvider(context), SubMenuProvider {
-        override fun onCreateActionView(): View? {
-            return null // Just return null for a simple dropdown menu
-        }
+    internal inner class BuryProvider(context: Context) : ActionProviderCompat(context), SubMenuProvider {
 
         override val subMenu: Int
             get() = R.menu.reviewer_bury
@@ -1499,10 +1497,7 @@ open class Reviewer : AbstractFlashcardViewer() {
     /**
      * Inner class which implements the submenu for the Schedule button
      */
-    internal inner class ScheduleProvider(context: Context?) : ActionProvider(context), SubMenuProvider {
-        override fun onCreateActionView(): View? {
-            return null // Just return null for a simple dropdown menu
-        }
+    internal inner class ScheduleProvider(context: Context) : ActionProviderCompat(context), SubMenuProvider {
 
         override fun hasSubMenu(): Boolean {
             return true

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckPickerContextMenu.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckPickerContextMenu.kt
@@ -112,7 +112,7 @@ class DeckPickerContextMenu(private val collection: Collection) : AnalyticsDialo
             }
             DeckPickerContextMenuOption.CREATE_SHORTCUT -> {
                 Timber.i("Create icon for a deck")
-                (activity as DeckPicker?)!!.createIcon(context, deckId)
+                (activity as DeckPicker?)!!.createIcon(requireContext(), deckId)
             }
             DeckPickerContextMenuOption.RENAME_DECK -> {
                 Timber.i("Rename deck selected")

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/UndoAction.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/UndoAction.kt
@@ -33,12 +33,12 @@ abstract class UndoAction
     @IntDef(R.string.undo_action_change_deck_multi, R.string.menu_delete_note, R.string.card_browser_delete_card, R.string.card_browser_mark_card, R.string.card_browser_unmark_card, R.string.menu_suspend_card, R.string.card_browser_unsuspend_card, R.string.undo_action_review, R.string.menu_bury_note, R.string.menu_suspend_note, R.string.card_editor_reposition_card, R.string.card_editor_reschedule_card, R.string.menu_bury_card, R.string.card_editor_reset_card)
     annotation class UndoNameId
 
-    private fun getLocale(resources: Resources): Locale {
+    private fun getLocale(resources: Resources): Locale? {
         return getLocaleCompat(resources)
     }
 
-    fun name(res: Resources): String {
-        return res.getString(undoNameId).lowercase(getLocale(res))
+    fun name(res: Resources): String? {
+        return getLocale(res)?.let { res.getString(undoNameId).lowercase(it) }
     }
 
     /**

--- a/AnkiDroid/src/main/java/com/ichi2/ui/RtlCompliantActionProvider.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/ui/RtlCompliantActionProvider.kt
@@ -20,7 +20,7 @@ import android.view.View
 import android.widget.ImageButton
 import androidx.annotation.VisibleForTesting
 import androidx.appcompat.widget.TooltipCompat
-import androidx.core.view.ActionProvider
+import com.ichi2.anki.ActionProviderCompat
 import com.ichi2.anki.R
 import com.ichi2.utils.KotlinCleanup
 
@@ -28,19 +28,10 @@ import com.ichi2.utils.KotlinCleanup
  * An Rtl version of a normal action view, where the drawable is mirrored
  */
 @KotlinCleanup("auto-lint class")
-class RtlCompliantActionProvider(context: Context) : ActionProvider(context) {
+class RtlCompliantActionProvider(context: Context) : ActionProviderCompat(context) {
     @JvmField
     @VisibleForTesting
     val mActivity: Activity
-
-    /**
-     * Deprecated method, no need to set it up.
-     * https://developer.android.com/reference/kotlin/androidx/core/view/ActionProvider#oncreateactionview
-     */
-    @Deprecated("")
-    override fun onCreateActionView(): View? {
-        return null
-    }
 
     override fun onCreateActionView(forItem: MenuItem): View {
         val actionView = ImageButton(context, null, R.attr.actionButtonStyle)

--- a/AnkiDroid/src/main/java/com/ichi2/utils/LanguageUtil.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/LanguageUtil.kt
@@ -105,7 +105,7 @@ object LanguageUtil {
     }
 
     @JvmStatic
-    fun getLocaleCompat(resources: Resources): Locale {
+    fun getLocaleCompat(resources: Resources): Locale? {
         return ConfigurationCompat.getLocales(resources.configuration)[0]
     }
 }


### PR DESCRIPTION
## Purpose / Description

This PR update the core-ktx dependency to the latest version(1.8.0 at this moment). This update produces some build errors due to some changes into the declared nullability in the library api:

- ActionProvider declares now onCreateActionView() as returning a non null value, I changed all the overrides to throw an error(to catch any issues now) which should be safe as the platform uses the version which takes a MenuItem
- IconCompat.createWithResource() now requires a non null Context which can be provided safely from where the method was used(DeckPicker.createIcon -> DeckPickerContextMenu)
- ConfigurationCompat.getLocales().getLocale() is declared now to return a nullable value, I added `!!` to keep the current code intact
- MenuItemCompat declares getActionProvider() now as returning a nullable value, in Reviewer where it is used I added `!!` which is safe because the MenuItems for which it is called get an ActionProvider set on them unconditionally


## Fixes

Closes #11505 

## How Has This Been Tested?

Ran the tests, used the area of the app touched by changes.

## Checklist

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
