### PR TITLE
[GSoC] Extract sync preferences to a new category

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/LanguageUtils.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/LanguageUtils.kt
@@ -40,6 +40,14 @@ object LanguageUtils {
         }
     }
 
+    /**
+     * @return if app is using a RTL language
+     */
+    fun appLanguageIsRTL(): Boolean {
+        val directionality = Character.getDirectionality(Locale.getDefault().displayName[0])
+        return directionality == Character.DIRECTIONALITY_RIGHT_TO_LEFT || directionality == Character.DIRECTIONALITY_RIGHT_TO_LEFT_ARABIC
+    }
+
     private fun stripScriptAndExtensions(localeCodeStr: String): String {
         val hashPos = localeCodeStr.indexOf('#')
         return if (hashPos >= 0) localeCodeStr.substring(0, hashPos) else localeCodeStr

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.kt
@@ -1460,6 +1460,19 @@ class Preferences : AnkiActivity() {
             return ver
         }
 
+        /**
+         * Join [strings] with ` • ` as separator
+         * to build a summary string for some preferences categories
+         * e.g. `foo`, `bar`, `hi` ->  `foo • bar • hi`
+         */
+        fun buildCategorySummary(vararg strings: String): String {
+            return if (!LanguageUtils.appLanguageIsRTL()) {
+                strings.joinToString(separator = " • ")
+            } else {
+                strings.reversed().joinToString(separator = " • ")
+            }
+        }
+
         /** Whether the user is logged on to AnkiWeb  */
         fun hasAnkiWebAccount(preferences: SharedPreferences): Boolean =
             preferences.getString("username", "")!!.isNotEmpty()

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.kt
@@ -458,6 +458,18 @@ class Preferences : AnkiActivity() {
             return preference as T
         }
 
+        @Suppress("UNCHECKED_CAST")
+        /**
+         * Obtains a non-null reference to the preference whose
+         * key is defined with given [resId] or throws
+         * e.g. `requirePreference(R.string.day_theme_key)` returns
+         * the preference whose key is `@string/day_theme_key`
+         * The resource IDs with preferences keys can be found on `res/values/preferences.xml`
+         */
+        protected fun <T : Preference?> requirePreference(@StringRes resId: Int): T {
+            return requirePreference(getString(resId)) as T
+        }
+
         protected abstract val analyticsScreenNameConstant: String
 
         /**

--- a/AnkiDroid/src/main/res/values/01-core.xml
+++ b/AnkiDroid/src/main/res/values/01-core.xml
@@ -155,7 +155,7 @@
 
     <string name="sd_card_not_mounted">Device storage not mounted</string>
     <string name="empty_cloze_warning">Edit this note and add some cloze deletions. (%1$s)</string>
-    <string name="button_sync">Sync</string>
+    <string name="button_sync" comment="Text of the sync button">Sync</string>
     <string name="cancel_sync_confirm">Do you want to cancel the sync?</string>
     <string name="continue_sync">Continue sync</string>
     <string name="sync_cancelled">Sync cancelled</string>

--- a/AnkiDroid/src/main/res/values/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values/10-preferences.xml
@@ -25,6 +25,7 @@
     <string name="pref_cat_general" comment="name of the general preference category" maxLength="41">General</string>
     <string name="pref_cat_general_summ">General settings</string>
     <string name="pref_cat_reviewing" maxLength="41">Reviewing</string>
+    <string name="pref_cat_sync" comment="title of the sync preferences category" maxLength="41">Sync</string>
     <string name="pref_cat_reviewing_summ">Non-deck-specific reviewer settings</string>
     <string name="pref_cat_reviewer_behaviour" maxLength="41">Behavior</string>
     <string name="pref_cat_flashcard" maxLength="41">Display</string>

--- a/AnkiDroid/src/main/res/values/preferences.xml
+++ b/AnkiDroid/src/main/res/values/preferences.xml
@@ -28,6 +28,13 @@
     <string name="night_theme_key">nightTheme</string>
     <string name="gestures_preference">gestures</string>
     <string name="gestures_corner_touch_preference">gestureCornerTouch</string>
+    <!-- Sync preferences -->
+    <string name="pref_sync_screen_key">syncScreen</string>
+    <string name="sync_account_key">syncAccount</string>
+    <string name="sync_fetch_missing_media_key">syncFetchesMedia</string>
+    <string name="automatic_sync_choice_key">automaticSyncMode</string>
+    <string name="force_full_sync_key">force_full_sync</string>
+    <string name="custom_sync_server_key">custom_sync_server_link</string>
     <!-- Developer options -->
     <string name="pref_cat_dev_options" maxLength="41">Developer options</string>
     <string name="pref_trigger_crash_key">trigger_crash_preference</string>

--- a/AnkiDroid/src/main/res/xml/preference_headers.xml
+++ b/AnkiDroid/src/main/res/xml/preference_headers.xml
@@ -31,6 +31,13 @@
         android:title="@string/pref_cat_reviewing">
     </Preference>
 
+    <!-- Sync Preferences -->
+    <Preference
+        android:fragment="com.ichi2.anki.Preferences$SyncSettingsFragment"
+        android:key="@string/pref_sync_screen_key"
+        android:title="@string/pref_cat_sync">
+    </Preference>
+
     <!-- Appearance Preferences  -->
     <Preference
         android:fragment="com.ichi2.anki.Preferences$AppearanceSettingsFragment"

--- a/AnkiDroid/src/main/res/xml/preferences_advanced.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_advanced.xml
@@ -31,14 +31,6 @@
             android:key="deckPath"
             android:summary="@string/preference_summary_literal"
             android:title="@string/col_path" />
-        <com.ichi2.preferences.ConfirmationPreferenceCompat
-            android:key="force_full_sync"
-            android:title="@string/force_full_sync_title"
-            android:summary="@string/force_full_sync_summary" />
-        <Preference
-            android:key="custom_sync_server_link"
-            android:title="@string/custom_sync_server_title"
-            android:fragment="com.ichi2.anki.Preferences$CustomSyncServerSettingsFragment" />
         <PreferenceCategory android:title="@string/pref_cat_performance" >
             <com.ichi2.preferences.IncrementerNumberRangePreferenceCompat
                 android:defaultValue="8"

--- a/AnkiDroid/src/main/res/xml/preferences_general.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_general.xml
@@ -24,32 +24,6 @@
 <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
     android:title="@string/app_name"
     android:summary="@string/pref_cat_general_summ">
-    <PreferenceCategory android:title="@string/button_sync" >
-        <Preference
-            android:dialogTitle="@string/sync_account"
-            android:key="syncAccount"
-            android:summary="@string/sync_account_summ_logged_out"
-            android:title="@string/sync_account" >
-            <intent
-                android:targetClass="com.ichi2.anki.MyAccount"
-                android:targetPackage="com.ichi2.anki" />
-        </Preference>
-        <SwitchPreference
-            android:defaultValue="true"
-            android:key="syncFetchesMedia"
-            android:summary="@string/sync_fetch_missing_media_summ"
-            android:title="@string/sync_fetch_missing_media" />
-        <SwitchPreference
-            android:defaultValue="false"
-            android:key="automaticSyncMode"
-            android:summary="@string/automatic_sync_choice_summ"
-            android:title="@string/automatic_sync_choice" />
-        <SwitchPreference
-            android:defaultValue="true"
-            android:key="showSyncStatusBadge"
-            android:summary="@string/sync_status_badge_summ"
-            android:title="@string/sync_status_badge" />
-    </PreferenceCategory>
     <PreferenceCategory android:title="@string/app_name">
         <ListPreference
             android:entries="@array/add_to_cur_labels"

--- a/AnkiDroid/src/main/res/xml/preferences_sync.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_sync.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~  Copyright (c) 2022 Brayan Oliveira <brayandso.dev@gmail.com>
+  ~
+  ~  This program is free software; you can redistribute it and/or modify it under
+  ~  the terms of the GNU General Public License as published by the Free Software
+  ~  Foundation; either version 3 of the License, or (at your option) any later
+  ~  version.
+  ~
+  ~  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+  ~  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+  ~  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+  ~
+  ~  You should have received a copy of the GNU General Public License along with
+  ~  this program.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
+    android:title="@string/pref_cat_sync">
+    <Preference
+        android:dialogTitle="@string/sync_account"
+        android:key="@string/sync_account_key"
+        android:summary="@string/sync_account_summ_logged_out"
+        android:title="@string/sync_account" >
+        <intent
+            android:targetClass="com.ichi2.anki.MyAccount"
+            android:targetPackage="com.ichi2.anki" />
+    </Preference>
+    <SwitchPreference
+        android:defaultValue="true"
+        android:key="@string/sync_fetch_missing_media_key"
+        android:summary="@string/sync_fetch_missing_media_summ"
+        android:title="@string/sync_fetch_missing_media" />
+    <SwitchPreference
+        android:defaultValue="false"
+        android:key="@string/automatic_sync_choice_key"
+        android:summary="@string/automatic_sync_choice_summ"
+        android:title="@string/automatic_sync_choice" />
+    <SwitchPreference
+        android:defaultValue="true"
+        android:key="showSyncStatusBadge"
+        android:summary="@string/sync_status_badge_summ"
+        android:title="@string/sync_status_badge" />
+    <com.ichi2.preferences.ConfirmationPreferenceCompat
+        android:key="@string/force_full_sync_key"
+        android:title="@string/force_full_sync_title"
+        android:summary="@string/force_full_sync_summary" />
+    <Preference
+        android:key="@string/custom_sync_server_key"
+        android:title="@string/custom_sync_server_title"
+        android:fragment="com.ichi2.anki.Preferences$CustomSyncServerSettingsFragment" />
+</PreferenceScreen>

--- a/AnkiDroid/src/test/java/com/ichi2/anki/PreferencesSimpleTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/PreferencesSimpleTest.kt
@@ -1,0 +1,46 @@
+/*
+ *  Copyright (c) 2022 Brayan Oliveira <brayandso.dev@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.ichi2.anki
+
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.equalTo
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
+import java.util.stream.Stream
+
+/**
+ * Test for [Preferences] without [RobolectricTest]. For performance
+ */
+class PreferencesSimpleTest {
+    @ParameterizedTest
+    @MethodSource("buildCategorySummary_LTR_Test_args")
+    fun buildCategorySummary_LTR_Test(strings: Array<String>, expected_summary: String) {
+        assertThat(Preferences.buildCategorySummary(*strings), equalTo(expected_summary))
+    }
+
+    companion object {
+        @JvmStatic
+        fun buildCategorySummary_LTR_Test_args(): Stream<Arguments> {
+            return Stream.of(
+                Arguments.of(arrayOf(""), ""),
+                Arguments.of(arrayOf("foo"), "foo"),
+                Arguments.of(arrayOf("foo", "bar"), "foo • bar"),
+                Arguments.of(arrayOf("foo", "bar", "hi", "there"), "foo • bar • hi • there"),
+            )
+        }
+    }
+}

--- a/AnkiDroid/src/test/java/com/ichi2/anki/PreferencesTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/PreferencesTest.kt
@@ -23,6 +23,7 @@ import org.hamcrest.Matchers.equalTo
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
 
 @RunWith(AndroidJUnit4::class)
 class PreferencesTest : RobolectricTest() {
@@ -51,6 +52,12 @@ class PreferencesTest : RobolectricTest() {
             preferences.setDayOffset(i)
             assertThat(getDayOffset(col), equalTo(i))
         }
+    }
+
+    @Test
+    @Config(qualifiers = "ar")
+    fun buildCategorySummary_RTL_Test() {
+        assertThat(Preferences.buildCategorySummary("حساب أنكي ويب", "مزامنة تلقائية"), equalTo("مزامنة تلقائية • حساب أنكي ويب"))
     }
 
     @Test


### PR DESCRIPTION
## Purpose / Description
Create a separate preferences category for the sync preferences

## Approach
On the commits

## How Has This Been Tested?

<details><summary>On my phone</summary>

![Screenshot_20220602-193336_AnkiDroid](https://user-images.githubusercontent.com/69634269/171749315-b6a0f7a4-c9ba-4484-82b7-b7da9fa4b501.png)


![Screenshot_20220602-191356_AnkiDroid](https://user-images.githubusercontent.com/69634269/171748662-955189b5-73e0-44d5-92b4-38e76d034258.png)

![Screenshot_20220602-191404_AnkiDroid](https://user-images.githubusercontent.com/69634269/171748670-7b6eb236-1211-4ed8-a8d7-a8096885087c.png)

![Screenshot_20220602-193305_AnkiDroid](https://user-images.githubusercontent.com/69634269/171749320-02e398cf-0627-496f-85f7-be43bf4e5e49.png)

</details>

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
