### PR TITLE
Scoped Storage: Execution of a list of Operations + preemption

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/scopedstorage/MigrateUserData.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/scopedstorage/MigrateUserData.kt
@@ -144,7 +144,7 @@ class MigrateUserData private constructor(val source: Directory, val destination
         /**
          * Performs an operation, reports errors and continues on failure
          */
-        fun execSafe(operation: Operation, op: (Operation) -> Unit) {
+        open fun execSafe(operation: Operation, op: (Operation) -> Unit) {
             try {
                 op(operation)
             } catch (e: Exception) {
@@ -257,6 +257,88 @@ class MigrateUserData private constructor(val source: Directory, val destination
     ) : Operation() {
         override fun execute(context: MigrationContext) = standardOperation.execute(context)
         override val retryOperations get() = listOf(retryOperation)
+    }
+
+    /**
+     * An Executor allows execution of a list of tasks, provides progress reporting via a [MigrationContext]
+     * and allows tasks to be preempted (for example: copying an image used in the Reviewer
+     * should take priority over a background migration
+     * of a random file)
+     */
+    class Executor(private val operations: ArrayDeque<Operation>) {
+        /** Whether [terminate] was called. Once this is called, a new instance should be used */
+        private var terminated: Boolean = false
+        /**
+         * A list of operations to be executed before [operations]
+         * [operations] should only be executed if this list is clear
+         */
+        private val preempted: ArrayDeque<Operation> = ArrayDeque()
+
+        /**
+         * Executes operations from both [operations] and [preempted]
+         * Any operation is [preempted] takes priority
+         * Completes when:
+         * * [MigrationContext] determines too many failures have occurred or a critical failure has occurred (via `reportError`)
+         * * [operations] and [preempted] are empty
+         * * [terminated] is set via [terminate]
+         */
+        fun execute(context: MigrationContext) {
+            while (operations.any() || preempted.any()) {
+                clearPreemptedQueue(context)
+                if (terminated || !operations.any()) {
+                    return
+                }
+
+                context.execSafe(operations.removeFirst()) {
+                    val replacements = it.execute(context)
+                    operations.addAll(0, replacements)
+                }
+            }
+        }
+
+        /**
+         * Executes all items in the preempted queue
+         *
+         * After this has completed either: [preempted] is empty, OR [terminated] is true
+         */
+        private fun clearPreemptedQueue(context: MigrationContext) {
+            while (true) {
+                if (terminated) return
+
+                // exit if we've got no more items
+                val nextItem = getNextPreemptedItem() ?: return
+                Timber.d("executing preempted operation: %s", nextItem)
+                context.execSafe(nextItem) {
+                    val replacements = it.execute(context)
+                    addPreempted(replacements)
+                }
+            }
+        }
+
+        fun prepend(operation: Operation) = operations.addFirst(operation)
+        fun append(operation: Operation) = operations.add(operation)
+        fun appendAll(operations: List<Operation>) = this.operations.addAll(operations)
+
+        // region preemption (synchronized)
+
+        private fun addPreempted(replacements: List<Operation>) {
+            // insert all at the end of the queue
+            synchronized(preempted) { preempted.addAll(replacements) }
+        }
+        private fun getNextPreemptedItem() = synchronized(preempted) {
+            if (!preempted.any()) {
+                return@synchronized null
+            }
+            return@synchronized preempted.removeFirst()
+        }
+        fun preempt(operation: Operation) = synchronized(preempted) { preempted.add(operation) }
+
+        // endregion
+
+        /** Stops execution of [execute] */
+        fun terminate() {
+            this.terminated = true
+        }
     }
 }
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/ExecutorTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/ExecutorTest.kt
@@ -1,0 +1,195 @@
+/*
+ *  Copyright (c) 2022 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.servicelayer.scopedstorage
+
+import android.annotation.SuppressLint
+import com.ichi2.anki.servicelayer.scopedstorage.MigrateUserData.Executor
+import com.ichi2.anki.servicelayer.scopedstorage.MigrateUserData.Operation
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.equalTo
+import org.hamcrest.Matchers.hasSize
+import org.junit.Test
+import org.mockito.kotlin.mock
+
+// TODO: Remove [MockExecutor] and now use a 'real' executor in tests
+
+/** Test for [Executor] */
+class ExecutorTest {
+
+    /** the system under test: no initial operations */
+    private val underTest = Executor(ArrayDeque())
+    /** execution context: allows access to the order of execution */
+    private val executionContext = MockMigrationContext()
+
+    /**
+     * pass in two elements to the [Executor]: they should be executed in the same order.
+     */
+    @Test
+    fun `Regular operations are executed in order of addition`() {
+        val opOne = mock<Operation>()
+        val opTwo = mock<Operation>()
+
+        underTest.appendAll(listOf(opOne, opTwo))
+
+        underTest.execute(executionContext)
+
+        assertThat("first operation should be executed first", executionContext.executed[0], equalTo(opOne))
+        assertThat("second operation should be executed second", executionContext.executed[1], equalTo(opTwo))
+    }
+
+    @Test
+    fun `Execution succeeds with only preempted tasks`() {
+        val opOne = mock<Operation>()
+        val opTwo = mock<Operation>()
+
+        underTest.preempt(opOne)
+        underTest.preempt(opTwo)
+
+        underTest.execute(executionContext)
+
+        assertThat("first operation should be executed first", executionContext.executed[0], equalTo(opOne))
+        assertThat("second operation should be executed second", executionContext.executed[1], equalTo(opTwo))
+    }
+
+    /**
+     * pass in one to the [Executor], then [prepend][Executor.prepend] one: the prepended should be executed first
+     */
+    @Test
+    fun `Prepend adds an operation to the start of the list`() {
+        val opOne = mock<Operation>()
+        val opTwo = mock<Operation>()
+
+        underTest.append(opOne)
+        underTest.prepend(opTwo)
+
+        underTest.execute(executionContext)
+
+        assertThat("prepended operation should be executed first", executionContext.executed[0], equalTo(opTwo))
+        assertThat("regular operation should be executed after prepended operation", executionContext.executed[1], equalTo(opOne))
+    }
+
+    /**
+     * Pass in two elements. While the first element is being executed, preempt an element
+     * The preempted element should be added before the second 'initial' element.
+     */
+    @Test
+    fun `A preempted element is executed before a regular element`() {
+        val opOne = BlockedOperation()
+        val opTwo = mock<Operation>()
+
+        val preemptedOp = mock<Operation>()
+
+        underTest.appendAll(listOf(opOne, opTwo))
+
+        // start executing (blocked on op 1)
+        executeInDifferentThreadThenWaitForCompletion {
+            spinUntil { opOne.isExecuting }
+            underTest.preempt(preemptedOp)
+            opOne.isBlocked = false
+        }
+
+        assertThat("Initial operation should be executed first", executionContext.executed[0], equalTo(opOne))
+        assertThat("Preemption should take priority over next over normal operation", executionContext.executed[1], equalTo(preemptedOp))
+        assertThat("All operations should be executed", executionContext.executed[2], equalTo(opTwo))
+    }
+
+    /** add two preempted operations: terminate after the first and ensure that only one is executed */
+    @Test
+    fun `Termination does not continue executing preempted tasks`() {
+        val blockingOp = BlockedOperation()
+        val opTwo = mock<Operation>()
+
+        underTest.preempt(blockingOp)
+        underTest.preempt(opTwo)
+
+        executeInDifferentThreadThenWaitForCompletion {
+            spinUntil { blockingOp.isExecuting }
+            underTest.terminate()
+            blockingOp.isBlocked = false
+        }
+
+        assertThat(executionContext.executed[0], equalTo(blockingOp))
+        assertThat(
+            "a preempted operation is not run if terminate() is called",
+            executionContext.executed, hasSize(1)
+        )
+    }
+
+    /** add two normal operations: terminate after the first and ensure that only one is executed */
+    @Test
+    fun `Termination does not continue executing regular tasks`() {
+        val blockingOp = BlockedOperation()
+        val opTwo = mock<Operation>()
+
+        underTest.appendAll(listOf(blockingOp, opTwo))
+
+        executeInDifferentThreadThenWaitForCompletion {
+            spinUntil { blockingOp.isExecuting }
+            underTest.terminate()
+            blockingOp.isBlocked = false
+        }
+
+        assertThat(executionContext.executed[0], equalTo(blockingOp))
+        assertThat(
+            "a regular operation is not run if terminate() is called",
+            executionContext.executed, hasSize(1)
+        )
+    }
+
+    /**
+     * Executes the executor in one thread, and executes the provided lambda in the main thread
+     * Timeout: one second, either the operation is completed, or an exception is thrown
+     */
+    private fun executeInDifferentThreadThenWaitForCompletion(f: (() -> Unit)) {
+        Thread { underTest.execute(executionContext) }
+            .apply {
+                start()
+                f()
+                join(ONE_SECOND)
+            }
+    }
+
+    /**
+     * An operation which spins until [isBlocked] is set to false
+     */
+    class BlockedOperation : Operation() {
+        var isBlocked = true
+        var isExecuting = false
+        override fun execute(context: MigrateUserData.MigrationContext): List<Operation> {
+            this.isExecuting = true
+            spinUntil { !isBlocked }
+            return emptyList()
+        }
+    }
+
+    companion object {
+        private const val ONE_SECOND = 1000 * 1L
+    }
+}
+
+/** Spins until the provided function is true */
+@SuppressLint("DirectSystemCurrentTimeMillisUsage")
+private fun spinUntil(f: (() -> Boolean)) {
+    val timeoutMillis = 2000
+    val startTime = System.currentTimeMillis()
+    while (!f()) {
+        // spin eternally: SPIN SPIN SPIN SPIN SPIN SPIN
+        if (System.currentTimeMillis() - startTime > timeoutMillis) {
+            throw IllegalStateException("spun until $timeoutMillis")
+        }
+    }
+}

--- a/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/MockMigrationContext.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/MockMigrationContext.kt
@@ -22,6 +22,8 @@ open class MockMigrationContext : MigrateUserData.MigrationContext() {
     val exceptions get() = errors.map { it.exception }
     var logExceptions: Boolean = false
     val progress = mutableListOf<NumberOfBytes>()
+    /** A list of tasks which were passed into [execSafe] */
+    val executed = mutableListOf<MigrateUserData.Operation>()
 
     override fun reportError(throwingOperation: MigrateUserData.Operation, ex: Exception) {
         if (!logExceptions) {
@@ -35,6 +37,14 @@ open class MockMigrationContext : MigrateUserData.MigrationContext() {
     }
 
     data class ReportedError(val operation: MigrateUserData.Operation, val exception: Exception)
+
+    override fun execSafe(
+        operation: MigrateUserData.Operation,
+        op: (MigrateUserData.Operation) -> Unit
+    ) {
+        this.executed.add(operation)
+        super.execSafe(operation, op)
+    }
 }
 
 /**


### PR DESCRIPTION
An executor allows execution of a list of operations and preemption

Primarily to ensure that the reviewing experience is not delayed if the scoped storage migration is going on the background.

This allows a single folder to be specified, removing any additional code complexity in the reviewer, and instead taking it on in the migration path: via prioritizing a 'reviewer initiated file copy'

#5304

## Approach
_How does this change address the problem?_

## How Has This Been Tested?

Unit tested

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
