### PR TITLE
Remove deprecated LocalBroadcastManager

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -249,7 +249,6 @@ dependencies {
     implementation "androidx.core:core-ktx:1.7.0"
     implementation 'androidx.exifinterface:exifinterface:1.3.3'
     implementation 'androidx.fragment:fragment-ktx:1.4.1'
-    implementation 'androidx.localbroadcastmanager:localbroadcastmanager:1.0.0'
     implementation "androidx.preference:preference-ktx:1.2.0"
     implementation 'androidx.recyclerview:recyclerview:1.2.1'
     implementation 'androidx.sqlite:sqlite-framework:2.2.0'

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.java
@@ -33,7 +33,7 @@ import android.os.LocaleList;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.VisibleForTesting;
-import androidx.localbroadcastmanager.content.LocalBroadcastManager;
+import androidx.lifecycle.MutableLiveData;
 
 import android.util.Log;
 import android.webkit.CookieManager;
@@ -113,6 +113,7 @@ public class AnkiDroidApp extends Application {
     /** HACK: Whether an exception report has been thrown - TODO: Rewrite an ACRA Listener to do this */
     @VisibleForTesting
     public static boolean sSentExceptionReportHack;
+    private final MutableLiveData<Void> mNotifications = new MutableLiveData<>();
 
     @NonNull
     public static InputStream getResourceAsStream(@NonNull String name) {
@@ -226,10 +227,12 @@ public class AnkiDroidApp extends Application {
         Timber.i("AnkiDroidApp: Starting Services");
         new BootService().onReceive(this, new Intent(this, BootService.class));
 
-        // Register BroadcastReceiver NotificationService
-        NotificationService ns = new NotificationService();
-        LocalBroadcastManager lbm = LocalBroadcastManager.getInstance(this);
-        lbm.registerReceiver(ns, new IntentFilter(NotificationService.INTENT_ACTION));
+        // Register for notifications
+        mNotifications.observeForever(unused -> NotificationService.triggerNotificationFor(this));
+    }
+
+    public void scheduleNotification() {
+        mNotifications.postValue(null);
     }
 
     @SuppressWarnings("deprecation") // 7109: setAcceptFileSchemeCookies

--- a/AnkiDroid/src/main/java/com/ichi2/anki/services/NotificationService.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/services/NotificationService.kt
@@ -32,54 +32,58 @@ import com.ichi2.widget.WidgetStatus
 import timber.log.Timber
 
 class NotificationService : BroadcastReceiver() {
-    override fun onReceive(context: Context, intent: Intent) {
-        Timber.i("NotificationService: OnStartCommand")
-        val manager = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
-        val preferences = AnkiDroidApp.getSharedPrefs(context)
-        val minCardsDue = preferences.getString(Preferences.MINIMUM_CARDS_DUE_FOR_NOTIFICATION, Integer.toString(Preferences.PENDING_NOTIFICATIONS_ONLY))!!.toInt()
-        val dueCardsCount = WidgetStatus.fetchDue(context)
-        if (dueCardsCount >= minCardsDue) {
-            // Build basic notification
-            val cardsDueText = context.resources
-                .getQuantityString(R.plurals.widget_minimum_cards_due_notification_ticker_text, dueCardsCount, dueCardsCount)
-
-            // This generates a log warning "Use of stream types is deprecated..."
-            // The NotificationCompat code uses setSound() no matter what we do and triggers it.
-            val builder = NotificationCompat.Builder(
-                context,
-                NotificationChannels.getId(NotificationChannels.Channel.GENERAL)
-            )
-                .setCategory(NotificationCompat.CATEGORY_REMINDER)
-                .setSmallIcon(R.drawable.ic_stat_notify)
-                .setColor(ContextCompat.getColor(context, R.color.material_light_blue_700))
-                .setContentTitle(cardsDueText)
-                .setTicker(cardsDueText)
-            // Enable vibrate and blink if set in preferences
-            if (preferences.getBoolean("widgetVibrate", false)) {
-                builder.setVibrate(longArrayOf(1000, 1000, 1000))
-            }
-            if (preferences.getBoolean("widgetBlink", false)) {
-                builder.setLights(Color.BLUE, 1000, 1000)
-            }
-            // Creates an explicit intent for an Activity in your app
-            val resultIntent = Intent(context, DeckPicker::class.java)
-            resultIntent.flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
-            val resultPendingIntent = CompatHelper.compat.getImmutableActivityIntent(
-                context, 0, resultIntent,
-                PendingIntent.FLAG_UPDATE_CURRENT
-            )
-            builder.setContentIntent(resultPendingIntent)
-            // mId allows you to update the notification later on.
-            manager.notify(WIDGET_NOTIFY_ID, builder.build())
-        } else {
-            // Cancel the existing notification, if any.
-            manager.cancel(WIDGET_NOTIFY_ID)
-        }
-    }
 
     companion object {
         /** The id of the notification for due cards.  */
         private const val WIDGET_NOTIFY_ID = 1
-        const val INTENT_ACTION = "com.ichi2.anki.intent.action.SHOW_NOTIFICATION"
+
+        @JvmStatic
+        fun triggerNotificationFor(context: Context) {
+            Timber.i("NotificationService: OnStartCommand")
+            val manager = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+            val preferences = AnkiDroidApp.getSharedPrefs(context)
+            val minCardsDue = preferences.getString(Preferences.MINIMUM_CARDS_DUE_FOR_NOTIFICATION, Integer.toString(Preferences.PENDING_NOTIFICATIONS_ONLY))!!.toInt()
+            val dueCardsCount = WidgetStatus.fetchDue(context)
+            if (dueCardsCount >= minCardsDue) {
+                // Build basic notification
+                val cardsDueText = context.resources
+                    .getQuantityString(R.plurals.widget_minimum_cards_due_notification_ticker_text, dueCardsCount, dueCardsCount)
+                // This generates a log warning "Use of stream types is deprecated..."
+                // The NotificationCompat code uses setSound() no matter what we do and triggers it.
+                val builder = NotificationCompat.Builder(
+                    context,
+                    NotificationChannels.getId(NotificationChannels.Channel.GENERAL)
+                )
+                    .setCategory(NotificationCompat.CATEGORY_REMINDER)
+                    .setSmallIcon(R.drawable.ic_stat_notify)
+                    .setColor(ContextCompat.getColor(context, R.color.material_light_blue_700))
+                    .setContentTitle(cardsDueText)
+                    .setTicker(cardsDueText)
+                // Enable vibrate and blink if set in preferences
+                if (preferences.getBoolean("widgetVibrate", false)) {
+                    builder.setVibrate(longArrayOf(1000, 1000, 1000))
+                }
+                if (preferences.getBoolean("widgetBlink", false)) {
+                    builder.setLights(Color.BLUE, 1000, 1000)
+                }
+                // Creates an explicit intent for an Activity in your app
+                val resultIntent = Intent(context, DeckPicker::class.java)
+                resultIntent.flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
+                val resultPendingIntent = CompatHelper.compat.getImmutableActivityIntent(
+                    context, 0, resultIntent,
+                    PendingIntent.FLAG_UPDATE_CURRENT
+                )
+                builder.setContentIntent(resultPendingIntent)
+                // mId allows you to update the notification later on.
+                manager.notify(WIDGET_NOTIFY_ID, builder.build())
+            } else {
+                // Cancel the existing notification, if any.
+                manager.cancel(WIDGET_NOTIFY_ID)
+            }
+        }
+    }
+
+    override fun onReceive(context: Context, intent: Intent) {
+        triggerNotificationFor(context)
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/widget/WidgetStatus.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/widget/WidgetStatus.kt
@@ -15,14 +15,11 @@
 package com.ichi2.widget
 
 import android.content.Context
-import android.content.Intent
 import android.util.Pair
-import androidx.localbroadcastmanager.content.LocalBroadcastManager
 import com.ichi2.anki.AnkiDroidApp
 import com.ichi2.anki.CollectionHelper
 import com.ichi2.anki.MetaDB
 import com.ichi2.anki.Preferences
-import com.ichi2.anki.services.NotificationService
 import com.ichi2.async.BaseAsyncTask
 import com.ichi2.libanki.sched.Counts
 import com.ichi2.utils.KotlinCleanup
@@ -98,9 +95,7 @@ object WidgetStatus {
             if (sSmallWidgetEnabled) {
                 UpdateService().doUpdate(result)
             }
-            val intent = Intent(NotificationService.INTENT_ACTION)
-            val appContext = result.applicationContext
-            LocalBroadcastManager.getInstance(appContext).sendBroadcast(intent)
+            (result.applicationContext as? AnkiDroidApp)?.scheduleNotification()
         }
 
         private fun updateCounts(context: Context) {


### PR DESCRIPTION
## Purpose / Description

This PR removes the LocalBroadcastManager which was deprecated and replaces it with LiveData. So instead of the old system, now the application class has a LiveData field on which other parts of the code(WidgetStatus) can send an event to indicate that a notification should be shown.

The NotificationService was refactored to extract the code from onReceive into a method(no changes here just basic copy to a new method) so it can be called by the application class directly when a notification should be shown.

## Fixes
Closes #10185 
Closes #10183 

## How Has This Been Tested?

Ran the usual tests, and notifications seem to appear like normal. Keep in mind that I don't use the notification system at all with AnkiDroid so take extra care with reviewing.

## Checklist

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
