### PR TITLE
Reduce number of notification by caching previous values

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/services/NotificationService.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/services/NotificationService.kt
@@ -38,7 +38,17 @@ class NotificationService : BroadcastReceiver() {
         val preferences = AnkiDroidApp.getSharedPrefs(context)
         val minCardsDue = preferences.getString(Preferences.MINIMUM_CARDS_DUE_FOR_NOTIFICATION, Integer.toString(Preferences.PENDING_NOTIFICATIONS_ONLY))!!.toInt()
         val dueCardsCount = WidgetStatus.fetchDue(context)
+        val currentNotificationValues = Pair(dueCardsCount, minCardsDue)
         if (dueCardsCount >= minCardsDue) {
+            previousNotificationValues = if (previousNotificationValues != null) {
+                if (previousNotificationValues == currentNotificationValues) {
+                    return
+                } else {
+                    currentNotificationValues
+                }
+            } else {
+                currentNotificationValues
+            }
             // Build basic notification
             val cardsDueText = context.resources
                 .getQuantityString(R.plurals.widget_minimum_cards_due_notification_ticker_text, dueCardsCount, dueCardsCount)
@@ -81,5 +91,11 @@ class NotificationService : BroadcastReceiver() {
         /** The id of the notification for due cards.  */
         private const val WIDGET_NOTIFY_ID = 1
         const val INTENT_ACTION = "com.ichi2.anki.intent.action.SHOW_NOTIFICATION"
+
+        /**
+         * Cache for the last values used for notifications. There's no need to show a notification
+         * if the current values we are using were already used to show a notification.
+         */
+        private var previousNotificationValues: Pair<Int, Int>? = null
     }
 }


### PR DESCRIPTION
## Purpose / Description

Part of #6476 .
As I was working on #11515 I saw that the number of notification could be easily reduced with the code below. I know someone is working on this in #11487 and I'm leaving this code more as proof of concept(and because I wasted time on it before seeing the other PR).

## How Has This Been Tested?

Ran the usual tests, and notifications seem to reduce in number. Keep in mind that I don't use the notification system at all with AnkiDroid so take extra care with reviewing.

## Checklist

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
