### PR TITLE
[GSoC] Extract notifications preferences to a new category

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.kt
@@ -405,8 +405,17 @@ class Preferences : AnkiActivity() {
         override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
             setPreferencesFromResource(R.xml.preference_headers, rootKey)
 
+            // Sync preferences summary
             findPreference<Preference>(getString(R.string.pref_sync_screen_key))!!
                 .summary = buildCategorySummary(getString(R.string.sync_account), getString(R.string.automatic_sync_choice))
+
+            // Notifications preferences summary
+            findPreference<Preference>(getString(R.string.pref_notifications_screen_key))!!
+                .summary = buildCategorySummary(
+                getString(R.string.notification_pref_title),
+                getString(R.string.notification_minimum_cards_due_vibrate),
+                getString(R.string.notification_minimum_cards_due_blink),
+            )
 
             if (isRestrictedLearningDevice) {
                 findPreference<Preference>("pref_screen_advanced")!!.isVisible = false

--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/NotificationsSettingsFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/NotificationsSettingsFragment.kt
@@ -1,0 +1,39 @@
+/*
+ *  Copyright (c) 2022 Brayan Oliveira <brayandso.dev@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.ichi2.anki.preferences
+
+import androidx.preference.SwitchPreference
+import com.ichi2.anki.Preferences.SpecificSettingsFragment
+import com.ichi2.anki.R
+import com.ichi2.utils.AdaptionUtil.isRestrictedLearningDevice
+
+/**
+ * Fragment with preferences related to notifications
+ */
+class NotificationsSettingsFragment : SpecificSettingsFragment() {
+    override val preferenceResource: Int
+        get() = R.xml.preferences_notifications
+    override val analyticsScreenNameConstant: String
+        get() = "prefs.notifications"
+
+    override fun initSubscreen() {
+        addPreferencesFromResource(preferenceResource)
+        if (isRestrictedLearningDevice) {
+            preferenceScreen.removePreference(requirePreference<SwitchPreference>(R.string.pref_notifications_vibrate_key))
+            preferenceScreen.removePreference(requirePreference<SwitchPreference>(R.string.pref_notifications_blink_key))
+        }
+    }
+}

--- a/AnkiDroid/src/main/res/values/preferences.xml
+++ b/AnkiDroid/src/main/res/values/preferences.xml
@@ -35,6 +35,11 @@
     <string name="automatic_sync_choice_key">automaticSyncMode</string>
     <string name="force_full_sync_key">force_full_sync</string>
     <string name="custom_sync_server_key">custom_sync_server_link</string>
+    <!-- Notification preferences -->
+    <string name="pref_notifications_screen_key">notificationsScreen</string>
+    <string name="pref_notifications_minimum_cards_due_key">minimumCardsDueForNotification</string>
+    <string name="pref_notifications_vibrate_key">widgetVibrate</string>
+    <string name="pref_notifications_blink_key">widgetBlink</string>
     <!-- Developer options -->
     <string name="pref_cat_dev_options" maxLength="41">Developer options</string>
     <string name="pref_trigger_crash_key">trigger_crash_preference</string>

--- a/AnkiDroid/src/main/res/xml/preference_headers.xml
+++ b/AnkiDroid/src/main/res/xml/preference_headers.xml
@@ -38,6 +38,13 @@
         android:title="@string/pref_cat_sync">
     </Preference>
 
+    <!-- Notifications -->
+    <Preference
+        android:fragment="com.ichi2.anki.preferences.NotificationsSettingsFragment"
+        android:key="@string/pref_notifications_screen_key"
+        android:title="@string/notification_pref">
+    </Preference>
+
     <!-- Appearance Preferences  -->
     <Preference
         android:fragment="com.ichi2.anki.Preferences$AppearanceSettingsFragment"

--- a/AnkiDroid/src/main/res/xml/preferences_general.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_general.xml
@@ -24,7 +24,6 @@
 <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
     android:title="@string/pref_cat_general"
     android:summary="@string/pref_cat_general_summ">
-    <PreferenceCategory android:title="@string/app_name">
         <ListPreference
             android:entries="@array/add_to_cur_labels"
             android:entryValues="@array/add_to_cur_values"
@@ -52,22 +51,4 @@
             android:entryValues="@array/error_reporting_choice_values"
             android:key="reportErrorMode"
             android:title="@string/error_reporting_choice" />
-    </PreferenceCategory>
-    <PreferenceCategory android:title="@string/notification_pref"
-        android:key="category_general_notification_pref">
-        <ListPreference
-            android:defaultValue="1000000"
-            android:entries="@array/notification_minimum_cards_due_labels"
-            android:entryValues="@array/notification_minimum_cards_due_values"
-            android:key="minimumCardsDueForNotification"
-            android:title="@string/notification_pref_title" />
-        <SwitchPreference
-            android:defaultValue="false"
-            android:key="widgetVibrate"
-            android:title="@string/notification_minimum_cards_due_vibrate" />
-        <SwitchPreference
-            android:defaultValue="false"
-            android:key="widgetBlink"
-            android:title="@string/notification_minimum_cards_due_blink" />
-    </PreferenceCategory>
 </PreferenceScreen>

--- a/AnkiDroid/src/main/res/xml/preferences_notifications.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_notifications.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~  Copyright (c) 2022 Brayan Oliveira <brayandso.dev@gmail.com>
+  ~
+  ~  This program is free software; you can redistribute it and/or modify it under
+  ~  the terms of the GNU General Public License as published by the Free Software
+  ~  Foundation; either version 3 of the License, or (at your option) any later
+  ~  version.
+  ~
+  ~  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+  ~  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+  ~  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+  ~
+  ~  You should have received a copy of the GNU General Public License along with
+  ~  this program.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
+    android:title="@string/notification_pref"
+    android:key="@string/pref_notifications_screen_key">
+    <ListPreference
+        android:defaultValue="1000000"
+        android:entries="@array/notification_minimum_cards_due_labels"
+        android:entryValues="@array/notification_minimum_cards_due_values"
+        android:key="@string/pref_notifications_minimum_cards_due_key"
+        android:title="@string/notification_pref_title" />
+    <SwitchPreference
+        android:defaultValue="false"
+        android:key="@string/pref_notifications_vibrate_key"
+        android:title="@string/notification_minimum_cards_due_vibrate" />
+    <SwitchPreference
+        android:defaultValue="false"
+        android:key="@string/pref_notifications_blink_key"
+        android:title="@string/notification_minimum_cards_due_blink" />
+</PreferenceScreen>


### PR DESCRIPTION
## Purpose / Description
Extract notifications preferences to a new category

## Approach
1. Extract them from `General`
2. Create a new fragment
3. Build a summary based on them

![Screenshot_20220603-164241_AnkiDroid](https://user-images.githubusercontent.com/69634269/171942295-9ad8e20a-169d-44ee-9913-cf9c65b1a899.png)

![Screenshot_20220603-164803_AnkiDroid](https://user-images.githubusercontent.com/69634269/171942267-8ca12b1f-ada5-4061-8796-68ee77883809.png)


## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
