### PR TITLE
[GSoC] Reorganize reviewing preferences

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.kt
@@ -406,6 +406,13 @@ class Preferences : AnkiActivity() {
         override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
             setPreferencesFromResource(R.xml.preference_headers, rootKey)
 
+            // Reviewing preferences summary
+            findPreference<Preference>(getString(R.string.pref_reviewing_screen_key))!!
+                .summary = buildCategorySummary(
+                getString(R.string.pref_cat_scheduling),
+                getString(R.string.timeout_answer_text)
+            )
+
             // Sync preferences summary
             findPreference<Preference>(getString(R.string.pref_sync_screen_key))!!
                 .summary = buildCategorySummary(getString(R.string.sync_account), getString(R.string.automatic_sync_choice))
@@ -416,6 +423,13 @@ class Preferences : AnkiActivity() {
                 getString(R.string.notification_pref_title),
                 getString(R.string.notification_minimum_cards_due_vibrate),
                 getString(R.string.notification_minimum_cards_due_blink),
+            )
+
+            // Accessibility preferences summary
+            findPreference<Preference>(getString(R.string.pref_accessibility_screen_key))!!
+                .summary = buildCategorySummary(
+                getString(R.string.card_zoom),
+                getString(R.string.button_size),
             )
 
             // Controls preferences summary
@@ -769,33 +783,6 @@ class Preferences : AnkiActivity() {
 
         override fun initSubscreen() {
             addPreferencesFromResource(R.xml.preferences_reviewing)
-            // Show error toast if the user tries to disable answer button without gestures on
-            val buttonsPreference = requirePreference<Preference>(getString(R.string.answer_buttons_position_preference))
-            buttonsPreference.onPreferenceChangeListener = Preference.OnPreferenceChangeListener { _: Preference?, newValue: Any ->
-                val prefs = AnkiDroidApp.getSharedPrefs(requireContext())
-                if (prefs.getBoolean(GestureProcessor.PREF_KEY, false) || newValue != "none") {
-                    return@OnPreferenceChangeListener true
-                } else {
-                    showThemedToast(
-                        requireContext(),
-                        R.string.full_screen_error_gestures, false
-                    )
-                    return@OnPreferenceChangeListener false
-                }
-            }
-            val fullscreenPreference = requirePreference<ListPreference>(FullScreenMode.PREF_KEY)
-            fullscreenPreference.onPreferenceChangeListener = Preference.OnPreferenceChangeListener { _, newValue: Any ->
-                val prefs = AnkiDroidApp.getSharedPrefs(requireContext())
-                if (prefs.getBoolean(GestureProcessor.PREF_KEY, false) || FullScreenMode.FULLSCREEN_ALL_GONE.getPreferenceValue() != newValue) {
-                    return@OnPreferenceChangeListener true
-                } else {
-                    showThemedToast(
-                        requireContext(),
-                        R.string.full_screen_error_gestures, false
-                    )
-                    return@OnPreferenceChangeListener false
-                }
-            }
         }
     }
 
@@ -837,6 +824,26 @@ class Preferences : AnkiActivity() {
 
         override fun initSubscreen() {
             addPreferencesFromResource(R.xml.preferences_appearance)
+            // Show error toast if the user tries to disable answer button without gestures on
+            requirePreference<Preference>(R.string.answer_buttons_position_preference).setOnPreferenceChangeListener() { _, newValue: Any ->
+                val prefs = AnkiDroidApp.getSharedPrefs(requireContext())
+                if (prefs.getBoolean(GestureProcessor.PREF_KEY, false) || newValue != "none") {
+                    true
+                } else {
+                    showThemedToast(requireContext(), R.string.full_screen_error_gestures, false)
+                    false
+                }
+            }
+            requirePreference<ListPreference>(FullScreenMode.PREF_KEY).setOnPreferenceChangeListener { _, newValue: Any ->
+                val prefs = AnkiDroidApp.getSharedPrefs(requireContext())
+                if (prefs.getBoolean(GestureProcessor.PREF_KEY, false) || FullScreenMode.FULLSCREEN_ALL_GONE.getPreferenceValue() != newValue) {
+                    true
+                } else {
+                    showThemedToast(requireContext(), R.string.full_screen_error_gestures, false)
+                    false
+                }
+            }
+            // Configure background
             mBackgroundImage = requirePreference<SwitchPreference>("deckPickerBackground")
             mBackgroundImage!!.onPreferenceClickListener = Preference.OnPreferenceClickListener {
                 if (mBackgroundImage!!.isChecked) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/AccessibilitySettingsFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/AccessibilitySettingsFragment.kt
@@ -1,0 +1,33 @@
+/*
+ *  Copyright (c) 2022 Brayan Oliveira <brayandso.dev@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.ichi2.anki.preferences
+
+import com.ichi2.anki.Preferences.SpecificSettingsFragment
+import com.ichi2.anki.R
+
+/**
+ * Fragment with preferences related to notifications
+ */
+class AccessibilitySettingsFragment : SpecificSettingsFragment() {
+    override val preferenceResource: Int
+        get() = R.xml.preferences_acessibility
+    override val analyticsScreenNameConstant: String
+        get() = "prefs.accessibility"
+
+    override fun initSubscreen() {
+        addPreferencesFromResource(preferenceResource)
+    }
+}

--- a/AnkiDroid/src/main/res/drawable/ic_accessibility_24.xml
+++ b/AnkiDroid/src/main/res/drawable/ic_accessibility_24.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#FFFFFF"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M12,2c1.1,0 2,0.9 2,2s-0.9,2 -2,2 -2,-0.9 -2,-2 0.9,-2 2,-2zM21,9h-6v13h-2v-6h-2v6L9,22L9,9L3,9L3,7h18v2z"/>
+</vector>

--- a/AnkiDroid/src/main/res/values/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values/10-preferences.xml
@@ -26,9 +26,7 @@
     <string name="pref_cat_general_summ">General settings</string>
     <string name="pref_cat_reviewing" maxLength="41">Reviewing</string>
     <string name="pref_cat_sync" comment="title of the sync preferences category" maxLength="41">Sync</string>
-    <string name="pref_cat_reviewing_summ">Non-deck-specific reviewer settings</string>
     <string name="pref_cat_scheduling" maxLength="41">Scheduling</string>
-    <string name="pref_cat_flashcard" maxLength="41">Display</string>
     <string name="pref_cat_whiteboard" maxLength="41">Whiteboard</string>
     <string name="pref_cat_appearance" maxLength="41">Appearance</string>
     <string name="pref_cat_appearance_summ">Change themes and default font</string>
@@ -185,6 +183,9 @@
     <string name="html_javascript_debugging" maxLength="41">HTML / Javascript Debugging</string>
     <string name="html_javascript_debugging_summ">Enable remote WebView connections, and save card HTML to AnkiDroid directory</string>
 
+    <!-- Appearance settings -->
+    <string name="pref_cat_reviewer" maxLength="41">Reviewer</string>
+    <string name="accessibility" maxLength="41">Accessibility</string>
     <!-- Paste clipboard image as png option -->
     <string name="paste_as_png" maxLength="41">Paste clipboard images as PNG</string>
     <string name="paste_as_png_summary">By default Anki pastes images on the clipboard as JPG files to save disk space. You can use this option to paste as PNG images instead.</string>

--- a/AnkiDroid/src/main/res/values/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values/10-preferences.xml
@@ -27,7 +27,7 @@
     <string name="pref_cat_reviewing" maxLength="41">Reviewing</string>
     <string name="pref_cat_sync" comment="title of the sync preferences category" maxLength="41">Sync</string>
     <string name="pref_cat_reviewing_summ">Non-deck-specific reviewer settings</string>
-    <string name="pref_cat_reviewer_behaviour" maxLength="41">Behavior</string>
+    <string name="pref_cat_scheduling" maxLength="41">Scheduling</string>
     <string name="pref_cat_flashcard" maxLength="41">Display</string>
     <string name="pref_cat_whiteboard" maxLength="41">Whiteboard</string>
     <string name="pref_cat_appearance" maxLength="41">Appearance</string>

--- a/AnkiDroid/src/main/res/values/preferences.xml
+++ b/AnkiDroid/src/main/res/values/preferences.xml
@@ -18,7 +18,6 @@
     <string name="show_progress_preference">showProgress</string>
     <string name="show_eta_preference">showETA</string>
     <string name="show_large_answer_buttons_preference">showLargeAnswerButtons</string>
-    <string name="white_board_stroke_width_preference">whiteBoardStrokeWidth</string>
     <string name="timeout_answer_preference">timeoutAnswer</string>
     <string name="automatic_answer_action_preference">automaticAnswerAction</string>
     <string name="timeout_answer_seconds_preference">timeoutAnswerSeconds</string>

--- a/AnkiDroid/src/main/res/values/preferences.xml
+++ b/AnkiDroid/src/main/res/values/preferences.xml
@@ -27,6 +27,8 @@
     <string name="night_theme_key">nightTheme</string>
     <string name="gestures_preference">gestures</string>
     <string name="gestures_corner_touch_preference">gestureCornerTouch</string>
+    <string name="pref_reviewing_screen_key">reviewingScreen</string>
+    <string name="pref_accessibility_screen_key">accessibilityScreen</string>
     <string name="pref_controls_screen_key">controlsScreen</string>
     <!-- Sync preferences -->
     <string name="pref_sync_screen_key">syncScreen</string>

--- a/AnkiDroid/src/main/res/xml/preference_headers.xml
+++ b/AnkiDroid/src/main/res/xml/preference_headers.xml
@@ -28,7 +28,7 @@
     <!-- Reviewing Preferences -->
     <Preference
         android:fragment="com.ichi2.anki.Preferences$ReviewingSettingsFragment"
-        android:summary="@string/pref_cat_reviewing_summ"
+        android:key="@string/pref_reviewing_screen_key"
         android:title="@string/pref_cat_reviewing"
         android:icon="@drawable/ic_flashcard_black">
     </Preference>
@@ -64,6 +64,14 @@
         android:key="@string/pref_controls_screen_key"
         android:title="@string/pref_cat_controls"
         android:icon="@drawable/ic_touch">
+    </Preference>
+
+    <!-- Accessibility -->
+    <Preference
+        android:fragment="com.ichi2.anki.preferences.AccessibilitySettingsFragment"
+        android:key="@string/pref_accessibility_screen_key"
+        android:title="@string/accessibility"
+        android:icon="@drawable/ic_accessibility_24">
     </Preference>
 
     <!-- Advanced Preferences -->

--- a/AnkiDroid/src/main/res/xml/preferences_acessibility.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_acessibility.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~  Copyright (c) 2022 Brayan Oliveira <brayandso.dev@gmail.com>
+  ~
+  ~  This program is free software; you can redistribute it and/or modify it under
+  ~  the terms of the GNU General Public License as published by the Free Software
+  ~  Foundation; either version 3 of the License, or (at your option) any later
+  ~  version.
+  ~
+  ~  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+  ~  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+  ~  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+  ~
+  ~  You should have received a copy of the GNU General Public License along with
+  ~  this program.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://arbitrary.app.namespace/com.ichi2.anki"
+    android:title="@string/accessibility">
+    <com.ichi2.preferences.SeekBarPreferenceCompat
+        android:defaultValue="100"
+        android:key="@string/card_zoom_preference"
+        android:max="300"
+        android:summary="@string/preference_summary_percentage"
+        android:text=" %"
+        android:title="@string/card_zoom"
+        app:interval="10"
+        app:min="10" />
+    <com.ichi2.preferences.SeekBarPreferenceCompat
+        android:defaultValue="100"
+        android:key="@string/image_zoom_preference"
+        android:max="300"
+        android:summary="@string/preference_summary_percentage"
+        android:text=" %"
+        android:title="@string/image_zoom"
+        app:interval="10"
+        app:min="50" />
+    <com.ichi2.preferences.SeekBarPreferenceCompat
+        android:defaultValue="100"
+        android:key="@string/answer_button_size_preference"
+        android:max="200"
+        android:summary="@string/preference_summary_percentage"
+        android:text=" %"
+        android:title="@string/button_size"
+        app:interval="10"
+        app:min="10" />
+    <SwitchPreference
+        android:key="@string/show_large_answer_buttons_preference"
+        android:defaultValue="false"
+        android:summary="@string/show_large_answer_buttons_summ"
+        android:title="@string/show_large_answer_buttons"/>
+</PreferenceScreen>

--- a/AnkiDroid/src/main/res/xml/preferences_appearance.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_appearance.xml
@@ -23,7 +23,7 @@
 <!-- Fonts & Style Preferences -->
 <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://arbitrary.app.namespace/com.ichi2.anki"
-            android:title="@string/pref_cat_appearance"
+        android:title="@string/pref_cat_appearance"
         android:key="appearance_preference_group"
         android:summary="@string/pref_cat_appearance_summ">
     <PreferenceCategory android:title="@string/pref_cat_themes" >
@@ -56,32 +56,74 @@
             android:shouldDisableView="true"
             android:title="@string/choose_an_image" />
     </PreferenceCategory>
-        <PreferenceCategory android:title="@string/pref_cat_fonts" >
-            <ListPreference
-                android:defaultValue="@string/empty_string"
-                android:key="defaultFont"
-                android:shouldDisableView="true"
-                android:title="@string/default_font" />
-            <ListPreference
-                android:defaultValue="0"
-                android:key="overrideFontBehavior"
-                android:entries="@array/override_font_labels"
-                android:entryValues="@array/override_font_values"
-                android:title="@string/override_font" />
-            <ListPreference
-                android:defaultValue="@string/empty_string"
-                android:key="browserEditorFont"
-                android:title="@string/pref_browser_editor_font" />
-            <com.ichi2.preferences.SeekBarPreferenceCompat
-                android:defaultValue="100"
-                android:key="relativeCardBrowserFontSize"
-                android:max="200"
-                android:summary="@string/preference_summary_percentage"
-                android:text=" %"
-                android:title="@string/card_browser_font_size"
-                app:interval="10"
-                app:min="10" />
-        </PreferenceCategory>
+    <PreferenceCategory android:title="@string/pref_cat_reviewer" >
+        <Preference
+            android:summary="@string/custom_buttons_summary"
+            android:title="@string/custom_buttons"
+            android:key="@string/custom_buttons_link_preference"
+            android:fragment="com.ichi2.anki.Preferences$CustomButtonsSettingsFragment" />
+        <ListPreference
+            android:defaultValue="0"
+            android:key="@string/fullscreen_mode_preference"
+            android:entries="@array/full_screen_mode_labels"
+            android:entryValues="@array/full_screen_mode_values"
+            android:title="@string/fullscreen_review" />
+        <SwitchPreference
+            android:defaultValue="false"
+            android:key="@string/center_vertically_preference"
+            android:summary="@string/vertical_centering_summ"
+            android:title="@string/vertical_centering" />
+        <SwitchPreference
+            android:key="@string/show_estimates_preference"
+            android:summary="@string/show_estimates_summ"
+            android:title="@string/show_estimates" />
+        <ListPreference
+            android:defaultValue="bottom"
+            android:entries="@array/answer_buttons_position_labels"
+            android:entryValues="@array/answer_buttons_position"
+            android:key="@string/answer_buttons_position_preference"
+            android:title="@string/answer_buttons_position" />
+        <SwitchPreference
+            android:key="@string/show_topbar_preference"
+            android:defaultValue="true"
+            android:summary="@string/show_top_bar_summ"
+            android:title="@string/show_top_bar" />
+        <SwitchPreference
+            android:key="@string/show_progress_preference"
+            android:summary="@string/show_progress_summ"
+            android:title="@string/show_progress" />
+        <SwitchPreference
+            android:key="@string/show_eta_preference"
+            android:defaultValue="true"
+            android:summary="@string/show_eta_summ"
+            android:title="@string/show_eta" />
+    </PreferenceCategory>
+    <PreferenceCategory android:title="@string/pref_cat_fonts" >
+        <ListPreference
+            android:defaultValue="@string/empty_string"
+            android:key="defaultFont"
+            android:shouldDisableView="true"
+            android:title="@string/default_font" />
+        <ListPreference
+            android:defaultValue="0"
+            android:key="overrideFontBehavior"
+            android:entries="@array/override_font_labels"
+            android:entryValues="@array/override_font_values"
+            android:title="@string/override_font" />
+        <ListPreference
+            android:defaultValue="@string/empty_string"
+            android:key="browserEditorFont"
+            android:title="@string/pref_browser_editor_font" />
+        <com.ichi2.preferences.SeekBarPreferenceCompat
+            android:defaultValue="100"
+            android:key="relativeCardBrowserFontSize"
+            android:max="200"
+            android:summary="@string/preference_summary_percentage"
+            android:text=" %"
+            android:title="@string/card_browser_font_size"
+            app:interval="10"
+            app:min="10" />
+    </PreferenceCategory>
     <PreferenceCategory android:title="@string/card_browser">
         <SwitchPreference
             android:checked="false"

--- a/AnkiDroid/src/main/res/xml/preferences_reviewing.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_reviewing.xml
@@ -132,15 +132,6 @@
             android:summary="@string/show_large_answer_buttons_summ"
             android:title="@string/show_large_answer_buttons"/>
     </PreferenceCategory>
-    <PreferenceCategory android:title="@string/pref_cat_whiteboard" >
-        <com.ichi2.preferences.SeekBarPreferenceCompat
-            android:defaultValue="6"
-            android:key="@string/white_board_stroke_width_preference"
-            android:max="30"
-            android:summary="@string/preference_summary_literal"
-            android:text=""
-            android:title="@string/whiteboard_stroke_width" />
-    </PreferenceCategory>
     <PreferenceCategory android:title="@string/timeout_answer_text" >
         <SwitchPreference
             android:defaultValue="false"

--- a/AnkiDroid/src/main/res/xml/preferences_reviewing.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_reviewing.xml
@@ -24,7 +24,7 @@
 <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://arbitrary.app.namespace/com.ichi2.anki"
     android:title="@string/pref_cat_reviewing"
-    android:summary="@string/pref_cat_reviewing_summ" >
+    android:key="@string/pref_reviewing_screen_key">
     <PreferenceCategory android:title="@string/pref_cat_scheduling" >
         <ListPreference
             android:entries="@array/new_spread_labels"
@@ -52,85 +52,6 @@
             android:title="@string/time_limit"
             app:max="9999"
             app:min="0" />
-    </PreferenceCategory>
-    <PreferenceCategory android:title="@string/pref_cat_flashcard" >
-        <Preference
-            android:summary="@string/custom_buttons_summary"
-            android:title="@string/custom_buttons"
-            android:key="@string/custom_buttons_link_preference"
-            android:fragment="com.ichi2.anki.Preferences$CustomButtonsSettingsFragment" />
-        <SwitchPreference
-            android:defaultValue="false"
-            android:key="@string/keep_screen_on_preference"
-            android:summary="@string/pref_keep_screen_on_summ"
-            android:title="@string/pref_keep_screen_on" />
-        <ListPreference
-            android:defaultValue="0"
-            android:key="@string/fullscreen_mode_preference"
-            android:entries="@array/full_screen_mode_labels"
-            android:entryValues="@array/full_screen_mode_values"
-            android:title="@string/fullscreen_review" />
-        <SwitchPreference
-            android:defaultValue="false"
-            android:key="@string/center_vertically_preference"
-            android:summary="@string/vertical_centering_summ"
-            android:title="@string/vertical_centering" />
-        <SwitchPreference
-            android:key="@string/show_estimates_preference"
-            android:summary="@string/show_estimates_summ"
-            android:title="@string/show_estimates" />
-        <com.ichi2.preferences.SeekBarPreferenceCompat
-            android:defaultValue="100"
-            android:key="@string/card_zoom_preference"
-            android:max="300"
-            android:summary="@string/preference_summary_percentage"
-            android:text=" %"
-            android:title="@string/card_zoom"
-            app:interval="10"
-            app:min="10" />
-        <com.ichi2.preferences.SeekBarPreferenceCompat
-            android:defaultValue="100"
-            android:key="@string/image_zoom_preference"
-            android:max="300"
-            android:summary="@string/preference_summary_percentage"
-            android:text=" %"
-            android:title="@string/image_zoom"
-            app:interval="10"
-            app:min="50" />
-        <com.ichi2.preferences.SeekBarPreferenceCompat
-            android:defaultValue="100"
-            android:key="@string/answer_button_size_preference"
-            android:max="200"
-            android:summary="@string/preference_summary_percentage"
-            android:text=" %"
-            android:title="@string/button_size"
-            app:interval="10"
-            app:min="10" />
-        <ListPreference
-            android:defaultValue="bottom"
-            android:entries="@array/answer_buttons_position_labels"
-            android:entryValues="@array/answer_buttons_position"
-            android:key="@string/answer_buttons_position_preference"
-            android:title="@string/answer_buttons_position" />
-        <SwitchPreference
-            android:key="@string/show_topbar_preference"
-            android:defaultValue="true"
-            android:summary="@string/show_top_bar_summ"
-            android:title="@string/show_top_bar" />
-        <SwitchPreference
-            android:key="@string/show_progress_preference"
-            android:summary="@string/show_progress_summ"
-            android:title="@string/show_progress" />
-        <SwitchPreference
-            android:key="@string/show_eta_preference"
-            android:defaultValue="true"
-            android:summary="@string/show_eta_summ"
-            android:title="@string/show_eta" />
-        <SwitchPreference
-            android:key="@string/show_large_answer_buttons_preference"
-            android:defaultValue="false"
-            android:summary="@string/show_large_answer_buttons_summ"
-            android:title="@string/show_large_answer_buttons"/>
     </PreferenceCategory>
     <PreferenceCategory android:title="@string/timeout_answer_text" >
         <SwitchPreference
@@ -162,6 +83,11 @@
             android:title="@string/timeout_question_seconds" />
     </PreferenceCategory>
     <PreferenceCategory android:title="@string/pref_cat_advanced">
+        <SwitchPreference
+            android:defaultValue="false"
+            android:key="@string/keep_screen_on_preference"
+            android:summary="@string/pref_keep_screen_on_summ"
+            android:title="@string/pref_keep_screen_on" />
         <SwitchPreference
             android:key="@string/new_timezone_handling_preference"
             android:title="@string/new_timezone"

--- a/AnkiDroid/src/main/res/xml/preferences_reviewing.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_reviewing.xml
@@ -52,18 +52,6 @@
             android:title="@string/time_limit"
             app:max="9999"
             app:min="0" />
-        <SwitchPreference
-            android:key="@string/new_timezone_handling_preference"
-            android:title="@string/new_timezone"
-            android:defaultValue="false" />
-        <com.ichi2.preferences.NumberRangePreferenceCompat
-            android:defaultValue="200"
-            android:key="@string/double_tap_time_interval_preference"
-            android:summary="@string/pref_double_tap_time_interval_summary"
-            android:title="@string/pref_double_tap_time_interval"
-            app:min="0"
-            app:max="2000" />
-
     </PreferenceCategory>
     <PreferenceCategory android:title="@string/pref_cat_flashcard" >
         <Preference
@@ -181,5 +169,18 @@
             android:max="60"
             android:summary="@string/timeout_answer_seconds_summ"
             android:title="@string/timeout_question_seconds" />
+    </PreferenceCategory>
+    <PreferenceCategory android:title="@string/pref_cat_advanced">
+        <SwitchPreference
+            android:key="@string/new_timezone_handling_preference"
+            android:title="@string/new_timezone"
+            android:defaultValue="false" />
+        <com.ichi2.preferences.NumberRangePreferenceCompat
+            android:defaultValue="200"
+            android:key="@string/double_tap_time_interval_preference"
+            android:summary="@string/pref_double_tap_time_interval_summary"
+            android:title="@string/pref_double_tap_time_interval"
+            app:min="0"
+            app:max="2000" />
     </PreferenceCategory>
 </PreferenceScreen>

--- a/AnkiDroid/src/main/res/xml/preferences_reviewing.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_reviewing.xml
@@ -25,7 +25,7 @@
     xmlns:app="http://arbitrary.app.namespace/com.ichi2.anki"
     android:title="@string/pref_cat_reviewing"
     android:summary="@string/pref_cat_reviewing_summ" >
-    <PreferenceCategory android:title="@string/pref_cat_reviewer_behaviour" >
+    <PreferenceCategory android:title="@string/pref_cat_scheduling" >
         <ListPreference
             android:entries="@array/new_spread_labels"
             android:entryValues="@array/new_spread_values"


### PR DESCRIPTION
## Approach
1. Move `New time zone handling` and `Double tap time` to a subcategory called `Advanced`
2. Rename `behavior` subcategory to `scheduling`
3. Remove Whiteboard stroke width preference
4. Create a new subcategory called `Accessibility` on Appearance and move some of the reviewing preferences there
5. Create a new subcategory called `Reviewer` on Appearance and move some of the reviewing preferences there
6. Build Reviewing category from other strings


https://user-images.githubusercontent.com/69634269/174076398-4c62ad02-a4a0-4dc7-bcbb-13d951e68d25.mp4



## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
