### PR TITLE
Enable DrawAllocation lint check

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/stats/ChartView.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/stats/ChartView.kt
@@ -23,6 +23,7 @@ import android.graphics.Rect
 import android.util.AttributeSet
 import android.view.View
 import com.ichi2.anki.Statistics.ChartFragment
+import com.ichi2.utils.KotlinCleanup
 import com.wildplot.android.rendering.PlotSheet
 import com.wildplot.android.rendering.graphics.wrapper.GraphicsWrap
 import timber.log.Timber
@@ -31,6 +32,10 @@ class ChartView : View {
     private var mFragment: ChartFragment? = null
     private var mPlotSheet: PlotSheet? = null
     private var mDataIsSet = false
+    @KotlinCleanup("is this really needed?")
+    private val drawingBoundsRect = Rect()
+    private val paint = Paint(Paint.LINEAR_TEXT_FLAG)
+    private val graphicsWrap = GraphicsWrap()
 
     // The following constructors are needed for the layout inflater
     constructor(context: Context?) : super(context) {
@@ -49,17 +54,16 @@ class ChartView : View {
         // Timber.d("drawing chart");
         if (mDataIsSet) {
             // Paint paint = new Paint(Paint.LINEAR_TEXT_FLAG | Paint.ANTI_ALIAS_FLAG);
-            val paint = Paint(Paint.LINEAR_TEXT_FLAG)
-            paint.isAntiAlias = true
-            paint.style = Paint.Style.STROKE
-            val g = GraphicsWrap(canvas, paint)
-            val field = Rect()
-            getDrawingRect(field)
-            if (mPlotSheet != null) {
-                mPlotSheet!!.paint(g)
-            } else {
-                super.onDraw(canvas)
+            paint.apply {
+                reset()
+                isAntiAlias = true
+                style = Paint.Style.STROKE
             }
+            graphicsWrap.paint = paint
+            graphicsWrap.canvas = canvas
+            drawingBoundsRect.setEmpty()
+            getDrawingRect(drawingBoundsRect)
+            mPlotSheet?.paint(graphicsWrap) ?: super.onDraw(canvas)
         } else {
             super.onDraw(canvas)
         }

--- a/AnkiDroid/src/main/java/com/wildplot/android/rendering/graphics/wrapper/GraphicsWrap.kt
+++ b/AnkiDroid/src/main/java/com/wildplot/android/rendering/graphics/wrapper/GraphicsWrap.kt
@@ -22,11 +22,17 @@ import android.graphics.RectF
 import android.graphics.Typeface
 
 /**
- * Wrapper of swing/awt graphics class for android use
+ * Wrapper of swing/awt graphics class for android use.
+ *
+ * NOTE: for performance reasons(usage in onDraw) this class has declared dependencies on Paint and
+ * Canvas which must be manually supplied before using any of its properties/methods.
  *
  * @author Michael Goldbach
  */
-class GraphicsWrap(private val canvas: Canvas, val paint: Paint) {
+class GraphicsWrap {
+    lateinit var canvas: Canvas
+    lateinit var paint: Paint
+
     var stroke: StrokeWrap
         get() = StrokeWrap(paint.strokeWidth)
         set(stroke) {

--- a/lint-release.xml
+++ b/lint-release.xml
@@ -58,6 +58,7 @@
     <issue id="TextFields" severity="fatal" />
     <issue id="LogConditional" severity="fatal" />
     <issue id="ImplicitSamInstance" severity="fatal" />
+    <issue id="DrawAllocation" severity="fatal" />
 
     <!-- this is new with AGP7.1+, does not appear to create value -->
     <issue id="IntentFilterUniqueDataAttributes" severity="ignore" />
@@ -211,7 +212,6 @@
     <issue id="TrustAllX509TrustManager" severity="ignore" />
     <issue id="InvalidImeActionId" severity="ignore" />
     <issue id="InvalidPackage" severity="ignore" />
-    <issue id="DrawAllocation" severity="ignore" />
     <issue id="UseSparseArrays" severity="ignore" />
     <issue id="UseValueOf" severity="ignore" />
     <issue id="JavascriptInterface" severity="ignore" />


### PR DESCRIPTION
## Purpose / Description

This PR enables the DrawAllocation lint check. There were violations in ChartView.onDraw(), I moved the instantiations outside the method and  setup the objects to be reset every onDraw call. I changed GraphicsWrap's constructor to have the constructor properties as lateinit, this should be fine as the class is only used from onDraw() and it's also stateless.
## Fixes

Closes #10488 
Closes #10499

## Approach
_How does this change address the problem?_

## How Has This Been Tested?

Ran the usual tests.

## Checklist

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
