### PR TITLE
Enable MergeRootFrame lint check

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
@@ -923,7 +923,6 @@ abstract class AbstractFlashcardViewer :
     // Set the content view to the one provided and initialize accessors.
     @KotlinCleanup("Move a lot of these to onCreate()")
     protected open fun initLayout() {
-        val cardContainer = findViewById<FrameLayout>(R.id.flashcard_frame)
         mTopBarLayout = findViewById(R.id.top_bar)
         mCardFrame = findViewById(R.id.flashcard)
         mCardFrameParent = mCardFrame!!.parent as ViewGroup
@@ -979,18 +978,27 @@ abstract class AbstractFlashcardViewer :
         )
         val answerArea = findViewById<LinearLayout>(R.id.bottom_area_layout)
         val answerAreaParams = answerArea.layoutParams as RelativeLayout.LayoutParams
-        val cardContainerParams = cardContainer.layoutParams as RelativeLayout.LayoutParams
+        val whiteboardContainer = findViewById<FrameLayout>(R.id.whiteboard)
+        val whiteboardContainerParams = whiteboardContainer.layoutParams as RelativeLayout.LayoutParams
+        val flashcardContainerParams = mCardFrame!!.layoutParams as RelativeLayout.LayoutParams
+        val touchLayerContainerParams = mTouchLayer!!.layoutParams as RelativeLayout.LayoutParams
         when (answerButtonsPosition) {
             "top" -> {
-                cardContainerParams.addRule(RelativeLayout.BELOW, R.id.bottom_area_layout)
+                whiteboardContainerParams.addRule(RelativeLayout.BELOW, R.id.bottom_area_layout)
+                flashcardContainerParams.addRule(RelativeLayout.BELOW, R.id.bottom_area_layout)
+                touchLayerContainerParams.addRule(RelativeLayout.BELOW, R.id.bottom_area_layout)
                 answerAreaParams.addRule(RelativeLayout.BELOW, R.id.mic_tool_bar_layer)
                 answerArea.removeView(mAnswerField)
                 answerArea.addView(mAnswerField, 1)
                 answerArea.visibility = View.VISIBLE
             }
             "bottom" -> {
-                cardContainerParams.addRule(RelativeLayout.ABOVE, R.id.bottom_area_layout)
-                cardContainerParams.addRule(RelativeLayout.BELOW, R.id.mic_tool_bar_layer)
+                whiteboardContainerParams.addRule(RelativeLayout.ABOVE, R.id.bottom_area_layout)
+                whiteboardContainerParams.addRule(RelativeLayout.BELOW, R.id.mic_tool_bar_layer)
+                flashcardContainerParams.addRule(RelativeLayout.ABOVE, R.id.bottom_area_layout)
+                flashcardContainerParams.addRule(RelativeLayout.BELOW, R.id.mic_tool_bar_layer)
+                touchLayerContainerParams.addRule(RelativeLayout.ABOVE, R.id.bottom_area_layout)
+                touchLayerContainerParams.addRule(RelativeLayout.BELOW, R.id.mic_tool_bar_layer)
                 answerAreaParams.addRule(RelativeLayout.ALIGN_PARENT_BOTTOM)
                 answerArea.visibility = View.VISIBLE
             }
@@ -998,7 +1006,9 @@ abstract class AbstractFlashcardViewer :
             else -> Timber.w("Unknown answerButtonsPosition: %s", answerButtonsPosition)
         }
         answerArea.layoutParams = answerAreaParams
-        cardContainer.layoutParams = cardContainerParams
+        whiteboardContainer.layoutParams = whiteboardContainerParams
+        mCardFrame!!.layoutParams = flashcardContainerParams
+        mTouchLayer!!.layoutParams = touchLayerContainerParams
     }
 
     @SuppressLint("SetJavaScriptEnabled") // they request we review carefully because of XSS security, we have

--- a/AnkiDroid/src/main/res/layout/activity_load_pronounciation.xml
+++ b/AnkiDroid/src/main/res/layout/activity_load_pronounciation.xml
@@ -1,5 +1,13 @@
+<!--
+NOTE: tools:ignore="MergeRootFrame" was added preemptively to temporarily quiet lint when
+MergeRootFrame is enabled later(until LoadPronunciationActivity is refactored and the views which
+it manually creates in its onCreate are moved to this layout(the root layout will then need to
+change from a FrameLayout and render this MergeRootFrame issue irrelevant))
+ -->
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
+    tools:ignore="MergeRootFrame"
     android:layout_height="match_parent">
 
     <LinearLayout

--- a/AnkiDroid/src/main/res/layout/reviewer_flashcard.xml
+++ b/AnkiDroid/src/main/res/layout/reviewer_flashcard.xml
@@ -21,17 +21,12 @@
 ~ this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
 
-<FrameLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
-    android:layout_gravity="center"
-    android:id="@+id/flashcard_frame"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:layout_margin="0dip">
+<merge xmlns:android="http://schemas.android.com/apk/res/android">
 
     <FrameLayout
         android:layout_gravity="center"
         android:id="@+id/flashcard"
+        android:layout_margin="0dip"
         android:layout_width="match_parent"
         android:layout_height="match_parent" />
     <FrameLayout
@@ -47,4 +42,4 @@
         android:layout_margin="0dip"
         android:layout_width="match_parent"
         android:layout_height="match_parent" />
-</FrameLayout>
+</merge>

--- a/AnkiDroid/src/main/res/layout/reviewer_flashcard_fullscreen.xml
+++ b/AnkiDroid/src/main/res/layout/reviewer_flashcard_fullscreen.xml
@@ -15,12 +15,7 @@
 ~ this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
 
-<FrameLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
-    android:layout_gravity="center"
-    android:id="@+id/flashcard_frame"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent">
+<merge xmlns:android="http://schemas.android.com/apk/res/android">
     <FrameLayout
         android:layout_gravity="center"
         android:id="@+id/flashcard"
@@ -37,4 +32,4 @@
         android:id="@+id/whiteboard"
         android:layout_width="match_parent"
         android:layout_height="match_parent" />
-</FrameLayout>
+</merge>

--- a/AnkiDroid/src/main/res/layout/reviewer_flashcard_fullscreen_noanswers.xml
+++ b/AnkiDroid/src/main/res/layout/reviewer_flashcard_fullscreen_noanswers.xml
@@ -15,12 +15,7 @@
 ~ this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
 
-<FrameLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
-    android:layout_gravity="center"
-    android:id="@+id/flashcard_frame"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent">
+<merge xmlns:android="http://schemas.android.com/apk/res/android">
 
     <FrameLayout
         android:layout_gravity="center"
@@ -38,4 +33,4 @@
         android:id="@+id/whiteboard"
         android:layout_width="match_parent"
         android:layout_height="match_parent" />
-</FrameLayout>
+</merge>

--- a/AnkiDroid/src/main/res/layout/reviewer_fullscreen_noanswers.xml
+++ b/AnkiDroid/src/main/res/layout/reviewer_fullscreen_noanswers.xml
@@ -14,7 +14,10 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content" />
 
-        <include layout="@layout/reviewer_flashcard_fullscreen_noanswers" />
+        <include
+            layout="@layout/reviewer_flashcard_fullscreen_noanswers"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content" />
         <!-- Controls that are overlaid over the main content when the user interrupts immersive mode -->
         <RelativeLayout
             android:id="@+id/front_frame"

--- a/lint-release.xml
+++ b/lint-release.xml
@@ -48,6 +48,7 @@
     <issue id="UselessParent" severity="fatal" />
     <issue id="ObsoleteLayoutParam" severity="fatal" />
     <issue id="ObsoleteSdkInt" severity="fatal" />
+    <issue id="MergeRootFrame" severity="fatal" />
 
     <!--           RTL Rules               -->
     <issue id="RtlCompat" severity="fatal" />
@@ -250,7 +251,6 @@
     <issue id="ManifestResource" severity="ignore" />
     <issue id="ManifestTypo" severity="ignore" />
     <issue id="MergeMarker" severity="ignore" />
-    <issue id="MergeRootFrame" severity="ignore" />
     <issue id="IncompatibleMediaBrowserServiceCompatVersion" severity="ignore" />
     <issue id="InnerclassSeparator" severity="ignore" />
     <issue id="Instantiatable" severity="ignore" />


### PR DESCRIPTION
## Purpose / Description

This PR enables the MergeRootFrame lint check. There were some violations:

- activity_load_pronunciation.xml  I suppresed this violation as it will become invalid in the future. At this moment LoadPronunciationActiviy creates some views in its onCreate() method and then adds them to this layout, those views can and should be added directly to the layout which will make the current violation invalid
- reviewer_*.xml switched to using the merge tag. The replaced FrameLayout had the role of taking placement layout rules according to the user settings, after replacing it with the merge tag I replicated taking those layout rules for each of the child views.

## Fixes

Closes #10502 
Closes #10550 

## How Has This Been Tested?

Ran the usual tests. I tested the reviewer layouts and the functionality seems the same.

## Checklist

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
