### PR TITLE
Fix `follow system dark mode` on custom/auto schedule

### DIFF
--- a/AnkiDroid/src/main/AndroidManifest.xml
+++ b/AnkiDroid/src/main/AndroidManifest.xml
@@ -173,13 +173,13 @@
             android:name="com.ichi2.anki.DeckPicker"
             android:theme="@style/Theme_Dark_Compat.Launcher"
             android:exported="false"
-            android:configChanges="keyboardHidden|orientation|screenSize|locale"
+            android:configChanges="keyboardHidden|orientation|screenSize|locale|uiMode"
             />
         <activity
             android:name="com.ichi2.anki.StudyOptionsActivity"
             android:label="StudyOptions"
             android:exported="false"
-            android:configChanges="keyboardHidden|locale|orientation|screenSize"
+            android:configChanges="keyboardHidden|locale|orientation|screenSize|uiMode"
             android:parentActivityName=".DeckPicker"
             >
         </activity>
@@ -203,7 +203,7 @@
             android:label="@string/card_browser"
             android:theme="@style/Theme_Dark_Compat.Launcher"
             android:exported="true"
-            android:configChanges="keyboardHidden|orientation|locale|screenSize"
+            android:configChanges="keyboardHidden|orientation|locale|screenSize|uiMode"
             android:parentActivityName=".DeckPicker"
             >
         </activity>
@@ -211,18 +211,18 @@
             android:name=".ModelBrowser"
             android:label="@string/model_browser_label"
             android:exported="false"
-            android:configChanges="keyboardHidden|orientation|locale|screenSize"
+            android:configChanges="keyboardHidden|orientation|locale|screenSize|uiMode"
             />
         <activity
             android:name=".ModelFieldEditor"
             android:label="@string/model_editor_label"
-            android:configChanges="keyboardHidden|orientation|locale|screenSize"
+            android:configChanges="keyboardHidden|orientation|locale|screenSize|uiMode"
             />
         <activity
             android:name="com.ichi2.anki.Reviewer"
             android:exported="true"
             android:theme="@style/Theme_Dark_Compat.Launcher"
-            android:configChanges="keyboardHidden|orientation|locale|screenSize"
+            android:configChanges="keyboardHidden|orientation|locale|screenSize|uiMode"
             android:windowSoftInputMode="adjustResize"
             android:parentActivityName=".DeckPicker">
             <intent-filter>
@@ -233,20 +233,20 @@
         <activity
             android:name="com.ichi2.anki.VideoPlayer"
             android:exported="false"
-            android:configChanges="keyboardHidden|orientation|locale|screenSize"
+            android:configChanges="keyboardHidden|orientation|locale|screenSize|uiMode"
             android:theme="@android:style/Theme.NoTitleBar.Fullscreen"
             />
         <activity
             android:name="com.ichi2.anki.MyAccount"
             android:label="@string/menu_my_account"
             android:exported="false"
-            android:configChanges="keyboardHidden|orientation|locale|screenSize"
+            android:configChanges="keyboardHidden|orientation|locale|screenSize|uiMode"
             />
         <activity
             android:name="com.ichi2.anki.Preferences"
             android:label="@string/preferences_title"
             android:exported="false"
-            android:configChanges="keyboardHidden|orientation|locale|screenSize"
+            android:configChanges="keyboardHidden|orientation|locale|screenSize|uiMode"
             android:theme="@style/LegacyActionBarLight"
             >
             <intent-filter>
@@ -257,21 +257,21 @@
             android:name="com.ichi2.anki.DeckOptions"
             android:label="@string/deckpreferences_title"
             android:exported="false"
-            android:configChanges="keyboardHidden|orientation|locale|screenSize"
+            android:configChanges="keyboardHidden|orientation|locale|screenSize|uiMode"
             android:theme="@style/LegacyActionBarLight"
             />
         <activity
             android:name=".FilteredDeckOptions"
             android:label="@string/deckpreferences_title"
             android:exported="false"
-            android:configChanges="keyboardHidden|orientation|locale|screenSize"
+            android:configChanges="keyboardHidden|orientation|locale|screenSize|uiMode"
             android:theme="@style/LegacyActionBarLight"
             />
         <activity
             android:name="com.ichi2.anki.Info"
             android:label="@string/about_title"
             android:exported="false"
-            android:configChanges="locale"
+            android:configChanges="locale|uiMode"
             />
 
         <activity-alias
@@ -291,7 +291,7 @@
             android:label="@string/fact_adder_intent_title"
             android:theme="@style/Theme_Dark_Compat.Launcher"
             android:exported="true"
-            android:configChanges="keyboardHidden|orientation|locale|screenSize"
+            android:configChanges="keyboardHidden|orientation|locale|screenSize|uiMode"
             >
             <intent-filter>
                 <action android:name="org.openintents.action.CREATE_FLASHCARD" />
@@ -306,7 +306,7 @@
         <activity
             android:name="com.canhub.cropper.CropImageActivity"
             android:exported="true"
-            android:configChanges="keyboardHidden|orientation|locale|screenSize"
+            android:configChanges="keyboardHidden|orientation|locale|screenSize|uiMode"
             android:theme="@style/Base.Theme.AppCompat" />
         <activity
             android:name="com.ichi2.anki.analytics.AnkiDroidCrashReportDialog"
@@ -319,7 +319,7 @@
         <activity
             android:name="com.ichi2.anki.Statistics"
             android:exported="false"
-            android:configChanges="keyboardHidden|orientation|locale|screenSize"
+            android:configChanges="keyboardHidden|orientation|locale|screenSize|uiMode"
             android:parentActivityName=".DeckPicker"
             >
         </activity>
@@ -327,33 +327,33 @@
             android:name="com.ichi2.anki.Previewer"
             android:label="@string/preview_title"
             android:exported="false"
-            android:configChanges="locale"
+            android:configChanges="locale|uiMode"
             />
         <activity
             android:name="com.ichi2.anki.CardTemplatePreviewer"
             android:label="@string/preview_title"
             android:exported="false"
-            android:configChanges="locale"
+            android:configChanges="locale|uiMode"
             />
         <activity
             android:name=".multimediacard.activity.MultimediaEditFieldActivity"
             android:label="@string/title_activity_edit_text"
             android:exported="false"
-            android:configChanges="keyboardHidden|orientation|locale|screenSize"
+            android:configChanges="keyboardHidden|orientation|locale|screenSize|uiMode"
             >
         </activity>
         <activity
             android:name="com.ichi2.anki.multimediacard.activity.LoadPronunciationActivity"
             android:label="@string/multimedia_editor_text_field_editing_say"
             android:exported="false"
-            android:configChanges="keyboardHidden|orientation|locale|screenSize"
+            android:configChanges="keyboardHidden|orientation|locale|screenSize|uiMode"
             >
         </activity>
         <activity
             android:name="com.ichi2.anki.CardTemplateEditor"
             android:label="@string/title_activity_template_editor"
             android:exported="false"
-            android:configChanges="keyboardHidden|orientation|locale|screenSize"
+            android:configChanges="keyboardHidden|orientation|locale|screenSize|uiMode"
             android:windowSoftInputMode="stateAlwaysHidden|adjustPan"
             >
         </activity>
@@ -361,17 +361,17 @@
             android:name=".CardTemplateBrowserAppearanceEditor"
             android:label="@string/card_template_browser_appearance_title"
             android:exported="false"
-            android:configChanges="keyboardHidden|orientation|locale|screenSize"
+            android:configChanges="keyboardHidden|orientation|locale|screenSize|uiMode"
             />
         <activity
             android:name=".CardInfo"
             android:label="@string/card_info_title"
             android:exported="false"
-            android:configChanges="keyboardHidden|orientation|locale|screenSize"
+            android:configChanges="keyboardHidden|orientation|locale|screenSize|uiMode"
             />
         <activity
             android:name=".SharedDecksActivity"
-            android:configChanges="keyboardHidden|orientation|screenSize|locale"
+            android:configChanges="keyboardHidden|orientation|screenSize|locale|uiMode"
             android:label="@string/download_deck"
             android:theme="@style/Theme.MaterialComponents.NoActionBar" />
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiActivity.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiActivity.java
@@ -8,6 +8,7 @@ import android.content.ActivityNotFoundException;
 import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
+import android.content.res.Configuration;
 import android.graphics.BitmapFactory;
 import android.graphics.Color;
 import android.media.AudioManager;
@@ -51,6 +52,7 @@ import com.ichi2.compat.customtabs.CustomTabsFallback;
 import com.ichi2.compat.customtabs.CustomTabsHelper;
 import com.ichi2.libanki.Collection;
 import com.ichi2.libanki.CollectionGetter;
+import com.ichi2.libanki.Config;
 import com.ichi2.themes.Themes;
 import com.ichi2.utils.AdaptionUtil;
 import com.ichi2.utils.AndroidUiUtils;
@@ -126,6 +128,17 @@ public class AnkiActivity extends AppCompatActivity implements SimpleMessageDial
         Timber.i("AnkiActivity::onStop - %s", mActivityName);
         super.onStop();
         mCustomTabActivityHelper.unbindCustomTabsService(this);
+    }
+
+    @Override
+    public void onConfigurationChanged(@NonNull Configuration newConfig) {
+        super.onConfigurationChanged(newConfig);
+        boolean newNightModeStatus = (newConfig.uiMode & Configuration.UI_MODE_NIGHT_MASK) == Configuration.UI_MODE_NIGHT_YES;
+        // Check if system night mode has changed
+        if (Themes.systemIsInNightMode != newNightModeStatus) {
+            Themes.systemIsInNightMode = newNightModeStatus;
+            restartActivity();
+        }
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.kt
@@ -911,14 +911,14 @@ class Preferences : AnkiActivity() {
             }
 
             dayThemePref.setOnPreferenceChangeListener { _, newValue ->
-                if (newValue != dayThemePref.value && !systemIsInNightMode(requireContext())) {
+                if (newValue != dayThemePref.value && !systemIsInNightMode) {
                     restartActivityOnBackStackTop()
                 }
                 true
             }
 
             nightThemePref.setOnPreferenceChangeListener { _, newValue ->
-                if (newValue != nightThemePref.value && systemIsInNightMode(requireContext())) {
+                if (newValue != nightThemePref.value && systemIsInNightMode) {
                     restartActivityOnBackStackTop()
                 }
                 true

--- a/AnkiDroid/src/main/java/com/ichi2/themes/Themes.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/themes/Themes.kt
@@ -18,13 +18,12 @@
 
 package com.ichi2.themes
 
-import android.app.UiModeManager
 import android.content.Context
+import android.content.res.Configuration
 import androidx.annotation.StringDef
 import androidx.core.content.ContextCompat
 import com.ichi2.anki.AnkiDroidApp
 import com.ichi2.anki.R
-import timber.log.Timber
 
 /**
  * Handles the user selectable themes
@@ -37,6 +36,10 @@ object Themes {
     const val ALPHA_ICON_ENABLED_LIGHT = 255 // 100%
     const val ALPHA_ICON_DISABLED_LIGHT = 76 // 31%
     const val ALPHA_ICON_ENABLED_DARK = 138 // 54%
+
+    @JvmField
+    var systemIsInNightMode: Boolean = AnkiDroidApp.getInstance().resources.configuration.uiMode
+        .and(Configuration.UI_MODE_NIGHT_MASK) == Configuration.UI_MODE_NIGHT_YES
 
     // Themes preferences keys
     private const val APP_THEME_KEY = "appTheme"
@@ -79,7 +82,7 @@ object Themes {
     fun setTheme(context: Context) {
         val prefs = AnkiDroidApp.getSharedPrefs(context.applicationContext)
         if (themeFollowsSystem(context)) {
-            if (systemIsInNightMode(context)) {
+            if (systemIsInNightMode) {
                 when (prefs.getString(NIGHT_THEME_KEY, NIGHT_BLACK_THEME)) {
                     NIGHT_BLACK_THEME -> context.setTheme(R.style.Theme_Black_Compat)
                     NIGHT_DARK_THEME -> context.setTheme(R.style.Theme_Dark_Compat)
@@ -110,7 +113,7 @@ object Themes {
         val applicationContext = context.applicationContext
         val prefs = AnkiDroidApp.getSharedPrefs(applicationContext)
         if (themeFollowsSystem(applicationContext)) {
-            if (systemIsInNightMode(applicationContext)) {
+            if (systemIsInNightMode) {
                 when (prefs.getString(NIGHT_THEME_KEY, NIGHT_BLACK_THEME)) {
                     NIGHT_BLACK_THEME -> context.setTheme(R.style.LegacyActionBarBlack)
                     NIGHT_DARK_THEME -> context.setTheme(R.style.LegacyActionBarDark)
@@ -183,7 +186,7 @@ object Themes {
     fun getCurrentTheme(context: Context): String {
         val prefs = AnkiDroidApp.getSharedPrefs(context)
         if (themeFollowsSystem(context)) {
-            if (systemIsInNightMode(context)) {
+            if (systemIsInNightMode) {
                 when (prefs.getString(NIGHT_THEME_KEY, NIGHT_BLACK_THEME)) {
                     NIGHT_BLACK_THEME -> return APP_BLACK_THEME
                     NIGHT_DARK_THEME -> return APP_DARK_THEME
@@ -196,19 +199,6 @@ object Themes {
             }
         }
         return prefs.getString(APP_THEME_KEY, APP_LIGHT_THEME)!!
-    }
-
-    /**
-     * @return if user system is in night mode
-     */
-    @JvmStatic
-    fun systemIsInNightMode(context: Context): Boolean {
-        val uiModeManager = ContextCompat.getSystemService(context, UiModeManager::class.java)
-        if (uiModeManager != null) {
-            return uiModeManager.nightMode == UiModeManager.MODE_NIGHT_YES
-        }
-        Timber.w("Unable to getSystemService() - UIModeManager")
-        return false
     }
 
     /**


### PR DESCRIPTION
## Purpose / Description
Beta is coming, time to pay for my sins and fix my errors.

## Fixes
Fixes #10619

## Approach
On learning ↓

## How Has This Been Tested?


https://user-images.githubusercontent.com/69634269/172047099-361b80e6-3e25-4c4e-9519-1c2afa398be8.mp4



## Learning (optional, can help others)

If you want to create a light/dark theme, you just need to use one of the `.DayNight` theme variantes as your theme's parent, then create a `values-night` (even Google is inconsitent with `light/dark` and `day/night` naming) folder where you should put your dark variant of the theme, which should have the same name of the light one.

Then use https://developer.android.com/reference/androidx/appcompat/app/AppCompatDelegate#setDefaultNightMode(int) to tell if you want to follow system, always light or always dark

This works quite well if you ***DON'T want to mix themes***, i.e. your light theme will always be paired with the same night theme

If that's not your case, like it's not ours (we want the user to use any theme combinations they want), you have to detect yourself which mode the system is on. You just need to do this:
```kotlin
context.resources.configuration.uiMode.and(Configuration.UI_MODE_NIGHT_MASK) == Configuration.UI_MODE_NIGHT_YES
```
Some apps use it and it works like a charm.

BBBBBBBBBBuuuuuuuuuut, for some reason it doesn't work perfectly on AnkiDroid, yaaaaaaaaayyyyyyyyyyy. The problem is that `uiMode` isn't updated if `dark mode` is changed and AnkiDroid is open and I don't know why.
- As I said, it works on other apps and on a dummy project as well
- Not a context level problem (tested with context, applicationContext and baseContext)
- Not a lifecycle problem (doesn't matter if it's `onCreate`, before `setContentView` or whatever)

So to fix it, I relied on `uiModeManager`, which does update with `dark mode` changes. But `uiModeManager` is an older API that can't tell if `auto` or `custom` schedule is using light or dark mode. Therefore, `uiMode` still to be used on these cases. Now auto/custom schedule will work, which is some progress, with the caveat of having to reopen the app if the user changes to them while the app is open.

The result isn't the ideal one, but will handle most of the cases, so I consider it a step forward

P.S.: IMHO, definetely not a pleasant API

P.S.2: Now that I look again at it after 2 months, my code isn't pleasant as well. Should be refactoring it as well soon because I need some themes tweaks to my preferences project

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
