### PR TITLE
fix: exit message when using the review shortcut

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
@@ -489,6 +489,11 @@ abstract class AbstractFlashcardViewer :
             val nextCardAndResult = result.value
             if (nextCardAndResult.hasNoMoreCards()) {
                 closeReviewer(RESULT_NO_MORE_CARDS, true)
+
+                // When launched with a shortcut, we want to display a message when finishing
+                if (intent.getBooleanExtra(EXTRA_STARTED_WITH_SHORTCUT, false)) {
+                    showThemedToast(baseContext, R.string.studyoptions_congrats_finished, false)
+                }
                 return
             }
             currentCard = nextCardAndResult.nextScheduledCard()

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NavigationDrawerActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NavigationDrawerActivity.kt
@@ -404,6 +404,8 @@ abstract class NavigationDrawerActivity :
         const val REQUEST_STATISTICS = 102
         const val FULL_SCREEN_NAVIGATION_DRAWER = "gestureFullScreenNavigationDrawer"
 
+        const val EXTRA_STARTED_WITH_SHORTCUT = "com.ichi2.anki.StartedWithShortcut"
+
         @TargetApi(Build.VERSION_CODES.N_MR1)
         fun enablePostShortcut(context: Context) {
             if (Build.VERSION.SDK_INT < Build.VERSION_CODES.N_MR1) {
@@ -415,6 +417,7 @@ abstract class NavigationDrawerActivity :
             val intentReviewCards = Intent(context, Reviewer::class.java)
             intentReviewCards.action = Intent.ACTION_VIEW
             intentReviewCards.flags = Intent.FLAG_ACTIVITY_CLEAR_TASK
+            intentReviewCards.putExtra(EXTRA_STARTED_WITH_SHORTCUT, true)
             val reviewCardsShortcut = ShortcutInfo.Builder(context, "reviewCardsShortcutId")
                 .setShortLabel(context.getString(R.string.studyoptions_start))
                 .setLongLabel(context.getString(R.string.studyoptions_start))

--- a/AnkiDroid/src/test/java/com/ichi2/anki/AbstractFlashcardViewerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/AbstractFlashcardViewerTest.kt
@@ -36,6 +36,7 @@ import org.junit.runner.RunWith
 import org.mockito.Mockito.*
 import org.robolectric.Robolectric
 import org.robolectric.android.controller.ActivityController
+import org.robolectric.shadows.ShadowToast
 import java.util.*
 import java.util.stream.Stream
 
@@ -196,7 +197,7 @@ class AbstractFlashcardViewerTest : RobolectricTest() {
 
     @Test
     fun automaticAnswerDisabledProperty() {
-        val controller = getViewerController(true)
+        val controller = getViewerController(true, false)
         val viewer = controller.get()
         assertThat("not disabled initially", viewer.mAutomaticAnswer.isDisabled, equalTo(false))
         controller.pause()
@@ -207,7 +208,7 @@ class AbstractFlashcardViewerTest : RobolectricTest() {
 
     @Test
     fun noAutomaticAnswerAfterRenderProcessGoneAndPaused_issue9632() {
-        val controller = getViewerController(true)
+        val controller = getViewerController(true, false)
         val viewer = controller.get()
         viewer.mAutomaticAnswer = AutomaticAnswer(viewer, AutomaticAnswerSettings(AutomaticAnswerAction.BURY_CARD, true, 5, 5))
         viewer.executeCommand(ViewerCommand.COMMAND_SHOW_ANSWER)
@@ -217,6 +218,14 @@ class AbstractFlashcardViewerTest : RobolectricTest() {
         assertThat("no auto answer after pause", viewer.hasAutomaticAnswerQueued(), equalTo(false))
         viewer.mOnRenderProcessGoneDelegate.onRenderProcessGone(viewer.webView!!, mock(RenderProcessGoneDetail::class.java))
         assertThat("no auto answer after onRenderProcessGone when paused", viewer.hasAutomaticAnswerQueued(), equalTo(false))
+    }
+
+    @Test
+    fun shortcutShowsToastOnFinish() {
+        val viewer: NonAbstractFlashcardViewer = getViewer(true, true)
+        viewer.executeCommand(ViewerCommand.COMMAND_FLIP_OR_ANSWER_BETTER_THAN_RECOMMENDED)
+        viewer.executeCommand(ViewerCommand.COMMAND_FLIP_OR_ANSWER_BETTER_THAN_RECOMMENDED)
+        assertEquals("Congratulations! You have finished for now.", ShadowToast.getTextOfLatestToast())
     }
 
     private fun showNextCard(viewer: NonAbstractFlashcardViewer) {
@@ -230,17 +239,26 @@ class AbstractFlashcardViewerTest : RobolectricTest() {
 
     @CheckResult
     private fun getViewer(addCard: Boolean): NonAbstractFlashcardViewer {
-        return getViewerController(addCard).get()
+        return getViewer(addCard, false)
     }
 
     @CheckResult
-    private fun getViewerController(addCard: Boolean): ActivityController<NonAbstractFlashcardViewer> {
+    private fun getViewer(addCard: Boolean, startedWithShortcut: Boolean): NonAbstractFlashcardViewer {
+        return getViewerController(addCard, startedWithShortcut).get()
+    }
+
+    @CheckResult
+    private fun getViewerController(addCard: Boolean, startedWithShortcut: Boolean): ActivityController<NonAbstractFlashcardViewer> {
         if (addCard) {
             val n = col.newNote()
             n.setField(0, "a")
             col.addNote(n)
         }
-        val multimediaController = Robolectric.buildActivity(NonAbstractFlashcardViewer::class.java, Intent())
+        val intent = Intent()
+        if (startedWithShortcut) {
+            intent.putExtra(NavigationDrawerActivity.EXTRA_STARTED_WITH_SHORTCUT, true)
+        }
+        val multimediaController = Robolectric.buildActivity(NonAbstractFlashcardViewer::class.java, intent)
             .create().start().resume().visible()
         saveControllerForCleanup(multimediaController)
         val viewer = multimediaController.get()

--- a/AnkiDroid/src/test/java/com/ichi2/anki/AbstractFlashcardViewerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/AbstractFlashcardViewerTest.kt
@@ -225,7 +225,7 @@ class AbstractFlashcardViewerTest : RobolectricTest() {
         val viewer: NonAbstractFlashcardViewer = getViewer(true, true)
         viewer.executeCommand(ViewerCommand.COMMAND_FLIP_OR_ANSWER_BETTER_THAN_RECOMMENDED)
         viewer.executeCommand(ViewerCommand.COMMAND_FLIP_OR_ANSWER_BETTER_THAN_RECOMMENDED)
-        assertEquals("Congratulations! You have finished for now.", ShadowToast.getTextOfLatestToast())
+        assertEquals(getResourceString(R.string.studyoptions_congrats_finished), ShadowToast.getTextOfLatestToast())
     }
 
     private fun showNextCard(viewer: NonAbstractFlashcardViewer) {


### PR DESCRIPTION
## Purpose / Description
When using a [shortcut](https://developer.android.com/guide/topics/ui/shortcuts) for review, we may need to inform the user when exiting the activity:
- If we successfully completed the review (otherwise the user is surprised of the sudden exit #10841)
- If there's nothing to review (otherwise the user doesn't understand why the app just opens and closes #10840)

The shortcuts were recently introduced with #8648.

## Fixes
Fixes #10841: display a message when the review is completed
fixes (partially) #10840: display a message when no card to review (but ideally the message should be "no cards to review" rather than "review finished")

## Approach
As suggested [here](https://github.com/ankidroid/Anki-Android/issues/8648#issuecomment-822581182), use a Toast to inform the user.

#10840 and #10841 suggested to return to the main view when finishing. 
However, in my opinion, the purpose of shortcuts is to quickly perform the desired action (add note, review, view notes). Therefore, exiting when finishing or having no cards to review is more coherent, wdyt?
Also, the current approach allows to keep the complexity minimal.

## How Has This Been Tested?
- With a Pixel 5 API 31 Emulator
- With a Samsung Galaxy S7

Test that a message is displayed when the review is completed #10841:
![10841_review_completed](https://user-images.githubusercontent.com/88279943/172066030-f55ed082-0211-463b-bc51-9db2343d2dbd.gif)

Test that a message is displayed when nothing to review #10840:
![10840_no_card](https://user-images.githubusercontent.com/88279943/172066037-cf1ff507-12bd-4fa5-aec6-3ba0a1c12cc7.gif)

## Learning (optional, can help others)
About shortcuts: https://developer.android.com/guide/topics/ui/shortcuts

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars). 
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
  - Is it relevant for this change?
