### PR TITLE
NF: Remove getbase:floatingactionbutton dependency

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -282,7 +282,6 @@ dependencies {
     implementation "ch.acra:acra-limiter:$acra_version"
 
     implementation 'com.afollestad.material-dialogs:core:0.9.6.0'
-    implementation 'com.getbase:floatingactionbutton:1.10.1'
     // io.github.java-diff-utils:java-diff-utils is the natural successor here, but requires API24, #7091
     implementation 'org.bitbucket.cowwoc:diff-match-patch:1.2'
     // noinspection GradleDependency - commons-compress 1.12 - later versions use `File.toPath`; API26 can remove?

--- a/AnkiDroid/src/main/res/values-ldrtl/styles.xml
+++ b/AnkiDroid/src/main/res/values-ldrtl/styles.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-
-    <style name="FloatingActionsMenu">
-        <item name="fab_labelsPosition">right</item>
-    </style>
-
-</resources>

--- a/AnkiDroid/src/main/res/values/styles.xml
+++ b/AnkiDroid/src/main/res/values/styles.xml
@@ -94,11 +94,6 @@
         <item name="android:textColor">?attr/easyButtonTextColor</item>
     </style>
 
-
-    <style name="FloatingActionsMenu">
-        <item name="fab_labelsPosition">left</item>
-    </style>
-
     <!-- FAB menu items -->
     <style name="menu_labels_style">
         <item name="android:background">?attr/fab_item_background</item>


### PR DESCRIPTION
## Purpose / Description
Material's FAB replaced it a long time ago and the its style settings, so it doesn't have a use and should be removed

## Approach
Remove the related code

## How Has This Been Tested?

Emulator on API 25

https://user-images.githubusercontent.com/69634269/172067969-64ddb46e-2066-49ab-bac6-a5fe0272c14f.mp4


https://user-images.githubusercontent.com/69634269/172067971-bf19aa9f-e4c4-491f-b0d2-45a5ac3fd477.mp4


## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [X] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
