### PR TITLE
NF: async task result is not necessarily nullable

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/async/BaseAsyncTask.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/async/BaseAsyncTask.kt
@@ -21,7 +21,7 @@ import com.ichi2.utils.MethodLogger.log
 import com.ichi2.utils.Threads
 
 @Suppress("deprecation") // #7108: AsyncTask
-open class BaseAsyncTask<Params, Progress, Result> : android.os.AsyncTask<Params, Progress, Result?>(), ProgressSenderAndCancelListener<Progress> {
+open class BaseAsyncTask<Params, Progress, Result> : android.os.AsyncTask<Params, Progress, Result>(), ProgressSenderAndCancelListener<Progress> {
     override fun onPreExecute() {
         if (DEBUG) {
             log()
@@ -30,7 +30,7 @@ open class BaseAsyncTask<Params, Progress, Result> : android.os.AsyncTask<Params
         super.onPreExecute()
     }
 
-    override fun onPostExecute(result: Result?) {
+    override fun onPostExecute(result: Result) {
         if (DEBUG) {
             log()
         }

--- a/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.kt
@@ -63,7 +63,7 @@ import java.util.concurrent.ExecutionException
  */
 @KotlinCleanup("IDE Lint")
 @KotlinCleanup("Lots to do")
-open class CollectionTask<Progress, Result>(val task: TaskDelegateBase<Progress, Result>, private val listener: TaskListener<in Progress, in Result?>?, private var previousTask: CollectionTask<*, *>?) : BaseAsyncTask<Void, Progress, Result>(), Cancellable {
+open class CollectionTask<Progress, Result>(val task: TaskDelegateBase<Progress, Result>, private val listener: TaskListener<in Progress, in Result>?, private var previousTask: CollectionTask<*, *>?) : BaseAsyncTask<Void, Progress, Result>(), Cancellable {
     /**
      * A reference to the application context to use to fetch the current Collection object.
      */
@@ -149,7 +149,7 @@ open class CollectionTask<Progress, Result>(val task: TaskDelegateBase<Progress,
     }
 
     /** Delegates to the [TaskListener] for this task.  */
-    override fun onPostExecute(result: Result?) {
+    override fun onPostExecute(result: Result) {
         super.onPostExecute(result)
         listener?.onPostExecute(result)
         Timber.d("enabling garbage collection of mPreviousTask...")

--- a/AnkiDroid/src/main/java/com/ichi2/async/Connection.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/async/Connection.kt
@@ -98,13 +98,13 @@ class Connection : BaseAsyncTask<Connection.Payload, Any, Connection.Payload>() 
     /*
      * Runs on GUI thread
      */
-    override fun onPostExecute(result: Payload?) {
+    override fun onPostExecute(result: Payload) {
         super.onPostExecute(result)
         // Sync has ended so release the wake lock
         if (mWakeLock.isHeld) {
             mWakeLock.release()
         }
-        if (mListener != null && result != null) {
+        if (mListener != null) {
             mListener!!.onPostExecute(result)
         }
     }


### PR DESCRIPTION
No idea why it was added to always be potentially nullable.
Now it transmits its nullability status like everything else.