### PR TITLE
[GSoC] migrated AnkiStatsTaskHandler.createChart() to suspend function

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/Statistics.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Statistics.kt
@@ -31,6 +31,7 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.core.os.bundleOf
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentActivity
+import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.RecyclerView.AdapterDataObserver
 import androidx.viewpager2.adapter.FragmentStateAdapter
 import androidx.viewpager2.widget.ViewPager2
@@ -50,6 +51,7 @@ import com.ichi2.libanki.stats.Stats
 import com.ichi2.libanki.stats.Stats.AxisType
 import com.ichi2.libanki.stats.Stats.ChartType
 import com.ichi2.ui.FixedTextView
+import kotlinx.coroutines.*
 import timber.log.Timber
 import java.util.Locale
 
@@ -219,8 +221,7 @@ class Statistics : NavigationDrawerActivity(), DeckSelectionListener, SubtitleLi
         // track current settings for each individual fragment
         protected var deckId: Long = 0
 
-        // #7108: AsyncTask
-        protected lateinit var statisticsTask: AsyncTask<*, *, *>
+        protected lateinit var statisticsJob: Job
 
         // #7108: AsyncTask
         protected lateinit var statisticsOverviewTask: AsyncTask<*, *, *>
@@ -250,8 +251,8 @@ class Statistics : NavigationDrawerActivity(), DeckSelectionListener, SubtitleLi
         protected fun cancelTasks() {
             Timber.w("canceling tasks")
 
-            if (this::statisticsTask.isInitialized) {
-                stopTaskGracefully(statisticsTask)
+            if (this::statisticsJob.isInitialized) {
+                statisticsJob.cancel()
             }
             if (this::statisticsOverviewTask.isInitialized) {
                 stopTaskGracefully(statisticsOverviewTask)
@@ -331,6 +332,16 @@ class Statistics : NavigationDrawerActivity(), DeckSelectionListener, SubtitleLi
         private var mSectionNumber = 0
         private var mType = AxisType.TYPE_MONTH
         private var mIsCreated = false
+        private val statisticsScope = lifecycleScope + CoroutineExceptionHandler { _, throwable ->
+            when (throwable) {
+                is CancellationException -> {
+                    Timber.e("Statistics : Statistics job cancelled", throwable)
+                }
+                else -> {
+                    Timber.e("Statistics : Unknown Exception occurred ", throwable)
+                }
+            }
+        }
 
         override fun onCreateView(
             inflater: LayoutInflater,
@@ -385,9 +396,9 @@ class Statistics : NavigationDrawerActivity(), DeckSelectionListener, SubtitleLi
         private fun createChart() {
             val statisticsActivity = requireActivity() as Statistics
             val taskHandler = statisticsActivity.taskHandler
-            statisticsTask = taskHandler!!.createChart(
-                getChartTypeFromPosition(mSectionNumber), mChart, mProgressBar
-            )
+            statisticsJob = statisticsScope.launch {
+                taskHandler!!.createChart(getChartTypeFromPosition(mSectionNumber), mProgressBar, mChart)
+            }
         }
 
         override fun checkAndUpdate() {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Statistics.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Statistics.kt
@@ -332,16 +332,6 @@ class Statistics : NavigationDrawerActivity(), DeckSelectionListener, SubtitleLi
         private var mSectionNumber = 0
         private var mType = AxisType.TYPE_MONTH
         private var mIsCreated = false
-        private val statisticsScope = lifecycleScope + CoroutineExceptionHandler { _, throwable ->
-            when (throwable) {
-                is CancellationException -> {
-                    Timber.e("Statistics : Statistics job cancelled", throwable)
-                }
-                else -> {
-                    Timber.e("Statistics : Unknown Exception occurred ", throwable)
-                }
-            }
-        }
 
         override fun onCreateView(
             inflater: LayoutInflater,
@@ -396,7 +386,10 @@ class Statistics : NavigationDrawerActivity(), DeckSelectionListener, SubtitleLi
         private fun createChart() {
             val statisticsActivity = requireActivity() as Statistics
             val taskHandler = statisticsActivity.taskHandler
-            statisticsJob = statisticsScope.launch {
+            val exceptionHandler = CoroutineExceptionHandler { _, throwable ->
+                Timber.e(throwable, "createChart failed with error")
+            }
+            statisticsJob = viewLifecycleOwner.lifecycleScope.launch(exceptionHandler) {
                 taskHandler!!.createChart(getChartTypeFromPosition(mSectionNumber), mProgressBar, mChart)
             }
         }


### PR DESCRIPTION
## Purpose / Description
AsyncTask to coroutines migration

## Approach
Replaced the usage of AsyncTask to create a chart with the suspend function. Since with coroutines we can easily switch context between the main and background thread, there is no need for a callback-based approach. 

## How Has This Been Tested?
Runs as expected on Realme 6i

https://user-images.githubusercontent.com/69595691/172148243-bd5180e7-a201-4816-9695-61a68c84d2f8.mp4


https://user-images.githubusercontent.com/69595691/172148207-af2cdad3-ef88-46dd-8d37-c0db10433265.mp4

## Learning
Use of [Mutex](https://kotlinlang.org/docs/shared-mutable-state-and-concurrency.html#mutual-exclusion) for thread safety on critical section with suspending functions.

## Checklist

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [ ] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
