### PR TITLE
i18nResources and graphData for getting data from backend

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/backend/DroidBackend.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/backend/DroidBackend.kt
@@ -19,6 +19,7 @@ import BackendProto.Backend.ExtractAVTagsOut
 import BackendProto.Backend.RenderCardOut
 import android.content.Context
 import androidx.annotation.VisibleForTesting
+import com.google.protobuf.ByteString
 import com.ichi2.libanki.Collection
 import com.ichi2.libanki.DB
 import com.ichi2.libanki.DeckConfig
@@ -85,4 +86,10 @@ interface DroidBackend {
 
     @Throws(BackendNotSupportedException::class)
     fun renderCardForTemplateManager(templateRenderContext: TemplateRenderContext): RenderCardOut
+
+    @Throws(BackendNotSupportedException::class)
+    fun i18nResources(): ByteString
+
+    @Throws(BackendNotSupportedException::class)
+    fun graphData(search: String, days: Int): ByteString
 }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/backend/JavaDroidBackend.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/backend/JavaDroidBackend.java
@@ -18,6 +18,7 @@ package com.ichi2.libanki.backend;
 
 import android.content.Context;
 
+import com.google.protobuf.ByteString;
 import com.ichi2.libanki.Collection;
 import com.ichi2.libanki.DB;
 import com.ichi2.libanki.TemplateManager;
@@ -106,6 +107,20 @@ public class JavaDroidBackend implements DroidBackend {
 
     @Override
     public @NonNull Backend.RenderCardOut renderCardForTemplateManager(@NonNull TemplateManager.TemplateRenderContext templateRenderContext) throws BackendNotSupportedException {
+        throw new BackendNotSupportedException();
+    }
+
+
+    @NonNull
+    @Override
+    public ByteString i18nResources() throws BackendNotSupportedException {
+        throw new BackendNotSupportedException();
+    }
+
+
+    @NonNull
+    @Override
+    public ByteString graphData(@NonNull String search, int days) throws BackendNotSupportedException {
         throw new BackendNotSupportedException();
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/backend/RustDroidBackend.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/backend/RustDroidBackend.kt
@@ -19,6 +19,7 @@ package com.ichi2.libanki.backend
 import BackendProto.Backend.ExtractAVTagsOut
 import BackendProto.Backend.RenderCardOut
 import android.content.Context
+import com.google.protobuf.ByteString
 import com.ichi2.libanki.Collection
 import com.ichi2.libanki.DB
 import com.ichi2.libanki.TemplateManager.TemplateRenderContext
@@ -94,6 +95,10 @@ open class RustDroidBackend(
     override fun renderCardForTemplateManager(templateRenderContext: TemplateRenderContext): RenderCardOut {
         throw BackendNotSupportedException()
     }
+
+    override fun i18nResources(): ByteString = backend.backend.i18nResources().json
+
+    override fun graphData(search: String, days: Int): ByteString = backend.backend.graphs(search, days).toByteString()
 
     companion object {
         const val UNUSED_VALUE = 0


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
For porting graph view from Anki to AnkiDroid, it needs have implementation for getting `i18nResources` and `graphData` data.

## Fixes
Fixes _Link to the issues._

## Approach
Took the idea from https://github.com/krmanik/Anki-Android/pull/23 and implemented it.

1. Implemented Rust backend functionality in `JavaDroidBackend.java`
2. Implemented Interface to the rust backend in `DroidBackend.kt`
3. Override in `RustDroidBackend.kt` 

## How Has This Been Tested?
Tested on another branch with the same implementation

## Learning (optional, can help others)
https://github.com/krmanik/Anki-Android/pull/23

_Links to blog posts, patterns, libraries or addons used to solve this problem_

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
