### PR TITLE
Load local file requested using file protocol in reviewer (json & text file)

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
@@ -2211,6 +2211,13 @@ abstract class AbstractFlashcardViewer :
                 // shouldInterceptRequest is not running on the UI thread.
                 runOnUiThread { mDisplayMediaLoadedFromHttpWarningSnackbar.execOnceForReference(mCurrentCard!!) }
             }
+
+            val ankiLoadLocalFile = AnkiLoadLocalFile(baseContext)
+            val decoded = decodeUrl(url.toString())
+            if (ankiLoadLocalFile.isLoadingLocalFile(decoded)) {
+                return ankiLoadLocalFile.getLocalFileFromCollectionDir(decoded)
+            }
+
             return null
         }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiLoadLocalFile.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiLoadLocalFile.kt
@@ -1,0 +1,78 @@
+/****************************************************************************************
+ * Copyright (c) 2022 Mani infinyte01@gmail.com                                         *
+ *                                                                                      *
+ *                                                                                      *
+ * This program is free software; you can redistribute it and/or modify it under        *
+ * the terms of the GNU General Public License as published by the Free Software        *
+ * Foundation; either version 3 of the License, or (at your option) any later           *
+ * version.                                                                             *
+ *                                                                                      *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *                                                                                      *
+ * You should have received a copy of the GNU General Public License along with         *
+ * this program.  If not, see <http://www.gnu.org/licenses/>.                            *
+ *                                                                                      *
+ * *************************************************************************************/
+
+package com.ichi2.anki
+
+import android.content.Context
+import android.webkit.WebResourceResponse
+import java.io.File
+import java.io.FileInputStream
+import java.io.InputStream
+import java.util.HashMap
+
+class AnkiLoadLocalFile(val context: Context) {
+
+    /**
+     * Return web response for file requested over file:/// protocol
+     *
+     * @param url decoded url loading in reviewer
+     * @return web response with content of the file from collection dir
+     */
+    fun getLocalFileFromCollectionDir(url: String): WebResourceResponse? {
+        val streamResponse = { data: InputStream, mime: String ->
+            WebResourceResponse(mime, "utf-8", 200, "OK", HashMap(), data)
+        }
+
+        val fileResponse = { path: String, mime: String ->
+            val inputStream: InputStream = FileInputStream(path)
+            streamResponse(inputStream, mime)
+        }
+
+        val filename = url.split("/").last()
+        var mimeType = ""
+
+        if (filename.endsWith(".json")) {
+            mimeType = "text/json"
+        }
+
+        if (filename.endsWith(".txt")) {
+            mimeType = "text/plain"
+        }
+
+        val currentAnkiDroidDirectory = CollectionHelper.getCurrentAnkiDroidDirectory(context)
+        val filePath = "$currentAnkiDroidDirectory/collection.media/$filename"
+        if (File(filePath).exists()) {
+            return fileResponse(filePath, mimeType)
+        }
+
+        return null
+    }
+
+    fun isLoadingLocalFile(url: String): Boolean {
+        if (url.startsWith("file:///")) {
+            if (url.endsWith(".json")) {
+                return true
+            }
+
+            if (url.endsWith(".txt")) {
+                return true
+            }
+        }
+        return false
+    }
+}


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
I use [Anki-Xiehanzi](https://github.com/krmanik/Anki-Xiehanzi) deck to study Chinese language and always want it to be offline, but json files in the deck need to be served over localhost because `file:///` protocol gives error when loading file other than `js`.

Anki desktop load this file because it uses localhost so all files in `collection.media` are accessible over `http://127.0.0.1:<port>`.

## Fixes
Fixes #8525

## Approach
When file (json & text) requested over `file:///` protocol then implementation in this PR will return the web response with file content.
1. Used idea from https://github.com/krmanik/Anki-Android/pull/23 for serving file over `file:///`
2. Create a class for handling mime type and web response
3. Check if url start with file protocol and ends with file extension
4. Then from `AbstractFlashcardViewer` decoded url passed to `AnkiLoadLocalFile`
5. In `AnkiLoadLocalFile` the url split with `/` and last string used as filename
6. The filename and mime type used to read file and return response

## How Has This Been Tested?
1. Created a `test.json` file in `collection.media` dir
2. Used chrome dev tools to send request
```js
var xhttp = new XMLHttpRequest();
xhttp.onreadystatechange = function() {
    if (this.readyState == 4 && this.status == 200) {
       console.log(xhttp.responseText);
    }
};
xhttp.open("GET", "test.json", true);
xhttp.send();
```

Note: fetch will not return the file, but XMLHttpRequest will get the file.
```
Fetch API cannot load file:///storage/emulated/0/AnkiDroid/collection.media/test.json. URL scheme "file" is not supported.
```

![image](https://user-images.githubusercontent.com/12841290/172458528-96127448-7eee-4352-ae72-af145f8d46a4.png)

## Learning (optional, can help others)
https://github.com/krmanik/Anki-Android/pull/23

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
