### PR TITLE
Replace `Time` arg by current time

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/BackupManager.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/BackupManager.kt
@@ -90,7 +90,7 @@ open class BackupManager {
             Timber.d("performBackup: No backup created. Last backup younger than 5 hours")
             return false
         }
-        val backupFilename = getNameForNewBackup(time) ?: return false
+        val backupFilename = getNameForNewBackup(time.gregorianCalendar()) ?: return false
 
         // Abort backup if destination already exists (extremely unlikely)
         val backupFile = getBackupFile(colFile, backupFilename)
@@ -372,13 +372,13 @@ open class BackupManager {
         }
 
         /**
+         * @param [cal] the current time with a Gregorian Calendar
          * @return filename with pattern collection-yyyy-MM-dd-HH-mm based on given time parameter
          */
         @JvmStatic
-        fun getNameForNewBackup(time: Time): String? {
+        fun getNameForNewBackup(cal: Calendar): String? {
             /** Changes in the file name pattern should be updated as well in
              * [getBackupTimeString] and [com.ichi2.anki.dialogs.DatabaseErrorDialog.onCreateDialog] */
-            val cal: Calendar = time.gregorianCalendar()
             val backupFilename: String = try {
                 String.format(Utils.ENGLISH_LOCALE, "collection-%s.colpkg", df.format(cal.time))
             } catch (e: UnknownFormatConversionException) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/BackupManager.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/BackupManager.kt
@@ -284,7 +284,7 @@ open class BackupManager {
                     Timber.e("repairCollection - dump to %s.tmp failed", deckPath)
                     return false
                 }
-                if (!moveDatabaseToBrokenDirectory(deckPath, false, time)) {
+                if (!moveDatabaseToBrokenDirectory(deckPath, false, time.genToday(utcOffset()))) {
                     Timber.e("repairCollection - could not move corrupt file to broken directory")
                     return false
                 }
@@ -299,11 +299,10 @@ open class BackupManager {
             return false
         }
 
-        fun moveDatabaseToBrokenDirectory(colPath: String, moveConnectedFilesToo: Boolean, time: Time): Boolean {
+        fun moveDatabaseToBrokenDirectory(colPath: String, moveConnectedFilesToo: Boolean, value: Date): Boolean {
             val colFile = File(colPath)
 
             // move file
-            val value: Date = time.genToday(utcOffset())
             var movedFilename = String.format(
                 Utils.ENGLISH_LOCALE,
                 colFile.name.replace(".anki2", "") +

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckOptions.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckOptions.kt
@@ -43,7 +43,6 @@ import com.ichi2.compat.CompatHelper
 import com.ichi2.libanki.Consts
 import com.ichi2.libanki.Deck
 import com.ichi2.libanki.DeckConfig
-import com.ichi2.libanki.utils.Time
 import com.ichi2.preferences.NumberRangePreference
 import com.ichi2.preferences.StepsPreference
 import com.ichi2.preferences.TimePreference
@@ -306,7 +305,7 @@ class DeckOptions :
 
                                 alarmManager.cancel(reminderIntent)
                                 if (value as Boolean) {
-                                    val calendar = reminderToCalendar(col.time, reminder)
+                                    val calendar = reminderToCalendar(col.time.calendar(), reminder)
 
                                     alarmManager.setRepeating(
                                         AlarmManager.RTC_WAKEUP,
@@ -342,7 +341,7 @@ class DeckOptions :
                                 )
                                 alarmManager.cancel(reminderIntent)
 
-                                val calendar = reminderToCalendar(col.time, reminder)
+                                val calendar = reminderToCalendar(col.time.calendar(), reminder)
 
                                 alarmManager.setRepeating(
                                     AlarmManager.RTC_WAKEUP,
@@ -779,9 +778,7 @@ class DeckOptions :
     }
 
     companion object {
-        fun reminderToCalendar(time: Time, reminder: JSONObject): Calendar {
-
-            val calendar = time.calendar()
+        fun reminderToCalendar(calendar: Calendar, reminder: JSONObject): Calendar {
 
             calendar[Calendar.HOUR_OF_DAY] = reminder.getJSONArray("time").getInt(0)
             calendar[Calendar.MINUTE] = reminder.getJSONArray("time").getInt(1)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DrawingActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DrawingActivity.kt
@@ -74,7 +74,7 @@ class DrawingActivity : AnkiActivity() {
 
     private fun finishWithSuccess() {
         try {
-            val savedWhiteboardFileName = mWhiteboard.saveWhiteboard(col.time)
+            val savedWhiteboardFileName = mWhiteboard.saveWhiteboard(col.time.currentDate)
             val resultData = Intent()
             resultData.putExtra(EXTRA_RESULT_WHITEBOARD, savedWhiteboardFileName)
             setResult(RESULT_OK, resultData)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.kt
@@ -313,7 +313,7 @@ class Preferences : AnkiActivity() {
                 col.setMod()
             }
         }
-        scheduleNotification(col.time, this)
+        scheduleNotification(col.time.calendar(), this)
     }
 
     fun updateNotificationPreference(listPreference: ListPreference) {
@@ -582,7 +582,7 @@ class Preferences : AnkiActivity() {
                         if (listPreference != null) {
                             preferencesActivity.updateNotificationPreference(listPreference)
                             if (listPreference.value.toInt() < PENDING_NOTIFICATIONS_ONLY) {
-                                scheduleNotification(preferencesActivity.col.time, preferencesActivity)
+                                scheduleNotification(preferencesActivity.col.time.calendar(), preferencesActivity)
                             } else {
                                 val intent = CompatHelper.compat.getImmutableBroadcastIntent(
                                     preferencesActivity, 0,

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
@@ -440,7 +440,7 @@ open class Reviewer : AbstractFlashcardViewer() {
                 Timber.i("Reviewer:: Save whiteboard button pressed")
                 if (whiteboard != null) {
                     try {
-                        val savedWhiteboardFileName = whiteboard!!.saveWhiteboard(col.time).path
+                        val savedWhiteboardFileName = whiteboard!!.saveWhiteboard(col.time.currentDate).path
                         showThemedToast(this@Reviewer, getString(R.string.white_board_image_saved, savedWhiteboardFileName), true)
                     } catch (e: Exception) {
                         Timber.w(e)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/UIUtils.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/UIUtils.kt
@@ -15,7 +15,6 @@ import com.google.android.material.snackbar.Snackbar
 import com.ichi2.async.CollectionTask.SaveCollection
 import com.ichi2.async.TaskListener
 import com.ichi2.async.TaskManager
-import com.ichi2.libanki.utils.Time
 import timber.log.Timber
 import java.util.*
 
@@ -138,8 +137,7 @@ object UIUtils {
     }
 
     @JvmStatic
-    fun getDayStart(time: Time): Long {
-        val cal = time.calendar()
+    fun getDayStart(cal: Calendar): Long {
         if (cal[Calendar.HOUR_OF_DAY] < 4) {
             cal.roll(Calendar.DAY_OF_YEAR, -1)
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Whiteboard.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Whiteboard.kt
@@ -34,13 +34,14 @@ import androidx.core.content.ContextCompat
 import com.ichi2.anki.cardviewer.CardAppearance.Companion.isInNightMode
 import com.ichi2.anki.dialogs.WhiteBoardWidthDialog
 import com.ichi2.compat.CompatHelper
-import com.ichi2.libanki.utils.Time
 import com.ichi2.libanki.utils.TimeUtils
 import com.ichi2.utils.DisplayUtils.getDisplayDimensions
 import com.ichi2.utils.KotlinCleanup
 import com.mrudultora.colorpicker.ColorPickerPopUp
 import timber.log.Timber
 import java.io.FileNotFoundException
+import java.util.*
+import kotlin.collections.ArrayList
 import kotlin.math.abs
 import kotlin.math.max
 
@@ -484,7 +485,7 @@ class Whiteboard(activity: AnkiActivity, handleMultiTouch: Boolean, inverted: Bo
     }
 
     @Throws(FileNotFoundException::class)
-    fun saveWhiteboard(time: Time?): Uri {
+    fun saveWhiteboard(date: Date): Uri {
         val bitmap = Bitmap.createBitmap(this.width, this.height, Bitmap.Config.ARGB_8888)
         val canvas = Canvas(bitmap)
         if (foregroundColor != Color.BLACK) {
@@ -493,7 +494,7 @@ class Whiteboard(activity: AnkiActivity, handleMultiTouch: Boolean, inverted: Bo
             canvas.drawColor(Color.WHITE)
         }
         draw(canvas)
-        val baseFileName = "Whiteboard" + TimeUtils.getTimestamp(time!!.currentDate)
+        val baseFileName = "Whiteboard" + TimeUtils.getTimestamp(date)
         // TODO: Fix inconsistent CompressFormat 'JPEG' and file extension 'png'
         return CompatHelper.compat.saveImage(context, bitmap, baseFileName, "png", Bitmap.CompressFormat.JPEG, 95)
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Whiteboard.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Whiteboard.kt
@@ -493,7 +493,7 @@ class Whiteboard(activity: AnkiActivity, handleMultiTouch: Boolean, inverted: Bo
             canvas.drawColor(Color.WHITE)
         }
         draw(canvas)
-        val baseFileName = "Whiteboard" + TimeUtils.getTimestamp(time!!)
+        val baseFileName = "Whiteboard" + TimeUtils.getTimestamp(time!!.currentDate)
         // TODO: Fix inconsistent CompressFormat 'JPEG' and file extension 'png'
         return CompatHelper.compat.saveImage(context, bitmap, baseFileName, "png", Bitmap.CompressFormat.JPEG, 95)
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DatabaseErrorDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DatabaseErrorDialog.kt
@@ -27,6 +27,7 @@ import com.afollestad.materialdialogs.MaterialDialog
 import com.ichi2.anki.*
 import com.ichi2.async.Connection
 import com.ichi2.libanki.Consts
+import com.ichi2.libanki.utils.Time
 import com.ichi2.utils.SyncStatus
 import com.ichi2.utils.UiUtil.makeBold
 import com.ichi2.utils.contentNullable
@@ -259,7 +260,13 @@ class DatabaseErrorDialog : AsyncDialogFragment() {
                         val time = ch.getTimeSafe(context)
                         ch.closeCollection(false, "DatabaseErrorDialog: Before Create New Collection")
                         val path1 = CollectionHelper.getCollectionPath(activity)
-                        if (BackupManager.moveDatabaseToBrokenDirectory(path1, false, time)) {
+                        if (BackupManager.moveDatabaseToBrokenDirectory(
+                                path1, false,
+                                time.genToday(
+                                        Time.utcOffset()
+                                    )
+                            )
+                        ) {
                             (activity as DeckPicker?)!!.restartActivity()
                         } else {
                             (activity as DeckPicker?)!!.showDatabaseErrorDialog(DIALOG_LOAD_FAILED)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/export/ActivityExportingDelegate.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/export/ActivityExportingDelegate.kt
@@ -67,7 +67,7 @@ class ActivityExportingDelegate(private val activity: AnkiActivity, private val 
         val exportDir = File(activity.externalCacheDir, "export")
         exportDir.mkdirs()
         val exportPath: File
-        val timeStampSuffix = "-" + TimeUtils.getTimestamp(collectionSupplier.get().time)
+        val timeStampSuffix = "-" + TimeUtils.getTimestamp(collectionSupplier.get().time.currentDate)
         exportPath = if (path != null) {
             // filename has been explicitly specified
             File(exportDir, path)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/services/BootService.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/services/BootService.kt
@@ -86,7 +86,7 @@ class BootService : BroadcastReceiver() {
                         ),
                         0
                     )
-                    val calendar = DeckOptions.reminderToCalendar(col.time, reminder)
+                    val calendar = DeckOptions.reminderToCalendar(col.time.calendar(), reminder)
                     alarmManager.setRepeating(
                         AlarmManager.RTC_WAKEUP,
                         calendar.timeInMillis,

--- a/AnkiDroid/src/main/java/com/ichi2/anki/services/BootService.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/services/BootService.kt
@@ -9,7 +9,6 @@ import com.ichi2.anki.*
 import com.ichi2.anki.UIUtils.showThemedToast
 import com.ichi2.compat.CompatHelper
 import com.ichi2.libanki.Collection
-import com.ichi2.libanki.utils.Time
 import com.ichi2.utils.Permissions.hasStorageAccessPermission
 import timber.log.Timber
 import java.util.Calendar
@@ -33,7 +32,7 @@ class BootService : BroadcastReceiver() {
         }
         Timber.i("Executing Boot Service")
         catchAlarmManagerErrors(context) { scheduleDeckReminder(context) }
-        catchAlarmManagerErrors(context) { scheduleNotification(col.time, context) }
+        catchAlarmManagerErrors(context) { scheduleNotification(col.time.calendar(), context) }
         mFailedToShowNotifications = false
         sWasRun = true
     }
@@ -106,14 +105,13 @@ class BootService : BroadcastReceiver() {
         private var sWasRun = false
 
         @JvmStatic
-        fun scheduleNotification(time: Time, context: Context) {
+        fun scheduleNotification(calendar: Calendar, context: Context) {
             val alarmManager = context.getSystemService(Context.ALARM_SERVICE) as AlarmManager
             val sp = AnkiDroidApp.getSharedPrefs(context)
             // Don't schedule a notification if the due reminders setting is not enabled
             if (sp.getString(Preferences.MINIMUM_CARDS_DUE_FOR_NOTIFICATION, Integer.toString(Preferences.PENDING_NOTIFICATIONS_ONLY))!!.toInt() >= Preferences.PENDING_NOTIFICATIONS_ONLY) {
                 return
             }
-            val calendar = time.calendar()
             calendar[Calendar.HOUR_OF_DAY] = getRolloverHourOfDay(context)
             calendar[Calendar.MINUTE] = 0
             calendar[Calendar.SECOND] = 0

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.kt
@@ -157,7 +157,7 @@ open class Collection @VisibleForTesting constructor(
         tags = initTags()
         load()
         if (crt == 0L) {
-            crt = UIUtils.getDayStart(time) / 1000
+            crt = UIUtils.getDayStart(time.calendar()) / 1000
         }
         mStartReps = 0
         mStartTime = 0

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Storage.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Storage.java
@@ -329,7 +329,7 @@ public class Storage {
                 _setColVars(db, time);
             }
             // This line is required for testing - otherwise Rust will override a mocked time.
-            db.execute("update col set crt = ?", UIUtils.getDayStart(time) / 1000);
+            db.execute("update col set crt = ?", UIUtils.getDayStart(time.calendar()) / 1000);
         } else {
             db.execute("PRAGMA page_size = 4096");
             db.execute("PRAGMA legacy_file_format = 0");

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/utils/TimeUtils.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/utils/TimeUtils.kt
@@ -19,7 +19,7 @@ import java.text.SimpleDateFormat
 import java.util.*
 
 object TimeUtils {
-    fun getTimestamp(time: Time): String {
-        return SimpleDateFormat("yyyyMMddHHmmss", Locale.US).format(time.currentDate)
+    fun getTimestamp(date: Date): String {
+        return SimpleDateFormat("yyyyMMddHHmmss", Locale.US).format(date)
     }
 }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/BackupManagerSimpleTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/BackupManagerSimpleTest.kt
@@ -65,14 +65,14 @@ class BackupManagerSimpleTest {
         val date = BackupManager.parseBackupTimeString("1970-01-02-00-46")
         assertNotNull(date)
         val timestamp = date.time
-        val backupName = BackupManager.getNameForNewBackup(MockTime(timestamp))
+        val backupName = BackupManager.getNameForNewBackup(MockTime(timestamp).gregorianCalendar())
 
         assertEquals("Backup name doesn't match naming pattern", "collection-1970-01-02-00-46.colpkg", backupName)
     }
 
     @Test
     fun nameOfNewBackupsCanBeParsed() {
-        val backupName = BackupManager.getNameForNewBackup(MockTime(100000000))
+        val backupName = BackupManager.getNameForNewBackup(MockTime(100000000).gregorianCalendar())
         assertNotNull(backupName)
 
         val ts = BackupManager.getBackupDate(backupName)


### PR DESCRIPTION
`Time` is a complex classes, that returns current time. It is useful when we actually need to measure duration or keep track of time through work. But most utilities function just need current time. On top of that, it may help makes test simpler to write for those function, since we just have to create a moment, and not a Time object.

It was tested, merged with #11565 and all tests passe.

It will conflict with #11563. I'm fine with solving conflict if the other PR comes first. However, I believe this one makes more sens first, as reading #11563 I realized that some methods requiring a full `Time` object made no sens