### PR TITLE
Some var cleanups for CardTemplateEditor

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.kt
@@ -519,11 +519,12 @@ open class CardTemplateEditor : AnkiActivity(), DeckSelectionListener {
                 Timber.i("CardTemplateEditor:: Add template button pressed")
                 // Show confirmation dialog
                 val ordinal = mTemplateEditor.viewPager.currentItem
-                var numAffectedCards = 0
                 // isOrdinalPendingAdd method will check if there are any new card types added or not,
                 // if TempModel has new card type then numAffectedCards will be 0 by default.
-                if (!TemporaryModel.isOrdinalPendingAdd(tempModel!!, ordinal)) {
-                    numAffectedCards = col.models.tmplUseCount(tempModel.model, ordinal)
+                val numAffectedCards = if (!TemporaryModel.isOrdinalPendingAdd(tempModel!!, ordinal)) {
+                    col.models.tmplUseCount(tempModel.model, ordinal)
+                } else {
+                    0
                 }
                 confirmAddCards(tempModel.model, numAffectedCards)
                 return true
@@ -545,10 +546,11 @@ open class CardTemplateEditor : AnkiActivity(), DeckSelectionListener {
                 }
 
                 // Show confirmation dialog
-                var numAffectedCards = 0
-                if (!TemporaryModel.isOrdinalPendingAdd(tempModel, ordinal)) {
+                val numAffectedCards = if (!TemporaryModel.isOrdinalPendingAdd(tempModel, ordinal)) {
                     Timber.d("Ordinal is not a pending add, so we'll get the current card count for confirmation")
-                    numAffectedCards = col.models.tmplUseCount(tempModel.model, ordinal)
+                    col.models.tmplUseCount(tempModel.model, ordinal)
+                } else {
+                    0
                 }
                 confirmDeleteCards(template, tempModel.model, numAffectedCards)
                 return true


### PR DESCRIPTION
## Purpose / Description

Removes the need of some `var`s inside CardTemplateEditor.kt.

## Fixes

Part of #11450 

## How Has This Been Tested?

Ran the usual tests.

## Checklist

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
