### PR TITLE
Remove some vars in NoteEditor

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
@@ -517,10 +517,7 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
         // #6762 values are reversed if using a keyboard and pressing Ctrl+Shift+LeftArrow
         val start = Math.min(selectionStart, selectionEnd)
         val end = Math.max(selectionStart, selectionEnd)
-        var text = ""
-        if (textBox.text != null) {
-            text = textBox.text.toString()
-        }
+        val text = textBox.text?.toString() ?: ""
 
         // Split the text in the places where the formatting will take place
         val beforeText = text.substring(0, start)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
@@ -1896,11 +1896,7 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
     }
 
     private fun updateField(field: FieldEditText?): Boolean {
-        var fieldContent = ""
-        val fieldText = field!!.text
-        if (fieldText != null) {
-            fieldContent = fieldText.toString()
-        }
+        val fieldContent = field!!.text?.toString() ?: ""
         val correctedFieldContent = NoteService.convertToHtmlNewline(fieldContent, shouldReplaceNewlines())
         if (mEditorNote!!.values()[field.ord] != correctedFieldContent) {
             mEditorNote!!.values()[field.ord] = correctedFieldContent


### PR DESCRIPTION
## Purpose / Description

Remove the need for a var variable in two locations inside NoteEditor.

## Fixes

Part of #11450 


## How Has This Been Tested?

Ran the usual tests.

## Checklist

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
