### PR TITLE
fix: deprecation in FieldEditText

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/FieldEditText.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/FieldEditText.kt
@@ -167,9 +167,8 @@ class FieldEditText : FixedEditText, NoteService.NoteField {
     /**
      * Restore the default style of this view.
      */
-    @Suppress("deprecation")
     fun setDefaultStyle() {
-        setBackgroundDrawable(mOrigBackground)
+        background = mOrigBackground
     }
 
     fun setSelectionChangeListener(listener: TextSelectionListener?) {


### PR DESCRIPTION
## Purpose / Description
fix: `setBackgroundDrawable` deprecation in FieldEditText

## Approach
Following this approach : https://stackoverflow.com/a/18844271/9062752

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
