### PR TITLE
fix: `toLowerCase` deprecation in BeolingusParser

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/beolingus/parsing/BeolingusParser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/beolingus/parsing/BeolingusParser.kt
@@ -46,9 +46,8 @@ object BeolingusParser {
             // Perform .contains() due to #5376 (a "%20{noun}" suffix).
             // Perform .toLowerCase() due to #5810 ("hello" should match "Hello").
             // See #5810 for discussion on Locale complexities. Currently unhandled.
-            @Suppress("DEPRECATION")
             @KotlinCleanup("improve null handling of m.group() possibly returning null")
-            if (m.group(2)!!.toLowerCase(Locale.ROOT).contains(wordToSearchFor!!.toLowerCase(Locale.ROOT))) {
+            if (m.group(2)!!.lowercase(Locale.ROOT).contains(wordToSearchFor!!.lowercase(Locale.ROOT))) {
                 Timber.d("pronunciation URL is https://dict.tu-chemnitz.de%s", m.group(1))
                 return "https://dict.tu-chemnitz.de" + m.group(1)
             }


### PR DESCRIPTION
## Purpose / Description
Fixed: `toLowerCase` deprecation in BeolingusParser

## Approach
used `lowercase` instead of `toLowerCase`

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
