### PR TITLE
Clarify instructions in backend library requirements

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -262,15 +262,23 @@ dependencies {
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.13.3'
     implementation 'com.github.CanHub:Android-Image-Cropper:4.2.1'
 
-    // build with ./gradlew rsdroid:assembleRelease
-    // In my experience, using `files()` currently requires a reindex operation.
-    // implementation files("C:\\GitHub\\Rust-Test\\rsdroid\\build\\outputs\\aar\\rsdroid-release.aar")
+    // Backend libraries
+
     implementation 'com.google.protobuf:protobuf-java:3.21.1' // This is required when loading from a file
+
+    // To test with locally-built versions:
+    // - use the docs in Anki-Android-Backend to build a local version
+    // - switch the commented and uncommented lines below
+    // - run a gradle sync
+
     implementation "io.github.david-allison-1:anki-android-backend:$ankidroid_backend_version"
-    // build with ./gradlew rsdroid-testing:assembleRelease
-    // RobolectricTest.java: replace RustBackendLoader.init(); with RustBackendLoader.loadRsdroid(path);
-    // A path for a testing library is typically under rsdroid-testing/assets
     testImplementation "io.github.david-allison-1:anki-android-backend-testing:$ankidroid_backend_version"
+    // implementation files("../../Anki-Android-Backend/rsdroid/build/outputs/aar/rsdroid-release.aar")
+    // testImplementation files("../../Anki-Android-Backend/rsdroid-testing/build/libs/rsdroid-testing-0.1.10.jar")
+
+    // On Windows, you can use something like
+    // implementation files("C:\\GitHub\\Rust-Test\\rsdroid\\build\\outputs\\aar\\rsdroid-release.aar")
+
     // A path for a testing library which provide Parameterized Test
     testImplementation "org.junit.jupiter:junit-jupiter:$junit_version"
     testImplementation "org.junit.jupiter:junit-jupiter-params:$junit_version"


### PR DESCRIPTION
Makes it clearer that a testImplementation is also required