### PR TITLE
Use IN_PROCESS compiler strategy only on CI builds

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,6 @@
 import org.gradle.internal.jvm.Jvm
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompilerExecutionStrategy
 
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
@@ -125,6 +127,14 @@ ext {
         // Standard_DS2_v2 https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#cloud-hosts-for-github-hosted-runners
         // Which is 1:1 https://docs.microsoft.com/en-gb/azure/virtual-machines/acu : DS1_v2 - DS15_v2 | 1:1
         gradleTestMaxParallelForks = 2
+
+        // separate gradle compile process is a major speed improvement, but consumes 2x RAM
+        // the CI machines don't have enough RAM to do that without going in to swap quite a bit
+        // so for CI machines only - to improve reliability despite compilation speed hit, compile kotlin in process
+        println "CI build detected: setting compiler execution strategy to IN_PROCESS"
+        tasks.withType(KotlinCompile).configureEach {
+            compilerExecutionStrategy.set(KotlinCompilerExecutionStrategy.IN_PROCESS)
+        }
     } else {
         // Use 50% of cores to account for SMT which doesn't help this workload
         gradleTestMaxParallelForks = Runtime.runtime.availableProcessors().intdiv(2) ?: 1

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@
 
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
-org.gradle.jvmargs=-Xmx2048M -Dkotlin.compiler.execution.strategy=in-process -Dfile.encoding=UTF-8
+org.gradle.jvmargs=-Xmx2048M -Dfile.encoding=UTF-8
 
 # AndroidX package structure to make it clearer which packages are bundled with the
 # Android operating system, and which are packaged with your app's APK


### PR DESCRIPTION
## Purpose / Description
Building the app was slow if with `in_process` as compiler strategy, but we need `in_process` for CI builds

## Fixes
Fixes #11575

## Approach
- Set the compiler strategy only on CI builds, as written [here](https://github.com/ankidroid/Anki-Android/issues/11575#issuecomment-1151239413)

## How Has This Been Tested?

- Compare times before and after the change by this fix (8x speed improvement)
    - Build the app on Android Studio
    - Create a comment just to change anything and build the app again

To test CI, I've run CI on my fork and checked if Windows unit-test don't timeout (I suppose that was the problem without `in_process`
https://github.com/BrayanDSO/Anki-Android/runs/6843632189?check_suite_focus=true#step:7:19
https://github.com/BrayanDSO/Anki-Android/runs/6843502303?check_suite_focus=true#step:7:19
https://github.com/BrayanDSO/Anki-Android/runs/6843800724?check_suite_focus=true

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
