### PR TITLE
Replaced CollectionUtils.getLastListElement() with last() in FinderTest.

### DIFF
--- a/AnkiDroid/src/test/java/com/ichi2/libanki/FinderTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/FinderTest.kt
@@ -28,7 +28,6 @@ import com.ichi2.libanki.sched.SchedV2
 import com.ichi2.libanki.stats.Stats
 import com.ichi2.libanki.utils.TimeManager
 import com.ichi2.testutils.AnkiAssert
-import com.ichi2.utils.CollectionUtils.getLastListElement
 import com.ichi2.utils.KotlinCleanup
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.greaterThan
@@ -217,22 +216,18 @@ class FinderTest : RobolectricTest() {
         col.flush()
         assertTrue(
             latestCardIds.contains(
-                getLastListElement(
-                    col.findCards(
-                        "front:*",
-                        SortOrder.UseCollectionOrdering()
-                    )
-                )
+                col.findCards(
+                    "front:*",
+                    SortOrder.UseCollectionOrdering()
+                ).last()
             )
         )
         assertTrue(
             latestCardIds.contains(
-                getLastListElement(
-                    col.findCards(
-                        "",
-                        SortOrder.UseCollectionOrdering()
-                    )
-                )
+                col.findCards(
+                    "",
+                    SortOrder.UseCollectionOrdering()
+                ).last()
             )
         )
         col.set_config("sortType", "noteFld")
@@ -240,24 +235,20 @@ class FinderTest : RobolectricTest() {
         assertEquals(catCard.id, col.findCards("", SortOrder.UseCollectionOrdering())[0])
         assertTrue(
             latestCardIds.contains(
-                getLastListElement(
-                    col.findCards(
-                        "",
-                        SortOrder.UseCollectionOrdering()
-                    )
-                )
+                col.findCards(
+                    "",
+                    SortOrder.UseCollectionOrdering()
+                ).last()
             )
         )
         col.set_config("sortType", "cardMod")
         col.flush()
         assertTrue(
             latestCardIds.contains(
-                getLastListElement(
-                    col.findCards(
-                        "",
-                        SortOrder.UseCollectionOrdering()
-                    )
-                )
+                col.findCards(
+                    "",
+                    SortOrder.UseCollectionOrdering()
+                ).last()
             )
         )
         assertEquals(firstCardId, col.findCards("", SortOrder.UseCollectionOrdering())[0])


### PR DESCRIPTION
## Purpose / Description
All instances of CollectionUtils.getLastListElement() needs to be replaced with last() for cleanup.
Look at [this](https://github.com/ankidroid/Anki-Android/pull/11388/files#r877560222) comment to know why this needs to be replaced.

## Checklist

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented on your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
