### PR TITLE
Fix NoteEditor "Scroll toolbar" menu item sync bug

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
@@ -889,6 +889,8 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
             !shouldHideToolbar()
         menu.findItem(R.id.action_capitalize).isChecked =
             AnkiDroidApp.getSharedPrefs(this).getBoolean("note_editor_capitalize", true)
+        menu.findItem(R.id.action_scroll_toolbar).isChecked =
+            AnkiDroidApp.getSharedPrefs(this).getBoolean("noteEditorScrollToolbar", true)
         return super.onCreateOptionsMenu(menu)
     }
 


### PR DESCRIPTION
## Purpose / Description

At the moment the _Scroll Toolbar_ menu item in note editor doesn't properly follow its backing preference. You can see this by going to the note editor, unchecking/checking this menu item, leaving the editor and then coming back. This PR fixes this bug by updating the menu item's check status from the preferences when setting up the toolbar menu.

## How Has This Been Tested?

Ran the usual tests.

## Checklist

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
