### PR TITLE
Use `Settings` string instead of `Preferences`

### DIFF
--- a/AnkiDroid/src/main/AndroidManifest.xml
+++ b/AnkiDroid/src/main/AndroidManifest.xml
@@ -244,7 +244,7 @@
             />
         <activity
             android:name="com.ichi2.anki.Preferences"
-            android:label="@string/preferences_title"
+            android:label="@string/settings"
             android:exported="false"
             android:configChanges="keyboardHidden|orientation|locale|screenSize"
             android:theme="@style/LegacyActionBarLight"

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.kt
@@ -106,7 +106,7 @@ class Preferences : AnkiActivity() {
             setHomeButtonEnabled(true)
             setDisplayHomeAsUpEnabled(true)
         }
-        title = resources.getText(R.string.preferences_title)
+        title = resources.getText(R.string.settings)
 
         val fragment = getInitialFragment(intent)
 
@@ -134,7 +134,7 @@ class Preferences : AnkiActivity() {
         actionBar?.title = if (fragment is SpecificSettingsFragment) {
             fragment.preferenceScreen.title
         } else {
-            getString(R.string.preferences_title)
+            getString(R.string.settings)
         }
     }
 

--- a/AnkiDroid/src/main/res/values/04-network.xml
+++ b/AnkiDroid/src/main/res/values/04-network.xml
@@ -46,7 +46,6 @@
     <string name="lost_mail_instructions">Forgot Email?</string>
 
     <!-- AndroidManifest.xml -->
-    <string name="preferences_title">Preferences</string>
     <string name="deckpreferences_title">Options for XXX</string>
     <string name="sync_prepare_syncing">Preparing syncing…</string>
     <string name="sync_preparing_full_sync_message">Preparing full sync…</string>


### PR DESCRIPTION
To keep consistency.

`Settings` is the best option because it is a 01-core.xml's string and therefore more translated

## Fixes
Fixes #11608, fixes #11267

## How Has This Been Tested?

![image](https://user-images.githubusercontent.com/69634269/173371315-94351bb8-e980-424d-9325-555872a96bce.png)

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [X] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
