### PR TITLE
NF: waitForAllToFinish corrected

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/async/TaskManager.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/TaskManager.java
@@ -135,7 +135,7 @@ public abstract class TaskManager {
      */
     @SuppressWarnings("UnusedReturnValue")
     public static boolean waitForAllToFinish(Integer timeoutSeconds) {
-        return sTaskManager.waitToFinishConcrete(timeoutSeconds);
+        return sTaskManager.waitForAllToFinishConcrete(timeoutSeconds);
     }
     public abstract boolean waitForAllToFinishConcrete(Integer timeoutSeconds);
 


### PR DESCRIPTION
In 94aa0358e1da6a33f0f02519f4105db20dd2d249 I introduced an error.
The abstract `waitForAllToFinish` was deferring to `waitToFinishConcrete`
instead of `waitForAllToFinishConcrete`.

I have no knowledge of any issue it corrected, and I'm surprised by the
implementation of this method. Still, I correct it so that whether or not this
method is relevant can be discussed by itself.