### PR TITLE
Changing note type to cloze while in edit mode bug fix

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
@@ -724,15 +724,15 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
         }
         saveToggleStickyMap()
 
+        // Different from libAnki, block if there are no cloze deletions.
+        // DEFECT: This does not block addition if cloze transpositions are in non-cloze fields.
+        if (isClozeType && !hasClozeDeletions()) {
+            displayErrorSavingNote()
+            return
+        }
+
         // treat add new note and edit existing note independently
         if (mAddNote) {
-            // Different from libAnki, block if there are no cloze deletions.
-            // DEFECT: This does not block addition if cloze transpositions are in non-cloze fields.
-            if (isClozeType && !hasClozeDeletions()) {
-                displayErrorSavingNote()
-                return
-            }
-
             // load all of the fields into the note
             for (f in mEditFields!!) {
                 updateField(f)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
@@ -1485,7 +1485,7 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
                     mModelChangeFieldMap!![idx] = newFieldIndex
                 }
                 // Reload the fields
-                updateFieldsFromMap(currentlySelectedModel)
+                updateFieldsFromMap(currentlySelectedModel, true)
                 true
             }
             popup.show()
@@ -1915,9 +1915,9 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
     /**
      * Update all the field EditText views based on the currently selected note type and the mModelChangeFieldMap
      */
-    private fun updateFieldsFromMap(newModel: Model?) {
+    private fun updateFieldsFromMap(newModel: Model?, editModelMode: Boolean) {
         val type = FieldChangeType.refreshWithMap(newModel, mModelChangeFieldMap, shouldReplaceNewlines())
-        populateEditFields(type, true)
+        populateEditFields(type, editModelMode)
         updateCards(newModel)
     }
 
@@ -2005,7 +2005,7 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
                     }
                 }
                 // Update the field text edits based on the default mapping just assigned
-                updateFieldsFromMap(newModel)
+                updateFieldsFromMap(newModel, false)
                 // Don't let the user change any other values at the same time as changing note type
                 mSelectedTags = mEditorNote!!.tags
                 updateTags()


### PR DESCRIPTION
## Purpose / Description
Changing note type to cloze while in edit mode would disable the `FieldEditLine`s and also saving a cloze-type note without any cloze deletions, wouldn't show error toast

## Fixes
Fixes #11626

## Approach
_How does this change address the problem?_

## How Has This Been Tested?

https://user-images.githubusercontent.com/59933477/173639764-e4bbc53f-5e04-4530-bf26-cd5c936280bd.mov



## Checklist

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [x] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
