### PR TITLE
AbstractFlashcardViewer: remove multiple type declarations after `_`

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
@@ -44,7 +44,6 @@ import androidx.annotation.StringRes
 import androidx.annotation.VisibleForTesting
 import androidx.coordinatorlayout.widget.CoordinatorLayout
 import androidx.webkit.WebViewAssetLoader
-import com.afollestad.materialdialogs.DialogAction
 import com.afollestad.materialdialogs.MaterialDialog
 import com.drakeet.drawer.FullDraggableContainer
 import com.google.android.material.snackbar.Snackbar
@@ -467,8 +466,8 @@ abstract class AbstractFlashcardViewer :
                     .positiveText(R.string.dialog_continue)
                     .negativeText(R.string.close)
                     .cancelable(true)
-                    .onNegative { _: MaterialDialog?, _: DialogAction? -> finishWithAnimation(ActivityTransitionAnimation.Direction.END) }
-                    .onPositive { _: MaterialDialog?, _: DialogAction? -> col.startTimebox() }
+                    .onNegative { _, _ -> finishWithAnimation(ActivityTransitionAnimation.Direction.END) }
+                    .onPositive { _, _ -> col.startTimebox() }
                     .cancelListener { col.startTimebox() }
                     .show()
             }
@@ -880,7 +879,7 @@ abstract class AbstractFlashcardViewer :
             )
             .positiveText(R.string.dialog_positive_delete)
             .negativeText(R.string.dialog_cancel)
-            .onPositive { _: MaterialDialog?, _: DialogAction? ->
+            .onPositive { _, _ ->
                 Timber.i("AbstractFlashcardViewer:: OK button pressed to delete note %d", mCurrentCard!!.nid)
                 mSoundPlayer.stopSounds()
                 deleteNoteWithoutConfirmation()


### PR DESCRIPTION
## Purpose / Description
AbstractFlashcardViewer: remove multiple type declarations after `_`

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
