### PR TITLE
fix: Improve error if super.setUp() not called

### DIFF
--- a/AnkiDroid/src/test/java/com/ichi2/anki/RobolectricTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/RobolectricTest.kt
@@ -20,6 +20,7 @@ import android.content.Context
 import android.content.Intent
 import android.content.SharedPreferences
 import android.os.Looper
+import androidx.annotation.CallSuper
 import androidx.annotation.CheckResult
 import androidx.annotation.NonNull
 import androidx.core.content.edit
@@ -80,6 +81,7 @@ open class RobolectricTest : CollectionGetter {
     val mTaskScheduler = TaskSchedulerRule()
 
     @Before
+    @CallSuper
     open fun setUp() {
         TimeManager.resetWith(MockTime(2020, 7, 7, 7, 0, 0, 0, 10))
 
@@ -156,6 +158,7 @@ open class RobolectricTest : CollectionGetter {
     }
 
     @After
+    @CallSuper
     open fun tearDown() {
 
         // If you don't clean up your ActivityControllers you will get OOM errors
@@ -318,7 +321,13 @@ open class RobolectricTest : CollectionGetter {
     /** A collection. Created one second ago, not near cutoff time.
      * Each time time is checked, it advance by 10 ms. Not enough to create any change visible to user, but ensure
      * we don't get two equal time. */
-    override fun getCol(): Collection = CollectionHelper.getInstance().getCol(targetContext)
+    override fun getCol(): Collection {
+        try {
+            return CollectionHelper.getInstance().getCol(targetContext)
+        } catch (e: UnsatisfiedLinkError) {
+            throw RuntimeException("Failed to load collection. Did you call super.setUp()?", e)
+        }
+    }
 
     protected val collectionTime: MockTime
         get() = TimeManager.time as MockTime

--- a/AnkiDroid/src/test/java/com/ichi2/anki/stats/AnkiStatsTaskHandlerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/stats/AnkiStatsTaskHandlerTest.kt
@@ -40,6 +40,7 @@ class AnkiStatsTaskHandlerTest : RobolectricTest() {
 
     @Before
     override fun setUp() {
+        super.setUp()
         MockitoAnnotations.openMocks(this)
         whenever(mCol.db).thenReturn(null)
         whenever(mCol.dbClosed).thenReturn(true)

--- a/lint-release.xml
+++ b/lint-release.xml
@@ -23,6 +23,7 @@
     <issue id="NewApi" severity="fatal" />
     <issue id="HardcodedText" severity="fatal" />
     <issue id="InlinedApi" severity="fatal" />
+    <issue id="MissingSuperCall" severity="fatal" />
     <issue id="StringFormatCount" severity="fatal" />
     <issue id="StringFormatMatches" severity="fatal" />
     <issue id="StringFormatInvalid" severity="fatal" />
@@ -122,7 +123,6 @@
     <issue id="ButtonOrder" severity="ignore" />
     <issue id="ButtonStyle" severity="ignore" />
     <issue id="ByteOrderMark" severity="ignore" />
-    <issue id="MissingSuperCall" severity="ignore" />
     <issue id="AdapterViewChildren" severity="ignore" />
     <issue id="ScrollViewCount" severity="ignore" />
     <issue id="PermissionImpliesUnsupportedChromeOsHardware" severity="ignore" />


### PR DESCRIPTION
Adds in lint check and fixes error message

Previous Error was:

```
java.lang.UnsatisfiedLinkError: 'long net.ankiweb.rsdroid.NativeMethods.openBackend(byte[])'
	at net.ankiweb.rsdroid.NativeMethods.openBackend(Native Method)
	...
```

The `Error` is only thrown in the case that Robolectric is used

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
