### PR TITLE
[GSoC] Add categories icons

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.kt
@@ -37,6 +37,7 @@ import androidx.annotation.StringRes
 import androidx.annotation.VisibleForTesting
 import androidx.annotation.XmlRes
 import androidx.appcompat.app.ActionBar
+import androidx.appcompat.content.res.AppCompatResources
 import androidx.core.content.edit
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentManager
@@ -423,6 +424,7 @@ class Preferences : AnkiActivity() {
             if (BuildConfig.DEBUG) {
                 val devOptions = Preference(requireContext()).apply {
                     title = getString(R.string.pref_cat_dev_options)
+                    icon = AppCompatResources.getDrawable(requireContext(), R.drawable.ic_code)
                     setOnPreferenceClickListener {
                         parentFragmentManager.beginTransaction()
                             .replace(R.id.settings_container, DevOptionsFragment())
@@ -432,6 +434,11 @@ class Preferences : AnkiActivity() {
                     }
                 }
                 preferenceScreen.addPreference(devOptions)
+            }
+            // Set icons colors
+            for (index in 0 until preferenceScreen.preferenceCount) {
+                val preference = preferenceScreen.getPreference(index)
+                preference.icon?.setTint(Themes.getColorFromAttr(requireContext(), R.attr.prefIconColor))
             }
         }
     }

--- a/AnkiDroid/src/main/res/drawable/ic_code.xml
+++ b/AnkiDroid/src/main/res/drawable/ic_code.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#FFFFFF"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M9.4,16.6L4.8,12l4.6,-4.6L8,6l-6,6 6,6 1.4,-1.4zM14.6,16.6l4.6,-4.6 -4.6,-4.6L16,6l6,6 -6,6 -1.4,-1.4z"/>
+</vector>

--- a/AnkiDroid/src/main/res/drawable/ic_notifications.xml
+++ b/AnkiDroid/src/main/res/drawable/ic_notifications.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#FFFFFF"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M12,22c1.1,0 2,-0.9 2,-2h-4c0,1.1 0.89,2 2,2zM18,16v-5c0,-3.07 -1.64,-5.64 -4.5,-6.32L13.5,4c0,-0.83 -0.67,-1.5 -1.5,-1.5s-1.5,0.67 -1.5,1.5v0.68C7.63,5.36 6,7.92 6,11v5l-2,2v1h16v-1l-2,-2z"/>
+</vector>

--- a/AnkiDroid/src/main/res/drawable/ic_touch.xml
+++ b/AnkiDroid/src/main/res/drawable/ic_touch.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#FFFFFF"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M9,11.24V7.5C9,6.12 10.12,5 11.5,5S14,6.12 14,7.5v3.74c1.21,-0.81 2,-2.18 2,-3.74C16,5.01 13.99,3 11.5,3S7,5.01 7,7.5C7,9.06 7.79,10.43 9,11.24zM18.84,15.87l-4.54,-2.26c-0.17,-0.07 -0.35,-0.11 -0.54,-0.11H13v-6C13,6.67 12.33,6 11.5,6S10,6.67 10,7.5v10.74c-3.6,-0.76 -3.54,-0.75 -3.67,-0.75c-0.31,0 -0.59,0.13 -0.79,0.33l-0.79,0.8l4.94,4.94C9.96,23.83 10.34,24 10.75,24h6.79c0.75,0 1.33,-0.55 1.44,-1.28l0.75,-5.27c0.01,-0.07 0.02,-0.14 0.02,-0.2C19.75,16.63 19.37,16.09 18.84,15.87z"/>
+</vector>

--- a/AnkiDroid/src/main/res/values/attrs.xml
+++ b/AnkiDroid/src/main/res/values/attrs.xml
@@ -125,6 +125,7 @@
     <attr name="customTabNavBarColor" format="color"/>
     <!-- Popup menus' background color -->
     <attr name="popupBackgroundColor" format="reference"/>
+    <attr name="prefIconColor" format="color"/>
 
     <attr name="editTextDisabled" format="color"/>
 

--- a/AnkiDroid/src/main/res/values/theme_black.xml
+++ b/AnkiDroid/src/main/res/values/theme_black.xml
@@ -115,6 +115,7 @@
 
         <item name="editTextDisabled">@color/material_grey_700</item>
         <item name="android:navigationBarColor">@color/black</item>
+        <item name="prefIconColor">?android:attr/textColor</item>
     </style>
 
     <!-- Preferences screens -->

--- a/AnkiDroid/src/main/res/values/theme_light.xml
+++ b/AnkiDroid/src/main/res/values/theme_light.xml
@@ -134,6 +134,7 @@ APIs. It's visible when there aren't enough decks to fill the screen.
         <!--Custom Tabs colors-->
         <item name="customTabNavBarColor">@color/material_light_blue_500</item>
         <item name="popupBackgroundColor">@android:color/white</item>
+        <item name="prefIconColor">?android:attr/textColor</item>
 
         <item name="editTextDisabled">@color/material_grey_500</item>
     </style>

--- a/AnkiDroid/src/main/res/values/theme_plain.xml
+++ b/AnkiDroid/src/main/res/values/theme_plain.xml
@@ -49,6 +49,7 @@
         <item name="customTabNavBarColor">@color/material_grey_500</item>
 
         <item name="currentDeckBackground">@drawable/item_background_selected</item>
+        <item name="prefIconColor">?attr/colorPrimary</item>
     </style>
 
     <!-- Preferences screens -->

--- a/AnkiDroid/src/main/res/xml/preference_headers.xml
+++ b/AnkiDroid/src/main/res/xml/preference_headers.xml
@@ -21,28 +21,32 @@
     <Preference
         android:fragment="com.ichi2.anki.Preferences$GeneralSettingsFragment"
         android:summary="@string/pref_cat_general_summ"
-        android:title="@string/pref_cat_general">
+        android:title="@string/pref_cat_general"
+        android:icon="@drawable/ic_settings_black">
     </Preference>
 
     <!-- Reviewing Preferences -->
     <Preference
         android:fragment="com.ichi2.anki.Preferences$ReviewingSettingsFragment"
         android:summary="@string/pref_cat_reviewing_summ"
-        android:title="@string/pref_cat_reviewing">
+        android:title="@string/pref_cat_reviewing"
+        android:icon="@drawable/ic_flashcard_black">
     </Preference>
 
     <!-- Sync Preferences -->
     <Preference
         android:fragment="com.ichi2.anki.Preferences$SyncSettingsFragment"
         android:key="@string/pref_sync_screen_key"
-        android:title="@string/pref_cat_sync">
+        android:title="@string/pref_cat_sync"
+        android:icon="@drawable/ic_sync_white">
     </Preference>
 
     <!-- Notifications -->
     <Preference
         android:fragment="com.ichi2.anki.preferences.NotificationsSettingsFragment"
         android:key="@string/pref_notifications_screen_key"
-        android:title="@string/notification_pref">
+        android:title="@string/notification_pref"
+        android:icon="@drawable/ic_notifications">
     </Preference>
 
     <!-- Appearance Preferences  -->
@@ -50,7 +54,8 @@
         android:fragment="com.ichi2.anki.Preferences$AppearanceSettingsFragment"
         android:key="appearance_preference_group"
         android:summary="@string/pref_cat_appearance_summ"
-        android:title="@string/pref_cat_appearance">
+        android:title="@string/pref_cat_appearance"
+        android:icon="@drawable/ic_color_lens_white_24dp">
     </Preference>
 
     <!-- Navigation Preferences -->
@@ -64,7 +69,8 @@
     <Preference
         android:fragment="com.ichi2.anki.Preferences$ControlsSettingsFragment"
         android:summary="@string/pref_cat_controls_summ"
-        android:title="@string/pref_cat_controls">
+        android:title="@string/pref_cat_controls"
+        android:icon="@drawable/ic_touch">
     </Preference>
 
     <!-- Advanced Preferences -->
@@ -72,6 +78,7 @@
         android:fragment="com.ichi2.anki.Preferences$AdvancedSettingsFragment"
         android:key="pref_screen_advanced"
         android:summary="@string/pref_cat_advanced_summ"
-        android:title="@string/pref_cat_advanced">
+        android:title="@string/pref_cat_advanced"
+        android:icon="@drawable/ic_tune_white">
     </Preference>
 </PreferenceScreen>


### PR DESCRIPTION
## Purpose / Description
Icons are pretty

## Approach
- Add some icons
- Add their colors (textColor for light, dark and black; primary for plain)

Gestures category not updated because it will be removed with #11647

## How Has This Been Tested?

![WhatsApp Image 2022-06-17 at 11 48 34 (1)](https://user-images.githubusercontent.com/69634269/174322073-7fc491b3-de6e-426d-868d-0783c21e9f90.jpeg)
![WhatsApp Image 2022-06-17 at 11 48 34](https://user-images.githubusercontent.com/69634269/174322076-8ca2ccec-8202-4879-bd5e-d3f08cf7f2e8.jpeg)
![WhatsApp Image 2022-06-17 at 11 48 33 (1)](https://user-images.githubusercontent.com/69634269/174322078-53e41eea-cdda-4bbd-acac-40a77725b90c.jpeg)
![WhatsApp Image 2022-06-17 at 11 48 33](https://user-images.githubusercontent.com/69634269/174322082-7aff0a3d-a016-47d1-846e-49afe8878a60.jpeg)

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [X] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
