### PR TITLE
[GSoC] fix: LoadPronunciationActivity didn't inherit AnkiActivity

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/activity/LoadPronunciationActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/activity/LoadPronunciationActivity.kt
@@ -19,13 +19,13 @@
 
 package com.ichi2.anki.multimediacard.activity
 
-import android.app.Activity
 import android.content.DialogInterface
 import android.content.Intent
 import android.os.Bundle
 import android.view.Menu
 import android.view.View
 import android.widget.*
+import com.ichi2.anki.AnkiActivity
 import com.ichi2.anki.R
 import com.ichi2.anki.UIUtils.showThemedToast
 import com.ichi2.anki.multimediacard.beolingus.parsing.BeolingusParser
@@ -48,9 +48,8 @@ import java.util.*
  * User picks a source language and the source is passed as extra.
  * <p>
  * When activity finished, it passes the filepath as another extra to the caller.
- * FIXME why isn't this extending AnkiActivity?
  */
-open class LoadPronunciationActivity : Activity(), DialogInterface.OnCancelListener {
+open class LoadPronunciationActivity : AnkiActivity(), DialogInterface.OnCancelListener {
     private var mStopped = false
     private lateinit var source: String
     private lateinit var mTranslationAddress: String
@@ -123,7 +122,7 @@ open class LoadPronunciationActivity : Activity(), DialogInterface.OnCancelListe
         mLoadingLayoutMessage.text = message
     }
 
-    private fun hideProgressBar() {
+    override fun hideProgressBar() {
         mLoadingLayout.visibility = View.GONE
         mMainLayout.visibility = View.VISIBLE
     }
@@ -271,6 +270,7 @@ open class LoadPronunciationActivity : Activity(), DialogInterface.OnCancelListe
     }
 
     // This is called when MP3 Download is finished.
+    @Suppress("DEPRECATION") // finish()
     fun receiveMp3File(result: String?) {
         if (mStopped) {
             return
@@ -291,6 +291,7 @@ open class LoadPronunciationActivity : Activity(), DialogInterface.OnCancelListe
         finish()
     }
 
+    @Suppress("DEPRECATION") // finish()
     private fun finishCancel() {
         val resultData = Intent()
         setResult(RESULT_CANCELED, resultData)
@@ -337,6 +338,7 @@ open class LoadPronunciationActivity : Activity(), DialogInterface.OnCancelListe
     }
 
     // If the loading and dialog are cancelled
+    @Suppress("DEPRECATION") // finish()
     override fun onCancel(dialog: DialogInterface) {
         mStopped = true
         hideProgressBar()


### PR DESCRIPTION
## Purpose / Description
Fixed: LoadPronunciationActivity didn't inherit AnkiActivity
In order to use coroutine `lifecycleScope`, it must inherit ComponentActivity or its descendent.

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [ ] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
