### PR TITLE
Fix paste from browser into note field not working

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/FieldEditText.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/FieldEditText.kt
@@ -47,6 +47,8 @@ import com.ichi2.utils.ClipboardUtil.hasImage
 import com.ichi2.utils.KotlinCleanup
 import timber.log.Timber
 import java.util.*
+import kotlin.math.max
+import kotlin.math.min
 
 class FieldEditText : FixedEditText, NoteService.NoteField {
     override var ord = 0
@@ -212,17 +214,13 @@ class FieldEditText : FixedEditText, NoteService.NoteField {
     @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
     fun pastePlainText(): Boolean {
         getPlainText(clipboard, context)?.let { pasted ->
-            selectionStart.run {
-                // setText also sets selectionStart to 0
-                setText(
-                    text!!.substring(
-                        0,
-                        selectionStart
-                    ) + pasted + text!!.substring(selectionEnd)
-                )
-                setSelection(this + pasted.length)
-                return true
-            }
+            val start = min(selectionStart, selectionEnd)
+            val end = max(selectionStart, selectionEnd)
+            setText(
+                text!!.substring(0, start) + pasted + text!!.substring(end)
+            )
+            setSelection(start + pasted.length)
+            return true
         }
         return false
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/FieldEditText.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/FieldEditText.kt
@@ -54,7 +54,7 @@ class FieldEditText : FixedEditText, NoteService.NoteField {
     private var mSelectionChangeListener: TextSelectionListener? = null
     private var mImageListener: ImagePasteListener? = null
     @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
-    var mClipboard: ClipboardManager? = null
+    var clipboard: ClipboardManager? = null
 
     constructor(context: Context?) : super(context!!)
     constructor(context: Context?, attr: AttributeSet?) : super(context!!, attr)
@@ -88,7 +88,7 @@ class FieldEditText : FixedEditText, NoteService.NoteField {
 
     fun init() {
         try {
-            mClipboard = context.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
+            clipboard = context.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
         } catch (e: Exception) {
             Timber.w(e)
         }
@@ -201,8 +201,8 @@ class FieldEditText : FixedEditText, NoteService.NoteField {
     override fun onTextContextMenuItem(id: Int): Boolean {
         // This handles both CTRL+V and "Paste"
         if (id == android.R.id.paste) {
-            if (hasImage(mClipboard)) {
-                return onImagePaste(getImageUri(mClipboard))
+            if (hasImage(clipboard)) {
+                return onImagePaste(getImageUri(clipboard))
             }
             return pastePlainText()
         }
@@ -211,7 +211,7 @@ class FieldEditText : FixedEditText, NoteService.NoteField {
 
     @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
     fun pastePlainText(): Boolean {
-        getPlainText(mClipboard, context)?.let { pasted ->
+        getPlainText(clipboard, context)?.let { pasted ->
             selectionStart.run {
                 // setText also sets selectionStart to 0
                 setText(

--- a/AnkiDroid/src/main/java/com/ichi2/anki/FieldEditText.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/FieldEditText.kt
@@ -20,7 +20,10 @@ import android.content.ClipboardManager
 import android.content.Context
 import android.graphics.drawable.Drawable
 import android.net.Uri
-import android.os.*
+import android.os.Build
+import android.os.LocaleList
+import android.os.Parcel
+import android.os.Parcelable
 import android.text.InputType
 import android.util.AttributeSet
 import android.view.View
@@ -41,7 +44,6 @@ import com.ichi2.utils.ClipboardUtil.getImageUri
 import com.ichi2.utils.ClipboardUtil.hasImage
 import com.ichi2.utils.KotlinCleanup
 import timber.log.Timber
-import java.lang.Exception
 import java.util.*
 
 class FieldEditText : FixedEditText, NoteService.NoteField {
@@ -198,12 +200,15 @@ class FieldEditText : FixedEditText, NoteService.NoteField {
         if (id == android.R.id.paste) {
             if (hasImage(mClipboard)) {
                 return onImagePaste(getImageUri(mClipboard))
-            } else if (mClipboard?.hasPrimaryClip() == true) {
+            }
+            if (mClipboard?.hasPrimaryClip() == true) {
                 mClipboard?.primaryClip?.run {
-                    this@FieldEditText.run {
-                        setText("${text}${getItemAt(0).coerceToText(context)}")
-                        setSelection(text!!.length)
-                    }
+                    this@FieldEditText
+                        .takeIf { itemCount > 0 }
+                        ?.run {
+                            setText("${text}${getItemAt(0).coerceToText(context)}")
+                            setSelection(text!!.length)
+                        }
                     return true
                 }
             }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/FieldEditText.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/FieldEditText.kt
@@ -201,17 +201,25 @@ class FieldEditText : FixedEditText, NoteService.NoteField {
             if (hasImage(mClipboard)) {
                 return onImagePaste(getImageUri(mClipboard))
             }
-            if (mClipboard?.hasPrimaryClip() == true) {
-                mClipboard?.primaryClip?.run {
+            mClipboard
+                ?.takeIf { it.hasPrimaryClip() }
+                ?.primaryClip?.run {
                     this@FieldEditText
                         .takeIf { itemCount > 0 }
                         ?.run {
-                            setText("${text}${getItemAt(0).coerceToText(context)}")
-                            setSelection(text!!.length)
+                            val pasted = getItemAt(0).coerceToText(context)
+                            selectionStart.run {
+                                // setText also sets selectionStart to 0
+                                setText(
+                                    text!!.substring(0, selectionStart) +
+                                        pasted +
+                                        text!!.substring(selectionEnd)
+                                )
+                                setSelection(this + pasted.length)
+                            }
+                            return true
                         }
-                    return true
                 }
-            }
         }
         return false
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/FieldEditText.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/FieldEditText.kt
@@ -51,9 +51,9 @@ class FieldEditText : FixedEditText, NoteService.NoteField {
     private var mImageListener: ImagePasteListener? = null
     private var mClipboard: ClipboardManager? = null
 
-    constructor(context: Context?) : super(context!!) {}
-    constructor(context: Context?, attr: AttributeSet?) : super(context!!, attr) {}
-    constructor(context: Context?, attrs: AttributeSet?, defStyle: Int) : super(context!!, attrs, defStyle) {}
+    constructor(context: Context?) : super(context!!)
+    constructor(context: Context?, attr: AttributeSet?) : super(context!!, attr)
+    constructor(context: Context?, attrs: AttributeSet?, defStyle: Int) : super(context!!, attrs, defStyle)
 
     override fun onAttachedToWindow() {
         super.onAttachedToWindow()
@@ -193,35 +193,22 @@ class FieldEditText : FixedEditText, NoteService.NoteField {
         return savedState
     }
 
-    @KotlinCleanup("Return instead of using _id")
     override fun onTextContextMenuItem(id: Int): Boolean {
         // This handles both CTRL+V and "Paste"
-        var _id = id
-        if (id == android.R.id.paste && hasImage(mClipboard)) {
-            return onImagePaste(getImageUri(mClipboard))
-        }
-
-        /*
-        * The following code replaces the instruction "paste with formatting" with "paste as plan text"
-        * Since AnkiDroid does not know how to use formatted text and strips the formatting when saving the note,
-        * it ensures that the user sees the exact plain text which is actually being saved, not the formatted text.
-        */
-
-        // https://stackoverflow.com/a/45319485
         if (id == android.R.id.paste) {
-            /**
-             * Modified StackOverflow answer:
-             * Pasting as plain text for VERSION_CODES < M required modifying
-             * the user's clipboard, and hence has not been used.
-             *
-             * During testing, older devices pasted text as plain text by default,
-             * so there was no need for a TO-DO
-             */
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-                _id = android.R.id.pasteAsPlainText
+            if (hasImage(mClipboard)) {
+                return onImagePaste(getImageUri(mClipboard))
+            } else if (mClipboard?.hasPrimaryClip() == true) {
+                mClipboard?.primaryClip?.run {
+                    this@FieldEditText.run {
+                        setText("${text}${getItemAt(0).coerceToText(context)}")
+                        setSelection(text!!.length)
+                    }
+                    return true
+                }
             }
         }
-        return super.onTextContextMenuItem(_id)
+        return false
     }
 
     @KotlinCleanup("Make param non-null")
@@ -257,7 +244,7 @@ class FieldEditText : FixedEditText, NoteService.NoteField {
     internal class SavedState : BaseSavedState {
         var ord = 0
 
-        constructor(superState: Parcelable?) : super(superState) {}
+        constructor(superState: Parcelable?) : super(superState)
 
         override fun writeToParcel(out: Parcel, flags: Int) {
             super.writeToParcel(out, flags)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/FieldEditText.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/FieldEditText.kt
@@ -41,6 +41,7 @@ import com.ichi2.themes.Themes.getColorFromAttr
 import com.ichi2.ui.FixedEditText
 import com.ichi2.utils.ClipboardUtil.IMAGE_MIME_TYPES
 import com.ichi2.utils.ClipboardUtil.getImageUri
+import com.ichi2.utils.ClipboardUtil.getPlainText
 import com.ichi2.utils.ClipboardUtil.hasImage
 import com.ichi2.utils.KotlinCleanup
 import timber.log.Timber
@@ -201,25 +202,14 @@ class FieldEditText : FixedEditText, NoteService.NoteField {
             if (hasImage(mClipboard)) {
                 return onImagePaste(getImageUri(mClipboard))
             }
-            mClipboard
-                ?.takeIf { it.hasPrimaryClip() }
-                ?.primaryClip?.run {
-                    this@FieldEditText
-                        .takeIf { itemCount > 0 }
-                        ?.run {
-                            val pasted = getItemAt(0).coerceToText(context)
-                            selectionStart.run {
-                                // setText also sets selectionStart to 0
-                                setText(
-                                    text!!.substring(0, selectionStart) +
-                                        pasted +
-                                        text!!.substring(selectionEnd)
-                                )
-                                setSelection(this + pasted.length)
-                            }
-                            return true
-                        }
+            getPlainText(mClipboard, context)?.let { pasted ->
+                selectionStart.run {
+                    // setText also sets selectionStart to 0
+                    setText(text!!.substring(0, selectionStart) + pasted + text!!.substring(selectionEnd))
+                    setSelection(this + pasted.length)
                 }
+                return true
+            }
         }
         return false
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
@@ -1243,6 +1243,13 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
         }
     }
 
+    /** Sets EditText at index [fieldIndex]'s text to [newString] */
+    @VisibleForTesting
+    fun setField(fieldIndex: Int, newString: String) {
+        clearField(fieldIndex)
+        insertStringInField(getFieldForTest(fieldIndex), newString)
+    }
+
     /** @param col Readonly variable to get cache dir
      */
     @KotlinCleanup("fix the requireNoNulls")

--- a/AnkiDroid/src/main/java/com/ichi2/utils/ClipboardUtil.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/ClipboardUtil.kt
@@ -18,6 +18,7 @@ package com.ichi2.utils
 import android.content.ClipData
 import android.content.ClipDescription
 import android.content.ClipboardManager
+import android.content.Context
 import android.net.Uri
 import androidx.annotation.CheckResult
 
@@ -28,68 +29,48 @@ object ClipboardUtil {
 
     @JvmStatic
     fun hasImage(clipboard: ClipboardManager?): Boolean {
-        if (clipboard == null) {
-            return false
-        }
-        if (!clipboard.hasPrimaryClip()) {
-            return false
-        }
-        val primaryClip = clipboard.primaryClip
-        return hasImage(primaryClip!!.description)
+        return clipboard
+            ?.takeIf { it.hasPrimaryClip() }
+            ?.primaryClip
+            ?.let { hasImage(it.description) }
+            ?: false
     }
 
     @JvmStatic
     fun hasImage(description: ClipDescription?): Boolean {
-        if (description == null) {
-            return false
-        }
-        for (mimeType in IMAGE_MIME_TYPES) {
-            if (description.hasMimeType(mimeType)) {
-                return true
-            }
-        }
-        return false
+        return description
+            ?.run { IMAGE_MIME_TYPES.any { hasMimeType(it) } }
+            ?: false
     }
+
+    private fun getFirstItem(clipboard: ClipboardManager?) = clipboard
+        ?.takeIf { it.hasPrimaryClip() }
+        ?.primaryClip
+        ?.takeIf { it.itemCount > 0 }
+        ?.getItemAt(0)
 
     @JvmStatic
     fun getImageUri(clipboard: ClipboardManager?): Uri? {
-        if (clipboard == null) {
-            return null
-        }
-        if (!clipboard.hasPrimaryClip()) {
-            return null
-        }
-        val primaryClip = clipboard.primaryClip
-        return if (primaryClip!!.itemCount == 0) {
-            null
-        } else primaryClip.getItemAt(0).uri
+        return getFirstItem(clipboard)?.uri
     }
 
     @JvmStatic
     @CheckResult
     fun getText(clipboard: ClipboardManager?): CharSequence? {
-        if (clipboard == null) {
-            return null
-        }
-        if (!clipboard.hasPrimaryClip()) {
-            return null
-        }
-        val data = clipboard.primaryClip
-        if (data!!.itemCount == 0) {
-            return null
-        }
-        val i = data.getItemAt(0)
-        return i.text
+        return getFirstItem(clipboard)?.text
     }
 
     @JvmStatic
     @CheckResult
-    fun getDescriptionLabel(clip: ClipData?): CharSequence? {
-        if (clip == null) {
-            return null
-        }
-        return if (clip.description == null) {
-            null
-        } else clip.description.label
+    fun getPlainText(clipboard: ClipboardManager?, context: Context): CharSequence? {
+        return getFirstItem(clipboard)?.coerceToText(context)
+    }
+
+    @JvmStatic
+    @CheckResult
+    fun getDescriptionLabel(clipboard: ClipData?): CharSequence? {
+        return clipboard
+            ?.description
+            ?.label
     }
 }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/NoteEditorTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/NoteEditorTest.kt
@@ -317,9 +317,9 @@ class NoteEditorTest : RobolectricTest() {
         val editor = getNoteEditorAddingNote(DECK_LIST, NoteEditor::class.java)
         editor.setCurrentlySelectedModel(col.models.byName("Basic")!!.getLong("id"))
         val field = editor.getFieldForTest(0)
-        field.mClipboard!!.setPrimaryClip(ClipData.newHtmlText("text", "text", "<span style=\"color: red\">text</span>"))
-        assertTrue(field.mClipboard!!.hasPrimaryClip())
-        assertNotNull(field.mClipboard!!.primaryClip)
+        field.clipboard!!.setPrimaryClip(ClipData.newHtmlText("text", "text", "<span style=\"color: red\">text</span>"))
+        assertTrue(field.clipboard!!.hasPrimaryClip())
+        assertNotNull(field.clipboard!!.primaryClip)
 
         // test pasting in the middle (cursor mode: selecting)
         editor.setField(0, "012345")

--- a/AnkiDroid/src/test/java/com/ichi2/anki/NoteEditorTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/NoteEditorTest.kt
@@ -329,6 +329,14 @@ class NoteEditorTest : RobolectricTest() {
         assertEquals(5, field.selectionStart)
         assertEquals(5, field.selectionEnd)
 
+        // test pasting in the middle (cursor mode: selecting backwards)
+        editor.setField(0, "012345")
+        field.setSelection(2, 1) // selecting "1"
+        assertTrue(field.pastePlainText())
+        assertEquals("0text2345", field.fieldText)
+        assertEquals(5, field.selectionStart)
+        assertEquals(5, field.selectionEnd)
+
         // test pasting in the middle (cursor mode: normal)
         editor.setField(0, "012345")
         field.setSelection(4) // after "3"

--- a/AnkiDroid/src/test/java/com/ichi2/anki/NoteEditorTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/NoteEditorTest.kt
@@ -16,6 +16,7 @@
 package com.ichi2.anki
 
 import android.app.Activity
+import android.content.ClipData
 import android.content.Intent
 import android.widget.EditText
 import android.widget.TextView
@@ -42,8 +43,9 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.Shadows.shadowOf
 import org.robolectric.annotation.Config
-import java.util.*
+import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
 
 @RunWith(AndroidJUnit4::class)
 @KotlinCleanup("IDE lint")
@@ -308,6 +310,48 @@ class NoteEditorTest : RobolectricTest() {
         val editor = getNoteEditorAddingNote(DECK_LIST, NoteEditor::class.java)
         editor.setCurrentlySelectedModel(cloze.getLong("id"))
         assertThat(editor.deckId, equalTo(Consts.DEFAULT_DECK_ID))
+    }
+
+    @Test
+    fun pasteHtmlAsPlainTextTest() {
+        val editor = getNoteEditorAddingNote(DECK_LIST, NoteEditor::class.java)
+        editor.setCurrentlySelectedModel(col.models.byName("Basic")!!.getLong("id"))
+        val field = editor.getFieldForTest(0)
+        field.mClipboard!!.setPrimaryClip(ClipData.newHtmlText("text", "text", "<span style=\"color: red\">text</span>"))
+        assertTrue(field.mClipboard!!.hasPrimaryClip())
+        assertNotNull(field.mClipboard!!.primaryClip)
+
+        // test pasting in the middle (cursor mode: selecting)
+        editor.setField(0, "012345")
+        field.setSelection(1, 2) // selecting "1"
+        assertTrue(field.pastePlainText())
+        assertEquals("0text2345", field.fieldText)
+        assertEquals(5, field.selectionStart)
+        assertEquals(5, field.selectionEnd)
+
+        // test pasting in the middle (cursor mode: normal)
+        editor.setField(0, "012345")
+        field.setSelection(4) // after "3"
+        assertTrue(field.pastePlainText())
+        assertEquals("0123text45", field.fieldText)
+        assertEquals(8, field.selectionStart)
+        assertEquals(8, field.selectionEnd)
+
+        // test pasting at the start
+        editor.setField(0, "012345")
+        field.setSelection(0) // before "0"
+        assertTrue(field.pastePlainText())
+        assertEquals("text012345", field.fieldText)
+        assertEquals(4, field.selectionStart)
+        assertEquals(4, field.selectionEnd)
+
+        // test pasting at the end
+        editor.setField(0, "012345")
+        field.setSelection(6) // after "5"
+        assertTrue(field.pastePlainText())
+        assertEquals("012345text", field.fieldText)
+        assertEquals(10, field.selectionStart)
+        assertEquals(10, field.selectionEnd)
     }
 
     private fun getCopyNoteIntent(editor: NoteEditor): Intent {


### PR DESCRIPTION
## Purpose / Description
Pasting plain text from samsung native browser into note fields wouldn't work.

## Fixes
Fixes #11574

## Approach
rewrote `FieldEditText::onTextContextMenuItem` to paste as plain text using `coerceToText` in `primaryClip.getItemAt(0).coerceToText(context)`.

## How Has This Been Tested?
Tested on real device:

https://user-images.githubusercontent.com/59933477/174403631-6412f7dc-07a6-4d67-9b02-7132795fd2b0.mp4



## Checklist

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [x] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
