### PR TITLE
[GSoC] Fix sync button color

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.kt
@@ -446,7 +446,7 @@ class Preferences : AnkiActivity() {
             // Set icons colors
             for (index in 0 until preferenceScreen.preferenceCount) {
                 val preference = preferenceScreen.getPreference(index)
-                preference.icon?.setTint(Themes.getColorFromAttr(requireContext(), R.attr.prefIconColor))
+                preference.icon?.setTint(Themes.getColorFromAttr(requireContext(), R.attr.iconColor))
             }
         }
     }

--- a/AnkiDroid/src/main/res/drawable/ic_sync.xml
+++ b/AnkiDroid/src/main/res/drawable/ic_sync.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="?attr/iconColor"
+    android:viewportHeight="24.0" android:viewportWidth="24.0"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="?attr/iconColor" android:pathData="M12,4L12,1L8,5l4,4L12,6c3.31,0 6,2.69 6,6 0,1.01 -0.25,1.97 -0.7,2.8l1.46,1.46C19.54,15.03 20,13.57 20,12c0,-4.42 -3.58,-8 -8,-8zM12,18c-3.31,0 -6,-2.69 -6,-6 0,-1.01 0.25,-1.97 0.7,-2.8L5.24,7.74C4.46,8.97 4,10.43 4,12c0,4.42 3.58,8 8,8v3l4,-4 -4,-4v3z"/>
+</vector>

--- a/AnkiDroid/src/main/res/drawable/ic_sync_white.xml
+++ b/AnkiDroid/src/main/res/drawable/ic_sync_white.xml
@@ -1,5 +1,0 @@
-<vector android:height="24dp" android:tint="#FFFFFF"
-    android:viewportHeight="24.0" android:viewportWidth="24.0"
-    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
-    <path android:fillColor="#FF000000" android:pathData="M12,4L12,1L8,5l4,4L12,6c3.31,0 6,2.69 6,6 0,1.01 -0.25,1.97 -0.7,2.8l1.46,1.46C19.54,15.03 20,13.57 20,12c0,-4.42 -3.58,-8 -8,-8zM12,18c-3.31,0 -6,-2.69 -6,-6 0,-1.01 0.25,-1.97 0.7,-2.8L5.24,7.74C4.46,8.97 4,10.43 4,12c0,4.42 3.58,8 8,8v3l4,-4 -4,-4v3z"/>
-</vector>

--- a/AnkiDroid/src/main/res/menu/deck_picker.xml
+++ b/AnkiDroid/src/main/res/menu/deck_picker.xml
@@ -12,7 +12,7 @@
     -->
     <item
         android:id="@+id/action_sync"
-        android:icon="@drawable/ic_sync_white"
+        android:icon="@drawable/ic_sync"
         android:title="@string/button_sync"
         ankidroid:showAsAction="always"/>
     <item

--- a/AnkiDroid/src/main/res/values/attrs.xml
+++ b/AnkiDroid/src/main/res/values/attrs.xml
@@ -125,7 +125,7 @@
     <attr name="customTabNavBarColor" format="color"/>
     <!-- Popup menus' background color -->
     <attr name="popupBackgroundColor" format="reference"/>
-    <attr name="prefIconColor" format="color"/>
+    <attr name="iconColor" format="color"/>
 
     <attr name="editTextDisabled" format="color"/>
 

--- a/AnkiDroid/src/main/res/values/styles.xml
+++ b/AnkiDroid/src/main/res/values/styles.xml
@@ -108,6 +108,7 @@
         <item name="android:textColorSecondary">@color/white</item>
         <!-- Overflow menu style -->
         <item name="popupTheme">@style/ActionBar.Popup</item>
+        <item name="iconColor">@color/white</item>
     </style>
 
     <!-- For all other action bar popups like overflow menu (except spinner dropdown in Lollipop). -->

--- a/AnkiDroid/src/main/res/values/theme_black.xml
+++ b/AnkiDroid/src/main/res/values/theme_black.xml
@@ -115,7 +115,7 @@
 
         <item name="editTextDisabled">@color/material_grey_700</item>
         <item name="android:navigationBarColor">@color/black</item>
-        <item name="prefIconColor">?android:attr/textColor</item>
+        <item name="iconColor">?android:attr/textColor</item>
     </style>
 
     <!-- Preferences screens -->

--- a/AnkiDroid/src/main/res/values/theme_light.xml
+++ b/AnkiDroid/src/main/res/values/theme_light.xml
@@ -134,7 +134,7 @@ APIs. It's visible when there aren't enough decks to fill the screen.
         <!--Custom Tabs colors-->
         <item name="customTabNavBarColor">@color/material_light_blue_500</item>
         <item name="popupBackgroundColor">@android:color/white</item>
-        <item name="prefIconColor">?android:attr/textColor</item>
+        <item name="iconColor">?android:attr/textColor</item>
 
         <item name="editTextDisabled">@color/material_grey_500</item>
     </style>

--- a/AnkiDroid/src/main/res/values/theme_plain.xml
+++ b/AnkiDroid/src/main/res/values/theme_plain.xml
@@ -49,7 +49,7 @@
         <item name="customTabNavBarColor">@color/material_grey_500</item>
 
         <item name="currentDeckBackground">@drawable/item_background_selected</item>
-        <item name="prefIconColor">?attr/colorPrimary</item>
+        <item name="iconColor">?attr/colorPrimary</item>
     </style>
 
     <!-- Preferences screens -->

--- a/AnkiDroid/src/main/res/xml/preference_headers.xml
+++ b/AnkiDroid/src/main/res/xml/preference_headers.xml
@@ -38,7 +38,7 @@
         android:fragment="com.ichi2.anki.Preferences$SyncSettingsFragment"
         android:key="@string/pref_sync_screen_key"
         android:title="@string/pref_cat_sync"
-        android:icon="@drawable/ic_sync_white">
+        android:icon="@drawable/ic_sync">
     </Preference>
 
     <!-- Notifications -->


### PR DESCRIPTION
## Purpose / Description
If user changed themes, the sync icon would use the same color of the sync category icon

## Approach
Make sync icon inherit its color from `iconColor` attribute and set it to white on the top bar style.

More work could be done to untangle some icons from their colors and use styles to tint them instead of doing it programatically (e.g. on the reviewer app bar actions). I currently don't have time to untangle all the XMLs and icons, which should be a fair amount of work, but I particularly see it as an valid issue.

## How Has This Been Tested?

https://user-images.githubusercontent.com/69634269/174460499-e9d40a31-b445-41e6-b32f-45bd0d16c515.mp4

## Learning (optional, can help others)
TIL that setting the tint of an icon is a global change which will be shown if an activity is recreated.

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [X] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
