### PR TITLE
build(deps): update underlying ktlint to 0.47.x

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -287,7 +287,7 @@ dependencies {
     implementation 'androidx.webkit:webkit:1.6.0'
     // Note: the design support library can be quite buggy, so test everything thoroughly before updating it
     implementation 'com.google.android.material:material:1.8.0'
-    implementation 'com.fasterxml.jackson.core:jackson-databind:2.14.1'
+    implementation 'com.fasterxml.jackson.core:jackson-databind:2.14.2'
     implementation 'com.vanniktech:android-image-cropper:4.5.0'
     implementation 'org.nanohttpd:nanohttpd:2.3.1'
 

--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/ACRATest.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/ACRATest.kt
@@ -65,7 +65,6 @@ class ACRATest : InstrumentedTest() {
     @Test
     @Throws(Exception::class)
     fun testDebugConfiguration() {
-
         // Debug mode overrides all saved state so no setup needed
         CrashReportService.setDebugACRAConfig(sharedPrefs)
         assertArrayEquals(
@@ -93,7 +92,6 @@ class ACRATest : InstrumentedTest() {
     @Test
     @Throws(Exception::class)
     fun testProductionConfigurationUserDisabled() {
-
         // set up as if the user had prefs saved to disable completely
         setReportConfig(CrashReportService.FEEDBACK_REPORT_NEVER)
 

--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/ContentProviderTest.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/ContentProviderTest.kt
@@ -74,6 +74,7 @@ class ContentProviderTest : InstrumentedTest() {
 
     // Whether tear down should be executed. I.e. if set up was not cancelled.
     private var mTearDown = false
+
     @KotlinCleanup("lateinit")
     private var mNumDecksBeforeTest = 0
 
@@ -293,7 +294,8 @@ class ContentProviderTest : InstrumentedTest() {
         col = reopenCol() // test that the changes are physically saved to the DB
         assertNotNull("Check template uri", templateUri)
         assertEquals(
-            "Check template uri ord", expectedOrd.toLong(),
+            "Check template uri ord",
+            expectedOrd.toLong(),
             ContentUris.parseId(
                 templateUri!!
             )
@@ -609,7 +611,8 @@ class ContentProviderTest : InstrumentedTest() {
                     i.toString()
                 )
                 assertThat(
-                    "Update rows", cr.update(tmplUri, cv, null, null),
+                    "Update rows",
+                    cr.update(tmplUri, cv, null, null),
                     `is`(
                         greaterThan(0)
                     )
@@ -652,7 +655,8 @@ class ContentProviderTest : InstrumentedTest() {
         assertNotNull(allModels)
         allModels.use {
             assertThat(
-                "Check that there is at least one result", allModels.count,
+                "Check that there is at least one result",
+                allModels.count,
                 `is`(greaterThan(0))
             )
             while (allModels.moveToNext()) {
@@ -692,7 +696,8 @@ class ContentProviderTest : InstrumentedTest() {
                     val numCards =
                         allModels.getInt(allModels.getColumnIndex(FlashCardsContract.Model.NUM_CARDS))
                     assertThat(
-                        "Check that valid number of cards", numCards,
+                        "Check that valid number of cards",
+                        numCards,
                         `is`(
                             greaterThanOrEqualTo(1)
                         )
@@ -961,7 +966,11 @@ class ContentProviderTest : InstrumentedTest() {
         val col = col
         val sched = col.sched
         val reviewInfoCursor = contentResolver.query(
-            FlashCardsContract.ReviewInfo.CONTENT_URI, null, null, null, null
+            FlashCardsContract.ReviewInfo.CONTENT_URI,
+            null,
+            null,
+            null,
+            null
         )
         assertNotNull(reviewInfoCursor)
         assertEquals("Check that we actually received one card", 1, reviewInfoCursor.count)
@@ -1005,7 +1014,11 @@ class ContentProviderTest : InstrumentedTest() {
         val selectedDeckBeforeTest = col.decks.selected()
         col.decks.select(1) // select Default deck
         val reviewInfoCursor = contentResolver.query(
-            FlashCardsContract.ReviewInfo.CONTENT_URI, null, deckSelector, deckArguments, null
+            FlashCardsContract.ReviewInfo.CONTENT_URI,
+            null,
+            deckSelector,
+            deckArguments,
+            null
         )
         assertNotNull(reviewInfoCursor)
         assertEquals("Check that we actually received one card", 1, reviewInfoCursor.count)
@@ -1171,7 +1184,6 @@ class ContentProviderTest : InstrumentedTest() {
      */
     @Test
     fun testSuspendCard() {
-
         // get the first card due
         // ----------------------
         val col = col
@@ -1193,6 +1205,7 @@ class ContentProviderTest : InstrumentedTest() {
         val reviewInfoUri = FlashCardsContract.ReviewInfo.CONTENT_URI
         val noteId = card.note().id
         val cardOrd = card.ord
+
         @KotlinCleanup("rename, while valid suspend is a kotlin soft keyword")
         val values = ContentValues().apply {
             val suspend = 1
@@ -1307,6 +1320,7 @@ class ContentProviderTest : InstrumentedTest() {
         private val TEST_MODEL_AFMT = arrayOf("{{BACK}}", "{{FRONTS}}")
         private val TEST_NOTE_FIELDS = arrayOf("dis is za Fr0nt", "Te\$t")
         private const val TEST_MODEL_CSS = "styleeeee"
+
         @Suppress("SameParameterValue")
         private fun setupNewNote(
             col: com.ichi2.libanki.Collection,
@@ -1321,7 +1335,8 @@ class ContentProviderTest : InstrumentedTest() {
             }
             newNote.addTag(tag)
             assertThat(
-                "At least one card added for note", col.addNote(newNote),
+                "At least one card added for note",
+                col.addNote(newNote),
                 `is`(
                     greaterThanOrEqualTo(1)
                 )

--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/LayoutValidationTest.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/LayoutValidationTest.kt
@@ -38,6 +38,7 @@ class LayoutValidationTest : InstrumentedTest() {
     @JvmField // required for Parameter
     @Parameterized.Parameter(1)
     var name: String? = null
+
     @Test
     @Throws(Exception::class)
     fun ensureLayout() {

--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/NotificationChannelTest.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/NotificationChannelTest.kt
@@ -46,8 +46,10 @@ class NotificationChannelTest : InstrumentedTest() {
         GrantPermissionRule.grant(Manifest.permission.WRITE_EXTERNAL_STORAGE)
     private var mCurrentAPI = -1
     private var mTargetAPI = -1
+
     @KotlinCleanup("lateinit")
     private var mManager: NotificationManager? = null
+
     @Before
     @UiThreadTest
     fun setUp() {

--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/libanki/HttpTest.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/libanki/HttpTest.kt
@@ -43,7 +43,6 @@ class HttpTest {
     @Suppress("DEPRECATION")
     @Test
     fun testLogin() {
-
         val username = "AnkiDroidInstrumentedTestUser"
         val password = "AnkiDroidInstrumentedTestInvalidPass"
         val invalidPayload = Connection.Payload(arrayOf(username, password, HostNum(null)))

--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/libanki/ImportTest.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/libanki/ImportTest.kt
@@ -61,6 +61,7 @@ class ImportTest : InstrumentedTest() {
     // Allowing it to re-run now, 3 times, in case it flakes again.
     @get:Rule
     var retry = RetryRule(10)
+
     @Before
     @Throws(IOException::class)
     fun setUp() {
@@ -77,7 +78,6 @@ class ImportTest : InstrumentedTest() {
     @Test
     @Throws(IOException::class, JSONException::class, ImportExportException::class)
     fun testAnki2Mediadupes() {
-
         // add a note that references a sound
         var n = testCol.newNote()
         n.setField(0, "[sound:foo.mp3]")

--- a/AnkiDroid/src/androidTest/java/com/ichi2/ui/ActionBarOverflowTest.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/ui/ActionBarOverflowTest.kt
@@ -34,7 +34,8 @@ class ActionBarOverflowTest {
     fun hasValidActionBarReflectionMethod() {
         assertThat(
             "Ensures that there is a valid way to obtain a listener",
-            ActionBarOverflow.hasUsableMethod(), equalTo(true)
+            ActionBarOverflow.hasUsableMethod(),
+            equalTo(true)
         )
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anim/ViewAnimation.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anim/ViewAnimation.kt
@@ -30,32 +30,50 @@ object ViewAnimation {
         when (type) {
             SLIDE_IN_FROM_RIGHT -> {
                 animation = translateAnimation(
-                    +1.0f, 0.0f, 0.0f, 0.0f
+                    +1.0f,
+                    0.0f,
+                    0.0f,
+                    0.0f
                 )
             }
             SLIDE_OUT_TO_RIGHT -> {
                 animation = translateAnimation(
-                    0.0f, +1.0f, 0.0f, 0.0f
+                    0.0f,
+                    +1.0f,
+                    0.0f,
+                    0.0f
                 )
             }
             SLIDE_IN_FROM_LEFT -> {
                 animation = translateAnimation(
-                    -1.0f, 0.0f, 0.0f, 0.0f
+                    -1.0f,
+                    0.0f,
+                    0.0f,
+                    0.0f
                 )
             }
             SLIDE_OUT_TO_LEFT -> {
                 animation = translateAnimation(
-                    0.0f, -1.0f, 0.0f, 0.0f
+                    0.0f,
+                    -1.0f,
+                    0.0f,
+                    0.0f
                 )
             }
             SLIDE_IN_FROM_BOTTOM -> {
                 animation = translateAnimation(
-                    0.0f, 0.0f, +1.0f, 0.0f
+                    0.0f,
+                    0.0f,
+                    +1.0f,
+                    0.0f
                 )
             }
             SLIDE_IN_FROM_TOP -> {
                 animation = translateAnimation(
-                    0.0f, 0.0f, -1.0f, 0.0f
+                    0.0f,
+                    0.0f,
+                    -1.0f,
+                    0.0f
                 )
             }
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
@@ -178,12 +178,16 @@ abstract class AbstractFlashcardViewer :
     protected var answerField: FixedEditText? = null
     protected var flipCardLayout: LinearLayout? = null
     private var easeButtonsLayout: LinearLayout? = null
+
     @KotlinCleanup("internal for AnkiDroidJsApi")
     internal var easeButton1: EaseButton? = null
+
     @KotlinCleanup("internal for AnkiDroidJsApi")
     internal var easeButton2: EaseButton? = null
+
     @KotlinCleanup("internal for AnkiDroidJsApi")
     internal var easeButton3: EaseButton? = null
+
     @KotlinCleanup("internal for AnkiDroidJsApi")
     internal var easeButton4: EaseButton? = null
     protected var topBarLayout: RelativeLayout? = null
@@ -224,6 +228,7 @@ abstract class AbstractFlashcardViewer :
     private var mViewerUrl: String? = null
     private var mAssetLoader: WebViewAssetLoader? = null
     private val mFadeDuration = 300
+
     @KotlinCleanup("made internal for tests")
     @VisibleForTesting(otherwise = VisibleForTesting.PROTECTED)
     internal var sched: AbstractSched? = null
@@ -652,7 +657,9 @@ abstract class AbstractFlashcardViewer :
     override fun onKeyDown(keyCode: Int, event: KeyEvent): Boolean {
         return if (processCardFunction { cardWebView: WebView? -> processHardwareButtonScroll(keyCode, cardWebView) }) {
             true
-        } else super.onKeyDown(keyCode, event)
+        } else {
+            super.onKeyDown(keyCode, event)
+        }
     }
 
     public override val currentCardId: CardId? get() = currentCard?.id
@@ -825,7 +832,6 @@ abstract class AbstractFlashcardViewer :
                 legacyUndo()
             } else {
                 return launchCatchingTask {
-
                     if (!backendUndoAndShowPopup(findViewById(R.id.flip_card))) {
                         legacyUndo()
                     }
@@ -1247,7 +1253,6 @@ abstract class AbstractFlashcardViewer :
     }
 
     protected open fun restoreCollectionPreferences(col: Collection) {
-
         // These are preferences we pull out of the collection instead of SharedPreferences
         try {
             mShowNextReviewTime = col.get_config_boolean("estTimes")
@@ -1653,104 +1658,106 @@ abstract class AbstractFlashcardViewer :
     override fun executeCommand(which: ViewerCommand, fromGesture: Gesture?): Boolean {
         return if (isControlBlocked && which !== ViewerCommand.EXIT) {
             false
-        } else when (which) {
-            ViewerCommand.SHOW_ANSWER -> {
-                if (displayAnswer) {
-                    return false
+        } else {
+            when (which) {
+                ViewerCommand.SHOW_ANSWER -> {
+                    if (displayAnswer) {
+                        return false
+                    }
+                    displayCardAnswer()
+                    true
                 }
-                displayCardAnswer()
-                true
-            }
-            ViewerCommand.FLIP_OR_ANSWER_EASE1 -> {
-                flipOrAnswerCard(EASE_1)
-                true
-            }
-            ViewerCommand.FLIP_OR_ANSWER_EASE2 -> {
-                flipOrAnswerCard(EASE_2)
-                true
-            }
-            ViewerCommand.FLIP_OR_ANSWER_EASE3 -> {
-                flipOrAnswerCard(EASE_3)
-                true
-            }
-            ViewerCommand.FLIP_OR_ANSWER_EASE4 -> {
-                flipOrAnswerCard(EASE_4)
-                true
-            }
-            ViewerCommand.FLIP_OR_ANSWER_RECOMMENDED -> {
-                flipOrAnswerCard(getRecommendedEase(false))
-                true
-            }
-            ViewerCommand.FLIP_OR_ANSWER_BETTER_THAN_RECOMMENDED -> {
-                flipOrAnswerCard(getRecommendedEase(true))
-                true
-            }
-            ViewerCommand.EXIT -> {
-                closeReviewer(RESULT_DEFAULT, false)
-                true
-            }
-            ViewerCommand.UNDO -> {
-                if (!isUndoAvailable) {
-                    return false
+                ViewerCommand.FLIP_OR_ANSWER_EASE1 -> {
+                    flipOrAnswerCard(EASE_1)
+                    true
                 }
-                undo()
-                true
-            }
-            ViewerCommand.EDIT -> {
-                editCard(fromGesture)
-                true
-            }
-            ViewerCommand.TAG -> {
-                showTagsDialog()
-                true
-            }
-            ViewerCommand.BURY_CARD -> buryCard()
-            ViewerCommand.BURY_NOTE -> buryNote()
-            ViewerCommand.SUSPEND_CARD -> suspendCard()
-            ViewerCommand.SUSPEND_NOTE -> suspendNote()
-            ViewerCommand.DELETE -> {
-                showDeleteNoteDialog()
-                true
-            }
-            ViewerCommand.PLAY_MEDIA -> {
-                playSounds(true)
-                true
-            }
-            ViewerCommand.PAGE_UP -> {
-                onPageUp()
-                true
-            }
-            ViewerCommand.PAGE_DOWN -> {
-                onPageDown()
-                true
-            }
-            ViewerCommand.ABORT_AND_SYNC -> {
-                abortAndSync()
-                true
-            }
-            ViewerCommand.RECORD_VOICE -> {
-                recordVoice()
-                true
-            }
-            ViewerCommand.REPLAY_VOICE -> {
-                replayVoice()
-                true
-            }
-            ViewerCommand.TOGGLE_WHITEBOARD -> {
-                toggleWhiteboard()
-                true
-            }
-            ViewerCommand.SHOW_HINT -> {
-                loadUrlInViewer("javascript: showHint();")
-                true
-            }
-            ViewerCommand.SHOW_ALL_HINTS -> {
-                loadUrlInViewer("javascript: showAllHints();")
-                true
-            }
-            else -> {
-                Timber.w("Unknown command requested: %s", which)
-                false
+                ViewerCommand.FLIP_OR_ANSWER_EASE2 -> {
+                    flipOrAnswerCard(EASE_2)
+                    true
+                }
+                ViewerCommand.FLIP_OR_ANSWER_EASE3 -> {
+                    flipOrAnswerCard(EASE_3)
+                    true
+                }
+                ViewerCommand.FLIP_OR_ANSWER_EASE4 -> {
+                    flipOrAnswerCard(EASE_4)
+                    true
+                }
+                ViewerCommand.FLIP_OR_ANSWER_RECOMMENDED -> {
+                    flipOrAnswerCard(getRecommendedEase(false))
+                    true
+                }
+                ViewerCommand.FLIP_OR_ANSWER_BETTER_THAN_RECOMMENDED -> {
+                    flipOrAnswerCard(getRecommendedEase(true))
+                    true
+                }
+                ViewerCommand.EXIT -> {
+                    closeReviewer(RESULT_DEFAULT, false)
+                    true
+                }
+                ViewerCommand.UNDO -> {
+                    if (!isUndoAvailable) {
+                        return false
+                    }
+                    undo()
+                    true
+                }
+                ViewerCommand.EDIT -> {
+                    editCard(fromGesture)
+                    true
+                }
+                ViewerCommand.TAG -> {
+                    showTagsDialog()
+                    true
+                }
+                ViewerCommand.BURY_CARD -> buryCard()
+                ViewerCommand.BURY_NOTE -> buryNote()
+                ViewerCommand.SUSPEND_CARD -> suspendCard()
+                ViewerCommand.SUSPEND_NOTE -> suspendNote()
+                ViewerCommand.DELETE -> {
+                    showDeleteNoteDialog()
+                    true
+                }
+                ViewerCommand.PLAY_MEDIA -> {
+                    playSounds(true)
+                    true
+                }
+                ViewerCommand.PAGE_UP -> {
+                    onPageUp()
+                    true
+                }
+                ViewerCommand.PAGE_DOWN -> {
+                    onPageDown()
+                    true
+                }
+                ViewerCommand.ABORT_AND_SYNC -> {
+                    abortAndSync()
+                    true
+                }
+                ViewerCommand.RECORD_VOICE -> {
+                    recordVoice()
+                    true
+                }
+                ViewerCommand.REPLAY_VOICE -> {
+                    replayVoice()
+                    true
+                }
+                ViewerCommand.TOGGLE_WHITEBOARD -> {
+                    toggleWhiteboard()
+                    true
+                }
+                ViewerCommand.SHOW_HINT -> {
+                    loadUrlInViewer("javascript: showHint();")
+                    true
+                }
+                ViewerCommand.SHOW_ALL_HINTS -> {
+                    loadUrlInViewer("javascript: showAllHints();")
+                    true
+                }
+                else -> {
+                    Timber.w("Unknown command requested: %s", which)
+                    false
+                }
             }
         }
     }
@@ -2603,6 +2610,7 @@ abstract class AbstractFlashcardViewer :
          * Should be protected, using non-JVM static members protected in the superclass companion is unsupported yet
          */
         const val INITIAL_HIDE_DELAY = 200
+
         // I don't see why we don't do this by intent.
         /** to be sent to and from the card editor  */
         @set:VisibleForTesting(otherwise = VisibleForTesting.NONE)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.kt
@@ -64,6 +64,7 @@ open class AnkiDroidApp : Application() {
     /** An exception if the WebView subsystem fails to load  */
     private var mWebViewError: Throwable? = null
     private val mNotifications = MutableLiveData<Void?>()
+
     @KotlinCleanup("can move analytics here now")
     override fun attachBaseContext(base: Context) {
         // update base context with preferred app language before attach
@@ -260,7 +261,9 @@ open class AnkiDroidApp : Application() {
                     // throw new IllegalStateException(
                     //        "Synthetic stacktrace didn't have enough elements: are you using proguard?");
                     // --- end of alteration from upstream Timber.DebugTree.getTag ---
-                } else createStackElementTag(stackTrace[CALL_STACK_INDEX])
+                } else {
+                    createStackElementTag(stackTrace[CALL_STACK_INDEX])
+                }
             }
 
         // ----  END copied from Timber.DebugTree because DebugTree.getTag() is package private ----

--- a/AnkiDroid/src/main/java/com/ichi2/anki/BackendBackups.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/BackendBackups.kt
@@ -39,7 +39,7 @@ fun DeckPicker.importColpkg(colpkgPath: String) {
                 if (progress.hasImporting()) {
                     text = progress.importing
                 }
-            },
+            }
         ) {
             CollectionManager.importColpkg(colpkgPath)
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/BackendImporting.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/BackendImporting.kt
@@ -41,7 +41,7 @@ fun DeckPicker.importApkgs(apkgPaths: List<String>) {
                     if (progress.hasImporting()) {
                         text = progress.importing
                     }
-                },
+                }
             ) {
                 undoableOp {
                     importAnkiPackage(apkgPath)
@@ -105,7 +105,7 @@ suspend fun AnkiActivity.exportApkg(
             if (progress.hasExporting()) {
                 text = progress.exporting
             }
-        },
+        }
     ) {
         withCol {
             newBackend.exportAnkiPackage(apkgPath, withScheduling, withMedia, limit)
@@ -115,14 +115,14 @@ suspend fun AnkiActivity.exportApkg(
 
 suspend fun AnkiActivity.exportColpkg(
     colpkgPath: String,
-    withMedia: Boolean,
+    withMedia: Boolean
 ) {
     withProgress(
         extractProgress = {
             if (progress.hasExporting()) {
                 text = progress.exporting
             }
-        },
+        }
     ) {
         withCol {
             newBackend.exportCollectionPackage(colpkgPath, withMedia, true)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/BackendUndo.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/BackendUndo.kt
@@ -35,7 +35,6 @@ suspend fun FragmentActivity.backendUndoAndShowPopup(anchorView: View? = null): 
         }
 
         showSnackbar(TR.undoActionUndone(changes.operation)) {
-
             // A snackbar may obscure vital elements (e.g: the answer buttons on the Reviewer)
             // `anchorView` stops this
             anchorView?.let { setAnchorView(anchorView) }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/BackupManager.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/BackupManager.kt
@@ -113,7 +113,9 @@ open class BackupManager {
         // If have no backups, then a backup is necessary
         return if (len <= 0) {
             false
-        } else colBackups[len - 1].lastModified() == colFile.lastModified()
+        } else {
+            colBackups[len - 1].lastModified() == colFile.lastModified()
+        }
 
         // no collection changes means we don't need a backup
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -239,6 +239,7 @@ open class CardBrowser :
     @get:VisibleForTesting(otherwise = VisibleForTesting.NONE)
     var isInMultiSelectMode = false
         private set
+
     @get:VisibleForTesting(otherwise = VisibleForTesting.NONE)
     var isTruncated = false
     private val mCheckedCards = Collections.synchronizedSet(LinkedHashSet<CardCache>())
@@ -399,7 +400,8 @@ open class CardBrowser :
             if (searchName.isNullOrEmpty()) {
                 showThemedToast(
                     this@CardBrowser,
-                    getString(R.string.card_browser_list_my_searches_new_search_error_empty_name), true
+                    getString(R.string.card_browser_list_my_searches_new_search_error_empty_name),
+                    true
                 )
                 return
             }
@@ -413,7 +415,8 @@ open class CardBrowser :
             } else {
                 showThemedToast(
                     this@CardBrowser,
-                    getString(R.string.card_browser_list_my_searches_new_search_error_dup), true
+                    getString(R.string.card_browser_list_my_searches_new_search_error_dup),
+                    true
                 )
             }
         }
@@ -443,8 +446,8 @@ open class CardBrowser :
      * Change Deck
      * @param did Id of the deck
      */
-    @VisibleForTesting
     // TODO: This function can be simplified a lot
+    @VisibleForTesting
     fun moveSelectedCardsToDeck(did: DeckId) {
         val selectedDeck = col.decks.get(did)
         // TODO: Currently try-catch is at every level which isn't required, simplify that
@@ -577,7 +580,8 @@ open class CardBrowser :
         val cardsColumn1Spinner = findViewById<Spinner>(R.id.browser_column1_spinner)
         val column1Adapter = ArrayAdapter.createFromResource(
             this,
-            R.array.browser_column1_headings, android.R.layout.simple_spinner_item
+            R.array.browser_column1_headings,
+            android.R.layout.simple_spinner_item
         )
         column1Adapter.setDropDownViewResource(R.layout.spinner_custom_layout)
         cardsColumn1Spinner.adapter = column1Adapter
@@ -606,7 +610,8 @@ open class CardBrowser :
         val cardsColumn2Spinner = findViewById<Spinner>(R.id.browser_column2_spinner)
         val column2Adapter = ArrayAdapter.createFromResource(
             this,
-            R.array.browser_column2_headings, android.R.layout.simple_spinner_item
+            R.array.browser_column2_headings,
+            android.R.layout.simple_spinner_item
         )
         // The custom layout for the adapter is used to prevent the overlapping of various interactive components on the screen
         column2Adapter.setDropDownViewResource(R.layout.spinner_custom_layout)
@@ -638,7 +643,8 @@ open class CardBrowser :
         cardsAdapter = MultiColumnListAdapter(
             this,
             R.layout.card_item_browser,
-            columnsContent, intArrayOf(R.id.card_sfld, R.id.card_column2),
+            columnsContent,
+            intArrayOf(R.id.card_sfld, R.id.card_column2),
             sflRelativeFontSize,
             sflCustomFont
         )
@@ -667,10 +673,10 @@ open class CardBrowser :
             if (isInMultiSelectMode) {
                 var hasChanged = false
                 for (
-                    i in min(mLastSelectedPosition, position)..max(
-                        mLastSelectedPosition,
-                        position
-                    )
+                i in min(mLastSelectedPosition, position)..max(
+                    mLastSelectedPosition,
+                    position
+                )
                 ) {
                     val card = cardsListView!!.getItemAtPosition(i) as CardCache
 
@@ -697,8 +703,12 @@ open class CardBrowser :
         window.setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_ALWAYS_HIDDEN)
         val deckId = col.decks.selected()
         deckSpinnerSelection = DeckSpinnerSelection(
-            this, col, findViewById(R.id.toolbar_spinner),
-            showAllDecks = true, alwaysShowDefault = false, showFilteredDecks = true
+            this,
+            col,
+            findViewById(R.id.toolbar_spinner),
+            showAllDecks = true,
+            alwaysShowDefault = false,
+            showFilteredDecks = true
         )
         inCardsMode = AnkiDroidApp.getSharedPrefs(this).getBoolean("inCardsMode", true)
         isTruncated = AnkiDroidApp.getSharedPrefs(this).getBoolean("isTruncated", false)
@@ -738,7 +748,6 @@ open class CardBrowser :
                 }
             }
             KeyEvent.KEYCODE_E -> {
-
                 // Ctrl+Shift+E: Export (TODO)
                 if (event.isCtrlPressed) {
                     Timber.i("Ctrl+E: Add Note")
@@ -1131,8 +1140,10 @@ open class CardBrowser :
                 val searchTerms = mSearchView!!.query.toString()
                 showDialogFragment(
                     newInstance(
-                        null, mMySearchesDialogListener,
-                        searchTerms, CardBrowserMySearchesDialog.CARD_BROWSER_MY_SEARCHES_TYPE_SAVE
+                        null,
+                        mMySearchesDialogListener,
+                        searchTerms,
+                        CardBrowserMySearchesDialog.CARD_BROWSER_MY_SEARCHES_TYPE_SAVE
                     )
                 )
                 return true
@@ -1146,8 +1157,10 @@ open class CardBrowser :
                 )
                 showDialogFragment(
                     newInstance(
-                        savedFilters, mMySearchesDialogListener,
-                        "", CardBrowserMySearchesDialog.CARD_BROWSER_MY_SEARCHES_TYPE_LIST
+                        savedFilters,
+                        mMySearchesDialogListener,
+                        "",
+                        CardBrowserMySearchesDialog.CARD_BROWSER_MY_SEARCHES_TYPE_LIST
                     )
                 )
                 return true
@@ -1570,7 +1583,9 @@ open class CardBrowser :
         mTagsDialogListenerAction = TagsDialogListenerAction.EDIT_TAGS
         val dialog = mTagsDialogFactory!!.newTagsDialog().withArguments(
             TagsDialog.DialogType.EDIT_TAGS,
-            checkedTags, uncheckedTags, allTags
+            checkedTags,
+            uncheckedTags,
+            allTags
         )
         showDialogFragment(dialog)
     }
@@ -1578,7 +1593,9 @@ open class CardBrowser :
     private fun showFilterByTagsDialog() {
         mTagsDialogListenerAction = TagsDialogListenerAction.FILTER
         val dialog = mTagsDialogFactory!!.newTagsDialog().withArguments(
-            TagsDialog.DialogType.FILTER_BY_TAG, ArrayList(0), col.tags.all()
+            TagsDialog.DialogType.FILTER_BY_TAG,
+            ArrayList(0),
+            col.tags.all()
         )
         showDialogFragment(dialog)
     }
@@ -1712,10 +1729,12 @@ open class CardBrowser :
     override val subtitleText: String
         get() {
             val count = cardCount
-            @androidx.annotation.StringRes val subtitleId = if (inCardsMode)
+
+            @androidx.annotation.StringRes val subtitleId = if (inCardsMode) {
                 R.plurals.card_browser_subtitle
-            else
+            } else {
                 R.plurals.card_browser_subtitle_notes_mode
+            }
             return resources.getQuantityString(subtitleId, count, count)
         }
 
@@ -2039,8 +2058,11 @@ open class CardBrowser :
     protected suspend fun renderBrowserQAParams(firstVisibleItem: Int, visibleItemCount: Int, cards: CardCollection<CardCache>) {
         Timber.d("Starting Q&A background rendering")
         val result = renderBrowserQA(
-            cards, firstVisibleItem, visibleItemCount,
-            mColumn1Index, mColumn2Index
+            cards,
+            firstVisibleItem,
+            visibleItemCount,
+            mColumn1Index,
+            mColumn2Index
         ) {
             // Note: This is called every time a card is rendered.
             // It blocks the long-click callback while the task is running, so usage of the task should be minimized
@@ -2470,7 +2492,9 @@ open class CardBrowser :
             }
             return if (javaClass != other.javaClass) {
                 false
-            } else id == (other as CardCache).id
+            } else {
+                id == (other as CardCache).id
+            }
         }
 
         override fun hashCode(): Int {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardInfo.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardInfo.kt
@@ -267,7 +267,9 @@ class CardInfo : AnkiActivity() {
             fun intervalAsTimeSeconds(): Long {
                 return if (ivl < 0) {
                     -ivl
-                } else ivl * Stats.SECONDS_PER_DAY
+                } else {
+                    ivl * Stats.SECONDS_PER_DAY
+                }
             }
 
             // saves space if we just use seconds rather than a "s" suffix

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateBrowserAppearanceEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateBrowserAppearanceEditor.kt
@@ -187,13 +187,15 @@ class CardTemplateBrowserAppearanceEditor : AnkiActivity() {
             fun fromIntent(intent: Intent?): Result? {
                 return if (intent == null) {
                     null
-                } else try {
-                    val question = intent.getStringExtra(INTENT_QUESTION_FORMAT)
-                    val answer = intent.getStringExtra(INTENT_ANSWER_FORMAT)
-                    Result(question, answer)
-                } catch (e: Exception) {
-                    Timber.w(e, "Could not read result from intent")
-                    null
+                } else {
+                    try {
+                        val question = intent.getStringExtra(INTENT_QUESTION_FORMAT)
+                        val answer = intent.getStringExtra(INTENT_ANSWER_FORMAT)
+                        Result(question, answer)
+                    } catch (e: Exception) {
+                        Timber.w(e, "Could not read result from intent")
+                        null
+                    }
                 }
             }
         }
@@ -205,6 +207,7 @@ class CardTemplateBrowserAppearanceEditor : AnkiActivity() {
 
         /** Specified the card browser should use the default template formatter  */
         const val VALUE_USE_DEFAULT = ""
+
         @CheckResult
         fun getIntentFromTemplate(context: Context, template: JSONObject): Intent {
             val browserQuestionTemplate = template.getString("bqfmt")

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.kt
@@ -584,7 +584,8 @@ open class CardTemplateEditor : AnkiActivity(), DeckSelectionListener {
                         return false
                     }
                 },
-                viewLifecycleOwner, Lifecycle.State.RESUMED
+                viewLifecycleOwner,
+                Lifecycle.State.RESUMED
             )
         }
 
@@ -688,7 +689,6 @@ open class CardTemplateEditor : AnkiActivity(), DeckSelectionListener {
                 val currentDeletes = tempModel.getDeleteDbOrds(position)
                 // TODO - this is a SQL query on GUI thread - should see a DeckTask conversion ideally
                 if (col.models.getCardIdsForModel(tempModel.modelId, currentDeletes) == null) {
-
                     // It is possible but unlikely that a user has an in-memory template addition that would
                     // generate cards making the deletion safe, but we don't handle that. All users who do
                     // not already have cards generated making it safe will see this error message:
@@ -748,7 +748,8 @@ open class CardTemplateEditor : AnkiActivity(), DeckSelectionListener {
                     R.plurals.card_template_editor_confirm_delete,
                     numAffectedCards
                 ),
-                numAffectedCards, tmpl.optString("name")
+                numAffectedCards,
+                tmpl.optString("name")
             )
             d.setArgs(msg)
 
@@ -918,8 +919,10 @@ open class CardTemplateEditor : AnkiActivity(), DeckSelectionListener {
         private const val EDITOR_NOTE_ID = "noteId"
         private const val EDITOR_START_ORD_ID = "ordId"
         private const val CARD_INDEX = "card_ord"
+
         @Suppress("unused")
         private const val REQUEST_PREVIEWER = 0
+
         @Suppress("unused")
         private const val REQUEST_CARD_BROWSER_APPEARANCE = 1
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplatePreviewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplatePreviewer.kt
@@ -385,7 +385,9 @@ open class CardTemplatePreviewer : AbstractFlashcardViewer() {
         override val isEmpty: Boolean
             get() = if (mNote != null) {
                 false
-            } else super.isEmpty
+            } else {
+                super.isEmpty
+            }
 
         /** Override the method that fetches the model so we can render unsaved models  */
         override fun model(): Model {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CollectionHelper.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CollectionHelper.kt
@@ -74,7 +74,8 @@ open class CollectionHelper {
         Timber.i("Begin openCollection: %s", path)
         val backend = BackendFactory.getBackend(context)
         val collection = Storage.collection(
-            context, path,
+            context,
+            path,
             server = false,
             log = true,
             backend = backend
@@ -218,13 +219,15 @@ open class CollectionHelper {
             }
             val required = Formatter.formatShortFileSize(context, mRequiredSpace)
             val insufficientSpace = context.resources.getString(
-                R.string.integrity_check_insufficient_space, required
+                R.string.integrity_check_insufficient_space,
+                required
             )
 
             // Also concat in the extra content showing the current free space.
             val currentFree = Formatter.formatShortFileSize(context, mFreeSpace)
             val insufficientSpaceCurrentFree = context.resources.getString(
-                R.string.integrity_check_insufficient_space_extra_content, currentFree
+                R.string.integrity_check_insufficient_space_extra_content,
+                currentFree
             )
             return insufficientSpace + insufficientSpaceCurrentFree
         }
@@ -534,10 +537,12 @@ open class CollectionHelper {
                     getDefaultAnkiDroidDirectory(context),
                     "androidTest"
                 ).absolutePath
-            } else PreferenceExtensions.getOrSetString(
-                preferences,
-                PREF_COLLECTION_PATH
-            ) { getDefaultAnkiDroidDirectory(context) }
+            } else {
+                PreferenceExtensions.getOrSetString(
+                    preferences,
+                    PREF_COLLECTION_PATH
+                ) { getDefaultAnkiDroidDirectory(context) }
+            }
         }
 
         /** Fetches additional collection data not required for

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CollectionManager.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CollectionManager.kt
@@ -299,10 +299,13 @@ object CollectionManager {
                 val caller = stackTraceElements.filter {
                     val klass = it.className
                     for (
-                        text in listOf(
-                            "CollectionManager", "dalvik", "java.lang",
-                            "CollectionHelper", "AnkiActivity"
-                        )
+                    text in listOf(
+                        "CollectionManager",
+                        "dalvik",
+                        "java.lang",
+                        "CollectionHelper",
+                        "AnkiActivity"
+                    )
                     ) {
                         if (text in klass) {
                             return@filter false

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CoroutineHelpers.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CoroutineHelpers.kt
@@ -166,7 +166,7 @@ private fun showError(context: Context, msg: String, exception: Throwable) {
 suspend fun <T> Backend.withProgress(
     extractProgress: ProgressContext.() -> Unit,
     updateUi: ProgressContext.() -> Unit,
-    block: suspend CoroutineScope.() -> T,
+    block: suspend CoroutineScope.() -> T
 ): T {
     return coroutineScope {
         val monitor = launch {
@@ -278,7 +278,7 @@ private suspend fun <T> withProgressDialog(
 private suspend fun monitorProgress(
     backend: Backend,
     extractProgress: ProgressContext.() -> Unit,
-    updateUi: ProgressContext.() -> Unit,
+    updateUi: ProgressContext.() -> Unit
 ) {
     val state = ProgressContext(Progress.getDefaultInstance())
     while (true) {
@@ -299,7 +299,7 @@ data class ProgressContext(
     var progress: Progress,
     var text: String = "",
     /** If set, shows progress bar with a of b complete. */
-    var amount: Pair<Int, Int>? = null,
+    var amount: Pair<Int, Int>? = null
 )
 
 @Suppress("Deprecation") // ProgressDialog deprecation

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CrashReportService.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CrashReportService.kt
@@ -48,12 +48,22 @@ object CrashReportService {
     /** Our ACRA configurations, initialized during Application.onCreate()  */
     @JvmStatic
     private var logcatArgs = arrayOf(
-        "-t", "100", "-v", "time", "ActivityManager:I", "SQLiteLog:W", AnkiDroidApp.TAG + ":D", "*:S"
+        "-t",
+        "100",
+        "-v",
+        "time",
+        "ActivityManager:I",
+        "SQLiteLog:W",
+        AnkiDroidApp.TAG + ":D",
+        "*:S"
     )
+
     @JvmStatic
     private var dialogEnabled = true
+
     @JvmStatic
     private lateinit var toastText: String
+
     @JvmStatic
     lateinit var acraCoreConfigBuilder: CoreConfigurationBuilder
         private set

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DatabaseCheck.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DatabaseCheck.kt
@@ -34,7 +34,7 @@ fun DeckPicker.handleDatabaseCheck() {
                     }
                 }
             },
-            onCancel = null,
+            onCancel = null
         ) {
             withCol {
                 newBackend.fixIntegrity()

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckOptionsActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckOptionsActivity.kt
@@ -136,7 +136,9 @@ class DeckOptionsActivity :
 
                     mValues["reminderEnabled"] = reminder.getBoolean("enabled").toString()
                     mValues["reminderTime"] = String.format(
-                        "%1$02d:%2$02d", reminderTime.getLong(0), reminderTime.getLong(1)
+                        "%1$02d:%2$02d",
+                        reminderTime.getLong(0),
+                        reminderTime.getLong(1)
                     )
                 } else {
                     mValues["reminderEnabled"] = "false"
@@ -171,8 +173,10 @@ class DeckOptionsActivity :
         fun preConfChange() {
             val res = deckOptionsActivity.resources
             progressDialog = StyledProgressDialog.show(
-                deckOptionsActivity as Context, null,
-                res?.getString(R.string.reordering_cards), false
+                deckOptionsActivity as Context,
+                null,
+                res?.getString(R.string.reordering_cards),
+                false
             )
         }
 
@@ -282,7 +286,8 @@ class DeckOptionsActivity :
                                 // Don't remove the options group if it's the default group
                                 UIUtils.showThemedToast(
                                     this@DeckOptionsActivity,
-                                    resources.getString(R.string.default_conf_delete_error), false
+                                    resources.getString(R.string.default_conf_delete_error),
+                                    false
                                 )
                             } else {
                                 // Remove options group, handling the case where the user needs to confirm full sync
@@ -346,7 +351,8 @@ class DeckOptionsActivity :
                                     applicationContext,
                                     mOptions.getLong("id").toInt(),
                                     Intent(applicationContext, ReminderService::class.java).putExtra(
-                                        ReminderService.EXTRA_DECK_OPTION_ID, mOptions.getLong("id")
+                                        ReminderService.EXTRA_DECK_OPTION_ID,
+                                        mOptions.getLong("id")
                                     ),
                                     0
                                 )
@@ -700,7 +706,6 @@ class DeckOptionsActivity :
 
     companion object {
         fun reminderToCalendar(time: Time, reminder: JSONObject): Calendar {
-
             val calendar = time.calendar()
 
             calendar[Calendar.HOUR_OF_DAY] = reminder.getJSONArray("time").getInt(0)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -22,6 +22,7 @@
 // usage of 'this' in constructors when class is non-final - weak warning
 // should be OK as this is only non-final for tests
 @file:Suppress("LeakingThis")
+
 package com.ichi2.anki
 
 import android.Manifest
@@ -135,6 +136,7 @@ import kotlin.system.measureTimeMillis
 
 const val MIGRATION_WAS_LAST_POSTPONED_AT_SECONDS = "secondWhenMigrationWasPostponedLast"
 const val POSTPONE_MIGRATION_INTERVAL_DAYS = 5L
+
 /**
  * The current entry point for AnkiDroid. Displays decks, allowing users to study. Many other functions.
  *
@@ -177,6 +179,7 @@ open class DeckPicker :
     private var mShortAnimDuration = 0
     private var mBackButtonPressedToExit = false
     private lateinit var mDeckPickerContent: RelativeLayout
+
     @Suppress("Deprecation") // TODO: Encapsulate ProgressDialog within a class to limit the use of deprecated functionality
     private var mProgressDialog: android.app.ProgressDialog? = null
     private var mStudyoptionsFrame: View? = null // not lateInit - can be null
@@ -189,6 +192,7 @@ open class DeckPicker :
     private lateinit var mNoDecksPlaceholder: LinearLayout
     private lateinit var mPullToSyncWrapper: SwipeRefreshLayout
     private lateinit var mReviewSummaryTextView: TextView
+
     @KotlinCleanup("make lateinit, but needs more changes")
     private var mUnmountReceiver: BroadcastReceiver? = null
     private lateinit var mFloatingActionMenu: DeckPickerFloatingActionMenu
@@ -332,7 +336,9 @@ open class DeckPicker :
             if (context.mProgressDialog == null || !context.mProgressDialog!!.isShowing) {
                 context.mProgressDialog = StyledProgressDialog.show(
                     context,
-                    context.resources.getString(R.string.import_title), null, false
+                    context.resources.getString(R.string.import_title),
+                    null,
+                    false
                 )
             }
         }
@@ -366,7 +372,8 @@ open class DeckPicker :
                 context.mProgressDialog = StyledProgressDialog.show(
                     context,
                     context.resources.getString(R.string.import_title),
-                    context.resources.getString(R.string.import_replacing), false
+                    context.resources.getString(R.string.import_replacing),
+                    false
                 )
             }
         }
@@ -379,6 +386,7 @@ open class DeckPicker :
             context.mProgressDialog!!.setMessage(value)
         }
     }
+
     // ----------------------------------------------------------------------------
     // ANDROID ACTIVITY METHODS
     // ----------------------------------------------------------------------------
@@ -1103,7 +1111,6 @@ open class DeckPicker :
     }
 
     private fun showStartupScreensAndDialogs(preferences: SharedPreferences, skip: Int) {
-
         // For Android 8/8.1 we want to use software rendering by default or the Reviewer UI is broken #7369
         if (sdkVersion == Build.VERSION_CODES.O ||
             sdkVersion == Build.VERSION_CODES.O_MR1
@@ -1620,7 +1627,8 @@ open class DeckPicker :
             if (mProgressDialog == null || !mProgressDialog!!.isShowing) {
                 try {
                     mProgressDialog = StyledProgressDialog.show(
-                        this@DeckPicker, resources.getString(R.string.sync_title),
+                        this@DeckPicker,
+                        resources.getString(R.string.sync_title),
                         """
                                 ${resources.getString(R.string.sync_title)}
                                 ${resources.getString(R.string.sync_up_down_size, mCountUp, mCountDown)}
@@ -1745,7 +1753,8 @@ open class DeckPicker :
                                 diff >= 86100 -> {
                                     // The difference if more than a day minus 5 minutes acceptable by ankiweb error
                                     res.getString(
-                                        R.string.sync_log_clocks_unsynchronized, diff,
+                                        R.string.sync_log_clocks_unsynchronized,
+                                        diff,
                                         res.getString(R.string.sync_log_clocks_unsynchronized_date)
                                     )
                                 }
@@ -1753,7 +1762,8 @@ open class DeckPicker :
                                     // The difference would be within limit if we adjusted the time by few hours
                                     // It doesn't work for all timezones, but it covers most and it's a guess anyway
                                     res.getString(
-                                        R.string.sync_log_clocks_unsynchronized, diff,
+                                        R.string.sync_log_clocks_unsynchronized,
+                                        diff,
                                         res.getString(R.string.sync_log_clocks_unsynchronized_tz)
                                     )
                                 }
@@ -1849,7 +1859,8 @@ open class DeckPicker :
                                 if (dialogMessage == null) {
                                     dialogMessage = res.getString(
                                         R.string.sync_log_error_specific,
-                                        code.toString(), result[1]
+                                        code.toString(),
+                                        result[1]
                                     )
                                 }
                             } else {
@@ -1968,7 +1979,9 @@ open class DeckPicker :
             val frag = supportFragmentManager.findFragmentById(R.id.studyoptions_fragment)
             return if (frag is StudyOptionsFragment) {
                 frag
-            } else null
+            } else {
+                null
+            }
         }
 
     /**
@@ -2088,7 +2101,8 @@ open class DeckPicker :
                 setAction(R.string.study_more) {
                     val d = mCustomStudyDialogFactory.newCustomStudyDialog().withArguments(
                         CustomStudyDialog.ContextMenuConfiguration.LIMITS,
-                        col.decks.selected(), true
+                        col.decks.selected(),
+                        true
                     )
                     showDialogFragment(d)
                 }
@@ -2127,7 +2141,8 @@ open class DeckPicker :
                 setAction(R.string.custom_study) {
                     val d = mCustomStudyDialogFactory.newCustomStudyDialog().withArguments(
                         CustomStudyDialog.ContextMenuConfiguration.EMPTY_SCHEDULE,
-                        col.decks.selected(), true
+                        col.decks.selected(),
+                        true
                     )
                     showDialogFragment(d)
                 }
@@ -2233,7 +2248,8 @@ open class DeckPicker :
             mNoDecksPlaceholder.visibility = if (isEmpty) View.VISIBLE else View.GONE
         } else {
             val translation = TypedValue.applyDimension(
-                TypedValue.COMPLEX_UNIT_DIP, 8f,
+                TypedValue.COMPLEX_UNIT_DIP,
+                8f,
                 resources.displayMetrics
             )
             val decksListShown = mDeckPickerContent.visibility == View.VISIBLE
@@ -2618,8 +2634,10 @@ open class DeckPicker :
     internal inner class CheckDatabaseListener : TaskListener<String, Pair<Boolean, CheckDatabaseResult?>?>() {
         override fun onPreExecute() {
             mProgressDialog = StyledProgressDialog.show(
-                this@DeckPicker, AnkiDroidApp.appResources.getString(R.string.app_name),
-                resources.getString(R.string.check_db_message), false
+                this@DeckPicker,
+                AnkiDroidApp.appResources.getString(R.string.app_name),
+                resources.getString(R.string.check_db_message),
+                false
             )
         }
 
@@ -2842,6 +2860,7 @@ open class DeckPicker :
         get() = getSharedPrefs(baseContext).getLong(MIGRATION_WAS_LAST_POSTPONED_AT_SECONDS, 0L)
         set(timeInSecond) = getSharedPrefs(baseContext)
             .edit { putLong(MIGRATION_WAS_LAST_POSTPONED_AT_SECONDS, timeInSecond) }
+
     /**
      * Show a dialog offering to migrate, postpone or learn more.
      */
@@ -2856,7 +2875,8 @@ open class DeckPicker :
             else -> R.string.migration_update_request_dialog_download_warning
         }
 
-        @Language("HTML") val message = """${getString(R.string.migration_update_request)}
+        @Language("HTML")
+        val message = """${getString(R.string.migration_update_request)}
             <br>
             <br>${getString(ifYouUninstallMessageId)}"""
 
@@ -2903,7 +2923,7 @@ data class OptionsMenuState(
     /** If undo is available, a string describing the action. */
     val undoIcon: String?,
     val syncIcon: SyncIconState,
-    val offerToMigrate: Boolean,
+    val offerToMigrate: Boolean
 )
 
 enum class SyncIconState {
@@ -2911,10 +2931,11 @@ enum class SyncIconState {
     PendingChanges,
     FullSync,
     NotLoggedIn,
+
     /**
      * The icon should appear as disabled. Currently only occurs during scoped storage migration.
      */
-    Disabled,
+    Disabled
 }
 
 /**

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckSpinnerSelection.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckSpinnerSelection.kt
@@ -57,7 +57,7 @@ class DeckSpinnerSelection(
     private val spinner: Spinner,
     private val showAllDecks: Boolean,
     private val alwaysShowDefault: Boolean,
-    private val showFilteredDecks: Boolean,
+    private val showFilteredDecks: Boolean
 ) {
     /**
      * All of the decks shown to the user.
@@ -112,7 +112,6 @@ class DeckSpinnerSelection(
         }
         val noteDeckAdapter: ArrayAdapter<String?> = object : ArrayAdapter<String?>(context, R.layout.multiline_spinner_item, deckNames as List<String?>) {
             override fun getDropDownView(position: Int, convertView: View?, parent: ViewGroup): View {
-
                 // Cast the drop down items (popup items) as text view
                 val tv = super.getDropDownView(position, convertView, parent) as TextView
 
@@ -189,7 +188,9 @@ class DeckSpinnerSelection(
     fun selectDeckById(deckId: DeckId, setAsCurrentDeck: Boolean): Boolean {
         return if (deckId == ALL_DECKS_ID) {
             selectAllDecks()
-        } else selectDeck(deckId, setAsCurrentDeck)
+        } else {
+            selectDeck(deckId, setAsCurrentDeck)
+        }
     }
 
     /**

--- a/AnkiDroid/src/main/java/com/ichi2/anki/FieldEditText.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/FieldEditText.kt
@@ -55,6 +55,7 @@ class FieldEditText : FixedEditText, NoteService.NoteField {
     private var mOrigBackground: Drawable? = null
     private var mSelectionChangeListener: TextSelectionListener? = null
     private var mImageListener: ImagePasteListener? = null
+
     @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
     var clipboard: ClipboardManager? = null
 
@@ -103,7 +104,8 @@ class FieldEditText : FixedEditText, NoteService.NoteField {
         val inputConnection = super.onCreateInputConnection(editorInfo) ?: return null
         EditorInfoCompat.setContentMimeTypes(editorInfo, IMAGE_MIME_TYPES)
         ViewCompat.setOnReceiveContentListener(
-            this, IMAGE_MIME_TYPES,
+            this,
+            IMAGE_MIME_TYPES,
             object : OnReceiveContentListener {
                 override fun onReceiveContent(view: View, payload: ContentInfoCompat): ContentInfoCompat? {
                     val pair = payload.partition { item -> item.uri != null }
@@ -219,7 +221,9 @@ class FieldEditText : FixedEditText, NoteService.NoteField {
     private fun onImagePaste(imageUri: Uri?): Boolean {
         return if (imageUri == null) {
             false
-        } else mImageListener!!.onImagePaste(this, imageUri)
+        } else {
+            mImageListener!!.onImagePaste(this, imageUri)
+        }
     }
 
     override fun onRestoreInstanceState(state: Parcelable) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/FilterSheetBottomFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/FilterSheetBottomFragment.kt
@@ -54,8 +54,10 @@ class FilterSheetBottomFragment :
     private lateinit var flagListAdapter: FlagsAdapter
 
     private lateinit var flagToggleIcon: ImageView
+
     /** Heading of the Flags filter section */
     private lateinit var filterHeaderFlags: TextView
+
     /** Icon of the Flags filter section */
     private lateinit var filterIconFlags: ImageView
 
@@ -145,9 +147,7 @@ class FilterSheetBottomFragment :
         }
 
         flagsHeaderLayout.setOnClickListener {
-
             if (SystemClock.elapsedRealtime() - lastClickTime > DELAY_TIME) {
-
                 lastClickTime = SystemClock.elapsedRealtime().toInt()
 
                 if (flagsRecyclerViewLayout.isVisible) {
@@ -164,7 +164,6 @@ class FilterSheetBottomFragment :
     private fun createQuery(
         flagList: Set<SearchNode.Flag>
     ): String {
-
         if (flagList.isEmpty()) {
             return ""
         }
@@ -207,6 +206,7 @@ class FilterSheetBottomFragment :
         inner class ViewHolder(view: View) : RecyclerView.ViewHolder(view) {
             private val itemTextView: TextView = view.findViewById(R.id.filter_list_item)
             val icon: ImageView = view.findViewById(R.id.filter_list_icon)
+
             /** Checks whether flagSearchItems was empty before adding new element to it */
 
             private fun onFlagItemClicked(item: Flags) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Info.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Info.kt
@@ -40,6 +40,7 @@ import timber.log.Timber
  */
 class Info : AnkiActivity() {
     private var mWebView: WebView? = null
+
     @SuppressLint("SetJavaScriptEnabled")
     override fun onCreate(savedInstanceState: Bundle?) {
         if (showedActivityFailedScreen(savedInstanceState)) {
@@ -103,7 +104,6 @@ class Info : AnkiActivity() {
                 mWebView!!.settings.javaScriptEnabled = true
                 mWebView!!.webViewClient = object : WebViewClient() {
                     override fun onPageFinished(view: WebView, url: String) {
-
                         /* The order of below javascript code must not change (this order works both in debug and release mode)
                                  *  or else it will break in any one mode.
                                  */

--- a/AnkiDroid/src/main/java/com/ichi2/anki/InitialActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/InitialActivity.kt
@@ -30,7 +30,6 @@ object InitialActivity {
     /** Returns null on success  */
     @CheckResult
     fun getStartupFailureType(context: Context): StartupFailure? {
-
         // A WebView failure means that we skip `AnkiDroidApp`, and therefore haven't loaded the collection
         if (AnkiDroidApp.webViewFailedToLoad()) {
             return StartupFailure.WEBVIEW_FAILED

--- a/AnkiDroid/src/main/java/com/ichi2/anki/LeakCanaryConfiguration.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/LeakCanaryConfiguration.kt
@@ -33,7 +33,7 @@ object LeakCanaryConfiguration {
             retainedVisibleThreshold = 0,
             referenceMatchers = AndroidReferenceMatchers.appDefaults,
             computeRetainedHeapSize = false,
-            maxStoredHeapDumps = 0,
+            maxStoredHeapDumps = 0
         )
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/MetaDB.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/MetaDB.kt
@@ -63,10 +63,11 @@ object MetaDB {
     private fun openDB(context: Context) {
         try {
             mMetaDb = context.openOrCreateDatabase(DATABASE_NAME, 0, null).let {
-                if (it.needUpgrade(DATABASE_VERSION))
+                if (it.needUpgrade(DATABASE_VERSION)) {
                     upgradeDB(it, DATABASE_VERSION)
-                else
+                } else {
                     it
+                }
             }
             Timber.v("Opening MetaDB")
         } catch (e: Exception) {
@@ -225,7 +226,10 @@ object MetaDB {
                 mMetaDb!!.execSQL(
                     "INSERT INTO languages (did, ord, qa, language) " + " VALUES (?, ?, ?, ?);",
                     arrayOf<Any>(
-                        did, ord, qa.int, language
+                        did,
+                        ord,
+                        qa.int,
+                        language
                     )
                 )
                 Timber.v("Store language for deck %d", did)
@@ -233,7 +237,10 @@ object MetaDB {
                 mMetaDb!!.execSQL(
                     "UPDATE languages SET language = ? WHERE did = ? AND ord = ? AND qa = ?;",
                     arrayOf<Any>(
-                        language, did, ord, qa.int
+                        language,
+                        did,
+                        ord,
+                        qa.int
                     )
                 )
                 Timber.v("Update language for deck %d", did)
@@ -460,8 +467,13 @@ object MetaDB {
         var cursor: Cursor? = null
         try {
             cursor = mMetaDb!!.query(
-                "smallWidgetStatus", arrayOf("due", "eta"),
-                null, null, null, null, null
+                "smallWidgetStatus",
+                arrayOf("due", "eta"),
+                null,
+                null,
+                null,
+                null,
+                null
             )
             if (cursor.moveToNext()) {
                 return intArrayOf(cursor.getInt(0), cursor.getInt(1))

--- a/AnkiDroid/src/main/java/com/ichi2/anki/MyAccount.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/MyAccount.kt
@@ -50,6 +50,7 @@ open class MyAccount : AnkiActivity() {
     private lateinit var mUsername: EditText
     private lateinit var mPassword: TextInputEditField
     private lateinit var mUsernameLoggedIn: TextView
+
     @Suppress("Deprecation")
     private var mProgressDialog: android.app.ProgressDialog? = null
     var toolbar: Toolbar? = null
@@ -116,7 +117,8 @@ open class MyAccount : AnkiActivity() {
                 mLoginListener,
                 Connection.Payload(
                     arrayOf(
-                        username, password,
+                        username,
+                        password,
                         getInstance(this)
                     )
                 )
@@ -155,7 +157,8 @@ open class MyAccount : AnkiActivity() {
                 mLoginListener,
                 Connection.Payload(
                     arrayOf(
-                        username, password,
+                        username,
+                        password,
                         getInstance(this)
                     )
                 )
@@ -262,8 +265,10 @@ open class MyAccount : AnkiActivity() {
             Timber.d("loginListener.onPreExecute()")
             if (mProgressDialog == null || !mProgressDialog!!.isShowing) {
                 mProgressDialog = StyledProgressDialog.show(
-                    this@MyAccount, null,
-                    resources.getString(R.string.alert_logging_message), false
+                    this@MyAccount,
+                    null,
+                    resources.getString(R.string.alert_logging_message),
+                    false
                 )
             }
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NavigationDrawerActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NavigationDrawerActivity.kt
@@ -61,6 +61,7 @@ abstract class NavigationDrawerActivity :
      */
     protected var fragmented = false
     private var mNavButtonGoesBack = false
+
     // Navigation drawer list item entries
     private lateinit var mDrawerLayout: DrawerLayout
     private lateinit var mNavigationView: NavigationView
@@ -77,7 +78,9 @@ abstract class NavigationDrawerActivity :
 
         // Using ClosableDrawerLayout as a parent view.
         val closableDrawerLayout = LayoutInflater.from(this).inflate(
-            navigationDrawerLayout, null, false
+            navigationDrawerLayout,
+            null,
+            false
         ) as ClosableDrawerLayout
         // Get CoordinatorLayout using resource ID
         val coordinatorLayout = LayoutInflater.from(this)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
@@ -134,6 +134,7 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
 
     // non-null after onCollectionLoaded
     private var mEditorNote: Note? = null
+
     /* Null if adding a new card. Presently NonNull if editing an existing note - but this is subject to change */
     private var mCurrentEditedCard: Card? = null
     private var mSelectedTags: ArrayList<String>? = null
@@ -142,6 +143,7 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
     var deckId: DeckId = 0
         private set
     private var mAllModelIds: List<Long>? = null
+
     @KotlinCleanup("this ideally should be Int, Int?")
     private var mModelChangeFieldMap: MutableMap<Int, Int>? = null
     private var mModelChangeCardMap: HashMap<Int, Int?>? = null
@@ -201,7 +203,9 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
             }
             return if (allFieldsHaveContent()) {
                 R.string.note_editor_no_cards_created_all_fields
-            } else R.string.note_editor_no_cards_created
+            } else {
+                R.string.note_editor_no_cards_created
+            }
 
             // Otherwise, display "no cards created".
         }
@@ -360,7 +364,9 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
         }
         mDeckSpinnerSelection =
             DeckSpinnerSelection(
-                this, col, findViewById(R.id.note_deck_spinner),
+                this,
+                col,
+                findViewById(R.id.note_deck_spinner),
                 showAllDecks = false,
                 alwaysShowDefault = true,
                 showFilteredDecks = false
@@ -429,7 +435,6 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
     }
 
     private fun modifyCurrentSelection(formatter: Toolbar.TextFormatter, textBox: FieldEditText) {
-
         // get the current text and selection locations
         val selectionStart = textBox.selectionStart
         val selectionEnd = textBox.selectionEnd
@@ -623,7 +628,9 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
         // changed fields?
         return if (isFieldEdited) {
             true
-        } else isTagsEdited
+        } else {
+            isTagsEdited
+        }
         // changed tags?
     }
 
@@ -801,7 +808,6 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
             val dialog = ConfirmationDialog()
             dialog.setArgs(res.getString(R.string.full_sync_confirmation))
             val confirm = Runnable {
-
                 // Bypass the check once the user confirms
                 col.modSchemaNoCheck()
                 try {
@@ -1178,7 +1184,6 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
                 }
             }
             REQUEST_TEMPLATE_EDIT -> {
-
                 // Model can change regardless of exit type - update ourselves and CardBrowser
                 mReloadRequired = true
                 mEditorNote!!.reloadModel()
@@ -1677,8 +1682,12 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
     private fun updateToolbar() {
         val editorLayout = findViewById<View>(R.id.note_editor_layout)
         val bottomMargin =
-            if (shouldHideToolbar()) 0 else resources.getDimension(R.dimen.note_editor_toolbar_height)
-                .toInt()
+            if (shouldHideToolbar()) {
+                0
+            } else {
+                resources.getDimension(R.dimen.note_editor_toolbar_height)
+                    .toInt()
+            }
         val params = editorLayout.layoutParams as MarginLayoutParams
         params.bottomMargin = bottomMargin
         editorLayout.layoutParams = params
@@ -1711,7 +1720,6 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
         }
         val buttons = toolbarButtons
         for (b in buttons) {
-
             // 0th button shows as '1' and is Ctrl + 1
             val visualIndex = b.index + 1
             var text = visualIndex.toString()

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Onboarding.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Onboarding.kt
@@ -80,7 +80,7 @@ abstract class Onboarding<Feature>(
                     DECK_PICKER_ONBOARDING,
                     REVIEWER_ONBOARDING,
                     NOTE_EDITOR_ONBOARDING,
-                    CARD_BROWSER_ONBOARDING,
+                    CARD_BROWSER_ONBOARDING
                 )
             )
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/OnboardingUtils.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/OnboardingUtils.kt
@@ -32,6 +32,7 @@ class OnboardingUtils {
          * Preference can be toggled by visiting 'Advanced' settings in the app.
          */
         const val SHOW_ONBOARDING = "showOnboarding"
+
         @VisibleForTesting
         val featureConstants: MutableSet<String> = HashSet()
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
@@ -123,6 +123,7 @@ open class Reviewer : AbstractFlashcardViewer() {
     @get:VisibleForTesting(otherwise = VisibleForTesting.NONE)
     var whiteboard: Whiteboard? = null
         protected set
+
     // Record Audio
     /** File of the temporary mic record  */
     @get:VisibleForTesting(otherwise = VisibleForTesting.NONE)
@@ -152,7 +153,8 @@ open class Reviewer : AbstractFlashcardViewer() {
             val cardCount: Int = result!!.value.result.size
             showThemedToast(
                 this,
-                resources.getQuantityString(toastResourceId, cardCount, cardCount), true
+                resources.getQuantityString(toastResourceId, cardCount, cardCount),
+                true
             )
         }
     }
@@ -203,7 +205,9 @@ open class Reviewer : AbstractFlashcardViewer() {
             val isShownInActionBar = mActionButtons.isShownInActionBar(ActionButtons.RES_FLAG)
             return if (isShownInActionBar != null && isShownInActionBar && !mPrefFullscreenReview) {
                 CardMarker.FLAG_NONE
-            } else actualValue
+            } else {
+                actualValue
+            }
         }
 
     override fun createWebView(): WebView {
@@ -601,7 +605,8 @@ open class Reviewer : AbstractFlashcardViewer() {
     private fun openOrToggleMicToolbar() {
         if (!canRecordAudio(this)) {
             ActivityCompat.requestPermissions(
-                this, arrayOf(Manifest.permission.RECORD_AUDIO),
+                this,
+                arrayOf(Manifest.permission.RECORD_AUDIO),
                 REQUEST_AUDIO_PERMISSION
             )
         } else {
@@ -633,7 +638,8 @@ open class Reviewer : AbstractFlashcardViewer() {
             return
         }
         val lp2 = FrameLayout.LayoutParams(
-            ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT
+            ViewGroup.LayoutParams.MATCH_PARENT,
+            ViewGroup.LayoutParams.MATCH_PARENT
         )
         audioView!!.layoutParams = lp2
         val micToolBarLayer = findViewById<LinearLayout>(R.id.mic_tool_bar_layer)
@@ -925,7 +931,9 @@ open class Reviewer : AbstractFlashcardViewer() {
     override fun onKeyUp(keyCode: Int, event: KeyEvent): Boolean {
         return if (mProcessor.onKeyUp(keyCode, event)) {
             true
-        } else super.onKeyUp(keyCode, event)
+        } else {
+            super.onKeyUp(keyCode, event)
+        }
     }
 
     private fun <T> setupSubMenu(menu: Menu, @IdRes parentMenu: Int, subMenuProvider: T) where T : ActionProvider?, T : SubMenuProvider? {
@@ -1400,20 +1408,27 @@ open class Reviewer : AbstractFlashcardViewer() {
     private fun suspendNoteAvailable(): Boolean {
         return if (currentCard == null || isControlBlocked) {
             false
-        } else col.db.queryScalar(
-            "select 1 from cards where nid = ? and id != ? and queue != " + Consts.QUEUE_TYPE_SUSPENDED + " limit 1",
-            currentCard!!.nid, currentCard!!.id
-        ) == 1
+        } else {
+            col.db.queryScalar(
+                "select 1 from cards where nid = ? and id != ? and queue != " + Consts.QUEUE_TYPE_SUSPENDED + " limit 1",
+                currentCard!!.nid,
+                currentCard!!.id
+            ) == 1
+        }
         // whether there exists a sibling not buried.
     }
+
     @KotlinCleanup("mCurrentCard handling")
     private fun buryNoteAvailable(): Boolean {
         return if (currentCard == null || isControlBlocked) {
             false
-        } else col.db.queryScalar(
-            "select 1 from cards where nid = ? and id != ? and queue >=  " + Consts.QUEUE_TYPE_NEW + " limit 1",
-            currentCard!!.nid, currentCard!!.id
-        ) == 1
+        } else {
+            col.db.queryScalar(
+                "select 1 from cards where nid = ? and id != ? and queue >=  " + Consts.QUEUE_TYPE_NEW + " limit 1",
+                currentCard!!.nid,
+                currentCard!!.id
+            ) == 1
+        }
         // Whether there exists a sibling which is neither suspended nor buried
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/SharedDecksActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/SharedDecksActivity.kt
@@ -186,5 +186,5 @@ data class DownloadFile(
     val url: String,
     val userAgent: String,
     val contentDisposition: String,
-    val mimeType: String,
+    val mimeType: String
 ) : Serializable

--- a/AnkiDroid/src/main/java/com/ichi2/anki/SharedDecksDownloadFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/SharedDecksDownloadFragment.kt
@@ -141,7 +141,8 @@ class SharedDecksDownloadFragment : Fragment() {
         activity?.registerReceiver(mOnComplete, IntentFilter(DownloadManager.ACTION_DOWNLOAD_COMPLETE))
 
         val currentFileName = URLUtil.guessFileName(
-            fileToBeDownloaded.url, fileToBeDownloaded.contentDisposition,
+            fileToBeDownloaded.url,
+            fileToBeDownloaded.contentDisposition,
             fileToBeDownloaded.mimeType
         )
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Statistics.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Statistics.kt
@@ -115,8 +115,12 @@ class Statistics : NavigationDrawerActivity(), DeckSelectionListener, SubtitleLi
             else -> Timber.w("Unknown defaultDeck: %s", defaultDeck)
         }
         mDeckSpinnerSelection = DeckSpinnerSelection(
-            this, col,
-            findViewById(R.id.toolbar_spinner), showAllDecks = true, alwaysShowDefault = true, showFilteredDecks = true
+            this,
+            col,
+            findViewById(R.id.toolbar_spinner),
+            showAllDecks = true,
+            alwaysShowDefault = true,
+            showFilteredDecks = true
         )
         mDeckSpinnerSelection.initializeActionBarDeckSpinner(this.supportActionBar!!)
         mDeckSpinnerSelection.selectDeckById(mStatsDeckId, false)
@@ -285,7 +289,8 @@ class Statistics : NavigationDrawerActivity(), DeckSelectionListener, SubtitleLi
                 mTabLayoutMediator.detach()
             }
             mTabLayoutMediator = TabLayoutMediator(
-                slidingTabLayout, mActivityPager
+                slidingTabLayout,
+                mActivityPager
             ) { tab: TabLayout.Tab, position: Int -> tab.text = getTabTitle(position) }
             mTabLayoutMediator.attach()
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsFragment.kt
@@ -583,7 +583,6 @@ class StudyOptionsFragment : Fragment(), Toolbar.OnMenuItemClickListener {
     private fun rebuildUi(result: DeckStudyData?, refreshDecklist: Boolean) {
         dismissProgressDialog()
         if (result != null) {
-
             // Don't do anything if the fragment is no longer attached to it's Activity or col has been closed
             if (activity == null) {
                 Timber.e("StudyOptionsFragment.mRefreshFragmentListener :: can't refresh")
@@ -718,8 +717,10 @@ class StudyOptionsFragment : Fragment(), Toolbar.OnMenuItemClickListener {
          */
         @Suppress("unused")
         private const val BROWSE_CARDS = 3
+
         @Suppress("unused")
         private const val STATISTICS = 4
+
         @Suppress("unused")
         private const val DECK_OPTIONS = 5
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Sync.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Sync.kt
@@ -68,7 +68,7 @@ fun isLoggedIn() = AnkiDroidApp.getSharedPrefs(AnkiDroidApp.instance).getString(
 
 fun DeckPicker.handleNewSync(
     conflict: Connection.ConflictResolution?,
-    syncMedia: Boolean,
+    syncMedia: Boolean
 ) {
     val auth = this.syncAuth() ?: return
     val deckPicker = this
@@ -139,7 +139,7 @@ private fun cancelSync(backend: Backend) {
 private suspend fun handleNormalSync(
     deckPicker: DeckPicker,
     auth: SyncAuth,
-    syncMedia: Boolean,
+    syncMedia: Boolean
 ) {
     val output = deckPicker.withProgress(
         extractProgress = {
@@ -199,7 +199,7 @@ private fun fullDownloadProgress(title: String): ProgressContext.() -> Unit {
 private suspend fun handleDownload(
     deckPicker: DeckPicker,
     auth: SyncAuth,
-    syncMedia: Boolean,
+    syncMedia: Boolean
 ) {
     deckPicker.withProgress(
         extractProgress = fullDownloadProgress(TR.syncDownloadingFromAnkiweb()),
@@ -229,7 +229,7 @@ private suspend fun handleDownload(
 private suspend fun handleUpload(
     deckPicker: DeckPicker,
     auth: SyncAuth,
-    syncMedia: Boolean,
+    syncMedia: Boolean
 ) {
     deckPicker.withProgress(
         extractProgress = fullDownloadProgress(TR.syncUploadingToAnkiweb()),
@@ -282,7 +282,7 @@ private suspend fun handleMediaSync(
             },
             updateUi = {
                 dialog.setMessage(text)
-            },
+            }
         ) {
             withContext(Dispatchers.IO) {
                 backend.syncMedia(auth)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/TemporaryModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/TemporaryModel.kt
@@ -37,6 +37,7 @@ class TemporaryModel(model: Model) {
 
     private var mTemplateChanges = ArrayList<Array<Any>>()
     var editedModelFileName: String? = null
+
     @KotlinCleanup("make this a constructor property")
     val model: Model
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Whiteboard.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Whiteboard.kt
@@ -172,7 +172,9 @@ class Whiteboard(activity: AnkiActivity, handleMultiTouch: Boolean, inverted: Bo
                 MotionEvent.ACTION_POINTER_UP -> trySecondFingerClick(event)
                 else -> false
             }
-        } else false
+        } else {
+            false
+        }
     }
 
     /**
@@ -521,7 +523,8 @@ class Whiteboard(activity: AnkiActivity, handleMultiTouch: Boolean, inverted: Bo
             val whiteboard = Whiteboard(context, handleMultiTouch, currentTheme.isNightMode)
             mWhiteboardMultiTouchMethods = whiteboardMultiTouchMethods
             val lp2 = FrameLayout.LayoutParams(
-                ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                ViewGroup.LayoutParams.MATCH_PARENT
             )
             whiteboard.layoutParams = lp2
             val fl = context.findViewById<FrameLayout>(R.id.whiteboard)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/analytics/AnkiDroidCrashReportDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/analytics/AnkiDroidCrashReportDialog.kt
@@ -66,7 +66,9 @@ class AnkiDroidCrashReportDialog : CrashReportDialog(), DialogInterface.OnClickL
     override fun buildCustomView(savedInstanceState: Bundle?): View {
         val preferences = AnkiDroidApp.getSharedPrefs(this)
         val inflater = layoutInflater
-        @SuppressLint("InflateParams") val rootView = // when you inflate into an alert dialog, you have no parent view
+
+        @SuppressLint("InflateParams")
+        val rootView = // when you inflate into an alert dialog, you have no parent view
             inflater.inflate(R.layout.feedback, null)
         mAlwaysReportCheckBox = rootView.findViewById(R.id.alwaysReportCheckbox)
         mAlwaysReportCheckBox?.isChecked = preferences.getBoolean("autoreportCheckboxValue", true)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/analytics/UsageAnalytics.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/analytics/UsageAnalytics.kt
@@ -39,6 +39,7 @@ import timber.log.Timber
 @KotlinCleanup("see if we can make variables lazy, or properties without the `s` prefix")
 object UsageAnalytics {
     const val ANALYTICS_OPTIN_KEY = "analyticsOptIn"
+
     @KotlinCleanup("lateinit")
     private var sAnalytics: GoogleAnalytics? = null
     private var sOriginalUncaughtExceptionHandler: Thread.UncaughtExceptionHandler? = null
@@ -136,9 +137,7 @@ object UsageAnalytics {
         Thread.setDefaultUncaughtExceptionHandler(sOriginalUncaughtExceptionHandler)
         sOriginalUncaughtExceptionHandler = null
     }
-    /**
-     * Determine whether we are disabled or not
-     */
+
     /**
      * Allow users to enable or disable analytics
      *
@@ -174,7 +173,6 @@ object UsageAnalytics {
      */
     @Synchronized
     fun reInitialize() {
-
         // send any pending async hits, re-chain default exception handlers and re-init
         Timber.i("reInitialize()")
         sAnalytics!!.flush()
@@ -283,7 +281,9 @@ object UsageAnalytics {
         // if we're not under the ACRA process then we're fine to initialize a WebView
         return if (!ACRA.isACRASenderServiceProcess()) {
             true
-        } else hasSetDataDirectory()
+        } else {
+            hasSetDataDirectory()
+        }
 
         // If we have a custom data directory, then the crash will not occur.
     }
@@ -313,7 +313,6 @@ object UsageAnalytics {
      */
     private class AndroidDefaultRequest : DefaultRequest() {
         fun setAndroidRequestParameters(context: Context): DefaultRequest {
-
             // Are we running on really large screens or small screens? Send raw screen size
             try {
                 val size = DisplayUtils.getDisplayDimensions(context)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/CardAppearance.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/CardAppearance.kt
@@ -87,6 +87,7 @@ class CardAppearance(private val customFonts: ReviewerCustomFonts, private val c
             // font-weight to 700
             return content.replace("font-weight:600;", "font-weight:700;")
         }
+
         /**
          * hasUserDefinedNightMode finds out if the user has included class .night_mode in card's stylesheet
          */

--- a/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/CardHtml.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/CardHtml.kt
@@ -43,7 +43,7 @@ class CardHtml(
     private val getAnswerContentWithoutFrontSide_slow: (() -> String),
     @RustCleanup("too many variables, combine once we move away from backend")
     private var questionSound: List<SoundOrVideoTag>? = null,
-    private var answerSound: List<SoundOrVideoTag>? = null,
+    private var answerSound: List<SoundOrVideoTag>? = null
 ) {
     fun getSoundTags(sideFor: Side): List<SoundOrVideoTag> {
         if (sideFor == this.side) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/CardTemplate.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/CardTemplate.kt
@@ -24,6 +24,7 @@ class CardTemplate(template: String) {
     private var mPreClass: String? = null
     private var mPreContent: String? = null
     private var mPostContent: String? = null
+
     @CheckResult
     fun render(content: String, style: String, script: String, cardClass: String): String {
         return mPreStyle + style + mPreScript + script + mPreClass + cardClass + mPreContent + content + mPostContent

--- a/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/Gesture.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/Gesture.kt
@@ -36,7 +36,7 @@ fun interface GestureListener {
 }
 
 enum class Gesture(
-    @get:JvmName("getResourceId") val resourceId: Int,
+    @get:JvmName("getResourceId") val resourceId: Int
 ) {
     SWIPE_UP(R.string.gestures_swipe_up),
     SWIPE_DOWN(R.string.gestures_swipe_down),
@@ -75,6 +75,7 @@ enum class TapGestureMode {
      * are ambiguous in a nine-point system and thus not interchangeable
      */
     FOUR_POINT,
+
     /**
      * Divide the screen into 9 equally sized squares for touch targets.
      * Better for tablets

--- a/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/GestureProcessor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/GestureProcessor.kt
@@ -54,8 +54,9 @@ class GestureProcessor(private val processor: ViewerCommand.CommandProcessor?) {
         val associatedCommands = HashMap<Gesture, ViewerCommand>()
         for (command in ViewerCommand.values()) {
             for (mappableBinding in MappableBinding.fromPreference(preferences, command)) {
-                if (mappableBinding.binding.isGesture)
+                if (mappableBinding.binding.isGesture) {
                     associatedCommands[mappableBinding.binding.gesture!!] = command
+                }
             }
         }
         gestureDoubleTap = associatedCommands[Gesture.DOUBLE_TAP]

--- a/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/TypeAnswer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/TypeAnswer.kt
@@ -46,9 +46,11 @@ class TypeAnswer(
 
     /** What the learner actually typed (externally mutable) */
     var input = ""
+
     /** Font face of the 'compare to' field */
     var font = ""
         private set
+
     /** The font size of the 'compare to' field */
     var size = 0
         private set

--- a/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/ViewerCommand.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/ViewerCommand.kt
@@ -124,19 +124,23 @@ enum class ViewerCommand(val resourceId: Int) {
             when (this) {
                 FLIP_OR_ANSWER_EASE1 -> from(
                     keyCode(KeyEvent.KEYCODE_BUTTON_Y, CardSide.BOTH),
-                    keyCode(KeyEvent.KEYCODE_1, CardSide.ANSWER), keyCode(KeyEvent.KEYCODE_NUMPAD_1, CardSide.ANSWER)
+                    keyCode(KeyEvent.KEYCODE_1, CardSide.ANSWER),
+                    keyCode(KeyEvent.KEYCODE_NUMPAD_1, CardSide.ANSWER)
                 )
                 FLIP_OR_ANSWER_EASE2 -> from(
                     keyCode(KeyEvent.KEYCODE_BUTTON_X, CardSide.BOTH),
-                    keyCode(KeyEvent.KEYCODE_2, CardSide.ANSWER), keyCode(KeyEvent.KEYCODE_NUMPAD_2, CardSide.ANSWER)
+                    keyCode(KeyEvent.KEYCODE_2, CardSide.ANSWER),
+                    keyCode(KeyEvent.KEYCODE_NUMPAD_2, CardSide.ANSWER)
                 )
                 FLIP_OR_ANSWER_EASE3 -> from(
                     keyCode(KeyEvent.KEYCODE_BUTTON_B, CardSide.BOTH),
-                    keyCode(KeyEvent.KEYCODE_3, CardSide.ANSWER), keyCode(KeyEvent.KEYCODE_NUMPAD_3, CardSide.ANSWER)
+                    keyCode(KeyEvent.KEYCODE_3, CardSide.ANSWER),
+                    keyCode(KeyEvent.KEYCODE_NUMPAD_3, CardSide.ANSWER)
                 )
                 FLIP_OR_ANSWER_EASE4 -> from(
                     keyCode(KeyEvent.KEYCODE_BUTTON_A, CardSide.BOTH),
-                    keyCode(KeyEvent.KEYCODE_4, CardSide.ANSWER), keyCode(KeyEvent.KEYCODE_NUMPAD_4, CardSide.ANSWER)
+                    keyCode(KeyEvent.KEYCODE_4, CardSide.ANSWER),
+                    keyCode(KeyEvent.KEYCODE_NUMPAD_4, CardSide.ANSWER)
                 )
                 FLIP_OR_ANSWER_RECOMMENDED -> from(
                     keyCode(KeyEvent.KEYCODE_DPAD_CENTER, CardSide.BOTH),

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/CreateDeckDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/CreateDeckDialog.kt
@@ -172,7 +172,6 @@ class CreateDeckDialog(private val context: Context, private val title: Int, pri
         if (deckName.isNotEmpty()) {
             when (deckDialogType) {
                 DeckDialogType.DECK -> {
-
                     // create deck
                     createDeck(deckName)
                 }
@@ -180,12 +179,10 @@ class CreateDeckDialog(private val context: Context, private val title: Int, pri
                     renameDeck(deckName)
                 }
                 DeckDialogType.SUB_DECK -> {
-
                     // create sub deck
                     createSubDeck(parentId!!, deckName)
                 }
                 DeckDialogType.FILTERED_DECK -> {
-
                     // create filtered deck
                     createFilteredDeck(deckName)
                 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DatabaseErrorDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DatabaseErrorDialog.kt
@@ -64,7 +64,6 @@ class DatabaseErrorDialog : AsyncDialogFragment() {
         }
         return when (type) {
             DIALOG_LOAD_FAILED -> {
-
                 // Collection failed to load; give user the option of either choosing from repair options, or closing
                 // the activity
                 dialog.show {
@@ -81,7 +80,6 @@ class DatabaseErrorDialog : AsyncDialogFragment() {
                 }
             }
             DIALOG_DB_ERROR -> {
-
                 // Database Check failed to execute successfully; give user the option of either choosing from repair
                 // options, submitting an error report, or closing the activity
                 dialog.show {
@@ -103,7 +101,6 @@ class DatabaseErrorDialog : AsyncDialogFragment() {
                 }
             }
             DIALOG_ERROR_HANDLING -> {
-
                 // The user has asked to see repair options; allow them to choose one of the repair options or go back
                 // to the previous dialog
                 val options = ArrayList<String>(6)
@@ -176,7 +173,6 @@ class DatabaseErrorDialog : AsyncDialogFragment() {
                 }
             }
             DIALOG_REPAIR_COLLECTION -> {
-
                 // Allow user to run BackupManager.repairCollection()
                 dialog.show {
                     contentNullable(message)
@@ -189,7 +185,6 @@ class DatabaseErrorDialog : AsyncDialogFragment() {
                 }
             }
             DIALOG_RESTORE_BACKUP -> {
-
                 // Allow user to restore one of the backups
                 val path = CollectionHelper.getCollectionPath(requireContext())
                 mBackups = BackupManager.getBackups(File(path))
@@ -244,7 +239,6 @@ class DatabaseErrorDialog : AsyncDialogFragment() {
                 dialog
             }
             DIALOG_NEW_COLLECTION -> {
-
                 // Allow user to create a new empty collection
                 dialog.show {
                     contentNullable(message)
@@ -263,7 +257,6 @@ class DatabaseErrorDialog : AsyncDialogFragment() {
                 }
             }
             DIALOG_CONFIRM_DATABASE_CHECK -> {
-
                 // Confirmation dialog for database check
                 dialog.show {
                     contentNullable(message)
@@ -275,7 +268,6 @@ class DatabaseErrorDialog : AsyncDialogFragment() {
                 }
             }
             DIALOG_CONFIRM_RESTORE_BACKUP -> {
-
                 // Confirmation dialog for backup restore
                 dialog.show {
                     contentNullable(message)
@@ -287,7 +279,6 @@ class DatabaseErrorDialog : AsyncDialogFragment() {
                 }
             }
             DIALOG_FULL_SYNC_FROM_SERVER -> {
-
                 // Allow user to do a full-sync from the server
                 dialog.show {
                     contentNullable(message)
@@ -299,7 +290,6 @@ class DatabaseErrorDialog : AsyncDialogFragment() {
                 }
             }
             DIALOG_DB_LOCKED -> {
-
                 // If the database is locked, all we can do is ask the user to exit.
                 dialog.show {
                     contentNullable(message)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckPickerContextMenu.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckPickerContextMenu.kt
@@ -180,7 +180,9 @@ class DeckPickerContextMenu(private val collection: Collection) : AnalyticsDialo
             val cls = loadFragmentClass(classLoader, className)
             return if (cls == DeckPickerContextMenu::class.java) {
                 newDeckPickerContextMenu()
-            } else super.instantiate(classLoader, className)
+            } else {
+                super.instantiate(classLoader, className)
+            }
         }
 
         private fun newDeckPickerContextMenu(): DeckPickerContextMenu =

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckSelectionDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckSelectionDialog.kt
@@ -344,11 +344,15 @@ open class DeckSelectionDialog : AnalyticsDialogFragment() {
             if (deckId == Stats.ALL_DECKS_ID) {
                 return if (other.deckId == Stats.ALL_DECKS_ID) {
                     0
-                } else -1
+                } else {
+                    -1
+                }
             }
             return if (other.deckId == Stats.ALL_DECKS_ID) {
                 1
-            } else DeckNameComparator.INSTANCE.compare(name, other.name)
+            } else {
+                DeckNameComparator.INSTANCE.compare(name, other.name)
+            }
         }
 
         companion object {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ExportCompleteDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ExportCompleteDialog.kt
@@ -42,7 +42,7 @@ class ExportCompleteDialog(private val listener: ExportCompleteDialogListener) :
         super.onCreate(savedInstanceState)
         val options = listOf(
             getString(R.string.export_select_save_app),
-            getString(R.string.export_select_share_app),
+            getString(R.string.export_select_share_app)
         )
         return MaterialDialog(requireActivity()).show {
             title(text = notificationTitle)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/HelpDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/HelpDialog.kt
@@ -52,18 +52,26 @@ object HelpDialog {
         UsageAnalytics.sendAnalyticsEvent(UsageAnalytics.Category.LINK_CLICKED, UsageAnalytics.Actions.OPENED_HELPDIALOG)
         val allItems = arrayOf<RecursivePictureMenu.Item>(
             ItemHeader(
-                R.string.help_title_using_ankidroid, R.drawable.ic_manual_black_24dp, UsageAnalytics.Actions.OPENED_USING_ANKIDROID,
+                R.string.help_title_using_ankidroid,
+                R.drawable.ic_manual_black_24dp,
+                UsageAnalytics.Actions.OPENED_USING_ANKIDROID,
                 FunctionItem(
-                    R.string.help_item_ankidroid_manual, R.drawable.ic_manual_black_24dp, UsageAnalytics.Actions.OPENED_ANKIDROID_MANUAL
+                    R.string.help_item_ankidroid_manual,
+                    R.drawable.ic_manual_black_24dp,
+                    UsageAnalytics.Actions.OPENED_ANKIDROID_MANUAL
                 ) { activity -> openManual(activity) },
                 LinkItem(R.string.help_item_anki_manual, R.drawable.ic_manual_black_24dp, UsageAnalytics.Actions.OPENED_ANKI_MANUAL, R.string.link_anki_manual),
                 LinkItem(R.string.help_item_ankidroid_faq, R.drawable.ic_help_black_24dp, UsageAnalytics.Actions.OPENED_ANKIDROID_FAQ, R.string.link_ankidroid_faq)
             ),
             ItemHeader(
-                R.string.help_title_get_help, R.drawable.ic_help_black_24dp, UsageAnalytics.Actions.OPENED_GET_HELP,
+                R.string.help_title_get_help,
+                R.drawable.ic_help_black_24dp,
+                UsageAnalytics.Actions.OPENED_GET_HELP,
                 LinkItem(R.string.help_item_mailing_list, R.drawable.ic_email_black_24dp, UsageAnalytics.Actions.OPENED_MAILING_LIST, R.string.link_forum),
                 FunctionItem(
-                    R.string.help_item_report_bug, R.drawable.ic_bug_report_black_24dp, UsageAnalytics.Actions.OPENED_REPORT_BUG
+                    R.string.help_item_report_bug,
+                    R.drawable.ic_bug_report_black_24dp,
+                    UsageAnalytics.Actions.OPENED_REPORT_BUG
                 ) { activity -> openFeedback(activity) },
                 exceptionReportItem
             ),
@@ -77,7 +85,9 @@ object HelpDialog {
                 LinkItem(R.string.help_item_twitter, R.drawable.twitter, UsageAnalytics.Actions.OPENED_TWITTER, R.string.link_twitter)
             ),
             ItemHeader(
-                R.string.help_title_privacy, R.drawable.ic_baseline_privacy_tip_24, UsageAnalytics.Actions.OPENED_PRIVACY,
+                R.string.help_title_privacy,
+                R.drawable.ic_baseline_privacy_tip_24,
+                UsageAnalytics.Actions.OPENED_PRIVACY,
                 LinkItem(R.string.help_item_ankidroid_privacy_policy, R.drawable.ic_baseline_policy_24, UsageAnalytics.Actions.OPENED_ANKIDROID_PRIVACY_POLICY, R.string.link_ankidroid_privacy_policy),
                 LinkItem(R.string.help_item_ankiweb_privacy_policy, R.drawable.ic_baseline_policy_24, UsageAnalytics.Actions.OPENED_ANKIWEB_PRIVACY_POLICY, R.string.link_ankiweb_privacy_policy),
                 LinkItem(R.string.help_item_ankiweb_terms_and_conditions, R.drawable.ic_baseline_description_24, UsageAnalytics.Actions.OPENED_ANKIWEB_TERMS_AND_CONDITIONS, R.string.link_ankiweb_terms_and_conditions)
@@ -96,7 +106,9 @@ object HelpDialog {
             rateAppItem,
             LinkItem(R.string.help_item_support_other_ankidroid, R.drawable.ic_help_black_24dp, UsageAnalytics.Actions.OPENED_OTHER, R.string.link_contribution),
             FunctionItem(
-                R.string.send_feedback, R.drawable.ic_email_black_24dp, UsageAnalytics.Actions.OPENED_SEND_FEEDBACK
+                R.string.send_feedback,
+                R.drawable.ic_email_black_24dp,
+                UsageAnalytics.Actions.OPENED_SEND_FEEDBACK
             ) { activity -> openFeedback(activity) }
         )
         val itemList = ArrayList(listOf(*allItems))
@@ -234,7 +246,8 @@ object HelpDialog {
             val wasReportSent = CrashReportService.sendReport(activity)
             if (!wasReportSent) {
                 showThemedToast(
-                    activity, activity.getString(R.string.help_dialog_exception_report_debounce),
+                    activity,
+                    activity.getString(R.string.help_dialog_exception_report_debounce),
                     true
                 )
             }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ImportFileSelectionFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ImportFileSelectionFragment.kt
@@ -60,7 +60,7 @@ class ImportFileSelectionFragment {
                     R.drawable.ic_manual_black_24dp,
                     UsageAnalytics.Actions.IMPORT_COLPKG_FILE,
                     OpenFilePicker(DeckPicker.PICK_APKG_FILE)
-                ),
+                )
             )
             if (!BackendFactory.defaultLegacySchema) {
                 val mimes = arrayOf("text/plain", "text/comma-separated-values", "text/csv", "text/tab-separated-values")

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/KeySelectionDialogUtils.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/KeySelectionDialogUtils.kt
@@ -31,7 +31,7 @@ object KeySelectionDialogUtils {
             KeyEvent.KEYCODE_ALT_RIGHT,
             KeyEvent.KEYCODE_META_LEFT,
             KeyEvent.KEYCODE_META_RIGHT,
-            KeyEvent.KEYCODE_FUNCTION,
+            KeyEvent.KEYCODE_FUNCTION
         )
         return { !modifierKeyCodes.contains(it) }
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/MediaCheckDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/MediaCheckDialog.kt
@@ -124,7 +124,9 @@ class MediaCheckDialog : AsyncDialogFragment() {
         get() {
             return if (requireArguments().getInt("dialogType") == DIALOG_CONFIRM_MEDIA_CHECK) {
                 resources.getString(R.string.check_media_title)
-            } else resources.getString(R.string.app_name)
+            } else {
+                resources.getString(R.string.app_name)
+            }
         }
 
     override val dialogHandlerMessage: Message

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ModelBrowserContextMenu.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ModelBrowserContextMenu.kt
@@ -40,5 +40,5 @@ class ModelBrowserContextMenu : AnalyticsDialogFragment() {
 enum class ModelBrowserContextMenuAction(val order: Int, @StringRes val actionTextResId: Int) {
     Template(0, R.string.model_browser_template),
     Rename(1, R.string.model_browser_rename),
-    Delete(2, R.string.model_browser_delete),
+    Delete(2, R.string.model_browser_delete)
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/RescheduleDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/RescheduleDialog.kt
@@ -88,17 +88,19 @@ class RescheduleDialog : IntegerDialog() {
             )
             return if (currentCard.isInDynamicDeck) {
                 message
-            } else """
+            } else {
+                """
      $message
      
      ${
-            resources.getQuantityString(
-                R.plurals.reschedule_card_dialog_interval,
-                currentCard.ivl,
-                currentCard.ivl
-            )
+                resources.getQuantityString(
+                    R.plurals.reschedule_card_dialog_interval,
+                    currentCard.ivl,
+                    currentCard.ivl
+                )
+                }
+                """.trimIndent()
             }
-            """.trimIndent()
         }
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ScopedStorageMigrationDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ScopedStorageMigrationDialog.kt
@@ -168,7 +168,8 @@ fun openUrl(activity: AnkiActivity): OpenUri = activity::openUrl
  * @return the dialog
  */
 fun AlertDialog.Builder.addScopedStorageLearnMoreLinkAndShow(@Language("HTML") message: String): AlertDialog {
-    @Language("HTML") val messageWithLink = """$message
+    @Language("HTML")
+    val messageWithLink = """$message
             <br>
             <br><a href='${context.getString(R.string.link_scoped_storage_faq)}'>${context.getString(R.string.scoped_storage_learn_more)}</a>
     """.trimIndent().parseAsHtml()

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/SimpleMessageDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/SimpleMessageDialog.kt
@@ -61,8 +61,10 @@ class SimpleMessageDialog : AsyncDialogFragment() {
     companion object {
         /** The title of the notification/dialog */
         private const val ARGS_TITLE = "title"
+
         /** The content of the notification/dialog */
         private const val ARGS_MESSAGE = "message"
+
         /**
          * If the calling activity should be reloaded when 'OK' is pressed.
          * @see SimpleMessageDialogListener.dismissSimpleMessageDialog

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/SyncErrorDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/SyncErrorDialog.kt
@@ -48,7 +48,6 @@ class SyncErrorDialog : AsyncDialogFragment() {
             .cancelable(true)
         return when (requireArguments().getInt("dialogType")) {
             DIALOG_USER_NOT_LOGGED_IN_SYNC -> {
-
                 // User not logged in; take them to login screen
                 dialog.show {
                     iconAttr(R.attr.dialogSyncErrorIcon)
@@ -59,7 +58,6 @@ class SyncErrorDialog : AsyncDialogFragment() {
                 }
             }
             DIALOG_CONNECTION_ERROR -> {
-
                 // Connection error; allow user to retry or cancel
                 dialog.show {
                     iconAttr(R.attr.dialogSyncErrorIcon)
@@ -73,7 +71,6 @@ class SyncErrorDialog : AsyncDialogFragment() {
                 }
             }
             DIALOG_SYNC_CONFLICT_RESOLUTION -> {
-
                 // Sync conflict; allow user to cancel, or choose between local and remote versions
                 dialog.show {
                     iconAttr(R.attr.dialogSyncErrorIcon)
@@ -91,7 +88,6 @@ class SyncErrorDialog : AsyncDialogFragment() {
                 }
             }
             DIALOG_SYNC_CONFLICT_CONFIRM_KEEP_LOCAL -> {
-
                 // Confirmation before pushing local collection to server after sync conflict
                 dialog.show {
                     iconAttr(R.attr.dialogSyncErrorIcon)
@@ -104,7 +100,6 @@ class SyncErrorDialog : AsyncDialogFragment() {
                 }
             }
             DIALOG_SYNC_CONFLICT_CONFIRM_KEEP_REMOTE -> {
-
                 // Confirmation before overwriting local collection with server collection after sync conflict
                 dialog.show {
                     iconAttr(R.attr.dialogSyncErrorIcon)
@@ -117,7 +112,6 @@ class SyncErrorDialog : AsyncDialogFragment() {
                 }
             }
             DIALOG_SYNC_SANITY_ERROR -> {
-
                 // Sync sanity check error; allow user to cancel, or choose between local and remote versions
                 dialog.show {
                     positiveButton(R.string.sync_sanity_local) {
@@ -132,7 +126,6 @@ class SyncErrorDialog : AsyncDialogFragment() {
                 }
             }
             DIALOG_SYNC_SANITY_ERROR_CONFIRM_KEEP_LOCAL -> {
-
                 // Confirmation before pushing local collection to server after sanity check error
                 dialog.show {
                     positiveButton(R.string.dialog_positive_replace) {
@@ -143,7 +136,6 @@ class SyncErrorDialog : AsyncDialogFragment() {
                 }
             }
             DIALOG_SYNC_SANITY_ERROR_CONFIRM_KEEP_REMOTE -> {
-
                 // Confirmation before overwriting local collection with server collection after sanity check error
                 dialog.show {
                     positiveButton(R.string.dialog_positive_replace) {
@@ -201,7 +193,9 @@ class SyncErrorDialog : AsyncDialogFragment() {
         get() {
             return if (requireArguments().getInt("dialogType") == DIALOG_USER_NOT_LOGGED_IN_SYNC) {
                 resources.getString(R.string.sync_error)
-            } else title
+            } else {
+                title
+            }
         }
 
     private val message: String?
@@ -229,7 +223,9 @@ class SyncErrorDialog : AsyncDialogFragment() {
         get() {
             return if (requireArguments().getInt("dialogType") == DIALOG_USER_NOT_LOGGED_IN_SYNC) {
                 resources.getString(R.string.not_logged_in_title)
-            } else message
+            } else {
+                message
+            }
         }
 
     override val dialogHandlerMessage: Message

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/customstudy/CustomStudyDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/customstudy/CustomStudyDialog.kt
@@ -130,7 +130,6 @@ class CustomStudyDialog(private val collection: Collection, private val customSt
                         customStudyListener?.showDialogFragment(d)
                     }
                     STUDY_TAGS -> {
-
                         /*
                          * This is a special Dialog for CUSTOM STUDY, where instead of only collecting a
                          * number, it is necessary to collect a list of tags. This case handles the creation
@@ -139,13 +138,13 @@ class CustomStudyDialog(private val collection: Collection, private val customSt
                         val currentDeck = requireArguments().getLong("did")
 
                         val dialogFragment = TagsDialog().withArguments(
-                            TagsDialog.DialogType.CUSTOM_STUDY_TAGS, ArrayList(),
+                            TagsDialog.DialogType.CUSTOM_STUDY_TAGS,
+                            ArrayList(),
                             ArrayList(collection.tags.byDeck(currentDeck, true))
                         )
                         customStudyListener?.showDialogFragment(dialogFragment)
                     }
                     else -> {
-
                         // User asked for a standard custom study option
                         val d = CustomStudyDialog(collection, customStudyListener)
                             .withArguments(
@@ -179,7 +178,8 @@ class CustomStudyDialog(private val collection: Collection, private val customSt
         */
         // Input dialogs
         // Show input dialog for an individual custom study dialog
-        @SuppressLint("InflateParams") val v = requireActivity().layoutInflater.inflate(R.layout.styled_custom_study_details_dialog, null)
+        @SuppressLint("InflateParams")
+        val v = requireActivity().layoutInflater.inflate(R.layout.styled_custom_study_details_dialog, null)
         val textView1 = v.findViewById<TextView>(R.id.custom_study_details_text1)
         val textView2 = v.findViewById<TextView>(R.id.custom_study_details_text2)
         val editText = v.findViewById<EditText>(R.id.custom_study_details_edittext2)
@@ -234,9 +234,11 @@ class CustomStudyDialog(private val collection: Collection, private val customSt
                             arrayOf(
                                 String.format(
                                     Locale.US,
-                                    "rated:%d:1", n
+                                    "rated:%d:1",
+                                    n
                                 ),
-                                Consts.DYN_MAX_SIZE, Consts.DYN_RANDOM
+                                Consts.DYN_MAX_SIZE,
+                                Consts.DYN_RANDOM
                             ),
                             false
                         )
@@ -247,9 +249,11 @@ class CustomStudyDialog(private val collection: Collection, private val customSt
                             arrayOf(
                                 String.format(
                                     Locale.US,
-                                    "prop:due<=%d", n
+                                    "prop:due<=%d",
+                                    n
                                 ),
-                                Consts.DYN_MAX_SIZE, Consts.DYN_DUE
+                                Consts.DYN_MAX_SIZE,
+                                Consts.DYN_DUE
                             ),
                             true
                         )
@@ -263,7 +267,8 @@ class CustomStudyDialog(private val collection: Collection, private val customSt
                             arrayOf(
                                 "is:new added:" +
                                     n,
-                                Consts.DYN_MAX_SIZE, Consts.DYN_OLDEST
+                                Consts.DYN_MAX_SIZE,
+                                Consts.DYN_OLDEST
                             ),
                             false
                         )
@@ -333,7 +338,8 @@ class CustomStudyDialog(private val collection: Collection, private val customSt
             JSONArray(),
             arrayOf(
                 sb.toString(),
-                Consts.DYN_MAX_SIZE, Consts.DYN_RANDOM
+                Consts.DYN_MAX_SIZE,
+                Consts.DYN_RANDOM
             ),
             true
         )
@@ -375,8 +381,12 @@ class CustomStudyDialog(private val collection: Collection, private val customSt
                 }
             EMPTY_SCHEDULE -> // Special custom study options to show when extending the daily study limits is not applicable
                 return listOf(
-                    STUDY_FORGOT, STUDY_AHEAD, STUDY_RANDOM,
-                    STUDY_PREVIEW, STUDY_TAGS, DECK_OPTIONS
+                    STUDY_FORGOT,
+                    STUDY_AHEAD,
+                    STUDY_RANDOM,
+                    STUDY_PREVIEW,
+                    STUDY_TAGS,
+                    DECK_OPTIONS
                 )
         }
     }
@@ -501,6 +511,7 @@ class CustomStudyDialog(private val collection: Collection, private val customSt
      */
     interface ContextMenuAttribute<T> where T : Enum<*> {
         val value: Int
+
         @get:StringRes val stringResource: Int?
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/customstudy/CustomStudyDialogFactory.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/customstudy/CustomStudyDialogFactory.kt
@@ -26,7 +26,9 @@ class CustomStudyDialogFactory(val collectionSupplier: Supplier<Collection>, pri
         val cls = loadFragmentClass(classLoader, className)
         return if (cls == CustomStudyDialog::class.java) {
             newCustomStudyDialog()
-        } else super.instantiate(classLoader, className)
+        } else {
+            super.instantiate(classLoader, className)
+        }
     }
 
     fun newCustomStudyDialog(): CustomStudyDialog {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/tags/TagsArrayAdapter.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/tags/TagsArrayAdapter.kt
@@ -38,6 +38,7 @@ class TagsArrayAdapter(private val tags: TagsList, private val resources: Resour
         internal lateinit var node: TagTreeNode
         internal val mExpandButton: ImageButton = itemView.findViewById(R.id.id_expand_button)
         internal val mCheckBoxView: CheckBoxTriStates = itemView.findViewById(R.id.tags_dialog_tag_item_checkbox)
+
         // TextView contains the displayed tag (only the last part), while the full tag is stored in TagTreeNode
         internal val mTextView: TextView = itemView.findViewById(R.id.tags_dialog_tag_item_text)
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/tags/TagsDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/tags/TagsDialog.kt
@@ -136,7 +136,8 @@ class TagsDialog : AnalyticsDialogFragment {
             "filled as prefix properly. In other dialog types, long-clicking a tag behaves like a short click."
     )
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
-        @SuppressLint("InflateParams") val tagsDialogView = LayoutInflater.from(activity).inflate(R.layout.tags_dialog, null, false)
+        @SuppressLint("InflateParams")
+        val tagsDialogView = LayoutInflater.from(activity).inflate(R.layout.tags_dialog, null, false)
         mTagsListRecyclerView = tagsDialogView.findViewById(R.id.tags_dialog_tags_list)
         val tagsListRecyclerView: RecyclerView? = mTagsListRecyclerView
         tagsListRecyclerView?.requestFocus()
@@ -174,7 +175,8 @@ class TagsDialog : AnalyticsDialogFragment {
             .positiveButton(text = mPositiveText!!) {
                 tagsDialogListener.onSelectedTags(
                     mTags!!.copyOfCheckedTagList(),
-                    mTags!!.copyOfIndeterminateTagList(), mSelectedOption
+                    mTags!!.copyOfIndeterminateTagList(),
+                    mSelectedOption
                 )
             }
             .negativeButton(R.string.dialog_cancel)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/tags/TagsDialogFactory.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/tags/TagsDialogFactory.kt
@@ -23,7 +23,9 @@ class TagsDialogFactory(val listener: TagsDialogListener) : ExtendedFragmentFact
         val cls = loadFragmentClass(classLoader, className)
         return if (cls == TagsDialog::class.java) {
             newTagsDialog()
-        } else super.instantiate(classLoader, className)
+        } else {
+            super.instantiate(classLoader, className)
+        }
     }
 
     fun newTagsDialog(): TagsDialog {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/tags/TagsDialogListener.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/tags/TagsDialogListener.kt
@@ -37,7 +37,8 @@ interface TagsDialogListener {
     fun onSelectedTags(selectedTags: List<String>, indeterminateTags: List<String>, option: Int)
     fun <F> F.registerFragmentResultReceiver() where F : Fragment, F : TagsDialogListener {
         parentFragmentManager.setFragmentResultListener(
-            ON_SELECTED_TAGS_KEY, this,
+            ON_SELECTED_TAGS_KEY,
+            this,
             FragmentResultListener { _: String?, bundle: Bundle ->
                 val selectedTags: List<String> = bundle.getStringArrayList(ON_SELECTED_TAGS__SELECTED_TAGS)!!
                 val indeterminateTags: List<String> = bundle.getStringArrayList(ON_SELECTED_TAGS__INDETERMINATE_TAGS)!!

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/tags/TagsList.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/tags/TagsList.kt
@@ -129,6 +129,7 @@ class TagsList constructor(
         addAncestors(tag)
         return true
     }
+
     /**
      * Mark a tag as checked tag.
      * Optionally mark ancestors as indeterminate

--- a/AnkiDroid/src/main/java/com/ichi2/anki/export/ActivityExportingDelegate.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/export/ActivityExportingDelegate.kt
@@ -202,7 +202,7 @@ class ActivityExportingDelegate(private val activity: AnkiActivity, private val 
                 activity.getString(
                     R.string.export_email_text,
                     activity.getString(R.string.link_manual),
-                    activity.getString(R.string.link_distributions),
+                    activity.getString(R.string.link_distributions)
                 )
             )
             .intent.apply {
@@ -311,13 +311,15 @@ class ActivityExportingDelegate(private val activity: AnkiActivity, private val 
         if (::mExportFileName.isInitialized && !mExportFileName.endsWith(".colpkg")) return
         AnkiDroidApp.getSharedPrefs(activity).edit {
             putLong(
-                LAST_SUCCESSFUL_EXPORT_AT_SECOND_KEY, TimeManager.time.intTime()
+                LAST_SUCCESSFUL_EXPORT_AT_SECOND_KEY,
+                TimeManager.time.intTime()
             )
         }
         val col = collectionSupplier.get()
         AnkiDroidApp.getSharedPrefs(activity).edit {
             putLong(
-                LAST_SUCCESSFUL_EXPORT_AT_MOD_KEY, col.mod
+                LAST_SUCCESSFUL_EXPORT_AT_MOD_KEY,
+                col.mod
             )
         }
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/export/ExportDialogsFactory.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/export/ExportDialogsFactory.kt
@@ -34,7 +34,9 @@ internal class ExportDialogsFactory(
         }
         return if (cls == ExportCompleteDialog::class.java) {
             newExportCompleteDialog()
-        } else super.instantiate(classLoader, className)
+        } else {
+            super.instantiate(classLoader, className)
+        }
     }
 
     fun newExportDialog(): ExportDialog {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/introduction/SetupCollectionFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/introduction/SetupCollectionFragment.kt
@@ -81,6 +81,7 @@ class SetupCollectionFragment : Fragment() {
     enum class CollectionSetupOption {
         /** Continues to the DeckPicker with a new collection */
         DeckPickerWithNewCollection,
+
         /** Syncs an existing profile from AnkiWeb */
         SyncFromExistingAccount
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/jsaddons/TgzPackageExtract.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/jsaddons/TgzPackageExtract.kt
@@ -125,7 +125,6 @@ class TgzPackageExtract(private val context: Context) {
      */
     @Throws(Exception::class)
     fun extractTarGzipToAddonFolder(tarballFile: File, addonsPackageDir: AddonsPackageDir) {
-
         require(isGzip(tarballFile)) { context.getString(R.string.not_valid_js_addon, tarballFile.absolutePath) }
 
         try {
@@ -285,7 +284,6 @@ class TgzPackageExtract(private val context: Context) {
                 while (total + BUFFER <= TOO_BIG_SIZE &&
                     tarInputStream.read(data, 0, BUFFER).also { count = it } != -1
                 ) {
-
                     bufferOutput.write(data, 0, count)
                     total += count
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/model/Directory.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/model/Directory.kt
@@ -57,6 +57,7 @@ class Directory private constructor(val directory: File) {
          * Otherwise returns `null`.
          */
         fun createInstance(path: String): Directory? = createInstance(File(path))
+
         /**
          * Returns a [Directory] from [file] if `Directory` precondition holds; i.e. [file] is an existing directory.
          * Otherwise returns `null`.
@@ -67,6 +68,7 @@ class Directory private constructor(val directory: File) {
             }
             return Directory(file)
         }
+
         /** Creates an instance. Only call it if [Directory] preconditions are known to be true */
         fun createInstanceUnsafe(file: File) = Directory(file)
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/model/DiskFile.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/model/DiskFile.kt
@@ -30,6 +30,7 @@ import java.io.File
 class DiskFile private constructor(val file: File) {
     /** @see [File.renameTo] */
     fun renameTo(destination: File): Boolean = file.renameTo(destination)
+
     /** @see [FileUtils.contentEquals] */
     fun contentEquals(f2: File): Boolean = FileUtils.contentEquals(file, f2)
     override fun toString(): String = file.canonicalPath

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/AudioView.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/AudioView.kt
@@ -352,7 +352,8 @@ class AudioView private constructor(context: Context, resPlay: Int, resPause: In
                 CrashReportService.sendExceptionReport(e, "Unable to create recorder tool bar")
                 showThemedToast(
                     context,
-                    context.getText(R.string.multimedia_editor_audio_view_create_failed).toString(), true
+                    context.getText(R.string.multimedia_editor_audio_view_create_failed).toString(),
+                    true
                 )
                 null
             }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/MediaPlayer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/MediaPlayer.kt
@@ -53,8 +53,9 @@ class MediaPlayer :
 
     override fun setDataSource(context: Context, uri: Uri) {
         super.setDataSource(context, uri)
-        if (state == IDLE)
+        if (state == IDLE) {
             state = INITIALIZED
+        }
     }
 
     override fun setDataSource(
@@ -64,44 +65,51 @@ class MediaPlayer :
         cookies: MutableList<HttpCookie>?
     ) {
         super.setDataSource(context, uri, headers, cookies)
-        if (state == IDLE)
+        if (state == IDLE) {
             state = INITIALIZED
+        }
     }
 
     override fun setDataSource(context: Context, uri: Uri, headers: MutableMap<String, String>?) {
         super.setDataSource(context, uri, headers)
-        if (state == IDLE)
+        if (state == IDLE) {
             state = INITIALIZED
+        }
     }
 
     override fun setDataSource(path: String?) {
         super.setDataSource(path)
-        if (state == IDLE)
+        if (state == IDLE) {
             state = INITIALIZED
+        }
     }
 
     override fun setDataSource(afd: AssetFileDescriptor) {
         super.setDataSource(afd)
-        if (state == IDLE)
+        if (state == IDLE) {
             state = INITIALIZED
+        }
     }
 
     override fun setDataSource(fd: FileDescriptor?) {
         super.setDataSource(fd)
-        if (state == IDLE)
+        if (state == IDLE) {
             state = INITIALIZED
+        }
     }
 
     override fun setDataSource(fd: FileDescriptor?, offset: Long, length: Long) {
         super.setDataSource(fd, offset, length)
-        if (state == IDLE)
+        if (state == IDLE) {
             state = INITIALIZED
+        }
     }
 
     override fun setDataSource(dataSource: MediaDataSource?) {
         super.setDataSource(dataSource)
-        if (state == IDLE)
+        if (state == IDLE) {
             state = INITIALIZED
+        }
     }
 
     override fun reset() {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/activity/LoadPronunciationActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/activity/LoadPronunciationActivity.kt
@@ -103,7 +103,8 @@ open class LoadPronunciationActivity : AnkiActivity(), DialogInterface.OnCancelL
         mLanguageLister = LanguageListerBeolingus()
         mSpinnerFrom = Spinner(this)
         val adapter = ArrayAdapter(
-            this, android.R.layout.simple_spinner_item,
+            this,
+            android.R.layout.simple_spinner_item,
             mLanguageLister.languages
         )
         adapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/activity/MultimediaEditFieldActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/activity/MultimediaEditFieldActivity.kt
@@ -101,7 +101,8 @@ class MultimediaEditFieldActivity : AnkiActivity(), OnRequestPermissionsResultCa
         if (field is AudioRecordingField && !Permissions.canRecordAudio(this)) {
             Timber.d("Requesting Audio Permissions")
             ActivityCompat.requestPermissions(
-                this, arrayOf(Manifest.permission.RECORD_AUDIO),
+                this,
+                arrayOf(Manifest.permission.RECORD_AUDIO),
                 REQUEST_AUDIO_PERMISSION
             )
             return true
@@ -113,7 +114,8 @@ class MultimediaEditFieldActivity : AnkiActivity(), OnRequestPermissionsResultCa
         ) {
             Timber.d("Requesting Camera Permissions")
             ActivityCompat.requestPermissions(
-                this, arrayOf(Manifest.permission.CAMERA),
+                this,
+                arrayOf(Manifest.permission.CAMERA),
                 REQUEST_CAMERA_PERMISSION
             )
             return true

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/activity/PickStringDialogFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/activity/PickStringDialogFragment.kt
@@ -44,7 +44,8 @@ class PickStringDialogFragment : DialogFragment() {
         builder.setTitle(mTitle)
         val adapter = ArrayAdapter(
             requireActivity(),
-            R.layout.simple_list_item_1, mPossibleChoices!!
+            R.layout.simple_list_item_1,
+            mPossibleChoices!!
         )
         builder.setAdapter(adapter, mListener)
         return builder.create()

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicImageFieldController.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicImageFieldController.kt
@@ -96,6 +96,7 @@ class BasicImageFieldController : FieldControllerBase(), IFieldController {
             return min(height * 0.4, width * 0.6).toInt()
         }
     private lateinit var cropImageRequest: ActivityResultLauncher<CropImageContractOptions>
+
     @VisibleForTesting
     lateinit var registryToUse: ActivityResultRegistry
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicMediaClipFieldController.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicMediaClipFieldController.kt
@@ -118,7 +118,8 @@ class BasicMediaClipFieldController : FieldControllerBase(), IFieldController {
             if (cursor == null) {
                 showThemedToast(
                     AnkiDroidApp.instance.applicationContext,
-                    AnkiDroidApp.instance.getString(R.string.multimedia_editor_something_wrong), true
+                    AnkiDroidApp.instance.getString(R.string.multimedia_editor_something_wrong),
+                    true
                 )
                 return
             }
@@ -137,7 +138,8 @@ class BasicMediaClipFieldController : FieldControllerBase(), IFieldController {
                     CrashReportService.sendExceptionReport(e, "Media Clip addition failed. Name " + mediaClipFullName + " / cursor mime type column type " + cursor.getType(2))
                     showThemedToast(
                         AnkiDroidApp.instance.applicationContext,
-                        AnkiDroidApp.instance.getString(R.string.multimedia_editor_something_wrong), true
+                        AnkiDroidApp.instance.getString(R.string.multimedia_editor_something_wrong),
+                        true
                     )
                     return
                 }
@@ -154,7 +156,8 @@ class BasicMediaClipFieldController : FieldControllerBase(), IFieldController {
             CrashReportService.sendExceptionReport(e, "handleMediaSelection:tempFile")
             showThemedToast(
                 AnkiDroidApp.instance.applicationContext,
-                AnkiDroidApp.instance.getString(R.string.multimedia_editor_something_wrong), true
+                AnkiDroidApp.instance.getString(R.string.multimedia_editor_something_wrong),
+                true
             )
             return
         }
@@ -175,7 +178,8 @@ class BasicMediaClipFieldController : FieldControllerBase(), IFieldController {
             CrashReportService.sendExceptionReport(e, "handleMediaSelection:copyFromProvider")
             showThemedToast(
                 AnkiDroidApp.instance.applicationContext,
-                AnkiDroidApp.instance.getString(R.string.multimedia_editor_something_wrong), true
+                AnkiDroidApp.instance.getString(R.string.multimedia_editor_something_wrong),
+                true
             )
         }
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/ImageField.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/ImageField.kt
@@ -72,6 +72,7 @@ class ImageField : FieldBase(), IField {
 
     companion object {
         private const val serialVersionUID = 4431611060655809687L
+
         @VisibleForTesting
         fun formatImageFileName(file: File): String {
             return if (file.exists()) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/impl/MultimediaEditableNote.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/impl/MultimediaEditableNote.kt
@@ -66,7 +66,9 @@ class MultimediaEditableNote : IMultimediaEditableNote {
     override fun getField(index: Int): IField? {
         return if (index in 0 until numberOfFields) {
             fieldsPrivate[index]
-        } else null
+        } else {
+            null
+        }
     }
 
     override fun setField(index: Int, field: IField?): Boolean {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/language/LanguageListerBase.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/language/LanguageListerBase.kt
@@ -41,7 +41,9 @@ open class LanguageListerBase {
     fun getCodeFor(Language: String): String? {
         return if (mLanguageMap.containsKey(Language)) {
             mLanguageMap[Language]
-        } else null
+        } else {
+            null
+        }
     }
 
     val languages: ArrayList<String>

--- a/AnkiDroid/src/main/java/com/ichi2/anki/noteeditor/Toolbar.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/noteeditor/Toolbar.kt
@@ -64,6 +64,7 @@ class Toolbar : FrameLayout {
     var formatListener: TextFormatListener? = null
     private val mToolbar: LinearLayout
     private val mToolbarLayout: LinearLayout
+
     /** A list of buttons, typically user-defined which modify text + selection */
     private val mCustomButtons: MutableList<View> = ArrayList()
     private val mRows: MutableList<LinearLayout> = ArrayList()

--- a/AnkiDroid/src/main/java/com/ichi2/anki/notetype/ManageNotetypes.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/notetype/ManageNotetypes.kt
@@ -59,13 +59,13 @@ class ManageNotetypes : AnkiActivity() {
                 launchForChanges<ModelFieldEditor>(
                     mapOf(
                         "title" to it.name,
-                        "noteTypeID" to it.id,
+                        "noteTypeID" to it.id
                     )
                 )
             },
             onEditCards = { launchForChanges<CardTemplateEditor>(mapOf("modelId" to it.id)) },
             onRename = ::renameNotetype,
-            onDelete = ::deleteNotetype,
+            onDelete = ::deleteNotetype
         )
     }
     private val outsideChangesLauncher =
@@ -227,7 +227,7 @@ class ManageNotetypes : AnkiActivity() {
                 optionsToDisplay.map {
                     String.format(
                         if (it.isStandard) addPrefixStr else clonePrefixStr,
-                        it.name,
+                        it.name
                     )
                 }
             ).apply {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/notetype/NotetypeAdapter.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/notetype/NotetypeAdapter.kt
@@ -46,7 +46,7 @@ internal class NotetypesAdapter(
     private val onShowFields: (NoteTypeUiModel) -> Unit,
     private val onEditCards: (NoteTypeUiModel) -> Unit,
     private val onRename: (NoteTypeUiModel) -> Unit,
-    private val onDelete: (NoteTypeUiModel) -> Unit,
+    private val onDelete: (NoteTypeUiModel) -> Unit
 ) : ListAdapter<NoteTypeUiModel, NotetypeViewHolder>(notetypeNamesAndCountDiff) {
     private val layoutInflater = LayoutInflater.from(context)
 
@@ -56,7 +56,7 @@ internal class NotetypesAdapter(
             onDelete = onDelete,
             onRename = onRename,
             onEditCards = onEditCards,
-            onShowFields = onShowFields,
+            onShowFields = onShowFields
         )
     }
 
@@ -70,7 +70,7 @@ internal class NotetypeViewHolder(
     onShowFields: (NoteTypeUiModel) -> Unit,
     onEditCards: (NoteTypeUiModel) -> Unit,
     onRename: (NoteTypeUiModel) -> Unit,
-    onDelete: (NoteTypeUiModel) -> Unit,
+    onDelete: (NoteTypeUiModel) -> Unit
 ) : RecyclerView.ViewHolder(rowView) {
     val name: TextView = rowView.findViewById(R.id.note_name)
     val useCount: TextView = rowView.findViewById(R.id.note_use_count)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/notetype/NotetypeUiModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/notetype/NotetypeUiModel.kt
@@ -25,7 +25,7 @@ import anki.notetypes.NotetypeNameIdUseCount
 internal data class NoteTypeUiModel(
     val id: Long,
     val name: String,
-    val useCount: Int,
+    val useCount: Int
 )
 
 internal fun NotetypeNameIdUseCount.toUiModel(): NoteTypeUiModel =

--- a/AnkiDroid/src/main/java/com/ichi2/anki/pages/PagesActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/pages/PagesActivity.kt
@@ -84,6 +84,7 @@ class PagesActivity : AnkiActivity() {
          * as arguments of the [PageFragment] that will be opened
          */
         const val EXTRA_PAGE_ARGS = "pageArgs"
+
         /**
          * Extra key of [PagesActivity]'s intent that must be included and
          * hold the name of an [Anki HTML page](https://github.com/ankitects/anki/tree/main/ts)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/NotificationsSettingsFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/NotificationsSettingsFragment.kt
@@ -53,8 +53,10 @@ class NotificationsSettingsFragment : SettingsFragment() {
                     scheduleNotification(TimeManager.time, requireContext())
                 } else {
                     val intent = CompatHelper.compat.getImmutableBroadcastIntent(
-                        requireContext(), 0,
-                        Intent(requireContext(), NotificationService::class.java), 0
+                        requireContext(),
+                        0,
+                        Intent(requireContext(), NotificationService::class.java),
+                        0
                     )
                     val alarmManager = requireActivity().getSystemService(ALARM_SERVICE) as AlarmManager
                     alarmManager.cancel(intent)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/provider/CardContentProvider.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/provider/CardContentProvider.kt
@@ -204,7 +204,6 @@ class CardContentProvider : ContentProvider() {
                 col.db.query(sql, *(selectionArgs ?: arrayOf()))
             }
             NOTES -> {
-
                 /* Search for notes using the libanki browser syntax */
                 val proj = sanitizeNoteProjection(projection)
                 val query = selection ?: ""
@@ -218,7 +217,6 @@ class CardContentProvider : ContentProvider() {
                 }
             }
             NOTES_ID -> {
-
                 /* Direct access note with specific ID*/
                 val noteId = uri.pathSegments[1]
                 val proj = sanitizeNoteProjection(projection)
@@ -258,7 +256,6 @@ class CardContentProvider : ContentProvider() {
                 rv
             }
             MODELS_ID_TEMPLATES -> {
-
                 /* Direct access model templates */
                 val models = col.models
                 val currentModel = models.get(getModelIdFromUri(uri, col))
@@ -278,7 +275,6 @@ class CardContentProvider : ContentProvider() {
                 rv
             }
             MODELS_ID_TEMPLATES_ID -> {
-
                 /* Direct access model template with specific ID */
                 val models = col.models
                 val ord = uri.lastPathSegment!!.toInt()
@@ -410,7 +406,6 @@ class CardContentProvider : ContentProvider() {
         when (match) {
             NOTES_V2, NOTES -> throw IllegalArgumentException("Not possible to update notes directly (only through data URI)")
             NOTES_ID -> {
-
                 /* Direct access note details
                  */
                 val currentNote = getNoteFromUri(uri, col)
@@ -779,7 +774,6 @@ class CardContentProvider : ContentProvider() {
         // Find out what data the user is requesting
         return when (sUriMatcher.match(uri)) {
             NOTES -> {
-
                 /* Insert new note with specified fields and tags
                  */
                 val modelId = values!!.getAsLong(FlashCardsContract.Note.MID)
@@ -1263,7 +1257,9 @@ class CardContentProvider : ContentProvider() {
     private fun hasReadWritePermission(): Boolean {
         return if (BuildConfig.DEBUG) { // Allow self-calling of the provider only in debug builds (e.g. for unit tests)
             context!!.checkCallingOrSelfPermission(FlashCardsContract.READ_WRITE_PERMISSION) == PackageManager.PERMISSION_GRANTED
-        } else context!!.checkCallingPermission(FlashCardsContract.READ_WRITE_PERMISSION) == PackageManager.PERMISSION_GRANTED
+        } else {
+            context!!.checkCallingPermission(FlashCardsContract.READ_WRITE_PERMISSION) == PackageManager.PERMISSION_GRANTED
+        }
     }
 
     /** Returns true if the calling package is known to be "rogue" and should be blocked.
@@ -1275,7 +1271,9 @@ class CardContentProvider : ContentProvider() {
             val callingPi = pm.getPackageInfo(callingPackage!!, PackageManager.GET_PERMISSIONS)
             if (callingPi?.requestedPermissions == null) {
                 false
-            } else !listOf(*callingPi.requestedPermissions).contains(FlashCardsContract.READ_WRITE_PERMISSION)
+            } else {
+                !listOf(*callingPi.requestedPermissions).contains(FlashCardsContract.READ_WRITE_PERMISSION)
+            }
         } catch (e: PackageManager.NameNotFoundException) {
             Timber.w(e)
             false

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/ActionButtons.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/ActionButtons.kt
@@ -49,7 +49,9 @@ class ActionButtons(reviewerUi: ReviewerUi) {
     private fun findMenuItem(@IdRes resId: Int): MenuItem? {
         return if (mMenu == null) {
             null
-        } else mMenu!!.findItem(resId)
+        } else {
+            mMenu!!.findItem(resId)
+        }
     }
 
     private fun isLikelyActionButton(@IdRes resourceId: Int): Boolean {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/AnswerButtons.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/AnswerButtons.kt
@@ -54,6 +54,7 @@ enum class AnswerButtons {
      * * * See: [Anki - Hard/good interval is longer than good/easy](https://faqs.ankiweb.net/hard-good-interval-longer-than-good-easy.html)
      */
     HARD,
+
     /**
      * In Step-Mode, Good moves to the next step, or performs a regular graduation
      *

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/FullScreenMode.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/FullScreenMode.kt
@@ -24,8 +24,10 @@ enum class FullScreenMode(private val prefValue: String) {
 
     /** Display both navigation and buttons (default) */
     BUTTONS_AND_MENU("0"),
+
     /** Remove the menu bar, keeps answer button. */
     BUTTONS_ONLY("1"),
+
     /** Remove both menu bar and buttons. Can only be set if gesture is on. */
     FULLSCREEN_ALL_GONE("2");
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/GestureMapper.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/GestureMapper.kt
@@ -86,9 +86,11 @@ class GestureMapper {
     fun gesture(height: Int, width: Int, posX: Float, posY: Float): Gesture? {
         return if (width == 0 || height == 0) {
             null
-        } else when (tapGestureMode) {
-            TapGestureMode.FOUR_POINT -> fromTap(height, width, posX, posY)
-            TapGestureMode.NINE_POINT -> fromTapCorners(height, width, posX, posY)
+        } else {
+            when (tapGestureMode) {
+                TapGestureMode.FOUR_POINT -> fromTap(height, width, posX, posY)
+                TapGestureMode.NINE_POINT -> fromTapCorners(height, width, posX, posY)
+            }
         }
     }
 
@@ -159,7 +161,9 @@ class GestureMapper {
             }
             return if (valueFloor < 1) {
                 TriState.LOW
-            } else TriState.MID
+            } else {
+                TriState.MID
+            }
         }
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/MappableBinding.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/MappableBinding.kt
@@ -71,9 +71,11 @@ class MappableBinding(val binding: Binding, private val screen: Screen) {
         // one is null
         return if (keys == null || thisKeys == null) {
             false
-        } else (thisKeys.shiftMatches(true) == keys.shiftMatches(true) || thisKeys.shiftMatches(false) == keys.shiftMatches(false)) &&
-            (thisKeys.ctrlMatches(true) == keys.ctrlMatches(true) || thisKeys.ctrlMatches(false) == keys.ctrlMatches(false)) &&
-            (thisKeys.altMatches(true) == keys.altMatches(true) || thisKeys.altMatches(false) == keys.altMatches(false))
+        } else {
+            (thisKeys.shiftMatches(true) == keys.shiftMatches(true) || thisKeys.shiftMatches(false) == keys.shiftMatches(false)) &&
+                (thisKeys.ctrlMatches(true) == keys.ctrlMatches(true) || thisKeys.ctrlMatches(false) == keys.ctrlMatches(false)) &&
+                (thisKeys.altMatches(true) == keys.altMatches(true) || thisKeys.altMatches(false) == keys.altMatches(false))
+        }
 
         // Perf: Could get a slight improvement if we check that both instances are not subclasses
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/PeripheralKeymap.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/PeripheralKeymap.kt
@@ -55,7 +55,9 @@ class PeripheralKeymap(reviewerUi: ReviewerUi, commandProcessor: ViewerCommand.C
     fun onKeyDown(keyCode: Int, event: KeyEvent): Boolean {
         return if (!mHasSetup || event.repeatCount > 0) {
             false
-        } else mKeyMap.onKeyUp(keyCode, event)
+        } else {
+            mKeyMap.onKeyUp(keyCode, event)
+        }
     }
 
     @Suppress("UNUSED_PARAMETER")

--- a/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/NoteService.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/NoteService.kt
@@ -176,7 +176,9 @@ object NoteService {
     fun convertToHtmlNewline(fieldData: String, replaceNewlines: Boolean): String {
         return if (!replaceNewlines) {
             fieldData
-        } else fieldData.replace(FieldEditText.NEW_LINE, "<br>")
+        } else {
+            fieldData.replace(FieldEditText.NEW_LINE, "<br>")
+        }
     }
 
     suspend fun toggleMark(note: Note) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/PreferenceUpgradeService.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/PreferenceUpgradeService.kt
@@ -283,7 +283,7 @@ object PreferenceUpgradeService {
                 Pair(37, ViewerCommand.TOGGLE_WHITEBOARD),
                 Pair(41, ViewerCommand.SHOW_HINT),
                 Pair(42, ViewerCommand.SHOW_ALL_HINTS),
-                Pair(43, ViewerCommand.ADD_NOTE),
+                Pair(43, ViewerCommand.ADD_NOTE)
             )
 
             override fun upgrade(preferences: SharedPreferences) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/SchedulerService.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/SchedulerService.kt
@@ -26,7 +26,6 @@ import com.ichi2.libanki.UndoAction.UndoNameId
 import com.ichi2.utils.Computation
 import timber.log.Timber
 import java.util.*
-import java.util.concurrent.CancellationException
 import kotlin.collections.ArrayList
 import com.ichi2.libanki.Collection as AnkiCollection
 
@@ -44,6 +43,7 @@ class SchedulerService {
      */
     class NextCard<out T>(private val card: Card?, val result: T) {
         fun hasNoMoreCards(): Boolean = card == null
+
         /** Returns the next scheduled card
          * Only call if noMoreCards returns false */
         fun nextScheduledCard(): Card = card!!
@@ -188,7 +188,11 @@ class SchedulerService {
         }
     }
 
-    class UndoRepositionRescheduleResetCards(@StringRes @UndoNameId undoNameId: Int, private val cardsCopied: Array<Card>) : UndoAction(undoNameId) {
+    class UndoRepositionRescheduleResetCards(
+        @StringRes @UndoNameId
+        undoNameId: Int,
+        private val cardsCopied: Array<Card>
+    ) : UndoAction(undoNameId) {
         override fun undo(col: AnkiCollection): Card? {
             Timber.i("Undoing action of type %s on %d cards", javaClass, cardsCopied.size)
             for (card in cardsCopied) {
@@ -221,7 +225,7 @@ class SchedulerService {
             }
         }
 
-        fun AnkiMethod<*>.rescheduleRepositionReset(cards: Array<Card>, @UndoNameId @StringRes undoNameId: Int, actualActualTask: () -> Unit): Computation<Optional<Card>> {
+        fun AnkiMethod<*>.rescheduleRepositionReset(cards: Array<Card>, @UndoNameId @StringRes undoNameId: Int, actualActualTask: () -> Unit): Computation<Optional<Card>> { // ktlint-disable
             val sched = col.sched
             // collect undo information, sensitive to memory pressure, same for all 3 cases
             try {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/ScopedStorageService.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/ScopedStorageService.kt
@@ -241,7 +241,9 @@ object ScopedStorageService {
         val internalScopedDir = File(internalScopedDirPath).canonicalFile
         Timber.i(
             "isLegacyStorage(): current dir: %s\nscoped external dirs: %s\nscoped internal dir: %s",
-            currentDirPath, externalScopedDirs.joinToString(", "), internalScopedDirPath
+            currentDirPath,
+            externalScopedDirs.joinToString(", "),
+            internalScopedDirPath
         )
 
         // Loop to check if the current AnkiDroid directory or any of its parents are the same as the root directories

--- a/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/SearchService.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/SearchService.kt
@@ -30,6 +30,7 @@ class SearchService {
 
         @get:JvmName("hasResult")
         val hasResult = result != null
+
         @get:JvmName("hasError")
         val hasError = error != null
         fun size() = result?.size ?: 0

--- a/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/scopedstorage/MoveConflictedFile.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/scopedstorage/MoveConflictedFile.kt
@@ -49,7 +49,6 @@ class MoveConflictedFile private constructor(
 ) : Operation() {
 
     override fun execute(context: MigrationContext): List<Operation> {
-
         // create the "conflict" folder if it didn't exist, and the relative path to the file
         // example: "AnkiDroid/conflict/collection.media/subfolder"
         createDirectory(proposedDestinationFile.parentFile!!)
@@ -88,6 +87,7 @@ class MoveConflictedFile private constructor(
 
     companion object {
         const val CONFLICT_DIRECTORY = "conflict"
+
         /**
          * @param sourceFile The file to move from
          * @param destinationTopLevel The top level directory to move to (non-relative path). "/storage/emulated/0/AnkiDroid/"
@@ -99,7 +99,6 @@ class MoveConflictedFile private constructor(
             destinationTopLevel: Directory,
             sourceRelativePath: RelativeFilePath
         ): MoveConflictedFile {
-
             // we add /conflict/ to the path inside this method. If this already occurred, something was wrong
             if (sourceRelativePath.path.firstOrNull() == CONFLICT_DIRECTORY) {
                 throw IllegalStateException("can't move from a root path of 'conflict': $sourceRelativePath")

--- a/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/scopedstorage/MoveDirectory.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/scopedstorage/MoveDirectory.kt
@@ -36,7 +36,6 @@ import java.io.File
 
 data class MoveDirectory(val source: Directory, val destination: File) : Operation() {
     override fun execute(context: MigrationContext): List<Operation> {
-
         // This seems unlikely to happen. Both paths need to be on the same mount point
         // We use directory.exists() to ensure that this operation doesn't occur twice. renameTo
         // is likely to be expensive, so we use the creation of the target directory to mark

--- a/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/scopedstorage/migrateuserdata/MigrateUserData.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/scopedstorage/migrateuserdata/MigrateUserData.kt
@@ -35,6 +35,7 @@ import timber.log.Timber
 import java.io.File
 
 typealias NumberOfBytes = Long
+
 /**
  * Function that is executed when one file is migrated, with the number of bytes moved.
  * Called with 0 when the file is already present in destination (i.e. successful move with no byte copied)
@@ -162,6 +163,7 @@ open class MigrateUserData protected constructor(val source: Directory, val dest
          * @param transferred The number of bytes of the transferred file
          */
         abstract fun reportProgress(transferred: NumberOfBytes)
+
         /**
          * Whether [File#renameTo] should be attempted
          *
@@ -296,6 +298,7 @@ open class MigrateUserData protected constructor(val source: Directory, val dest
     open class Executor(private val operations: ArrayDeque<Operation>) {
         /** Whether [terminate] was called. Once this is called, a new instance should be used */
         private var terminated: Boolean = false
+
         /**
          * A list of operations to be executed before [operations]
          * [operations] should only be executed if this list is clear
@@ -479,7 +482,6 @@ open class MigrateUserData protected constructor(val source: Directory, val dest
      * @throws RuntimeException Various other failings if only a single exception was thrown
      */
     override fun task(col: Collection, collectionTask: ProgressSenderAndCancelListener<NumberOfBytes>): Boolean {
-
         val context = initializeContext(collectionTask::doProgress)
 
         // define the function here, so we can execute it on retry

--- a/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/scopedstorage/migrateuserdata/UserDataMigrationPreferences.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/scopedstorage/migrateuserdata/UserDataMigrationPreferences.kt
@@ -34,6 +34,7 @@ class UserDataMigrationPreferences private constructor(val source: String, val d
     val migrationInProgress = source.isNotEmpty()
     val sourceFile get() = File(source)
     val destinationFile get() = File(destination)
+
     // Throws if migration can't occur as expected.
     fun check() {
         // ensure that both are set, or both are empty

--- a/AnkiDroid/src/main/java/com/ichi2/anki/services/NotificationService.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/services/NotificationService.kt
@@ -69,7 +69,9 @@ class NotificationService : BroadcastReceiver() {
                 val resultIntent = Intent(context, DeckPicker::class.java)
                 resultIntent.flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
                 val resultPendingIntent = CompatHelper.compat.getImmutableActivityIntent(
-                    context, 0, resultIntent,
+                    context,
+                    0,
+                    resultIntent,
                     PendingIntent.FLAG_UPDATE_CURRENT
                 )
                 builder.setContentIntent(resultPendingIntent)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/services/ReminderService.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/services/ReminderService.kt
@@ -134,7 +134,6 @@ class ReminderService : BroadcastReceiver() {
 
     // getDeckOptionDue information, will recur one time to workaround collection close if recur is true
     private fun getDeckOptionDue(col: Collection, dConfId: Long, recur: Boolean): List<DeckDueTreeNode>? {
-
         // Avoid crashes if the deck option group is deleted while we
         // are working
         if (col.dbClosed || col.decks.getConf(dConfId) == null) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/snackbar/SnackbarPackageWorkaround.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/snackbar/SnackbarPackageWorkaround.kt
@@ -13,6 +13,7 @@
  */
 
 @file:Suppress("PackageDirectoryMismatch")
+
 package com.google.android.material.snackbar
 
 /*

--- a/AnkiDroid/src/main/java/com/ichi2/anki/stats/AnkiStatsTaskHandler.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/stats/AnkiStatsTaskHandler.kt
@@ -52,7 +52,7 @@ class AnkiStatsTaskHandler private constructor(
     suspend fun createChart(
         chartType: ChartType,
         progressBar: ProgressBar,
-        chartView: ChartView,
+        chartView: ChartView
     ) = withContext(defaultDispatcher) {
         mutex.withLock {
             val plotSheet = if (!this.isActive) {
@@ -61,8 +61,10 @@ class AnkiStatsTaskHandler private constructor(
             } else {
                 Timber.d("Starting CreateChartTask, type: %s", chartType.name)
                 val chartBuilder = ChartBuilder(
-                    chartView, collectionData,
-                    mDeckId, chartType
+                    chartView,
+                    collectionData,
+                    mDeckId,
+                    chartType
                 )
                 chartBuilder.renderChart(statType)
             }
@@ -114,6 +116,7 @@ class AnkiStatsTaskHandler private constructor(
         var instance: AnkiStatsTaskHandler? = null
             private set
         private val mutex = Mutex()
+
         @Synchronized
         fun getInstance(
             collection: Collection,

--- a/AnkiDroid/src/main/java/com/ichi2/anki/stats/ChartBuilder.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/stats/ChartBuilder.kt
@@ -323,7 +323,6 @@ class ChartBuilder(private val chartView: ChartView, private val collectionData:
     }
 
     fun ticsCalc(pixelDistance: Int, field: RectangleWrap, deltaRange: Double): Double {
-
         // Make approximation of number of ticks based on desired number of pixels per tick
         val numTicks = (field.height / pixelDistance).toDouble()
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/stats/ChartView.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/stats/ChartView.kt
@@ -32,6 +32,7 @@ class ChartView : View {
     private var mFragment: ChartFragment? = null
     private var mPlotSheet: PlotSheet? = null
     private var mDataIsSet = false
+
     @KotlinCleanup("is this really needed?")
     private val drawingBoundsRect = Rect()
     private val paint = Paint(Paint.LINEAR_TEXT_FLAG)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/stats/OverviewStatsBuilder.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/stats/OverviewStatsBuilder.kt
@@ -65,7 +65,9 @@ class OverviewStatsBuilder(private val webView: WebView, private val col: Collec
             val percentage: Double
                 get() = if (correct == 0) {
                     0.0
-                } else correct.toDouble() / total.toDouble() * 100.0
+                } else {
+                    correct.toDouble() / total.toDouble() * 100.0
+                }
         }
     }
 
@@ -98,7 +100,8 @@ class OverviewStatsBuilder(private val webView: WebView, private val col: Collec
         val daysStudied = res.getString(
             stats_overview_days_studied,
             (oStats.daysStudied.toFloat() / oStats.allDays.toFloat() * 100).toInt(),
-            oStats.daysStudied, oStats.allDays
+            oStats.daysStudied,
+            oStats.allDays
         )
 
         // FORECAST
@@ -192,7 +195,9 @@ class OverviewStatsBuilder(private val webView: WebView, private val col: Collec
         stringBuilder.append(
             res.getQuantityString(
                 com.ichi2.anki.R.plurals.stats_today_cards,
-                todayStats[CARDS_INDEX], todayStats[CARDS_INDEX], span
+                todayStats[CARDS_INDEX],
+                todayStats[CARDS_INDEX],
+                span
             )
         )
         stringBuilder.append("<br>")

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/NoteTypeSpinnerUtils.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/NoteTypeSpinnerUtils.kt
@@ -30,7 +30,7 @@ fun setupNoteTypeSpinner(context: Context, noteTypeSpinner: Spinner, col: Collec
     noteTypeSpinner.adapter = ArrayAdapter(
         context,
         android.R.layout.simple_spinner_dropdown_item,
-        modelNames,
+        modelNames
     ).apply {
         // The resource passed to the constructor is normally used for both the spinner view
         // and the dropdown list. This keeps the former and overrides the latter.

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/dialogs/tools/AsyncDialogs.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/dialogs/tools/AsyncDialogs.kt
@@ -55,7 +55,7 @@ open class AsyncDialogBuilder(private val alertDialogBuilder: AlertDialog.Builde
     fun setMultiChoiceItems(
         items: List<CharSequence>,
         checkedItems: CheckedItems,
-        disablePositiveButtonIfNoItemsChosen: Boolean = true,
+        disablePositiveButtonIfNoItemsChosen: Boolean = true
     ) {
         this.checkedItems = when (checkedItems) {
             is CheckedItems.All -> BooleanArray(items.size) { true }
@@ -92,10 +92,13 @@ open class AsyncDialogBuilder(private val alertDialogBuilder: AlertDialog.Builde
 class CompoundDialogBuilder(private val alertDialogBuilder: AlertDialog.Builder) : AsyncDialogBuilder(alertDialogBuilder) {
     /** @see AlertDialog.Builder.setTitle */
     fun setTitle(@StringRes titleId: Int): AlertDialog.Builder = alertDialogBuilder.setTitle(titleId)
+
     /** @see AlertDialog.Builder.setTitle */
     fun setTitle(title: CharSequence): AlertDialog.Builder = alertDialogBuilder.setTitle(title)
+
     /** @see AlertDialog.Builder.setMessage */
     fun setMessage(@StringRes messageId: Int): AlertDialog.Builder = alertDialogBuilder.setMessage(messageId)
+
     /** @see AlertDialog.Builder.setMessage */
     fun setMessage(message: CharSequence): AlertDialog.Builder = alertDialogBuilder.setMessage(message)
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/preferences/screens/BackupLimitsPresenter.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/preferences/screens/BackupLimitsPresenter.kt
@@ -128,7 +128,7 @@ class BackupLimitsPresenter(private val fragment: PreferenceFragmentCompat) : De
             minutesBetweenAutomaticBackupsPreference,
             dailyBackupsToKeepPreference,
             weeklyBackupsToKeepPreference,
-            monthlyBackupsToKeepPreference,
+            monthlyBackupsToKeepPreference
         ).forEach { preference ->
             preference.summaryProvider = Preference.SummaryProvider<EditTextPreference> {
                 when (viewModel.flowOfState.value) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/managespace/FileUtils.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/managespace/FileUtils.kt
@@ -182,8 +182,9 @@ class CanNotWriteToOrCreateFileException(val file: File) : Exception() {
 }
 
 suspend fun CollectionDirectoryProvider.ensureCanWriteToOrCreateCollectionDirectory() {
-    if (!withContext(Dispatchers.IO) { collectionDirectory.canWriteToOrCreate() })
+    if (!withContext(Dispatchers.IO) { collectionDirectory.canWriteToOrCreate() }) {
         throw CanNotWriteToOrCreateFileException(collectionDirectory)
+    }
 }
 
 suspend fun CollectionDirectoryProvider.collectionDirectoryExists() =

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/managespace/ManageSpaceFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/managespace/ManageSpaceFragment.kt
@@ -209,7 +209,7 @@ class ManageSpaceFragment : SettingsFragment() {
             viewModel.flowOfDeleteUnusedMediaSize to deleteUnusedMediaPreference,
             viewModel.flowOfDeleteCollectionSize to deleteCollectionPreference,
             viewModel.flowOfDeleteEverythingSize to deleteEverythingPreference,
-            viewModel.flowOfDeleteBackupsSize to deleteBackupsPreference,
+            viewModel.flowOfDeleteBackupsSize to deleteBackupsPreference
         ).forEach { (flowOfSize, preference) ->
             lifecycleScope.launch { flowOfSize.collect { size -> preference.setWidgetTextBy(size) } }
         }
@@ -317,6 +317,7 @@ class ManageSpaceFragment : SettingsFragment() {
     /************************************* Delete everything **************************************/
 
     @StringRes private var deleteEverythingDialogTitle: Int = 0
+
     @StringRes private var deleteEverythingDialogMessage: Int = 0
 
     private fun adjustDeleteEverythingStringsDependingOnCollectionLocation(preference: Preference) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/web/PreferenceBackedHostNum.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/web/PreferenceBackedHostNum.kt
@@ -62,11 +62,13 @@ class PreferenceBackedHostNum(hostNum: Int?, private val preferences: SharedPref
         private fun convertFromPreferenceValue(hostNum: String?): Int? {
             return if (hostNum == null) {
                 getDefaultHostNum()
-            } else try {
-                hostNum.toInt()
-            } catch (e: Exception) {
-                Timber.w(e)
-                getDefaultHostNum()
+            } else {
+                try {
+                    hostNum.toInt()
+                } catch (e: Exception) {
+                    Timber.w(e)
+                    getDefaultHostNum()
+                }
             }
         }
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/widgets/DeckAdapter.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/widgets/DeckAdapter.kt
@@ -41,6 +41,7 @@ import java.util.*
 @KotlinCleanup("lots to do")
 class DeckAdapter(private val layoutInflater: LayoutInflater, context: Context) : RecyclerView.Adapter<DeckAdapter.ViewHolder>(), Filterable {
     private val mDeckList: MutableList<TreeNode<AbstractDeckTreeNode>>
+
     /** A subset of mDeckList (currently displayed)  */
     private val mCurrentDeckList: MutableList<TreeNode<AbstractDeckTreeNode>> = ArrayList()
     private val mZeroCountColor: Int
@@ -356,7 +357,6 @@ class DeckAdapter(private val layoutInflater: LayoutInflater, context: Context) 
         }
 
         private fun filterDeckInternal(filterPattern: String, root: TreeNode<AbstractDeckTreeNode>): TreeNode<AbstractDeckTreeNode>? {
-
             // If a deck contains the string, then all its children are valid
             if (containsFilterString(filterPattern, root.value)) {
                 return root

--- a/AnkiDroid/src/main/java/com/ichi2/anki/workarounds/AppLoadedFromBackupWorkaround.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/workarounds/AppLoadedFromBackupWorkaround.kt
@@ -66,7 +66,6 @@ object AppLoadedFromBackupWorkaround {
 
         // If we don't kill the process, the backup is not "done" and reopening the app show the same message.
         Thread {
-
             // 3.5 seconds sleep, as the toast is killed on process death.
             // Same as the default value of LENGTH_LONG
             try {

--- a/AnkiDroid/src/main/java/com/ichi2/annotations/NeedsTest.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/annotations/NeedsTest.kt
@@ -33,9 +33,12 @@ package com.ichi2.annotations
  * @param value the explanation for why the test is required.
  */
 @Target(
-    AnnotationTarget.CLASS, AnnotationTarget.FUNCTION,
-    AnnotationTarget.VALUE_PARAMETER, AnnotationTarget.EXPRESSION,
-    AnnotationTarget.FIELD, AnnotationTarget.PROPERTY
+    AnnotationTarget.CLASS,
+    AnnotationTarget.FUNCTION,
+    AnnotationTarget.VALUE_PARAMETER,
+    AnnotationTarget.EXPRESSION,
+    AnnotationTarget.FIELD,
+    AnnotationTarget.PROPERTY
 )
 @Repeatable
 @Retention(AnnotationRetention.SOURCE)

--- a/AnkiDroid/src/main/java/com/ichi2/async/CollectionOperations.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/async/CollectionOperations.kt
@@ -44,7 +44,7 @@ fun updateCard(
     col: Collection,
     editCard: Card,
     isFromReviewer: Boolean,
-    canAccessScheduler: Boolean,
+    canAccessScheduler: Boolean
 ): Card {
     Timber.d("doInBackgroundUpdateNote")
     // Save the note
@@ -84,7 +84,7 @@ fun updateCard(
  */
 fun updateMultipleNotes(
     col: Collection,
-    notesToUpdate: List<Note>,
+    notesToUpdate: List<Note>
 ): List<Note> {
     Timber.d("CollectionOperations: updateMultipleNotes")
     return col.db.executeInTransaction {
@@ -133,8 +133,12 @@ fun updateValuesFromDeck(
         val totalNewCount = sched.totalNewForCurrentDeck()
         val totalCount = sched.cardCount()
         StudyOptionsFragment.DeckStudyData(
-            counts.new, counts.lrn, counts.rev, totalNewCount,
-            totalCount, sched.eta(counts)
+            counts.new,
+            counts.lrn,
+            counts.rev,
+            totalNewCount,
+            totalCount,
+            sched.eta(counts)
         )
     } catch (e: RuntimeException) {
         Timber.e(e, "doInBackgroundUpdateValuesFromDeck - an error occurred")
@@ -302,7 +306,7 @@ fun saveModel(
  */
 fun deleteMultipleNotes(
     col: Collection,
-    cardIds: List<Long>,
+    cardIds: List<Long>
 ): Array<Card> {
     val cards = cardIds.map { col.getCard(it) }.toTypedArray()
     return col.db.executeInTransaction {

--- a/AnkiDroid/src/main/java/com/ichi2/compat/CompatV21.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/CompatV21.kt
@@ -93,6 +93,7 @@ open class CompatV21 : Compat {
     ): T? {
         return intent.getParcelableExtra<T>(name)
     }
+
     // Until API 26 do the copy using streams
     @Throws(IOException::class)
     override fun copyFile(source: String, target: String) {
@@ -190,7 +191,8 @@ open class CompatV21 : Compat {
         audioFocusRequest: AudioFocusRequest?
     ) {
         audioManager.requestAudioFocus(
-            audioFocusChangeListener, AudioManager.STREAM_MUSIC,
+            audioFocusChangeListener,
+            AudioManager.STREAM_MUSIC,
             AudioManager.AUDIOFOCUS_GAIN_TRANSIENT_MAY_DUCK
         )
     }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/AnkiPackageExporter.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/AnkiPackageExporter.kt
@@ -486,6 +486,7 @@ class AnkiPackageExporter : AnkiExporter {
  */
 internal class ZipFile(path: String?) {
     private val mZos: ZipArchiveOutputStream
+
     @Throws(IOException::class)
     fun write(path: String?, entry: String?) {
         val bis = BufferedInputStream(FileInputStream(path), BUFFER_SIZE)

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/BackendImportExport.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/BackendImportExport.kt
@@ -62,13 +62,13 @@ fun CollectionV16.awaitBackupCompletion() {
 fun importCollectionPackage(
     backend: Backend,
     colPath: String,
-    colpkgPath: String,
+    colpkgPath: String
 ) {
     backend.importCollectionPackage(
         colPath = colPath,
         backupPath = colpkgPath,
         mediaFolder = colPath.replace(".anki2", ".media"),
-        mediaDb = colPath.replace(".anki2", ".media.db"),
+        mediaDb = colPath.replace(".anki2", ".media.db")
     )
 }
 
@@ -108,7 +108,7 @@ fun CollectionV16.exportAnkiPackage(
     withScheduling: Boolean,
     withMedia: Boolean,
     limit: ExportLimit,
-    legacy: Boolean = true,
+    legacy: Boolean = true
 ) {
     backend.exportAnkiPackage(outPath, withScheduling, withMedia, legacy, limit)
 }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Card.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Card.kt
@@ -404,7 +404,9 @@ open class Card : Cloneable {
     override fun equals(other: Any?): Boolean {
         return if (other is Card) {
             this.id == other.id
-        } else super.equals(other)
+        } else {
+            super.equals(other)
+        }
     }
 
     override fun hashCode(): Int {
@@ -552,7 +554,9 @@ open class Card : Cloneable {
         override fun equals(other: Any?): Boolean {
             return if (other !is Cache) {
                 false
-            } else this.id == other.id
+            } else {
+                this.id == other.id
+            }
         }
 
         fun loadQA(reload: Boolean, browser: Boolean) {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.kt
@@ -167,6 +167,7 @@ open class Collection(
     open var crt: Long = 0
     open var mod: Long = 0
     open var scm: Long = 0
+
     @RustCleanup("remove")
     var dirty: Boolean = false
     private var mUsn = 0
@@ -341,7 +342,8 @@ open class Collection(
         while (true) {
             db.query(
                 "SELECT substr($columnName, ?, ?) FROM col",
-                pos.toString(), chunk.toString()
+                pos.toString(),
+                chunk.toString()
             ).use { cursor ->
                 if (!cursor.moveToFirst()) {
                     return buf.toString()
@@ -790,6 +792,7 @@ open class Collection(
                     val ord = cur.getInt(2)
                     val did = cur.getLong(3)
                     val due = cur.getLong(4)
+
                     @Consts.CARD_TYPE val type = cur.getInt(5)
 
                     // existing cards
@@ -1177,7 +1180,9 @@ open class Collection(
         val flag = flags and 0b111
         return if (flag == 0) {
             ""
-        } else "flag$flag"
+        } else {
+            "flag$flag"
+        }
     }
     /*
       Finding cards ************************************************************ ***********************************
@@ -1210,6 +1215,7 @@ open class Collection(
     fun buildSearchString(node: SearchNode): String {
         return backend.buildSearchString(node)
     }
+
     /** Return a list of card ids  */
     @KotlinCleanup("set reasonable defaults")
     fun findCards(search: String): List<Long> {
@@ -1313,7 +1319,9 @@ open class Collection(
                 get_config_int("timeLim"),
                 sched.reps - mStartReps
             )
-        } else null
+        } else {
+            null
+        }
     }
 
     /*
@@ -1335,7 +1343,9 @@ open class Collection(
     fun undoType(): UndoAction? {
         return if (!undo.isEmpty()) {
             undo.last
-        } else null
+        } else {
+            null
+        }
     }
 
     open fun undoName(res: Resources): String {
@@ -1354,8 +1364,6 @@ open class Collection(
         return lastUndo.undo(this)
     }
 
-    @BlocksSchemaUpgrade("audit all UI actions that call this, and make sure they call a backend method")
-    @RustCleanup("this will be unnecessary after legacy schema dropped")
     /**
      * In the legacy schema, this adds the undo action to the undo list.
      * In the new schema, this action is not useful, as the backend stores its own
@@ -1363,6 +1371,8 @@ open class Collection(
      * operation available. If you find an action is not undoable with the new backend,
      * you probably need to be calling the relevant backend method to perform it,
      * instead of trying to do it with raw SQL. */
+    @BlocksSchemaUpgrade("audit all UI actions that call this, and make sure they call a backend method")
+    @RustCleanup("this will be unnecessary after legacy schema dropped")
     fun markUndo(undoAction: UndoAction) {
         Timber.d("markUndo() of type %s", undoAction.javaClass)
         undo.add(undoAction)
@@ -1473,7 +1483,8 @@ open class Collection(
             val badOrd = db.queryScalar(
                 "select 1 from cards where (ord < 0 or ord >= ?) and nid in ( " +
                     "select id from notes where mid = ?) limit 1",
-                tmpls.length(), m.getLong("id")
+                tmpls.length(),
+                m.getLong("id")
             ) > 0
             if (badOrd) {
                 return false
@@ -1768,7 +1779,9 @@ open class Collection(
                 Utils.ids2str(dynDeckIds) +
                 "and odid in " +
                 Utils.ids2str(dynIdsAndZero),
-            nextDeckId, TimeManager.time.intTime(), usn()
+            nextDeckId,
+            TimeManager.time.intTime(),
+            usn()
         )
         result.cardsWithFixedHomeDeckCount = cardIds.size
         val message = String.format(Locale.US, "Fixed %d cards with no home deck", cardIds.size)
@@ -1840,7 +1853,9 @@ open class Collection(
                 "UPDATE cards SET due = ?, ivl = 1, mod = ?, usn = ? WHERE id IN " + Utils.ids2str(
                     ids
                 ),
-                sched.today, TimeManager.time.intTime(), usn()
+                sched.today,
+                TimeManager.time.intTime(),
+                usn()
             )
         }
         return problems
@@ -2032,7 +2047,8 @@ open class Collection(
                     )
                     if (firstException == null) {
                         val details = String.format(
-                            Locale.ROOT, "deleteNotesWithWrongFieldCounts row: %d col: %d",
+                            Locale.ROOT,
+                            "deleteNotesWithWrongFieldCounts row: %d col: %d",
                             currentRow,
                             cur.columnCount
                         )
@@ -2205,7 +2221,10 @@ open class Collection(
             "update cards set flags = (flags & ~?) | ?, usn=?, mod=? where id in " + Utils.ids2str(
                 cids
             ),
-            7, flag, usn(), TimeManager.time.intTime()
+            7,
+            flag,
+            usn(),
+            TimeManager.time.intTime()
         )
     }
 
@@ -2326,35 +2345,45 @@ open class Collection(
     fun get_config(key: String, defaultValue: Boolean?): Boolean? {
         return if (config!!.isNull(key)) {
             defaultValue
-        } else config!!.getBoolean(key)
+        } else {
+            config!!.getBoolean(key)
+        }
     }
 
     @Contract("_, !null -> !null")
     fun get_config(key: String, defaultValue: Long?): Long? {
         return if (config!!.isNull(key)) {
             defaultValue
-        } else config!!.getLong(key)
+        } else {
+            config!!.getLong(key)
+        }
     }
 
     @Contract("_, !null -> !null")
     fun get_config(key: String, defaultValue: Int?): Int? {
         return if (config!!.isNull(key)) {
             defaultValue
-        } else config!!.getInt(key)
+        } else {
+            config!!.getInt(key)
+        }
     }
 
     @Contract("_, !null -> !null")
     fun get_config(key: String, defaultValue: Double?): Double? {
         return if (config!!.isNull(key)) {
             defaultValue
-        } else config!!.getDouble(key)
+        } else {
+            config!!.getDouble(key)
+        }
     }
 
     @Contract("_, !null -> !null")
     fun get_config(key: String, defaultValue: String?): String? {
         return if (config!!.isNull(key)) {
             defaultValue
-        } else config!!.getString(key)
+        } else {
+            config!!.getString(key)
+        }
     }
 
     /** Edits to the config are not persisted to the preferences  */
@@ -2362,7 +2391,9 @@ open class Collection(
     fun get_config(key: String, defaultValue: JSONObject?): JSONObject? {
         return if (config!!.isNull(key)) {
             if (defaultValue == null) null else defaultValue.deepClone()
-        } else config!!.getJSONObject(key).deepClone()
+        } else {
+            config!!.getJSONObject(key).deepClone()
+        }
     }
 
     /** Edits to the array are not persisted to the preferences  */
@@ -2370,7 +2401,9 @@ open class Collection(
     fun get_config(key: String, defaultValue: JSONArray?): JSONArray? {
         return if (config!!.isNull(key)) {
             if (defaultValue == null) null else JSONArray(defaultValue)
-        } else JSONArray(config!!.getJSONArray(key))
+        } else {
+            JSONArray(config!!.getJSONArray(key))
+        }
     }
 
     fun set_config(key: String, value: Boolean) {
@@ -2446,7 +2479,9 @@ open class Collection(
     open fun setDeck(cids: LongArray, did: Long) {
         db.execute(
             "update cards set did=?,usn=?,mod=? where id in " + Utils.ids2str(cids),
-            did, usn(), TimeManager.time.intTime()
+            did,
+            usn(),
+            TimeManager.time.intTime()
         )
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/CollectionV16.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/CollectionV16.kt
@@ -140,13 +140,13 @@ class CollectionV16(
 
     override fun findCards(
         search: String,
-        order: SortOrder,
+        order: SortOrder
     ): List<Long> {
         val adjustedOrder = if (order is SortOrder.UseCollectionOrdering) {
             @Suppress("DEPRECATION")
             SortOrder.BuiltinSortKind(
                 get_config("sortType", null as String?) ?: "noteFld",
-                get_config("sortBackwards", false) ?: false,
+                get_config("sortBackwards", false) ?: false
             )
         } else {
             order
@@ -161,13 +161,13 @@ class CollectionV16(
 
     override fun findNotes(
         query: String,
-        order: SortOrder,
+        order: SortOrder
     ): List<Long> {
         val adjustedOrder = if (order is SortOrder.UseCollectionOrdering) {
             @Suppress("DEPRECATION")
             SortOrder.BuiltinSortKind(
                 get_config("noteSortType", null as String?) ?: "noteFld",
-                get_config("browserNoteSortBackwards", false) ?: false,
+                get_config("browserNoteSortBackwards", false) ?: false
             )
         } else {
             order

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/ConfigManager.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/ConfigManager.kt
@@ -28,12 +28,19 @@ abstract class ConfigManager {
      * a mapping whose value is [JSONObject.NULL].
      */
     @CheckResult abstract fun isNull(key: String): Boolean
+
     @CheckResult abstract fun getString(key: String): String
+
     @CheckResult abstract fun getBoolean(key: String): Boolean
+
     @CheckResult abstract fun getDouble(key: String): Double
+
     @CheckResult abstract fun getInt(key: String): Int
+
     @CheckResult abstract fun getLong(key: String): Long
+
     @CheckResult abstract fun getJSONArray(key: String): JSONArray
+
     @CheckResult abstract fun getJSONObject(key: String): JSONObject
 
     abstract fun put(key: String, value: Boolean)

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Consts.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Consts.kt
@@ -23,6 +23,7 @@ object Consts {
     const val NEW_CARDS_DISTRIBUTE = 0
     const val NEW_CARDS_LAST = 1
     const val NEW_CARDS_FIRST = 2
+
     @Retention(AnnotationRetention.SOURCE)
     @IntDef(NEW_CARDS_DISTRIBUTE, NEW_CARDS_LAST, NEW_CARDS_FIRST)
     annotation class NEW_CARD_ORDER
@@ -30,6 +31,7 @@ object Consts {
     // new card insertion order
     const val NEW_CARDS_RANDOM = 0
     const val NEW_CARDS_DUE = 1
+
     @Retention(AnnotationRetention.SOURCE)
     @IntDef(NEW_CARDS_RANDOM, NEW_CARDS_DUE)
     annotation class NEW_CARDS_INSERTION
@@ -43,6 +45,7 @@ object Consts {
     const val QUEUE_TYPE_REV = 2
     const val QUEUE_TYPE_DAY_LEARN_RELEARN = 3
     const val QUEUE_TYPE_PREVIEW = 4
+
     @Retention(AnnotationRetention.SOURCE)
     @IntDef(QUEUE_TYPE_MANUALLY_BURIED, QUEUE_TYPE_SIBLING_BURIED, QUEUE_TYPE_SUSPENDED, QUEUE_TYPE_NEW, QUEUE_TYPE_LRN, QUEUE_TYPE_REV, QUEUE_TYPE_DAY_LEARN_RELEARN, QUEUE_TYPE_PREVIEW)
     annotation class CARD_QUEUE
@@ -52,6 +55,7 @@ object Consts {
     const val CARD_TYPE_LRN = 1
     const val CARD_TYPE_REV = 2
     const val CARD_TYPE_RELEARNING = 3
+
     @Retention(AnnotationRetention.SOURCE)
     @IntDef(CARD_TYPE_NEW, CARD_TYPE_LRN, CARD_TYPE_REV, CARD_TYPE_RELEARNING)
     annotation class CARD_TYPE
@@ -60,6 +64,7 @@ object Consts {
     const val REM_CARD = 0
     const val REM_NOTE = 1
     const val REM_DECK = 2
+
     @Retention(AnnotationRetention.SOURCE)
     @IntDef(REM_CARD, REM_NOTE, REM_DECK)
     annotation class REM_TYPE
@@ -83,6 +88,7 @@ object Consts {
     const val DYN_REVADDED = 7
     const val DYN_DUEPRIORITY = 8
     const val DYN_MAX_SIZE = 99999
+
     @Retention(AnnotationRetention.SOURCE)
     @IntDef(DYN_OLDEST, DYN_RANDOM, DYN_SMALLINT, DYN_BIGINT, DYN_LAPSES, DYN_ADDED, DYN_DUE, DYN_REVADDED, DYN_DUEPRIORITY)
     annotation class DYN_PRIORITY
@@ -90,6 +96,7 @@ object Consts {
     // model types
     const val MODEL_STD = 0
     const val MODEL_CLOZE = 1
+
     @Retention(AnnotationRetention.SOURCE)
     @IntDef(MODEL_STD, MODEL_CLOZE)
     annotation class MODEL_TYPE
@@ -97,6 +104,7 @@ object Consts {
     // deck types
     const val DECK_STD = 0
     const val DECK_DYN = 1
+
     @Retention(AnnotationRetention.SOURCE)
     @IntDef(DECK_STD, DECK_DYN)
     annotation class DECK_TYPE
@@ -105,6 +113,7 @@ object Consts {
 
     // deck schema & syncing vars
     const val LEGACY_SCHEMA_VERSION = 11
+
     /** Only used by the dialog shown to user */
     const val BACKEND_SCHEMA_VERSION = 18
 
@@ -125,6 +134,7 @@ object Consts {
     const val BUTTON_TWO = 2
     const val BUTTON_THREE = 3
     const val BUTTON_FOUR = 4
+
     @Retention(AnnotationRetention.SOURCE)
     @IntDef(BUTTON_ONE, BUTTON_TWO, BUTTON_THREE, BUTTON_FOUR)
     annotation class BUTTON_TYPE
@@ -136,6 +146,7 @@ object Consts {
     const val REVLOG_RELRN = 2
     const val REVLOG_CRAM = 3
     const val REVLOG_MANUAL = 4
+
     @Retention(AnnotationRetention.SOURCE)
     @IntDef(REVLOG_LRN, REVLOG_REV, REVLOG_RELRN, REVLOG_CRAM, REVLOG_MANUAL)
     annotation class REVLOG_TYPE

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/DB.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/DB.kt
@@ -203,11 +203,13 @@ class DB(db: SupportSQLiteDatabase) {
     @KotlinCleanup("""Use Kotlin string. Change split so that there is no empty string after last ";".""")
     fun executeScript(@Language("SQL") sql: String) {
         mod = true
-        @Suppress("PLATFORM_CLASS_MAPPED_TO_KOTLIN") val queries = java.lang.String(sql).split(";")
+        @Suppress("PLATFORM_CLASS_MAPPED_TO_KOTLIN")
+        val queries = java.lang.String(sql).split(";")
         for (query in queries) {
             database.execSQL(query)
         }
     }
+
     /** update must always be called via DB in order to mark the db as changed  */
     fun update(
         table: String,

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/DeckManager.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/DeckManager.kt
@@ -35,9 +35,11 @@ abstract class DeckManager {
      */
 
     abstract fun load(@Language("JSON") decks: String, dconf: String)
+
     @RustCleanup("Unused in V16")
     /** @throws DeckRenameException */
     abstract fun save()
+
     /** Can be called with either a deck or a deck configuration.
      * @throws DeckRenameException */
     abstract fun save(g: Deck)
@@ -50,24 +52,31 @@ abstract class DeckManager {
      */
 
     abstract fun id_for_name(name: String): Long?
+
     @Throws(DeckRenameException::class)
     abstract fun id(name: String): Long
+
     /** Same as id, but rename ancestors if filtered to avoid failure */
     fun id_safe(name: String) = id_safe(name, Decks.DEFAULT_DECK)
+
     /** Same as id, but rename ancestors if filtered to avoid failure */
     abstract fun id_safe(name: String, type: String): Long
 
     /** Remove the deck. delete any cards inside and child decks. */
     fun rem(did: DeckId) = rem(did, true)
+
     /** Remove the deck. Delete child decks. If cardsToo, delete any cards inside. */
     fun rem(did: DeckId, cardsToo: Boolean = true) = rem(did, cardsToo, true)
+
     /** Remove the deck. If cardsToo, delete any cards inside. */
     abstract fun rem(did: DeckId, cardsToo: Boolean = true, childrenToo: Boolean = true)
 
     /** An unsorted list of all deck names. */
     fun allNames() = allNames(true)
+
     /** An unsorted list of all deck names. */
     abstract fun allNames(dyn: Boolean = true): List<String>
+
     /** A list of all decks. */
     abstract fun all(): List<Deck>
     abstract fun allIds(): Set<Long>
@@ -77,9 +86,11 @@ abstract class DeckManager {
     /** Return the number of decks. */
     @RustCleanup("This is a long in V16 - shouldn't make a difference, but needs investigation")
     abstract fun count(): Int
-    @CheckResult
+
     /** Obtains the deck from the DeckID, or default if the deck was not found */
+    @CheckResult
     fun get(did: DeckId): Deck = get(did, true)!!
+
     /**
      * Obtains the deck from the DeckID
      * @param did The deck to obtain
@@ -114,8 +125,10 @@ abstract class DeckManager {
     abstract fun updateConf(g: DeckConfig)
 
     fun confId(name: String): Long = confId(name, Decks.DEFAULT_CONF)
+
     /** Create a new configuration and return id */
     abstract fun confId(name: String, cloneFrom: String): Long
+
     /**
      * Remove a configuration and update all decks using it.
      * @throws ConfirmModSchemaException
@@ -144,11 +157,14 @@ abstract class DeckManager {
      */
     /** The currently active dids. Make sure to copy before modifying. */
     abstract fun active(): LinkedList<Long>
+
     /** The currently selected did. */
     abstract fun selected(): Long
     abstract fun current(): Deck
+
     /** Select a new branch. */
     abstract fun select(did: DeckId)
+
     /**
      * All children of did as nodes of (key:name, value:id)
      *
@@ -158,6 +174,7 @@ abstract class DeckManager {
     abstract fun children(did: DeckId): TreeMap<String, Long>
     abstract fun childDids(did: DeckId, childMap: Decks.Node): List<Long>
     abstract fun childMap(): Decks.Node
+
     /** All parents of did. */
     abstract fun parents(did: DeckId): List<Deck>
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.kt
@@ -626,8 +626,8 @@ class Decks(private val col: Collection) : DeckManager() {
     override fun confForDid(did: Long): DeckConfig {
         val deck = get(did, false)!!
         if (deck.has("conf")) {
-            @KotlinCleanup("Clarify comment. It doesn't make sense when using :?")
             // fall back on default
+            @KotlinCleanup("Clarify comment. It doesn't make sense when using :?")
             val conf = getConf(deck.getLong("conf")) ?: getConf(1L)!!
             return conf.apply {
                 put("dyn", DECK_STD)
@@ -959,6 +959,7 @@ class Decks(private val col: Collection) : DeckManager() {
             save()
         }
     }
+
     /*
       Dynamic decks
      */
@@ -992,6 +993,7 @@ class Decks(private val col: Collection) : DeckManager() {
 
         // not in libAnki
         const val DECK_SEPARATOR = "::"
+
         @KotlinCleanup("Maybe use triple quotes and @language? for these properties")
         const val DEFAULT_DECK = (
             "" +
@@ -1079,6 +1081,7 @@ class Decks(private val col: Collection) : DeckManager() {
         }
 
         private val spaceAroundSeparator = Pattern.compile("\\s*::\\s*")
+
         @Suppress("NAME_SHADOWING")
         @VisibleForTesting
         fun strip(deckName: String): String {
@@ -1097,6 +1100,7 @@ class Decks(private val col: Collection) : DeckManager() {
      * **************************************
      */
         private val normalized = HashMap<String?, String>()
+
         @KotlinCleanup("nullability")
         fun normalizeName(name: String?): String? {
             if (!normalized.containsKey(name)) {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/DecksV16.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/DecksV16.kt
@@ -29,7 +29,7 @@
     "MemberVisibilityCanBePrivate",
     "FunctionName",
     "ConvertToStringTemplate",
-    "LocalVariableName",
+    "LocalVariableName"
 )
 
 package com.ichi2.libanki
@@ -387,7 +387,8 @@ class DecksV16(private val col: CollectionV16) :
     @Deprecated("decks.allNames() is deprecated, use .all_names_and_ids()")
     fun allNames(dyn: bool = true, force_default: bool = true): MutableList<str> {
         return this.all_names_and_ids(
-            skip_empty_default = !force_default, include_filtered = dyn
+            skip_empty_default = !force_default,
+            include_filtered = dyn
         ).map { x ->
             x.name
         }.toMutableList()

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Finder.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Finder.kt
@@ -44,7 +44,7 @@ class Finder(private val col: Collection) {
     @CheckResult
     private fun _findCards(
         query: String,
-        _order: SortOrder,
+        _order: SortOrder
     ): List<Long> {
         val tokens = _tokenize(query)
         val res1 = _where(tokens)
@@ -295,7 +295,9 @@ class Finder(private val col: Collection) {
         }
         return if (s.bad) {
             Pair(null, null)
-        } else Pair(s.q, args.toTypedArray())
+        } else {
+            Pair(s.q, args.toTypedArray())
+        }
     }
 
     /**
@@ -517,19 +519,25 @@ class Finder(private val col: Collection) {
     private fun _findNids(`val`: String): String? {
         return if (fNidsPattern.matcher(`val`).find()) {
             null
-        } else "n.id in ($`val`)"
+        } else {
+            "n.id in ($`val`)"
+        }
     }
 
     private fun _findCids(`val`: String): String? {
         return if (fNidsPattern.matcher(`val`).find()) {
             null
-        } else "c.id in ($`val`)"
+        } else {
+            "c.id in ($`val`)"
+        }
     }
 
     private fun _findMid(`val`: String): String? {
         return if (fMidPattern.matcher(`val`).find()) {
             null
-        } else "n.mid = $`val`"
+        } else {
+            "n.mid = $`val`"
+        }
     }
 
     private fun _findModel(`val`: String): String {
@@ -696,7 +704,9 @@ class Finder(private val col: Collection) {
         }
         return if (nids.isEmpty()) {
             "0"
-        } else "n.id in " + Utils.ids2str(nids)
+        } else {
+            "n.id in " + Utils.ids2str(nids)
+        }
     }
 
     private fun _findDupes(`val`: String): String? {
@@ -713,7 +723,8 @@ class Finder(private val col: Collection) {
         val nids: MutableList<Long> = ArrayList()
         col.db.query(
             "select id, flds from notes where mid=? and csum=?",
-            mid, csum
+            mid,
+            csum
         ).use { cur ->
             val nid = cur.getLong(0)
             val flds = cur.getString(1)
@@ -779,6 +790,7 @@ class Finder(private val col: Collection) {
         ): Int {
             @Suppress("NAME_SHADOWING")
             var src = src
+
             @Suppress("NAME_SHADOWING")
             var dst = dst
             val mmap: MutableMap<Long, Int> = HashMap()

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Media.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Media.kt
@@ -227,6 +227,7 @@ create table meta (dirMod int, lastUsn int); insert into meta values (0, 0);"""
         for (s in strings) {
             @Suppress("NAME_SHADOWING")
             var s = s
+
             // handle latex
             @KotlinCleanup("change to .map { }")
             val svg = model.optBoolean("latexsvg", false)
@@ -573,7 +574,9 @@ create table meta (dirMod int, lastUsn int); insert into meta values (0, 0);"""
         val mtime = _mtime(dir())
         return if (mod != 0L && mod == mtime) {
             null
-        } else mtime
+        } else {
+            mtime
+        }
     }
 
     @KotlinCleanup("destructure directly val (added, removed) = _changes()")
@@ -875,7 +878,10 @@ create table meta (dirMod int, lastUsn int); insert into meta values (0, 0);"""
         val path = File(dir(), fname).absolutePath
         db!!.execute(
             "insert or replace into media values (?,?,?,?)",
-            fname, _checksum(path), _mtime(path), 1
+            fname,
+            _checksum(path),
+            _mtime(path),
+            1
         )
     }
 
@@ -890,7 +896,10 @@ create table meta (dirMod int, lastUsn int); insert into meta values (0, 0);"""
         Timber.d("Marking media file removal in media db: %s", fname)
         db!!.execute(
             "insert or replace into media values (?,?,?,?)",
-            fname, null, 0, 1
+            fname,
+            null,
+            0,
+            1
         )
     }
 
@@ -1035,5 +1044,5 @@ create table meta (dirMod int, lastUsn int); insert into meta values (0, 0);"""
 data class MediaCheckResult(
     val missingFileNames: List<String>,
     val unusedFileNames: List<String>,
-    val invalidFileNames: List<String>,
+    val invalidFileNames: List<String>
 )

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Model.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Model.kt
@@ -50,6 +50,7 @@ class Model : JSONObject {
     constructor(json: JSONObject) : super() {
         json.deepClonedInto(this)
     }
+
     /**
      * Creates a model object form json string
      */

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/ModelManager.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/ModelManager.kt
@@ -36,6 +36,7 @@ abstract class ModelManager(protected val col: Collection) {
     /** Mark M modified if provided, and schedule registry flush. */
     fun save() = save(null)
     fun save(m: Model?) = save(m, false)
+
     /**
      * Save a model
      * @param m model to save
@@ -70,6 +71,7 @@ abstract class ModelManager(protected val col: Collection) {
 
     /** get model with ID, or null.  */
     abstract fun get(id: Long): Model?
+
     /** get all models  */
     abstract fun all(): List<Model>
 
@@ -91,6 +93,7 @@ abstract class ModelManager(protected val col: Collection) {
     abstract fun rem(m: Model)
 
     abstract fun add(m: Model)
+
     /** Add or update an existing model. Used for syncing and merging.  */
     open fun update(m: Model) = update(m, true)
 
@@ -120,6 +123,7 @@ abstract class ModelManager(protected val col: Collection) {
      */
     @RustCleanup("use all_use_counts()")
     abstract fun useCount(m: Model): Int
+
     /**
      * Number of notes using m
      * @param m The model to the count the notes of.
@@ -142,15 +146,19 @@ abstract class ModelManager(protected val col: Collection) {
     abstract fun newField(name: String): JSONObject
 
     abstract fun sortIdx(m: Model): Int
+
     @Throws(ConfirmModSchemaException::class)
     abstract fun setSortIdx(m: Model, idx: Int)
 
     @Throws(ConfirmModSchemaException::class)
     abstract fun addField(m: Model, field: JSONObject)
+
     @Throws(ConfirmModSchemaException::class)
     abstract fun remField(m: Model, field: JSONObject)
+
     @Throws(ConfirmModSchemaException::class)
     abstract fun moveField(m: Model, field: JSONObject, idx: Int)
+
     @Throws(ConfirmModSchemaException::class)
     abstract fun renameField(m: Model, field: JSONObject, newName: String)
 
@@ -160,6 +168,7 @@ abstract class ModelManager(protected val col: Collection) {
 
     @Throws(ConfirmModSchemaException::class)
     abstract fun addTemplate(m: Model, template: JSONObject)
+
     /**
      * Removing a template
      *
@@ -314,6 +323,7 @@ abstract class ModelManager(protected val col: Collection) {
 
     /** Add template without schema mod */
     protected abstract fun _addTemplate(m: Model, template: JSONObject)
+
     /** Add field without schema mod */
     protected abstract fun _addField(m: Model, field: JSONObject)
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Models.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Models.kt
@@ -44,6 +44,7 @@ class Models(col: Collection) : ModelManager(col) {
      */
 
     private var mChanged = false
+
     @KotlinCleanup("lateinit")
     private var mModels: HashMap<Long, Model>? = null
 
@@ -58,6 +59,7 @@ class Models(col: Collection) : ModelManager(col) {
         mChanged = false
         mModels = HashMap()
         val modelarray = JSONObject(json)
+
         @KotlinCleanup("simplify with ?.forEach{}")
         val ids = modelarray.names()
         if (ids != null) {
@@ -116,6 +118,7 @@ class Models(col: Collection) : ModelManager(col) {
             false
         }
     }
+
     /*
       Retrieving and creating models
       ***********************************************************************************************
@@ -465,7 +468,9 @@ class Models(col: Collection) : ModelManager(col) {
                     r.add(
                         arrayOf(
                             Utils.joinFields(fn.transform(Utils.splitFields(cur.getString(1)))),
-                            time.intTime(), col.usn(), cur.getLong(0)
+                            time.intTime(),
+                            col.usn(),
+                            cur.getLong(0)
                         )
                     )
                 }
@@ -524,7 +529,10 @@ class Models(col: Collection) : ModelManager(col) {
         col.db
             .execute(
                 "update cards set ord = ord - 1, usn = ?, mod = ? where nid in (select id from notes where mid = ?) and ord > ?",
-                col.usn(), time.intTime(), m.getLong("id"), ord
+                col.usn(),
+                time.intTime(),
+                m.getLong("id"),
+                ord
             )
         tmpls = m.getJSONArray("tmpls")
         val tmpls2 = JSONArray()
@@ -576,7 +584,9 @@ class Models(col: Collection) : ModelManager(col) {
         col.db.execute(
             "update cards set ord = (case " + sb +
                 " end),usn=?,mod=? where nid in (select id from notes where mid = ?)",
-            col.usn(), time.intTime(), m.getLong("id")
+            col.usn(),
+            time.intTime(),
+            m.getLong("id")
         )
     }
 
@@ -584,6 +594,7 @@ class Models(col: Collection) : ModelManager(col) {
         @Suppress("UNUSED_VARIABLE") // unused upstream as well
         val rem = col.genCards(nids(m), m)!!
     }
+
     /*
       Model changing ***********************************************************************************************
      */
@@ -640,7 +651,8 @@ class Models(col: Collection) : ModelManager(col) {
         val nmType = newModel.getInt("type")
         val nflds = newModel.getJSONArray("tmpls").length()
         col.db.query(
-            "select id, ord from cards where nid = ?", nid
+            "select id, ord from cards where nid = ?",
+            nid
         ).use { cur ->
             while (cur.moveToNext()) {
                 // if the src model is a cloze, we ignore the map, as the gui doesn't currently
@@ -832,6 +844,7 @@ class Models(col: Collection) : ModelManager(col) {
         private val fClozePattern1 = Pattern.compile("\\{\\{[^}]*?cloze:(?:[^}]?:)*(.+?)\\}\\}")
         private val fClozePattern2 = Pattern.compile("<%cloze:(.+?)%>")
         private val fClozeOrdPattern = Pattern.compile("(?si)\\{\\{c(\\d+)::.*?\\}\\}")
+
         @KotlinCleanup("Use triple quotes for this properties and maybe `@language('json'')`")
         const val DEFAULT_MODEL = (
             "{\"sortf\": 0, " +
@@ -922,9 +935,12 @@ class Models(col: Collection) : ModelManager(col) {
                 // For cloze, getting the list of cloze numbes is linear in the size of the template
                 // So computing the full list is almost as efficient as checking for a particular number
                 !_availClozeOrds(m, sfld, false).contains(ord)
-            } else emptyStandardCard(
-                m.getJSONArray("tmpls").getJSONObject(ord), m.nonEmptyFields(sfld)
-            )
+            } else {
+                emptyStandardCard(
+                    m.getJSONArray("tmpls").getJSONObject(ord),
+                    m.nonEmptyFields(sfld)
+                )
+            }
         }
 
         /**
@@ -955,12 +971,14 @@ class Models(col: Collection) : ModelManager(col) {
                     sfld,
                     allowEmpty == AllowEmpty.TRUE || allowEmpty == AllowEmpty.ONLY_CLOZE
                 )
-            } else _availStandardOrds(
-                m,
-                sfld,
-                nodes!!,
-                allowEmpty == AllowEmpty.TRUE
-            )
+            } else {
+                _availStandardOrds(
+                    m,
+                    sfld,
+                    nodes!!,
+                    allowEmpty == AllowEmpty.TRUE
+                )
+            }
         }
 
         fun availOrds(
@@ -974,7 +992,9 @@ class Models(col: Collection) : ModelManager(col) {
                     sfld,
                     allowEmpty == AllowEmpty.TRUE || allowEmpty == AllowEmpty.ONLY_CLOZE
                 )
-            } else _availStandardOrds(m, sfld, allowEmpty == AllowEmpty.TRUE)
+            } else {
+                _availStandardOrds(m, sfld, allowEmpty == AllowEmpty.TRUE)
+            }
         }
 
         fun _availStandardOrds(
@@ -1031,17 +1051,13 @@ class Models(col: Collection) : ModelManager(col) {
             }
             return namesOfFieldsContainingClozeCache[question]!!
         }
+
         /**
          * @param m A note type with cloze
          * @param sflds The fields of a note of type m. (Assume the size of the array is the number of fields)
          * @param allowEmpty Whether we allow to generate at least one card even if they are all empty
          * @return The indexes (in increasing order) of cards that should be generated according to req rules.
          * If empty is not allowed, it will contains ord 1.
-         */
-        /**
-         * @param m A note type with cloze
-         * @param sflds The fields of a note of type m. (Assume the size of the array is the number of fields)
-         * @return The indexes (in increasing order) of cards that should be generated according to req rules.
          */
         @KotlinCleanup("sflds: String? to string")
         @KotlinCleanup("return arrayListOf(0)")
@@ -1068,7 +1084,9 @@ class Models(col: Collection) : ModelManager(col) {
             return if (ords.isEmpty() && allowEmpty) {
                 // empty clozes use first ord
                 ArrayList(listOf(0))
-            } else ArrayList(ords)
+            } else {
+                ArrayList(ords)
+            }
         }
     }
     // private long mCrt = mCol.getTime().intTime();

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/ModelsV16.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/ModelsV16.kt
@@ -50,6 +50,7 @@ class NoteTypeNameIDUseCount(val id: Long, val name: String, val useCount: UInt)
 class BackendNote(val fields: MutableList<String>)
 
 private typealias int = Long
+
 // # types
 private typealias Field = JSONObject // Dict<str, Any>
 private typealias Template = JSONObject // Dict<str, Union3<str, int, Unit>>
@@ -457,7 +458,6 @@ class ModelsV16(col: CollectionV16) : ModelManager(col) {
 
     /** Modifies schema. */
     fun set_sort_index(nt: NoteType, idx: Int) {
-
         assert(0 <= idx && idx < len(nt.flds))
         nt.sortf = idx
     }
@@ -604,7 +604,7 @@ class ModelsV16(col: CollectionV16) : ModelManager(col) {
             oldNotetypeId = m.id,
             newNotetypeId = newModel.id,
             currentSchema = col.scm,
-            oldNotetypeName = m.name,
+            oldNotetypeName = m.name
         )
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Note.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Note.kt
@@ -121,14 +121,17 @@ class Note : Cloneable {
             usn = col.usn()
         }
         val csumAndStrippedFieldField = Utils.sfieldAndCsum(
-            fields, col.models.sortIdx(mModel)
+            fields,
+            col.models.sortIdx(mModel)
         )
         val sfld = csumAndStrippedFieldField.first
         val tags = stringTags()
         val fields = joinedFields()
         if (mod == null && col.db.queryScalar(
                 "select 1 from notes where id = ? and tags = ? and flds = ?",
-                this.id.toString(), tags, fields
+                this.id.toString(),
+                tags,
+                fields
             ) > 0
         ) {
             return
@@ -293,16 +296,19 @@ class Note : Cloneable {
             return DupeOrEmpty.EMPTY
         }
         val csumAndStrippedFieldField = Utils.sfieldAndCsum(
-            fields, 0
+            fields,
+            0
         )
         val csum = csumAndStrippedFieldField.second
         // find any matching csums and compare
         val strippedFirstField = csumAndStrippedFieldField.first
         for (
-            flds in col.db.queryStringList(
-                "SELECT flds FROM notes WHERE csum = ? AND id != ? AND mid = ?",
-                csum, this.id, mid
-            )
+        flds in col.db.queryStringList(
+            "SELECT flds FROM notes WHERE csum = ? AND id != ? AND mid = ?",
+            csum,
+            this.id,
+            mid
+        )
         ) {
             if (Utils.stripHTMLMedia(
                     Utils.splitFields(flds)[0]

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/SortOrder.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/SortOrder.kt
@@ -25,10 +25,13 @@ import net.ankiweb.rsdroid.RustCleanup
  */
 abstract class SortOrder {
     class NoOrdering : SortOrder()
+
     /** Based on config: sortType and sortBackwards */
     class UseCollectionOrdering : SortOrder()
+
     /** A custom SQL string placed after "order by" */
     class AfterSqlOrderBy(val customOrdering: String) : SortOrder()
+
     @Deprecated("Not yet usable - unhandled in Java backend")
     @RustCleanup("remove @Deprecated once Java backend is gone")
     class BuiltinSortKind(val value: String, val reverse: Boolean) : SortOrder()

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Sound.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Sound.kt
@@ -41,11 +41,11 @@ import java.lang.ref.WeakReference
 import java.util.*
 import java.util.regex.Pattern
 
-@KotlinCleanup("IDE Lint")
 // NICE_TO_HAVE: Abstract, then add tests for #6111
 /**
  * Class used to parse, load and play sound files on AnkiDroid.
  */
+@KotlinCleanup("IDE Lint")
 class Sound {
     /**
      * Media player used to play the sounds. It's Nullable and that it is set only if a sound is playing or paused, otherwise it is null.
@@ -66,6 +66,7 @@ class Sound {
      * Weak reference to the activity which is attempting to play the sound
      */
     private var mCallingActivity: WeakReference<Activity?>? = null
+
     @VisibleForTesting
     fun getSounds(side: SoundSide): ArrayList<String>? {
         if (side == SoundSide.QUESTION_AND_ANSWER) {
@@ -367,7 +368,9 @@ class Sound {
     val currentAudioUri: String?
         get() = if (mCurrentAudioUri == null) {
             null
-        } else mCurrentAudioUri.toString()
+        } else {
+            mCurrentAudioUri.toString()
+        }
 
     fun notifyConfigurationChanged(videoView: VideoView) {
         if (mMediaPlayer != null) {
@@ -584,7 +587,9 @@ class Sound {
             val trimmedSound = sound.trim { it <= ' ' }
             return if (hasURIScheme(trimmedSound)) {
                 trimmedSound
-            } else soundDir + Uri.encode(trimRight(sound))
+            } else {
+                soundDir + Uri.encode(trimRight(sound))
+            }
         }
 
         /**

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/StdModels.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/StdModels.kt
@@ -27,7 +27,8 @@ class StdModels(
     private val function: CreateStdModels,
     /** Essentially, the default name. As a resource, so that it can
      * be localized later.  */
-    @field:StringRes @param:StringRes private val defaultNameRes: Int
+    @field:StringRes @param:StringRes
+    private val defaultNameRes: Int
 ) {
     fun interface CreateStdModels {
         fun create(mm: ModelManager, name: String): Model

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/TagManager.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/TagManager.kt
@@ -33,6 +33,7 @@ abstract class TagManager {
      */
     @RustCleanup("Tags.java only")
     abstract fun load(json: String)
+
     @RustCleanup("Tags.java only")
     abstract fun flush()
 
@@ -43,15 +44,19 @@ abstract class TagManager {
 
     /** Given a list of tags, add any missing ones to tag registry. */
     fun register(tags: Iterable<String>) = register(tags, null)
+
     /** Given a list of tags, add any missing ones to tag registry. */
     fun register(tags: Iterable<String>, usn: Int? = null) = register(tags, usn, false)
+
     /** Given a list of tags, add any missing ones to tag registry.
      * @param clear_first Whether to clear the tags in the database before registering the provided tags
      * */
     abstract fun register(tags: Iterable<String>, usn: Int? = null, clear_first: Boolean = false)
     abstract fun all(): List<String>
+
     /** Add any missing tags from notes to the tags list. The old list is cleared first */
     fun registerNotes() = registerNotes(null)
+
     /**
      * Add any missing tags from notes to the tags list.
      * @param nids The old list is cleared first if this is null
@@ -59,8 +64,10 @@ abstract class TagManager {
     abstract fun registerNotes(nids: kotlin.collections.Collection<Long>? = null)
 
     abstract fun allItems(): Iterable<TagUsnTuple>
+
     @RustCleanup("Tags.java only")
     abstract fun save()
+
     /**
      * byDeck returns the tags of the cards in the deck
      * @param did the deck id
@@ -85,6 +92,7 @@ abstract class TagManager {
 
     /** Parse a string and return a list of tags. */
     abstract fun split(tags: String): MutableList<String>
+
     /** Join tags into a single string, with leading and trailing spaces. */
     abstract fun join(tags: kotlin.collections.Collection<String>): String
 
@@ -99,6 +107,7 @@ abstract class TagManager {
     /** Strip duplicates, adjust case to match existing tags, and sort. */
     @RustCleanup("List, not Collection")
     abstract fun canonify(tagList: List<String>): java.util.AbstractSet<String>
+
     /** @return True if TAG is in TAGS. Ignore case. */
     abstract fun inList(tag: String, tags: Iterable<String>): Boolean
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Tags.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Tags.kt
@@ -109,7 +109,8 @@ class Tags
     override fun allItems(): Set<TagUsnTuple> {
         return mTags.entries.map { (key, value): Map.Entry<String, Int?> ->
             TagUsnTuple(
-                key, value!!
+                key,
+                value!!
             )
         }.toSet()
     }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/TagsV16.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/TagsV16.kt
@@ -99,10 +99,11 @@ class TagsV16(val col: CollectionV16) : TagManager() {
     /* Remove space-separated tags from provided notes. */
     fun bulkRemove(
         noteIds: List<Long>,
-        tags: String,
+        tags: String
     ): OpChangesWithCount {
         return col.backend.removeNoteTags(
-            noteIds = noteIds, tags = tags
+            noteIds = noteIds,
+            tags = tags
         )
     }
 
@@ -138,7 +139,6 @@ class TagsV16(val col: CollectionV16) : TagManager() {
 
     /** Add tags if they don't exist, and canonify. */
     fun addToStr(addtags: String, tags: String): String {
-
         val currentTags = split(tags)
         for (tag in split(addtags)) {
             if (!inList(tag, currentTags)) {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/TemplateManager.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/TemplateManager.kt
@@ -72,7 +72,7 @@ class TemplateManager {
                                 TemplateReplacement(
                                     field_name = node.replacement.fieldName,
                                     current_text = node.replacement.currentText,
-                                    filters = node.replacement.filtersList,
+                                    filters = node.replacement.filtersList
                                 )
                             )
                         )
@@ -92,7 +92,7 @@ class TemplateManager {
                         lang = tag.tts.lang,
                         voices = tag.tts.voicesList,
                         otherArgs = tag.tts.otherArgsList,
-                        speed = tag.tts.speed,
+                        speed = tag.tts.speed
                     )
                 }
             }
@@ -145,7 +145,7 @@ class TemplateManager {
                 card: Card,
                 notetype: NoteType,
                 template: JSONObject,
-                fill_empty: bool,
+                fill_empty: bool
             ): TemplateRenderContext {
                 return TemplateRenderContext(
                     note.col,
@@ -153,7 +153,7 @@ class TemplateManager {
                     note,
                     notetype = notetype,
                     template = template,
-                    fill_empty = fill_empty,
+                    fill_empty = fill_empty
                 )
             }
         }
@@ -213,7 +213,7 @@ class TemplateManager {
                     question_text = e.localizedMessage ?: e.toString(),
                     answer_text = e.localizedMessage ?: e.toString(),
                     question_av_tags = emptyList(),
-                    answer_av_tags = emptyList(),
+                    answer_av_tags = emptyList()
                 )
             }
 
@@ -236,7 +236,7 @@ class TemplateManager {
                 answer_text = aoutText,
                 question_av_tags = av_tags_to_native(qout.avTagsList),
                 answer_av_tags = av_tags_to_native(aout.avTagsList),
-                css = note_type().getString("css"),
+                css = note_type().getString("css")
             )
 
             return output
@@ -251,7 +251,7 @@ class TemplateManager {
                         _note.toBackendNote(),
                         _card.ord,
                         BackendUtils.to_json_bytes(_template!!.deepClone()),
-                        _fill_empty,
+                        _fill_empty
                     )
                 } else {
                     // existing card (eg study mode)

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/UndoAction.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/UndoAction.kt
@@ -27,8 +27,10 @@ import java.util.*
 abstract class UndoAction
 /**
  * For all descendants, we assume that a card/note/object passed as argument is never going to be changed again.
- * It's the caller responsibility to clone the object if necessary. */
-(@field:UndoNameId @field:StringRes @param:StringRes @param:UndoNameId val undoNameId: Int) {
+ * It's the caller responsibility to clone the object if necessary. */(
+    @field:UndoNameId @field:StringRes @param:StringRes @param:UndoNameId
+    val undoNameId: Int
+) {
     @Retention(AnnotationRetention.SOURCE)
     @IntDef(R.string.undo_action_change_deck_multi, R.string.menu_delete_note, R.string.card_browser_delete_card, R.string.card_browser_mark_card, R.string.card_browser_unmark_card, R.string.menu_suspend_card, R.string.card_browser_unsuspend_card, R.string.undo_action_review, R.string.menu_bury_note, R.string.menu_suspend_note, R.string.card_editor_reposition_card, R.string.card_editor_reschedule_card, R.string.menu_bury_card, R.string.card_editor_reset_card)
     annotation class UndoNameId
@@ -54,7 +56,11 @@ abstract class UndoAction
          * @param card the card currently in the reviewer
          * @return An UndoAction which, if executed, put back the `card` in the state given here
          */
-        fun revertNoteToProvidedState(@StringRes @UndoNameId undoNameId: Int, card: Card): UndoAction {
+        fun revertNoteToProvidedState(
+            @StringRes @UndoNameId
+            undoNameId: Int,
+            card: Card
+        ): UndoAction {
             return revertToProvidedState(undoNameId, card, card.note().cards())
         }
 
@@ -64,7 +70,11 @@ abstract class UndoAction
          * @param card the card currently in the reviewer
          * @return An UndoAction which, if executed, put back the `card` in the state given here
          */
-        fun revertCardToProvidedState(@StringRes @UndoNameId undoNameId: Int, card: Card): UndoAction {
+        fun revertCardToProvidedState(
+            @StringRes @UndoNameId
+            undoNameId: Int,
+            card: Card
+        ): UndoAction {
             return revertToProvidedState(undoNameId, card, mutableListOf(card.clone()))
         }
 
@@ -75,7 +85,12 @@ abstract class UndoAction
          * @param cards The cards that must be reverted
          * @return An UndoAction which, if executed, put back the `card` in the state given here
          */
-        private fun revertToProvidedState(@StringRes @UndoNameId undoNameId: Int, card: Card, cards: Iterable<Card>): UndoAction {
+        private fun revertToProvidedState(
+            @StringRes @UndoNameId
+            undoNameId: Int,
+            card: Card,
+            cards: Iterable<Card>
+        ): UndoAction {
             return object : UndoAction(undoNameId) {
                 override fun undo(col: Collection): Card {
                     Timber.i("Undo: %d", undoNameId)

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Utils.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Utils.kt
@@ -186,7 +186,8 @@ object Utils {
         return if (time_s < TIME_HOUR_LONG) {
             // get time remaining, but never less than 1
             time_x = max(
-                (time_s / TIME_MINUTE).roundToInt(), 1
+                (time_s / TIME_MINUTE).roundToInt(),
+                1
             )
             res.getQuantityString(R.plurals.reviewer_window_title, time_x, time_x)
             // It used to be minutes only. So the word "minutes" is not
@@ -295,6 +296,7 @@ object Utils {
             )
         }
     }
+
     /*
      * Locale
      * ***********************************************************************************************
@@ -373,6 +375,7 @@ object Utils {
         htmlEntities.appendTail(sb)
         return sb.toString()
     }
+
     /*
      * IDs
      * ***********************************************************************************************
@@ -533,6 +536,7 @@ object Utils {
         // -1 ensures that we don't drop empty fields at the ends
         return fields.split(FIELD_SEPARATOR).toTypedArray()
     }
+
     /*
      * Checksums
      * ***********************************************************************************************
@@ -804,10 +808,13 @@ object Utils {
         try {
             Timber.d("Creating new file... = %s", destination)
             f.createNewFile()
-            @SuppressLint("DirectSystemCurrentTimeMillisUsage") val startTimeMillis =
+            @SuppressLint("DirectSystemCurrentTimeMillisUsage")
+            val startTimeMillis =
                 System.currentTimeMillis()
             val sizeBytes = compat.copyFile(source, destination)
-            @SuppressLint("DirectSystemCurrentTimeMillisUsage") val endTimeMillis =
+
+            @SuppressLint("DirectSystemCurrentTimeMillisUsage")
+            val endTimeMillis =
                 System.currentTimeMillis()
             Timber.d("Finished writeToFile!")
             val durationSeconds = (endTimeMillis - startTimeMillis) / 1000
@@ -838,6 +845,7 @@ object Utils {
     fun isIntentAvailable(context: Context, action: String?): Boolean {
         return isIntentAvailable(context, action, null)
     }
+
     @KotlinCleanup("Use @JmOverloads, remove fun passing null for ComponentName")
     @KotlinCleanup("Simplify function body")
     @Suppress("deprecation") // queryIntentActivities
@@ -1012,8 +1020,10 @@ object Utils {
         // AnkiWeb reads this string and uses , and : as delimiters, so we remove them.
         val model = Build.MODEL.replace(',', ' ').replace(':', ' ')
         return String.format(
-            Locale.US, "android:%s:%s",
-            Build.VERSION.RELEASE, model
+            Locale.US,
+            "android:%s:%s",
+            Build.VERSION.RELEASE,
+            model
         )
     }
 
@@ -1024,7 +1034,8 @@ object Utils {
         // AnkiWeb reads this string and uses , and : as delimiters, so we remove them.
         val model = Build.MODEL.replace(',', ' ').replace(':', ' ')
         return String.format(
-            Locale.US, "android:%s:%s:%s",
+            Locale.US,
+            "android:%s:%s:%s",
             BuildConfig.VERSION_NAME,
             Build.VERSION.RELEASE,
             model
@@ -1041,7 +1052,9 @@ object Utils {
     fun nfcNormalized(txt: String): String {
         return if (!Normalizer.isNormalized(txt, Normalizer.Form.NFC)) {
             Normalizer.normalize(txt, Normalizer.Form.NFC)
-        } else txt
+        } else {
+            txt
+        }
     }
 
     /**

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/backend/exception/DeckRenameException.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/backend/exception/DeckRenameException.kt
@@ -14,7 +14,9 @@ class DeckRenameException
     override val message: String?
         get() = if (errorCode == FILTERED_NOSUBDECKS) {
             "Deck $mDeckName has filtered ancestor $mFilteredAncestorName"
-        } else super.message
+        } else {
+            super.message
+        }
 
     fun getLocalizedMessage(res: Resources): String {
         return when (errorCode) {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/importer/Anki2Importer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/importer/Anki2Importer.kt
@@ -68,6 +68,7 @@ open class Anki2Importer(col: Collection?, file: String) : Importer(col!!, file)
 
     /** If importing SchedV1 into SchedV2 we need to reset the learning cards  */
     private var mMustResetLearning = false
+
     @Throws(ImportExportException::class)
     override fun run() {
         publishProgress(0, 0, 0)
@@ -405,6 +406,7 @@ open class Anki2Importer(col: Collection?, file: String) : Importer(col!!, file)
         mModelMap!![srcMid] = mid
         return mid
     }
+
     /*
      * Decks
      * ***********************************************************
@@ -530,7 +532,9 @@ open class Anki2Importer(col: Collection?, file: String) : Importer(col!!, file)
                     val scid = cid // To keep track of card id in source
                     var did = cur.getLong(2)
                     val ord = cur.getInt(3)
+
                     @CARD_TYPE var type = cur.getInt(4)
+
                     @CARD_QUEUE var queue = cur.getInt(5)
                     var due = cur.getLong(6)
                     val ivl = cur.getLong(7)
@@ -721,7 +725,6 @@ open class Anki2Importer(col: Collection?, file: String) : Importer(col!!, file)
             // Mark file addition to media db (see note in Media.java)
             dst.media.markFileAdd(fname)
         } catch (e: IOException) {
-
             // the user likely used subdirectories
             Timber.e(e, "Error copying file %s.", fname)
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/importer/Importer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/importer/Importer.kt
@@ -35,6 +35,7 @@ abstract class Importer(col: Collection, protected var file: String) {
     var cardCount: Int
         protected set
     protected val mCol: Collection
+
     @KotlinCleanup("rename")
     protected var _total: Int
     private var mTs: Long = 0
@@ -42,6 +43,7 @@ abstract class Importer(col: Collection, protected var file: String) {
     protected lateinit var src: Collection
     protected val context: Context
     protected var progress: TaskManager.ProgressCallback<String>? = null
+
     @Throws(ImportExportException::class)
     abstract fun run()
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/AbstractDeckTreeNode.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/AbstractDeckTreeNode.kt
@@ -66,8 +66,10 @@ abstract class AbstractDeckTreeNode(
     /** Line representing this string without its children. Used in timbers only.  */
     protected open fun toStringLine(): String? {
         return String.format(
-            Locale.US, "%s, %d",
-            fullDeckName, did
+            Locale.US,
+            "%s, %d",
+            fullDeckName,
+            did
         )
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/BaseSched.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/BaseSched.kt
@@ -95,7 +95,7 @@ abstract class BaseSched(val col: Collection) {
         col.newBackend.backend.buryOrSuspendCards(
             cardIds = cids.toList(),
             noteIds = listOf(),
-            mode = mode,
+            mode = mode
         )
     }
 
@@ -254,7 +254,7 @@ abstract class BaseSched(val col: Collection) {
         col.newBackend.backend.extendLimits(
             deckId = col.decks.selected(),
             newDelta = newc,
-            reviewDelta = rev,
+            reviewDelta = rev
         )
     }
 
@@ -475,7 +475,8 @@ abstract class BaseSched(val col: Collection) {
     fun totalRevForCurrentDeck(): Int {
         return col.db.queryScalar(
             "SELECT count() FROM cards WHERE id IN (SELECT id FROM cards WHERE did IN " + _deckLimit() + "  AND queue = " + Consts.QUEUE_TYPE_REV + " AND due <= ? LIMIT ?)",
-            today, REPORT_LIMIT
+            today,
+            REPORT_LIMIT
         )
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/DeckDueTreeNode.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/DeckDueTreeNode.kt
@@ -46,8 +46,13 @@ class DeckDueTreeNode(
 ) : AbstractDeckTreeNode(fullDeckName, did, collapsed, filtered) {
     override fun toString(): String {
         return String.format(
-            Locale.US, "%s, %d, %d, %d, %d",
-            fullDeckName, did, revCount, lrnCount, newCount
+            Locale.US,
+            "%s, %d, %d, %d, %d",
+            fullDeckName,
+            did,
+            revCount,
+            lrnCount,
+            newCount
         )
     }
 
@@ -101,8 +106,13 @@ class DeckDueTreeNode(
     /** Line representing this string without its children. Used in timbers only.  */
     override fun toStringLine(): String {
         return String.format(
-            Locale.US, "%s, %d, %d, %d, %d\n",
-            fullDeckName, did, revCount, lrnCount, newCount
+            Locale.US,
+            "%s, %d, %d, %d, %d\n",
+            fullDeckName,
+            did,
+            revCount,
+            lrnCount,
+            newCount
         )
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/LrnCard.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/LrnCard.kt
@@ -21,7 +21,8 @@ import com.ichi2.libanki.Collection
 
 class LrnCard(col: Collection, val due: Long, cid: Long) :
     Card.Cache(
-        col, cid
+        col,
+        cid
     ),
     Comparable<LrnCard> {
     override fun compareTo(other: LrnCard): Int {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Sched.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Sched.kt
@@ -129,7 +129,9 @@ class Sched(col: Collection) : SchedV2(col) {
                 ).length() > 1
             ) {
                 3
-            } else 2
+            } else {
+                2
+            }
         } else if (card.queue == Consts.QUEUE_TYPE_REV) {
             4
         } else {
@@ -143,7 +145,8 @@ class Sched(col: Collection) : SchedV2(col) {
         col.log(col.db.queryLongList("select id from cards where " + queueIsBuriedSnippet() + " and did in " + sids))
         col.db.execute(
             "update cards set mod=?,usn=?," + _restoreQueueSnippet() + " where " + queueIsBuriedSnippet() + " and did in " + sids,
-            time.intTime(), col.usn()
+            time.intTime(),
+            col.usn()
         )
     }
     /*
@@ -156,6 +159,7 @@ class Sched(col: Collection) : SchedV2(col) {
         _checkDay()
         col.decks.checkIntegrity()
         val allDecksSorted = col.decks.allSorted()
+
         @KotlinCleanup("input should be non-null")
         val lims = HashUtil.HashMapInit<String?, Array<Int>>(allDecksSorted.size)
         val deckNodes = ArrayList<DeckDueTreeNode>(allDecksSorted.size)
@@ -266,7 +270,9 @@ class Sched(col: Collection) : SchedV2(col) {
         // collapse or finish
         return if (_preloadLrnCard(true)) {
             arrayOf(mLrnQueue)
-        } else arrayOf()
+        } else {
+            arrayOf()
+        }
     }
 
     /**
@@ -281,14 +287,18 @@ class Sched(col: Collection) : SchedV2(col) {
         mLrnCount = col.db.queryScalar(
             "SELECT sum(left / 1000) FROM (SELECT left FROM cards WHERE did IN " + _deckLimit() +
                 " AND queue = " + Consts.QUEUE_TYPE_LRN + " AND due < ? and id != ? LIMIT ?)",
-            dayCutoff, currentCardId(), mReportLimit
+            dayCutoff,
+            currentCardId(),
+            mReportLimit
         )
         if (isCancelled(cancelListener)) return
         // day
         mLrnCount += col.db.queryScalar(
             "SELECT count() FROM cards WHERE did IN " + _deckLimit() + " AND queue = " + Consts.QUEUE_TYPE_DAY_LEARN_RELEARN + " AND due <= ? " +
                 "AND id != ? LIMIT ?",
-            mToday!!, currentCardId(), mReportLimit
+            mToday!!,
+            currentCardId(),
+            mReportLimit
         )
     }
 
@@ -317,7 +327,9 @@ class Sched(col: Collection) : SchedV2(col) {
          */mLrnQueue.setFilled()
         col.db.query(
             "SELECT due, id FROM cards WHERE did IN " + _deckLimit() + " AND queue = " + Consts.QUEUE_TYPE_LRN + " AND due < ? AND id != ? LIMIT ?",
-            dayCutoff, currentCardId(), mReportLimit
+            dayCutoff,
+            currentCardId(),
+            mReportLimit
         ).use { cur ->
             while (cur.moveToNext()) {
                 mLrnQueue.add(cur.getLong(0), cur.getLong(1))
@@ -347,6 +359,7 @@ class Sched(col: Collection) : SchedV2(col) {
      */
     override fun _answerLrnCard(card: Card, @BUTTON_TYPE ease: Int) {
         val conf = _lrnConf(card)
+
         @REVLOG_TYPE val type: Int
         type = if (card.isInDynamicDeck && !card.wasNew) {
             Consts.REVLOG_CRAM
@@ -518,7 +531,8 @@ class Sched(col: Collection) : SchedV2(col) {
         col.db.execute(
             "update cards set due = odue, queue = " + Consts.QUEUE_TYPE_REV + ", mod = ?" +
                 ", usn = ?, odue = 0 where queue IN (" + Consts.QUEUE_TYPE_LRN + "," + Consts.QUEUE_TYPE_DAY_LEARN_RELEARN + ") and type = " + Consts.CARD_TYPE_REV + " " + extra,
-            time.intTime(), col.usn()
+            time.intTime(),
+            col.usn()
         )
         // new cards in learning
         forgetCards(col.db.queryLongList("SELECT id FROM cards WHERE queue IN (" + Consts.QUEUE_TYPE_LRN + "," + Consts.QUEUE_TYPE_DAY_LEARN_RELEARN + ") " + extra))
@@ -530,13 +544,17 @@ class Sched(col: Collection) : SchedV2(col) {
                 "SELECT sum(left / 1000) FROM (SELECT left FROM cards WHERE did = ?" +
                     " AND queue = " + Consts.QUEUE_TYPE_LRN + " AND due < ?" +
                     " LIMIT ?)",
-                did, time.intTime() + col.get_config_int("collapseTime"), mReportLimit
+                did,
+                time.intTime() + col.get_config_int("collapseTime"),
+                mReportLimit
             )
             cnt + col.db.queryScalar(
                 "SELECT count() FROM (SELECT 1 FROM cards WHERE did = ?" +
                     " AND queue = " + Consts.QUEUE_TYPE_DAY_LEARN_RELEARN + " AND due <= ?" +
                     " LIMIT ?)",
-                did, mToday!!, mReportLimit
+                did,
+                mToday!!,
+                mReportLimit
             )
         } catch (e: SQLException) {
             throw RuntimeException(e)
@@ -556,6 +574,7 @@ class Sched(col: Collection) : SchedV2(col) {
             considerCurrentCard
         )
     }
+
     /**
      * Maximal number of rev card still to see today in deck d. It's computed as:
      * the number of rev card to see by day according
@@ -590,7 +609,9 @@ class Sched(col: Collection) : SchedV2(col) {
         lim = Math.min(lim, mReportLimit)
         return col.db.queryScalar(
             "SELECT count() FROM (SELECT 1 FROM cards WHERE did = ? AND queue = " + Consts.QUEUE_TYPE_REV + " AND due <= ? LIMIT ?)",
-            did, mToday!!, lim
+            did,
+            mToday!!,
+            lim
         )
     }
 
@@ -613,7 +634,10 @@ class Sched(col: Collection) : SchedV2(col) {
         return col.db.queryScalar(
             "SELECT count() FROM (SELECT id FROM cards WHERE did = ? AND queue = " + Consts.QUEUE_TYPE_REV + " and due <= ? " +
                 " AND id != ? LIMIT ?)",
-            did, mToday!!, currentCardId(), lim
+            did,
+            mToday!!,
+            currentCardId(),
+            lim
         )
     }
 
@@ -638,11 +662,14 @@ class Sched(col: Collection) : SchedV2(col) {
                 val idName = if (allowSibling) "id" else "nid"
                 val id = if (allowSibling) currentCardId() else currentCardNid()
                 for (
-                    cid in col.db.queryLongList(
-                        "SELECT id FROM cards WHERE did = ? AND queue = " + Consts.QUEUE_TYPE_REV + " AND due <= ?" +
-                            " AND " + idName + " != ? LIMIT ?",
-                        did, mToday!!, id, lim
-                    )
+                cid in col.db.queryLongList(
+                    "SELECT id FROM cards WHERE did = ? AND queue = " + Consts.QUEUE_TYPE_REV + " AND due <= ?" +
+                        " AND " + idName + " != ? LIMIT ?",
+                    did,
+                    mToday!!,
+                    id,
+                    lim
+                )
                 ) {
                     /* Difference with upstream: we take current card into account.
                      *
@@ -957,6 +984,7 @@ class Sched(col: Collection) : SchedV2(col) {
         }
         // dynamic deck; override some attributes, use original deck for others
         val oconf = col.decks.confForDid(card.oDid)
+
         @KotlinCleanup("use ?:")
         var delays = conf.optJSONArray("delays")
         if (delays == null) {
@@ -1006,7 +1034,9 @@ class Sched(col: Collection) : SchedV2(col) {
         val conf = _cardConf(card)
         return if (conf.getInt("dyn") == DECK_STD) {
             true
-        } else conf.getBoolean("resched")
+        } else {
+            conf.getBoolean("resched")
+        }
     }
 
     /**
@@ -1068,10 +1098,12 @@ class Sched(col: Collection) : SchedV2(col) {
             val conf = _lapseConf(card)
             if (conf.getJSONArray("delays").length() > 0) {
                 (conf.getJSONArray("delays").getDouble(0) * 60.0).toLong()
-            } else _nextLapseIvl(
-                card,
-                conf
-            ) * SECONDS_PER_DAY
+            } else {
+                _nextLapseIvl(
+                    card,
+                    conf
+                ) * SECONDS_PER_DAY
+            }
         } else {
             // review
             _nextRevIvl(card, ease) * SECONDS_PER_DAY
@@ -1091,24 +1123,28 @@ class Sched(col: Collection) : SchedV2(col) {
             // early removal
             if (!_resched(card)) {
                 0
-            } else _graduatingIvl(
-                card,
-                conf,
-                true,
-                false
-            ) * SECONDS_PER_DAY
+            } else {
+                _graduatingIvl(
+                    card,
+                    conf,
+                    true,
+                    false
+                ) * SECONDS_PER_DAY
+            }
         } else {
             val left = card.left % 1000 - 1
             if (left <= 0) {
                 // graduate
                 if (!_resched(card)) {
                     0
-                } else _graduatingIvl(
-                    card,
-                    conf,
-                    false,
-                    false
-                ) * SECONDS_PER_DAY
+                } else {
+                    _graduatingIvl(
+                        card,
+                        conf,
+                        false,
+                        false
+                    ) * SECONDS_PER_DAY
+                }
             } else {
                 _delayForGrade(conf, left).toLong()
             }
@@ -1127,7 +1163,8 @@ class Sched(col: Collection) : SchedV2(col) {
         col.db.execute(
             "UPDATE cards SET queue = " + Consts.QUEUE_TYPE_SUSPENDED + ", mod = ?, usn = ? WHERE id IN " +
                 Utils.ids2str(ids),
-            time.intTime(), col.usn()
+            time.intTime(),
+            col.usn()
         )
     }
 
@@ -1151,7 +1188,8 @@ class Sched(col: Collection) : SchedV2(col) {
             "update cards set " + queueIsBuriedSnippet() + ",mod=?,usn=? where id in " + Utils.ids2str(
                 cids
             ),
-            time.intTime(), col.usn()
+            time.intTime(),
+            col.usn()
         )
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SimpleCardQueue.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SimpleCardQueue.kt
@@ -19,7 +19,8 @@ package com.ichi2.libanki.sched
 import com.ichi2.libanki.Card
 import com.ichi2.utils.KotlinCleanup
 
-@KotlinCleanup("Make sched non-null ") class SimpleCardQueue(sched: AbstractSched?) : CardQueue<Card.Cache?>(sched) {
+@KotlinCleanup("Make sched non-null ")
+class SimpleCardQueue(sched: AbstractSched?) : CardQueue<Card.Cache?>(sched) {
     fun add(id: Long) {
         add(col?.let { Card.Cache(it, id) })
     }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/stats/AdvancedStatistics.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/stats/AdvancedStatistics.kt
@@ -174,8 +174,10 @@ class AdvancedStatistics {
                 ).toDouble() // Y-Axis: # Young
             seriesList[REVIEW_TYPE_RELEARN_PLUS_1][t] = data[REVIEW_TYPE_LEARN_PLUS_1]
                 .toDouble() // Y-Axis: # Learn
-            if (data[TIME] > lastElement) lastElement = data[TIME]
-                .toDouble() // X-Axis: Max. value (only for TYPE_LIFE)
+            if (data[TIME] > lastElement) {
+                lastElement = data[TIME]
+                    .toDouble() // X-Axis: Max. value (only for TYPE_LIFE)
+            }
             if (data[TIME] == 0) {
                 zeroIndex = t // Because we retrieve dues in the past and we should not cumulate them
             }
@@ -314,9 +316,17 @@ class AdvancedStatistics {
                     nInState[i][CARD_TYPE_NEW].toDouble()
                 )
             } else {
-                if (i == 0) nInStateCum[i] = doubleArrayOf(
-                    i.toDouble(), 0.0, 0.0, 0.0, 0.0
-                ) else nInStateCum[i] = nInStateCum[i - 1]
+                if (i == 0) {
+                    nInStateCum[i] = doubleArrayOf(
+                        i.toDouble(),
+                        0.0,
+                        0.0,
+                        0.0,
+                        0.0
+                    )
+                } else {
+                    nInStateCum[i] = nInStateCum[i - 1]
+                }
             }
         }
 
@@ -478,10 +488,12 @@ class AdvancedStatistics {
             mProbabilities[CARD_TYPE_NEW] =
                 calculateProbabilitiesForNewEaseForCurrentEase(queryNew, mPriorNew)
             mProbabilities[CARD_TYPE_YOUNG] = calculateProbabilitiesForNewEaseForCurrentEase(
-                queryYoung, mPriorYoung
+                queryYoung,
+                mPriorYoung
             )
             mProbabilities[CARD_TYPE_MATURE] = calculateProbabilitiesForNewEaseForCurrentEase(
-                queryMature, mPriorMature
+                queryMature,
+                mPriorMature
             )
             mProbabilitiesCumulative[CARD_TYPE_NEW] = cumsum(
                 mProbabilities[CARD_TYPE_NEW]
@@ -736,15 +748,19 @@ class AdvancedStatistics {
             // Since it's the average, it can be a non-integer
             // Adding a review to a non-integer can make it exceed the maximum # reviews per day, but not by 1 or more
             // So if we take the floor when displaying it, we will display the maximum # reviews
-            simulationResult = if (mSettings!!.computeNDays > 0) SimulationResult(
-                nTimeBins,
-                timeBinLength,
-                DOUBLE_TO_INT_MODE_FLOOR
-            ) else SimulationResult(
-                nTimeBins,
-                timeBinLength,
-                DOUBLE_TO_INT_MODE_ROUND
-            )
+            simulationResult = if (mSettings!!.computeNDays > 0) {
+                SimulationResult(
+                    nTimeBins,
+                    timeBinLength,
+                    DOUBLE_TO_INT_MODE_FLOOR
+                )
+            } else {
+                SimulationResult(
+                    nTimeBins,
+                    timeBinLength,
+                    DOUBLE_TO_INT_MODE_ROUND
+                )
+            }
 
             // nSmooth=1
 
@@ -880,10 +896,14 @@ class AdvancedStatistics {
             for (i in 0 until m) {
                 intMatrix[i] = IntArray(n)
                 for (j in 0 until n) {
-                    if (doubleToIntMode == DOUBLE_TO_INT_MODE_ROUND) intMatrix[i]!![j] =
-                        Math.round(
-                            doubleMatrix[i][j]
-                        ).toInt() else intMatrix[i]!![j] = doubleMatrix[i][j].toInt()
+                    if (doubleToIntMode == DOUBLE_TO_INT_MODE_ROUND) {
+                        intMatrix[i]!![j] =
+                            Math.round(
+                                doubleMatrix[i][j]
+                            ).toInt()
+                    } else {
+                        intMatrix[i]!![j] = doubleMatrix[i][j].toInt()
+                    }
                 }
             }
             return intMatrix.requireNoNulls()
@@ -1307,8 +1327,12 @@ class AdvancedStatistics {
             mOutcome = 0
 
             // # Rate-limit new cards by shifting starting time
-            if (card.type == CARD_TYPE_NEW) t = newCardSimulator.simulateNewCard(mDeck) else t =
-                card.due
+            if (card.type == CARD_TYPE_NEW) {
+                t = newCardSimulator.simulateNewCard(mDeck)
+            } else {
+                t =
+                    card.due
+            }
 
             // Set state of card between start and first review
             // New reviews happen with probability 1
@@ -1347,9 +1371,13 @@ class AdvancedStatistics {
                 mNewCard!!.setAll(mCard)
                 val reviewOutcome: ReviewOutcome
                 reviewOutcome =
-                    if (t >= mSettings!!.computeNDays || mProb < mSettings!!.computeMaxError) mClassifier.simSingleReview(
-                        mNewCard
-                    ) else mClassifier.simSingleReview(mNewCard, mOutcome)
+                    if (t >= mSettings!!.computeNDays || mProb < mSettings!!.computeMaxError) {
+                        mClassifier.simSingleReview(
+                            mNewCard
+                        )
+                    } else {
+                        mClassifier.simSingleReview(mNewCard, mOutcome)
+                    }
 
                 // Timber.d("Simulation at t=" + tElapsed + ": outcome " + outcomeIdx + ": " + reviewOutcome.toString() );
                 mNewCard = reviewOutcome.card
@@ -1359,11 +1387,13 @@ class AdvancedStatistics {
                 mNewCard!!.lastReview = t
 
                 // If card failed, update "relearn" count
-                if (mNewCard!!.correct == 0) mSimulationResult.incrementNReviews(
-                    3,
-                    t,
-                    mProb * outcomeProb
-                )
+                if (mNewCard!!.correct == 0) {
+                    mSimulationResult.incrementNReviews(
+                        3,
+                        t,
+                        mProb * outcomeProb
+                    )
+                }
 
                 // Set state of card between current and next review
                 mSimulationResult.updateNInState(

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/stats/Stats.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/stats/Stats.kt
@@ -194,6 +194,7 @@ class Stats(private val col: com.ichi2.libanki.Collection, did: Long) {
         } else {
             3600.0 // hours
         }
+
         @Suppress("UNUSED_VARIABLE")
         val cut = col.sched.dayCutoff
         val cardCount = col.db.queryScalar("select count(id) from cards $lim")
@@ -465,7 +466,8 @@ from cards where did in ${_limit()} and queue = ${Consts.QUEUE_TYPE_REV}"""
         mHasColoredCumulative = false
         cumulative = createCumulative(
             arrayOf(
-                seriesList!![0], seriesList!![1]
+                seriesList!![0],
+                seriesList!![1]
             ),
             mZeroIndex
         )
@@ -520,7 +522,10 @@ from cards where did in ${_limit()} and queue = ${Consts.QUEUE_TYPE_REV}"""
             R.string.statistics_mature
         )
         mColors = intArrayOf(
-            R.attr.stats_cram, R.attr.stats_learn, R.attr.stats_relearn, R.attr.stats_young,
+            R.attr.stats_cram,
+            R.attr.stats_learn,
+            R.attr.stats_relearn,
+            R.attr.stats_young,
             R.attr.stats_mature
         )
         var num = 0
@@ -601,8 +606,12 @@ from cards where did in ${_limit()} and queue = ${Consts.QUEUE_TYPE_REV}"""
                 while (cur.moveToNext()) {
                     list.add(
                         doubleArrayOf(
-                            cur.getDouble(0), cur.getDouble(5), cur.getDouble(1), cur.getDouble(4),
-                            cur.getDouble(2), cur.getDouble(3)
+                            cur.getDouble(0),
+                            cur.getDouble(5),
+                            cur.getDouble(1),
+                            cur.getDouble(4),
+                            cur.getDouble(2),
+                            cur.getDouble(3)
                         )
                     )
                 }
@@ -884,7 +893,8 @@ from cards where did in ${_limit()} and queue = ${Consts.QUEUE_TYPE_REV}"""
         }
         Collections.sort(list) { s1: DoubleArray, s2: DoubleArray ->
             java.lang.Double.compare(
-                s1[0], s2[0]
+                s1[0],
+                s2[0]
             )
         }
         seriesList = Array(4) { DoubleArray(list.size) }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sync/HttpSyncer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sync/HttpSyncer.kt
@@ -88,11 +88,14 @@ open class HttpSyncer(
     @Volatile
     private var mHttpClient: OkHttpClient? = null
     private val mHostNum: HostNum
+
     @KotlinCleanup("simplify with ?:")
     private val httpClient: OkHttpClient
         get() = if (mHttpClient != null) {
             mHttpClient!!
-        } else setupHttpClient()
+        } else {
+            setupHttpClient()
+        }
 
     // PERF: Thread safety isn't required for the current implementation
     @Synchronized

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sync/MediaSyncer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sync/MediaSyncer.kt
@@ -178,7 +178,8 @@ class MediaSyncer(
                 }
                 con.publishProgress(
                     String.format(
-                        AnkiDroidApp.appResources.getString(R.string.sync_media_changes_count), toSend
+                        AnkiDroidApp.appResources.getString(R.string.sync_media_changes_count),
+                        toSend
                     )
                 )
                 val changes = server.uploadChanges(zip)
@@ -190,7 +191,9 @@ class MediaSyncer(
                     String.format(
                         Locale.US,
                         "processed %d, serverUsn %d, clientUsn %d",
-                        processedCnt, serverLastUsn, lastUsn
+                        processedCnt,
+                        serverLastUsn,
+                        lastUsn
                     )
                 )
                 if (serverLastUsn - processedCnt == lastUsn) {
@@ -243,7 +246,8 @@ class MediaSyncer(
                 }
                 con.publishProgress(
                     String.format(
-                        AnkiDroidApp.appResources.getString(R.string.sync_media_downloaded_count), mDownloadCount
+                        AnkiDroidApp.appResources.getString(R.string.sync_media_downloaded_count),
+                        mDownloadCount
                     )
                 )
             } catch (e: IOException) {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/template/ParsedNode.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/template/ParsedNode.kt
@@ -56,9 +56,13 @@ abstract class ParsedNode {
         } catch (er: TemplateError) {
             Timber.w(er)
             val side =
-                if (question) context.getString(R.string.card_template_editor_front) else context.getString(
-                    R.string.card_template_editor_back
-                )
+                if (question) {
+                    context.getString(R.string.card_template_editor_front)
+                } else {
+                    context.getString(
+                        R.string.card_template_editor_back
+                    )
+                }
             val explanation = context.getString(R.string.has_a_problem, side, er.message(context))
             val more_explanation =
                 "<a href=\"" + TEMPLATE_ERROR_LINK + "\">" + context.getString(R.string.more_information) + "</a>"

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/template/TemplateFilters.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/template/TemplateFilters.kt
@@ -203,7 +203,8 @@ object TemplateFilters {
                         replacement,
                         Matcher.quoteReplacement(
                             m.group(0)!!.replace(
-                                "{{c$ord::", "{{C$ord::"
+                                "{{c$ord::",
+                                "{{C$ord::"
                             )
                         )
                     )

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/template/Tokenizer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/template/Tokenizer.kt
@@ -172,6 +172,7 @@ class Tokenizer internal constructor(template: String) : Iterator<Tokenizer.Toke
          * Same as rslib/src/template's ALT_HANDLEBAR_DIRECTIVE upstream */
         @VisibleForTesting
         val ALT_HANDLEBAR_DIRECTIVE = "{{=<% %>=}}"
+
         @VisibleForTesting
         fun new_to_legacy(template_part: String): String {
             return template_part.replace("{{", "<%").replace("}}", "%>")
@@ -202,13 +203,15 @@ class Tokenizer internal constructor(template: String) : Iterator<Tokenizer.Toke
             }
             return if (text_size == 0) {
                 null
-            } else IResult(
-                Token(
-                    TokenKind.TEXT,
-                    template.substring(0, text_size)
-                ),
-                template.substring(text_size)
-            )
+            } else {
+                IResult(
+                    Token(
+                        TokenKind.TEXT,
+                        template.substring(0, text_size)
+                    ),
+                    template.substring(text_size)
+                )
+            }
         }
 
         /**
@@ -226,23 +229,25 @@ class Tokenizer internal constructor(template: String) : Iterator<Tokenizer.Toke
                     TokenKind.REPLACEMENT,
                     start
                 )
-            } else when (start[0]) {
-                '#' -> Token(
-                    TokenKind.OPEN_CONDITIONAL,
-                    start.substring(1).trim { it <= ' ' }
-                )
-                '/' -> Token(
-                    TokenKind.CLOSE_CONDITIONAL,
-                    start.substring(1).trim { it <= ' ' }
-                )
-                '^' -> Token(
-                    TokenKind.OPEN_NEGATED,
-                    start.substring(1).trim { it <= ' ' }
-                )
-                else -> Token(
-                    TokenKind.REPLACEMENT,
-                    start
-                )
+            } else {
+                when (start[0]) {
+                    '#' -> Token(
+                        TokenKind.OPEN_CONDITIONAL,
+                        start.substring(1).trim { it <= ' ' }
+                    )
+                    '/' -> Token(
+                        TokenKind.CLOSE_CONDITIONAL,
+                        start.substring(1).trim { it <= ' ' }
+                    )
+                    '^' -> Token(
+                        TokenKind.OPEN_NEGATED,
+                        start.substring(1).trim { it <= ' ' }
+                    )
+                    else -> Token(
+                        TokenKind.REPLACEMENT,
+                        start
+                    )
+                }
             }
         }
 
@@ -259,7 +264,9 @@ class Tokenizer internal constructor(template: String) : Iterator<Tokenizer.Toke
             }
             return if (legacy) {
                 legacy_handlebar_token(template)
-            } else null
+            } else {
+                null
+            }
         }
 
         /**

--- a/AnkiDroid/src/main/java/com/ichi2/preferences/ControlPreference.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/preferences/ControlPreference.kt
@@ -49,10 +49,17 @@ import java.util.*
  * * Allow maps other than the reviewer
  */
 class ControlPreference : ListPreference {
-    @Suppress("unused") constructor(context: Context, attrs: AttributeSet?, defStyleAttr: Int, defStyleRes: Int) : super(context, attrs, defStyleAttr, defStyleRes)
-    @Suppress("unused") constructor(context: Context, attrs: AttributeSet?, defStyleAttr: Int) : super(context, attrs, defStyleAttr)
-    @Suppress("unused") constructor(context: Context, attrs: AttributeSet?) : super(context, attrs)
-    @Suppress("unused") constructor(context: Context) : super(context)
+    @Suppress("unused")
+    constructor(context: Context, attrs: AttributeSet?, defStyleAttr: Int, defStyleRes: Int) : super(context, attrs, defStyleAttr, defStyleRes)
+
+    @Suppress("unused")
+    constructor(context: Context, attrs: AttributeSet?, defStyleAttr: Int) : super(context, attrs, defStyleAttr)
+
+    @Suppress("unused")
+    constructor(context: Context, attrs: AttributeSet?) : super(context, attrs)
+
+    @Suppress("unused")
+    constructor(context: Context) : super(context)
 
     fun refreshEntries() {
         val entryTitles: MutableList<CharSequence> = ArrayList()

--- a/AnkiDroid/src/main/java/com/ichi2/preferences/HtmlHelpPreference.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/preferences/HtmlHelpPreference.kt
@@ -50,7 +50,7 @@ class HtmlHelpPreference(context: Context, attrs: AttributeSet?) : Preference(co
         arrayOf(
             getString(R.styleable.HtmlHelpPreference_substitution1),
             getString(R.styleable.HtmlHelpPreference_substitution2),
-            getString(R.styleable.HtmlHelpPreference_substitution3),
+            getString(R.styleable.HtmlHelpPreference_substitution3)
         )
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/preferences/NumberRangePreference.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/preferences/NumberRangePreference.kt
@@ -157,6 +157,7 @@ open class NumberRangePreference : android.preference.EditTextPreference, AutoFo
          * @return the persisted value.
          */
         get() = getPersistedInt(mMin)
+
         /**
          * Set this preference's value. The value is validated and persisted as an Integer.
          *

--- a/AnkiDroid/src/main/java/com/ichi2/preferences/SeekBarPreferenceCompat.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/preferences/SeekBarPreferenceCompat.kt
@@ -258,7 +258,8 @@ constructor(
         fun getLayoutParams(weight: Float): LinearLayout.LayoutParams {
             return LinearLayout.LayoutParams(
                 LinearLayout.LayoutParams.WRAP_CONTENT,
-                LinearLayout.LayoutParams.WRAP_CONTENT, weight
+                LinearLayout.LayoutParams.WRAP_CONTENT,
+                weight
             )
         }
     }

--- a/AnkiDroid/src/main/java/com/ichi2/preferences/StepsPreference.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/preferences/StepsPreference.kt
@@ -72,7 +72,8 @@ class StepsPreference : android.preference.EditTextPreference, AutoFocusable {
                 showThemedToast(context, context.resources.getString(R.string.steps_error), false)
             } else if (validated.isEmpty() && !mAllowEmpty) {
                 showThemedToast(
-                    context, context.resources.getString(R.string.steps_min_error),
+                    context,
+                    context.resources.getString(R.string.steps_min_error),
                     false
                 )
             } else {

--- a/AnkiDroid/src/main/java/com/ichi2/preferences/VersatileTextPreference.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/preferences/VersatileTextPreference.kt
@@ -41,7 +41,8 @@ open class VersatileTextPreference(context: Context, attrs: AttributeSet?) :
     EditTextPreference(context, attrs), DialogFragmentProvider {
 
     fun interface Validator {
-        @Throws(Exception::class) fun validate(value: String)
+        @Throws(Exception::class)
+        fun validate(value: String)
     }
 
     val referenceEditText = AppCompatEditText(context, attrs)

--- a/AnkiDroid/src/main/java/com/ichi2/themes/HtmlColors.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/themes/HtmlColors.kt
@@ -26,7 +26,8 @@ import java.util.regex.Pattern
 @KotlinCleanup("for better possibly-null handling")
 object HtmlColors {
     private val fHtmlColorPattern = Pattern.compile(
-        "((?:color|background)\\s*[=:]\\s*\"?)((?:[a-z]+|#[0-9a-f]+|rgb\\([0-9]+,\\s*[0-9],+\\s*[0-9]+\\)))([\";\\s])", Pattern.CASE_INSENSITIVE
+        "((?:color|background)\\s*[=:]\\s*\"?)((?:[a-z]+|#[0-9a-f]+|rgb\\([0-9]+,\\s*[0-9],+\\s*[0-9]+\\)))([\";\\s])",
+        Pattern.CASE_INSENSITIVE
     )
     private val fShortHexColorPattern = Pattern.compile("^#([0-9a-f])([0-9a-f])([0-9a-f])$", Pattern.CASE_INSENSITIVE)
     private val fLongHexColorPattern = Pattern.compile("^#([0-9a-f]{2})([0-9a-f]{2})([0-9a-f]{2})$", Pattern.CASE_INSENSITIVE)
@@ -46,7 +47,9 @@ object HtmlColors {
         val normalisedName = name.lowercase(Locale.US)
         return if (sColorsMap!!.containsKey(normalisedName)) {
             sColorsMap!![normalisedName]
-        } else name
+        } else {
+            name
+        }
     }
 
     /**
@@ -67,7 +70,8 @@ object HtmlColors {
                     m2 = fShortHexColorPattern.matcher(color)
                     if (m2.find()) {
                         color = String.format(
-                            Locale.US, "#%x%x%x",
+                            Locale.US,
+                            "#%x%x%x",
                             0xf - m2.group(1)!!.toInt(16),
                             0xf - m2.group(2)!!.toInt(16),
                             0xf - m2.group(3)!!.toInt(16)
@@ -77,7 +81,8 @@ object HtmlColors {
                     m2 = fLongHexColorPattern.matcher(color)
                     if (m2.find()) {
                         color = String.format(
-                            Locale.US, "#%02x%02x%02x",
+                            Locale.US,
+                            "#%02x%02x%02x",
                             0xff - m2.group(1)!!.toInt(16),
                             0xff - m2.group(2)!!.toInt(16),
                             0xff - m2.group(3)!!.toInt(16)
@@ -87,7 +92,8 @@ object HtmlColors {
                     m2 = fRgbColorPattern.matcher(color)
                     if (m2.find()) {
                         color = String.format(
-                            Locale.US, "rgb(%d, %d, %d)",
+                            Locale.US,
+                            "rgb(%d, %d, %d)",
                             0xff - m2.group(1)!!.toInt(),
                             0xff - m2.group(2)!!.toInt(),
                             0xff - m2.group(3)!!.toInt()

--- a/AnkiDroid/src/main/java/com/ichi2/ui/AnimationUtil.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/ui/AnimationUtil.kt
@@ -35,8 +35,10 @@ object AnimationUtil {
         }
         val set = AnimationSet(true)
         val expandAnimation = ScaleAnimation(
-            1f, 1f,
-            1f, 0.5f
+            1f,
+            1f,
+            1f,
+            0.5f
         )
         expandAnimation.duration = DURATION_MILLIS.toLong()
         expandAnimation.setAnimationListener(object : Animation.AnimationListener {
@@ -67,8 +69,10 @@ object AnimationUtil {
         // Sadly this seems necessary - yScale didn't work.
         val set = AnimationSet(true)
         val resetEditTextScale = ScaleAnimation(
-            1f, 1f,
-            1f, 1f
+            1f,
+            1f,
+            1f,
+            1f
         )
         resetEditTextScale.duration = DURATION_MILLIS.toLong()
         val alphaAnimation = AlphaAnimation(0.0f, 1.0f)

--- a/AnkiDroid/src/main/java/com/ichi2/ui/AppCompatPreferenceActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/ui/AppCompatPreferenceActivity.kt
@@ -152,7 +152,9 @@ abstract class AppCompatPreferenceActivity<PreferenceHack : AppCompatPreferenceA
             Timber.d("getString(key=%s, defValue=%s)", key, defValue)
             return if (!mValues.containsKey(key)) {
                 defValue
-            } else mValues[key]
+            } else {
+                mValues[key]
+            }
         }
 
         override fun registerOnSharedPreferenceChangeListener(listener: SharedPreferences.OnSharedPreferenceChangeListener) {

--- a/AnkiDroid/src/main/java/com/ichi2/ui/AutoSizeCheckBoxPreference.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/ui/AutoSizeCheckBoxPreference.kt
@@ -27,10 +27,17 @@ import com.ichi2.utils.ViewGroupUtils.getAllChildren
 
 @Suppress("deprecation") // TODO Tracked in https://github.com/ankidroid/Anki-Android/issues/5019
 class AutoSizeCheckBoxPreference : android.preference.CheckBoxPreference {
-    @Suppress("unused") constructor(context: Context?) : super(context) {}
-    @Suppress("unused") constructor(context: Context?, attrs: AttributeSet?) : super(context, attrs) {}
-    @Suppress("unused") constructor(context: Context?, attrs: AttributeSet?, defStyleAttr: Int) : super(context, attrs, defStyleAttr) {}
-    @Suppress("unused") constructor(context: Context?, attrs: AttributeSet?, defStyleAttr: Int, defStyleRes: Int) : super(context, attrs, defStyleAttr, defStyleRes) {}
+    @Suppress("unused")
+    constructor(context: Context?) : super(context) {}
+
+    @Suppress("unused")
+    constructor(context: Context?, attrs: AttributeSet?) : super(context, attrs) {}
+
+    @Suppress("unused")
+    constructor(context: Context?, attrs: AttributeSet?, defStyleAttr: Int) : super(context, attrs, defStyleAttr) {}
+
+    @Suppress("unused")
+    constructor(context: Context?, attrs: AttributeSet?, defStyleAttr: Int, defStyleRes: Int) : super(context, attrs, defStyleAttr, defStyleRes) {}
 
     @Deprecated("Deprecated in Java")
     override fun onBindView(view: View) {

--- a/AnkiDroid/src/main/java/com/ichi2/ui/CheckBoxTriStates.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/ui/CheckBoxTriStates.kt
@@ -43,7 +43,6 @@ class CheckBoxTriStates : AppCompatCheckBox {
     }
 
     override fun setOnCheckedChangeListener(listener: OnCheckedChangeListener?) {
-
         // we never truly set the listener to the client implementation, instead we only hold
         // a reference to it and invoke it when needed.
         if (mPrivateListener !== listener) {
@@ -145,7 +144,10 @@ class CheckBoxTriStates : AppCompatCheckBox {
         cycleIndeterminateToChecked = false
         if (attrs != null) {
             val a = context.theme.obtainStyledAttributes(
-                attrs, R.styleable.CheckBoxTriStates, 0, 0
+                attrs,
+                R.styleable.CheckBoxTriStates,
+                0,
+                0
             )
             cycleCheckedToIndeterminate = a.getBoolean(
                 R.styleable.CheckBoxTriStates_cycle_checked_to_indeterminate,

--- a/AnkiDroid/src/main/java/com/ichi2/ui/SeekBarPreference.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/ui/SeekBarPreference.kt
@@ -150,7 +150,8 @@ class SeekBarPreference(context: Context, attrs: AttributeSet) : android.prefere
     fun getLayoutParams(weight: Float): LinearLayout.LayoutParams {
         return LinearLayout.LayoutParams(
             LinearLayout.LayoutParams.WRAP_CONTENT,
-            LinearLayout.LayoutParams.WRAP_CONTENT, weight
+            LinearLayout.LayoutParams.WRAP_CONTENT,
+            weight
         )
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/ui/TvNavigationElement.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/ui/TvNavigationElement.kt
@@ -32,6 +32,7 @@ class TvNavigationElement : View {
     constructor(context: Context?) : super(context)
     constructor(context: Context?, attrs: AttributeSet?) : super(context, attrs)
     constructor(context: Context?, attrs: AttributeSet?, defStyleAttr: Int) : super(context, attrs, defStyleAttr)
+
     @Suppress("unused")
     constructor(context: Context?, attrs: AttributeSet?, defStyleAttr: Int, defStyleRes: Int) : super(context, attrs, defStyleAttr, defStyleRes)
 

--- a/AnkiDroid/src/main/java/com/ichi2/utils/BundleUtils.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/BundleUtils.kt
@@ -32,7 +32,9 @@ object BundleUtils {
     fun getNullableLong(bundle: Bundle?, key: String): Long? {
         return if (bundle == null || !bundle.containsKey(key)) {
             null
-        } else bundle.getLong(key)
+        } else {
+            bundle.getLong(key)
+        }
     }
 
     /**

--- a/AnkiDroid/src/main/java/com/ichi2/utils/ContentResolverUtil.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/ContentResolverUtil.kt
@@ -67,7 +67,9 @@ object ContentResolverUtil {
         }
         return if (extension == null) {
             null
-        } else "image.$extension"
+        } else {
+            "image.$extension"
+        }
     }
 
     @CheckResult

--- a/AnkiDroid/src/main/java/com/ichi2/utils/DiffEngine.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/DiffEngine.kt
@@ -71,8 +71,9 @@ open class DiffEngine {
 
         /** Prevents combining marks not getting highlighted properly if a span starts with them, by adding a "&nbsp;" before them (#10665) */
         fun escapeLoneMarks(s: String): String {
-            if (s[0].category.code.startsWith("M"))
+            if (s[0].category.code.startsWith("M")) {
                 return "\\xa0$s"
+            }
             return s
         }
 

--- a/AnkiDroid/src/main/java/com/ichi2/utils/ExceptionUtil.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/ExceptionUtil.kt
@@ -79,7 +79,9 @@ object ExceptionUtil {
         } catch (e: Exception) {
             CrashReportService.sendExceptionReport(e, origin)
             UIUtils.showThemedToast(
-                context, context.getString(R.string.multimedia_editor_something_wrong), true
+                context,
+                context.getString(R.string.multimedia_editor_something_wrong),
+                true
             )
         }
     }

--- a/AnkiDroid/src/main/java/com/ichi2/utils/FileUtil.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/FileUtil.kt
@@ -37,6 +37,7 @@ object FileUtil {
             defaultValue
         }
     }
+
     /** Returns the current download Directory */
     fun getDownloadDirectory(): String {
         return Environment.DIRECTORY_DOWNLOADS
@@ -78,7 +79,9 @@ object FileUtil {
         val index = fileName.lastIndexOf(".")
         return if (index < 1) {
             null
-        } else AbstractMap.SimpleEntry(fileName.substring(0, index), fileName.substring(index))
+        } else {
+            AbstractMap.SimpleEntry(fileName.substring(0, index), fileName.substring(index))
+        }
     }
 
     /**

--- a/AnkiDroid/src/main/java/com/ichi2/utils/ImportUtils.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/ImportUtils.kt
@@ -219,7 +219,6 @@ object ImportUtils {
         }
 
         private fun validateImportTypes(context: Context, dataList: ArrayList<Uri>): String? {
-
             var apkgCount = 0
             var colpkgCount = 0
 
@@ -368,7 +367,6 @@ object ImportUtils {
              * @param pathList list of path(s) to apkg file which will be imported
              */
             private fun sendShowImportFileDialogMsg(pathList: ArrayList<String>) {
-
                 // Get the filename from the path
                 val f = File(pathList.first())
                 val filename = f.name

--- a/AnkiDroid/src/main/java/com/ichi2/utils/KotlinCleanup.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/KotlinCleanup.kt
@@ -36,9 +36,13 @@ annotation class KotlinCleanup(val value: String)
  * by default.
  */
 @Target(
-    AnnotationTarget.CLASS, AnnotationTarget.FUNCTION,
-    AnnotationTarget.VALUE_PARAMETER, AnnotationTarget.EXPRESSION,
-    AnnotationTarget.FIELD, AnnotationTarget.PROPERTY, AnnotationTarget.LOCAL_VARIABLE
+    AnnotationTarget.CLASS,
+    AnnotationTarget.FUNCTION,
+    AnnotationTarget.VALUE_PARAMETER,
+    AnnotationTarget.EXPRESSION,
+    AnnotationTarget.FIELD,
+    AnnotationTarget.PROPERTY,
+    AnnotationTarget.LOCAL_VARIABLE
 )
 @Retention(AnnotationRetention.SOURCE)
 @Repeatable

--- a/AnkiDroid/src/main/java/com/ichi2/utils/LanguageUtil.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/LanguageUtil.kt
@@ -125,7 +125,7 @@ object LanguageUtil {
         "yue", // Cantonese / 粵語
         "zh-CN", // Chinese (China) / 中文 (中国)
         "zh-TW", // Chinese (Taiwan) / 中文 (台灣)
-        "zu", // Zulu / isiZulu
+        "zu" // Zulu / isiZulu
     )
 
     /** Backend languages; may not include recently added ones.
@@ -184,7 +184,7 @@ object LanguageUtil {
         "uk", // Yкраїнська мова
         "vi", // Tiếng Việt
         "zh-CN", // 简体中文
-        "zh-TW", // 繁體中文
+        "zh-TW" // 繁體中文
     )
 
     /**
@@ -271,6 +271,7 @@ object LanguageUtil {
      * @return the language defined by the preferences, or the empty string.
      */
     fun SharedPreferences.getLanguage() = getString(Preferences.LANGUAGE, "")
+
     /**
      * @return the language defined by the preferences, or otherwise the default locale
      */

--- a/AnkiDroid/src/main/java/com/ichi2/utils/NoteFieldDecorator.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/NoteFieldDecorator.kt
@@ -59,7 +59,7 @@ object NoteFieldDecorator {
         "unacvatpuvarfr",
         "jro5atnl",
         "FuevquneTbry",
-        "Nxfunl0701",
+        "Nxfunl0701"
     )
 
     fun aplicaHuevo(fieldText: String?): String? {
@@ -84,10 +84,13 @@ object NoteFieldDecorator {
         val revuelto = StringBuilder()
         for (i in 0 until huevo.length) {
             var c = huevo[i]
-            if (c >= 'a' && c <= 'm') c += 13.toChar().code
-            else if (c >= 'A' && c <= 'M') c += 13.toChar().code
-            else if (c >= 'n' && c <= 'z') c -= 13.toChar().code
-            else if (c >= 'N' && c <= 'Z') c -= 13.toChar().code
+            if (c >= 'a' && c <= 'm') {
+                c += 13.toChar().code
+            } else if (c >= 'A' && c <= 'M') {
+                c += 13.toChar().code
+            } else if (c >= 'n' && c <= 'z') {
+                c -= 13.toChar().code
+            } else if (c >= 'N' && c <= 'Z') c -= 13.toChar().code
             revuelto.append(c)
         }
         return revuelto.toString()

--- a/AnkiDroid/src/main/java/com/ichi2/utils/SyncStatus.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/SyncStatus.kt
@@ -27,6 +27,7 @@ import net.ankiweb.rsdroid.BackendFactory
 
 enum class SyncStatus {
     INCONCLUSIVE, NO_ACCOUNT, NO_CHANGES, HAS_CHANGES, FULL_SYNC, BADGE_DISABLED,
+
     /**
      * Scope storage migration is ongoing. Sync should be disabled.
      */

--- a/AnkiDroid/src/main/java/com/ichi2/utils/TypedFilter.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/TypedFilter.kt
@@ -29,7 +29,6 @@ abstract class TypedFilter<T>(private val getCurrentItems: (() -> List<T>)) : Fi
     }
 
     override fun performFiltering(constraint: CharSequence?): FilterResults {
-
         val itemsBeforeFiltering = getCurrentItems()
 
         if (constraint.isNullOrBlank()) {
@@ -60,6 +59,7 @@ abstract class TypedFilter<T>(private val getCurrentItems: (() -> List<T>)) : Fi
      * @see Filter.performFiltering
      */
     abstract fun filterResults(constraint: CharSequence, items: List<T>): List<T>
+
     /** @see android.widget.Filter.publishResults */
     abstract fun publishResults(constraint: CharSequence?, results: List<T>)
 }

--- a/AnkiDroid/src/main/java/com/ichi2/utils/WebViewDebugging.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/WebViewDebugging.kt
@@ -24,6 +24,7 @@ import androidx.annotation.UiThread
 
 object WebViewDebugging {
     private var sHasSetDataDirectory = false
+
     @UiThread
     fun initializeDebugging(sharedPrefs: SharedPreferences) {
         // DEFECT: We might be able to cache this value: check what happens on WebView Renderer crash

--- a/AnkiDroid/src/main/java/com/ichi2/widget/AnkiDroidWidgetSmall.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/widget/AnkiDroidWidgetSmall.kt
@@ -152,7 +152,9 @@ class AnkiDroidWidgetSmall : AppWidgetProvider() {
             ankiDroidIntent.action = Intent.ACTION_MAIN
             ankiDroidIntent.addCategory(Intent.CATEGORY_LAUNCHER)
             val pendingAnkiDroidIntent = CompatHelper.compat.getImmutableActivityIntent(
-                context, 0, ankiDroidIntent,
+                context,
+                0,
+                ankiDroidIntent,
                 PendingIntent.FLAG_UPDATE_CURRENT
             )
             updateViews.setOnClickPendingIntent(R.id.ankidroid_widget_small_button, pendingAnkiDroidIntent)

--- a/AnkiDroid/src/main/java/com/wildplot/android/parsing/Atom.kt
+++ b/AnkiDroid/src/main/java/com/wildplot/android/parsing/Atom.kt
@@ -53,9 +53,12 @@ class Atom(private val parser: TopLevelParser) : TreeElement {
                 expression = expressionInBrackets
                 atomType = EXP_IN_BRACKETS
                 true
-            } else false
-        } else
+            } else {
+                false
+            }
+        } else {
             false
+        }
     }
 
     private fun initAsFunctionMath(atomString: String): Boolean {
@@ -64,7 +67,9 @@ class Atom(private val parser: TopLevelParser) : TreeElement {
             atomType = FUNCTION_MATH
             atomObject = mathFunctionAtom
             true
-        } else false
+        } else {
+            false
+        }
     }
 
     private fun initAsFunctionX(atomString: String): Boolean {
@@ -73,7 +78,9 @@ class Atom(private val parser: TopLevelParser) : TreeElement {
             atomType = FUNCTION_X
             atomObject = functionXAtom
             true
-        } else false
+        } else {
+            false
+        }
     }
 
     private fun initAsFunctionXY(atomString: String): Boolean {
@@ -82,7 +89,9 @@ class Atom(private val parser: TopLevelParser) : TreeElement {
             atomType = FUNCTION_X_Y
             atomObject = functionXYAtom
             true
-        } else false
+        } else {
+            false
+        }
     }
 
     private fun initAsNumber(atomString: String): Boolean {
@@ -91,7 +100,9 @@ class Atom(private val parser: TopLevelParser) : TreeElement {
             atomType = numberAtom.getAtomType()
             atomObject = numberAtom
             true
-        } else false
+        } else {
+            false
+        }
     }
 
     private fun initAsXVariable(atomString: String): Boolean {
@@ -99,7 +110,9 @@ class Atom(private val parser: TopLevelParser) : TreeElement {
             atomType = VARIABLE
             atomObject = XVariableAtom(parser)
             true
-        } else false
+        } else {
+            false
+        }
     }
 
     private fun initAsYVariable(atomString: String): Boolean {
@@ -107,7 +120,9 @@ class Atom(private val parser: TopLevelParser) : TreeElement {
             atomType = VARIABLE
             atomObject = YVariableAtom(parser)
             true
-        } else false
+        } else {
+            false
+        }
     }
 
     private fun initAsVariable(atomString: String): Boolean {
@@ -116,7 +131,9 @@ class Atom(private val parser: TopLevelParser) : TreeElement {
             atomType = variableAtom.atomType
             atomObject = variableAtom
             true
-        } else false
+        } else {
+            false
+        }
     }
 
     @get:Throws(ExpressionFormatException::class)

--- a/AnkiDroid/src/main/java/com/wildplot/android/parsing/AtomTypes/MathFunctionAtom.kt
+++ b/AnkiDroid/src/main/java/com/wildplot/android/parsing/AtomTypes/MathFunctionAtom.kt
@@ -14,6 +14,7 @@
  * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
  ****************************************************************************************/
 @file:Suppress("PackageName") // AtomTypes: copied from wildplot library
+
 package com.wildplot.android.parsing.AtomTypes
 
 import com.wildplot.android.parsing.Expression
@@ -71,19 +72,21 @@ class MathFunctionAtom(funcString: String, private val parser: TopLevelParser) :
     override val value: Double
         get() = if (hasSavedValue) {
             savedValue
-        } else when (mathType) {
-            MathType.SIN -> sin(expression!!.value)
-            MathType.COS -> cos(expression!!.value)
-            MathType.TAN -> tan(expression!!.value)
-            MathType.SQRT -> sqrt(expression!!.value)
-            MathType.ACOS -> acos(expression!!.value)
-            MathType.ASIN -> asin(expression!!.value)
-            MathType.ATAN -> atan(expression!!.value)
-            MathType.SINH -> sinh(expression!!.value)
-            MathType.COSH -> cosh(expression!!.value)
-            MathType.LOG -> log10(expression!!.value)
-            MathType.LN -> ln(expression!!.value)
-            MathType.INVALID -> throw ExpressionFormatException("Number is Invalid, cannot parse")
+        } else {
+            when (mathType) {
+                MathType.SIN -> sin(expression!!.value)
+                MathType.COS -> cos(expression!!.value)
+                MathType.TAN -> tan(expression!!.value)
+                MathType.SQRT -> sqrt(expression!!.value)
+                MathType.ACOS -> acos(expression!!.value)
+                MathType.ASIN -> asin(expression!!.value)
+                MathType.ATAN -> atan(expression!!.value)
+                MathType.SINH -> sinh(expression!!.value)
+                MathType.COSH -> cosh(expression!!.value)
+                MathType.LOG -> log10(expression!!.value)
+                MathType.LN -> ln(expression!!.value)
+                MathType.INVALID -> throw ExpressionFormatException("Number is Invalid, cannot parse")
+            }
         }
 
     @get:Throws(ExpressionFormatException::class)

--- a/AnkiDroid/src/main/java/com/wildplot/android/rendering/PieChart.kt
+++ b/AnkiDroid/src/main/java/com/wildplot/android/rendering/PieChart.kt
@@ -79,7 +79,11 @@ class PieChart(plotSheet: PlotSheet, values: DoubleArray, colors: Array<ColorWra
         // last one does need some corrections to fill a full circle:
         g.color = lastSectorColor
         g.fillArc(
-            left, top, diameter, diameter, currentAngle,
+            left,
+            top,
+            diameter,
+            diameter,
+            currentAngle,
             360f + FIRST_SECTOR_OFFSET - currentAngle
         )
         g.color = ColorWrap.black

--- a/AnkiDroid/src/main/java/com/wildplot/android/rendering/PlotSheet.kt
+++ b/AnkiDroid/src/main/java/com/wildplot/android/rendering/PlotSheet.kt
@@ -209,7 +209,8 @@ class PlotSheet : Drawable {
 
             // right frame
             g.fillRect(
-                field.width + 1 - rightFrameThickness, upperFrameThickness,
+                field.width + 1 - rightFrameThickness,
+                upperFrameThickness,
                 rightFrameThickness +
                     leftFrameThickness,
                 field.height - bottomFrameThickness
@@ -217,8 +218,10 @@ class PlotSheet : Drawable {
 
             // bottom frame
             g.fillRect(
-                leftFrameThickness, field.height - bottomFrameThickness,
-                field.width - rightFrameThickness, bottomFrameThickness + 1
+                leftFrameThickness,
+                field.height - bottomFrameThickness,
+                field.width - rightFrameThickness,
+                bottomFrameThickness + 1
             )
 
             // make small black border frame

--- a/AnkiDroid/src/main/java/com/wildplot/android/rendering/XAxis.kt
+++ b/AnkiDroid/src/main/java/com/wildplot/android/rendering/XAxis.kt
@@ -122,7 +122,8 @@ class XAxis
         }
         pixelDistance = Math.abs(
             plotSheet.xToGraphic(0.0, field) - plotSheet.xToGraphic(
-                tic, field
+                tic,
+                field
             )
         )
         if (tic < 1e-2 || tic > 1e2) {
@@ -156,7 +157,8 @@ class XAxis
         val arrowheadPos = floatArrayOf(
             plotSheet.xToGraphic(
                 Math.min(
-                    plotSheet.getxRange()[1], end
+                    plotSheet.getxRange()[1],
+                    end
                 ),
                 field
             ),
@@ -186,7 +188,8 @@ class XAxis
                 floatArrayOf(plotSheet.xToGraphic(0.0, field), plotSheet.yToGraphic(yOffset, field))
             if (mHasName) {
                 g.drawString(
-                    name, field.width / 2 - width / 2,
+                    name,
+                    field.width / 2 - width / 2,
                     Math.round(
                         middlePosition[1] + fontHeight * 2.5f
                     ).toFloat()

--- a/AnkiDroid/src/main/java/com/wildplot/android/rendering/XGrid.kt
+++ b/AnkiDroid/src/main/java/com/wildplot/android/rendering/XGrid.kt
@@ -93,12 +93,16 @@ class XGrid
      */
     private fun drawGridLine(y: Double, g: GraphicsWrap, field: RectangleWrap) {
         g.drawLine(
-            plotSheet.xToGraphic(0.0, field), plotSheet.yToGraphic(y, field),
-            plotSheet.xToGraphic(-xLength, field), plotSheet.yToGraphic(y, field)
+            plotSheet.xToGraphic(0.0, field),
+            plotSheet.yToGraphic(y, field),
+            plotSheet.xToGraphic(-xLength, field),
+            plotSheet.yToGraphic(y, field)
         )
         g.drawLine(
-            plotSheet.xToGraphic(0.0, field), plotSheet.yToGraphic(y, field),
-            plotSheet.xToGraphic(xLength, field), plotSheet.yToGraphic(y, field)
+            plotSheet.xToGraphic(0.0, field),
+            plotSheet.yToGraphic(y, field),
+            plotSheet.xToGraphic(xLength, field),
+            plotSheet.yToGraphic(y, field)
         )
     }
 

--- a/AnkiDroid/src/main/java/com/wildplot/android/rendering/YAxis.kt
+++ b/AnkiDroid/src/main/java/com/wildplot/android/rendering/YAxis.kt
@@ -138,7 +138,8 @@ class YAxis
                     end,
                     field
                 ) + cleanSpace && plotSheet.yToGraphic(currentY, field) <= plotSheet.yToGraphic(
-                        start, field
+                        start,
+                        field
                     ) - cleanSpace && plotSheet.yToGraphic(
                         currentY,
                         field
@@ -175,7 +176,8 @@ class YAxis
             plotSheet.xToGraphic(xOffset, field),
             plotSheet.yToGraphic(
                 Math.min(
-                    plotSheet.getyRange()[1], end
+                    plotSheet.getyRange()[1],
+                    end
                 ),
                 field
             )
@@ -259,7 +261,8 @@ class YAxis
             g.drawString(font, middlePosition[0] - width * 0.1f, middlePosition[1] + width / 2.0f)
         } else {
             g.drawString(
-                font, Math.round(coordStart[0] - width * 1.1f).toFloat(),
+                font,
+                Math.round(coordStart[0] - width * 1.1f).toFloat(),
                 Math.round(
                     coordStart[1] + fontHeight * 0.4f
                 ).toFloat()
@@ -303,7 +306,8 @@ class YAxis
             g.drawString(font, middlePosition[0] + width * 0.1f, middlePosition[1] - width / 2.0f)
         } else {
             g.drawString(
-                font, Math.round(coordStart[0] + width * 0.1f).toFloat(),
+                font,
+                Math.round(coordStart[0] + width * 0.1f).toFloat(),
                 Math.round(
                     coordStart[1] + fontHeight * 0.4f
                 ).toFloat()
@@ -393,7 +397,8 @@ class YAxis
                     end,
                     field
                 ) + cleanSpace && plotSheet.yToGraphic(currentY, field) <= plotSheet.yToGraphic(
-                        start, field
+                        start,
+                        field
                     ) - cleanSpace && plotSheet.yToGraphic(
                         currentY,
                         field

--- a/AnkiDroid/src/main/java/com/wildplot/android/rendering/YGrid.kt
+++ b/AnkiDroid/src/main/java/com/wildplot/android/rendering/YGrid.kt
@@ -109,12 +109,16 @@ class YGrid
      */
     private fun drawGridLine(x: Double, g: GraphicsWrap, field: RectangleWrap) {
         g.drawLine(
-            plotSheet.xToGraphic(x, field), plotSheet.yToGraphic(0.0, field),
-            plotSheet.xToGraphic(x, field), plotSheet.yToGraphic(yLength, field)
+            plotSheet.xToGraphic(x, field),
+            plotSheet.yToGraphic(0.0, field),
+            plotSheet.xToGraphic(x, field),
+            plotSheet.yToGraphic(yLength, field)
         )
         g.drawLine(
-            plotSheet.xToGraphic(x, field), plotSheet.yToGraphic(0.0, field),
-            plotSheet.xToGraphic(x, field), plotSheet.yToGraphic(-yLength, field)
+            plotSheet.xToGraphic(x, field),
+            plotSheet.yToGraphic(0.0, field),
+            plotSheet.xToGraphic(x, field),
+            plotSheet.yToGraphic(-yLength, field)
         )
     }
 

--- a/AnkiDroid/src/test/java/com/ichi2/anim/ActivityTransitionAnimationTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anim/ActivityTransitionAnimationTest.kt
@@ -50,7 +50,7 @@ class ActivityTransitionAnimationTest {
             return Stream.of(
                 Arguments.of(Direction.START, Direction.END),
                 Arguments.of(Direction.UP, Direction.DOWN),
-                Arguments.of(Direction.RIGHT, Direction.LEFT),
+                Arguments.of(Direction.RIGHT, Direction.LEFT)
             )
         }
     }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/ActivityStartupUnderBackupTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/ActivityStartupUnderBackupTest.kt
@@ -47,6 +47,7 @@ class ActivityStartupUnderBackupTest : RobolectricTest() {
     @ParameterizedRobolectricTestRunner.Parameter(1)
     @JvmField // required for Parameter
     var mActivityName: String? = null
+
     @Before
     fun before() {
         notYetHandled(CropImageActivity::class.java.simpleName, "cannot implemented - activity from canhub.cropper")

--- a/AnkiDroid/src/test/java/com/ichi2/anki/AnalyticsTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/AnalyticsTest.kt
@@ -44,6 +44,7 @@ class AnalyticsTest {
 
     @Mock
     private lateinit var mMockSharedPreferencesEditor: SharedPreferences.Editor
+
     @Before
     fun setUp() {
         UsageAnalytics.resetForTests()

--- a/AnkiDroid/src/test/java/com/ichi2/anki/AnkiActivityTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/AnkiActivityTest.kt
@@ -32,7 +32,8 @@ class AnkiActivityTest : RobolectricTest() {
     fun themeChangeIsValid() {
         // #12404 - fail to respond to day/night mode change
         val activity = startActivityNormallyOpenCollectionWithIntent(
-            AnkiActivity::class.java, Intent()
+            AnkiActivity::class.java,
+            Intent()
         )
         assertThat(Themes.currentTheme, equalTo(Theme.LIGHT))
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.kt
@@ -657,8 +657,10 @@ class CardBrowserTest : RobolectricTest() {
             Timber.w("Can't use childAt on position $position for a single click as it is not visible")
         }
         listener.onItemLongClick(
-            null, childAt,
-            position, toSelect.getItemIdAtPosition(position)
+            null,
+            childAt,
+            position,
+            toSelect.getItemIdAtPosition(position)
         )
         advanceRobolectricUiLooper()
     }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/CardInfoModelTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/CardInfoModelTest.kt
@@ -25,6 +25,7 @@ import org.junit.runner.RunWith
 @RunWith(AndroidJUnit4::class)
 class CardInfoModelTest : RobolectricTest() {
     private var mModel: CardInfo.CardInfoModel? = null
+
     @Before
     fun setupModel() {
         // using a card from my collection

--- a/AnkiDroid/src/test/java/com/ichi2/anki/CardTemplateEditorTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/CardTemplateEditorTest.kt
@@ -169,7 +169,6 @@ class CardTemplateEditorTest : RobolectricTest() {
     @Test
     @Throws(Exception::class)
     fun testTemplateAdd() {
-
         // Make sure we test previewing a new card template - not working for real yet
         val modelName = "Basic"
         val collectionBasicModelOriginal = getCurrentDatabaseModelCopy(modelName)

--- a/AnkiDroid/src/test/java/com/ichi2/anki/CardTemplatePreviewerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/CardTemplatePreviewerTest.kt
@@ -38,7 +38,6 @@ class CardTemplatePreviewerTest : RobolectricTest() {
 
     @Test
     fun testPreviewUnsavedTemplate() {
-
         val modelName = "Basic"
         val collectionBasicModelOriginal = getCurrentDatabaseModelCopy(modelName)
         val template = collectionBasicModelOriginal.getJSONArray("tmpls").getJSONObject(0)
@@ -142,7 +141,6 @@ class CardTemplatePreviewerTest : RobolectricTest() {
 
     @Test
     fun testPreviewNormal() {
-
         // Make sure we test previewing a new card template
         val modelName = "Basic (and reversed card)"
         val collectionBasicModelOriginal = getCurrentDatabaseModelCopy(modelName)

--- a/AnkiDroid/src/test/java/com/ichi2/anki/DeckAdapterFilterTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/DeckAdapterFilterTest.kt
@@ -71,7 +71,7 @@ class DeckAdapterFilterTest {
                 TreeNode(DeckTreeNode("Chanson::Important", 6)),
                 TreeNode(DeckTreeNode("Chanson::Important::Stuff", 7)),
                 TreeNode(DeckTreeNode("Chanson::Important::Math", 8)),
-                TreeNode(DeckTreeNode("Chanson::Important::Stuff::Other Stuff", 9)),
+                TreeNode(DeckTreeNode("Chanson::Important::Stuff::Other Stuff", 9))
             )
 
             deckList.getByDid(0).children.addAll(deckList.getByDids(1, 4, 6))

--- a/AnkiDroid/src/test/java/com/ichi2/anki/DeckPickerFloatingActionMenuTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/DeckPickerFloatingActionMenuTest.kt
@@ -46,20 +46,33 @@ import kotlin.test.assertTrue
 class DeckPickerFloatingActionMenuTest {
 
     @Mock private val deckPicker: DeckPicker = mock()
+
     @Mock private lateinit var mFabMain: FloatingActionButton
+
     @Mock private val mAddSharedLayout: LinearLayout = mock(defaultAnswer = Answers.RETURNS_MOCKS)
+
     @Mock private val mAddDeckLayout: LinearLayout = mock(defaultAnswer = Answers.RETURNS_MOCKS)
+
     @Mock private val mAddNoteLayout: LinearLayout = mock(defaultAnswer = Answers.RETURNS_MOCKS)
+
     @Mock private val mFabBGLayout: View = mock()
+
     @Mock private val mLinearLayout: LinearLayout = mock()
+
     @Mock private val mStudyOptionsFrame: View = mock()
+
     @Mock private lateinit var view: View
 
     @Mock private val addNoteButton: FloatingActionButton = mock()
+
     @Mock private val addSharedButton: FloatingActionButton = mock()
+
     @Mock private val addDeckButton: FloatingActionButton = mock()
+
     @Mock private val addNoteLabel: TextView = mock()
+
     @Mock private val addSharedLabel: TextView = mock()
+
     @Mock private val addDeckLabel: TextView = mock()
 
     @InjectMocks

--- a/AnkiDroid/src/test/java/com/ichi2/anki/DeckPickerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/DeckPickerTest.kt
@@ -198,7 +198,8 @@ class DeckPickerTest : RobolectricTest() {
         sched.card
         ensureCollectionLoadIsSynchronous()
         val deckPicker = super.startActivityNormallyOpenCollectionWithIntent(
-            DeckPicker::class.java, Intent()
+            DeckPicker::class.java,
+            Intent()
         )
         assertEquals(10, deckPicker.dueTree!![0].value.newCount.toLong())
     }
@@ -208,7 +209,8 @@ class DeckPickerTest : RobolectricTest() {
         val did = addDeck("Hello World")
         assertThat("Deck was added", col.decks.count(), equalTo(2))
         val deckPicker = startActivityNormallyOpenCollectionWithIntent(
-            DeckPicker::class.java, Intent()
+            DeckPicker::class.java,
+            Intent()
         )
         deckPicker.confirmDeckDeletion(did)
         advanceRobolectricLooperWithSleep()
@@ -225,12 +227,14 @@ class DeckPickerTest : RobolectricTest() {
         // And they are more likely to be empty temporarily
         val did = addDynamicDeck("filtered")
         val deckPicker = startActivityNormallyOpenCollectionWithIntent(
-            DeckPicker::class.java, Intent()
+            DeckPicker::class.java,
+            Intent()
         )
         deckPicker.confirmDeckDeletion(did)
         val fragment = deckPicker.getDialogFragment<DialogFragment>()
         assertThat(
-            "deck deletion confirmation window should be shown", fragment,
+            "deck deletion confirmation window should be shown",
+            fragment,
             instanceOf(DeckPickerConfirmDeleteDeckDialog::class.java)
         )
     }
@@ -253,7 +257,8 @@ class DeckPickerTest : RobolectricTest() {
             BackendEmulatingOpenConflict.enable()
             InitialActivityWithConflictTest.setupForDatabaseConflict()
             val d = super.startActivityNormallyOpenCollectionWithIntent(
-                DeckPickerEx::class.java, Intent()
+                DeckPickerEx::class.java,
+                Intent()
             )
             assertThat(
                 "A specific dialog for a conflict should be shown",
@@ -280,7 +285,8 @@ class DeckPickerTest : RobolectricTest() {
             InitialActivityWithConflictTest.setupForDefault()
             BackendEmulatingOpenConflict.enable()
             val d = super.startActivityNormallyOpenCollectionWithIntent(
-                DeckPickerEx::class.java, Intent()
+                DeckPickerEx::class.java,
+                Intent()
             )
 
             // grant permissions
@@ -307,7 +313,8 @@ class DeckPickerTest : RobolectricTest() {
             AnkiDroidApp.getSharedPrefs(targetContext).edit().putString("lastVersion", "0.1")
                 .apply()
             val d = super.startActivityNormallyOpenCollectionWithIntent(
-                DeckPickerEx::class.java, Intent()
+                DeckPickerEx::class.java,
+                Intent()
             )
             assertThat(
                 "Analytics opt-in should be displayed",
@@ -326,7 +333,8 @@ class DeckPickerTest : RobolectricTest() {
         try {
             enableNullCollection()
             val d = super.startActivityNormallyOpenCollectionWithIntent(
-                DeckPickerEx::class.java, Intent()
+                DeckPickerEx::class.java,
+                Intent()
             )
             d.updateMenuState()
             assertThat(
@@ -344,7 +352,8 @@ class DeckPickerTest : RobolectricTest() {
         try {
             grantWritePermissions()
             val d = super.startActivityNormallyOpenCollectionWithIntent(
-                DeckPickerEx::class.java, Intent()
+                DeckPickerEx::class.java,
+                Intent()
             )
             d.updateMenuState()
             assertThat(
@@ -364,7 +373,8 @@ class DeckPickerTest : RobolectricTest() {
             revokeWritePermissions()
             enableNullCollection()
             val d = super.startActivityNormallyOpenCollectionWithIntent(
-                DeckPickerEx::class.java, Intent()
+                DeckPickerEx::class.java,
+                Intent()
             )
 
             // Neither collection, not its models will be initialized without storage permission
@@ -381,7 +391,8 @@ class DeckPickerTest : RobolectricTest() {
         try {
             grantWritePermissions()
             val d = super.startActivityNormallyOpenCollectionWithIntent(
-                DeckPickerEx::class.java, Intent()
+                DeckPickerEx::class.java,
+                Intent()
             )
             assertThat(
                 "Collection initialization ensured by CollectionTask.LoadCollectionComplete",
@@ -389,7 +400,8 @@ class DeckPickerTest : RobolectricTest() {
                 notNullValue()
             )
             assertThat(
-                "Collection Models Loaded", d.col.models,
+                "Collection Models Loaded",
+                d.col.models,
                 notNullValue()
             )
         } finally {
@@ -408,7 +420,8 @@ class DeckPickerTest : RobolectricTest() {
             setupColV16()
             InitialActivityWithConflictTest.setupForValid(targetContext)
             val deckPicker: DeckPicker = super.startActivityNormallyOpenCollectionWithIntent(
-                DeckPickerEx::class.java, Intent()
+                DeckPickerEx::class.java,
+                Intent()
             )
             waitForAsyncTasksToComplete()
             assertThat(
@@ -440,7 +453,8 @@ class DeckPickerTest : RobolectricTest() {
             DbUtils.performQuery(targetContext, "drop table decks")
             InitialActivityWithConflictTest.setupForValid(targetContext)
             val deckPicker = super.startActivityNormallyOpenCollectionWithIntent(
-                DeckPickerEx::class.java, Intent()
+                DeckPickerEx::class.java,
+                Intent()
             )
             waitForAsyncTasksToComplete()
             assertThat(
@@ -463,7 +477,8 @@ class DeckPickerTest : RobolectricTest() {
             setupColV250()
             InitialActivityWithConflictTest.setupForValid(targetContext)
             val deckPicker = super.startActivityNormallyOpenCollectionWithIntent(
-                DeckPickerEx::class.java, Intent()
+                DeckPickerEx::class.java,
+                Intent()
             )
             waitForAsyncTasksToComplete()
             assertThat(
@@ -490,7 +505,8 @@ class DeckPickerTest : RobolectricTest() {
     fun checkDisplayOfStudyOptionsOnTablet() {
         assumeTrue("We are running on a tablet", mQualifiers!!.contains("xlarge"))
         val deckPickerEx = super.startActivityNormallyOpenCollectionWithIntent(
-            DeckPickerEx::class.java, Intent()
+            DeckPickerEx::class.java,
+            Intent()
         )
         val studyOptionsFragment =
             deckPickerEx.supportFragmentManager.findFragmentById(R.id.studyoptions_fragment) as StudyOptionsFragment?
@@ -507,7 +523,8 @@ class DeckPickerTest : RobolectricTest() {
         // Reason for using 2 as the number of decks -> This deck + Default deck
         assertThat("Deck added", col.decks.count(), equalTo(2))
         val deckPicker = startActivityNormallyOpenCollectionWithIntent(
-            DeckPicker::class.java, Intent()
+            DeckPicker::class.java,
+            Intent()
         )
         assertThat(
             "Deck is being displayed",
@@ -522,7 +539,8 @@ class DeckPickerTest : RobolectricTest() {
         // Default deck does not get displayed in the DeckPicker if the default deck is empty.
         assertThat("Contains only default deck", col.decks.count(), equalTo(1))
         val deckPicker = startActivityNormallyOpenCollectionWithIntent(
-            DeckPicker::class.java, Intent()
+            DeckPicker::class.java,
+            Intent()
         )
         assertThat(
             "No deck is being displayed",

--- a/AnkiDroid/src/test/java/com/ichi2/anki/ModelFieldEditorTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/ModelFieldEditorTest.kt
@@ -103,7 +103,9 @@ class ModelFieldEditorTest(private val forbiddenCharacter: String) : Robolectric
                     intent.putExtra("title", modelName)
                     intent.putExtra("noteTypeID", findModelIdByName(modelName))
                     val modelFieldEditor = startActivityNormallyOpenCollectionWithIntent(
-                        this, ModelFieldEditor::class.java, intent
+                        this,
+                        ModelFieldEditor::class.java,
+                        intent
                     )
                     when (fieldOperationType) {
                         FieldOperationType.ADD_FIELD -> modelFieldEditor.addField(fieldNameInput)
@@ -130,6 +132,7 @@ class ModelFieldEditorTest(private val forbiddenCharacter: String) : Robolectric
 
     companion object {
         private val sForbiddenCharacters = arrayOf("#", "^", "/", " ", "\t")
+
         @ParameterizedRobolectricTestRunner.Parameters(name = "\"{0}\"")
         @Suppress("unused")
         @JvmStatic // required: Parameters

--- a/AnkiDroid/src/test/java/com/ichi2/anki/ProductionCrashReportingTreeTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/ProductionCrashReportingTreeTest.kt
@@ -35,7 +35,6 @@ import java.lang.RuntimeException
 class ProductionCrashReportingTreeTest {
     @Before
     fun setUp() {
-
         // setup - simply instrument the class and do same log init as production
         Timber.plant(AnkiDroidApp.ProductionCrashReportingTree())
     }
@@ -83,11 +82,10 @@ class ProductionCrashReportingTreeTest {
      */
     @Test
     fun testProductionLogTag() {
-
         var testWithProperClassNameCalled = false
+
         // this is required to ensure 'NativeMethodAccessorImpl' isn't the class name
         fun testWithProperClassName(autoClosed: MockedStatic<Log>) {
-
             // Now let's run through our API calls...
             Timber.i("info level message")
             Timber.w("warn level message")

--- a/AnkiDroid/src/test/java/com/ichi2/anki/ReviewerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/ReviewerTest.kt
@@ -47,6 +47,7 @@ class ReviewerTest : RobolectricTest() {
     @JvmField // required for Parameter
     @ParameterizedRobolectricTestRunner.Parameter
     var schedVersion = 0
+
     @Before
     override fun setUp() {
         super.setUp()
@@ -288,7 +289,6 @@ class ReviewerTest : RobolectricTest() {
 
     @Suppress("SameParameterValue")
     private fun assertCounts(r: Reviewer, newCount: Int, stepCount: Int, revCount: Int) {
-
         val jsApi = r.javaScriptFunction()
         val countList = listOf(
             jsApi.ankiGetNewCardCount(),

--- a/AnkiDroid/src/test/java/com/ichi2/anki/RobolectricTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/RobolectricTest.kt
@@ -133,7 +133,6 @@ open class RobolectricTest : CollectionGetter {
     @After
     @CallSuper
     open fun tearDown() {
-
         // If you don't clean up your ActivityControllers you will get OOM errors
         for (controller in mControllersForCleanup) {
             Timber.d("Calling destroy on controller %s", controller.get().toString())

--- a/AnkiDroid/src/test/java/com/ichi2/anki/RobolectricTestAnnotationTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/RobolectricTestAnnotationTest.kt
@@ -24,7 +24,10 @@ import org.junit.Test
 class RobolectricTestAnnotationTest : RobolectricTest() {
     @Test
     fun readableErrorIfNotAnnotated() {
-        val exception = assertThrows<IllegalStateException> { @Suppress("UNUSED_VARIABLE") val unused = this.targetContext }
+        val exception = assertThrows<IllegalStateException> {
+            @Suppress("UNUSED_VARIABLE")
+            val unused = this.targetContext
+        }
         assertThat(exception.message, containsString("RobolectricTestAnnotationTest"))
         assertThat(exception.message, containsString("@RunWith(AndroidJUnit4.class)"))
     }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/TemporaryModelTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/TemporaryModelTest.kt
@@ -33,7 +33,6 @@ class TemporaryModelTest : RobolectricTest() {
     @Test
     @Throws(Exception::class)
     fun testTempModelStorage() {
-
         // Start off with clean state in the cache dir
         TemporaryModel.clearTempModelFiles()
 
@@ -58,7 +57,6 @@ class TemporaryModelTest : RobolectricTest() {
     @Test
     @Suppress("deprecation") // getSerializable
     fun testAddDeleteTracking() {
-
         // Assume you start with a 2 template model (like "Basic (and reversed)")
         // Add a 3rd new template, remove the 2nd, remove the 1st, add a new now-2nd, remove 1st again
         // ...and it should reduce to just removing the original 1st/2nd and adding the final as first

--- a/AnkiDroid/src/test/java/com/ichi2/anki/WhiteboardDefaultForegroundColorTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/WhiteboardDefaultForegroundColorTest.kt
@@ -32,6 +32,7 @@ class WhiteboardDefaultForegroundColorTest : RobolectricTest() {
     @ParameterizedRobolectricTestRunner.Parameter(1)
     @JvmField // required for Parameter
     var mExpectedResult = 0
+
     @Test
     fun testDefaultForegroundColor() {
         assertThat(foregroundColor, equalTo(mExpectedResult))

--- a/AnkiDroid/src/test/java/com/ichi2/anki/analytics/AnalyticsConstantsTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/analytics/AnalyticsConstantsTest.kt
@@ -88,7 +88,8 @@ object AnalyticsConstantsTest {
         fun checkAnalyticsString() {
             Assert.assertEquals(
                 "Re-check if you renamed any string in the analytics string constants of Actions class or AnalyticsConstantsTest.listOfConstantFields. If so, revert them as those string constants must not change as they are compared in analytics.",
-                analyticsString, getStringFromReflection(analyticsString)
+                analyticsString,
+                getStringFromReflection(analyticsString)
             )
         }
 
@@ -118,12 +119,14 @@ object AnalyticsConstantsTest {
             if (fieldSize > listOfConstantFields.size) {
                 Assert.assertEquals(
                     "Add the newly added analytics constant to AnalyticsConstantsTest.listOfConstantFields. NOTE: Constants should not be renamed as we cannot compare these in analytics.",
-                    listOfConstantFields.size, fieldSize
+                    listOfConstantFields.size,
+                    fieldSize
                 )
             } else if (fieldSize < listOfConstantFields.size) {
                 Assert.assertEquals(
                     "If a constant is removed, it should be removed from AnalyticsConstantsTest.listOfConstantFields. NOTE: Constants should not be renamed as we cannot compare these in analytics.",
-                    listOfConstantFields.size, fieldSize
+                    listOfConstantFields.size,
+                    fieldSize
                 )
             } else {
                 Assert.assertEquals(listOfConstantFields.size, fieldSize)

--- a/AnkiDroid/src/test/java/com/ichi2/anki/cardviewer/TypeAnswerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/cardviewer/TypeAnswerTest.kt
@@ -47,6 +47,7 @@ class TypeAnswerTest {
 <hr id=answer>
 
 $!"""
+
         @Language("HTML")
         val expectedOutput = """<style>.card {
  font-family: arial;
@@ -80,6 +81,7 @@ $!"""
 <hr id=answer>
 
 hello"""
+
         @Language("HTML")
         val expectedOutput = """<style>.card {
  font-family: arial;
@@ -114,6 +116,7 @@ hello"""
 <hr id=answer>
 
 hello"""
+
         @Language("HTML")
         val expectedOutput = """<style>.card {
  font-family: arial;
@@ -148,6 +151,7 @@ hello"""
 <hr id=answer>
 
 $!"""
+
         @Language("HTML")
         val expectedOutput = """<style>.card {
  font-family: arial;
@@ -182,6 +186,7 @@ $!"""
 <hr id=answer>
 
 $!"""
+
         @Language("HTML")
         val expectedOutput = """<style>.card {
  font-family: arial;
@@ -216,6 +221,7 @@ $!"""
 <hr id=answer>
 
 $!"""
+
         @Language("HTML")
         val expectedOutput = """<style>.card {
  font-family: arial;

--- a/AnkiDroid/src/test/java/com/ichi2/anki/cardviewer/ViewerCommandTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/cardviewer/ViewerCommandTest.kt
@@ -24,7 +24,6 @@ class ViewerCommandTest {
 
     @Test
     fun preference_keys_are_not_changed() {
-
         val names = Joiner.on(", ").join(ViewerCommand.values().map { x -> x.preferenceKey })
 
         // NONE OF THESE SHOULD BE CHANGED OR A USER WILL LOSE THE ASSOCIATED PREFERENCES

--- a/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/CreateDeckDialogTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/CreateDeckDialogTest.kt
@@ -154,7 +154,8 @@ class CreateDeckDialogTest : RobolectricTest() {
 
             updateSearchDecksIcon(deckPicker)
             assertEquals(
-                deckPicker.optionsMenuState?.searchIcon, decksCount() >= 10
+                deckPicker.optionsMenuState?.searchIcon,
+                decksCount() >= 10
             )
 
             // After the last deck was created, delete a deck

--- a/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/tags/TagsDialogTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/tags/TagsDialogTest.kt
@@ -86,7 +86,8 @@ class TagsDialogTest {
             val returnedList = AtomicReference<List<String>?>()
             val returnedOption = AtomicInteger()
             f.parentFragmentManager.setFragmentResultListener(
-                TagsDialogListener.ON_SELECTED_TAGS_KEY, mockLifecycleOwner(),
+                TagsDialogListener.ON_SELECTED_TAGS_KEY,
+                mockLifecycleOwner(),
                 { _: String?, bundle: Bundle ->
                     returnedList.set(bundle.getStringArrayList(TagsDialogListener.ON_SELECTED_TAGS__SELECTED_TAGS))
                     returnedOption.set(bundle.getInt(TagsDialogListener.ON_SELECTED_TAGS__OPTION))
@@ -227,10 +228,16 @@ class TagsDialogTest {
     fun test_TagsDialog_expandPathToCheckedTagsUponOpening() {
         val type = TagsDialog.DialogType.FILTER_BY_TAG
         val allTags = listOf(
-            "fruit::apple", "fruit::pear", "fruit::pear::big", "sport::football", "sport::tennis", "book"
+            "fruit::apple",
+            "fruit::pear",
+            "fruit::pear::big",
+            "sport::football",
+            "sport::tennis",
+            "book"
         )
         val checkedTags = listOf(
-            "fruit::pear::big", "sport::tennis"
+            "fruit::pear::big",
+            "sport::tennis"
         )
         val args = TagsDialog(ParametersUtils.whatever())
             .withArguments(type, checkedTags, allTags)
@@ -370,11 +377,15 @@ class TagsDialogTest {
     fun test_SearchTag_showAllRelevantTags() {
         val type = TagsDialog.DialogType.FILTER_BY_TAG
         val allTags = listOf(
-            "common::speak", "common::speak::tennis", "common::sport::tennis",
-            "common::sport::football", "common::sport::football::small"
+            "common::speak",
+            "common::speak::tennis",
+            "common::sport::tennis",
+            "common::sport::football",
+            "common::sport::football::small"
         )
         val checkedTags = listOf(
-            "common::speak::tennis", "common::sport::tennis",
+            "common::speak::tennis",
+            "common::sport::tennis",
             "common::sport::football::small"
         )
         val args = TagsDialog(ParametersUtils.whatever())
@@ -458,8 +469,11 @@ class TagsDialogTest {
     fun test_CheckTags_intermediateTagsShouldToggleDynamically() {
         val type = TagsDialog.DialogType.FILTER_BY_TAG
         val allTags = listOf(
-            "common::speak", "common::speak::tennis", "common::sport::tennis",
-            "common::sport::football", "common::sport::football::small"
+            "common::speak",
+            "common::speak::tennis",
+            "common::sport::tennis",
+            "common::sport::football",
+            "common::sport::football::small"
         )
         val checkedTags = emptyList<String>()
         val args = TagsDialog(ParametersUtils.whatever())
@@ -596,7 +610,8 @@ class TagsDialogTest {
             editText.setText("hello ")
             Assert.assertEquals(
                 "The space should be replaced by '::' without mistakenly clear everything.",
-                "hello::", editText.text.toString()
+                "hello::",
+                editText.text.toString()
             )
 
             editText.setText("hello")

--- a/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/tags/TagsListTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/tags/TagsListTest.kt
@@ -27,6 +27,7 @@ import java.util.*
 class TagsListTest {
     lateinit var tagsList: TagsList
     lateinit var tagsListWithIndeterminate: TagsList
+
     @Before
     @Throws(Exception::class)
     fun setUp() {
@@ -45,11 +46,13 @@ class TagsListTest {
 
         assertEquals(
             "All tags list should not contain any duplicates",
-            listOf("a", "b"), list.copyOfAllTagList()
+            listOf("a", "b"),
+            list.copyOfAllTagList()
         )
         assertEquals(
             "Checked tags list should not contain any duplicates",
-            listOf("b"), list.copyOfCheckedTagList()
+            listOf("b"),
+            list.copyOfCheckedTagList()
         )
     }
 
@@ -66,15 +69,18 @@ class TagsListTest {
 
         assertEquals(
             "All tags list should not contain any duplicates",
-            listOf("a", "b", "c", "d"), list.copyOfAllTagList()
+            listOf("a", "b", "c", "d"),
+            list.copyOfAllTagList()
         )
         assertEquals(
             "Checked tags list should not contain any duplicates",
-            listOf("b"), list.copyOfCheckedTagList()
+            listOf("b"),
+            list.copyOfCheckedTagList()
         )
         assertEquals(
             "indeterminate tags list should be empty",
-            listOf<Any>(), list.copyOfIndeterminateTagList()
+            listOf<Any>(),
+            list.copyOfIndeterminateTagList()
         )
     }
 
@@ -89,11 +95,13 @@ class TagsListTest {
 
         assertEquals(
             "All tags list should not contain any duplicates (case insensitive)",
-            listOf("aA", "bb"), list.copyOfAllTagList()
+            listOf("aA", "bb"),
+            list.copyOfAllTagList()
         )
         assertEquals(
             "Checked tags list should not contain any duplicates  (case insensitive)",
-            listOf("bb"), list.copyOfCheckedTagList()
+            listOf("bb"),
+            list.copyOfCheckedTagList()
         )
     }
 
@@ -110,16 +118,19 @@ class TagsListTest {
 
         assertEquals(
             "All tags list should not contain any duplicates (case insensitive)",
-            listOf("aA", "bb", "cc", "dd", "ff"), list.copyOfAllTagList()
+            listOf("aA", "bb", "cc", "dd", "ff"),
+            list.copyOfAllTagList()
         )
         assertEquals(
             "Checked tags list should not contain any duplicates  (case insensitive)",
-            listOf("ff"), list.copyOfCheckedTagList()
+            listOf("ff"),
+            list.copyOfCheckedTagList()
         )
         assertEquals(
             "Checked tags list should not contain any duplicates  (case insensitive)\n" +
                 "and IndeterminateTagList is correct".trimIndent(),
-            listOf("bb", "dd"), list.copyOfIndeterminateTagList()
+            listOf("bb", "dd"),
+            list.copyOfIndeterminateTagList()
         )
     }
 
@@ -134,11 +145,13 @@ class TagsListTest {
 
         assertEquals(
             "Extra tags in checked not found in all tags, must be added to all tags list",
-            listOf("aA", "bb", "cc"), list.copyOfAllTagList()
+            listOf("aA", "bb", "cc"),
+            list.copyOfAllTagList()
         )
         assertEquals(
             "Extra tags in checked not found in all tags, must be found when retrieving checked tag list",
-            listOf("bb", "cc"), list.copyOfCheckedTagList()
+            listOf("bb", "cc"),
+            list.copyOfCheckedTagList()
         )
     }
 
@@ -155,11 +168,13 @@ class TagsListTest {
 
         assertEquals(
             "Extra tags in checked not found in all tags, must be added to all tags list",
-            listOf("aA", "bb", "Cc", "zz", "dD"), list.copyOfAllTagList()
+            listOf("aA", "bb", "Cc", "zz", "dD"),
+            list.copyOfAllTagList()
         )
         assertEquals(
             "Extra tags in checked not found in all tags, must be found when retrieving checked tag list",
-            listOf("zz"), list.copyOfCheckedTagList()
+            listOf("zz"),
+            list.copyOfCheckedTagList()
         )
         assertEquals(listOf("bb", "Cc"), list.copyOfIndeterminateTagList())
     }
@@ -184,7 +199,8 @@ class TagsListTest {
         assertEquals(listOf("cat1::aa", "cat1::bb", "cat2::bb::aa", "cat2::bb::bb"), list.copyOfCheckedTagList())
         assertEquals(
             "Ancestors of checked tags should be marked as indeterminate",
-            listOf("cat1", "cat2", "cat2::bb"), list.copyOfIndeterminateTagList()
+            listOf("cat1", "cat2", "cat2::bb"),
+            list.copyOfIndeterminateTagList()
         )
     }
 
@@ -251,11 +267,13 @@ class TagsListTest {
         )
         assertEquals(
             "The newly added 'anki' tag should be found when retrieving all tags list",
-            join(TAGS, "anki"), tagsList.copyOfAllTagList()
+            join(TAGS, "anki"),
+            tagsList.copyOfAllTagList()
         )
         assertSameElementsIgnoreOrder(
             "Adding operations should have nothing to do with the checked status of tags",
-            CHECKED_TAGS, tagsList.copyOfCheckedTagList()
+            CHECKED_TAGS,
+            tagsList.copyOfCheckedTagList()
         )
     }
 
@@ -312,11 +330,13 @@ class TagsListTest {
         )
         assertEquals(
             "Changing the status of tags to be checked should have noting to do with all tag list",
-            TAGS, tagsList.copyOfAllTagList()
+            TAGS,
+            tagsList.copyOfAllTagList()
         ) // no change
         assertSameElementsIgnoreOrder(
             "The checked 'flags' tag should be found when retrieving list of checked tag",
-            join(CHECKED_TAGS, "flags"), tagsList.copyOfCheckedTagList()
+            join(CHECKED_TAGS, "flags"),
+            tagsList.copyOfCheckedTagList()
         )
     }
 
@@ -328,7 +348,8 @@ class TagsListTest {
         )
         assertEquals(
             "Changing the status of tags to be checked should have noting to do with all tag list",
-            TAGS, tagsListWithIndeterminate.copyOfAllTagList()
+            TAGS,
+            tagsListWithIndeterminate.copyOfAllTagList()
         )
         assertTrue(
             "The checked 'faces' tag should be found when retrieving list of checked tag",
@@ -356,11 +377,13 @@ class TagsListTest {
         )
         assertEquals(
             "Changing the status of tags to be unchecked should have noting to do with all tag list",
-            TAGS, tagsList.copyOfAllTagList()
+            TAGS,
+            tagsList.copyOfAllTagList()
         ) // no change
         assertSameElementsIgnoreOrder(
             "The unchecked 'colors' tag should be not be found when retrieving list of checked tag",
-            minus(CHECKED_TAGS, "colors"), tagsList.copyOfCheckedTagList()
+            minus(CHECKED_TAGS, "colors"),
+            tagsList.copyOfCheckedTagList()
         )
     }
 
@@ -372,7 +395,8 @@ class TagsListTest {
         )
         assertEquals(
             "Changing the status of tags to be checked should have noting to do with all tag list",
-            TAGS, tagsListWithIndeterminate.copyOfAllTagList()
+            TAGS,
+            tagsListWithIndeterminate.copyOfAllTagList()
         )
         assertFalse(
             "Changing from indeterminate to unchecked should not affect checked tags",
@@ -446,7 +470,8 @@ class TagsListTest {
         tagsList.sort()
         assertEquals(
             "Calling #sort on TagsList should result on sorting all tags",
-            SORTED_TAGS, tagsList.copyOfAllTagList()
+            SORTED_TAGS,
+            tagsList.copyOfAllTagList()
         )
     }
 
@@ -456,7 +481,8 @@ class TagsListTest {
         tagsListWithIndeterminate.sort()
         assertEquals(
             "Calling #sort on TagsList should result on sorting all tags",
-            SORTED_TAGS, tagsListWithIndeterminate.copyOfAllTagList()
+            SORTED_TAGS,
+            tagsListWithIndeterminate.copyOfAllTagList()
         )
     }
 
@@ -472,7 +498,8 @@ class TagsListTest {
             tagsList.sort()
             assertEquals(
                 "Calling #sort on TagsList should result on sorting all tags",
-                SORTED_TAGS, tagsList.copyOfAllTagList()
+                SORTED_TAGS,
+                tagsList.copyOfAllTagList()
             )
 
             MockCollection.verify({ Collections.sort(ArgumentMatchers.any(), ArgumentMatchers.any<Comparator<in Any>>()) }, Mockito.never())

--- a/AnkiDroid/src/test/java/com/ichi2/anki/jsaddons/TgzPackageExtractTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/jsaddons/TgzPackageExtractTest.kt
@@ -114,7 +114,6 @@ class TgzPackageExtractTest : RobolectricTest() {
     @Test
     @Throws(IOException::class, ArchiveException::class)
     fun unTarTest() {
-
         // first unGzip .tgz file to .tar
         val unGzipFile = addonPackage.unGzip(File(tarballPath), addonDir)
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/multimediacard/AudioRecorderAndroidTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/multimediacard/AudioRecorderAndroidTest.kt
@@ -38,6 +38,7 @@ class AudioRecorderAndroidTest : RobolectricTest() {
 
     @InjectMocks
     private lateinit var mInjectedRecorder: AudioRecorder
+
     @Before
     fun before() {
         MockitoAnnotations.openMocks(this)

--- a/AnkiDroid/src/test/java/com/ichi2/anki/multimediacard/AudioRecorderTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/multimediacard/AudioRecorderTest.kt
@@ -31,6 +31,7 @@ class AudioRecorderTest {
 
     @InjectMocks
     private lateinit var mInjectedRecorder: AudioRecorder
+
     @Before
     fun before() {
         MockitoAnnotations.openMocks(this)

--- a/AnkiDroid/src/test/java/com/ichi2/anki/multimediacard/fields/BasicImageFieldControllerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/multimediacard/fields/BasicImageFieldControllerTest.kt
@@ -85,7 +85,8 @@ open class BasicImageFieldControllerTest : MultimediaEditFieldActivityTestBase()
         val f = File("test.svg")
         controller.setImagePreview(f, 100)
         assertThat(
-            "A SVG image file can't be previewed", ShadowToast.getTextOfLatestToast(),
+            "A SVG image file can't be previewed",
+            ShadowToast.getTextOfLatestToast(),
             equalTo(getResourceString(R.string.multimedia_editor_svg_preview))
         )
         assertThat("A SVG image file can't be previewed", controller.isShowingPreview, equalTo(false))

--- a/AnkiDroid/src/test/java/com/ichi2/anki/preferences/PreferencesSimpleTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/preferences/PreferencesSimpleTest.kt
@@ -41,7 +41,7 @@ class PreferencesSimpleTest {
                 Arguments.of(arrayOf(""), ""),
                 Arguments.of(arrayOf("foo"), "foo"),
                 Arguments.of(arrayOf("foo", "bar"), "foo • bar"),
-                Arguments.of(arrayOf("foo", "bar", "hi", "there"), "foo • bar • hi • there"),
+                Arguments.of(arrayOf("foo", "bar", "hi", "there"), "foo • bar • hi • there")
             )
         }
     }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/preferences/SettingsSearchBarTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/preferences/SettingsSearchBarTest.kt
@@ -65,7 +65,8 @@ class SettingsSearchBarTest : RobolectricTest() {
             assertNotNull(fragment)
             assertThat(
                 "${targetContext.resources.getResourceName(resId)} should match the preferenceResource of ${fragment::class.simpleName}",
-                fragment.preferenceResource, equalTo(resId)
+                fragment.preferenceResource,
+                equalTo(resId)
             )
         }
     }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/reviewer/AnswerTimerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/reviewer/AnswerTimerTest.kt
@@ -32,9 +32,9 @@ import org.mockito.Mockito
 import org.mockito.kotlin.*
 import org.robolectric.annotation.Config
 
+// This is difficult to test as Chronometer.mStarted isn't visible
 @RunWith(AndroidJUnit4::class)
 @Config(application = EmptyApplication::class)
-// This is difficult to test as Chronometer.mStarted isn't visible
 class AnswerTimerTest {
     lateinit var chronometer: Chronometer
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/reviewer/GestureMapperTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/reviewer/GestureMapperTest.kt
@@ -29,6 +29,7 @@ import kotlin.test.assertNull
 
 class GestureMapperTest {
     private val mSut = GestureMapper()
+
     @Test
     fun zeroWidthReturnsNothing() {
         assertNull(mSut.gesture(0, 10, 10f, 10f))

--- a/AnkiDroid/src/test/java/com/ichi2/anki/reviewer/KeyboardShortcutIntegrationTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/reviewer/KeyboardShortcutIntegrationTest.kt
@@ -42,6 +42,7 @@ import java.io.IOException
 @RunWith(AndroidJUnit4::class)
 class KeyboardShortcutIntegrationTest : RobolectricTest() {
     private lateinit var mReviewer: Reviewer
+
     @Before
     override fun setUp() {
         super.setUp()

--- a/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/ScopedStorageAndroidTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/ScopedStorageAndroidTest.kt
@@ -102,7 +102,7 @@ class ScopedStorageAndroidTest {
         val depthThreeRootDirectory = sharedRootDirectory.createTransientDirectory("third").createTransientDirectory("third").createTransientDirectory("third")
         val templatePath = sharedRootDirectory.createTransientDirectory("final")
 
-        runTestWithTwoExternalDirectories(arrayOf(depthTwoRootDirectory, depthThreeRootDirectory, depthOneRootDirectory,)) {
+        runTestWithTwoExternalDirectories(arrayOf(depthTwoRootDirectory, depthThreeRootDirectory, depthOneRootDirectory)) {
             val best = ScopedStorageService.getBestDefaultRootDirectory(ApplicationProvider.getApplicationContext(), templatePath)
             assertThat("ambiguous, so should return first path", best.canonicalPath, equalTo(depthTwoRootDirectory.canonicalPath))
         }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/ExecutorTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/ExecutorTest.kt
@@ -34,6 +34,7 @@ class ExecutorTest {
 
     /** the system under test: no initial operations */
     private val underTest = Executor(ArrayDeque())
+
     /** execution context: allows access to the order of execution */
     private val executionContext = MockMigrationContext()
 
@@ -127,7 +128,8 @@ class ExecutorTest {
         assertThat(executionContext.executed[0], equalTo(blockingOp))
         assertThat(
             "a preempted operation is not run if terminate() is called",
-            executionContext.executed, hasSize(1)
+            executionContext.executed,
+            hasSize(1)
         )
     }
 
@@ -148,7 +150,8 @@ class ExecutorTest {
         assertThat(executionContext.executed[0], equalTo(blockingOp))
         assertThat(
             "a regular operation is not run if terminate() is called",
-            executionContext.executed, hasSize(1)
+            executionContext.executed,
+            hasSize(1)
         )
     }
 
@@ -171,6 +174,7 @@ class ExecutorTest {
     class BlockedOperation : Operation() {
         // Semaphore that can be acquired once the operation is not blocked anymore
         val isBlocked = Semaphore(1).apply { acquire() }
+
         // Semaphore that can be acquired after operation start executing
         var isExecuting = Semaphore(1).apply { acquire() }
         override fun execute(context: MigrationContext): List<Operation> {

--- a/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/MigrateEssentialFilesIntegrationTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/MigrateEssentialFilesIntegrationTest.kt
@@ -168,7 +168,6 @@ class MigrateEssentialFilesIntegrationTest : RobolectricTest() {
     }
 
     private fun migrateEssentialFiles(stubbing: (KStubbing<MigrateEssentialFiles>.(MigrateEssentialFiles) -> Unit)? = null) {
-
         fun mock(e: MigrateEssentialFiles): MigrateEssentialFiles {
             return if (stubbing == null) e else spy(e, stubbing)
         }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/MockMigrationContext.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/MockMigrationContext.kt
@@ -27,6 +27,7 @@ open class MockMigrationContext : MigrationContext() {
     val exceptions get() = errors.map { it.exception }
     var logExceptions: Boolean = false
     val progress = mutableListOf<NumberOfBytes>()
+
     /** A list of tasks which were passed into [execSafe] */
     val executed = mutableListOf<Operation>()
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/OperationTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/OperationTest.kt
@@ -64,11 +64,13 @@ interface OperationTest {
          */
         var beforeFile: File? = null
             private set
+
         /**
          * The second file, it moves fails. Null if no moved occurred.
          */
         var failedFile: File? = null // ensure the second file fails
             private set
+
         /**
          * The last file moved, after the failed file. Null if no moved occurred.
          */

--- a/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/ScopedStorageMigrationIntegrationTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/ScopedStorageMigrationIntegrationTest.kt
@@ -84,7 +84,8 @@ class ScopedStorageMigrationIntegrationTest : RobolectricTest() {
 
         assertThat(
             "a number of files should remain to allow the user to restore their collection",
-            fileCount(inputDirectory), equalTo(MigrateUserDataTester.INTEGRATION_INTENDED_REMAINING_FILE_COUNT)
+            fileCount(inputDirectory),
+            equalTo(MigrateUserDataTester.INTEGRATION_INTENDED_REMAINING_FILE_COUNT)
         )
     }
 
@@ -181,7 +182,8 @@ class ScopedStorageMigrationIntegrationTest : RobolectricTest() {
 
         assertThat(
             "collection media should be deleted on retry if empty",
-            File(underTest.source.directory, "collection.media"), not(anExistingDirectory())
+            File(underTest.source.directory, "collection.media"),
+            not(anExistingDirectory())
         )
 
         assertThat("no external retries should be made", underTest.externalRetries, equalTo(0))
@@ -238,8 +240,10 @@ private constructor(source: Directory, destination: Directory, val filesToMigrat
 
     /** The number of files in [destination] */
     val migratedFilesCount: Int get() = fileCount(destination.directory)
+
     /** The number of files in [source] */
     val sourceFilesCount: Int get() = fileCount(source.directory)
+
     /** The number of files in the "conflict" directory */
     val conflictedFilesCount: Int get() {
         if (!conflictDirectory.exists()) {
@@ -305,7 +309,10 @@ private fun fileCount(directory: File): Int {
 
     val files = directory.listFiles()
     return files!!.sumOf {
-        if (it.isFile) return@sumOf 1
-        else return@sumOf fileCount(it) + 1
+        if (it.isFile) {
+            return@sumOf 1
+        } else {
+            return@sumOf fileCount(it) + 1
+        }
     }
 }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/servicemodel/UpgradeGesturesToControlsTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/servicemodel/UpgradeGesturesToControlsTest.kt
@@ -184,7 +184,7 @@ class UpgradeGesturesToControlsTest(private val testData: TestData) : Robolectri
             // pref key, keyCode, opposite key
             return arrayListOf<Array<Any>>(
                 arrayOf(TestData(PREF_KEY_VOLUME_UP, KEYCODE_VOLUME_UP, PREF_KEY_VOLUME_DOWN, volume_up_binding)),
-                arrayOf(TestData(PREF_KEY_VOLUME_DOWN, KEYCODE_VOLUME_DOWN, PREF_KEY_VOLUME_UP, volume_down_binding)),
+                arrayOf(TestData(PREF_KEY_VOLUME_DOWN, KEYCODE_VOLUME_DOWN, PREF_KEY_VOLUME_UP, volume_down_binding))
             ).toList()
         }
         data class TestData(val affectedPreferenceKey: String, val keyCode: Int, val unaffectedPreferenceKey: String, val binding: MappableBinding)

--- a/AnkiDroid/src/test/java/com/ichi2/anki/services/NoteServiceTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/services/NoteServiceTest.kt
@@ -45,6 +45,7 @@ import java.io.IOException
 class NoteServiceTest : RobolectricTest() {
     @KotlinCleanup("lateinit")
     var testCol: Collection? = null
+
     @Before
     fun before() {
         testCol = col

--- a/AnkiDroid/src/test/java/com/ichi2/anki/stats/AnkiStatsTaskHandlerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/stats/AnkiStatsTaskHandlerTest.kt
@@ -31,7 +31,8 @@ class AnkiStatsTaskHandlerTest : RobolectricTest() {
     @Test
     fun testCreateReviewSummaryStatistics() = runTest {
         val deckPicker = startActivityNormallyOpenCollectionWithIntent(
-            DeckPicker::class.java, Intent()
+            DeckPicker::class.java,
+            Intent()
         )
         assertNull(AnkiStatsTaskHandler.getReviewSummaryStatisticsString(deckPicker))
     }

--- a/AnkiDroid/src/test/java/com/ichi2/async/ForegroundTaskManager.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/async/ForegroundTaskManager.kt
@@ -62,7 +62,9 @@ class ForegroundTaskManager(private val colGetter: CollectionGetter) : TaskManag
         task: TaskDelegateBase<Progress, Result>?,
         listener: TaskListener<in Progress, in Result?>?
     ) : CollectionTask<Progress, Result>(
-        task!!, listener, null
+        task!!,
+        listener,
+        null
     )
 
     companion object {

--- a/AnkiDroid/src/test/java/com/ichi2/compat/CompatDirectoryContentTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/compat/CompatDirectoryContentTest.kt
@@ -74,9 +74,10 @@ class CompatDirectoryContentTest : Test21And26() {
     fun non_existent_dir_test() {
         val directory = createTransientDirectory()
         directory.delete()
-        assertThrows<FileNotFoundException>({
-            compat.contentOfDirectory(directory)
-        }
+        assertThrows<FileNotFoundException>(
+            {
+                compat.contentOfDirectory(directory)
+            }
         )
     }
 
@@ -84,9 +85,10 @@ class CompatDirectoryContentTest : Test21And26() {
     @Test
     fun file_test() {
         val file = createTransientFile("foo")
-        val exception = assertThrowsSubclass<IOException>({
-            compat.contentOfDirectory(file)
-        }
+        val exception = assertThrowsSubclass<IOException>(
+            {
+                compat.contentOfDirectory(file)
+            }
         )
         if (isV26) {
             assertThat("Starting at API 26, this should be a NotDirectoryException", exception, instanceOf(NotDirectoryException::class.java))

--- a/AnkiDroid/src/test/java/com/ichi2/compat/Test21And26.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/compat/Test21And26.kt
@@ -40,13 +40,13 @@ abstract class Test21And26 {
     companion object {
         @JvmStatic // required for Parameters
         @Parameterized.Parameters(name = "{1}")
-
         fun data(): Iterable<Array<Any>> = sequence {
             yield(arrayOf(CompatV21(), "CompatV21"))
             yield(arrayOf(CompatV26(), "CompatV26"))
         }.asIterable()
 
         lateinit var staticCompat: Compat
+
         @BeforeClass
         @JvmStatic // required for @BeforeClass
         fun setupClass() {

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/FinderTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/FinderTest.kt
@@ -301,7 +301,9 @@ class FinderTest : RobolectricTest() {
         // should be able to limit to parent col, no children
         var id = col.db.queryLongScalar("select id from cards limit 1")
         col.db.execute(
-            "update cards set did = ? where id = ?", addDeck("Default::Child"), id
+            "update cards set did = ? where id = ?",
+            addDeck("Default::Child"),
+            id
         )
         col.save()
         assertEquals(7, col.findCards("deck:default").size)
@@ -432,7 +434,8 @@ class FinderTest : RobolectricTest() {
         val did = note.firstCard().did
         assertEquals(currentDid, did)
         val cb = super.startActivityNormallyOpenCollectionWithIntent(
-            CardBrowser::class.java, Intent()
+            CardBrowser::class.java,
+            Intent()
         )
         cb.deckSpinnerSelection!!.updateDeckPosition(currentDid)
         advanceRobolectricLooperWithSleep()

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/MathJaxClozeTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/MathJaxClozeTest.kt
@@ -98,7 +98,6 @@ class MathJaxClozeTest : RobolectricTest() {
 
     @Test
     fun textContainsMathjax() {
-
         assertFalse(MathJax.textContainsMathjax("Hello world."))
         assertFalse(MathJax.textContainsMathjax(""))
         assertTrue(MathJax.textContainsMathjax("This is an inline! \\(1 \\div 2 =\\){{c1::\\(\\frac{1}{2}\\)}}"))

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/ModelTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/ModelTest.kt
@@ -112,7 +112,6 @@ class ModelTest : RobolectricTest() {
     @Test
     @Throws(ConfirmModSchemaException::class)
     fun test_modelDelete() {
-
         val col = col
         val note = col.newNote()
         note.setItem("Front", "1")

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/StorageLockingTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/StorageLockingTest.kt
@@ -33,6 +33,7 @@ import org.junit.runner.RunWith
 class StorageLockingTest : RobolectricTest() {
 
     private var toCleanup: Collection? = null
+
     @After
     fun after() {
         toCleanup?.close()

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/StorageTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/StorageTest.kt
@@ -284,7 +284,9 @@ open class StorageTest : RobolectricTest() {
             val breq = e.getJSONArray(2)
             return if (areq.length() != 1 || breq.length() != 1) {
                 false
-            } else areq.getInt(0) == breq.getInt(0)
+            } else {
+                areq.getInt(0) == breq.getInt(0)
+            }
         }
 
         private fun assertConfEqual(expectedData: CollectionData) {

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/TextNoteExporterTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/TextNoteExporterTest.kt
@@ -35,6 +35,7 @@ class TextNoteExporterTest(
     private lateinit var collection: Collection
     private lateinit var exporter: TextNoteExporter
     private lateinit var noteList: List<Note>
+
     @Before
     override fun setUp() {
         super.setUp()

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/UndoTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/UndoTest.kt
@@ -82,9 +82,9 @@ class UndoTest : RobolectricTest() {
         }
     }
 
+    // TODO why is this test ignored if it doesn't have @Ignore(happens for both java and kotlin versions)
     @Test
     @Throws(Exception::class)
-    // TODO why is this test ignored if it doesn't have @Ignore(happens for both java and kotlin versions)
     fun test_review() {
         val col = colV2
         with(col) {

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/UtilsTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/UtilsTest.kt
@@ -116,7 +116,8 @@ class UtilsTest {
         for (s in strings) {
             assertEquals(
                 s.replace("\n", "\\n") + " should be removed.",
-                "", Utils.stripHTML(s)
+                "",
+                Utils.stripHTML(s)
             )
         }
     }
@@ -134,7 +135,8 @@ class UtilsTest {
         for (s in strings) {
             assertEquals(
                 s.replace("\n", "\\n") + " should be removed.",
-                "", Utils.stripHTML(s)
+                "",
+                Utils.stripHTML(s)
             )
         }
     }

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/sched/AbstractSchedTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/sched/AbstractSchedTest.kt
@@ -44,6 +44,7 @@ class AbstractSchedTest : RobolectricTest() {
     @ParameterizedRobolectricTestRunner.Parameter
     @JvmField // required for Parameter
     var schedVersion = 0
+
     @Before
     override fun setUp() {
         super.setUp()

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/sched/SchedUpgradeTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/sched/SchedUpgradeTest.kt
@@ -33,7 +33,8 @@ class SchedUpgradeTest : RobolectricTest() {
     @Test
     fun schedulerForNewCollectionIsV2() {
         assertThat(
-            "A new collection should be sched v2", col.sched,
+            "A new collection should be sched v2",
+            col.sched,
             not(
                 instanceOf(
                     Sched::class.java
@@ -50,7 +51,8 @@ class SchedUpgradeTest : RobolectricTest() {
         col.close()
 
         assertThat(
-            "A collection with no schedVer should be v1", col.sched,
+            "A collection with no schedVer should be v1",
+            col.sched,
             instanceOf(
                 Sched::class.java
             )

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/sched/SchedV2Test.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/sched/SchedV2Test.kt
@@ -197,7 +197,8 @@ open class SchedV2Test : RobolectricTest() {
         Assert.assertEquals(
             "Tree has not the expected structure",
             expectedTree(
-                col, true
+                col,
+                true
             ),
             tree
         )

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/template/TemplateTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/template/TemplateTest.kt
@@ -47,7 +47,8 @@ class TemplateTest : RobolectricTest() {
 
         assertThat(rendered, notNullValue())
         assertThat(
-            rendered, containsString("there is no field called '!Front'")
+            rendered,
+            containsString("there is no field called '!Front'")
         )
     }
 

--- a/AnkiDroid/src/test/java/com/ichi2/preferences/TimePreferenceTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/preferences/TimePreferenceTest.kt
@@ -37,7 +37,9 @@ class TimePreferenceTest(private val parsableHour: String, private val expectedH
         @Parameterized.Parameters
         fun data(): Collection<Array<Any>> {
             return listOf(
-                arrayOf("00:00", 0), arrayOf("01:00", 1), arrayOf("24:00", 24)
+                arrayOf("00:00", 0),
+                arrayOf("01:00", 1),
+                arrayOf("24:00", 24)
             )
         }
     }

--- a/AnkiDroid/src/test/java/com/ichi2/testutils/ActivityList.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/testutils/ActivityList.kt
@@ -45,7 +45,8 @@ object ActivityList {
             // IntentHandler has unhandled intents
             get(IntentHandler::class.java) { ctx: Context ->
                 getReviewDeckIntent(
-                    ctx, 1L
+                    ctx,
+                    1L
                 )
             },
             get(StudyOptionsActivity::class.java),

--- a/AnkiDroid/src/test/java/com/ichi2/testutils/CollectionDBCorruption.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/testutils/CollectionDBCorruption.kt
@@ -43,10 +43,10 @@ object CollectionDBCorruption {
         Timber.w("Explicitly corrupted database file: $path")
     }
 
-    @NeedsTest("test with a new collection")
     /**
      * Closes and corrupts [CollectionHelper]'s collection
      */
+    @NeedsTest("test with a new collection")
     fun closeAndCorrupt(context: Context): String {
         val col = CollectionHelper.instance.getCol(context)!!
         val path = col.path

--- a/AnkiDroid/src/test/java/com/ichi2/testutils/MockTime.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/testutils/MockTime.kt
@@ -37,7 +37,8 @@ open class MockTime(initTime: Long, private val step: Int = 0) : Time() {
         milliseconds: Int,
         step: Int
     ) : this(
-        timeStamp(year, month, date, hourOfDay, minute, second, milliseconds), step
+        timeStamp(year, month, date, hourOfDay, minute, second, milliseconds),
+        step
     )
 
     /** Time in millisecond since epoch.  */

--- a/AnkiDroid/src/test/java/com/ichi2/ui/BindingPreferenceTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/ui/BindingPreferenceTest.kt
@@ -32,7 +32,6 @@ class BindingPreferenceTest {
 
     @Test
     fun serialization_deserialization_returns_same_result() {
-
         val str = getSampleBindings().toPreferenceString()
 
         val again = MappableBinding.fromPreferenceString(str)

--- a/AnkiDroid/src/test/java/com/ichi2/utils/FileUtilTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/utils/FileUtilTest.kt
@@ -32,6 +32,7 @@ class FileUtilTest {
     @get:Rule
     var temporaryDirectory = TemporaryFolder()
     private var testDirectorySize: Long = 0
+
     @Throws(Exception::class)
     private fun createSrcFilesForTest(temporaryRoot: File, testDirName: String): File {
         val grandParentDir = File(temporaryRoot, testDirName)

--- a/AnkiDroid/src/test/java/com/ichi2/utils/JSONObjectTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/utils/JSONObjectTest.kt
@@ -871,6 +871,7 @@ class JSONObjectTest {
     private lateinit var mCorrectJsonObjectWithArray: JSONObject
     private lateinit var mCorrectJsonObjectNestedWithArray: JSONObject
     lateinit var booleanMap: MutableMap<String, Boolean>
+
     @Before
     @Test
     fun setUp() {
@@ -972,6 +973,7 @@ class JSONObjectTest {
             Assert.assertEquals(fromMapJsonObject.getBoolean("key$i"), i % 2 == 0)
         }
     }
+
     /**
      * Tests that exception is caught in the catch statement
      */

--- a/AnkiDroid/src/test/java/com/ichi2/utils/LanguageUtilsTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/utils/LanguageUtilsTest.kt
@@ -50,7 +50,8 @@ class LanguageUtilsTest {
         assertThat(
             "Languages have been updated, please modify test variables: " +
                 "PREVIOUS_LANGUAGES and CURRENT_LANGUAGES",
-            actual, Matchers.contains(*CURRENT_LANGUAGES)
+            actual,
+            Matchers.contains(*CURRENT_LANGUAGES)
         )
     }
 

--- a/AnkiDroid/src/test/java/com/ichi2/utils/SequenceUtilTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/utils/SequenceUtilTest.kt
@@ -26,7 +26,6 @@ class SequenceUtilTest {
 
     @Test
     fun test_take_while_including_first_non_match() {
-
         // empty works and returns empty
         val empty = listOf<String>().asSequence().takeWhileIncludingFirstNonMatch { true }.toList()
 

--- a/AnkiDroid/src/test/java/com/ichi2/utils/TagsUtilTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/utils/TagsUtilTest.kt
@@ -40,10 +40,13 @@ class TagsUtilTest {
         @Parameterized.Parameter(3)
         @JvmField // required for Parameter
         var updated: List<String>? = null
+
         @Test
         fun test() {
             val actual = TagsUtil.getUpdatedTags(
-                previous!!, selected!!, indeterminate!!
+                previous!!,
+                selected!!,
+                indeterminate!!
             )
             assertListEquals(updated, actual)
         }

--- a/AnkiDroid/src/test/java/com/ichi2/utils/UniqueArrayListTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/utils/UniqueArrayListTest.kt
@@ -467,7 +467,14 @@ class UniqueArrayListTest {
 
         assertEquals(
             listOf(
-                6L, 7L, 8L, 9L, 10L, 11L, 12L, 13L
+                6L,
+                7L,
+                8L,
+                9L,
+                10L,
+                11L,
+                12L,
+                13L
             ),
             list
         )
@@ -480,7 +487,11 @@ class UniqueArrayListTest {
 
         assertEquals(
             listOf(
-                6L, 7L, 8L, 9L, 10L
+                6L,
+                7L,
+                8L,
+                9L,
+                10L
             ),
             uniqueList.subList(5, 10)
         )

--- a/AnkiDroid/src/test/java/com/wildplot/android/rendering/PieChartParameterizedTest.kt
+++ b/AnkiDroid/src/test/java/com/wildplot/android/rendering/PieChartParameterizedTest.kt
@@ -76,7 +76,10 @@ class PieChartParameterizedTest {
             if (arcLengths[i] == 0.0) continue
             inOrder.verify(graphics)?.color = colors[i]
             inOrder.verify(graphics)?.fillArc(
-                anyFloat(), anyFloat(), anyFloat(), anyFloat(),
+                anyFloat(),
+                anyFloat(),
+                anyFloat(),
+                anyFloat(),
                 floatThat(closeTo(startAngles[i])),
                 floatThat(closeTo(arcLengths[i]))
             )

--- a/AnkiDroid/src/test/java/com/wildplot/android/rendering/PieChartTest.kt
+++ b/AnkiDroid/src/test/java/com/wildplot/android/rendering/PieChartTest.kt
@@ -60,22 +60,29 @@ class PieChartTest {
     @Test
     fun paintShouldNotDrawAnythingIfValuesAreZero() {
         mPieChart = PieChart(
-            mPlot!!, doubleArrayOf(0.0, 0.0),
+            mPlot!!,
+            doubleArrayOf(0.0, 0.0),
             arrayOf(
-                ColorWrap.RED, ColorWrap.GREEN
+                ColorWrap.RED,
+                ColorWrap.GREEN
             )
         )
         mPieChart!!.paint(mGraphics!!)
         verify(mGraphics, never()).fillArc(
-            anyFloat(), anyFloat(), anyFloat(), anyFloat(),
-            anyFloat(), anyFloat()
+            anyFloat(),
+            anyFloat(),
+            anyFloat(),
+            anyFloat(),
+            anyFloat(),
+            anyFloat()
         )
     }
 
     @Test
     fun paintShouldDrawFullRedCircleIfOneValue() {
         mPieChart = PieChart(
-            mPlot!!, doubleArrayOf(1.0),
+            mPlot!!,
+            doubleArrayOf(1.0),
             arrayOf(
                 ColorWrap.RED
             )
@@ -85,7 +92,10 @@ class PieChartTest {
         mPieChart!!.paint(mGraphics)
         verify(mGraphics).color = ColorWrap.RED
         verify(mGraphics).fillArc(
-            anyFloat(), anyFloat(), anyFloat(), anyFloat(),
+            anyFloat(),
+            anyFloat(),
+            anyFloat(),
+            anyFloat(),
             floatThat(closeTo(-90.0)),
             floatThat(closeTo(360.0))
         )
@@ -94,9 +104,11 @@ class PieChartTest {
     @Test
     fun paintShouldDrawTwoSectorsWithGivenColors() {
         mPieChart = PieChart(
-            mPlot!!, doubleArrayOf(1.0, 1.0),
+            mPlot!!,
+            doubleArrayOf(1.0, 1.0),
             arrayOf(
-                ColorWrap.RED, ColorWrap.GREEN
+                ColorWrap.RED,
+                ColorWrap.GREEN
             )
         )
         val r = createRectangleMock(100, 100)
@@ -105,13 +117,19 @@ class PieChartTest {
         mPieChart!!.paint(mGraphics)
         verify(mGraphics).color = ColorWrap.RED
         verify(mGraphics).fillArc(
-            anyFloat(), anyFloat(), anyFloat(), anyFloat(),
+            anyFloat(),
+            anyFloat(),
+            anyFloat(),
+            anyFloat(),
             floatThat(closeTo(-90.0)),
             floatThat(closeTo(180.0))
         )
         verify(mGraphics).color = ColorWrap.GREEN
         verify(mGraphics).fillArc(
-            anyFloat(), anyFloat(), anyFloat(), anyFloat(),
+            anyFloat(),
+            anyFloat(),
+            anyFloat(),
+            anyFloat(),
             floatThat(closeTo(90.0)),
             floatThat(closeTo(180.0))
         )

--- a/api/src/main/java/com/ichi2/anki/FlashCardsContract.kt
+++ b/api/src/main/java/com/ichi2/anki/FlashCardsContract.kt
@@ -227,23 +227,27 @@ public object FlashCardsContract {
          */
         @Suppress("ObjectPropertyName")
         public const val _ID: String = "_id"
+
         // field is part of the default projection available to the clients
         @Suppress("MemberVisibilityCanBePrivate")
         public const val GUID: String = "guid"
         public const val MID: String = "mid"
         public const val ALLOW_EMPTY: String = "allow_empty"
         public const val MOD: String = "mod"
+
         // field is part of the default projection available to the clients
         @Suppress("MemberVisibilityCanBePrivate")
         public const val USN: String = "usn"
         public const val TAGS: String = "tags"
         public const val FLDS: String = "flds"
+
         // field is part of the default projection available to the clients
         @Suppress("MemberVisibilityCanBePrivate")
         public const val SFLD: String = "sfld"
         public const val CSUM: String = "csum"
         public const val FLAGS: String = "flags"
         public const val DATA: String = "data"
+
         @JvmField // required for Java API
         public val DEFAULT_PROJECTION: Array<String> = arrayOf(
             _ID,
@@ -372,6 +376,7 @@ public object FlashCardsContract {
          * This is only used when the "Deck for new cards" preference is set to "Decide by note type"
          */
         public const val DECK_ID: String = "deck_id"
+
         @JvmField // required for Java API
         public val DEFAULT_PROJECTION: Array<String> = arrayOf(
             _ID,
@@ -606,6 +611,7 @@ public object FlashCardsContract {
          * (like a duplicate of the question) this is removed for ANSWER_PURE
          */
         public const val ANSWER_PURE: String = "answer_pure"
+
         @JvmField // required for Java API
         public val DEFAULT_PROJECTION: Array<String> = arrayOf(
             NOTE_ID,
@@ -784,6 +790,7 @@ public object FlashCardsContract {
          * Write-only field, allows suspending of a card when set to 1
          */
         public const val SUSPEND: String = "suspended"
+
         @JvmField // required for Java API
         public val DEFAULT_PROJECTION: Array<String> = arrayOf(
             NOTE_ID,
@@ -894,6 +901,7 @@ public object FlashCardsContract {
     public object Deck {
         @JvmField // required for Java API
         public val CONTENT_ALL_URI: Uri = Uri.withAppendedPath(AUTHORITY_URI, "decks")
+
         @JvmField // required for Java API
         public val CONTENT_SELECTED_URI: Uri = Uri.withAppendedPath(AUTHORITY_URI, "selected_deck")
 
@@ -926,6 +934,7 @@ public object FlashCardsContract {
          * Deck description
          */
         public const val DECK_DESC: String = "deck_desc"
+
         @JvmField // required for Java API
         public val DEFAULT_PROJECTION: Array<String> = arrayOf(
             DECK_NAME,

--- a/api/src/main/java/com/ichi2/anki/api/AddContentApi.kt
+++ b/api/src/main/java/com/ichi2/anki/api/AddContentApi.kt
@@ -122,7 +122,9 @@ public class AddContentApi(context: Context) {
         // Add the notes to the content provider and put the new note ids into the result array
         return if (newNoteValuesList.isEmpty()) {
             0
-        } else compat.insertNotes(deckId, newNoteValuesList.toTypedArray())
+        } else {
+            compat.insertNotes(deckId, newNoteValuesList.toTypedArray())
+        }
     }
 
     /**
@@ -189,7 +191,9 @@ public class AddContentApi(context: Context) {
         val notes = compat.findDuplicateNotes(mid, listOf(key))
         return if (notes!!.size() == 0) {
             emptyList<NoteInfo>()
-        } else notes.valueAt(0)
+        } else {
+            notes.valueAt(0)
+        }
     }
 
     /**
@@ -243,7 +247,9 @@ public class AddContentApi(context: Context) {
         return query.use { cursor ->
             if (!cursor.moveToNext()) {
                 null
-            } else NoteInfo.buildFromCursor(cursor)
+            } else {
+                NoteInfo.buildFromCursor(cursor)
+            }
         }
     }
 
@@ -283,7 +289,7 @@ public class AddContentApi(context: Context) {
                 val a = cardsCursor.getString(cardsCursor.getColumnIndex(Card.ANSWER))
                 cards[n] = hashMapOf(
                     "q" to q,
-                    "a" to a,
+                    "a" to a
                 )
             }
         }
@@ -299,8 +305,14 @@ public class AddContentApi(context: Context) {
      */
     public fun addNewBasicModel(name: String): Long? {
         return addNewCustomModel(
-            name, BasicModel.FIELDS, BasicModel.CARD_NAMES, BasicModel.QFMT,
-            BasicModel.AFMT, null, null, null
+            name,
+            BasicModel.FIELDS,
+            BasicModel.CARD_NAMES,
+            BasicModel.QFMT,
+            BasicModel.AFMT,
+            null,
+            null,
+            null
         )
     }
 
@@ -312,8 +324,14 @@ public class AddContentApi(context: Context) {
      */
     public fun addNewBasic2Model(name: String): Long? {
         return addNewCustomModel(
-            name, Basic2Model.FIELDS, Basic2Model.CARD_NAMES, Basic2Model.QFMT,
-            Basic2Model.AFMT, null, null, null
+            name,
+            Basic2Model.FIELDS,
+            Basic2Model.CARD_NAMES,
+            Basic2Model.QFMT,
+            Basic2Model.AFMT,
+            null,
+            null,
+            null
         )
     }
 
@@ -475,7 +493,9 @@ public class AddContentApi(context: Context) {
             return selectedDeckQuery.use { selectedDeckCursor ->
                 if (selectedDeckCursor.moveToNext()) {
                     selectedDeckCursor.getString(selectedDeckCursor.getColumnIndex(Deck.DECK_NAME))
-                } else null
+                } else {
+                    null
+                }
             }
         } // Get the current model
 
@@ -526,18 +546,19 @@ public class AddContentApi(context: Context) {
             // PackageManager#resolveContentProvider docs suggest flags should be 0 (but that gives null metadata)
             // GET_META_DATA seems to work anyway
             val info =
-                if (Build.VERSION.SDK_INT >= 33)
+                if (Build.VERSION.SDK_INT >= 33) {
                     mContext.packageManager.resolveContentProvider(
                         FlashCardsContract.AUTHORITY,
                         PackageManager.ComponentInfoFlags.of(
                             PackageManager.GET_META_DATA.toLong()
                         )
                     )
-                else
+                } else {
                     mContext.packageManager.resolveContentProvider(
                         FlashCardsContract.AUTHORITY,
                         PackageManager.GET_META_DATA
                     )
+                }
 
             return if (info?.metaData != null && info.metaData.containsKey(
                     PROVIDER_SPEC_META_DATA_KEY
@@ -657,9 +678,11 @@ public class AddContentApi(context: Context) {
     private inner class CompatV2 : CompatV1() {
         override fun queryNotes(modelId: Long): Cursor? {
             return mResolver.query(
-                Note.CONTENT_URI_V2, PROJECTION,
+                Note.CONTENT_URI_V2,
+                PROJECTION,
                 String.format(Locale.US, "%s=%d", Note.MID, modelId),
-                null, null
+                null,
+                null
             )
         }
 
@@ -747,13 +770,14 @@ public class AddContentApi(context: Context) {
         @JvmStatic // required for API
         public fun getAnkiDroidPackageName(context: Context): String? {
             val manager = context.packageManager
-            return if (Build.VERSION.SDK_INT >= 33)
+            return if (Build.VERSION.SDK_INT >= 33) {
                 manager.resolveContentProvider(
                     FlashCardsContract.AUTHORITY,
                     PackageManager.ComponentInfoFlags.of(0L)
                 )?.packageName
-            else
+            } else {
                 manager.resolveContentProvider(FlashCardsContract.AUTHORITY, 0)?.packageName
+            }
         }
     }
 }

--- a/api/src/main/java/com/ichi2/anki/api/Basic2Model.kt
+++ b/api/src/main/java/com/ichi2/anki/api/Basic2Model.kt
@@ -7,12 +7,15 @@ package com.ichi2.anki.api
 internal object Basic2Model {
     @JvmField // required for Java API
     val FIELDS = arrayOf("Front", "Back")
+
     // List of card names that will be used in AnkiDroid (one for each direction of learning)
     @JvmField // required for Java API
     val CARD_NAMES = arrayOf("Card 1", "Card 2")
+
     // Template for the question of each card
     @JvmField // required for Java API
     internal val QFMT = arrayOf("{{Front}}", "{{Back}}")
+
     @JvmField // required for Java API
     internal val AFMT = arrayOf(
         """{{FrontSide}}

--- a/api/src/main/java/com/ichi2/anki/api/BasicModel.kt
+++ b/api/src/main/java/com/ichi2/anki/api/BasicModel.kt
@@ -8,12 +8,15 @@ internal class BasicModel {
     companion object {
         @JvmField // required for API
         var FIELDS = arrayOf("Front", "Back")
+
         // List of card names that will be used in AnkiDroid (one for each direction of learning)
         @JvmField // required for API
         val CARD_NAMES = arrayOf("Card 1")
+
         // Template for the question of each card
         @JvmField // required for API
         val QFMT = arrayOf("{{Front}}")
+
         @JvmField // required for API
         val AFMT = arrayOf(
             """{{FrontSide}}

--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,7 @@ buildscript {
         classpath "app.brant:amazonappstorepublisher:0.1.0"
 
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-        classpath "org.jlleitschuh.gradle:ktlint-gradle:11.0.0"
+        classpath "org.jlleitschuh.gradle:ktlint-gradle:11.1.0"
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -80,7 +80,8 @@ subprojects {
             // remove version override when ktlint gradle plugin releases with 0.45+ transitive
             // check for "ktlint" here:
             // https://github.com/JLLeitschuh/ktlint-gradle/blob/master/plugin/gradle/libs.versions.toml
-            version = "0.45.2"
+            // Also, refrain from using ktlint 0.48+ until this is resolved: https://github.com/JLLeitschuh/ktlint-gradle/issues/622
+            version = "0.47.1"
             disabledRules = ["no-wildcard-imports"]
         }
 

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/IssueRegistry.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/IssueRegistry.kt
@@ -14,6 +14,7 @@
  * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
  ****************************************************************************************/
 @file:Suppress("UnstableApiUsage")
+
 package com.ichi2.anki.lint
 
 import com.android.tools.lint.client.api.IssueRegistry

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/rules/DirectSnackbarMakeUsage.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/DirectSnackbarMakeUsage.kt
@@ -14,6 +14,7 @@
  *  this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 @file:Suppress("UnstableApiUsage")
+
 package com.ichi2.anki.lint.rules
 
 import com.android.tools.lint.detector.api.*

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/rules/DirectSystemCurrentTimeMillisUsage.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/DirectSystemCurrentTimeMillisUsage.kt
@@ -14,6 +14,7 @@
  * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
  ****************************************************************************************/
 @file:Suppress("UnstableApiUsage")
+
 package com.ichi2.anki.lint.rules
 
 import com.android.tools.lint.detector.api.*

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/rules/DirectSystemTimeInstantiation.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/DirectSystemTimeInstantiation.kt
@@ -14,6 +14,7 @@
  * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
  ****************************************************************************************/
 @file:Suppress("UnstableApiUsage")
+
 package com.ichi2.anki.lint.rules
 
 import com.android.tools.lint.detector.api.*
@@ -43,7 +44,8 @@ class DirectSystemTimeInstantiation : Detector(), SourceCodeScanner {
             "Creating SystemTime instances directly means time cannot be controlled during" +
                 " testing, so it is not allowed. Use the collection's getTime() method instead"
         private val implementation = Implementation(
-            DirectSystemTimeInstantiation::class.java, Scope.JAVA_FILE_SCOPE
+            DirectSystemTimeInstantiation::class.java,
+            Scope.JAVA_FILE_SCOPE
         )
         val ISSUE: Issue = Issue.create(
             ID,

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/rules/DirectToastMakeTextUsage.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/DirectToastMakeTextUsage.kt
@@ -14,6 +14,7 @@
  *  this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 @file:Suppress("UnstableApiUsage")
+
 package com.ichi2.anki.lint.rules
 
 import com.android.tools.lint.detector.api.*

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/rules/DuplicateCrowdInStrings.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/DuplicateCrowdInStrings.kt
@@ -33,6 +33,7 @@
  *  https://android.googlesource.com/platform/tools/base/+/studio-master-dev/lint/libs/lint-checks/src/main/java/com/android/tools/lint/checks/StringCasingDetector.kt?autodive=0%2F
  */
 @file:Suppress("UnstableApiUsage")
+
 package com.ichi2.anki.lint.rules
 
 import com.android.SdkConstants.*

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/rules/DuplicateTextInPreferencesXml.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/DuplicateTextInPreferencesXml.kt
@@ -14,6 +14,7 @@
  * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
  ****************************************************************************************/
 @file:Suppress("UnstableApiUsage")
+
 package com.ichi2.anki.lint.rules
 
 import com.android.resources.ResourceFolderType

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/rules/FixedPreferencesTitleLength.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/FixedPreferencesTitleLength.kt
@@ -14,6 +14,7 @@
  *  this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 @file:Suppress("UnstableApiUsage")
+
 package com.ichi2.anki.lint.rules
 
 import com.android.resources.ResourceFolderType

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/rules/HardcodedPreferenceKey.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/HardcodedPreferenceKey.kt
@@ -14,6 +14,7 @@
  *  this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 @file:Suppress("UnstableApiUsage")
+
 package com.ichi2.anki.lint.rules
 
 import com.android.resources.ResourceFolderType

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/rules/InvalidStringFormatDetector.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/InvalidStringFormatDetector.kt
@@ -15,6 +15,7 @@
  */
 
 @file:Suppress("UnstableApiUsage")
+
 package com.ichi2.anki.lint.rules
 
 import com.android.SdkConstants.*
@@ -95,7 +96,8 @@ class InvalidStringFormatDetector : ResourceXmlDetector() {
             if (it.matches(INVALID_FORMAT_PATTERN) && it != "XXX%") {
                 val location = context.createLocationHandle(element).resolve()
                 context.report(
-                    ISSUE, location,
+                    ISSUE,
+                    location,
                     "You have specified the string in wrong format" +
                         "Please check that '%' sign been applied only to valid parameters. " +
                         "Your string might be having a regular word with '%' sign after it. " +

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/rules/JUnitNullAssertionDetector.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/JUnitNullAssertionDetector.kt
@@ -15,6 +15,7 @@
  */
 
 @file:Suppress("UnstableApiUsage")
+
 package com.ichi2.anki.lint.rules
 
 import com.android.tools.lint.detector.api.*

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/rules/KotlinMigrationBrokenEmails.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/KotlinMigrationBrokenEmails.kt
@@ -15,6 +15,7 @@
  */
 
 @file:Suppress("UnstableApiUsage")
+
 package com.ichi2.anki.lint.rules
 
 import com.android.tools.lint.detector.api.*

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/rules/KotlinMigrationFixLineBreaks.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/KotlinMigrationFixLineBreaks.kt
@@ -16,6 +16,7 @@
  */
 
 @file:Suppress("UnstableApiUsage")
+
 package com.ichi2.anki.lint.rules
 
 import com.android.tools.lint.detector.api.*

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/rules/NonPositionalFormatSubstitutions.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/NonPositionalFormatSubstitutions.kt
@@ -15,6 +15,7 @@
  */
 
 @file:Suppress("UnstableApiUsage")
+
 package com.ichi2.anki.lint.rules
 
 import com.android.SdkConstants
@@ -63,7 +64,6 @@ class NonPositionalFormatSubstitutions : ResourceXmlDetector() {
     override fun getApplicableElements() = listOf(SdkConstants.TAG_STRING, SdkConstants.TAG_PLURALS)
 
     override fun visitElement(context: XmlContext, element: Element) {
-
         val elementsToCheck = when (element.tagName) {
             SdkConstants.TAG_PLURALS -> element.childrenSequence()
                 // skip if the item was not a plural (style, etc...)

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/rules/PrintStackTraceUsage.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/PrintStackTraceUsage.kt
@@ -14,6 +14,7 @@
  *  this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 @file:Suppress("UnstableApiUsage")
+
 package com.ichi2.anki.lint.rules
 
 import com.android.tools.lint.detector.api.*

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/rules/VariableNamingDetector.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/VariableNamingDetector.kt
@@ -15,6 +15,7 @@
  */
 
 @file:Suppress("UnstableApiUsage")
+
 package com.ichi2.anki.lint.rules
 
 import com.android.tools.lint.client.api.UElementHandler

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/utils/Aapt2Util.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/utils/Aapt2Util.kt
@@ -57,6 +57,7 @@ object Aapt2Util {
     sealed class FormatData {
         /** Format string representing a date */
         object DateFormatData : FormatData()
+
         /**
          * Data regarding a string which will be passed into getString or getQuantityString
          * @param argCount The number of arguments
@@ -74,7 +75,6 @@ object Aapt2Util {
     }
 
     fun verifyJavaStringFormat(str: String): FormatData {
-
         var argCount = 0
         var nonpositional = false
 
@@ -82,7 +82,6 @@ object Aapt2Util {
         fun c() = str[index]
 
         while (index < str.length) {
-
             if (c() == '%' && index + 1 < str.length) {
                 index++
 

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/utils/Constants.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/utils/Constants.kt
@@ -14,6 +14,7 @@
  * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
  ****************************************************************************************/
 @file:Suppress("UnstableApiUsage")
+
 package com.ichi2.anki.lint.utils
 
 import com.android.tools.lint.detector.api.Category

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/utils/ImportStatementDetector.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/utils/ImportStatementDetector.kt
@@ -14,6 +14,7 @@
  *  this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 @file:Suppress("UnstableApiUsage")
+
 package com.ichi2.anki.lint.utils
 
 import com.android.tools.lint.client.api.UElementHandler

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/utils/KotlinCleanup.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/utils/KotlinCleanup.kt
@@ -18,9 +18,13 @@ package com.ichi2.anki.lint.utils
 
 /** Use when code can be changed after further conversion to Kotlin */
 @Target(
-    AnnotationTarget.CLASS, AnnotationTarget.FUNCTION,
-    AnnotationTarget.VALUE_PARAMETER, AnnotationTarget.EXPRESSION,
-    AnnotationTarget.FIELD, AnnotationTarget.PROPERTY, AnnotationTarget.LOCAL_VARIABLE
+    AnnotationTarget.CLASS,
+    AnnotationTarget.FUNCTION,
+    AnnotationTarget.VALUE_PARAMETER,
+    AnnotationTarget.EXPRESSION,
+    AnnotationTarget.FIELD,
+    AnnotationTarget.PROPERTY,
+    AnnotationTarget.LOCAL_VARIABLE
 )
 @Retention(AnnotationRetention.SOURCE)
 @Repeatable


### PR DESCRIPTION
## Pull Request template

## Purpose / Description

ktlint-gradle supports new ktlint underlying versions now

It still transitively pulls in a ktlint version with a memory leak though (0.43.2) I checked - so we still need the override

ktlint underlying is at 0.48.2: https://github.com/pinterest/ktlint/releases

But ktlint-gradle does not quite handle that yet: https://github.com/JLLeitschuh/ktlint-gradle/issues/622

It goes without saying that this is not a high priority, but it is also just a big spacing diff for the most part so, :shrug: 

The only part of the diff which is an actual change is the `build.gradle` version change here: https://github.com/ankidroid/Anki-Android/pull/11661/commits/5f7ceda3d20585f22ac91a1f349283d077520d70#diff-49a96e7eea8a94af862798a45174e6ac43eb4f8b4bd40759b5da63ba31ec3ef7
(transitively because of this: https://pinterest.github.io/ktlint/faq/#why-is-editorconfig-property-disabled_rules-deprecated-and-how-do-i-resolve-this)

So this updates us to 0.47.1 which is much more modern ktlint, but not the latest to avoid the upstream issue 622, and it does a format on the codebase to pull it up to standards

