### PR TITLE
[GSoC] NF: clean ControlPreference.kt

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.kt
@@ -67,7 +67,7 @@ import com.ichi2.libanki.Utils
 import com.ichi2.libanki.backend.exception.BackendNotSupportedException
 import com.ichi2.libanki.utils.TimeManager
 import com.ichi2.preferences.*
-import com.ichi2.preferences.ControlPreference.Companion.setup
+import com.ichi2.preferences.ControlPreference.Companion.addAllControlPreferencesToCategory
 import com.ichi2.themes.Themes
 import com.ichi2.themes.Themes.setThemeLegacy
 import com.ichi2.themes.Themes.systemIsInNightMode
@@ -1262,8 +1262,7 @@ class Preferences : AnkiActivity() {
 
         override fun initSubscreen() {
             addPreferencesFromResource(R.xml.preferences_controls)
-            val cat = requirePreference<PreferenceCategory>("key_map_category")
-            setup(cat)
+            addAllControlPreferencesToCategory(requirePreference(R.string.controls_command_mapping_cat_key))
         }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.kt
@@ -521,7 +521,6 @@ class Preferences : AnkiActivity() {
                 is IncrementerNumberRangePreferenceCompat -> IncrementerNumberRangePreferenceCompat.IncrementerNumberRangeDialogFragmentCompat.newInstance(preference.getKey())
                 is NumberRangePreferenceCompat -> NumberRangePreferenceCompat.NumberRangeDialogFragmentCompat.newInstance(preference.getKey())
                 is SeekBarPreferenceCompat -> SeekBarPreferenceCompat.SeekBarDialogFragmentCompat.newInstance(preference.getKey())
-                is ControlPreference -> ControlPreference.View.newInstance(preference.getKey())
                 else -> null
             }
 

--- a/AnkiDroid/src/main/java/com/ichi2/preferences/ControlPreference.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/preferences/ControlPreference.kt
@@ -238,16 +238,14 @@ class ControlPreference : ListPreference {
         private const val ADD_GESTURE_INDEX = -1
 
         /** Attaches all possible [ControlPreference] elements to a given [PreferenceCategory] */
-        @JvmStatic
-        fun setup(cat: PreferenceCategory) {
-            val commands = Arrays.stream(ViewerCommand.values()).collect(Collectors.toList())
-            val context = cat.context
-            for (c in commands) {
-                val p = ControlPreference(context)
-                p.setTitle(c.resourceId)
-                p.key = c.preferenceKey
-                p.setDefaultValue(c.defaultValue.toPreferenceString())
-                cat.addPreference(p)
+        fun addAllControlPreferencesToCategory(category: PreferenceCategory) {
+            for (command in ViewerCommand.values()) {
+                val preference = ControlPreference(category.context).apply {
+                    setTitle(command.resourceId)
+                    key = command.preferenceKey
+                    setDefaultValue(command.defaultValue.toPreferenceString())
+                }
+                category.addPreference(preference)
             }
         }
     }

--- a/AnkiDroid/src/main/java/com/ichi2/preferences/ControlPreference.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/preferences/ControlPreference.kt
@@ -17,13 +17,8 @@
 package com.ichi2.preferences
 
 import android.content.Context
-import android.os.Bundle
-import android.text.TextUtils
 import android.util.AttributeSet
-import android.view.KeyEvent.KEYCODE_VOLUME_DOWN
-import android.view.KeyEvent.KEYCODE_VOLUME_UP
 import androidx.preference.ListPreference
-import androidx.preference.ListPreferenceDialogFragmentCompat
 import androidx.preference.PreferenceCategory
 import com.afollestad.materialdialogs.MaterialDialog
 import com.ichi2.anki.AnkiDroidApp
@@ -34,14 +29,10 @@ import com.ichi2.anki.cardviewer.ViewerCommand
 import com.ichi2.anki.dialogs.CardSideSelectionDialog
 import com.ichi2.anki.dialogs.GestureSelectionDialogBuilder
 import com.ichi2.anki.dialogs.KeySelectionDialogBuilder
-import com.ichi2.anki.reviewer.Binding
 import com.ichi2.anki.reviewer.CardSide
 import com.ichi2.anki.reviewer.MappableBinding
 import com.ichi2.anki.reviewer.MappableBinding.Companion.fromGesture
 import com.ichi2.anki.reviewer.MappableBinding.Companion.toPreferenceString
-import timber.log.Timber
-import java.util.*
-import java.util.stream.Collectors
 
 /**
  * A preference which allows mapping of inputs to actions (example: keys -> commands)
@@ -79,29 +70,9 @@ class ControlPreference : ListPreference {
         entryValues = entryIndices.map { it.toString() }.toTypedArray()
     }
 
-    class View : ListPreferenceDialogFragmentCompat() {
-        override fun onCreate(savedInstanceState: Bundle?) {
-            // must be called before super
-            refreshPreferenceEntities()
-            super.onCreate(savedInstanceState)
-        }
-
-        private fun refreshPreferenceEntities() {
-            Timber.d("refreshPreferenceEntities()")
-            val pref = this.preference as ControlPreference
-            pref.refreshEntries()
-        }
-
-        companion object {
-            @JvmStatic
-            fun newInstance(key: String): View {
-                val fragment = View()
-                val b = Bundle(1)
-                b.putString(ARG_KEY, key)
-                fragment.arguments = b
-                return fragment
-            }
-        }
+    override fun onClick() {
+        refreshEntries()
+        super.onClick()
     }
 
     /** The summary that appears on the preference */

--- a/AnkiDroid/src/main/java/com/ichi2/preferences/ControlPreference.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/preferences/ControlPreference.kt
@@ -105,8 +105,8 @@ class ControlPreference : ListPreference {
     }
 
     /** The summary that appears on the preference */
-    override fun getSummary(): CharSequence =
-        TextUtils.join(", ", MappableBinding.fromPreferenceString(value).map { it.toDisplayString(context) })
+    override fun getSummary(): CharSequence = MappableBinding.fromPreferenceString(value)
+        .joinToString(", ") { it.toDisplayString(context) }
 
     /** Called when an element is selected in the ListView */
     override fun callChangeListener(newValue: Any?): Boolean {
@@ -157,13 +157,6 @@ class ControlPreference : ListPreference {
         }
         // don't persist the value
         return false
-    }
-
-    /** Volume keys shouldn't be mapped until we remove the 'Volume' gestures */
-    fun isVolumeKey(binding: Binding): Boolean {
-        if (!binding.isKeyCode) return false
-        val keycode = binding.keycode
-        return keycode == KEYCODE_VOLUME_DOWN || keycode == KEYCODE_VOLUME_UP
     }
 
     /**

--- a/AnkiDroid/src/main/res/values/preferences.xml
+++ b/AnkiDroid/src/main/res/values/preferences.xml
@@ -31,6 +31,7 @@
     <string name="pref_accessibility_screen_key">accessibilityScreen</string>
     <string name="pref_controls_screen_key">controlsScreen</string>
     <string name="pref_reset_languages_key">resetLanguages</string>
+    <string name="controls_command_mapping_cat_key">key_map_category</string>
     <!-- Sync preferences -->
     <string name="pref_sync_screen_key">syncScreen</string>
     <string name="sync_account_key">syncAccount</string>

--- a/AnkiDroid/src/main/res/xml/preferences_controls.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_controls.xml
@@ -52,5 +52,5 @@
         app:interval="1"
         app:min="20" />
     <!-- This category is expanded in BindingPreference.setup -->
-    <PreferenceCategory android:title="@string/controls_main_category" android:key="key_map_category" />
+    <PreferenceCategory android:title="@string/controls_main_category" android:key="@string/controls_command_mapping_cat_key" />
 </PreferenceScreen>


### PR DESCRIPTION
## Purpose / Description
Part of the process of getting rid of `setTargetFragment` deprecation

## Approach
On the commits

## How Has This Been Tested?

Used the control preferences on the app

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
