### PR TITLE
Change flag colors for light and dark themes for better accesibility 

### DIFF
--- a/AnkiDroid/src/main/res/drawable/ic_flag_blue.xml
+++ b/AnkiDroid/src/main/res/drawable/ic_flag_blue.xml
@@ -5,5 +5,5 @@
     android:viewportHeight="24">
   <path
       android:pathData="M14.4,6L14,4H5v17h2v-7h5.6l0.4,2h7V6z"
-      android:fillColor="@color/material_blue_700"/>
+      android:fillColor="@color/flag_reviewer_blue"/>
 </vector>

--- a/AnkiDroid/src/main/res/drawable/ic_flag_green.xml
+++ b/AnkiDroid/src/main/res/drawable/ic_flag_green.xml
@@ -5,5 +5,5 @@
     android:viewportHeight="24">
   <path
       android:pathData="M14.4,6L14,4H5v17h2v-7h5.6l0.4,2h7V6z"
-      android:fillColor="#77ff77"/>
+      android:fillColor="@color/flag_reviewer_green"/>
 </vector>

--- a/AnkiDroid/src/main/res/drawable/ic_flag_orange.xml
+++ b/AnkiDroid/src/main/res/drawable/ic_flag_orange.xml
@@ -5,5 +5,5 @@
     android:viewportHeight="24">
   <path
       android:pathData="M14.4,6L14,4H5v17h2v-7h5.6l0.4,2h7V6z"
-      android:fillColor="#ff9800"/>
+      android:fillColor="@color/flag_orange"/>
 </vector>

--- a/AnkiDroid/src/main/res/drawable/ic_flag_orange.xml
+++ b/AnkiDroid/src/main/res/drawable/ic_flag_orange.xml
@@ -5,5 +5,5 @@
     android:viewportHeight="24">
   <path
       android:pathData="M14.4,6L14,4H5v17h2v-7h5.6l0.4,2h7V6z"
-      android:fillColor="#ff9900"/>
+      android:fillColor="#ff9800"/>
 </vector>

--- a/AnkiDroid/src/main/res/drawable/ic_flag_pink.xml
+++ b/AnkiDroid/src/main/res/drawable/ic_flag_pink.xml
@@ -5,5 +5,5 @@
     android:viewportHeight="24">
   <path
       android:pathData="M14.4,6L14,4H5v17h2v-7h5.6l0.4,2h7V6z"
-      android:fillColor="#FF82EE"/>
+      android:fillColor="@color/flag_reviewer_pink"/>
 </vector>

--- a/AnkiDroid/src/main/res/drawable/ic_flag_pink.xml
+++ b/AnkiDroid/src/main/res/drawable/ic_flag_pink.xml
@@ -5,5 +5,5 @@
     android:viewportHeight="24">
   <path
       android:pathData="M14.4,6L14,4H5v17h2v-7h5.6l0.4,2h7V6z"
-      android:fillColor="@color/flag_pink"/>
+      android:fillColor="#FF82EE"/>
 </vector>

--- a/AnkiDroid/src/main/res/drawable/ic_flag_purple.xml
+++ b/AnkiDroid/src/main/res/drawable/ic_flag_purple.xml
@@ -5,5 +5,5 @@
     android:viewportHeight="24">
   <path
       android:pathData="M14.4,6L14,4H5v17h2v-7h5.6l0.4,2h7V6z"
-      android:fillColor="#9649DD"/>
+      android:fillColor="@color/flag_reviewer_purple"/>
 </vector>

--- a/AnkiDroid/src/main/res/drawable/ic_flag_purple.xml
+++ b/AnkiDroid/src/main/res/drawable/ic_flag_purple.xml
@@ -5,5 +5,5 @@
     android:viewportHeight="24">
   <path
       android:pathData="M14.4,6L14,4H5v17h2v-7h5.6l0.4,2h7V6z"
-      android:fillColor="@color/flag_purple"/>
+      android:fillColor="#9649DD"/>
 </vector>

--- a/AnkiDroid/src/main/res/drawable/ic_flag_red.xml
+++ b/AnkiDroid/src/main/res/drawable/ic_flag_red.xml
@@ -5,5 +5,5 @@
     android:viewportHeight="24">
   <path
       android:pathData="M14.4,6L14,4H5v17h2v-7h5.6l0.4,2h7V6z"
-      android:fillColor="#ff0000"/>
+      android:fillColor="@color/flag_reviewer_red"/>
 </vector>

--- a/AnkiDroid/src/main/res/drawable/ic_flag_red.xml
+++ b/AnkiDroid/src/main/res/drawable/ic_flag_red.xml
@@ -5,5 +5,5 @@
     android:viewportHeight="24">
   <path
       android:pathData="M14.4,6L14,4H5v17h2v-7h5.6l0.4,2h7V6z"
-      android:fillColor="#ff6666"/>
+      android:fillColor="#ff0000"/>
 </vector>

--- a/AnkiDroid/src/main/res/drawable/ic_flag_turquoise.xml
+++ b/AnkiDroid/src/main/res/drawable/ic_flag_turquoise.xml
@@ -5,5 +5,5 @@
     android:viewportHeight="24">
   <path
       android:pathData="M14.4,6L14,4H5v17h2v-7h5.6l0.4,2h7V6z"
-      android:fillColor="#00D1B5"/>
+      android:fillColor="@color/flag_reviewer_turquoise"/>
 </vector>

--- a/AnkiDroid/src/main/res/drawable/ic_flag_turquoise.xml
+++ b/AnkiDroid/src/main/res/drawable/ic_flag_turquoise.xml
@@ -5,5 +5,5 @@
     android:viewportHeight="24">
   <path
       android:pathData="M14.4,6L14,4H5v17h2v-7h5.6l0.4,2h7V6z"
-      android:fillColor="@color/flag_turquoise"/>
+      android:fillColor="#00D1B5"/>
 </vector>

--- a/AnkiDroid/src/main/res/values/colors.xml
+++ b/AnkiDroid/src/main/res/values/colors.xml
@@ -106,6 +106,7 @@
     <color name="note_editor_selected_item_background">#D1D0CE</color>
     <color name="note_editor_selected_item_text">#000000</color>
 
+    <!-- For Card background in Card Browser -->
     <color name="flag_red">#FF4747</color>
     <color name="flag_orange">#FFB647</color>
     <color name="flag_green">#6FF06F</color>
@@ -121,6 +122,15 @@
     <color name="flag_pink_dark">#A70D64</color>
     <color name="flag_turquoise_dark">#138072</color>
     <color name="flag_purple_dark">#6320A0</color>
+
+    <!-- For flag icons -->
+    <color name="flag_reviewer_red">#ff0000</color>
+    <color name="flag_reviewer_orange">#ff9800</color>
+    <color name="flag_reviewer_green">#77ff77</color>
+    <color name="flag_reviewer_blue">#ff1976d2</color>
+    <color name="flag_reviewer_pink">#FF82EE</color>
+    <color name="flag_reviewer_turquoise">#00D1B5</color>
+    <color name="flag_reviewer_purple">#9649DD</color>
 
     <color name="badge_error">#f45000</color>
     <color name="badge_warning">#ff5e13</color>

--- a/AnkiDroid/src/main/res/values/colors.xml
+++ b/AnkiDroid/src/main/res/values/colors.xml
@@ -106,13 +106,21 @@
     <color name="note_editor_selected_item_background">#D1D0CE</color>
     <color name="note_editor_selected_item_text">#000000</color>
 
-    <color name="flag_red">#ff0000</color>
-    <color name="flag_orange">#FF9800</color>
-    <color name="flag_green">#00ff00</color>
-    <color name="flag_blue">#0000ff</color>
-    <color name="flag_pink">#ff82ee</color>
-    <color name="flag_turquoise">#00d1b5</color>
-    <color name="flag_purple">#9649dd</color>
+    <color name="flag_red">#FF4747</color>
+    <color name="flag_orange">#FFB647</color>
+    <color name="flag_green">#6FF06F</color>
+    <color name="flag_blue">#5289FF</color>
+    <color name="flag_pink">#FF99F1</color>
+    <color name="flag_turquoise">#85FFEF</color>
+    <color name="flag_purple">#C398EC</color>
+
+    <color name="flag_red_dark">#D32525</color>
+    <color name="flag_orange_dark">#BB7A17</color>
+    <color name="flag_green_dark">#057A05</color>
+    <color name="flag_blue_dark">#1A4FC2</color>
+    <color name="flag_pink_dark">#A70D64</color>
+    <color name="flag_turquoise_dark">#138072</color>
+    <color name="flag_purple_dark">#6320A0</color>
 
     <color name="badge_error">#f45000</color>
     <color name="badge_warning">#ff5e13</color>

--- a/AnkiDroid/src/main/res/values/theme_black.xml
+++ b/AnkiDroid/src/main/res/values/theme_black.xml
@@ -82,13 +82,13 @@
         <item name="suspendedColor">#A8A634</item>
         <item name="selectedColor">#a86634</item>
         <item name="markedColor">#391080</item>
-        <item name="flagRed">@color/flag_red</item>
-        <item name="flagOrange">@color/flag_orange</item>
-        <item name="flagGreen">@color/flag_green</item>
-        <item name="flagBlue">@color/flag_blue</item>
-        <item name="flagPink">@color/flag_pink</item>
-        <item name="flagTurquoise">@color/flag_turquoise</item>
-        <item name="flagPurple">@color/flag_purple</item>
+        <item name="flagRed">@color/flag_red_dark</item>
+        <item name="flagOrange">@color/flag_orange_dark</item>
+        <item name="flagGreen">@color/flag_green_dark</item>
+        <item name="flagBlue">@color/flag_blue_dark</item>
+        <item name="flagPink">@color/flag_pink_dark</item>
+        <item name="flagTurquoise">@color/flag_turquoise_dark</item>
+        <item name="flagPurple">@color/flag_purple_dark</item>
         <!-- Note editor colors -->
         <item name="duplicateColor">#855</item>
         <!-- Note editor colors -->

--- a/AnkiDroid/src/main/res/values/theme_dark.xml
+++ b/AnkiDroid/src/main/res/values/theme_dark.xml
@@ -86,13 +86,13 @@
         <!-- Browser colors -->
         <item name="suspendedColor">@color/material_grey_700</item>
         <item name="markedColor">@color/material_deep_purple_400</item>
-        <item name="flagRed">@color/flag_red</item>
-        <item name="flagOrange">@color/flag_orange</item>
-        <item name="flagGreen">@color/flag_green</item>
-        <item name="flagBlue">@color/flag_blue</item>
-        <item name="flagPink">@color/flag_pink</item>
-        <item name="flagTurquoise">@color/flag_turquoise</item>
-        <item name="flagPurple">@color/flag_purple</item>
+        <item name="flagRed">@color/flag_red_dark</item>
+        <item name="flagOrange">@color/flag_orange_dark</item>
+        <item name="flagGreen">@color/flag_green_dark</item>
+        <item name="flagBlue">@color/flag_blue_dark</item>
+        <item name="flagPink">@color/flag_pink_dark</item>
+        <item name="flagTurquoise">@color/flag_turquoise_dark</item>
+        <item name="flagPurple">@color/flag_purple_dark</item>
         <!-- Note editor colors -->
         <item name="duplicateColor">#855</item>
         <item name="editTextBackgroundColor">#EE5C5C5C</item>


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
To make the text on flagged cards more readable

## Fixes
Fixes #11671 
## Approach
Choose shades of colors that pass the accessibility scanner

## How Has This Been Tested?

### Before
![1655962500220](https://user-images.githubusercontent.com/86671025/175663824-4399842b-1101-492d-ad84-ff93bcef9347.jpeg)

### After
### Light mode
![1656102804254](https://user-images.githubusercontent.com/86671025/175663514-8be1258c-6bfc-4922-abc6-d0861972b0ba.jpeg)

### Dark mode - only the orange color doesn't pass accessibility, but if I make it any darker it wouldn't be a shade of orange anymore so left it there
![1656102804261](https://user-images.githubusercontent.com/86671025/175663540-6fb6f029-f8b8-4828-accb-524024a13aa6.jpeg)


## Learning (optional, can help others)
_Describe the research stage_

_Links to blog posts, patterns, libraries or addons used to solve this problem_

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [x] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
