### PR TITLE
fix: Spacing issue in Beolingus Search

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/beolingus/parsing/BeolingusParser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/beolingus/parsing/BeolingusParser.kt
@@ -45,9 +45,14 @@ object BeolingusParser {
         while (m.find()) {
             // Perform .contains() due to #5376 (a "%20{noun}" suffix).
             // Perform .toLowerCase() due to #5810 ("hello" should match "Hello").
+            // Perform .replace() due to #11365 (" Hello " should match "Hello").
             // See #5810 for discussion on Locale complexities. Currently unhandled.
             @KotlinCleanup("improve null handling of m.group() possibly returning null")
-            if (m.group(2)!!.lowercase(Locale.ROOT).contains(wordToSearchFor!!.lowercase(Locale.ROOT))) {
+            if (m.group(2)!!.lowercase(Locale.ROOT).contains(
+                    wordToSearchFor!!.lowercase(Locale.ROOT)
+                        .replace("\\s".toRegex(), "")
+                )
+            ) {
                 Timber.d("pronunciation URL is https://dict.tu-chemnitz.de%s", m.group(1))
                 return "https://dict.tu-chemnitz.de" + m.group(1)
             }


### PR DESCRIPTION
## Purpose / Description
The search for " Hello " ( a string with spaces ) was failing when it was searched in Beolingus while loading the pronunciation for that word.

## Fixes
Fixes #11365 

## Approach
The .replace() function in BeolingusParser takes all the extra spaces in a string and convert it into a Regex and then replaces it with an empty string.

## How Has This Been Tested?
Tested manually on my device.
Android Version: 9
Device: Asus Max Pro M2

## Learning (optional, can help others)
_Describe the research stage_

_Links to blog posts, patterns, libraries or addons used to solve this problem_

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
