### PR TITLE
NF: Remove AnkiActivity.finish() deprecation

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiActivity.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiActivity.java
@@ -317,10 +317,9 @@ public class AnkiActivity extends AppCompatActivity implements SimpleMessageDial
     }
 
 
-    @Deprecated
     @Override
     public void finish() {
-        super.finish();
+        finishWithAnimation(Direction.DEFAULT);
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardInfo.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardInfo.kt
@@ -105,21 +105,17 @@ class CardInfo : AnkiActivity() {
         this.model = model
     }
 
-    fun closeCardInfo() {
+    override fun finish() {
         val animation: Parcelable? = intent.getParcelableExtra(FINISH_ANIMATION_EXTRA)
         if (animation is ActivityTransitionAnimation.Direction) {
             finishWithAnimation(animation)
         } else {
-            finishWithoutAnimation()
+            super.finish()
         }
     }
 
-    override fun onBackPressed() {
-        closeCardInfo()
-    }
-
     override fun onActionBarBackPressed(): Boolean {
-        closeCardInfo()
+        finish()
         return true
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.kt
@@ -925,7 +925,7 @@ class Preferences : AnkiActivity() {
             val fragmentClassNames = arrayOf(AppearanceSettingsFragment::class.java.name)
             intent.putExtra(EXTRA_BACKSTACK_FRAGMENTS, fragmentClassNames)
             requireContext().startActivity(intent)
-            this.requireActivity().finish()
+            requireActivity().finish()
         }
 
         /** Initializes the list of custom fonts shown in the preferences.  */


### PR DESCRIPTION
## Purpose / Description
The sole purpose of the deprecation is to force to use `finishWithAnimation` our `finishWithoutAnimation`, methods which create the possibility of disabling the animations on E-ink devices

But this didn't block uses of `requireActivity().finish()` or `(x as Activity).finish()`, some animations would show regardless of the E-ink setting

Removing the deprecation and setting it to use the default animation fixes the problem while keeping `finish()` default behavior

## How Has This Been Tested?

Emulator on SDK 25.
1. Enable safer display mode on Advanced
2. Change theme
3. (no animation should appear)

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
