### PR TITLE
Make CardTemplateEditor show where error

### DIFF
--- a/AnkiDroid/src/main/res/values/01-core.xml
+++ b/AnkiDroid/src/main/res/values/01-core.xml
@@ -186,6 +186,8 @@
     <string name="invalid_template">A card could not be generated</string>
     <string name="card_template_editor_would_delete_note">Removing this card type would cause one or more notes to be deleted. Please create and save a new card type first.</string>
     <string name="card_template_editor_save_error">Unable to save card template changes: %s</string>
+    <string name="card_template_editor_invalid_field_error">Error:\nField doesn\'t exist</string>
+    <string name="card_template_editor_invalid_field_toast_button">Where?</string>
     <string name="template_for_current_card_deleted">The card type for the current card was deleted.</string>
 
     <!-- Card Browser Appearance -->


### PR DESCRIPTION
## Purpose / Description
Make CardTemplateEditor show error if it contains an invalid field

## Fixes
Fixes #11672

## Approach
Modified `CollectionTask::SaveModel()` to check in new template for {{field}}s that aren't actual fields. If any were found, show a snackbar with error message and a button that navigates to the error location if clicked.

## How Has This Been Tested?

https://user-images.githubusercontent.com/59933477/175817922-5a44ea15-4599-4639-bf76-46ee4bc22d92.mp4



## Checklist

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [x] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
