### PR TITLE
[GSoC] Refactor preferences fragments initialization

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiActivity.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiActivity.java
@@ -139,7 +139,7 @@ public class AnkiActivity extends AppCompatActivity implements SimpleMessageDial
             Themes.systemIsInNightMode = newNightModeStatus;
             if (Themes.themeFollowsSystem()) {
                 Themes.updateCurrentTheme();
-                restartActivity();
+                recreate();
             }
         }
     }


### PR DESCRIPTION
## Purpose / Description
Changing dark mode would restart the activity on the initial screen instead of the the one the user was at

+ cleanups

## Approach
On the commits

## How Has This Been Tested?

On my phone by changing configuration (e.g. dark mode)

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
