### PR TITLE
Add Toast for "max one word" pronunciation

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/activity/LoadPronunciationActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/activity/LoadPronunciationActivity.kt
@@ -207,7 +207,9 @@ open class LoadPronunciationActivity : AnkiActivity(), DialogInterface.OnCancelL
             mPronunciationAddress = BeolingusParser.getPronunciationAddressFromTranslation(result, source)
             if (mPronunciationAddress.contentEquals("no")) {
                 failNoPronunciation()
-                if (!source.lowercase(Locale.getDefault()).contentEquals(source)) {
+                if (source.split(" ").size > 1) {
+                    showToastLong(gtxt(R.string.multimedia_editor_only_one_words))
+                } else if (!source.lowercase(Locale.getDefault()).contentEquals(source)) {
                     showToastLong(gtxt(R.string.multimedia_editor_word_search_try_lower_case))
                 }
                 return

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/activity/LoadPronunciationActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/activity/LoadPronunciationActivity.kt
@@ -207,7 +207,7 @@ open class LoadPronunciationActivity : AnkiActivity(), DialogInterface.OnCancelL
             mPronunciationAddress = BeolingusParser.getPronunciationAddressFromTranslation(result, source)
             if (mPronunciationAddress.contentEquals("no")) {
                 failNoPronunciation()
-                if (source.split(" ").size > 1) {
+                if (source.contains(" ")) {
                     showToastLong(gtxt(R.string.multimedia_editor_only_one_words))
                 } else if (!source.lowercase(Locale.getDefault()).contentEquals(source)) {
                     showToastLong(gtxt(R.string.multimedia_editor_word_search_try_lower_case))

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/activity/LoadPronunciationActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/activity/LoadPronunciationActivity.kt
@@ -50,7 +50,6 @@ import kotlinx.coroutines.withContext
 import timber.log.Timber
 import java.io.UnsupportedEncodingException
 import java.net.URLEncoder
-import java.util.Locale
 
 /**
  * Activity to load pronunciation files from Beolingus.
@@ -208,8 +207,8 @@ open class LoadPronunciationActivity : AnkiActivity(), DialogInterface.OnCancelL
             if (mPronunciationAddress.contentEquals("no")) {
                 failNoPronunciation()
                 if (source.contains(" ")) {
-                    showToastLong(gtxt(R.string.multimedia_editor_only_one_words))
-                } else if (!source.lowercase(Locale.getDefault()).contentEquals(source)) {
+                    showToastLong(gtxt(R.string.multimedia_editor_only_one_word))
+                } else if (source.any { it.isUpperCase() }) {
                     showToastLong(gtxt(R.string.multimedia_editor_word_search_try_lower_case))
                 }
                 return

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/beolingus/parsing/BeolingusParser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/beolingus/parsing/BeolingusParser.kt
@@ -21,7 +21,6 @@ package com.ichi2.anki.multimediacard.beolingus.parsing
 import com.ichi2.utils.KotlinCleanup
 import org.intellij.lang.annotations.Language
 import timber.log.Timber
-import java.util.*
 import java.util.regex.Pattern
 
 /**
@@ -47,7 +46,7 @@ object BeolingusParser {
             // Perform .toLowerCase() due to #5810 ("hello" should match "Hello").
             // See #5810 for discussion on Locale complexities. Currently unhandled.
             @KotlinCleanup("improve null handling of m.group() possibly returning null")
-            if (m.group(2)!!.lowercase(Locale.ROOT).contains(wordToSearchFor!!.lowercase(Locale.ROOT))) {
+            if (m.group(2)!!.contains(wordToSearchFor!!, ignoreCase = true)) {
                 Timber.d("pronunciation URL is https://dict.tu-chemnitz.de%s", m.group(1))
                 return "https://dict.tu-chemnitz.de" + m.group(1)
             }

--- a/AnkiDroid/src/main/res/values/16-multimedia-editor.xml
+++ b/AnkiDroid/src/main/res/values/16-multimedia-editor.xml
@@ -30,6 +30,7 @@
     <string name="multimedia_editor_pron_looking_up">Looking up pronunciation</string>
     <!-- in controller when fails -->
     <string name="multimedia_editor_pron_pronunciation_failed">Pronunciation failed</string>
+    <string name="multimedia_editor_only_one_words">Only one word at a time is supported</string>
     <string name="multimedia_editor_word_search_try_lower_case">Try using only lower case characters</string>
     <string name="multimedia_editor_poweredbeolingus">Powered by Beolingus</string>
 

--- a/AnkiDroid/src/main/res/values/16-multimedia-editor.xml
+++ b/AnkiDroid/src/main/res/values/16-multimedia-editor.xml
@@ -30,7 +30,7 @@
     <string name="multimedia_editor_pron_looking_up">Looking up pronunciation</string>
     <!-- in controller when fails -->
     <string name="multimedia_editor_pron_pronunciation_failed">Pronunciation failed</string>
-    <string name="multimedia_editor_only_one_words">Only one word at a time is supported</string>
+    <string name="multimedia_editor_only_one_word">Only one word at a time is supported</string>
     <string name="multimedia_editor_word_search_try_lower_case">Try using only lower case characters</string>
     <string name="multimedia_editor_poweredbeolingus">Powered by Beolingus</string>
 


### PR DESCRIPTION

## Purpose / Description
In Pronunciation, If a string with more than one word was entered, the proper error toast wouldn't show up

## Fixes
Fixes #11748 

## Approach
Added toast in LoadPronunciationActivity::DownloadFileTask for if `source` is more than one word

## Checklist

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [x] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
