### PR TITLE
Bump fragments library dependency to 1.5.0

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -251,7 +251,7 @@ dependencies {
     implementation 'androidx.browser:browser:1.4.0'
     implementation "androidx.core:core-ktx:1.8.0"
     implementation 'androidx.exifinterface:exifinterface:1.3.3'
-    implementation 'androidx.fragment:fragment-ktx:1.4.1'
+    implementation "androidx.fragment:fragment-ktx:$fragments_version"
     implementation "androidx.preference:preference-ktx:1.2.0"
     implementation 'androidx.recyclerview:recyclerview:1.2.1'
     implementation 'androidx.sqlite:sqlite-framework:2.2.0'
@@ -333,7 +333,7 @@ dependencies {
     testImplementation 'org.apache.commons:commons-exec:1.3' // obtaining the OS
 
     // debugImplementation required vs testImplementation: https://issuetracker.google.com/issues/128612536
-    debugImplementation 'androidx.fragment:fragment-testing:1.4.1'
+    debugImplementation "androidx.fragment:fragment-testing:$fragments_version"
 
     // May need a resolution strategy for support libs to our versions
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.kt
@@ -31,8 +31,11 @@ import androidx.annotation.CheckResult
 import androidx.annotation.RequiresApi
 import androidx.annotation.StringRes
 import androidx.annotation.VisibleForTesting
+import androidx.core.view.MenuHost
+import androidx.core.view.MenuProvider
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentActivity
+import androidx.lifecycle.Lifecycle
 import androidx.viewpager2.adapter.FragmentStateAdapter
 import androidx.viewpager2.widget.ViewPager2
 import com.afollestad.materialdialogs.DialogAction
@@ -377,8 +380,6 @@ open class CardTemplateEditor : AnkiActivity(), DeckSelectionListener {
             }
             mEditorEditText.addTextChangedListener(templateEditorWatcher)
 
-            // Enable menu
-            setHasOptionsMenu(true)
             return mainView
         }
 
@@ -459,6 +460,7 @@ open class CardTemplateEditor : AnkiActivity(), DeckSelectionListener {
                     insertField(bundle.getString(InsertFieldDialog.KEY_INSERTED_FIELD)!!)
                 }
             }
+            setupMenu()
         }
 
         private fun initTabLayoutMediator() {
@@ -476,111 +478,118 @@ open class CardTemplateEditor : AnkiActivity(), DeckSelectionListener {
             super.onResume()
         }
 
-        override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
-            menu.clear()
-            inflater.inflate(R.menu.card_template_editor, menu)
+        private fun setupMenu() {
+            // Enable menu
+            (requireActivity() as MenuHost).addMenuProvider(
+                object : MenuProvider {
+                    override fun onCreateMenu(menu: Menu, menuInflater: MenuInflater) {
+                        menu.clear()
+                        menuInflater.inflate(R.menu.card_template_editor, menu)
 
-            if (mTemplateEditor.tempModel!!.model.isCloze) {
-                Timber.d("Editing cloze model, disabling add/delete card template and deck override functionality")
-                menu.findItem(R.id.action_add).isVisible = false
-                menu.findItem(R.id.action_add_deck_override).isVisible = false
-            } else {
-                val template = getCurrentTemplate()
+                        if (mTemplateEditor.tempModel!!.model.isCloze) {
+                            Timber.d("Editing cloze model, disabling add/delete card template and deck override functionality")
+                            menu.findItem(R.id.action_add).isVisible = false
+                            menu.findItem(R.id.action_add_deck_override).isVisible = false
+                        } else {
+                            val template = getCurrentTemplate()
 
-                @StringRes val overrideStringRes = if (template != null && template.has("did") && !template.isNull("did")) {
-                    R.string.card_template_editor_deck_override_on
-                } else {
-                    R.string.card_template_editor_deck_override_off
-                }
-                menu.findItem(R.id.action_add_deck_override).setTitle(overrideStringRes)
-            }
+                            @StringRes val overrideStringRes = if (template != null && template.has("did") && !template.isNull("did")) {
+                                R.string.card_template_editor_deck_override_on
+                            } else {
+                                R.string.card_template_editor_deck_override_off
+                            }
+                            menu.findItem(R.id.action_add_deck_override).setTitle(overrideStringRes)
+                        }
 
-            // It is invalid to delete if there is only one card template, remove the option from UI
-            if (mTemplateEditor.tempModel!!.templateCount < 2) {
-                menu.findItem(R.id.action_delete).isVisible = false
-            }
+                        // It is invalid to delete if there is only one card template, remove the option from UI
+                        if (mTemplateEditor.tempModel!!.templateCount < 2) {
+                            menu.findItem(R.id.action_delete).isVisible = false
+                        }
 
-            // marked insert field menu item invisible for style view
-            val isInsertFieldItemVisible = currentEditorViewId != R.id.styling_edit
-            menu.findItem(R.id.action_insert_field).isVisible = isInsertFieldItemVisible
-            super.onCreateOptionsMenu(menu, inflater)
-        }
+                        // marked insert field menu item invisible for style view
+                        val isInsertFieldItemVisible = currentEditorViewId != R.id.styling_edit
+                        menu.findItem(R.id.action_insert_field).isVisible = isInsertFieldItemVisible
+                    }
 
-        override fun onOptionsItemSelected(item: MenuItem): Boolean {
-            val col = mTemplateEditor.col
-            val tempModel = mTemplateEditor.tempModel
-            val itemId = item.itemId
-            @KotlinCleanup("when")
-            if (itemId == R.id.action_add) {
-                Timber.i("CardTemplateEditor:: Add template button pressed")
-                // Show confirmation dialog
-                val ordinal = mTemplateEditor.viewPager.currentItem
-                // isOrdinalPendingAdd method will check if there are any new card types added or not,
-                // if TempModel has new card type then numAffectedCards will be 0 by default.
-                val numAffectedCards = if (!TemporaryModel.isOrdinalPendingAdd(tempModel!!, ordinal)) {
-                    col.models.tmplUseCount(tempModel.model, ordinal)
-                } else {
-                    0
-                }
-                confirmAddCards(tempModel.model, numAffectedCards)
-                return true
-            } else if (itemId == R.id.action_insert_field) {
-                showInsertFieldDialog()
-            } else if (itemId == R.id.action_delete) {
-                Timber.i("CardTemplateEditor:: Delete template button pressed")
-                val res = resources
-                val ordinal = mTemplateEditor.viewPager.currentItem
-                val template = tempModel!!.getTemplate(ordinal)
-                // Don't do anything if only one template
-                if (tempModel.templateCount < 2) {
-                    mTemplateEditor.showSimpleMessageDialog(res.getString(R.string.card_template_editor_cant_delete))
-                    return true
-                }
+                    override fun onMenuItemSelected(menuItem: MenuItem): Boolean {
+                        val col = mTemplateEditor.col
+                        val tempModel = mTemplateEditor.tempModel
+                        val itemId = menuItem.itemId
+                        @KotlinCleanup("when")
+                        if (itemId == R.id.action_add) {
+                            Timber.i("CardTemplateEditor:: Add template button pressed")
+                            // Show confirmation dialog
+                            val ordinal = mTemplateEditor.viewPager.currentItem
+                            // isOrdinalPendingAdd method will check if there are any new card types added or not,
+                            // if TempModel has new card type then numAffectedCards will be 0 by default.
+                            val numAffectedCards = if (!TemporaryModel.isOrdinalPendingAdd(tempModel!!, ordinal)) {
+                                col.models.tmplUseCount(tempModel.model, ordinal)
+                            } else {
+                                0
+                            }
+                            confirmAddCards(tempModel.model, numAffectedCards)
+                            return true
+                        } else if (itemId == R.id.action_insert_field) {
+                            showInsertFieldDialog()
+                        } else if (itemId == R.id.action_delete) {
+                            Timber.i("CardTemplateEditor:: Delete template button pressed")
+                            val res = resources
+                            val ordinal = mTemplateEditor.viewPager.currentItem
+                            val template = tempModel!!.getTemplate(ordinal)
+                            // Don't do anything if only one template
+                            if (tempModel.templateCount < 2) {
+                                mTemplateEditor.showSimpleMessageDialog(res.getString(R.string.card_template_editor_cant_delete))
+                                return true
+                            }
 
-                if (deletionWouldOrphanNote(col, tempModel, ordinal)) {
-                    return true
-                }
+                            if (deletionWouldOrphanNote(col, tempModel, ordinal)) {
+                                return true
+                            }
 
-                // Show confirmation dialog
-                val numAffectedCards = if (!TemporaryModel.isOrdinalPendingAdd(tempModel, ordinal)) {
-                    Timber.d("Ordinal is not a pending add, so we'll get the current card count for confirmation")
-                    col.models.tmplUseCount(tempModel.model, ordinal)
-                } else {
-                    0
-                }
-                confirmDeleteCards(template, tempModel.model, numAffectedCards)
-                return true
-            } else if (itemId == R.id.action_add_deck_override) {
-                displayDeckOverrideDialog(col, tempModel)
-                return true
-            } else if (itemId == R.id.action_preview) {
-                performPreview()
-                return true
-            } else if (itemId == R.id.action_confirm) {
-                Timber.i("CardTemplateEditor:: Save model button pressed")
-                if (modelHasChanged()) {
-                    val confirmButton = mTemplateEditor.findViewById<View>(R.id.action_confirm)
-                    if (confirmButton != null) {
-                        if (!confirmButton.isEnabled) {
-                            Timber.d("CardTemplateEditor::discarding extra click after button disabled")
+                            // Show confirmation dialog
+                            val numAffectedCards = if (!TemporaryModel.isOrdinalPendingAdd(tempModel, ordinal)) {
+                                Timber.d("Ordinal is not a pending add, so we'll get the current card count for confirmation")
+                                col.models.tmplUseCount(tempModel.model, ordinal)
+                            } else {
+                                0
+                            }
+                            confirmDeleteCards(template, tempModel.model, numAffectedCards)
+                            return true
+                        } else if (itemId == R.id.action_add_deck_override) {
+                            displayDeckOverrideDialog(col, tempModel)
+                            return true
+                        } else if (itemId == R.id.action_preview) {
+                            performPreview()
+                            return true
+                        } else if (itemId == R.id.action_confirm) {
+                            Timber.i("CardTemplateEditor:: Save model button pressed")
+                            if (modelHasChanged()) {
+                                val confirmButton = mTemplateEditor.findViewById<View>(R.id.action_confirm)
+                                if (confirmButton != null) {
+                                    if (!confirmButton.isEnabled) {
+                                        Timber.d("CardTemplateEditor::discarding extra click after button disabled")
+                                        return true
+                                    }
+                                    confirmButton.isEnabled = false
+                                }
+                                tempModel!!.saveToDatabase(saveModelAndExitHandler())
+                            } else {
+                                Timber.d("CardTemplateEditor:: model has not changed, exiting")
+                                mTemplateEditor.finishWithAnimation(END)
+                            }
+
+                            return true
+                        } else if (itemId == R.id.action_card_browser_appearance) {
+                            Timber.i("CardTemplateEditor::Card Browser Template button pressed")
+                            val currentTemplate = getCurrentTemplate()
+                            currentTemplate?.let { launchCardBrowserAppearance(it) }
                             return true
                         }
-                        confirmButton.isEnabled = false
+                        return false
                     }
-                    tempModel!!.saveToDatabase(saveModelAndExitHandler())
-                } else {
-                    Timber.d("CardTemplateEditor:: model has not changed, exiting")
-                    mTemplateEditor.finishWithAnimation(END)
-                }
-
-                return true
-            } else if (itemId == R.id.action_card_browser_appearance) {
-                Timber.i("CardTemplateEditor::Card Browser Template button pressed")
-                val currentTemplate = getCurrentTemplate()
-                currentTemplate?.let { launchCardBrowserAppearance(it) }
-                return super.onOptionsItemSelected(item)
-            }
-            return super.onOptionsItemSelected(item)
+                },
+                viewLifecycleOwner, Lifecycle.State.RESUMED
+            )
         }
 
         fun performPreview() {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Statistics.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Statistics.kt
@@ -337,7 +337,6 @@ class Statistics : NavigationDrawerActivity(), DeckSelectionListener, SubtitleLi
             container: ViewGroup?,
             savedInstanceState: Bundle?
         ): View? {
-            setHasOptionsMenu(true)
             val bundle = arguments
             mSectionNumber = bundle!!.getInt(ARG_SECTION_NUMBER)
             // int sectionNumber = 0;
@@ -424,7 +423,6 @@ class Statistics : NavigationDrawerActivity(), DeckSelectionListener, SubtitleLi
             container: ViewGroup?,
             savedInstanceState: Bundle?
         ): View? {
-            setHasOptionsMenu(true)
             val rootView = inflater.inflate(R.layout.fragment_anki_stats_overview, container, false)
             val handler = (requireActivity() as Statistics).taskHandler
             // Workaround for issue 2406 -- crash when resuming after app is purged from RAM

--- a/build.gradle
+++ b/build.gradle
@@ -13,6 +13,7 @@ buildscript {
     ext.hamcrest_version = '2.2'
     ext.junit_version = '5.8.2'
     ext.coroutines_version = '1.6.2'
+    ext.fragments_version = "1.5.0"
 
     repositories {
         google()


### PR DESCRIPTION
## Purpose / Description

I've extracted the version number for the fragments library into the main build to make it easier to upgrade the two connected artifacts. To fix the deprecation in the new version I used the recommended approach [from the docs](https://developer.android.com/jetpack/androidx/releases/activity#1.4.0-alpha01)(moving the current code from the old platform methods onCreateOptionsMenu/onOptionsItemSelected to the methods in MenuProvider).
In Statistics the setHasOptionsMenu() calls  were useless as the fragments didn't contribute to the menu with any items.

## Fixes
Closes #11742 
Closes #11743 

## How Has This Been Tested?

Ran the usual tests, checked the menus.

## Learning (optional, can help others)

More info about the new APIs in [this video](https://io.google/2022/program/c9085b18-4e8e-4183-b303-1d1716b0c070/) from Google IO.

## Checklist

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
