### PR TITLE
Make fullscreen reviewer occupy system bars

### DIFF
--- a/AnkiDroid/src/main/res/layout/reviewer_fullscreen.xml
+++ b/AnkiDroid/src/main/res/layout/reviewer_fullscreen.xml
@@ -2,7 +2,6 @@
 android:layout_width="match_parent"
 android:layout_height="match_parent"
 android:focusableInTouchMode="true"
-android:fitsSystemWindows="true"
 xmlns:android="http://schemas.android.com/apk/res/android">
     <!-- Main content that takes up the fullscreen -->
     <RelativeLayout


### PR DESCRIPTION
## Purpose / Description

Make fullscreen reviewer occupy system bars

There are two fullscreen modes:
  * Hide system bars
  * Hide system bars and answer buttons

Both of these hide the system bars. However, the former, unlike
the latter, wasn't occupying the space liberated by those.

## Fixes

Fixes #11747

## Approach

~~I had to add 13 new classes and a custom annotation processor~~ One xml attribute removed.

## How Has This Been Tested?

Tested on my devices running Android 11 and Android 7. Before & after

<img src=https://user-images.githubusercontent.com/1710718/176999467-b762aa39-92c4-46de-9f7b-3a23c482e65a.png width=300> <img src=https://user-images.githubusercontent.com/1710718/176999463-371e40b4-2712-45ab-b936-e8b5a4cbbf23.png width=300>


## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [ ] You have commented your code, particularly in hard-to-understand areas
- [ ] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
