### PR TITLE
lint: enable CheckResult & Kotlin Cleanup on `Counts`

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Counts.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Counts.kt
@@ -17,8 +17,6 @@
 package com.ichi2.libanki.sched
 
 import androidx.annotation.CheckResult
-import com.ichi2.utils.KotlinCleanup
-import java.util.*
 
 /**
  * Represents the three counts shown in deck picker and reviewer. Semantically more meaningful than int[]
@@ -58,9 +56,7 @@ class Counts @JvmOverloads constructor(var new: Int = 0, var lrn: Int = 0, var r
      * @return the sum of the three counts
      */
     @CheckResult
-    fun count(): Int {
-        return new + lrn + rev
-    }
+    fun count(): Int = new + lrn + rev
 
     override fun equals(other: Any?): Boolean {
         if (this === other) {
@@ -73,12 +69,7 @@ class Counts @JvmOverloads constructor(var new: Int = 0, var lrn: Int = 0, var r
         return new == counts.new && rev == counts.rev && lrn == counts.lrn
     }
 
-    override fun hashCode(): Int {
-        @KotlinCleanup("Kotlin listOf instead of Java Arrays.asList")
-        return Arrays.asList(new, rev, lrn).hashCode()
-    }
+    override fun hashCode(): Int = listOf(new, rev, lrn).hashCode()
 
-    override fun toString(): String {
-        return "[" + new + ", " + lrn + ", " + rev + "]"
-    }
+    override fun toString(): String = "[$new, $lrn, $rev]"
 }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Counts.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Counts.kt
@@ -16,6 +16,7 @@
 
 package com.ichi2.libanki.sched
 
+import androidx.annotation.CheckResult
 import com.ichi2.utils.KotlinCleanup
 import java.util.*
 
@@ -56,6 +57,7 @@ class Counts @JvmOverloads constructor(var new: Int = 0, var lrn: Int = 0, var r
     /**
      * @return the sum of the three counts
      */
+    @CheckResult
     fun count(): Int {
         return new + lrn + rev
     }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/InitialActivityTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/InitialActivityTest.kt
@@ -16,6 +16,7 @@
 
 package com.ichi2.anki
 
+import android.annotation.SuppressLint
 import android.content.SharedPreferences
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
@@ -74,6 +75,7 @@ class InitialActivityTest : RobolectricTest() {
     }
 
     @Test
+    @SuppressLint("CheckResult") // performSetupFromFreshInstallOrClearedPreferences
     fun new_install_or_preference_data_wipe_means_preferences_up_to_date() {
         mockStatic(PreferenceUpgradeService::class.java).use { mocked ->
             InitialActivity.performSetupFromFreshInstallOrClearedPreferences(mSharedPreferences)

--- a/AnkiDroid/src/test/java/com/ichi2/anki/cardviewer/CardTemplateTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/cardviewer/CardTemplateTest.kt
@@ -15,6 +15,7 @@
  */
 package com.ichi2.anki.cardviewer
 
+import android.annotation.SuppressLint
 import com.ichi2.testutils.AnkiAssert.assertDoesNotThrow
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.*
@@ -34,6 +35,7 @@ class CardTemplateTest {
     }
 
     @Test
+    @SuppressLint("CheckResult") //  .render
     fun stressTest() {
         // At length = 10000000
         // ~500ms before

--- a/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/utils/HelpDialogTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/utils/HelpDialogTest.kt
@@ -15,6 +15,7 @@
  */
 package com.ichi2.anki.dialogs.utils
 
+import android.annotation.SuppressLint
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.ichi2.anki.RobolectricTest
 import com.ichi2.anki.RunInBackground
@@ -33,7 +34,7 @@ class HelpDialogTest : RobolectricTest() {
     @RunInBackground
     fun testMenuDoesNotCrash() {
         val dialog = createInstance(targetContext) as RecursivePictureMenu
-        super.openDialogFragmentUsingActivity(dialog)
+        openDialogFragment(dialog)
         val v = getRecyclerViewFor(dialog)
         MatcherAssert.assertThat(v.childCount, Matchers.`is`(4))
     }
@@ -42,8 +43,13 @@ class HelpDialogTest : RobolectricTest() {
     @RunInBackground
     fun testMenuSupportAnkiDroidDoesNotCrash() {
         val dialog = createInstanceForSupportAnkiDroid(targetContext) as RecursivePictureMenu
-        super.openDialogFragmentUsingActivity(dialog)
+        openDialogFragment(dialog)
         val v = getRecyclerViewFor(dialog)
         MatcherAssert.assertThat(v.childCount, Matchers.`is`(5))
+    }
+
+    @SuppressLint("CheckResult") // openDialogFragmentUsingActivity
+    private fun openDialogFragment(dialog: RecursivePictureMenu) {
+        super.openDialogFragmentUsingActivity(dialog)
     }
 }

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/CardTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/CardTest.kt
@@ -53,6 +53,7 @@ class CardTest : RobolectricTest() {
     }
 
     @Test
+    @SuppressLint("CheckResult") // col.models.current()!!.getLong("id")
     fun test_misc_cards() {
         val note = col.newNote()
         note.setItem("Front", "1")

--- a/AnkiDroid/src/test/java/com/ichi2/utils/JSONObjectTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/utils/JSONObjectTest.kt
@@ -36,6 +36,7 @@ Most of the code is:
  */
 package com.ichi2.utils
 
+import android.annotation.SuppressLint
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.ichi2.testutils.AnkiAssert.assertThrows
 import com.ichi2.testutils.EmptyApplication
@@ -57,6 +58,7 @@ import java.util.*
  */
 @RunWith(AndroidJUnit4::class)
 @Config(application = EmptyApplication::class)
+@SuppressLint("CheckResult") // many usages: checking exceptions
 class JSONObjectTest {
     @Test
     fun testEmptyObject() {

--- a/lint-release.xml
+++ b/lint-release.xml
@@ -56,6 +56,7 @@
     <issue id="RtlEnabled" severity="fatal" />
     <issue id="RtlHardcoded" severity="fatal" />
 
+    <issue id="CheckResult" severity="fatal" />
     <issue id="RedundantNamespace" severity="fatal" />
     <issue id="TextFields" severity="fatal" />
     <issue id="LogConditional" severity="fatal" />
@@ -322,7 +323,6 @@
     <issue id="AuthLeak" severity="ignore" />
     <issue id="PluralsCandidate" severity="ignore" />
     <issue id="UseCheckPermission" severity="ignore" />
-    <issue id="CheckResult" severity="ignore" />
     <issue id="ResourceAsColor" severity="ignore" />
     <issue id="MissingPermission" severity="ignore" />
     <issue id="Range" severity="ignore" />


### PR DESCRIPTION
Stemmed from a code review where `.count()` was unnecessarily called

Realised that Kotlin didn't check `@CheckResult` by default, and we hadn't enabled the lint

Then did some cleanup on `Counts()`

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
