### PR TITLE
fix: remove duplicate "TextFields" lint

### DIFF
--- a/lint-release.xml
+++ b/lint-release.xml
@@ -331,7 +331,6 @@
     <issue id="WrongThread" severity="ignore" />
     <issue id="VisibleForTests" severity="ignore" />
     <issue id="ProtectedPermissions" severity="ignore" />
-    <issue id="TextFields" severity="ignore" />
     <issue id="TextViewEdits" severity="ignore" />
     <issue id="SelectableText" severity="ignore" />
     <issue id="MenuTitle" severity="ignore" />


### PR DESCRIPTION
Added in edaf6febd0aaf4c2ce6baea52d7f0a3912b39381

Forgot to remove the 'ignore'

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
