### PR TITLE
test(ci): ignore a flaky test in CI

### DIFF
--- a/AnkiDroid/src/test/java/com/ichi2/anki/servicemodel/UpgradeGesturesToControlsTestNoParam.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/servicemodel/UpgradeGesturesToControlsTestNoParam.kt
@@ -25,6 +25,7 @@ import org.hamcrest.CoreMatchers.equalTo
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers
 import org.junit.Before
+import org.junit.Ignore
 import org.junit.Test
 import org.junit.runner.RunWith
 import timber.log.Timber
@@ -44,6 +45,7 @@ class UpgradeGesturesToControlsTestNoParam : RobolectricTest() {
     }
 
     @Test
+    @Ignore("flaky in CI")
     fun test_preferences_not_opened_happy_path() {
         // if the user has not opened the gestures, then nothing should be mapped
         assertThat(prefs.contains(PREF_KEY_VOLUME_DOWN), equalTo(false))


### PR DESCRIPTION

@BrayanDSO this has been flaking in CI so I'm ignoring it for now - could you look in to this if you have time? Not the highest priority but if you keep a list, something for the list since it's a shame to lose coverage on something that seems so close to working well as a test :-) - thanks