### PR TITLE
Fix tests related to preferences

### DIFF
--- a/AnkiDroid/src/test/java/com/ichi2/anki/servicemodel/PreferenceUpgradeServiceTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/servicemodel/PreferenceUpgradeServiceTest.kt
@@ -45,7 +45,8 @@ class PreferenceUpgradeServiceTest : RobolectricTest() {
     private lateinit var mPrefs: SharedPreferences
 
     @Before
-    fun before() {
+    override fun setUp() {
+        super.setUp()
         mPrefs = AnkiDroidApp.getSharedPrefs(targetContext)
     }
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/servicemodel/UpgradeGesturesToControlsTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/servicemodel/UpgradeGesturesToControlsTest.kt
@@ -32,14 +32,12 @@ import org.hamcrest.Matchers
 import org.hamcrest.Matchers.empty
 import org.hamcrest.Matchers.hasSize
 import org.junit.Before
-import org.junit.Ignore
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.ParameterizedRobolectricTestRunner
 import timber.log.Timber
 
 @RunWith(ParameterizedRobolectricTestRunner::class)
-@Ignore("flaky in ci")
 class UpgradeGesturesToControlsTest(private val testData: TestData) : RobolectricTest() {
     private val changedKeys = HashSet<String>()
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/servicemodel/UpgradeGesturesToControlsTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/servicemodel/UpgradeGesturesToControlsTest.kt
@@ -47,7 +47,8 @@ class UpgradeGesturesToControlsTest(private val testData: TestData) : Robolectri
     private lateinit var instance: UpgradeGesturesToControls
 
     @Before
-    fun setup() {
+    override fun setUp() {
+        super.setUp()
         prefs = super.getPreferences()
         instance = UpgradeGesturesToControls()
         prefs.registerOnSharedPreferenceChangeListener { _, key -> run { Timber.i("added key $key"); changedKeys.add(key) } }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/servicemodel/UpgradeGesturesToControlsTestNoParam.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/servicemodel/UpgradeGesturesToControlsTestNoParam.kt
@@ -25,7 +25,6 @@ import org.hamcrest.CoreMatchers.equalTo
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers
 import org.junit.Before
-import org.junit.Ignore
 import org.junit.Test
 import org.junit.runner.RunWith
 import timber.log.Timber
@@ -46,7 +45,6 @@ class UpgradeGesturesToControlsTestNoParam : RobolectricTest() {
     }
 
     @Test
-    @Ignore("flaky in CI")
     fun test_preferences_not_opened_happy_path() {
         // if the user has not opened the gestures, then nothing should be mapped
         assertThat(prefs.contains(PREF_KEY_VOLUME_DOWN), equalTo(false))
@@ -59,7 +57,6 @@ class UpgradeGesturesToControlsTestNoParam : RobolectricTest() {
     }
 
     @Test
-    @Ignore("flaky in CI")
     fun test_preferences_opened_happy_path() {
         // the default is that the user has not mapped the gesture, but has opened the screen
         // so they are set to NOTHING which had "0" as value

--- a/AnkiDroid/src/test/java/com/ichi2/anki/servicemodel/UpgradeGesturesToControlsTestNoParam.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/servicemodel/UpgradeGesturesToControlsTestNoParam.kt
@@ -38,7 +38,8 @@ class UpgradeGesturesToControlsTestNoParam : RobolectricTest() {
     private lateinit var instance: UpgradeGesturesToControls
 
     @Before
-    fun setup() {
+    override fun setUp() {
+        super.setUp()
         prefs = super.getPreferences()
         instance = UpgradeGesturesToControls()
         prefs.registerOnSharedPreferenceChangeListener { _, key -> run { Timber.i("added key $key"); changedKeys.add(key) } }


### PR DESCRIPTION
## Purpose / Description

This PR fixes the initialization of the tests related to preferences by properly binding them to the RobolectricTest superclass initialization. Hopefully, this would fix the flakiness of these tests, if not the last commit can be reverted to mark the tests as ignored. I'll be monitoring the PRs for failures related to this, if you see a failure please ping me(if they do fail I want to try something else as I have another theory why they fail).

## How Has This Been Tested?

Ran the unit tests.

## Checklist

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
