### PR TITLE
Fix context menu selection for DeckPicker

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckPickerContextMenu.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckPickerContextMenu.kt
@@ -55,7 +55,7 @@ class DeckPickerContextMenu(private val collection: Collection) : AnalyticsDialo
             .noAutoDismiss()
             .listItems(items = contextMenuOptions.map { resources.getString(it.optionName) }) {
                     _: MaterialDialog, index: Int, _: CharSequence ->
-                handleActionOnLongClick(index)
+                handleActionOnLongClick(contextMenuOptions[index])
             }
     }
 
@@ -90,8 +90,8 @@ class DeckPickerContextMenu(private val collection: Collection) : AnalyticsDialo
         }
 
     // Handle item selection on context menu which is shown when the user long-clicks on a deck
-    private fun handleActionOnLongClick(index: Int) {
-        when (DeckPickerContextMenuOption.fromId(index)) {
+    private fun handleActionOnLongClick(selectedOption: DeckPickerContextMenuOption) {
+        when (selectedOption) {
             DeckPickerContextMenuOption.DELETE_DECK -> {
                 Timber.i("Delete deck selected")
                 (activity as DeckPicker?)!!.confirmDeckDeletion(deckId)


### PR DESCRIPTION
## Purpose / Description

The update of the material dialogs library to the latest version introduced a bug which triggered an incorrect action in response to user selection in DeckPicker's context menu. The previous code used the index of the item selected from the context menu dialog against a list of known actions, this will not work as the list of actual options used in the content menu is dynamic.

## Fixes
Fixes #11786 

## How Has This Been Tested?

Verified that the correct action is done in response to user selection in DeckPicker's context menu.

## Checklist

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
