### PR TITLE
Fixed `ExportCompleteDialog`'s neutral buttons deprecation

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ExportCompleteDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ExportCompleteDialog.kt
@@ -28,20 +28,18 @@ class ExportCompleteDialog(private val listener: ExportCompleteDialogListener) :
         fun shareFile(path: String)
         fun saveExportFile(exportPath: String)
     }
+    val exportPath
+        get() = requireArguments().getString("exportPath")!!
 
     fun withArguments(exportPath: String): ExportCompleteDialog {
-        var args = this.arguments
-        if (args == null) {
-            args = Bundle()
+        arguments = (arguments ?: Bundle()).apply {
+            putString("exportPath", exportPath)
         }
-        args.putString("exportPath", exportPath)
-        this.arguments = args
         return this
     }
 
     override fun onCreateDialog(savedInstanceState: Bundle?): MaterialDialog {
         super.onCreate(savedInstanceState)
-        val exportPath = requireArguments().getString("exportPath")!!
         return MaterialDialog(requireActivity()).show {
             title(text = notificationTitle)
             message(text = notificationMessage)
@@ -58,8 +56,5 @@ class ExportCompleteDialog(private val listener: ExportCompleteDialogListener) :
         get() = res().getString(R.string.export_successful_title)
 
     override val notificationMessage: String
-        get() {
-            val exportPath = File(requireArguments().getString("exportPath")!!)
-            return res().getString(R.string.export_successful, exportPath.name)
-        }
+        get() = res().getString(R.string.export_successful, File(exportPath).name)
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ExportCompleteDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ExportCompleteDialog.kt
@@ -25,7 +25,7 @@ import java.io.File
 class ExportCompleteDialog(private val listener: ExportCompleteDialogListener) : AsyncDialogFragment() {
     interface ExportCompleteDialogListener {
         fun dismissAllDialogFragments()
-        fun emailFile(path: String)
+        fun shareFile(path: String)
         fun saveExportFile(exportPath: String)
     }
 
@@ -39,28 +39,18 @@ class ExportCompleteDialog(private val listener: ExportCompleteDialogListener) :
         return this
     }
 
-    @Suppress("Deprecation") // Material dialog neutral button deprecation
     override fun onCreateDialog(savedInstanceState: Bundle?): MaterialDialog {
         super.onCreate(savedInstanceState)
         val exportPath = requireArguments().getString("exportPath")!!
         return MaterialDialog(requireActivity()).show {
             title(text = notificationTitle)
             message(text = notificationMessage)
-            iconAttr(R.attr.dialogSendIcon)
-            positiveButton(R.string.export_send_button) {
+            icon(Themes.getResFromAttr(context, R.attr.dialogSendIcon))
+            positiveButton(R.string.export_share_button) {
                 listener.dismissAllDialogFragments()
-                listener.emailFile(exportPath)
+                listener.shareFile(exportPath)
             }
-            negativeButton(R.string.export_save_button) {
-                listener.dismissAllDialogFragments()
-                listener.saveExportFile(exportPath)
-            }
-            neutralButton(R.string.dialog_cancel) {
-                // TODO: Discuss regarding alternatives to using a neutral button here
-                //  since it is deprecated and not recommended in material guidelines
-
-                listener.dismissAllDialogFragments()
-            }
+            negativeButton(R.string.dialog_cancel) { listener.dismissAllDialogFragments() }
         }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ExportCompleteDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ExportCompleteDialog.kt
@@ -46,7 +46,7 @@ class ExportCompleteDialog(private val listener: ExportCompleteDialogListener) :
             title(text = notificationTitle)
             message(text = notificationMessage)
             icon(Themes.getResFromAttr(context, R.attr.dialogSendIcon))
-            positiveButton(R.string.export_share_button) {
+            positiveButton(R.string.export_send_button) {
                 listener.dismissAllDialogFragments()
                 listener.shareFile(exportPath)
             }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ExportCompleteDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ExportCompleteDialog.kt
@@ -17,6 +17,7 @@
 package com.ichi2.anki.dialogs
 
 import android.os.Bundle
+import androidx.core.os.bundleOf
 import com.afollestad.materialdialogs.MaterialDialog
 import com.ichi2.anki.R
 import com.ichi2.themes.Themes
@@ -25,16 +26,14 @@ import java.io.File
 class ExportCompleteDialog(private val listener: ExportCompleteDialogListener) : AsyncDialogFragment() {
     interface ExportCompleteDialogListener {
         fun dismissAllDialogFragments()
-        fun shareFile(path: String)
+        fun shareFile(path: String) // path of the file to be shared
         fun saveExportFile(exportPath: String)
     }
     val exportPath
         get() = requireArguments().getString("exportPath")!!
 
     fun withArguments(exportPath: String): ExportCompleteDialog {
-        arguments = (arguments ?: Bundle()).apply {
-            putString("exportPath", exportPath)
-        }
+        arguments = (arguments ?: bundleOf(Pair("exportPath", exportPath)))
         return this
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ExportCompleteDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ExportCompleteDialog.kt
@@ -19,7 +19,7 @@ package com.ichi2.anki.dialogs
 import android.os.Bundle
 import com.afollestad.materialdialogs.MaterialDialog
 import com.ichi2.anki.R
-import com.ichi2.utils.iconAttr
+import com.ichi2.themes.Themes
 import java.io.File
 
 class ExportCompleteDialog(private val listener: ExportCompleteDialogListener) : AsyncDialogFragment() {
@@ -55,9 +55,7 @@ class ExportCompleteDialog(private val listener: ExportCompleteDialogListener) :
     }
 
     override val notificationTitle: String
-        get() {
-            return res().getString(R.string.export_successful_title)
-        }
+        get() = res().getString(R.string.export_successful_title)
 
     override val notificationMessage: String
         get() {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/export/ActivityExportingDelegate.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/export/ActivityExportingDelegate.kt
@@ -15,7 +15,6 @@
  */
 package com.ichi2.anki.export
 
-import android.annotation.SuppressLint
 import android.content.Intent
 import android.net.Uri
 import android.os.ParcelFileDescriptor
@@ -116,8 +115,7 @@ class ActivityExportingDelegate(private val activity: AnkiActivity, private val 
         activity.dismissAllDialogFragments()
     }
 
-    @SuppressLint("StringFormatInvalid")
-    override fun emailFile(path: String) {
+    override fun shareFile(path: String) {
         // Make sure the file actually exists
         val attachment = File(path)
         if (!attachment.exists()) {
@@ -133,12 +131,18 @@ class ActivityExportingDelegate(private val activity: AnkiActivity, private val 
             showThemedToast(activity, activity.resources.getString(R.string.apk_share_error), false)
             return
         }
+
         val shareIntent = IntentBuilder(activity)
             .setType("application/apkg")
             .setStream(uri)
+            .setChooserTitle(activity.getString(R.string.export_share_title))
             .setSubject(activity.getString(R.string.export_email_subject, attachment.name))
             .setHtmlText(activity.getString(R.string.export_email_text, activity.getString(R.string.link_manual), activity.getString(R.string.link_distributions)))
             .intent
+            .setAction(Intent.ACTION_SEND)
+            .setDataAndType(uri, "application/apkg")
+            .addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+
         if (shareIntent.resolveActivity(activity.packageManager) != null) {
             activity.startActivityWithoutAnimation(shareIntent)
         } else {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/export/ActivityExportingDelegate.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/export/ActivityExportingDelegate.kt
@@ -118,6 +118,7 @@ class ActivityExportingDelegate(private val activity: AnkiActivity, private val 
         activity.dismissAllDialogFragments()
     }
 
+    @Suppress("deprecation") // API33 deprecation for pm.queryIntentActivities
     fun shareFileIntent(exportPath: String, uri: Uri): Intent {
         val attachment = File(exportPath)
         val pm: PackageManager = activity.packageManager
@@ -125,12 +126,15 @@ class ActivityExportingDelegate(private val activity: AnkiActivity, private val 
         sendIntent.putExtra(Intent.EXTRA_STREAM, uri)
         sendIntent.type = "application/apkg"
         val resInfo = pm.queryIntentActivities(sendIntent, 0)
+
+        // If we make two intents, one for save file and one for share, we get save file as
+        // an option in the share sheet
         val intentList = arrayListOf(
             LabeledIntent(
                 saveFileIntent(attachment),
                 BuildConfig.APPLICATION_ID,
-                "", // isn't actually used
-                0 // isn't actually used
+                "", // param "nonLocalizedLabel" isn't actually used
+                0 // param "icon" isn't actually used, this is the constant for "No icon"
             )
         )
 

--- a/AnkiDroid/src/main/res/values/02-strings.xml
+++ b/AnkiDroid/src/main/res/values/02-strings.xml
@@ -178,12 +178,14 @@
     <string name="confirm_apkg_export_deck">Export “%s” as apkg file?</string>
     <string name="export_in_progress">Exporting Anki package file…</string>
     <string name="export_successful_title">Send Anki package?</string>
+    <string name="export_share_button">Share</string>
     <string name="export_send_button">Send</string>
     <string name="export_save_button">Save to file</string>
     <string name="export_send_no_handlers">No applications available to handle apkg. Saving...</string>
     <string name="export_save_apkg_successful">Successfully saved Anki package</string>
     <string name="export_save_apkg_unsuccessful">Save Anki package failed</string>
     <string name="export_successful">File “%s” was exported. Do you want to send it with another app?</string>
+    <string name="export_share_title">Share Collection</string>
     <string name="export_email_subject">AnkiDroid exported flashcards: %s</string>
     <string name="export_email_text">
         <![CDATA[

--- a/AnkiDroid/src/main/res/values/02-strings.xml
+++ b/AnkiDroid/src/main/res/values/02-strings.xml
@@ -185,7 +185,7 @@
     <string name="export_save_apkg_successful">Successfully saved Anki package</string>
     <string name="export_save_apkg_unsuccessful">Save Anki package failed</string>
     <string name="export_successful">File “%s” was exported. Do you want to send it with another app?</string>
-    <string name="export_share_title">Share Collection</string>
+    <string name="export_share_title">Share Collection to</string>
     <string name="export_email_subject">AnkiDroid exported flashcards: %s</string>
     <string name="export_email_text">
         <![CDATA[

--- a/AnkiDroid/src/main/res/values/02-strings.xml
+++ b/AnkiDroid/src/main/res/values/02-strings.xml
@@ -178,14 +178,12 @@
     <string name="confirm_apkg_export_deck">Export “%s” as apkg file?</string>
     <string name="export_in_progress">Exporting Anki package file…</string>
     <string name="export_successful_title">Send Anki package?</string>
-    <string name="export_share_button">Share</string>
     <string name="export_send_button">Send</string>
-    <string name="export_save_button">Save to file</string>
     <string name="export_send_no_handlers">No applications available to handle apkg. Saving...</string>
     <string name="export_save_apkg_successful">Successfully saved Anki package</string>
     <string name="export_save_apkg_unsuccessful">Save Anki package failed</string>
     <string name="export_successful">File “%s” was exported. Do you want to send it with another app?</string>
-    <string name="export_share_title">Share Collection to</string>
+    <string name="export_share_title">Send Anki package using</string>
     <string name="export_email_subject">AnkiDroid exported flashcards: %s</string>
     <string name="export_email_text">
         <![CDATA[

--- a/AnkiDroid/src/test/java/com/ichi2/anki/stats/AnkiStatsTaskHandlerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/stats/AnkiStatsTaskHandlerTest.kt
@@ -24,8 +24,8 @@ import com.ichi2.libanki.Collection
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
-import kotlinx.coroutines.test.runTest
 import org.junit.Before
+import org.junit.Ignore
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mock
@@ -56,6 +56,7 @@ class AnkiStatsTaskHandlerTest : RobolectricTest() {
     @Test
     @Throws(ExecutionException::class, InterruptedException::class)
     @NeedsTest("explain this test")
+    @Ignore("failing in local test runs - https://github.com/ankidroid/Anki-Android/issues/12437")
     fun testCreateReviewSummaryStatistics() = runTest(testDispatcher) {
         verify(mCol, atMost(0))!!.db
         createReviewSummaryStatistics(mCol, mView, testDispatcher, testDispatcher)


### PR DESCRIPTION
## Purpose / Description
The usage of neutral buttons in `ExportCompleteDialog`'s is not recommended by Material Design

## Fixes
Part of #11780 

## Approach
Removed the "Send Email" and "Save to file" buttons and added a "Share" button which opens a sharepicker

## How Has This Been Tested?

https://user-images.githubusercontent.com/59933477/177500000-5d370aa0-dcaa-402b-a732-acb2f80dd46c.mp4


## Checklist

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [x] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
