### PR TITLE
Fix code style checks failures due to @CheckResult

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/ReadText.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ReadText.kt
@@ -15,6 +15,7 @@
  ****************************************************************************************/
 package com.ichi2.anki
 
+import android.annotation.SuppressLint
 import android.content.Context
 import android.net.Uri
 import android.os.Bundle
@@ -87,6 +88,7 @@ object ReadText {
      * @param ord  The card template ordinal
      * @param qa   The card question or card answer
      */
+    @SuppressLint("CheckResult")
     fun selectTts(text: String?, did: Long, ord: Int, qa: SoundSide?, context: Context) {
         // TODO: Consolidate with ReadText.readCardSide
         textToSpeak = text

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/CardBrowserMySearchesDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/CardBrowserMySearchesDialog.kt
@@ -1,6 +1,7 @@
 //noinspection MissingCopyrightHeader #8659
 package com.ichi2.anki.dialogs
 
+import android.annotation.SuppressLint
 import android.app.Dialog
 import android.os.Bundle
 import androidx.recyclerview.widget.DividerItemDecoration
@@ -30,6 +31,7 @@ class CardBrowserMySearchesDialog : AnalyticsDialogFragment() {
     }
 
     @Suppress("UNCHECKED_CAST")
+    @SuppressLint("CheckResult")
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
         super.onCreate(savedInstanceState)
         val dialog = MaterialDialog(requireActivity())

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/CardBrowserOrderDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/CardBrowserOrderDialog.kt
@@ -16,6 +16,7 @@
 
 package com.ichi2.anki.dialogs
 
+import android.annotation.SuppressLint
 import android.app.Dialog
 import android.os.Bundle
 import com.afollestad.materialdialogs.MaterialDialog
@@ -26,6 +27,7 @@ import com.ichi2.anki.R
 import com.ichi2.anki.analytics.AnalyticsDialogFragment
 
 class CardBrowserOrderDialog : AnalyticsDialogFragment() {
+    @SuppressLint("CheckResult")
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
         super.onCreate(savedInstanceState)
         val res = resources

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/CardSideSelectionDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/CardSideSelectionDialog.kt
@@ -15,6 +15,7 @@
  */
 package com.ichi2.anki.dialogs
 
+import android.annotation.SuppressLint
 import android.content.Context
 import com.afollestad.materialdialogs.MaterialDialog
 import com.afollestad.materialdialogs.list.listItems
@@ -25,6 +26,7 @@ import com.ichi2.anki.reviewer.CardSide
 class CardSideSelectionDialog {
 
     companion object {
+        @SuppressLint("CheckResult")
         fun displayInstance(ctx: Context, callback: (c: CardSide) -> Unit) {
             val items = listOf(
                 R.string.card_side_both,

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/CreateDeckDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/CreateDeckDialog.kt
@@ -16,6 +16,7 @@
 
 package com.ichi2.anki.dialogs
 
+import android.annotation.SuppressLint
 import android.content.Context
 import com.afollestad.materialdialogs.MaterialDialog
 import com.afollestad.materialdialogs.input.getInputField
@@ -60,6 +61,7 @@ class CreateDeckDialog(private val context: Context, private val title: Int, pri
         }
 
     fun showDialog(): MaterialDialog {
+        @SuppressLint("CheckResult")
         val dialog = MaterialDialog(context).show {
             title(title)
             positiveButton(R.string.dialog_ok) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DatabaseErrorDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DatabaseErrorDialog.kt
@@ -16,6 +16,7 @@
 
 package com.ichi2.anki.dialogs
 
+import android.annotation.SuppressLint
 import android.content.DialogInterface
 import android.os.Bundle
 import android.os.Message
@@ -46,6 +47,7 @@ class DatabaseErrorDialog : AsyncDialogFragment() {
     private lateinit var mBackups: Array<File>
 
     @Suppress("Deprecation") // Material dialog neutral button deprecation
+    @SuppressLint("CheckResult")
     override fun onCreateDialog(savedInstanceState: Bundle?): MaterialDialog {
         super.onCreate(savedInstanceState)
         val type = requireArguments().getInt("dialogType")

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ExportDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ExportDialog.kt
@@ -16,6 +16,7 @@
 
 package com.ichi2.anki.dialogs
 
+import android.annotation.SuppressLint
 import android.os.Bundle
 import com.afollestad.materialdialogs.MaterialDialog
 import com.afollestad.materialdialogs.list.listItemsMultiChoice
@@ -51,6 +52,7 @@ class ExportDialog(private val listener: ExportDialogListener) : AnalyticsDialog
         return this
     }
 
+    @SuppressLint("CheckResult")
     override fun onCreateDialog(savedInstanceState: Bundle?): MaterialDialog {
         super.onCreate(savedInstanceState)
         val res = resources

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/IntegerDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/IntegerDialog.kt
@@ -16,6 +16,7 @@
 
 package com.ichi2.anki.dialogs
 
+import android.annotation.SuppressLint
 import android.os.Bundle
 import android.text.InputType
 import com.afollestad.materialdialogs.MaterialDialog
@@ -46,6 +47,7 @@ open class IntegerDialog : AnalyticsDialogFragment() {
 
     override fun onCreateDialog(savedInstanceState: Bundle?): MaterialDialog {
         super.onCreate(savedInstanceState)
+        @SuppressLint("CheckResult")
         val show = MaterialDialog(requireActivity()).show {
             title(text = requireArguments().getString("title")!!)
             positiveButton(R.string.dialog_ok)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ModelBrowserContextMenu.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ModelBrowserContextMenu.kt
@@ -1,6 +1,7 @@
 //noinspection MissingCopyrightHeader #8659
 package com.ichi2.anki.dialogs
 
+import android.annotation.SuppressLint
 import android.app.Dialog
 import android.os.Bundle
 import androidx.annotation.StringRes
@@ -14,6 +15,7 @@ import timber.log.Timber
 
 class ModelBrowserContextMenu : AnalyticsDialogFragment() {
 
+    @SuppressLint("CheckResult")
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
         super.onCreate(savedInstanceState)
         val items = ModelBrowserContextMenuAction.values().sortedBy { it.order }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ModelEditorContextMenu.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ModelEditorContextMenu.kt
@@ -2,6 +2,7 @@
 
 package com.ichi2.anki.dialogs
 
+import android.annotation.SuppressLint
 import android.app.Dialog
 import android.os.Build
 import android.os.Bundle
@@ -21,6 +22,7 @@ import timber.log.Timber
  */
 open class ModelEditorContextMenu : AnalyticsDialogFragment() {
 
+    @SuppressLint("CheckResult")
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
         super.onCreate(savedInstanceState)
         // add only the actions which can be done at the current API level

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ScopedStorageMigrationDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ScopedStorageMigrationDialog.kt
@@ -16,6 +16,7 @@
 
 package com.ichi2.anki.dialogs
 
+import android.annotation.SuppressLint
 import android.app.Dialog
 import android.content.Context
 import android.net.Uri
@@ -45,6 +46,7 @@ typealias OpenUri = (Uri) -> Unit
  */
 object ScopedStorageMigrationDialog {
     @Suppress("Deprecation") // Material dialog neutral button deprecation
+    @SuppressLint("CheckResult")
     @JvmStatic
     fun showDialog(ctx: Context, openUri: OpenUri, initiateScopedStorage: Runnable): Dialog {
         return MaterialDialog(ctx).show {
@@ -81,6 +83,7 @@ object ScopedStorageMigrationDialog {
  * Then performs a migration to scoped storage
  */
 object ScopedStorageMigrationConfirmationDialog {
+    @SuppressLint("CheckResult")
     fun showDialog(ctx: Context, initiateScopedStorage: Runnable): Dialog {
         val li = LayoutInflater.from(ctx)
         val view = li.inflate(R.layout.scoped_storage_confirmation, null)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/noteeditor/Toolbar.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/noteeditor/Toolbar.kt
@@ -15,6 +15,7 @@
  */
 package com.ichi2.anki.noteeditor
 
+import android.annotation.SuppressLint
 import android.app.Activity
 import android.content.Context
 import android.graphics.Bitmap
@@ -217,6 +218,7 @@ class Toolbar : FrameLayout {
      *
      * @see [R.array.html_size_codes]
      */
+    @SuppressLint("CheckResult")
     private fun displayFontSizeDialog() {
         val results = resources.getStringArray(R.array.html_size_codes)
 
@@ -236,6 +238,7 @@ class Toolbar : FrameLayout {
     /**
      * Displays a dialog which allows `<h1>` to `<h6>` to be inserted
      */
+    @SuppressLint("CheckResult")
     private fun displayInsertHeadingDialog() {
         MaterialDialog(context).show {
             listItems(items = listOf("h1", "h2", "h3", "h4", "h5")) { _: MaterialDialog, _: Int, charSequence: CharSequence ->

--- a/AnkiDroid/src/main/java/com/ichi2/preferences/ControlPreference.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/preferences/ControlPreference.kt
@@ -16,6 +16,7 @@
 
 package com.ichi2.preferences
 
+import android.annotation.SuppressLint
 import android.content.Context
 import android.util.AttributeSet
 import androidx.preference.ListPreference
@@ -84,6 +85,7 @@ class ControlPreference : ListPreference {
         .joinToString(", ") { it.toDisplayString(context) }
 
     /** Called when an element is selected in the ListView */
+    @SuppressLint("CheckResult")
     override fun callChangeListener(newValue: Any?): Boolean {
         when (val index: Int = (newValue as String).toInt()) {
             ADD_GESTURE_INDEX -> {


### PR DESCRIPTION
## Purpose / Description

At the moment running `lint` over the main branch fails because of `@ CheckResult`  for code related to material dialogs(the new version of material dialogs library added `@ CheckResult` to most of its methods and David enabled this check recently). I went over the failures and added `@ SupressLint` to the methods or, when possible, to dialog declared variables.


## How Has This Been Tested?

Lint checks succeed. 

## Checklist

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
