### PR TITLE
cleanup: ActionBarOverflowTest

### DIFF
--- a/AnkiDroid/src/androidTest/java/com/ichi2/ui/ActionBarOverflowTest.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/ui/ActionBarOverflowTest.kt
@@ -20,23 +20,21 @@ import android.view.MenuItem
 import androidx.appcompat.view.menu.MenuBuilder
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
-import com.ichi2.utils.KotlinCleanup
 import org.hamcrest.MatcherAssert.assertThat
-import org.hamcrest.Matchers.`is`
+import org.hamcrest.Matchers.equalTo
 import org.hamcrest.Matchers.notNullValue
 import org.junit.Assert.fail
 import org.junit.Test
 import org.junit.runner.RunWith
 import java.lang.reflect.InvocationTargetException
 
-@KotlinCleanup("is -> equalTo")
 @RunWith(AndroidJUnit4::class)
 class ActionBarOverflowTest {
     @Test
     fun hasValidActionBarReflectionMethod() {
         assertThat(
             "Ensures that there is a valid way to obtain a listener",
-            ActionBarOverflow.hasUsableMethod(), `is`(true)
+            ActionBarOverflow.hasUsableMethod(), equalTo(true)
         )
     }
 


### PR DESCRIPTION
\## Purpose / Description
Kotlin cleanup: `is` -> `equalTo` in ActionBarOverflowTest

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
