### PR TITLE
Fix context menu in CustomStudyDialog

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/customstudy/CustomStudyDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/customstudy/CustomStudyDialog.kt
@@ -106,7 +106,7 @@ class CustomStudyDialog(private val collection: Collection, private val customSt
         return MaterialDialog(requireActivity())
             .title(R.string.custom_study)
             .cancelable(true)
-            .listItems(items = getValuesFromKeys(keyValueMap, listIds).toList().map { it as CharSequence }) { _: MaterialDialog, index: Int, charSequence: CharSequence ->
+            .listItems(items = getValuesFromKeys(keyValueMap, listIds).toList().map { it as CharSequence }) { _: MaterialDialog, _: Int, charSequence: CharSequence ->
                 when (ContextMenuOption.fromString(resources, charSequence.toString())) {
                     DECK_OPTIONS -> {
                         // User asked to permanently change the deck options
@@ -144,7 +144,7 @@ class CustomStudyDialog(private val collection: Collection, private val customSt
                         // User asked for a standard custom study option
                         val d = CustomStudyDialog(collection, customStudyListener)
                             .withArguments(
-                                ContextMenuOption.fromInt(index),
+                                ContextMenuOption.fromString(resources, charSequence.toString()),
                                 requireArguments().getLong("did"),
                                 jumpToReviewer
                             )


### PR DESCRIPTION
## Purpose / Description

Fixes the context menu in CustomDialog's context menu.This happened because the index of the user selected option wasn't properly mapped to a valid option in the source code.

## Fixes

Fixes #11801 

## How Has This Been Tested?

Ran the tests, checked that the menu works.

## Checklist

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
