### PR TITLE
Fix functionality for dialogs of NoteEditor toolbar

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
@@ -1832,7 +1832,7 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
     private fun displayAddToolbarDialog() {
         toolbarDialog.show {
             title(R.string.add_toolbar_item)
-            customView(R.layout.note_editor_toolbar_add_custom_item, scrollable = true)
+            customView(R.layout.note_editor_toolbar_add_custom_item, scrollable = true, horizontalPadding = true)
             positiveButton(R.string.dialog_positive_create) {
                 val view = it.view
                 val etIcon = view.findViewById<EditText>(R.id.note_editor_toolbar_item_icon)
@@ -1852,8 +1852,8 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
         etIcon.setText(currentButton.buttonText)
         et.setText(currentButton.prefix)
         et2.setText(currentButton.suffix)
-        toolbarDialog
-            .customView(view = view, scrollable = true)
+        val editToolbarDialog = toolbarDialog
+            .customView(view = view, scrollable = true, horizontalPadding = true)
             .positiveButton(R.string.save) {
                 editToolbarButton(
                     etIcon.text.toString(),
@@ -1865,10 +1865,10 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
         btnDelete.setOnClickListener {
             suggestRemoveButton(
                 currentButton,
-                toolbarDialog
+                editToolbarDialog
             )
         }
-        toolbarDialog.show()
+        editToolbarDialog.show()
     }
 
     private fun setNoteTypePosition() {


### PR DESCRIPTION
## Purpose / Description

Fixes the missing functionality in NoteEditor's toolbar options. Also adds the `horizontalPadding` attribute for the dialog's  customView to match the previous(before the material library update) UI.

## Fixes

Fixes #11806 

## How Has This Been Tested?

Ran the tests, manually checked the menus that they work.

## Checklist

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

