### PR TITLE
Fix some of the issues with material dialogs vertical padding

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckSelectionDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckSelectionDialog.kt
@@ -97,7 +97,7 @@ open class DeckSelectionDialog : AnalyticsDialogFragment() {
         adjustToolbar(dialogView, adapter)
         mDialog = MaterialDialog(requireActivity())
             .neutralButton(R.string.dialog_cancel) // Shouldn't it be negative button?
-            .customView(view = dialogView)
+            .customView(view = dialogView, noVerticalPadding = true)
         if (arguments.getBoolean(KEEP_RESTORE_DEFAULT_BUTTON)) {
             (mDialog as MaterialDialog).negativeButton(R.string.restore_default) {
                 onDeckSelected(null)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/tags/TagsDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/tags/TagsDialog.kt
@@ -179,7 +179,7 @@ class TagsDialog : AnalyticsDialogFragment {
                 )
             }
             .negativeButton(R.string.dialog_cancel)
-            .customView(view = tagsDialogView)
+            .customView(view = tagsDialogView, noVerticalPadding = true)
         val dialog: MaterialDialog? = mDialog
         resizeWhenSoftInputShown(dialog?.window!!)
         return dialog


### PR DESCRIPTION
## Purpose / Description

Some custom views used inside MaterialDialogs didn't properly set their vertical padding. In another PR I'm going to review this issue with padding for material dialogs to fix any other problems.

Before & after tags dialog:

<img src="https://user-images.githubusercontent.com/52494258/178102256-a68001c7-c756-449f-bb78-4c24d15cbf35.png" width="50%" height="50%" /><img src="https://user-images.githubusercontent.com/52494258/178102297-0b6e4aa8-38e3-4d69-83f2-00591cbe884f.png" width="50%" height="50%" />

Before & after move dialog:
<img src="https://user-images.githubusercontent.com/52494258/178102317-c4801e49-a40b-450d-97d7-4eb4475c444d.png" width="50%" height="50%" /><img src="https://user-images.githubusercontent.com/52494258/178102318-afebf98d-22f0-464e-9d46-0c288f190fac.png" width="50%" height="50%" />

## Fixes

Fixes #11804

## How Has This Been Tested?

Checked the UI and the padding is no more.

## Checklist

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
