### PR TITLE
ExportDialog "ok" button disabled fix

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ExportDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ExportDialog.kt
@@ -83,16 +83,11 @@ class ExportDialog(private val listener: ExportDialogListener) : AnalyticsDialog
             listItemsMultiChoice(
                 items = items,
                 initialSelection = checked.toIntArray(),
+                allowEmptySelection = true,
                 waitForPositiveButton = false
             ) { _: MaterialDialog, ints: IntArray, _: List<CharSequence> ->
-                mIncludeMedia = false
-                mIncludeSched = false
-                for (integer in ints) {
-                    when (integer) {
-                        INCLUDE_SCHED -> mIncludeSched = true
-                        INCLUDE_MEDIA -> mIncludeMedia = true
-                    }
-                }
+                mIncludeMedia = ints.contains(INCLUDE_MEDIA)
+                mIncludeSched = ints.contains(INCLUDE_SCHED)
             }
         }
     }


### PR DESCRIPTION

## Fixes
Fixes #11810 

## Approach
add `allowEmptySelection = true` to the MaterialDialog builder to enable it

## How Has This Been Tested?
<img width="339" alt="image" src="https://user-images.githubusercontent.com/59933477/178121472-e408e817-8377-48ab-ba4f-90502a842818.png">


## Checklist

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [x] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
