### PR TITLE
Fix padding for material dialogs

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/ModelBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ModelBrowser.kt
@@ -263,7 +263,7 @@ class ModelBrowser : AnkiActivity() {
         val newModelAdapter = ArrayAdapter(this, R.layout.dropdown_deck_item, mNewModelLabels!!.toList())
         addSelectionSpinner.adapter = newModelAdapter
         MaterialDialog(this).show {
-            customView(view = addSelectionSpinner, scrollable = true)
+            customView(view = addSelectionSpinner, scrollable = true, horizontalPadding = true)
             title(R.string.model_browser_add)
             positiveButton(R.string.dialog_ok) {
                 modelNameInput = FixedEditText(this@ModelBrowser)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ModelFieldEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ModelFieldEditor.kt
@@ -175,7 +175,7 @@ class ModelFieldEditor : AnkiActivity(), LocaleSelectionDialogHandler {
         fieldNameInput?.let { _fieldNameInput ->
             _fieldNameInput.isSingleLine = true
             MaterialDialog(this).show {
-                customView(view = _fieldNameInput)
+                customView(view = _fieldNameInput, horizontalPadding = true)
                 title(R.string.model_field_editor_add)
                 positiveButton(R.string.dialog_ok) {
                     // Name is valid, now field is added
@@ -266,7 +266,7 @@ class ModelFieldEditor : AnkiActivity(), LocaleSelectionDialogHandler {
             _fieldNameInput.setText(mFieldsLabels[currentPos])
             _fieldNameInput.setSelection(_fieldNameInput.text!!.length)
             MaterialDialog(this).show {
-                customView(view = _fieldNameInput)
+                customView(view = _fieldNameInput, horizontalPadding = true)
                 title(R.string.model_field_editor_rename)
                 positiveButton(R.string.rename) {
                     if (uniqueName(_fieldNameInput) == null) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/LocaleSelectionDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/LocaleSelectionDialog.kt
@@ -75,7 +75,7 @@ class LocaleSelectionDialog : AnalyticsDialogFragment() {
 
         // Only show a negative button, use the RecyclerView for positive actions
         val dialog = MaterialDialog(activity).show {
-            customView(view = tagsDialogView)
+            customView(view = tagsDialogView, noVerticalPadding = true)
             negativeButton(text = getString(R.string.dialog_cancel)) {
                 mDialogHandler!!.onLocaleSelectionCancelled()
             }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/customstudy/CustomStudyDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/customstudy/CustomStudyDialog.kt
@@ -196,7 +196,7 @@ class CustomStudyDialog(private val collection: Collection, private val customSt
         val jumpToReviewer = requireArguments().getBoolean("jumpToReviewer")
         // Set material dialog parameters
         val dialog = MaterialDialog(requireActivity())
-            .customView(view = v, scrollable = true)
+            .customView(view = v, scrollable = true, noVerticalPadding = true, horizontalPadding = true)
             .positiveButton(R.string.dialog_ok) {
                 // Get the value selected by user
                 val n: Int = try {


### PR DESCRIPTION
## Purpose / Description

Fix padding issues for dialogs after the update of the material dialogs library. This follows the padding that existed before the library update.

Custom study dialogs before and after:

<img src="https://user-images.githubusercontent.com/52494258/178133264-869927c0-266b-40d7-80a7-d9a783402409.png" width="50%" height="50%" /><img src="https://user-images.githubusercontent.com/52494258/178133265-3b4067bf-2023-4072-92ca-0ad7faa055d4.png" width="50%" height="50%" />

LocalSelectionDialog before and after:

<img src="https://user-images.githubusercontent.com/52494258/178133321-eacd5648-35f1-4f36-af02-04a1aaeaa12e.png" width="50%" height="50%" /><img src="https://user-images.githubusercontent.com/52494258/178133322-7f97fecf-7f16-44fd-935b-65e18beee88e.png" width="50%" height="50%" />

ModelBrowser dialog:

<img src="https://user-images.githubusercontent.com/52494258/178133358-cf13d68b-e1aa-408c-bd13-c0b6deae6e00.png" width="50%" height="50%" /><img src="https://user-images.githubusercontent.com/52494258/178133359-60dc57ee-63e4-490b-8af9-e80c12411d1f.png" width="50%" height="50%" />

ModelFieldEditor dialogs:

<img src="https://user-images.githubusercontent.com/52494258/178133390-2f0e7889-1e9f-4419-aac5-302155381a7d.png" width="50%" height="50%" /><img src="https://user-images.githubusercontent.com/52494258/178133393-5e57e913-4602-49ff-a9da-48708efba862.png" width="50%" height="50%" />

<img src="https://user-images.githubusercontent.com/52494258/178133389-623107b2-032d-4e92-bc11-ab10b73c8d29.png" width="50%" height="50%" /><img src="https://user-images.githubusercontent.com/52494258/178133392-e0ea20a3-9a2f-411c-9450-0913aae395eb.png" width="50%" height="50%" />

## How Has This Been Tested?

Ran tests, checked the menus

## Checklist

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
