### PR TITLE
Fix FullScreenNavDrawer pref not updating with activities further back in backstack

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/NavigationDrawerActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NavigationDrawerActivity.kt
@@ -69,7 +69,10 @@ abstract class NavigationDrawerActivity :
      */
     private var mPendingRunnable: Runnable? = null
 
+    private var mFullScreenDrawerEnabled: Boolean = false
+
     override fun setContentView(@LayoutRes layoutResID: Int) {
+        Timber.d("setContentView()")
         val preferences = AnkiDroidApp.getSharedPrefs(baseContext)
 
         // Using ClosableDrawerLayout as a parent view.
@@ -79,7 +82,8 @@ abstract class NavigationDrawerActivity :
         // Get CoordinatorLayout using resource ID
         val coordinatorLayout = LayoutInflater.from(this)
             .inflate(layoutResID, closableDrawerLayout, false) as CoordinatorLayout
-        if (preferences.getBoolean(FULL_SCREEN_NAVIGATION_DRAWER, false)) {
+        mFullScreenDrawerEnabled = preferences.getBoolean(FULL_SCREEN_NAVIGATION_DRAWER, false)
+        if (mFullScreenDrawerEnabled) {
             // If full screen navigation drawer is needed, then add FullDraggableContainer as a child view of closableDrawerLayout.
             // Then add coordinatorLayout as a child view of fullDraggableContainer.
             val fullDraggableContainer = FullDraggableContainer(this)
@@ -90,6 +94,14 @@ abstract class NavigationDrawerActivity :
             closableDrawerLayout.addView(coordinatorLayout, 0)
         }
         setContentView(closableDrawerLayout)
+    }
+
+    override fun onStart() {
+        super.onStart()
+        // Fixes #11813
+        if (mFullScreenDrawerEnabled != preferences.getBoolean(FULL_SCREEN_NAVIGATION_DRAWER, false)) {
+            restartActivity()
+        }
     }
 
     @get:LayoutRes


### PR DESCRIPTION
## Fixes
Fixes #11813

## Approach
Check in `NavigationDrawerActivity#onStart()` if the `mFullScreenDrawerEnabled` set in `setContentView` is the same as current pref value. If they're not the same, restart the activity therefore recalling `setContentView()`

## How Has This Been Tested?

https://user-images.githubusercontent.com/59933477/178141191-bd62fd99-9f79-4901-9994-8569cbc434a6.mov



## Checklist

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [x] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
