### PR TITLE
Fix styles textColorSecondary

### DIFF
--- a/AnkiDroid/src/main/res/color/prefs_item_dark_secondary.xml
+++ b/AnkiDroid/src/main/res/color/prefs_item_dark_secondary.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android" >
+    <item android:state_enabled="false" android:color="#5b5b5b"/>
+    <item android:color="@color/theme_dark_secondary_text"/>
+</selector>

--- a/AnkiDroid/src/main/res/color/prefs_item_light_secondary.xml
+++ b/AnkiDroid/src/main/res/color/prefs_item_light_secondary.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android" >
+    <item android:state_enabled="false" android:color="#8f8f8f"/>
+    <item android:color="@color/theme_light_secondary_text"/>
+</selector>

--- a/AnkiDroid/src/main/res/values/theme_black.xml
+++ b/AnkiDroid/src/main/res/values/theme_black.xml
@@ -123,6 +123,6 @@
         <item name="windowActionBar">true</item>
         <item name="windowNoTitle">false</item>
         <item name="android:textColor">@color/prefs_item_dark</item>
-        <item name="android:textColorSecondary">@color/prefs_item_dark</item>
+        <item name="android:textColorSecondary">@color/prefs_item_dark_secondary</item>
     </style>
 </resources>

--- a/AnkiDroid/src/main/res/values/theme_dark.xml
+++ b/AnkiDroid/src/main/res/values/theme_dark.xml
@@ -131,6 +131,6 @@
         <item name="windowActionBar">true</item>
         <item name="windowNoTitle">false</item>
         <item name="android:textColor">@color/prefs_item_dark</item>
-        <item name="android:textColorSecondary">@color/prefs_item_dark</item>
+        <item name="android:textColorSecondary">@color/prefs_item_dark_secondary</item>
     </style>
 </resources>

--- a/AnkiDroid/src/main/res/values/theme_light.xml
+++ b/AnkiDroid/src/main/res/values/theme_light.xml
@@ -17,7 +17,7 @@ APIs. It's visible when there aren't enough decks to fill the screen.
     <color name="theme_light_primary_light">@color/material_light_blue_100</color>
     <color name="theme_light_accent">@color/material_blue_grey_700</color>
     <color name="theme_light_primary_text">@color/black</color>
-    <color name="theme_light_secondary_text">#de000000</color>  <!-- 87 percent black -->
+    <color name="theme_light_secondary_text">@color/material_grey_700</color>
     <color name="theme_light_row_current">#ececec</color>
     <color name="theme_light_drawer_row_current">#E8E8E8</color>
     <color name="theme_light_drawer_item">#DE000000</color>
@@ -135,7 +135,6 @@ APIs. It's visible when there aren't enough decks to fill the screen.
         <item name="customTabNavBarColor">@color/material_light_blue_500</item>
         <item name="popupBackgroundColor">@android:color/white</item>
         <item name="iconColor">?android:attr/textColor</item>
-
         <item name="editTextDisabled">@color/material_grey_500</item>
     </style>
 
@@ -145,6 +144,6 @@ APIs. It's visible when there aren't enough decks to fill the screen.
         <item name="windowActionBar">true</item>
         <item name="windowNoTitle">false</item>
         <item name="android:textColor">@color/prefs_item_light</item>
-        <item name="android:textColorSecondary">@color/prefs_item_light</item>
+        <item name="android:textColorSecondary">@color/prefs_item_light_secondary</item>
     </style>
 </resources>

--- a/AnkiDroid/src/main/res/values/theme_plain.xml
+++ b/AnkiDroid/src/main/res/values/theme_plain.xml
@@ -61,6 +61,6 @@
         <item name="windowActionBar">true</item>
         <item name="windowNoTitle">false</item>
         <item name="android:textColor">@color/prefs_item_light</item>
-        <item name="android:textColorSecondary">@color/prefs_item_light</item>
+        <item name="android:textColorSecondary">@color/prefs_item_light_secondary</item>
     </style>
 </resources>


### PR DESCRIPTION
## Purpose / Description
Preferences textColorSecondary used the same color as the primary

## Approach
1. Add a selector for secondary color for light and dark themes
2. Change light themes secondary color to material gray 700 because it was barely distinguishable from the textColorPrimary

## How Has This Been Tested?
![Screenshot_20220710-114237_AnkiDroid](https://user-images.githubusercontent.com/69634269/178149698-38a9296b-cd72-4069-a283-313c01443888.png)
![Screenshot_20220710-114209_AnkiDroid](https://user-images.githubusercontent.com/69634269/178149700-682f74c4-8c50-4ea9-b201-dc20e622fad7.png)
![Screenshot_20220710-114216_AnkiDroid](https://user-images.githubusercontent.com/69634269/178149701-c02ca00e-dcd8-4cf8-82b4-abe4c7e840c2.png)
![Screenshot_20220710-114228_AnkiDroid](https://user-images.githubusercontent.com/69634269/178149703-89065c9c-a17c-4eb1-a7f3-6fd8feccbf69.png)

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [X] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
