### PR TITLE
Removing duplicate "contributor"

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,9 +87,9 @@ Join Us On
 ## Credits
 
 
-### Github Contributors
+### Code Contributors
 
-Thanks to these awesome contributors who keep this project going
+Thanks to these awesome code contributors who keep this project going
 
 <a href="https://github.com/ankidroid/Anki-Android/graphs/contributors"><img src="https://opencollective.com/ankidroid/contributors.svg?width=890&button=false" /></a>
 
@@ -121,15 +121,6 @@ Thanks to these awesome contributors who keep this project going
 Thank you to all our backers! 🙏
 
 <a href="https://opencollective.com/ankidroid#backers" target="_blank"><img src="https://opencollective.com/ankidroid/backers.svg?width=890"></a>
-
-### [Contributors](https://opencollective.com/ankidroid#contributors)
-
-Our Awesome Team of Contributors
-
-<a href="https://opencollective.com/ankidroid#contributors" target="_blank"><img src="https://opencollective.com/ankidroid/contributors.svg?width=890"></a>
-
-
-
 
 License
 -------


### PR DESCRIPTION
I also renamed it to "code contributor", as I feel it's a more exact description. Github is technically true, but not really interesting. Also, technically, translations also ends on github, and the authors are not listed
