### PR TITLE
Fixed reviewer not updating if flag changed in Cardbrowser and more than 1 activity in stack

### DIFF
--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/ReviewerTest.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/ReviewerTest.kt
@@ -26,11 +26,15 @@ import androidx.test.espresso.contrib.DrawerActions.open
 import androidx.test.espresso.matcher.ViewMatchers.*
 import androidx.test.ext.junit.rules.ActivityScenarioRule
 import com.ichi2.anki.TestUtils.first
+import com.ichi2.anki.testutil.RetryRule
 import com.ichi2.libanki.utils.TimeManager
 import org.junit.Rule
 import org.junit.Test
 
 class ReviewerTest {
+    @get:Rule
+    val mRetryRule: RetryRule = RetryRule(5)
+
     @get:Rule
     val mActivityRule = ActivityScenarioRule(DeckPicker::class.java)
 
@@ -56,6 +60,7 @@ class ReviewerTest {
 
         // start reviewing note
         onView(withText(deckName)).perform(click())
+        Thread.sleep(1000)
         onView(withId(R.id.mark_icon)).check(isInvisible())
 
         // go to Stats
@@ -75,6 +80,7 @@ class ReviewerTest {
         Espresso.pressBack() // back to stats
         Espresso.pressBack() // back to reviewer
 
+        Thread.sleep(1000)
         onView(withId(R.id.mark_icon)).check(isVisible())
     }
 

--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/ReviewerTest.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/ReviewerTest.kt
@@ -1,0 +1,86 @@
+/****************************************************************************************
+ *                                                                                      *
+ * Copyright (c) 2022 Dorrin Sotoudeh <dorrinsotoudeh123@gmail.com>                     *
+ *                                                                                      *
+ * This program is free software; you can redistribute it and/or modify it under        *
+ * the terms of the GNU General Public License as published by the Free Software        *
+ * Foundation; either version 3 of the License, or (at your option) any later           *
+ * version.                                                                             *
+ *                                                                                      *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *                                                                                      *
+ * You should have received a copy of the GNU General Public License along with         *
+ * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ ****************************************************************************************/
+
+package com.ichi2.anki
+
+import androidx.test.espresso.Espresso
+import androidx.test.espresso.Espresso.closeSoftKeyboard
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.action.ViewActions.*
+import androidx.test.espresso.assertion.ViewAssertions.matches
+import androidx.test.espresso.contrib.DrawerActions.open
+import androidx.test.espresso.matcher.ViewMatchers.*
+import androidx.test.ext.junit.rules.ActivityScenarioRule
+import com.ichi2.anki.TestUtils.first
+import com.ichi2.libanki.utils.TimeManager
+import org.junit.Rule
+import org.junit.Test
+
+class ReviewerTest {
+    @get:Rule
+    val mActivityRule = ActivityScenarioRule(DeckPicker::class.java)
+
+    /**
+     * Test for #11831
+     */
+    @Test
+    fun markingCardInCBUpdatesNoteEditorIfMoreThan1ActivityInStack() {
+        val deckName = "Deck" + TimeManager.time.intTimeMS()
+        // create deck
+        onView(withId(R.id.fab_main)).perform(click())
+        onView(withId(R.id.add_deck_action)).perform(click())
+        onView(withId(R.id.md_input_message)).perform(typeText(deckName))
+        onView(withId(R.id.md_button_positive)).perform(click())
+        // select deck
+        onView(withText(deckName)).perform(click())
+        // add note
+        onView(withId(R.id.snackbar_action)).perform(click())
+        onView(first(withId(R.id.id_note_editText))).perform(typeText("1"))
+        onView(withId(R.id.action_save)).perform(click())
+        closeSoftKeyboard()
+        Espresso.pressBack()
+
+        // start reviewing note
+        onView(withText(deckName)).perform(click())
+        onView(withId(R.id.mark_icon)).check(isInvisible())
+
+        // go to Stats
+        onView(withId(R.id.drawer_layout)).perform(open())
+        onView(withId(R.id.nav_stats)).perform(click())
+        // go to CardBrowser
+        onView(withId(R.id.drawer_layout)).perform(open())
+        onView(withId(R.id.nav_browser)).perform(click())
+
+        // select card
+        onView(withId(R.id.card_item_browser)).perform(longClick())
+        // mark card
+        onView(withId(R.id.action_mark_card)).perform(click())
+
+        // go back to reviewer
+        Espresso.pressBack() // close multiselect
+        Espresso.pressBack() // back to stats
+        Espresso.pressBack() // back to reviewer
+
+        onView(withId(R.id.mark_icon)).check(isVisible())
+    }
+
+    companion object {
+        private fun isVisible() = withVisibility(Visibility.VISIBLE)
+        private fun isInvisible() = withVisibility(Visibility.INVISIBLE)
+        private fun withVisibility(vis: Visibility) = matches(withEffectiveVisibility(vis))
+    }
+}

--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/TestUtils.java
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/TestUtils.java
@@ -59,6 +59,13 @@ public class TestUtils {
     }
 
     /**
+     * Get first view when there are multiple matches
+     */
+    public static Matcher<View> first(final Matcher<View> matcher) {
+        return withIndex(matcher, 0);
+    }
+
+    /**
      * Get instance of current activity
      */
     public static Activity getActivityInstance() {

--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/testutil/RetryRule.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/testutil/RetryRule.kt
@@ -1,0 +1,54 @@
+/****************************************************************************************
+ *                                                                                      *
+ * Copyright (c) 2022 Dorrin Sotoudeh <dorrinsotoudeh123@gmail.com>                     *
+ *                                                                                      *
+ * This program is free software; you can redistribute it and/or modify it under        *
+ * the terms of the GNU General Public License as published by the Free Software        *
+ * Foundation; either version 3 of the License, or (at your option) any later           *
+ * version.                                                                             *
+ *                                                                                      *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *                                                                                      *
+ * You should have received a copy of the GNU General Public License along with         *
+ * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ ****************************************************************************************/
+
+package com.ichi2.anki.testutil
+
+import org.junit.rules.TestRule
+import org.junit.runner.Description
+import org.junit.runners.model.Statement
+
+/**
+ * Adding this rule to the test class will make every test that fails, run [retryCount] times.
+ * If it failed every time, it is an actual fail
+ * @param retryCount the maximum number of times to run test
+ * @sample [@get:Rule val retry: Retry = Retry(2)]
+ */
+class RetryRule(private val retryCount: Int) : TestRule {
+    override fun apply(base: Statement, description: Description): Statement =
+        statement(base, description)
+
+    private fun statement(base: Statement, description: Description): Statement =
+        object : Statement() {
+            @Throws(Throwable::class)
+            override fun evaluate() {
+                var caughtThrowable: Throwable? = null
+
+                // implement retry logic here
+                for (i in 0 until retryCount) {
+                    try {
+                        base.evaluate()
+                        return
+                    } catch (t: Throwable) {
+                        caughtThrowable = t
+                        println("${description.displayName}: run ${i + 1} failed")
+                    }
+                }
+                println("${description.displayName}: giving up after $retryCount failures")
+                throw caughtThrowable!!
+            }
+        }
+}

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -193,7 +193,7 @@ open class CardBrowser : NavigationDrawerActivity(), SubtitleListener, DeckSelec
             mShouldRestoreScroll = true
             // in use by reviewer?
             if (reviewerCardId == mCurrentCardId) {
-                mReloadRequired = true
+                reloadRequired = true
             }
         }
         invalidateOptionsMenu() // maybe the availability of undo changed
@@ -225,7 +225,7 @@ open class CardBrowser : NavigationDrawerActivity(), SubtitleListener, DeckSelec
         ) {
             searchCards()
             if (reviewerCardId == mCurrentCardId) {
-                mReloadRequired = true
+                reloadRequired = true
             }
         }
         invalidateOptionsMenu() // maybe the availability of undo changed
@@ -295,7 +295,7 @@ open class CardBrowser : NavigationDrawerActivity(), SubtitleListener, DeckSelec
 
         override fun actualOnPostExecute(context: CardBrowser, result: Computation<NextCard<Array<Card>>>) {
             Timber.d("CardBrowser::RepositionCardHandler() onPostExecute")
-            context.mReloadRequired = true
+            context.reloadRequired = true
             val cardCount: Int = result.value.result.size
             showThemedToast(
                 context,
@@ -317,7 +317,7 @@ open class CardBrowser : NavigationDrawerActivity(), SubtitleListener, DeckSelec
 
         override fun actualOnPostExecute(context: CardBrowser, result: Computation<NextCard<Array<Card>>>) {
             Timber.d("CardBrowser::ResetProgressCardHandler() onPostExecute")
-            context.mReloadRequired = true
+            context.reloadRequired = true
             val cardCount: Int = result.value.result.size
             showThemedToast(
                 context,
@@ -339,7 +339,7 @@ open class CardBrowser : NavigationDrawerActivity(), SubtitleListener, DeckSelec
 
         override fun actualOnPostExecute(context: CardBrowser, result: Computation<NextCard<Array<Card>>>) {
             Timber.d("CardBrowser::RescheduleCardHandler() onPostExecute")
-            context.mReloadRequired = true
+            context.reloadRequired = true
             val cardCount: Int = result.value.result.size
             showThemedToast(
                 context,
@@ -454,7 +454,7 @@ open class CardBrowser : NavigationDrawerActivity(), SubtitleListener, DeckSelec
                 mCardsAdapter!!.notifyDataSetChanged()
             } else {
                 if (contains(reviewerCardId)) {
-                    mReloadRequired = true
+                    reloadRequired = true
                 }
                 executeChangeCollectionTask(this, mNewDid)
             }
@@ -1690,7 +1690,7 @@ open class CardBrowser : NavigationDrawerActivity(), SubtitleListener, DeckSelec
     private fun removeNotesView(cardsIds: Collection<Long>, reorderCards: Boolean) {
         val idToPos = getPositionMap(mCards)
         val idToRemove = cardsIds.filter { cId -> idToPos.containsKey(cId) }
-        mReloadRequired = mReloadRequired || cardsIds.contains(reviewerCardId)
+        reloadRequired = reloadRequired || cardsIds.contains(reviewerCardId)
         val newMCards: MutableList<CardCache> = mCards
             .filterNot { c -> idToRemove.contains(c.id) }
             .mapIndexed { i, c -> CardCache(c, i) }
@@ -1716,7 +1716,7 @@ open class CardBrowser : NavigationDrawerActivity(), SubtitleListener, DeckSelec
             browser.hideProgressBar()
             browser.invalidateOptionsMenu() // maybe the availability of undo changed
             if (result.value.map { card -> card.id }.contains(browser.reviewerCardId)) {
-                browser.mReloadRequired = true
+                browser.reloadRequired = true
             }
         }
     }
@@ -1737,7 +1737,7 @@ open class CardBrowser : NavigationDrawerActivity(), SubtitleListener, DeckSelec
             browser.hideProgressBar()
             browser.invalidateOptionsMenu() // maybe the availability of undo changed
             if (result.value.map { card -> card.id }.contains(browser.reviewerCardId)) {
-                browser.mReloadRequired = true
+                browser.reloadRequired = true
             }
         }
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -232,7 +232,6 @@ open class CardBrowser : NavigationDrawerActivity(), SubtitleListener, DeckSelec
     }
     private var mLastRenderStart: Long = 0
     private var mActionBarTitle: TextView? = null
-    private var mReloadRequired = false
 
     @get:VisibleForTesting(otherwise = VisibleForTesting.NONE)
     var isInMultiSelectMode = false
@@ -810,15 +809,8 @@ open class CardBrowser : NavigationDrawerActivity(), SubtitleListener, DeckSelec
 
     override fun onBackPressed() {
         when {
-            isDrawerOpen -> super.onBackPressed()
             isInMultiSelectMode -> endMultiSelectMode()
-            else -> {
-                Timber.i("Back key pressed")
-                val data = Intent()
-                // Add reload flag to result intent so that schedule reset when returning to note editor
-                data.putExtra("reloadRequired", mReloadRequired)
-                closeCardBrowser(RESULT_OK, data)
-            }
+            else -> super.onBackPressed()
         }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NavigationDrawerActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NavigationDrawerActivity.kt
@@ -69,11 +69,11 @@ abstract class NavigationDrawerActivity :
      */
     private var mPendingRunnable: Runnable? = null
 
-    protected var mReloadRequired = false
+    protected var reloadRequired = false
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        mReloadRequired = savedInstanceState?.getBoolean("reloadRequired")
+        reloadRequired = savedInstanceState?.getBoolean("reloadRequired")
             ?: intent.getBooleanExtra("reloadRequired", false)
     }
 
@@ -102,7 +102,7 @@ abstract class NavigationDrawerActivity :
 
     override fun onStart() {
         super.onStart()
-        Timber.i("mReloadRequired = $mReloadRequired")
+        Timber.i("mReloadRequired = $reloadRequired")
     }
 
     @get:LayoutRes
@@ -258,7 +258,7 @@ abstract class NavigationDrawerActivity :
             }
         } else {
             if (listOf("reloadRequired", "currentCard").map { data?.extras?.get(it) }.all { it != null }) {
-                mReloadRequired = true
+                reloadRequired = true
                 intent.putExtra("currentCard", data?.getLongExtra("currentCard", -1))
             } else {
                 super.onActivityResult(requestCode, resultCode, data)
@@ -271,9 +271,9 @@ abstract class NavigationDrawerActivity :
         if (isDrawerOpen) {
             closeDrawer()
         } else {
-            Timber.i("mReloadRequired = $mReloadRequired, currentCardId = $currentCardId")
+            Timber.i("mReloadRequired = $reloadRequired, currentCardId = $currentCardId")
             val data = Intent().apply {
-                setupCardIdAndReloadRequired(toIntent = this, reloadRequired = mReloadRequired)
+                setupCardIdAndReloadRequired(toIntent = this, reloadRequired = reloadRequired)
             }
             close(RESULT_OK, data)
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Previewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Previewer.kt
@@ -63,7 +63,7 @@ class Previewer : AbstractFlashcardViewer() {
         if (savedInstanceState != null) {
             mIndex = savedInstanceState.getInt("index", mIndex)
             mShowingAnswer = savedInstanceState.getBoolean("showingAnswer", mShowingAnswer)
-            mReloadRequired = savedInstanceState.getBoolean("reloadRequired")
+            reloadRequired = savedInstanceState.getBoolean("reloadRequired")
             mNoteChanged = savedInstanceState.getBoolean("noteChanged")
         }
         if (mCardList.isEmpty() || mIndex < 0 || mIndex > mCardList.size - 1) {
@@ -184,7 +184,7 @@ class Previewer : AbstractFlashcardViewer() {
         outState.putLongArray("cardList", mCardList)
         outState.putInt("index", mIndex)
         outState.putBoolean("showingAnswer", mShowingAnswer)
-        outState.putBoolean("reloadRequired", mReloadRequired)
+        outState.putBoolean("reloadRequired", reloadRequired)
         outState.putBoolean("noteChanged", mNoteChanged)
         super.onSaveInstanceState(outState)
     }
@@ -217,7 +217,7 @@ class Previewer : AbstractFlashcardViewer() {
     }
 
     override fun performReload() {
-        mReloadRequired = true
+        reloadRequired = true
         val newCardList = col.filterToValidCards(mCardList)
         if (newCardList.isEmpty()) {
             finishWithoutAnimation()
@@ -274,7 +274,7 @@ class Previewer : AbstractFlashcardViewer() {
     private val resultIntent: Intent
         get() {
             val intent = Intent()
-            intent.putExtra("reloadRequired", mReloadRequired)
+            intent.putExtra("reloadRequired", reloadRequired)
             intent.putExtra("noteChanged", mNoteChanged)
             return intent
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Previewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Previewer.kt
@@ -50,7 +50,6 @@ class Previewer : AbstractFlashcardViewer() {
     private lateinit var mProgressText: TextView
 
     /** Communication with Browser  */
-    private var mReloadRequired = false
     private var mNoteChanged = false
     private var previewLayout: PreviewLayout? = null
     override fun onCreate(savedInstanceState: Bundle?) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Statistics.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Statistics.kt
@@ -495,6 +495,7 @@ class Statistics : NavigationDrawerActivity(), DeckSelectionListener, SubtitleLi
             if (intent.hasExtra("selectedDeck")) {
                 data.putExtra("originalDeck", intent.getLongExtra("selectedDeck", 0L))
             }
+            setupCardIdAndReloadRequired(toIntent = data, reloadRequired = mReloadRequired)
             setResult(RESULT_CANCELED, data)
             finishWithAnimation(ActivityTransitionAnimation.Direction.END)
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Statistics.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Statistics.kt
@@ -495,7 +495,7 @@ class Statistics : NavigationDrawerActivity(), DeckSelectionListener, SubtitleLi
             if (intent.hasExtra("selectedDeck")) {
                 data.putExtra("originalDeck", intent.getLongExtra("selectedDeck", 0L))
             }
-            setupCardIdAndReloadRequired(toIntent = data, reloadRequired = mReloadRequired)
+            setupCardIdAndReloadRequired(toIntent = data, reloadRequired = reloadRequired)
             setResult(RESULT_CANCELED, data)
             finishWithAnimation(ActivityTransitionAnimation.Direction.END)
         }


### PR DESCRIPTION
## Fixes
Fixes #11831 

## Approach
- 11831: Added "currentCard" and "reloadRequired" the intents in `NavigationDrawerActivity#onBackPressed` and recieved them in `NavigationDrawerActivity#onActivityResult`

## How Has This Been Tested?

https://user-images.githubusercontent.com/59933477/178156452-1237423f-d700-4ec5-ac2d-fab7f8514084.mov


## Checklist

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [x] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
