### PR TITLE
Revert "Enable the preferences tests which were ignored for being flaky"

### DIFF
--- a/AnkiDroid/src/test/java/com/ichi2/anki/servicemodel/UpgradeGesturesToControlsTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/servicemodel/UpgradeGesturesToControlsTest.kt
@@ -32,12 +32,14 @@ import org.hamcrest.Matchers
 import org.hamcrest.Matchers.empty
 import org.hamcrest.Matchers.hasSize
 import org.junit.Before
+import org.junit.Ignore
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.ParameterizedRobolectricTestRunner
 import timber.log.Timber
 
 @RunWith(ParameterizedRobolectricTestRunner::class)
+@Ignore("flaky in ci")
 class UpgradeGesturesToControlsTest(private val testData: TestData) : RobolectricTest() {
     private val changedKeys = HashSet<String>()
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/servicemodel/UpgradeGesturesToControlsTestNoParam.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/servicemodel/UpgradeGesturesToControlsTestNoParam.kt
@@ -25,6 +25,7 @@ import org.hamcrest.CoreMatchers.equalTo
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers
 import org.junit.Before
+import org.junit.Ignore
 import org.junit.Test
 import org.junit.runner.RunWith
 import timber.log.Timber
@@ -45,6 +46,7 @@ class UpgradeGesturesToControlsTestNoParam : RobolectricTest() {
     }
 
     @Test
+    @Ignore("flaky in CI")
     fun test_preferences_not_opened_happy_path() {
         // if the user has not opened the gestures, then nothing should be mapped
         assertThat(prefs.contains(PREF_KEY_VOLUME_DOWN), equalTo(false))
@@ -57,6 +59,7 @@ class UpgradeGesturesToControlsTestNoParam : RobolectricTest() {
     }
 
     @Test
+    @Ignore("flaky in CI")
     fun test_preferences_opened_happy_path() {
         // the default is that the user has not mapped the gesture, but has opened the screen
         // so they are set to NOTHING which had "0" as value


### PR DESCRIPTION
## Purpose / Description

Reverting commit 7752cf62 as the tests are still failing.

## How Has This Been Tested?

Ran the usual tests.

## Checklist

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
