### PR TITLE
Refactor PreferenceUpgradeService to use prefs.edit{} extension

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/PreferenceUpgradeService.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/PreferenceUpgradeService.kt
@@ -137,7 +137,7 @@ object PreferenceUpgradeService {
                 // clear all prefs if super old version to prevent any errors
                 if (previousVersionCode < 20300130) {
                     Timber.i("Old version of Anki - Clearing preferences")
-                    preferences.edit().clear().apply()
+                    preferences.edit { clear() }
                 }
                 // when upgrading from before 2.5alpha35
                 if (previousVersionCode < 20500135) {
@@ -145,13 +145,17 @@ object PreferenceUpgradeService {
                     // Card zooming behaviour was changed the preferences renamed
                     val oldCardZoom = preferences.getInt("relativeDisplayFontSize", 100)
                     val oldImageZoom = preferences.getInt("relativeImageSize", 100)
-                    preferences.edit().putInt("cardZoom", oldCardZoom).apply()
-                    preferences.edit().putInt("imageZoom", oldImageZoom).apply()
-                    if (!preferences.getBoolean("useBackup", true)) {
-                        preferences.edit().putInt("backupMax", 0).apply()
+                    preferences.edit {
+                        putInt("cardZoom", oldCardZoom)
+                        putInt("imageZoom", oldImageZoom)
                     }
-                    preferences.edit().remove("useBackup").apply()
-                    preferences.edit().remove("intentAdditionInstantAdd").apply()
+                    if (!preferences.getBoolean("useBackup", true)) {
+                        preferences.edit { putInt("backupMax", 0) }
+                    }
+                    preferences.edit {
+                        remove("useBackup")
+                        remove("intentAdditionInstantAdd")
+                    }
                 }
                 FullScreenMode.upgradeFromLegacyPreference(preferences)
             }


### PR DESCRIPTION
## Purpose / Description

Replaces usages of `SharedPreferences.edit().apply()` with the newer kotlin friendly `SharedPreference.edit{}` extension for consistency in PreferencUpgradeService class.

## How Has This Been Tested?

Ran the usual tests.

## Checklist

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
