### PR TITLE
Fix Full screen navigation drawer overtaking child view gestures

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/NavigationDrawerActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NavigationDrawerActivity.kt
@@ -39,10 +39,10 @@ import androidx.core.content.ContextCompat
 import androidx.core.view.GravityCompat
 import androidx.drawerlayout.widget.ClosableDrawerLayout
 import androidx.drawerlayout.widget.DrawerLayout
-import com.drakeet.drawer.FullDraggableContainer
 import com.google.android.material.navigation.NavigationView
 import com.ichi2.anim.ActivityTransitionAnimation.Direction.*
 import com.ichi2.anki.dialogs.HelpDialog
+import com.ichi2.anki.workarounds.FullDraggableContainerFix
 import com.ichi2.libanki.CardId
 import com.ichi2.themes.Themes
 import com.ichi2.utils.HandlerUtils
@@ -84,7 +84,7 @@ abstract class NavigationDrawerActivity :
         if (preferences.getBoolean(FULL_SCREEN_NAVIGATION_DRAWER, false)) {
             // If full screen navigation drawer is needed, then add FullDraggableContainer as a child view of closableDrawerLayout.
             // Then add coordinatorLayout as a child view of fullDraggableContainer.
-            val fullDraggableContainer = FullDraggableContainer(this)
+            val fullDraggableContainer = FullDraggableContainerFix(this)
             fullDraggableContainer.addView(coordinatorLayout)
             closableDrawerLayout.addView(fullDraggableContainer, 0)
         } else {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/workarounds/FullDraggableContainerFix.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/workarounds/FullDraggableContainerFix.kt
@@ -1,0 +1,84 @@
+/*
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.workarounds
+
+import android.content.Context
+import android.util.AttributeSet
+import android.view.MotionEvent
+import android.view.MotionEvent.ACTION_DOWN
+import com.drakeet.drawer.FullDraggableContainer
+
+/**
+ * [FullDraggableContainer] is the thing that allows opening the navigation drawer
+ * by swiping right anywhere on the screen.
+ * It has an issue in that it will intercept all rightwards swipes,
+ * even if a view inside it also wants these events. For instance,
+ *
+ *   * You can't swipe snackbars to the right to dismiss them, or
+ *
+ *   * You can't drag card browser search field cursor by dragging finger right across the field.
+ *     (Dragging the finger left, and dragging the cursor *handle* right works, however.)
+ *
+ * The problem is twofold;
+ *
+ *   * The container does not listen for children asking it not to intercept touch, and
+ *
+ *   * The container eats up the motion events, not passing them to children in the first place.
+ *
+ * This solves the issue in the following way:
+ *
+ *   * When the container wants to intercept motion events, we skip *this one* interception event,
+ *     allowing it to propagate to children.
+ *
+ *   * The child, which hopefully has a similar threshold for catching motion events,
+ *     will capture the view, and request its parent to not intercept touch,
+ *     which will propagate to us as well.
+ *
+ *   * We then skip all events until the child removes the request
+ *     (it actually does not do that in practice),
+ *     or when we receive another finger press, which signifies a new gesture.
+ *
+ * (It may seem that it would be possible to solve this by having a larger interception distance
+ * on parent than on child. In practice, however, since the devices are slow and fingers are fast,
+ * the interception usually happens on the second or the first motion event,
+ * and finger travel distance is usually much higher than the usual threshold of about 8 dp.)
+ */
+
+class FullDraggableContainerFix @JvmOverloads constructor(context: Context, attrs: AttributeSet? = null) :
+    FullDraggableContainer(context, attrs) {
+
+    private var childRequestedNoTouchInterception = false
+    private var lastWeWantToIntercept = false
+
+    override fun requestDisallowInterceptTouchEvent(disallowIntercept: Boolean) {
+        super.requestDisallowInterceptTouchEvent(disallowIntercept)
+        childRequestedNoTouchInterception = disallowIntercept
+    }
+
+    override fun onInterceptTouchEvent(event: MotionEvent): Boolean {
+        if (childRequestedNoTouchInterception) {
+            if (event.actionMasked == ACTION_DOWN) {
+                childRequestedNoTouchInterception = false
+            } else {
+                return false
+            }
+        }
+
+        val weWantToIntercept = super.onInterceptTouchEvent(event)
+        val shouldSkipThisInterception = weWantToIntercept && !lastWeWantToIntercept
+        lastWeWantToIntercept = weWantToIntercept
+        return if (shouldSkipThisInterception) false else weWantToIntercept
+    }
+}


### PR DESCRIPTION
## Purpose / Description

The option Full screen navigation drawer allows opening the navigation drawer by swiping right anywhere on the screen. It has an issue in that it will intercept all rightwards swipes, even if a view inside it also wants these events. This fixes it.

## Fixes

Closes #11588.

## Approach

Createad a workaround subclass. See code comment for details.

## How Has This Been Tested?

Tested on my device running Android 11. I can not run emulator, so this was **NOT** tested on other devices. This is is the kind of thing that can vary between OS versions and device manufacturers, so it would be **VERY NICE** if this was tested on at least some devices.

If you are going to test it, make a note of issue #11813.

## Checklist

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [ ] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [x] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)