### PR TITLE
Fix all things snackbars

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
@@ -1787,7 +1787,7 @@ abstract class AbstractFlashcardViewer :
     /** Displays a snackbar which does not obscure the answer buttons  */
     private fun showSnackbar(mainText: String?, @StringRes buttonText: Int, onClickListener: View.OnClickListener?) {
         // BUG: Moving from full screen to non-full screen obscures the buttons
-        val sb = getSnackbar(this, mainText, Snackbar.LENGTH_LONG, buttonText, onClickListener, webView!!, null)
+        val sb = getSnackbar(mainText, Snackbar.LENGTH_LONG, buttonText, onClickListener, webView!!, null)
         val easeButtons = findViewById<View>(R.id.answer_options_layout)
         val previewButtons = findViewById<View>(R.id.preview_buttons_layout)
         val upperView = if (previewButtons != null && previewButtons.visibility != View.GONE) previewButtons else easeButtons

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
@@ -47,10 +47,8 @@ import androidx.webkit.WebViewAssetLoader
 import anki.collection.OpChanges
 import com.afollestad.materialdialogs.MaterialDialog
 import com.drakeet.drawer.FullDraggableContainer
-import com.google.android.material.snackbar.Snackbar
 import com.ichi2.anim.ActivityTransitionAnimation
 import com.ichi2.anim.ActivityTransitionAnimation.getInverseTransition
-import com.ichi2.anki.UIUtils.getSnackbar
 import com.ichi2.anki.UIUtils.saveCollectionInBackground
 import com.ichi2.anki.UIUtils.showThemedToast
 import com.ichi2.anki.cardviewer.*
@@ -74,6 +72,7 @@ import com.ichi2.anki.servicelayer.NoteService.isMarked
 import com.ichi2.anki.servicelayer.SchedulerService.*
 import com.ichi2.anki.servicelayer.TaskListenerBuilder
 import com.ichi2.anki.servicelayer.UndoService.Undo
+import com.ichi2.anki.snackbar.showSnackbar
 import com.ichi2.annotations.NeedsTest
 import com.ichi2.async.CollectionTask.PreloadNextCard
 import com.ichi2.async.CollectionTask.UpdateNote
@@ -1787,17 +1786,17 @@ abstract class AbstractFlashcardViewer :
     }
 
     /** Displays a snackbar which does not obscure the answer buttons  */
-    private fun showSnackbar(mainText: String?, @StringRes buttonText: Int, onClickListener: View.OnClickListener?) {
+    private fun showSnackbarAboveAnswerButtons(text: String, @StringRes buttonTextResource: Int, onClickListener: View.OnClickListener) {
         // BUG: Moving from full screen to non-full screen obscures the buttons
-        val sb = getSnackbar(mainText, Snackbar.LENGTH_LONG, buttonText, onClickListener, webView!!, null)
+        showSnackbar(text) {
+            setAction(buttonTextResource, onClickListener)
 
-        if (mAnswerButtonsPosition == "bottom") {
-            val easeButtons = findViewById<View>(R.id.answer_options_layout)
-            val previewButtons = findViewById<View>(R.id.preview_buttons_layout)
-            sb.anchorView = if (previewButtons.isVisible) previewButtons else easeButtons
+            if (mAnswerButtonsPosition == "bottom") {
+                val easeButtons = findViewById<View>(R.id.answer_options_layout)
+                val previewButtons = findViewById<View>(R.id.preview_buttons_layout)
+                anchorView = if (previewButtons.isVisible) previewButtons else easeButtons
+            }
         }
-
-        sb.show()
     }
 
     private fun onPageUp() {
@@ -2507,12 +2506,12 @@ abstract class AbstractFlashcardViewer :
 
     private fun displayCouldNotFindMediaSnackbar(filename: String?) {
         val onClickListener = View.OnClickListener { openUrl(Uri.parse(getString(R.string.link_faq_missing_media))) }
-        showSnackbar(getString(R.string.card_viewer_could_not_find_image, filename), R.string.help, onClickListener)
+        showSnackbarAboveAnswerButtons(getString(R.string.card_viewer_could_not_find_image, filename), R.string.help, onClickListener)
     }
 
     private fun displayMediaUpgradeRequiredSnackbar() {
         val onClickListener = View.OnClickListener { openUrl(Uri.parse(getString(R.string.link_faq_invalid_protocol_relative))) }
-        showSnackbar(getString(R.string.card_viewer_media_relative_protocol), R.string.help, onClickListener)
+        showSnackbarAboveAnswerButtons(getString(R.string.card_viewer_media_relative_protocol), R.string.help, onClickListener)
     }
 
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
@@ -42,7 +42,7 @@ import androidx.annotation.CheckResult
 import androidx.annotation.IdRes
 import androidx.annotation.StringRes
 import androidx.annotation.VisibleForTesting
-import androidx.coordinatorlayout.widget.CoordinatorLayout
+import androidx.core.view.isVisible
 import androidx.webkit.WebViewAssetLoader
 import anki.collection.OpChanges
 import com.afollestad.materialdialogs.MaterialDialog
@@ -1790,20 +1790,13 @@ abstract class AbstractFlashcardViewer :
     private fun showSnackbar(mainText: String?, @StringRes buttonText: Int, onClickListener: View.OnClickListener?) {
         // BUG: Moving from full screen to non-full screen obscures the buttons
         val sb = getSnackbar(mainText, Snackbar.LENGTH_LONG, buttonText, onClickListener, webView!!, null)
-        val easeButtons = findViewById<View>(R.id.answer_options_layout)
-        val previewButtons = findViewById<View>(R.id.preview_buttons_layout)
-        val upperView = if (previewButtons != null && previewButtons.visibility != View.GONE) previewButtons else easeButtons
 
-        // we need to check for View.GONE as setting the anchor does not seem to respect this property
-        // (there's a gap even if the view is invisible)
-        if (upperView != null && upperView.visibility != View.GONE && mAnswerButtonsPosition == "bottom") {
-            val sbView = sb.view
-            val layoutParams = sbView.layoutParams as CoordinatorLayout.LayoutParams
-            layoutParams.anchorId = upperView.id
-            layoutParams.anchorGravity = Gravity.TOP
-            layoutParams.gravity = Gravity.TOP
-            sbView.layoutParams = layoutParams
+        if (mAnswerButtonsPosition == "bottom") {
+            val easeButtons = findViewById<View>(R.id.answer_options_layout)
+            val previewButtons = findViewById<View>(R.id.preview_buttons_layout)
+            sb.anchorView = if (previewButtons.isVisible) previewButtons else easeButtons
         }
+
         sb.show()
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
@@ -148,6 +148,7 @@ abstract class AbstractFlashcardViewer :
     private var mScrollingButtons = false
     private var mGesturesEnabled = false
     private var mLargeAnswerButtons = false
+    private var mAnswerButtonsPosition: String? = "bottom"
     private var mDoubleTapTimeInterval = DEFAULT_DOUBLE_TAP_TIME_INTERVAL
 
     // Android WebView
@@ -1006,6 +1007,7 @@ abstract class AbstractFlashcardViewer :
             getString(R.string.answer_buttons_position_preference),
             "bottom"
         )
+        mAnswerButtonsPosition = answerButtonsPosition
         val answerArea = findViewById<LinearLayout>(R.id.bottom_area_layout)
         val answerAreaParams = answerArea.layoutParams as RelativeLayout.LayoutParams
         val whiteboardContainer = findViewById<FrameLayout>(R.id.whiteboard)
@@ -1794,7 +1796,7 @@ abstract class AbstractFlashcardViewer :
 
         // we need to check for View.GONE as setting the anchor does not seem to respect this property
         // (there's a gap even if the view is invisible)
-        if (upperView != null && upperView.visibility != View.GONE) {
+        if (upperView != null && upperView.visibility != View.GONE && mAnswerButtonsPosition == "bottom") {
             val sbView = sb.view
             val layoutParams = sbView.layoutParams as CoordinatorLayout.LayoutParams
             layoutParams.anchorId = upperView.id

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiActivity.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiActivity.java
@@ -46,6 +46,7 @@ import com.ichi2.anki.analytics.UsageAnalytics;
 import com.ichi2.anki.dialogs.AsyncDialogFragment;
 import com.ichi2.anki.dialogs.DialogHandler;
 import com.ichi2.anki.dialogs.SimpleMessageDialog;
+import com.ichi2.anki.snackbar.SnackbarsKt;
 import com.ichi2.async.CollectionLoader;
 import com.ichi2.compat.CompatHelper;
 import com.ichi2.compat.customtabs.CustomTabActivityHelper;
@@ -300,7 +301,7 @@ public class AnkiActivity extends AppCompatActivity implements SimpleMessageDial
             super.startActivityForResult(intent, requestCode);
         } catch (ActivityNotFoundException e) {
             Timber.w(e);
-            UIUtils.showSimpleSnackbar(this, R.string.activity_start_failed,true);
+            SnackbarsKt.showSnackbar(this, R.string.activity_start_failed);
         }
     }
 
@@ -324,7 +325,7 @@ public class AnkiActivity extends AppCompatActivity implements SimpleMessageDial
             launcher.launch(intent, ActivityTransitionAnimation.getAnimationOptions(this, animation));
         } catch (ActivityNotFoundException e) {
             Timber.w(e);
-            UIUtils.showSimpleSnackbar(this, R.string.activity_start_failed, true);
+            SnackbarsKt.showSnackbar(this, R.string.activity_start_failed);
         }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidJsAPI.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidJsAPI.kt
@@ -24,15 +24,15 @@ import android.content.Intent
 import android.net.ConnectivityManager
 import android.net.Uri
 import android.text.TextUtils
-import android.view.View
 import android.webkit.JavascriptInterface
 import android.webkit.WebView
-import android.widget.TextView
 import com.github.zafarkhaja.semver.Version
 import com.google.android.material.snackbar.Snackbar
 import com.ichi2.anim.ActivityTransitionAnimation
 import com.ichi2.anki.UIUtils.showThemedToast
 import com.ichi2.anki.servicelayer.SearchService
+import com.ichi2.anki.snackbar.setMaxLines
+import com.ichi2.anki.snackbar.showSnackbar
 import com.ichi2.async.CollectionTask.SearchCards
 import com.ichi2.async.TaskListener
 import com.ichi2.async.TaskManager
@@ -107,20 +107,14 @@ open class AnkiDroidJsAPI(private val activity: AbstractFlashcardViewer) {
      */
     fun showDeveloperContact(errorCode: Int) {
         val errorMsg: String = context.getString(R.string.anki_js_error_code, errorCode)
-        val parentLayout: View = activity.findViewById(android.R.id.content)
         val snackbarMsg: String = context.getString(R.string.api_version_developer_contact, cardSuppliedDeveloperContact, errorMsg)
-        val snackbar: Snackbar? = UIUtils.showSnackbar(
-            activity,
-            snackbarMsg,
-            false,
-            R.string.reviewer_invalid_api_version_visit_documentation,
-            { activity.openUrl(Uri.parse("https://github.com/ankidroid/Anki-Android/wiki")) },
-            parentLayout,
-            null
-        )
-        val snackbarTextView = snackbar!!.view.findViewById<TextView>(com.google.android.material.R.id.snackbar_text)
-        snackbarTextView.maxLines = 3
-        snackbar.show()
+
+        activity.showSnackbar(snackbarMsg, Snackbar.LENGTH_INDEFINITE) {
+            setMaxLines(3)
+            setAction(R.string.reviewer_invalid_api_version_visit_documentation) {
+                activity.openUrl(Uri.parse("https://github.com/ankidroid/Anki-Android/wiki"))
+            }
+        }
     }
 
     /**

--- a/AnkiDroid/src/main/java/com/ichi2/anki/BackendUndo.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/BackendUndo.kt
@@ -18,7 +18,7 @@ package com.ichi2.anki
 
 import androidx.fragment.app.FragmentActivity
 import com.ichi2.anki.CollectionManager.TR
-import com.ichi2.anki.UIUtils.showSimpleSnackbar
+import com.ichi2.anki.snackbar.showSnackbar
 import com.ichi2.libanki.undoNew
 import com.ichi2.libanki.undoableOp
 import com.ichi2.utils.BlocksSchemaUpgrade
@@ -31,11 +31,7 @@ suspend fun FragmentActivity.backendUndoAndShowPopup(): Boolean {
                 undoNew()
             }
         }
-        showSimpleSnackbar(
-            this,
-            TR.undoActionUndone(changes.operation),
-            false
-        )
+        showSnackbar(TR.undoActionUndone(changes.operation))
         true
     } catch (exc: BackendException) {
         @BlocksSchemaUpgrade("Backend module should export this as a separate Exception")

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CoroutineHelpers.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CoroutineHelpers.kt
@@ -23,7 +23,7 @@ import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentActivity
 import androidx.lifecycle.coroutineScope
 import anki.collection.Progress
-import com.ichi2.anki.UIUtils.showSimpleSnackbar
+import com.ichi2.anki.snackbar.showSnackbar
 import com.ichi2.libanki.Collection
 import kotlinx.coroutines.*
 import net.ankiweb.rsdroid.Backend
@@ -37,6 +37,17 @@ import kotlin.coroutines.suspendCoroutine
  * Launch a job that catches any uncaught errors and reports them to the user.
  * Errors from the backend contain localized text that is often suitable to show to the user as-is.
  * Other errors should ideally be handled in the block.
+ *
+ * TODO: This seems to be similar to [com.ichi2.async.catchingLifecycleScope],
+ *   perhaps put the two methods together?
+ *
+ * TODO: The try/except block here catches CancellationException, is this right?
+ *   If it is, add a comment explaining why.
+ *
+ * TODO: `Throwable.getLocalizedMessage()` might be null, and `BackendException` constructor
+ *   accepts a null message, so `exc.localizedMessage!!` is probably dangerous.
+ *   If not, add a comment explaining why, or refactor to have a method that returns
+ *   a non-null localized message.
  */
 fun FragmentActivity.launchCatchingTask(
     errorMessage: String? = null,
@@ -50,7 +61,7 @@ fun FragmentActivity.launchCatchingTask(
             // do nothing
         } catch (exc: BackendInterruptedException) {
             Timber.e("caught: %s %s", exc, extraInfo)
-            showSimpleSnackbar(this@launchCatchingTask, exc.localizedMessage, false)
+            exc.localizedMessage?.let { showSnackbar(it) }
         } catch (exc: BackendException) {
             Timber.e("caught: %s %s", exc, extraInfo)
             showError(this@launchCatchingTask, exc.localizedMessage!!)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ModelFieldEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ModelFieldEditor.kt
@@ -30,9 +30,9 @@ import androidx.annotation.VisibleForTesting
 import androidx.fragment.app.DialogFragment
 import com.afollestad.materialdialogs.MaterialDialog
 import com.afollestad.materialdialogs.customview.customView
+import com.google.android.material.snackbar.Snackbar
 import com.ichi2.anim.ActivityTransitionAnimation
 import com.ichi2.anki.UIUtils.saveCollectionInBackground
-import com.ichi2.anki.UIUtils.showSimpleSnackbar
 import com.ichi2.anki.UIUtils.showThemedToast
 import com.ichi2.anki.dialogs.ConfirmationDialog
 import com.ichi2.anki.dialogs.LocaleSelectionDialog
@@ -41,6 +41,7 @@ import com.ichi2.anki.dialogs.ModelEditorContextMenu.Companion.newInstance
 import com.ichi2.anki.dialogs.ModelEditorContextMenu.ModelEditorContextMenuAction
 import com.ichi2.anki.exception.ConfirmModSchemaException
 import com.ichi2.anki.servicelayer.LanguageHintService.setLanguageHintForField
+import com.ichi2.anki.snackbar.showSnackbar
 import com.ichi2.async.CollectionTask.AddField
 import com.ichi2.async.CollectionTask.ChangeSortField
 import com.ichi2.async.CollectionTask.DeleteField
@@ -500,7 +501,7 @@ class ModelFieldEditor : AnkiActivity(), LocaleSelectionDialogHandler {
     private fun addFieldLocaleHint(selectedLocale: Locale) {
         setLanguageHintForField(col.models, mModel, currentPos, selectedLocale)
         val format = getString(R.string.model_field_editor_language_hint_dialog_success_result, selectedLocale.displayName)
-        showSimpleSnackbar(this, format, true)
+        showSnackbar(format, Snackbar.LENGTH_SHORT)
     }
 
     @RequiresApi(api = Build.VERSION_CODES.N)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/MyAccount.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/MyAccount.kt
@@ -29,8 +29,7 @@ import androidx.appcompat.widget.Toolbar
 import androidx.core.content.edit
 import com.google.android.material.textfield.TextInputLayout
 import com.ichi2.anim.ActivityTransitionAnimation
-import com.ichi2.anki.UIUtils.showSimpleSnackbar
-import com.ichi2.anki.UIUtils.showSnackbar
+import com.ichi2.anki.snackbar.showSnackbar
 import com.ichi2.anki.web.HostNumFactory.getInstance
 import com.ichi2.async.Connection
 import com.ichi2.libanki.sync.CustomSyncServerUrlException
@@ -233,13 +232,14 @@ class MyAccount : AnkiActivity() {
             if (loginMessage.isNullOrEmpty()) {
                 if (messageResource == R.string.youre_offline && !Connection.allowLoginSyncOnNoConnection) {
                     // #6396 - Add a temporary "Try Anyway" button until we sort out `isOnline`
-                    // val root = this.findViewById<View>(R.id.root_layout)
-                    showSnackbar(this, messageResource, false, R.string.sync_even_if_offline, {
-                        Connection.allowLoginSyncOnNoConnection = true
-                        login()
-                    }, null)
+                    showSnackbar(messageResource) {
+                        setAction(R.string.sync_even_if_offline) {
+                            Connection.allowLoginSyncOnNoConnection = true
+                            login()
+                        }
+                    }
                 } else {
-                    showSimpleSnackbar(this, messageResource, false)
+                    showSnackbar(messageResource)
                 }
             } else {
                 val res = AnkiDroidApp.getAppResources()
@@ -285,14 +285,14 @@ class MyAccount : AnkiActivity() {
             } else {
                 Timber.e("Login failed, error code %d", data.returnType)
                 if (data.returnType == 403) {
-                    showSimpleSnackbar(this@MyAccount, R.string.invalid_username_password, true)
+                    showSnackbar(R.string.invalid_username_password)
                 } else {
                     val message = resources.getString(R.string.connection_error_message)
                     val result = data.result
                     if (!result.isNullOrEmpty() && result[0] is Exception) {
                         showSimpleMessageDialog(message, getHumanReadableLoginErrorMessage(result[0] as Exception), false)
                     } else {
-                        showSimpleSnackbar(this@MyAccount, message, false)
+                        showSnackbar(message)
                     }
                 }
             }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
@@ -73,6 +73,7 @@ import com.ichi2.anki.noteeditor.Toolbar.TextWrapper
 import com.ichi2.anki.receiver.SdCardReceiver
 import com.ichi2.anki.servicelayer.LanguageHintService
 import com.ichi2.anki.servicelayer.NoteService
+import com.ichi2.anki.snackbar.showSnackbar
 import com.ichi2.anki.ui.NoteTypeSpinnerUtils
 import com.ichi2.anki.widgets.DeckDropDownAdapter.SubtitleListener
 import com.ichi2.anki.widgets.PopupMenuWithIcons
@@ -573,11 +574,7 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
                     insertCloze(if (event.isAltPressed) AddClozeType.SAME_NUMBER else AddClozeType.INCREMENT_NUMBER)
                     // Anki Desktop warns, but still inserts the cloze
                     if (!isClozeType) {
-                        UIUtils.showSimpleSnackbar(
-                            this,
-                            R.string.note_editor_insert_cloze_no_cloze_note_type,
-                            false
-                        )
+                        showSnackbar(R.string.note_editor_insert_cloze_no_cloze_note_type)
                     }
                 }
             }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ReadText.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ReadText.kt
@@ -25,9 +25,8 @@ import android.view.WindowManager.BadTokenException
 import androidx.annotation.VisibleForTesting
 import com.afollestad.materialdialogs.MaterialDialog
 import com.afollestad.materialdialogs.list.listItems
-import com.google.android.material.snackbar.Snackbar
-import com.ichi2.anki.UIUtils.showSnackbar
 import com.ichi2.anki.UIUtils.showThemedToast
+import com.ichi2.anki.snackbar.showSnackbar
 import com.ichi2.libanki.DeckId
 import com.ichi2.libanki.Sound.SoundSide
 import com.ichi2.libanki.TTSTag
@@ -274,13 +273,11 @@ object ReadText {
                     override fun onError(utteranceId: String) {
                         Timber.v("Android TTS failed. Check logcat for error. Indicates a problem with Android TTS engine.")
                         val helpUrl = Uri.parse(context.getString(R.string.link_faq_tts))
-                        val ankiActivity = context as AnkiActivity?
-                        ankiActivity!!.mayOpenUrl(helpUrl)
-                        showSnackbar(
-                            ankiActivity, R.string.no_tts_available_message, false, R.string.help,
-                            { openTtsHelpUrl(helpUrl) }, ankiActivity.findViewById(R.id.root_layout),
-                            Snackbar.Callback()
-                        )
+                        val ankiActivity = context as AnkiActivity
+                        ankiActivity.mayOpenUrl(helpUrl)
+                        ankiActivity.showSnackbar(R.string.no_tts_available_message) {
+                            setAction(R.string.help) { openTtsHelpUrl(helpUrl) }
+                        }
                     }
 
                     override fun onStart(arg0: String) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsFragment.kt
@@ -34,10 +34,10 @@ import androidx.core.text.HtmlCompat
 import androidx.fragment.app.Fragment
 import com.ichi2.anim.ActivityTransitionAnimation
 import com.ichi2.anim.ActivityTransitionAnimation.slide
-import com.ichi2.anki.UIUtils.showSnackbar
 import com.ichi2.anki.dialogs.customstudy.CustomStudyDialog
 import com.ichi2.anki.servicelayer.ComputeResult
 import com.ichi2.anki.servicelayer.UndoService.Undo
+import com.ichi2.anki.snackbar.showSnackbar
 import com.ichi2.annotations.NeedsTest
 import com.ichi2.async.CollectionTask.*
 import com.ichi2.async.TaskListener
@@ -414,8 +414,8 @@ class StudyOptionsFragment : Fragment(), Toolbar.OnMenuItemClickListener {
         if (result.resultCode == AbstractFlashcardViewer.RESULT_NO_MORE_CARDS) {
             // If no more cards getting returned while counts > 0 (due to learn ahead limit) then show a snackbar
             if (col!!.sched.count() > 0 && mStudyOptionsView != null) {
-                val rootLayout = mStudyOptionsView!!.findViewById<View>(R.id.studyoptions_main)
-                showSnackbar(requireActivity(), R.string.studyoptions_no_cards_due, false, 0, null, rootLayout)
+                mStudyOptionsView!!.findViewById<View>(R.id.studyoptions_main)
+                    .showSnackbar(R.string.studyoptions_no_cards_due)
             }
         }
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/UIUtils.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/UIUtils.kt
@@ -2,15 +2,10 @@
 
 package com.ichi2.anki
 
-import android.app.Activity
 import android.content.Context
 import android.util.DisplayMetrics
-import android.view.View
-import android.widget.TextView
 import android.widget.Toast
 import androidx.annotation.StringRes
-import com.google.android.material.snackbar.Snackbar
-import com.ichi2.anki.snackbar.fixSwipeDismissBehavior
 import com.ichi2.async.CollectionTask.SaveCollection
 import com.ichi2.async.TaskListener
 import com.ichi2.async.TaskManager
@@ -32,99 +27,6 @@ object UIUtils {
     @JvmStatic
     fun showThemedToast(context: Context?, @StringRes textResource: Int, shortLength: Boolean) {
         Toast.makeText(context, textResource, if (shortLength) Toast.LENGTH_SHORT else Toast.LENGTH_LONG).show()
-    }
-
-    /**
-     * Show a simple Toast-like Snackbar with no actions.
-     * To enable swipe-to-dismiss, the Activity layout should include a CoordinatorLayout with id "root_layout"
-     */
-    @JvmStatic
-    fun showSimpleSnackbar(activity: Activity, mainTextResource: Int, shortLength: Boolean): Snackbar? {
-        val root = activity.findViewById<View>(R.id.root_layout)
-        return showSnackbar(activity, mainTextResource, shortLength, -1, null, root)
-    }
-
-    @JvmStatic
-    fun showSimpleSnackbar(activity: Activity, mainText: String?, shortLength: Boolean): Snackbar? {
-        val root = activity.findViewById<View>(R.id.root_layout)
-        return showSnackbar(activity, mainText, shortLength, -1, null, root, null)
-    }
-
-    /**
-     * Show a snackbar with an action
-     * @param mainTextResource resource for the main text string
-     * @param shortLength whether or not to use long length
-     * @param actionTextResource resource for the text string shown as the action
-     * @param listener listener for the action (if null no action shown)
-     * @param root View Snackbar will attach to. Should be CoordinatorLayout for swipe-to-dismiss to work.
-     * @return Snackbar object
-     */
-    @JvmStatic
-    @JvmOverloads
-    fun showSnackbar(
-        activity: Activity,
-        mainTextResource: Int,
-        shortLength: Boolean,
-        actionTextResource: Int,
-        listener: View.OnClickListener?,
-        root: View?,
-        callback: Snackbar.Callback? = null
-    ): Snackbar? {
-        val mainText = activity.resources.getString(mainTextResource)
-        return showSnackbar(activity, mainText, shortLength, actionTextResource, listener, root, callback)
-    }
-
-    @JvmStatic
-    fun showSnackbar(
-        activity: Activity,
-        mainText: String?,
-        shortLength: Boolean,
-        actionTextResource: Int,
-        listener: View.OnClickListener?,
-        root: View?,
-        callback: Snackbar.Callback?
-    ): Snackbar? {
-        return showSnackbar(activity, mainText, if (shortLength) Snackbar.LENGTH_SHORT else Snackbar.LENGTH_LONG, actionTextResource, listener, root, callback)
-    }
-
-    @JvmStatic
-    fun showSnackbar(
-        activity: Activity,
-        mainText: String?,
-        length: Int,
-        actionTextResource: Int,
-        listener: View.OnClickListener?,
-        rootView: View?,
-        callback: Snackbar.Callback?
-    ): Snackbar? {
-        var root = rootView
-        if (root == null) {
-            root = activity.findViewById(android.R.id.content)
-            if (root == null) {
-                Timber.e("Could not show Snackbar due to null View")
-                return null
-            }
-        }
-        val sb = getSnackbar(mainText, length, actionTextResource, listener, root, callback)
-        sb.show()
-        return sb
-    }
-
-    @JvmStatic
-    fun getSnackbar(mainText: String?, length: Int, actionTextResource: Int, listener: View.OnClickListener?, root: View, callback: Snackbar.Callback?): Snackbar {
-        val sb = Snackbar.make(root, mainText!!, length)
-        sb.fixSwipeDismissBehavior()
-        if (listener != null) {
-            sb.setAction(actionTextResource, listener)
-        }
-        if (callback != null) {
-            sb.addCallback(callback)
-        }
-
-        // Prevent tablets from truncating to 1 line
-        sb.view.findViewById<TextView>(com.google.android.material.R.id.snackbar_text)?.maxLines = 2
-
-        return sb
     }
 
     @JvmStatic

--- a/AnkiDroid/src/main/java/com/ichi2/anki/UIUtils.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/UIUtils.kt
@@ -4,13 +4,11 @@ package com.ichi2.anki
 
 import android.app.Activity
 import android.content.Context
-import android.graphics.Color
 import android.util.DisplayMetrics
 import android.view.View
 import android.widget.TextView
 import android.widget.Toast
 import androidx.annotation.StringRes
-import androidx.core.content.ContextCompat
 import com.google.android.material.snackbar.Snackbar
 import com.ichi2.anki.snackbar.fixSwipeDismissBehavior
 import com.ichi2.async.CollectionTask.SaveCollection
@@ -107,13 +105,13 @@ object UIUtils {
                 return null
             }
         }
-        val sb = getSnackbar(activity, mainText, length, actionTextResource, listener, root, callback)
+        val sb = getSnackbar(mainText, length, actionTextResource, listener, root, callback)
         sb.show()
         return sb
     }
 
     @JvmStatic
-    fun getSnackbar(activity: Activity?, mainText: String?, length: Int, actionTextResource: Int, listener: View.OnClickListener?, root: View, callback: Snackbar.Callback?): Snackbar {
+    fun getSnackbar(mainText: String?, length: Int, actionTextResource: Int, listener: View.OnClickListener?, root: View, callback: Snackbar.Callback?): Snackbar {
         val sb = Snackbar.make(root, mainText!!, length)
         sb.fixSwipeDismissBehavior()
         if (listener != null) {
@@ -122,15 +120,10 @@ object UIUtils {
         if (callback != null) {
             sb.addCallback(callback)
         }
-        // Make the text white to avoid interference from our theme colors.
-        val view = sb.view
-        val tv = view.findViewById<TextView>(com.google.android.material.R.id.snackbar_text)
-        val action = view.findViewById<TextView>(com.google.android.material.R.id.snackbar_action)
-        if (tv != null && action != null) {
-            tv.setTextColor(Color.WHITE)
-            action.setTextColor(ContextCompat.getColor(activity!!, R.color.material_light_blue_500))
-            tv.maxLines = 2 // prevent tablets from truncating to 1 line
-        }
+
+        // Prevent tablets from truncating to 1 line
+        sb.view.findViewById<TextView>(com.google.android.material.R.id.snackbar_text)?.maxLines = 2
+
         return sb
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/UIUtils.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/UIUtils.kt
@@ -12,6 +12,7 @@ import android.widget.Toast
 import androidx.annotation.StringRes
 import androidx.core.content.ContextCompat
 import com.google.android.material.snackbar.Snackbar
+import com.ichi2.anki.snackbar.fixSwipeDismissBehavior
 import com.ichi2.async.CollectionTask.SaveCollection
 import com.ichi2.async.TaskListener
 import com.ichi2.async.TaskManager
@@ -122,6 +123,7 @@ object UIUtils {
     @JvmStatic
     fun getSnackbar(activity: Activity?, mainText: String?, length: Int, actionTextResource: Int, listener: View.OnClickListener?, root: View, callback: Snackbar.Callback?): Snackbar {
         val sb = Snackbar.make(root, mainText!!, length)
+        sb.fixSwipeDismissBehavior()
         if (listener != null) {
             sb.setAction(actionTextResource, listener)
         }
@@ -143,6 +145,7 @@ object UIUtils {
     @JvmStatic
     fun getDismissibleSnackbar(activity: Activity?, mainText: String, length: Int, dismissTextResource: Int, root: View): Snackbar {
         val sb = Snackbar.make(root, mainText, length)
+        sb.fixSwipeDismissBehavior()
         sb.setAction(dismissTextResource) {
             sb.dismiss()
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/UIUtils.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/UIUtils.kt
@@ -52,14 +52,6 @@ object UIUtils {
         return showSnackbar(activity, mainText, shortLength, -1, null, root, null)
     }
 
-    @JvmStatic
-    fun showDismissibleSnackbar(activity: Activity, mainText: String, dismissTextResource: Int, length: Int = 5000): Snackbar {
-        val root = activity.findViewById<View>(android.R.id.content)
-        val sb = getDismissibleSnackbar(activity, mainText, length, dismissTextResource, root)
-        sb.show()
-        return sb
-    }
-
     /**
      * Show a snackbar with an action
      * @param mainTextResource resource for the main text string
@@ -129,25 +121,6 @@ object UIUtils {
         }
         if (callback != null) {
             sb.addCallback(callback)
-        }
-        // Make the text white to avoid interference from our theme colors.
-        val view = sb.view
-        val tv = view.findViewById<TextView>(com.google.android.material.R.id.snackbar_text)
-        val action = view.findViewById<TextView>(com.google.android.material.R.id.snackbar_action)
-        if (tv != null && action != null) {
-            tv.setTextColor(Color.WHITE)
-            action.setTextColor(ContextCompat.getColor(activity!!, R.color.material_light_blue_500))
-            tv.maxLines = 2 // prevent tablets from truncating to 1 line
-        }
-        return sb
-    }
-
-    @JvmStatic
-    fun getDismissibleSnackbar(activity: Activity?, mainText: String, length: Int, dismissTextResource: Int, root: View): Snackbar {
-        val sb = Snackbar.make(root, mainText, length)
-        sb.fixSwipeDismissBehavior()
-        sb.setAction(dismissTextResource) {
-            sb.dismiss()
         }
         // Make the text white to avoid interference from our theme colors.
         val view = sb.view

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/tags/TagsDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/tags/TagsDialog.kt
@@ -24,8 +24,8 @@ import com.afollestad.materialdialogs.customview.customView
 import com.afollestad.materialdialogs.input.getInputField
 import com.afollestad.materialdialogs.input.input
 import com.ichi2.anki.R
-import com.ichi2.anki.UIUtils.showSnackbar
 import com.ichi2.anki.analytics.AnalyticsDialogFragment
+import com.ichi2.anki.snackbar.showSnackbar
 import com.ichi2.annotations.NeedsTest
 import com.ichi2.utils.DisplayUtils.resizeWhenSoftInputShown
 import com.ichi2.utils.TagsUtil
@@ -288,11 +288,10 @@ class TagsDialog : AnalyticsDialogFragment {
                 setExpandTarget(tag)
                 refresh()
             }
+
             // Show a snackbar to let the user know the tag was added successfully
-            showSnackbar(
-                requireActivity(), feedbackText, false, -1, null,
-                mDialog!!.view.findViewById(R.id.tags_dialog_snackbar), null
-            )
+            mDialog!!.view.findViewById<View>(R.id.tags_dialog_snackbar)
+                .showSnackbar(feedbackText)
         }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/export/ActivityExportingDelegate.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/export/ActivityExportingDelegate.kt
@@ -22,14 +22,14 @@ import android.os.ParcelFileDescriptor
 import androidx.activity.result.ActivityResult
 import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.result.contract.ActivityResultContracts
-import androidx.annotation.StringRes
 import androidx.core.app.ShareCompat.IntentBuilder
 import androidx.core.content.FileProvider
+import com.google.android.material.snackbar.Snackbar
 import com.ichi2.anki.*
-import com.ichi2.anki.UIUtils.showSimpleSnackbar
 import com.ichi2.anki.UIUtils.showThemedToast
 import com.ichi2.anki.dialogs.ExportCompleteDialog.ExportCompleteDialogListener
 import com.ichi2.anki.dialogs.ExportDialog.ExportDialogListener
+import com.ichi2.anki.snackbar.showSnackbar
 import com.ichi2.async.CollectionTask.ExportApkg
 import com.ichi2.async.TaskManager
 import com.ichi2.compat.CompatHelper
@@ -143,7 +143,7 @@ class ActivityExportingDelegate(private val activity: AnkiActivity, private val 
             activity.startActivityWithoutAnimation(shareIntent)
         } else {
             // Try to save it?
-            showSimpleSnackbar(activity, R.string.export_send_no_handlers, false)
+            activity.showSnackbar(R.string.export_send_no_handlers)
             saveExportFile(path)
         }
     }
@@ -153,7 +153,7 @@ class ActivityExportingDelegate(private val activity: AnkiActivity, private val 
         val attachment = File(exportPath)
         if (!attachment.exists()) {
             Timber.e("saveExportFile() Specified apkg file %s does not exist", exportPath)
-            showSimpleSnackbar(activity, R.string.export_save_apkg_unsuccessful, false)
+            activity.showSnackbar(R.string.export_save_apkg_unsuccessful)
             return
         }
 
@@ -171,8 +171,12 @@ class ActivityExportingDelegate(private val activity: AnkiActivity, private val 
 
     private fun saveFileCallback(result: ActivityResult) {
         val isSuccessful = exportToProvider(result.data!!, true)
-        @StringRes val message = if (isSuccessful) R.string.export_save_apkg_successful else R.string.export_save_apkg_unsuccessful
-        showSimpleSnackbar(activity, activity.getString(message), isSuccessful)
+
+        if (isSuccessful) {
+            activity.showSnackbar(R.string.export_save_apkg_successful, Snackbar.LENGTH_SHORT)
+        } else {
+            activity.showSnackbar(R.string.export_save_apkg_unsuccessful)
+        }
     }
 
     private fun exportToProvider(intent: Intent, deleteAfterExport: Boolean): Boolean {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/snackbar/SensibleSwipeDismissBehavior.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/snackbar/SensibleSwipeDismissBehavior.kt
@@ -22,7 +22,7 @@ import androidx.coordinatorlayout.widget.CoordinatorLayout
 import androidx.core.view.marginLeft
 import androidx.core.view.marginRight
 import androidx.customview.widget.ViewDragHelper
-import com.google.android.material.behavior.SwipeDismissBehavior
+import com.google.android.material.snackbar.BaseTransientBottomBar
 import com.ichi2.anki.AnkiDroidApp
 import com.ichi2.anki.UIUtils
 import kotlin.math.absoluteValue
@@ -44,15 +44,15 @@ import kotlin.math.sign
  *   * If you drag the snackbar to the right, and then flinging it to the left,
  *     it will suddenly change course and start moving to the right.
  */
-open class SensibleSwipeDismissBehavior<V : View> : SwipeDismissBehavior<V>() {
+open class SensibleSwipeDismissBehavior : BaseTransientBottomBar.Behavior() {
     private var viewDragHelper: ViewDragHelper? = null
 
-    override fun onInterceptTouchEvent(parent: CoordinatorLayout, child: V, event: MotionEvent): Boolean {
+    override fun onInterceptTouchEvent(parent: CoordinatorLayout, child: View, event: MotionEvent): Boolean {
         ensureViewDragHelper(parent)
         return viewDragHelper!!.shouldInterceptTouchEvent(event)
     }
 
-    override fun onTouchEvent(parent: CoordinatorLayout, child: V, event: MotionEvent): Boolean {
+    override fun onTouchEvent(parent: CoordinatorLayout, child: View, event: MotionEvent): Boolean {
         viewDragHelper?.processTouchEvent(event)
         return viewDragHelper != null
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/snackbar/SensibleSwipeDismissBehavior.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/snackbar/SensibleSwipeDismissBehavior.kt
@@ -73,6 +73,10 @@ open class SensibleSwipeDismissBehavior<V : View> : SwipeDismissBehavior<V>() {
 
         override fun clampViewPositionVertical(child: View, top: Int, dy: Int) = child.top
 
+        override fun onViewDragStateChanged(state: Int) {
+            listener?.onDragStateChanged(state)
+        }
+
         override fun tryCaptureView(child: View, pointerId: Int) = true
 
         override fun onViewCaptured(child: View, pointerId: Int) {
@@ -83,7 +87,9 @@ open class SensibleSwipeDismissBehavior<V : View> : SwipeDismissBehavior<V>() {
         }
 
         override fun onViewReleased(child: View, xvel: Float, yvel: Float) {
-            val targetChildLeft = when (shouldDismiss(child, xvel)) {
+            val dismiss = shouldDismiss(child, xvel)
+
+            val targetChildLeft = when (dismiss) {
                 Dismiss.DoNotDismiss -> initialChildLeft
                 Dismiss.ToTheRight -> initialChildLeft + child.width + child.marginRight
                 Dismiss.ToTheLeft -> initialChildLeft - child.width - child.marginLeft
@@ -94,9 +100,13 @@ open class SensibleSwipeDismissBehavior<V : View> : SwipeDismissBehavior<V>() {
                     override fun run() {
                         if (viewDragHelper?.continueSettling(true) == true) {
                             child.postOnAnimation(this)
+                        } else if (dismiss != Dismiss.DoNotDismiss) {
+                            listener?.onDismiss(child)
                         }
                     }
                 })
+            } else if (dismiss != Dismiss.DoNotDismiss) {
+                listener?.onDismiss(child)
             }
         }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/snackbar/SensibleSwipeDismissBehavior.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/snackbar/SensibleSwipeDismissBehavior.kt
@@ -23,6 +23,7 @@ import androidx.core.view.marginLeft
 import androidx.core.view.marginRight
 import androidx.customview.widget.ViewDragHelper
 import com.google.android.material.snackbar.BaseTransientBottomBar
+import com.google.android.material.snackbar.Snackbar
 import com.ichi2.anki.AnkiDroidApp
 import com.ichi2.anki.UIUtils
 import kotlin.math.absoluteValue
@@ -77,7 +78,7 @@ open class SensibleSwipeDismissBehavior : BaseTransientBottomBar.Behavior() {
             listener?.onDragStateChanged(state)
         }
 
-        override fun tryCaptureView(child: View, pointerId: Int) = true
+        override fun tryCaptureView(child: View, pointerId: Int) = child is Snackbar.SnackbarLayout
 
         override fun onViewCaptured(child: View, pointerId: Int) {
             if (initialChildLeft == Int.MIN_VALUE) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/snackbar/SensibleSwipeDismissBehavior.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/snackbar/SensibleSwipeDismissBehavior.kt
@@ -1,0 +1,138 @@
+/*
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.snackbar
+
+import android.view.MotionEvent
+import android.view.View
+import android.view.ViewGroup
+import androidx.annotation.VisibleForTesting
+import androidx.coordinatorlayout.widget.CoordinatorLayout
+import androidx.core.view.marginLeft
+import androidx.core.view.marginRight
+import androidx.customview.widget.ViewDragHelper
+import com.google.android.material.behavior.SwipeDismissBehavior
+import com.ichi2.anki.AnkiDroidApp
+import com.ichi2.anki.UIUtils
+import kotlin.math.absoluteValue
+import kotlin.math.sign
+
+/**
+ * This is more a fix for the inconsistent behavior of `SwipeDismissBehavior`,
+ * rather than a custom implementation. This addresses the following issues:
+ *
+ *   * When the snackbar is swiped to the right, its opacity changes,
+ *     but not when swiped to the left;
+ *
+ *   * When moving the snackbar to dismiss it, the target distance calculation does not take
+ *     the margins into account, which makes the snackbar briefly appear stuck near the edge;
+ *
+ *   * Any amount of horizontal velocity will dismiss the snackbar,
+ *     which can result in user dismissing the snackbar even though they didn't want to;
+ *
+ *   * If you drag the snackbar to the right, and then flinging it to the left,
+ *     it will suddenly change course and start moving to the right.
+ */
+open class SensibleSwipeDismissBehavior<V : View> : SwipeDismissBehavior<V>() {
+    private var viewDragHelper: ViewDragHelper? = null
+
+    override fun onInterceptTouchEvent(parent: CoordinatorLayout, child: V, event: MotionEvent): Boolean {
+        ensureViewDragHelper(parent)
+        return viewDragHelper!!.shouldInterceptTouchEvent(event)
+    }
+
+    override fun onTouchEvent(parent: CoordinatorLayout, child: V, event: MotionEvent): Boolean {
+        viewDragHelper?.processTouchEvent(event)
+        return viewDragHelper != null
+    }
+
+    private fun ensureViewDragHelper(parent: ViewGroup) {
+        if (viewDragHelper == null) {
+            viewDragHelper = ViewDragHelper.create(parent, ViewDragHelperCallback())
+        }
+    }
+
+    /** See [com.google.android.material.behavior.SwipeDismissBehavior.dragCallback] */
+    inner class ViewDragHelperCallback : ViewDragHelper.Callback() {
+        @VisibleForTesting var initialChildLeft = Int.MIN_VALUE
+
+        override fun getViewHorizontalDragRange(child: View) = child.width
+
+        override fun clampViewPositionHorizontal(child: View, left: Int, dx: Int) = left
+
+        override fun clampViewPositionVertical(child: View, top: Int, dy: Int) = child.top
+
+        override fun tryCaptureView(child: View, pointerId: Int) = true
+
+        override fun onViewCaptured(child: View, pointerId: Int) {
+            if (initialChildLeft == Int.MIN_VALUE) {
+                initialChildLeft = child.left
+            }
+            child.parent?.requestDisallowInterceptTouchEvent(true)
+        }
+
+        override fun onViewReleased(child: View, xvel: Float, yvel: Float) {
+            val targetChildLeft = when (shouldDismiss(child, xvel)) {
+                Dismiss.DoNotDismiss -> initialChildLeft
+                Dismiss.ToTheRight -> initialChildLeft + child.width + child.marginRight
+                Dismiss.ToTheLeft -> initialChildLeft - child.width - child.marginLeft
+            }
+
+            if (viewDragHelper?.settleCapturedViewAt(targetChildLeft, child.top) == true) {
+                child.postOnAnimation(object : Runnable {
+                    override fun run() {
+                        if (viewDragHelper?.continueSettling(true) == true) {
+                            child.postOnAnimation(this)
+                        }
+                    }
+                })
+            }
+        }
+
+        /**
+         * The finger was lifted off the snackbar, which may still have horizontal velocity.
+         * This decides whether the snackbar should be dismissed.
+         *
+         *   * If current snackbar speed is high, dismiss to the direction of fling;
+         *
+         *   * If snackbar traveled a lot, and currently is either stationary,
+         *     or is moving away from the original position,
+         *     dismiss to the direction of the closest edge;
+         *
+         *   * Else do not dismiss, and return to original position.
+         */
+        @VisibleForTesting fun shouldDismiss(child: View, xvel: Float): Dismiss {
+            return if (xvel.absoluteValue > FLING_TO_DISMISS_SPEED_THRESHOLD) {
+                if (xvel > 0f) Dismiss.ToTheRight else Dismiss.ToTheLeft
+            } else {
+                val distanceTraveled = child.left - initialChildLeft
+                val distanceTraveledRatio = distanceTraveled.absoluteValue.toFloat() / child.width
+                val shouldDismiss = distanceTraveledRatio > DRAG_TO_DISMISS_DISTANCE_RATIO &&
+                    (xvel == 0f || xvel.sign.toInt() == distanceTraveled.sign)
+                when {
+                    !shouldDismiss -> Dismiss.DoNotDismiss
+                    distanceTraveled > 0 -> Dismiss.ToTheRight
+                    else -> Dismiss.ToTheLeft
+                }
+            }
+        }
+    }
+}
+
+@VisibleForTesting enum class Dismiss { DoNotDismiss, ToTheLeft, ToTheRight }
+
+private val FLING_TO_DISMISS_SPEED_THRESHOLD =
+    UIUtils.convertDpToPixel(1000f, AnkiDroidApp.getInstance().applicationContext)
+
+private const val DRAG_TO_DISMISS_DISTANCE_RATIO = .5f

--- a/AnkiDroid/src/main/java/com/ichi2/anki/snackbar/SnackbarPackageWorkaround.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/snackbar/SnackbarPackageWorkaround.kt
@@ -1,0 +1,23 @@
+/*
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+@file:Suppress("PackageDirectoryMismatch")
+package com.google.android.material.snackbar
+
+/*
+ * This only exists so that we can call onAttachedToWindow, which is package-private.
+ */
+fun Snackbar.onAttachedToWindow2() {
+    onAttachedToWindow()
+}

--- a/AnkiDroid/src/main/java/com/ichi2/anki/snackbar/Snackbars.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/snackbar/Snackbars.kt
@@ -21,7 +21,6 @@ import android.widget.TextView
 import androidx.annotation.RequiresApi
 import androidx.annotation.StringRes
 import androidx.coordinatorlayout.widget.CoordinatorLayout
-import com.google.android.material.behavior.SwipeDismissBehavior
 import com.google.android.material.snackbar.Snackbar
 import com.google.android.material.snackbar.onAttachedToWindow2
 import com.ichi2.anki.BuildConfig
@@ -181,7 +180,7 @@ fun View.showSnackbar(
 ) {
     val snackbar = Snackbar.make(this, text, duration)
     snackbar.setMaxLines(2)
-    snackbar.fixSwipeDismissBehavior()
+    snackbar.behavior = SwipeDismissBehaviorFix()
 
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
         snackbar.fixMarginsWhenInsetsChange()
@@ -197,30 +196,6 @@ fun View.showSnackbar(
 fun Snackbar.setMaxLines(maxLines: Int) {
     view.findViewById<TextView>(com.google.android.material.R.id.snackbar_text)?.maxLines = maxLines
 }
-
-/**
- * This changes the default behavior to the fixed one, preserving the original listener.
- * When dragging or settling, this listener pauses the timer that removes the snackbar,
- * so it does not disappear from under your finger.
- */
-private fun Snackbar.fixSwipeDismissBehavior() {
-    addCallback(object : Snackbar.Callback() {
-        override fun onShown(snackbar: Snackbar) {
-            actualBehavior = SwipeDismissBehaviorFix<View>().apply {
-                listener = actualBehavior?.listener
-            }
-        }
-    })
-}
-
-private var Snackbar.actualBehavior: SwipeDismissBehavior<View>?
-    get() {
-        return (view.layoutParams as? CoordinatorLayout.LayoutParams)
-            ?.behavior as? SwipeDismissBehavior
-    }
-    set(value) {
-        (view.layoutParams as? CoordinatorLayout.LayoutParams)?.behavior = value
-    }
 
 /**
  * When bottom inset change, for instance, when keyboard is open or closed,

--- a/AnkiDroid/src/main/java/com/ichi2/anki/snackbar/Snackbars.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/snackbar/Snackbars.kt
@@ -1,0 +1,188 @@
+/*
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.snackbar
+
+import android.app.Activity
+import android.view.View
+import android.widget.TextView
+import androidx.annotation.StringRes
+import com.google.android.material.snackbar.Snackbar
+import com.ichi2.anki.BuildConfig
+import com.ichi2.anki.R
+import com.ichi2.anki.UIUtils.showThemedToast
+import timber.log.Timber
+
+typealias SnackbarBuilder = Snackbar.() -> Unit
+
+/**
+ * Show a snackbar.
+ *
+ * You can create snackbars by calling `showSnackbar` on either an activity or a view.
+ * As `CoordinatorLayout` is responsible for proper placement and animation of snackbars,
+ *
+ *   * if calling on an activity, the activity **MUST** have a `CoordinatorLayout`
+ *     with id `root_layout`;
+ *
+ *   * if calling on a view, the view **MUST** be either a `CoordinatorLayout`,
+ *     or a (possibly indirect) child of `CoordinatorLayout`.
+ *
+ * Any additional configuration can be done in the configuration block, e.g.
+ *
+ *     showSnackbar(text) {
+ *         addCallback(callback)
+ *     }
+ *
+ * @receiver An [Activity] that has a [CoordinatorLayout] with id `root_layout`.
+ * @param textResource String resource to show, can be formatted.
+ * @param duration Optional. For how long to show the snackbar. Can be one of:
+ *     [Snackbar.LENGTH_SHORT], [Snackbar.LENGTH_LONG] (default), [Snackbar.LENGTH_INDEFINITE],
+ *     or exact duration in milliseconds.
+ * @param snackbarBuilder Optional. A configuration block with the [Snackbar] as `this`.
+ */
+@JvmOverloads
+fun Activity.showSnackbar(
+    @StringRes textResource: Int,
+    duration: Int = Snackbar.LENGTH_LONG,
+    snackbarBuilder: SnackbarBuilder? = null
+) {
+    val text = getText(textResource)
+    showSnackbar(text, duration, snackbarBuilder)
+}
+
+/**
+ * Show a snackbar.
+ *
+ * You can create snackbars by calling `showSnackbar` on either an activity or a view.
+ * As `CoordinatorLayout` is responsible for proper placement and animation of snackbars,
+ *
+ *   * if calling on an activity, the activity **MUST** have a `CoordinatorLayout`
+ *     with id `root_layout`;
+ *
+ *   * if calling on a view, the view **MUST** be either a `CoordinatorLayout`,
+ *     or a (possibly indirect) child of `CoordinatorLayout`.
+ *
+ * Any additional configuration can be done in the configuration block, e.g.
+ *
+ *     showSnackbar(text) {
+ *         addCallback(callback)
+ *     }
+ *
+ * @receiver An [Activity] that has a [CoordinatorLayout] with id `root_layout`.
+ * @param text Text to show, can be formatted.
+ * @param duration Optional. For how long to show the snackbar. Can be one of:
+ *     [Snackbar.LENGTH_SHORT], [Snackbar.LENGTH_LONG] (default), [Snackbar.LENGTH_INDEFINITE],
+ *     or exact duration in milliseconds.
+ * @param snackbarBuilder Optional. A configuration block with the [Snackbar] as `this`.
+ */
+fun Activity.showSnackbar(
+    text: CharSequence,
+    duration: Int = Snackbar.LENGTH_LONG,
+    snackbarBuilder: SnackbarBuilder? = null
+) {
+    val view: View? = findViewById(R.id.root_layout)
+
+    if (view != null) {
+        view.showSnackbar(text, duration, snackbarBuilder)
+    } else {
+        val errorMessage = "While trying to show a snackbar, " +
+            "could not find a view with id root_layout in $this"
+
+        if (BuildConfig.DEBUG) {
+            throw IllegalArgumentException(errorMessage)
+        } else {
+            Timber.e(errorMessage)
+            showThemedToast(this, text, false)
+        }
+    }
+}
+
+/**
+ * Show a snackbar.
+ *
+ * You can create snackbars by calling `showSnackbar` on either an activity or a view.
+ * As `CoordinatorLayout` is responsible for proper placement and animation of snackbars,
+ *
+ *   * if calling on an activity, the activity **MUST** have a `CoordinatorLayout`
+ *     with id `root_layout`;
+ *
+ *   * if calling on a view, the view **MUST** be either a `CoordinatorLayout`,
+ *     or a (possibly indirect) child of `CoordinatorLayout`.
+ *
+ * Any additional configuration can be done in the configuration block, e.g.
+ *
+ *     showSnackbar(text) {
+ *         addCallback(callback)
+ *     }
+ *
+ * @receiver A [View] that is either a [CoordinatorLayout],
+ *     or a (possibly indirect) child of `CoordinatorLayout`.
+ * @param textResource String resource to show, can be formatted.
+ * @param duration Optional. For how long to show the snackbar. Can be one of:
+ *     [Snackbar.LENGTH_SHORT], [Snackbar.LENGTH_LONG] (default), [Snackbar.LENGTH_INDEFINITE],
+ *     or exact duration in milliseconds.
+ * @param snackbarBuilder Optional. A configuration block with the [Snackbar] as `this`.
+ */
+fun View.showSnackbar(
+    @StringRes textResource: Int,
+    duration: Int = Snackbar.LENGTH_LONG,
+    snackbarBuilder: SnackbarBuilder? = null
+) {
+    val text = resources.getText(textResource)
+    showSnackbar(text, duration, snackbarBuilder)
+}
+
+/**
+ * Show a snackbar.
+ *
+ * You can create snackbars by calling `showSnackbar` on either an activity or a view.
+ * As `CoordinatorLayout` is responsible for proper placement and animation of snackbars,
+ *
+ *   * if calling on an activity, the activity **MUST** have a `CoordinatorLayout`
+ *     with id `root_layout`;
+ *
+ *   * if calling on a view, the view **MUST** be either a `CoordinatorLayout`,
+ *     or a (possibly indirect) child of `CoordinatorLayout`.
+ *
+ * Any additional configuration can be done in the configuration block, e.g.
+ *
+ *     showSnackbar(text) {
+ *         addCallback(callback)
+ *     }
+ *
+ * @receiver A [View] that is either a [CoordinatorLayout],
+ *     or a (possibly indirect) child of `CoordinatorLayout`.
+ * @param text Text to show, can be formatted.
+ * @param duration Optional. For how long to show the snackbar. Can be one of:
+ *     [Snackbar.LENGTH_SHORT], [Snackbar.LENGTH_LONG] (default), [Snackbar.LENGTH_INDEFINITE],
+ *     or exact duration in milliseconds.
+ * @param snackbarBuilder Optional. A configuration block with the [Snackbar] as `this`.
+ */
+fun View.showSnackbar(
+    text: CharSequence,
+    duration: Int = Snackbar.LENGTH_LONG,
+    snackbarBuilder: SnackbarBuilder? = null
+) {
+    val snackbar = Snackbar.make(this, text, duration)
+    snackbar.fixSwipeDismissBehavior()
+    snackbar.setMaxLines(2)
+
+    if (snackbarBuilder != null) { snackbar.snackbarBuilder() }
+
+    snackbar.show()
+}
+
+fun Snackbar.setMaxLines(maxLines: Int) {
+    view.findViewById<TextView>(com.google.android.material.R.id.snackbar_text)?.maxLines = maxLines
+}

--- a/AnkiDroid/src/main/java/com/ichi2/anki/snackbar/Snackbars.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/snackbar/Snackbars.kt
@@ -179,7 +179,6 @@ fun View.showSnackbar(
     val snackbar = Snackbar.make(this, text, duration)
     snackbar.setMaxLines(2)
     snackbar.fixSwipeDismissBehavior()
-    snackbar.actualBehavior?.setSwipeDirection(SwipeDismissBehavior.SWIPE_DIRECTION_ANY)
 
     if (snackbarBuilder != null) { snackbar.snackbarBuilder() }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/snackbar/Snackbars.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/snackbar/Snackbars.kt
@@ -18,6 +18,8 @@ import android.app.Activity
 import android.view.View
 import android.widget.TextView
 import androidx.annotation.StringRes
+import androidx.coordinatorlayout.widget.CoordinatorLayout
+import com.google.android.material.behavior.SwipeDismissBehavior
 import com.google.android.material.snackbar.Snackbar
 import com.ichi2.anki.BuildConfig
 import com.ichi2.anki.R
@@ -175,14 +177,41 @@ fun View.showSnackbar(
     snackbarBuilder: SnackbarBuilder? = null
 ) {
     val snackbar = Snackbar.make(this, text, duration)
-    snackbar.fixSwipeDismissBehavior()
     snackbar.setMaxLines(2)
+    snackbar.fixSwipeDismissBehavior()
+    snackbar.actualBehavior?.setSwipeDirection(SwipeDismissBehavior.SWIPE_DIRECTION_ANY)
 
     if (snackbarBuilder != null) { snackbar.snackbarBuilder() }
 
     snackbar.show()
 }
 
+/* ********************************************************************************************** */
+
 fun Snackbar.setMaxLines(maxLines: Int) {
     view.findViewById<TextView>(com.google.android.material.R.id.snackbar_text)?.maxLines = maxLines
 }
+
+/**
+ * This changes the default behavior to the fixed one, preserving the original listener.
+ * When dragging or settling, this listener pauses the timer that removes the snackbar,
+ * so it does not disappear from under your finger.
+ */
+private fun Snackbar.fixSwipeDismissBehavior() {
+    addCallback(object : Snackbar.Callback() {
+        override fun onShown(snackbar: Snackbar) {
+            actualBehavior = SwipeDismissBehaviorFix<View>().apply {
+                listener = actualBehavior?.listener
+            }
+        }
+    })
+}
+
+private var Snackbar.actualBehavior: SwipeDismissBehavior<View>?
+    get() {
+        return (view.layoutParams as? CoordinatorLayout.LayoutParams)
+            ?.behavior as? SwipeDismissBehavior
+    }
+    set(value) {
+        (view.layoutParams as? CoordinatorLayout.LayoutParams)?.behavior = value
+    }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/snackbar/SwipeDismissBehaviorFix.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/snackbar/SwipeDismissBehaviorFix.kt
@@ -56,10 +56,10 @@ import com.google.android.material.behavior.SwipeDismissBehavior
  * Note that this fix is currently used for [SensibleSwipeDismissBehavior],
  * but is applicable to [SwipeDismissBehavior] as well.
  */
-class SwipeDismissBehaviorFix<V : View> : SensibleSwipeDismissBehavior<V>() {
+class SwipeDismissBehaviorFix : SensibleSwipeDismissBehavior() {
     private var ignoreCallsToOnTouchEvent = false
 
-    override fun onInterceptTouchEvent(parent: CoordinatorLayout, child: V, event: MotionEvent): Boolean {
+    override fun onInterceptTouchEvent(parent: CoordinatorLayout, child: View, event: MotionEvent): Boolean {
         if (!parent.isPointInChildBounds(child, event.x.toInt(), event.y.toInt())) return false
 
         ignoreCallsToOnTouchEvent = true
@@ -68,7 +68,7 @@ class SwipeDismissBehaviorFix<V : View> : SensibleSwipeDismissBehavior<V>() {
         }
     }
 
-    override fun onTouchEvent(parent: CoordinatorLayout, child: V, event: MotionEvent): Boolean {
+    override fun onTouchEvent(parent: CoordinatorLayout, child: View, event: MotionEvent): Boolean {
         if (ignoreCallsToOnTouchEvent) return false
         return super.onTouchEvent(parent, child, event)
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/snackbar/SwipeDismissBehaviorFix.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/snackbar/SwipeDismissBehaviorFix.kt
@@ -43,11 +43,23 @@ import com.google.android.material.snackbar.Snackbar
  *
  * This fix solves the issue in a very simple way, by ignoring calls to [onTouchEvent]
  * during the call to [onInterceptTouchEvent].
+ *
+ * Another problem with SwipeDismissBehavior is that the way it uses ViewDragHelper,
+ * event interception may happen well past the initial start of the gesture.
+ * ViewDragHelper will capture the view under the finger,
+ * which at this point might be some unrelated view, and *that* view will be moved instead.
+ *
+ * This solves the issue by never intercepting touch events unless the finger is over the snackbar.
+ * This does prevent the user from moving snackbar if they put a finger on it,
+ * move it directly upwards, and then to the side.
+ * However, this inconvenience is rather minor and fixing it properly might require too much effort.
  */
 class SwipeDismissBehaviorFix<V : View> : SwipeDismissBehavior<V>() {
     private var ignoreCallsToOnTouchEvent = false
 
     override fun onInterceptTouchEvent(parent: CoordinatorLayout, child: V, event: MotionEvent): Boolean {
+        if (!parent.isPointInChildBounds(child, event.x.toInt(), event.y.toInt())) return false
+
         ignoreCallsToOnTouchEvent = true
         return super.onInterceptTouchEvent(parent, child, event).also {
             ignoreCallsToOnTouchEvent = false

--- a/AnkiDroid/src/main/java/com/ichi2/anki/snackbar/SwipeDismissBehaviorFix.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/snackbar/SwipeDismissBehaviorFix.kt
@@ -1,0 +1,84 @@
+/*
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.snackbar
+
+import android.view.MotionEvent
+import android.view.View
+import androidx.coordinatorlayout.widget.CoordinatorLayout
+import androidx.customview.widget.ViewDragHelper
+import com.google.android.material.behavior.SwipeDismissBehavior
+import com.google.android.material.snackbar.Snackbar
+
+/**
+ * This exists to help Snackbars actually move on the screen when you try to swipe them away.
+ * With the default SwipeDismissBehavior, while you can can dismiss them by flinging,
+ * they stay in place while you do so, and only ever disappear to the right,
+ * not into the direction of the fling. The library provides the functionality, it's just broken.
+ *
+ * The issue is, when we get a move event, ViewDragHelper will capture the view for dragging,
+ * and ask parent to stop intercepting further touches. This propagates to CoordinatorLayout,
+ * which then resets touch behavior for its children--including us.
+ *
+ * The sequence of unfortunate events:
+ *   * [onInterceptTouchEvent]
+ *   * [ViewDragHelper.shouldInterceptTouchEvent]
+ *   * [ViewDragHelper.tryCaptureViewForDrag]
+ *   * [ViewDragHelper.captureChildView]
+ *   * [ViewDragHelper.Callback.onViewCaptured]
+ *   * [CoordinatorLayout.requestDisallowInterceptTouchEvent]
+ *   * [CoordinatorLayout.resetTouchBehaviors]
+ *   * [onTouchEvent]
+ *
+ * This fix solves the issue in a very simple way, by ignoring calls to [onTouchEvent]
+ * during the call to [onInterceptTouchEvent].
+ */
+class SwipeDismissBehaviorFix<V : View> : SwipeDismissBehavior<V>() {
+    private var ignoreCallsToOnTouchEvent = false
+
+    override fun onInterceptTouchEvent(parent: CoordinatorLayout, child: V, event: MotionEvent): Boolean {
+        ignoreCallsToOnTouchEvent = true
+        return super.onInterceptTouchEvent(parent, child, event).also {
+            ignoreCallsToOnTouchEvent = false
+        }
+    }
+
+    override fun onTouchEvent(parent: CoordinatorLayout, child: V, event: MotionEvent): Boolean {
+        if (ignoreCallsToOnTouchEvent) return false
+        return super.onTouchEvent(parent, child, event)
+    }
+}
+
+/**
+ * This does three things:
+ *   * Changes the default behavior to the fixed one;
+ *   * Copies the listener from the default behavior. When dragging or settling,
+ *     this listener pauses the timer that removes the snackbar,
+ *     so it does not disappear from under your finger;
+ *   * Allows swiping the snackbar to the left, as well as to the right.
+ */
+fun Snackbar.fixSwipeDismissBehavior() {
+    addCallback(object : Snackbar.Callback() {
+        override fun onShown(snackbar: Snackbar) {
+            super.onShown(snackbar)
+            val params = snackbar.view.layoutParams
+            if (params is CoordinatorLayout.LayoutParams) {
+                params.behavior = SwipeDismissBehaviorFix<View>().apply {
+                    listener = (params.behavior as? SwipeDismissBehavior)?.listener
+                    setSwipeDirection(SwipeDismissBehavior.SWIPE_DIRECTION_ANY)
+                }
+            }
+        }
+    })
+}

--- a/AnkiDroid/src/main/java/com/ichi2/anki/snackbar/SwipeDismissBehaviorFix.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/snackbar/SwipeDismissBehaviorFix.kt
@@ -52,8 +52,11 @@ import com.google.android.material.behavior.SwipeDismissBehavior
  * This does prevent the user from moving snackbar if they put a finger on it,
  * move it directly upwards, and then to the side.
  * However, this inconvenience is rather minor and fixing it properly might require too much effort.
+ *
+ * Note that this fix is currently used for [SensibleSwipeDismissBehavior],
+ * but is applicable to [SwipeDismissBehavior] as well.
  */
-class SwipeDismissBehaviorFix<V : View> : SwipeDismissBehavior<V>() {
+class SwipeDismissBehaviorFix<V : View> : SensibleSwipeDismissBehavior<V>() {
     private var ignoreCallsToOnTouchEvent = false
 
     override fun onInterceptTouchEvent(parent: CoordinatorLayout, child: V, event: MotionEvent): Boolean {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/snackbar/SwipeDismissBehaviorFix.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/snackbar/SwipeDismissBehaviorFix.kt
@@ -43,16 +43,6 @@ import com.google.android.material.behavior.SwipeDismissBehavior
  * This fix solves the issue in a very simple way, by ignoring calls to [onTouchEvent]
  * during the call to [onInterceptTouchEvent].
  *
- * Another problem with SwipeDismissBehavior is that the way it uses ViewDragHelper,
- * event interception may happen well past the initial start of the gesture.
- * ViewDragHelper will capture the view under the finger,
- * which at this point might be some unrelated view, and *that* view will be moved instead.
- *
- * This solves the issue by never intercepting touch events unless the finger is over the snackbar.
- * This does prevent the user from moving snackbar if they put a finger on it,
- * move it directly upwards, and then to the side.
- * However, this inconvenience is rather minor and fixing it properly might require too much effort.
- *
  * Note that this fix is currently used for [SensibleSwipeDismissBehavior],
  * but is applicable to [SwipeDismissBehavior] as well.
  */
@@ -60,8 +50,6 @@ class SwipeDismissBehaviorFix : SensibleSwipeDismissBehavior() {
     private var ignoreCallsToOnTouchEvent = false
 
     override fun onInterceptTouchEvent(parent: CoordinatorLayout, child: View, event: MotionEvent): Boolean {
-        if (!parent.isPointInChildBounds(child, event.x.toInt(), event.y.toInt())) return false
-
         ignoreCallsToOnTouchEvent = true
         return super.onInterceptTouchEvent(parent, child, event).also {
             ignoreCallsToOnTouchEvent = false

--- a/AnkiDroid/src/main/java/com/ichi2/anki/snackbar/SwipeDismissBehaviorFix.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/snackbar/SwipeDismissBehaviorFix.kt
@@ -19,7 +19,6 @@ import android.view.View
 import androidx.coordinatorlayout.widget.CoordinatorLayout
 import androidx.customview.widget.ViewDragHelper
 import com.google.android.material.behavior.SwipeDismissBehavior
-import com.google.android.material.snackbar.Snackbar
 
 /**
  * This exists to help Snackbars actually move on the screen when you try to swipe them away.
@@ -70,27 +69,4 @@ class SwipeDismissBehaviorFix<V : View> : SwipeDismissBehavior<V>() {
         if (ignoreCallsToOnTouchEvent) return false
         return super.onTouchEvent(parent, child, event)
     }
-}
-
-/**
- * This does three things:
- *   * Changes the default behavior to the fixed one;
- *   * Copies the listener from the default behavior. When dragging or settling,
- *     this listener pauses the timer that removes the snackbar,
- *     so it does not disappear from under your finger;
- *   * Allows swiping the snackbar to the left, as well as to the right.
- */
-fun Snackbar.fixSwipeDismissBehavior() {
-    addCallback(object : Snackbar.Callback() {
-        override fun onShown(snackbar: Snackbar) {
-            super.onShown(snackbar)
-            val params = snackbar.view.layoutParams
-            if (params is CoordinatorLayout.LayoutParams) {
-                params.behavior = SwipeDismissBehaviorFix<View>().apply {
-                    listener = (params.behavior as? SwipeDismissBehavior)?.listener
-                    setSwipeDirection(SwipeDismissBehavior.SWIPE_DIRECTION_ANY)
-                }
-            }
-        }
-    })
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/widgets/FabBehavior.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/widgets/FabBehavior.kt
@@ -18,9 +18,9 @@ package com.ichi2.anki.widgets
 import android.content.Context
 import android.util.AttributeSet
 import android.view.View
+import android.view.animation.DecelerateInterpolator
 import androidx.coordinatorlayout.widget.CoordinatorLayout
-import androidx.core.view.ViewCompat
-import androidx.core.view.isVisible
+import com.google.android.material.snackbar.BaseTransientBottomBar
 import com.google.android.material.snackbar.Snackbar.SnackbarLayout
 import com.ichi2.anki.AnkiDroidApp
 import com.ichi2.anki.UIUtils
@@ -30,40 +30,45 @@ import com.ichi2.anki.UIUtils
  * Defines the behavior for the floating action button. If the dependency is a Snackbar, move the
  * fab up.
  */
-class FabBehavior : CoordinatorLayout.Behavior<View> {
-    private var mTranslationY = 0f
-
-    constructor() : super() {}
-    constructor(context: Context?, attrs: AttributeSet?) : super(context, attrs) {}
+@Suppress("UNUSED")
+class FabBehavior @JvmOverloads constructor(context: Context, attrs: AttributeSet? = null) :
+    CoordinatorLayout.Behavior<View>(context, attrs) {
 
     override fun layoutDependsOn(parent: CoordinatorLayout, child: View, dependency: View): Boolean {
         return dependency is SnackbarLayout
     }
 
-    override fun onDependentViewChanged(parent: CoordinatorLayout, fab: View, dependency: View): Boolean {
-        if (dependency is SnackbarLayout && fab.visibility == View.VISIBLE) {
-            val translationY = getFabTranslationYForSnackbar(parent, fab)
-            if (translationY != mTranslationY) {
-                ViewCompat.animate(fab).cancel()
-                fab.translationY = translationY
-                mTranslationY = translationY
-            }
-        }
+    override fun onDependentViewChanged(parent: CoordinatorLayout, fab: View, snackbar: View): Boolean {
+        val fabTranslationY = calculateFabTranslationYForSnackbar(fab, snackbar)
+        translateFabToYWithAnimation(fab, fabTranslationY, SNACKBAR_FADE_IN_DURATION)
         return false
     }
 
-    override fun onDependentViewRemoved(parent: CoordinatorLayout, fab: View, dependency: View) {
-        super.onDependentViewRemoved(parent, fab, dependency)
-        if (dependency is SnackbarLayout && fab.visibility == View.VISIBLE) {
-            val translationY = getFabTranslationYForSnackbar(parent, fab)
-            if (translationY != mTranslationY) {
-                ViewCompat.animate(fab).cancel()
-                fab.translationY = 0f
-                mTranslationY = 0f
-            }
+    override fun onDependentViewRemoved(parent: CoordinatorLayout, fab: View, snackbar: View) {
+        translateFabToYWithAnimation(fab, 0f, SNACKBAR_FADE_OUT_DURATION)
+    }
+
+    private var lastFabTranslationY = 0f
+
+    private fun translateFabToYWithAnimation(fab: View, fabTranslationY: Float, duration: Long) {
+        if (lastFabTranslationY != fabTranslationY) {
+            lastFabTranslationY = fabTranslationY
+            fab.animate()
+                .setInterpolator(DecelerateInterpolator(2f))
+                .translationY(fabTranslationY)
+                .setDuration(duration)
+                .start()
         }
     }
 }
+
+/**
+ * These are the same as:
+ *   * [BaseTransientBottomBar.ANIMATION_FADE_IN_DURATION]
+ *   * [BaseTransientBottomBar.ANIMATION_FADE_OUT_DURATION]
+ */
+private const val SNACKBAR_FADE_IN_DURATION = 150L
+private const val SNACKBAR_FADE_OUT_DURATION = 75L
 
 /**
  * Here, fab is the entire layout containing the button itself, related menu and the margin.
@@ -72,14 +77,10 @@ class FabBehavior : CoordinatorLayout.Behavior<View> {
  */
 private val MAX_OVERLAP = UIUtils.convertDpToPixel(10f, AnkiDroidApp.getInstance().applicationContext)
 
-private fun getFabTranslationYForSnackbar(parent: CoordinatorLayout, fab: View): Float {
-    return parent.getDependencies(fab)
-        .filter { view -> view is SnackbarLayout && view.isVisible }
-        .minOfOrNull { snackbar ->
-            val untranslatedFabBottom = fab.bottom
-            val effectiveSnackbarTop = snackbar.top + snackbar.translationY
-            val overlap = untranslatedFabBottom - effectiveSnackbarTop
+private fun calculateFabTranslationYForSnackbar(fab: View, snackbar: View): Float {
+    val untranslatedFabBottom = fab.bottom
+    val effectiveSnackbarTop = snackbar.top + snackbar.translationY
+    val overlap = untranslatedFabBottom - effectiveSnackbarTop
 
-            if (overlap > MAX_OVERLAP) -(overlap - MAX_OVERLAP) else 0f
-        } ?: 0f
+    return if (overlap > MAX_OVERLAP) -(overlap - MAX_OVERLAP) else 0f
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/widgets/FabBehavior.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/widgets/FabBehavior.kt
@@ -56,7 +56,7 @@ class FabBehavior : CoordinatorLayout.Behavior<View> {
         super.onDependentViewRemoved(parent, fab, dependency)
         if (dependency is SnackbarLayout && fab.visibility == View.VISIBLE) {
             val translationY = getFabTranslationYForSnackbar(parent, fab)
-            if (translationY == mTranslationY) {
+            if (translationY != mTranslationY) {
                 ViewCompat.animate(fab).cancel()
                 fab.translationY = 0f
                 mTranslationY = 0f

--- a/AnkiDroid/src/main/java/com/ichi2/async/CoroutineHelpers.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/async/CoroutineHelpers.kt
@@ -23,8 +23,7 @@ import android.app.Activity
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.coroutineScope
 import com.ichi2.anki.CrashReportService
-import com.ichi2.anki.R
-import com.ichi2.anki.UIUtils.showDismissibleSnackbar
+import com.ichi2.anki.UIUtils.showSimpleSnackbar
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
@@ -48,7 +47,7 @@ fun LifecycleOwner.catchingLifecycleScope(
     } catch (e: Exception) {
         // TODO: localize
         Timber.w(e, errorMessage)
-        showDismissibleSnackbar(activity, "An error occurred: $e", R.string.close)
+        showSimpleSnackbar(activity, "An error occurred: $e", shortLength = false)
         CrashReportService.sendExceptionReport(e, activity::class.java.simpleName)
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/async/CoroutineHelpers.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/async/CoroutineHelpers.kt
@@ -23,7 +23,7 @@ import android.app.Activity
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.coroutineScope
 import com.ichi2.anki.CrashReportService
-import com.ichi2.anki.UIUtils.showSimpleSnackbar
+import com.ichi2.anki.snackbar.showSnackbar
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
@@ -47,7 +47,7 @@ fun LifecycleOwner.catchingLifecycleScope(
     } catch (e: Exception) {
         // TODO: localize
         Timber.w(e, errorMessage)
-        showSimpleSnackbar(activity, "An error occurred: $e", shortLength = false)
+        activity.showSnackbar("An error occurred: $e")
         CrashReportService.sendExceptionReport(e, activity::class.java.simpleName)
     }
 }

--- a/AnkiDroid/src/main/res/layout-xlarge/homescreen.xml
+++ b/AnkiDroid/src/main/res/layout-xlarge/homescreen.xml
@@ -2,7 +2,7 @@
 <androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
                                            android:layout_width="match_parent"
                                            android:layout_height="match_parent"
-                                           android:fitsSystemWindows="true">
+                                           >
         <LinearLayout
             android:id="@+id/deckpicker_xl_view"
             android:layout_width="match_parent"

--- a/AnkiDroid/src/main/res/layout/homescreen.xml
+++ b/AnkiDroid/src/main/res/layout/homescreen.xml
@@ -2,6 +2,6 @@
 <androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
                                            android:layout_width="match_parent"
                                            android:layout_height="match_parent"
-                                           android:fitsSystemWindows="true">
+                                           >
     <include layout="@layout/deck_picker"/>
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/AnkiDroid/src/main/res/values/attrs.xml
+++ b/AnkiDroid/src/main/res/values/attrs.xml
@@ -154,6 +154,9 @@
 
     <attr name="editTextDisabled" format="color"/>
 
+    <attr name="snackbarBackgroundTintColor" format="color"/>
+    <attr name="snackbarButtonTextColor" format="color"/>
+
     <declare-styleable name="CheckBoxTriStates">
         <attr name="cycle_checked_to_indeterminate" format="boolean" />
         <attr name="cycle_indeterminate_to_checked" format="boolean" />

--- a/AnkiDroid/src/main/res/values/dimens.xml
+++ b/AnkiDroid/src/main/res/values/dimens.xml
@@ -28,4 +28,6 @@
     <dimen name="deck_picker_left_padding">24dp</dimen>
     <dimen name="deck_picker_right_padding">4dp</dimen>
     <dimen name="note_editor_toolbar_height">52dp</dimen>
+
+    <dimen name="mtrl_snackbar_background_corner_radius">8dp</dimen>
 </resources>

--- a/AnkiDroid/src/main/res/values/styles.xml
+++ b/AnkiDroid/src/main/res/values/styles.xml
@@ -171,4 +171,21 @@
     <style name="CustomBottomSheetStyle" parent="Widget.Design.BottomSheet.Modal">
         <item name="android:background">@drawable/rounded_bottom_sheet</item>
     </style>
+
+    <!-- Snackbars -->
+    <style name="SnackbarStyle" parent="Widget.MaterialComponents.Snackbar">
+        <item name="android:backgroundTint">?attr/snackbarBackgroundTintColor</item>
+        <!-- Material snackbar sets button text color by layering its current text color, set with
+             android:textColor below, over surface color with the alpha set by this attribute.
+             Since the app doesn't use material theming, let's disable this color blending.
+             TODO Remove if the app moves to material theming. -->
+        <item name="actionTextColorAlpha">1.0</item>
+    </style>
+    <style name="SnackbarButtonStyle" parent="Widget.MaterialComponents.Button.TextButton.Snackbar">
+        <item name="android:textColor">?attr/snackbarButtonTextColor</item>
+        <!-- Material buttons have some letter spacing added, but since no other components
+             in the app use material theming, let's remove it for the sake of consistency.
+             TODO Remove if the app moves to material theming. -->
+        <item name="android:letterSpacing">0</item>
+    </style>
 </resources>

--- a/AnkiDroid/src/main/res/values/theme_black.xml
+++ b/AnkiDroid/src/main/res/values/theme_black.xml
@@ -125,6 +125,11 @@
         <item name="filterItemTextColor">@color/theme_dark_drawer_item</item>
         <item name="filterItemTextColorSelected">@color/material_light_blue_500</item>
         <item name="filterHeaderDivider">@color/white</item>
+
+        <!-- Snackbar -->
+        <item name="snackbarTextViewStyle">@style/SnackbarTextStyleBlack</item>
+        <item name="snackbarBackgroundTintColor">#ff303030</item>
+        <item name="snackbarButtonTextColor">@color/material_light_blue_300</item>
     </style>
 
     <!-- Preferences screens -->
@@ -141,5 +146,9 @@
         <item name="android:statusBarColor">@android:color/transparent</item>
         <item name="android:navigationBarColor">@color/black</item>
         <item name="bottomSheetStyle">@style/CustomBottomSheetStyle</item>
+    </style>
+
+    <style name="SnackbarTextStyleBlack" parent="@style/Widget.MaterialComponents.Snackbar.TextView">
+        <item name="android:textColor">@color/white</item>
     </style>
 </resources>

--- a/AnkiDroid/src/main/res/values/theme_dark.xml
+++ b/AnkiDroid/src/main/res/values/theme_dark.xml
@@ -10,7 +10,7 @@
     <color name="theme_dark_drawer_row_current">#33999999</color>
     <color name="theme_dark_drawer_item">#DEFFFFFF</color>
 
-    <style name="Theme_Dark" parent="@style/Theme.AppCompat">
+    <style name="Theme_Dark" parent="@style/Theme.MaterialComponents.Bridge">
         <!-- Android colors -->
         <item name="colorPrimary">@color/theme_dark_primary</item>
         <item name="colorPrimaryDark">@color/theme_dark_primary_dark</item>
@@ -133,6 +133,12 @@
         <item name="filterItemTextColorSelected">@color/theme_dark_accent</item>
         <item name="filterHeaderDivider">@color/white</item>
 
+        <!-- Snackbar. Attributes snackbarStyle, snackbarTextViewStyle and snackbarButtonStyle
+             must be *all* present in a theme (or its parent) in order for the snackbar
+             to pick up the proper layout that uses these attributes. -->
+        <item name="snackbarStyle">@style/Widget.MaterialComponents.Snackbar</item>
+        <item name="snackbarTextViewStyle">@style/Widget.MaterialComponents.Snackbar.TextView</item>
+        <item name="snackbarButtonStyle">@style/Widget.MaterialComponents.Button.TextButton.Snackbar</item>
     </style>
 
     <!-- Preferences screens -->

--- a/AnkiDroid/src/main/res/values/theme_dark.xml
+++ b/AnkiDroid/src/main/res/values/theme_dark.xml
@@ -136,9 +136,11 @@
         <!-- Snackbar. Attributes snackbarStyle, snackbarTextViewStyle and snackbarButtonStyle
              must be *all* present in a theme (or its parent) in order for the snackbar
              to pick up the proper layout that uses these attributes. -->
-        <item name="snackbarStyle">@style/Widget.MaterialComponents.Snackbar</item>
+        <item name="snackbarStyle">@style/SnackbarStyle</item>
         <item name="snackbarTextViewStyle">@style/Widget.MaterialComponents.Snackbar.TextView</item>
-        <item name="snackbarButtonStyle">@style/Widget.MaterialComponents.Button.TextButton.Snackbar</item>
+        <item name="snackbarButtonStyle">@style/SnackbarButtonStyle</item>
+        <item name="snackbarBackgroundTintColor">#cfcfcf</item>
+        <item name="snackbarButtonTextColor">@color/material_light_blue_900</item>
     </style>
 
     <!-- Preferences screens -->

--- a/AnkiDroid/src/main/res/values/theme_light.xml
+++ b/AnkiDroid/src/main/res/values/theme_light.xml
@@ -149,9 +149,11 @@ APIs. It's visible when there aren't enough decks to fill the screen.
         <!-- Snackbar. Attributes snackbarStyle, snackbarTextViewStyle and snackbarButtonStyle
              must be *all* present in a theme (or its parent) in order for the snackbar
              to pick up the proper layout that uses these attributes. -->
-        <item name="snackbarStyle">@style/Widget.MaterialComponents.Snackbar</item>
+        <item name="snackbarStyle">@style/SnackbarStyle</item>
         <item name="snackbarTextViewStyle">@style/Widget.MaterialComponents.Snackbar.TextView</item>
-        <item name="snackbarButtonStyle">@style/Widget.MaterialComponents.Button.TextButton.Snackbar</item>
+        <item name="snackbarButtonStyle">@style/SnackbarButtonStyle</item>
+        <item name="snackbarBackgroundTintColor">@color/material_grey_800</item>
+        <item name="snackbarButtonTextColor">@color/material_light_blue_300</item>
     </style>
 
     <!-- Preferences screens -->

--- a/AnkiDroid/src/main/res/values/theme_light.xml
+++ b/AnkiDroid/src/main/res/values/theme_light.xml
@@ -23,7 +23,7 @@ APIs. It's visible when there aren't enough decks to fill the screen.
     <color name="theme_light_drawer_item">#DE000000</color>
 
     <!-- DarkActionBar needed for readable text in the menu opened by the hardware menu button -->
-    <style name="Theme_Light" parent="@style/Theme.AppCompat.Light.DarkActionBar">
+    <style name="Theme_Light" parent="@style/Theme.MaterialComponents.Light.DarkActionBar.Bridge">
         <!-- Android colors -->
         <item name="colorPrimary">@color/theme_light_primary</item>
         <item name="colorPrimaryDark">@color/theme_light_primary_dark</item>
@@ -145,6 +145,13 @@ APIs. It's visible when there aren't enough decks to fill the screen.
         <item name="filterItemTextColor">@color/theme_light_drawer_item</item>
         <item name="filterItemTextColorSelected">@color/material_light_blue_500</item>
         <item name="filterHeaderDivider">@color/black</item>
+
+        <!-- Snackbar. Attributes snackbarStyle, snackbarTextViewStyle and snackbarButtonStyle
+             must be *all* present in a theme (or its parent) in order for the snackbar
+             to pick up the proper layout that uses these attributes. -->
+        <item name="snackbarStyle">@style/Widget.MaterialComponents.Snackbar</item>
+        <item name="snackbarTextViewStyle">@style/Widget.MaterialComponents.Snackbar.TextView</item>
+        <item name="snackbarButtonStyle">@style/Widget.MaterialComponents.Button.TextButton.Snackbar</item>
     </style>
 
     <!-- Preferences screens -->

--- a/AnkiDroid/src/main/res/values/theme_plain.xml
+++ b/AnkiDroid/src/main/res/values/theme_plain.xml
@@ -62,6 +62,8 @@
         <item name="filterItemTextColor">@color/theme_light_drawer_item</item>
         <item name="filterItemTextColorSelected">@color/material_light_blue_500</item>
         <item name="filterHeaderDivider">@color/black</item>
+
+        <item name="snackbarButtonTextColor">#96bdce</item>
     </style>
 
     <!-- Preferences screens -->

--- a/AnkiDroid/src/test/java/com/ichi2/anki/snackbar/SensibleSwipeDismissBehaviorTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/snackbar/SensibleSwipeDismissBehaviorTest.kt
@@ -1,0 +1,93 @@
+/*
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.snackbar
+
+import android.view.View
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Test
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.runner.RunWith
+import org.mockito.Mockito.mock
+import org.mockito.kotlin.whenever
+
+@RunWith(AndroidJUnit4::class)
+internal class SensibleSwipeDismissBehaviorTest {
+    private val behavior = SensibleSwipeDismissBehavior().ViewDragHelperCallback().apply {
+        initialChildLeft = 0
+    }
+
+    private val snackbar = mock(View::class.java).apply {
+        whenever(width).thenReturn(100)
+    }
+
+    private fun positionSnackbarAtX(x: Int) {
+        whenever(snackbar.left).thenReturn(x)
+    }
+
+    @Test fun `Stationary snackbar isn't dismissed if it hasn't traveled`() {
+        assertEquals(Dismiss.DoNotDismiss, behavior.shouldDismiss(snackbar, 0f))
+    }
+
+    @Test fun `Stationary snackbar isn't dismissed if it hasn't traveled far`() {
+        positionSnackbarAtX(-5)
+        assertEquals(Dismiss.DoNotDismiss, behavior.shouldDismiss(snackbar, 0f))
+
+        positionSnackbarAtX(+5)
+        assertEquals(Dismiss.DoNotDismiss, behavior.shouldDismiss(snackbar, 0f))
+    }
+
+    @Test fun `Stationary snackbar is dismissed if it has traveled far`() {
+        positionSnackbarAtX(+80)
+        assertEquals(Dismiss.ToTheRight, behavior.shouldDismiss(snackbar, 0f))
+
+        positionSnackbarAtX(-80)
+        assertEquals(Dismiss.ToTheLeft, behavior.shouldDismiss(snackbar, 0f))
+    }
+
+    @Test fun `Moving snackbar isn't dismissed if it hasn't traveled far and is moving slowly`() {
+        assertEquals(Dismiss.DoNotDismiss, behavior.shouldDismiss(snackbar, 100f))
+        assertEquals(Dismiss.DoNotDismiss, behavior.shouldDismiss(snackbar, -100f))
+
+        positionSnackbarAtX(+5)
+        assertEquals(Dismiss.DoNotDismiss, behavior.shouldDismiss(snackbar, 100f))
+        assertEquals(Dismiss.DoNotDismiss, behavior.shouldDismiss(snackbar, -100f))
+    }
+
+    @Test fun `Moving snackbar isn't dismissed if it has traveled far, but is moving slowly towards initial position`() {
+        positionSnackbarAtX(+80)
+        assertEquals(Dismiss.DoNotDismiss, behavior.shouldDismiss(snackbar, -100f))
+
+        positionSnackbarAtX(-80)
+        assertEquals(Dismiss.DoNotDismiss, behavior.shouldDismiss(snackbar, +100f))
+    }
+
+    @Test fun `Moving snackbar is dismissed if it has traveled far and is moving towards the closest edge, even if slowly`() {
+        positionSnackbarAtX(+80)
+        assertEquals(Dismiss.ToTheRight, behavior.shouldDismiss(snackbar, +100f))
+
+        positionSnackbarAtX(-80)
+        assertEquals(Dismiss.ToTheLeft, behavior.shouldDismiss(snackbar, -100f))
+    }
+
+    @Test fun `Moving snackbar is dismissed if it is moving fast`() {
+        assertEquals(Dismiss.ToTheRight, behavior.shouldDismiss(snackbar, +1000000f))
+
+        positionSnackbarAtX(+80)
+        assertEquals(Dismiss.ToTheLeft, behavior.shouldDismiss(snackbar, -1000000f))
+
+        positionSnackbarAtX(-80)
+        assertEquals(Dismiss.ToTheRight, behavior.shouldDismiss(snackbar, +1000000f))
+    }
+}

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/rules/DirectSnackbarMakeUsage.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/DirectSnackbarMakeUsage.kt
@@ -24,9 +24,9 @@ import com.intellij.psi.PsiMethod
 import org.jetbrains.uast.UCallExpression
 
 /**
- * This custom Lint rules will raise an error if a developer uses the {com.google.android.material.snackbar.Snackbar#make(...)} method
- * instead of using the method provided by the UIUtils class {com.ichi2.anki.UIUtils#showSimpleSnackbar(...)}
- * or {com.ichi2.anki.UIUtils#showSnackbar(...)}.
+ * This custom Lint rule will raise an error if a developer uses
+ * the com.google.android.material.snackbar.Snackbar.make method instead of
+ * using the method provided in com.ichi2.anki.snackbar.SnackbarsKt.showSnackbar.
  */
 class DirectSnackbarMakeUsage : Detector(), SourceCodeScanner {
 
@@ -35,8 +35,9 @@ class DirectSnackbarMakeUsage : Detector(), SourceCodeScanner {
         const val ID = "DirectSnackbarMakeUsage"
 
         @VisibleForTesting
-        const val DESCRIPTION = "Use UIUtils.showSimpleSnackbar or UIUtils.showSnackbar instead of Snackbar.make"
-        private const val EXPLANATION = "To improve code consistency within the codebase you should use UIUtils.showSimpleSnackbar or UIUtils.showSnackbar " +
+        const val DESCRIPTION = "Use SnackbarsKt.showSnackbar instead of Snackbar.make"
+        private const val EXPLANATION = "To improve code consistency within the codebase " +
+            "you should use SnackbarsKt.showSnackbar " +
             "in place of the library Snackbar.make(...).show()"
         private val implementation = Implementation(DirectSnackbarMakeUsage::class.java, Scope.JAVA_FILE_SCOPE)
         @JvmField
@@ -57,7 +58,7 @@ class DirectSnackbarMakeUsage : Detector(), SourceCodeScanner {
         super.visitMethodCall(context, node, method)
         val evaluator = context.evaluator
         val foundClasses = context.uastFile!!.classes
-        if (!LintUtils.isAnAllowedClass(foundClasses, "UIUtils") &&
+        if (!LintUtils.isAnAllowedClass(foundClasses, "SnackbarsKt") &&
             evaluator.isMemberInClass(method, "com.google.android.material.snackbar.Snackbar")
         ) {
             context.report(

--- a/lint-rules/src/test/java/com/ichi2/anki/lint/rules/DirectSnackbarMakeUsageTest.kt
+++ b/lint-rules/src/test/java/com/ichi2/anki/lint/rules/DirectSnackbarMakeUsageTest.kt
@@ -54,12 +54,12 @@ public class TestJavaClass {
 """
 
     @Language("JAVA")
-    private val javaFileWithUIUtils = """                            
+    private val javaFileWithSnackbarsKt = """                            
 package com.ichi2.anki.lint.rules;                             
                                                                
 import com.google.android.material.snackbar.Snackbar;          
                                                                
-public class UIUtils {                                         
+public class SnackbarsKt {                                         
                                                                
     public static void main(String[] args) {                   
         Snackbar snackbar = Snackbar.make();                   
@@ -84,11 +84,11 @@ public class UIUtils {
     }
 
     @Test
-    fun allowsUsageForUIUtils() {
+    fun allowsUsageForSnackbarsKt() {
         TestLintTask.lint()
             .allowMissingSdk()
             .allowCompilationErrors()
-            .files(JavaTestFile.create(stubSnackbar), JavaTestFile.create(javaFileWithUIUtils))
+            .files(JavaTestFile.create(stubSnackbar), JavaTestFile.create(javaFileWithSnackbarsKt))
             .issues(DirectSnackbarMakeUsage.ISSUE)
             .run()
             .expectClean()


### PR DESCRIPTION
This makes snackbars look like snackbars, behave like snackbars, move the way you would expect them to move. No surprises, nothing fancy, just plain ol' boring snackbars.

<img src="https://user-images.githubusercontent.com/1710718/178287362-7431d8cf-b008-4ebd-b3db-80ec67246260.png" width=250><img src="https://user-images.githubusercontent.com/1710718/178287372-c8793c3f-bc81-4ebd-ac10-e55c22cc4ad0.png" width=250><img src="https://user-images.githubusercontent.com/1710718/178287383-be02a320-e612-4124-baad-2f86597cffa6.png" width=250><img src="https://user-images.githubusercontent.com/1710718/178287402-c0f271ae-3113-4069-b223-04416edd8391.png" width=250><img src="https://user-images.githubusercontent.com/1710718/178287419-74e8920b-6822-4295-9456-569093218943.png" width=250><img src="https://user-images.githubusercontent.com/1710718/178287447-8e054c02-9cf9-464b-b463-469ce35d47e8.png" width=250><img src="https://user-images.githubusercontent.com/1710718/178287460-9f72fd98-a42b-4d72-8a94-7cb705b57d08.png" width=250><img src="https://user-images.githubusercontent.com/1710718/178287475-15e63d44-54e3-438c-884f-911a5d9e7122.png" width=250><img src="https://user-images.githubusercontent.com/1710718/178287486-c2b558be-17a2-4ed6-afc6-fae8f9d849b6.png" width=250>

## Purpose / Description

Currently, there are many problems with snackbars.

  * Snackbars can appear too low (inside the gesture zone), too high (some distance above the gesture zone), and *way* too high, over toolbar (huh??);
  * Snackbars don't visibly move when you drag them;
  * Snackbars can only be flicked or dragged to the right;
  * When you dismiss the snackbar by flicking, the fab will get stuck;
  * Snackbars aren't properly styled. They are rectangularey, no margins, no elevation;
  * When insets change, snackbars fail to adjust position properly.

You can see these problems in many an app, including the ones from Google itself. Most of these issues arise from the bugs in the material library. These bugs mask other bugs in material library:

  * When you dismiss a snackbar, it will be moved to the side, but that ignores snackbar margins, so it will briefly appear stuck near the edge;
  * Flicking a snackbar may dismiss it in the wrong direction;
  * `CoordinatorLayout` updates may cause snackbar flicker in original position while it is settling (found [this](https://stackoverflow.com/questions/22865291) after fixing)
  * This...

https://user-images.githubusercontent.com/1710718/178286944-ab51d05b-777f-43ee-92e6-cf5fdc839a5b.mp4

## Approach

I tried to explain neatly in every commit what it addresses and how. Please take a look!

I resorted to some pretty awful workarounds in some places. While what they do may be atrocious, I tried making these workarounds in such a way that it's easy to remove them if need be.

## How Has This Been Tested?

Tested on my devices running Android 11 and 6. I can not run emulator, so this was **NOT** tested on other devices. I hope that this **IS** tested on more devices before this is merged.

## Some thoughts

* Snackbars are “supposed” to appear above fab according to the guidelines, but our fab expands so that wouldn't work I guess. Besides, in Gmail, which is I guess a paragon of material design or something, snackbars also move the fab. ¯\\\_(ツ)_/¯
* We could make snackbar color reflect its purpose, e.g. green snackbars for success, red for errors.
* Some app allow long-tapping on snackbars to get some debug level information, such as full exception tracebacks. I think this is pretty intuitive!

## Checklist

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [ ] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [x] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)