### PR TITLE
Fix selection in incompatible database version dialog

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DatabaseErrorDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DatabaseErrorDialog.kt
@@ -331,7 +331,7 @@ class DatabaseErrorDialog : AsyncDialogFragment() {
                     positiveButton(R.string.close) {
                         exit()
                     }
-                    listItems(items = options) { _: MaterialDialog, index: Int, _: CharSequence ->
+                    listItems(items = options, waitForPositiveButton = false) { _: MaterialDialog, index: Int, _: CharSequence ->
                         when (values[index]) {
                             0 -> (activity as DeckPicker?)!!.showDatabaseErrorDialog(
                                 DIALOG_RESTORE_BACKUP


### PR DESCRIPTION
## Purpose / Description

Small tweak to the incompatible database version dialog to allow direct selection for its list items.

## Fixes

Fixes #11811 

## How Has This Been Tested?

Ran the tests, checked that the dialog works.

## Checklist

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
