### PR TITLE
remove extra comment in BeolingusParser

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/beolingus/parsing/BeolingusParser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/beolingus/parsing/BeolingusParser.kt
@@ -43,7 +43,6 @@ object BeolingusParser {
         val m = PRONUNCIATION_PATTERN.matcher(html)
         while (m.find()) {
             // Perform .contains() due to #5376 (a "%20{noun}" suffix).
-            // Perform .toLowerCase() due to #5810 ("hello" should match "Hello").
             // See #5810 for discussion on Locale complexities. Currently unhandled.
             @KotlinCleanup("improve null handling of m.group() possibly returning null")
             if (m.group(2)!!.contains(wordToSearchFor!!, ignoreCase = true)) {


### PR DESCRIPTION
## Purpose / Description
cleanup: remove comment in BeolingusParser.kt

## Approach
removing the comment as the `.toLowerCase()` is not used in BeolingusParser anymore. Instead it is now being handled in `LoadPronunciationActivity` itself.

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
