### PR TITLE
[Unit Test]: Check trimming of extra spaces

### DIFF
--- a/AnkiDroid/src/test/java/com/ichi2/anki/multimediacard/beolingus/parsing/BeolingusParserTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/multimediacard/beolingus/parsing/BeolingusParserTest.kt
@@ -49,6 +49,20 @@ class BeolingusParserTest {
     }
 
     @Test
+    fun `Test to check trimming of extra spaces`() {
+        // confirm " Hello " matches "Hello" when loading pronunciation using Beolingus search
+        @Language("HTML")
+        val html = "" +
+            "<a href=\"/dings.cgi?speak=en/2/0/zQbP7qZh_u2;text=Hello\" " +
+            "onclick=\"return s(this)\" onmouseover=\"return u('Hello')\">" +
+            "<img src=\"/pics/s1.png\" width=\"16\" height=\"16\" " +
+            "alt=\"[listen]\" title=\"Hello\" border=\"0\" align=\"top\" /></a>"
+
+        val pronunciationUrl = BeolingusParser.getPronunciationAddressFromTranslation(html, " Hello ".trim())
+        assertEquals("https://dict.tu-chemnitz.de/dings.cgi?speak=en/2/0/zQbP7qZh_u2;text=Hello", pronunciationUrl)
+    }
+
+    @Test
     fun testEszettCasing() {
         // Some transformations lose the Eszett: "ß".toUpperCase() == "SS".
         // Ensure that we don't do this.


### PR DESCRIPTION
## Purpose / Description
Unit Test to check trimming of extra spaces entered in Beolingus Search while loading the pronunciation of a word. 
It checks if an entered string search of (" Hello ") matches (Hello)

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
