### PR TITLE
CardBrowser truncate check update on change deck

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -896,6 +896,7 @@ open class CardBrowser : NavigationDrawerActivity(), SubtitleListener, DeckSelec
                 // Provide SearchView with the previous search terms
                 mSearchView!!.setQuery(mSearchTerms!!, false)
             }
+            menu.findItem(R.id.action_truncate).isChecked = isTruncated
         } else {
             // multi-select mode
             menuInflater.inflate(R.menu.card_browser_multiselect, menu)


### PR DESCRIPTION
## Fixes
Fixes #11848 

## Approach
Set MenuItem's check to `isTruncated` in `CardBrowser#onCreateOptionsMenu`

## How Has This Been Tested?


https://user-images.githubusercontent.com/59933477/179094976-59350126-76d9-46f7-9fff-74c4b712215f.mov



## Checklist

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [x] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
