### PR TITLE
[GSoC] Fix App bar buttons screen summaries

### DIFF
--- a/AnkiDroid/src/main/res/xml/preferences_custom_buttons.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_custom_buttons.xml
@@ -26,6 +26,7 @@ Ensure to add the custom icons to Preferences.java's reset functionality
 TODO: Add a unit test
 -->
 <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:title="@string/custom_buttons">
     <Preference
         android:key="@string/reset_custom_buttons_key"
@@ -36,73 +37,85 @@ TODO: Add a unit test
             android:entries="@array/custom_button_labels"
             android:entryValues="@array/custom_button_values"
             android:key="@string/custom_button_undo_key"
-            android:title="@string/undo" />
+            android:title="@string/undo"
+            app:useSimpleSummaryProvider="true"/>
         <ListPreference
             android:defaultValue="0"
             android:entries="@array/custom_button_labels"
             android:entryValues="@array/custom_button_values"
             android:key="@string/custom_button_schedule_card_key"
-            android:title="@string/card_editor_reschedule_card" />
+            android:title="@string/card_editor_reschedule_card"
+            app:useSimpleSummaryProvider="true"/>
         <ListPreference
             android:defaultValue="2"
             android:entries="@array/custom_button_labels"
             android:entryValues="@array/custom_button_values"
             android:key="@string/custom_button_flag_key"
-            android:title="@string/menu_flag" />
+            android:title="@string/menu_flag"
+            app:useSimpleSummaryProvider="true"/>
         <ListPreference
             android:defaultValue="1"
             android:entries="@array/custom_button_labels"
             android:entryValues="@array/custom_button_values"
             android:key="@string/custom_button_edit_card_key"
-            android:title="@string/cardeditor_title_edit_card" />
+            android:title="@string/cardeditor_title_edit_card"
+            app:useSimpleSummaryProvider="true"/>
         <ListPreference
             android:defaultValue="0"
             android:entries="@array/custom_button_labels"
             android:entryValues="@array/custom_button_values"
             android:key="@string/custom_button_tags_key"
-            android:title="@string/menu_edit_tags" />
+            android:title="@string/menu_edit_tags"
+            app:useSimpleSummaryProvider="true"/>
         <ListPreference
             android:defaultValue="3"
             android:entries="@array/custom_button_labels"
             android:entryValues="@array/custom_button_values"
             android:key="@string/custom_button_add_card_key"
-            android:title="@string/menu_add_note" />
+            android:title="@string/menu_add_note"
+            app:useSimpleSummaryProvider="true"/>
         <ListPreference
             android:defaultValue="1"
             android:entries="@array/custom_button_labels"
             android:entryValues="@array/custom_button_values"
             android:key="@string/custom_button_replay_key"
-            android:title="@string/replay_audio" />
+            android:title="@string/replay_audio"
+            app:useSimpleSummaryProvider="true"/>
         <ListPreference
             android:defaultValue="3"
             android:entries="@array/custom_button_labels"
             android:entryValues="@array/custom_button_values"
             android:key="@string/custom_button_card_info_key"
-            android:title="@string/card_info_title" />
+            android:title="@string/card_info_title"
+            app:useSimpleSummaryProvider="true"/>
         <ListPreference
             android:defaultValue="0"
             android:entries="@array/custom_button_labels"
             android:entryValues="@array/custom_button_values"
             android:key="@string/custom_button_select_tts_key"
-            android:title="@string/select_tts" />
+            android:title="@string/select_tts"
+            app:useSimpleSummaryProvider="true"/>
         <ListPreference
             android:defaultValue="0"
             android:entries="@array/custom_button_labels"
             android:entryValues="@array/custom_button_values"
             android:key="@string/custom_button_deck_options_key"
-            android:title="@string/menu__deck_options" />
+            android:title="@string/menu__deck_options"
+            app:useSimpleSummaryProvider="true"/>
         <ListPreference
             android:defaultValue="1"
             android:entries="@array/custom_button_labels"
             android:entryValues="@array/custom_button_values"
             android:key="@string/custom_button_mark_card_key"
-            android:title="@string/menu_mark_note" />
+            android:title="@string/menu_mark_note"
+            app:useSimpleSummaryProvider="true"/>
         <ListPreference
             android:defaultValue="0"
             android:entries="@array/custom_button_labels"
             android:entryValues="@array/custom_button_values"
             android:key="@string/custom_button_toggle_mic_toolbar_key"
-            android:title="@string/menu_toggle_mic_tool_bar" />
+            android:title="@string/menu_toggle_mic_tool_bar"
+            app:useSimpleSummaryProvider="true"/>
     </PreferenceCategory>
     <PreferenceCategory android:title="@string/menu_dismiss_note" >
         <ListPreference
@@ -110,19 +123,22 @@ TODO: Add a unit test
             android:entries="@array/custom_button_labels"
             android:entryValues="@array/custom_button_values"
             android:key="@string/custom_button_bury_key"
-            android:title="@string/menu_bury" />
+            android:title="@string/menu_bury"
+            app:useSimpleSummaryProvider="true"/>
         <ListPreference
             android:defaultValue="0"
             android:entries="@array/custom_button_labels"
             android:entryValues="@array/custom_button_values"
             android:key="@string/custom_button_suspend_key"
-            android:title="@string/menu_suspend" />
+            android:title="@string/menu_suspend"
+            app:useSimpleSummaryProvider="true"/>
         <ListPreference
             android:defaultValue="0"
             android:entries="@array/custom_button_labels"
             android:entryValues="@array/custom_button_values"
             android:key="@string/custom_button_delete_key"
-            android:title="@string/menu_delete_note" />
+            android:title="@string/menu_delete_note"
+            app:useSimpleSummaryProvider="true"/>
     </PreferenceCategory>
     <PreferenceCategory android:title="@string/pref_cat_whiteboard" >
         <ListPreference
@@ -130,30 +146,35 @@ TODO: Add a unit test
             android:entries="@array/custom_button_labels"
             android:entryValues="@array/custom_button_values"
             android:key="@string/custom_button_enable_whiteboard_key"
-            android:title="@string/enable_whiteboard" />
+            android:title="@string/enable_whiteboard"
+            app:useSimpleSummaryProvider="true"/>
         <ListPreference
             android:defaultValue="0"
             android:entries="@array/custom_button_labels"
             android:entryValues="@array/custom_button_values"
             android:key="@string/custom_button_save_whiteboard_key"
-            android:title="@string/save_whiteboard" />
+            android:title="@string/save_whiteboard"
+            app:useSimpleSummaryProvider="true"/>
         <ListPreference
             android:defaultValue="1"
             android:entries="@array/custom_button_labels"
             android:entryValues="@array/custom_button_values"
             android:key="@string/custom_button_whiteboard_pen_color_key"
-            android:title="@string/title_whiteboard_pen_color" />
+            android:title="@string/title_whiteboard_pen_color"
+            app:useSimpleSummaryProvider="true"/>
         <ListPreference
             android:defaultValue="2"
             android:entries="@array/custom_button_labels"
             android:entryValues="@array/custom_button_values"
             android:key="@string/custom_button_show_hide_whiteboard_key"
-            android:title="@string/hide_whiteboard" />
+            android:title="@string/hide_whiteboard"
+            app:useSimpleSummaryProvider="true"/>
         <ListPreference
             android:defaultValue="1"
             android:entries="@array/custom_button_labels"
             android:entryValues="@array/custom_button_values"
             android:key="@string/custom_button_clear_whiteboard_key"
-            android:title="@string/clear_whiteboard" />
+            android:title="@string/clear_whiteboard"
+            app:useSimpleSummaryProvider="true"/>
     </PreferenceCategory>
 </PreferenceScreen>


### PR DESCRIPTION
~~On top of #11866. Only the last commit is new. I'll rebase once that is merged~~

## Fixes
I forgot to add the summary providers for the custom buttons screen when I did the XXX summary replacement PRs

### Before
![image](https://user-images.githubusercontent.com/69634269/179354774-211b61a2-5070-40a4-a864-a33a3f5e3423.png)

### After
![image](https://user-images.githubusercontent.com/69634269/179354830-7155abf8-fa5c-460e-bc7a-b5c866ce55fc.png)


## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [X] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
