### PR TITLE
Fix Flag Colors on App Bar

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/FilterSheetBottomFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/FilterSheetBottomFragment.kt
@@ -59,7 +59,7 @@ class FilterSheetBottomFragment :
 
     // flagName is displayed in filter sheet as the name of the filter
     enum class Flags(@StringRes private val flagNameRes: Int, val flagNode: SearchNode.Flag, @DrawableRes val flagIcon: Int) {
-        NO_FLAG(R.string.menu_flag_card_zero, SearchNode.Flag.FLAG_NONE, R.drawable.ic_flag_transparent),
+        NO_FLAG(R.string.menu_flag_card_zero, SearchNode.Flag.FLAG_NONE, R.drawable.label_icon_flags),
         RED(R.string.menu_flag_card_one, SearchNode.Flag.FLAG_RED, R.drawable.ic_flag_red),
         ORANGE(R.string.menu_flag_card_two, SearchNode.Flag.FLAG_ORANGE, R.drawable.ic_flag_orange),
         GREEN(R.string.menu_flag_card_three, SearchNode.Flag.FLAG_GREEN, R.drawable.ic_flag_green),

--- a/AnkiDroid/src/main/res/drawable/ic_flag_transparent.xml
+++ b/AnkiDroid/src/main/res/drawable/ic_flag_transparent.xml
@@ -1,7 +1,6 @@
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
     android:width="24dp"
     android:height="24dp"
-    android:tint="?attr/filterItemTextColor"
     android:viewportWidth="24"
     android:viewportHeight="24">
   <path


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
`ic_flag_transparent.xml` was already being used for the flag icon on the app bar, and using it for the  `No flag` option in the filter sheet broke it.

## Fixes
Fixes #11868 

## Approach
Revert `ic_flag_transparent.xml` to its original state, and use a different drawable resource for the `No flag` option

## How Has This Been Tested?

<img width="723" alt="image" src="https://user-images.githubusercontent.com/86671025/179357085-fa3d218c-a451-460e-b864-a614bf0cd9de.png">

<img width="302" alt="image" src="https://user-images.githubusercontent.com/86671025/179357095-668542c0-6c0f-414c-a179-f6480cf9d878.png">


Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration (SDK version(s), emulator or physical, etc)

## Learning (optional, can help others)
_Describe the research stage_

_Links to blog posts, patterns, libraries or addons used to solve this problem_

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
