### PR TITLE
[GSoC] Refactor preferences initialization

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.kt
@@ -229,7 +229,6 @@ class Preferences : AnkiActivity() {
                 try {
                     when (pref.key) {
                         AUTOMATIC_ANSWER_ACTION -> (pref as ListPreference).setValueIndex(col.get_config(AutomaticAnswerAction.CONFIG_KEY, 0.toInt())!!)
-                        NEW_SPREAD -> (pref as ListPreference).setValueIndex(col.get_config_int("newSpread"))
                         DAY_OFFSET -> (pref as SeekBarPreferenceCompat).value = getDayOffset(col)
                     }
                 } catch (e: NumberFormatException) {
@@ -438,10 +437,6 @@ class Preferences : AnkiActivity() {
                         keepScreenOn!!.isChecked = (pref as SwitchPreference).isChecked
                     }
                     LANGUAGE -> preferencesActivity.closePreferences()
-                    NEW_SPREAD -> {
-                        preferencesActivity.col.set_config("newSpread", (pref as ListPreference).value.toInt())
-                        preferencesActivity.col.setMod()
-                    }
                     AUTOMATIC_ANSWER_ACTION -> {
                         preferencesActivity.col.set_config(AutomaticAnswerAction.CONFIG_KEY, (pref as ListPreference).value.toInt())
                         preferencesActivity.col.setMod()
@@ -637,6 +632,18 @@ class Preferences : AnkiActivity() {
         override fun initSubscreen() {
             addPreferencesFromResource(R.xml.preferences_reviewing)
             val col = col!!
+
+            // New cards position
+            // Represents the collections pref "newSpread": i.e.
+            // whether the new cards are added at the end of the queue or randomly in it.
+            requirePreference<ListPreference>(R.string.new_spread_preference).apply {
+                setValueIndex(col.get_config_int("newSpread"))
+                setOnPreferenceChangeListener { _, newValue ->
+                    col.set_config("newSpread", ((newValue as String).toInt()))
+                    col.setMod()
+                    true
+                }
+            }
 
             // Learn ahead limit
             // Represents the collections pref "collapseTime": i.e.
@@ -1375,12 +1382,6 @@ class Preferences : AnkiActivity() {
         const val PENDING_NOTIFICATIONS_ONLY = 1000000
 
         /**
-         * Represents in Android preferences the collections configuration "newSpread": i.e.
-         * whether the new cards are added at the end of the queue or randomly in it.
-         */
-        private const val NEW_SPREAD = "newSpread"
-
-        /**
          * Represents in Android preference the collection's configuration "rollover"
          * in sched v2, and crt in sched v1. I.e. at which time of the day does the scheduler reset
          */
@@ -1409,7 +1410,7 @@ class Preferences : AnkiActivity() {
          */
         const val MINIMUM_CARDS_DUE_FOR_NOTIFICATION = "minimumCardsDueForNotification"
         private val sCollectionPreferences = arrayOf(
-            NEW_SPREAD, DAY_OFFSET, AUTOMATIC_ANSWER_ACTION
+            DAY_OFFSET, AUTOMATIC_ANSWER_ACTION
         )
         const val INITIAL_FRAGMENT_EXTRA = "initial_fragment"
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.kt
@@ -498,7 +498,6 @@ class Preferences : AnkiActivity() {
                 setValueIndex(if (col.get_config("addToCur", true)!!) 0 else 1)
                 setOnPreferenceChangeListener { _, newValue ->
                     col.set_config("addToCur", "0" == newValue)
-                    col.setMod()
                     true
                 }
             }
@@ -509,7 +508,6 @@ class Preferences : AnkiActivity() {
                 isChecked = col.get_config("pastePNG", false)!!
                 setOnPreferenceChangeListener { _, newValue ->
                     col.set_config("pastePNG", newValue)
-                    col.setMod()
                     true
                 }
             }
@@ -556,7 +554,6 @@ class Preferences : AnkiActivity() {
                 setValueIndex(col.get_config_int("newSpread"))
                 setOnPreferenceChangeListener { _, newValue ->
                     col.set_config("newSpread", ((newValue as String).toInt()))
-                    col.setMod()
                     true
                 }
             }
@@ -570,7 +567,6 @@ class Preferences : AnkiActivity() {
                 setFormattedSummary(R.string.pref_summary_minutes)
                 setOnPreferenceChangeListener { _, newValue ->
                     col.set_config("collapseTime", ((newValue as String).toInt() * 60))
-                    col.setMod()
                     true
                 }
             }
@@ -583,7 +579,6 @@ class Preferences : AnkiActivity() {
                 setFormattedSummary(R.string.pref_summary_minutes)
                 setOnPreferenceChangeListener { _, newValue ->
                     col.set_config("timeLim", ((newValue as String).toInt() * 60))
-                    col.setMod()
                     true
                 }
             }
@@ -610,7 +605,6 @@ class Preferences : AnkiActivity() {
                 setValueIndex(col.get_config(AutomaticAnswerAction.CONFIG_KEY, 0.toInt())!!)
                 setOnPreferenceChangeListener { _, newValue ->
                     col.set_config(AutomaticAnswerAction.CONFIG_KEY, (newValue as String).toInt())
-                    col.setMod()
                     true
                 }
             }
@@ -668,7 +662,6 @@ class Preferences : AnkiActivity() {
                             return@positiveButton
                         }
                         col!!.modSchemaNoCheck()
-                        col!!.setMod()
                         showThemedToast(
                             requireContext(),
                             R.string.force_full_sync_confirmation,
@@ -816,7 +809,6 @@ class Preferences : AnkiActivity() {
                 isChecked = col.get_config_boolean("estTimes")
                 setOnPreferenceChangeListener { _, newValue ->
                     col.set_config("estTimes", newValue)
-                    col.setMod()
                     true
                 }
             }
@@ -827,7 +819,6 @@ class Preferences : AnkiActivity() {
                 isChecked = col.get_config_boolean("dueCounts")
                 setOnPreferenceChangeListener { _, newValue ->
                     col.set_config("dueCounts", newValue)
-                    col.setMod()
                     true
                 }
             }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.kt
@@ -228,7 +228,6 @@ class Preferences : AnkiActivity() {
             if (col != null) {
                 try {
                     when (pref.key) {
-                        SHOW_PROGRESS -> (pref as SwitchPreference).isChecked = col.get_config_boolean("dueCounts")
                         LEARN_CUTOFF -> (pref as NumberRangePreferenceCompat).setValue(col.get_config_int("collapseTime") / 60)
                         TIME_LIMIT -> (pref as NumberRangePreferenceCompat).setValue(col.get_config_int("timeLim") / 60)
                         USE_CURRENT -> (pref as ListPreference).setValueIndex(if (col.get_config("addToCur", true)!!) 0 else 1)
@@ -442,10 +441,6 @@ class Preferences : AnkiActivity() {
                         keepScreenOn!!.isChecked = (pref as SwitchPreference).isChecked
                     }
                     LANGUAGE -> preferencesActivity.closePreferences()
-                    SHOW_PROGRESS -> {
-                        preferencesActivity.col.set_config("dueCounts", (pref as SwitchPreference).isChecked)
-                        preferencesActivity.col.setMod()
-                    }
                     NEW_SPREAD -> {
                         preferencesActivity.col.set_config("newSpread", (pref as ListPreference).value.toInt())
                         preferencesActivity.col.setMod()
@@ -857,6 +852,17 @@ class Preferences : AnkiActivity() {
                 isChecked = col.get_config_boolean("estTimes")
                 setOnPreferenceChangeListener { _, newValue ->
                     col.set_config("estTimes", newValue)
+                    col.setMod()
+                    true
+                }
+            }
+            // Show progress
+            // Represents the collection pref "dueCounts": i.e.
+            // whether the remaining number of cards should be shown.
+            requirePreference<SwitchPreference>(R.string.show_progress_preference).apply {
+                isChecked = col.get_config_boolean("dueCounts")
+                setOnPreferenceChangeListener { _, newValue ->
+                    col.set_config("dueCounts", newValue)
                     col.setMod()
                     true
                 }
@@ -1352,12 +1358,6 @@ class Preferences : AnkiActivity() {
         const val PENDING_NOTIFICATIONS_ONLY = 1000000
 
         /**
-         * Represents in Android preferences the collections configuration "dueCounts": i.e.
-         * whether the remaining number of cards should be shown.
-         */
-        private const val SHOW_PROGRESS = "showProgress"
-
-        /**
          * Represents in Android preferences the collections configuration "collapseTime": i.e.
          * if there are no card to review now, but there are learning cards remaining for today, we show those learning cards if they are due before LEARN_CUTOFF minutes
          * Note that "collapseTime" is in second while LEARN_CUTOFF is in minute.
@@ -1413,7 +1413,6 @@ class Preferences : AnkiActivity() {
          */
         const val MINIMUM_CARDS_DUE_FOR_NOTIFICATION = "minimumCardsDueForNotification"
         private val sCollectionPreferences = arrayOf(
-            SHOW_PROGRESS,
             LEARN_CUTOFF, TIME_LIMIT, USE_CURRENT, NEW_SPREAD, DAY_OFFSET, AUTOMATIC_ANSWER_ACTION
         )
         const val INITIAL_FRAGMENT_EXTRA = "initial_fragment"

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.kt
@@ -228,7 +228,6 @@ class Preferences : AnkiActivity() {
             if (col != null) {
                 try {
                     when (pref.key) {
-                        USE_CURRENT -> (pref as ListPreference).setValueIndex(if (col.get_config("addToCur", true)!!) 0 else 1)
                         AUTOMATIC_ANSWER_ACTION -> (pref as ListPreference).setValueIndex(col.get_config(AutomaticAnswerAction.CONFIG_KEY, 0.toInt())!!)
                         NEW_SPREAD -> (pref as ListPreference).setValueIndex(col.get_config_int("newSpread"))
                         DAY_OFFSET -> (pref as SeekBarPreferenceCompat).value = getDayOffset(col)
@@ -443,10 +442,6 @@ class Preferences : AnkiActivity() {
                         preferencesActivity.col.set_config("newSpread", (pref as ListPreference).value.toInt())
                         preferencesActivity.col.setMod()
                     }
-                    USE_CURRENT -> {
-                        preferencesActivity.col.set_config("addToCur", "0" == (pref as ListPreference).value)
-                        preferencesActivity.col.setMod()
-                    }
                     AUTOMATIC_ANSWER_ACTION -> {
                         preferencesActivity.col.set_config(AutomaticAnswerAction.CONFIG_KEY, (pref as ListPreference).value.toInt())
                         preferencesActivity.col.setMod()
@@ -584,6 +579,18 @@ class Preferences : AnkiActivity() {
             // Build languages
             initializeLanguageDialog(screen)
 
+            // Deck for new cards
+            // Represents in the collections pref "addToCur": i.e.
+            // if true, then add note to current decks, otherwise let the note type's configuration decide
+            // Note that "addToCur" is a boolean while USE_CURRENT is "0" or "1"
+            requirePreference<ListPreference>(R.string.deck_for_new_cards_key).apply {
+                setValueIndex(if (col.get_config("addToCur", true)!!) 0 else 1)
+                setOnPreferenceChangeListener { _, newValue ->
+                    col.set_config("addToCur", "0" == newValue)
+                    col.setMod()
+                    true
+                }
+            }
             // Paste PNG
             // Represents in the collection's pref "pastePNG" , i.e.
             // whether to convert clipboard uri to png format or not.
@@ -1368,13 +1375,6 @@ class Preferences : AnkiActivity() {
         const val PENDING_NOTIFICATIONS_ONLY = 1000000
 
         /**
-         * Represents in Android preferences the collections configuration "addToCur": i.e.
-         * if true, then add note to current decks, otherwise let the note type's configuration decide
-         * Note that "addToCur" is a boolean while USE_CURRENT is "0" or "1"
-         */
-        private const val USE_CURRENT = "useCurrent"
-
-        /**
          * Represents in Android preferences the collections configuration "newSpread": i.e.
          * whether the new cards are added at the end of the queue or randomly in it.
          */
@@ -1409,7 +1409,7 @@ class Preferences : AnkiActivity() {
          */
         const val MINIMUM_CARDS_DUE_FOR_NOTIFICATION = "minimumCardsDueForNotification"
         private val sCollectionPreferences = arrayOf(
-            USE_CURRENT, NEW_SPREAD, DAY_OFFSET, AUTOMATIC_ANSWER_ACTION
+            NEW_SPREAD, DAY_OFFSET, AUTOMATIC_ANSWER_ACTION
         )
         const val INITIAL_FRAGMENT_EXTRA = "initial_fragment"
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.kt
@@ -228,7 +228,6 @@ class Preferences : AnkiActivity() {
             if (col != null) {
                 try {
                     when (pref.key) {
-                        SHOW_ESTIMATE -> (pref as SwitchPreference).isChecked = col.get_config_boolean("estTimes")
                         SHOW_PROGRESS -> (pref as SwitchPreference).isChecked = col.get_config_boolean("dueCounts")
                         LEARN_CUTOFF -> (pref as NumberRangePreferenceCompat).setValue(col.get_config_int("collapseTime") / 60)
                         TIME_LIMIT -> (pref as NumberRangePreferenceCompat).setValue(col.get_config_int("timeLim") / 60)
@@ -445,10 +444,6 @@ class Preferences : AnkiActivity() {
                     LANGUAGE -> preferencesActivity.closePreferences()
                     SHOW_PROGRESS -> {
                         preferencesActivity.col.set_config("dueCounts", (pref as SwitchPreference).isChecked)
-                        preferencesActivity.col.setMod()
-                    }
-                    SHOW_ESTIMATE -> {
-                        preferencesActivity.col.set_config("estTimes", (pref as SwitchPreference).isChecked)
                         preferencesActivity.col.setMod()
                     }
                     NEW_SPREAD -> {
@@ -746,6 +741,7 @@ class Preferences : AnkiActivity() {
 
         override fun initSubscreen() {
             addPreferencesFromResource(R.xml.preferences_appearance)
+            val col = col!!
             // Card browser font scaling
             requirePreference<SeekBarPreferenceCompat>(R.string.pref_card_browser_font_scale_key)
                 .setFormattedSummary(R.string.pref_summary_percentage)
@@ -853,6 +849,18 @@ class Preferences : AnkiActivity() {
                 true
             }
             initializeCustomFontsDialog()
+
+            // Show estimate time
+            // Represents the collection pref "estTime": i.e.
+            // whether the buttons should indicate the duration of the interval if we click on them.
+            requirePreference<SwitchPreference>(R.string.show_estimates_preference).apply {
+                isChecked = col.get_config_boolean("estTimes")
+                setOnPreferenceChangeListener { _, newValue ->
+                    col.set_config("estTimes", newValue)
+                    col.setMod()
+                    true
+                }
+            }
         }
 
         /** Initializes the list of custom fonts shown in the preferences.  */
@@ -1344,11 +1352,6 @@ class Preferences : AnkiActivity() {
         const val PENDING_NOTIFICATIONS_ONLY = 1000000
 
         /**
-         * Represents in Android preferences the collections configuration "estTime": i.e. whether the buttons should indicate the duration of the interval if we click on them.
-         */
-        private const val SHOW_ESTIMATE = "showEstimates"
-
-        /**
          * Represents in Android preferences the collections configuration "dueCounts": i.e.
          * whether the remaining number of cards should be shown.
          */
@@ -1410,7 +1413,7 @@ class Preferences : AnkiActivity() {
          */
         const val MINIMUM_CARDS_DUE_FOR_NOTIFICATION = "minimumCardsDueForNotification"
         private val sCollectionPreferences = arrayOf(
-            SHOW_ESTIMATE, SHOW_PROGRESS,
+            SHOW_PROGRESS,
             LEARN_CUTOFF, TIME_LIMIT, USE_CURRENT, NEW_SPREAD, DAY_OFFSET, AUTOMATIC_ANSWER_ACTION
         )
         const val INITIAL_FRAGMENT_EXTRA = "initial_fragment"

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.kt
@@ -236,7 +236,6 @@ class Preferences : AnkiActivity() {
                         AUTOMATIC_ANSWER_ACTION -> (pref as ListPreference).setValueIndex(col.get_config(AutomaticAnswerAction.CONFIG_KEY, 0.toInt())!!)
                         NEW_SPREAD -> (pref as ListPreference).setValueIndex(col.get_config_int("newSpread"))
                         DAY_OFFSET -> (pref as SeekBarPreferenceCompat).value = getDayOffset(col)
-                        PASTE_PNG -> (pref as SwitchPreference).isChecked = col.get_config("pastePNG", false)!!
                     }
                 } catch (e: NumberFormatException) {
                     throw RuntimeException(e)
@@ -475,11 +474,6 @@ class Preferences : AnkiActivity() {
                     DAY_OFFSET -> {
                         preferencesActivity.setDayOffset((pref as SeekBarPreferenceCompat).value)
                     }
-                    PASTE_PNG -> {
-
-                        preferencesActivity.col.set_config("pastePNG", (pref as SwitchPreference).isChecked)
-                        preferencesActivity.col.setMod()
-                    }
                     MINIMUM_CARDS_DUE_FOR_NOTIFICATION -> {
                         val listPreference = screen.findPreference<ListPreference>(MINIMUM_CARDS_DUE_FOR_NOTIFICATION)
                         if (listPreference != null) {
@@ -598,6 +592,7 @@ class Preferences : AnkiActivity() {
 
         override fun initSubscreen() {
             addPreferencesFromResource(R.xml.preferences_general)
+            val col = col!!
             val screen = preferenceScreen
             if (isRestrictedLearningDevice) {
                 val switchPrefVibrate = requirePreference<SwitchPreference>("widgetVibrate")
@@ -608,6 +603,18 @@ class Preferences : AnkiActivity() {
             }
             // Build languages
             initializeLanguageDialog(screen)
+
+            // Paste PNG
+            // Represents in the collection's pref "pastePNG" , i.e.
+            // whether to convert clipboard uri to png format or not.
+            requirePreference<SwitchPreference>(R.string.paste_png_key).apply {
+                isChecked = col.get_config("pastePNG", false)!!
+                setOnPreferenceChangeListener { _, newValue ->
+                    col.set_config("pastePNG", newValue)
+                    col.setMod()
+                    true
+                }
+            }
         }
 
         private fun initializeLanguageDialog(screen: PreferenceScreen) {
@@ -1379,13 +1386,6 @@ class Preferences : AnkiActivity() {
          * in sched v2, and crt in sched v1. I.e. at which time of the day does the scheduler reset
          */
         private const val DAY_OFFSET = "dayOffset"
-
-        /**
-         * Represents in Android preference the collection's configuration "pastePNG" , i.e.
-         * whether to convert clipboard uri to png format or not.
-         * TODO: convert to png if a image file has transparency, or at least if it supports it.
-         */
-        private const val PASTE_PNG = "pastePNG"
 
         /**
          * Represents in Android preferences the collection's "Automatic Answer" action.

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.kt
@@ -932,7 +932,7 @@ class Preferences : AnkiActivity() {
             }
             setupContextMenuPreference(CardBrowserContextMenu.CARD_BROWSER_CONTEXT_MENU_PREF_KEY, R.string.card_browser_context_menu)
             setupContextMenuPreference(AnkiCardContextMenu.ANKI_CARD_CONTEXT_MENU_PREF_KEY, R.string.context_menu_anki_card_label)
-            if (col!!.schedVer() == 1) {
+            if (col != null && col!!.schedVer() == 1) {
                 Timber.i("Displaying V1-to-V2 scheduler preference")
                 val schedVerPreference = SwitchPreference(requireContext())
                 schedVerPreference.setTitle(R.string.sched_v2)

--- a/AnkiDroid/src/main/java/com/ichi2/preferences/NumberRangePreferenceCompat.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/preferences/NumberRangePreferenceCompat.kt
@@ -205,14 +205,6 @@ open class NumberRangePreferenceCompat : EditTextPreference {
             editText.filters = arrayOf(*editText.filters, InputFilter.LengthFilter(numberRangePreference.maxDigits))
         }
 
-        override fun onDialogClosed(positiveResult: Boolean) {
-            if (!positiveResult) {
-                return
-            }
-
-            numberRangePreference.setValue(editText.text.toString())
-        }
-
         companion object {
             @JvmStatic
             fun newInstance(key: String?): NumberRangeDialogFragmentCompat {

--- a/AnkiDroid/src/main/res/xml/preferences_notifications.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_notifications.xml
@@ -16,13 +16,15 @@
   -->
 <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
     android:title="@string/notification_pref"
-    android:key="@string/pref_notifications_screen_key">
+    android:key="@string/pref_notifications_screen_key"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
     <ListPreference
         android:defaultValue="1000000"
         android:entries="@array/notification_minimum_cards_due_labels"
         android:entryValues="@array/notification_minimum_cards_due_values"
         android:key="@string/pref_notifications_minimum_cards_due_key"
-        android:title="@string/notification_pref_title" />
+        android:title="@string/notification_pref_title"
+        app:useSimpleSummaryProvider="true"/>
     <SwitchPreference
         android:defaultValue="false"
         android:key="@string/pref_notifications_vibrate_key"


### PR DESCRIPTION
~~On top of #11866. I should rebase once that is merged.~~

## Purpose / Description

Preferences initialization was a bit messy. Every screen ran [initAllPreferences](https://github.com/ankidroid/Anki-Android/blob/abd1f8bfc316cdf11aba51af7bda7f5b05c493d7/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.kt#L205) and [initPreference](https://github.com/ankidroid/Anki-Android/blob/abd1f8bfc316cdf11aba51af7bda7f5b05c493d7/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.kt#L225) multiple times, making things quite hard to follow. 

To keep things tidy, concise, and keep the preferences' configuration responsability on themselves and on their screens, I've done some refactors on the preferences activity

## Approach

1. Extract the preferences initialization to their screens on the `Init X preference individually` commits
- The required changes that escape the previous 2 patterns are marked on the commits as a `**` on the message beginning and are described as well

## How Has This Been Tested?

Manually opened/changed all preferences and it still works correctly. I should upload a video of it later.

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
