### PR TITLE
[GSoC] Refactor preferences update

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.java
@@ -45,7 +45,6 @@ import com.ichi2.anki.services.BootService;
 import com.ichi2.anki.services.NotificationService;
 import com.ichi2.compat.CompatHelper;
 import com.ichi2.themes.Themes;
-import com.ichi2.libanki.Consts;
 import com.ichi2.utils.AdaptionUtil;
 import com.ichi2.utils.ExceptionUtil;
 import com.ichi2.utils.LanguageUtil;
@@ -55,7 +54,6 @@ import com.ichi2.utils.Permissions;
 import net.ankiweb.rsdroid.BackendFactory;
 
 import java.io.InputStream;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Locale;
 import java.util.regex.Matcher;
@@ -209,9 +207,9 @@ public class AnkiDroidApp extends Application {
         if (BuildConfig.DEBUG && !AdaptionUtil.isRunningAsUnitTest()) {
             preferences.edit().putBoolean("html_javascript_debugging", true).apply();
         }
-        
-        CardBrowserContextMenu.ensureConsistentStateWithSharedPreferences(this);
-        AnkiCardContextMenu.ensureConsistentStateWithSharedPreferences(this);
+
+        CardBrowserContextMenu.ensureConsistentStateWithPreferenceStatus(this, preferences.getBoolean(getString(R.string.card_browser_external_context_menu_key), false));
+        AnkiCardContextMenu.ensureConsistentStateWithPreferenceStatus(this, preferences.getBoolean(getString(R.string.anki_card_external_context_menu_key), true));
         NotificationChannels.setup(getApplicationContext());
 
         // Configure WebView to allow file scheme pages to access cookies.

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.kt
@@ -368,8 +368,6 @@ class Preferences : AnkiActivity() {
                 when (key) {
                     CustomSyncServer.PREFERENCE_CUSTOM_MEDIA_SYNC_URL, CustomSyncServer.PREFERENCE_CUSTOM_SYNC_BASE, CustomSyncServer.PREFERENCE_ENABLE_CUSTOM_SYNC_SERVER -> // This may be a tad hasty - performed before "back" is pressed.
                         handleSyncServerPreferenceChange(preferencesActivity.baseContext)
-                    CardBrowserContextMenu.CARD_BROWSER_CONTEXT_MENU_PREF_KEY -> CardBrowserContextMenu.ensureConsistentStateWithSharedPreferences(preferencesActivity)
-                    AnkiCardContextMenu.ANKI_CARD_CONTEXT_MENU_PREF_KEY -> AnkiCardContextMenu.ensureConsistentStateWithSharedPreferences(preferencesActivity)
                 }
             } catch (e: BadTokenException) {
                 Timber.e(e, "Preferences: BadTokenException on showDialog")
@@ -929,8 +927,25 @@ class Preferences : AnkiActivity() {
                     }
                 }
             }
-            setupContextMenuPreference(CardBrowserContextMenu.CARD_BROWSER_CONTEXT_MENU_PREF_KEY, R.string.card_browser_context_menu)
-            setupContextMenuPreference(AnkiCardContextMenu.ANKI_CARD_CONTEXT_MENU_PREF_KEY, R.string.context_menu_anki_card_label)
+            // Card browser context menu
+            requirePreference<SwitchPreference>(R.string.card_browser_external_context_menu_key).apply {
+                title = getString(R.string.card_browser_enable_external_context_menu, getString(R.string.card_browser_context_menu))
+                summary = getString(R.string.card_browser_enable_external_context_menu_summary, getString(R.string.card_browser_context_menu))
+                setOnPreferenceChangeListener { _, newValue ->
+                    CardBrowserContextMenu.ensureConsistentStateWithPreferenceStatus(requireContext(), newValue as Boolean)
+                    true
+                }
+            }
+            // Anki card context menu
+            requirePreference<SwitchPreference>(R.string.anki_card_external_context_menu_key).apply {
+                title = getString(R.string.card_browser_enable_external_context_menu, getString(R.string.context_menu_anki_card_label))
+                summary = getString(R.string.card_browser_enable_external_context_menu_summary, getString(R.string.context_menu_anki_card_label))
+                setOnPreferenceChangeListener { _, newValue ->
+                    AnkiCardContextMenu.ensureConsistentStateWithPreferenceStatus(requireContext(), newValue as Boolean)
+                    true
+                }
+            }
+
             if (col != null && col!!.schedVer() == 1) {
                 Timber.i("Displaying V1-to-V2 scheduler preference")
                 val schedVerPreference = SwitchPreference(requireContext())
@@ -1016,16 +1031,6 @@ class Preferences : AnkiActivity() {
                 requireActivity().packageManager.setComponentEnabledSetting(providerName, state, PackageManager.DONT_KILL_APP)
                 true
             }
-        }
-
-        private fun setupContextMenuPreference(key: String, @StringRes contextMenuName: Int) {
-            // FIXME: The menu is named in the system language (as it's defined in the manifest which may be
-            //  different than the app language
-            val cardBrowserContextMenuPreference = requirePreference<SwitchPreference>(key)
-            val menuName = getString(contextMenuName)
-            // Note: The below format strings are generic, not card browser specific despite the name
-            cardBrowserContextMenuPreference.title = getString(R.string.card_browser_enable_external_context_menu, menuName)
-            cardBrowserContextMenuPreference.summary = getString(R.string.card_browser_enable_external_context_menu_summary, menuName)
         }
 
         private fun removeUnnecessaryAdvancedPrefs() {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.kt
@@ -367,10 +367,6 @@ class Preferences : AnkiActivity() {
                 when (key) {
                     CustomSyncServer.PREFERENCE_CUSTOM_MEDIA_SYNC_URL, CustomSyncServer.PREFERENCE_CUSTOM_SYNC_BASE, CustomSyncServer.PREFERENCE_ENABLE_CUSTOM_SYNC_SERVER -> // This may be a tad hasty - performed before "back" is pressed.
                         handleSyncServerPreferenceChange(preferencesActivity.baseContext)
-                    "timeoutAnswer" -> {
-                        val keepScreenOn = screen.findPreference<SwitchPreference>("keepScreenOn")
-                        keepScreenOn!!.isChecked = (pref as SwitchPreference).isChecked
-                    }
                     CrashReportService.FEEDBACK_REPORT_KEY -> {
                         val value = prefs!!.getString(CrashReportService.FEEDBACK_REPORT_KEY, "")
                         CrashReportService.onPreferenceChanged(preferencesActivity, value!!)
@@ -582,6 +578,15 @@ class Preferences : AnkiActivity() {
                     true
                 }
             }
+            // Automatic display answer
+            requirePreference<SwitchPreference>(R.string.timeout_answer_preference).setOnPreferenceChangeListener { _, newValue ->
+                // Enable `Keep screen on` along with the automatic display answer preference
+                if (newValue == true) {
+                    requirePreference<SwitchPreference>(R.string.keep_screen_on_preference).isChecked = true
+                }
+                true
+            }
+
             /**
              * Timeout answer
              * An integer representing the action when "Automatic Answer" flips a card from answer to question

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.kt
@@ -50,6 +50,7 @@ import com.ichi2.anki.contextmenu.CardBrowserContextMenu
 import com.ichi2.anki.exception.ConfirmModSchemaException
 import com.ichi2.anki.exception.StorageAccessException
 import com.ichi2.anki.preferences.AboutFragment
+import com.ichi2.anki.provider.CardContentProvider
 import com.ichi2.anki.reviewer.AutomaticAnswerAction
 import com.ichi2.anki.reviewer.FullScreenMode
 import com.ichi2.anki.services.BootService.Companion.scheduleNotification
@@ -370,19 +371,6 @@ class Preferences : AnkiActivity() {
                     CrashReportService.FEEDBACK_REPORT_KEY -> {
                         val value = prefs!!.getString(CrashReportService.FEEDBACK_REPORT_KEY, "")
                         CrashReportService.onPreferenceChanged(preferencesActivity, value!!)
-                    }
-                    "providerEnabled" -> {
-                        val providerName = ComponentName(preferencesActivity, "com.ichi2.anki.provider.CardContentProvider")
-                        val pm = preferencesActivity.packageManager
-                        val state: Int
-                        if ((pref as SwitchPreference).isChecked) {
-                            state = PackageManager.COMPONENT_ENABLED_STATE_ENABLED
-                            Timber.i("AnkiDroid ContentProvider enabled by user")
-                        } else {
-                            state = PackageManager.COMPONENT_ENABLED_STATE_DISABLED
-                            Timber.i("AnkiDroid ContentProvider disabled by user")
-                        }
-                        pm.setComponentEnabledSetting(providerName, state, PackageManager.DONT_KILL_APP)
                     }
                     CardBrowserContextMenu.CARD_BROWSER_CONTEXT_MENU_PREF_KEY -> CardBrowserContextMenu.ensureConsistentStateWithSharedPreferences(preferencesActivity)
                     AnkiCardContextMenu.ANKI_CARD_CONTEXT_MENU_PREF_KEY -> AnkiCardContextMenu.ensureConsistentStateWithSharedPreferences(preferencesActivity)
@@ -1012,6 +1000,20 @@ class Preferences : AnkiActivity() {
                 } else {
                     getString(R.string.disabled)
                 }
+            }
+
+            // Enable API
+            requirePreference<SwitchPreference>(R.string.enable_api_key).setOnPreferenceChangeListener { _, newValue ->
+                val providerName = ComponentName(requireContext(), CardContentProvider::class.java.name)
+                val state = if (newValue == true) {
+                    Timber.i("AnkiDroid ContentProvider enabled by user")
+                    PackageManager.COMPONENT_ENABLED_STATE_ENABLED
+                } else {
+                    Timber.i("AnkiDroid ContentProvider disabled by user")
+                    PackageManager.COMPONENT_ENABLED_STATE_DISABLED
+                }
+                requireActivity().packageManager.setComponentEnabledSetting(providerName, state, PackageManager.DONT_KILL_APP)
+                true
             }
         }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.kt
@@ -330,7 +330,7 @@ class Preferences : AnkiActivity() {
         }
 
         override fun onSharedPreferenceChanged(sharedPreferences: SharedPreferences, key: String) {
-            updatePreference(activity as Preferences, sharedPreferences, key)
+            updatePreference(activity as Preferences, key)
         }
 
         @Suppress("deprecation") // setTargetFragment
@@ -356,7 +356,7 @@ class Preferences : AnkiActivity() {
          * @param prefs instance of SharedPreferences
          * @param key key in prefs which is being updated
          */
-        private fun updatePreference(preferencesActivity: Preferences, prefs: SharedPreferences?, key: String) {
+        private fun updatePreference(preferencesActivity: Preferences, key: String) {
             try {
                 val screen = preferenceScreen
                 val pref = screen.findPreference<Preference>(key)
@@ -368,10 +368,6 @@ class Preferences : AnkiActivity() {
                 when (key) {
                     CustomSyncServer.PREFERENCE_CUSTOM_MEDIA_SYNC_URL, CustomSyncServer.PREFERENCE_CUSTOM_SYNC_BASE, CustomSyncServer.PREFERENCE_ENABLE_CUSTOM_SYNC_SERVER -> // This may be a tad hasty - performed before "back" is pressed.
                         handleSyncServerPreferenceChange(preferencesActivity.baseContext)
-                    CrashReportService.FEEDBACK_REPORT_KEY -> {
-                        val value = prefs!!.getString(CrashReportService.FEEDBACK_REPORT_KEY, "")
-                        CrashReportService.onPreferenceChanged(preferencesActivity, value!!)
-                    }
                     CardBrowserContextMenu.CARD_BROWSER_CONTEXT_MENU_PREF_KEY -> CardBrowserContextMenu.ensureConsistentStateWithSharedPreferences(preferencesActivity)
                     AnkiCardContextMenu.ANKI_CARD_CONTEXT_MENU_PREF_KEY -> AnkiCardContextMenu.ensureConsistentStateWithSharedPreferences(preferencesActivity)
                 }
@@ -476,6 +472,11 @@ class Preferences : AnkiActivity() {
                     col.set_config("pastePNG", newValue)
                     true
                 }
+            }
+            // Error reporting mode
+            requirePreference<ListPreference>(R.string.error_reporting_mode_key).setOnPreferenceChangeListener { _, newValue ->
+                CrashReportService.onPreferenceChanged(requireContext(), newValue as String)
+                true
             }
         }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.kt
@@ -48,6 +48,7 @@ import com.ichi2.anki.contextmenu.CardBrowserContextMenu
 import com.ichi2.anki.exception.ConfirmModSchemaException
 import com.ichi2.anki.exception.StorageAccessException
 import com.ichi2.anki.preferences.AboutFragment
+import com.ichi2.anki.preferences.setOnPreferenceChangeListener
 import com.ichi2.anki.provider.CardContentProvider
 import com.ichi2.anki.reviewer.AutomaticAnswerAction
 import com.ichi2.anki.reviewer.FullScreenMode
@@ -380,9 +381,8 @@ class Preferences : AnkiActivity() {
             // Note that "addToCur" is a boolean while USE_CURRENT is "0" or "1"
             requirePreference<ListPreference>(R.string.deck_for_new_cards_key).apply {
                 setValueIndex(if (col.get_config("addToCur", true)!!) 0 else 1)
-                setOnPreferenceChangeListener { _, newValue ->
+                setOnPreferenceChangeListener { newValue ->
                     col.set_config("addToCur", "0" == newValue)
-                    true
                 }
             }
             // Paste PNG
@@ -390,15 +390,13 @@ class Preferences : AnkiActivity() {
             // whether to convert clipboard uri to png format or not.
             requirePreference<SwitchPreference>(R.string.paste_png_key).apply {
                 isChecked = col.get_config("pastePNG", false)!!
-                setOnPreferenceChangeListener { _, newValue ->
+                setOnPreferenceChangeListener { newValue ->
                     col.set_config("pastePNG", newValue)
-                    true
                 }
             }
             // Error reporting mode
-            requirePreference<ListPreference>(R.string.error_reporting_mode_key).setOnPreferenceChangeListener { _, newValue ->
+            requirePreference<ListPreference>(R.string.error_reporting_mode_key).setOnPreferenceChangeListener { newValue ->
                 CrashReportService.onPreferenceChanged(requireContext(), newValue as String)
-                true
             }
         }
 
@@ -426,9 +424,8 @@ class Preferences : AnkiActivity() {
             // It's only possible to change the language by recreating the activity,
             // so do it if the language has changed.
             // TODO recreate the activity and keep its previous state instead of just closing it
-            languageSelection.setOnPreferenceChangeListener { _, _ ->
+            languageSelection.setOnPreferenceChangeListener { _ ->
                 (requireActivity() as Preferences).closePreferences()
-                true
             }
         }
     }
@@ -447,9 +444,8 @@ class Preferences : AnkiActivity() {
             // whether the new cards are added at the end of the queue or randomly in it.
             requirePreference<ListPreference>(R.string.new_spread_preference).apply {
                 setValueIndex(col.get_config_int("newSpread"))
-                setOnPreferenceChangeListener { _, newValue ->
+                setOnPreferenceChangeListener { newValue ->
                     col.set_config("newSpread", ((newValue as String).toInt()))
-                    true
                 }
             }
 
@@ -460,9 +456,8 @@ class Preferences : AnkiActivity() {
             requirePreference<NumberRangePreferenceCompat>(R.string.learn_cutoff_preference).apply {
                 setValue(col.get_config_int("collapseTime") / 60)
                 setFormattedSummary(R.string.pref_summary_minutes)
-                setOnPreferenceChangeListener { _, newValue ->
+                setOnPreferenceChangeListener { newValue ->
                     col.set_config("collapseTime", ((newValue as String).toInt() * 60))
-                    true
                 }
             }
             // Timebox time limit
@@ -472,9 +467,8 @@ class Preferences : AnkiActivity() {
             requirePreference<NumberRangePreferenceCompat>(R.string.time_limit_preference).apply {
                 setValue(col.get_config_int("timeLim") / 60)
                 setFormattedSummary(R.string.pref_summary_minutes)
-                setOnPreferenceChangeListener { _, newValue ->
+                setOnPreferenceChangeListener { newValue ->
                     col.set_config("timeLim", ((newValue as String).toInt() * 60))
-                    true
                 }
             }
             // Start of next day
@@ -483,18 +477,16 @@ class Preferences : AnkiActivity() {
             requirePreference<SeekBarPreferenceCompat>(R.string.day_offset_preference).apply {
                 value = getDayOffset(col)
                 setFormattedSummary(R.string.day_offset_summary)
-                setOnPreferenceChangeListener { _, newValue ->
+                setOnPreferenceChangeListener { newValue ->
                     (requireActivity() as Preferences).setDayOffset(newValue as Int)
-                    true
                 }
             }
             // Automatic display answer
-            requirePreference<SwitchPreference>(R.string.timeout_answer_preference).setOnPreferenceChangeListener { _, newValue ->
+            requirePreference<SwitchPreference>(R.string.timeout_answer_preference).setOnPreferenceChangeListener { newValue ->
                 // Enable `Keep screen on` along with the automatic display answer preference
                 if (newValue == true) {
                     requirePreference<SwitchPreference>(R.string.keep_screen_on_preference).isChecked = true
                 }
-                true
             }
 
             /**
@@ -507,9 +499,8 @@ class Preferences : AnkiActivity() {
              * */
             requirePreference<ListPreference>(R.string.automatic_answer_action_preference).apply {
                 setValueIndex(col.get_config(AutomaticAnswerAction.CONFIG_KEY, 0.toInt())!!)
-                setOnPreferenceChangeListener { _, newValue ->
+                setOnPreferenceChangeListener { newValue ->
                     col.set_config(AutomaticAnswerAction.CONFIG_KEY, (newValue as String).toInt())
-                    true
                 }
             }
             // Time to show answer
@@ -523,7 +514,7 @@ class Preferences : AnkiActivity() {
             requirePreference<SwitchPreference>(R.string.new_timezone_handling_preference).apply {
                 isChecked = col.sched._new_timezone_enabled()
                 isEnabled = col.schedVer() > 1
-                setOnPreferenceChangeListener { _, newValue ->
+                setOnPreferenceChangeListener { newValue ->
                     if (newValue == true) {
                         try {
                             col.sched.set_creation_offset()
@@ -533,7 +524,6 @@ class Preferences : AnkiActivity() {
                     } else {
                         col.sched.clear_creation_offset()
                     }
-                    true
                 }
             }
         }
@@ -682,7 +672,7 @@ class Preferences : AnkiActivity() {
             dayThemePref.isEnabled = themeIsFollowSystem
             nightThemePref.isEnabled = themeIsFollowSystem
 
-            appThemePref.setOnPreferenceChangeListener { _, newValue ->
+            appThemePref.setOnPreferenceChangeListener { newValue ->
                 val selectedThemeIsFollowSystem = newValue == Themes.FOLLOW_SYSTEM_MODE
                 dayThemePref.isEnabled = selectedThemeIsFollowSystem
                 nightThemePref.isEnabled = selectedThemeIsFollowSystem
@@ -697,25 +687,22 @@ class Preferences : AnkiActivity() {
                         requireActivity().recreate()
                     }
                 }
-                true
             }
 
-            dayThemePref.setOnPreferenceChangeListener { _, newValue ->
+            dayThemePref.setOnPreferenceChangeListener { newValue ->
                 if (newValue != dayThemePref.value && !systemIsInNightMode && newValue != currentTheme.id) {
                     dayThemePref.value = newValue.toString()
                     updateCurrentTheme()
                     requireActivity().recreate()
                 }
-                true
             }
 
-            nightThemePref.setOnPreferenceChangeListener { _, newValue ->
+            nightThemePref.setOnPreferenceChangeListener { newValue ->
                 if (newValue != nightThemePref.value && systemIsInNightMode && newValue != currentTheme.id) {
                     nightThemePref.value = newValue.toString()
                     updateCurrentTheme()
                     requireActivity().recreate()
                 }
-                true
             }
             initializeCustomFontsDialog()
 
@@ -724,9 +711,8 @@ class Preferences : AnkiActivity() {
             // whether the buttons should indicate the duration of the interval if we click on them.
             requirePreference<SwitchPreference>(R.string.show_estimates_preference).apply {
                 isChecked = col.get_config_boolean("estTimes")
-                setOnPreferenceChangeListener { _, newValue ->
+                setOnPreferenceChangeListener { newValue ->
                     col.set_config("estTimes", newValue)
-                    true
                 }
             }
             // Show progress
@@ -734,9 +720,8 @@ class Preferences : AnkiActivity() {
             // whether the remaining number of cards should be shown.
             requirePreference<SwitchPreference>(R.string.show_progress_preference).apply {
                 isChecked = col.get_config_boolean("dueCounts")
-                setOnPreferenceChangeListener { _, newValue ->
+                setOnPreferenceChangeListener { newValue ->
                     col.set_config("dueCounts", newValue)
-                    true
                 }
             }
         }
@@ -850,18 +835,16 @@ class Preferences : AnkiActivity() {
             requirePreference<SwitchPreference>(R.string.card_browser_external_context_menu_key).apply {
                 title = getString(R.string.card_browser_enable_external_context_menu, getString(R.string.card_browser_context_menu))
                 summary = getString(R.string.card_browser_enable_external_context_menu_summary, getString(R.string.card_browser_context_menu))
-                setOnPreferenceChangeListener { _, newValue ->
+                setOnPreferenceChangeListener { newValue ->
                     CardBrowserContextMenu.ensureConsistentStateWithPreferenceStatus(requireContext(), newValue as Boolean)
-                    true
                 }
             }
             // Anki card context menu
             requirePreference<SwitchPreference>(R.string.anki_card_external_context_menu_key).apply {
                 title = getString(R.string.card_browser_enable_external_context_menu, getString(R.string.context_menu_anki_card_label))
                 summary = getString(R.string.card_browser_enable_external_context_menu_summary, getString(R.string.context_menu_anki_card_label))
-                setOnPreferenceChangeListener { _, newValue ->
+                setOnPreferenceChangeListener { newValue ->
                     AnkiCardContextMenu.ensureConsistentStateWithPreferenceStatus(requireContext(), newValue as Boolean)
-                    true
                 }
             }
 
@@ -938,7 +921,7 @@ class Preferences : AnkiActivity() {
             }
 
             // Enable API
-            requirePreference<SwitchPreference>(R.string.enable_api_key).setOnPreferenceChangeListener { _, newValue ->
+            requirePreference<SwitchPreference>(R.string.enable_api_key).setOnPreferenceChangeListener { newValue ->
                 val providerName = ComponentName(requireContext(), CardContentProvider::class.java.name)
                 val state = if (newValue == true) {
                     Timber.i("AnkiDroid ContentProvider enabled by user")
@@ -948,7 +931,6 @@ class Preferences : AnkiActivity() {
                     PackageManager.COMPONENT_ENABLED_STATE_DISABLED
                 }
                 requireActivity().packageManager.setComponentEnabledSetting(providerName, state, PackageManager.DONT_KILL_APP)
-                true
             }
         }
 
@@ -1080,9 +1062,8 @@ class Preferences : AnkiActivity() {
 
         override fun initSubscreen() {
             // Use custom sync server
-            requirePreference<SwitchPreference>(R.string.custom_sync_server_enable_key).setOnPreferenceChangeListener { _, _ ->
+            requirePreference<SwitchPreference>(R.string.custom_sync_server_enable_key).setOnPreferenceChangeListener { _ ->
                 handleSyncServerPreferenceChange(requireContext())
-                true
             }
             // Sync url
             requirePreference<Preference>(R.string.custom_sync_server_base_url_key).setOnPreferenceChangeListener { _, newValue: Any ->

--- a/AnkiDroid/src/main/java/com/ichi2/anki/contextmenu/AnkiCardContextMenu.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/contextmenu/AnkiCardContextMenu.kt
@@ -18,20 +18,13 @@ package com.ichi2.anki.contextmenu
 import android.content.Context
 
 class AnkiCardContextMenu(context: Context) : SystemContextMenu(context) {
-
-    override val defaultEnabledStatus: Boolean
-        get() = true
-    override val preferenceKey: String
-        get() = ANKI_CARD_CONTEXT_MENU_PREF_KEY
     override val activityName: String
         get() = "com.ichi2.anki.AnkiCardContextMenuAction"
 
     companion object {
-        const val ANKI_CARD_CONTEXT_MENU_PREF_KEY = "anki_card_enable_external_context_menu"
-
         @JvmStatic
-        fun ensureConsistentStateWithSharedPreferences(context: Context) {
-            AnkiCardContextMenu(context).ensureConsistentStateWithSharedPreferences()
+        fun ensureConsistentStateWithPreferenceStatus(context: Context, preferenceStatus: Boolean) {
+            AnkiCardContextMenu(context).ensureConsistentStateWithPreferenceStatus(preferenceStatus)
         }
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/contextmenu/CardBrowserContextMenu.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/contextmenu/CardBrowserContextMenu.kt
@@ -18,20 +18,13 @@ package com.ichi2.anki.contextmenu
 import android.content.Context
 
 class CardBrowserContextMenu(context: Context) : SystemContextMenu(context) {
-
-    override val defaultEnabledStatus: Boolean
-        get() = false
-    override val preferenceKey: String
-        get() = CARD_BROWSER_CONTEXT_MENU_PREF_KEY
     override val activityName: String
         get() = "com.ichi2.anki.CardBrowserContextMenuAction"
 
     companion object {
-        const val CARD_BROWSER_CONTEXT_MENU_PREF_KEY = "card_browser_enable_external_context_menu"
-
         @JvmStatic
-        fun ensureConsistentStateWithSharedPreferences(context: Context) {
-            CardBrowserContextMenu(context).ensureConsistentStateWithSharedPreferences()
+        fun ensureConsistentStateWithPreferenceStatus(context: Context, preferenceStatus: Boolean) {
+            CardBrowserContextMenu(context).ensureConsistentStateWithPreferenceStatus(preferenceStatus)
         }
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/contextmenu/SystemContextMenu.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/contextmenu/SystemContextMenu.kt
@@ -19,14 +19,10 @@ import android.content.ComponentName
 import android.content.Context
 import android.content.pm.PackageManager
 import androidx.annotation.CheckResult
-import com.ichi2.anki.AnkiDroidApp
 import timber.log.Timber
 import java.lang.Exception
 
 abstract class SystemContextMenu(private val context: Context) {
-    protected abstract val defaultEnabledStatus: Boolean
-    protected abstract val preferenceKey: String
-
     /** We use an activity alias as the name so we can disable the context menu without disabling the activity  */
     protected abstract val activityName: String
     fun setSystemMenuEnabled(enabled: Boolean) {
@@ -38,17 +34,13 @@ abstract class SystemContextMenu(private val context: Context) {
         }
     }
 
-    fun ensureConsistentStateWithSharedPreferences() {
-        val preferenceStatus = preferenceStatus
+    fun ensureConsistentStateWithPreferenceStatus(preferenceStatus: Boolean) {
         val actualStatus = systemMenuStatus
         if (actualStatus == null || actualStatus != preferenceStatus) {
             Timber.d("Modifying Context Menu Status: Preference was %b", preferenceStatus)
             setSystemMenuEnabled(preferenceStatus)
         }
     }
-
-    protected val preferenceStatus: Boolean
-        get() = AnkiDroidApp.getSharedPrefs(context).getBoolean(preferenceKey, defaultEnabledStatus)
 
     @get:CheckResult
     private val systemMenuStatus: Boolean?

--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/AccessibilitySettingsFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/AccessibilitySettingsFragment.kt
@@ -15,22 +15,20 @@
  */
 package com.ichi2.anki.preferences
 
-import com.ichi2.anki.Preferences.SpecificSettingsFragment
+import com.ichi2.anki.Preferences.SettingsFragment
 import com.ichi2.anki.R
 import com.ichi2.preferences.SeekBarPreferenceCompat
 
 /**
  * Fragment with preferences related to notifications
  */
-class AccessibilitySettingsFragment : SpecificSettingsFragment() {
+class AccessibilitySettingsFragment : SettingsFragment() {
     override val preferenceResource: Int
         get() = R.xml.preferences_acessibility
     override val analyticsScreenNameConstant: String
         get() = "prefs.accessibility"
 
     override fun initSubscreen() {
-        addPreferencesFromResource(preferenceResource)
-
         // Card zoom
         requirePreference<SeekBarPreferenceCompat>(R.string.card_zoom_preference)
             .setFormattedSummary(R.string.pref_summary_percentage)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/NotificationsSettingsFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/NotificationsSettingsFragment.kt
@@ -21,7 +21,7 @@ import android.content.Intent
 import androidx.preference.ListPreference
 import androidx.preference.SwitchPreference
 import com.ichi2.anki.Preferences
-import com.ichi2.anki.Preferences.SpecificSettingsFragment
+import com.ichi2.anki.Preferences.SettingsFragment
 import com.ichi2.anki.R
 import com.ichi2.anki.services.BootService.Companion.scheduleNotification
 import com.ichi2.anki.services.NotificationService
@@ -32,14 +32,13 @@ import com.ichi2.utils.AdaptionUtil.isRestrictedLearningDevice
 /**
  * Fragment with preferences related to notifications
  */
-class NotificationsSettingsFragment : SpecificSettingsFragment() {
+class NotificationsSettingsFragment : SettingsFragment() {
     override val preferenceResource: Int
         get() = R.xml.preferences_notifications
     override val analyticsScreenNameConstant: String
         get() = "prefs.notifications"
 
     override fun initSubscreen() {
-        addPreferencesFromResource(preferenceResource)
         if (isRestrictedLearningDevice) {
             preferenceScreen.removePreference(requirePreference<SwitchPreference>(R.string.pref_notifications_vibrate_key))
             preferenceScreen.removePreference(requirePreference<SwitchPreference>(R.string.pref_notifications_blink_key))

--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/PreferenceUtils.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/PreferenceUtils.kt
@@ -1,0 +1,31 @@
+/*
+ *  Copyright (c) 2022 Brayan Oliveira <brayandso.dev@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.ichi2.anki.preferences
+
+import androidx.preference.Preference
+
+/**
+ * Sets the callback to be invoked when this preference is changed by the user
+ * (but before the internal state has been updated) on the internal onPreferenceChangeListener,
+ * returning true on it by default
+ * @param onPreferenceChangeListener The callback to be invoked
+ */
+fun Preference.setOnPreferenceChangeListener(onPreferenceChangeListener: (newValue: Any) -> Unit) {
+    this.setOnPreferenceChangeListener { _, newValue ->
+        onPreferenceChangeListener(newValue)
+        true
+    }
+}

--- a/AnkiDroid/src/main/res/values/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values/10-preferences.xml
@@ -104,7 +104,6 @@
     <string name="sync_fetch_missing_media_summ">Automatically fetch missing media when syncing</string>
     <string name="sync_account" maxLength="41">AnkiWeb account</string>
     <string name="sync_account_summ_logged_out">Not logged in</string>
-    <string name="sync_account_summ_logged_in" comment="The summary for the account setting when logged in. Parameter is the username (email)">%s</string>
     <string name="automatic_sync_choice" maxLength="41">Automatic synchronization</string>
     <string name="automatic_sync_choice_summ">Sync automatically on app start/exit if the last sync was more than 10
         minutes ago.</string>


### PR DESCRIPTION
Continuation of #11873

## Purpose / Description

Updating preferences was problematic, with [updatePreference](https://github.com/ankidroid/Anki-Android/blob/abd1f8bfc316cdf11aba51af7bda7f5b05c493d7/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.kt#L438) being ran every time any preference is changed. Also, the preferences activity had the responsability of mananing methods of specific preferences, which isn't a good design (e.g. [this](https://github.com/ankidroid/Anki-Android/blob/abd1f8bfc316cdf11aba51af7bda7f5b05c493d7/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.kt#L280))

To keep things tidy, concise, and keep the preferences' configuration responsability on themselves and on their screens, I've done some refactors on the preferences activity

## Approach

1. Extract the preferences update to their screens on the `Update X preference individually` commits
- The required changes that escape the previous patternare marked on the commits as a `**` on the message beginning and are described on their respective commit messages.

## How Has This Been Tested?

Manually opened/changed all preferences and it still works correctly. I should upload a video of it later.

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)