### PR TITLE
fix: Android Studio Designer + deck_picker_dialog

### DIFF
--- a/AnkiDroid/src/main/AndroidManifest.xml
+++ b/AnkiDroid/src/main/AndroidManifest.xml
@@ -75,6 +75,7 @@
         android:preserveLegacyExternalStorage="true"
         android:resizeableActivity="true"
         android:supportsRtl="true"
+        android:theme="@style/Theme_Light"
         >
         <activity android:name=".DrawingActivity"
             android:label="@string/drawing"

--- a/AnkiDroid/src/main/res/layout/deck_picker_dialog.xml
+++ b/AnkiDroid/src/main/res/layout/deck_picker_dialog.xml
@@ -17,6 +17,7 @@
 
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:orientation="vertical"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
@@ -29,7 +30,9 @@
         android:layout_alignParentTop="true"
         android:theme="@style/ActionBarStyle"
         android:background="?attr/colorPrimary"
-        app:popupTheme="@style/ActionBar.Popup">
+        app:popupTheme="@style/ActionBar.Popup"
+        tools:title="@string/search_deck"
+        tools:menu="@menu/deck_picker_dialog_menu">
     </androidx.appcompat.widget.Toolbar>
 
     <com.ichi2.ui.FixedTextView android:id="@+id/deck_picker_dialog_summary"
@@ -40,11 +43,14 @@
         android:padding="8dp"
         android:gravity="center"
         android:textIsSelectable="false"
-        android:layout_below="@id/deck_picker_dialog_toolbar"/>
+        android:layout_below="@id/deck_picker_dialog_toolbar"
+        tools:text="optional summary for 'deck override' picker"/>
 
-    <androidx.recyclerview.widget.RecyclerView android:id="@+id/deck_picker_dialog_list"
-                                               android:scrollbars="vertical"
-                                               android:layout_width="match_parent"
-                                               android:layout_height="wrap_content"
-                                               android:layout_below="@id/deck_picker_dialog_summary"/>
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/deck_picker_dialog_list"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_below="@id/deck_picker_dialog_summary"
+        android:scrollbars="vertical"
+        tools:listitem="@layout/deck_picker_dialog_list_item" />
 </RelativeLayout>

--- a/AnkiDroid/src/main/res/layout/deck_picker_dialog_list_item.xml
+++ b/AnkiDroid/src/main/res/layout/deck_picker_dialog_list_item.xml
@@ -17,6 +17,8 @@
 
 <!-- An item in a deck selection screen. Partially based off deck_item -->
 <com.ichi2.ui.FixedTextView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    tools:showIn="@layout/deck_picker_dialog"
     android:id="@+id/deck_picker_dialog_list_item_value"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"


### PR DESCRIPTION
We fix the default theme, then fix a single screen which was flagged as being bad

## Fixes
Maybe #11878 - reviewer's choice

## How Has This Been Tested?
API 31 emulator

## Learning (optional, can help others)
Comments from: https://github.com/ankidroid/Anki-Android/issues/11878#issuecomment-1186546310
https://developer.android.com/guide/topics/manifest/application-element#theme

* `layout/toolbar` means we can't set the preview for title/menu, it may not be a worthwhile abstraction (and we may want a custom `View` instead)

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

![Screenshot 2022-07-17 at 21 06 05](https://user-images.githubusercontent.com/62114487/179422957-3de00615-851e-446b-8d2d-f3bd8012a49a.png)
