### PR TITLE
Fix crash during deck filtering

### DIFF
--- a/.idea/dictionaries/usernames.xml
+++ b/.idea/dictionaries/usernames.xml
@@ -20,6 +20,7 @@
       <w>Freidle</w>
       <w>Goel</w>
       <w>Gruber</w>
+      <w>Guelman</w>
       <w>Houssam</w>
       <w>Jadhav</w>
       <w>Jolta</w>

--- a/AnkiDroid/src/main/java/com/ichi2/anki/widgets/DeckAdapter.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/widgets/DeckAdapter.kt
@@ -376,7 +376,7 @@ class DeckAdapter(private val layoutInflater: LayoutInflater, context: Context) 
 
             // we have a root, and a list of trees with the counts already calculated.
             return TreeNode(root.value).apply {
-                children.addAll(ret)
+                childrenCopy.addAll(ret)
             }
         }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/widgets/DeckAdapter.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/widgets/DeckAdapter.kt
@@ -383,7 +383,7 @@ class DeckAdapter(private val layoutInflater: LayoutInflater, context: Context) 
 
         private fun containsFilterString(filterPattern: String, root: AbstractDeckTreeNode): Boolean {
             val deckName = root.fullDeckName
-            return deckName.contains(filterPattern, ignoreCase = true)
+            return deckName.lowercase(Locale.getDefault()).contains(filterPattern) || deckName.lowercase(Locale.ROOT).contains(filterPattern)
         }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/widgets/DeckAdapter.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/widgets/DeckAdapter.kt
@@ -361,7 +361,6 @@ class DeckAdapter(private val layoutInflater: LayoutInflater, context: Context) 
             if (containsFilterString(filterPattern, root.value)) {
                 return root
             }
-            // Must use copy for iteration to avoid ConcurrentModificationException
             val children = root.children
             val ret: MutableList<TreeNode<AbstractDeckTreeNode>> = ArrayList(children.size)
             for (child in children) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/widgets/DeckAdapter.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/widgets/DeckAdapter.kt
@@ -361,9 +361,10 @@ class DeckAdapter(private val layoutInflater: LayoutInflater, context: Context) 
             if (containsFilterString(filterPattern, root.value)) {
                 return root
             }
-            val children = root.children.toMutableList()
-            val ret: MutableList<TreeNode<AbstractDeckTreeNode>> = ArrayList(children.size)
-            for (child in children) {
+            // Must use copy for iteration to avoid ConcurrentModificationException
+            val childrenCopy = root.children.toMutableList()
+            val ret: MutableList<TreeNode<AbstractDeckTreeNode>> = ArrayList(childrenCopy.size)
+            for (child in childrenCopy) {
                 val returned = filterDeckInternal(filterPattern, child)
                 if (returned != null) {
                     ret.add(returned)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/widgets/DeckAdapter.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/widgets/DeckAdapter.kt
@@ -25,6 +25,7 @@ import android.view.View
 import android.view.View.OnLongClickListener
 import android.view.ViewGroup
 import android.widget.*
+import androidx.annotation.VisibleForTesting
 import androidx.core.content.ContextCompat
 import androidx.recyclerview.widget.RecyclerView
 import com.ichi2.anki.R
@@ -343,7 +344,8 @@ class DeckAdapter(private val layoutInflater: LayoutInflater, context: Context) 
         return DeckFilter()
     }
 
-    private inner class DeckFilter : TypedFilter<TreeNode<AbstractDeckTreeNode>>(mDeckList) {
+    @VisibleForTesting
+    inner class DeckFilter(deckList: List<TreeNode<AbstractDeckTreeNode>> = mDeckList) : TypedFilter<TreeNode<AbstractDeckTreeNode>>(deckList) {
         override fun filterResults(constraint: CharSequence, items: List<TreeNode<AbstractDeckTreeNode>>): List<TreeNode<AbstractDeckTreeNode>> {
             val filterPattern = constraint.toString().lowercase(Locale.getDefault()).trim { it <= ' ' }
             return items.mapNotNull { t: TreeNode<AbstractDeckTreeNode> -> filterDeckInternal(filterPattern, t) }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/widgets/DeckAdapter.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/widgets/DeckAdapter.kt
@@ -362,9 +362,9 @@ class DeckAdapter(private val layoutInflater: LayoutInflater, context: Context) 
                 return root
             }
             // Must use copy for iteration to avoid ConcurrentModificationException
-            val childrenCopy = root.children.toMutableList()
-            val ret: MutableList<TreeNode<AbstractDeckTreeNode>> = ArrayList(childrenCopy.size)
-            for (child in childrenCopy) {
+            val children = root.children
+            val ret: MutableList<TreeNode<AbstractDeckTreeNode>> = ArrayList(children.size)
+            for (child in children) {
                 val returned = filterDeckInternal(filterPattern, child)
                 if (returned != null) {
                     ret.add(returned)
@@ -376,7 +376,7 @@ class DeckAdapter(private val layoutInflater: LayoutInflater, context: Context) 
 
             // we have a root, and a list of trees with the counts already calculated.
             return TreeNode(root.value).apply {
-                childrenCopy.addAll(ret)
+                this.children.addAll(ret)
             }
         }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/widgets/DeckAdapter.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/widgets/DeckAdapter.kt
@@ -381,7 +381,7 @@ class DeckAdapter(private val layoutInflater: LayoutInflater, context: Context) 
 
         private fun containsFilterString(filterPattern: String, root: AbstractDeckTreeNode): Boolean {
             val deckName = root.fullDeckName
-            return deckName.lowercase(Locale.getDefault()).contains(filterPattern) || deckName.lowercase(Locale.ROOT).contains(filterPattern)
+            return deckName.contains(filterPattern, ignoreCase = true)
         }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/widgets/DeckAdapter.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/widgets/DeckAdapter.kt
@@ -361,7 +361,7 @@ class DeckAdapter(private val layoutInflater: LayoutInflater, context: Context) 
             if (containsFilterString(filterPattern, root.value)) {
                 return root
             }
-            val children = root.children
+            val children = root.children.toMutableList()
             val ret: MutableList<TreeNode<AbstractDeckTreeNode>> = ArrayList(children.size)
             for (child in children) {
                 val returned = filterDeckInternal(filterPattern, child)

--- a/AnkiDroid/src/main/java/com/ichi2/utils/TypedFilter.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/TypedFilter.kt
@@ -17,7 +17,6 @@
 package com.ichi2.utils
 
 import android.widget.Filter
-import timber.log.Timber
 
 /** Implementation of [Filter] which is strongly typed */
 abstract class TypedFilter<T>(private val getCurrentItems: (() -> List<T>)) : Filter() {

--- a/AnkiDroid/src/main/java/com/ichi2/utils/TypedFilter.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/TypedFilter.kt
@@ -17,6 +17,7 @@
 package com.ichi2.utils
 
 import android.widget.Filter
+import timber.log.Timber
 
 /** Implementation of [Filter] which is strongly typed */
 abstract class TypedFilter<T>(private val getCurrentItems: (() -> List<T>)) : Filter() {
@@ -51,7 +52,14 @@ abstract class TypedFilter<T>(private val getCurrentItems: (() -> List<T>)) : Fi
     override fun publishResults(constraint: CharSequence?, results: FilterResults?) {
         // this is only ever called from performFiltering so we can guarantee the value is non-null
         // and can be cast to List<T>
-        val list = results!!.values as List<T>
+        val list = try {
+            results!!.values as List<T>
+        } catch (npe: NullPointerException) {
+            // allow publishResults to fail gracefully while reporting error
+            Timber.e(npe)
+
+            listOf()
+        }
         publishResults(constraint, list)
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/utils/TypedFilter.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/TypedFilter.kt
@@ -49,10 +49,9 @@ abstract class TypedFilter<T>(private val getCurrentItems: (() -> List<T>)) : Fi
 
     @Suppress("UNCHECKED_CAST")
     override fun publishResults(constraint: CharSequence?, results: FilterResults?) {
-        // this is only ever called from performFiltering so we can guarantee the value is non-null
-        // and can be cast to List<T>
-        val list = results!!.values as List<T>
-        publishResults(constraint, list)
+        // this is only ever called from performFiltering so we can guarantee the value can be cast to List<T>
+        val list = results?.values as List<T>?
+        publishResults(constraint, list.orEmpty())
     }
 
     /**

--- a/AnkiDroid/src/main/java/com/ichi2/utils/TypedFilter.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/TypedFilter.kt
@@ -50,8 +50,8 @@ abstract class TypedFilter<T>(private val getCurrentItems: (() -> List<T>)) : Fi
     @Suppress("UNCHECKED_CAST")
     override fun publishResults(constraint: CharSequence?, results: FilterResults?) {
         // this is only ever called from performFiltering so we can guarantee the value can be cast to List<T>
-        val list = results?.values as List<T>?
-        publishResults(constraint, list.orEmpty())
+        val list = results!!.values as List<T>
+        publishResults(constraint, list)
     }
 
     /**

--- a/AnkiDroid/src/main/java/com/ichi2/utils/TypedFilter.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/TypedFilter.kt
@@ -57,7 +57,6 @@ abstract class TypedFilter<T>(private val getCurrentItems: (() -> List<T>)) : Fi
         } catch (npe: NullPointerException) {
             // allow publishResults to fail gracefully while reporting error
             Timber.e(npe)
-
             listOf()
         }
         publishResults(constraint, list)

--- a/AnkiDroid/src/main/java/com/ichi2/utils/TypedFilter.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/TypedFilter.kt
@@ -52,13 +52,7 @@ abstract class TypedFilter<T>(private val getCurrentItems: (() -> List<T>)) : Fi
     override fun publishResults(constraint: CharSequence?, results: FilterResults?) {
         // this is only ever called from performFiltering so we can guarantee the value is non-null
         // and can be cast to List<T>
-        val list = try {
-            results!!.values as List<T>
-        } catch (npe: NullPointerException) {
-            // allow publishResults to fail gracefully while reporting error
-            Timber.e(npe)
-            listOf()
-        }
+        val list = results!!.values as List<T>
         publishResults(constraint, list)
     }
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/DeckAdapterFilterTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/DeckAdapterFilterTest.kt
@@ -1,3 +1,19 @@
+/****************************************************************************************
+ * Copyright (c) 2022 Shai Guelman <shaiguelman@gmail.com>                        *
+ *                                                                                      *
+ * This program is free software; you can redistribute it and/or modify it under        *
+ * the terms of the GNU General Public License as published by the Free Software        *
+ * Foundation; either version 3 of the License, or (at your option) any later           *
+ * version.                                                                             *
+ *                                                                                      *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *                                                                                      *
+ * You should have received a copy of the GNU General Public License along with         *
+ * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ ****************************************************************************************/
+
 package com.ichi2.anki
 
 import com.ichi2.anki.widgets.DeckAdapter

--- a/AnkiDroid/src/test/java/com/ichi2/anki/DeckAdapterFilterTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/DeckAdapterFilterTest.kt
@@ -4,13 +4,11 @@ import com.ichi2.anki.widgets.DeckAdapter
 import com.ichi2.libanki.sched.AbstractDeckTreeNode
 import com.ichi2.libanki.sched.DeckTreeNode
 import com.ichi2.libanki.sched.TreeNode
-import org.junit.After
 import org.junit.Assert
 import org.junit.Before
 import org.junit.Test
 import org.mockito.Mock
 import org.mockito.MockitoAnnotations
-import org.mockito.kotlin.whenever
 
 class DeckAdapterFilterTest {
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/DeckAdapterFilterTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/DeckAdapterFilterTest.kt
@@ -1,0 +1,83 @@
+package com.ichi2.anki
+
+import com.ichi2.anki.widgets.DeckAdapter
+import com.ichi2.libanki.sched.AbstractDeckTreeNode
+import com.ichi2.libanki.sched.DeckTreeNode
+import com.ichi2.libanki.sched.TreeNode
+import org.junit.After
+import org.junit.Assert
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mock
+import org.mockito.MockitoAnnotations
+import org.mockito.kotlin.whenever
+
+class DeckAdapterFilterTest {
+
+    @Mock
+    lateinit var adapter: DeckAdapter
+
+    lateinit var filter: DeckAdapter.DeckFilter
+
+    @Before
+    fun setUp() {
+        MockitoAnnotations.openMocks(this)
+        filter = adapter.DeckFilter(deckList)
+    }
+
+    @Test
+    fun verifyFilterResultsReturnsCorrectList() {
+
+        val pattern = "Math"
+
+        val actual = filter.filterResults(pattern, deckList)
+        val expected = deckList.getByDids(0, 4, 5, 6, 8)
+
+        Assert.assertArrayEquals(
+            actual.toTypedArray(),
+            expected.toTypedArray()
+        )
+    }
+
+    @Test
+    fun verifyFilterResultsReturnsNullWhenForNoMatches() {
+        val deckList = deckList
+        val pattern = "geometry"
+
+        val actual = filter.filterResults(pattern, deckList)
+
+        Assert.assertTrue(actual.isEmpty())
+    }
+
+    private val deckList: MutableList<TreeNode<AbstractDeckTreeNode>>
+        get() {
+            val deckList: MutableList<TreeNode<AbstractDeckTreeNode>> = mutableListOf(
+                TreeNode(DeckTreeNode("Chanson", 0)),
+                TreeNode(DeckTreeNode("Chanson::A Vers", 1)),
+                TreeNode(DeckTreeNode("Chanson::A Vers::1", 2)),
+                TreeNode(DeckTreeNode("Chanson::A Vers::Other", 3)),
+                TreeNode(DeckTreeNode("Chanson::Math HW", 4)),
+                TreeNode(DeckTreeNode("Chanson::Math HW::Theory", 5)),
+                TreeNode(DeckTreeNode("Chanson::Important", 6)),
+                TreeNode(DeckTreeNode("Chanson::Important::Stuff", 7)),
+                TreeNode(DeckTreeNode("Chanson::Important::Math", 8)),
+                TreeNode(DeckTreeNode("Chanson::Important::Stuff::Other Stuff", 9)),
+            )
+
+            deckList.getByDid(0).children.addAll(deckList.getByDids(1, 4, 6))
+            deckList.getByDid(1).children.addAll(deckList.getByDids(2, 3))
+            deckList.getByDid(4).children.addAll(deckList.getByDids(5))
+            deckList.getByDid(6).children.addAll(deckList.getByDids(7, 8))
+            deckList.getByDid(7).children.addAll(deckList.getByDids(9))
+
+            return deckList
+        }
+
+    private fun List<TreeNode<AbstractDeckTreeNode>>.getByDid(did: Long): TreeNode<AbstractDeckTreeNode> {
+        return this.first { it.value.did == did }
+    }
+
+    private fun List<TreeNode<AbstractDeckTreeNode>>.getByDids(vararg dids: Long): List<TreeNode<AbstractDeckTreeNode>> {
+        return this.filter { it.value.did in dids }
+    }
+}

--- a/AnkiDroid/src/test/java/com/ichi2/anki/DeckAdapterFilterTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/DeckAdapterFilterTest.kt
@@ -49,7 +49,7 @@ class DeckAdapterFilterTest {
     }
 
     @Test
-    fun verifyFilterResultsReturnsNullWhenForNoMatches() {
+    fun verifyFilterResultsReturnsEmptyForNoMatches() {
         val deckList = deckList
         val pattern = "geometry"
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/DeckAdapterFilterTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/DeckAdapterFilterTest.kt
@@ -45,7 +45,7 @@ class DeckAdapterFilterTest {
         val actual = filter.filterResults(pattern, deckList)
         val expected = deckList.getByDids(0, 4, 5, 6, 8)
 
-        Assert.assertEquals(actual, expected)
+        Assert.assertEquals(expected, actual)
     }
 
     @Test

--- a/AnkiDroid/src/test/java/com/ichi2/anki/DeckAdapterFilterTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/DeckAdapterFilterTest.kt
@@ -13,7 +13,6 @@
  * You should have received a copy of the GNU General Public License along with         *
  * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
  ****************************************************************************************/
-
 package com.ichi2.anki
 
 import com.ichi2.anki.widgets.DeckAdapter

--- a/AnkiDroid/src/test/java/com/ichi2/anki/DeckAdapterFilterTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/DeckAdapterFilterTest.kt
@@ -28,9 +28,9 @@ import org.mockito.MockitoAnnotations
 class DeckAdapterFilterTest {
 
     @Mock
-    lateinit var adapter: DeckAdapter
+    private lateinit var adapter: DeckAdapter
 
-    lateinit var filter: DeckAdapter.DeckFilter
+    private lateinit var filter: DeckAdapter.DeckFilter
 
     @Before
     fun setUp() {
@@ -40,16 +40,12 @@ class DeckAdapterFilterTest {
 
     @Test
     fun verifyFilterResultsReturnsCorrectList() {
-
         val pattern = "Math"
 
         val actual = filter.filterResults(pattern, deckList)
         val expected = deckList.getByDids(0, 4, 5, 6, 8)
 
-        Assert.assertArrayEquals(
-            actual.toTypedArray(),
-            expected.toTypedArray()
-        )
+        Assert.assertEquals(actual, expected)
     }
 
     @Test


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
Fixes issue where search bar was not filtering properly and crashing the app.

## Fixes
Fixes [#11877](https://github.com/ankidroid/Anki-Android/issues/11877)

## Approach
Creates a copy of the list of decks before filtering. The error was caused by using the same list in filtering as in the UI. I also made a small optimization of the containsFilterString method as well as added error catching in TypedFilter in case error happens again.

## How Has This Been Tested?

Reproduced error using process described in the issue before and after code changes. Screenshot of results after code changes:

![Screenshot_20220717-200601](https://user-images.githubusercontent.com/42308480/179432656-e1b62b2c-d71c-4b30-aa97-9e3ec5cbac7e.png)

## Learning (optional, can help others)

[Stack overflow post that helped me narrow the issue](https://stackoverflow.com/questions/41316886/concurrentmodificationexception-inside-publishresult-arrayadapter)

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
