### PR TITLE
Fix disabled "Choose another" button in the restore backup dialog

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DatabaseErrorDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DatabaseErrorDialog.kt
@@ -238,6 +238,10 @@ class DatabaseErrorDialog : AsyncDialogFragment() {
                                 }
                             }
                         }
+                        // needed because listItemsSingleChoice disables the positive button and we
+                        // want to allow in the dialog direct item selection and different action for
+                        // positive button
+                        .setActionButtonEnabled(WhichButton.POSITIVE, true)
                 }
                 dialog.setOnKeyListener { _: DialogInterface?, keyCode: Int, _: KeyEvent? ->
                     if (keyCode == KeyEvent.KEYCODE_BACK) {


### PR DESCRIPTION
## Purpose / Description

This dialog shows a list of backups from which the user can choose and a button("Choose another") to select a backup from the file system. Using `listItemsSingleChoice` disables the positive button if initialSelection is not set.

## Fixes

Fixes #11883 

## How Has This Been Tested?

Checked the availability of the button in the dialog.

## Checklist

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
