### PR TITLE
NF: findOneCardByNote

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.kt
@@ -671,7 +671,7 @@ open class CollectionTask<Progress, Result>(val task: TaskDelegateBase<Progress,
             val searchResult: MutableList<CardCache> = ArrayList()
             val searchResult_: List<Long>
             searchResult_ = try {
-                col.findNotes(query).requireNoNulls()
+                col.findOneCardByNote(query).requireNoNulls()
             } catch (e: Exception) {
                 // exception can occur via normal operation
                 Timber.w(e)
@@ -679,8 +679,8 @@ open class CollectionTask<Progress, Result>(val task: TaskDelegateBase<Progress,
             }
             Timber.d("The search found %d cards", searchResult_.size)
             var position = 0
-            for (nid in searchResult_) {
-                val card = CardCache(Note(col, nid).firstCard().id, col, position++)
+            for (cid in searchResult_) {
+                val card = CardCache(cid, col, position++)
                 searchResult.add(card)
             }
             // Render the first few items

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.kt
@@ -1332,6 +1332,12 @@ open class Collection(
         return Finder(this).findCards(search, order, task)
     }
 
+    /** Return a list of card ids  */
+    @KotlinCleanup("Remove in V16.") // Not in libAnki
+    fun findOneCardByNote(query: String?): List<Long> {
+        return Finder(this).findOneCardByNote(query)
+    }
+
     /** Return a list of note ids  */
     fun findNotes(query: String?): List<Long> {
         return Finder(this).findNotes(query)


### PR DESCRIPTION
Allow to improve card browser's note mode by ensuring that one card by note is
directly queried.

This is temporary code, since back-end will ensure we get this feature
efficiently in Rust.