### PR TITLE
Change return type for `setGraphPreferencesRaw` to bytetarray

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/stats/BackendStats.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/stats/BackendStats.kt
@@ -35,6 +35,6 @@ fun CollectionV16.getGraphPreferencesRaw(): ByteArray {
     return prefs.toByteArray()
 }
 
-fun CollectionV16.setGraphPreferencesRaw(input: ByteArray) {
-    backend.setGraphPreferencesRaw(input)
+fun CollectionV16.setGraphPreferencesRaw(input: ByteArray): ByteArray {
+    return backend.setGraphPreferencesRaw(input)
 }


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
The `setGraphPreferencesRaw` should return `ByteArray`

## Fixes
Fixes _Link to the issues._

## Approach
Updated existing implementation

## How Has This Been Tested?

## Learning (optional, can help others)
_Describe the research stage_

_Links to blog posts, patterns, libraries or addons used to solve this problem_

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
