### PR TITLE
Fix sync from server issue due to an invalid context

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sync/FullSyncer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sync/FullSyncer.kt
@@ -107,7 +107,7 @@ class FullSyncer(col: Collection?, hkey: String?, con: Connection, hostNum: Host
         mCon.publishProgress(R.string.sync_check_download_file)
         var tempDb: DB? = null
         try {
-            tempDb = DB.withAndroidFramework(mCol!!.context, tpath)
+            tempDb = DB.withAndroidFramework(AnkiDroidApp.getInstance(), tpath)
             if (!"ok".equals(tempDb.queryString("PRAGMA integrity_check"), ignoreCase = true)) {
                 Timber.e("Full sync - downloaded file corrupt")
                 return ConnectionResultType.REMOTE_DB_ERROR


### PR DESCRIPTION
## Purpose / Description

This bug was happening because the update to the 2.1.54 backend used code that required a Context, which was retrieved from a null Collection. Fixed it by using the application context which is always available.

Note: I verified that the forced sync from web is ok(@Arthur-Milchior could you please also verify this?) but there's another bug when syncing(arbitraryString) due to a kotlin migration bug(I'll provide a pr for that as well).

## Fixes

Fixes #11891 

## How Has This Been Tested?

Ran the tests, verified that the sync is successful when forcing from web.

## Checklist

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
