### PR TITLE
fix: IDE lint in SchedTimingToday

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/backend/model/SchedTimingToday.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/backend/model/SchedTimingToday.kt
@@ -20,12 +20,12 @@ interface SchedTimingToday {
      *
      * uint32 upstream
      * */
-    fun days_elapsed(): Int
+    fun daysElapsed(): Int
 
     /**
      * Timestamp of the next day rollover.
      *
      * int64 upstream
      * */
-    fun next_day_at(): Long
+    fun nextDayAt(): Long
 }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/backend/model/SchedTimingTodayProto.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/backend/model/SchedTimingTodayProto.kt
@@ -21,11 +21,11 @@ import anki.scheduler.SchedTimingTodayResponse
  * Adapter for SchedTimingTodayOut2 result from Rust
  */
 class SchedTimingTodayProto(private val data: SchedTimingTodayResponse) : SchedTimingToday {
-    override fun days_elapsed(): Int {
+    override fun daysElapsed(): Int {
         return data.daysElapsed
     }
 
-    override fun next_day_at(): Long {
+    override fun nextDayAt(): Long {
         return data.nextDayAt
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
@@ -31,7 +31,6 @@ import android.text.TextUtils;
 import android.text.style.StyleSpan;
 import android.util.Pair;
 
-import com.ichi2.anki.AnkiDroidApp;
 import com.ichi2.anki.R;
 import com.ichi2.async.CancelListener;
 import com.ichi2.async.CollectionTask;
@@ -2195,8 +2194,8 @@ public class SchedV2 extends AbstractSched {
             mToday = _daysSinceCreation();
             mDayCutoff = _dayCutoff();
         } else if (_new_timezone_enabled()) {
-            mToday = timing.days_elapsed();
-            mDayCutoff = timing.next_day_at();
+            mToday = timing.daysElapsed();
+            mDayCutoff = timing.nextDayAt();
         } else {
             mToday = _daysSinceCreation();
             mDayCutoff = _dayCutoff();


### PR DESCRIPTION
## Purpose / Description
fix IDE lint by renaming the functions names in SchedTimingToday.kt

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
