### PR TITLE
fix: Make the database error dialog not cancelable by outside touches

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DatabaseErrorDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DatabaseErrorDialog.kt
@@ -56,6 +56,7 @@ class DatabaseErrorDialog : AsyncDialogFragment() {
         val isLoggedIn = SyncStatus.isLoggedIn
         dialog.cancelable(true)
             .title(text = title)
+            .cancelOnTouchOutside(false)
         var sqliteInstalled = false
         try {
             sqliteInstalled = Runtime.getRuntime().exec("sqlite3 --version").waitFor() == 0


### PR DESCRIPTION
## Purpose / Description
In order to prevent the user navigating around the app with a null collection and then potentially crash the app

## Fixes
Fixes #11894

## Approach
Add `.cancelOnTouchOutside(false)` to the database error dialog

## How Has This Been Tested?

On my phone
1. Replace `collection.anki2` with a empty file with the same name
2. Open the app
3. Try to cancel the dialog by touching outside it

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
