### PR TITLE
fixed NPE during sync

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sync/Syncer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sync/Syncer.kt
@@ -442,14 +442,14 @@ class Syncer(
     // }
     // return result;
     // }
-    private fun usnLim(): Pair<String, Array<Any>?> {
+    private fun usnLim(): Pair<String, Array<Any>> {
         return if (col.server) {
             Pair(
                 "usn >= ?",
                 arrayOf(mMinUsn)
             )
         } else {
-            Pair("usn = -1", null)
+            Pair("usn = -1", arrayOf())
         }
     }
 
@@ -582,7 +582,7 @@ class Syncer(
         val decks = JSONArray()
         val limAndArgs = usnLim()
         col.db
-            .query("SELECT oid, type FROM graves WHERE " + limAndArgs.first, *limAndArgs.second!!)
+            .query("SELECT oid, type FROM graves WHERE " + limAndArgs.first, *limAndArgs.second)
             .use { cur ->
                 while (cur.moveToNext()) {
                     @Consts.REM_TYPE val type = cur.getInt(1)


### PR DESCRIPTION
## Purpose / Description
Bug fix- Sync fail due to NPE. I think this bug was introduced as a result of Kotlin Migration #11864 of Syncer.java and wasn't picked up by test.

## Fixes
May be a part of #11891, not sure.

## Approach
Instead of retuning null from `useLim` return an empty array.

## How Has This Been Tested?
Unit tested and on Realme 6i API 30

## Learning
After any change, make sure to test on real-device from your own side. Automated tests are not always enough. 🥲

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [ ] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

https://user-images.githubusercontent.com/69595691/180387511-e4d1ac96-6ff0-4ceb-921d-2ae09003844c.mp4