### PR TITLE
Fix FieldEditText context menu items not working

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/FieldEditText.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/FieldEditText.kt
@@ -207,7 +207,7 @@ class FieldEditText : FixedEditText, NoteService.NoteField {
             }
             return pastePlainText()
         }
-        return false
+        return super.onTextContextMenuItem(id)
     }
 
     @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)


### PR DESCRIPTION
## Fixes
Fixes #11865

## Approach
Fixed return of `FieldEditText#onTextContextMenuItem` to be `super` call rather than false

## How Has This Been Tested?


https://user-images.githubusercontent.com/59933477/180474860-44234a7b-fa50-48d4-8c63-46220f42303b.mov



## Checklist

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [x] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
