### PR TITLE
Modify `findNotes()` to use V16 `searchNotes()` function

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.kt
@@ -1353,7 +1353,7 @@ open class Collection(
      * @param order only used in overridden V16 findNotes() method
      * */
     @JvmOverloads
-    open fun findNotes(query: String?, order: SortOrder = SortOrder.NoOrdering()): List<Long> {
+    open fun findNotes(query: String, order: SortOrder = SortOrder.NoOrdering()): List<Long> {
         return Finder(this).findNotes(query)
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.kt
@@ -1349,8 +1349,11 @@ open class Collection(
         return Finder(this).findOneCardByNote(query)
     }
 
-    /** Return a list of note ids  */
-    fun findNotes(query: String?): List<Long> {
+    /** Return a list of note ids
+     * @param order only used in overridden V16 findNotes() method
+     * */
+    @JvmOverloads
+    open fun findNotes(query: String?, order: SortOrder = SortOrder.NoOrdering()): List<Long> {
         return Finder(this).findNotes(query)
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/CollectionV16.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/CollectionV16.kt
@@ -157,20 +157,20 @@ class CollectionV16(
     }
 
     override fun findNotes(
-        query: String?,
+        query: String,
         order: SortOrder,
     ): List<Long> {
         val adjustedOrder = if (order is SortOrder.UseCollectionOrdering) {
             @Suppress("DEPRECATION")
             SortOrder.BuiltinSortKind(
                 get_config("noteSortType", null as String?) ?: "noteFld",
-                get_config("sortBackwards", false) ?: false,
+                get_config("browserNoteSortBackwards", false) ?: false,
             )
         } else {
             order
         }
         val noteIDsList = try {
-            backend.searchNotes(query!!, adjustedOrder.toProtoBuf())
+            backend.searchNotes(query, adjustedOrder.toProtoBuf())
         } catch (e: BackendInvalidInputException) {
             throw InvalidSearchException(e)
         }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/CollectionV16.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/CollectionV16.kt
@@ -156,6 +156,27 @@ class CollectionV16(
         return cardIdsList
     }
 
+    override fun findNotes(
+        query: String?,
+        order: SortOrder,
+    ): List<Long> {
+        val adjustedOrder = if (order is SortOrder.UseCollectionOrdering) {
+            @Suppress("DEPRECATION")
+            SortOrder.BuiltinSortKind(
+                get_config("noteSortType", null as String?) ?: "noteFld",
+                get_config("sortBackwards", false) ?: false,
+            )
+        } else {
+            order
+        }
+        val noteIDsList = try {
+            backend.searchNotes(query!!, adjustedOrder.toProtoBuf())
+        } catch (e: BackendInvalidInputException) {
+            throw InvalidSearchException(e)
+        }
+        return noteIDsList
+    }
+
     /** Takes raw input from TypeScript frontend and returns suitable translations. */
     fun i18nResourcesRaw(input: ByteArray): ByteArray {
         return backend.i18nResourcesRaw(input = input)

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sync/Syncer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sync/Syncer.kt
@@ -442,14 +442,14 @@ class Syncer(
     // }
     // return result;
     // }
-    private fun usnLim(): Pair<String, Array<Any>?> {
+    private fun usnLim(): Pair<String, Array<Any>> {
         return if (col.server) {
             Pair(
                 "usn >= ?",
                 arrayOf(mMinUsn)
             )
         } else {
-            Pair("usn = -1", null)
+            Pair("usn = -1", arrayOf())
         }
     }
 
@@ -582,7 +582,7 @@ class Syncer(
         val decks = JSONArray()
         val limAndArgs = usnLim()
         col.db
-            .query("SELECT oid, type FROM graves WHERE " + limAndArgs.first, *limAndArgs.second!!)
+            .query("SELECT oid, type FROM graves WHERE " + limAndArgs.first, *limAndArgs.second)
             .use { cur ->
                 while (cur.moveToNext()) {
                     @Consts.REM_TYPE val type = cur.getInt(1)


### PR DESCRIPTION
Modify SearchNotes to be able to use both legacy and V16 functions

## Pull Request template

## Purpose / Description
Add support for using new backend method `searchNotes()`

## Approach
By checking the schema version, the newer function is used on using V16. The newer `searchNotes()` function includes a parameter for sorting, which is not supported in legacy.

`findNotes()` function is modified in `Collection` so that V16 can be used when enabled

## How Has This Been Tested?

On my phone by enabling V16 backend in settings.

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
