### PR TITLE
Update ic_add_note.xml (new add sign)

### DIFF
--- a/AnkiDroid/src/main/res/drawable/ic_add_note.xml
+++ b/AnkiDroid/src/main/res/drawable/ic_add_note.xml
@@ -1,30 +1,9 @@
-<!--
-  ~ Copyright 2021, Google Material Design Icons
-  ~
-  ~ Licensed under the Apache License, Version 2.0 (the "License");
-  ~ you may not use this file except in compliance with the License.
-  ~ You may obtain a copy of the License at
-  ~
-  ~    http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing, software
-  ~ distributed under the License is distributed on an "AS IS" BASIS,
-  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~ See the License for the specific language governing permissions and
-  ~ limitations under the License.
-  ~
-  ~ Modifications (GitHub: joshakaw, 2021):
-  ~  Base icon: payments - outline from Google Material Icons
-  ~  Removed the circle from the middle of the rounded rectangle
-  ~  Removed the background outline of the 2nd card
-  ~  Added a plus icon, and removed, with padding, the area that the plus took up
-  -->
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="24dp"
-    android:height="24dp"
-    android:viewportWidth="24"
-    android:viewportHeight="24">
+    android:width="16dp"
+    android:height="16dp"
+    android:viewportWidth="16"
+    android:viewportHeight="16">
   <path
-      android:pathData="M18.3711,6.2324C17.3254,6.2419 16.1991,6.2498 15.7422,6.2441L4.4961,6.2441C3.3961,6.2441 2.4961,7.1441 2.4961,8.2441L2.4961,16.2441C2.4961,17.3441 3.3961,18.2441 4.4961,18.2441L18.4961,18.2441C19.5961,18.2441 20.4961,17.3441 20.4961,16.2441C20.4338,14.8996 20.4687,10.7235 20.502,8.1699C20.5161,7.0871 19.5684,6.2216 18.3711,6.2324zM6.9805,8.3496L8.9805,8.3496L8.9805,11.1484L11.7793,11.1484L11.7793,13.1484L8.9805,13.1484L8.9805,15.9492L6.9805,15.9492L6.9805,13.1484L4.2793,13.1484L4.2793,11.1484L6.9805,11.1484L6.9805,8.3496z"
+      android:pathData="M9.293,0H4a2,2 0,0 0,-2 2v12a2,2 0,0 0,2 2h8a2,2 0,0 0,2 -2V4.707A1,1 0,0 0,13.707 4L10,0.293A1,1 0,0 0,9.293 0zM9.5,3.5v-2l3,3h-2a1,1 0,0 1,-1 -1zM8.5,7v1.5H10a0.5,0.5 0,0 1,0 1H8.5V11a0.5,0.5 0,0 1,-1 0V9.5H6a0.5,0.5 0,0 1,0 -1h1.5V7a0.5,0.5 0,0 1,1 0z"
       android:fillColor="#ffffff"/>
 </vector>


### PR DESCRIPTION
## Update ic_add_note.xml (new add sign)

## Description
The shape of the current Add note icon doesn't look like a note, but a card. So I changed it and got a good one

## Fixes
Issue no #10773
[Fixes _Link to the issues._](https://github.com/ankidroid/Anki-Android/issues/10773)

## Approach
By deleting old ic_add_note.xml to new good looking ic_add_note.xml

## How Has This Been Tested?
I have use Genymotion Emulator to test this change
Tested on SDK 29, 30, 31 and 32.


## Checklist

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [x] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
