### PR TITLE
Ensure unit test of API build and succeed

### DIFF
--- a/api/src/test/java/com/ichi2/anki/api/ApiUtilsTest.java
+++ b/api/src/test/java/com/ichi2/anki/api/ApiUtilsTest.java
@@ -80,11 +80,6 @@ public class ApiUtilsTest {
     }
 
     @Test
-    public void splitTagsShouldReturnNullWhenStringIsNull() {
-        assertNull(Utils.splitTags(null));
-    }
-
-    @Test
     public void shouldGenerateProperCheckSum() {
         assertEquals(3533307532L, Utils.fieldChecksum("AnkiDroid"));
     }

--- a/api/src/test/java/com/ichi2/anki/api/ApiUtilsTest.java
+++ b/api/src/test/java/com/ichi2/anki/api/ApiUtilsTest.java
@@ -47,11 +47,6 @@ public class ApiUtilsTest {
     }
 
     @Test
-    public void splitFieldsShouldReturnNullWhenStringIsNull() {
-        assertNull(Utils.splitFields(null));
-    }
-
-    @Test
     public void joinTagsShouldReturnEmptyStringWhenSetIsValid() {
         Set<String> set = new HashSet<>();
         set.add("A");

--- a/api/src/test/java/com/ichi2/anki/api/ApiUtilsTest.java
+++ b/api/src/test/java/com/ichi2/anki/api/ApiUtilsTest.java
@@ -86,6 +86,6 @@ public class ApiUtilsTest {
 
     @Test
     public void shouldGenerateProperCheckSum() {
-        assertEquals(Long.valueOf(3533307532L), Utils.fieldChecksum("AnkiDroid"));
+        assertEquals(3533307532L, Utils.fieldChecksum("AnkiDroid"));
     }
 }


### PR DESCRIPTION
Related to bug #11917. It does not fix it as it do not ensure the API gets tested by CI.

I believe removing the tests is the good solution, as I don't believe any of the tested method should accept a nullable input today and that none of its usage expect a nullable answer