### PR TITLE
Fix Rate menu item availability in help/support dialogs

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/NavigationDrawerActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NavigationDrawerActivity.kt
@@ -299,13 +299,20 @@ abstract class NavigationDrawerActivity :
                 }
                 R.id.nav_settings -> {
                     Timber.i("Navigating to settings")
-                    launchActivityForResultWithAnimation(Intent(this@NavigationDrawerActivity, Preferences::class.java), mPreferencesLauncher, FADE)
+                    launchActivityForResultWithAnimation(
+                        Intent(
+                            this@NavigationDrawerActivity,
+                            Preferences::class.java
+                        ),
+                        mPreferencesLauncher,
+                        FADE
+                    )
                     // #6192 - stop crash on changing collection path - cancel tasks if moving to settings
                     (this as? Statistics)?.finishWithAnimation(FADE)
                 }
                 R.id.nav_help -> {
                     Timber.i("Navigating to help")
-                    showDialogFragment(HelpDialog.createInstance(this))
+                    showDialogFragment(HelpDialog.createInstance())
                 }
                 R.id.support_ankidroid -> {
                     Timber.i("Navigating to support AnkiDroid")
@@ -313,7 +320,6 @@ abstract class NavigationDrawerActivity :
                 }
             }
         }
-
         closeDrawer()
         return true
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/HelpDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/HelpDialog.kt
@@ -30,7 +30,6 @@ import com.ichi2.anki.UIUtils.showThemedToast
 import com.ichi2.anki.analytics.UsageAnalytics
 import com.ichi2.anki.dialogs.HelpDialog.FunctionItem.ActivityConsumer
 import com.ichi2.anki.dialogs.RecursivePictureMenu.Companion.createInstance
-import com.ichi2.anki.dialogs.RecursivePictureMenu.Companion.removeFrom
 import com.ichi2.anki.dialogs.RecursivePictureMenu.ItemHeader
 import com.ichi2.utils.AdaptionUtil.isUserATestClient
 import com.ichi2.utils.IntentUtil.canOpenIntent
@@ -49,10 +48,9 @@ object HelpDialog {
     }
 
     @JvmStatic
-    fun createInstance(context: Context?): DialogFragment {
+    fun createInstance(): DialogFragment {
         val exceptionReportItem = ExceptionReportItem(R.string.help_title_send_exception, R.drawable.ic_round_assignment_24, UsageAnalytics.Actions.EXCEPTION_REPORT)
         UsageAnalytics.sendAnalyticsEvent(UsageAnalytics.Category.LINK_CLICKED, UsageAnalytics.Actions.OPENED_HELPDIALOG)
-        val rateAppItem = RateAppItem(R.string.help_item_support_rate_ankidroid, R.drawable.ic_star_black_24, UsageAnalytics.Actions.OPENED_RATE)
         val allItems = arrayOf<RecursivePictureMenu.Item>(
             ItemHeader(
                 R.string.help_title_using_ankidroid, R.drawable.ic_manual_black_24dp, UsageAnalytics.Actions.OPENED_USING_ANKIDROID,
@@ -96,11 +94,7 @@ object HelpDialog {
                 LinkItem(R.string.help_item_ankiweb_terms_and_conditions, R.drawable.ic_baseline_description_24, UsageAnalytics.Actions.OPENED_ANKIWEB_TERMS_AND_CONDITIONS, R.string.link_ankiweb_terms_and_conditions)
             )
         )
-        val itemList = ArrayList(listOf(*allItems))
-        if (!canOpenIntent(context!!, AnkiDroidApp.getMarketIntent(context))) {
-            removeFrom(itemList, rateAppItem)
-        }
-        return createInstance(itemList, R.string.help)
+        return createInstance(ArrayList(listOf(*allItems)), R.string.help)
     }
 
     @JvmStatic
@@ -124,7 +118,7 @@ object HelpDialog {
         )
         val itemList = ArrayList(listOf(*allItems))
         if (!canOpenIntent(context!!, AnkiDroidApp.getMarketIntent(context))) {
-            removeFrom(itemList, rateAppItem)
+            itemList.remove(rateAppItem)
         }
         return createInstance(itemList, R.string.help_title_support_ankidroid)
     }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/utils/HelpDialogTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/utils/HelpDialogTest.kt
@@ -17,12 +17,17 @@ package com.ichi2.anki.dialogs.utils
 
 import android.annotation.SuppressLint
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.ichi2.anki.AnkiDroidApp
 import com.ichi2.anki.RobolectricTest
 import com.ichi2.anki.RunInBackground
 import com.ichi2.anki.dialogs.HelpDialog.createInstance
 import com.ichi2.anki.dialogs.HelpDialog.createInstanceForSupportAnkiDroid
 import com.ichi2.anki.dialogs.RecursivePictureMenu
 import com.ichi2.anki.dialogs.utils.RecursivePictureMenuUtil.Companion.getRecyclerViewFor
+import com.ichi2.utils.IntentUtil
+import io.mockk.every
+import io.mockk.mockkStatic
+import io.mockk.unmockkStatic
 import org.hamcrest.MatcherAssert
 import org.hamcrest.Matchers
 import org.junit.Test
@@ -33,10 +38,10 @@ class HelpDialogTest : RobolectricTest() {
     @Test
     @RunInBackground
     fun testMenuDoesNotCrash() {
-        val dialog = createInstance(targetContext) as RecursivePictureMenu
+        val dialog = createInstance() as RecursivePictureMenu
         openDialogFragment(dialog)
         val v = getRecyclerViewFor(dialog)
-        MatcherAssert.assertThat(v.childCount, Matchers.equalTo(4))
+        MatcherAssert.assertThat(v.adapter!!.itemCount, Matchers.equalTo(4))
     }
 
     @Test
@@ -45,7 +50,27 @@ class HelpDialogTest : RobolectricTest() {
         val dialog = createInstanceForSupportAnkiDroid(targetContext) as RecursivePictureMenu
         openDialogFragment(dialog)
         val v = getRecyclerViewFor(dialog)
-        MatcherAssert.assertThat(v.childCount, Matchers.equalTo(5))
+        // to make the test more flexible, calculate the expected menu items count by actually
+        // checking what intents are available on the test environment
+        val expectedCount = if (IntentUtil.canOpenIntent(targetContext, AnkiDroidApp.getMarketIntent(targetContext))) {
+            6 // +1 because the "Rate" menu item should be shown as Play Store app is available on the system
+        } else {
+            5 // the default value for support dialog menu items count
+        }
+        MatcherAssert.assertThat(v.adapter!!.itemCount, Matchers.equalTo(expectedCount))
+    }
+
+    @Test
+    @RunInBackground
+    fun testMenuSupportAnkiDroidShowsRateWhenPossible() {
+        mockkStatic(IntentUtil::canOpenIntent)
+        every { IntentUtil.canOpenIntent(targetContext, any()) } returns true
+        val dialog = createInstanceForSupportAnkiDroid(targetContext) as RecursivePictureMenu
+        openDialogFragment(dialog)
+        val v = getRecyclerViewFor(dialog)
+        // 6 because the option to rate the app is possible on the device
+        MatcherAssert.assertThat(v.adapter!!.itemCount, Matchers.equalTo(6))
+        unmockkStatic(IntentUtil::canOpenIntent)
     }
 
     @SuppressLint("CheckResult") // openDialogFragmentUsingActivity


### PR DESCRIPTION
This PR fixes some bugs related to code around the `Rate` menu item from the help/support dialogs. Changes:

- removes the code related to `Rate` from `HelpDialog.createInstance()` because the option is not used at all in the help menu. This also allows the simplification of the method by removing its `context` parameter.
- fixes a bug related to `Rate` from `HelpDialog.createInstanceForSupportAnkiDroid()` which made the `Rate` menu option to appear even if the application to handle it is not present on the device. See the before and after picture below on a device which doesn't have the play store app installed:
<img src="https://user-images.githubusercontent.com/52494258/180742297-0a0bf89b-b079-4ac1-bf99-67ac0d720221.png" width="50%" height="50%" /><img src="https://user-images.githubusercontent.com/52494258/180743033-cedcacfd-f7c7-48d4-adf8-8b87d483522b.png" width="50%" height="50%" />

On the majority of devices with the store application available there are no changes and the `Rate` menu option is available:
<img src="https://user-images.githubusercontent.com/52494258/180743270-64644883-bc19-4a59-adf0-00a70c1160f8.png" width="50%" height="50%" />

- fixes the `testMenuSupportAnkiDroidShowsRateWhenPossible()` test which was passing be luck. Although the menu has 6 items(see above the bug) the test passed because it looked for 5 children in the dialog and Robolectric allows only a set height for the RecyclerView(which resulted in the view to have 5 children ). The fix was to use the adapter which is a source of truth not affected by UI issues. 
- added a test to make sure the dialog shows the `Rate` menu item when the store app is available(important as the Robolectric environment doesn't have it)
- some cleanups for the tests, `is` to `equalTo`, as I already touched those lines 

## How Has This Been Tested?

Ran the tests, manually checked the dialogs.

## Checklist

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
