### PR TITLE
[GSoC] NF: Add a comment explaining setTargetFragment deprecation suppression

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/SettingsFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/SettingsFragment.kt
@@ -79,7 +79,10 @@ abstract class SettingsFragment : PreferenceFragmentCompat() {
 
     protected abstract val analyticsScreenNameConstant: String
 
-    @Suppress("deprecation") // setTargetFragment
+    @Suppress("deprecation") // setTargetFragment #9452
+    // androidx.preference.PreferenceDialogFragmentCompat uses the deprecated method
+    // `getTargetFragment()`, which throws if `setTargetFragment()` isn't used before.
+    // While this isn't fixed on upstream, suppress the deprecation warning
     override fun onDisplayPreferenceDialog(preference: Preference) {
         val dialogFragment = when (preference) {
             is IncrementerNumberRangePreferenceCompat -> IncrementerNumberRangePreferenceCompat.IncrementerNumberRangeDialogFragmentCompat.newInstance(preference.getKey())


### PR DESCRIPTION
## Purpose / Description
As I've commented on #9452:

Currently, the only place setTargetFragment is used is on Preferences.kt

It is necessary to use it, because AndroidX PreferenceDialogFragmentCompat calls getTargetFragment(). If this happens without setTargetFragment getting called before, it leads to a crash, which means that we can't exchange it to [setFragmentResultListener](https://developer.android.com/reference/androidx/fragment/app/FragmentManager#setFragmentResultListener(java.lang.String,androidx.lifecycle.LifecycleOwner,androidx.fragment.app.FragmentResultListener)) as well.

This is definitely a upstream problem, and the current best course of action is to suppress the warning and give a +1 to these issues on Google issue tracker:

https://issuetracker.google.com/issues/181793702
https://issuetracker.google.com/issues/212905758

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
