### PR TITLE
[GSoC] Reorganize some preferences + refactors

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/AccessibilitySettingsFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/AccessibilitySettingsFragment.kt
@@ -37,5 +37,8 @@ class AccessibilitySettingsFragment : SettingsFragment() {
         // Answer button size
         requirePreference<SeekBarPreferenceCompat>(R.string.answer_button_size_preference)
             .setFormattedSummary(R.string.pref_summary_percentage)
+        // Card browser font scaling
+        requirePreference<SeekBarPreferenceCompat>(R.string.pref_card_browser_font_scale_key)
+            .setFormattedSummary(R.string.pref_summary_percentage)
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/AdvancedSettingsFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/AdvancedSettingsFragment.kt
@@ -24,7 +24,6 @@ import android.content.pm.PackageManager
 import android.net.Uri
 import androidx.preference.EditTextPreference
 import androidx.preference.Preference
-import androidx.preference.PreferenceCategory
 import androidx.preference.SwitchPreference
 import com.afollestad.materialdialogs.MaterialDialog
 import com.ichi2.anki.*
@@ -114,19 +113,18 @@ class AdvancedSettingsFragment : SettingsFragment() {
     }
 
     private fun removeUnnecessaryAdvancedPrefs() {
-        val plugins = findPreference<PreferenceCategory>("category_plugins")
         // Disable the emoji/kana buttons to scroll preference if those keys don't exist
         if (!CompatHelper.hasKanaAndEmojiKeys()) {
             val emojiScrolling = findPreference<SwitchPreference>("scrolling_buttons")
-            if (emojiScrolling != null && plugins != null) {
-                plugins.removePreference(emojiScrolling)
+            if (emojiScrolling != null) {
+                preferenceScreen.removePreference(emojiScrolling)
             }
         }
         // Disable the double scroll preference if no scrolling keys
         if (!CompatHelper.hasScrollKeys() && !CompatHelper.hasKanaAndEmojiKeys()) {
             val doubleScrolling = findPreference<SwitchPreference>("double_scrolling")
-            if (doubleScrolling != null && plugins != null) {
-                plugins.removePreference(doubleScrolling)
+            if (doubleScrolling != null) {
+                preferenceScreen.removePreference(doubleScrolling)
             }
         }
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/AdvancedSettingsFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/AdvancedSettingsFragment.kt
@@ -28,8 +28,6 @@ import androidx.preference.PreferenceCategory
 import androidx.preference.SwitchPreference
 import com.afollestad.materialdialogs.MaterialDialog
 import com.ichi2.anki.*
-import com.ichi2.anki.contextmenu.AnkiCardContextMenu
-import com.ichi2.anki.contextmenu.CardBrowserContextMenu
 import com.ichi2.anki.exception.ConfirmModSchemaException
 import com.ichi2.anki.exception.StorageAccessException
 import com.ichi2.anki.provider.CardContentProvider
@@ -67,23 +65,6 @@ class AdvancedSettingsFragment : SettingsFragment() {
                 }
             }
         }
-        // Card browser context menu
-        requirePreference<SwitchPreference>(R.string.card_browser_external_context_menu_key).apply {
-            title = getString(R.string.card_browser_enable_external_context_menu, getString(R.string.card_browser_context_menu))
-            summary = getString(R.string.card_browser_enable_external_context_menu_summary, getString(R.string.card_browser_context_menu))
-            setOnPreferenceChangeListener { newValue ->
-                CardBrowserContextMenu.ensureConsistentStateWithPreferenceStatus(requireContext(), newValue as Boolean)
-            }
-        }
-        // Anki card context menu
-        requirePreference<SwitchPreference>(R.string.anki_card_external_context_menu_key).apply {
-            title = getString(R.string.card_browser_enable_external_context_menu, getString(R.string.context_menu_anki_card_label))
-            summary = getString(R.string.card_browser_enable_external_context_menu_summary, getString(R.string.context_menu_anki_card_label))
-            setOnPreferenceChangeListener { newValue ->
-                AnkiCardContextMenu.ensureConsistentStateWithPreferenceStatus(requireContext(), newValue as Boolean)
-            }
-        }
-
         if (col != null && col!!.schedVer() == 1) {
             Timber.i("Displaying V1-to-V2 scheduler preference")
             val schedVerPreference = SwitchPreference(requireContext())

--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/AdvancedSettingsFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/AdvancedSettingsFragment.kt
@@ -28,7 +28,6 @@ import androidx.preference.PreferenceCategory
 import androidx.preference.SwitchPreference
 import com.afollestad.materialdialogs.MaterialDialog
 import com.ichi2.anki.*
-import com.ichi2.anki.exception.ConfirmModSchemaException
 import com.ichi2.anki.exception.StorageAccessException
 import com.ichi2.anki.provider.CardContentProvider
 import com.ichi2.compat.CompatHelper
@@ -40,7 +39,6 @@ class AdvancedSettingsFragment : SettingsFragment() {
     override val analyticsScreenNameConstant: String
         get() = "prefs.advanced"
 
-    @Suppress("Deprecation") // Material dialog neutral button deprecation
     override fun initSubscreen() {
         val screen = preferenceScreen
         // Check that input is valid before committing change in the collection path
@@ -64,42 +62,6 @@ class AdvancedSettingsFragment : SettingsFragment() {
                     false
                 }
             }
-        }
-        if (col != null && col!!.schedVer() == 1) {
-            Timber.i("Displaying V1-to-V2 scheduler preference")
-            val schedVerPreference = SwitchPreference(requireContext())
-            schedVerPreference.setTitle(R.string.sched_v2)
-            schedVerPreference.setSummary(R.string.sched_v2_summ)
-            schedVerPreference.onPreferenceChangeListener = Preference.OnPreferenceChangeListener { _, _ ->
-                MaterialDialog(requireContext()).show {
-                    // Going to V2
-                    title(R.string.sched_ver_toggle_title)
-                        .message(R.string.sched_ver_1to2)
-                        .positiveButton(R.string.dialog_ok) {
-                            col!!.modSchemaNoCheck()
-                            try {
-                                col!!.changeSchedulerVer(2)
-                                screen.removePreference(schedVerPreference)
-                            } catch (e2: ConfirmModSchemaException) {
-                                // This should never be reached as we explicitly called modSchemaNoCheck()
-                                throw RuntimeException(e2)
-                            }
-                        }
-                        .neutralButton(R.string.help) {
-                            // call v2 scheduler documentation website
-                            val uri = Uri.parse(getString(R.string.link_anki_2_scheduler))
-                            val intent = Intent(Intent.ACTION_VIEW, uri)
-                            startActivity(intent)
-                        }
-                        .negativeButton(R.string.dialog_cancel) {
-                            schedVerPreference.isChecked = false
-                        }
-                }
-                false
-            }
-            // meaning of order here is the position of Preference in xml layout.
-            schedVerPreference.order = 5
-            screen.addPreference(schedVerPreference)
         }
         // Adding change logs in both debug and release builds
         Timber.i("Adding open changelog")

--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/AppearanceSettingsFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/AppearanceSettingsFragment.kt
@@ -28,7 +28,6 @@ import com.ichi2.anki.UIUtils
 import com.ichi2.anki.cardviewer.GestureProcessor
 import com.ichi2.anki.reviewer.FullScreenMode
 import com.ichi2.libanki.Utils
-import com.ichi2.preferences.SeekBarPreferenceCompat
 import com.ichi2.themes.Theme
 import com.ichi2.themes.Themes
 import timber.log.Timber
@@ -45,10 +44,6 @@ class AppearanceSettingsFragment : SettingsFragment() {
 
     override fun initSubscreen() {
         val col = col!!
-        // Card browser font scaling
-        requirePreference<SeekBarPreferenceCompat>(R.string.pref_card_browser_font_scale_key)
-            .setFormattedSummary(R.string.pref_summary_percentage)
-
         // Show error toast if the user tries to disable answer button without gestures on
         requirePreference<Preference>(R.string.answer_buttons_position_preference).setOnPreferenceChangeListener() { _, newValue: Any ->
             val prefs = AnkiDroidApp.getSharedPrefs(requireContext())

--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/GeneralSettingsFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/GeneralSettingsFragment.kt
@@ -22,6 +22,8 @@ import com.ichi2.anki.CollectionHelper
 import com.ichi2.anki.CrashReportService
 import com.ichi2.anki.Preferences
 import com.ichi2.anki.R
+import com.ichi2.anki.contextmenu.AnkiCardContextMenu
+import com.ichi2.anki.contextmenu.CardBrowserContextMenu
 import com.ichi2.utils.AdaptionUtil.isRestrictedLearningDevice
 import com.ichi2.utils.LanguageUtil
 import java.util.*
@@ -66,6 +68,22 @@ class GeneralSettingsFragment : SettingsFragment() {
         // Error reporting mode
         requirePreference<ListPreference>(R.string.error_reporting_mode_key).setOnPreferenceChangeListener { newValue ->
             CrashReportService.onPreferenceChanged(requireContext(), newValue as String)
+        }
+        // Anki card context menu
+        requirePreference<SwitchPreference>(R.string.anki_card_external_context_menu_key).apply {
+            title = getString(R.string.card_browser_enable_external_context_menu, getString(R.string.context_menu_anki_card_label))
+            summary = getString(R.string.card_browser_enable_external_context_menu_summary, getString(R.string.context_menu_anki_card_label))
+            setOnPreferenceChangeListener { newValue ->
+                AnkiCardContextMenu.ensureConsistentStateWithPreferenceStatus(requireContext(), newValue as Boolean)
+            }
+        }
+        // Card browser context menu
+        requirePreference<SwitchPreference>(R.string.card_browser_external_context_menu_key).apply {
+            title = getString(R.string.card_browser_enable_external_context_menu, getString(R.string.card_browser_context_menu))
+            summary = getString(R.string.card_browser_enable_external_context_menu_summary, getString(R.string.card_browser_context_menu))
+            setOnPreferenceChangeListener { newValue ->
+                CardBrowserContextMenu.ensureConsistentStateWithPreferenceStatus(requireContext(), newValue as Boolean)
+            }
         }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/GeneralSettingsFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/GeneralSettingsFragment.kt
@@ -16,7 +16,6 @@
 package com.ichi2.anki.preferences
 
 import androidx.preference.ListPreference
-import androidx.preference.PreferenceCategory
 import androidx.preference.SwitchPreference
 import com.ichi2.anki.CollectionHelper
 import com.ichi2.anki.CrashReportService
@@ -24,7 +23,6 @@ import com.ichi2.anki.Preferences
 import com.ichi2.anki.R
 import com.ichi2.anki.contextmenu.AnkiCardContextMenu
 import com.ichi2.anki.contextmenu.CardBrowserContextMenu
-import com.ichi2.utils.AdaptionUtil.isRestrictedLearningDevice
 import com.ichi2.utils.LanguageUtil
 import java.util.*
 
@@ -36,13 +34,6 @@ class GeneralSettingsFragment : SettingsFragment() {
 
     override fun initSubscreen() {
         val col = col!!
-        if (isRestrictedLearningDevice) {
-            val switchPrefVibrate = requirePreference<SwitchPreference>("widgetVibrate")
-            val switchPrefBlink = requirePreference<SwitchPreference>("widgetBlink")
-            val category = requirePreference<PreferenceCategory>("category_general_notification_pref")
-            category.removePreference(switchPrefVibrate)
-            category.removePreference(switchPrefBlink)
-        }
         // Build languages
         initializeLanguageDialog()
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/HeaderFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/HeaderFragment.kt
@@ -29,7 +29,7 @@ class HeaderFragment : PreferenceFragmentCompat() {
         setPreferencesFromResource(R.xml.preference_headers, rootKey)
 
         // General category summary
-        findPreference<Preference>(getString(R.string.pref_general_screen_key))!!
+        requirePreference<Preference>(R.string.pref_general_screen_key)
             .summary = buildCategorySummary(
             R.string.language,
             R.string.pref_cat_studying,
@@ -37,21 +37,21 @@ class HeaderFragment : PreferenceFragmentCompat() {
         )
 
         // Reviewing preferences summary
-        findPreference<Preference>(getString(R.string.pref_reviewing_screen_key))!!
+        requirePreference<Preference>(R.string.pref_reviewing_screen_key)
             .summary = buildCategorySummary(
             R.string.pref_cat_scheduling,
             R.string.timeout_answer_text
         )
 
         // Sync preferences summary
-        findPreference<Preference>(getString(R.string.pref_sync_screen_key))!!
+        requirePreference<Preference>(R.string.pref_sync_screen_key)
             .summary = buildCategorySummary(
             R.string.sync_account,
             R.string.automatic_sync_choice
         )
 
         // Notifications preferences summary
-        findPreference<Preference>(getString(R.string.pref_notifications_screen_key))!!
+        requirePreference<Preference>(R.string.pref_notifications_screen_key)
             .summary = buildCategorySummary(
             R.string.notification_pref_title,
             R.string.notification_minimum_cards_due_vibrate,
@@ -59,7 +59,7 @@ class HeaderFragment : PreferenceFragmentCompat() {
         )
 
         // Appearance category summary
-        findPreference<Preference>(getString(R.string.pref_appearance_screen_key))!!
+        requirePreference<Preference>(R.string.pref_appearance_screen_key)
             .summary = buildCategorySummary(
             R.string.pref_cat_themes,
             R.string.pref_cat_fonts,
@@ -67,14 +67,14 @@ class HeaderFragment : PreferenceFragmentCompat() {
         )
 
         // Accessibility preferences summary
-        findPreference<Preference>(getString(R.string.pref_accessibility_screen_key))!!
+        requirePreference<Preference>(R.string.pref_accessibility_screen_key)
             .summary = buildCategorySummary(
             R.string.card_zoom,
             R.string.button_size,
         )
 
         // Controls preferences summary
-        findPreference<Preference>(getString(R.string.pref_controls_screen_key))!!
+        requirePreference<Preference>(R.string.pref_controls_screen_key)
             .summary = buildCategorySummary(
             R.string.pref_cat_gestures,
             R.string.keyboard,
@@ -82,7 +82,7 @@ class HeaderFragment : PreferenceFragmentCompat() {
         )
 
         // Advanced category summary
-        findPreference<Preference>(getString(R.string.pref_advanced_screen_key))!!
+        requirePreference<Preference>(R.string.pref_advanced_screen_key)
             .summary = buildCategorySummary(
             R.string.pref_cat_workarounds,
             R.string.pref_cat_plugins
@@ -104,7 +104,7 @@ class HeaderFragment : PreferenceFragmentCompat() {
     }
 
     fun setDevOptionsVisibility(isVisible: Boolean) {
-        findPreference<Preference>(getString(R.string.pref_dev_options_screen_key))!!.isVisible = isVisible
+        requirePreference<Preference>(R.string.pref_dev_options_screen_key).isVisible = isVisible
     }
 
     /**

--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/HeaderFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/HeaderFragment.kt
@@ -28,6 +28,14 @@ class HeaderFragment : PreferenceFragmentCompat() {
     override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
         setPreferencesFromResource(R.xml.preference_headers, rootKey)
 
+        // General category summary
+        findPreference<Preference>(getString(R.string.pref_general_screen_key))!!
+            .summary = buildCategorySummary(
+            R.string.language,
+            R.string.pref_cat_studying,
+            R.string.pref_cat_system_wide
+        )
+
         // Reviewing preferences summary
         findPreference<Preference>(getString(R.string.pref_reviewing_screen_key))!!
             .summary = buildCategorySummary(
@@ -50,6 +58,14 @@ class HeaderFragment : PreferenceFragmentCompat() {
             R.string.notification_minimum_cards_due_blink,
         )
 
+        // Appearance category summary
+        findPreference<Preference>(getString(R.string.pref_appearance_screen_key))!!
+            .summary = buildCategorySummary(
+            R.string.pref_cat_themes,
+            R.string.pref_cat_fonts,
+            R.string.pref_cat_reviewer
+        )
+
         // Accessibility preferences summary
         findPreference<Preference>(getString(R.string.pref_accessibility_screen_key))!!
             .summary = buildCategorySummary(
@@ -63,6 +79,13 @@ class HeaderFragment : PreferenceFragmentCompat() {
             R.string.pref_cat_gestures,
             R.string.keyboard,
             R.string.bluetooth
+        )
+
+        // Advanced category summary
+        findPreference<Preference>(getString(R.string.pref_advanced_screen_key))!!
+            .summary = buildCategorySummary(
+            R.string.pref_cat_workarounds,
+            R.string.pref_cat_plugins
         )
 
         if (AdaptionUtil.isRestrictedLearningDevice) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/HeaderFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/HeaderFragment.kt
@@ -16,6 +16,7 @@
 package com.ichi2.anki.preferences
 
 import android.os.Bundle
+import androidx.annotation.StringRes
 import androidx.preference.Preference
 import androidx.preference.PreferenceFragmentCompat
 import com.ichi2.anki.Preferences
@@ -29,39 +30,39 @@ class HeaderFragment : PreferenceFragmentCompat() {
 
         // Reviewing preferences summary
         findPreference<Preference>(getString(R.string.pref_reviewing_screen_key))!!
-            .summary = Preferences.buildCategorySummary(
-            getString(R.string.pref_cat_scheduling),
-            getString(R.string.timeout_answer_text)
+            .summary = buildCategorySummary(
+            R.string.pref_cat_scheduling,
+            R.string.timeout_answer_text
         )
 
         // Sync preferences summary
         findPreference<Preference>(getString(R.string.pref_sync_screen_key))!!
-            .summary = Preferences.buildCategorySummary(
-            getString(R.string.sync_account),
-            getString(R.string.automatic_sync_choice)
+            .summary = buildCategorySummary(
+            R.string.sync_account,
+            R.string.automatic_sync_choice
         )
 
         // Notifications preferences summary
         findPreference<Preference>(getString(R.string.pref_notifications_screen_key))!!
-            .summary = Preferences.buildCategorySummary(
-            getString(R.string.notification_pref_title),
-            getString(R.string.notification_minimum_cards_due_vibrate),
-            getString(R.string.notification_minimum_cards_due_blink),
+            .summary = buildCategorySummary(
+            R.string.notification_pref_title,
+            R.string.notification_minimum_cards_due_vibrate,
+            R.string.notification_minimum_cards_due_blink,
         )
 
         // Accessibility preferences summary
         findPreference<Preference>(getString(R.string.pref_accessibility_screen_key))!!
-            .summary = Preferences.buildCategorySummary(
-            getString(R.string.card_zoom),
-            getString(R.string.button_size),
+            .summary = buildCategorySummary(
+            R.string.card_zoom,
+            R.string.button_size,
         )
 
         // Controls preferences summary
         findPreference<Preference>(getString(R.string.pref_controls_screen_key))!!
-            .summary = Preferences.buildCategorySummary(
-            getString(R.string.pref_cat_gestures),
-            getString(R.string.keyboard),
-            getString(R.string.bluetooth)
+            .summary = buildCategorySummary(
+            R.string.pref_cat_gestures,
+            R.string.keyboard,
+            R.string.bluetooth
         )
 
         if (AdaptionUtil.isRestrictedLearningDevice) {
@@ -81,5 +82,17 @@ class HeaderFragment : PreferenceFragmentCompat() {
 
     fun setDevOptionsVisibility(isVisible: Boolean) {
         findPreference<Preference>(getString(R.string.pref_dev_options_screen_key))!!.isVisible = isVisible
+    }
+
+    /**
+     * Join the strings defined by [resIds]
+     * with ` • ` as separator to build a summary string for preferences categories.
+     * e.g. if `R.string.appName` and `R.string.msg` are given as arguments,
+     * and they correspond respectively to the strings `AnkiDroid` and `Message`,
+     * those strings are joined and return `AnkiDroid • Message`
+     */
+    private fun buildCategorySummary(@StringRes vararg resIds: Int): String {
+        val strings = resIds.map { getString(it) }
+        return Preferences.buildCategorySummary(*strings.toTypedArray())
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/HeaderFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/HeaderFragment.kt
@@ -84,6 +84,7 @@ class HeaderFragment : PreferenceFragmentCompat() {
         // Advanced category
         requirePreference<Preference>(R.string.pref_advanced_screen_key).apply {
             summary = buildCategorySummary(
+                R.string.statistics,
                 R.string.pref_cat_workarounds,
                 R.string.pref_cat_plugins
             )

--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/HeaderFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/HeaderFragment.kt
@@ -28,7 +28,7 @@ class HeaderFragment : PreferenceFragmentCompat() {
     override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
         setPreferencesFromResource(R.xml.preference_headers, rootKey)
 
-        // General category summary
+        // General category
         requirePreference<Preference>(R.string.pref_general_screen_key)
             .summary = buildCategorySummary(
             R.string.language,
@@ -36,21 +36,21 @@ class HeaderFragment : PreferenceFragmentCompat() {
             R.string.pref_cat_system_wide
         )
 
-        // Reviewing preferences summary
+        // Reviewing category
         requirePreference<Preference>(R.string.pref_reviewing_screen_key)
             .summary = buildCategorySummary(
             R.string.pref_cat_scheduling,
             R.string.timeout_answer_text
         )
 
-        // Sync preferences summary
+        // Sync category
         requirePreference<Preference>(R.string.pref_sync_screen_key)
             .summary = buildCategorySummary(
             R.string.sync_account,
             R.string.automatic_sync_choice
         )
 
-        // Notifications preferences summary
+        // Notifications category
         requirePreference<Preference>(R.string.pref_notifications_screen_key)
             .summary = buildCategorySummary(
             R.string.notification_pref_title,
@@ -58,7 +58,7 @@ class HeaderFragment : PreferenceFragmentCompat() {
             R.string.notification_minimum_cards_due_blink,
         )
 
-        // Appearance category summary
+        // Appearance category
         requirePreference<Preference>(R.string.pref_appearance_screen_key)
             .summary = buildCategorySummary(
             R.string.pref_cat_themes,
@@ -66,14 +66,14 @@ class HeaderFragment : PreferenceFragmentCompat() {
             R.string.pref_cat_reviewer
         )
 
-        // Accessibility preferences summary
+        // Accessibility category
         requirePreference<Preference>(R.string.pref_accessibility_screen_key)
             .summary = buildCategorySummary(
             R.string.card_zoom,
             R.string.button_size,
         )
 
-        // Controls preferences summary
+        // Controls category
         requirePreference<Preference>(R.string.pref_controls_screen_key)
             .summary = buildCategorySummary(
             R.string.pref_cat_gestures,
@@ -81,17 +81,18 @@ class HeaderFragment : PreferenceFragmentCompat() {
             R.string.bluetooth
         )
 
-        // Advanced category summary
-        requirePreference<Preference>(R.string.pref_advanced_screen_key)
-            .summary = buildCategorySummary(
-            R.string.pref_cat_workarounds,
-            R.string.pref_cat_plugins
-        )
-
-        if (AdaptionUtil.isRestrictedLearningDevice) {
-            findPreference<Preference>("pref_screen_advanced")!!.isVisible = false
+        // Advanced category
+        requirePreference<Preference>(R.string.pref_advanced_screen_key).apply {
+            summary = buildCategorySummary(
+                R.string.pref_cat_workarounds,
+                R.string.pref_cat_plugins
+            )
+            if (AdaptionUtil.isRestrictedLearningDevice) {
+                isVisible = false
+            }
         }
 
+        // Developer options category
         if (DevOptionsFragment.isEnabled(requireContext())) {
             setDevOptionsVisibility(true)
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/PreferenceUtils.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/PreferenceUtils.kt
@@ -15,7 +15,9 @@
  */
 package com.ichi2.anki.preferences
 
+import androidx.annotation.StringRes
 import androidx.preference.Preference
+import androidx.preference.PreferenceFragmentCompat
 
 /**
  * Sets the callback to be invoked when this preference is changed by the user
@@ -28,4 +30,25 @@ fun Preference.setOnPreferenceChangeListener(onPreferenceChangeListener: (newVal
         onPreferenceChangeListener(newValue)
         true
     }
+}
+
+/** Obtains a non-null reference to the preference defined by the key, or throws  */
+@Suppress("UNCHECKED_CAST")
+fun <T : Preference> PreferenceFragmentCompat.requirePreference(key: String): T {
+    val preference = findPreference<Preference>(key)
+        ?: throw IllegalStateException("missing preference: '$key'")
+    return preference as T
+}
+
+/**
+ * Obtains a non-null reference to the preference whose
+ * key is defined with given [resId] or throws
+ * e.g. `requirePreference(R.string.day_theme_key)` returns
+ * the preference whose key is `@string/day_theme_key`
+ * The resource IDs with preferences keys can be found on `res/values/preferences.xml`
+ */
+@Suppress("UNCHECKED_CAST")
+fun <T : Preference> PreferenceFragmentCompat.requirePreference(@StringRes resId: Int): T {
+    val key = getString(resId)
+    return requirePreference(key)
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/PreferenceUtils.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/PreferenceUtils.kt
@@ -33,8 +33,7 @@ fun Preference.setOnPreferenceChangeListener(onPreferenceChangeListener: (newVal
 }
 
 /** Obtains a non-null reference to the preference defined by the key, or throws  */
-@Suppress("UNCHECKED_CAST")
-fun <T : Preference> PreferenceFragmentCompat.requirePreference(key: String): T {
+inline fun <reified T : Preference> PreferenceFragmentCompat.requirePreference(key: String): T {
     val preference = findPreference<Preference>(key)
         ?: throw IllegalStateException("missing preference: '$key'")
     return preference as T
@@ -47,8 +46,7 @@ fun <T : Preference> PreferenceFragmentCompat.requirePreference(key: String): T 
  * the preference whose key is `@string/day_theme_key`
  * The resource IDs with preferences keys can be found on `res/values/preferences.xml`
  */
-@Suppress("UNCHECKED_CAST")
-fun <T : Preference> PreferenceFragmentCompat.requirePreference(@StringRes resId: Int): T {
+inline fun <reified T : Preference> PreferenceFragmentCompat.requirePreference(@StringRes resId: Int): T {
     val key = getString(resId)
     return requirePreference(key)
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/SettingsFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/SettingsFragment.kt
@@ -18,7 +18,6 @@ package com.ichi2.anki.preferences
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
-import androidx.annotation.StringRes
 import androidx.annotation.XmlRes
 import androidx.preference.Preference
 import androidx.preference.PreferenceFragmentCompat
@@ -55,26 +54,6 @@ abstract class SettingsFragment : PreferenceFragmentCompat() {
         UsageAnalytics.sendAnalyticsScreenView(analyticsScreenNameConstant)
         addPreferencesFromResource(preferenceResource)
         initSubscreen()
-    }
-
-    /** Obtains a non-null reference to the preference defined by the key, or throws  */
-    @Suppress("UNCHECKED_CAST")
-    protected fun <T : Preference?> requirePreference(key: String): T {
-        val preference = findPreference<Preference>(key)
-            ?: throw IllegalStateException("missing preference: '$key'")
-        return preference as T
-    }
-
-    @Suppress("UNCHECKED_CAST")
-    /**
-     * Obtains a non-null reference to the preference whose
-     * key is defined with given [resId] or throws
-     * e.g. `requirePreference(R.string.day_theme_key)` returns
-     * the preference whose key is `@string/day_theme_key`
-     * The resource IDs with preferences keys can be found on `res/values/preferences.xml`
-     */
-    protected fun <T : Preference?> requirePreference(@StringRes resId: Int): T {
-        return requirePreference(getString(resId)) as T
     }
 
     protected abstract val analyticsScreenNameConstant: String

--- a/AnkiDroid/src/main/res/values/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values/10-preferences.xml
@@ -161,10 +161,6 @@
     <string name="day_offset_summary">%s hours past midnight</string>
     <string name="xlabel_dayoffset_seekbar" maxLength="41">Midnight</string>
     <string name="ylabel_dayoffset_seekbar" maxLength="41">11PM</string>
-    <string name="sched_v2" maxLength="41">V2 scheduler</string>
-    <string name="sched_v2_summ">Enable the new scheduler. Forces changes in one direction on next sync</string>
-    <string name="sched_ver_toggle_title">Confirm</string>
-    <string name="sched_ver_1to2">The experimental scheduler could cause incorrect scheduling. Please ensure you have read the documentation first. Proceed?</string>
     <string name="pref_keep_screen_on" maxLength="41">Keep screen on</string>
     <string name="pref_keep_screen_on_summ">Disable screen timeout</string>
     <string name="convert_fen_text" maxLength="41">Chess notation support</string>

--- a/AnkiDroid/src/main/res/values/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values/10-preferences.xml
@@ -27,6 +27,8 @@
         name="pref_summary_percentage">%s\%%</string>
     <!-- preferences.xml categories-->
     <string name="pref_cat_general" comment="name of the general preference category" maxLength="41">General</string>
+    <string name="pref_cat_studying" maxLength="41">Studying</string>
+    <string name="pref_cat_system_wide" maxLength="41">System-wide</string>
     <string name="pref_cat_general_summ">General settings</string>
     <string name="pref_cat_reviewing" maxLength="41">Reviewing</string>
     <string name="pref_cat_sync" comment="title of the sync preferences category" maxLength="41">Sync</string>

--- a/AnkiDroid/src/main/res/values/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values/10-preferences.xml
@@ -40,7 +40,6 @@
     <string name="pref_cat_controls" maxLength="41">Controls</string>
     <string name="pref_cat_advanced" maxLength="41">Advanced</string>
     <string name="pref_cat_advanced_summ">Optimization and experimental features</string>
-    <string name="pref_cat_performance" maxLength="41">Performance</string>
     <string name="pref_cat_workarounds" maxLength="41">Workarounds</string>
     <string name="pref_cat_plugins" maxLength="41">Plugins</string>
 

--- a/AnkiDroid/src/main/res/values/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values/10-preferences.xml
@@ -29,19 +29,16 @@
     <string name="pref_cat_general" comment="name of the general preference category" maxLength="41">General</string>
     <string name="pref_cat_studying" maxLength="41">Studying</string>
     <string name="pref_cat_system_wide" maxLength="41">System-wide</string>
-    <string name="pref_cat_general_summ">General settings</string>
     <string name="pref_cat_reviewing" maxLength="41">Reviewing</string>
     <string name="pref_cat_sync" comment="title of the sync preferences category" maxLength="41">Sync</string>
     <string name="pref_cat_scheduling" maxLength="41">Scheduling</string>
     <string name="pref_cat_whiteboard" maxLength="41">Whiteboard</string>
     <string name="pref_cat_appearance" maxLength="41">Appearance</string>
-    <string name="pref_cat_appearance_summ">Change themes and default font</string>
     <string name="pref_cat_themes" maxLength="41">Themes</string>
     <string name="pref_cat_fonts" maxLength="41">Fonts</string>
     <string name="pref_cat_gestures" maxLength="41">Gestures</string>
     <string name="pref_cat_controls" maxLength="41">Controls</string>
     <string name="pref_cat_advanced" maxLength="41">Advanced</string>
-    <string name="pref_cat_advanced_summ">Optimization and experimental features</string>
     <string name="pref_cat_workarounds" maxLength="41">Workarounds</string>
     <string name="pref_cat_plugins" maxLength="41">Plugins</string>
 

--- a/AnkiDroid/src/main/res/values/constants.xml
+++ b/AnkiDroid/src/main/res/values/constants.xml
@@ -160,7 +160,6 @@
     <string name="link_ankidroid_development_guide">https://github.com/ankidroid/Anki-Android/wiki/Development-Guide</string>
     <string name="link_ankidroid_faq">https://github.com/ankidroid/Anki-Android/wiki/FAQ</string>
     <string name="link_opencollective_donate">https://opencollective.com/ankidroid/contribute</string>
-    <string name="link_anki_2_scheduler">https://faqs.ankiweb.net/the-anki-2.1-scheduler.html</string>
     <string name="link_ankiweb_docs_cloze_deletion">https://docs.ankiweb.net/editing.html#cloze-deletion</string>
     <string name="link_distributions">https://apps.ankiweb.net/#download</string>
     <string name="link_ankiweb_lost_email_instructions">https://github.com/ankidroid/Anki-Android/wiki/FAQ#forgotten-ankiweb-email-instructions</string>

--- a/AnkiDroid/src/main/res/xml/preference_headers.xml
+++ b/AnkiDroid/src/main/res/xml/preference_headers.xml
@@ -22,7 +22,6 @@
     <!--  General Preferences -->
     <Preference
         android:fragment="com.ichi2.anki.preferences.GeneralSettingsFragment"
-        android:summary="@string/pref_cat_general_summ"
         android:title="@string/pref_cat_general"
         android:icon="@drawable/ic_settings_black"
         android:key="@string/pref_general_screen_key">
@@ -56,7 +55,6 @@
     <Preference
         android:fragment="com.ichi2.anki.preferences.AppearanceSettingsFragment"
         android:key="@string/pref_appearance_screen_key"
-        android:summary="@string/pref_cat_appearance_summ"
         android:title="@string/pref_cat_appearance"
         android:icon="@drawable/ic_color_lens_white_24dp">
     </Preference>
@@ -81,7 +79,6 @@
     <Preference
         android:fragment="com.ichi2.anki.preferences.AdvancedSettingsFragment"
         android:key="@string/pref_advanced_screen_key"
-        android:summary="@string/pref_cat_advanced_summ"
         android:title="@string/pref_cat_advanced"
         android:icon="@drawable/ic_tune_white">
     </Preference>

--- a/AnkiDroid/src/main/res/xml/preferences_accessibility.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_accessibility.xml
@@ -46,4 +46,12 @@
         android:defaultValue="false"
         android:summary="@string/show_large_answer_buttons_summ"
         android:title="@string/show_large_answer_buttons"/>
+    <com.ichi2.preferences.SeekBarPreferenceCompat
+        android:defaultValue="100"
+        android:key="@string/pref_card_browser_font_scale_key"
+        android:max="200"
+        android:text=" %"
+        android:title="@string/card_browser_font_size"
+        app:interval="10"
+        app:min="10" />
 </PreferenceScreen>

--- a/AnkiDroid/src/main/res/xml/preferences_advanced.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_advanced.xml
@@ -38,6 +38,19 @@
             app1:useSimpleSummaryProvider="true"
             app:min="0"
             app:max="99" />
+        <PreferenceCategory android:title="@string/statistics">
+            <ListPreference
+                android:entries="@array/stats_default_deck_labels"
+                android:entryValues="@array/stats_default_deck_values"
+                android:key="@string/stats_default_deck_key"
+                android:title="@string/stats_default_deck_title"
+                android:defaultValue="current"
+                app1:useSimpleSummaryProvider="true"/>
+            <Preference
+                android:key="@string/pref_advanced_statistics_key"
+                android:title="@string/advanced_statistics_title"
+                android:fragment="com.ichi2.anki.preferences.AdvancedStatisticsSettingsFragment" />
+        </PreferenceCategory>
         <PreferenceCategory
             android:key="@string/pref_cat_workarounds_key"
             android:title="@string/pref_cat_workarounds" >
@@ -133,16 +146,5 @@
                 android:key="@string/double_scrolling_gap_key"
                 android:summary="@string/double_scrolling_gap_summ"
                 android:title="@string/double_scrolling_gap" />
-            <ListPreference
-                android:entries="@array/stats_default_deck_labels"
-                android:entryValues="@array/stats_default_deck_values"
-                android:key="@string/stats_default_deck_key"
-                android:title="@string/stats_default_deck_title"
-                android:defaultValue="current"
-                app1:useSimpleSummaryProvider="true"/>
-            <Preference
-                android:key="@string/pref_advanced_statistics_key"
-                android:title="@string/advanced_statistics_title"
-                android:fragment="com.ichi2.anki.preferences.AdvancedStatisticsSettingsFragment" />
         </PreferenceCategory>
 </PreferenceScreen>

--- a/AnkiDroid/src/main/res/xml/preferences_advanced.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_advanced.xml
@@ -90,11 +90,6 @@
                 android:summary="@string/type_in_answer_focus_summ"
                 android:dependency="@string/use_input_tag_key"
                 android:title="@string/type_in_answer_focus" />
-            <SwitchPreference
-                android:defaultValue="false"
-                android:key="@string/exit_via_double_tap_back_key"
-                android:summary="@string/exit_via_double_tap_back_summ"
-                android:title="@string/exit_via_double_tap_back" />
             <!-- #9639 - allow all files in media selection dialog - .opus is application/octet-stream
             in older versions of Android (fixed between API 26 and API 30)
              We don't want to allow this by default, but we want an override -->

--- a/AnkiDroid/src/main/res/xml/preferences_advanced.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_advanced.xml
@@ -32,15 +32,13 @@
             android:key="@string/pref_ankidroid_directory_key"
             android:title="@string/col_path"
             app1:useSimpleSummaryProvider="true"/>
-        <PreferenceCategory android:title="@string/pref_cat_performance" >
-            <com.ichi2.preferences.IncrementerNumberRangePreferenceCompat
-                android:defaultValue="8"
-                android:key="@string/pref_backup_max_key"
-                android:title="@string/pref_backup_max"
-                app1:useSimpleSummaryProvider="true"
-                app:min="0"
-                app:max="99" />
-        </PreferenceCategory>
+        <com.ichi2.preferences.IncrementerNumberRangePreferenceCompat
+            android:defaultValue="8"
+            android:key="@string/pref_backup_max_key"
+            android:title="@string/pref_backup_max"
+            app1:useSimpleSummaryProvider="true"
+            app:min="0"
+            app:max="99" />
         <PreferenceCategory
             android:key="@string/pref_cat_workarounds_key"
             android:title="@string/pref_cat_workarounds" >

--- a/AnkiDroid/src/main/res/xml/preferences_advanced.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_advanced.xml
@@ -25,7 +25,6 @@
     xmlns:app="http://arbitrary.app.namespace/com.ichi2.anki"
     xmlns:app1="http://schemas.android.com/apk/res-auto"
     android:title="@string/pref_cat_advanced"
-    android:summary="@string/pref_cat_advanced_summ"
     android:key="@string/pref_advanced_screen_key">
         <EditTextPreference
             android:defaultValue="/sdcard/AnkiDroid"

--- a/AnkiDroid/src/main/res/xml/preferences_advanced.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_advanced.xml
@@ -38,6 +38,30 @@
             app1:useSimpleSummaryProvider="true"
             app:min="0"
             app:max="99" />
+        <SwitchPreference
+            android:defaultValue="false"
+            android:key="@string/tts_key"
+            android:summary="@string/tts_summ"
+            android:title="@string/tts" />
+        <Preference
+            android:summary="@string/reset_languages_summ"
+            android:title="@string/reset_languages"
+            android:key="@string/pref_reset_languages_key" />
+        <SwitchPreference
+            android:defaultValue="false"
+            android:key="@string/convert_fen_text_key"
+            android:summary="@string/convert_fen_text_summ"
+            android:title="@string/convert_fen_text" />
+        <SwitchPreference
+            android:defaultValue="false"
+            android:key="@string/more_scrolling_buttons_key"
+            android:summary="@string/more_scrolling_buttons_summ"
+            android:title="@string/more_scrolling_buttons" />
+        <SwitchPreference
+            android:defaultValue="false"
+            android:key="@string/double_scrolling_gap_key"
+            android:summary="@string/double_scrolling_gap_summ"
+            android:title="@string/double_scrolling_gap" />
         <PreferenceCategory android:title="@string/statistics">
             <ListPreference
                 android:entries="@array/stats_default_deck_labels"
@@ -122,29 +146,5 @@
                 android:summary="@string/thirdparty_apps_summary"
                 android:title="@string/thirdparty_apps_title">
             </Preference>
-            <SwitchPreference
-                android:defaultValue="false"
-                android:key="@string/tts_key"
-                android:summary="@string/tts_summ"
-                android:title="@string/tts" />
-            <Preference
-                android:summary="@string/reset_languages_summ"
-                android:title="@string/reset_languages"
-                android:key="@string/pref_reset_languages_key" />
-            <SwitchPreference
-                android:defaultValue="false"
-                android:key="@string/convert_fen_text_key"
-                android:summary="@string/convert_fen_text_summ"
-                android:title="@string/convert_fen_text" />
-            <SwitchPreference
-                android:defaultValue="false"
-                android:key="@string/more_scrolling_buttons_key"
-                android:summary="@string/more_scrolling_buttons_summ"
-                android:title="@string/more_scrolling_buttons" />
-            <SwitchPreference
-                android:defaultValue="false"
-                android:key="@string/double_scrolling_gap_key"
-                android:summary="@string/double_scrolling_gap_summ"
-                android:title="@string/double_scrolling_gap" />
         </PreferenceCategory>
 </PreferenceScreen>

--- a/AnkiDroid/src/main/res/xml/preferences_advanced.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_advanced.xml
@@ -152,15 +152,5 @@
                 android:key="@string/pref_advanced_statistics_key"
                 android:title="@string/advanced_statistics_title"
                 android:fragment="com.ichi2.anki.preferences.AdvancedStatisticsSettingsFragment" />
-            <!-- Title and summary are variable, handled in string:
-            card_browser_enable_external_context_menu -->
-            <SwitchPreference
-                android:id="@+id/card_browser_external_context_menu"
-                android:defaultValue="false"
-                android:key="@string/card_browser_external_context_menu_key"/>
-            <SwitchPreference
-                android:id="@+id/anki_card_external_context_menu"
-                android:defaultValue="true"
-                android:key="@string/anki_card_external_context_menu_key"/>
         </PreferenceCategory>
 </PreferenceScreen>

--- a/AnkiDroid/src/main/res/xml/preferences_advanced.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_advanced.xml
@@ -152,11 +152,6 @@
                 android:key="@string/pref_advanced_statistics_key"
                 android:title="@string/advanced_statistics_title"
                 android:fragment="com.ichi2.anki.preferences.AdvancedStatisticsSettingsFragment" />
-            <SwitchPreference
-                android:defaultValue="false"
-                android:key="@string/html_javascript_debugging_key"
-                android:summary="@string/html_javascript_debugging_summ"
-                android:title="@string/html_javascript_debugging"/>
             <!-- Title and summary are variable, handled in string:
             card_browser_enable_external_context_menu -->
             <SwitchPreference

--- a/AnkiDroid/src/main/res/xml/preferences_appearance.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_appearance.xml
@@ -123,14 +123,6 @@
             android:key="@string/pref_browser_and_editor_font_key"
             android:title="@string/pref_browser_editor_font"
             app1:useSimpleSummaryProvider="true"/>
-        <com.ichi2.preferences.SeekBarPreferenceCompat
-            android:defaultValue="100"
-            android:key="@string/pref_card_browser_font_scale_key"
-            android:max="200"
-            android:text=" %"
-            android:title="@string/card_browser_font_size"
-            app:interval="10"
-            app:min="10" />
     </PreferenceCategory>
     <PreferenceCategory android:title="@string/card_browser">
         <SwitchPreference

--- a/AnkiDroid/src/main/res/xml/preferences_appearance.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_appearance.xml
@@ -25,8 +25,7 @@
     xmlns:app="http://arbitrary.app.namespace/com.ichi2.anki"
     xmlns:app1="http://schemas.android.com/apk/res-auto"
         android:title="@string/pref_cat_appearance"
-        android:key="@string/pref_appearance_screen_key"
-        android:summary="@string/pref_cat_appearance_summ">
+        android:key="@string/pref_appearance_screen_key">
     <PreferenceCategory android:title="@string/pref_cat_themes" >
         <ListPreference
             android:defaultValue="0"

--- a/AnkiDroid/src/main/res/xml/preferences_dev_options.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_dev_options.xml
@@ -20,6 +20,11 @@
         android:title="@string/dev_options_enabled_pref"
         android:key="@string/dev_options_enabled_by_user_key"
         android:defaultValue="true"/>
+    <SwitchPreference
+        android:defaultValue="false"
+        android:key="@string/html_javascript_debugging_key"
+        android:summary="@string/html_javascript_debugging_summ"
+        android:title="@string/html_javascript_debugging"/>
     <Preference
         android:title="Trigger test crash"
         android:summary="Touch here for an immediate test crash"

--- a/AnkiDroid/src/main/res/xml/preferences_dev_options.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_dev_options.xml
@@ -14,6 +14,10 @@
   ~  You should have received a copy of the GNU General Public License along with
   ~  this program.  If not, see <http://www.gnu.org/licenses/>.
   -->
+<!--
+~ Some strings aren't translated because these preferences are aimed
+~ at developers, who are assumed to speak English.
+-->
 <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
     android:title="@string/pref_cat_dev_options">
     <SwitchPreference

--- a/AnkiDroid/src/main/res/xml/preferences_general.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_general.xml
@@ -56,4 +56,14 @@
             android:key="@string/error_reporting_mode_key"
             android:title="@string/error_reporting_choice"
             app:useSimpleSummaryProvider="true"/>
+        <!-- Title and summary are variable, handled in string:
+            card_browser_enable_external_context_menu -->
+        <SwitchPreference
+            android:id="@+id/anki_card_external_context_menu"
+            android:defaultValue="true"
+            android:key="@string/anki_card_external_context_menu_key"/>
+        <SwitchPreference
+            android:id="@+id/card_browser_external_context_menu"
+            android:defaultValue="false"
+            android:key="@string/card_browser_external_context_menu_key"/>
 </PreferenceScreen>

--- a/AnkiDroid/src/main/res/xml/preferences_general.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_general.xml
@@ -27,16 +27,17 @@
     android:summary="@string/pref_cat_general_summ"
     android:key="@string/pref_general_screen_key">
         <ListPreference
-            android:entries="@array/add_to_cur_labels"
-            android:entryValues="@array/add_to_cur_values"
-            android:key="@string/deck_for_new_cards_key"
-            android:title="@string/use_current"
-            app:useSimpleSummaryProvider="true"/>
-        <ListPreference
             android:defaultValue="@string/empty_string"
             android:key="@string/pref_language_key"
             android:icon="@drawable/ic_language_black_24dp"
             android:title="@string/language"
+            app:useSimpleSummaryProvider="true"/>
+        <ListPreference
+            android:defaultValue="2"
+            android:entries="@array/error_reporting_choice_labels"
+            android:entryValues="@array/error_reporting_choice_values"
+            android:key="@string/error_reporting_mode_key"
+            android:title="@string/error_reporting_choice"
             app:useSimpleSummaryProvider="true"/>
         <SwitchPreference
             android:defaultValue="false"
@@ -49,26 +50,29 @@
             android:summary="@string/paste_as_png_summary"
             android:maxLength="41"
             android:key="@string/paste_png_key"/>
-        <ListPreference
-            android:defaultValue="2"
-            android:entries="@array/error_reporting_choice_labels"
-            android:entryValues="@array/error_reporting_choice_values"
-            android:key="@string/error_reporting_mode_key"
-            android:title="@string/error_reporting_choice"
-            app:useSimpleSummaryProvider="true"/>
-        <SwitchPreference
-            android:defaultValue="false"
-            android:key="@string/exit_via_double_tap_back_key"
-            android:summary="@string/exit_via_double_tap_back_summ"
-            android:title="@string/exit_via_double_tap_back" />
+        <PreferenceCategory android:title="@string/pref_cat_studying">
+            <ListPreference
+                android:entries="@array/add_to_cur_labels"
+                android:entryValues="@array/add_to_cur_values"
+                android:key="@string/deck_for_new_cards_key"
+                android:title="@string/use_current"
+                app:useSimpleSummaryProvider="true"/>
+            <SwitchPreference
+                android:defaultValue="false"
+                android:key="@string/exit_via_double_tap_back_key"
+                android:summary="@string/exit_via_double_tap_back_summ"
+                android:title="@string/exit_via_double_tap_back" />
+        </PreferenceCategory>
         <!-- Title and summary are variable, handled in string:
             card_browser_enable_external_context_menu -->
-        <SwitchPreference
-            android:id="@+id/anki_card_external_context_menu"
-            android:defaultValue="true"
-            android:key="@string/anki_card_external_context_menu_key"/>
-        <SwitchPreference
-            android:id="@+id/card_browser_external_context_menu"
-            android:defaultValue="false"
-            android:key="@string/card_browser_external_context_menu_key"/>
+        <PreferenceCategory android:title="@string/pref_cat_system_wide">
+            <SwitchPreference
+                android:id="@+id/anki_card_external_context_menu"
+                android:defaultValue="true"
+                android:key="@string/anki_card_external_context_menu_key"/>
+            <SwitchPreference
+                android:id="@+id/card_browser_external_context_menu"
+                android:defaultValue="false"
+                android:key="@string/card_browser_external_context_menu_key"/>
+        </PreferenceCategory>
 </PreferenceScreen>

--- a/AnkiDroid/src/main/res/xml/preferences_general.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_general.xml
@@ -23,6 +23,7 @@
 <!--  General Preferences -->
 <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:title="@string/pref_cat_general"
     android:summary="@string/pref_cat_general_summ"
     android:key="@string/pref_general_screen_key">
@@ -69,10 +70,14 @@
             <SwitchPreference
                 android:id="@+id/anki_card_external_context_menu"
                 android:defaultValue="true"
-                android:key="@string/anki_card_external_context_menu_key"/>
+                android:key="@string/anki_card_external_context_menu_key"
+                tools:title="‘Anki Card’ Menu"
+                tools:summary="Enables the ‘Anki Card’ context menu globally"/>
             <SwitchPreference
                 android:id="@+id/card_browser_external_context_menu"
                 android:defaultValue="false"
-                android:key="@string/card_browser_external_context_menu_key"/>
+                android:key="@string/card_browser_external_context_menu_key"
+                tools:title="‘Card Browser’ Menu"
+                tools:summary="Enables the ‘Card Browser’ context menu globally"/>
         </PreferenceCategory>
 </PreferenceScreen>

--- a/AnkiDroid/src/main/res/xml/preferences_general.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_general.xml
@@ -56,6 +56,11 @@
             android:key="@string/error_reporting_mode_key"
             android:title="@string/error_reporting_choice"
             app:useSimpleSummaryProvider="true"/>
+        <SwitchPreference
+            android:defaultValue="false"
+            android:key="@string/exit_via_double_tap_back_key"
+            android:summary="@string/exit_via_double_tap_back_summ"
+            android:title="@string/exit_via_double_tap_back" />
         <!-- Title and summary are variable, handled in string:
             card_browser_enable_external_context_menu -->
         <SwitchPreference

--- a/AnkiDroid/src/main/res/xml/preferences_general.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_general.xml
@@ -25,7 +25,6 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:title="@string/pref_cat_general"
-    android:summary="@string/pref_cat_general_summ"
     android:key="@string/pref_general_screen_key">
         <ListPreference
             android:defaultValue="@string/empty_string"


### PR DESCRIPTION
## Purpose / Description
~~On top of #11919~~

This is the last preferences reorganization PR I want to do for GSoC. Previously I'd thought about moving all the preferences from Advanced to the other screens, but after thinking a while, I've come to the conclusion that the it's best to keep it as a bucket of "Things most users won't need or are really advanced, therefore they shouldn't dispute space with the relevant ones".

As an example we have `Simple typed answer formatting`, only useful if typed answer is used AND the typed answer uses Polytonic Greek characters AND older webviews are being used (see #7901 if you are curious).

Other preferences there will be gone some day (e.g. `Replace newlines with HTML` when the visual editor is implemented). Others can be moved to the activities they impact (e.g. `Default deck when opening statistics` being moved to the statistics screen). And others need analytics (#11642) to evaluate if they can be discarded.

So, overall there isn't anything else I want to move right now.


## Approach
- Moved preferences:
    - `HTML/Javascript debug`: Advanced → Developer options
    - `Card browser` and `Anki card` context menus, and `Press back twite to go back/exit`: Advanced → General
    - `Card browser font scaling`: Appearance → Accessibility
- Removed `V2 scheduler` preference
    - 142f789a7bddaf46fbc4f9bd7e32defd3e4ae84d forces/requires/prompts to use the V2 scheduler when the user tries to study, so this preference is no longer necessary
- Build summaries for the remaining categories (General, Appearance and Advanced)
- Some cleanups around HeaderFragment.kt

## How Has This Been Tested?

Opened the app and opened the preferences categories to see if I get any crash

https://user-images.githubusercontent.com/69634269/181976491-8194e168-c999-48b6-a33e-c46ec44dd99e.mp4

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [X] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
