### PR TITLE
NF: remove unchecked cast when possible

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -2091,7 +2091,7 @@ open class DeckPicker :
                 context.showCollectionErrorDialog()
                 return
             }
-            context.mDueTree = result.map { x -> x.unsafeCastToType(AbstractDeckTreeNode::class.java) }
+            context.mDueTree = result.map { x -> x.unsafeCastToType() }
             context.renderPage()
             // Update the mini statistics bar as well
             deckPicker?.launchCatchingTask {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/CardBrowserMySearchesDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/CardBrowserMySearchesDialog.kt
@@ -30,7 +30,6 @@ class CardBrowserMySearchesDialog : AnalyticsDialogFragment() {
         fun onSaveSearch(searchName: String?, searchTerms: String?)
     }
 
-    @Suppress("UNCHECKED_CAST")
     @SuppressLint("CheckResult")
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
         super.onCreate(savedInstanceState)

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/TreeNode.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/TreeNode.kt
@@ -35,12 +35,5 @@ data class TreeNode<T : Any>(val value: T) {
         }
     }
 
-    /** UNSAFE. Casts the tree to [U] */
-    @KotlinCleanup("should be removable after DeckPicker is converted")
-    @Suppress("UNUSED_PARAMETER")
-    fun <U : Any> unsafeCastToType(unused: Class<U>): TreeNode<U> {
-        return unsafeCastToType()
-    }
-
     override fun toString(): String = "$value, $children"
 }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sync/RemoteMediaServer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sync/RemoteMediaServer.kt
@@ -164,10 +164,9 @@ class RemoteMediaServer(
      * @return The "data" element from the HTTP response from the server. The type of object returned is determined by
      * returnType.
      */
-    @Suppress("UNCHECKED_CAST")
     @Throws(MediaSyncException::class)
     // NOTE: the original name of the method was _dataOnly which followed upstream naming
-    private fun <T> dataOnly(resp: JSONObject, returnType: Class<T>): T {
+    private inline fun <reified T> dataOnly(resp: JSONObject, returnType: Class<T>): T {
         if (!TextUtils.isEmpty(resp.optString("err"))) {
             val err = resp.getString("err")
             col?.log("error returned: $err")

--- a/AnkiDroid/src/main/java/com/ichi2/utils/ExtendedFragmentFactory.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/ExtendedFragmentFactory.kt
@@ -62,8 +62,7 @@ abstract class ExtendedFragmentFactory : FragmentFactory {
      * Attaches the factory to an activity by setting the current activity fragment factory as the base factory
      * and updating the activity with the extended factory
      */
-    fun <F : ExtendedFragmentFactory?> attachToActivity(activity: AppCompatActivity): F {
-        @Suppress("UNCHECKED_CAST")
+    inline fun <reified F : ExtendedFragmentFactory?> attachToActivity(activity: AppCompatActivity): F {
         return attachToFragmentManager<ExtendedFragmentFactory>(activity.supportFragmentManager) as F
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/utils/FragmentFactoryUtils.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/FragmentFactoryUtils.kt
@@ -24,8 +24,7 @@ object FragmentFactoryUtils {
      * A convenience util method that instantiate a fragment using the passed activity [FragmentFactory]
      */
     @JvmStatic
-    @Suppress("UNCHECKED_CAST")
-    fun <F : Fragment?> instantiate(activity: FragmentActivity, cls: Class<F>): F {
+    inline fun <reified F : Fragment?> instantiate(activity: FragmentActivity, cls: Class<F>): F {
         val factory = activity.supportFragmentManager.fragmentFactory
         return factory.instantiate(activity.classLoader, cls.name) as F
     }

--- a/AnkiDroid/src/main/java/com/ichi2/utils/UniqueArrayList.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/UniqueArrayList.kt
@@ -111,7 +111,6 @@ private constructor(
      *
      * @see Collections.sort
      */
-    @Suppress("UNCHECKED_CAST")
     @KotlinCleanup("sortWith")
     override fun sort(c: Comparator<in E>?) {
         sortOverride(c)

--- a/AnkiDroid/src/test/java/com/ichi2/testutils/RecyclerViewUtils.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/testutils/RecyclerViewUtils.kt
@@ -18,8 +18,7 @@ package com.ichi2.testutils
 import androidx.recyclerview.widget.RecyclerView
 
 object RecyclerViewUtils {
-    @Suppress("UNCHECKED_CAST")
-    fun <VH : RecyclerView.ViewHolder?> viewHolderAt(recyclerView: RecyclerView, position: Int): VH {
+    inline fun <reified VH : RecyclerView.ViewHolder?> viewHolderAt(recyclerView: RecyclerView, position: Int): VH {
         return recyclerView.findViewHolderForAdapterPosition(position) as VH
     }
 }


### PR DESCRIPTION
This can be done simply by reifying types, which itself requires inlining the
function.

This can't be done when the uncheckd is due to the fact that we cast to a type
with type parameters, for recursive function, and when the function has state effect.
