### PR TITLE
NF: uses `get` instead of `[]` on AsyncTask

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/async/SingleTaskManager.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/async/SingleTaskManager.kt
@@ -115,7 +115,7 @@ class SingleTaskManager : TaskManager() {
                     mLatestInstance!!.task.javaClass
                 )
                 if (timeoutSeconds != null) {
-                    mLatestInstance!![timeoutSeconds.toLong(), TimeUnit.SECONDS]
+                    mLatestInstance!!.get(timeoutSeconds.toLong(), TimeUnit.SECONDS)
                 } else {
                     mLatestInstance!!.get()
                 }


### PR DESCRIPTION
Using the array syntax is clearly wrong. It seems to indicate that the time is a
parameter of what we want to get, which is absolutely not the case.
