### PR TITLE
[GSoC] Add `Use new backend` (persistent) preference

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.java
@@ -173,6 +173,15 @@ public class AnkiDroidApp extends Application {
         // Get preferences
         SharedPreferences preferences = getSharedPrefs(this);
 
+        // TODO remove the following if-block once AnkiDroid uses the new schema by default
+        if (BuildConfig.LEGACY_SCHEMA) {
+            boolean isNewSchemaEnabledByPref = preferences.getBoolean(getString(R.string.pref_rust_backend_key), false);
+            if (isNewSchemaEnabledByPref) {
+                Timber.i("New schema enabled by preference");
+                BackendFactory.setDefaultLegacySchema(false);
+            }
+        }
+
         CrashReportService.initialize(this);
 
         if (BuildConfig.DEBUG) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/AdvancedSettingsFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/AdvancedSettingsFragment.kt
@@ -121,7 +121,8 @@ class AdvancedSettingsFragment : SettingsFragment() {
             setOnPreferenceChangeListener { newValue ->
                 if (newValue == true) {
                     confirmExperimentalChange(
-                        R.string.use_rust_backend_title, R.string.use_rust_backend_summary,
+                        R.string.use_rust_backend_title,
+                        R.string.use_rust_backend_warning,
                         onCancel = { isChecked = false },
                         onConfirm = {
                             BackendFactory.defaultLegacySchema = false

--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/DevOptionsFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/DevOptionsFragment.kt
@@ -22,7 +22,6 @@ import androidx.preference.SwitchPreference
 import com.afollestad.materialdialogs.MaterialDialog
 import com.ichi2.anki.*
 import com.ichi2.anki.analytics.UsageAnalytics
-import net.ankiweb.rsdroid.BackendFactory
 import timber.log.Timber
 
 /**
@@ -73,15 +72,6 @@ class DevOptionsFragment : SettingsFragment() {
         requirePreference<Preference>(getString(R.string.pref_reset_onboarding_key)).setOnPreferenceClickListener {
             OnboardingUtils.reset(requireContext())
             true
-        }
-        // Use V16 Backend
-        requirePreference<Preference>(getString(R.string.pref_rust_backend_key)).apply {
-            setDefaultValue(!BackendFactory.defaultLegacySchema)
-            setOnPreferenceClickListener {
-                BackendFactory.defaultLegacySchema = false
-                (requireActivity() as Preferences).restartWithNewDeckPicker()
-                true
-            }
         }
         // Use scoped storage
         requirePreference<Preference>(getString(R.string.pref_scoped_storage_key)).apply {

--- a/AnkiDroid/src/main/res/values/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values/10-preferences.xml
@@ -333,6 +333,12 @@ this formatter is used if the bind only applies to both the question and the ans
     Keys cannot be translated yet.">Remove ‘%s’</string>
     <string name="bindings_already_bound">Already bound to ‘%s’</string>
 
+    <!-- Advanced -->
+    <string name="pref_cat_experimental" maxLength="41">Experimental</string>
+    <string name="experimental_pref_confirmation" maxLength="41">Enable ‘%s’</string>
+    <string name="use_rust_backend_title" maxLength="41">Use the new backend</string>
+    <string name="use_rust_backend_summary">Enables newer Anki features, such as the v3 scheduler\nUNSTABLE. Do not use on a collection you care about. NOT reverted on app close</string>
+
     <!-- Developer options -->
     <string name="pref_cat_dev_options" maxLength="41">Developer options</string>
     <string name="dev_options_enabled_pref" maxLength="41">Enable developer options</string>

--- a/AnkiDroid/src/main/res/values/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values/10-preferences.xml
@@ -338,6 +338,7 @@ this formatter is used if the bind only applies to both the question and the ans
     <string name="experimental_pref_confirmation" maxLength="41">Enable ‘%s’</string>
     <string name="use_rust_backend_title" maxLength="41">Use the new backend</string>
     <string name="use_rust_backend_summary">Enables newer Anki features, such as the v3 scheduler\nUNSTABLE. Do not use on a collection you care about. NOT reverted on app close</string>
+    <string name="use_rust_backend_warning">There is a chance this could corrupt your installation completely, requiring app uninstall and deletion of the AnkiDroid folder, and has a chance of propagating corruption via sync to AnkiWeb.\n\nWe welcome the testing, but please make sure you have a valid non-AnkiWeb backup.</string>
 
     <!-- Developer options -->
     <string name="pref_cat_dev_options" maxLength="41">Developer options</string>

--- a/AnkiDroid/src/main/res/xml/preferences_advanced.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_advanced.xml
@@ -147,4 +147,12 @@
                 android:title="@string/thirdparty_apps_title">
             </Preference>
         </PreferenceCategory>
+        <PreferenceCategory
+            android:title="@string/pref_cat_experimental">
+            <SwitchPreference
+                android:key="@string/pref_rust_backend_key"
+                android:title="@string/use_rust_backend_title"
+                android:summary="@string/use_rust_backend_summary"
+                android:defaultValue="false"/>
+        </PreferenceCategory>
 </PreferenceScreen>

--- a/AnkiDroid/src/main/res/xml/preferences_dev_options.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_dev_options.xml
@@ -47,15 +47,11 @@
         android:key="@string/pref_show_onboarding_key"
         android:defaultValue="false"/>
     <Preference
-        android:title="@string/reset_onboarding"
-        android:summary="@string/reset_onboarding_desc"
-        android:key="@string/pref_reset_onboarding_key"/>
-    <Preference
-        android:title="Use V16 Backend"
-        android:summary="UNSTABLE. DO NOT USE ON A COLLECTION YOU CARE ABOUT. REVERTED ON APP CLOSE"
-        android:key="@string/pref_rust_backend_key"/>
-    <Preference
         android:title="Enable Scoped Storage"
         android:summary="UNSTABLE. DO NOT USE ON A COLLECTION YOU CARE ABOUT. REVERTED ON APP CLOSE"
         android:key="@string/pref_scoped_storage_key"/>
+    <Preference
+        android:title="@string/reset_onboarding"
+        android:summary="@string/reset_onboarding_desc"
+        android:key="@string/pref_reset_onboarding_key"/>
 </PreferenceScreen>


### PR DESCRIPTION
## Purpose / Description
- The V16 pref is useful to testing in case the dev forgot to set `legacy_schema=false` on `local.properties` while not having to re-enable every time the app is reopened.

## Fixes
A tiny bit of #6772

## Approach
On the commits

## How Has This Been Tested?

Emulator SDK 25

[untitled.webm](https://user-images.githubusercontent.com/69634269/183134062-0567319e-86a3-4bf0-ad59-d61f066f9273.webm)

(not so sure why Android Studio recording is getting dark, maybe I should buy a faster computer)

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
