### PR TITLE
NF: uses NoteId instead of Long

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardInfo.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardInfo.kt
@@ -219,7 +219,7 @@ class CardInfo : AnkiActivity() {
         val cardType: String?,
         val noteType: String,
         val deckName: String,
-        val noteId: Long,
+        val noteId: NoteId,
         val entries: List<RevLogEntry>
     ) {
         val due: String

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.kt
@@ -73,7 +73,7 @@ open class CardTemplateEditor : AnkiActivity(), DeckSelectionListener {
         private set
     private var mFieldNames: List<String>? = null
     private var mModelId: Long = 0
-    private var mNoteId: Long = 0
+    private var mNoteId: NoteId = 0
 
     // the position of the cursor in the editor view
     private var tabToCursorPosition: HashMap<Int, Int?>? = null
@@ -952,7 +952,7 @@ open class CardTemplateEditor : AnkiActivity(), DeckSelectionListener {
         companion object {
             fun newInstance(
                 cardIndex: Int,
-                noteId: Long,
+                noteId: NoteId,
                 cursorPosition: Int,
                 viewId: Int
             ): CardTemplateFragment {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/provider/CardContentProvider.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/provider/CardContentProvider.kt
@@ -1253,7 +1253,7 @@ class CardContentProvider : ContentProvider() {
         return getCard(noteId, ord, col)
     }
 
-    private fun getCard(noteId: Long, ord: Int, col: Collection): Card {
+    private fun getCard(noteId: NoteId, ord: Int, col: Collection): Card {
         val currentNote = col.getNote(noteId)
         var currentCard: Card? = null
         for (card in currentNote.cards()) {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Card.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Card.kt
@@ -79,7 +79,7 @@ open class Card : Cloneable {
     // BEGIN SQL table entries
     @set:VisibleForTesting
     var id: Long
-    var nid: Long = 0
+    var nid: NoteId = 0
     var did: DeckId = 0
     var ord = 0
     var mod: Long = 0

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.kt
@@ -775,7 +775,7 @@ open class Collection(
 
     @JvmOverloads
     fun <T> genCards(
-        nid: Long,
+        nid: NoteId,
         model: Model,
         task: T? = null
     ): ArrayList<Long>? where T : ProgressSender<Int?>?, T : CancelListener? {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/ModelManager.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/ModelManager.kt
@@ -183,7 +183,7 @@ abstract class ModelManager(protected val col: Collection) {
      * @throws ConfirmModSchemaException
      */
     @Throws(ConfirmModSchemaException::class)
-    abstract fun change(m: Model, nid: Long, newModel: Model, fmap: Map<Int, Int?>?, cmap: Map<Int, Int?>?)
+    abstract fun change(m: Model, nid: NoteId, newModel: Model, fmap: Map<Int, Int?>?, cmap: Map<Int, Int?>?)
 
     /*
       Schema hash ***********************************************************************************************

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/ModelsV16.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/ModelsV16.kt
@@ -562,7 +562,7 @@ class ModelsV16(col: CollectionV16) : ModelManager(col) {
 
     override fun change(
         m: NoteType,
-        nid: Long,
+        nid: NoteId,
         newModel: NoteType,
         fmap: Map<Int, Int?>?,
         cmap: Map<Int, Int?>?

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/PythonTypes.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/PythonTypes.kt
@@ -26,10 +26,9 @@ import java.util.*
 internal typealias Dict<K, V> = HashMap<K, V>
 internal typealias ImmutableList<T> = List<T>
 internal typealias str = String
-/**
- */
 internal typealias DeckId = Long
 internal typealias dcid = Long
+internal typealias NoteId = Long
 internal typealias ntid = Long
 internal typealias bool = Boolean
 internal typealias Tuple<T1, T2> = Pair<T1, T2>

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/importer/Anki2Importer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/importer/Anki2Importer.kt
@@ -55,7 +55,7 @@ open class Anki2Importer(col: Collection?, file: String) : Importer(col!!, file)
     private val mAllowUpdate: Boolean
     private var mDupeOnSchemaChange: Boolean
 
-    private class NoteTriple(val nid: Long, val mod: Long, val mid: Long)
+    private class NoteTriple(val nid: NoteId, val mod: Long, val mid: Long)
 
     private var mNotes: MutableMap<String, NoteTriple>? = null
     private var mDecks: MutableMap<Long, Long>? = null

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/importer/NoteImporter.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/importer/NoteImporter.kt
@@ -399,7 +399,7 @@ open class NoteImporter(col: com.ichi2.libanki.Collection, file: String) : Impor
         val mLapses = 0
     }
 
-    private class Triple(val nid: Long, val ord: Int, val card: ForeignCard)
+    private class Triple(val nid: NoteId, val ord: Int, val card: ForeignCard)
     companion object {
         /** A magic string used in [this.mMapping] when a csv field should be mapped to the tags of a note  */
         const val TAGS_IDENTIFIER = "_tags"

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/BaseSched.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/BaseSched.kt
@@ -103,7 +103,7 @@ abstract class BaseSched(val col: Collection) {
      * Bury all cards for note until next session.
      * @param nid The id of the targeted note.
      */
-    open fun buryNote(nid: Long) {
+    open fun buryNote(nid: NoteId) {
         col.newBackend.backend.buryOrSuspendCards(
             cardIds = listOf(),
             noteIds = listOf(nid),


### PR DESCRIPTION
It's used upstream. It was defined in notes.py, but since Notes.java may not get
converted, consts is the most relevant place to put it.

Those ones were found by searching for "nodeId: Long", "NoteId: Long" and "nid:
Long".