### PR TITLE
NF: replace Long by CardId

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
@@ -672,7 +672,7 @@ abstract class AbstractFlashcardViewer :
     }
 
     @KotlinCleanup("Use ?:")
-    public override val currentCardId: Long?
+    public override val currentCardId: CardId?
         get() = if (mCurrentCard == null) {
             null
         } else mCurrentCard!!.id

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidJsAPI.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidJsAPI.kt
@@ -37,6 +37,7 @@ import com.ichi2.async.CollectionTask.SearchCards
 import com.ichi2.async.TaskListener
 import com.ichi2.async.TaskManager
 import com.ichi2.libanki.Card
+import com.ichi2.libanki.CardId
 import com.ichi2.libanki.Consts.CARD_QUEUE
 import com.ichi2.libanki.Consts.CARD_TYPE
 import com.ichi2.libanki.Decks
@@ -395,7 +396,7 @@ open class AnkiDroidJsAPI(private val activity: AbstractFlashcardViewer) {
     @JavascriptInterface
     fun ankiSearchCard(query: String?) {
         val intent = Intent(context, CardBrowser::class.java)
-        val currentCardId: Long = currentCard.id
+        val currentCardId: CardId = currentCard.id
         intent.putExtra("currentCard", currentCardId)
         intent.putExtra("search_query", query)
         activity.startActivityForResultWithAnimation(intent, NavigationDrawerActivity.REQUEST_BROWSE_CARDS, ActivityTransitionAnimation.Direction.START)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -162,7 +162,7 @@ open class CardBrowser :
     private var mUndoSnackbar: Snackbar? = null
 
     // card that was clicked (not marked)
-    private var mCurrentCardId: Long = 0
+    private var mCurrentCardId: CardId = 0
     private var mOrder = 0
     private var mOrderAsc = false
     private var mColumn1Index = 0
@@ -245,7 +245,7 @@ open class CardBrowser :
     private val mCheckedCards = Collections.synchronizedSet(LinkedHashSet<CardCache>())
     private var mLastSelectedPosition = 0
     private var mActionBarMenu: Menu? = null
-    private var mOldCardId: Long = 0
+    private var mOldCardId: CardId = 0
     private var mOldCardTopOffset = 0
     private var mShouldRestoreScroll = false
     private var mPostAutoScroll = false
@@ -773,7 +773,7 @@ open class CardBrowser :
 
     /** Opens the note editor for a card.
      * We use the Card ID to specify the preview target  */
-    private fun openNoteEditorForCard(cardId: Long) {
+    private fun openNoteEditorForCard(cardId: CardId) {
         mCurrentCardId = cardId
         sCardBrowserCard = col.getCard(mCurrentCardId)
         // start note editor using the card we just loaded
@@ -1390,7 +1390,7 @@ open class CardBrowser :
         TaskManager.cancelCurrentlyExecutingTask()
     }
 
-    private val reviewerCardId: Long
+    private val reviewerCardId: CardId
         get() = intent.getLongExtra("currentCard", -1)
 
     private fun showEditTagsDialog() {
@@ -1399,7 +1399,7 @@ open class CardBrowser :
         }
         val allTags = col.tags.all()
         val selectedNotes = selectedCardIds
-            .map { cardId: Long? -> col.getCard(cardId!!).note() }
+            .map { cardId: CardId? -> col.getCard(cardId!!).note() }
             .distinct()
         val checkedTags = selectedNotes
             .flatMap { note: Note -> note.tags }
@@ -1555,7 +1555,7 @@ open class CardBrowser :
 
     private fun editSelectedCardsTags(selectedTags: List<String>, indeterminateTags: List<String>) {
         val selectedNotes = selectedCardIds
-            .map { cardId: Long? -> col.getCard(cardId!!).note() }
+            .map { cardId: CardId? -> col.getCard(cardId!!).note() }
             .distinct()
         for (note in selectedNotes) {
             val previousTags: List<String> = note.tags
@@ -2578,7 +2578,7 @@ open class CardBrowser :
     }
 
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)
-    fun getPropertiesForCardId(cardId: Long): CardCache {
+    fun getPropertiesForCardId(cardId: CardId): CardCache {
         return mCards.find { c -> c.id == cardId } ?: throw IllegalStateException(String.format(Locale.US, "Card '%d' not found", cardId))
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardInfo.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardInfo.kt
@@ -47,7 +47,7 @@ class CardInfo : AnkiActivity() {
     @get:VisibleForTesting(otherwise = VisibleForTesting.NONE)
     var model: CardInfoModel? = null
         private set
-    private var mCardId: Long = 0
+    private var mCardId: CardId = 0
     override fun onCreate(savedInstanceState: Bundle?) {
         if (showedActivityFailedScreen(savedInstanceState)) {
             return
@@ -206,7 +206,7 @@ class CardInfo : AnkiActivity() {
     }
 
     class CardInfoModel(
-        val cardId: Long,
+        val cardId: CardId,
         val firstReviewDate: Long?,
         val latestReviewDate: Long?,
         val dues: String,

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NavigationDrawerActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NavigationDrawerActivity.kt
@@ -43,6 +43,7 @@ import com.drakeet.drawer.FullDraggableContainer
 import com.google.android.material.navigation.NavigationView
 import com.ichi2.anim.ActivityTransitionAnimation.Direction.*
 import com.ichi2.anki.dialogs.HelpDialog
+import com.ichi2.libanki.CardId
 import com.ichi2.themes.Themes
 import com.ichi2.utils.HandlerUtils
 import com.ichi2.utils.KotlinCleanup
@@ -328,7 +329,7 @@ abstract class NavigationDrawerActivity :
     }
 
     // Override this to specify a specific card id
-    protected open val currentCardId: Long?
+    protected open val currentCardId: CardId?
         get() = null
 
     protected fun showBackIcon() {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
@@ -1386,7 +1386,7 @@ open class Reviewer : AbstractFlashcardViewer() {
         }
     }
 
-    override val currentCardId: Long?
+    override val currentCardId: CardId?
         get() = mCurrentCard!!.id
 
     override fun onWindowFocusChanged(hasFocus: Boolean) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/OnRenderProcessGoneDelegate.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/OnRenderProcessGoneDelegate.kt
@@ -25,6 +25,7 @@ import com.afollestad.materialdialogs.MaterialDialog
 import com.ichi2.anki.AbstractFlashcardViewer
 import com.ichi2.anki.R
 import com.ichi2.anki.UIUtils.showThemedToast
+import com.ichi2.libanki.CardId
 import timber.log.Timber
 
 /**
@@ -39,7 +40,7 @@ open class OnRenderProcessGoneDelegate(val target: AbstractFlashcardViewer) {
      * Last card that the WebView Renderer crashed on.
      * If we get 2 crashes on the same card, then we likely have an infinite loop and want to exit gracefully.
      */
-    private var mLastCrashingCardId: Long? = null
+    private var mLastCrashingCardId: CardId? = null
 
     /** Fix: #5780 - WebView Renderer OOM crashes reviewer  */
     @RequiresApi(api = Build.VERSION_CODES.O)
@@ -124,7 +125,7 @@ open class OnRenderProcessGoneDelegate(val target: AbstractFlashcardViewer) {
     }
 
     @TargetApi(Build.VERSION_CODES.O)
-    protected open fun displayRenderLoopDialog(currentCardId: Long, detail: RenderProcessGoneDetail) {
+    protected open fun displayRenderLoopDialog(currentCardId: CardId, detail: RenderProcessGoneDetail) {
         val cardInformation = java.lang.Long.toString(currentCardId)
         val res = target.resources
         val errorDetails = if (detail.didCrash()) res.getString(R.string.webview_crash_unknwon_detailed) else res.getString(R.string.webview_crash_oom_details)
@@ -153,7 +154,7 @@ open class OnRenderProcessGoneDelegate(val target: AbstractFlashcardViewer) {
         return !lifecycle.currentState.isAtLeast(Lifecycle.State.STARTED)
     }
 
-    private fun webViewRendererLastCrashedOnCard(cardId: Long): Boolean =
+    private fun webViewRendererLastCrashedOnCard(cardId: CardId): Boolean =
         mLastCrashingCardId != null && mLastCrashingCardId == cardId
 
     private fun canRecoverFromWebViewRendererCrash(): Boolean =

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.kt
@@ -1159,7 +1159,7 @@ open class Collection(
      * Returns hash of id, question, answer.
      */
     fun _renderQA(
-        cid: Long,
+        cid: CardId,
         model: Model,
         did: DeckId,
         ord: Int,
@@ -1172,7 +1172,7 @@ open class Collection(
 
     @RustCleanup("#8951 - Remove FrontSide added to the front")
     fun _renderQA(
-        cid: Long,
+        cid: CardId,
         model: Model,
         did: DeckId,
         ord: Int,

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/PythonTypes.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/PythonTypes.kt
@@ -27,6 +27,7 @@ internal typealias Dict<K, V> = HashMap<K, V>
 internal typealias ImmutableList<T> = List<T>
 internal typealias str = String
 internal typealias DeckId = Long
+internal typealias CardId = Long
 internal typealias dcid = Long
 internal typealias NoteId = Long
 internal typealias ntid = Long

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/CardQueue.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/CardQueue.kt
@@ -17,6 +17,7 @@
 package com.ichi2.libanki.sched
 
 import com.ichi2.libanki.Card
+import com.ichi2.libanki.CardId
 import com.ichi2.libanki.Collection
 import com.ichi2.utils.KotlinCleanup
 import java.util.*
@@ -38,7 +39,7 @@ internal abstract class CardQueue<T : Card.Cache?>( // We need to store mSched a
         return queue.remove()!!.card
     }
 
-    fun remove(cid: Long): Boolean {
+    fun remove(cid: CardId): Boolean {
         // CardCache and LrnCache with the same id will be considered as equal so it's a valid implementation.
         return queue.remove(col?.let { Card.Cache(it, cid) })
     }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/LrnCardQueue.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/LrnCardQueue.kt
@@ -16,6 +16,8 @@
 
 package com.ichi2.libanki.sched
 
+import com.ichi2.libanki.CardId
+
 internal class LrnCardQueue(sched: AbstractSched) : CardQueue<LrnCard>(sched) {
     /**
      * Whether the queue already contains its current expected value.
@@ -24,7 +26,7 @@ internal class LrnCardQueue(sched: AbstractSched) : CardQueue<LrnCard>(sched) {
     var isFilled = false
         private set
 
-    fun add(due: Long, cid: Long) {
+    fun add(due: Long, cid: CardId) {
         add(LrnCard(col, due, cid))
     }
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.kt
@@ -30,6 +30,7 @@ import com.google.errorprone.annotations.CheckReturnValue
 import com.ichi2.anki.CardBrowser.CardCache
 import com.ichi2.async.CollectionTask.SearchCards
 import com.ichi2.async.TaskManager
+import com.ichi2.libanki.CardId
 import com.ichi2.libanki.Consts
 import com.ichi2.libanki.Note
 import com.ichi2.libanki.SortOrder.NoOrdering
@@ -307,7 +308,7 @@ class CardBrowserTest : RobolectricTest() {
         assertThat(
             "All cards should be flagged",
             stream(cardBrowser.cardIds)
-                .map { cardId: Long -> getCardFlagAfterFlagChangeDone(cardBrowser, cardId).toLong() }
+                .map { cardId: CardId -> getCardFlagAfterFlagChangeDone(cardBrowser, cardId).toLong() }
                 .noneMatch { flag1: Long -> flag1 != flagForAll.toLong() }
         )
     }
@@ -326,7 +327,7 @@ class CardBrowserTest : RobolectricTest() {
         assertThat("The card flag value should be reflected in the UI", actualFlag, equalTo(1))
     }
 
-    private fun getCardFlagAfterFlagChangeDone(cardBrowser: CardBrowser, cardId: Long): Int {
+    private fun getCardFlagAfterFlagChangeDone(cardBrowser: CardBrowser, cardId: CardId): Int {
         return cardBrowser.getPropertiesForCardId(cardId).card.userFlag()
     }
 
@@ -750,7 +751,7 @@ class CardBrowserTest : RobolectricTest() {
         return multimediaController.get()
     }
 
-    private fun removeCardFromCollection(cardId: Long) {
+    private fun removeCardFromCollection(cardId: CardId) {
         col.remCards(listOf(cardId))
     }
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/cardviewer/OnRenderProcessGoneDelegateTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/cardviewer/OnRenderProcessGoneDelegateTest.kt
@@ -23,6 +23,7 @@ import androidx.annotation.RequiresApi
 import androidx.lifecycle.Lifecycle
 import com.ichi2.anki.AbstractFlashcardViewer
 import com.ichi2.libanki.Card
+import com.ichi2.libanki.CardId
 import com.ichi2.utils.KotlinCleanup
 import com.ichi2.utils.StrictMock.Companion.strictMock
 import org.hamcrest.MatcherAssert.assertThat
@@ -185,7 +186,7 @@ class OnRenderProcessGoneDelegateTest {
             displayedToast = true
         }
 
-        override fun displayRenderLoopDialog(currentCardId: Long, detail: RenderProcessGoneDetail) {
+        override fun displayRenderLoopDialog(currentCardId: CardId, detail: RenderProcessGoneDetail) {
             displayedDialog = true
             onCloseRenderLoopDialog()
         }


### PR DESCRIPTION
CardId is defined in cards.py upstream. Since Cards.java may not be converted,
Consts.kt may be the better place for it.

Values were found by searching "cid: Long" and "ardId: Long".