### PR TITLE
NF: replace Long by NotetypeId

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.kt
@@ -72,7 +72,7 @@ open class CardTemplateEditor : AnkiActivity(), DeckSelectionListener {
     var tempModel: TemporaryModel? = null
         private set
     private var mFieldNames: List<String>? = null
-    private var mModelId: Long = 0
+    private var mModelId: NoteTypeId = 0
     private var mNoteId: NoteId = 0
 
     // the position of the cursor in the editor view

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
@@ -2149,7 +2149,7 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
     }
 
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)
-    fun setCurrentlySelectedModel(mid: Long) {
+    fun setCurrentlySelectedModel(mid: NoteTypeId) {
         val position = mAllModelIds!!.indexOf(mid)
         check(position != -1) { "$mid not found" }
         mNoteTypeSpinner!!.setSelection(position)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/TemporaryModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/TemporaryModel.kt
@@ -24,6 +24,7 @@ import com.ichi2.async.CollectionTask.SaveModel
 import com.ichi2.async.TaskManager
 import com.ichi2.compat.CompatHelper.Companion.compat
 import com.ichi2.libanki.Model
+import com.ichi2.libanki.NoteTypeId
 import com.ichi2.utils.JSONObject
 import com.ichi2.utils.KotlinCleanup
 import timber.log.Timber
@@ -72,7 +73,7 @@ class TemporaryModel(model: Model) {
     val templateCount: Int
         get() = model.getJSONArray("tmpls").length()
 
-    val modelId: Long
+    val modelId: NoteTypeId
         get() = model.getLong("id")
 
     fun updateCss(css: String?) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/impl/MultimediaEditableNote.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/impl/MultimediaEditableNote.kt
@@ -21,6 +21,7 @@ package com.ichi2.anki.multimediacard.impl
 
 import com.ichi2.anki.multimediacard.IMultimediaEditableNote
 import com.ichi2.anki.multimediacard.fields.IField
+import com.ichi2.libanki.NoteTypeId
 import org.acra.util.IOUtils
 import java.util.*
 
@@ -33,7 +34,7 @@ class MultimediaEditableNote : IMultimediaEditableNote {
     override var isModified = false
         private set
     private var mFields: ArrayList<IField?>? = null
-    var modelId: Long = 0
+    var modelId: NoteTypeId = 0
 
     /**
      * Field values in the note editor, before any editing has taken place

--- a/AnkiDroid/src/main/java/com/ichi2/anki/provider/CardContentProvider.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/provider/CardContentProvider.kt
@@ -264,7 +264,7 @@ class CardContentProvider : ContentProvider() {
                 val models = col.models
                 val columns = projection ?: FlashCardsContract.Model.DEFAULT_PROJECTION
                 val rv = MatrixCursor(columns, 1)
-                for (modelId: Long in models.getModels().keys) {
+                for (modelId: NoteTypeId in models.getModels().keys) {
                     addModelToCursor(modelId, models, rv, columns)
                 }
                 rv
@@ -904,7 +904,7 @@ class CardContentProvider : ContentProvider() {
             MODELS_ID_TEMPLATES -> {
                 run {
                     val models: ModelManager = col.models
-                    val mid: Long = getModelIdFromUri(uri, col)
+                    val mid: NoteTypeId = getModelIdFromUri(uri, col)
                     val existingModel: Model? = models.get(mid)
                     if (existingModel == null) {
                         throw IllegalArgumentException("model missing: " + mid)
@@ -935,7 +935,7 @@ class CardContentProvider : ContentProvider() {
             MODELS_ID_FIELDS -> {
                 run {
                     val models: ModelManager = col.models
-                    val mid: Long = getModelIdFromUri(uri, col)
+                    val mid: NoteTypeId = getModelIdFromUri(uri, col)
                     val existingModel: Model? = models.get(mid)
                     if (existingModel == null) {
                         throw IllegalArgumentException("model missing: " + mid)
@@ -1050,7 +1050,7 @@ class CardContentProvider : ContentProvider() {
         }
     }
 
-    private fun addModelToCursor(modelId: Long, models: ModelManager, rv: MatrixCursor, columns: Array<String>) {
+    private fun addModelToCursor(modelId: NoteTypeId, models: ModelManager, rv: MatrixCursor, columns: Array<String>) {
         val jsonObject = models.get(modelId)
         val rb = rv.newRow()
         try {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/NoteService.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/NoteService.kt
@@ -28,6 +28,7 @@ import com.ichi2.anki.multimediacard.IMultimediaEditableNote
 import com.ichi2.anki.multimediacard.fields.*
 import com.ichi2.anki.multimediacard.impl.MultimediaEditableNote
 import com.ichi2.libanki.Note
+import com.ichi2.libanki.NoteTypeId
 import com.ichi2.libanki.exception.EmptyMediaException
 import com.ichi2.utils.JSONException
 import com.ichi2.utils.JSONObject
@@ -68,7 +69,7 @@ object NoteService {
     }
 
     @JvmStatic
-    fun updateMultimediaNoteFromFields(col: com.ichi2.libanki.Collection, fields: Array<String>, modelId: Long, mmNote: MultimediaEditableNote) {
+    fun updateMultimediaNoteFromFields(col: com.ichi2.libanki.Collection, fields: Array<String>, modelId: NoteTypeId, mmNote: MultimediaEditableNote) {
         for (i in fields.indices) {
             val value = fields[i]
             var field: IField?

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.kt
@@ -769,7 +769,7 @@ open class Collection(
         return genCards(Utils.collection2Array(nids), model, task)
     }
 
-    fun genCards(nids: kotlin.collections.Collection<Long?>?, mid: Long): ArrayList<Long>? {
+    fun genCards(nids: kotlin.collections.Collection<Long?>?, mid: NoteTypeId): ArrayList<Long>? {
         return genCards(nids, models.get(mid)!!)
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/ModelManager.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/ModelManager.kt
@@ -258,7 +258,7 @@ abstract class ModelManager(protected val col: Collection) {
      * @param ords array of ints, each one is the ordinal a the card template in the given model
      * @return null if deleting ords would orphan notes, long[] of related card ids to delete if it is safe
      */
-    open fun getCardIdsForModel(modelId: Long, ords: IntArray): List<Long?>? {
+    open fun getCardIdsForModel(modelId: NoteTypeId, ords: IntArray): List<Long?>? {
         val cardIdsToDeleteSql = "select c2.id from cards c2, notes n2 where c2.nid=n2.id and n2.mid = ? and c2.ord  in " + Utils.ids2str(ords)
         val cids: List<Long?> = col.db.queryLongList(cardIdsToDeleteSql, modelId)
         // Timber.d("cardIdsToDeleteSql was ' %s' and got %s", cardIdsToDeleteSql, Utils.ids2str(cids));

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/ModelsV16.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/ModelsV16.kt
@@ -37,7 +37,7 @@ import net.ankiweb.rsdroid.RustCleanup
 import net.ankiweb.rsdroid.exceptions.BackendNotFoundException
 import timber.log.Timber
 
-class NoteTypeNameID(val name: String, val id: ntid)
+class NoteTypeNameID(val name: String, val id: NoteTypeId)
 class NoteTypeNameIDUseCount(val id: Long, val name: String, val useCount: UInt)
 class BackendNote(val fields: MutableList<String>)
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/PythonTypes.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/PythonTypes.kt
@@ -30,6 +30,6 @@ internal typealias DeckId = Long
 internal typealias CardId = Long
 internal typealias dcid = Long
 internal typealias NoteId = Long
-internal typealias ntid = Long
+internal typealias NoteTypeId = Long
 internal typealias bool = Boolean
 internal typealias Tuple<T1, T2> = Pair<T1, T2>

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/importer/Anki2Importer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/importer/Anki2Importer.kt
@@ -55,7 +55,7 @@ open class Anki2Importer(col: Collection?, file: String) : Importer(col!!, file)
     private val mAllowUpdate: Boolean
     private var mDupeOnSchemaChange: Boolean
 
-    private class NoteTriple(val nid: NoteId, val mod: Long, val mid: Long)
+    private class NoteTriple(val nid: NoteId, val mod: Long, val mid: NoteTypeId)
 
     private var mNotes: MutableMap<String, NoteTriple>? = null
     private var mDecks: MutableMap<Long, Long>? = null
@@ -740,7 +740,7 @@ open class Anki2Importer(col: Collection?, file: String) : Importer(col!!, file)
     }
 
     // running splitFields() on every note is fairly expensive and actually not necessary
-    private fun _mungeMedia(mid: Long, fields: String): String {
+    private fun _mungeMedia(mid: NoteTypeId, fields: String): String {
         var _fields = fields
         for (p in Media.REGEXPS) {
             val m = p.matcher(_fields)


### PR DESCRIPTION
NotetypeId is defined upstream in models.py.
Since we may not convert Models.java, defining it in consts.kt seems the better
place

Those variables were found by searching for "mid: Long" and "odelId: Long".