### PR TITLE
NF: Remove StringUtil.strip()

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/AnkiPackageExporter.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/AnkiPackageExporter.kt
@@ -26,7 +26,6 @@ import com.ichi2.utils.CollectionUtils.addAll
 import com.ichi2.utils.JSONException
 import com.ichi2.utils.JSONObject
 import com.ichi2.utils.KotlinCleanup
-import com.ichi2.utils.StringUtil.strip
 import org.apache.commons.compress.archivers.zip.ZipArchiveEntry
 import org.apache.commons.compress.archivers.zip.ZipArchiveOutputStream
 import timber.log.Timber
@@ -103,7 +102,7 @@ open class Exporter(@JvmField protected val col: Collection, protected val did: 
         s = s.replace("\\[sound:[^]]+\\]".toRegex(), "")
         s = Utils.stripHTML(s)
         s = s.replace("[ \\n\\t]+".toRegex(), " ")
-        s = strip(s)!!
+        s = s.trim()
         return s
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/TemplateManager.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/TemplateManager.kt
@@ -28,7 +28,6 @@ import com.ichi2.libanki.backend.model.to_backend_note
 import com.ichi2.libanki.utils.append
 import com.ichi2.libanki.utils.len
 import com.ichi2.utils.JSONObject
-import com.ichi2.utils.StringUtil
 import net.ankiweb.rsdroid.RustCleanup
 import net.ankiweb.rsdroid.exceptions.BackendTemplateException
 import timber.log.Timber
@@ -168,7 +167,7 @@ class TemplateManager {
                 val fields = _note.items().map { Pair(it[0], it[1]) }.toMap().toMutableMap()
 
                 // add (most) special fields
-                fields["Tags"] = StringUtil.strip(_note.stringTags())
+                fields["Tags"] = _note.stringTags().trim()
                 fields["Type"] = _note_type.name
                 fields["Deck"] = _col.decks.name(_card.oDid or _card.did)
                 fields["Subdeck"] = Decks.basename(fields["Deck"])

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/TextNoteExporter.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/TextNoteExporter.kt
@@ -14,7 +14,6 @@ package com.ichi2.libanki
 
 import android.text.TextUtils
 import com.ichi2.utils.KotlinCleanup
-import com.ichi2.utils.StringUtil.strip
 import java.io.BufferedWriter
 import java.io.FileOutputStream
 import java.io.IOException
@@ -61,7 +60,7 @@ class TextNoteExporter(
                     row.add(processText(field!!))
                 }
                 if (includedTags) {
-                    row.add(strip(tags))
+                    row.add(tags.trim())
                 }
                 @KotlinCleanup("use kotlin joinToString function")
                 data.add(TextUtils.join("\t", row))

--- a/AnkiDroid/src/main/java/com/ichi2/utils/StringUtil.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/StringUtil.kt
@@ -34,35 +34,6 @@ object StringUtil {
         return if (newLength < s.length) s.substring(0, newLength) else s
     }
 
-    /**
-     * Remove all whitespace from the start and the end of a [String].
-     *
-     * A whitespace is defined by [Character.isWhitespace]
-     *
-     * @param string the string to be stripped, may be null
-     * @return the stripped string
-     */
-    @JvmStatic
-    @Contract("null -> null; !null -> !null")
-    fun strip(string: String?): String? {
-        if (string.isNullOrEmpty()) return string
-
-        var start = 0
-        while (start < string.length && Character.isWhitespace(string[start])) {
-            start++
-        }
-        if (start == string.length) {
-            return ""
-        }
-        var end = string.length
-        while (end > start && Character.isWhitespace(string[end - 1])) {
-            end--
-        }
-        return if (start == 0 && end == string.length) {
-            string
-        } else string.substring(start, end)
-    }
-
     /** Converts the string to where the first letter is uppercase, and the rest of the string is lowercase  */
     @JvmStatic
     @Contract("null -> null; !null -> !null")

--- a/AnkiDroid/src/test/java/com/ichi2/utils/StringUtilTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/utils/StringUtilTest.kt
@@ -15,7 +15,6 @@
  */
 package com.ichi2.utils
 
-import com.ichi2.utils.StringUtil.strip
 import com.ichi2.utils.StringUtil.toTitleCase
 import com.ichi2.utils.StringUtil.trimRight
 import org.hamcrest.MatcherAssert.assertThat
@@ -23,8 +22,6 @@ import org.hamcrest.Matchers.equalTo
 import org.hamcrest.Matchers.nullValue
 import org.hamcrest.Matchers.sameInstance
 import org.junit.Test
-import kotlin.test.assertEquals
-import kotlin.test.junit5.JUnit5Asserter.assertNull
 
 class StringUtilTest {
     @Test
@@ -46,41 +43,6 @@ class StringUtilTest {
     fun trimRightDoesNothingOnTrimmedString() {
         val input = " foo"
         assertThat(trimRight(input), sameInstance(input))
-    }
-
-    @Test
-    fun strip_on_null_return_null() {
-        assertNull("", strip(null))
-    }
-
-    @Test
-    fun strip_on_empty_return_empty() {
-        assertEquals("", strip(""))
-    }
-
-    @Test
-    fun string_on_nonempty_full_of_whitespace_return_empty() {
-        assertEquals("", strip(" \u0020\u2001  "))
-    }
-
-    @Test
-    fun strip_leading_spaces() {
-        assertEquals("Hello", strip("   \t\n Hello"))
-    }
-
-    @Test
-    fun strip_trailing_spaces() {
-        assertEquals("MyNameIs", strip("MyNameIs\n\u2009\u205F\t   \u3000 "))
-    }
-
-    @Test
-    fun strip_trailing_and_leading_spaces() {
-        assertEquals("Tarek", strip("\n\u2006 \r\n\t\u000CTarek   \u0009"))
-    }
-
-    @Test
-    fun strip_does_nothing_on_stripped_string() {
-        assertEquals("Java", strip("Java"))
     }
 
     @Test


### PR DESCRIPTION
Useless now that Kotlin's .trim() can be used

## Approach
Exchange it with .trim()

## How Has This Been Tested?

Unit tests

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
