### PR TITLE
[GSoC] Remove "New timezone handling" preference

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/ReviewingSettingsFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/ReviewingSettingsFragment.kt
@@ -20,7 +20,6 @@ import androidx.preference.SwitchPreference
 import com.ichi2.anki.Preferences
 import com.ichi2.anki.R
 import com.ichi2.anki.reviewer.AutomaticAnswerAction
-import com.ichi2.libanki.backend.exception.BackendNotSupportedException
 import com.ichi2.preferences.NumberRangePreferenceCompat
 import com.ichi2.preferences.SeekBarPreferenceCompat
 
@@ -103,22 +102,5 @@ class ReviewingSettingsFragment : SettingsFragment() {
         // Time to show question
         requirePreference<SeekBarPreferenceCompat>(R.string.timeout_question_seconds_preference)
             .setFormattedSummary(R.string.pref_summary_seconds)
-
-        // New timezone handling
-        requirePreference<SwitchPreference>(R.string.new_timezone_handling_preference).apply {
-            isChecked = col.sched._new_timezone_enabled()
-            isEnabled = col.schedVer() > 1
-            setOnPreferenceChangeListener { newValue ->
-                if (newValue == true) {
-                    try {
-                        col.sched.set_creation_offset()
-                    } catch (e: BackendNotSupportedException) {
-                        throw e.alreadyUsingRustBackend()
-                    }
-                } else {
-                    col.sched.clear_creation_offset()
-                }
-            }
-        }
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/BaseSched.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/BaseSched.kt
@@ -531,16 +531,8 @@ abstract class BaseSched(val col: Collection) {
     // New timezone handling
     // ////////////////////////////////////////////////////////////////////////
 
-    fun _new_timezone_enabled(): Boolean {
-        return col.has_config_not_null("creationOffset")
-    }
-
     fun useNewTimezoneCode() {
         set_creation_offset()
-    }
-
-    fun clear_creation_offset() {
-        col.remove_config("creationOffset")
     }
 
     /** true if there are any rev cards due.  */

--- a/AnkiDroid/src/main/res/values/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values/10-preferences.xml
@@ -154,7 +154,6 @@
     <string name="new_spread" maxLength="41">New card position</string>
     <string name="learn_cutoff" maxLength="41">Learn ahead limit</string>
     <string name="time_limit" maxLength="41">Timebox time limit</string>
-    <string name="new_timezone" maxLength="41">New timezone handling</string>
     <string name="day_offset_with_description" maxLength="41">Start of next day</string>
     <string name="day_offset_summary">%s hours past midnight</string>
     <string name="xlabel_dayoffset_seekbar" maxLength="41">Midnight</string>

--- a/AnkiDroid/src/main/res/values/preferences.xml
+++ b/AnkiDroid/src/main/res/values/preferences.xml
@@ -18,7 +18,6 @@
     <string name="timeout_answer_seconds_preference">timeoutAnswerSeconds</string>
     <string name="timeout_question_seconds_preference">timeoutQuestionSeconds</string>
     <string name="keep_screen_on_preference">keepScreenOn</string>
-    <string name="new_timezone_handling_preference">newTimezoneHandling</string>
     <string name="double_tap_time_interval_preference">doubleTapTimeInterval</string>
     <!-- Sync -->
     <string name="pref_sync_screen_key">syncScreen</string>

--- a/AnkiDroid/src/main/res/xml/preferences_reviewing.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_reviewing.xml
@@ -86,10 +86,6 @@
             android:key="@string/keep_screen_on_preference"
             android:summary="@string/pref_keep_screen_on_summ"
             android:title="@string/pref_keep_screen_on" />
-        <SwitchPreference
-            android:key="@string/new_timezone_handling_preference"
-            android:title="@string/new_timezone"
-            android:defaultValue="false" />
         <com.ichi2.preferences.NumberRangePreferenceCompat
             android:defaultValue="200"
             android:key="@string/double_tap_time_interval_preference"

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/sched/SchedV2Test.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/sched/SchedV2Test.kt
@@ -296,28 +296,6 @@ open class SchedV2Test : RobolectricTest() {
             col.has_config("localOffset"),
             Matchers.`is`(true)
         )
-        val sched = col.sched
-        MatcherAssert.assertThat(
-            "new timezone should be enabled by default",
-            sched._new_timezone_enabled(),
-            Matchers.`is`(true)
-        )
-
-        // a second call should be fine
-        sched.set_creation_offset()
-        MatcherAssert.assertThat(
-            "new timezone should still be enabled",
-            sched._new_timezone_enabled(),
-            Matchers.`is`(true)
-        )
-        // we can obtain the offset from "crt" without an issue - do not test the return as it depends on the local timezone
-        sched._current_timezone_offset()
-        sched.clear_creation_offset()
-        MatcherAssert.assertThat(
-            "new timezone should be disabled after clear",
-            sched._new_timezone_enabled(),
-            Matchers.`is`(false)
-        )
     }
 
     @get:Throws(Exception::class)


### PR DESCRIPTION
New timezone handling is always used by default after 712ec6b48e0bf41ffce4d01dc55bbbce08bd60fd, so the preference is now useless

## How Has This Been Tested?

Ran CI

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
