### PR TITLE
Make possible to commit hunks on Kotlin again

### DIFF
--- a/pre-commit
+++ b/pre-commit
@@ -2,34 +2,49 @@
 set -e
 
 runKtlint () {
-    CHANGED_KT_FILES="$(git --no-pager diff --name-status --no-color --cached | awk '$1 != "D" && $2 ~ /\.kts|\.kt/ { print $2 }')"
+    # Following code was generated automatically by running ./gradlew addKtlintFormatGitPreCommitHook
+    # for reference, see https://github.com/JLLeitschuh/ktlint-gradle#additional-helper-tasks
+    # and for the implementation, https://github.com/JLLeitschuh/ktlint-gradle/blob/master/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/GitHook.kt
+    # The only change made was replacing "exit" for "return", as this is running inside a function
+    ######## KTLINT-GRADLE HOOK START ########
 
-    if [ -z "$CHANGED_KT_FILES" ]; then
-        echo "No Kotlin staged files. Hence, skipping pre-commit Ktlint run."
+    CHANGED_FILES="$(git --no-pager diff --name-status --no-color --cached | awk '$1 != "D" && $NF ~ /\.kts?$/ { print $NF }')"
+
+    if [ -z "$CHANGED_FILES" ]; then
+        echo "No Kotlin staged files."
         return 0
     fi;
 
-    echo "Running Ktlint over these files:"
-    echo "$CHANGED_KT_FILES"
+    echo "Running ktlint over these files:"
+    echo "$CHANGED_FILES"
 
+    diff=.git/unstaged-ktlint-git-hook.diff
+    git diff --color=never > $diff
+    if [ -s $diff ]; then
+      git apply -R $diff
+    fi
 
-    # -q removes noise from the output if it fails.
-    # TODO: -w is better, but https://github.com/JLLeitschuh/ktlint-gradle/issues/457 adds noise
-    # -w should display: "CriticalExceptionTest.kt:19:1 Wildcard import (cannot be auto-corrected)"
-    # Cleaning and retrying only if the ktlint fails
-    if ! ./gradlew -q ktlintFormat ; then
-        echo "Cleaning the project and retrying."
-        # Clean is required because of https://github.com/ankidroid/Anki-Android/issues/9521
-        ./gradlew clean
-        ./gradlew -q ktlintFormat
-    fi;
+    ./gradlew --quiet ktlintFormat -PinternalKtlintGitFilter="$CHANGED_FILES"
+    gradle_command_exit_code=$?
 
-    echo "Completed ./gradlew ktlintFormat run."
-    echo "$CHANGED_KT_FILES" | while read -r file; do
-        if [ -f "$file" ]; then
-            git add "$file"
+    echo "Completed ktlint run."
+
+    echo "$CHANGED_FILES" | while read -r file; do
+        if [ -f $file ]; then
+            git add $file
         fi
     done
+
+
+    if [ -s $diff ]; then
+      git apply --ignore-whitespace $diff
+    fi
+    rm $diff
+    unset diff
+
+    echo "Completed ktlint hook."
+    exit $gradle_command_exit_code
+    ######## KTLINT-GRADLE HOOK END ########
 }
 
 runPrettier () {


### PR DESCRIPTION
## Fixes
Fixes #9390

## Approach
Replaced the old runKtlint() code with the one generated by `./gradlew addKtlintFormatGitPreCommitHook`

for reference, see https://github.com/JLLeitschuh/ktlint-gradle#additional-helper-tasks, and for the implementation, https://github.com/JLLeitschuh/ktlint-gradle/blob/master/plugin/src/main/kotlin/org/jlleitschuh/gradle/ktlint/GitHook.kt

 The idea came from https://github.com/ankidroid/Anki-Android/issues/9390#issuecomment-950353851

## How Has This Been Tested?

https://user-images.githubusercontent.com/69634269/183875558-937f7fc7-a4a6-4178-ad20-cb597f11de31.mp4


## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
