### PR TITLE
fixing unnecessary rebuild of filtered deck  after opening filter deck option

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/FilteredDeckOptions.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/FilteredDeckOptions.kt
@@ -467,7 +467,9 @@ class FilteredDeckOptions : AppCompatPreferenceActivity() {
         newOrderPref.value = pref.getString("order", "0")
         newOrderPrefSecond.setEntries(R.array.cram_deck_conf_order_labels)
         newOrderPrefSecond.setEntryValues(R.array.cram_deck_conf_order_values)
-        newOrderPrefSecond.value = pref.getString("order_2", "5")
+        if (pref.secondFilter) {
+            newOrderPrefSecond.value = pref.getString("order_2", "5")
+        }
     }
 
     /**


### PR DESCRIPTION

## Purpose / Description
There was unnecessary rebuild of filtered deck after opening filter deck options 

## Fixes
Fixes #10767 

## Approach
The getString method tries to commit the default value which further notifies the listeners to rebuild the deck .Since the value is only required if second filter is enabled  I put a condition so that it is called only when it is needed.

## How Has This Been Tested?

Tested on my personal device oppo a52