### PR TITLE
NF: Exchange `.beginTransaction` for `.commit`

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -50,6 +50,7 @@ import androidx.core.content.ContextCompat
 import androidx.core.content.pm.ShortcutInfoCompat
 import androidx.core.content.pm.ShortcutManagerCompat
 import androidx.core.graphics.drawable.IconCompat
+import androidx.fragment.app.commit
 import androidx.recyclerview.widget.DividerItemDecoration
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
@@ -1889,9 +1890,9 @@ open class DeckPicker :
      */
     private fun loadStudyOptionsFragment(withDeckOptions: Boolean) {
         val details = StudyOptionsFragment.newInstance(withDeckOptions)
-        val ft = supportFragmentManager.beginTransaction()
-        ft.replace(R.id.studyoptions_fragment, details)
-        ft.commit()
+        supportFragmentManager.commit {
+            replace(R.id.studyoptions_fragment, details)
+        }
     }
 
     val fragment: StudyOptionsFragment?

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.kt
@@ -26,6 +26,7 @@ import androidx.annotation.VisibleForTesting
 import androidx.appcompat.app.ActionBar
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentManager
+import androidx.fragment.app.commit
 import com.ichi2.anim.ActivityTransitionAnimation
 import com.ichi2.anki.preferences.AboutFragment
 import com.ichi2.anki.preferences.HeaderFragment
@@ -92,10 +93,9 @@ class Preferences : AnkiActivity() {
                 throw RuntimeException("Failed to load $fragmentClassName", e)
             }
         }
-        supportFragmentManager
-            .beginTransaction()
-            .replace(R.id.settings_container, initialFragment, initialFragment::class.java.name)
-            .commit()
+        supportFragmentManager.commit {
+            replace(R.id.settings_container, initialFragment, initialFragment::class.java.name)
+        }
     }
 
     override fun onDestroy() {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/SharedDecksActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/SharedDecksActivity.kt
@@ -27,6 +27,7 @@ import androidx.appcompat.widget.SearchView
 import androidx.appcompat.widget.Toolbar
 import androidx.core.content.ContextCompat
 import androidx.core.os.bundleOf
+import androidx.fragment.app.commit
 import timber.log.Timber
 import java.io.Serializable
 
@@ -100,9 +101,9 @@ class SharedDecksActivity : AnkiActivity() {
             val sharedDecksDownloadFragment = SharedDecksDownloadFragment()
             sharedDecksDownloadFragment.arguments = bundleOf(DOWNLOAD_FILE to DownloadFile(url, userAgent, contentDisposition, mimetype))
 
-            supportFragmentManager.beginTransaction()
-                .add(R.id.shared_decks_fragment_container, sharedDecksDownloadFragment, SHARED_DECKS_DOWNLOAD_FRAGMENT)
-                .commit()
+            supportFragmentManager.commit {
+                add(R.id.shared_decks_fragment_container, sharedDecksDownloadFragment, SHARED_DECKS_DOWNLOAD_FRAGMENT)
+            }
         }
 
         mWebView.webViewClient = mWebViewClient
@@ -126,7 +127,9 @@ class SharedDecksActivity : AnkiActivity() {
                     } else {
                         Timber.i("Back pressed when download is not in progress but download screen is open, close fragment")
                         // Remove fragment
-                        supportFragmentManager.beginTransaction().remove(it).commit()
+                        supportFragmentManager.commit {
+                            remove(it)
+                        }
                     }
                 }
                 supportFragmentManager.popBackStackImmediate()

--- a/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsActivity.kt
@@ -18,6 +18,7 @@ package com.ichi2.anki
 import android.content.Intent
 import android.os.Bundle
 import android.view.MenuItem
+import androidx.fragment.app.commit
 import com.ichi2.anim.ActivityTransitionAnimation
 import com.ichi2.anki.StudyOptionsFragment.StudyOptionsListener
 import com.ichi2.anki.UIUtils.saveCollectionInBackground
@@ -49,7 +50,9 @@ class StudyOptionsActivity : NavigationDrawerActivity(), StudyOptionsListener, C
             withDeckOptions = intent.extras!!.getBoolean("withDeckOptions")
         }
         val currentFragment = StudyOptionsFragment.newInstance(withDeckOptions)
-        supportFragmentManager.beginTransaction().replace(R.id.studyoptions_frame, currentFragment).commit()
+        supportFragmentManager.commit {
+            replace(R.id.studyoptions_frame, currentFragment)
+        }
     }
 
     private val currentFragment: StudyOptionsFragment?


### PR DESCRIPTION
It automatically commits on the end of the code block, similar to what `.edit{}` does with sharedPreferences

## Pull Request template

## Purpose / Description
cleanup

## How Has This Been Tested?

Hasn't

## Learning (optional, can help others)
From androidx.app.FragmentManager
```kotlin
/**
 * Run [body] in a [FragmentTransaction] which is automatically committed if it completes without
 * exception.
 *
 * The transaction will be completed by calling [FragmentTransaction.commit] unless [allowStateLoss]
 * is set to `true` in which case [FragmentTransaction.commitAllowingStateLoss] will be used.
 */
public inline fun FragmentManager.commit(
    allowStateLoss: Boolean = false,
    body: FragmentTransaction.() -> Unit
) {
    val transaction = beginTransaction()
    transaction.body()
    if (allowStateLoss) {
        transaction.commitAllowingStateLoss()
    } else {
        transaction.commit()
    }
}
```

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
