### PR TITLE
[GSoC] refactor: Migrate preferences formatted summaries configuration to the XMLs

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/AccessibilitySettingsFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/AccessibilitySettingsFragment.kt
@@ -16,7 +16,6 @@
 package com.ichi2.anki.preferences
 
 import com.ichi2.anki.R
-import com.ichi2.preferences.SeekBarPreferenceCompat
 
 /**
  * Fragment with preferences related to notifications
@@ -28,17 +27,5 @@ class AccessibilitySettingsFragment : SettingsFragment() {
         get() = "prefs.accessibility"
 
     override fun initSubscreen() {
-        // Card zoom
-        requirePreference<SeekBarPreferenceCompat>(R.string.card_zoom_preference)
-            .setFormattedSummary(R.string.pref_summary_percentage)
-        // Image zoom
-        requirePreference<SeekBarPreferenceCompat>(R.string.image_zoom_preference)
-            .setFormattedSummary(R.string.pref_summary_percentage)
-        // Answer button size
-        requirePreference<SeekBarPreferenceCompat>(R.string.answer_button_size_preference)
-            .setFormattedSummary(R.string.pref_summary_percentage)
-        // Card browser font scaling
-        requirePreference<SeekBarPreferenceCompat>(R.string.pref_card_browser_font_scale_key)
-            .setFormattedSummary(R.string.pref_summary_percentage)
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/AdvancedStatisticsSettingsFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/AdvancedStatisticsSettingsFragment.kt
@@ -16,7 +16,6 @@
 package com.ichi2.anki.preferences
 
 import com.ichi2.anki.R
-import com.ichi2.preferences.SeekBarPreferenceCompat
 
 class AdvancedStatisticsSettingsFragment : SettingsFragment() {
     override val preferenceResource: Int
@@ -25,8 +24,5 @@ class AdvancedStatisticsSettingsFragment : SettingsFragment() {
         get() = "prefs.advanced_statistics"
 
     override fun initSubscreen() {
-        // Precision of computation
-        requirePreference<SeekBarPreferenceCompat>(R.string.pref_computation_precision_key)
-            .setFormattedSummary(R.string.pref_summary_percentage)
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/ReviewingSettingsFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/ReviewingSettingsFragment.kt
@@ -49,7 +49,6 @@ class ReviewingSettingsFragment : SettingsFragment() {
         // Note that "collapseTime" is in second while LEARN_CUTOFF is in minute.
         requirePreference<NumberRangePreferenceCompat>(R.string.learn_cutoff_preference).apply {
             setValue(col.get_config_int("collapseTime") / 60)
-            setFormattedSummary(R.string.pref_summary_minutes)
             setOnPreferenceChangeListener { newValue ->
                 col.set_config("collapseTime", ((newValue as String).toInt() * 60))
             }
@@ -60,7 +59,6 @@ class ReviewingSettingsFragment : SettingsFragment() {
         // Note that "timeLim" is in seconds while TIME_LIMIT is in minutes.
         requirePreference<NumberRangePreferenceCompat>(R.string.time_limit_preference).apply {
             setValue(col.get_config_int("timeLim") / 60)
-            setFormattedSummary(R.string.pref_summary_minutes)
             setOnPreferenceChangeListener { newValue ->
                 col.set_config("timeLim", ((newValue as String).toInt() * 60))
             }
@@ -70,7 +68,6 @@ class ReviewingSettingsFragment : SettingsFragment() {
         // in sched v2, and crt in sched v1. I.e. at which time of the day does the scheduler reset
         requirePreference<SeekBarPreferenceCompat>(R.string.day_offset_preference).apply {
             value = Preferences.getDayOffset(col)
-            setFormattedSummary(R.string.day_offset_summary)
             setOnPreferenceChangeListener { newValue ->
                 (requireActivity() as Preferences).setDayOffset(newValue as Int)
             }
@@ -97,13 +94,6 @@ class ReviewingSettingsFragment : SettingsFragment() {
                 col.set_config(AutomaticAnswerAction.CONFIG_KEY, (newValue as String).toInt())
             }
         }
-        // Time to show answer
-        requirePreference<SeekBarPreferenceCompat>(R.string.timeout_answer_seconds_preference)
-            .setFormattedSummary(R.string.pref_summary_seconds)
-        // Time to show question
-        requirePreference<SeekBarPreferenceCompat>(R.string.timeout_question_seconds_preference)
-            .setFormattedSummary(R.string.pref_summary_seconds)
-
         // New timezone handling
         requirePreference<SwitchPreference>(R.string.new_timezone_handling_preference).apply {
             isChecked = col.sched._new_timezone_enabled()

--- a/AnkiDroid/src/main/java/com/ichi2/preferences/NumberRangePreferenceCompat.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/preferences/NumberRangePreferenceCompat.kt
@@ -33,25 +33,30 @@ import timber.log.Timber
 
 open class NumberRangePreferenceCompat : EditTextPreference {
     constructor(context: Context, attrs: AttributeSet?, defStyleAttr: Int, defStyleRes: Int) : super(context, attrs, defStyleAttr, defStyleRes) {
-        min = getMinFromAttributes(attrs)
-        max = getMaxFromAttributes(attrs)
-        defaultValue = getDefaultValueFromAttributes(attrs)
+        setup(attrs)
     }
     constructor(context: Context, attrs: AttributeSet?, defStyleAttr: Int) : super(context, attrs, defStyleAttr) {
-        min = getMinFromAttributes(attrs)
-        max = getMaxFromAttributes(attrs)
-        defaultValue = getDefaultValueFromAttributes(attrs)
+        setup(attrs)
     }
     constructor(context: Context, attrs: AttributeSet?) : super(context, attrs) {
+        setup(attrs)
+    }
+    constructor(context: Context) : super(context)
+
+    fun setup(attrs: AttributeSet?) {
         min = getMinFromAttributes(attrs)
         max = getMaxFromAttributes(attrs)
         defaultValue = getDefaultValueFromAttributes(attrs)
-    }
-    constructor(context: Context) : super(context) {
-        defaultValue = null
+
+        val formattedSummary = attrs?.getAttributeResourceValue(AnkiDroidApp.XML_CUSTOM_NAMESPACE, "formattedSummary", -1)
+        if (formattedSummary != null && formattedSummary != -1) {
+            setSummaryProvider {
+                context.getString(formattedSummary, text)
+            }
+        }
     }
 
-    val defaultValue: String?
+    var defaultValue: String? = null
 
     var min = 0
         protected set

--- a/AnkiDroid/src/main/java/com/ichi2/preferences/NumberRangePreferenceCompat.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/preferences/NumberRangePreferenceCompat.kt
@@ -25,7 +25,6 @@ import android.text.TextUtils
 import android.util.AttributeSet
 import android.view.View
 import android.widget.EditText
-import androidx.annotation.StringRes
 import androidx.preference.EditTextPreference
 import androidx.preference.EditTextPreferenceDialogFragmentCompat
 import com.ichi2.anki.AnkiDroidApp
@@ -62,10 +61,6 @@ open class NumberRangePreferenceCompat : EditTextPreference {
         protected set
     var max = 0
         private set
-
-    fun setFormattedSummary(@StringRes resId: Int) {
-        setSummaryProvider { context.getString(resId, text) }
-    }
 
     /** The maximum available number of digits */
     val maxDigits: Int get() = max.toString().length

--- a/AnkiDroid/src/main/java/com/ichi2/preferences/SeekBarPreferenceCompat.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/preferences/SeekBarPreferenceCompat.kt
@@ -60,20 +60,20 @@ class SeekBarPreferenceCompat : DialogPreference {
     private var mYLabel = 0
 
     constructor(context: Context, attrs: AttributeSet?, defStyleAttr: Int, defStyleRes: Int) : super(context, attrs, defStyleAttr, defStyleRes) {
-        setupVariables(attrs)
+        setupVariables(context, attrs)
     }
 
     constructor(context: Context, attrs: AttributeSet?, defStyleAttr: Int) : super(context, attrs, defStyleAttr) {
-        setupVariables(attrs)
+        setupVariables(context, attrs)
     }
 
     constructor(context: Context, attrs: AttributeSet?) : super(context, attrs) {
-        setupVariables(attrs)
+        setupVariables(context, attrs)
     }
 
     constructor(context: Context) : super(context)
 
-    private fun setupVariables(attrs: AttributeSet?) {
+    private fun setupVariables(context: Context, attrs: AttributeSet?) {
         mSuffix = attrs?.getAttributeValue(androidns, "text")
         mDefault = attrs?.getAttributeIntValue(androidns, "defaultValue", 0) ?: 0
         mMax = attrs?.getAttributeIntValue(androidns, "max", 100) ?: 100
@@ -84,6 +84,13 @@ class SeekBarPreferenceCompat : DialogPreference {
         val useSimpleSummaryProvider = attrs?.getAttributeBooleanValue(AnkiDroidApp.XML_CUSTOM_NAMESPACE, "useSimpleSummaryProvider", false) ?: false
         if (useSimpleSummaryProvider) {
             setSummaryProvider { value.toString() }
+        }
+
+        val formattedSummary = attrs?.getAttributeResourceValue(AnkiDroidApp.XML_CUSTOM_NAMESPACE, "formattedSummary", -1)
+        if (formattedSummary != null && formattedSummary != -1) {
+            setSummaryProvider {
+                context.getString(formattedSummary, value)
+            }
         }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/preferences/SeekBarPreferenceCompat.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/preferences/SeekBarPreferenceCompat.kt
@@ -106,10 +106,6 @@ class SeekBarPreferenceCompat : DialogPreference {
         }
     }
 
-    fun setFormattedSummary(@StringRes resId: Int) {
-        setSummaryProvider { context.getString(resId, value) }
-    }
-
     var value: Int
         get() = if (mValue == 0) {
             getPersistedInt(mDefault)

--- a/AnkiDroid/src/main/res/xml/preferences_accessibility.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_accessibility.xml
@@ -16,7 +16,10 @@
   -->
 <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://arbitrary.app.namespace/com.ichi2.anki"
+    xmlns:app1="http://schemas.android.com/apk/res-auto"
     android:title="@string/accessibility">
+    <!-- For some unknown reason, getAttributeResourceValue only works for the custom namespace
+    if "http://schemas.android.com/apk/res-auto" is set as namespace too -->
     <com.ichi2.preferences.SeekBarPreferenceCompat
         android:defaultValue="100"
         android:key="@string/card_zoom_preference"
@@ -24,7 +27,8 @@
         android:text=" %"
         android:title="@string/card_zoom"
         app:interval="10"
-        app:min="10" />
+        app:min="10"
+        app:formattedSummary="@string/pref_summary_percentage"/>
     <com.ichi2.preferences.SeekBarPreferenceCompat
         android:defaultValue="100"
         android:key="@string/image_zoom_preference"
@@ -32,7 +36,8 @@
         android:text=" %"
         android:title="@string/image_zoom"
         app:interval="10"
-        app:min="50" />
+        app:min="50"
+        app:formattedSummary="@string/pref_summary_percentage"/>
     <com.ichi2.preferences.SeekBarPreferenceCompat
         android:defaultValue="100"
         android:key="@string/answer_button_size_preference"
@@ -40,7 +45,8 @@
         android:text=" %"
         android:title="@string/button_size"
         app:interval="10"
-        app:min="10" />
+        app:min="10"
+        app:formattedSummary="@string/pref_summary_percentage"/>
     <SwitchPreference
         android:key="@string/show_large_answer_buttons_preference"
         android:defaultValue="false"
@@ -53,5 +59,6 @@
         android:text=" %"
         android:title="@string/card_browser_font_size"
         app:interval="10"
-        app:min="10" />
+        app:min="10"
+        app:formattedSummary="@string/pref_summary_percentage"/>
 </PreferenceScreen>

--- a/AnkiDroid/src/main/res/xml/preferences_advanced_statistics.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_advanced_statistics.xml
@@ -4,8 +4,10 @@
 <!-- Advanced Statistics Preferences -->
 <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://arbitrary.app.namespace/com.ichi2.anki"
+    xmlns:app1="http://schemas.android.com/apk/res-auto"
     android:title="@string/advanced_statistics_title">
-
+    <!-- For some unknown reason, getAttributeResourceValue only works for the custom namespace
+    if "http://schemas.android.com/apk/res-auto" is set as namespace too -->
     <SwitchPreference
         android:defaultValue="false"
         android:key="@string/pref_advanced_statistics_enabled_key"
@@ -18,7 +20,8 @@
         android:max="30"
         android:title="@string/advanced_forecast_stats_compute_n_days_title"
         app:interval="1"
-        app:min="0" />
+        app:min="0"
+        app:useSimpleSummaryProvider="true"/>
     <com.ichi2.preferences.SeekBarPreferenceCompat
         android:defaultValue="90"
         android:dependency="@string/pref_advanced_statistics_enabled_key"
@@ -28,7 +31,7 @@
         android:title="@string/advanced_forecast_stats_compute_precision_title"
         app:interval="1"
         app:min="0"
-        app:useSimpleSummaryProvider="true"/>
+        app:formattedSummary="@string/pref_summary_percentage"/>
     <com.ichi2.preferences.SeekBarPreferenceCompat
         android:defaultValue="1"
         android:dependency="@string/pref_advanced_statistics_enabled_key"

--- a/AnkiDroid/src/main/res/xml/preferences_reviewing.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_reviewing.xml
@@ -40,17 +40,20 @@
             app:interval="1"
             app:min="0"
             app:xlabel="@string/xlabel_dayoffset_seekbar"
-            app:ylabel="@string/ylabel_dayoffset_seekbar" />
+            app:ylabel="@string/ylabel_dayoffset_seekbar"
+            app:formattedSummary="@string/day_offset_summary"/>
         <com.ichi2.preferences.NumberRangePreferenceCompat
             android:key="@string/learn_cutoff_preference"
             android:title="@string/learn_cutoff"
             app:max="999"
-            app:min="0" />
+            app:min="0"
+            app:formattedSummary="@string/pref_summary_minutes"/>
         <com.ichi2.preferences.NumberRangePreferenceCompat
             android:key="@string/time_limit_preference"
             android:title="@string/time_limit"
             app:max="9999"
-            app:min="0" />
+            app:min="0"
+            app:formattedSummary="@string/pref_summary_minutes"/>
     </PreferenceCategory>
     <PreferenceCategory android:title="@string/timeout_answer_text" >
         <SwitchPreference
@@ -72,13 +75,15 @@
             android:dependency="@string/timeout_answer_preference"
             android:key="@string/timeout_answer_seconds_preference"
             android:max="30"
-            android:title="@string/timeout_answer_seconds" />
+            android:title="@string/timeout_answer_seconds"
+            app:formattedSummary="@string/pref_summary_seconds"/>
         <com.ichi2.preferences.SeekBarPreferenceCompat
             android:defaultValue="60"
             android:dependency="@string/timeout_answer_preference"
             android:key="@string/timeout_question_seconds_preference"
             android:max="60"
-            android:title="@string/timeout_question_seconds" />
+            android:title="@string/timeout_question_seconds"
+            app:formattedSummary="@string/pref_summary_seconds"/>
     </PreferenceCategory>
     <PreferenceCategory android:title="@string/pref_cat_advanced">
         <SwitchPreference


### PR DESCRIPTION
## Purpose / Description
It's better to keep the UI configuration as much as possible on the XMLs, so this is a step toward this goal.

## Approach
On the commits

## How Has This Been Tested?

Ran the app and saw if everything was the same way as before

## Learning (optional, can help others)
For some unknown reason (I've discovered by chance), getAttributeResourceValue only works for the custom namespace if "http://schemas.android.com/apk/res-auto" is set as namespace too.

Actually we should declare attributes on `attrs.xml` and get rid of the custom namespace everywhere. But I'm not doing this today (nor in the near future, as this envolves fixing DeckOptions and FilteredDeckOptions's prefs too)

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
