### PR TITLE
[GSoC] refactor preferences style attributes

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.kt
@@ -217,19 +217,6 @@ class Preferences : AnkiActivity() {
             return ver
         }
 
-        /**
-         * Join [strings] with ` • ` as separator
-         * to build a summary string for some preferences categories
-         * e.g. `foo`, `bar`, `hi` ->  `foo • bar • hi`
-         */
-        fun buildCategorySummary(vararg strings: String): String {
-            return if (!LanguageUtils.appLanguageIsRTL()) {
-                strings.joinToString(separator = " • ")
-            } else {
-                strings.reversed().joinToString(separator = " • ")
-            }
-        }
-
         /** Whether the user is logged on to AnkiWeb  */
         fun hasAnkiWebAccount(preferences: SharedPreferences): Boolean =
             preferences.getString("username", "")!!.isNotEmpty()

--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/HeaderFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/HeaderFragment.kt
@@ -16,10 +16,8 @@
 package com.ichi2.anki.preferences
 
 import android.os.Bundle
-import androidx.annotation.StringRes
 import androidx.preference.Preference
 import androidx.preference.PreferenceFragmentCompat
-import com.ichi2.anki.Preferences
 import com.ichi2.anki.R
 import com.ichi2.themes.Themes
 import com.ichi2.utils.AdaptionUtil
@@ -28,72 +26,12 @@ class HeaderFragment : PreferenceFragmentCompat() {
     override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
         setPreferencesFromResource(R.xml.preference_headers, rootKey)
 
-        // General category
-        requirePreference<Preference>(R.string.pref_general_screen_key)
-            .summary = buildCategorySummary(
-            R.string.language,
-            R.string.pref_cat_studying,
-            R.string.pref_cat_system_wide
-        )
-
-        // Reviewing category
-        requirePreference<Preference>(R.string.pref_reviewing_screen_key)
-            .summary = buildCategorySummary(
-            R.string.pref_cat_scheduling,
-            R.string.timeout_answer_text
-        )
-
-        // Sync category
-        requirePreference<Preference>(R.string.pref_sync_screen_key)
-            .summary = buildCategorySummary(
-            R.string.sync_account,
-            R.string.automatic_sync_choice
-        )
-
-        // Notifications category
-        requirePreference<Preference>(R.string.pref_notifications_screen_key)
-            .summary = buildCategorySummary(
-            R.string.notification_pref_title,
-            R.string.notification_minimum_cards_due_vibrate,
-            R.string.notification_minimum_cards_due_blink,
-        )
-
-        // Appearance category
-        requirePreference<Preference>(R.string.pref_appearance_screen_key)
-            .summary = buildCategorySummary(
-            R.string.pref_cat_themes,
-            R.string.pref_cat_fonts,
-            R.string.pref_cat_reviewer
-        )
-
-        // Accessibility category
-        requirePreference<Preference>(R.string.pref_accessibility_screen_key)
-            .summary = buildCategorySummary(
-            R.string.card_zoom,
-            R.string.button_size,
-        )
-
-        // Controls category
-        requirePreference<Preference>(R.string.pref_controls_screen_key)
-            .summary = buildCategorySummary(
-            R.string.pref_cat_gestures,
-            R.string.keyboard,
-            R.string.bluetooth
-        )
-
-        // Advanced category
         requirePreference<Preference>(R.string.pref_advanced_screen_key).apply {
-            summary = buildCategorySummary(
-                R.string.statistics,
-                R.string.pref_cat_workarounds,
-                R.string.pref_cat_plugins
-            )
             if (AdaptionUtil.isRestrictedLearningDevice) {
                 isVisible = false
             }
         }
 
-        // Developer options category
         if (DevOptionsFragment.isEnabled(requireContext())) {
             setDevOptionsVisibility(true)
         }
@@ -107,17 +45,5 @@ class HeaderFragment : PreferenceFragmentCompat() {
 
     fun setDevOptionsVisibility(isVisible: Boolean) {
         requirePreference<Preference>(R.string.pref_dev_options_screen_key).isVisible = isVisible
-    }
-
-    /**
-     * Join the strings defined by [resIds]
-     * with ` • ` as separator to build a summary string for preferences categories.
-     * e.g. if `R.string.appName` and `R.string.msg` are given as arguments,
-     * and they correspond respectively to the strings `AnkiDroid` and `Message`,
-     * those strings are joined and return `AnkiDroid • Message`
-     */
-    private fun buildCategorySummary(@StringRes vararg resIds: Int): String {
-        val strings = resIds.map { getString(it) }
-        return Preferences.buildCategorySummary(*strings.toTypedArray())
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/preferences/HeaderPreference.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/preferences/HeaderPreference.kt
@@ -1,0 +1,58 @@
+/*
+ *  Copyright (c) 2022 Brayan Oliveira <brayandso.dev@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.ichi2.preferences
+
+import android.content.Context
+import android.util.AttributeSet
+import androidx.core.content.withStyledAttributes
+import androidx.preference.Preference
+import com.ichi2.anki.LanguageUtils
+import com.ichi2.anki.R
+
+/**
+ * Preference used on the headers of [com.ichi2.anki.preferences.HeaderFragment]
+ */
+class HeaderPreference @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet? = null,
+    defStyleAttr: Int = R.attr.preferenceStyle,
+    defStyleRes: Int = R.style.Preference
+) : Preference(context, attrs, defStyleAttr, defStyleRes) {
+
+    init {
+        context.withStyledAttributes(attrs, R.styleable.HeaderPreference) {
+            val entries = getTextArray(R.styleable.HeaderPreference_summaryEntries)
+            if (entries != null) {
+                summary = buildHeaderSummary(*entries)
+            }
+        }
+    }
+
+    companion object {
+        /**
+         * Join [entries] with ` • ` as separator
+         * to build a summary string for some preferences categories
+         * e.g. `foo`, `bar`, `hi` ->  `foo • bar • hi`
+         */
+        fun buildHeaderSummary(vararg entries: CharSequence): String {
+            return if (!LanguageUtils.appLanguageIsRTL()) {
+                entries.joinToString(separator = " • ")
+            } else {
+                entries.reversed().joinToString(separator = " • ")
+            }
+        }
+    }
+}

--- a/AnkiDroid/src/main/java/com/ichi2/preferences/NumberRangePreferenceCompat.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/preferences/NumberRangePreferenceCompat.kt
@@ -25,35 +25,19 @@ import android.text.TextUtils
 import android.util.AttributeSet
 import android.view.View
 import android.widget.EditText
+import androidx.core.content.withStyledAttributes
 import androidx.preference.EditTextPreference
 import androidx.preference.EditTextPreferenceDialogFragmentCompat
 import com.ichi2.anki.AnkiDroidApp
+import com.ichi2.anki.R
 import timber.log.Timber
 
-open class NumberRangePreferenceCompat : EditTextPreference {
-    constructor(context: Context, attrs: AttributeSet?, defStyleAttr: Int, defStyleRes: Int) : super(context, attrs, defStyleAttr, defStyleRes) {
-        setup(attrs)
-    }
-    constructor(context: Context, attrs: AttributeSet?, defStyleAttr: Int) : super(context, attrs, defStyleAttr) {
-        setup(attrs)
-    }
-    constructor(context: Context, attrs: AttributeSet?) : super(context, attrs) {
-        setup(attrs)
-    }
-    constructor(context: Context) : super(context)
-
-    fun setup(attrs: AttributeSet?) {
-        min = getMinFromAttributes(attrs)
-        max = getMaxFromAttributes(attrs)
-        defaultValue = getDefaultValueFromAttributes(attrs)
-
-        val formattedSummary = attrs?.getAttributeResourceValue(AnkiDroidApp.XML_CUSTOM_NAMESPACE, "formattedSummary", -1)
-        if (formattedSummary != null && formattedSummary != -1) {
-            setSummaryProvider {
-                context.getString(formattedSummary, text)
-            }
-        }
-    }
+open class NumberRangePreferenceCompat @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet? = null,
+    defStyleAttr: Int = R.attr.editTextPreferenceStyle,
+    defStyleRes: Int = R.style.Preference_DialogPreference_EditTextPreference
+) : EditTextPreference(context, attrs, defStyleAttr, defStyleRes) {
 
     var defaultValue: String? = null
 
@@ -61,6 +45,21 @@ open class NumberRangePreferenceCompat : EditTextPreference {
         protected set
     var max = 0
         private set
+
+    init {
+        min = attrs?.getAttributeIntValue(AnkiDroidApp.XML_CUSTOM_NAMESPACE, "min", 0) ?: 0
+        max = attrs?.getAttributeIntValue(AnkiDroidApp.XML_CUSTOM_NAMESPACE, "max", Int.MAX_VALUE) ?: Int.MAX_VALUE
+        defaultValue = attrs?.getAttributeValue("http://schemas.android.com/apk/res/android", "defaultValue")
+
+        context.withStyledAttributes(attrs, R.styleable.CustomPreference) {
+            val summaryFormat = this.getString(R.styleable.CustomPreference_summaryFormat)
+            if (summaryFormat != null) {
+                setSummaryProvider {
+                    String.format(summaryFormat, text)
+                }
+            }
+        }
+    }
 
     /** The maximum available number of digits */
     val maxDigits: Int get() = max.toString().length
@@ -112,36 +111,6 @@ open class NumberRangePreferenceCompat : EditTextPreference {
                 min
             }
         }
-    }
-
-    /**
-     * Returns the value of the min attribute, or its default value if not specified
-     *
-     *
-     * This method should only be called once from the constructor.
-     */
-    private fun getMinFromAttributes(attrs: AttributeSet?): Int {
-        return attrs?.getAttributeIntValue(AnkiDroidApp.XML_CUSTOM_NAMESPACE, "min", 0) ?: 0
-    }
-
-    /**
-     * Returns the value of the max attribute, or its default value if not specified
-     *
-     *
-     * This method should only be called once from the constructor.
-     */
-    private fun getMaxFromAttributes(attrs: AttributeSet?): Int {
-        return attrs?.getAttributeIntValue(AnkiDroidApp.XML_CUSTOM_NAMESPACE, "max", Int.MAX_VALUE)
-            ?: Int.MAX_VALUE
-    }
-
-    /**
-     * Returns the default Value, or null if not specified
-     *
-     * This method should only be called once from the constructor.
-     */
-    private fun getDefaultValueFromAttributes(attrs: AttributeSet?): String? {
-        return attrs?.getAttributeValue("http://schemas.android.com/apk/res/android", "defaultValue")
     }
 
     /**

--- a/AnkiDroid/src/main/java/com/ichi2/preferences/SeekBarPreferenceCompat.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/preferences/SeekBarPreferenceCompat.kt
@@ -37,14 +37,22 @@ import android.widget.SeekBar.OnSeekBarChangeListener
 import android.widget.TextView
 import androidx.annotation.StringRes
 import androidx.appcompat.app.AlertDialog
+import androidx.core.content.withStyledAttributes
 import androidx.preference.DialogPreference
 import androidx.preference.PreferenceDialogFragmentCompat
 import com.ichi2.anki.AnkiDroidApp
+import com.ichi2.anki.R
 import com.ichi2.ui.FixedTextView
 import com.ichi2.utils.KotlinCleanup
 
 @KotlinCleanup("fix IDE lint issues")
-class SeekBarPreferenceCompat : DialogPreference {
+class SeekBarPreferenceCompat @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet? = null,
+    defStyleAttr: Int = R.attr.dialogPreferenceStyle,
+    defStyleRes: Int = R.style.Preference_DialogPreference
+) : DialogPreference(context, attrs, defStyleAttr, defStyleRes) {
+
     @KotlinCleanup("make it a lateinit var")
     private var mSuffix: String? = null
     private var mDefault = 0
@@ -59,21 +67,7 @@ class SeekBarPreferenceCompat : DialogPreference {
     @StringRes
     private var mYLabel = 0
 
-    constructor(context: Context, attrs: AttributeSet?, defStyleAttr: Int, defStyleRes: Int) : super(context, attrs, defStyleAttr, defStyleRes) {
-        setupVariables(context, attrs)
-    }
-
-    constructor(context: Context, attrs: AttributeSet?, defStyleAttr: Int) : super(context, attrs, defStyleAttr) {
-        setupVariables(context, attrs)
-    }
-
-    constructor(context: Context, attrs: AttributeSet?) : super(context, attrs) {
-        setupVariables(context, attrs)
-    }
-
-    constructor(context: Context) : super(context)
-
-    private fun setupVariables(context: Context, attrs: AttributeSet?) {
+    init {
         mSuffix = attrs?.getAttributeValue(androidns, "text")
         mDefault = attrs?.getAttributeIntValue(androidns, "defaultValue", 0) ?: 0
         mMax = attrs?.getAttributeIntValue(androidns, "max", 100) ?: 100
@@ -81,15 +75,16 @@ class SeekBarPreferenceCompat : DialogPreference {
         mInterval = attrs?.getAttributeIntValue(AnkiDroidApp.XML_CUSTOM_NAMESPACE, "interval", 1) ?: 1
         mXLabel = attrs?.getAttributeResourceValue(AnkiDroidApp.XML_CUSTOM_NAMESPACE, "xlabel", 0) ?: 0
         mYLabel = attrs?.getAttributeResourceValue(AnkiDroidApp.XML_CUSTOM_NAMESPACE, "ylabel", 0) ?: 0
-        val useSimpleSummaryProvider = attrs?.getAttributeBooleanValue(AnkiDroidApp.XML_CUSTOM_NAMESPACE, "useSimpleSummaryProvider", false) ?: false
-        if (useSimpleSummaryProvider) {
-            setSummaryProvider { value.toString() }
-        }
 
-        val formattedSummary = attrs?.getAttributeResourceValue(AnkiDroidApp.XML_CUSTOM_NAMESPACE, "formattedSummary", -1)
-        if (formattedSummary != null && formattedSummary != -1) {
-            setSummaryProvider {
-                context.getString(formattedSummary, value)
+        context.withStyledAttributes(attrs, R.styleable.CustomPreference) {
+            val useSimpleSummaryProvider = getBoolean(R.styleable.CustomPreference_useSimpleSummaryProvider, false)
+            if (useSimpleSummaryProvider) {
+                setSummaryProvider { value.toString() }
+            }
+
+            val summaryFormat = getString(R.styleable.CustomPreference_summaryFormat)
+            if (summaryFormat != null) {
+                setSummaryProvider { String.format(summaryFormat, value) }
             }
         }
     }

--- a/AnkiDroid/src/main/res/values/attrs.xml
+++ b/AnkiDroid/src/main/res/values/attrs.xml
@@ -31,6 +31,12 @@
     <declare-styleable name="SeekBarPreference">
         <attr name="interval" format="integer" />
     </declare-styleable>
+
+    <declare-styleable name="HeaderPreference">
+        <!-- String array of entries to join in order to build the preference summary -->
+        <attr name="summaryEntries" format="reference"/>
+    </declare-styleable>
+
     <!-- App buttons -->
     <attr name="largeButtonBackgroundColor" format="color"/>
     <attr name="largeButtonBackgroundColorFocused" format="color"/>

--- a/AnkiDroid/src/main/res/values/attrs.xml
+++ b/AnkiDroid/src/main/res/values/attrs.xml
@@ -32,6 +32,16 @@
         <attr name="interval" format="integer" />
     </declare-styleable>
 
+    <declare-styleable name="CustomPreference">
+        <!-- Whether the preference should automatically set its summary to the value saved for the
+             preference, and update the summary when the value is changed. Defaults to false -->
+        <attr name="useSimpleSummaryProvider" format="boolean"/>
+        <!-- Format string to be used as template to build the preference summary.
+             The placeholder is replaced by the preference value, and it must be only one placeholder.
+             If the preference value is updated, the summary is automatically updated as well. -->
+        <attr name="summaryFormat" format="string"/>
+    </declare-styleable>
+
     <declare-styleable name="HeaderPreference">
         <!-- String array of entries to join in order to build the preference summary -->
         <attr name="summaryEntries" format="reference"/>

--- a/AnkiDroid/src/main/res/values/constants.xml
+++ b/AnkiDroid/src/main/res/values/constants.xml
@@ -248,6 +248,53 @@
         <item>4</item>
     </string-array>
 
+    <!-- Preferences headers summaries -->
+    <string-array name="general_summary_entries">
+        <item>@string/language</item>
+        <item>@string/pref_cat_studying</item>
+        <item>@string/pref_cat_system_wide</item>
+    </string-array>
+
+    <string-array name="reviewing_summary_entries">
+        <item>@string/pref_cat_scheduling</item>
+        <item>@string/timeout_answer_text</item>
+    </string-array>
+
+    <string-array name="sync_summary_entries">
+        <item>@string/sync_account</item>
+        <item>@string/automatic_sync_choice</item>
+    </string-array>
+
+    <string-array name="notifications_summary_entries">
+        <item>@string/notification_pref_title</item>
+        <item>@string/notification_minimum_cards_due_vibrate</item>
+        <item>@string/notification_minimum_cards_due_blink</item>
+    </string-array>
+
+    <string-array name="appearance_summary_entries">
+        <item>@string/pref_cat_themes</item>
+        <item>@string/pref_cat_fonts</item>
+        <item>@string/pref_cat_reviewer</item>
+    </string-array>
+
+    <string-array name="accessibility_summary_entries">
+        <item>@string/card_zoom</item>
+        <item>@string/button_size</item>
+    </string-array>
+
+    <string-array name="controls_summary_entries">
+        <item>@string/pref_cat_gestures</item>
+        <item>@string/keyboard</item>
+        <item>@string/bluetooth</item>
+    </string-array>
+
+    <string-array name="advanced_summary_entries">
+        <item>@string/statistics</item>
+        <item>@string/pref_cat_workarounds</item>
+        <item>@string/pref_cat_plugins</item>
+    </string-array>
+
+
     <string name="answer_buttons_position_preference" translatable="false">answerButtonPosition</string>
     <string-array name="answer_buttons_position" translatable="false">
         <item>top</item>

--- a/AnkiDroid/src/main/res/xml/preference_headers.xml
+++ b/AnkiDroid/src/main/res/xml/preference_headers.xml
@@ -20,68 +20,76 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto">
     <!--  General Preferences -->
-    <Preference
+    <com.ichi2.preferences.HeaderPreference
         android:fragment="com.ichi2.anki.preferences.GeneralSettingsFragment"
         android:title="@string/pref_cat_general"
         android:icon="@drawable/ic_settings_black"
-        android:key="@string/pref_general_screen_key">
-    </Preference>
+        android:key="@string/pref_general_screen_key"
+        app:summaryEntries="@array/general_summary_entries">
+    </com.ichi2.preferences.HeaderPreference>
 
     <!-- Reviewing Preferences -->
-    <Preference
+    <com.ichi2.preferences.HeaderPreference
         android:fragment="com.ichi2.anki.preferences.ReviewingSettingsFragment"
         android:key="@string/pref_reviewing_screen_key"
         android:title="@string/pref_cat_reviewing"
-        android:icon="@drawable/ic_flashcard_black">
-    </Preference>
+        android:icon="@drawable/ic_flashcard_black"
+        app:summaryEntries="@array/reviewing_summary_entries">
+    </com.ichi2.preferences.HeaderPreference>
 
     <!-- Sync Preferences -->
-    <Preference
+    <com.ichi2.preferences.HeaderPreference
         android:fragment="com.ichi2.anki.preferences.SyncSettingsFragment"
         android:key="@string/pref_sync_screen_key"
         android:title="@string/pref_cat_sync"
-        android:icon="@drawable/ic_sync">
-    </Preference>
+        android:icon="@drawable/ic_sync"
+        app:summaryEntries="@array/sync_summary_entries">
+    </com.ichi2.preferences.HeaderPreference>
 
     <!-- Notifications -->
-    <Preference
+    <com.ichi2.preferences.HeaderPreference
         android:fragment="com.ichi2.anki.preferences.NotificationsSettingsFragment"
         android:key="@string/pref_notifications_screen_key"
         android:title="@string/notification_pref"
-        android:icon="@drawable/ic_notifications">
-    </Preference>
+        android:icon="@drawable/ic_notifications"
+        app:summaryEntries="@array/notifications_summary_entries">
+    </com.ichi2.preferences.HeaderPreference>
 
     <!-- Appearance Preferences  -->
-    <Preference
+    <com.ichi2.preferences.HeaderPreference
         android:fragment="com.ichi2.anki.preferences.AppearanceSettingsFragment"
         android:key="@string/pref_appearance_screen_key"
         android:title="@string/pref_cat_appearance"
-        android:icon="@drawable/ic_color_lens_white_24dp">
-    </Preference>
+        android:icon="@drawable/ic_color_lens_white_24dp"
+        app:summaryEntries="@array/appearance_summary_entries">
+    </com.ichi2.preferences.HeaderPreference>
 
     <!-- Keybinding preferences -->
-    <Preference
+    <com.ichi2.preferences.HeaderPreference
         android:fragment="com.ichi2.anki.preferences.ControlsSettingsFragment"
         android:key="@string/pref_controls_screen_key"
         android:title="@string/pref_cat_controls"
-        android:icon="@drawable/ic_touch">
-    </Preference>
+        android:icon="@drawable/ic_touch"
+        app:summaryEntries="@array/controls_summary_entries">
+    </com.ichi2.preferences.HeaderPreference>
 
     <!-- Accessibility -->
-    <Preference
+    <com.ichi2.preferences.HeaderPreference
         android:fragment="com.ichi2.anki.preferences.AccessibilitySettingsFragment"
         android:key="@string/pref_accessibility_screen_key"
         android:title="@string/accessibility"
-        android:icon="@drawable/ic_accessibility_24">
-    </Preference>
+        android:icon="@drawable/ic_accessibility_24"
+        app:summaryEntries="@array/accessibility_summary_entries">
+    </com.ichi2.preferences.HeaderPreference>
 
     <!-- Advanced Preferences -->
-    <Preference
+    <com.ichi2.preferences.HeaderPreference
         android:fragment="com.ichi2.anki.preferences.AdvancedSettingsFragment"
         android:key="@string/pref_advanced_screen_key"
         android:title="@string/pref_cat_advanced"
-        android:icon="@drawable/ic_tune_white">
-    </Preference>
+        android:icon="@drawable/ic_tune_white"
+        app:summaryEntries="@array/advanced_summary_entries">
+    </com.ichi2.preferences.HeaderPreference>
     <Preference
         android:key="@string/pref_dev_options_screen_key"
         android:title="@string/pref_cat_dev_options"

--- a/AnkiDroid/src/main/res/xml/preferences_accessibility.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_accessibility.xml
@@ -18,8 +18,6 @@
     xmlns:app="http://arbitrary.app.namespace/com.ichi2.anki"
     xmlns:app1="http://schemas.android.com/apk/res-auto"
     android:title="@string/accessibility">
-    <!-- For some unknown reason, getAttributeResourceValue only works for the custom namespace
-    if "http://schemas.android.com/apk/res-auto" is set as namespace too -->
     <com.ichi2.preferences.SeekBarPreferenceCompat
         android:defaultValue="100"
         android:key="@string/card_zoom_preference"
@@ -28,7 +26,7 @@
         android:title="@string/card_zoom"
         app:interval="10"
         app:min="10"
-        app:formattedSummary="@string/pref_summary_percentage"/>
+        app1:summaryFormat="@string/pref_summary_percentage"/>
     <com.ichi2.preferences.SeekBarPreferenceCompat
         android:defaultValue="100"
         android:key="@string/image_zoom_preference"
@@ -37,7 +35,7 @@
         android:title="@string/image_zoom"
         app:interval="10"
         app:min="50"
-        app:formattedSummary="@string/pref_summary_percentage"/>
+        app1:summaryFormat="@string/pref_summary_percentage"/>
     <com.ichi2.preferences.SeekBarPreferenceCompat
         android:defaultValue="100"
         android:key="@string/answer_button_size_preference"
@@ -46,7 +44,7 @@
         android:title="@string/button_size"
         app:interval="10"
         app:min="10"
-        app:formattedSummary="@string/pref_summary_percentage"/>
+        app1:summaryFormat="@string/pref_summary_percentage"/>
     <SwitchPreference
         android:key="@string/show_large_answer_buttons_preference"
         android:defaultValue="false"
@@ -60,5 +58,5 @@
         android:title="@string/card_browser_font_size"
         app:interval="10"
         app:min="10"
-        app:formattedSummary="@string/pref_summary_percentage"/>
+        app1:summaryFormat="@string/pref_summary_percentage"/>
 </PreferenceScreen>

--- a/AnkiDroid/src/main/res/xml/preferences_advanced_statistics.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_advanced_statistics.xml
@@ -6,8 +6,6 @@
     xmlns:app="http://arbitrary.app.namespace/com.ichi2.anki"
     xmlns:app1="http://schemas.android.com/apk/res-auto"
     android:title="@string/advanced_statistics_title">
-    <!-- For some unknown reason, getAttributeResourceValue only works for the custom namespace
-    if "http://schemas.android.com/apk/res-auto" is set as namespace too -->
     <SwitchPreference
         android:defaultValue="false"
         android:key="@string/pref_advanced_statistics_enabled_key"
@@ -21,7 +19,7 @@
         android:title="@string/advanced_forecast_stats_compute_n_days_title"
         app:interval="1"
         app:min="0"
-        app:useSimpleSummaryProvider="true"/>
+        app1:useSimpleSummaryProvider="true"/>
     <com.ichi2.preferences.SeekBarPreferenceCompat
         android:defaultValue="90"
         android:dependency="@string/pref_advanced_statistics_enabled_key"
@@ -31,7 +29,7 @@
         android:title="@string/advanced_forecast_stats_compute_precision_title"
         app:interval="1"
         app:min="0"
-        app:formattedSummary="@string/pref_summary_percentage"/>
+        app1:summaryFormat="@string/pref_summary_percentage"/>
     <com.ichi2.preferences.SeekBarPreferenceCompat
         android:defaultValue="1"
         android:dependency="@string/pref_advanced_statistics_enabled_key"
@@ -40,5 +38,5 @@
         android:title="@string/advanced_forecast_stats_mc_n_iterations_title"
         app:interval="1"
         app:min="1"
-        app:useSimpleSummaryProvider="true"/>
+        app1:useSimpleSummaryProvider="true"/>
 </PreferenceScreen>

--- a/AnkiDroid/src/main/res/xml/preferences_controls.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_controls.xml
@@ -18,6 +18,7 @@
 <!-- Key com.ichi2.ui.BindingPreferences -->
 <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://arbitrary.app.namespace/com.ichi2.anki"
+    xmlns:app1="http://schemas.android.com/apk/res-auto"
     android:title="@string/pref_cat_controls"
     android:key="@string/pref_controls_screen_key">
 
@@ -49,7 +50,7 @@
         android:title="@string/swipe_sensitivity"
         app:interval="1"
         app:min="20"
-        app:useSimpleSummaryProvider="true"/>
+        app1:useSimpleSummaryProvider="true"/>
     <!-- This category is expanded in BindingPreference.setup -->
     <PreferenceCategory android:title="@string/controls_main_category" android:key="@string/controls_command_mapping_cat_key" />
 </PreferenceScreen>

--- a/AnkiDroid/src/main/res/xml/preferences_reviewing.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_reviewing.xml
@@ -41,19 +41,19 @@
             app:min="0"
             app:xlabel="@string/xlabel_dayoffset_seekbar"
             app:ylabel="@string/ylabel_dayoffset_seekbar"
-            app:formattedSummary="@string/day_offset_summary"/>
+            app1:summaryFormat="@string/day_offset_summary"/>
         <com.ichi2.preferences.NumberRangePreferenceCompat
             android:key="@string/learn_cutoff_preference"
             android:title="@string/learn_cutoff"
             app:max="999"
             app:min="0"
-            app:formattedSummary="@string/pref_summary_minutes"/>
+            app1:summaryFormat="@string/pref_summary_minutes"/>
         <com.ichi2.preferences.NumberRangePreferenceCompat
             android:key="@string/time_limit_preference"
             android:title="@string/time_limit"
             app:max="9999"
             app:min="0"
-            app:formattedSummary="@string/pref_summary_minutes"/>
+            app1:summaryFormat="@string/pref_summary_minutes"/>
     </PreferenceCategory>
     <PreferenceCategory android:title="@string/timeout_answer_text" >
         <SwitchPreference
@@ -76,14 +76,14 @@
             android:key="@string/timeout_answer_seconds_preference"
             android:max="30"
             android:title="@string/timeout_answer_seconds"
-            app:formattedSummary="@string/pref_summary_seconds"/>
+            app1:summaryFormat="@string/pref_summary_seconds"/>
         <com.ichi2.preferences.SeekBarPreferenceCompat
             android:defaultValue="60"
             android:dependency="@string/timeout_answer_preference"
             android:key="@string/timeout_question_seconds_preference"
             android:max="60"
             android:title="@string/timeout_question_seconds"
-            app:formattedSummary="@string/pref_summary_seconds"/>
+            app1:summaryFormat="@string/pref_summary_seconds"/>
     </PreferenceCategory>
     <PreferenceCategory android:title="@string/pref_cat_advanced">
         <SwitchPreference

--- a/AnkiDroid/src/test/java/com/ichi2/anki/PreferencesSimpleTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/PreferencesSimpleTest.kt
@@ -15,6 +15,7 @@
  */
 package com.ichi2.anki
 
+import com.ichi2.preferences.HeaderPreference
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
 import org.junit.jupiter.params.ParameterizedTest
@@ -28,8 +29,8 @@ import java.util.stream.Stream
 class PreferencesSimpleTest {
     @ParameterizedTest
     @MethodSource("buildCategorySummary_LTR_Test_args")
-    fun buildCategorySummary_LTR_Test(strings: Array<String>, expected_summary: String) {
-        assertThat(Preferences.buildCategorySummary(*strings), equalTo(expected_summary))
+    fun buildCategorySummary_LTR_Test(entries: Array<String>, expected_summary: String) {
+        assertThat(HeaderPreference.buildHeaderSummary(*entries), equalTo(expected_summary))
     }
 
     companion object {

--- a/AnkiDroid/src/test/java/com/ichi2/anki/PreferencesTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/PreferencesTest.kt
@@ -18,6 +18,7 @@ package com.ichi2.anki
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.ichi2.anki.Preferences.Companion.getDayOffset
 import com.ichi2.anki.exception.ConfirmModSchemaException
+import com.ichi2.preferences.HeaderPreference
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
 import org.junit.Before
@@ -56,8 +57,8 @@ class PreferencesTest : RobolectricTest() {
 
     @Test
     @Config(qualifiers = "ar")
-    fun buildCategorySummary_RTL_Test() {
-        assertThat(Preferences.buildCategorySummary("حساب أنكي ويب", "مزامنة تلقائية"), equalTo("مزامنة تلقائية • حساب أنكي ويب"))
+    fun buildHeaderSummary_RTL_Test() {
+        assertThat(HeaderPreference.buildHeaderSummary("حساب أنكي ويب", "مزامنة تلقائية"), equalTo("مزامنة تلقائية • حساب أنكي ويب"))
     }
 
     @Test


### PR DESCRIPTION
## Purpose / Description
Use style attributes the way Android intends to and simplify some preferences' constructors to improve Android Studio's layout previews

## Approach
On the commits

## How Has This Been Tested?

1. See if the summaries are looking right on Android Studio's layout previewer now that this is possible
2. Run the app and do the same thing on it 

## Learning (optional, can help others)
Android's documentation has its fair limits, so I went to the source code to see how they handled preferences internally

https://cs.android.com/androidx/platform/frameworks/support/+/androidx-main:preference/preference/res/values/attrs.xml

https://cs.android.com/androidx/platform/frameworks/support/+/androidx-main:preference/preference/src/main/java/androidx/preference/ListPreference.java?q=listpreference

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
