### PR TITLE
NF: simplify catchingLifecycleScope

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/Statistics.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Statistics.kt
@@ -376,7 +376,7 @@ class Statistics : NavigationDrawerActivity(), DeckSelectionListener, SubtitleLi
         private fun createChart() {
             val statisticsActivity = requireActivity() as Statistics
             val taskHandler = statisticsActivity.taskHandler
-            statisticsJob = viewLifecycleOwner.catchingLifecycleScope(requireActivity()) {
+            statisticsJob = catchingLifecycleScope {
                 taskHandler.createChart(getChartTypeFromPosition(mSectionNumber), mProgressBar, mChart)
             }
         }
@@ -451,7 +451,7 @@ class Statistics : NavigationDrawerActivity(), DeckSelectionListener, SubtitleLi
 
         private fun createStatisticOverview() {
             val handler = (requireActivity() as Statistics).taskHandler
-            statisticsJob = catchingLifecycleScope(requireActivity(), "createStatisticOverview failed with error") {
+            statisticsJob = catchingLifecycleScope("createStatisticOverview failed with error") {
                 handler.createStatisticsOverview(mWebView, mProgressBar)
             }
         }

--- a/AnkiDroid/src/main/java/com/ichi2/async/CoroutineHelpers.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/async/CoroutineHelpers.kt
@@ -20,6 +20,7 @@
 package com.ichi2.async
 
 import android.app.Activity
+import androidx.fragment.app.Fragment
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.coroutineScope
 import com.ichi2.anki.CrashReportService
@@ -30,7 +31,7 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import timber.log.Timber
 
-/*
+/**
  * Launch a job that catches any uncaught errors, informs the user and prints it to Log.
  * Errors from the backend contain localized text that is often suitable to show to the user as-is.
  * Other errors should ideally be handled in the block.
@@ -51,3 +52,16 @@ fun LifecycleOwner.catchingLifecycleScope(
         CrashReportService.sendExceptionReport(e, activity::class.java.simpleName)
     }
 }
+
+/**
+ * @see [LifecycleOwner.catchingLifecycleScope]
+ */
+fun Fragment.catchingLifecycleScope(
+    errorMessage: String? = null,
+    block: suspend CoroutineScope.() -> Unit
+) = (this as LifecycleOwner).catchingLifecycleScope(requireActivity(), errorMessage, block)
+
+fun Activity.catchingLifecycleScope(
+    errorMessage: String? = null,
+    block: suspend CoroutineScope.() -> Unit
+) = (this as LifecycleOwner).catchingLifecycleScope(this, errorMessage, block)


### PR DESCRIPTION
My understanding is that this method will often be called either on fragments,
and using the fragment's activity. So it seems to make sense to simplify it,
ensuring that we avoid a parameter that will probably never change.

Actually, since activities are also LifecycleOwner, it may be possible to ensure
this method is even simpler, by defining it on activities instead of defining it
on LifecycleOwner. Unless we have a reason to use an activity distinct from the
LifecycleOwner.

Also cleaning from function I viewed at the same time