### PR TITLE
`data` in Card is lateinit

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Card.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Card.kt
@@ -102,7 +102,7 @@ open class Card : Cloneable {
     var oDue: Long = 0
     var oDid: DeckId = 0
     private var flags = 0
-    private var data: String? = null
+    private lateinit var data: String
 
     // END SQL table entries
     @set:JvmName("setRenderOutput")


### PR DESCRIPTION
It is set to a String in both constructors. This is the only case currently where DB may receive a null value. Ensuring its lateinit remove this constraint, freeing DB.java conversion