### PR TITLE
test: LeakCanary channels are auto-created / okay to have

### DIFF
--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/NotificationChannelTest.java
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/NotificationChannelTest.java
@@ -83,6 +83,13 @@ public class NotificationChannelTest extends InstrumentedTest {
         if (mTargetAPI < 26) {
             expectedChannels += 1;
         }
+
+        // Any channels we see that are for "LeakCanary" are okay. They are auto-created on test devices.
+        for (NotificationChannel channel : channels) {
+            if (channel.getName().toString().contains("LeakCanary")) {
+                expectedChannels += 1;
+            }
+        }
         assertEquals("Incorrect channel count", expectedChannels, channels.size());
 
         for (NotificationChannels.Channel channel : NotificationChannels.Channel.values()) {


### PR DESCRIPTION
## Pull Request template

## Purpose / Description

On my local emulators, the android tests are frequently false-negative because of a previous testing session leaving LeakCanary channels laying around after being auto-created

This PR alters the success criteria of the notification channels test to allow these auto-created LeakCanary tests to exist without failing for having the wrong number of expected channels

## Approach

Any notification channel with "LeakCanary" in it is considered acceptable by adding it to the expected channel count

## How Has This Been Tested?

Re-ran the test locally with the changes

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
