### PR TITLE
fixed: deck search not scrolling to current deck in statistics

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckSpinnerSelection.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckSpinnerSelection.kt
@@ -238,7 +238,7 @@ class DeckSpinnerSelection(
             decks.removeIf { x: SelectableDeck -> x.deckId == Consts.DEFAULT_DECK_ID }
         }
         val dialog = DeckSelectionDialog.newInstance(context.getString(R.string.search_deck), null, false, decks)
-        val did: Long? = (context as? Statistics)?.getCurrentDeckId()
+        val did: DeckId? = (context as? Statistics)?.getCurrentDeckId()
         if (did != null) {
             dialog.requireArguments().putLong("currentDeckId", did)
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckSpinnerSelection.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckSpinnerSelection.kt
@@ -238,6 +238,10 @@ class DeckSpinnerSelection(
             decks.removeIf { x: SelectableDeck -> x.deckId == Consts.DEFAULT_DECK_ID }
         }
         val dialog = DeckSelectionDialog.newInstance(context.getString(R.string.search_deck), null, false, decks)
+        val did: Long? = (context as? Statistics)?.getCurrentDeckId()
+        if (did != null) {
+            dialog.requireArguments().putLong("currentDeckId", did)
+        }
         AnkiActivity.showDialogFragment(mFragmentManagerSupplier.getFragmentManager(), dialog)
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Statistics.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Statistics.kt
@@ -489,7 +489,7 @@ class Statistics : NavigationDrawerActivity(), DeckSelectionListener, SubtitleLi
         }
     }
 
-    fun getCurrentDeckId(): Long {
+    fun getCurrentDeckId(): DeckId {
         return mStatsDeckId
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Statistics.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Statistics.kt
@@ -489,6 +489,10 @@ class Statistics : NavigationDrawerActivity(), DeckSelectionListener, SubtitleLi
         }
     }
 
+    fun getCurrentDeckId(): Long {
+        return mStatsDeckId
+    }
+
     companion object {
         const val TODAYS_STATS_TAB_POSITION = 0
         const val FORECAST_TAB_POSITION = 1

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckSelectionDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckSelectionDialog.kt
@@ -97,7 +97,7 @@ open class DeckSelectionDialog : AnalyticsDialogFragment() {
         val args = requireArguments()
         if (args.containsKey("currentDeckId")) {
             val did = args.getLong("currentDeckId")
-            recyclerView.scrollToPosition(getPositionOfDeck(did, decks))
+            recyclerView.scrollToPosition(getPositionOfDeck(did, adapter.getCurrentlyDisplayedDecks()))
         }
         mDialog = MaterialDialog(requireActivity())
             .neutralButton(R.string.dialog_cancel) // Shouldn't it be negative button?
@@ -110,10 +110,10 @@ open class DeckSelectionDialog : AnalyticsDialogFragment() {
         return mDialog!!
     }
 
-    private fun getPositionOfDeck(did: Long, decks: List<SelectableDeck>): Int {
+    private fun getPositionOfDeck(did: DeckId, decks: List<SelectableDeck>): Int {
         var i = 0
         var pos = 0
-        for (item in decks.sorted()) {
+        for (item in decks) {
             if (did == item.deckId) {
                 pos = i
                 break
@@ -298,6 +298,10 @@ open class DeckSelectionDialog : AnalyticsDialogFragment() {
 
         override fun getFilter(): Filter {
             return DecksFilter()
+        }
+
+        fun getCurrentlyDisplayedDecks(): List<SelectableDeck> {
+            return mCurrentlyDisplayedDecks
         }
 
         private inner class DecksFilter : TypedFilter<SelectableDeck>(mAllDecksList) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckSelectionDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckSelectionDialog.kt
@@ -110,18 +110,8 @@ open class DeckSelectionDialog : AnalyticsDialogFragment() {
         return mDialog!!
     }
 
-    private fun getPositionOfDeck(did: DeckId, decks: List<SelectableDeck>): Int {
-        var i = 0
-        var pos = 0
-        for (item in decks) {
-            if (did == item.deckId) {
-                pos = i
-                break
-            }
-            i++
-        }
-        return pos
-    }
+    private fun getPositionOfDeck(did: DeckId, decks: List<SelectableDeck>) =
+        decks.indexOfFirst { it.deckId == did }
 
     private fun getSummaryMessage(arguments: Bundle): String? {
         return arguments.getString(SUMMARY_MESSAGE)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckSelectionDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckSelectionDialog.kt
@@ -94,6 +94,11 @@ open class DeckSelectionDialog : AnalyticsDialogFragment() {
         val adapter = DecksArrayAdapter(decks)
         recyclerView.adapter = adapter
         adjustToolbar(dialogView, adapter)
+        val args = requireArguments()
+        if (args.containsKey("currentDeckId")) {
+            val did = args.getLong("currentDeckId")
+            recyclerView.scrollToPosition(getPositionOfDeck(did, decks))
+        }
         mDialog = MaterialDialog(requireActivity())
             .neutralButton(R.string.dialog_cancel) // Shouldn't it be negative button?
             .customView(view = dialogView, noVerticalPadding = true)
@@ -103,6 +108,19 @@ open class DeckSelectionDialog : AnalyticsDialogFragment() {
             }
         }
         return mDialog!!
+    }
+
+    private fun getPositionOfDeck(did: Long, decks: List<SelectableDeck>): Int {
+        var i = 0
+        var pos = 0
+        for (item in decks.sorted()) {
+            if (did == item.deckId) {
+                pos = i
+                break
+            }
+            i++
+        }
+        return pos
     }
 
     private fun getSummaryMessage(arguments: Bundle): String? {


### PR DESCRIPTION
## Purpose / Description
fix: deck search not scrolling to current deck in statistics

## Fixes
Fixes #9935 

## Approach
1.Passed the current deck Id as argument to the dialog fragment
2.found the position of the deck in recycler view
3.Scroll to that position

## How Has This Been Tested?
Tested on my personal device.