### PR TITLE
[GSoC] Add a lint rule to use string resources for preferences keys + extract deck options/filtered deck options keys

### DIFF
--- a/AnkiDroid/src/main/res/values/deck_options.xml
+++ b/AnkiDroid/src/main/res/values/deck_options.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~  Copyright (c) 2022 Brayan Oliveira <brayandso.dev@gmail.com>
+  ~
+  ~  This program is free software; you can redistribute it and/or modify it under
+  ~  the terms of the GNU General Public License as published by the Free Software
+  ~  Foundation; either version 3 of the License, or (at your option) any later
+  ~  version.
+  ~
+  ~  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+  ~  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+  ~  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+  ~
+  ~  You should have received a copy of the GNU General Public License along with
+  ~  this program.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+<resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="MissingTranslation,DuplicateCrowdInStrings">
+    <string name="deck_options_deckConf_key">deckConf</string>
+    <string name="deck_options_currentConf_key">currentConf</string>
+    <string name="deck_options_confAdd_key">confAdd</string>
+    <string name="deck_options_confRemove_key">confRemove</string>
+    <string name="deck_options_confRename_key">confRename</string>
+    <string name="deck_options_confRestore_key">confRestore</string>
+    <string name="deck_options_confSetSubdecks_key">confSetSubdecks</string>
+    <string name="deck_options_newSteps_key">newSteps</string>
+    <string name="deck_options_newOrder_key">newOrder</string>
+    <string name="deck_options_newPerDay_key">newPerDay</string>
+    <string name="deck_options_newGradIvl_key">newGradIvl</string>
+    <string name="deck_options_newEasy_key">newEasy</string>
+    <string name="deck_options_newFactor_key">newFactor</string>
+    <string name="deck_options_newBury_key">newBury</string>
+    <string name="deck_options_revPerDay_key">revPerDay</string>
+    <string name="deck_options_easyBonus_key">easyBonus</string>
+    <string name="deck_options_hardFactor_key">hardFactor</string>
+    <string name="deck_options_revIvlFct_key">revIvlFct</string>
+    <string name="deck_options_revMaxIvl_key">revMaxIvl</string>
+    <string name="deck_options_revBury_key">revBury</string>
+    <string name="deck_options_revUseGeneralTimeoutSettings_key">revUseGeneralTimeoutSettings</string>
+    <string name="deck_options_revTimeoutAnswer_key">revTimeoutAnswer</string>
+    <string name="deck_options_revTimeoutAnswerSeconds_key">revTimeoutAnswerSeconds</string>
+    <string name="deck_options_revTimeoutQuestionSeconds_key">revTimeoutQuestionSeconds</string>
+    <string name="deck_options_lapSteps_key">lapSteps</string>
+    <string name="deck_options_lapNewIvl_key">lapNewIvl</string>
+    <string name="deck_options_lapMinIvl_key">lapMinIvl</string>
+    <string name="deck_options_lapLeechThres_key">lapLeechThres</string>
+    <string name="deck_options_lapLeechAct_key">lapLeechAct</string>
+    <string name="deck_options_maxAnswerTime_key">maxAnswerTime</string>
+    <string name="deck_options_showAnswerTimer_key">showAnswerTimer</string>
+    <string name="deck_options_autoPlayAudio_key">autoPlayAudio</string>
+    <string name="deck_options_replayQuestion_key">replayQuestion</string>
+    <string name="deck_options_reminderEnabled_key">reminderEnabled</string>
+    <string name="deck_options_reminderTime_key">reminderTime</string>
+    <string name="deck_options_desc_key">desc</string>
+</resources>

--- a/AnkiDroid/src/main/res/values/filtered_deck_options.xml
+++ b/AnkiDroid/src/main/res/values/filtered_deck_options.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~  Copyright (c) 2022 Brayan Oliveira <brayandso.dev@gmail.com>
+  ~
+  ~  This program is free software; you can redistribute it and/or modify it under
+  ~  the terms of the GNU General Public License as published by the Free Software
+  ~  Foundation; either version 3 of the License, or (at your option) any later
+  ~  version.
+  ~
+  ~  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+  ~  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+  ~  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+  ~
+  ~  You should have received a copy of the GNU General Public License along with
+  ~  this program.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+<resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="MissingTranslation,DuplicateCrowdInStrings">
+    <string name="filtered_deck_search_key">search</string>
+    <string name="filtered_deck_limit_key">limit</string>
+    <string name="filtered_deck_order_key">order</string>
+    <string name="filtered_deck_secondFilter_key">secondFilter</string>
+    <string name="filtered_deck_search_2_key">search_2</string>
+    <string name="filtered_deck_limit_2_key">limit_2</string>
+    <string name="filtered_deck_order_2_key">order_2</string>
+    <string name="filtered_deck_studyOptions_key">studyOptions</string>
+    <string name="filtered_deck_resched_key">resched</string>
+    <string name="filtered_deck_stepsOn_key">stepsOn</string>
+    <string name="filtered_deck_steps_key">steps</string>
+    <string name="filtered_deck_filterSecond_key">filterSecond</string>
+</resources>

--- a/AnkiDroid/src/main/res/xml/cram_deck_options.xml
+++ b/AnkiDroid/src/main/res/xml/cram_deck_options.xml
@@ -20,56 +20,56 @@
 
     <PreferenceCategory android:title="@string/deck_conf_cram_filter" >
         <EditTextPreference
-            android:key="search"
+            android:key="@string/filtered_deck_search_key"
             android:title="@string/deck_conf_cram_search" />
 
         <com.ichi2.preferences.IncrementerNumberRangePreference
-            android:key="limit"
+            android:key="@string/filtered_deck_limit_key"
             android:numeric="integer"
             android:title="@string/deck_conf_cram_limit"
             app:max="99999"
             app:min="1" />
 
         <ListPreference
-            android:key="order"
+            android:key="@string/filtered_deck_order_key"
             android:title="@string/deck_conf_cram_order" />
     </PreferenceCategory>
-    <PreferenceCategory android:title="@string/deck_conf_cram_filter" android:key="secondFilter" android:enabled="false">
+    <PreferenceCategory android:title="@string/deck_conf_cram_filter" android:key="@string/filtered_deck_secondFilter_key" android:enabled="false">
         <EditTextPreference
-            android:key="search_2"
+            android:key="@string/filtered_deck_search_2_key"
             android:title="@string/deck_conf_cram_search" />
 
         <com.ichi2.preferences.IncrementerNumberRangePreference
-            android:key="limit_2"
+            android:key="@string/filtered_deck_limit_2_key"
             android:numeric="integer"
             android:title="@string/deck_conf_cram_limit"
             app:max="99999"
             app:min="1" />
 
         <ListPreference
-            android:key="order_2"
+            android:key="@string/filtered_deck_order_2_key"
             android:title="@string/deck_conf_cram_order" />
     </PreferenceCategory>
-    <PreferenceCategory android:title="@string/study_options" android:key="studyOptions" >
+    <PreferenceCategory android:title="@string/study_options" android:key="@string/filtered_deck_studyOptions_key" >
         <CheckBoxPreference
             android:defaultValue="true"
-            android:key="resched"
+            android:key="@string/filtered_deck_resched_key"
             android:summary="@string/deck_conf_cram_reschedule_summ"
             android:title="@string/deck_conf_cram_reschedule" />
         <CheckBoxPreference
             android:defaultValue="true"
             android:disableDependentsState="false"
-            android:key="stepsOn"
+            android:key="@string/filtered_deck_stepsOn_key"
             android:title="@string/deck_conf_cram_steps_summ" />
 
         <com.ichi2.preferences.StepsPreference
-            android:dependency="stepsOn"
-            android:key="steps"
+            android:dependency="@string/filtered_deck_stepsOn_key"
+            android:key="@string/filtered_deck_steps_key"
             android:title="@string/deck_conf_cram_steps"
             app:allowEmpty="false" />
 
         <CheckBoxPreference
-            android:key="filterSecond"
+            android:key="@string/filtered_deck_filterSecond_key"
             android:summary="@string/deck_conf_cram_filter_2_check"
             android:title="@string/deck_conf_cram_filter" />
     </PreferenceCategory>

--- a/AnkiDroid/src/main/res/xml/deck_options.xml
+++ b/AnkiDroid/src/main/res/xml/deck_options.xml
@@ -20,17 +20,17 @@
         <Preference
             android:summary="@string/deck_conf_group_summ" />
         <ListPreference
-            android:key="deckConf"
+            android:key="@string/deck_options_deckConf_key"
             android:title="@string/deck_conf_group" />
         <PreferenceScreen android:title="@string/deck_conf_manage"
             android:summary="@string/deck_conf_manage_summ" >
             <Preference
                 android:enabled="false"
-                android:key="currentConf"
+                android:key="@string/deck_options_currentConf_key"
                 android:title="@string/deck_conf_current_group" />
 
             <com.ichi2.preferences.AutoFocusEditTextPreference
-                android:key="confAdd"
+                android:key="@string/deck_options_confAdd_key"
                 android:summary="@string/deck_conf_add_summ"
                 android:title="@string/deck_conf_add" />
 
@@ -38,20 +38,20 @@
                 android:dialogIcon="@drawable/ic_warning_black"
                 android:dialogMessage="@string/deck_conf_remove_message"
                 android:dialogTitle="@string/dialog_positive_remove"
-                android:key="confRemove"
+                android:key="@string/deck_options_confRemove_key"
                 android:negativeButtonText="@string/dialog_cancel"
                 android:positiveButtonText="@string/dialog_positive_remove"
                 android:title="@string/dialog_positive_remove" />
 
             <com.ichi2.preferences.AutoFocusEditTextPreference
-                android:key="confRename"
+                android:key="@string/deck_options_confRename_key"
                 android:title="@string/deck_conf_rename" />
 
             <com.ichi2.preferences.CustomDialogPreference
                 android:dialogIcon="@drawable/ic_warning_black"
                 android:dialogMessage="@string/deck_conf_reset_message"
                 android:dialogTitle="@string/deck_conf_reset"
-                android:key="confRestore"
+                android:key="@string/deck_options_confRestore_key"
                 android:negativeButtonText="@string/dialog_cancel"
                 android:positiveButtonText="@string/dialog_positive_restore"
                 android:title="@string/deck_conf_reset" />
@@ -59,7 +59,7 @@
                 android:dialogIcon="@drawable/ic_warning_black"
                 android:dialogMessage="@string/deck_conf_set_subdecks_message"
                 android:dialogTitle="@string/deck_conf_set_subdecks"
-                android:key="confSetSubdecks"
+                android:key="@string/deck_options_confSetSubdecks_key"
                 android:negativeButtonText="@string/dialog_cancel"
                 android:positiveButtonText="@string/dialog_positive_set"
                 android:title="@string/deck_conf_set_subdecks" />
@@ -67,70 +67,70 @@
 
         <PreferenceScreen android:title="@string/deck_conf_new_cards" >
             <com.ichi2.preferences.StepsPreference
-                android:key="newSteps"
+                android:key="@string/deck_options_newSteps_key"
                 android:title="@string/deck_conf_steps"
                 app:allowEmpty="false" />
 
             <ListPreference
-                android:key="newOrder"
+                android:key="@string/deck_options_newOrder_key"
                 android:summary=""
                 android:title="@string/deck_conf_order" />
             <com.ichi2.preferences.IncrementerNumberRangePreference
-                android:key="newPerDay"
+                android:key="@string/deck_options_newPerDay_key"
                 android:title="@string/deck_conf_new_cards_day"
                 app:max="9999"
                 app:min="0" />
             <com.ichi2.preferences.IncrementerNumberRangePreference
-                android:key="newGradIvl"
+                android:key="@string/deck_options_newGradIvl_key"
                 android:summary="@string/deck_conf_days"
                 android:title="@string/deck_conf_graduating_ivl"
                 app:max="99"
                 app:min="1" />
             <com.ichi2.preferences.IncrementerNumberRangePreference
-                android:key="newEasy"
+                android:key="@string/deck_options_newEasy_key"
                 android:summary="@string/deck_conf_days"
                 android:title="@string/deck_conf_easy_ivl"
                 app:max="99"
                 app:min="1" />
             <com.ichi2.preferences.NumberRangePreference
-                android:key="newFactor"
+                android:key="@string/deck_options_newFactor_key"
                 android:summary="@string/deck_conf_percent"
                 android:title="@string/deck_conf_start_ease"
                 app:max="999"
                 app:min="100" />
             <CheckBoxPreference
                 android:defaultValue="true"
-                android:key="newBury"
+                android:key="@string/deck_options_newBury_key"
                 android:summary="@string/deck_conf_new_bury_summ"
                 android:title="@string/deck_conf_new_bury" />
         </PreferenceScreen>
         <PreferenceScreen android:title="@string/deck_conf_rev_cards" >
             <com.ichi2.preferences.IncrementerNumberRangePreference
-                android:key="revPerDay"
+                android:key="@string/deck_options_revPerDay_key"
                 android:title="@string/deck_conf_max_rev"
                 app:max="9999"
                 app:min="0" />
             <com.ichi2.preferences.NumberRangePreference
-                android:key="easyBonus"
+                android:key="@string/deck_options_easyBonus_key"
                 android:summary="@string/deck_conf_percent"
                 android:title="@string/deck_conf_easy_bonus"
                 app:max="1000"
                 app:min="100" />
             <com.ichi2.preferences.NumberRangePreference
-                android:key="hardFactor"
+                android:key="@string/deck_options_hardFactor_key"
                 android:summary="@string/deck_conf_percent"
                 android:title="@string/deck_conf_hard_factor"
                 android:enabled="false"
                 app:max="120"
                 app:min="5" />
             <com.ichi2.preferences.NumberRangePreference
-                android:key="revIvlFct"
+                android:key="@string/deck_options_revIvlFct_key"
                 android:summary="@string/deck_conf_percent"
                 android:title="@string/deck_conf_ivl_fct"
                 app:max="999"
                 app:min="0" />
             <com.ichi2.preferences.NumberRangePreference
-                android:key="revMaxIvl"
+                android:key="@string/deck_options_revMaxIvl_key"
                 android:summary="@string/deck_conf_days"
                 android:title="@string/deck_conf_max_ivl"
                 app:max="99999"
@@ -138,7 +138,7 @@
 
             <CheckBoxPreference
                 android:defaultValue="true"
-                android:key="revBury"
+                android:key="@string/deck_options_revBury_key"
                 android:summary="@string/deck_conf_rev_bury_summ"
                 android:title="@string/deck_conf_rev_bury" />
 
@@ -146,27 +146,27 @@
                 <CheckBoxPreference
                     android:defaultValue="true"
                     android:disableDependentsState="true"
-                    android:key="revUseGeneralTimeoutSettings"
+                    android:key="@string/deck_options_revUseGeneralTimeoutSettings_key"
                     android:title="@string/deck_conf_use_general_timeout_settings"
                     android:summary="@string/deck_conf_use_general_timeout_settings_summ" />
                 <CheckBoxPreference
                     android:defaultValue="false"
                     android:disableDependentsState="false"
-                    android:dependency="revUseGeneralTimeoutSettings"
-                    android:key="revTimeoutAnswer"
+                    android:dependency="@string/deck_options_revUseGeneralTimeoutSettings_key"
+                    android:key="@string/deck_options_revTimeoutAnswer_key"
                     android:summary="@string/timeout_answer_summ"
                     android:title="@string/timeout_answer_text" />
                 <com.ichi2.ui.SeekBarPreference
                     android:defaultValue="20"
-                    android:dependency="revTimeoutAnswer"
-                    android:key="revTimeoutAnswerSeconds"
+                    android:dependency="@string/deck_options_revTimeoutAnswer_key"
+                    android:key="@string/deck_options_revTimeoutAnswerSeconds_key"
                     android:max="30"
                     android:summary="@string/timeout_answer_seconds_summ"
                     android:title="@string/timeout_answer_seconds" />
                 <com.ichi2.ui.SeekBarPreference
                     android:defaultValue="60"
-                    android:dependency="revTimeoutAnswer"
-                    android:key="revTimeoutQuestionSeconds"
+                    android:dependency="@string/deck_options_revTimeoutAnswer_key"
+                    android:key="@string/deck_options_revTimeoutQuestionSeconds_key"
                     android:max="60"
                     android:summary="@string/timeout_answer_seconds_summ"
                     android:title="@string/timeout_question_seconds" />
@@ -174,62 +174,62 @@
         </PreferenceScreen>
         <PreferenceScreen android:title="@string/deck_conf_lps_cards" >
             <com.ichi2.preferences.StepsPreference
-                android:key="lapSteps"
+                android:key="@string/deck_options_lapSteps_key"
                 android:title="@string/deck_conf_steps"
                 app:allowEmpty="true" />
 
             <com.ichi2.preferences.IncrementerNumberRangePreference
-                android:key="lapNewIvl"
+                android:key="@string/deck_options_lapNewIvl_key"
                 android:summary="@string/deck_conf_percent"
                 android:title="@string/deck_conf_new_lps_ivl"
                 app:max="100"
                 app:min="0" />
             <com.ichi2.preferences.IncrementerNumberRangePreference
-                android:key="lapMinIvl"
+                android:key="@string/deck_options_lapMinIvl_key"
                 android:summary="@string/deck_conf_days"
                 android:title="@string/deck_conf_min_ivl"
                 app:max="99"
                 app:min="1" />
             <com.ichi2.preferences.IncrementerNumberRangePreference
-                android:key="lapLeechThres"
+                android:key="@string/deck_options_lapLeechThres_key"
                 android:summary="@string/deck_conf_fails"
                 android:title="@string/deck_conf_leech_thres"
                 app:max="99"
                 app:min="0" />
 
             <ListPreference
-                android:key="lapLeechAct"
+                android:key="@string/deck_options_lapLeechAct_key"
                 android:title="@string/deck_conf_leech_action" />
         </PreferenceScreen>
         <PreferenceScreen android:title="@string/deck_conf_general" >
             <com.ichi2.preferences.IncrementerNumberRangePreference
-                android:key="maxAnswerTime"
+                android:key="@string/deck_options_maxAnswerTime_key"
                 android:summary="@string/deck_conf_seconds"
                 android:title="@string/deck_conf_max_time"
                 app:max="3600"
                 app:min="30" />
 
             <CheckBoxPreference
-                android:key="showAnswerTimer"
+                android:key="@string/deck_options_showAnswerTimer_key"
                 android:title="@string/deck_conf_timer" />
             <CheckBoxPreference
-                android:key="autoPlayAudio"
+                android:key="@string/deck_options_autoPlayAudio_key"
                 android:title="@string/deck_conf_autoplay" />
             <CheckBoxPreference
-                android:key="replayQuestion"
+                android:key="@string/deck_options_replayQuestion_key"
                 android:summary="@string/deck_conf_replayq_summ"
                 android:title="@string/deck_conf_replayq" />
         </PreferenceScreen>
         <PreferenceScreen android:title="@string/deck_conf_reminders">
             <com.ichi2.ui.AutoSizeCheckBoxPreference
-                android:key="reminderEnabled"
+                android:key="@string/deck_options_reminderEnabled_key"
                 android:title="@string/deck_conf_reminders_enabled" />
             <com.ichi2.preferences.TimePreference
-                android:key="reminderTime"
+                android:key="@string/deck_options_reminderTime_key"
                 android:title="@string/deck_conf_reminders_time"
-                android:dependency="reminderEnabled" />
+                android:dependency="@string/deck_options_reminderEnabled_key" />
         </PreferenceScreen>
         <com.ichi2.preferences.AutoFocusEditTextPreference
-            android:key="desc"
+            android:key="@string/deck_options_desc_key"
             android:title="@string/deck_conf_deck_description" />
 </PreferenceScreen>

--- a/AnkiDroid/src/main/res/xml/preferences_custom_sync_server.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_custom_sync_server.xml
@@ -11,11 +11,11 @@
         android:summary="@string/custom_sync_server_enable_summary"
         android:defaultValue="false"/>
     <EditTextPreference
-        android:dependency="useCustomSyncServer"
+        android:dependency="@string/custom_sync_server_enable_key"
         android:key="@string/custom_sync_server_base_url_key"
         android:title="@string/custom_sync_server_base_url_title" />
     <EditTextPreference
-        android:dependency="useCustomSyncServer"
+        android:dependency="@string/custom_sync_server_enable_key"
         android:key="@string/custom_sync_server_media_url_key"
         android:title="@string/custom_sync_server_media_url_title" />
 </PreferenceScreen>

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/IssueRegistry.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/IssueRegistry.kt
@@ -17,6 +17,7 @@ import com.ichi2.anki.lint.rules.DirectToastMakeTextUsage
 import com.ichi2.anki.lint.rules.DuplicateCrowdInStrings
 import com.ichi2.anki.lint.rules.DuplicateTextInPreferencesXml
 import com.ichi2.anki.lint.rules.FixedPreferencesTitleLength
+import com.ichi2.anki.lint.rules.HardcodedPreferenceKey
 import com.ichi2.anki.lint.rules.InconsistentAnnotationUsage
 import com.ichi2.anki.lint.rules.InvalidStringFormatDetector
 import com.ichi2.anki.lint.rules.JUnitNullAssertionDetector
@@ -44,6 +45,7 @@ class IssueRegistry : IssueRegistry() {
                 DirectToastMakeTextUsage.ISSUE,
                 DuplicateCrowdInStrings.ISSUE,
                 DuplicateTextInPreferencesXml.ISSUE,
+                HardcodedPreferenceKey.ISSUE,
                 InconsistentAnnotationUsage.ISSUE,
                 JUnitNullAssertionDetector.ISSUE,
                 KotlinMigrationBrokenEmails.ISSUE,

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/rules/HardcodedPreferenceKey.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/HardcodedPreferenceKey.kt
@@ -1,0 +1,75 @@
+/*
+ *  Copyright (c) 2022 Brayan Oliveira <brayandso.dev@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+@file:Suppress("UnstableApiUsage")
+package com.ichi2.anki.lint.rules
+
+import com.android.resources.ResourceFolderType
+import com.android.tools.lint.detector.api.*
+import com.google.common.annotations.VisibleForTesting
+import com.ichi2.anki.lint.utils.Constants
+import org.w3c.dom.Element
+
+/**
+ * A Lint check to prevent using hardcoded strings on preferences keys
+ */
+class HardcodedPreferenceKey : ResourceXmlDetector() {
+
+    companion object {
+        @VisibleForTesting
+        val ID = "HardcodedPreferenceKey"
+
+        @VisibleForTesting
+        val DESCRIPTION = "Preference key should not be hardcoded"
+        private const val EXPLANATION = "Extract the key to a resources XML so it can be reused"
+        private val implementation = Implementation(HardcodedPreferenceKey::class.java, Scope.RESOURCE_FILE_SCOPE)
+        @JvmField
+        val ISSUE: Issue = Issue.create(
+            ID,
+            DESCRIPTION,
+            EXPLANATION,
+            Constants.ANKI_XML_CATEGORY,
+            Constants.ANKI_XML_PRIORITY,
+            Constants.ANKI_XML_SEVERITY,
+            implementation
+        )
+    }
+
+    override fun getApplicableElements(): Collection<String>? {
+        return ALL
+    }
+
+    override fun visitElement(context: XmlContext, element: Element) {
+        reportAttributeIfHardcoded(context, element, "android:key")
+        reportAttributeIfHardcoded(context, element, "android:dependency")
+    }
+
+    private fun reportAttributeIfHardcoded(context: XmlContext, element: Element, attributeName: String) {
+        val attrNode = element.getAttributeNode(attributeName) ?: return
+
+        if (isHardcodedString(attrNode.value)) {
+            context.report(ISSUE, element, context.getLocation(attrNode), DESCRIPTION)
+        }
+    }
+
+    private fun isHardcodedString(string: String): Boolean {
+        // resources start with a `@`, and attributes start with a `?`
+        return string.isNotEmpty() && !string.startsWith("@") && !string.startsWith("?")
+    }
+
+    override fun appliesTo(folderType: ResourceFolderType): Boolean {
+        return folderType == ResourceFolderType.XML
+    }
+}

--- a/lint-rules/src/test/java/com/ichi2/anki/lint/rules/HardcodedPreferenceKeyTest.kt
+++ b/lint-rules/src/test/java/com/ichi2/anki/lint/rules/HardcodedPreferenceKeyTest.kt
@@ -1,0 +1,88 @@
+/*
+ *  Copyright (c) 2022 Brayan Oliveira <brayandso.dev@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.ichi2.anki.lint.rules
+
+import com.android.tools.lint.checks.infrastructure.TestFiles
+import com.android.tools.lint.checks.infrastructure.TestLintTask.lint
+import org.intellij.lang.annotations.Language
+import org.junit.Test
+
+class HardcodedPreferenceKeyTest {
+    @Language("XML")
+    private val invalidXmlFile = "" +
+        "<PreferenceScreen xmlns:android=\"http://schemas.android.com/apk/res/android\" " +
+        "    android:title=\"@string/pref_cat_advanced\"                                " +
+        "    android:summary=\"@string/pref_cat_advanced_summ\"                         " +
+        "    android:key=\"pref_screen_advanced\">                                      " +
+        "        <EditTextPreference                                                    " +
+        "            android:defaultValue=\"/sdcard/AnkiDroid\"                         " +
+        "            android:key=\"deckPath\"                                           " +
+        "            android:summary=\"@string/preference_summary_literal\"             " +
+        "            android:title=\"@string/preference_literal\" />                    " +
+        "        <com.ichi2.ui.ConfirmationPreference                                   " +
+        "            android:key=\"force_full_sync\"                                    " +
+        "            android:dependency=\"deckPath\"                                    " +
+        "            android:title=\"@string/force_full_sync_title\"                    " +
+        "            android:summary=\"@string/force_full_sync_summary\" />             " +
+        "</PreferenceScreen>"
+
+    @Language("XML")
+    private val validXmlFile = """
+        <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
+            xmlns:app="http://schemas.android.com/apk/res-auto"
+            android:title="@string/pref_cat_general"
+            android:key="@string/pref_general_screen_key">
+            <Preference
+                android:title="foo"
+                android:summary="bar"/>
+            <ListPreference
+                android:defaultValue="@string/empty_string"
+                android:key="@string/pref_language_key"
+                android:icon="@drawable/ic_language_black_24dp"
+                android:title="@string/language"
+                app:useSimpleSummaryProvider="true"/>
+            <ListPreference
+                android:defaultValue="2"
+                android:entries="@array/error_reporting_choice_labels"
+                android:entryValues="@array/error_reporting_choice_values"
+                android:key="@string/error_reporting_mode_key"
+                android:title="@string/error_reporting_choice"
+                app:useSimpleSummaryProvider="true"/>
+        </PreferenceScreen>
+    """
+
+    @Test
+    fun showsErrorForInvalidFile() {
+        lint()
+            .allowMissingSdk()
+            .allowCompilationErrors()
+            .files(TestFiles.xml("res/xml/invalidpreference.xml", invalidXmlFile))
+            .issues(HardcodedPreferenceKey.ISSUE)
+            .run()
+            .expectErrorCount(4)
+    }
+
+    @Test
+    fun showsNoErrorForValidFile() {
+        lint()
+            .allowMissingSdk()
+            .allowCompilationErrors()
+            .files(TestFiles.xml("res/xml/validpreference.xml", validXmlFile))
+            .issues(HardcodedPreferenceKey.ISSUE)
+            .run()
+            .expectClean()
+    }
+}


### PR DESCRIPTION
## Fixes
Fixes #10423

## Approach
For the key extractions, just used a regex to replace the strings for keys, searching for `android:(?:key|dependency)="([^@].*?)"`. Deck options keys were replaced by `deck_options_KEYNAME_key` and filtered deck options were replaced by `filtered_deck_KEYNAME_key`. This way the change was easy to do and probably will be easy to review.

## How Has This Been Tested?

Ran lint and the unit tests created

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
