### PR TITLE
[GSoC] Add ability to browse one Card per Note in Browser

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -33,6 +33,7 @@ import androidx.activity.result.contract.ActivityResultContracts.StartActivityFo
 import androidx.annotation.CheckResult
 import androidx.annotation.VisibleForTesting
 import androidx.appcompat.widget.SearchView
+import androidx.core.content.edit
 import anki.collection.OpChanges
 import com.afollestad.materialdialogs.list.SingleChoiceListener
 import com.google.android.material.floatingactionbutton.FloatingActionButton
@@ -1247,9 +1248,10 @@ open class CardBrowser :
     fun switchCardOrNote(newCardsMode: bool) {
         val sharedPrefs = AnkiDroidApp.getSharedPrefs(this)
 
-        sharedPrefs.edit()
-            .putBoolean("inCardsMode", newCardsMode)
-            .apply()
+        sharedPrefs.edit {
+            this.putBoolean("inCardsMode", newCardsMode)
+            this.apply()
+        }
 
         inCardsMode = newCardsMode
         searchCards()
@@ -1258,9 +1260,10 @@ open class CardBrowser :
     fun onTruncate(newTruncateValue: Boolean) {
         val sharedPrefs = AnkiDroidApp.getSharedPrefs(this)
 
-        sharedPrefs.edit()
-            .putBoolean("isTruncated", newTruncateValue)
-            .apply()
+        sharedPrefs.edit {
+            this.putBoolean("isTruncated", newTruncateValue)
+            this.apply()
+        }
 
         isTruncated = newTruncateValue
         mCardsAdapter!!.notifyDataSetChanged()

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -685,7 +685,7 @@ open class CardBrowser :
             showAllDecks = true, alwaysShowDefault = false, showFilteredDecks = true
         )
         inCardsMode = AnkiDroidApp.getSharedPrefs(this).getBoolean("inCardsMode", true)
-        isTruncated = AnkiDroidApp.getSharedPrefs(this).getBoolean("isTruncated", true)
+        isTruncated = AnkiDroidApp.getSharedPrefs(this).getBoolean("isTruncated", false)
         mDeckSpinnerSelection!!.initializeActionBarDeckSpinner(this.supportActionBar!!)
         selectDeckAndSave(deckId)
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -1261,8 +1261,7 @@ open class CardBrowser :
         val sharedPrefs = AnkiDroidApp.getSharedPrefs(this)
 
         sharedPrefs.edit {
-            this.putBoolean("isTruncated", newTruncateValue)
-            this.apply()
+            putBoolean("isTruncated", newTruncateValue)
         }
 
         isTruncated = newTruncateValue

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -242,7 +242,6 @@ open class CardBrowser :
         private set
     @get:VisibleForTesting(otherwise = VisibleForTesting.NONE)
     var isTruncated = false
-        private set
     private val mCheckedCards = Collections.synchronizedSet(LinkedHashSet<CardCache>())
     private var mLastSelectedPosition = 0
     private var mActionBarMenu: Menu? = null

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -163,7 +163,8 @@ open class CardBrowser :
      * Cards mode or Notes mode.
      * True by default.
      * */
-    private var inCardsMode: Boolean = true
+    @get:VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+    var inCardsMode: Boolean = true
 
     // card that was clicked (not marked)
     private var mCurrentCardId: CardId = 0
@@ -1503,7 +1504,8 @@ open class CardBrowser :
     }
 
     @RustCleanup("remove card cache; switch to RecyclerView and browserRowForId (#11889)")
-    private fun searchCards() {
+    @VisibleForTesting
+    fun searchCards() {
         // cancel the previous search & render tasks if still running
         invalidate()
         if ("" != mSearchTerms && mSearchView != null) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/BrowserOptionsDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/BrowserOptionsDialog.kt
@@ -60,7 +60,7 @@ class BrowserOptionsDialog(private val inCardsMode: Boolean, private val isTrunc
 
         return MaterialAlertDialogBuilder(requireContext()).run {
             this.setView(dialogView)
-            this.setTitle("Browser Options")
+            this.setTitle(getString(R.string.browser_options_dialog_heading))
             this.setNegativeButton(getString(R.string.dialog_cancel)) { _: DialogInterface, _: Int ->
                 dismiss()
             }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/BrowserOptionsDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/BrowserOptionsDialog.kt
@@ -22,15 +22,23 @@ import android.os.Bundle
 import android.view.View
 import android.widget.CheckBox
 import android.widget.RadioButton
+import android.widget.RadioGroup
+import androidx.annotation.IdRes
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatDialogFragment
 import com.ichi2.anki.CardBrowser
 import com.ichi2.anki.R
 
 class BrowserOptionsDialog(private val inCardsMode: Boolean, private val isTruncated: Boolean) : AppCompatDialogFragment() {
+    private var newCardsMode = true
     private lateinit var dialogView: View
 
     private val positiveButtonClick = { _: DialogInterface, _: Int ->
+        @IdRes val selectedButtonId = dialogView.findViewById<RadioGroup>(R.id.select_browser_mode).checkedRadioButtonId
+        newCardsMode = selectedButtonId == R.id.select_cards_mode
+        if (inCardsMode != newCardsMode) {
+            (activity as CardBrowser).switchCardOrNote(newCardsMode)
+        }
         val newTruncate = dialogView.findViewById<CheckBox>(R.id.truncate_checkbox).isChecked
 
         if (newTruncate != isTruncated) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/BrowserOptionsDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/BrowserOptionsDialog.kt
@@ -24,8 +24,8 @@ import android.widget.CheckBox
 import android.widget.RadioButton
 import android.widget.RadioGroup
 import androidx.annotation.IdRes
-import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatDialogFragment
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.ichi2.anki.CardBrowser
 import com.ichi2.anki.R
 
@@ -47,8 +47,6 @@ class BrowserOptionsDialog(private val inCardsMode: Boolean, private val isTrunc
     }
 
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
-        val builder = AlertDialog.Builder(requireActivity())
-
         val layoutInflater = requireActivity().layoutInflater
         dialogView = layoutInflater.inflate(R.layout.browser_options_dialog, null)
 
@@ -60,7 +58,7 @@ class BrowserOptionsDialog(private val inCardsMode: Boolean, private val isTrunc
 
         dialogView.findViewById<CheckBox>(R.id.truncate_checkbox).isChecked = isTruncated
 
-        return builder.run {
+        return MaterialAlertDialogBuilder(requireContext()).run {
             this.setView(dialogView)
             this.setTitle("Browser Options")
             this.setNegativeButton(getString(R.string.dialog_cancel)) { _: DialogInterface, _: Int ->

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/BrowserOptionsDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/BrowserOptionsDialog.kt
@@ -30,10 +30,11 @@ import com.ichi2.anki.CardBrowser
 import com.ichi2.anki.R
 
 class BrowserOptionsDialog(private val inCardsMode: Boolean, private val isTruncated: Boolean) : AppCompatDialogFragment() {
-    private var newCardsMode = true
     private lateinit var dialogView: View
 
     private val positiveButtonClick = { _: DialogInterface, _: Int ->
+        val newCardsMode: Boolean
+
         @IdRes val selectedButtonId = dialogView.findViewById<RadioGroup>(R.id.select_browser_mode).checkedRadioButtonId
         newCardsMode = selectedButtonId == R.id.select_cards_mode
         if (inCardsMode != newCardsMode) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/BrowserOptionsDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/BrowserOptionsDialog.kt
@@ -1,0 +1,65 @@
+/*
+ *  Copyright (c) 2022 Akshit Sinha <akshitsinha3@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.dialogs
+
+import android.app.Dialog
+import android.content.DialogInterface
+import android.os.Bundle
+import android.view.View
+import android.widget.CheckBox
+import android.widget.RadioButton
+import androidx.appcompat.app.AlertDialog
+import androidx.appcompat.app.AppCompatDialogFragment
+import com.ichi2.anki.CardBrowser
+import com.ichi2.anki.R
+
+class BrowserOptionsDialog(private val inCardsMode: Boolean, private val isTruncated: Boolean) : AppCompatDialogFragment() {
+    private lateinit var dialogView: View
+
+    private val positiveButtonClick = { _: DialogInterface, _: Int ->
+        val newTruncate = dialogView.findViewById<CheckBox>(R.id.truncate_checkbox).isChecked
+
+        if (newTruncate != isTruncated) {
+            (activity as CardBrowser).onTruncate(newTruncate)
+        }
+    }
+
+    override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
+        val builder = AlertDialog.Builder(requireActivity())
+
+        val layoutInflater = requireActivity().layoutInflater
+        dialogView = layoutInflater.inflate(R.layout.browser_options_dialog, null)
+
+        if (inCardsMode) {
+            dialogView.findViewById<RadioButton>(R.id.select_cards_mode).isChecked = true
+        } else {
+            dialogView.findViewById<RadioButton>(R.id.select_notes_mode).isChecked = true
+        }
+
+        dialogView.findViewById<CheckBox>(R.id.truncate_checkbox).isChecked = isTruncated
+
+        return builder.run {
+            this.setView(dialogView)
+            this.setTitle("Browser Options")
+            this.setNegativeButton(getString(R.string.dialog_cancel)) { _: DialogInterface, _: Int ->
+                dismiss()
+            }
+            this.setPositiveButton(getString(R.string.dialog_ok), DialogInterface.OnClickListener(function = positiveButtonClick))
+            this.create()
+        }
+    }
+}

--- a/AnkiDroid/src/main/res/layout/browser_options_dialog.xml
+++ b/AnkiDroid/src/main/res/layout/browser_options_dialog.xml
@@ -41,7 +41,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:text="@string/toggle_browser_mode_help"
-            android:textColor="@color/material_grey_700"
+            android:textColor="?android:attr/textColorSecondary"
             android:layout_marginHorizontal="16dp" />
     </LinearLayout>
 
@@ -69,7 +69,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:text="@string/truncate_content_help"
-            android:textColor="@color/material_grey_700"
+            android:textColor="?android:attr/textColorSecondary"
             android:layout_marginHorizontal="16dp" />
 
     </LinearLayout>

--- a/AnkiDroid/src/main/res/layout/browser_options_dialog.xml
+++ b/AnkiDroid/src/main/res/layout/browser_options_dialog.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:layout_margin="8dp">
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/toggle_cards_notes"
+            android:textStyle="bold"
+            android:layout_marginHorizontal="16dp" />
+
+        <RadioGroup
+            android:id="@+id/select_browser_mode"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_margin="16dp">
+
+            <RadioButton
+                android:id="@+id/select_cards_mode"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/show_cards" />
+
+            <RadioButton
+                android:id="@+id/select_notes_mode"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/show_notes" />
+
+        </RadioGroup>
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/toggle_browser_mode_help"
+            android:textColor="@color/material_grey_700"
+            android:layout_marginHorizontal="16dp" />
+    </LinearLayout>
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:layout_margin="8dp">
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/card_browser_truncate"
+            android:textStyle="bold"
+            android:layout_marginHorizontal="16dp" />
+
+        <CheckBox
+            android:id="@+id/truncate_checkbox"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/card_browser_truncate"
+            android:layout_marginHorizontal="16dp" />
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/truncate_content_help"
+            android:textColor="@color/material_grey_700"
+            android:layout_marginHorizontal="16dp" />
+
+    </LinearLayout>
+
+
+
+</LinearLayout>

--- a/AnkiDroid/src/main/res/menu/card_browser.xml
+++ b/AnkiDroid/src/main/res/menu/card_browser.xml
@@ -88,10 +88,8 @@
         android:title="@string/card_browser_select_all"/>
 
     <item
-        android:id="@+id/action_truncate"
-        android:checkable="true"
-        android:checked="false"
-        android:title="@string/card_browser_truncate"
+        android:id="@+id/action_open_options"
+        android:title="@string/study_options"
         ankidroid:showAsAction="never"/>
 
 </menu>

--- a/AnkiDroid/src/main/res/values/02-strings.xml
+++ b/AnkiDroid/src/main/res/values/02-strings.xml
@@ -428,4 +428,11 @@
     <string name="validation_deck_already_exists">Deck exists</string>
     <string name="deck_created">Created deck</string>
     <string name="deck_renamed">Renamed deck</string>
+
+    <!-- Browser Options Dialog -->
+    <string name="show_cards">Cards</string>
+    <string name="show_notes">Notes</string>
+    <string name="toggle_cards_notes">Toggle Cards/Notes</string>
+    <string name="toggle_browser_mode_help">Toggle Showing cards or notes in the browser</string>
+    <string name="truncate_content_help">Truncate the height of each row of the Browser to show only first 3 lines of content</string>
 </resources>

--- a/AnkiDroid/src/main/res/values/02-strings.xml
+++ b/AnkiDroid/src/main/res/values/02-strings.xml
@@ -430,9 +430,10 @@
     <string name="deck_renamed">Renamed deck</string>
 
     <!-- Browser Options Dialog -->
-    <string name="show_cards">Cards</string>
-    <string name="show_notes">Notes</string>
+    <string name="show_cards" comment="Label for toggle cards button in BrowserOptionsDialog">Cards</string>
+    <string name="show_notes" comment="Label for toggle notes button in BrowserOptionsDialog">Notes</string>
     <string name="toggle_cards_notes">Toggle Cards/Notes</string>
     <string name="toggle_browser_mode_help">Toggle Showing cards or notes in the browser</string>
     <string name="truncate_content_help">Truncate the height of each row of the Browser to show only first 3 lines of content</string>
+    <string name="browser_options_dialog_heading">Browser Options</string>
 </resources>

--- a/AnkiDroid/src/main/res/values/06-statistics.xml
+++ b/AnkiDroid/src/main/res/values/06-statistics.xml
@@ -24,10 +24,10 @@
     <string name="statistics_unlearned">Unseen</string>
     <string name="statistics_suspended">Suspended</string>
     <string name="statistics_buried">Buried</string>
-    <string name="statistics_relearn" comment="Labbel of the axis in the graph indicating the number of reviews of cards while they are in relearning mode.">Relearn</string>
+    <string name="statistics_relearn" comment="Label of the axis in the graph indicating the number of reviews of cards while they are in relearning mode.">Relearn</string>
     <string name="statistics_learn" comment="Label of the number of review of card in learning done in some amount of time">Learn</string>
     <string name="statistics_cram">Cram</string>
-    <string name="stats_cards">Cards</string>
+    <string name="stats_cards" comment="Title to use in stats pages">Cards</string>
     <string name="stats_cards_intervals">Cards with given interval</string>
     <string name="stats_cumulative_cards">Cumulative cards</string>
     <string name="stats_cumulative_answers">Cumulative answers</string>

--- a/AnkiDroid/src/main/res/values/07-cardbrowser.xml
+++ b/AnkiDroid/src/main/res/values/07-cardbrowser.xml
@@ -24,6 +24,10 @@
         <item quantity="one">%d card shown</item>
         <item quantity="other">%d cards shown</item>
     </plurals>
+    <plurals name="card_browser_subtitle_notes_mode">
+        <item quantity="one">%d note shown</item>
+        <item quantity="other">%d notes shown</item>
+    </plurals>
 
     <string name="card_browser_all_decks">All decks</string>
     <string name="card_browser_delete_card">Delete notes</string>

--- a/AnkiDroid/src/main/res/values/theme_black.xml
+++ b/AnkiDroid/src/main/res/values/theme_black.xml
@@ -135,6 +135,8 @@
         <!-- Introduction -->
         <item name="introductionLogoTransparent">#55111111</item>
 
+        <!-- Browser Options Dialog-->
+        <item name="colorSurface">@color/theme_black_primary</item>
     </style>
 
     <!-- Preferences screens -->

--- a/AnkiDroid/src/main/res/values/theme_dark.xml
+++ b/AnkiDroid/src/main/res/values/theme_dark.xml
@@ -150,6 +150,8 @@
         <!-- Introduction -->
         <item name="introductionLogoTransparent">#883d3d3d</item>
 
+        <!-- Browser Options Dialog-->
+        <item name="colorSurface">@color/theme_dark_primary</item>
     </style>
 
     <!-- Preferences screens -->

--- a/AnkiDroid/src/main/res/values/theme_light.xml
+++ b/AnkiDroid/src/main/res/values/theme_light.xml
@@ -164,6 +164,8 @@ APIs. It's visible when there aren't enough decks to fill the screen.
         <!-- Introduction -->
         <item name="introductionLogoTransparent">#99FFFFFF</item>
 
+        <!-- Browser Options Dialog-->
+        <item name="colorSurface">@color/white</item>
     </style>
 
     <!-- Preferences screens -->

--- a/AnkiDroid/src/main/res/values/theme_plain.xml
+++ b/AnkiDroid/src/main/res/values/theme_plain.xml
@@ -73,6 +73,9 @@
 
         <!-- Introduction -->
         <item name="introductionLogoTransparent">#99FFFFFF</item>
+
+        <!-- Browser Options Dialog-->
+        <item name="colorSurface">@color/white</item>
     </style>
 
     <!-- Preferences screens -->

--- a/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.kt
@@ -674,10 +674,16 @@ class CardBrowserTest : RobolectricTest() {
     }
 
     /** Returns an instance of [CardBrowser] containing [noteCount] notes */
-    private fun getBrowserWithNotes(noteCount: Int): CardBrowser {
+    private fun getBrowserWithNotes(noteCount: Int, reversed: Boolean = false): CardBrowser {
         ensureCollectionLoadIsSynchronous()
-        for (i in 0 until noteCount) {
-            addNoteUsingBasicModel(i.toString(), "back")
+        if (reversed) {
+            for (i in 0 until noteCount) {
+                addNoteUsingBasicAndReversedModel(i.toString(), "back")
+            }
+        } else {
+            for (i in 0 until noteCount) {
+                addNoteUsingBasicModel(i.toString(), "back")
+            }
         }
         return super.startRegularActivity<CardBrowser>(Intent()).also {
             advanceRobolectricUiLooper() // may be a fix for flaky tests
@@ -741,5 +747,26 @@ class CardBrowserTest : RobolectricTest() {
             assertThat(column1.ellipsize, nullValue())
             assertThat(column2.ellipsize, nullValue())
         }
+    }
+
+    @Test
+    fun checkCardsNotesMode() {
+        val cardBrowser = getBrowserWithNotes(3, true)
+
+        // set browser to be in cards mode
+        cardBrowser.inCardsMode = true
+        cardBrowser.searchCards()
+
+        advanceRobolectricUiLooper()
+        // check if we get both cards of each note
+        assertThat(cardBrowser.mCards.size(), equalTo(6))
+
+        // set browser to be in notes mode
+        cardBrowser.inCardsMode = false
+        cardBrowser.searchCards()
+
+        // check if we get one card per note
+        advanceRobolectricUiLooper()
+        assertThat(cardBrowser.mCards.size(), equalTo(3))
     }
 }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.kt
@@ -706,16 +706,8 @@ class CardBrowserTest : RobolectricTest() {
     @Test
     fun truncateAndExpand() {
         val cardBrowser = getBrowserWithNotes(3)
-        val shadowActivity = shadowOf(cardBrowser)
-        val truncateOption = shadowActivity.optionsMenu.findItem(R.id.action_truncate)
-
-        // Simulating check "Truncate content"
-        selectMenuItem(cardBrowser, R.id.action_truncate)
-
-        // "Truncate content" is checked
-        assertTrue(truncateOption.isChecked)
         // "isTruncated" variable set to true
-        assertTrue(cardBrowser.isTruncated)
+        cardBrowser.isTruncated = true
 
         // Testing whether each card is truncated and ellipsized
         for (i in 0 until (cardBrowser.mCardsListView!!.childCount)) {
@@ -732,14 +724,8 @@ class CardBrowserTest : RobolectricTest() {
             assertThat(column2.ellipsize, equalTo(TextUtils.TruncateAt.END))
         }
 
-        // Simulating uncheck "Truncate content"
-        selectMenuItem(cardBrowser, R.id.action_truncate)
-
-        // "Truncate content" is unchecked
-        assertFalse(truncateOption.isChecked)
-
         // "isTruncate" variable set to false
-        assertFalse(cardBrowser.isTruncated)
+        cardBrowser.isTruncated = false
 
         // Testing whether each card is expanded and not ellipsized
         for (i in 0 until (cardBrowser.mCardsListView!!.childCount)) {


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
Add the functionality to see only one card per note when enabled, following upstream Anki Note mode of the Browser. Especially helpful when you have for example a lot of cloze deletions in one note, with this feature you can choose to see only one card instead of all of them.

## Fixes
Fixes #7939 

## Approach
By creating a variable to keep track of whether the browser is currently in Cards mode or Notes mode, different `Search` functions (committed earlier) are called accordingly. Part 1 of this commit just introduces the feature to view one card by note, further commits will include accommodating the column headers and their values (eg: avg. ease) to correctly display the values accordingly.

## How Has This Been Tested?

https://user-images.githubusercontent.com/86671025/185841802-0512a40c-e7c2-4bc5-9865-e5f71247c1ab.mp4

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
