### PR TITLE
Fix crash if NumberRangePref value is empty on close

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/ReviewingSettingsFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/ReviewingSettingsFragment.kt
@@ -39,7 +39,7 @@ class ReviewingSettingsFragment : SettingsFragment() {
         requirePreference<ListPreference>(R.string.new_spread_preference).apply {
             setValueIndex(col.get_config_int("newSpread"))
             setOnPreferenceChangeListener { newValue ->
-                col.set_config("newSpread", ((newValue as String).toInt()))
+                col.set_config("newSpread", newValue as Int)
             }
         }
 
@@ -50,7 +50,7 @@ class ReviewingSettingsFragment : SettingsFragment() {
         requirePreference<NumberRangePreferenceCompat>(R.string.learn_cutoff_preference).apply {
             setValue(col.get_config_int("collapseTime") / 60)
             setOnPreferenceChangeListener { newValue ->
-                col.set_config("collapseTime", ((newValue as String).toInt() * 60))
+                col.set_config("collapseTime", (newValue as Int * 60))
             }
         }
         // Timebox time limit
@@ -60,7 +60,7 @@ class ReviewingSettingsFragment : SettingsFragment() {
         requirePreference<NumberRangePreferenceCompat>(R.string.time_limit_preference).apply {
             setValue(col.get_config_int("timeLim") / 60)
             setOnPreferenceChangeListener { newValue ->
-                col.set_config("timeLim", ((newValue as String).toInt() * 60))
+                col.set_config("timeLim", (newValue as Int * 60))
             }
         }
         // Start of next day

--- a/AnkiDroid/src/main/java/com/ichi2/preferences/NumberRangePreferenceCompat.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/preferences/NumberRangePreferenceCompat.kt
@@ -181,7 +181,7 @@ open class NumberRangePreferenceCompat @JvmOverloads constructor(
             if (!positiveResult || editText.text.isEmpty()) {
                 return
             }
-            val newValue = editText.text.toString()
+            val newValue = editText.text.toString().toInt()
             if (numberRangePreference.callChangeListener(newValue)) {
                 numberRangePreference.setValue(newValue)
             }

--- a/AnkiDroid/src/main/java/com/ichi2/preferences/NumberRangePreferenceCompat.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/preferences/NumberRangePreferenceCompat.kt
@@ -30,6 +30,7 @@ import androidx.preference.EditTextPreference
 import androidx.preference.EditTextPreferenceDialogFragmentCompat
 import com.ichi2.anki.AnkiDroidApp
 import com.ichi2.anki.R
+import com.ichi2.annotations.NeedsTest
 import timber.log.Timber
 
 open class NumberRangePreferenceCompat @JvmOverloads constructor(
@@ -172,6 +173,18 @@ open class NumberRangePreferenceCompat @JvmOverloads constructor(
 
             // Clone the existing filters so we don't override them, then append our one at the end.
             editText.filters = arrayOf(*editText.filters, InputFilter.LengthFilter(numberRangePreference.maxDigits))
+        }
+
+        @NeedsTest("value is set to preference previous value if text is blank")
+        override fun onDialogClosed(positiveResult: Boolean) {
+            // don't change the value if the dialog was cancelled or closed without any text
+            if (!positiveResult || editText.text.isEmpty()) {
+                return
+            }
+            val newValue = editText.text.toString()
+            if (numberRangePreference.callChangeListener(newValue)) {
+                numberRangePreference.setValue(newValue)
+            }
         }
 
         companion object {


### PR DESCRIPTION
## Purpose / Description
The app crashes if you delete all text on a NumberRangePreference , e.g. Timebox time limit + if sent a text with leading zeroes, the summary would have the leading zeroes as well, e.g. "0050"

## Approach
Make a check at `onDialogClosed`

## How Has This Been Tested?

1. Settings > Reviewing > Timebox time limit
2. Erase all text
3. Confirm
4. See if the new value is 0

---
1. Settings > Reviewing > Timebox time limit
2. Write "0050"
3. Confirm
4. See if the new value is 50

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
