### PR TITLE
Fix crash in new schema when user tries to change notetype of card

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/ModelManager.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/ModelManager.kt
@@ -183,7 +183,7 @@ abstract class ModelManager(protected val col: Collection) {
      * @throws ConfirmModSchemaException
      */
     @Throws(ConfirmModSchemaException::class)
-    abstract fun change(m: Model, nid: NoteId, newModel: Model, fmap: Map<Int, Int?>?, cmap: Map<Int, Int?>?)
+    abstract fun change(m: Model, nid: NoteId, newModel: Model, fmap: Map<Int, Int?>, cmap: Map<Int, Int?>)
 
     /*
       Schema hash ***********************************************************************************************

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Models.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Models.java
@@ -789,15 +789,10 @@ public class Models extends ModelManager {
 
     /** {@inheritDoc} */
     @Override
-    public void change(Model m, long nid, Model newModel, @Nullable Map<Integer, Integer> fmap, @Nullable Map<Integer, Integer> cmap) throws ConfirmModSchemaException {
+    public void change(Model m, long nid, Model newModel, @NonNull Map<Integer, Integer> fmap, @NonNull Map<Integer, Integer> cmap) throws ConfirmModSchemaException {
         mCol.modSchema();
-        assert (newModel.getLong("id") == m.getLong("id")) || (fmap != null && cmap != null);
-        if (fmap != null) {
-            _changeNote(nid, newModel, fmap);
-        }
-        if (cmap != null) {
-            _changeCards(nid, m, newModel, cmap);
-        }
+        _changeNote(nid, newModel, fmap);
+        _changeCards(nid, m, newModel, cmap);
         mCol.genCards(nid, newModel);
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/ModelsV16.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/ModelsV16.kt
@@ -27,6 +27,7 @@ package com.ichi2.libanki
 
 import anki.notetypes.StockNotetype
 import com.ichi2.anki.R
+import com.ichi2.libanki.Consts.MODEL_CLOZE
 import com.ichi2.libanki.Utils.*
 import com.ichi2.libanki.backend.*
 import com.ichi2.libanki.backend.BackendUtils.to_json_bytes
@@ -557,17 +558,57 @@ class ModelsV16(col: CollectionV16) : ModelManager(col) {
     # Model changing
     ##########################################################################
     # - maps are ord->ord, and there should not be duplicate targets
-    # - newModel should be self if model is not changing
+    # - newModel should be same as m if model is not changing
      */
 
+    /** A compatibility wrapper that converts legacy-style arguments and
+     * feeds them into a backend request, so that AnkiDroid's editor-bound
+     * notetype changing can be used. Changing the notetype via the editor is
+     * not ideal: it doesn't let users re-order fields in a 2 element note,
+     * doesn't provide a warning to users about fields/cards that will be removed,
+     * and doesn't allow mapping one source field to multiple target fields. In
+     * the future, it may be worth removing this routine and exposing the
+     * change_notetype.html page to the user instead. The editor could remove
+     * the field-reordering code, and when saving a note where the notetype
+     * has been changed, the separate change_notetype screen could be shown.
+     * It would also be a good idea to expose change notetype as a bulk action
+     * in the browsing screen, so that the user can change the notetype of
+     * multiple notes at once.
+     * */
     override fun change(
         m: NoteType,
         nid: NoteId,
         newModel: NoteType,
-        fmap: Map<Int, Int?>?,
-        cmap: Map<Int, Int?>?
+        fmap: Map<Int, Int?>,
+        cmap: Map<Int, Int?>
     ) {
-        TODO("backend provides new API")
+        col.modSchema()
+        val fieldMap = convertLegacyMap(fmap, newModel.fieldsNames.size)
+        val templateMap =
+            if (cmap.isEmpty() || m.type == MODEL_CLOZE || newModel.type == MODEL_CLOZE) {
+                listOf()
+            } else {
+                convertLegacyMap(cmap, newModel.templatesNames.size)
+            }
+        col.backend.changeNotetype(
+            noteIds = listOf(nid),
+            newFields = fieldMap,
+            newTemplates = templateMap,
+            oldNotetypeId = newModel.id,
+            newNotetypeId = newModel.id,
+            currentSchema = col.scm,
+            oldNotetypeName = m.name,
+        )
+    }
+
+    /** Convert old->new map to list of old indexes/nulls */
+    private fun convertLegacyMap(map: Map<Int, Int?>, newSize: Int): Iterable<Int> {
+        val newToOld = map.entries.filter({ it.value != null }).associate { (k, v) -> v to k }
+        val output = mutableListOf<Int>()
+        for (idx in 0 until newSize) {
+            output.append(newToOld[idx] ?: -1)
+        }
+        return output
     }
 
     /*

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/ModelTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/ModelTest.kt
@@ -524,11 +524,6 @@ class ModelTest : RobolectricTest() {
     @Test
     @Throws(ConfirmModSchemaException::class)
     fun test_modelChange() {
-
-        if (!BackendFactory.defaultLegacySchema) {
-            // backend provides different API with TypeScript frontend
-            return
-        }
         val col = col
         val cloze = col.models.byName("Cloze")
         // enable second template and add a note
@@ -545,9 +540,10 @@ class ModelTest : RobolectricTest() {
         col.addNote(note)
         // switch fields
         var map: MutableMap<Int, Int?> = HashMap()
+        val noOp = mapOf<Int, Int?>(0 to 0, 1 to 1)
         map[0] = 1
         map[1] = 0
-        col.models.change(basic, note.id, basic, map, null)
+        col.models.change(basic, note.id, basic, map, noOp)
         note.load()
         assertEquals("b123", note.getItem("Front"))
         assertEquals("note", note.getItem("Back"))
@@ -558,7 +554,7 @@ class ModelTest : RobolectricTest() {
         assertThat(c1.q(), containsString("note"))
         assertEquals(0, c0.ord)
         assertEquals(1, c1.ord)
-        col.models.change(basic, note.id, basic, null, map)
+        col.models.change(basic, note.id, basic, noOp, map)
         note.load()
         c0.load()
         c1.load()
@@ -576,7 +572,7 @@ class ModelTest : RobolectricTest() {
         //     // The low precision timer on Windows reveals a race condition
         //     time.sleep(0.05);
         // }
-        col.models.change(basic, note.id, basic, null, map)
+        col.models.change(basic, note.id, basic, noOp, map)
         note.load()
         c0.load()
         // the card was deleted
@@ -585,7 +581,7 @@ class ModelTest : RobolectricTest() {
         // an unmapped field becomes blank
         assertEquals("b123", note.getItem("Front"))
         assertEquals("note", note.getItem("Back"))
-        col.models.change(basic, note.id, basic, map, null)
+        col.models.change(basic, note.id, basic, map, noOp)
         note.load()
         assertEquals("", note.getItem("Front"))
         assertEquals("note", note.getItem("Back"))


### PR DESCRIPTION
+ make the field/card map non-null, as null values were not being used
outside tests

Closes #12049 