### PR TITLE
Fix save search in CardBrowser when dialog has no list

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/CardBrowserMySearchesDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/CardBrowserMySearchesDialog.kt
@@ -72,12 +72,14 @@ class CardBrowserMySearchesDialog : AnalyticsDialogFragment() {
                     mySearchesDialogListener!!.onSaveSearch(text.toString(), currentSearchTerms)
                 }
         }
-        val layoutManager = dialog.getRecyclerView().layoutManager as LinearLayoutManager
-        val dividerItemDecoration = DividerItemDecoration(dialog.getRecyclerView().context, layoutManager.orientation)
-        val scale = resources.displayMetrics.density
-        val dpAsPixels = (5 * scale + 0.5f).toInt()
-        dialog.view.setPadding(dpAsPixels, 0, dpAsPixels, dpAsPixels)
-        dialog.getRecyclerView().addItemDecoration(dividerItemDecoration)
+        runCatching { dialog.getRecyclerView() }.onSuccess { recyclerView ->
+            val layoutManager = recyclerView.layoutManager as LinearLayoutManager
+            val dividerItemDecoration = DividerItemDecoration(recyclerView.context, layoutManager.orientation)
+            val scale = resources.displayMetrics.density
+            val dpAsPixels = (5 * scale + 0.5f).toInt()
+            dialog.view.setPadding(dpAsPixels, 0, dpAsPixels, dpAsPixels)
+            recyclerView.addItemDecoration(dividerItemDecoration)
+        }
         return dialog
     }
 


### PR DESCRIPTION
## Purpose / Description

The current code in CardBrowser does some setup for its dialogs if they show a list of items. However the dialog for the save search card doesn't show a list of items and using this option triggers a crash(no RecyclerView). This PR fixes this by attempting to retrieve the RecyclerView of the dialog(if not found it throws a IllegalStateException) and doing the work only if the call succeeds. This follows the code used before the material library update which checked for null when retrieving the RecyclerView from the dialog before using it.

## Fixes

Fixes #12057 

## How Has This Been Tested?

Ran the tests.

## Checklist

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
