### PR TITLE
perf: testAnswerCard

### DIFF
--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/ContentProviderTest.java
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/ContentProviderTest.java
@@ -921,7 +921,7 @@ public class ContentProviderTest extends InstrumentedTest {
         values.put(FlashCardsContract.ReviewInfo.TIME_TAKEN, timeTaken);
         int updateCount = cr.update(reviewInfoUri, values, null, null);
         assertEquals("Check if update returns 1", 1, updateCount);
-        try { Thread.currentThread().wait(500); } catch (Exception e) {/* do nothing */}
+        try { Thread.currentThread().join(500); } catch (Exception e) {/* do nothing */}
         col.reset();
         Card newCard = col.getSched().getCard();
         if(newCard != null){


### PR DESCRIPTION
`wait` uses Object.wait which depends on `notify`, we wanted `Thread.join()`.

This is useful before the Kotlin migration as Kotlin no longer has Object.wait

## How Has This Been Tested?


Test only 

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
