### PR TITLE
NF: Replace FragmentLayout with FragmentContainerView as the container for fragments

### DIFF
--- a/AnkiDroid/src/main/res/layout-xlarge/homescreen.xml
+++ b/AnkiDroid/src/main/res/layout-xlarge/homescreen.xml
@@ -13,7 +13,7 @@
                 android:layout_width="1dip"
                 android:layout_weight="3"
                 android:layout_height="match_parent"/>
-            <FrameLayout
+            <androidx.fragment.app.FragmentContainerView
                 android:id="@+id/studyoptions_fragment"
                 android:layout_weight="2"
                 android:layout_width="1dip"

--- a/AnkiDroid/src/main/res/layout/preferences.xml
+++ b/AnkiDroid/src/main/res/layout/preferences.xml
@@ -23,7 +23,7 @@
 
     <include layout="@layout/toolbar" />
 
-    <FrameLayout
+    <androidx.fragment.app.FragmentContainerView
         android:id="@+id/settings_container"
         android:layout_width="0dp"
         android:layout_height="0dp"


### PR DESCRIPTION
It's now Android's preferred container for fragments (https://developer.android.com/jetpack/androidx/releases/fragment#version_120_3)

And as it extends FrameLayout (https://developer.android.com/reference/androidx/fragment/app/FragmentContainerView) there shouldn't be a problem

## How Has This Been Tested?

1. Ran the app on a SDK 25 Tablet emulator to see if the deck picker study options fragment was being shown correctly
2. Open the preferences' screen


## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
