### PR TITLE
[GSoC] Add option to import text files

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -823,6 +823,9 @@ open class DeckPicker :
             if (!importResult.isSuccess) {
                 ImportUtils.showImportUnsuccessfulDialog(this, importResult.humanReadableMessage, false)
             }
+        } else if (requestCode == PICK_CSV_FILE && resultCode == RESULT_OK) {
+            ImportUtils.getFileCachedCopy(this, data!!) ?: return
+            showThemedToast(this, "CSV importer is not implemented yet", true)
         }
     }
 
@@ -2691,6 +2694,7 @@ open class DeckPicker :
         const val SHOW_STUDYOPTIONS = 11
         private const val ADD_NOTE = 12
         const val PICK_APKG_FILE = 13
+        const val PICK_CSV_FILE = 14
 
         // For automatic syncing
         // 10 minutes in milliseconds.

--- a/AnkiDroid/src/main/java/com/ichi2/anki/analytics/UsageAnalytics.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/analytics/UsageAnalytics.kt
@@ -453,5 +453,8 @@ object UsageAnalytics {
 
         @AnalyticsConstant
         val IMPORT_COLPKG_FILE = "Import COLPKG"
+
+        @AnalyticsConstant
+        val IMPORT_CSV_FILE = "Import CSV"
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DatabaseErrorDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DatabaseErrorDialog.kt
@@ -219,7 +219,7 @@ class DatabaseErrorDialog : AsyncDialogFragment() {
                     }
                     dialog.title(R.string.backup_restore_select_title)
                         .positiveButton(R.string.restore_backup_choose_another) {
-                            ImportFileSelectionFragment.openImportFilePicker(activity as AnkiActivity)
+                            ImportFileSelectionFragment.openImportFilePicker(activity as AnkiActivity, DeckPicker.PICK_APKG_FILE)
                         }
                         .negativeButton(R.string.dialog_cancel)
                         .listItemsSingleChoice(items = dates.toTypedArray().toList(), waitForPositiveButton = false) { _: MaterialDialog, index: Int, _: CharSequence ->

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ImportFileSelectionFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ImportFileSelectionFragment.kt
@@ -24,6 +24,7 @@ import com.ichi2.anki.analytics.UsageAnalytics
 import com.ichi2.anki.dialogs.HelpDialog.FunctionItem
 import com.ichi2.annotations.NeedsTest
 import com.ichi2.utils.KotlinCleanup
+import net.ankiweb.rsdroid.BackendFactory
 import timber.log.Timber
 
 @NeedsTest("Selecting APKG allows multiple files")
@@ -57,6 +58,16 @@ class ImportFileSelectionFragment {
                     OpenFilePicker(DeckPicker.PICK_APKG_FILE)
                 ),
             )
+            if (!BackendFactory.defaultLegacySchema) {
+                importItems.add(
+                    FunctionItem(
+                        R.string.import_csv,
+                        R.drawable.ic_baseline_description_24,
+                        UsageAnalytics.Actions.IMPORT_CSV_FILE,
+                        OpenFilePicker(DeckPicker.PICK_CSV_FILE, multiple = false, mimeType = "text/plain")
+                    )
+                )
+            }
             return RecursivePictureMenu.createInstance(ArrayList(importItems), R.string.menu_import)
         }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ImportFileSelectionFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ImportFileSelectionFragment.kt
@@ -37,9 +37,9 @@ class ImportFileSelectionFragment {
             // this needs a deckPicker for now. See use of PICK_APKG_FILE
 
             // This is required for serialization of the lambda
-            class OpenFilePicker(var multiple: Boolean = false) : FunctionItem.ActivityConsumer {
+            class OpenFilePicker(val requestCode: Int, var multiple: Boolean = false, val mimeType: String = "*/*") : FunctionItem.ActivityConsumer {
                 override fun consume(activity: AnkiActivity) {
-                    openImportFilePicker(activity, multiple)
+                    openImportFilePicker(activity, requestCode, multiple, mimeType)
                 }
             }
 
@@ -48,13 +48,13 @@ class ImportFileSelectionFragment {
                     R.string.import_deck_package,
                     R.drawable.ic_manual_black_24dp,
                     UsageAnalytics.Actions.IMPORT_APKG_FILE,
-                    OpenFilePicker(true)
+                    OpenFilePicker(DeckPicker.PICK_APKG_FILE, true)
                 ),
                 FunctionItem(
                     R.string.import_collection_package,
                     R.drawable.ic_manual_black_24dp,
                     UsageAnalytics.Actions.IMPORT_COLPKG_FILE,
-                    OpenFilePicker()
+                    OpenFilePicker(DeckPicker.PICK_APKG_FILE)
                 ),
             )
             return RecursivePictureMenu.createInstance(ArrayList(importItems), R.string.menu_import)
@@ -62,16 +62,16 @@ class ImportFileSelectionFragment {
 
         // needs to be static for serialization
         @JvmStatic
-        fun openImportFilePicker(activity: AnkiActivity, multiple: Boolean = false) {
+        fun openImportFilePicker(activity: AnkiActivity, requestCode: Int, multiple: Boolean = false, mimeType: String = "*/*") {
             Timber.d("openImportFilePicker() delegating to file picker intent")
             val intent = Intent(Intent.ACTION_OPEN_DOCUMENT)
             intent.addCategory(Intent.CATEGORY_OPENABLE)
-            intent.type = "*/*"
+            intent.type = mimeType
             intent.putExtra("android.content.extra.SHOW_ADVANCED", true)
             intent.putExtra("android.content.extra.FANCY", true)
             intent.putExtra("android.content.extra.SHOW_FILESIZE", true)
             intent.putExtra(Intent.EXTRA_ALLOW_MULTIPLE, multiple)
-            activity.startActivityForResultWithoutAnimation(intent, DeckPicker.PICK_APKG_FILE)
+            activity.startActivityForResultWithoutAnimation(intent, requestCode)
         }
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/utils/ImportUtils.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/ImportUtils.kt
@@ -112,7 +112,7 @@ object ImportUtils {
             } catch (e: Exception) {
                 CrashReportService.sendExceptionReport(e, "handleFileImport")
                 Timber.e(e, "failed to handle import intent")
-                ImportResult.fromErrorString(context.getString(R.string.import_error_exception, e.localizedMessage))
+                ImportResult.fromErrorString(context.getString(R.string.import_error_handle_exception, e.localizedMessage))
             }
         }
 

--- a/AnkiDroid/src/main/java/com/ichi2/utils/ImportUtils.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/ImportUtils.kt
@@ -280,9 +280,9 @@ object ImportUtils {
             return MimeTypeMap.getFileExtensionFromUrl(file.toString())
         }
 
-        protected open fun getFileNameFromContentProvider(context: Context, data: Uri?): String? {
+        protected open fun getFileNameFromContentProvider(context: Context, data: Uri): String? {
             var filename: String? = null
-            context.contentResolver.query(data!!, arrayOf(OpenableColumns.DISPLAY_NAME), null, null, null).use { cursor ->
+            context.contentResolver.query(data, arrayOf(OpenableColumns.DISPLAY_NAME), null, null, null).use { cursor ->
                 if (cursor != null && cursor.moveToFirst()) {
                     filename = cursor.getString(0)
                     Timber.d("handleFileImport() Importing from content provider: %s", filename)

--- a/AnkiDroid/src/main/java/com/ichi2/utils/ImportUtils.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/ImportUtils.kt
@@ -64,6 +64,13 @@ object ImportUtils {
         return FileImporter().handleFileImport(context, intent)
     }
 
+    /**
+     * Makes a cached copy of the file selected on [intent] and returns its path
+     */
+    fun getFileCachedCopy(context: Context, intent: Intent): String? {
+        return FileImporter().getFileCachedCopy(context, intent)
+    }
+
     @JvmStatic
     fun showImportUnsuccessfulDialog(activity: Activity, errorMessage: String?, exitActivity: Boolean) {
         FileImporter().showImportUnsuccessfulDialog(activity, errorMessage, exitActivity)
@@ -123,6 +130,20 @@ object ImportUtils {
                 handleContentProviderFile(context, intent, dataList)
             } else {
                 ImportResult.fromErrorString(context.getString(R.string.import_error_handle_exception))
+            }
+        }
+
+        /**
+         * Makes a cached copy of the file selected on [intent] and returns its path
+         */
+        fun getFileCachedCopy(context: Context, intent: Intent): String? {
+            val uri = getUris(intent)?.get(0) ?: return null
+            val filename = ensureValidLength(getFileNameFromContentProvider(context, uri) ?: return null)
+            val tempPath = Uri.fromFile(File(context.cacheDir, filename)).encodedPath!!
+            return if (copyFileToCache(context, uri, tempPath)) {
+                tempPath
+            } else {
+                null
             }
         }
 

--- a/AnkiDroid/src/main/res/values/02-strings.xml
+++ b/AnkiDroid/src/main/res/values/02-strings.xml
@@ -163,7 +163,7 @@
     <string name="import_succeeded_but_check_database">Data import succeeded but post-import cleanup failed. Run check database later. Root cause: %s</string>
     <string name="import_error_unhandled_request">Unable to process import request</string>
     <string name="import_error_corrupt_zip">The apkg file is corrupt. Please delete and re-download it.\n\nRoot cause: %s</string>
-    <string name="import_error_exception">Failed to import package\n\n%s</string>
+    <string name="import_error_handle_exception">Failed to import file\n\n%s</string>
     <string name="import_error_not_apkg_extension">Filename “%s” doesn’t have .apkg or .colpkg extension</string>
     <string name="import_error_load_imported_database">Anki Database (.anki2) replacements are not yet supported. Please see the manual for replacement instructions.</string>
     <string name="import_error_content_provider">The selected file couldn’t be imported automatically by AnkiDroid. Please see the user manual for how to manually import anki files: \n%s</string>

--- a/AnkiDroid/src/main/res/values/02-strings.xml
+++ b/AnkiDroid/src/main/res/values/02-strings.xml
@@ -161,14 +161,12 @@
     <string name="import_log_insufficient_space_error">There is not enough space to import the package.\nNeeded - %1$s \nAvailable - %2$s.\n\nHaving Trouble? Try to free space on your phone if possible. Alternatively, sync uses less space than import. You may try importing the package with a device with more space (for example Anki Desktop) and then sync it to this device.</string>
     <string name="import_log_file_cache_cleared">Error importing file, likely a cache clear during processing.\nPlease try again</string>
     <string name="import_succeeded_but_check_database">Data import succeeded but post-import cleanup failed. Run check database later. Root cause: %s</string>
-    <string name="import_error_unhandled_request">Unable to process import request</string>
     <string name="import_error_corrupt_zip">The apkg file is corrupt. Please delete and re-download it.\n\nRoot cause: %s</string>
     <string name="import_error_handle_exception">Failed to import file\n\n%s</string>
     <string name="import_error_not_apkg_extension">Filename “%s” doesn’t have .apkg or .colpkg extension</string>
     <string name="import_error_load_imported_database">Anki Database (.anki2) replacements are not yet supported. Please see the manual for replacement instructions.</string>
     <string name="import_error_content_provider">The selected file couldn’t be imported automatically by AnkiDroid. Please see the user manual for how to manually import anki files: \n%s</string>
     <string name="import_error_copy_file_to_cache">copyFileToCache() failed (possibly out of storage space)</string>
-    <string name="import_error_unhandled_scheme">Unhandled import from: “%s”</string>
     <string name="import_error_multiple_colpkg">Multiple colpkg files were selected.</string>
     <string name="import_error_colpkg_apkg">Both apkg &amp; colpkg files were selected at once.</string>
     <string name="import_stats_error">Some errors occurred while importing the following files:\n%s</string>>

--- a/AnkiDroid/src/main/res/values/03-dialogs.xml
+++ b/AnkiDroid/src/main/res/values/03-dialogs.xml
@@ -266,7 +266,7 @@
 
     <string name="import_deck_package">Deck package (.apkg)</string>
     <string name="import_collection_package">Collection package (.colpkg)</string>
-
+    <string name="import_csv">Text file (.txt, .csv)</string>
     <!-- Deck selection dialog -->
     <string name="cannot_create_subdeck_for_all_decks">You cannot create a subdeck for all decks</string>
 </resources>

--- a/AnkiDroid/src/test/java/com/ichi2/anki/analytics/AnalyticsConstantsTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/analytics/AnalyticsConstantsTest.kt
@@ -67,6 +67,7 @@ object AnalyticsConstantsTest {
         listOfConstantFields.add("Exception Report")
         listOfConstantFields.add("Import APKG")
         listOfConstantFields.add("Import COLPKG")
+        listOfConstantFields.add("Import CSV")
     }
 
     internal val analyticsConstantFields

--- a/AnkiDroid/src/test/java/com/ichi2/utils/ImportUtilsTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/utils/ImportUtilsTest.kt
@@ -130,7 +130,7 @@ class ImportUtilsTest : RobolectricTest() {
             return true
         }
 
-        override fun getFileNameFromContentProvider(context: Context, data: Uri?): String? {
+        override fun getFileNameFromContentProvider(context: Context, data: Uri): String? {
             return fileName
         }
     }


### PR DESCRIPTION
## Purpose / Description
This just adds the option, not the actual text/csv import implementation. which will be the next PR

As the CSV importer will require the new backend, the options is only shown if the new backend is enabled

## Approach
On the commits

## How Has This Been Tested?

1. Enable the new backend
2. Tap the three dot menu on the Deck picker > Import
3. Choose "Text file (.txt, .csv)
4. Select a text file
5. See if the "CSV importer is not implemented yet" is shown

![image](https://user-images.githubusercontent.com/69634269/185417119-c7add351-da1b-4221-b6aa-c9f624f2ab8a.png)

![image](https://user-images.githubusercontent.com/69634269/185417176-c72ebc9f-b8ee-438f-9523-22c919e65c7d.png)


## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
