### PR TITLE
rename: Sound.kt -> SoundKt.kt

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Sound.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Sound.java
@@ -56,7 +56,7 @@ import androidx.annotation.Nullable;
 import androidx.annotation.VisibleForTesting;
 import timber.log.Timber;
 
-import static com.ichi2.libanki.SoundKt.addPlayIcons;
+import static com.ichi2.libanki.SoundKtKt.addPlayIcons;
 
 
 //NICE_TO_HAVE: Abstract, then add tests fir #6111

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/SoundKt.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/SoundKt.kt
@@ -25,7 +25,9 @@
 package com.ichi2.libanki
 
 import com.ichi2.anki.CollectionManager.withCol
+import com.ichi2.utils.KotlinCleanup
 
+@KotlinCleanup("combine file with Sound.kt if done in libAnki")
 /**
  * Records information about a text to speech tag.
  */


### PR DESCRIPTION
'Sound.kt' blocks conversion of Sound.java to Kotlin as we can't have different files with the same name