### PR TITLE
Remove whitespace and code style checklist items

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -21,9 +21,7 @@ _Links to blog posts, patterns, libraries or addons used to solve this problem_
 ## Checklist
 _Please, go through these checks before submitting the PR._
 
-- [ ] You have not changed whitespace unnecessarily (it makes diffs hard to read)
 - [ ] You have a descriptive commit message with a short title (first line, max 50 chars).
-- [ ] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
 - [ ] You have commented your code, particularly in hard-to-understand areas
 - [ ] You have performed a self-review of your own code
 - [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)


### PR DESCRIPTION
These items are now handled by lint checks + pre-commit hooks for Kotlin-based code

We have very little Java code, and I feel it's very unlikely that new users will be modifying this before we remove the remainder

This streamlines the process of submitting a PR, which hopefully encourages new contributors to participate in the repo

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
