### PR TITLE
Make switch color blue on `Light` theme + Fix `colorAccent` low contrast on dark themes

### DIFF
--- a/AnkiDroid/src/main/res/color/drawer_item_text_dark.xml
+++ b/AnkiDroid/src/main/res/color/drawer_item_text_dark.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
-    <item android:state_checked="true" android:color="@color/theme_dark_accent"/>
+    <item android:state_checked="true" android:color="?attr/colorAccent"/>
     <item android:color="@color/theme_dark_drawer_item"/>
 </selector>

--- a/AnkiDroid/src/main/res/values/colors.xml
+++ b/AnkiDroid/src/main/res/values/colors.xml
@@ -70,6 +70,7 @@
     <color name="material_indigo_200">#9fa8da</color>
     <color name="material_indigo_700">#ff303f9f</color>
     <color name="material_indigo_A700">#ff304ffe</color>
+    <color name="material_blue_400">#ff42a5f5</color>
     <color name="material_blue_500">#ff2196f3</color>
     <color name="material_blue_600">#ff1e88e5</color>
     <color name="material_blue_700">#ff1976d2</color>

--- a/AnkiDroid/src/main/res/values/theme_black.xml
+++ b/AnkiDroid/src/main/res/values/theme_black.xml
@@ -3,7 +3,6 @@
     <color name="theme_black_primary">#000000</color>
     <color name="theme_black_primary_dark">#000000</color>
     <color name="theme_black_primary_light">#151515</color>
-    <color name="theme_black_accent">#1565C0</color>
     <color name="theme_black_primary_text">#fff</color> <!-- Alternative: #808080 -->
     <color name="theme_black_secondary_text">#a0a0a0</color>
     <color name="theme_black_row_current">#1a1a1a</color>
@@ -12,7 +11,7 @@
         <!-- Android colors -->
         <item name="colorPrimary">@color/theme_black_primary_dark</item>
         <item name="colorPrimaryDark">@color/black</item>
-        <item name="colorAccent">@color/theme_black_accent</item>
+        <item name="colorAccent">@color/material_blue_500</item>
         <item name="android:textColor">@color/theme_black_primary_text</item>
         <item name="android:textColorPrimary">@color/theme_black_primary_text</item>
         <item name="android:textColorSecondary">@color/theme_black_secondary_text</item>

--- a/AnkiDroid/src/main/res/values/theme_black.xml
+++ b/AnkiDroid/src/main/res/values/theme_black.xml
@@ -18,6 +18,7 @@
         <item name="android:textColorSecondary">@color/theme_black_secondary_text</item>
         <item name="android:colorBackground">@color/theme_black_primary</item>
         <item name="android:windowBackground">@color/theme_black_primary</item>
+        <item name="colorControlActivated">?attr/colorAccent</item>
         <!-- App buttons -->
         <item name="largeButtonBackgroundColor">#303030</item>
         <item name="largeButtonBackgroundColorFocused">#444444</item>

--- a/AnkiDroid/src/main/res/values/theme_dark.xml
+++ b/AnkiDroid/src/main/res/values/theme_dark.xml
@@ -20,6 +20,7 @@
         <item name="android:textColorSecondary">@color/theme_dark_secondary_text</item>
         <item name="android:colorBackground">@color/material_theme_grey</item>
         <item name="android:windowBackground">@color/material_theme_grey</item>
+        <item name="colorControlActivated">?attr/colorAccent</item>
         <!-- Navigation drawer -->
         <item name="navDrawerItemColor">@color/drawer_item_text_dark</item>
         <item name="navDrawerItemBackgroundColor">@drawable/drawer_item_background_dark</item>

--- a/AnkiDroid/src/main/res/values/theme_dark.xml
+++ b/AnkiDroid/src/main/res/values/theme_dark.xml
@@ -3,7 +3,6 @@
     <color name="theme_dark_primary">#3d3d3d</color>
     <color name="theme_dark_primary_dark">@color/material_grey_900</color>
     <color name="theme_dark_primary_light">@color/material_grey_800</color>
-    <color name="theme_dark_accent">@color/material_light_blue_700</color>
     <color name="theme_dark_primary_text">@color/white</color>
     <color name="theme_dark_secondary_text">#b2ffffff</color>
     <color name="theme_dark_row_current">#393939</color>
@@ -14,7 +13,7 @@
         <!-- Android colors -->
         <item name="colorPrimary">@color/theme_dark_primary</item>
         <item name="colorPrimaryDark">@color/theme_dark_primary_dark</item>
-        <item name="colorAccent">@color/theme_dark_accent</item>
+        <item name="colorAccent">@color/material_blue_400</item>
         <item name="android:textColor">@color/theme_dark_primary_text</item>
         <item name="android:textColorPrimary">@color/theme_dark_primary_text</item>
         <item name="android:textColorSecondary">@color/theme_dark_secondary_text</item>
@@ -136,7 +135,7 @@
         <item name="filterItemBackground">@color/theme_dark_primary_dark</item>
         <item name="filterItemBackgroundSelected">@color/theme_dark_drawer_row_current</item>
         <item name="filterItemTextColor">@color/theme_dark_drawer_item</item>
-        <item name="filterItemTextColorSelected">@color/theme_dark_accent</item>
+        <item name="filterItemTextColorSelected">?attr/colorAccent</item>
         <item name="filterHeaderDivider">@color/white</item>
 
         <!-- Snackbar. Attributes snackbarStyle, snackbarTextViewStyle and snackbarButtonStyle

--- a/AnkiDroid/src/main/res/values/theme_light.xml
+++ b/AnkiDroid/src/main/res/values/theme_light.xml
@@ -33,6 +33,7 @@ APIs. It's visible when there aren't enough decks to fill the screen.
         <item name="android:textColorSecondary">@color/theme_light_secondary_text</item>
         <item name="android:colorBackground">@android:color/white</item>
         <item name="android:windowBackground">@android:color/white</item>
+        <item name="colorControlActivated">?attr/colorPrimary</item>
         <!-- Navigation drawer theme -->
         <item name="navDrawerItemColor">@color/drawer_item_text_light</item>
         <item name="navDrawerItemBackgroundColor">@drawable/drawer_item_background_light</item>

--- a/AnkiDroid/src/main/res/values/theme_plain.xml
+++ b/AnkiDroid/src/main/res/values/theme_plain.xml
@@ -15,6 +15,7 @@
         <item name="android:textColor">@color/theme_plain_primary_text</item>
         <item name="android:textColorPrimary">@color/theme_plain_primary_text</item>
         <item name="android:textColorSecondary">@color/theme_plain_secondary_text</item>
+        <item name="colorControlActivated">?attr/colorAccent</item>
         <!-- App buttons -->
         <item name="largeButtonBackgroundColor">#607D8B</item>
         <item name="largeButtonBackgroundColorFocused">#587180</item>


### PR DESCRIPTION
## Fixes
Fixes #10909
Fixes #12020
Closes #11043

## Approach
On the commits

## How Has This Been Tested?

1. Go to one of the Settings categories
2. On light theme: see if switches are blue
3. On dark theme: see if pass accessibility scanner
4. On black theme: see if pass accessibility scanner

![Screenshot_20220819-060638_AnkiDroid](https://user-images.githubusercontent.com/69634269/185586891-c3d1e358-7731-4176-85b4-856752e1f322.png)
![Screenshot_20220819-061210_AnkiDroid](https://user-images.githubusercontent.com/69634269/185586899-2b8e0797-fc9b-48d2-b6d6-b8eafa282cb1.png)
![Screenshot_20220819-060850_AnkiDroid](https://user-images.githubusercontent.com/69634269/185586902-d91a1f45-dedd-4958-b0e4-cdb8a411953e.png)


## Learning (optional, can help others)
Good old stack overflow: https://stackoverflow.com/questions/11253512/change-on-color-of-a-switch

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [X] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
