### PR TITLE
Use snackbars instead of toasts on the Settings fragments

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/AdvancedSettingsFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/AdvancedSettingsFragment.kt
@@ -27,6 +27,7 @@ import com.afollestad.materialdialogs.MaterialDialog
 import com.ichi2.anki.*
 import com.ichi2.anki.exception.StorageAccessException
 import com.ichi2.anki.provider.CardContentProvider
+import com.ichi2.anki.snackbar.showSnackbar
 import com.ichi2.compat.CompatHelper
 import net.ankiweb.rsdroid.BackendFactory
 import timber.log.Timber
@@ -78,7 +79,7 @@ class AdvancedSettingsFragment : SettingsFragment() {
                 message(R.string.reset_languages_question)
                 positiveButton(R.string.dialog_ok) {
                     if (MetaDB.resetLanguages(requireContext())) {
-                        UIUtils.showThemedToast(requireContext(), R.string.reset_confirmation, true)
+                        showSnackbar(R.string.reset_confirmation)
                     }
                 }
                 negativeButton(R.string.dialog_cancel)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/AppearanceSettingsFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/AppearanceSettingsFragment.kt
@@ -27,6 +27,7 @@ import com.ichi2.anki.R
 import com.ichi2.anki.UIUtils
 import com.ichi2.anki.cardviewer.GestureProcessor
 import com.ichi2.anki.reviewer.FullScreenMode
+import com.ichi2.anki.snackbar.showSnackbar
 import com.ichi2.libanki.Utils
 import com.ichi2.themes.Theme
 import com.ichi2.themes.Themes
@@ -50,7 +51,9 @@ class AppearanceSettingsFragment : SettingsFragment() {
             if (prefs.getBoolean(GestureProcessor.PREF_KEY, false) || newValue != "none") {
                 true
             } else {
-                UIUtils.showThemedToast(requireContext(), R.string.full_screen_error_gestures, false)
+                // TODO add a button on the snackbar that leads directly to the
+                // Controls fragment and highlight the gesture preference
+                showSnackbar(R.string.full_screen_error_gestures)
                 false
             }
         }
@@ -59,7 +62,9 @@ class AppearanceSettingsFragment : SettingsFragment() {
             if (prefs.getBoolean(GestureProcessor.PREF_KEY, false) || FullScreenMode.FULLSCREEN_ALL_GONE.getPreferenceValue() != newValue) {
                 true
             } else {
-                UIUtils.showThemedToast(requireContext(), R.string.full_screen_error_gestures, false)
+                // TODO add a button on the snackbar that leads directly to the
+                // Controls fragment and highlight the gesture preference
+                showSnackbar(R.string.full_screen_error_gestures)
                 false
             }
         }
@@ -79,24 +84,12 @@ class AppearanceSettingsFragment : SettingsFragment() {
                 val imgFile = File(currentAnkiDroidDirectory, "DeckPickerBackground.png")
                 if (imgFile.exists()) {
                     if (imgFile.delete()) {
-                        UIUtils.showThemedToast(
-                            requireContext(),
-                            getString(R.string.background_image_removed),
-                            false
-                        )
+                        showSnackbar(R.string.background_image_removed)
                     } else {
-                        UIUtils.showThemedToast(
-                            requireContext(),
-                            getString(R.string.error_deleting_image),
-                            false
-                        )
+                        showSnackbar(R.string.error_deleting_image)
                     }
                 } else {
-                    UIUtils.showThemedToast(
-                        requireContext(),
-                        getString(R.string.background_image_removed),
-                        false
-                    )
+                    showSnackbar(R.string.background_image_removed)
                 }
             }
             true
@@ -225,7 +218,7 @@ class AppearanceSettingsFragment : SettingsFragment() {
                         (requireContext().contentResolver.openInputStream(selectedImage) as FileInputStream).channel.use { sourceChannel ->
                             FileOutputStream(destFile).channel.use { destChannel ->
                                 destChannel.transferFrom(sourceChannel, 0, sourceChannel.size())
-                                UIUtils.showThemedToast(requireContext(), getString(R.string.background_image_applied), false)
+                                showSnackbar(R.string.background_image_applied)
                             }
                         }
                     } else {
@@ -235,14 +228,14 @@ class AppearanceSettingsFragment : SettingsFragment() {
                 }
             } catch (e: OutOfMemoryError) {
                 Timber.w(e)
-                UIUtils.showThemedToast(requireContext(), getString(R.string.error_selecting_image, e.localizedMessage), false)
+                showSnackbar(getString(R.string.error_selecting_image, e.localizedMessage))
             } catch (e: Exception) {
                 Timber.w(e)
-                UIUtils.showThemedToast(requireContext(), getString(R.string.error_selecting_image, e.localizedMessage), false)
+                showSnackbar(getString(R.string.error_selecting_image, e.localizedMessage))
             }
         } else {
             mBackgroundImage!!.isChecked = false
-            UIUtils.showThemedToast(requireContext(), getString(R.string.no_image_selected), false)
+            showSnackbar(R.string.no_image_selected)
         }
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/DevOptionsFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/DevOptionsFragment.kt
@@ -21,6 +21,7 @@ import androidx.preference.SwitchPreference
 import com.afollestad.materialdialogs.MaterialDialog
 import com.ichi2.anki.*
 import com.ichi2.anki.analytics.UsageAnalytics
+import com.ichi2.anki.snackbar.showSnackbar
 import timber.log.Timber
 
 /**
@@ -57,9 +58,9 @@ class DevOptionsFragment : SettingsFragment() {
         // Make it possible to test analytics
         requirePreference<Preference>(getString(R.string.pref_analytics_debug_key)).setOnPreferenceClickListener {
             if (UsageAnalytics.isEnabled) {
-                UIUtils.showThemedToast(requireContext(), "Analytics set to dev mode", true)
+                showSnackbar("Analytics set to dev mode")
             } else {
-                UIUtils.showThemedToast(requireContext(), "Done! Enable Analytics in 'General' settings to use.", true)
+                showSnackbar("Done! Enable Analytics in 'General' settings to use.")
             }
             UsageAnalytics.setDevMode()
             true

--- a/AnkiDroid/src/main/java/com/ichi2/anki/snackbar/Snackbars.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/snackbar/Snackbars.kt
@@ -21,6 +21,7 @@ import android.widget.TextView
 import androidx.annotation.RequiresApi
 import androidx.annotation.StringRes
 import androidx.coordinatorlayout.widget.CoordinatorLayout
+import androidx.fragment.app.Fragment
 import com.google.android.material.snackbar.Snackbar
 import com.google.android.material.snackbar.onAttachedToWindow2
 import com.ichi2.anki.BuildConfig
@@ -189,6 +190,75 @@ fun View.showSnackbar(
     if (snackbarBuilder != null) { snackbar.snackbarBuilder() }
 
     snackbar.show()
+}
+
+/**
+ * Show a snackbar.
+ *
+ * You can create snackbars by calling `showSnackbar` on either an activity or a view.
+ * As `CoordinatorLayout` is responsible for proper placement and animation of snackbars,
+ *
+ *   * if calling on an activity, the activity **MUST** have a `CoordinatorLayout`
+ *     with id `root_layout`;
+ *
+ *   * if calling on a view, the view **MUST** be either a `CoordinatorLayout`,
+ *     or a (possibly indirect) child of `CoordinatorLayout`.
+ *
+ * Any additional configuration can be done in the configuration block, e.g.
+ *
+ *     showSnackbar(text) {
+ *         addCallback(callback)
+ *     }
+ *
+ * @receiver A [View] that is either a [CoordinatorLayout],
+ *     or a (possibly indirect) child of `CoordinatorLayout`.
+ * @param text Text to show, can be formatted.
+ * @param duration Optional. For how long to show the snackbar. Can be one of:
+ *     [Snackbar.LENGTH_SHORT], [Snackbar.LENGTH_LONG] (default), [Snackbar.LENGTH_INDEFINITE],
+ *     or exact duration in milliseconds.
+ * @param snackbarBuilder Optional. A configuration block with the [Snackbar] as `this`.
+ */
+fun Fragment.showSnackbar(
+    text: CharSequence,
+    duration: Int = Snackbar.LENGTH_LONG,
+    snackbarBuilder: SnackbarBuilder? = null
+) {
+    requireActivity().showSnackbar(text, duration, snackbarBuilder)
+}
+
+/**
+ * Show a snackbar.
+ *
+ * You can create snackbars by calling `showSnackbar` on either an activity or a view.
+ * As `CoordinatorLayout` is responsible for proper placement and animation of snackbars,
+ *
+ *   * if calling on an activity, the activity **MUST** have a `CoordinatorLayout`
+ *     with id `root_layout`;
+ *
+ *   * if calling on a view, the view **MUST** be either a `CoordinatorLayout`,
+ *     or a (possibly indirect) child of `CoordinatorLayout`.
+ *
+ * Any additional configuration can be done in the configuration block, e.g.
+ *
+ *     showSnackbar(text) {
+ *         addCallback(callback)
+ *     }
+ *
+ * @receiver A [View] that is either a [CoordinatorLayout],
+ *     or a (possibly indirect) child of `CoordinatorLayout`.
+ * @param textResource String resource to show, can be formatted.
+ * @param duration Optional. For how long to show the snackbar. Can be one of:
+ *     [Snackbar.LENGTH_SHORT], [Snackbar.LENGTH_LONG] (default), [Snackbar.LENGTH_INDEFINITE],
+ *     or exact duration in milliseconds.
+ * @param snackbarBuilder Optional. A configuration block with the [Snackbar] as `this`.
+ */
+fun Fragment.showSnackbar(
+    @StringRes textResource: Int,
+    duration: Int = Snackbar.LENGTH_LONG,
+    snackbarBuilder: SnackbarBuilder? = null
+) {
+    val text = resources.getText(textResource)
+    showSnackbar(text, duration, snackbarBuilder)
 }
 
 /* ********************************************************************************************** */


### PR DESCRIPTION
## Purpose / Description
More or less the same reason of #12040

## Approach
On the commits

## How Has This Been Tested?

Opened the settings screens and tapped the changed preferences (Reset language, Select backgorund, etc)

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
