### PR TITLE
Use snackbars instead of toasts on the reviewer's actions

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
@@ -47,6 +47,7 @@ import androidx.webkit.WebViewAssetLoader
 import anki.collection.OpChanges
 import com.afollestad.materialdialogs.MaterialDialog
 import com.drakeet.drawer.FullDraggableContainer
+import com.google.android.material.snackbar.Snackbar
 import com.ichi2.anim.ActivityTransitionAnimation
 import com.ichi2.anim.ActivityTransitionAnimation.getInverseTransition
 import com.ichi2.anki.UIUtils.saveCollectionInBackground
@@ -72,6 +73,7 @@ import com.ichi2.anki.servicelayer.NoteService.isMarked
 import com.ichi2.anki.servicelayer.SchedulerService.*
 import com.ichi2.anki.servicelayer.TaskListenerBuilder
 import com.ichi2.anki.servicelayer.UndoService.Undo
+import com.ichi2.anki.snackbar.SnackbarBuilder
 import com.ichi2.anki.snackbar.showSnackbar
 import com.ichi2.annotations.NeedsTest
 import com.ichi2.async.CollectionTask.PreloadNextCard
@@ -1786,10 +1788,14 @@ abstract class AbstractFlashcardViewer :
     }
 
     /** Displays a snackbar which does not obscure the answer buttons  */
-    private fun showSnackbarAboveAnswerButtons(text: String, @StringRes buttonTextResource: Int, onClickListener: View.OnClickListener) {
+    private fun showSnackbarAboveAnswerButtons(
+        text: CharSequence,
+        duration: Int = Snackbar.LENGTH_LONG,
+        snackbarBuilder: SnackbarBuilder? = null
+    ) {
         // BUG: Moving from full screen to non-full screen obscures the buttons
-        showSnackbar(text) {
-            setAction(buttonTextResource, onClickListener)
+        showSnackbar(text, duration) {
+            snackbarBuilder?.let { it() }
 
             if (mAnswerButtonsPosition == "bottom") {
                 val easeButtons = findViewById<View>(R.id.answer_options_layout)
@@ -1797,6 +1803,15 @@ abstract class AbstractFlashcardViewer :
                 anchorView = if (previewButtons.isVisible) previewButtons else easeButtons
             }
         }
+    }
+
+    private fun showSnackbarAboveAnswerButtons(
+        @StringRes textResource: Int,
+        duration: Int = Snackbar.LENGTH_LONG,
+        snackbarBuilder: SnackbarBuilder? = null
+    ) {
+        val text = getString(textResource)
+        showSnackbarAboveAnswerButtons(text, duration, snackbarBuilder)
     }
 
     private fun onPageUp() {
@@ -2505,13 +2520,15 @@ abstract class AbstractFlashcardViewer :
     }
 
     private fun displayCouldNotFindMediaSnackbar(filename: String?) {
-        val onClickListener = View.OnClickListener { openUrl(Uri.parse(getString(R.string.link_faq_missing_media))) }
-        showSnackbarAboveAnswerButtons(getString(R.string.card_viewer_could_not_find_image, filename), R.string.help, onClickListener)
+        showSnackbarAboveAnswerButtons(getString(R.string.card_viewer_could_not_find_image, filename)) {
+            setAction(R.string.help) { openUrl(Uri.parse(getString(R.string.link_faq_missing_media))) }
+        }
     }
 
     private fun displayMediaUpgradeRequiredSnackbar() {
-        val onClickListener = View.OnClickListener { openUrl(Uri.parse(getString(R.string.link_faq_invalid_protocol_relative))) }
-        showSnackbarAboveAnswerButtons(getString(R.string.card_viewer_media_relative_protocol), R.string.help, onClickListener)
+        showSnackbarAboveAnswerButtons(R.string.card_viewer_media_relative_protocol) {
+            setAction(R.string.help) { openUrl(Uri.parse(getString(R.string.link_faq_invalid_protocol_relative))) }
+        }
     }
 
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)


### PR DESCRIPTION
## Fixes
Closes #12040

## Approach
On the commits

## How Has This Been Tested?

1. Start reviewing
2. Suspend/Bury/Delete a card > see if a snackbar with a "Undo" button appears
3. Tap undo on the snackbar
4. Tap the normal undo button

note: With the new backend, the snackbar is shown with `!backendUndoAndShowPopup()`, which currently shows on top of the answer buttons (if at bottom). Left a TODO there

![image](https://user-images.githubusercontent.com/69634269/185606100-437c2de3-a802-421f-9d50-927b424d9d3a.png)

![image](https://user-images.githubusercontent.com/69634269/185606136-d9cea0f0-a095-4bc3-b7d0-3594b495c642.png)


## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [X] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
