### PR TITLE
Fix a few issues with Custom sync server

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -87,6 +87,7 @@ import com.ichi2.anki.servicelayer.SchedulerService.NextCard
 import com.ichi2.anki.servicelayer.UndoService.Undo
 import com.ichi2.anki.snackbar.showSnackbar
 import com.ichi2.anki.stats.AnkiStatsTaskHandler
+import com.ichi2.anki.web.CustomSyncServer
 import com.ichi2.anki.web.HostNumFactory
 import com.ichi2.anki.widgets.DeckAdapter
 import com.ichi2.annotations.NeedsTest
@@ -478,6 +479,10 @@ open class DeckPicker :
             }
         } else {
             requestStoragePermission()
+        }
+
+        if (!BackendFactory.defaultLegacySchema) {
+            CustomSyncServer.setOrUnsetEnvironmentalVariablesForBackend(this)
         }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -1565,15 +1565,17 @@ open class DeckPicker :
             mPullToSyncWrapper.isRefreshing = false
             showSyncErrorDialog(SyncErrorDialog.DIALOG_USER_NOT_LOGGED_IN_SYNC)
         } else {
+            val syncMedia = preferences.getBoolean("syncFetchesMedia", true)
+
             if (!BackendFactory.defaultLegacySchema) {
-                handleNewSync(conflict)
+                handleNewSync(conflict, syncMedia)
             } else {
                 Connection.sync(
                     mSyncListener,
                     Connection.Payload(
                         arrayOf(
                             hkey,
-                            preferences.getBoolean("syncFetchesMedia", true),
+                            syncMedia,
                             conflict,
                             HostNumFactory.getInstance(baseContext)
                         )

--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/CustomSyncServerSettingsFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/CustomSyncServerSettingsFragment.kt
@@ -34,7 +34,7 @@ class CustomSyncServerSettingsFragment : SettingsFragment() {
             CustomSyncServer.handleSyncServerPreferenceChange(requireContext())
         }
         // Sync url
-        requirePreference<Preference>(R.string.custom_sync_server_base_url_key).setOnPreferenceChangeListener { _, newValue: Any ->
+        requirePreference<Preference>(R.string.custom_sync_server_collection_url_key).setOnPreferenceChangeListener { _, newValue: Any ->
             val newUrl = newValue.toString()
             if (!URLUtil.isValidUrl(newUrl)) {
                 AlertDialog.Builder(requireContext())

--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/CustomSyncServerSettingsFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/CustomSyncServerSettingsFragment.kt
@@ -36,7 +36,7 @@ class CustomSyncServerSettingsFragment : SettingsFragment() {
         // Sync url
         requirePreference<Preference>(R.string.custom_sync_server_collection_url_key).setOnPreferenceChangeListener { _, newValue: Any ->
             val newUrl = newValue.toString()
-            if (!URLUtil.isValidUrl(newUrl)) {
+            if (newUrl.isNotEmpty() && !URLUtil.isValidUrl(newUrl)) {
                 AlertDialog.Builder(requireContext())
                     .setTitle(R.string.custom_sync_server_base_url_invalid)
                     .setPositiveButton(R.string.dialog_ok, null)
@@ -49,7 +49,7 @@ class CustomSyncServerSettingsFragment : SettingsFragment() {
         // Media url
         requirePreference<Preference>(R.string.custom_sync_server_media_url_key).setOnPreferenceChangeListener { _, newValue: Any ->
             val newUrl = newValue.toString()
-            if (!URLUtil.isValidUrl(newUrl)) {
+            if (newUrl.isNotEmpty() && !URLUtil.isValidUrl(newUrl)) {
                 AlertDialog.Builder(requireContext())
                     .setTitle(R.string.custom_sync_server_media_url_invalid)
                     .setPositiveButton(R.string.dialog_ok, null)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/SyncSettingsFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/SyncSettingsFragment.kt
@@ -58,7 +58,7 @@ class SyncSettingsFragment : SettingsFragment() {
             if (!CustomSyncServer.isEnabled(preferences)) {
                 getString(R.string.disabled)
             } else {
-                CustomSyncServer.getSyncBaseUrlOrDefault(preferences, "")
+                CustomSyncServer.getCollectionSyncUrl(preferences) ?: ""
             }
         }
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/PreferenceUpgradeService.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/PreferenceUpgradeService.kt
@@ -20,6 +20,7 @@ import android.content.SharedPreferences
 import android.view.KeyEvent
 import androidx.annotation.VisibleForTesting
 import androidx.core.content.edit
+import androidx.core.net.toUri
 import com.ichi2.anki.AnkiDroidApp
 import com.ichi2.anki.cardviewer.Gesture
 import com.ichi2.anki.cardviewer.ViewerCommand
@@ -86,6 +87,7 @@ object PreferenceUpgradeService {
                 yield(UpdateNoteEditorToolbarPrefs())
                 yield(UpgradeGesturesToControls())
                 yield(UpgradeDayAndNightThemes())
+                yield(UpgradeCustomCollectionSyncUrl())
             }
 
             /** Returns a list of preference upgrade classes which have not been applied */
@@ -368,5 +370,29 @@ object PreferenceUpgradeService {
                 }
             }
         }
+
+        internal class UpgradeCustomCollectionSyncUrl : PreferenceUpgrade(7) {
+            override fun upgrade(preferences: SharedPreferences) {
+                val oldUrl = preferences.getString(RemovedPreferences.PREFERENCE_CUSTOM_SYNC_BASE, null)
+                var newUrl: String? = null
+
+                if (oldUrl != null && oldUrl.isNotBlank()) {
+                    try {
+                        newUrl = oldUrl.toUri().buildUpon().appendPath("sync").toString() + "/"
+                    } catch (e: Exception) {
+                        Timber.e(e, "Error constructing new sync URL from '%s'", oldUrl)
+                    }
+                }
+
+                preferences.edit {
+                    remove(RemovedPreferences.PREFERENCE_CUSTOM_SYNC_BASE)
+                    if (newUrl != null) putString(CustomSyncServer.PREFERENCE_CUSTOM_COLLECTION_SYNC_URL, newUrl)
+                }
+            }
+        }
     }
+}
+
+object RemovedPreferences {
+    const val PREFERENCE_CUSTOM_SYNC_BASE = "syncBaseUrl"
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/web/CustomSyncServer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/web/CustomSyncServer.kt
@@ -21,31 +21,34 @@ import android.content.SharedPreferences
 import timber.log.Timber
 
 object CustomSyncServer {
-    const val PREFERENCE_CUSTOM_SYNC_BASE = "syncBaseUrl"
+    const val PREFERENCE_CUSTOM_COLLECTION_SYNC_URL = "customCollectionSyncUrl"
     const val PREFERENCE_CUSTOM_MEDIA_SYNC_URL = "syncMediaUrl"
     const val PREFERENCE_ENABLE_CUSTOM_SYNC_SERVER = "useCustomSyncServer"
 
-    @JvmStatic
+    fun getCollectionSyncUrl(preferences: SharedPreferences): String? {
+        return preferences.getString(PREFERENCE_CUSTOM_COLLECTION_SYNC_URL, null)
+    }
+
     fun getMediaSyncUrl(preferences: SharedPreferences): String? {
         return preferences.getString(PREFERENCE_CUSTOM_MEDIA_SYNC_URL, null)
     }
 
-    @JvmStatic
-    fun getSyncBaseUrl(preferences: SharedPreferences): String? {
-        return getSyncBaseUrlOrDefault(preferences, null)
+    fun getCollectionSyncUrlIfSetAndEnabledOrNull(preferences: SharedPreferences): String? {
+        if (!isEnabled(preferences)) return null
+        val collectionSyncUrl = getCollectionSyncUrl(preferences)
+        return if (collectionSyncUrl.isNullOrEmpty()) null else collectionSyncUrl
     }
 
-    @JvmStatic
-    fun getSyncBaseUrlOrDefault(userPreferences: SharedPreferences, defaultValue: String?): String? {
-        return userPreferences.getString(PREFERENCE_CUSTOM_SYNC_BASE, defaultValue)
+    fun getMediaSyncUrlIfSetAndEnabledOrNull(preferences: SharedPreferences): String? {
+        if (!isEnabled(preferences)) return null
+        val mediaSyncUrl = getMediaSyncUrl(preferences)
+        return if (mediaSyncUrl.isNullOrEmpty()) null else mediaSyncUrl
     }
 
-    @JvmStatic
     fun isEnabled(userPreferences: SharedPreferences): Boolean {
         return userPreferences.getBoolean(PREFERENCE_ENABLE_CUSTOM_SYNC_SERVER, false)
     }
 
-    @JvmStatic
     fun handleSyncServerPreferenceChange(context: Context?) {
         Timber.i("Sync Server Preferences updated.")
         // #4921 - if any of the preferences change, we should reset the HostNum.

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Consts.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Consts.kt
@@ -111,7 +111,7 @@ object Consts {
     /** The database schema version that we can downgrade from  */
     const val SYNC_MAX_BYTES = (2.5 * 1024 * 1024).toInt()
     const val SYNC_MAX_FILES = 25
-    const val SYNC_BASE = "https://sync%s.ankiweb.net/"
+
     @JvmField
     val DEFAULT_HOST_NUM: Int? = null
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sync/RemoteMediaServer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sync/RemoteMediaServer.kt
@@ -16,12 +16,10 @@
  ****************************************************************************************/
 package com.ichi2.libanki.sync
 
-import android.net.Uri
 import android.text.TextUtils
-import com.ichi2.anki.AnkiDroidApp
 import com.ichi2.anki.exception.MediaSyncException
 import com.ichi2.anki.exception.UnknownHttpResponseException
-import com.ichi2.anki.web.CustomSyncServer.getMediaSyncUrl
+import com.ichi2.anki.web.CustomSyncServer
 import com.ichi2.async.Connection
 import com.ichi2.libanki.Collection
 import com.ichi2.libanki.Utils
@@ -44,18 +42,9 @@ class RemoteMediaServer(
     hostNum: HostNum
 ) : HttpSyncer(hkey, con, hostNum) {
 
-    override fun syncURL(): String {
-        // Allow user to specify custom sync server
-        val userPreferences = AnkiDroidApp.getSharedPrefs(AnkiDroidApp.getInstance())
-        if (isUsingCustomSyncServer(userPreferences)) {
-            val mediaSyncBase = getMediaSyncUrl(userPreferences) ?: return defaultAnkiWebUrl
-            // Note: the preference did not necessarily contain /msync/, so we can't concat with the default as done in
-            // getDefaultAnkiWebUrl
-            return Uri.parse(mediaSyncBase).toString()
-        }
-        // Usual case
-        return defaultAnkiWebUrl
-    }
+    override fun getDefaultSyncUrl() = "https://sync${hostNum ?: ""}.ankiweb.net/msync/"
+
+    override fun getCustomSyncUrlOrNull() = CustomSyncServer.getMediaSyncUrlIfSetAndEnabledOrNull(preferences)
 
     @Throws(UnknownHttpResponseException::class, MediaSyncException::class)
     fun begin(): JSONObject {
@@ -178,11 +167,5 @@ class RemoteMediaServer(
             JSONArray::class.java -> return resp.getJSONArray("data") as T
         }
         throw RuntimeException("Did not specify a valid type for the 'data' element in response")
-    }
-
-    // Difference from libAnki: we allow a custom URL to specify a different prefix, so this is only used with the
-    // default URL
-    override fun getUrlPrefix(): String {
-        return "msync"
     }
 }

--- a/AnkiDroid/src/main/res/values/preferences.xml
+++ b/AnkiDroid/src/main/res/values/preferences.xml
@@ -85,7 +85,7 @@
     <!-- Custom sync server -->
     <string name="pref_custom_sync_server_screen_key">customSyncServerScreen</string>
     <string name="custom_sync_server_enable_key">useCustomSyncServer</string>
-    <string name="custom_sync_server_base_url_key">syncBaseUrl</string>
+    <string name="custom_sync_server_collection_url_key">customCollectionSyncUrl</string>
     <string name="custom_sync_server_media_url_key">syncMediaUrl</string>
     <!-- Advanced -->
     <string name="pref_advanced_screen_key">pref_screen_advanced</string>

--- a/AnkiDroid/src/main/res/xml/preferences_custom_sync_server.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_custom_sync_server.xml
@@ -12,7 +12,7 @@
         android:defaultValue="false"/>
     <EditTextPreference
         android:dependency="@string/custom_sync_server_enable_key"
-        android:key="@string/custom_sync_server_base_url_key"
+        android:key="@string/custom_sync_server_collection_url_key"
         android:title="@string/custom_sync_server_base_url_title" />
     <EditTextPreference
         android:dependency="@string/custom_sync_server_enable_key"

--- a/AnkiDroid/src/main/res/xml/preferences_custom_sync_server.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_custom_sync_server.xml
@@ -3,6 +3,7 @@
 
 <!-- Advanced Preferences -->
 <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:title="@string/custom_sync_server_title"
     android:key="@string/pref_custom_sync_server_screen_key">
     <SwitchPreference
@@ -13,9 +14,11 @@
     <EditTextPreference
         android:dependency="@string/custom_sync_server_enable_key"
         android:key="@string/custom_sync_server_collection_url_key"
-        android:title="@string/custom_sync_server_base_url_title" />
+        android:title="@string/custom_sync_server_base_url_title"
+        app:useSimpleSummaryProvider="true" />
     <EditTextPreference
         android:dependency="@string/custom_sync_server_enable_key"
         android:key="@string/custom_sync_server_media_url_key"
-        android:title="@string/custom_sync_server_media_url_title" />
+        android:title="@string/custom_sync_server_media_url_title"
+        app:useSimpleSummaryProvider="true" />
 </PreferenceScreen>

--- a/AnkiDroid/src/test/java/com/ichi2/anki/servicemodel/PreferenceUpgradeServiceTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/servicemodel/PreferenceUpgradeServiceTest.kt
@@ -25,6 +25,7 @@ import com.ichi2.anki.RobolectricTest
 import com.ichi2.anki.noteeditor.CustomToolbarButton
 import com.ichi2.anki.servicelayer.PreferenceUpgradeService
 import com.ichi2.anki.servicelayer.PreferenceUpgradeService.PreferenceUpgrade
+import com.ichi2.anki.servicelayer.RemovedPreferences
 import com.ichi2.anki.web.CustomSyncServer
 import com.ichi2.libanki.Consts
 import com.ichi2.testutils.EmptyApplication
@@ -170,5 +171,17 @@ class PreferenceUpgradeServiceTest : RobolectricTest() {
         assertThat(mPrefs.getString("dayTheme", "1"), equalTo("1"))
         assertThat(mPrefs.getString("nightTheme", "1"), equalTo("3"))
         assertThat(mPrefs.contains("invertedColors"), equalTo(false))
+    }
+
+    @Test
+    fun `Custom collection sync URL preference contains full path after upgrade`() {
+        mPrefs.edit {
+            putString(RemovedPreferences.PREFERENCE_CUSTOM_SYNC_BASE, "http://foo")
+        }
+
+        PreferenceUpgrade.UpgradeCustomCollectionSyncUrl().performUpgrade(mPrefs)
+
+        assertThat(mPrefs.contains(RemovedPreferences.PREFERENCE_CUSTOM_SYNC_BASE), equalTo(false))
+        assertThat(mPrefs.getString(CustomSyncServer.PREFERENCE_CUSTOM_COLLECTION_SYNC_URL, ""), equalTo("http://foo/sync/"))
     }
 }

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/sync/HttpSyncerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/sync/HttpSyncerTest.kt
@@ -16,8 +16,10 @@
 
 package com.ichi2.libanki.sync
 
+import androidx.core.content.edit
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.ichi2.anki.AnkiDroidApp
+import com.ichi2.anki.web.CustomSyncServer
 import com.ichi2.utils.KotlinCleanup
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
@@ -92,19 +94,19 @@ class HttpSyncerTest {
         assertThat(syncUrl, equalTo(sDefaultUrlWithHostNum))
     }
 
-    @KotlinCleanup("use edit{} extension function")
     private fun setCustomServerWithNoUrl() {
         val userPreferences = AnkiDroidApp.getSharedPrefs(AnkiDroidApp.getInstance())
-        userPreferences.edit().putBoolean("useCustomSyncServer", true).apply()
+        userPreferences.edit {
+            putBoolean(CustomSyncServer.PREFERENCE_ENABLE_CUSTOM_SYNC_SERVER, true)
+        }
     }
 
-    @KotlinCleanup("use edit{} extension function")
     private fun setCustomServer(s: String) {
         val userPreferences = AnkiDroidApp.getSharedPrefs(AnkiDroidApp.getInstance())
-        val e = userPreferences.edit()
-        e.putBoolean("useCustomSyncServer", true)
-        e.putString("syncBaseUrl", s)
-        e.apply()
+        userPreferences.edit {
+            putBoolean(CustomSyncServer.PREFERENCE_ENABLE_CUSTOM_SYNC_SERVER, true)
+            putString(CustomSyncServer.PREFERENCE_CUSTOM_COLLECTION_SYNC_URL, s)
+        }
     }
 
     private fun getServerWithHostNum(hostNum: Int?): HttpSyncer {
@@ -113,8 +115,8 @@ class HttpSyncerTest {
 
     @KotlinCleanup("rename all")
     companion object {
-        private const val sCustomServerWithNoFormatting = "https://sync.example.com/"
-        private const val sCustomServerWithFormatting = "https://sync%s.example.com/"
+        private const val sCustomServerWithNoFormatting = "https://sync.example.com/sync/"
+        private const val sCustomServerWithFormatting = "https://sync%s.example.com/sync/"
         private const val sDefaultUrlNoHostNum = "https://sync.ankiweb.net/sync/"
         private const val sDefaultUrlWithHostNum = "https://sync1.ankiweb.net/sync/"
     }


### PR DESCRIPTION
There's a few issues with custom sync servers. One of the settings is not consistent with the other and with what Anki expects; when using backend, custom sync servers and some other settings are not respected. Please see the commits for the list of changes. 

**Edit**: emulator tests [did pass](https://github.com/oakkitten/Anki-Android/actions/runs/2890274724) in my fork.

## Approach

One of the preferences was upgraded to match Anki. Environmental variables are set to make the backend use the custom servers. A new argument `syncMedia` is added to a few backend sync methods.

I tried splitting the first commit into several, but the result was just harder to understand, so. A few identifiers could have better names, but I opted for a smaller diff & consistency with surrounding identifiers.

One preference screen was slightly changed to include summaries.

<img src=https://user-images.githubusercontent.com/1710718/185750183-d3e26b82-b0b7-4035-b8db-38f9184421b8.png width=300>

## How Has This Been Tested?

Added a test for preference upgrade. Otherwise, tested on my Xiaomi MI A2 against Anki and ankisyncd.

## Remaining issues

There's a few issues at the end of the day.

* The custom sync URL preferences must have `/` at the end of the URLs. Most people consider `http://foo` to be equivalent to `http://foo/`, so they might omit the slash at the end. The legacy code will correctly append the `/` when adding suffixes, that is `http://foo/sync` will become `http://foo/sync/meta`. However the backend does that via a [simple string concatenation](https://github.com/ankitects/anki/blob/576b141e2b4e8a092f3cbf71ac57f6eb84531a9d/rslib/src/sync/http_client.rs#L280). This can lead to some quite obscure errors, e.g. inputting `http://192.168.1.90:8080` yields a dialog saying 

  > A network error occurred.
  >             
  > Error details: ⁨builder error: invalid port number⁩ 

  I did not try to work around this behavior, because this is also what Anki does, and if it is going to be fixed, it should be fixed in the backend. Alternatively, we could add a note that the user probably wants to have a `/` on the end of the stuff they put into these settings. @dae thoughts? Also you might be interested in other issues listed here.

* You could before, and you still can, specify either, or both, or none of the two sync servers—collection and media. If a server is not specified, the default AnkiWeb server, collection or media, is used instead. This is not reflected in the preferences UI, and is especially confusing considering there's a single switch that disables both settings. Also, the preference that opens the preference screen only says the name of the collection sync server in its summary, showing blank if it is not set.

  I suggest the following preference structure (Bold = title, regular = summary):

  * **Custom sync servers** *(opens screen)*
    Collection: http://192.168.1.90:8080/sync/
    Media: default

    * As an alternative to using AnkiWeb, you can use your own servers for synchronization between devices. You can specify either of the servers, or both; if not set, the default AnkiWeb server will be used instead. For example, you could use the sync server built into Anki to synchronize the collection while you are off the grid, and AnkiWeb to synchronize media while online. Learn more *(tappable)*.

    * **Collection sync server | *(switch)***
      http://192.168.1.90:8080/sync/

    * **Media sync server | *(switch)***
      Not set
  
  Here, the items on both sides of | are separately tappable:

  * If the sync server is not specified, tapping both the title and the switch will open a text input dialog, and if the user specifies a valid URL, it is set, and the switch turns on.

  * If the sync server is specified:

    * Tapping on the server will open a text input dialog. If user specifies a valid URL, it is set, and the switch stays or turns on; if user clears the input, URL is unset, and the switch turns off.

    * Tapping on the switch turns using this server on or off, without removing the URL.

  This description looks complicated but I think this would be easy to operate.

* If using Rust backend, In the case of server error, a dialog window is shown, saying
  
  > AnkiWeb encountered a problem. Please try again in a few minutes.

  As a custom sync server is probably not AnkiWeb, this might be misleading. Also, it would help if the actual error was shown.

* Also, if using Rust backend, in the case when the server is not accessible (or no internet), you will see

  > Please check your internet connection.
  >
  > Error details: ⁨error sending request for url (): error trying to connect: dns error: failed to lookup address information: No address associated with hostname⁩ 

  It would be helpful if this showed the actual URL.

* If using Rust backend, in the case of a successful collection sync and a failing media sync, you will see both the success snackbar and an error dialog. This is very confusing. The legacy error is not perfect but still much better than that.

  Also, there's no confirmation of media sync finishing.

* Not really an issue but if using Rust backend, there's no “You are offline. Try anyway” snackbar.

There are many more small issues that are rather obvious so I'm not mentioning them, however none of them seem to be preventing the sync from actually working.

P.S. For some reason AnkiDroid seems to be not migrating (upgrading) preferences unless app version changes. So if this is merged and a version bump doesn't follow soon after, the devs that use the Sync url preference will see its value vanish.

## Checklist

- [ ] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [x] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
