### PR TITLE
fix emulator OutOfMemory by forcing zygote init race win via warm reboot

### DIFF
--- a/.github/workflows/tests_emulator.yml
+++ b/.github/workflows/tests_emulator.yml
@@ -142,6 +142,9 @@ jobs:
           disable-animations: true
           script: |
             $ANDROID_HOME/platform-tools/adb logcat '*:D' > adb-log.txt &
+            sleep 5
+            $ANDROID_HOME/platform-tools/adb shell su root "setprop ctl.restart zygote"
+            sleep 10
             ./gradlew uninstallAll jacocoAndroidTestReport --daemon
 
       - name: Compress Emulator Log


### PR DESCRIPTION

## Pull Request template

## Purpose / Description

Our emulator tests have all the sudden become very flaky.
Proximate cause appears to be OutOfMemory death spiral in emulator processes.
Root cause is hypothesized to be a race between correct (sufficient) memory sizing and zygote init in boot sequence
This should work around that

Details here https://github.com/ankidroid/Anki-Android/issues/11091#issuecomment-1221325800


## Fixes
Unlogged general flakiness in tests_emulator.yml

## Approach
Warm reboot the emulator by restarting the zygote process
The sleep 5 / sleep 10 are just rough guesses that a) time to settle is needed b) that time is sufficient

## How Has This Been Tested?

It is in testing, adb logcat should show a zygote with something *other* than -Xmx16m
Ideally we see a -Xmx16m at start then a -Xmx"not 16m" later in zygote / art init arguments
It may take a couple runs (my guess is 3?) before the race is initially lost / then repaired to prove this works

## Learning (optional, can help others)

I found this: https://support.circleci.com/hc/en-us/articles/360021812453-Common-Android-memory-issues#zygote

Which leads to this: https://www.rainforestqa.com/blog/hunting-race-condition-in-android-10-emulator

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
