### PR TITLE
[GSoC] Add preference to allow/warn if using metered connections

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidJsAPI.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidJsAPI.kt
@@ -21,7 +21,6 @@ package com.ichi2.anki
 
 import android.content.Context
 import android.content.Intent
-import android.net.ConnectivityManager
 import android.net.Uri
 import android.text.TextUtils
 import android.webkit.JavascriptInterface
@@ -44,6 +43,7 @@ import com.ichi2.libanki.Decks
 import com.ichi2.libanki.SortOrder
 import com.ichi2.utils.JSONException
 import com.ichi2.utils.JSONObject
+import com.ichi2.utils.isActiveNetworkMetered
 import timber.log.Timber
 
 open class AnkiDroidJsAPI(private val activity: AbstractFlashcardViewer) {
@@ -398,14 +398,7 @@ open class AnkiDroidJsAPI(private val activity: AbstractFlashcardViewer) {
 
     @JavascriptInterface
     fun ankiIsActiveNetworkMetered(): Boolean {
-        return try {
-            val cm = AnkiDroidApp.instance.applicationContext
-                .getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
-            cm.isActiveNetworkMetered
-        } catch (e: Exception) {
-            Timber.w(e, "Exception obtaining metered connection - assuming metered connection")
-            true
-        }
+        return isActiveNetworkMetered()
     }
 
     // Know if {{tts}} is supported - issue #10443

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -925,11 +925,12 @@ open class DeckPicker :
 
         // Check whether the option is selected, the user is signed in and last sync was AUTOMATIC_SYNC_TIME ago
         // (currently 10 minutes)
-        val hkey = preferences.getString("hkey", "")
+        val isLoggedIn = preferences.getString("hkey", "")!!.isNotEmpty()
         val lastSyncTime = preferences.getLong("lastSyncTime", 0)
-        if (hkey!!.isNotEmpty() && preferences.getBoolean("automaticSyncMode", false) &&
-            Connection.isOnline && TimeManager.time.intTimeMS() - lastSyncTime > AUTOMATIC_SYNC_MIN_INTERVAL
-        ) {
+        val autoSyncIsEnabled = preferences.getBoolean("automaticSyncMode", false)
+        val syncIntervalPassed = TimeManager.time.intTimeMS() - lastSyncTime > AUTOMATIC_SYNC_MIN_INTERVAL
+
+        if (isLoggedIn && autoSyncIsEnabled && Connection.isOnline && syncIntervalPassed) {
             Timber.i("Triggering Automatic Sync")
             sync()
         }

--- a/AnkiDroid/src/main/java/com/ichi2/utils/NetworkUtils.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/NetworkUtils.kt
@@ -15,19 +15,15 @@
  */
 package com.ichi2.utils
 
-import android.content.Context
 import android.net.ConnectivityManager
+import androidx.core.content.getSystemService
 import com.ichi2.anki.AnkiDroidApp
-import timber.log.Timber
 
 fun isActiveNetworkMetered(): Boolean {
-    return try {
-        val cm = AnkiDroidApp.instance.applicationContext
-            .getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
-        cm.isActiveNetworkMetered
-    } catch (e: Exception) {
-        Timber.w(e, "Exception obtaining metered connection - assuming metered connection")
-        true
-    }
+    return AnkiDroidApp
+        .instance
+        .applicationContext
+        .getSystemService<ConnectivityManager>()
+        ?.isActiveNetworkMetered
+        ?: true
 }
-

--- a/AnkiDroid/src/main/java/com/ichi2/utils/NetworkUtils.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/NetworkUtils.kt
@@ -1,0 +1,33 @@
+/*
+ *  Copyright (c) 2022 Brayan Oliveira <brayandso.dev@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.ichi2.utils
+
+import android.content.Context
+import android.net.ConnectivityManager
+import com.ichi2.anki.AnkiDroidApp
+import timber.log.Timber
+
+fun isActiveNetworkMetered(): Boolean {
+    return try {
+        val cm = AnkiDroidApp.instance.applicationContext
+            .getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
+        cm.isActiveNetworkMetered
+    } catch (e: Exception) {
+        Timber.w(e, "Exception obtaining metered connection - assuming metered connection")
+        true
+    }
+}
+

--- a/AnkiDroid/src/main/res/values/03-dialogs.xml
+++ b/AnkiDroid/src/main/res/values/03-dialogs.xml
@@ -257,6 +257,7 @@
         <item quantity="one">An automatic sync may be triggered in %d second</item>
         <item quantity="other">An automatic sync may be triggered in %d seconds</item>
     </plurals>
+    <string name="metered_sync_warning">Your connection is metered. Data transfer may cost money</string>
     <string name="deck_picker_new">Number of new cards to see today in this deck.</string>
     <string name="deck_picker_rev">Number of cards due today in this deck.</string>
     <string name="deck_picker_lrn">Number of cards in learning in this deck.</string> <!-- This description is valid fos

--- a/AnkiDroid/src/main/res/values/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values/10-preferences.xml
@@ -100,6 +100,7 @@
     <string name="swipe_sensitivity" maxLength="41">Swipe sensitivity</string>
     <string name="tts" maxLength="41">Text to speech</string>
     <string name="tts_summ">Reads out question and answer if no sound file is included</string>
+    <!-- Sync -->
     <string name="sync_fetch_missing_media" maxLength="41">Fetch media on sync</string>
     <string name="sync_fetch_missing_media_summ">Automatically fetch missing media when syncing</string>
     <string name="sync_account" maxLength="41">AnkiWeb account</string>
@@ -109,6 +110,8 @@
         minutes ago.</string>
     <string name="sync_status_badge" maxLength="41">Display synchronization status</string>
     <string name="sync_status_badge_summ">Change the sync icon when changes can be uploaded</string>
+    <string name="metered_sync_title" maxLength="41">Allow sync on metered connections</string>
+    <string name="metered_sync_summary">If disabled, you will be warned if you try to sync on a metered connection</string>
     <string name="app_theme" maxLength="41">Theme</string>
     <string name="day_theme" maxLength="41">Day theme</string>
     <string name="night_theme" maxLength="41">Night theme</string>

--- a/AnkiDroid/src/main/res/values/preferences.xml
+++ b/AnkiDroid/src/main/res/values/preferences.xml
@@ -27,6 +27,7 @@
     <string name="automatic_sync_choice_key">automaticSyncMode</string>
     <string name="force_full_sync_key">force_full_sync</string>
     <string name="sync_status_badge_key">showSyncStatusBadge</string>
+    <string name="metered_sync_key">allowMetered</string>
     <string name="custom_sync_server_key">custom_sync_server_link</string>
     <!-- Appearance -->
     <string name="pref_appearance_screen_key">appearance_preference_group</string>

--- a/AnkiDroid/src/main/res/xml/preferences_sync.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_sync.xml
@@ -42,13 +42,15 @@
         android:key="@string/sync_status_badge_key"
         android:summary="@string/sync_status_badge_summ"
         android:title="@string/sync_status_badge" />
-    <Preference
-        android:key="@string/force_full_sync_key"
-        android:title="@string/force_full_sync_title"
-        android:summary="@string/force_full_sync_summary" />
-    <Preference
-        android:key="@string/custom_sync_server_key"
-        android:title="@string/custom_sync_server_title"
-        android:fragment="com.ichi2.anki.preferences.CustomSyncServerSettingsFragment"
-        search:ignore="true"/>
+    <PreferenceCategory android:title="@string/pref_cat_advanced">
+        <Preference
+            android:key="@string/force_full_sync_key"
+            android:title="@string/force_full_sync_title"
+            android:summary="@string/force_full_sync_summary" />
+        <Preference
+            android:key="@string/custom_sync_server_key"
+            android:title="@string/custom_sync_server_title"
+            android:fragment="com.ichi2.anki.preferences.CustomSyncServerSettingsFragment"
+            search:ignore="true"/>
+    </PreferenceCategory>
 </PreferenceScreen>

--- a/AnkiDroid/src/main/res/xml/preferences_sync.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_sync.xml
@@ -42,6 +42,11 @@
         android:key="@string/sync_status_badge_key"
         android:summary="@string/sync_status_badge_summ"
         android:title="@string/sync_status_badge" />
+    <SwitchPreference
+        android:defaultValue="false"
+        android:key="@string/metered_sync_key"
+        android:title="@string/metered_sync_title"
+        android:summary="@string/metered_sync_summary" />
     <PreferenceCategory android:title="@string/pref_cat_advanced">
         <Preference
             android:key="@string/force_full_sync_key"


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
Internet may be expensive 💵💰💲💸

## Fixes
Fixes #10706

## Approach
- Clean things a bit
- Create a "Advanced" category under "Sync", so things get a little more organized with the increasing number of preferences
- Add a preference to allow sync on metered connections (off by default)
     - If not allowed, auto sync under metered connections won't occur + the user will be warned if they trigger a manual sync under a metered connection
     - I'm quite open to string changes

## How Has This Been Tested?

https://user-images.githubusercontent.com/69634269/185769043-30b76c32-5e89-4b27-93b2-156638e26204.mp4


## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [X] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
