### PR TITLE
feat: improve deck creation/rename UX

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/CreateDeckDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/CreateDeckDialog.kt
@@ -35,6 +35,7 @@ import com.ichi2.utils.displayKeyboard
 import timber.log.Timber
 import java.util.function.Consumer
 
+// TODO: Use snackbars instead of toasts: https://github.com/ankidroid/Anki-Android/pull/12139#issuecomment-1224963182
 @NeedsTest("Ensure a toast is shown on a successful action")
 class CreateDeckDialog(private val context: Context, private val title: Int, private val deckDialogType: DeckDialogType, private val parentId: Long?) {
     private var mPreviousDeckName: String? = null

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/CreateDeckDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/CreateDeckDialog.kt
@@ -121,6 +121,8 @@ class CreateDeckDialog(private val context: Context, private val title: Int, pri
     fun createDeck(deckName: String) {
         if (Decks.isValidDeckName(deckName)) {
             createNewDeck(deckName)
+            // 11668: Display feedback if a deck is created
+            showThemedToast(context, R.string.deck_created, true)
         } else {
             Timber.d("CreateDeckDialog::createDeck - Not creating invalid deck name '%s'", deckName)
             showThemedToast(context, context.getString(R.string.invalid_deck_name), false)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/CreateDeckDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/CreateDeckDialog.kt
@@ -27,6 +27,7 @@ import com.ichi2.anki.CollectionHelper
 import com.ichi2.anki.R
 import com.ichi2.anki.UIUtils.showThemedToast
 import com.ichi2.anki.servicelayer.DeckService.deckExists
+import com.ichi2.annotations.NeedsTest
 import com.ichi2.libanki.DeckId
 import com.ichi2.libanki.Decks
 import com.ichi2.libanki.backend.exception.DeckRenameException
@@ -34,6 +35,7 @@ import com.ichi2.utils.displayKeyboard
 import timber.log.Timber
 import java.util.function.Consumer
 
+@NeedsTest("Ensure a toast is shown on a successful action")
 class CreateDeckDialog(private val context: Context, private val title: Int, private val deckDialogType: DeckDialogType, private val parentId: Long?) {
     private var mPreviousDeckName: String? = null
     private var mOnNewDeckCreated: Consumer<Long>? = null
@@ -136,6 +138,8 @@ class CreateDeckDialog(private val context: Context, private val title: Int, pri
             Timber.i("CreateDeckDialog::createFilteredDeck...")
             val newDeckId = col.decks.newDyn(deckName)
             mOnNewDeckCreated!!.accept(newDeckId)
+            // 11668: Display feedback if a deck is created
+            showThemedToast(context, R.string.deck_created, true)
         } catch (ex: DeckRenameException) {
             showThemedToast(context, ex.getLocalizedMessage(context.resources), false)
             return false
@@ -192,6 +196,8 @@ class CreateDeckDialog(private val context: Context, private val title: Int, pri
                 val deckId = decks.id(mPreviousDeckName!!)
                 decks.rename(decks.get(deckId), newName)
                 mOnNewDeckCreated!!.accept(deckId)
+                // 11668: Display feedback if a deck is renamed
+                showThemedToast(context, R.string.deck_renamed, true)
             } catch (e: DeckRenameException) {
                 Timber.w(e)
                 // We get a localized string from libanki to explain the error

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/CreateDeckDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/CreateDeckDialog.kt
@@ -41,9 +41,12 @@ class CreateDeckDialog(private val context: Context, private val title: Int, pri
         FILTERED_DECK, DECK, SUB_DECK, RENAME_DECK
     }
 
+    private val col
+        get() = CollectionHelper.getInstance().getCol(context)
+
     fun showFilteredDeckDialog() {
         Timber.i("CreateDeckDialog::showFilteredDeckDialog")
-        val names = CollectionHelper.getInstance().getCol(context).decks.allNames()
+        val names = col.decks.allNames()
         var n = 1
         val namePrefix = context.resources.getString(R.string.filtered_deck_name) + " "
         while (names.contains(namePrefix + n)) {
@@ -81,7 +84,7 @@ class CreateDeckDialog(private val context: Context, private val title: Int, pri
     }
 
     fun createSubDeck(did: DeckId, deckName: String?) {
-        val deckNameWithParentName = CollectionHelper.getInstance().getCol(context).decks.getSubdeckName(did, deckName)
+        val deckNameWithParentName = col.decks.getSubdeckName(did, deckName)
         createDeck(deckNameWithParentName!!)
     }
 
@@ -99,7 +102,7 @@ class CreateDeckDialog(private val context: Context, private val title: Int, pri
         try {
             // create filtered deck
             Timber.i("CreateDeckDialog::createFilteredDeck...")
-            val newDeckId = CollectionHelper.getInstance().getCol(context).decks.newDyn(deckName)
+            val newDeckId = col.decks.newDyn(deckName)
             mOnNewDeckCreated!!.accept(newDeckId)
         } catch (ex: DeckRenameException) {
             showThemedToast(context, ex.getLocalizedMessage(context.resources), false)
@@ -112,7 +115,7 @@ class CreateDeckDialog(private val context: Context, private val title: Int, pri
         try {
             // create normal deck or sub deck
             Timber.i("CreateDeckDialog::createNewDeck")
-            val newDeckId = CollectionHelper.getInstance().getCol(context).decks.id(deckName)
+            val newDeckId = col.decks.id(deckName)
             mOnNewDeckCreated!!.accept(newDeckId)
         } catch (filteredAncestor: DeckRenameException) {
             Timber.w(filteredAncestor)
@@ -153,9 +156,9 @@ class CreateDeckDialog(private val context: Context, private val title: Int, pri
             showThemedToast(context, context.getString(R.string.invalid_deck_name), false)
         } else if (newName != mPreviousDeckName) {
             try {
-                val col = CollectionHelper.getInstance().getCol(context)
-                val deckId = col.decks.id(mPreviousDeckName!!)
-                col.decks.rename(col.decks.get(deckId), newName)
+                val decks = col.decks
+                val deckId = decks.id(mPreviousDeckName!!)
+                decks.rename(decks.get(deckId), newName)
                 mOnNewDeckCreated!!.accept(deckId)
             } catch (e: DeckRenameException) {
                 Timber.w(e)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/DeckService.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/DeckService.kt
@@ -58,4 +58,10 @@ object DeckService {
             "select count() from cards where did in $ids or odid in $ids"
         )
     }
+
+    /**
+     * @return true if the collection contains a deck with the given name
+     */
+    fun deckExists(col: Collection, name: String) =
+        col.decks.byName(name) != null
 }

--- a/AnkiDroid/src/main/res/values/02-strings.xml
+++ b/AnkiDroid/src/main/res/values/02-strings.xml
@@ -426,4 +426,5 @@
 
     <!-- Deck Creation -->
     <string name="validation_deck_already_exists">Deck exists</string>
+    <string name="deck_created">Created deck</string>
 </resources>

--- a/AnkiDroid/src/main/res/values/02-strings.xml
+++ b/AnkiDroid/src/main/res/values/02-strings.xml
@@ -427,4 +427,5 @@
     <!-- Deck Creation -->
     <string name="validation_deck_already_exists">Deck exists</string>
     <string name="deck_created">Created deck</string>
+    <string name="deck_renamed">Renamed deck</string>
 </resources>

--- a/AnkiDroid/src/main/res/values/02-strings.xml
+++ b/AnkiDroid/src/main/res/values/02-strings.xml
@@ -423,4 +423,7 @@
     <string name="intro_sync_from_ankiweb">Sync from AnkiWeb</string>
 
     <string name="already_logged_in">Already logged in</string>
+
+    <!-- Deck Creation -->
+    <string name="validation_deck_already_exists">Deck exists</string>
 </resources>

--- a/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/CreateDeckDialogTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/CreateDeckDialogTest.kt
@@ -16,28 +16,29 @@
 
 package com.ichi2.anki.dialogs
 
-import android.widget.EditText
 import androidx.core.content.edit
 import androidx.lifecycle.Lifecycle
 import androidx.test.core.app.ActivityScenario
-import com.afollestad.materialdialogs.WhichButton
-import com.afollestad.materialdialogs.actions.getActionButton
-import com.afollestad.materialdialogs.input.getInputField
+import com.afollestad.materialdialogs.MaterialDialog
 import com.ichi2.anki.CollectionManager.withCol
 import com.ichi2.anki.DeckPicker
 import com.ichi2.anki.IntroductionActivity
 import com.ichi2.anki.R
 import com.ichi2.anki.RobolectricTest
+import com.ichi2.anki.dialogs.CreateDeckDialog.DeckDialogType
+import com.ichi2.anki.dialogs.utils.input
+import com.ichi2.anki.dialogs.utils.positiveButton
+import com.ichi2.libanki.DeckId
 import com.ichi2.libanki.DeckManager
 import com.ichi2.libanki.backend.exception.DeckRenameException
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.hamcrest.CoreMatchers.equalTo
-import org.hamcrest.MatcherAssert
+import org.hamcrest.MatcherAssert.*
+import org.junit.Ignore
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
-import java.util.*
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.atomic.AtomicReference
 import kotlin.coroutines.resume
@@ -61,7 +62,7 @@ class CreateDeckDialogTest : RobolectricTest() {
     @Test
     fun testCreateFilteredDeckFunction() {
         mActivityScenario!!.onActivity { activity: DeckPicker ->
-            val createDeckDialog = CreateDeckDialog(activity, R.string.new_deck, CreateDeckDialog.DeckDialogType.FILTERED_DECK, null)
+            val createDeckDialog = CreateDeckDialog(activity, R.string.new_deck, DeckDialogType.FILTERED_DECK, null)
             val isCreated = AtomicReference(false)
             val deckName = "filteredDeck"
             advanceRobolectricLooper()
@@ -70,13 +71,13 @@ class CreateDeckDialogTest : RobolectricTest() {
                 try {
                     isCreated.set(true)
                     val decks: DeckManager = activity.col.decks
-                    MatcherAssert.assertThat(id, equalTo(decks.id(deckName)))
+                    assertThat(id, equalTo(decks.id(deckName)))
                 } catch (filteredAncestor: DeckRenameException) {
                     throw RuntimeException(filteredAncestor)
                 }
             }
             createDeckDialog.createFilteredDeck(deckName)
-            MatcherAssert.assertThat(isCreated.get() as Boolean, equalTo(true))
+            assertThat(isCreated.get() as Boolean, equalTo(true))
         }
     }
 
@@ -85,7 +86,7 @@ class CreateDeckDialogTest : RobolectricTest() {
     fun testCreateSubDeckFunction() {
         val deckParentId = col.decks.id("Deck Name")
         mActivityScenario!!.onActivity { activity: DeckPicker ->
-            val createDeckDialog = CreateDeckDialog(activity, R.string.new_deck, CreateDeckDialog.DeckDialogType.SUB_DECK, deckParentId)
+            val createDeckDialog = CreateDeckDialog(activity, R.string.new_deck, DeckDialogType.SUB_DECK, deckParentId)
             val isCreated = AtomicReference(false)
             val deckName = "filteredDeck"
             advanceRobolectricLooper()
@@ -94,20 +95,20 @@ class CreateDeckDialogTest : RobolectricTest() {
                     isCreated.set(true)
                     val decks: DeckManager = activity.col.decks
                     val deckNameWithParentName = decks.getSubdeckName(deckParentId, deckName)
-                    MatcherAssert.assertThat(id, equalTo(decks.id(deckNameWithParentName!!)))
+                    assertThat(id, equalTo(decks.id(deckNameWithParentName!!)))
                 } catch (filteredAncestor: DeckRenameException) {
                     throw RuntimeException(filteredAncestor)
                 }
             }
             createDeckDialog.createSubDeck(deckParentId, deckName)
-            MatcherAssert.assertThat(isCreated.get(), equalTo(true))
+            assertThat(isCreated.get(), equalTo(true))
         }
     }
 
     @Test
     fun testCreateDeckFunction() {
         mActivityScenario!!.onActivity { activity: DeckPicker ->
-            val createDeckDialog = CreateDeckDialog(activity, R.string.new_deck, CreateDeckDialog.DeckDialogType.DECK, null)
+            val createDeckDialog = CreateDeckDialog(activity, R.string.new_deck, DeckDialogType.DECK, null)
             val isCreated = AtomicReference(false)
             val deckName = "Deck Name"
             advanceRobolectricLooper()
@@ -115,10 +116,10 @@ class CreateDeckDialogTest : RobolectricTest() {
                 // a deck was created
                 isCreated.set(true)
                 val decks: DeckManager = activity.col.decks
-                MatcherAssert.assertThat(id, equalTo(decks.byName(deckName)!!.getLong("id")))
+                assertThat(id, equalTo(decks.byName(deckName)!!.getLong("id")))
             }
             createDeckDialog.createDeck(deckName)
-            MatcherAssert.assertThat(isCreated.get(), equalTo(true))
+            assertThat(isCreated.get(), equalTo(true))
         }
     }
 
@@ -127,7 +128,7 @@ class CreateDeckDialogTest : RobolectricTest() {
         val deckName = "Deck Name"
         val deckNewName = "New Deck Name"
         mActivityScenario!!.onActivity { activity: DeckPicker ->
-            val createDeckDialog = CreateDeckDialog(activity, R.string.new_deck, CreateDeckDialog.DeckDialogType.RENAME_DECK, null)
+            val createDeckDialog = CreateDeckDialog(activity, R.string.new_deck, DeckDialogType.RENAME_DECK, null)
             createDeckDialog.deckName = deckName
             val isCreated = AtomicReference(false)
             advanceRobolectricLooper()
@@ -135,23 +136,21 @@ class CreateDeckDialogTest : RobolectricTest() {
                 // a deck name was renamed
                 isCreated.set(true)
                 val decks: DeckManager = activity.col.decks
-                MatcherAssert.assertThat(deckNewName, equalTo(decks.name(id!!)))
+                assertThat(deckNewName, equalTo(decks.name(id!!)))
             }
             createDeckDialog.renameDeck(deckNewName)
-            MatcherAssert.assertThat(isCreated.get(), equalTo(true))
+            assertThat(isCreated.get(), equalTo(true))
         }
     }
 
     @Test
     fun nameMayNotBeZeroLength() {
-        mActivityScenario!!.onActivity { activity: DeckPicker? ->
-            val createDeckDialog = CreateDeckDialog(activity!!, R.string.new_deck, CreateDeckDialog.DeckDialogType.DECK, null)
-            val materialDialog = createDeckDialog.showDialog()
-            val actionButton = materialDialog.getActionButton(WhichButton.POSITIVE)
-            MatcherAssert.assertThat("Ok is disabled if zero length input", actionButton.isEnabled, equalTo(false))
-            val editText: EditText? = Objects.requireNonNull(materialDialog.getInputField())
-            editText?.setText("NotEmpty")
-            MatcherAssert.assertThat("Ok is enabled if not zero length input", actionButton.isEnabled, equalTo(true))
+        testDialog(DeckDialogType.DECK) {
+            assertThat("Ok is disabled if zero length input", positiveButton.isEnabled, equalTo(false))
+            input = "NotEmpty"
+            assertThat("Ok is enabled if not zero length input", positiveButton.isEnabled, equalTo(true))
+            input = "A::B"
+            assertThat("OK is enabled if fully qualified input provided ('A::B')", positiveButton.isEnabled, equalTo(true))
         }
     }
 
@@ -220,6 +219,51 @@ class CreateDeckDialogTest : RobolectricTest() {
         }
         deckPicker.updateMenuState()
         assertEquals(deckPicker.optionsMenuState!!.searchIcon, true)
+    }
+
+    @Test
+    fun `Duplicate decks can't be created`() {
+        createDeck("deck")
+        createDeck("parent::child")
+        testDialog(DeckDialogType.DECK) {
+            input = "deck"
+            assertThat("Cannot create duplicate deck: 'deck'", positiveButton.isEnabled, equalTo(false))
+            input = "Deck"
+            assertThat("Cannot create duplicate deck: (case insensitive: 'Deck')", positiveButton.isEnabled, equalTo(false))
+            input = "Deck2"
+            assertThat("Can create deck with new name: 'Deck2'", positiveButton.isEnabled, equalTo(true))
+            input = "parent::child"
+            assertThat("Can't create fully qualified duplicate deck: 'parent::child'", positiveButton.isEnabled, equalTo(false))
+        }
+    }
+
+    @Test
+    fun `Duplicate subdecks can't be created`() {
+        // Subdecks have a 'context' of the parent deck: selecting 'A' and entering 'B' creates 'A::B'
+        createDeck("parent::child")
+        val parentDeckId = col.decks.byName("parent")!!.getLong("id")
+        testDialog(DeckDialogType.SUB_DECK, parentDeckId) {
+            input = "parent"
+            assertThat("'parent::parent' should be valid", positiveButton.isEnabled, equalTo(true))
+            input = "child"
+            assertThat("'parent::child' already exists so should be invalid", positiveButton.isEnabled, equalTo(false))
+            input = "Child"
+            assertThat("'parent::child' already exists so should be invalid (case insensitive)", positiveButton.isEnabled, equalTo(false))
+        }
+    }
+
+    private fun createDeck(deckName: String) {
+        col.decks.id(deckName)
+    }
+
+    /**
+     * Executes [callback] on the [MaterialDialog] created from [CreateDeckDialog]
+     */
+    private fun testDialog(deckDialogType: DeckDialogType, parentId: DeckId? = null, callback: (MaterialDialog.() -> Unit)) {
+        mActivityScenario!!.onActivity { activity: DeckPicker ->
+            val dialog = CreateDeckDialog(activity, R.string.new_deck, deckDialogType, parentId).showDialog()
+            callback(dialog)
+        }
     }
 
     private fun deckTreeName(start: Int, end: Int, prefix: String): String {

--- a/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/utils/MaterialDialogUtils.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/utils/MaterialDialogUtils.kt
@@ -1,0 +1,28 @@
+/*
+ *  Copyright (c) 2022 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.dialogs.utils
+
+import com.afollestad.materialdialogs.MaterialDialog
+import com.afollestad.materialdialogs.WhichButton
+import com.afollestad.materialdialogs.actions.getActionButton
+import com.afollestad.materialdialogs.input.getInputField
+
+val MaterialDialog.positiveButton get() = this.getActionButton(WhichButton.POSITIVE)
+
+var MaterialDialog.input
+    get() = this.getInputField().text.toString()
+    set(value) = this.getInputField().setText(value)


### PR DESCRIPTION
## Purpose / Description

When a deck was created, there was little visual feedback on success/failure:

* When a deck was invalid, the dialog just closed
* When a deck was created/renamed, the user was not informed

## Fixes
* Fixes #10528
* Solves part of #11668: deck creation

## Approach
* toasts are used when a success occurs, 
* validation on the form is used if a deck couldn't be created
  * The OK button is greyed out 
  * A message is shown if the name is used

## How Has This Been Tested?

<img width="382" alt="Screenshot 2022-08-23 at 23 15 19" src="https://user-images.githubusercontent.com/62114487/186277910-6e97131b-0839-4a24-a6c2-7112bddc8aa9.png">
<img width="381" alt="Screenshot 2022-08-23 at 23 15 11" src="https://user-images.githubusercontent.com/62114487/186277917-126f364d-7119-4f50-af06-ec6843789a88.png">
<img width="352" alt="Screenshot 2022-08-23 at 23 14 58" src="https://user-images.githubusercontent.com/62114487/186277920-b6a30472-70cf-437a-b76b-f50b24105af5.png">


## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
