### PR TITLE
NF: uses assertThrows instead of try{expectToFail}catch{}

### DIFF
--- a/AnkiDroid/src/test/java/com/ichi2/libanki/ClozeTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/ClozeTest.kt
@@ -4,7 +4,6 @@ package com.ichi2.libanki
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.ichi2.anki.RobolectricTest
-import com.ichi2.utils.JSONException
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.*
 import org.junit.Assert.*
@@ -17,12 +16,8 @@ class ClozeTest : RobolectricTest() {
     fun testCloze() {
         val d = col
         var f = d.newNote(d.models.byName("Cloze"))
-        try {
-            val name = f.model().getString("name")
-            assertEquals("Cloze", name)
-        } catch (e: JSONException) {
-            fail()
-        }
+        val name = f.model().getString("name")
+        assertEquals("Cloze", name)
         // a cloze model with no clozes is not empty
         f.setItem("Text", "nothing")
         assertThat(d.addNote(f), greaterThan(0))

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/ModelTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/ModelTest.kt
@@ -22,6 +22,7 @@ import com.ichi2.libanki.Consts.MODEL_CLOZE
 import com.ichi2.libanki.Models.REQ_ALL
 import com.ichi2.libanki.Models.REQ_ANY
 import com.ichi2.libanki.Utils.stripHTML
+import com.ichi2.testutils.assertThrowsSubclass
 import com.ichi2.utils.JSONArray
 import com.ichi2.utils.JSONObject
 import com.ichi2.utils.KotlinCleanup
@@ -695,12 +696,10 @@ class ModelTest : RobolectricTest() {
         val basic = mm.byName("Basic")
         val template = basic!!.getJSONArray("tmpls").getJSONObject(0)
         template.put("qfmt", "{{|Front}}{{Front}}{{/Front}}{{Front}}")
-        try {
+        assertThrowsSubclass<Exception>() {
             // in V16, the "save" throws, in V11, the "add" throws
             mm.save(basic, true)
             addNoteUsingBasicModel("foo", "bar")
-            fail()
-        } catch (er: Exception) {
         }
     }
 

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/template/ParserTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/template/ParserTest.kt
@@ -18,9 +18,9 @@ package com.ichi2.libanki.template
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.ichi2.anki.RobolectricTest
 import com.ichi2.libanki.template.TokenizerTest.Companion.new_to_legacy_template
+import com.ichi2.testutils.assertThrows
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
-import org.junit.Assert.fail
 import org.junit.Test
 import org.junit.runner.RunWith
 
@@ -51,25 +51,17 @@ class ParserTest : RobolectricTest() {
         )
         testParsing("{{#Foo}}{{Test}}{{/Foo}}", Conditional("Foo", Replacement("Test")))
         testParsing("{{^Foo}}{{Test}}{{/Foo}}", NegatedConditional("Foo", Replacement("Test")))
-        try {
+        assertThrows<TemplateError.NoClosingBrackets> {
             ParsedNode.parse_inner("{{foo")
-            fail()
-        } catch (ncb: TemplateError.NoClosingBrackets) {
         }
-        try {
+        assertThrows<TemplateError.ConditionalNotClosed> {
             ParsedNode.parse_inner("{{#foo}}")
-            fail()
-        } catch (ncb: TemplateError.ConditionalNotClosed) {
         }
-        try {
+        assertThrows<TemplateError.ConditionalNotOpen> {
             ParsedNode.parse_inner("{{/foo}}")
-            fail()
-        } catch (ncb: TemplateError.ConditionalNotOpen) {
         }
-        try {
+        assertThrows<TemplateError.WrongConditionalClosed> {
             ParsedNode.parse_inner("{{#bar}}{{/foo}}")
-            fail()
-        } catch (ncb: TemplateError.WrongConditionalClosed) {
         }
     }
 

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/template/TokenizerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/template/TokenizerTest.kt
@@ -30,10 +30,17 @@ import com.ichi2.libanki.template.Tokenizer.TokenKind.CLOSE_CONDITIONAL
 import com.ichi2.libanki.template.Tokenizer.TokenKind.OPEN_CONDITIONAL
 import com.ichi2.libanki.template.Tokenizer.TokenKind.OPEN_NEGATED
 import com.ichi2.libanki.template.Tokenizer.TokenKind.REPLACEMENT
+import com.ichi2.libanki.template.Tokenizer.classify_handle
+import com.ichi2.libanki.template.Tokenizer.handlebar_token
+import com.ichi2.libanki.template.Tokenizer.legacy_handlebar_token
+import com.ichi2.libanki.template.Tokenizer.new_handlebar_token
+import com.ichi2.libanki.template.Tokenizer.new_to_legacy
+import com.ichi2.libanki.template.Tokenizer.next_token
+import com.ichi2.libanki.template.Tokenizer.text_token
+import com.ichi2.testutils.assertThrows
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
 import org.hamcrest.Matchers.nullValue
-import org.junit.Assert.fail
 import org.junit.Test
 import org.junit.runner.RunWith
 
@@ -371,16 +378,14 @@ class TokenizerTest : RobolectricTest() {
             legacy_tokenizer.next(),
             equalTo(Tokenizer.Token(Tokenizer.TokenKind.TEXT, "iee "))
         )
-        try {
+        assertThrows<NoClosingBrackets> {
             tokenizer.next()
-            fail()
-        } catch (exc: NoClosingBrackets) {
+        }.let { exc ->
             assertThat(exc.remaining, equalTo("{{!ien nnr"))
         }
-        try {
+        assertThrows<NoClosingBrackets> {
             legacy_tokenizer.next()
-            fail()
-        } catch (exc: NoClosingBrackets) {
+        }.let { exc ->
             assertThat(exc.remaining, equalTo("<%!ien nnr"))
         }
         assertThat(tokenizer.hasNext(), equalTo(false))

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/template/TokenizerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/template/TokenizerTest.kt
@@ -30,13 +30,6 @@ import com.ichi2.libanki.template.Tokenizer.TokenKind.CLOSE_CONDITIONAL
 import com.ichi2.libanki.template.Tokenizer.TokenKind.OPEN_CONDITIONAL
 import com.ichi2.libanki.template.Tokenizer.TokenKind.OPEN_NEGATED
 import com.ichi2.libanki.template.Tokenizer.TokenKind.REPLACEMENT
-import com.ichi2.libanki.template.Tokenizer.classify_handle
-import com.ichi2.libanki.template.Tokenizer.handlebar_token
-import com.ichi2.libanki.template.Tokenizer.legacy_handlebar_token
-import com.ichi2.libanki.template.Tokenizer.new_handlebar_token
-import com.ichi2.libanki.template.Tokenizer.new_to_legacy
-import com.ichi2.libanki.template.Tokenizer.next_token
-import com.ichi2.libanki.template.Tokenizer.text_token
 import com.ichi2.testutils.assertThrows
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo

--- a/AnkiDroid/src/test/java/com/ichi2/utils/JSONArrayTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/utils/JSONArrayTest.kt
@@ -24,6 +24,7 @@ package com.ichi2.utils
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.ichi2.testutils.EmptyApplication
+import com.ichi2.testutils.assertThrows
 import org.junit.Assert.*
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -46,15 +47,11 @@ class JSONArrayTest {
         val array = JSONArray()
         assertEquals(0, array.length())
         assertEquals("", array.join(" AND "))
-        try {
+        assertThrows<JSONException> {
             array[0]
-            fail()
-        } catch (e: JSONException) {
         }
-        try {
+        assertThrows<JSONException> {
             array.getBoolean(0)
-            fail()
-        } catch (e: JSONException) {
         }
         assertEquals("[]", array.toString())
         assertEquals("[]", array.toString(4))
@@ -141,20 +138,14 @@ class JSONArrayTest {
         assertEquals("[null,null,null,null]", array.toString())
         // there's 2 ways to represent null; each behaves differently!
         assertEquals(JSONObject.NULL, array[0])
-        try {
+        assertThrows<JSONException> {
             array[1]
-            fail()
-        } catch (e: JSONException) {
         }
-        try {
+        assertThrows<JSONException> {
             array[2]
-            fail()
-        } catch (e: JSONException) {
         }
-        try {
+        assertThrows<JSONException> {
             array[3]
-            fail()
-        } catch (e: JSONException) {
         }
         assertEquals(JSONObject.NULL, array.opt(0))
         assertEquals(null, array.opt(1))
@@ -180,17 +171,13 @@ class JSONArrayTest {
         array.put(null)
         assertEquals("null", array[0])
         assertEquals(JSONObject.NULL, array[1])
-        try {
+        assertThrows<JSONException> {
             array[2]
-            fail()
-        } catch (e: JSONException) {
         }
         assertEquals("null", array.getString(0))
         assertEquals("null", array.getString(1))
-        try {
+        assertThrows<JSONException> {
             array.getString(2)
-            fail()
-        } catch (e: JSONException) {
         }
     }
 
@@ -281,10 +268,8 @@ class JSONArrayTest {
         assertEquals(9.223372036854776E18, array.getDouble(2), 0.0)
         assertEquals(Int.MAX_VALUE, array.getInt(2))
         assertFalse(array.isNull(3))
-        try {
+        assertThrows<JSONException> {
             array.getDouble(3)
-            fail()
-        } catch (e: JSONException) {
         }
         assertEquals(NaN, array.optDouble(3), 0.0)
         assertEquals(-1.0, array.optDouble(3, -1.0), 0.0)
@@ -388,20 +373,14 @@ class JSONArrayTest {
     @Test
     fun testPutUnsupportedNumbers() {
         val array = JSONArray()
-        try {
+        assertThrows<JSONException> {
             array.put(Double.NaN)
-            fail()
-        } catch (e: JSONException) {
         }
-        try {
+        assertThrows<JSONException> {
             array.put(0, Double.NEGATIVE_INFINITY)
-            fail()
-        } catch (e: JSONException) {
         }
-        try {
+        assertThrows<JSONException> {
             array.put(0, Double.POSITIVE_INFINITY)
-            fail()
-        } catch (e: JSONException) {
         }
     }
 
@@ -409,12 +388,11 @@ class JSONArrayTest {
     fun testPutUnsupportedNumbersAsObject() {
         val array = JSONArray()
 
-        try {
+        assertThrows<JSONException> {
             array.put(NaN)
             array.put(NEGATIVE_INFINITY)
             array.put(POSITIVE_INFINITY)
             assertEquals(null, array.toString())
-        } catch (e: JSONException) {
         }
     }
 
@@ -454,10 +432,8 @@ class JSONArrayTest {
 
     @Test
     fun testTokenerConstructorWrongType() {
-        try {
+        assertThrows<JSONException> {
             JSONArray(JSONTokener("{\"foo\": false}"))
-            fail()
-        } catch (e: JSONException) {
         }
     }
 
@@ -465,7 +441,6 @@ class JSONArrayTest {
     fun testTokenerConstructorNull() {
         try {
             JSONArray(null as JSONTokener?)
-            fail()
         } catch (e: NullPointerException) {
         }
     }
@@ -473,9 +448,9 @@ class JSONArrayTest {
     @Test
     fun testTokenerConstructorParseFail() {
         try {
-            JSONArray(JSONTokener("["))
-            fail()
-        } catch (e: JSONException) {
+            assertThrows<JSONException> {
+                JSONArray(JSONTokener("["))
+            }
         } catch (e: StackOverflowError) {
             fail("Stack overflowed on input: \"[\"")
         }
@@ -490,28 +465,24 @@ class JSONArrayTest {
 
     @Test
     fun testStringConstructorWrongType() {
-        try {
+        assertThrows<JSONException> {
             JSONArray("{\"foo\": false}")
-            fail()
-        } catch (e: JSONException) {
         }
     }
 
     @Test
     fun testStringConstructorNull() {
-        try {
+        assertThrows<NullPointerException> {
             JSONArray(null as String?)
-            fail()
-        } catch (e: NullPointerException) {
         }
     }
 
     @Test
     fun testStringConstructorParseFail() {
         try {
-            JSONArray("[")
-            fail()
-        } catch (e: JSONException) {
+            assertThrows<JSONException> {
+                JSONArray("[")
+            }
         } catch (e: StackOverflowError) {
             fail("Stack overflowed on input: \"[\"")
         }
@@ -534,25 +505,17 @@ class JSONArrayTest {
         assertEquals(null, array.opt(-3))
         assertEquals("", array.optString(3))
         assertEquals("", array.optString(-3))
-        try {
+        assertThrows<JSONException> {
             array[3]
-            fail()
-        } catch (e: JSONException) {
         }
-        try {
+        assertThrows<JSONException> {
             array[-3]
-            fail()
-        } catch (e: JSONException) {
         }
-        try {
+        assertThrows<JSONException> {
             array.getString(3)
-            fail()
-        } catch (e: JSONException) {
         }
-        try {
+        assertThrows<JSONException> {
             array.getString(-3)
-            fail()
-        } catch (e: JSONException) {
         }
     }
 }

--- a/AnkiDroid/src/test/java/com/ichi2/utils/JSONObjectTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/utils/JSONObjectTest.kt
@@ -38,9 +38,9 @@ package com.ichi2.utils
 
 import android.annotation.SuppressLint
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.ichi2.testutils.AnkiAssert.assertThrows
 import com.ichi2.testutils.EmptyApplication
 import com.ichi2.testutils.assertThrows
+import com.ichi2.testutils.assertThrowsSubclass
 import junit.framework.TestCase.*
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.core.IsNull.notNullValue
@@ -70,45 +70,29 @@ class JSONObjectTest {
         assertNull(testObject.toJSONArray(JSONArray()))
         assertEquals("{}", testObject.toString())
         assertEquals("{}", testObject.toString(5))
-        try {
+        assertThrows<JSONException> {
             testObject["foo"]
-            fail()
-        } catch (e: JSONException) {
         }
-        try {
+        assertThrows<JSONException> {
             testObject.getBoolean("foo")
-            fail()
-        } catch (e: JSONException) {
         }
-        try {
+        assertThrows<JSONException> {
             testObject.getDouble("foo")
-            fail()
-        } catch (e: JSONException) {
         }
-        try {
+        assertThrows<JSONException> {
             testObject.getInt("foo")
-            fail()
-        } catch (e: JSONException) {
         }
-        try {
+        assertThrows<JSONException> {
             testObject.getJSONArray("foo")
-            fail()
-        } catch (e: JSONException) {
         }
-        try {
+        assertThrows<JSONException> {
             testObject.getJSONObject("foo")
-            fail()
-        } catch (e: JSONException) {
         }
-        try {
+        assertThrows<JSONException> {
             testObject.getLong("foo")
-            fail()
-        } catch (e: JSONException) {
         }
-        try {
+        assertThrows<JSONException> {
             testObject.getString("foo")
-            fail()
-        } catch (e: JSONException) {
         }
         assertFalse(testObject.has("foo"))
         assertTrue(testObject.isNull("foo")) // isNull also means "is not present"
@@ -145,10 +129,8 @@ class JSONObjectTest {
         testObject.put("bar", Any())
         testObject.put("baz", Any())
         assertSame(value, testObject["foo"])
-        try {
+        assertThrows<JSONException> {
             testObject["FOO"]
-            fail()
-        } catch (e: JSONException) {
         }
     }
 
@@ -177,10 +159,8 @@ class JSONObjectTest {
         testObject.put("foo", null)
         assertEquals(0, testObject.length())
         assertFalse(testObject.has("foo"))
-        try {
+        assertThrows<JSONException> {
             testObject["foo"]
-            fail()
-        } catch (e: JSONException) {
         }
     }
 
@@ -199,20 +179,14 @@ class JSONObjectTest {
     @Test
     fun testPutOptUnsupportedNumbers() {
         val testObject = JSONObject()
-        try {
+        assertThrows<JSONException> {
             testObject.putOpt("foo", Double.NaN)
-            fail()
-        } catch (e: JSONException) {
         }
-        try {
+        assertThrows<JSONException> {
             testObject.putOpt("foo", Double.NEGATIVE_INFINITY)
-            fail()
-        } catch (e: JSONException) {
         }
-        try {
+        assertThrows<JSONException> {
             testObject.putOpt("foo", Double.POSITIVE_INFINITY)
-            fail()
-        } catch (e: JSONException) {
         }
     }
 
@@ -319,20 +293,14 @@ class JSONObjectTest {
     @Test
     fun testFloats() {
         val testObject = JSONObject()
-        try {
+        assertThrows<JSONException> {
             testObject.put("foo", Float.NaN)
-            fail()
-        } catch (e: JSONException) {
         }
-        try {
+        assertThrows<JSONException> {
             testObject.put("foo", Float.NEGATIVE_INFINITY)
-            fail()
-        } catch (e: JSONException) {
         }
-        try {
+        assertThrows<JSONException> {
             testObject.put("foo", Float.POSITIVE_INFINITY)
-            fail()
-        } catch (e: JSONException) {
         }
     }
 
@@ -361,10 +329,9 @@ class JSONObjectTest {
             }
         }
         val testObject = JSONObject()
-        try {
+        assertThrows<JSONException> {
             testObject.put("foo", nan)
             fail("Object.put() accepted a NaN (via a custom Number class)")
-        } catch (e: JSONException) {
         }
     }
 
@@ -416,10 +383,8 @@ class JSONObjectTest {
         assertEquals(9.223372036854776E18, testObject.getDouble("baz"), 0.0)
         assertEquals(Int.MAX_VALUE, testObject.getInt("baz"))
         assertFalse(testObject.isNull("quux"))
-        try {
+        assertThrows<JSONException> {
             testObject.getDouble("quux")
-            fail()
-        } catch (e: JSONException) {
         }
         assertEquals(Double.NaN, testObject.optDouble("quux"), 0.0)
         assertEquals(-1.0, testObject.optDouble("quux", -1.0), 0.0)
@@ -436,15 +401,11 @@ class JSONObjectTest {
         testObject.put("bar", b)
         assertSame(a, testObject.getJSONArray("foo"))
         assertSame(b, testObject.getJSONObject("bar"))
-        try {
+        assertThrows<JSONException> {
             testObject.getJSONObject("foo")
-            fail()
-        } catch (e: JSONException) {
         }
-        try {
+        assertThrows<JSONException> {
             testObject.getJSONArray("bar")
-            fail()
-        } catch (e: JSONException) {
         }
         assertEquals(a, testObject.optJSONArray("foo"))
         assertEquals(b, testObject.optJSONObject("bar"))
@@ -463,10 +424,8 @@ class JSONObjectTest {
     fun testArrayCoercion() {
         val testObject = JSONObject()
         testObject.put("foo", "[true]")
-        try {
+        assertThrows<JSONException> {
             testObject.getJSONArray("foo")
-            fail()
-        } catch (e: JSONException) {
         }
     }
 
@@ -474,32 +433,24 @@ class JSONObjectTest {
     fun testObjectCoercion() {
         val testObject = JSONObject()
         testObject.put("foo", "{}")
-        try {
+        assertThrows<JSONException> {
             testObject.getJSONObject("foo")
-            fail()
-        } catch (e: JSONException) {
         }
     }
 
     @Test
     fun testAccumulateValueChecking() {
         val testObject = JSONObject()
-        try {
+        assertThrows<JSONException> {
             testObject.accumulate("foo", Double.NaN)
-            fail()
-        } catch (e: JSONException) {
         }
         testObject.accumulate("foo", 1)
-        try {
+        assertThrows<JSONException> {
             testObject.accumulate("foo", Double.NaN)
-            fail()
-        } catch (e: JSONException) {
         }
         testObject.accumulate("foo", 2)
-        try {
+        assertThrows<JSONException> {
             testObject.accumulate("foo", Double.NaN)
-            fail()
-        } catch (e: JSONException) {
         }
     }
 
@@ -538,10 +489,8 @@ class JSONObjectTest {
         assertEquals(4, array.length())
         assertEquals(5.0, array[0])
         assertEquals(true, array[1])
-        try {
+        assertThrows<JSONException> {
             array[2]
-            fail()
-        } catch (e: JSONException) {
         }
         assertEquals(JSONObject.NULL, array[3])
     }
@@ -587,40 +536,28 @@ class JSONObjectTest {
     @Test
     fun testPutUnsupportedNumbers() {
         val testObject = JSONObject()
-        try {
+        assertThrows<JSONException> {
             testObject.put("foo", Double.NaN)
-            fail()
-        } catch (e: JSONException) {
         }
-        try {
+        assertThrows<JSONException> {
             testObject.put("foo", Double.NEGATIVE_INFINITY)
-            fail()
-        } catch (e: JSONException) {
         }
-        try {
+        assertThrows<JSONException> {
             testObject.put("foo", Double.POSITIVE_INFINITY)
-            fail()
-        } catch (e: JSONException) {
         }
     }
 
     @Test
     fun testPutUnsupportedNumbersAsObjects() {
         val testObject = JSONObject()
-        try {
+        assertThrows<JSONException> {
             testObject.put("foo", Double.NaN)
-            fail()
-        } catch (e: JSONException) {
         }
-        try {
+        assertThrows<JSONException> {
             testObject.put("foo", Double.NEGATIVE_INFINITY)
-            fail()
-        } catch (e: JSONException) {
         }
-        try {
+        assertThrows<JSONException> {
             testObject.put("foo", Double.POSITIVE_INFINITY)
-            fail()
-        } catch (e: JSONException) {
         }
     }
 
@@ -660,10 +597,9 @@ class JSONObjectTest {
     fun testMapConstructorWithBogusEntries() {
         val contents: MutableMap<Any?, Any?> = HashMap()
         contents[5] = 5
-        try {
+        assertThrowsSubclass<Exception> {
             JSONObject(contents)
             fail("JSONObject constructor doesn't validate its input!")
-        } catch (e: Exception) {
         }
     }
 
@@ -676,28 +612,22 @@ class JSONObjectTest {
 
     @Test
     fun testTokenerConstructorWrongType() {
-        try {
+        assertThrows<JSONException> {
             JSONObject(JSONTokener("[\"foo\", false]"))
-            fail()
-        } catch (e: JSONException) {
         }
     }
 
     @Test
     fun testTokenerConstructorNull() {
-        try {
+        assertThrows<NullPointerException> {
             JSONObject(null as JSONTokener?)
-            fail()
-        } catch (e: NullPointerException) {
         }
     }
 
     @Test
     fun testTokenerConstructorParseFail() {
-        try {
+        assertThrows<JSONException> {
             JSONObject(JSONTokener("{"))
-            fail()
-        } catch (e: JSONException) {
         }
     }
 
@@ -710,28 +640,22 @@ class JSONObjectTest {
 
     @Test
     fun testStringConstructorWrongType() {
-        try {
+        assertThrows<JSONException> {
             JSONObject("[\"foo\", false]")
-            fail()
-        } catch (e: JSONException) {
         }
     }
 
     @Test
     fun testStringConstructorNull() {
-        try {
+        assertThrows<NullPointerException> {
             JSONObject(null as String?)
-            fail()
-        } catch (e: NullPointerException) {
         }
     }
 
     @Test
     fun testStringonstructorParseFail() {
-        try {
+        assertThrows<JSONException> {
             JSONObject("{")
-            fail()
-        } catch (e: JSONException) {
         }
     }
 
@@ -877,10 +801,8 @@ class JSONObjectTest {
     fun testKeysEmptyObject() {
         val testObject = JSONObject()
         assertFalse(testObject.keys().hasNext())
-        try {
+        assertThrows<NoSuchElementException> {
             testObject.keys().next()
-            fail()
-        } catch (e: NoSuchElementException) {
         }
     }
 
@@ -898,10 +820,8 @@ class JSONObjectTest {
         result.add(keys.next())
         assertFalse(keys.hasNext())
         assertEquals(HashSet(Arrays.asList("foo", "bar")), result)
-        try {
+        assertThrows<NoSuchElementException> {
             keys.next()
-            fail()
-        } catch (e: NoSuchElementException) {
         }
     }
 
@@ -932,30 +852,22 @@ class JSONObjectTest {
         assertEquals("9223372036854775806", JSONObject.numberToString(9223372036854775806L))
         assertEquals("4.9E-324", JSONObject.numberToString(Double.MIN_VALUE))
         assertEquals("1.7976931348623157E308", JSONObject.numberToString(Double.MAX_VALUE))
-        try {
+        assertThrows<JSONException> {
             JSONObject.numberToString(Double.NaN)
-            fail()
-        } catch (e: JSONException) {
         }
-        try {
+        assertThrows<JSONException> {
             JSONObject.numberToString(Double.NEGATIVE_INFINITY)
-            fail()
-        } catch (e: JSONException) {
         }
-        try {
+        assertThrows<JSONException> {
             JSONObject.numberToString(Double.POSITIVE_INFINITY)
-            fail()
-        } catch (e: JSONException) {
         }
         assertEquals("0.001", JSONObject.numberToString(BigDecimal("0.001")))
         assertEquals(
             "9223372036854775806",
             JSONObject.numberToString(BigInteger("9223372036854775806"))
         )
-        try {
+        assertThrows<JSONException> {
             JSONObject.numberToString(null)
-            fail()
-        } catch (e: JSONException) {
         }
     }
 


### PR DESCRIPTION
It was not corrected in `testToJSONArrayNull` because the test should fail (but since the author didn't actually add `fail()` in it, it was not detected)