### PR TITLE
[GSoC] Make Filters persistent in Filter Sheet

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/FilterSheetBottomFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/FilterSheetBottomFragment.kt
@@ -76,6 +76,7 @@ class FilterSheetBottomFragment :
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View = inflater.inflate(R.layout.filter_bottom_sheet, container, false).apply {
+        // Create a query with currently selected filters, and close the filter sheet
         val applyButton = this.findViewById<Button>(R.id.apply_filter_button)
         applyButton.setOnClickListener {
             val filterQuery = createQuery(flagSearchItems)
@@ -86,6 +87,7 @@ class FilterSheetBottomFragment :
             dismiss()
         }
 
+        // Close the filter sheet
         val cancelButton = this.findViewById<Button>(R.id.cancel_filter_button)
         cancelButton.setOnClickListener {
             dismiss()

--- a/AnkiDroid/src/main/java/com/ichi2/anki/FilterSheetBottomFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/FilterSheetBottomFragment.kt
@@ -50,7 +50,7 @@ class FilterSheetBottomFragment :
     CollectionGetter {
     private lateinit var behavior: BottomSheetBehavior<View>
 
-    private var flagSearchItems = mutableListOf<SearchNode.Flag>()
+    private var flagSearchItems = mutableSetOf<SearchNode.Flag>()
 
     private lateinit var flagRecyclerView: RecyclerView
     private lateinit var flagListAdapter: FlagsAdapter
@@ -153,7 +153,7 @@ class FilterSheetBottomFragment :
     }
 
     private fun createQuery(
-        flagList: MutableList<SearchNode.Flag>
+        flagList: Set<SearchNode.Flag>
     ): String {
 
         if (flagList.isEmpty()) {
@@ -229,7 +229,7 @@ class FilterSheetBottomFragment :
                 }
             }
 
-            fun isSelected(flag: Flags, flagSearchItems: List<SearchNode.Flag>): bool {
+            fun isSelected(flag: Flags, flagSearchItems: Set<SearchNode.Flag>): bool {
                 return flagSearchItems.contains(flag.flagNode)
             }
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/FilterSheetBottomFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/FilterSheetBottomFragment.kt
@@ -55,10 +55,13 @@ class FilterSheetBottomFragment :
     private lateinit var flagRecyclerView: RecyclerView
     private lateinit var flagListAdapter: FlagsAdapter
 
+    private lateinit var flagsButton: LinearLayout
+    private lateinit var flagToggleIcon: ImageView
+
     private var lastClickTime = 0
 
     // flagName is displayed in filter sheet as the name of the filter
-    enum class Flags(@StringRes private val flagNameRes: Int, val flagNode: SearchNode.Flag, @DrawableRes val flagIcon: Int) {
+    enum class Flags(@StringRes private val flagNameRes: Int, val flagNode: SearchNode.Flag, @DrawableRes val flagToggleIcon: Int) {
         NO_FLAG(R.string.menu_flag_card_zero, SearchNode.Flag.FLAG_NONE, R.drawable.label_icon_flags),
         RED(R.string.menu_flag_card_one, SearchNode.Flag.FLAG_RED, R.drawable.ic_flag_red),
         ORANGE(R.string.menu_flag_card_two, SearchNode.Flag.FLAG_ORANGE, R.drawable.ic_flag_orange),
@@ -123,12 +126,23 @@ class FilterSheetBottomFragment :
         /*
          * Set the filter headings to be clickable:
          * Show/Hide the filter list on clicking
+         *
+         * If a filter is selected, change color of heading
          */
 
-        val flagsButton = requireView().findViewById<LinearLayout>(R.id.filterByFlagsText)
-        val flagIcon = requireView().findViewById<ImageView>(R.id.filter_flagListToggle)
+        flagsButton = requireView().findViewById(R.id.filterByFlagsLayout)
+        flagToggleIcon = requireView().findViewById(R.id.filter_flagListToggle)
         val flagsRecyclerViewLayout =
             requireView().findViewById<LinearLayout>(R.id.flagsRecyclerViewLayout)
+
+        if (flagSearchItems.isNotEmpty()) {
+            val filterHeader = flagsButton.findViewById<TextView>(R.id.filterByFlagsText)
+            val filterIcon = flagsButton.findViewById<ImageView>(R.id.filter_by_flags_icon)
+
+            filterHeader.setTextColor(getColorFromAttr(R.attr.filterItemTextColorSelected))
+            filterIcon.setColorFilter(getColorFromAttr(R.attr.filterItemTextColorSelected))
+            flagToggleIcon.setColorFilter(getColorFromAttr(R.attr.filterItemTextColorSelected))
+        }
 
         flagsButton.setOnClickListener {
 
@@ -138,10 +152,10 @@ class FilterSheetBottomFragment :
 
                 if (flagsRecyclerViewLayout.isVisible) {
                     flagsRecyclerViewLayout.visibility = View.GONE
-                    flagIcon.setImageResource(R.drawable.filter_sheet_unopened_list_icon)
+                    flagToggleIcon.setImageResource(R.drawable.filter_sheet_unopened_list_icon)
                 } else {
                     flagsRecyclerViewLayout.visibility = View.VISIBLE
-                    flagIcon.setImageResource(R.drawable.filter_sheet_opened_list_icon)
+                    flagToggleIcon.setImageResource(R.drawable.filter_sheet_opened_list_icon)
                 }
             }
         }
@@ -209,6 +223,20 @@ class FilterSheetBottomFragment :
 
                     flagSearchItems.remove(item.flagNode)
                 }
+                
+                // Change color of filter header to indicate a filter has been selected
+
+                val filterHeader = flagsButton.findViewById<TextView>(R.id.filterByFlagsText)
+                val filterIcon = flagsButton.findViewById<ImageView>(R.id.filter_by_flags_icon)
+                if (flagSearchItems.isNotEmpty()) {
+                    filterHeader.setTextColor(getColorFromAttr(R.attr.filterItemTextColorSelected))
+                    filterIcon.setColorFilter(getColorFromAttr(R.attr.filterItemTextColorSelected))
+                    flagToggleIcon.setColorFilter(getColorFromAttr(R.attr.filterItemTextColorSelected))
+                } else {
+                    filterHeader.setTextColor(getColorFromAttr(R.attr.filterItemTextColor))
+                    filterIcon.setColorFilter(getColorFromAttr(R.attr.filterItemTextColor))
+                    flagToggleIcon.setColorFilter(getColorFromAttr(R.attr.filterItemTextColor))
+                }
             }
 
             fun bind(
@@ -216,7 +244,7 @@ class FilterSheetBottomFragment :
                 position: Int
             ) {
                 itemTextView.text = currFlag.getFlagName(itemView.context)
-                icon.setImageResource(currFlag.flagIcon)
+                icon.setImageResource(currFlag.flagToggleIcon)
 
                 // If [currFlag] is currently selected, bind the view with the selected item background and text color
                 @NeedsTest("Test if background color is being correctly set if item is selected")

--- a/AnkiDroid/src/main/java/com/ichi2/anki/FilterSheetBottomFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/FilterSheetBottomFragment.kt
@@ -53,13 +53,11 @@ class FilterSheetBottomFragment :
     private lateinit var flagRecyclerView: RecyclerView
     private lateinit var flagListAdapter: FlagsAdapter
 
-    private lateinit var flagsButton: LinearLayout
     private lateinit var flagToggleIcon: ImageView
-
     /** Heading of the Flags filter section */
-    private lateinit var filterHeader: TextView
+    private lateinit var filterHeaderFlags: TextView
     /** Icon of the Flags filter section */
-    private lateinit var filterIcon: ImageView
+    private lateinit var filterIconFlags: ImageView
 
     private var lastClickTime = 0
 
@@ -133,21 +131,20 @@ class FilterSheetBottomFragment :
          * If a filter is selected, change color of heading
          */
 
-        flagsButton = requireView().findViewById(R.id.filterByFlagsLayout)
-        filterHeader = flagsButton.findViewById(R.id.filterByFlagsText)
-        filterIcon = flagsButton.findViewById(R.id.filter_by_flags_icon)
-
+        val flagsHeaderLayout = requireView().findViewById<LinearLayout>(R.id.filterByFlagsLayout)
+        filterHeaderFlags = flagsHeaderLayout.findViewById(R.id.filterByFlagsText)
+        filterIconFlags = flagsHeaderLayout.findViewById(R.id.filter_by_flags_icon)
         flagToggleIcon = requireView().findViewById(R.id.filter_flagListToggle)
         val flagsRecyclerViewLayout =
             requireView().findViewById<LinearLayout>(R.id.flagsRecyclerViewLayout)
 
         if (flagSearchItems.isNotEmpty()) {
-            filterHeader.setTextColor(getColorFromAttr(R.attr.filterItemTextColorSelected))
-            filterIcon.setColorFilter(getColorFromAttr(R.attr.filterItemTextColorSelected))
+            filterHeaderFlags.setTextColor(getColorFromAttr(R.attr.filterItemTextColorSelected))
+            filterIconFlags.setColorFilter(getColorFromAttr(R.attr.filterItemTextColorSelected))
             flagToggleIcon.setColorFilter(getColorFromAttr(R.attr.filterItemTextColorSelected))
         }
 
-        flagsButton.setOnClickListener {
+        flagsHeaderLayout.setOnClickListener {
 
             if (SystemClock.elapsedRealtime() - lastClickTime > DELAY_TIME) {
 
@@ -231,8 +228,8 @@ class FilterSheetBottomFragment :
                     return
                 }
                 setUnselectedColor()
-                filterHeader.setTextColor(getColorFromAttr(R.attr.filterItemTextColor))
-                filterIcon.setColorFilter(getColorFromAttr(R.attr.filterItemTextColor))
+                filterHeaderFlags.setTextColor(getColorFromAttr(R.attr.filterItemTextColor))
+                filterIconFlags.setColorFilter(getColorFromAttr(R.attr.filterItemTextColor))
                 flagToggleIcon.setColorFilter(getColorFromAttr(R.attr.filterItemTextColor))
             }
 
@@ -246,8 +243,8 @@ class FilterSheetBottomFragment :
                     return
                 }
                 setSelectedColor()
-                filterHeader.setTextColor(getColorFromAttr(R.attr.filterItemTextColorSelected))
-                filterIcon.setColorFilter(getColorFromAttr(R.attr.filterItemTextColorSelected))
+                filterHeaderFlags.setTextColor(getColorFromAttr(R.attr.filterItemTextColorSelected))
+                filterIconFlags.setColorFilter(getColorFromAttr(R.attr.filterItemTextColorSelected))
                 flagToggleIcon.setColorFilter(getColorFromAttr(R.attr.filterItemTextColorSelected))
             }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/FilterSheetBottomFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/FilterSheetBottomFragment.kt
@@ -211,11 +211,14 @@ class FilterSheetBottomFragment :
 
             private fun onFlagItemClicked(item: Flags, position: Int) {
                 val itemTextView = flagRecyclerView[position].findViewById<TextView>(R.id.filter_list_item)
+                /** Checks whether flagSearchItems was empty before adding new element to it */
+                var wasEmpty = false
 
                 if (!isSelected(item)) {
                     itemView.setBackgroundColor(getColorFromAttr(R.attr.filterItemBackgroundSelected))
                     itemTextView.setTextColor(getColorFromAttr(R.attr.filterItemTextColorSelected))
 
+                    wasEmpty = flagSearchItems.isEmpty()
                     flagSearchItems.add(item.flagNode)
                 } else {
                     flagRecyclerView[position].setBackgroundColor(getColorFromAttr(R.attr.filterItemBackground))
@@ -223,16 +226,17 @@ class FilterSheetBottomFragment :
 
                     flagSearchItems.remove(item.flagNode)
                 }
-                
+
                 // Change color of filter header to indicate a filter has been selected
 
                 val filterHeader = flagsButton.findViewById<TextView>(R.id.filterByFlagsText)
                 val filterIcon = flagsButton.findViewById<ImageView>(R.id.filter_by_flags_icon)
-                if (flagSearchItems.isNotEmpty()) {
+
+                if (wasEmpty) {
                     filterHeader.setTextColor(getColorFromAttr(R.attr.filterItemTextColorSelected))
                     filterIcon.setColorFilter(getColorFromAttr(R.attr.filterItemTextColorSelected))
                     flagToggleIcon.setColorFilter(getColorFromAttr(R.attr.filterItemTextColorSelected))
-                } else {
+                } else if (flagSearchItems.isEmpty()) {
                     filterHeader.setTextColor(getColorFromAttr(R.attr.filterItemTextColor))
                     filterIcon.setColorFilter(getColorFromAttr(R.attr.filterItemTextColor))
                     flagToggleIcon.setColorFilter(getColorFromAttr(R.attr.filterItemTextColor))

--- a/AnkiDroid/src/main/res/layout/filter_bottom_sheet.xml
+++ b/AnkiDroid/src/main/res/layout/filter_bottom_sheet.xml
@@ -67,7 +67,7 @@
                 android:orientation="vertical">
 
                 <LinearLayout
-                    android:id="@+id/filterByFlagsText"
+                    android:id="@+id/filterByFlagsLayout"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:foreground="?android:attr/selectableItemBackground"
@@ -81,10 +81,11 @@
                         android:src="@drawable/filter_sheet_opened_list_icon"/>
 
                     <ImageView
+                        android:id="@+id/filter_by_flags_icon"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:layout_gravity="center"
-                        android:src="@drawable/label_icon_flags"/>
+                        android:src="@drawable/label_icon_flags" />
 
                     <TextView
                         android:id="@+id/filterByFlagsText"

--- a/AnkiDroid/src/main/res/layout/filter_bottom_sheet.xml
+++ b/AnkiDroid/src/main/res/layout/filter_bottom_sheet.xml
@@ -3,6 +3,7 @@
 <LinearLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical"
@@ -13,16 +14,25 @@
         android:layout_height="wrap_content"
         android:orientation="horizontal">
 
+        <Button
+            android:id="@+id/cancel_filter_button"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/dialog_cancel"
+            android:textColor="?attr/filterItemTextColor"
+            style="@style/Widget.MaterialComponents.Button.TextButton" />
+
         <View
             android:layout_width="0dp"
             android:layout_height="0dp"
             android:layout_weight="1" />
 
         <Button
-            android:id="@+id/cancel_filter_button"
+            android:id="@+id/clear_filter_button"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="@string/dialog_cancel"
+            android:text="clear"
+            tools:ignore="HardcodedText"
             android:textColor="?attr/filterItemTextColor"
             style="@style/Widget.MaterialComponents.Button.TextButton" />
 
@@ -35,7 +45,7 @@
             style="@style/Widget.MaterialComponents.Button.TextButton" />
 
     </LinearLayout>
-®
+
     <View
         android:layout_width="match_parent"
         android:layout_height="1dp"
@@ -68,7 +78,7 @@
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:layout_gravity="center"
-                        android:src="@drawable/filter_sheet_unopened_list_icon"/>
+                        android:src="@drawable/filter_sheet_opened_list_icon"/>
 
                     <ImageView
                         android:layout_width="wrap_content"
@@ -91,8 +101,7 @@
                 <LinearLayout
                     android:id="@+id/flagsRecyclerViewLayout"
                     android:layout_width="match_parent"
-                    android:layout_height="match_parent"
-                    android:visibility="gone">
+                    android:layout_height="match_parent">
 
                     <androidx.recyclerview.widget.RecyclerView
                         android:id="@+id/filter_bottom_flag_list"


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
The current functionality for filters does not allow them to stay persistent, i.e, if I select some filters, apply them, and open the sheet again, those filters get reset. This PR improves on that and allows filters to stay persistent unless explicitly cleared.

Minor refactoring has also been performed.

## Approach
By passing in the `flagSearchItems` list to the `FlagsAdapter` class, It can check whether a filter is selected or not during the view binding, and depending on that, the selected/unselected look is set.

## How Has This Been Tested?

https://user-images.githubusercontent.com/86671025/186949439-7d82618f-f380-4ad0-b280-fe33308c8c33.mp4


## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
