### PR TITLE
fix: Check if AnkiDroidApp is initialized

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/utils/VersionUtils.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/VersionUtils.kt
@@ -35,7 +35,7 @@ object VersionUtils {
     val appName: String
         get() {
             var pkgName = AnkiDroidApp.TAG
-            val context: Context = AnkiDroidApp.getInstance()
+            val context: Context = applicationInstance ?: return AnkiDroidApp.TAG
             try {
                 val pInfo = context.packageManager.getPackageInfo(context.packageName, 0)
                 pkgName = context.getString(pInfo.applicationInfo.labelRes)
@@ -52,14 +52,12 @@ object VersionUtils {
     val pkgVersionName: String
         get() {
             var pkgVersion = "?"
-            val context: Context? = AnkiDroidApp.getInstance()
-            if (context != null) {
-                try {
-                    val pInfo = context.packageManager.getPackageInfo(context.packageName, 0)
-                    pkgVersion = pInfo.versionName
-                } catch (e: PackageManager.NameNotFoundException) {
-                    Timber.e(e, "Couldn't find package named %s", context.packageName)
-                }
+            val context: Context = applicationInstance ?: return pkgVersion
+            try {
+                val pInfo = context.packageManager.getPackageInfo(context.packageName, 0)
+                pkgVersion = pInfo.versionName
+            } catch (e: PackageManager.NameNotFoundException) {
+                Timber.e(e, "Couldn't find package named %s", context.packageName)
             }
             return pkgVersion
         }
@@ -70,7 +68,7 @@ object VersionUtils {
     @JvmStatic
     val pkgVersionCode: Long
         get() {
-            val context: Context = AnkiDroidApp.getInstance()
+            val context: Context = applicationInstance ?: return 0
             try {
                 val pInfo = context.packageManager.getPackageInfo(context.packageName, 0)
                 val versionCode = PackageInfoCompat.getLongVersionCode(pInfo)
@@ -88,6 +86,14 @@ object VersionUtils {
                 Timber.e(npe, "Unexpected exception getting version code?")
             }
             return 0
+        }
+
+    private val applicationInstance: Context?
+        get() = if (AnkiDroidApp.isInitialized()) {
+            AnkiDroidApp.getInstance()
+        } else {
+            Timber.w("AnkiDroid instance not set")
+            null
         }
 
     /**


### PR DESCRIPTION
We're going to convert `AnkiDroidApp` to Kotlin and `.instance` then returns a non-null

Therefore we need to guard in cases where it could be null due to an issue with the startup routine

## Approach

* Check for `isInitialized` instead of `getInstance() == null`

## How Has This Been Tested?

Unit tests pass in my `AnkiDroidApp` branch
## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
