### PR TITLE
Implement and use internal API for reading and writing preferences

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
@@ -73,6 +73,8 @@ import com.ichi2.anki.servicelayer.NoteService.isMarked
 import com.ichi2.anki.servicelayer.SchedulerService.*
 import com.ichi2.anki.servicelayer.TaskListenerBuilder
 import com.ichi2.anki.servicelayer.UndoService.Undo
+import com.ichi2.anki.settings.Settings
+import com.ichi2.anki.settings.settings
 import com.ichi2.anki.snackbar.SnackbarBuilder
 import com.ichi2.anki.snackbar.showSnackbar
 import com.ichi2.annotations.NeedsTest
@@ -149,7 +151,6 @@ abstract class AbstractFlashcardViewer :
     private var mScrollingButtons = false
     private var mGesturesEnabled = false
     private var mLargeAnswerButtons = false
-    private var mAnswerButtonsPosition: String? = "bottom"
     private var mDoubleTapTimeInterval = DEFAULT_DOUBLE_TAP_TIME_INTERVAL
 
     // Android WebView
@@ -1009,20 +1010,14 @@ abstract class AbstractFlashcardViewer :
         mAnswerField = findViewById(R.id.answer_field)
         initControls()
 
-        // Position answer buttons
-        val answerButtonsPosition = AnkiDroidApp.getSharedPrefs(this).getString(
-            getString(R.string.answer_buttons_position_preference),
-            "bottom"
-        )
-        mAnswerButtonsPosition = answerButtonsPosition
         val answerArea = findViewById<LinearLayout>(R.id.bottom_area_layout)
         val answerAreaParams = answerArea.layoutParams as RelativeLayout.LayoutParams
         val whiteboardContainer = findViewById<FrameLayout>(R.id.whiteboard)
         val whiteboardContainerParams = whiteboardContainer.layoutParams as RelativeLayout.LayoutParams
         val flashcardContainerParams = mCardFrame!!.layoutParams as RelativeLayout.LayoutParams
         val touchLayerContainerParams = mTouchLayer!!.layoutParams as RelativeLayout.LayoutParams
-        when (answerButtonsPosition) {
-            "top" -> {
+        when (settings.answerButtonsPosition) {
+            Settings.AnswerButtonsPosition.Top -> {
                 whiteboardContainerParams.addRule(RelativeLayout.BELOW, R.id.bottom_area_layout)
                 flashcardContainerParams.addRule(RelativeLayout.BELOW, R.id.bottom_area_layout)
                 touchLayerContainerParams.addRule(RelativeLayout.BELOW, R.id.bottom_area_layout)
@@ -1030,8 +1025,8 @@ abstract class AbstractFlashcardViewer :
                 answerArea.removeView(mAnswerField)
                 answerArea.addView(mAnswerField, 1)
             }
-            "bottom",
-            "none" -> {
+            Settings.AnswerButtonsPosition.Bottom,
+            Settings.AnswerButtonsPosition.None -> {
                 whiteboardContainerParams.addRule(RelativeLayout.ABOVE, R.id.bottom_area_layout)
                 whiteboardContainerParams.addRule(RelativeLayout.BELOW, R.id.mic_tool_bar_layer)
                 flashcardContainerParams.addRule(RelativeLayout.ABOVE, R.id.bottom_area_layout)
@@ -1040,9 +1035,8 @@ abstract class AbstractFlashcardViewer :
                 touchLayerContainerParams.addRule(RelativeLayout.BELOW, R.id.mic_tool_bar_layer)
                 answerAreaParams.addRule(RelativeLayout.ALIGN_PARENT_BOTTOM)
             }
-            else -> Timber.w("Unknown answerButtonsPosition: %s", answerButtonsPosition)
         }
-        answerArea.visibility = if (answerButtonsPosition == "none") View.GONE else View.VISIBLE
+        answerArea.visibility = if (settings.answerButtonsPosition == Settings.AnswerButtonsPosition.None) View.GONE else View.VISIBLE
         answerArea.layoutParams = answerAreaParams
         whiteboardContainer.layoutParams = whiteboardContainerParams
         mCardFrame!!.layoutParams = flashcardContainerParams
@@ -1811,7 +1805,7 @@ abstract class AbstractFlashcardViewer :
         showSnackbar(text, duration) {
             snackbarBuilder?.let { it() }
 
-            if (mAnswerButtonsPosition == "bottom") {
+            if (settings.answerButtonsPosition == Settings.AnswerButtonsPosition.Bottom) {
                 val easeButtons = findViewById<View>(R.id.answer_options_layout)
                 val previewButtons = findViewById<View>(R.id.preview_buttons_layout)
                 anchorView = if (previewButtons.isVisible) previewButtons else easeButtons

--- a/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/CardAppearance.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/CardAppearance.kt
@@ -18,6 +18,7 @@ package com.ichi2.anki.cardviewer
 import android.content.SharedPreferences
 import androidx.annotation.CheckResult
 import com.ichi2.anki.reviewer.ReviewerCustomFonts
+import com.ichi2.anki.settings.settings
 import com.ichi2.libanki.Card
 import com.ichi2.themes.Theme
 import com.ichi2.themes.Themes.currentTheme
@@ -81,7 +82,7 @@ class CardAppearance(private val customFonts: ReviewerCustomFonts, private val c
         fun create(customFonts: ReviewerCustomFonts, preferences: SharedPreferences): CardAppearance {
             val cardZoom = preferences.getInt("cardZoom", 100)
             val imageZoom = preferences.getInt("imageZoom", 100)
-            val centerVertically = preferences.getBoolean("centerVertically", false)
+            val centerVertically = settings.centerCardContentsVertically
             return CardAppearance(customFonts, cardZoom, imageZoom, centerVertically)
         }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/settings/Setting.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/settings/Setting.kt
@@ -1,0 +1,206 @@
+package com.ichi2.anki.settings
+
+import android.content.Context
+import android.content.SharedPreferences
+import androidx.annotation.StringRes
+import androidx.core.content.edit
+import okhttp3.HttpUrl
+import okhttp3.HttpUrl.Companion.toHttpUrl
+import timber.log.Timber
+import kotlin.jvm.Throws
+import kotlin.reflect.KProperty
+
+
+open class SettingRegistry(
+    val context: Context,
+    val preferences: SharedPreferences,
+) {
+    private val keyToSetting = mutableMapOf<String, Setting<*>>()
+    private val keyToChangeListeners = mutableMapOf<String, MutableList<() -> Unit>>()
+
+    // Stored in a field as preference manager doesn't keep strong references to listeners
+    private val registryListener = SharedPreferences.OnSharedPreferenceChangeListener { _, key ->
+        keyToChangeListeners[key]?.forEach { it() }
+    }
+
+    init { preferences.registerOnSharedPreferenceChangeListener(registryListener) }
+
+    @Throws(NoSuchElementException::class) fun getSetting(key: String) = keyToSetting.getValue(key)
+
+    fun Setting<*>.register() {
+        keyToSetting[key] = this
+    }
+
+    fun Setting<*>.whenChanged(block: () -> Unit) {
+        keyToChangeListeners.getOrPut(key, ::mutableListOf).add(block)
+    }
+}
+
+
+context(SettingRegistry) abstract class Setting<T>(
+    val key: String,
+    val default: T,
+) {
+    init {
+        register()
+
+        whenChanged {
+            reset()
+            Timber.v("Setting %s was changed to %s", key, value)
+        }
+    }
+
+    @Throws(Exception::class) protected abstract fun retrieve(): T
+
+    protected abstract fun store(value: T)
+
+    @Throws(Exception::class) abstract fun validate(storedValue: Any?)
+
+    @Suppress("UNCHECKED_CAST")
+    var value: T = Unit as T
+        private set
+        get() {
+            if (field == Unit) {
+                reset()
+            }
+            return field
+        }
+
+    private fun reset() {
+        value = try {
+            retrieve()
+        } catch (e: Exception) {
+            Timber.e(e, "Error while retrieving setting %s", key)
+            default
+        }
+    }
+
+    operator fun getValue(thisRef: Any?, property: KProperty<*>) = value
+
+    operator fun setValue(thisRef: Any?, property: KProperty<*>, value: T) {
+        store(value)
+        this.value = value
+    }
+}
+
+
+context(SettingRegistry) fun @receiver:StringRes Int.asString() = context.getString(this)
+
+
+/**************************************** Simple settings *****************************************/
+
+
+fun SettingRegistry.booleanSetting(@StringRes keyResource: Int, default: Boolean) =
+    object : Setting<Boolean>(keyResource.asString(), default) {
+        override fun retrieve() = preferences.getBoolean(key, default)
+        override fun store(value: Boolean) { preferences.edit { putBoolean(key, value) } }
+        override fun validate(storedValue: Any?) { storedValue as Boolean }
+    }
+
+
+fun SettingRegistry.intSetting(@StringRes keyResource: Int, default: Int) =
+    object : Setting<Int>(keyResource.asString(), default) {
+        override fun retrieve() = preferences.getInt(key, default)
+        override fun store(value: Int) { preferences.edit { putInt(key, value) } }
+        override fun validate(storedValue: Any?) { storedValue as Int }
+    }
+
+
+fun SettingRegistry.stringSetting(@StringRes keyResource: Int, default: String) =
+    object : Setting<String>(keyResource.asString(), default) {
+        override fun retrieve() = preferences.getString(key, null) ?: default
+        override fun store(value: String) { preferences.edit { putString(key, value) } }
+        override fun validate(storedValue: Any?) { storedValue as String }
+    }
+
+
+fun SettingRegistry.stringSetSetting(@StringRes keyResource: Int, default: Set<String>) =
+    object : Setting<Set<String>>(keyResource.asString(), default) {
+        override fun retrieve() = preferences.getStringSet(key, null) ?: default
+        override fun store(value: Set<String>) { preferences.edit { putStringSet(key, value) } }
+        override fun validate(storedValue: Any?) { storedValue as Set<*> } // For simplicity
+    }
+
+
+/************************************** Enum-based settings ***************************************/
+
+
+sealed interface StoredValueOrStoredValueResource
+
+interface StoredValue : StoredValueOrStoredValueResource { val storedValue: String }
+
+interface StoredValueResource : StoredValueOrStoredValueResource { val storedValueResource: Int }
+
+
+inline fun <reified E> SettingRegistry.computeStringValueToEnumValue():
+        Map<String, E> where E : Enum<E>, E : StoredValueOrStoredValueResource =
+    enumValues<E>().associateBy { enumValue: StoredValueOrStoredValueResource ->
+        when (enumValue) {
+            is StoredValue -> enumValue.storedValue
+            is StoredValueResource -> enumValue.storedValueResource.asString()
+        }
+    }
+
+
+inline fun <reified E> SettingRegistry.enumSetting(@StringRes keyResource: Int, default: E):
+        Setting<E> where E : Enum<E>, E : StoredValueOrStoredValueResource =
+    object : Setting<E>(keyResource.asString(), default) {
+        private val stringValueToEnumValue = computeStringValueToEnumValue<E>()
+        private val enumValueToStringValue = stringValueToEnumValue.map { (k, v) -> v to k }.toMap()
+
+        override fun retrieve(): E {
+            val storedValue = preferences.getString(key, null) ?: return default
+            return stringValueToEnumValue.getValue(storedValue)
+        }
+
+        override fun store(value: E) {
+            preferences.edit { putString(key, enumValueToStringValue[value]) }
+        }
+
+        override fun validate(storedValue: Any?) {
+            stringValueToEnumValue.getValue(storedValue as String)
+        }
+    }
+
+
+inline fun <reified E> SettingRegistry.enumSetSetting(@StringRes keyResource: Int, default: Set<E>):
+        Setting<Set<E>> where E : Enum<E>, E : StoredValueOrStoredValueResource =
+    object : Setting<Set<E>>(keyResource.asString(), default) {
+        private val stringValueToEnumValue = computeStringValueToEnumValue<E>()
+        private val enumValueToStringValue = stringValueToEnumValue.map { (k, v) -> v to k }.toMap()
+
+        override fun retrieve(): Set<E> {
+            val storedValue = preferences.getStringSet(key, null) ?: return default
+            return storedValue.map { stringValueToEnumValue.getValue(it) }.toSet()
+        }
+
+        override fun store(value: Set<E>) {
+            preferences.edit { putStringSet(key, value.map { enumValueToStringValue[it] }.toSet()) }
+        }
+
+        override fun validate(storedValue: Any?) {
+            (storedValue as Set<*>).forEach {
+                stringValueToEnumValue.getValue(it as String)
+            }
+        }
+    }
+
+
+/**************************************** Other settings ******************************************/
+
+
+fun SettingRegistry.httpUrlSetting(@StringRes keyResource: Int, default: HttpUrl?) =
+    object : Setting<HttpUrl?>(keyResource.asString(), default) {
+        override fun retrieve(): HttpUrl? {
+            val storedValue = preferences.getString(key, null) ?: return default
+            return storedValue.toHttpUrl()
+        }
+
+        override fun store(value: HttpUrl?) {
+            preferences.edit { putString(key, value?.toString()) }
+        }
+
+        override fun validate(storedValue: Any?) {
+            (storedValue as String?)?.toHttpUrl()
+        }
+    }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/settings/Settings.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/settings/Settings.kt
@@ -1,0 +1,34 @@
+package com.ichi2.anki.settings
+
+import android.content.Context
+import android.content.SharedPreferences
+import androidx.preference.PreferenceManager
+import com.ichi2.anki.AnkiDroidApp
+import com.ichi2.anki.R
+
+
+class Settings(context: Context, preferences: SharedPreferences) :
+        SettingRegistry(context, preferences) {
+
+    /**********************************************************************************************/
+    /***************************************** Appearance *****************************************/
+    /**********************************************************************************************/
+
+    enum class AnswerButtonsPosition(override val storedValue: String) : StoredValue {
+        Top("top"),
+        Bottom("bottom"),
+        None("none"),
+    }
+
+    var answerButtonsPosition by enumSetting(R.string.answer_buttons_position_preference, AnswerButtonsPosition.Bottom)
+
+    var centerCardContentsVertically by booleanSetting(R.string.center_vertically_preference, false)
+}
+
+
+val settings = run {
+    val context = AnkiDroidApp.getInstance()
+    val preferences = PreferenceManager.getDefaultSharedPreferences(context)
+
+    Settings(context, preferences)
+}

--- a/build.gradle
+++ b/build.gradle
@@ -103,7 +103,7 @@ subprojects {
         tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
             kotlinOptions {
                 allWarningsAsErrors = fatalWarnings
-                freeCompilerArgs = ['-Xjvm-default=all']
+                freeCompilerArgs = ['-Xjvm-default=all', "-Xcontext-receivers"]
             }
         }
     }


### PR DESCRIPTION
*At this point this is not a real PR but more like a RFC or something like that.*

Currently, preferences are retrieved using `SharedPreference` APIs directly, e.g.

```kt
val context = AnkiDroidApp.getInstance().baseContext
val preferences = AnkiDroidApp.getSharedPrefs(context)
val answerButtonPosition = preferences.getString("answerButtonPosition", "bottom")

if (answerButtonPosition == "bottom") { ... }
```

There's a few problems with this:

* It's verbose;
* In most cases the string and the default values are hardcoded. These same values are also hardcoded in XML;
* The return values are “raw” objects like strings, which might be fine for stuff like names or milliseconds, but you probably want to have stuff like enums for choises or `HttpUrl`s for HTTP URLs;
* This will crash if the stored value for `answerButtonPosition` is not a string;
* You have to think about nullability.

I propose to introduce a new internal API for retrieving and storing preferences, with which the above example will look like this:

```kt
if (settings.answerButtonPosition == Settings.AnswerButtonsPosition.Bottom) { ... }
```

The single runnable commit here is a proof-of-concept example of how this could look like. Only a few settings are fetched via the API.

* I named things “settings” simply to distinguish them from preferences. As in, preferences are the UI things, settings are internal things.

* I used context receivers as IMO these make the code a bit cleaner, but I am not sure if everyone will agree on this. As someone said on Reddit, Kotlin is going to develop diabetes with all the syntactic sugar it is building up. 😅

* Most of the setting keys are already conveniently in `R.string.` already, so we can use those; hopefully, this will be the only place where the string resource is used in code. E.g.

  ```kt
  var centerCardContentsVertically by booleanSetting(R.string.center_vertically_preference, false)
  ```

   Alternatively, it's possible to de-extract strings and revert to hardcoding them. As long as the string are not scattered all over the code, I am not sure if keeping strings in resources is of any substantial benefit. Especially if you consider that the default values are also hardcoded, as are the values for choice preferences.

* Most of the choice pereferences can be represented with enums. In XML, choice values (`"top"`, `"bottom"`) are often in `string-array`s. We can hardcode these values, e.g.
  
  ```kt
  enum class AnswerButtonsPosition(override val stringValue: String) : StringValue {
      Top("top"),
      Bottom("bottom"),
      None("none"),
  }
  ```

  Or we can extract strings and use those, for instance:

  ```kt
  enum class AnswerButtonsPosition(override val stringValueResource: Int) : StringValueResource {
      Top(R.string.preference__answer_buttons_position__top),
      Bottom(R.string.preference__answer_buttons_position__bottom),
      None(R.string.preference__answer_buttons_position__none),
  }
  ```

* Writing settings is straightforward:

  ```kt
  settings.centerCardContentsVertically = false
  ```

  However, this will create a new editor under the hood. It looks like it isn't possible to mandate the above statement to have an editor context, as in `settings.edit { centerCardContentsVertically = false }`, without also mandating it for retrieval. I wonder if this is an issue. `SharedPreferences.Editor` is useful especially if you want to have atomic changes; I'm not sure if there are places in the app where this matters.

* The settings are retrieved on the first read as well as on change. It is also possible to read all settings in advance, perhaps in a worker thread; also, it's possible to only invalidate settings on change instead of re-reading them.

   Also, as long as the the settings are retrieved in sync, I guess it's possible to swap the underlying setting storage layer for something else, while keeping the API (phrases like `settings.answerButtonPosition`), so that's neat.

* I suggest using the `Settings` class to also attach all the change listeners, e.g.
  
  ```kt
  var language by stringSetting(R.string.pref_language_key, "")
      .apply { 
          whenChanged { functionThatSetsLanguage(value) }
      }
  ```

* The API can also validate preferences, which can be used by UI preferences to prevent people from entering bad values, e.g. invalid URLs:

  ```kt
  try {
      settings.validate(key, newValue /* Any? is accepted */)
  } except (e: Exception) {
      // show a toast with error
  }
  ```

  This is currently done in the preferences code; I think this belongs here.

I did not look too far into this, so there's probably a few edge cases that I'm missing.