### PR TITLE
[GSoC] Simplified UpdateNote asynctask callbacks

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
@@ -404,37 +404,37 @@ abstract class AbstractFlashcardViewer :
         }
 
         override fun onPostExecute(result: Card?) {
-            if (result != null) {
-                if (mCurrentCard !== result) {
-                    /*
-                     * Before updating mCurrentCard, we check whether it is changing or not. If the current card changes,
-                     * then we need to display it as a new card, without showing the answer.
-                     */
-                    sDisplayAnswer = false
-                }
-                currentCard = result
-                TaskManager.launchCollectionTask(PreloadNextCard()) // Tasks should always be launched from GUI. So in
-                // listener and not in background
-                if (mCurrentCard == null) {
-                    // If the card is null means that there are no more cards scheduled for review.
-                    showProgressBar()
-                    closeReviewer(RESULT_NO_MORE_CARDS, true)
-                }
-                onCardEdited(mCurrentCard)
-                if (sDisplayAnswer) {
-                    mSoundPlayer.resetSounds() // load sounds from scratch, to expose any edit changes
-                    mAnswerSoundsAdded = false // causes answer sounds to be reloaded
-                    generateQuestionSoundList() // questions must be intentionally regenerated
-                    displayCardAnswer()
-                } else {
-                    displayCardQuestion()
-                }
-                hideProgressBar()
-            } else {
+            if (result == null) {
                 // RuntimeException occurred on update cards
                 closeReviewer(DeckPicker.RESULT_DB_ERROR, false)
                 return
             }
+
+            if (mCurrentCard !== result) {
+                /*
+                 * Before updating mCurrentCard, we check whether it is changing or not. If the current card changes,
+                 * then we need to display it as a new card, without showing the answer.
+                 */
+                sDisplayAnswer = false
+            }
+            currentCard = result
+            TaskManager.launchCollectionTask(PreloadNextCard()) // Tasks should always be launched from GUI. So in
+            // listener and not in background
+            if (mCurrentCard == null) {
+                // If the card is null means that there are no more cards scheduled for review.
+                showProgressBar()
+                closeReviewer(RESULT_NO_MORE_CARDS, true)
+            }
+            onCardEdited(mCurrentCard)
+            if (sDisplayAnswer) {
+                mSoundPlayer.resetSounds() // load sounds from scratch, to expose any edit changes
+                mAnswerSoundsAdded = false // causes answer sounds to be reloaded
+                generateQuestionSoundList() // questions must be intentionally regenerated
+                displayCardAnswer()
+            } else {
+                displayCardQuestion()
+            }
+            hideProgressBar()
         }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -1668,13 +1668,21 @@ open class CardBrowser :
         return UpdateCardHandler(this)
     }
 
-    private class UpdateCardHandler(browser: CardBrowser) : ListenerWithProgressBarCloseOnFalse<Card, Computation<*>?>("Card Browser - UpdateCardHandler.actualOnPostExecute(CardBrowser browser)", browser) {
-        override fun actualOnProgressUpdate(context: CardBrowser, value: Card) {
-            context.updateCardInList(value)
+    private class UpdateCardHandler(browser: CardBrowser) : TaskListenerWithContext<CardBrowser, Void, Card?>(browser) {
+
+        override fun actualOnPreExecute(context: CardBrowser) {
+            context.showProgressBar()
         }
 
-        override fun actualOnValidPostExecute(browser: CardBrowser, result: Computation<*>?) {
-            browser.hideProgressBar()
+        override fun actualOnPostExecute(context: CardBrowser, result: Card?) {
+            Timber.d("Card Browser - UpdateCardHandler.actualOnPostExecute()")
+            context.hideProgressBar()
+            if (result != null) {
+                context.updateCardInList(result)
+            } else {
+                // TODO: Too rude to close with error, allow user to backup their edited data
+                context.closeCardBrowser(DeckPicker.RESULT_DB_ERROR)
+            }
         }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.kt
@@ -175,7 +175,11 @@ open class CollectionTask<Progress, Result>(val task: TaskDelegateBase<Progress,
         }
     }
 
-    class UpdateNote(private val editCard: Card, val isFromReviewer: Boolean, private val canAccessScheduler: Boolean) : TaskDelegate<Void, Card?>() {
+    class UpdateNote(
+        private val editCard: Card,
+        val isFromReviewer: Boolean,
+        private val canAccessScheduler: Boolean
+    ) : TaskDelegate<Void, Card?>() {
         // returns updated card if no error and null if error
         override fun task(col: Collection, collectionTask: ProgressSenderAndCancelListener<Void>): Card? {
             Timber.d("doInBackgroundUpdateNote")


### PR DESCRIPTION
## Purpose / Description
When updating a single card, it is not required to show continuous progress since it a short task and user can be notified after the task has been finished. So instead of using onProgressUpdate callback, it is good to use onPostExecute for UI updates after the card has been updated.

THIS PR WILL HELP MIGRATING UPDATENOTES TO COROUTINE

## How this has been tested?
Passes existing tests and runs as expected on Realme 6i API 30 and Pixel 4a AVD API 31

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
