### PR TITLE
build: bump compileSdkVersion to 32

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -26,7 +26,7 @@ idea {
 
 def homePath = System.properties['user.home']
 android {
-    compileSdkVersion 31 // change api compileSdkVersion at the same time
+    compileSdkVersion 32 // change api compileSdkVersion at the same time
 
     defaultConfig {
         applicationId "com.ichi2.anki"

--- a/api/build.gradle
+++ b/api/build.gradle
@@ -12,7 +12,7 @@ repositories {
     mavenCentral()
 }
 android {
-    compileSdkVersion 31
+    compileSdkVersion 32
 
     defaultConfig {
         minSdkVersion 14


### PR DESCRIPTION
## Pull Request template

## Purpose / Description

Just a compile SDK bump, there were no deprecations noted

## Fixes
Unblocks #12165 which requires compileSdkVersion >= 32

## Approach
Bumped it in the two files it exists in

## How Has This Been Tested?

Local run of all CI targets

## Learning (optional, can help others)
_Describe the research stage_

_Links to blog posts, patterns, libraries or addons used to solve this problem_

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
