### PR TITLE
build: bump compileSdkVersion to 33

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -26,7 +26,7 @@ idea {
 
 def homePath = System.properties['user.home']
 android {
-    compileSdkVersion 32 // change api compileSdkVersion at the same time
+    compileSdkVersion 33 // change api compileSdkVersion at the same time
 
     defaultConfig {
         applicationId "com.ichi2.anki"

--- a/api/build.gradle
+++ b/api/build.gradle
@@ -12,7 +12,7 @@ repositories {
     mavenCentral()
 }
 android {
-    compileSdkVersion 32
+    compileSdkVersion 33
 
     defaultConfig {
         minSdkVersion 14

--- a/api/src/main/java/com/ichi2/anki/api/AddContentApi.kt
+++ b/api/src/main/java/com/ichi2/anki/api/AddContentApi.kt
@@ -584,16 +584,26 @@ class AddContentApi(context: Context) {
      * @return the spec version number or -1 if AnkiDroid is not installed.
      */
     // TODO: Kotlin Cleanup - val or fun - likely needs JvmField either way.
+    @Suppress("deprecation") // API33 symbol required until minSdkVersion >= 33
     val apiHostSpecVersion: Int
         get() {
             // PackageManager#resolveContentProvider docs suggest flags should be 0 (but that gives null metadata)
             // GET_META_DATA seems to work anyway
-            val info = mContext.packageManager.resolveContentProvider(
-                FlashCardsContract.AUTHORITY,
-                PackageManager.GET_META_DATA
-            )
-                ?: return -1
-            return if (info.metaData != null && info.metaData.containsKey(
+            val info =
+                if (Build.VERSION.SDK_INT >= 33)
+                    mContext.packageManager.resolveContentProvider(
+                        FlashCardsContract.AUTHORITY,
+                        PackageManager.ComponentInfoFlags.of(
+                            PackageManager.GET_META_DATA.toLong()
+                        )
+                    )
+                else
+                    mContext.packageManager.resolveContentProvider(
+                        FlashCardsContract.AUTHORITY,
+                        PackageManager.GET_META_DATA
+                    )
+
+            return if (info?.metaData != null && info.metaData.containsKey(
                     PROVIDER_SPEC_META_DATA_KEY
                 )
             ) {
@@ -816,10 +826,16 @@ class AddContentApi(context: Context) {
          * @return packageId of AnkiDroid if a supported version is not installed, otherwise null
          */
         // TODO: Kotlin Cleanup: simplify into one line fun
+        @Suppress("deprecation") // deprecated symbol until minSdkVersion >= 33
         fun getAnkiDroidPackageName(context: Context): String? {
             val manager = context.packageManager
-            val pi = manager.resolveContentProvider(FlashCardsContract.AUTHORITY, 0)
-            return pi?.packageName
+            return if (Build.VERSION.SDK_INT >= 33)
+                manager.resolveContentProvider(
+                    FlashCardsContract.AUTHORITY,
+                    PackageManager.ComponentInfoFlags.of(0L)
+                )?.packageName
+            else
+                manager.resolveContentProvider(FlashCardsContract.AUTHORITY, 0)?.packageName
         }
     }
 


### PR DESCRIPTION
## Pull Request template

## Purpose / Description

The goal here is to get the compile SDK version to the current version (33 was just released)

This is built on #12168 and should be rebased after it merges

This requires a change to AddContentApi to fix deprecation warnings, but that is blocked on a pending kotlin conversion #11377 


## Approach
Bump the 32 to 33, see what deprecations pop up, see if those are in kotlin yet, block :-)

## How Has This Been Tested?

It has not been tested, it's a speculative PR I will put in draft until the related PRs are through


## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
