### PR TITLE
Add Anki's new CardInfo page

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -1217,8 +1217,14 @@ open class CardBrowser :
             R.id.action_view_card_info -> {
                 val selectedCardIds = selectedCardIds
                 if (selectedCardIds.isNotEmpty()) {
-                    val intent = Intent(this, CardInfo::class.java)
-                    intent.putExtra("cardId", selectedCardIds[0])
+                    val cardId = selectedCardIds[0]
+                    val intent = if (BackendFactory.defaultLegacySchema) {
+                        Intent(this, CardInfo::class.java).apply {
+                            putExtra("cardId", cardId)
+                        }
+                    } else {
+                        com.ichi2.anki.pages.CardInfo.getIntent(this, cardId)
+                    }
                     startActivityWithAnimation(intent, ActivityTransitionAnimation.Direction.FADE)
                 }
                 return true

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
@@ -91,6 +91,7 @@ import com.ichi2.utils.KotlinCleanup
 import com.ichi2.utils.Permissions.canRecordAudio
 import com.ichi2.utils.ViewGroupUtils.setRenderWorkaround
 import com.ichi2.widget.WidgetStatus.update
+import net.ankiweb.rsdroid.BackendFactory
 import timber.log.Timber
 import java.io.File
 import java.lang.ref.WeakReference
@@ -688,9 +689,13 @@ open class Reviewer : AbstractFlashcardViewer() {
             showThemedToast(this, getString(R.string.multimedia_editor_something_wrong), true)
             return
         }
-        val intent = Intent(this, CardInfo::class.java)
+        val intent = if (BackendFactory.defaultLegacySchema) {
+            Intent(this, CardInfo::class.java)
+            intent.putExtra("cardId", mCurrentCard!!.id)
+        } else {
+            com.ichi2.anki.pages.CardInfo.getIntent(this, mCurrentCard!!.id)
+        }
         val animation = getAnimationTransitionFromGesture(fromGesture)
-        intent.putExtra("cardId", mCurrentCard!!.id)
         intent.putExtra(FINISH_ANIMATION_EXTRA, getInverseTransition(animation) as Parcelable)
         startActivityWithAnimation(intent, animation)
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/pages/CardInfo.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/pages/CardInfo.kt
@@ -1,0 +1,57 @@
+/*
+ *  Copyright (c) 2022 Brayan Oliveira <brayandso.dev@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.ichi2.anki.pages
+
+import android.content.Context
+import android.content.Intent
+import android.os.Bundle
+import android.webkit.WebView
+import com.ichi2.anki.R
+
+class CardInfo : PageFragment() {
+    override val title = R.string.card_info_title
+    override val pageName = PAGE_NAME
+    override lateinit var webViewClient: PageWebViewClient
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        val cardId = arguments?.getLong(ARG_CARD_ID)
+            ?: throw Exception("missing card ID argument")
+        webViewClient = CardInfoWebClient(cardId)
+        super.onCreate(savedInstanceState)
+    }
+
+    class CardInfoWebClient(val cardId: Long) : PageWebViewClient() {
+        override fun onPageFinished(view: WebView?, url: String?) {
+            // from upstream: https://github.com/ankitects/anki/blob/678c354fed4d98c0a8ef84fb7981ee085bd744a7/qt/aqt/browser/card_info.py#L66-L72
+            view!!.evaluateJavascript("anki.cardInfoPromise = anki.setupCardInfo(document.body);", null)
+            view.evaluateJavascript("anki.cardInfoPromise.then((c) => c.\$set({cardId: $cardId}));") {
+                super.onPageFinished(view, url)
+            }
+        }
+    }
+
+    companion object {
+        const val PAGE_NAME = "card-info"
+        private const val ARG_CARD_ID = "cardId"
+
+        fun getIntent(context: Context, cardId: Long): Intent {
+            val arguments = Bundle().apply {
+                putLong(ARG_CARD_ID, cardId)
+            }
+            return PagesActivity.getIntent(context, PAGE_NAME, arguments)
+        }
+    }
+}

--- a/AnkiDroid/src/main/java/com/ichi2/anki/pages/PagesActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/pages/PagesActivity.kt
@@ -81,6 +81,7 @@ class PagesActivity : AnkiActivity() {
      */
     private fun getPageFragment(pageName: String): PageFragment {
         return when (pageName) {
+            CardInfo.PAGE_NAME -> CardInfo()
             CsvImporter.PAGE_NAME -> CsvImporter()
             else -> throw Exception("'$pageName' page doesn't have a PageFragment associated")
         }


### PR DESCRIPTION
## Purpose / Description
Upstream has a HTML page for card info, which we can get for free

## Fixes
Fixes #12167 (i think)

## Approach
- Add the new page
- Eval the same JS of upstream (https://github.com/ankitects/anki/blob/678c354fed4d98c0a8ef84fb7981ee085bd744a7/qt/aqt/browser/card_info.py#L66-L72)
- Put it as the default if the new backend is being used


### Known issues

For a very brief moment, this screen shows up, but it is probably an upstream issue as it appears on Anki Desktop too (see 
https://github.com/ankidroid/Anki-Android/issues/6772#issuecomment-1208395273 for the discussion)

![image](https://user-images.githubusercontent.com/69634269/186726750-ecc954f9-e2ec-4afc-b8cd-48b14613cf39.png)


## How Has This Been Tested?

- Use the new backend
- Card browser
- Select a card
- Card info

---
- Use the new backend
- Enable "Card info" app bar button on settings
- Reviewer
- Card info

![Screenshot_20220825-140836_AnkiDroid](https://user-images.githubusercontent.com/69634269/186727597-b67e3ca8-5b56-4aff-8744-1025da4be6f0.png)


## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
