### PR TITLE
Add Anki's new Statistics page

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardInfo.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardInfo.kt
@@ -38,11 +38,13 @@ import com.ichi2.libanki.stats.Stats
 import com.ichi2.ui.FixedTextView
 import com.ichi2.utils.LanguageUtil
 import com.ichi2.utils.UiUtil.makeColored
+import net.ankiweb.rsdroid.RustCleanup
 import timber.log.Timber
 import java.text.DateFormat
 import java.util.*
 import java.util.function.Function
 
+@RustCleanup("Remove this whole activity and use the new Anki page once the new backend is the default")
 class CardInfo : AnkiActivity() {
     @get:VisibleForTesting(otherwise = VisibleForTesting.NONE)
     var model: CardInfoModel? = null

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NavigationDrawerActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NavigationDrawerActivity.kt
@@ -47,6 +47,7 @@ import com.ichi2.libanki.CardId
 import com.ichi2.themes.Themes
 import com.ichi2.utils.HandlerUtils
 import com.ichi2.utils.KotlinCleanup
+import net.ankiweb.rsdroid.BackendFactory
 import timber.log.Timber
 import java.util.*
 
@@ -294,7 +295,11 @@ abstract class NavigationDrawerActivity :
                 }
                 R.id.nav_stats -> {
                     Timber.i("Navigating to stats")
-                    val intent = Intent(this@NavigationDrawerActivity, Statistics::class.java)
+                    val intent = if (BackendFactory.defaultLegacySchema) {
+                        Intent(this@NavigationDrawerActivity, Statistics::class.java)
+                    } else {
+                        com.ichi2.anki.pages.Statistics.getIntent(this)
+                    }
                     startActivityForResultWithAnimation(intent, REQUEST_STATISTICS, START)
                 }
                 R.id.nav_settings -> {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Statistics.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Statistics.kt
@@ -53,9 +53,11 @@ import com.ichi2.libanki.stats.Stats.AxisType
 import com.ichi2.libanki.stats.Stats.ChartType
 import com.ichi2.ui.FixedTextView
 import kotlinx.coroutines.Job
+import net.ankiweb.rsdroid.RustCleanup
 import timber.log.Timber
 import java.util.Locale
 
+@RustCleanup("Remove this whole activity and use the new Anki page once the new backend is the default")
 class Statistics : NavigationDrawerActivity(), DeckSelectionListener, SubtitleListener {
     lateinit var viewPager: ViewPager2
         private set

--- a/AnkiDroid/src/main/java/com/ichi2/anki/pages/PagesActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/pages/PagesActivity.kt
@@ -83,6 +83,7 @@ class PagesActivity : AnkiActivity() {
         return when (pageName) {
             CardInfo.PAGE_NAME -> CardInfo()
             CsvImporter.PAGE_NAME -> CsvImporter()
+            Statistics.PAGE_NAME -> Statistics()
             else -> throw Exception("'$pageName' page doesn't have a PageFragment associated")
         }
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/pages/Statistics.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/pages/Statistics.kt
@@ -1,0 +1,34 @@
+/*
+ *  Copyright (c) 2022 Brayan Oliveira <brayandso.dev@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.ichi2.anki.pages
+
+import android.content.Context
+import android.content.Intent
+import com.ichi2.anki.R
+
+class Statistics : PageFragment() {
+    override val title = R.string.statistics
+    override val pageName = PAGE_NAME
+    override var webViewClient = PageWebViewClient()
+
+    companion object {
+        const val PAGE_NAME = "graphs"
+
+        fun getIntent(context: Context): Intent {
+            return PagesActivity.getIntent(context, PAGE_NAME)
+        }
+    }
+}

--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/AdvancedSettingsFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/AdvancedSettingsFragment.kt
@@ -30,6 +30,7 @@ import com.ichi2.anki.provider.CardContentProvider
 import com.ichi2.anki.snackbar.showSnackbar
 import com.ichi2.compat.CompatHelper
 import net.ankiweb.rsdroid.BackendFactory
+import net.ankiweb.rsdroid.RustCleanup
 import timber.log.Timber
 
 class AdvancedSettingsFragment : SettingsFragment() {
@@ -38,6 +39,10 @@ class AdvancedSettingsFragment : SettingsFragment() {
     override val analyticsScreenNameConstant: String
         get() = "prefs.advanced"
 
+    @RustCleanup(
+        "Remove 'Default deck for statistics' and 'Advanced statistics' preferences" +
+            "once the new backend is the default"
+    )
     override fun initSubscreen() {
         removeUnnecessaryAdvancedPrefs()
 
@@ -86,15 +91,30 @@ class AdvancedSettingsFragment : SettingsFragment() {
             }
             true
         }
-        // Advanced statistics
-        requirePreference<Preference>(R.string.pref_advanced_statistics_key).setSummaryProvider {
-            if (AnkiDroidApp.getSharedPrefs(requireContext()).getBoolean("advanced_statistics_enabled", false)) {
-                getString(R.string.enabled)
-            } else {
-                getString(R.string.disabled)
+        // Default deck for statistics
+        requirePreference<Preference>(R.string.stats_default_deck_key).apply {
+            // It doesn't have an effect on the new Statistics page,
+            // which is enabled together with the new backend
+            if (!BackendFactory.defaultLegacySchema) {
+                isEnabled = false
             }
         }
 
+        // Advanced statistics
+        requirePreference<Preference>(R.string.pref_advanced_statistics_key).apply {
+            // It doesn't have an effect on the new Statistics page,
+            // which is enabled together with the new backend
+            if (!BackendFactory.defaultLegacySchema) {
+                isEnabled = false
+            }
+            setSummaryProvider {
+                if (AnkiDroidApp.getSharedPrefs(requireContext()).getBoolean("advanced_statistics_enabled", false)) {
+                    getString(R.string.enabled)
+                } else {
+                    getString(R.string.disabled)
+                }
+            }
+        }
         // Enable API
         requirePreference<SwitchPreference>(R.string.enable_api_key).setOnPreferenceChangeListener { newValue ->
             val providerName = ComponentName(requireContext(), CardContentProvider::class.java.name)


### PR DESCRIPTION
## Purpose / Description
Anki has a pretty statistics screen that we can use, and the best part is that we can get it for free!

## Approach
- Add the screen
- Show it instead of the old one if the new backend is enabled


### Points to discuss
- What to do with `Default deck when opening statistics` preference, as it doesn't work with the new screen
- What to do with `Advanced statistics` preference, as it doesn't work with the new screen

## How Has This Been Tested?

- Enable the new backend
- Go to statistics

![Screenshot_20220825-141310_AnkiDroid](https://user-images.githubusercontent.com/69634269/186728544-d5c770eb-4fed-4539-991d-879025ecac24.png)

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [X] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
