### PR TITLE
Add Anki's new Deck Options page

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -2316,9 +2316,14 @@ open class DeckPicker :
             startActivityWithAnimation(i, FADE)
         } else {
             // otherwise open regular options
-            val i = Intent(this@DeckPicker, DeckOptions::class.java)
-            i.putExtra("did", did)
-            startActivityWithAnimation(i, FADE)
+            val intent = if (BackendFactory.defaultLegacySchema) {
+                Intent(this@DeckPicker, DeckOptions::class.java).apply {
+                    putExtra("did", did)
+                }
+            } else {
+                com.ichi2.anki.pages.DeckOptions.getIntent(this, did)
+            }
+            startActivityWithAnimation(intent, FADE)
         }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/pages/AnkiServer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/pages/AnkiServer.kt
@@ -67,6 +67,9 @@ class AnkiServer(
             "importCsv" -> activity.importCsvRaw(bytes)
             "getFieldNames" -> withCol { newBackend.getFieldNamesRaw(bytes) }
             "cardStats" -> withCol { newBackend.cardStatsRaw(bytes) }
+            "getDeckConfig" -> withCol { newBackend.getDeckConfigRaw(bytes) }
+            "getDeckConfigsForUpdate" -> withCol { newBackend.getDeckConfigsForUpdateRaw(bytes) }
+            "updateDeckConfigs" -> activity.updateDeckConfigsRaw(bytes)
             else -> { Timber.w("Unhandled Anki request: %s", methodName); null }
         }
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/pages/CardInfo.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/pages/CardInfo.kt
@@ -25,6 +25,7 @@ class CardInfo : PageFragment() {
     override val title = R.string.card_info_title
     override val pageName = "card-info"
     override lateinit var webViewClient: PageWebViewClient
+    override var webChromeClient = PageChromeClient()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         val cardId = arguments?.getLong(ARG_CARD_ID)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/pages/CsvImporter.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/pages/CsvImporter.kt
@@ -28,6 +28,7 @@ class CsvImporter : PageFragment() {
     override val title = R.string.menu_import
     override val pageName = "import-csv"
     override lateinit var webViewClient: PageWebViewClient
+    override var webChromeClient = PageChromeClient()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         val path = arguments?.getString(ARG_KEY_PATH) ?: throw Exception("missing path")

--- a/AnkiDroid/src/main/java/com/ichi2/anki/pages/DeckOptions.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/pages/DeckOptions.kt
@@ -1,0 +1,70 @@
+/*
+ *  Copyright (c) 2022 Brayan Oliveira <brayandso.dev@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.ichi2.anki.pages
+
+import android.content.Context
+import android.content.Intent
+import android.os.Bundle
+import android.webkit.WebView
+import anki.collection.OpChanges
+import com.ichi2.anki.CollectionManager
+import com.ichi2.anki.R
+import com.ichi2.libanki.CollectionV16
+import com.ichi2.libanki.undoableOp
+import com.ichi2.libanki.updateDeckConfigsRaw
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+class DeckOptions : PageFragment() {
+    override val title = R.string.menu__deck_options
+    override val pageName = "deck-options"
+    override lateinit var webViewClient: PageWebViewClient
+    override var webChromeClient = PageChromeClient()
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        val deckId = arguments?.getLong(ARG_DECK_ID)
+            ?: throw Exception("missing deck ID")
+        webViewClient = DeckOptionsWebClient(deckId)
+        super.onCreate(savedInstanceState)
+    }
+
+    class DeckOptionsWebClient(val deckId: Long) : PageWebViewClient() {
+        override fun onPageFinished(view: WebView?, url: String?) {
+            // from upstream: https://github.com/ankitects/anki/blob/678c354fed4d98c0a8ef84fb7981ee085bd744a7/qt/aqt/deckoptions.py#L55
+            view!!.evaluateJavascript("const \$deckOptions = anki.setupDeckOptions($deckId);") {
+                super.onPageFinished(view, url)
+            }
+        }
+    }
+
+    companion object {
+        const val ARG_DECK_ID = "deckId"
+
+        fun getIntent(context: Context, deckId: Long): Intent {
+            val arguments = Bundle().apply {
+                putLong(ARG_DECK_ID, deckId)
+            }
+            return PagesActivity.getIntent(context, DeckOptions::class, arguments)
+        }
+    }
+}
+
+suspend fun PagesActivity.updateDeckConfigsRaw(input: ByteArray): ByteArray {
+    val output = CollectionManager.withCol { (this as CollectionV16).updateDeckConfigsRaw(input) }
+    undoableOp { OpChanges.parseFrom(output) }
+    withContext(Dispatchers.Main) { finish() }
+    return output
+}

--- a/AnkiDroid/src/main/java/com/ichi2/anki/pages/PageChromeClient.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/pages/PageChromeClient.kt
@@ -1,0 +1,49 @@
+/*
+ *  Copyright (c) 2022 Brayan Oliveira <brayandso.dev@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.ichi2.anki.pages
+
+import android.webkit.JsResult
+import android.webkit.WebChromeClient
+import android.webkit.WebView
+import com.afollestad.materialdialogs.MaterialDialog
+import com.ichi2.anki.R
+import com.ichi2.anki.UIUtils
+
+open class PageChromeClient : WebChromeClient() {
+    override fun onJsAlert(
+        view: WebView?,
+        url: String?,
+        message: String?,
+        result: JsResult?
+    ): Boolean {
+        UIUtils.showThemedToast(view?.context, message, shortLength = true)
+        return true
+    }
+
+    override fun onJsConfirm(
+        view: WebView?,
+        url: String?,
+        message: String?,
+        result: JsResult?
+    ): Boolean {
+        MaterialDialog(view!!.context).show {
+            message?.let { message(text = message) }
+            positiveButton(R.string.dialog_ok) { result?.confirm() }
+            negativeButton(R.string.dialog_cancel) { result?.cancel() }
+        }
+        return true
+    }
+}

--- a/AnkiDroid/src/main/java/com/ichi2/anki/pages/PageFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/pages/PageFragment.kt
@@ -36,6 +36,7 @@ abstract class PageFragment : Fragment() {
     abstract val title: Int
     abstract val pageName: String
     abstract var webViewClient: PageWebViewClient
+    abstract var webChromeClient: PageChromeClient
 
     lateinit var webView: WebView
 
@@ -52,6 +53,7 @@ abstract class PageFragment : Fragment() {
         webView = view.findViewById<WebView>(R.id.pagesWebview).apply {
             settings.javaScriptEnabled = true
             webViewClient = this@PageFragment.webViewClient
+            webChromeClient = this@PageFragment.webChromeClient
         }
         val nightMode = if (Themes.currentTheme.isNightMode) "#night" else ""
         val url = "http://$HOST_NAME:$port/$pageName.html$nightMode"

--- a/AnkiDroid/src/main/java/com/ichi2/anki/pages/Statistics.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/pages/Statistics.kt
@@ -23,6 +23,7 @@ class Statistics : PageFragment() {
     override val title = R.string.statistics
     override val pageName = "graphs"
     override var webViewClient = PageWebViewClient()
+    override var webChromeClient = PageChromeClient()
 
     companion object {
         fun getIntent(context: Context): Intent {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/BackendDeckOptions.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/BackendDeckOptions.kt
@@ -1,0 +1,28 @@
+/***************************************************************************************
+ * Copyright (c) 2022 Ankitects Pty Ltd <http://apps.ankiweb.net>                       *
+ *                                                                                      *
+ * This program is free software; you can redistribute it and/or modify it under        *
+ * the terms of the GNU General Public License as published by the Free Software        *
+ * Foundation; either version 3 of the License, or (at your option) any later           *
+ * version.                                                                             *
+ *                                                                                      *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *                                                                                      *
+ * You should have received a copy of the GNU General Public License along with         *
+ * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ ****************************************************************************************/
+package com.ichi2.libanki
+
+fun CollectionV16.getDeckConfigRaw(input: ByteArray): ByteArray {
+    return backend.getDeckConfigRaw(input)
+}
+
+fun CollectionV16.getDeckConfigsForUpdateRaw(input: ByteArray): ByteArray {
+    return backend.getDeckConfigsForUpdateRaw(input)
+}
+
+fun CollectionV16.updateDeckConfigsRaw(input: ByteArray): ByteArray {
+    return backend.updateDeckConfigsRaw(input)
+}


### PR DESCRIPTION
## Purpose / Description
Free screen + spare a lot of work migrating DeckOptions.kt to use fragments and the androidx.Preference

## Approach
- Add the CollectionV16's deck options methods on BackendDeckOptions.kt
- Add the new page
- Use it if the new backend is enabled

## How Has This Been Tested?

https://user-images.githubusercontent.com/69634269/186731680-548ff459-7c7d-46e3-a973-b12d6124a46f.mp4

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [X] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
