### PR TITLE
[GSoC] Make the CSV importer accept .csv and .tsv extensions

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ImportFileSelectionFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ImportFileSelectionFragment.kt
@@ -38,9 +38,14 @@ class ImportFileSelectionFragment {
             // this needs a deckPicker for now. See use of PICK_APKG_FILE
 
             // This is required for serialization of the lambda
-            class OpenFilePicker(val requestCode: Int, var multiple: Boolean = false, val mimeType: String = "*/*") : FunctionItem.ActivityConsumer {
+            class OpenFilePicker(
+                val requestCode: Int,
+                var multiple: Boolean = false,
+                val mimeType: String = "*/*",
+                val extraMimes: Array<String>? = null
+            ) : FunctionItem.ActivityConsumer {
                 override fun consume(activity: AnkiActivity) {
-                    openImportFilePicker(activity, requestCode, multiple, mimeType)
+                    openImportFilePicker(activity, requestCode, multiple, mimeType, extraMimes)
                 }
             }
 
@@ -59,12 +64,18 @@ class ImportFileSelectionFragment {
                 ),
             )
             if (!BackendFactory.defaultLegacySchema) {
+                val mimes = arrayOf("text/plain", "text/comma-separated-values", "text/csv", "text/tab-separated-values")
                 importItems.add(
                     FunctionItem(
                         R.string.import_csv,
                         R.drawable.ic_baseline_description_24,
                         UsageAnalytics.Actions.IMPORT_CSV_FILE,
-                        OpenFilePicker(DeckPicker.PICK_CSV_FILE, multiple = false, mimeType = "text/plain")
+                        OpenFilePicker(
+                            DeckPicker.PICK_CSV_FILE,
+                            multiple = false,
+                            mimeType = "*/*",
+                            extraMimes = mimes
+                        )
                     )
                 )
             }
@@ -73,7 +84,13 @@ class ImportFileSelectionFragment {
 
         // needs to be static for serialization
         @JvmStatic
-        fun openImportFilePicker(activity: AnkiActivity, requestCode: Int, multiple: Boolean = false, mimeType: String = "*/*") {
+        fun openImportFilePicker(
+            activity: AnkiActivity,
+            requestCode: Int,
+            multiple: Boolean = false,
+            mimeType: String = "*/*",
+            extraMimes: Array<String>? = null
+        ) {
             Timber.d("openImportFilePicker() delegating to file picker intent")
             val intent = Intent(Intent.ACTION_OPEN_DOCUMENT)
             intent.addCategory(Intent.CATEGORY_OPENABLE)
@@ -82,6 +99,7 @@ class ImportFileSelectionFragment {
             intent.putExtra("android.content.extra.FANCY", true)
             intent.putExtra("android.content.extra.SHOW_FILESIZE", true)
             intent.putExtra(Intent.EXTRA_ALLOW_MULTIPLE, multiple)
+            extraMimes?.let { intent.putExtra(Intent.EXTRA_MIME_TYPES, it) }
             activity.startActivityForResultWithoutAnimation(intent, requestCode)
         }
     }


### PR DESCRIPTION
## Approach
to do it, an "extraMimes" param is added to openImportFilePicker, which can be passed to the intent wish a "EXTRA_MIME_TYPES" as extra.

ref: https://stackoverflow.com/questions/27367272/how-can-i-setup-an-android-intent-for-multiple-types-of-files-pdf-office-imag

## How Has This Been Tested?

- Enable the new backend
- Import > Text file
- See if you can select .csv, .tsv and .txt

![Screenshot_20220825-151346_Files](https://user-images.githubusercontent.com/69634269/186740279-b288f7e5-5619-48e3-aced-5926b5d5fbcd.png)


## Learning (optional, can help others)
_Describe the research stage_

_Links to blog posts, patterns, libraries or addons used to solve this problem_

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
