### PR TITLE
[GSoC] Simplified UpdateMultipleNotes asynctask callbacks

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -1557,6 +1557,7 @@ open class CardBrowser :
         }
     }
 
+    // TODO: method does heavy work on the main thread, move to a background thread/coroutine
     private fun editSelectedCardsTags(selectedTags: List<String>, indeterminateTags: List<String>) {
         val selectedNotes = selectedCardIds
             .map { cardId: CardId? -> col.getCard(cardId!!).note() }
@@ -1652,15 +1653,19 @@ open class CardBrowser :
         return UpdateMultipleNotesHandler(this)
     }
 
-    private class UpdateMultipleNotesHandler(browser: CardBrowser) : ListenerWithProgressBarCloseOnFalse<List<Note>, Computation<*>?>("Card Browser - UpdateMultipleNotesHandler.actualOnPostExecute(CardBrowser browser)", browser) {
-        override fun actualOnProgressUpdate(context: CardBrowser, value: List<Note>) {
-            val cardsToUpdate = value
-                .flatMap { n: Note -> n.cards() }
-            context.updateCardsInList(cardsToUpdate)
+    private class UpdateMultipleNotesHandler(browser: CardBrowser) : TaskListenerWithContext<CardBrowser, Void, List<Note>?>(browser) {
+        override fun actualOnPreExecute(context: CardBrowser) {
+            context.showProgressBar()
         }
 
-        override fun actualOnValidPostExecute(browser: CardBrowser, result: Computation<*>?) {
-            browser.hideProgressBar()
+        override fun actualOnPostExecute(context: CardBrowser, result: List<Note>?) {
+            context.hideProgressBar()
+            if (result != null) {
+                val cardsToUpdate = result.flatMap { n: Note -> n.cards() }
+                context.updateCardsInList(cardsToUpdate)
+            } else {
+                context.closeCardBrowser(DeckPicker.RESULT_DB_ERROR)
+            }
         }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.kt
@@ -218,10 +218,14 @@ open class CollectionTask<Progress, Result>(val task: TaskDelegateBase<Progress,
         }
     }
 
-    class UpdateMultipleNotes @JvmOverloads constructor(private val notesToUpdate: List<Note>, private val shouldUpdateCards: Boolean = false) : TaskDelegate<List<Note>, Computation<*>>() {
-        override fun task(col: Collection, collectionTask: ProgressSenderAndCancelListener<List<Note>>): Computation<*> {
+    // Currently being used only to update tags of multiple notes simultaneously
+    class UpdateMultipleNotes constructor(
+        private val notesToUpdate: List<Note>,
+        private val shouldUpdateCards: Boolean = false
+    ) : TaskDelegate<Void, List<Note>?>() {
+        override fun task(col: Collection, collectionTask: ProgressSenderAndCancelListener<Void>): List<Note>? {
             Timber.d("doInBackgroundUpdateMultipleNotes")
-            try {
+            return try {
                 col.db.executeInTransaction {
                     for (note in notesToUpdate) {
                         note.flush()
@@ -231,14 +235,13 @@ open class CollectionTask<Progress, Result>(val task: TaskDelegateBase<Progress,
                             }
                         }
                     }
-                    collectionTask.doProgress(notesToUpdate)
+                    notesToUpdate
                 }
             } catch (e: RuntimeException) {
                 Timber.w(e, "doInBackgroundUpdateMultipleNotes - RuntimeException on updating multiple note")
                 CrashReportService.sendExceptionReport(e, "doInBackgroundUpdateMultipleNotes")
-                return Computation.ERR
+                return null
             }
-            return Computation.OK
         }
     }
 


### PR DESCRIPTION
## Purpose / Description
When updating a multiple notes, it is not required to show continuous progress since it a short task and user can be notified after the task has been finished. So instead of using onProgressUpdate callback, it is good to use onPostExecute for UI updates after the notes has been updated.

## How Has This Been Tested?
Passes existing tests and runs as expected on Realme 6i API 30 and Pixel 4a AVD API 31

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
