### PR TITLE
Add option to enable the v3 scheduler

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/AdvancedSettingsFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/AdvancedSettingsFragment.kt
@@ -25,11 +25,13 @@ import androidx.preference.Preference
 import androidx.preference.SwitchPreference
 import com.afollestad.materialdialogs.MaterialDialog
 import com.ichi2.anki.*
+import com.ichi2.anki.CollectionManager.withCol
 import com.ichi2.anki.exception.StorageAccessException
 import com.ichi2.anki.provider.CardContentProvider
 import com.ichi2.anki.snackbar.showSnackbar
 import com.ichi2.compat.CompatHelper
 import net.ankiweb.rsdroid.BackendFactory
+import net.ankiweb.rsdroid.RustCleanup
 import timber.log.Timber
 
 class AdvancedSettingsFragment : SettingsFragment() {
@@ -107,11 +109,28 @@ class AdvancedSettingsFragment : SettingsFragment() {
             }
             requireActivity().packageManager.setComponentEnabledSetting(providerName, state, PackageManager.DONT_KILL_APP)
         }
+
+        // v3 scheduler
+        @RustCleanup("move this to Reviewing > Scheduling once the new backend is the default")
+        val v3schedPref = requirePreference<SwitchPreference>(R.string.enable_v3_sched_key).apply {
+            launchCatchingTask { withCol { isChecked = v3Enabled } }
+            // if new backend was enabled on local.properties, remove the pref dependency
+            if (!BuildConfig.LEGACY_SCHEMA) {
+                dependency = null
+                isEnabled = true
+            }
+            setOnPreferenceChangeListener { newValue: Any ->
+                Timber.d("v3 scheduler set to $newValue")
+                launchCatchingTask { withCol { v3Enabled = newValue as Boolean } }
+            }
+        }
+
         // Use V16 backend
         requirePreference<SwitchPreference>(R.string.pref_rust_backend_key).apply {
             if (!BuildConfig.LEGACY_SCHEMA) {
                 title = "New schema already enabled on local.properties"
                 isEnabled = false
+                isChecked = true
             }
             setOnPreferenceChangeListener { newValue ->
                 if (newValue == true) {
@@ -126,6 +145,7 @@ class AdvancedSettingsFragment : SettingsFragment() {
                     )
                 } else {
                     BackendFactory.defaultLegacySchema = true
+                    v3schedPref.isChecked = false
                     (requireActivity() as Preferences).restartWithNewDeckPicker()
                 }
             }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.kt
@@ -57,7 +57,6 @@ import com.ichi2.libanki.utils.TimeManager.time
 import com.ichi2.upgrade.Upgrade
 import com.ichi2.utils.*
 import net.ankiweb.rsdroid.Backend
-import net.ankiweb.rsdroid.BackendFactory
 import net.ankiweb.rsdroid.RustCleanup
 import org.jetbrains.annotations.Contract
 import timber.log.Timber
@@ -132,6 +131,9 @@ open class Collection(
         get() = dbInternal!!
 
     var dbInternal: DB? = null
+
+    /** whether the v3 scheduler is enabled */
+    open var v3Enabled: Boolean = false
 
     /**
      * Getters/Setters ********************************************************** *************************************
@@ -259,7 +261,7 @@ open class Collection(
         if (ver == 1) {
             sched = Sched(this)
         } else if (ver == 2) {
-            if (!BackendFactory.defaultLegacySchema && newBackend.v3Enabled) {
+            if (v3Enabled) {
                 sched = SchedV3(this.newBackend)
             } else {
                 sched = SchedV2(this)

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/CollectionV16.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/CollectionV16.kt
@@ -72,6 +72,14 @@ class CollectionV16(
     override val newDecks: DecksV16
         get() = this.decks as DecksV16
 
+    /** True if the V3 scheduled is enabled when schedVer is 2. */
+    override var v3Enabled: Boolean
+        get() = backend.getConfigBool(ConfigKey.Bool.SCHED_2021)
+        set(value) {
+            backend.setConfigBool(ConfigKey.Bool.SCHED_2021, value, undoable = false)
+            _loadScheduler()
+        }
+
     override fun load() {
         _config = initConf(null)
         decks = initDecks(null)
@@ -232,12 +240,4 @@ class CollectionV16(
     fun updateNote(note: Note) {
         backend.updateNotes(notes = listOf(note.toBackendNote()), skipUndoEntry = false)
     }
-
-    /** True if the V3 scheduled is enabled when schedVer is 2. */
-    var v3Enabled: Boolean
-        get() = backend.getConfigBool(ConfigKey.Bool.SCHED_2021)
-        set(value) {
-            backend.setConfigBool(ConfigKey.Bool.SCHED_2021, value, undoable = false)
-            _loadScheduler()
-        }
 }

--- a/AnkiDroid/src/main/res/values/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values/10-preferences.xml
@@ -341,6 +341,7 @@ this formatter is used if the bind only applies to both the question and the ans
     <string name="use_rust_backend_title" maxLength="41">Use the new backend</string>
     <string name="use_rust_backend_summary">Enables newer Anki features, such as the v3 scheduler\nUNSTABLE. Do not use on a collection you care about. NOT reverted on app close</string>
     <string name="use_rust_backend_warning">There is a chance this could corrupt your installation completely, requiring app uninstall and deletion of the AnkiDroid folder, and has a chance of propagating corruption via sync to AnkiWeb.\n\nWe welcome the testing, but please make sure you have a valid non-AnkiWeb backup.</string>
+    <string name="enable_v3_sched_title" maxLength="41">Use the v3 scheduler</string>
 
     <!-- Developer options -->
     <string name="pref_cat_dev_options" maxLength="41">Developer options</string>

--- a/AnkiDroid/src/main/res/values/preferences.xml
+++ b/AnkiDroid/src/main/res/values/preferences.xml
@@ -114,6 +114,7 @@
     <string name="anki_card_external_context_menu_key">anki_card_enable_external_context_menu</string>
     <string name="pref_reset_languages_key">resetLanguages</string>
     <string name="pref_backup_max_key">backupMax</string>
+    <string name="enable_v3_sched_key">v3sched</string>
     <!-- Advanced statistics -->
     <string name="pref_advanced_statistics_screen_key">advancedStatisticsScreen</string>
     <string name="pref_computation_precision_key">advanced_forecast_stats_compute_precision</string>

--- a/AnkiDroid/src/main/res/xml/preferences_advanced.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_advanced.xml
@@ -156,5 +156,10 @@
                 android:title="@string/use_rust_backend_title"
                 android:summary="@string/use_rust_backend_summary"
                 android:defaultValue="false"/>
+            <SwitchPreference
+                android:key="@string/enable_v3_sched_key"
+                android:dependency="@string/pref_rust_backend_key"
+                android:title="@string/enable_v3_sched_title"
+                android:defaultValue="false"/>
         </PreferenceCategory>
 </PreferenceScreen>


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
Help people test, and test and test and test and test all night long

## Approach
- extract part of the logic of `_loadScheduler()` into CollectionHelper.isV3Enabled
- add a new experimental preference called "Use the v3 scheduler"
    - it's dependent on the new backend, i.e. the user can only enable it if the new backend is being used

## How Has This Been Tested?

- Sync the collection
- Enable v3 on AnkiDroid -> sync -> see if it was enabled on another device
- Disable v3 on AnkiDroid -> sync -> see if it was disabled on another device
- Enable v3 on another device -> sync -> see if it was enabled on AnkiDroid
- Disable v3 on another device -> sync -> see if it was disabled on AnkiDroid

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)