### PR TITLE
Add `strings` label when res/values dir changes

### DIFF
--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -98,9 +98,13 @@ jobs:
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: context.issue.number,
-                body: `Message to maintainers, this PR contains strings changes. So read more about updating strings on wiki,
-                      https://github.com/ankidroid/Anki-Android/wiki/Development-Guide#localization-administration
-                      https://github.com/ankidroid/Anki-Android/wiki/Development-Guide#download-localized-strings`
+                body: `Message to maintainers, this PR contains strings changes. 
+            1. Before merging this PR, it is best to run the "Sync Translations" GitHub action, then make and merge a PR from the i18n_sync branch to get translations cleaned out.
+            2. Then merge this PR, and immediately do another translation PR so the huge change made by this PR's key changes are all by themselves.
+                
+            Read more about updating strings on the wiki,
+            - [localization-administration](https://github.com/ankidroid/Anki-Android/wiki/Development-Guide#localization-administration)
+            - [download-localized-strings](https://github.com/ankidroid/Anki-Android/wiki/Development-Guide#download-localized-strings)`
               })
             }
 

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -63,6 +63,25 @@ jobs:
       - uses: actions/github-script@v6
         with:
           script: |
+            const I18N_FILES = [
+                "01-core",
+                "02-strings",
+                "03-dialogs",
+                "04-network",
+                "05-feedback",
+                "06-statistics",
+                "07-cardbrowser",
+                "08-widget",
+                "09-backup",
+                "10-preferences",
+                "11-arrays",
+                "16-multimedia-editor",
+                "17-model-manager",
+                "18-standard-models",
+                "marketdescription",
+                "ankidroid-titles",
+            ];
+
             let stringsLabel = "strings";
 
             async function addLabel(labels) {
@@ -74,15 +93,37 @@ jobs:
               });
             }
 
+            async function addComments() {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body: `Message to maintainers, this PR contains strings changes. So read more about updating strings on wiki,
+                      https://github.com/ankidroid/Anki-Android/wiki/Development-Guide#localization-administration
+                      https://github.com/ankidroid/Anki-Android/wiki/Development-Guide#download-localized-strings`
+              })
+            }
+
             const changedFiles = await github.rest.pulls.listFiles({
               owner: context.repo.owner,
               repo: context.repo.repo,
               pull_number: context.issue.number,
             });
 
+            // loop through list of files in current pr, then check if filename contains in i18n file name,
+            // set boolean to true and use the boolean in outer loop to add label
+            let fileChanged = false;
             for (let files of changedFiles.data) {
-              if (files.filename.includes("AnkiDroid/src/main/res/values")) {
+              for (let i18n of I18N_FILES) {
+                if (files.filename.includes(i18n)) {
+                  fileChanged = true;
+                  break;
+                }
+              }
+
+              if (fileChanged) {
                 addLabel([stringsLabel]);
+                addComments();
                 break;
               }
             }

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -1,17 +1,18 @@
-name: Remove Labels
+name: Add/Remove Labels
 
 on:
   pull_request_target:
-    types: [ closed ]
+    types: [ opened, closed ]
 
 jobs:
   merge_job:
     if: github.event.pull_request.merged == true
     permissions:
       contents: read
-      pull-requests: write    
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
+    - uses: actions/checkout@v3
     - uses: actions/github-script@v6
       with:
         script: |
@@ -52,3 +53,36 @@ jobs:
                 }
             }
           }
+
+  add_label:
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v6
+        with:
+          script: |
+            let stringsLabel = "strings";
+
+            async function addLabel(labels) {
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                labels: labels
+              });
+            }
+
+            const changedFiles = await github.rest.pulls.listFiles({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number,
+            });
+
+            for (let files of changedFiles.data) {
+              if (files.filename.includes("AnkiDroid/src/main/res/values")) {
+                addLabel([stringsLabel]);
+                break;
+              }
+            }


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
Automate process of adding `strings` label when values dir changed.

## Fixes
Fixes _Link to the issues._

## Approach
1. Run git diff on res/values dir 
2. Use the result to run the github actions script

## How Has This Been Tested?
Tested on this PR
https://github.com/krmanik/Anki-Android-Copy/pull/1

## Learning (optional, can help others)
https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
