### PR TITLE
[GSoC] Migrated CollectionTask.UpdateNote to Coroutines

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
@@ -78,9 +78,9 @@ import com.ichi2.anki.snackbar.SnackbarBuilder
 import com.ichi2.anki.snackbar.showSnackbar
 import com.ichi2.annotations.NeedsTest
 import com.ichi2.async.CollectionTask.PreloadNextCard
-import com.ichi2.async.CollectionTask.UpdateNote
 import com.ichi2.async.TaskListener
 import com.ichi2.async.TaskManager
+import com.ichi2.async.updateCard
 import com.ichi2.compat.CompatHelper.Companion.compat
 import com.ichi2.libanki.*
 import com.ichi2.libanki.Collection
@@ -400,9 +400,13 @@ abstract class AbstractFlashcardViewer :
         }
     }
 
-    private val mUpdateCardHandler: TaskListener<Void, Card?> = object : TaskListener<Void, Card?>() {
-        override fun onPreExecute() = showProgressBar()
-        override fun onPostExecute(result: Card?) = onCardUpdated(result)
+    suspend fun saveEditedCard() {
+        val updatedCard: Card? = withProgress {
+            withCol {
+                updateCard(this, editorCard!!, true, canAccessScheduler())
+            }
+        }
+        onCardUpdated(updatedCard)
     }
 
     private fun onCardUpdated(result: Card?) {
@@ -759,10 +763,7 @@ abstract class AbstractFlashcardViewer :
             if (resultCode == RESULT_OK) {
                 // content of note was changed so update the note and current card
                 Timber.i("AbstractFlashcardViewer:: Saving card...")
-                TaskManager.launchCollectionTask(
-                    UpdateNote(editorCard!!, true, canAccessScheduler()),
-                    mUpdateCardHandler
-                )
+                launchCatchingTask { saveEditedCard() }
                 onEditedNoteChanged()
             } else if (resultCode == RESULT_CANCELED && !reloadRequired) {
                 // nothing was changed by the note editor so just redraw the card

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
@@ -401,7 +401,7 @@ abstract class AbstractFlashcardViewer :
     }
 
     suspend fun saveEditedCard() {
-        val updatedCard: Card? = withProgress {
+        val updatedCard: Card = withProgress {
             withCol {
                 updateCard(this, editorCard!!, true, canAccessScheduler())
             }
@@ -409,13 +409,7 @@ abstract class AbstractFlashcardViewer :
         onCardUpdated(updatedCard)
     }
 
-    private fun onCardUpdated(result: Card?) {
-        if (result == null) {
-            // RuntimeException occurred on update cards
-            closeReviewer(DeckPicker.RESULT_DB_ERROR, false)
-            return
-        }
-
+    private fun onCardUpdated(result: Card) {
         if (mCurrentCard !== result) {
             /*
              * Before updating mCurrentCard, we check whether it is changing or not. If the current card changes,

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
@@ -401,43 +401,42 @@ abstract class AbstractFlashcardViewer :
     }
 
     private val mUpdateCardHandler: TaskListener<Void, Card?> = object : TaskListener<Void, Card?>() {
-        override fun onPreExecute() {
+        override fun onPreExecute() = showProgressBar()
+        override fun onPostExecute(result: Card?) = onCardUpdated(result)
+    }
+
+    private fun onCardUpdated(result: Card?) {
+        if (result == null) {
+            // RuntimeException occurred on update cards
+            closeReviewer(DeckPicker.RESULT_DB_ERROR, false)
+            return
+        }
+
+        if (mCurrentCard !== result) {
+            /*
+             * Before updating mCurrentCard, we check whether it is changing or not. If the current card changes,
+             * then we need to display it as a new card, without showing the answer.
+             */
+            sDisplayAnswer = false
+        }
+        currentCard = result
+        TaskManager.launchCollectionTask(PreloadNextCard()) // Tasks should always be launched from GUI. So in
+        // listener and not in background
+        if (mCurrentCard == null) {
+            // If the card is null means that there are no more cards scheduled for review.
             showProgressBar()
+            closeReviewer(RESULT_NO_MORE_CARDS, true)
         }
-
-        override fun onPostExecute(result: Card?) {
-            if (result == null) {
-                // RuntimeException occurred on update cards
-                closeReviewer(DeckPicker.RESULT_DB_ERROR, false)
-                return
-            }
-
-            if (mCurrentCard !== result) {
-                /*
-                 * Before updating mCurrentCard, we check whether it is changing or not. If the current card changes,
-                 * then we need to display it as a new card, without showing the answer.
-                 */
-                sDisplayAnswer = false
-            }
-            currentCard = result
-            TaskManager.launchCollectionTask(PreloadNextCard()) // Tasks should always be launched from GUI. So in
-            // listener and not in background
-            if (mCurrentCard == null) {
-                // If the card is null means that there are no more cards scheduled for review.
-                showProgressBar()
-                closeReviewer(RESULT_NO_MORE_CARDS, true)
-            }
-            onCardEdited(mCurrentCard)
-            if (sDisplayAnswer) {
-                mSoundPlayer.resetSounds() // load sounds from scratch, to expose any edit changes
-                mAnswerSoundsAdded = false // causes answer sounds to be reloaded
-                generateQuestionSoundList() // questions must be intentionally regenerated
-                displayCardAnswer()
-            } else {
-                displayCardQuestion()
-            }
-            hideProgressBar()
+        onCardEdited(mCurrentCard)
+        if (sDisplayAnswer) {
+            mSoundPlayer.resetSounds() // load sounds from scratch, to expose any edit changes
+            mAnswerSoundsAdded = false // causes answer sounds to be reloaded
+            generateQuestionSoundList() // questions must be intentionally regenerated
+            displayCardAnswer()
+        } else {
+            displayCardQuestion()
         }
+        hideProgressBar()
     }
 
     @KotlinCleanup("nullability")

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -1698,22 +1698,13 @@ open class CardBrowser :
     }
 
     private suspend fun saveEditedCard() {
-        val updatedCard: Card? = withProgress {
+        Timber.d("CardBrowser - saveEditedCard()")
+        val updatedCard: Card = withProgress {
             withCol {
                 updateCard(this, sCardBrowserCard!!, isFromReviewer = false, false)
             }
         }
-        onCardUpdated(updatedCard)
-    }
-
-    private fun onCardUpdated(result: Card?) {
-        Timber.d("CardBrowser - onCardUpdated()")
-        if (result != null) {
-            updateCardInList(result)
-        } else {
-            // TODO: Too rude to close with error, allow user to backup their edited data
-            closeCardBrowser(DeckPicker.RESULT_DB_ERROR)
-        }
+        updateCardInList(updatedCard)
     }
 
     private class ChangeDeckHandler(browser: CardBrowser) : ListenerWithProgressBarCloseOnFalse<Any?, Computation<Array<Card>>?>("Card Browser - changeDeckHandler.actualOnPostExecute(CardBrowser browser)", browser) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -147,6 +147,9 @@ open class CardBrowser :
     @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
     var mCardsAdapter: MultiColumnListAdapter? = null
 
+    // TODO: Introduced for migration of [CollectionTask.UpdateNote] to Coroutines,remove after migration
+    private val context = this
+
     private var mSearchTerms: String = ""
     private var mRestrictOnDeck: String? = null
     private var mCurrentFlag = 0
@@ -1711,14 +1714,18 @@ open class CardBrowser :
         }
 
         override fun actualOnPostExecute(context: CardBrowser, result: Card?) {
-            Timber.d("Card Browser - UpdateCardHandler.actualOnPostExecute()")
-            context.hideProgressBar()
-            if (result != null) {
-                context.updateCardInList(result)
-            } else {
-                // TODO: Too rude to close with error, allow user to backup their edited data
-                context.closeCardBrowser(DeckPicker.RESULT_DB_ERROR)
-            }
+            context.onCardUpdated(result)
+        }
+    }
+
+    private fun onCardUpdated(result: Card?) {
+        Timber.d("CardBrowser - onCardUpdated()")
+        context.hideProgressBar()
+        if (result != null) {
+            context.updateCardInList(result)
+        } else {
+            // TODO: Too rude to close with error, allow user to backup their edited data
+            context.closeCardBrowser(DeckPicker.RESULT_DB_ERROR)
         }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/async/CollectionOperations.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/async/CollectionOperations.kt
@@ -26,7 +26,8 @@ import timber.log.Timber
  */
 
 /**
- * Returns updated card if no error and null if error
+ * Saves the newly updated card [editCard] to disk
+ * @return updated card
  */
 fun updateCard(
     col: Collection,
@@ -36,7 +37,6 @@ fun updateCard(
 ): Card {
     Timber.d("doInBackgroundUpdateNote")
     // Save the note
-    val sched = col.sched
     val editNote = editCard.note()
     if (BackendFactory.defaultLegacySchema) {
         col.db.executeInTransaction {
@@ -46,8 +46,7 @@ fun updateCard(
             editCard.flush()
         }
     } else {
-        // TODO: the proper way to do this would be to call this in undoableOp() in
-        // a coroutine
+        // TODO: the proper way to do this would be to call this in undoableOp() in a coroutine
         col.newBackend.updateNote(editNote)
         // no need to flush card in new path
     }
@@ -55,11 +54,10 @@ fun updateCard(
         if (col.decks.active().contains(editCard.did) || !canAccessScheduler) {
             editCard.apply {
                 load()
-                // reload qa-cache
-                q(true)
+                q(true) // reload qa-cache
             }
         } else {
-            sched.card!! // check: are there deleted too?
+            col.sched.card!! // check: are there deleted too?
         }
     } else {
         editCard

--- a/AnkiDroid/src/main/java/com/ichi2/async/CollectionOperations.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/async/CollectionOperations.kt
@@ -1,0 +1,74 @@
+/****************************************************************************************
+ * Copyright (c) 2022 Divyansh Kushwaha <kushwaha.divyansh.dxn@gmail.com>               *
+ *                                                                                      *
+ * This program is free software; you can redistribute it and/or modify it under        *
+ * the terms of the GNU General Public License as published by the Free Software        *
+ * Foundation; either version 3 of the License, or (at your option) any later           *
+ * version.                                                                             *
+ *                                                                                      *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *                                                                                      *
+ * You should have received a copy of the GNU General Public License along with         *
+ * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ ****************************************************************************************/
+
+package com.ichi2.async
+import com.ichi2.anki.CrashReportService
+import com.ichi2.libanki.Card
+import com.ichi2.libanki.Collection
+import net.ankiweb.rsdroid.BackendFactory
+import timber.log.Timber
+
+/**
+ * This file contains functions that have been migrated from [CollectionTask]
+ * Remove this comment when migration has been completed
+ */
+
+/**
+ * Returns updated card if no error and null if error
+ */
+fun updateCard(
+    col: Collection,
+    editCard: Card,
+    isFromReviewer: Boolean,
+    canAccessScheduler: Boolean,
+): Card? {
+    Timber.d("doInBackgroundUpdateNote")
+    // Save the note
+    val sched = col.sched
+    val editNote = editCard.note()
+    return try {
+        if (BackendFactory.defaultLegacySchema) {
+            col.db.executeInTransaction {
+                // TODO: undo integration
+                editNote.flush()
+                // flush card too, in case, did has been changed
+                editCard.flush()
+            }
+        } else {
+            // TODO: the proper way to do this would be to call this in undoableOp() in
+            // a coroutine
+            col.newBackend.updateNote(editNote)
+            // no need to flush card in new path
+        }
+        if (isFromReviewer) {
+            if (col.decks.active().contains(editCard.did) || !canAccessScheduler) {
+                editCard.apply {
+                    load()
+                    // reload qa-cache
+                    q(true)
+                }
+            } else {
+                sched.card!! // check: are there deleted too?
+            }
+        } else {
+            editCard
+        }
+    } catch (e: RuntimeException) {
+        Timber.e(e, "doInBackgroundUpdateNote - RuntimeException on updating note")
+        CrashReportService.sendExceptionReport(e, "doInBackgroundUpdateNote")
+        null
+    }
+}

--- a/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.kt
@@ -160,17 +160,6 @@ open class CollectionTask<Progress, Result>(val task: TaskDelegateBase<Progress,
         listener?.onCancelled()
     }
 
-    class UpdateNote(
-        private val editCard: Card,
-        val isFromReviewer: Boolean,
-        private val canAccessScheduler: Boolean
-    ) : TaskDelegate<Void, Card?>() {
-        // returns updated card if no error and null if error
-        override fun task(col: Collection, collectionTask: ProgressSenderAndCancelListener<Void>): Card? {
-            return updateCard(col, editCard, isFromReviewer, canAccessScheduler)
-        }
-    }
-
     // Currently being used only to update tags of multiple notes simultaneously
     class UpdateMultipleNotes constructor(
         private val notesToUpdate: List<Note>,

--- a/AnkiDroid/src/test/java/com/ichi2/anki/AbstractFlashcardViewerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/AbstractFlashcardViewerTest.kt
@@ -2,7 +2,6 @@
 
 package com.ichi2.anki
 
-import android.app.Activity
 import android.content.Intent
 import android.os.Build
 import android.webkit.RenderProcessGoneDetail
@@ -101,8 +100,7 @@ class AbstractFlashcardViewerTest : RobolectricTest() {
     }
 
     @Test
-    @Suppress("deprecation") // onActivityResult
-    fun testEditingCardChangesTypedAnswer() {
+    fun testEditingCardChangesTypedAnswer() = runTest {
         // 7363
         addNoteUsingBasicTypedModel("Hello", "World")
 
@@ -117,7 +115,7 @@ class AbstractFlashcardViewerTest : RobolectricTest() {
         val note = viewer.mCurrentCard!!.note()
         note.setField(1, "David")
 
-        viewer.onActivityResult(AbstractFlashcardViewer.EDIT_CURRENT_CARD, Activity.RESULT_OK, Intent())
+        viewer.saveEditedCard()
 
         waitForAsyncTasksToComplete()
 
@@ -125,8 +123,7 @@ class AbstractFlashcardViewerTest : RobolectricTest() {
     }
 
     @Test
-    @Suppress("deprecation") // onActivityResult
-    fun testEditingCardChangesTypedAnswerOnDisplayAnswer() {
+    fun testEditingCardChangesTypedAnswerOnDisplayAnswer() = runTest {
         // 7363
         addNoteUsingBasicTypedModel("Hello", "World")
 
@@ -145,7 +142,7 @@ class AbstractFlashcardViewerTest : RobolectricTest() {
         val note = viewer.mCurrentCard!!.note()
         note.setField(1, "David")
 
-        viewer.onActivityResult(AbstractFlashcardViewer.EDIT_CURRENT_CARD, Activity.RESULT_OK, Intent())
+        viewer.saveEditedCard()
 
         waitForAsyncTasksToComplete()
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/PreviewerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/PreviewerTest.kt
@@ -15,7 +15,6 @@
  */
 package com.ichi2.anki
 
-import android.app.Activity
 import android.widget.SeekBar
 import android.widget.TextView
 import androidx.test.ext.junit.runners.AndroidJUnit4
@@ -31,8 +30,7 @@ import org.robolectric.annotation.Config
 class PreviewerTest : RobolectricTest() {
 
     @Test
-    @Suppress("DEPRECATION")
-    fun editingNoteDoesNotChangePreviewedCardId() {
+    fun editingNoteDoesNotChangePreviewedCardId() = runTest {
         // #7801
         addNoteUsingBasicModel("Hello", "World")
 
@@ -43,16 +41,13 @@ class PreviewerTest : RobolectricTest() {
 
         assertThat("Initially should be previewing selected card", previewer.currentCardId, equalTo(cardToPreview.id))
 
-        previewer.onActivityResult(AbstractFlashcardViewer.EDIT_CURRENT_CARD, Activity.RESULT_OK, null)
-
-        advanceRobolectricLooperWithSleep()
+        previewer.saveEditedCard()
 
         assertThat("Should be previewing selected card after edit", previewer.currentCardId, equalTo(cardToPreview.id))
     }
 
     @Test
-    @Suppress("DEPRECATION")
-    fun editingNoteChangesContent() {
+    fun editingNoteChangesContent() = runTest {
         // #7801
         addNoteUsingBasicModel("Hello", "World")
 
@@ -65,9 +60,7 @@ class PreviewerTest : RobolectricTest() {
 
         cardToPreview.note().setField(0, "Hi")
 
-        previewer.onActivityResult(AbstractFlashcardViewer.EDIT_CURRENT_CARD, Activity.RESULT_OK, null)
-
-        advanceRobolectricLooperWithSleep()
+        previewer.saveEditedCard()
 
         assertThat("Card content should be updated after editing", previewer.cardContent, containsString("Hi"))
     }


### PR DESCRIPTION
## Purpose / Description
Migrated CollectionTask.UpdateNote to Coroutines

## Fixes
A part of #7108

## Approach
- Moved the functionality of CollectionTask.UpdateNote to CollectionOperations.updateNote
- CardBrowser: Previous implementation of UpdateCardHandler starts a progressBar in onPreExecute, updates the card-list from onPostExecute and **closes the CardBrowser with RESULT_DB_ERROR** (not good way). The newer implementation handles progressBar using withProgress{}, updated the card after the process and Error is handled by LaunchCatchingTask which **properly shows the error message without abruptly closing the CardBrowser**.
- AbstractFlashcardViewer: Similar to CardBrowser, just there is set of operations that is being done onPostExecute which has been replicated into onCardUpdated function.

## How Has This Been Tested?


## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
