### PR TITLE
ci: stop codecov from failing CI

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -14,3 +14,13 @@ coverage:
         # dropping slightly is ok - this stops the check failing on test timing variability
         # .12 was observed as the largest variability owing to timing forcing different test branch choice
         threshold: 0.15
+        # BUG: our coverage fluctuates, so codecov marks this as a build failure (#12227)
+        # stop codecov from failing CI until this is fixed
+        # https://docs.codecov.com/docs/commit-status#informational
+        informational: true
+    patch:
+      default:
+        # BUG: our coverage fluctuates, so codecov marks this as a build failure (#12227)
+        # stop codecov from failing CI until this is fixed
+        # https://docs.codecov.com/docs/commit-status#informational
+        informational: true

--- a/.idea/dictionaries/android.xml
+++ b/.idea/dictionaries/android.xml
@@ -14,6 +14,7 @@
       <w>backreference</w>
       <w>bmgr</w>
       <w>cheets</w>
+      <w>codecov</w>
       <w>constraintlayout</w>
       <w>contentvalue</w>
       <w>contextmenu</w>


### PR DESCRIPTION
Our code coverage fluctuates, meaning that CI is often shown as failed even on no-op operations

This is bad for our developer experience: we can't trust CI status to be reporting correctly, and this slows fixing actual issues

So, we mark codecov as 'informational' so only 'real' CI failures are shown to users

> If `true` is specified the resulting status will pass no matter what  the coverage is or what other settings are specified. Informational mode is great to use if you want to expose codecov information to other developers in your pull request without necessarily gating PRs on that information.

https://docs.codecov.com/docs/commit-status#informational

Related issue: #12227 - fixing the flakiness in other ways

## How Has This Been Tested?

This PR is the test - I want to see if the checks are removed, or marked as 'skipped/green' in the 

## Learning (optional, can help others)

- https://docs.codecov.com/docs/commit-status#informational
- https://community.codecov.com/t/informational-true-check-is-marked-as-failng/2428
- No CI is run if only `codecov.yml` is changed
- `informational` does still show a check, but this takes time

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
