### PR TITLE
fix: replace cloze with blank within <tts> tag

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/TtsParser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/TtsParser.kt
@@ -26,7 +26,7 @@ object TtsParser {
     fun getTextsToRead(html: String, clozeReplacement: String?): List<TTSTag> {
         val textsToRead: MutableList<TTSTag> = ArrayList()
         val elem = Jsoup.parseBodyFragment(html).body()
-        parseTtsElements(elem, textsToRead)
+        parseTtsElements(elem, textsToRead, clozeReplacement)
         if (textsToRead.isEmpty()) {
             // No <tts service="android"> elements found: return the text of the whole HTML fragment
             textsToRead.add(readWholeCard(elem.text().replace(TemplateFilters.CLOZE_DELETION_REPLACEMENT, clozeReplacement!!)))
@@ -34,15 +34,15 @@ object TtsParser {
         return textsToRead
     }
 
-    private fun parseTtsElements(element: Element, textsToRead: MutableList<TTSTag>) {
+    private fun parseTtsElements(element: Element, textsToRead: MutableList<TTSTag>, clozeReplacement: String?) {
         if ("tts".equals(element.tagName(), ignoreCase = true) &&
             "android".equals(element.attr("service"), ignoreCase = true)
         ) {
-            textsToRead.add(localisedText(element.text(), element.attr("voice")))
+            textsToRead.add(localisedText(element.text().replace(TemplateFilters.CLOZE_DELETION_REPLACEMENT, clozeReplacement!!), element.attr("voice")))
             return // ignore any children
         }
         for (child in element.children()) {
-            parseTtsElements(child, textsToRead)
+            parseTtsElements(child, textsToRead, clozeReplacement)
         }
     }
 

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/TtsParserTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/TtsParserTest.kt
@@ -37,6 +37,19 @@ class TtsParserTest {
     }
 
     @Test
+    fun clozeIsReplacedWithBlankInTTSTag() {
+        val content = """<style>.card {
+ font-family: arial;
+ font-size: 20px;
+ text-align: center;
+ color: black;
+ background-color: white;
+}.cloze {font-weight: bold;color: blue;}</style><tts service="android">This is a <span class=cloze>[...]</span></tts>"""
+        val actual = getTtsTagFrom(content)
+        assertThat(actual.fieldText, equalTo("This is a blank"))
+    }
+
+    @Test
     fun providedExampleClozeReplaces() {
         val content = """<style>.card {
  font-family: arial;


### PR DESCRIPTION
resolves ankidroid/Anki-Android#12233

## Pull Request template

## Purpose / Description
#12233

## Fixes
Fixes #12233

## Approach
Adds `replace` to another line of code which handles text within a `tts` tag.

## How Has This Been Tested?

Added a test for the `<tts service="android">` tag. It fails without the fix, passes with the fix.

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
