### PR TITLE
fix: suppressed stack trace when error in coroutine occurs.

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CoroutineHelpers.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CoroutineHelpers.kt
@@ -59,13 +59,13 @@ suspend fun <T> FragmentActivity.runCatchingTask(
     } catch (exc: CancellationException) {
         // do nothing
     } catch (exc: BackendInterruptedException) {
-        Timber.e("caught: %s %s", exc, extraInfo)
+        Timber.e(exc, extraInfo)
         exc.localizedMessage?.let { showSnackbar(it) }
     } catch (exc: BackendException) {
-        Timber.e("caught: %s %s", exc, extraInfo)
+        Timber.e(exc, extraInfo)
         showError(this, exc.localizedMessage!!)
     } catch (exc: Exception) {
-        Timber.e("caught: %s %s", exc, extraInfo)
+        Timber.e(exc, extraInfo)
         showError(this, exc.toString())
     }
     return null


### PR DESCRIPTION
Reason: The leading string in `Timber.e("caught: %s %s", exc, extraInfo)` caused  stack trace to be suppressed.

## Fixes
Fixes #12238


https://user-images.githubusercontent.com/69595691/187378845-4a4b2198-4f1f-4c72-a862-beabe6f35665.mp4
