### PR TITLE
[Cleanup] Removed Android 4.2 proguard workaround

### DIFF
--- a/AnkiDroid/proguard-rules.pro
+++ b/AnkiDroid/proguard-rules.pro
@@ -15,17 +15,3 @@
 #-keepclassmembers class fqcn.of.javascript.interface.for.webview {
 #   public *;
 #}
-
-# FIXME remove this entire Android 4.2 workaround from 12/3/15 timrae commit for 2.15.x+
-# Samsung Android 4.2 bug workaround
-# https://code.google.com/p/android/issues/detail?id=78377
--keepattributes **
--keep class !android.support.v7.view.menu.**,!android.support.design.internal.NavigationMenu,!android.support.design.internal.NavigationMenuPresenter,!android.support.design.internal.NavigationSubMenu,** {*;}
-#5806 - Class: ActionBarOverflow
--keep public class android.support.v7.internal.view.menu.** { *; }
--keep public class androidx.appcompat.view.menu.** { *; }
--dontpreverify
--dontoptimize
--dontshrink
--dontwarn **
--dontnote **


### PR DESCRIPTION
## Purpose / Description
[This](https://github.com/ankidroid/Anki-Android/pull/3942) workaround was initially implemented for app crashing on Samsung devices on Android 4.2.
We are currently only supporting API 21+ (Android 5.0) so there is no need for this workaround now & this can be removed.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented on your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
