### PR TITLE
Fix Card info on the legacy schema if opened from the deck picker

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
@@ -702,8 +702,9 @@ open class Reviewer : AbstractFlashcardViewer() {
             return
         }
         val intent = if (BackendFactory.defaultLegacySchema) {
-            Intent(this, CardInfo::class.java)
-            intent.putExtra("cardId", mCurrentCard!!.id)
+            Intent(this, CardInfo::class.java).apply {
+                putExtra("cardId", mCurrentCard!!.id)
+            }
         } else {
             com.ichi2.anki.pages.CardInfo.getIntent(this, mCurrentCard!!.id)
         }


### PR DESCRIPTION
## Purpose / Description
I've messed up and Card info couldn't be opened from the deck picker anymore

## Approach
Assign the intent variable properly

## How Has This Been Tested?

- Be sure that "Card info" app bar button isn't disabled
- Start reviewing
- Tap Card info

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
