### PR TITLE
Fix metered sync warning being shown if the user has no internet

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidJsAPI.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidJsAPI.kt
@@ -38,7 +38,7 @@ import com.ichi2.libanki.Decks
 import com.ichi2.libanki.SortOrder
 import com.ichi2.utils.JSONException
 import com.ichi2.utils.JSONObject
-import com.ichi2.utils.isActiveNetworkMetered
+import com.ichi2.utils.NetworkUtils
 import kotlinx.coroutines.runBlocking
 import timber.log.Timber
 
@@ -394,7 +394,7 @@ open class AnkiDroidJsAPI(private val activity: AbstractFlashcardViewer) {
 
     @JavascriptInterface
     fun ankiIsActiveNetworkMetered(): Boolean {
-        return isActiveNetworkMetered()
+        return NetworkUtils.isActiveNetworkMetered()
     }
 
     // Know if {{tts}} is supported - issue #10443

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -112,8 +112,8 @@ import com.ichi2.libanki.utils.TimeManager
 import com.ichi2.themes.StyledProgressDialog
 import com.ichi2.ui.BadgeDrawableBuilder
 import com.ichi2.utils.*
+import com.ichi2.utils.NetworkUtils.isActiveNetworkMetered
 import com.ichi2.utils.Permissions.hasStorageAccessPermission
-import com.ichi2.utils.isActiveNetworkMetered
 import com.ichi2.widget.WidgetStatus
 import kotlinx.coroutines.Job
 import net.ankiweb.rsdroid.BackendFactory

--- a/AnkiDroid/src/main/java/com/ichi2/utils/NetworkUtils.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/NetworkUtils.kt
@@ -19,11 +19,16 @@ import android.net.ConnectivityManager
 import androidx.core.content.getSystemService
 import com.ichi2.anki.AnkiDroidApp
 
-fun isActiveNetworkMetered(): Boolean {
-    return AnkiDroidApp
-        .instance
-        .applicationContext
-        .getSystemService<ConnectivityManager>()
-        ?.isActiveNetworkMetered
-        ?: true
+object NetworkUtils {
+    private val connectivityManager: ConnectivityManager?
+        get() = AnkiDroidApp
+            .instance
+            .applicationContext
+            .getSystemService()
+
+    fun isActiveNetworkMetered(): Boolean {
+        return connectivityManager
+            ?.isActiveNetworkMetered
+            ?: true
+    }
 }


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
The "You have no internet collection - Sync anyway" snackbar should be shown instead

## Fixes
Fixes #12258

## Approach
Add a method to check if the user is connected to the internet

## How Has This Been Tested?

https://user-images.githubusercontent.com/69634269/187761689-f59bedb8-2b0c-4ddb-a418-3ebd1de3dbd1.mp4


## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
