### PR TITLE
Switch JDK in GitHub Actions from adopt to temurin

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -42,10 +42,10 @@ jobs:
         with:
           fetch-depth: 1
 
-      - name: Configure JDK 1.11
+      - name: Configure JDK
         uses: actions/setup-java@v3
         with:
-          distribution: "adopt"
+          distribution: "temurin"
           java-version: "11" # ubuntu-latest is about to default to 11, force it everywhere
 
       - name: Verify JDK11

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,10 +17,10 @@ jobs:
           path: ~/.gradle/caches
           key: gradle-${{ hashFiles('**/*.gradle*') }}-v1
 
-      - name: Configure JDK 1.11
+      - name: Configure JDK
         uses: actions/setup-java@v3
         with:
-          distribution: "adopt"
+          distribution: "temurin"
           java-version: "11" # ubuntu-latest is about to default to 11, force it everywhere
 
       - name: Verify JDK11

--- a/.github/workflows/tests_emulator.yml
+++ b/.github/workflows/tests_emulator.yml
@@ -53,10 +53,10 @@ jobs:
         with:
           fetch-depth: 50
 
-      - name: Configure JDK 1.11
+      - name: Configure JDK
         uses: actions/setup-java@v3
         with:
-          distribution: "adopt"
+          distribution: "temurin"
           java-version: "11" # ubuntu-latest is about to default to 11, force it everywhere
 
       - name: Setup Gradle

--- a/.github/workflows/tests_unit.yml
+++ b/.github/workflows/tests_unit.yml
@@ -56,10 +56,10 @@ jobs:
         with:
           fetch-depth: 50
 
-      - name: Configure JDK 1.11
+      - name: Configure JDK
         uses: actions/setup-java@v3
         with:
-          distribution: "adopt"
+          distribution: "temurin"
           java-version: "11" # ubuntu-latest is about to default to 11, force it everywhere
 
       - name: Verify JDK11


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
According to the [docs](https://github.com/marketplace/actions/setup-java-jdk#supported-distributions)

> Adopt OpenJDK got moved to Eclipse Temurin and won't be updated anymore. It is highly recommended to migrate workflows from adopt to temurin to keep receiving software and security updates. See more details in the [Good-bye AdoptOpenJDK post](https://blog.adoptopenjdk.net/2021/08/goodbye-adoptopenjdk-hello-adoptium/).

## Fixes
Fixes #11992 

## Approach
Replaced all uses of `adopt` with `temurin`

## How Has This Been Tested?

Tested by running actions several times in my fork [here](https://github.com/RSBat/Anki-Android/actions?query=branch%3Ajdk-temurin++).

## Learning (optional, can help others)

I found it by accident, so I have no ideas how to track such deprecations. AnkiDroid already uses dependabot for GitHub actions, but it didn't do anything either.

For an overview of different JDKs there is [whichjdk.com](https://whichjdk.com).

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
