### PR TITLE
Use snackbar on `Press back to exit`

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -985,7 +985,7 @@ open class DeckPicker :
                     automaticSync()
                     finishWithAnimation()
                 } else {
-                    showThemedToast(this, getString(R.string.back_pressed_once), true)
+                    showSnackbar(R.string.back_pressed_once, Snackbar.LENGTH_SHORT)
                 }
                 mBackButtonPressedToExit = true
                 HandlerUtils.executeFunctionWithDelay(Consts.SHORT_TOAST_DURATION) { mBackButtonPressedToExit = false }


### PR DESCRIPTION
## Purpose / Description
Snackbars should be preferred. Similar to #12093 and #12092

## How Has This Been Tested?

- Enable the "Press back to exit" setting
- Press back on the deck picker

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
