### PR TITLE
refactor: CardBrowserTest + fix flaky tests

### DIFF
--- a/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.kt
@@ -30,6 +30,7 @@ import com.ichi2.libanki.Note
 import com.ichi2.testutils.AnkiActivityUtils.getDialogFragment
 import com.ichi2.testutils.AnkiAssert.assertDoesNotThrow
 import com.ichi2.testutils.IntentAssert
+import com.ichi2.testutils.revokeWritePermissions
 import com.ichi2.ui.FixedTextView
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.*
@@ -295,7 +296,7 @@ class CardBrowserTest : RobolectricTest() {
 
     @Test
     fun startupFromCardBrowserActionItemShouldEndActivityIfNoPermissions() {
-        InitialActivityWithConflictTest.revokeWritePermissions()
+        revokeWritePermissions()
         val inputIntent = Intent("android.intent.action.PROCESS_TEXT")
 
         val browserController = Robolectric.buildActivity(CardBrowser::class.java, inputIntent).create()

--- a/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.kt
@@ -74,30 +74,23 @@ class CardBrowserTest : RobolectricTest() {
     }
 
     @Test
-    @RunInBackground
     fun selectAllIsNotVisibleOnceCalled() {
         val browser = browserWithMultipleNotes
         selectMenuItem(browser, R.id.action_select_all)
-        advanceRobolectricLooperWithSleep()
         assertThat(browser.isShowingSelectAll, equalTo(false))
     }
 
     @Test
-    @RunInBackground
     fun selectNoneIsVisibleOnceSelectAllCalled() {
         val browser = browserWithMultipleNotes
         selectMenuItem(browser, R.id.action_select_all)
-        advanceRobolectricLooperWithSleep()
         assertThat(browser.isShowingSelectNone, equalTo(true))
     }
 
     @Test
-    @RunInBackground
     fun selectNoneIsVisibleWhenSelectingOne() {
         val browser = browserWithMultipleNotes
-        advanceRobolectricLooperWithSleep()
         selectOneOfManyCards(browser)
-        advanceRobolectricLooperWithSleep()
         assertThat(browser.isShowingSelectNone, equalTo(true))
     }
 
@@ -137,7 +130,6 @@ class CardBrowserTest : RobolectricTest() {
         // Sometimes an async operation deletes a card, we clear the data and rerender it to simulate this
         deleteCardAtPosition(browser, 0)
         assertDoesNotThrow { browser.rerenderAllCards() }
-        advanceRobolectricLooperWithSleep()
         assertThat(browser.cardCount(), equalTo(5L))
     }
 
@@ -213,8 +205,6 @@ class CardBrowserTest : RobolectricTest() {
         val b = getBrowserWithNotes(5)
         b.checkCardsAtPositions(0, 2)
 
-        advanceRobolectricLooperWithSleep()
-
         val cardIds = b.checkedCardIds
 
         for (cardId in cardIds) {
@@ -225,7 +215,6 @@ class CardBrowserTest : RobolectricTest() {
         assertDoesNotThrow { b.moveSelectedCardsToDeck(deckIdToChangeTo) }
 
         // assert
-        advanceRobolectricLooperWithSleep()
         for (cardId in cardIds) {
             assertThat("Deck should be changed", col.getCard(cardId).did, equalTo(deckIdToChangeTo))
         }
@@ -262,14 +251,12 @@ class CardBrowserTest : RobolectricTest() {
         // flag the selected card with flag = 1
         val flag = 1
         cardBrowser.flagTask(flag)
-        advanceRobolectricLooperWithSleep()
         // check if card flag turned to flag = 1
         assertThat("Card should be flagged", getCheckedCard(cardBrowser).card.userFlag(), equalTo(flag))
 
         // unflag the selected card with flag = 0
         val unflagFlag = 0
         cardBrowser.flagTask(unflagFlag)
-        advanceRobolectricLooperWithSleep()
         // check if card flag actually changed from flag = 1
         assertThat("Card flag should be removed", getCheckedCard(cardBrowser).card.userFlag(), not(flag))
 
@@ -279,7 +266,6 @@ class CardBrowserTest : RobolectricTest() {
         // flag all the cards with flag = 3
         val flagForAll = 3
         cardBrowser.flagTask(flagForAll)
-        advanceRobolectricLooperWithSleep()
         // check if all card flags turned to flag = 3
         assertThat(
             "All cards should be flagged",
@@ -333,7 +319,6 @@ class CardBrowserTest : RobolectricTest() {
 
         val b = browserWithNoNewCards
         b.filterByTag("sketchy::(1)")
-        advanceRobolectricLooperWithSleep()
 
         assertThat("tagged card should be returned", b.cardCount, equalTo(1))
     }
@@ -351,7 +336,6 @@ class CardBrowserTest : RobolectricTest() {
 
         val b = browserWithNoNewCards
         b.filterByFlag(1)
-        advanceRobolectricLooperWithSleep()
 
         assertThat("Flagged cards should be returned", b.cardCount, equalTo(2))
     }
@@ -448,8 +432,6 @@ class CardBrowserTest : RobolectricTest() {
 
         b.repositionCardsNoValidation(listOf(card.id), 2)
 
-        advanceRobolectricLooperWithSleep()
-
         assertThat("Position of checked card after reposition", card.getColumnHeaderText(CardBrowser.Column.DUE), equalTo("2"))
     }
 
@@ -473,8 +455,6 @@ class CardBrowserTest : RobolectricTest() {
 
         b.resetProgressNoConfirm(listOf(card.id))
 
-        advanceRobolectricLooperWithSleep()
-
         assertThat("Position of checked card after reset", card.getColumnHeaderText(CardBrowser.Column.DUE), equalTo("1"))
     }
 
@@ -490,8 +470,6 @@ class CardBrowserTest : RobolectricTest() {
         assertThat("Initial position of checked card", card.getColumnHeaderText(CardBrowser.Column.DUE), equalTo("1"))
 
         b.rescheduleWithoutValidation(listOf(card.id), 5)
-
-        advanceRobolectricLooperWithSleep()
 
         assertThat("Due of checked card after reschedule", card.getColumnHeaderText(CardBrowser.Column.DUE), equalTo("8/12/20"))
     }
@@ -509,14 +487,9 @@ class CardBrowserTest : RobolectricTest() {
 
         b.repositionCardsNoValidation(listOf(card.id), 2)
 
-        advanceRobolectricLooperWithSleep()
-
         assertThat("Position of checked card after reposition", card.getColumnHeaderText(CardBrowser.Column.DUE), equalTo("2"))
 
         b.onUndo()
-
-        advanceRobolectricLooperWithSleep()
-        advanceRobolectricLooperWithSleep()
 
         assertThat("Position of checked card after undo should be reset", card.getColumnHeaderText(CardBrowser.Column.DUE), equalTo("1"))
     }
@@ -531,8 +504,6 @@ class CardBrowserTest : RobolectricTest() {
         b.checkCardsAtPositions(0)
 
         b.rescheduleWithoutValidation(listOf(getCheckedCard(b).id), 2)
-
-        advanceRobolectricLooperWithSleep()
 
         assertUndoContains(b, R.string.deck_conf_cram_reschedule)
     }
@@ -564,7 +535,6 @@ class CardBrowserTest : RobolectricTest() {
 
         val cardBrowser = browserWithNoNewCards
         cardBrowser.searchCards("world or hello")
-        advanceRobolectricLooperWithSleep()
 
         assertThat("Cardbrowser has Deck 1 as selected deck", cardBrowser.selectedDeckNameForUi, equalTo("Deck 1"))
         assertThat("Results should only be from the selected deck", cardBrowser.cardCount, equalTo(1))
@@ -578,7 +548,6 @@ class CardBrowserTest : RobolectricTest() {
         var cardBrowserController = Robolectric.buildActivity(CardBrowser::class.java, Intent())
             .create().start().resume().visible()
         saveControllerForCleanup(cardBrowserController)
-        advanceRobolectricLooperWithSleep()
 
         // Make sure card has default value in sortType field
         assertThat("Initially Card Browser has order = noteFld", col.get_config_string("sortType"), equalTo("noteFld"))
@@ -622,12 +591,10 @@ class CardBrowserTest : RobolectricTest() {
 
         val cardBrowser = browserWithNoNewCards
         cardBrowser.searchCards("Hello")
-        advanceRobolectricLooperWithSleep()
         assertThat("Card browser should have Test Deck as the selected deck", cardBrowser.selectedDeckNameForUi, equalTo("Test Deck"))
         assertThat("Result should be empty", cardBrowser.cardCount, equalTo(0))
 
         cardBrowser.searchAllDecks()
-        advanceRobolectricLooperWithSleep()
         assertThat("Result should contain one card", cardBrowser.cardCount, equalTo(1))
     }
 
@@ -687,6 +654,7 @@ class CardBrowserTest : RobolectricTest() {
             null, childAt,
             position, toSelect.getItemIdAtPosition(position)
         )
+        advanceRobolectricUiLooper()
     }
 
     private fun selectMenuItem(browser: CardBrowser, action_select_all: Int) {
@@ -694,6 +662,7 @@ class CardBrowserTest : RobolectricTest() {
         // select seems to run an infinite loop :/
         val shadowActivity = shadowOf(browser)
         shadowActivity.clickMenuItem(action_select_all)
+        advanceRobolectricUiLooper()
     }
 
     private class CardBrowserSizeOne : CardBrowser() {

--- a/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.kt
@@ -679,7 +679,9 @@ class CardBrowserTest : RobolectricTest() {
         for (i in 0 until noteCount) {
             addNoteUsingBasicModel(i.toString(), "back")
         }
-        return super.startRegularActivity(Intent())
+        return super.startRegularActivity<CardBrowser>(Intent()).also {
+            advanceRobolectricUiLooper() // may be a fix for flaky tests
+        }
     }
 
     private fun removeCardFromCollection(cardId: CardId) {

--- a/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.kt
@@ -30,7 +30,7 @@ import com.ichi2.libanki.Note
 import com.ichi2.testutils.AnkiActivityUtils.getDialogFragment
 import com.ichi2.testutils.AnkiAssert.assertDoesNotThrow
 import com.ichi2.testutils.IntentAssert
-import com.ichi2.testutils.revokeWritePermissions
+import com.ichi2.testutils.withNoWritePermission
 import com.ichi2.ui.FixedTextView
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.*
@@ -296,20 +296,21 @@ class CardBrowserTest : RobolectricTest() {
 
     @Test
     fun startupFromCardBrowserActionItemShouldEndActivityIfNoPermissions() {
-        revokeWritePermissions()
-        val inputIntent = Intent("android.intent.action.PROCESS_TEXT")
+        withNoWritePermission {
+            val inputIntent = Intent("android.intent.action.PROCESS_TEXT")
 
-        val browserController = Robolectric.buildActivity(CardBrowser::class.java, inputIntent).create()
-        val cardBrowser = browserController.get()
-        saveControllerForCleanup(browserController)
+            val browserController = Robolectric.buildActivity(CardBrowser::class.java, inputIntent).create()
+            val cardBrowser = browserController.get()
+            saveControllerForCleanup(browserController)
 
-        val shadowActivity = shadowOf(cardBrowser)
-        val outputIntent = shadowActivity.nextStartedActivity
-        val component = assertNotNull(outputIntent.component)
+            val shadowActivity = shadowOf(cardBrowser)
+            val outputIntent = shadowActivity.nextStartedActivity
+            val component = assertNotNull(outputIntent.component)
 
-        assertThat("Deck Picker currently handles permissions, so should be called", component.className, equalTo("com.ichi2.anki.DeckPicker"))
-        assertThat("Activity should be finishing", cardBrowser.isFinishing)
-        assertThat("Activity should be cancelled as it did nothing", shadowActivity.resultCode, equalTo(Activity.RESULT_CANCELED))
+            assertThat("Deck Picker currently handles permissions, so should be called", component.className, equalTo("com.ichi2.anki.DeckPicker"))
+            assertThat("Activity should be finishing", cardBrowser.isFinishing)
+            assertThat("Activity should be cancelled as it did nothing", shadowActivity.resultCode, equalTo(Activity.RESULT_CANCELED))
+        }
     }
 
     @Test

--- a/AnkiDroid/src/test/java/com/ichi2/anki/DeckPickerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/DeckPickerTest.kt
@@ -18,7 +18,6 @@ import com.ichi2.testutils.AnkiActivityUtils.getDialogFragment
 import com.ichi2.utils.KotlinCleanup
 import com.ichi2.utils.ResourceLoader
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.runTest
 import net.ankiweb.rsdroid.BackendFactory
 import org.apache.commons.exec.OS
 import org.hamcrest.MatcherAssert.*
@@ -302,7 +301,7 @@ class DeckPickerTest : RobolectricTest() {
     fun deckPickerOpensWithHelpMakeAnkiDroidBetterDialog() {
         // Refactor: It would be much better to use a spy - see if we can get this into Robolectric
         try {
-            InitialActivityWithConflictTest.grantWritePermissions()
+            grantWritePermissions()
             BackupManagerTestUtilities.setupSpaceForBackup(targetContext)
             // We don't show it if the user is new.
             AnkiDroidApp.getSharedPrefs(targetContext).edit().putString("lastVersion", "0.1")
@@ -316,7 +315,7 @@ class DeckPickerTest : RobolectricTest() {
                 equalTo(true)
             )
         } finally {
-            InitialActivityWithConflictTest.revokeWritePermissions()
+            revokeWritePermissions()
             BackupManagerTestUtilities.reset()
         }
     }
@@ -343,7 +342,7 @@ class DeckPickerTest : RobolectricTest() {
     @Test
     fun showOptionsMenuWhenCollectionAccessible() = runTest {
         try {
-            InitialActivityWithConflictTest.grantWritePermissions()
+            grantWritePermissions()
             val d = super.startActivityNormallyOpenCollectionWithIntent(
                 DeckPickerEx::class.java, Intent()
             )
@@ -354,7 +353,7 @@ class DeckPickerTest : RobolectricTest() {
                 `is`(notNullValue())
             )
         } finally {
-            InitialActivityWithConflictTest.revokeWritePermissions()
+            revokeWritePermissions()
         }
     }
 
@@ -362,7 +361,7 @@ class DeckPickerTest : RobolectricTest() {
     @RunInBackground
     fun onResumeLoadCollectionFailureWithInaccessibleCollection() {
         try {
-            InitialActivityWithConflictTest.revokeWritePermissions()
+            revokeWritePermissions()
             enableNullCollection()
             val d = super.startActivityNormallyOpenCollectionWithIntent(
                 DeckPickerEx::class.java, Intent()
@@ -380,7 +379,7 @@ class DeckPickerTest : RobolectricTest() {
     @Test
     fun onResumeLoadCollectionSuccessWithAccessibleCollection() {
         try {
-            InitialActivityWithConflictTest.grantWritePermissions()
+            grantWritePermissions()
             val d = super.startActivityNormallyOpenCollectionWithIntent(
                 DeckPickerEx::class.java, Intent()
             )
@@ -394,7 +393,7 @@ class DeckPickerTest : RobolectricTest() {
                 notNullValue()
             )
         } finally {
-            InitialActivityWithConflictTest.revokeWritePermissions()
+            revokeWritePermissions()
         }
     }
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/InitialActivityWithConflictTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/InitialActivityWithConflictTest.kt
@@ -15,22 +15,20 @@
  */
 package com.ichi2.anki
 
-import android.Manifest
-import android.app.Application
 import android.content.Context
-import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.ichi2.anki.InitialActivity.StartupFailure
 import com.ichi2.anki.InitialActivity.getStartupFailureType
 import com.ichi2.testutils.BackendEmulatingOpenConflict
 import com.ichi2.testutils.BackupManagerTestUtilities
+import com.ichi2.testutils.grantWritePermissions
+import com.ichi2.testutils.revokeWritePermissions
 import org.hamcrest.CoreMatchers.equalTo
 import org.hamcrest.MatcherAssert.assertThat
 import org.junit.After
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.robolectric.Shadows
 import org.robolectric.shadows.ShadowEnvironment
 
 @RunWith(AndroidJUnit4::class)
@@ -78,18 +76,6 @@ class InitialActivityWithConflictTest : RobolectricTest() {
         fun setupForDefault() {
             revokeWritePermissions()
             ShadowEnvironment.setExternalStorageState("removed")
-        }
-
-        @JvmStatic
-        fun grantWritePermissions() {
-            val app = Shadows.shadowOf(ApplicationProvider.getApplicationContext<Context>() as Application)
-            app.grantPermissions(Manifest.permission.WRITE_EXTERNAL_STORAGE, Manifest.permission.READ_EXTERNAL_STORAGE)
-        }
-
-        @JvmStatic
-        fun revokeWritePermissions() {
-            val app = Shadows.shadowOf(ApplicationProvider.getApplicationContext<Context>() as Application)
-            app.denyPermissions(Manifest.permission.WRITE_EXTERNAL_STORAGE, Manifest.permission.READ_EXTERNAL_STORAGE)
         }
     }
 }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/RobolectricTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/RobolectricTest.kt
@@ -229,6 +229,22 @@ open class RobolectricTest : CollectionGetter {
             Shadows.shadowOf(Looper.getMainLooper()).runToEndOfTasks()
         }
 
+        /**
+         * * Causes all of the [Runnable]s that have been scheduled to run while advancing the clock to the start time of the last scheduled Runnable.
+         * * Executes all posted tasks scheduled before or at the current time
+         *
+         * Supersedes and will eventually replace [advanceRobolectricLooper] and [advanceRobolectricLooperWithSleep]
+         */
+        fun advanceRobolectricUiLooper() {
+            Shadows.shadowOf(Looper.getMainLooper()).apply {
+                runToEndOfTasks()
+                idle()
+                // CardBrowserTest:browserIsInMultiSelectModeWhenSelectingAll failed on Windows CI
+                // This line was added and may or may not make a difference
+                runToEndOfTasks()
+            }
+        }
+
         // Robolectric needs some help sometimes in form of a manual kick, then a wait, to stabilize UI activity
         @JvmStatic
         fun advanceRobolectricLooperWithSleep() {

--- a/AnkiDroid/src/test/java/com/ichi2/testutils/PermissionUtils.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/testutils/PermissionUtils.kt
@@ -1,0 +1,34 @@
+/*
+ *  Copyright (c) 2022 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.testutils
+
+import android.Manifest.permission.READ_EXTERNAL_STORAGE
+import android.Manifest.permission.WRITE_EXTERNAL_STORAGE
+import android.app.Application
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import org.robolectric.Shadows
+
+fun grantWritePermissions() {
+    val app = Shadows.shadowOf(ApplicationProvider.getApplicationContext<Context>() as Application)
+    app.grantPermissions(WRITE_EXTERNAL_STORAGE, READ_EXTERNAL_STORAGE)
+}
+
+fun revokeWritePermissions() {
+    val app = Shadows.shadowOf(ApplicationProvider.getApplicationContext<Context>() as Application)
+    app.denyPermissions(WRITE_EXTERNAL_STORAGE, READ_EXTERNAL_STORAGE)
+}

--- a/AnkiDroid/src/test/java/com/ichi2/testutils/PermissionUtils.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/testutils/PermissionUtils.kt
@@ -23,6 +23,16 @@ import android.content.Context
 import androidx.test.core.app.ApplicationProvider
 import org.robolectric.Shadows
 
+/** Executes [runnable] without [WRITE_EXTERNAL_STORAGE] and [READ_EXTERNAL_STORAGE] */
+fun withNoWritePermission(runnable: (() -> Unit)) {
+    try {
+        revokeWritePermissions()
+        runnable()
+    } finally {
+        grantWritePermissions()
+    }
+}
+
 fun grantWritePermissions() {
     val app = Shadows.shadowOf(ApplicationProvider.getApplicationContext<Context>() as Application)
     app.grantPermissions(WRITE_EXTERNAL_STORAGE, READ_EXTERNAL_STORAGE)


### PR DESCRIPTION
## Purpose / Description

I was investigating the flaky unit tests, and wanted to see what was going on

I could not reproduce the test failure, but a few frustrations occurred:

* Legacy code before `Robolectric.startActivity` was introduced
* `@KotlinCleanup`s
* `@RunInBackground` was used, which is pending for removal
* Some bad unit test asserts
* One issue with `revokeWritePermissions` not being reset, which may have caused test failures

I fixed all of these, and introduced `advanceRobolectricUiLooper` to allow for further migration away from `@RunInBackground`

I then added another `advanceRobolectricUiLooper` after creating the `Activity`, and the problems went away

#11091

## How Has This Been Tested?

Test only - tests run about 2 seconds faster expected - we shave 4*500ms off tests

## Learning 
* `advanceRobolectricUiLooper` is still required - `onCreateOptionsMenu` was not called otherwise due to an update


## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
