### PR TITLE
Add comments when PR opened and on branch other than i18n_sync

### DIFF
--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -55,6 +55,7 @@ jobs:
           }
 
   add_label:
+    if: (!(github.event.action == 'closed' && github.event.pull_request.merged != true)) && github.event.pull_request.merged != true && github.event.pull_request.head.ref != 'i18n_sync'
     permissions:
       contents: read
       pull-requests: write


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
Add comments when PR opened and on branch other than `i18n_sync`

## Fixes
Fixes #12265
Fixes #12266

## Approach
_How does this change address the problem?_

## How Has This Been Tested?
https://github.com/krmanik/Anki-Android-Copy/pull/14
https://github.com/krmanik/Anki-Android-Copy/pull/16

## Learning (optional, can help others)
https://octokit.github.io/rest.js/v18

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
