### PR TITLE
Use upstream's new filtered deck name pattern

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -786,7 +786,9 @@ open class DeckPicker :
                     openStudyOptions(true)
                 }
                 launchCatchingTask {
-                    createFilteredDeckDialog.showFilteredDeckDialog()
+                    withProgress {
+                        createFilteredDeckDialog.showFilteredDeckDialog()
+                    }
                 }
                 return true
             }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -785,7 +785,9 @@ open class DeckPicker :
                     // a filtered deck was created
                     openStudyOptions(true)
                 }
-                createFilteredDeckDialog.showFilteredDeckDialog()
+                launchCatchingTask {
+                    createFilteredDeckDialog.showFilteredDeckDialog()
+                }
                 return true
             }
             R.id.action_check_database -> {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/CreateDeckDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/CreateDeckDialog.kt
@@ -24,11 +24,11 @@ import com.afollestad.materialdialogs.actions.setActionButtonEnabled
 import com.afollestad.materialdialogs.input.getInputField
 import com.afollestad.materialdialogs.input.input
 import com.ichi2.anki.CollectionHelper
+import com.ichi2.anki.CollectionManager.withCol
 import com.ichi2.anki.R
 import com.ichi2.anki.UIUtils.showThemedToast
 import com.ichi2.anki.servicelayer.DeckService.deckExists
 import com.ichi2.annotations.NeedsTest
-import com.ichi2.libanki.CollectionV16
 import com.ichi2.libanki.DeckId
 import com.ichi2.libanki.Decks
 import com.ichi2.libanki.backend.exception.DeckRenameException
@@ -53,18 +53,20 @@ class CreateDeckDialog(private val context: Context, private val title: Int, pri
     private val col
         get() = CollectionHelper.getInstance().getCol(context)
 
-    fun showFilteredDeckDialog() {
+    suspend fun showFilteredDeckDialog() {
         Timber.i("CreateDeckDialog::showFilteredDeckDialog")
-        mInitialDeckName = if (!BackendFactory.defaultLegacySchema) {
-            (col as CollectionV16).getOrCreateFilteredDeck(did = 0).name
-        } else {
-            val names = col.decks.allNames()
-            var n = 1
-            val namePrefix = context.resources.getString(R.string.filtered_deck_name) + " "
-            while (names.contains(namePrefix + n)) {
-                n++
+        mInitialDeckName = withCol {
+            if (!BackendFactory.defaultLegacySchema) {
+                newBackend.getOrCreateFilteredDeck(did = 0).name
+            } else {
+                val names = decks.allNames()
+                var n = 1
+                val namePrefix = context.resources.getString(R.string.filtered_deck_name) + " "
+                while (names.contains(namePrefix + n)) {
+                    n++
+                }
+                namePrefix + n
             }
-            namePrefix + n
         }
         showDialog()
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/CreateDeckDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/CreateDeckDialog.kt
@@ -28,10 +28,13 @@ import com.ichi2.anki.R
 import com.ichi2.anki.UIUtils.showThemedToast
 import com.ichi2.anki.servicelayer.DeckService.deckExists
 import com.ichi2.annotations.NeedsTest
+import com.ichi2.libanki.CollectionV16
 import com.ichi2.libanki.DeckId
 import com.ichi2.libanki.Decks
 import com.ichi2.libanki.backend.exception.DeckRenameException
+import com.ichi2.libanki.getOrCreateFilteredDeck
 import com.ichi2.utils.displayKeyboard
+import net.ankiweb.rsdroid.BackendFactory
 import timber.log.Timber
 import java.util.function.Consumer
 
@@ -52,13 +55,17 @@ class CreateDeckDialog(private val context: Context, private val title: Int, pri
 
     fun showFilteredDeckDialog() {
         Timber.i("CreateDeckDialog::showFilteredDeckDialog")
-        val names = col.decks.allNames()
-        var n = 1
-        val namePrefix = context.resources.getString(R.string.filtered_deck_name) + " "
-        while (names.contains(namePrefix + n)) {
-            n++
+        mInitialDeckName = if (!BackendFactory.defaultLegacySchema) {
+            (col as CollectionV16).getOrCreateFilteredDeck(did = 0).name
+        } else {
+            val names = col.decks.allNames()
+            var n = 1
+            val namePrefix = context.resources.getString(R.string.filtered_deck_name) + " "
+            while (names.contains(namePrefix + n)) {
+                n++
+            }
+            namePrefix + n
         }
-        mInitialDeckName = namePrefix + n
         showDialog()
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/DecksV16.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/DecksV16.kt
@@ -38,6 +38,7 @@ package com.ichi2.libanki
 
 import anki.collection.OpChangesWithCount
 import anki.collection.OpChangesWithId
+import anki.decks.FilteredDeckForUpdate
 import com.google.protobuf.ByteString
 import com.ichi2.libanki.Decks.Companion.ACTIVE_DECKS
 import com.ichi2.libanki.Utils.ids2str
@@ -919,4 +920,12 @@ class DecksV16(private val col: CollectionV16) :
 // These take and return bytes that the frontend TypeScript code will encode/decode.
 fun CollectionV16.getDeckNamesRaw(input: ByteArray): ByteArray {
     return backend.getDeckNamesRaw(input)
+}
+
+/**
+ * Gets the filtered deck with given [did]
+ * or creates a new one if [did] = 0
+ */
+fun CollectionV16.getOrCreateFilteredDeck(did: DeckId): FilteredDeckForUpdate {
+    return backend.getOrCreateFilteredDeck(did = did)
 }


### PR DESCRIPTION
Only possible on the new backend

## Pull Request template

## Purpose / Description
AnkiDroid filtered deck default name scheme does not follow upstream current behavior.

## Fixes
Fixes #10622

## How Has This Been Tested?

Deck picker > Three dot menu > Create filtered deck > see if the dialog follows `Filtered deck HH:mm`

![image](https://user-images.githubusercontent.com/69634269/188121216-7c3edea8-ab67-4d01-abb1-34b1a26866fc.png)


## Learning (optional, can help others)

- Which method to use for this: https://github.com/ankidroid/Anki-Android/issues/10622#issuecomment-1234898146
- Can't be used with the old schema because it throws a SQlite error

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [X] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
