### PR TITLE
build(release): add 30s sleep after release creation

### DIFF
--- a/tools/release.sh
+++ b/tools/release.sh
@@ -151,6 +151,9 @@ fi
 
 github-release release --tag v"$VERSION" --name "AnkiDroid $VERSION" --description "**For regular users:**<br/><br/>Install the main APK below, trying the 'universal' build first for new installs. If it refuses to install and run correctly or you have previously installed from the Play Store, you must pick the APK that matches CPU instruction set for your device.<br/><br/>This will be arm64-v8a for most phones from the last few years but [here is a guide to help you choose](https://www.howtogeek.com/339665/how-to-find-your-android-devices-info-for-correct-apk-downloads/)<br/><br/><br/>**For testers and multiple profiles users:**<br/><br/>The builds with letter codes below (A, B, etc) are universal parallel builds. They will install side-by-side with the main APK for testing, or to connect to a different AnkiWeb account in combination with changing the storage directory in preferences" $PRE_RELEASE
 
+echo "Sleeping 30s to make sure the release exists, see issue 11746"
+sleep 30
+
 for ABI in $ABIS; do
   github-release upload --tag v"$VERSION" --name AnkiDroid-"$VERSION"-"$ABI".apk --file AnkiDroid-"$VERSION"-"$ABI".apk
 done


### PR DESCRIPTION
## Pull Request template

## Purpose / Description

The universal APK has not been uploading on release lately

## Fixes
Fixes #11746

## Approach
It never fails all APKs, just the first one or first few. So perhaps a delay will help

## How Has This Been Tested?

we won't know until a release is attempted

## Learning (optional, can help others)
Nothing is simple, and nothing stays working, without effort. Do the work

## Checklist
_Please, go through these checks before submitting the PR._

- [ ] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas
- [ ] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
