### PR TITLE
NF: simplify PagesActivity and Preferences fragment configuration

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.kt
@@ -46,6 +46,7 @@ import com.ichi2.libanki.Collection
 import com.ichi2.libanki.utils.TimeManager
 import com.ichi2.themes.Themes.setThemeLegacy
 import com.ichi2.utils.AdaptionUtil
+import com.ichi2.utils.getInstanceFromClassName
 import timber.log.Timber
 import java.util.*
 
@@ -93,7 +94,7 @@ class Preferences : AnkiActivity(), SearchPreferenceResultListener {
             HeaderFragment()
         } else {
             try {
-                Class.forName(fragmentClassName).newInstance() as Fragment
+                getInstanceFromClassName<Fragment>(fragmentClassName)
             } catch (e: Exception) {
                 throw RuntimeException("Failed to load $fragmentClassName", e)
             }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/pages/CardInfo.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/pages/CardInfo.kt
@@ -23,7 +23,7 @@ import com.ichi2.anki.R
 
 class CardInfo : PageFragment() {
     override val title = R.string.card_info_title
-    override val pageName = PAGE_NAME
+    override val pageName = "card-info"
     override lateinit var webViewClient: PageWebViewClient
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -44,14 +44,13 @@ class CardInfo : PageFragment() {
     }
 
     companion object {
-        const val PAGE_NAME = "card-info"
         private const val ARG_CARD_ID = "cardId"
 
         fun getIntent(context: Context, cardId: Long): Intent {
             val arguments = Bundle().apply {
                 putLong(ARG_CARD_ID, cardId)
             }
-            return PagesActivity.getIntent(context, PAGE_NAME, arguments)
+            return PagesActivity.getIntent(context, CardInfo::class, arguments)
         }
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/pages/CsvImporter.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/pages/CsvImporter.kt
@@ -26,7 +26,7 @@ import com.ichi2.anki.R
  */
 class CsvImporter : PageFragment() {
     override val title = R.string.menu_import
-    override val pageName = PAGE_NAME
+    override val pageName = "import-csv"
     override lateinit var webViewClient: PageWebViewClient
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -45,8 +45,6 @@ class CsvImporter : PageFragment() {
     }
 
     companion object {
-        const val PAGE_NAME = "import-csv"
-
         /** Key of [CsvImporter]'s argument that holds the path of the file to be imported */
         private const val ARG_KEY_PATH = "csvPath"
 
@@ -58,7 +56,7 @@ class CsvImporter : PageFragment() {
             val arguments = Bundle().apply {
                 putString(ARG_KEY_PATH, filePath)
             }
-            return PagesActivity.getIntent(context, PAGE_NAME, arguments)
+            return PagesActivity.getIntent(context, CsvImporter::class, arguments)
         }
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/pages/Statistics.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/pages/Statistics.kt
@@ -21,14 +21,12 @@ import com.ichi2.anki.R
 
 class Statistics : PageFragment() {
     override val title = R.string.statistics
-    override val pageName = PAGE_NAME
+    override val pageName = "graphs"
     override var webViewClient = PageWebViewClient()
 
     companion object {
-        const val PAGE_NAME = "graphs"
-
         fun getIntent(context: Context): Intent {
-            return PagesActivity.getIntent(context, PAGE_NAME)
+            return PagesActivity.getIntent(context, Statistics::class)
         }
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/AdvancedSettingsFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/AdvancedSettingsFragment.kt
@@ -207,9 +207,8 @@ class AdvancedSettingsFragment : SettingsFragment() {
     }
 
     companion object {
-        @JvmStatic
-        fun getSubscreenIntent(context: Context?): Intent {
-            return getSubscreenIntent(context, AdvancedSettingsFragment::class.java.name)
+        fun getSubscreenIntent(context: Context): Intent {
+            return getSubscreenIntent(context, AdvancedSettingsFragment::class)
         }
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/CustomButtonsSettingsFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/CustomButtonsSettingsFragment.kt
@@ -79,9 +79,8 @@ class CustomButtonsSettingsFragment : SettingsFragment() {
     }
 
     companion object {
-        @JvmStatic
-        fun getSubscreenIntent(context: Context?): Intent {
-            return getSubscreenIntent(context, CustomButtonsSettingsFragment::class.java.name)
+        fun getSubscreenIntent(context: Context): Intent {
+            return getSubscreenIntent(context, CustomButtonsSettingsFragment::class)
         }
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/SettingsFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/SettingsFragment.kt
@@ -28,6 +28,8 @@ import com.ichi2.libanki.Collection
 import com.ichi2.preferences.IncrementerNumberRangePreferenceCompat
 import com.ichi2.preferences.NumberRangePreferenceCompat
 import com.ichi2.preferences.SeekBarPreferenceCompat
+import kotlin.reflect.KClass
+import kotlin.reflect.jvm.jvmName
 
 abstract class SettingsFragment : PreferenceFragmentCompat() {
     /** @return The XML file which defines the preferences displayed by this PreferenceFragment
@@ -80,9 +82,9 @@ abstract class SettingsFragment : PreferenceFragmentCompat() {
 
     companion object {
         @JvmStatic
-        protected fun getSubscreenIntent(context: Context?, javaClassName: String): Intent {
+        protected fun getSubscreenIntent(context: Context, fragmentClass: KClass<out SettingsFragment>): Intent {
             return Intent(context, Preferences::class.java)
-                .putExtra(Preferences.INITIAL_FRAGMENT_EXTRA, javaClassName)
+                .putExtra(Preferences.INITIAL_FRAGMENT_EXTRA, fragmentClass.jvmName)
         }
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/utils/ReflectionUtils.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/ReflectionUtils.kt
@@ -1,0 +1,20 @@
+/*
+ *  Copyright (c) 2022 Brayan Oliveira <brayandso.dev@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.ichi2.utils
+
+inline fun <reified T> getInstanceFromClassName(javaClassName: String): T {
+    return Class.forName(javaClassName).newInstance() as T
+}

--- a/AnkiDroid/src/test/java/com/ichi2/testutils/PreferenceUtils.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/testutils/PreferenceUtils.kt
@@ -24,7 +24,7 @@ import java.util.concurrent.atomic.AtomicReference
 
 object PreferenceUtils {
     @JvmStatic
-    fun getAllCustomButtonKeys(context: Context?): Set<String> {
+    fun getAllCustomButtonKeys(context: Context): Set<String> {
         val ret = AtomicReference<Set<String>>()
         val i = CustomButtonsSettingsFragment.getSubscreenIntent(context)
         ActivityScenario.launch<Preferences>(i).use { scenario ->


### PR DESCRIPTION
## Purpose / Description
Simplify the code around getting the initial fragment for PagesActivity and Preferences

## Approach
On the commits

## How Has This Been Tested?

Run the app and open the current Anki HTML pages with the new backend (Statistics, csv importer and card info)


## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
