### PR TITLE
Fix dialog getting skipped on pressing back

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/ModelFieldEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ModelFieldEditor.kt
@@ -467,7 +467,6 @@ class ModelFieldEditor : AnkiActivity(), LocaleSelectionDialogHandler {
     }
 
     fun handleAction(contextMenuAction: ModelEditorContextMenuAction) {
-        supportFragmentManager.popBackStackImmediate()
         when (contextMenuAction) {
             ModelEditorContextMenuAction.Sort -> sortByField()
             ModelEditorContextMenuAction.Reposition -> repositionFieldDialog()


### PR DESCRIPTION
## Purpose / Description
Fix the issue of dialog getting skipped on pressing back at confirmation dialog.

## Fixes
Fixes #12053  

## Approach
Removed `popBackStackImmediate` method call which seemed unnecessary.

## Checklist

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [ ] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
