### PR TITLE
add post merge comments on strings labelled PR

### DIFF
--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -38,6 +38,19 @@ jobs:
             });
           }
 
+          async function addPostMergeComments() {
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: `Maintainers: Please [Sync Translations](https://github.com/ankidroid/Anki-Android/actions/workflows/sync_translations.yml) to produce a commit with only the automated changes from this PR.
+              
+          Read more about updating strings on the wiki,
+          - [localization-administration](https://github.com/ankidroid/Anki-Android/wiki/Development-Guide#localization-administration)
+          - [download-localized-strings](https://github.com/ankidroid/Anki-Android/wiki/Development-Guide#download-localized-strings)`
+            })
+          }
+
           let result = await github.rest.issues.listLabelsOnIssue({
             owner: context.repo.owner,
             repo: context.repo.repo,
@@ -50,6 +63,11 @@ jobs:
                 if (removeLabelsList.includes(label.name)) {
                   console.log("Removed: ", label.name);
                   removeLabel(label.name);
+                }
+
+                // add post merge comments for 'strings' labeled PR
+                if (label.name == "strings") {
+                  addPostMergeComments();
                 }
             }
           }


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
Add post merge commits to `strings` label PR. 

## Fixes
Fixes #12267

## Approach
Using GitHub scripts, when PR merged, the remove label search for labels to remove. If label match with `strings` then add comments.

## How Has This Been Tested?
Tested on local repository
https://github.com/krmanik/Anki-Android-Copy/pull/2

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration (SDK version(s), emulator or physical, etc)

## Learning (optional, can help others)
https://octokit.github.io/rest.js/

_Links to blog posts, patterns, libraries or addons used to solve this problem_

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
