### PR TITLE
[GSoC] Optimize preferences search bar configuration + enable search history

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/Preferences.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/Preferences.kt
@@ -123,7 +123,7 @@ class Preferences : AnkiActivity(), SearchPreferenceResultListener {
             setFragmentContainerViewId(R.id.settings_container)
             setBreadcrumbsEnabled(true)
             setFuzzySearchEnabled(false)
-            setHistoryEnabled(false)
+            setHistoryEnabled(true)
             textNoResults = getString(R.string.pref_search_no_results)
 
             index(R.xml.preferences_general)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/Preferences.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/Preferences.kt
@@ -53,6 +53,7 @@ import java.util.*
  * Preferences dialog.
  */
 class Preferences : AnkiActivity(), SearchPreferenceResultListener {
+    val searchConfiguration: SearchConfiguration by lazy { configureSearchBar() }
     lateinit var searchView: PreferencesSearchView
 
     // ----------------------------------------------------------------------------
@@ -109,17 +110,16 @@ class Preferences : AnkiActivity(), SearchPreferenceResultListener {
         val searchIcon = menu.findItem(R.id.preferences_search)
         searchView = searchIcon.actionView as PreferencesSearchView
         searchView.setActivity(this)
-
-        configureSearchBar(searchView.searchConfiguration)
+        searchView.searchConfiguration = searchConfiguration
 
         return super.onCreateOptionsMenu(menu)
     }
 
     /**
-     * Configures [searchConfig] for AnkiDroid's settings search bar and return it back
+     * @return the default [SearchConfiguration] for AnkiDroid settings
      */
-    fun configureSearchBar(searchConfig: SearchConfiguration): SearchConfiguration {
-        searchConfig.apply {
+    private fun configureSearchBar(): SearchConfiguration {
+        val searchConfig = SearchConfiguration(this).apply {
             setFragmentContainerViewId(R.id.settings_container)
             setBreadcrumbsEnabled(true)
             setFuzzySearchEnabled(false)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/PreferencesSearchView.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/PreferencesSearchView.kt
@@ -17,6 +17,7 @@ package com.ichi2.anki.preferences
 
 import android.content.Context
 import android.util.AttributeSet
+import com.bytehamster.lib.preferencesearch.SearchConfiguration
 import com.bytehamster.lib.preferencesearch.SearchPreferenceActionView
 
 /**
@@ -26,6 +27,11 @@ class PreferencesSearchView : SearchPreferenceActionView {
     constructor(context: Context?) : super(context)
     constructor(context: Context?, attrs: AttributeSet?) : super(context, attrs)
     constructor(context: Context?, attrs: AttributeSet?, defStyleAttr: Int) : super(context, attrs, defStyleAttr)
+
+    fun setSearchConfiguration(searchConfiguration: SearchConfiguration) {
+        this.searchConfiguration = searchConfiguration
+        this.searchConfiguration.setSearchBarEnabled(false)
+    }
 
     // Close the SearchPreferenceFragment in case the user taps on the toolbar's back button
     override fun onActionViewCollapsed() {

--- a/AnkiDroid/src/test/java/com/ichi2/anki/preferences/SettingsSearchBarTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/preferences/SettingsSearchBarTest.kt
@@ -34,7 +34,7 @@ class SettingsSearchBarTest : RobolectricTest() {
     @Suppress("UNCHECKED_CAST")
     fun `All indexed XML resIDs lead to the correct fragments on getFragmentFromXmlRes`() {
         val preferencesActivity = getPreferencesActivity()
-        val searchConfig = preferencesActivity.configureSearchBar(SearchConfiguration(preferencesActivity))
+        val searchConfig = preferencesActivity.searchConfiguration
 
         // Use reflection to access some private fields
         val filesToIndexField = getJavaFieldAsAccessible(SearchConfiguration::class.java, "filesToIndex")


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
On the 2.3.0 version of SearchPreference, the visibility of SearchConfiguration is now protected instead of private.

This allows saving and setting the search bar configuration instead of recreating it every time the menu is recreated, which happens when any fragment is opened

And about the search history: It was disabled before because the saved entries weren't good (see https://github.com/ByteHamster/SearchPreference/issues/25)

## Approach
On the commits

## How Has This Been Tested?

Settings > Tap the search icon > search something and tap an option > tap the search icon again > see the history

![image](https://user-images.githubusercontent.com/69634269/188272464-2e738897-8c98-4434-92d5-4a671b115466.png)


## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
