### PR TITLE
Simplify HashUtil method when possible

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
@@ -99,7 +99,7 @@ import com.ichi2.utils.ClipboardUtil.getText
 import com.ichi2.utils.Computation
 import com.ichi2.utils.HandlerUtils.executeFunctionWithDelay
 import com.ichi2.utils.HandlerUtils.newHandler
-import com.ichi2.utils.HashUtil.HashSetInit
+import com.ichi2.utils.HashSetInit
 import com.ichi2.utils.KotlinCleanup
 import com.ichi2.utils.WebViewDebugging.initializeDebugging
 import com.ichi2.utils.iconAttr

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardUtils.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardUtils.kt
@@ -4,7 +4,6 @@ package com.ichi2.anki
 import com.ichi2.anki.servicelayer.NoteService.isMarked
 import com.ichi2.libanki.Card
 import com.ichi2.libanki.Note
-import com.ichi2.utils.HashSetInit
 import java.util.*
 
 /**
@@ -14,13 +13,7 @@ object CardUtils {
     /**
      * @return List of corresponding notes without duplicates, even if the input list has multiple cards of the same note.
      */
-    fun getNotes(cards: Collection<Card>): Set<Note> {
-        val notes: MutableSet<Note> = HashSetInit(cards.size)
-        for (card in cards) {
-            notes.add(card.note())
-        }
-        return notes
-    }
+    fun getNotes(cards: Collection<Card>) = cards.map { it.note() }.toSet()
 
     /**
      * @return All cards of all notes

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardUtils.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardUtils.kt
@@ -4,7 +4,7 @@ package com.ichi2.anki
 import com.ichi2.anki.servicelayer.NoteService.isMarked
 import com.ichi2.libanki.Card
 import com.ichi2.libanki.Note
-import com.ichi2.utils.HashUtil.HashSetInit
+import com.ichi2.utils.HashSetInit
 import java.util.*
 
 /**

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
@@ -142,7 +142,7 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
     private var mAllModelIds: ArrayList<Long>? = null
     @KotlinCleanup("this ideally should be Int, Int?")
     private var mModelChangeFieldMap: MutableMap<Int, Int>? = null
-    private var mModelChangeCardMap: HashMap<Int, Int?>? = null
+    private var mModelChangeCardMap: MutableMap<Int, Int?>? = null
     private val mCustomViewIds = ArrayList<Int>()
 
     /* indicates if a new note is added or a card is edited */
@@ -1735,7 +1735,7 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
     private val toolbarButtons: ArrayList<CustomToolbarButton>
         get() {
             val set = AnkiDroidApp.getSharedPrefs(this)
-                .getStringSet(PREF_NOTE_EDITOR_CUSTOM_BUTTONS, HashUtil.HashSetInit(0))
+                .getStringSet(PREF_NOTE_EDITOR_CUSTOM_BUTTONS, HashSetInit(0))
             return CustomToolbarButton.fromStringSet(set!!)
         }
 
@@ -1989,13 +1989,13 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
                 }
                 // Initialize mapping between fields of old model -> new model
                 val itemsLength = mEditorNote!!.items().size
-                mModelChangeFieldMap = HashUtil.HashMapInit(itemsLength)
+                mModelChangeFieldMap = HashMapInit(itemsLength)
                 for (i in 0 until itemsLength) {
                     mModelChangeFieldMap!![i] = i
                 }
                 // Initialize mapping between cards new model -> old model
                 val templatesLength = tmpls.length()
-                mModelChangeCardMap = HashUtil.HashMapInit(templatesLength)
+                mModelChangeCardMap = HashMapInit(templatesLength)
                 for (i in 0 until templatesLength) {
                     if (i < mEditorNote!!.numberOfCards()) {
                         mModelChangeCardMap!![i] = i

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
@@ -1735,7 +1735,7 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
     private val toolbarButtons: ArrayList<CustomToolbarButton>
         get() {
             val set = AnkiDroidApp.getSharedPrefs(this)
-                .getStringSet(PREF_NOTE_EDITOR_CUSTOM_BUTTONS, HashSetInit(0))
+                .getStringSet(PREF_NOTE_EDITOR_CUSTOM_BUTTONS, setOf())
             return CustomToolbarButton.fromStringSet(set!!)
         }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/customstudy/CustomStudyDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/customstudy/CustomStudyDialog.kt
@@ -51,7 +51,7 @@ import com.ichi2.libanki.Consts.DYN_PRIORITY
 import com.ichi2.libanki.Deck
 import com.ichi2.libanki.DeckId
 import com.ichi2.libanki.backend.exception.DeckRenameException
-import com.ichi2.utils.HashUtil.HashMapInit
+import com.ichi2.utils.HashMapInit
 import com.ichi2.utils.JSONArray
 import com.ichi2.utils.JSONObject
 import com.ichi2.utils.KotlinCleanup
@@ -157,7 +157,7 @@ class CustomStudyDialog(private val collection: Collection, private val customSt
     }
 
     @KotlinCleanup("make this use enum instead of Int")
-    fun getValuesFromKeys(map: HashMap<Int, String>, keys: IntArray): Array<String?> {
+    fun getValuesFromKeys(map: Map<Int, String>, keys: IntArray): Array<String?> {
         val values = arrayOfNulls<String>(keys.size)
         for (i in keys.indices) {
             values[i] = map[keys[i]]
@@ -292,7 +292,7 @@ class CustomStudyDialog(private val collection: Collection, private val customSt
         return dialog
     }
 
-    private val keyValueMap: HashMap<Int, String>
+    private val keyValueMap: Map<Int, String>
         get() {
             val res = resources
             val keyValueMap = HashMapInit<Int, String>(10)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/customstudy/CustomStudyDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/customstudy/CustomStudyDialog.kt
@@ -51,7 +51,6 @@ import com.ichi2.libanki.Consts.DYN_PRIORITY
 import com.ichi2.libanki.Deck
 import com.ichi2.libanki.DeckId
 import com.ichi2.libanki.backend.exception.DeckRenameException
-import com.ichi2.utils.HashMapInit
 import com.ichi2.utils.JSONArray
 import com.ichi2.utils.JSONObject
 import com.ichi2.utils.KotlinCleanup
@@ -295,18 +294,18 @@ class CustomStudyDialog(private val collection: Collection, private val customSt
     private val keyValueMap: Map<Int, String>
         get() {
             val res = resources
-            val keyValueMap = HashMapInit<Int, String>(10)
-            keyValueMap[STANDARD.value] = res.getString(R.string.custom_study)
-            keyValueMap[STUDY_NEW.value] = res.getString(R.string.custom_study_increase_new_limit)
-            keyValueMap[STUDY_REV.value] = res.getString(R.string.custom_study_increase_review_limit)
-            keyValueMap[STUDY_FORGOT.value] = res.getString(R.string.custom_study_review_forgotten)
-            keyValueMap[STUDY_AHEAD.value] = res.getString(R.string.custom_study_review_ahead)
-            keyValueMap[STUDY_RANDOM.value] = res.getString(R.string.custom_study_random_selection)
-            keyValueMap[STUDY_PREVIEW.value] = res.getString(R.string.custom_study_preview_new)
-            keyValueMap[STUDY_TAGS.value] = res.getString(R.string.custom_study_limit_tags)
-            keyValueMap[DECK_OPTIONS.value] = res.getString(R.string.menu__deck_options)
-            keyValueMap[MORE_OPTIONS.value] = res.getString(R.string.more_options)
-            return keyValueMap
+            return mapOf(
+                STANDARD.value to res.getString(R.string.custom_study),
+                STUDY_NEW.value to res.getString(R.string.custom_study_increase_new_limit),
+                STUDY_REV.value to res.getString(R.string.custom_study_increase_review_limit),
+                STUDY_FORGOT.value to res.getString(R.string.custom_study_review_forgotten),
+                STUDY_AHEAD.value to res.getString(R.string.custom_study_review_ahead),
+                STUDY_RANDOM.value to res.getString(R.string.custom_study_random_selection),
+                STUDY_PREVIEW.value to res.getString(R.string.custom_study_preview_new),
+                STUDY_TAGS.value to res.getString(R.string.custom_study_limit_tags),
+                DECK_OPTIONS.value to res.getString(R.string.menu__deck_options),
+                MORE_OPTIONS.value to res.getString(R.string.more_options)
+            )
         }
 
     /**

--- a/AnkiDroid/src/main/java/com/ichi2/anki/noteeditor/CustomToolbarButton.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/noteeditor/CustomToolbarButton.kt
@@ -18,7 +18,7 @@ package com.ichi2.anki.noteeditor
 import android.text.TextUtils
 import com.ichi2.anki.noteeditor.Toolbar.TextWrapper
 import com.ichi2.libanki.Consts
-import com.ichi2.utils.HashUtil.HashSetInit
+import com.ichi2.utils.HashSetInit
 import timber.log.Timber
 import java.util.*
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/noteeditor/CustomToolbarButton.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/noteeditor/CustomToolbarButton.kt
@@ -18,7 +18,6 @@ package com.ichi2.anki.noteeditor
 import android.text.TextUtils
 import com.ichi2.anki.noteeditor.Toolbar.TextWrapper
 import com.ichi2.libanki.Consts
-import com.ichi2.utils.HashSetInit
 import timber.log.Timber
 import java.util.*
 
@@ -63,16 +62,7 @@ class CustomToolbarButton(var index: Int, var buttonText: ButtonText, val prefix
             return buttons
         }
 
-        fun toStringSet(buttons: ArrayList<CustomToolbarButton>): Set<String> {
-            val ret = HashSetInit<String>(buttons.size)
-            for (b in buttons) {
-                val values = arrayOf(b.index.toString(), b.buttonText, b.prefix, b.suffix)
-                for (i in values.indices) {
-                    values[i] = values[i].replace(Consts.FIELD_SEPARATOR, "")
-                }
-                ret.add(TextUtils.join(Consts.FIELD_SEPARATOR, values))
-            }
-            return ret
-        }
+        fun toStringSet(buttons: ArrayList<CustomToolbarButton>) =
+            buttons.map { b -> TextUtils.join(Consts.FIELD_SEPARATOR, listOf(b.index.toString(), b.buttonText, b.prefix, b.suffix).map { it.replace(Consts.FIELD_SEPARATOR, "") }) }.toSet()
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/ActionButtonStatus.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/ActionButtonStatus.kt
@@ -22,7 +22,7 @@ import android.view.MenuItem
 import androidx.annotation.IdRes
 import com.ichi2.anki.R
 import com.ichi2.themes.Themes
-import com.ichi2.utils.HashUtil.HashMapInit
+import com.ichi2.utils.HashMapInit
 import timber.log.Timber
 
 // loads of unboxing issues, which are safe

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/ReviewerCustomFonts.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/ReviewerCustomFonts.kt
@@ -21,7 +21,7 @@ import android.text.TextUtils
 import com.ichi2.anki.AnkiDroidApp
 import com.ichi2.anki.AnkiFont
 import com.ichi2.libanki.Utils
-import com.ichi2.utils.HashUtil.HashMapInit
+import com.ichi2.utils.HashMapInit
 
 class ReviewerCustomFonts(context: Context) {
     private val mCustomStyle: String

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/ReviewerCustomFonts.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/ReviewerCustomFonts.kt
@@ -21,7 +21,6 @@ import android.text.TextUtils
 import com.ichi2.anki.AnkiDroidApp
 import com.ichi2.anki.AnkiFont
 import com.ichi2.libanki.Utils
-import com.ichi2.utils.HashMapInit
 
 class ReviewerCustomFonts(context: Context) {
     private val mCustomStyle: String
@@ -37,7 +36,7 @@ class ReviewerCustomFonts(context: Context) {
      *
      * @return the default font style, or the empty string if no default font is set
      */
-    private fun getDefaultFontStyle(context: Context, customFontsMap: Map<String?, AnkiFont>): String? {
+    private fun getDefaultFontStyle(context: Context, customFontsMap: Map<String, AnkiFont>): String? {
         if (mDefaultFontStyle == null) {
             val preferences = AnkiDroidApp.getSharedPrefs(context)
             val defaultFont = customFontsMap[preferences.getString("defaultFont", null)]
@@ -56,7 +55,7 @@ class ReviewerCustomFonts(context: Context) {
      *
      * @return the override font style, or the empty string if no override font is set
      */
-    private fun getOverrideFontStyle(context: Context, customFontsMap: Map<String?, AnkiFont>): String? {
+    private fun getOverrideFontStyle(context: Context, customFontsMap: Map<String, AnkiFont>): String? {
         if (mOverrideFontStyle == null) {
             val preferences = AnkiDroidApp.getSharedPrefs(context)
             val defaultFont = customFontsMap[preferences.getString("defaultFont", null)]
@@ -76,7 +75,7 @@ class ReviewerCustomFonts(context: Context) {
      *
      * @return the font style, or the empty string if none applies
      */
-    private fun getDominantFontStyle(context: Context, customFontsMap: Map<String?, AnkiFont>): String? {
+    private fun getDominantFontStyle(context: Context, customFontsMap: Map<String, AnkiFont>): String? {
         if (mDominantFontStyle == null) {
             mDominantFontStyle = getOverrideFontStyle(context, customFontsMap)
             if (TextUtils.isEmpty(mDominantFontStyle)) {
@@ -104,7 +103,7 @@ class ReviewerCustomFonts(context: Context) {
          * <p>
          * Each font is mapped to the font family by the same name as the name of the font without the extension.
          */
-        private fun getCustomFontsStyle(customFontsMap: Map<String?, AnkiFont>): String {
+        private fun getCustomFontsStyle(customFontsMap: Map<String, AnkiFont>): String {
             val builder = StringBuilder()
             for (font in customFontsMap.values) {
                 builder.append(font.declaration)
@@ -118,14 +117,7 @@ class ReviewerCustomFonts(context: Context) {
          * <p>
          * The list of constructed lazily the first time is needed.
          */
-        private fun getCustomFontsMap(context: Context): Map<String?, AnkiFont> {
-            val fonts = Utils.getCustomFonts(context)
-            val customFontsMap: MutableMap<String?, AnkiFont> = HashMapInit(fonts.size)
-            for (f in fonts) {
-                customFontsMap[f.name] = f
-            }
-            return customFontsMap
-        }
+        private fun getCustomFontsMap(context: Context): Map<String, AnkiFont> = Utils.getCustomFonts(context).associateBy { it.name }
     }
 
     init {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/PreferenceUpgradeService.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/PreferenceUpgradeService.kt
@@ -33,7 +33,6 @@ import com.ichi2.anki.reviewer.MappableBinding
 import com.ichi2.anki.web.CustomSyncServer
 import com.ichi2.libanki.Consts
 import com.ichi2.themes.Themes
-import com.ichi2.utils.HashSetInit
 import timber.log.Timber
 
 private typealias VersionIdentifier = Int
@@ -215,7 +214,7 @@ object PreferenceUpgradeService {
 
             private fun getNewToolbarButtons(preferences: SharedPreferences): ArrayList<CustomToolbarButton> {
                 // get old toolbar prefs
-                val set = preferences.getStringSet("note_editor_custom_buttons", HashSetInit<String>(0)) as Set<String?>
+                val set = preferences.getStringSet("note_editor_custom_buttons", setOf()) as Set<String?>
                 // new list with buttons size
                 val buttons = ArrayList<CustomToolbarButton>(set.size)
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/PreferenceUpgradeService.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/PreferenceUpgradeService.kt
@@ -33,7 +33,7 @@ import com.ichi2.anki.reviewer.MappableBinding
 import com.ichi2.anki.web.CustomSyncServer
 import com.ichi2.libanki.Consts
 import com.ichi2.themes.Themes
-import com.ichi2.utils.HashUtil.HashSetInit
+import com.ichi2.utils.HashSetInit
 import timber.log.Timber
 
 private typealias VersionIdentifier = Int

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.kt
@@ -58,7 +58,6 @@ import com.ichi2.libanki.utils.TimeManager
 import com.ichi2.upgrade.Upgrade
 import com.ichi2.utils.*
 import com.ichi2.utils.HashMapInit
-import com.ichi2.utils.HashSetInit
 import net.ankiweb.rsdroid.Backend
 import net.ankiweb.rsdroid.RustCleanup
 import org.jetbrains.annotations.Contract
@@ -1102,11 +1101,7 @@ open class Collection(
         var qfmt = qfmtParam
         var afmt = afmtParam
         val fmap = Models.fieldMap(model)
-        val maps: Set<Map.Entry<String, Pair<Int, JSONObject>>> = fmap.entries
-        val fields: MutableMap<String, String> = HashMapInit(maps.size + 8)
-        for ((key, value) in maps) {
-            fields[key] = flist[value.first]
-        }
+        val fields: MutableMap<String, String> = fmap.mapValues { flist[it.value.first] }.toMutableMap()
         val cardNum = ord + 1
         fields["Tags"] = tags.trim { it <= ' ' }
         fields["Type"] = model.getString("name")
@@ -1696,10 +1691,7 @@ open class Collection(
 
         // obtain a list of all valid dconf IDs
         val allConf = decks.allConf()
-        val configIds = HashSetInit<Long>(allConf.size)
-        for (conf in allConf) {
-            configIds.add(conf.getLong("id"))
-        }
+        val configIds = allConf.map { conf -> conf.getLong("id") }.toSet()
         notifyProgress.run()
         @KotlinCleanup("use count { }")
         var changed = 0

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.kt
@@ -57,6 +57,8 @@ import com.ichi2.libanki.utils.Time
 import com.ichi2.libanki.utils.TimeManager
 import com.ichi2.upgrade.Upgrade
 import com.ichi2.utils.*
+import com.ichi2.utils.HashMapInit
+import com.ichi2.utils.HashSetInit
 import net.ankiweb.rsdroid.Backend
 import net.ankiweb.rsdroid.RustCleanup
 import org.jetbrains.annotations.Contract
@@ -768,11 +770,11 @@ open class Collection(
     ): ArrayList<Long>? where T : ProgressSender<Int>?, T : CancelListener? {
         val nbCount = noteCount()
         // For each note, indicates ords of cards it contains
-        val have = HashUtil.HashMapInit<Long, HashMap<Int, Long>>(nbCount)
+        val have = HashMapInit<Long, HashMap<Int, Long>>(nbCount)
         // For each note, the deck containing all of its cards, or 0 if siblings in multiple deck
-        val dids = HashUtil.HashMapInit<Long, Long>(nbCount)
+        val dids = HashMapInit<Long, Long>(nbCount)
         // For each note, an arbitrary due of one of its due card processed, if any exists
-        val dues = HashUtil.HashMapInit<Long, Long>(nbCount)
+        val dues = HashMapInit<Long, Long>(nbCount)
         var nodes: List<ParsedNode?>? = null
         if (model.getInt("type") != Consts.MODEL_CLOZE) {
             nodes = model.parsedNodes()
@@ -1078,7 +1080,7 @@ open class Collection(
         tags: String,
         flist: Array<String>,
         flags: Int
-    ): HashMap<String, String> {
+    ): Map<String, String> {
         return _renderQA(cid, model, did, ord, tags, flist, flags, false, null, null)
     }
 
@@ -1094,14 +1096,14 @@ open class Collection(
         browser: Boolean,
         qfmtParam: String?,
         afmtParam: String?
-    ): HashMap<String, String> {
+    ): Map<String, String> {
         // data is [cid, nid, mid, did, ord, tags, flds, cardFlags]
         // unpack fields and create dict
         var qfmt = qfmtParam
         var afmt = afmtParam
         val fmap = Models.fieldMap(model)
         val maps: Set<Map.Entry<String, Pair<Int, JSONObject>>> = fmap.entries
-        val fields: MutableMap<String, String> = HashUtil.HashMapInit(maps.size + 8)
+        val fields: MutableMap<String, String> = HashMapInit(maps.size + 8)
         for ((key, value) in maps) {
             fields[key] = flist[value.first]
         }
@@ -1120,7 +1122,7 @@ open class Collection(
         fields["Card"] = template.getString("name")
         fields[String.format(Locale.US, "c%d", cardNum)] = "1"
         // render q & a
-        val d = HashUtil.HashMapInit<String, String>(2)
+        val d = HashMapInit<String, String>(2)
         d["id"] = cid.toString()
         qfmt = if (qfmt.isNullOrEmpty()) template.getString("qfmt") else qfmt
         afmt = if (afmt.isNullOrEmpty()) template.getString("afmt") else afmt
@@ -1390,7 +1392,7 @@ open class Collection(
         } else {
             c.did
         }
-        val qa: HashMap<String, String> = if (browser) {
+        val qa: Map<String, String> = if (browser) {
             val bqfmt = t.getString("bqfmt")
             val bafmt = t.getString("bafmt")
             _renderQA(
@@ -1694,7 +1696,7 @@ open class Collection(
 
         // obtain a list of all valid dconf IDs
         val allConf = decks.allConf()
-        val configIds = HashUtil.HashSetInit<Long>(allConf.size)
+        val configIds = HashSetInit<Long>(allConf.size)
         for (conf in allConf) {
             configIds.add(conf.getLong("id"))
         }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.kt
@@ -32,7 +32,7 @@ import com.ichi2.libanki.backend.exception.DeckRenameException
 import com.ichi2.libanki.utils.TimeManager.time
 import com.ichi2.utils.*
 import com.ichi2.utils.CollectionUtils.addAll
-import com.ichi2.utils.HashUtil.HashMapInit
+import com.ichi2.utils.HashMapInit
 import net.ankiweb.rsdroid.RustCleanup
 import org.intellij.lang.annotations.Language
 import timber.log.Timber
@@ -51,9 +51,9 @@ class Decks(private val col: Collection) : DeckManager() {
     @get:RustCleanup("This exists in Rust as DecksDictProxy, but its usage is warned against")
     @KotlinCleanup("lateinit")
     @get:VisibleForTesting
-    var decks: HashMap<Long, Deck>? = null
+    var decks: MutableMap<Long, Deck>? = null
         private set
-    private var mDconf: HashMap<Long, DeckConfig>? = null
+    private var mDconf: MutableMap<Long, DeckConfig>? = null
 
     // Never access mNameMap directly. Uses byName
     @KotlinCleanup("lateinit (it's set in load)")
@@ -66,7 +66,7 @@ class Decks(private val col: Collection) : DeckManager() {
      */
     @KotlinCleanup("nullability")
     private class NameMap private constructor(size: Int) {
-        private val mNameMap: HashMap<String?, Deck>
+        private val mNameMap: MutableMap<String?, Deck>
 
         /**
          * @param name A name of deck to get

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.kt
@@ -39,6 +39,7 @@ import timber.log.Timber
 import java.text.Normalizer
 import java.util.*
 import java.util.regex.Pattern
+import kotlin.collections.HashMap
 
 // fixmes:
 // - make sure users can't set grad interval < 1
@@ -150,24 +151,14 @@ class Decks(private val col: Collection) : DeckManager() {
     override fun load(@Language("JSON") decks: String, dconf: String) {
         val decksarray = JSONObject(decks)
         var ids = decksarray.names()
-        this.decks = HashMapInit(decksarray.length())
-        if (ids != null) {
-            for (id in ids.stringIterable()) {
-                val o = Deck(decksarray.getJSONObject(id))
-                val longId = id.toLong()
-                this.decks!!.put(longId, o)
-            }
-        }
+        this.decks =
+            ids?.stringIterable()?.associate { id -> id.toLong() to Deck(decksarray.getJSONObject(id)) }
+                ?.toMutableMap()
+                ?: HashMap()
         mNameMap = NameMap.constructor(this.decks!!.values)
         val confarray = JSONObject(dconf)
         ids = confarray.names()
-        mDconf = HashMapInit(confarray.length())
-        if (ids != null) {
-            for (id in ids.stringIterable()) {
-                mDconf!![id.toLong()] =
-                    DeckConfig(confarray.getJSONObject(id), DeckConfig.Source.DECK_CONFIG)
-            }
-        }
+        mDconf = ids?.stringIterable()?.associate { id -> id.toLong() to DeckConfig(confarray.getJSONObject(id), DeckConfig.Source.DECK_CONFIG) }?.toMutableMap() ?: HashMap()
         mChanged = false
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Finder.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Finder.kt
@@ -25,7 +25,7 @@ import androidx.annotation.CheckResult
 import com.ichi2.libanki.SortOrder.*
 import com.ichi2.libanki.stats.Stats
 import com.ichi2.libanki.utils.TimeManager.time
-import com.ichi2.utils.HashUtil.HashMapInit
+import com.ichi2.utils.HashMapInit
 import com.ichi2.utils.JSONObject
 import com.ichi2.utils.KotlinCleanup
 import net.ankiweb.rsdroid.RustCleanup

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Media.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Media.kt
@@ -25,7 +25,7 @@ import com.ichi2.anki.CrashReportService
 import com.ichi2.libanki.exception.EmptyMediaException
 import com.ichi2.libanki.template.TemplateFilters
 import com.ichi2.utils.*
-import com.ichi2.utils.HashUtil.HashMapInit
+import com.ichi2.utils.HashMapInit
 import timber.log.Timber
 import java.io.*
 import java.util.*

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Model.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Model.kt
@@ -20,7 +20,7 @@ import android.text.TextUtils
 import androidx.annotation.CheckResult
 import com.ichi2.libanki.template.ParsedNode
 import com.ichi2.libanki.template.TemplateError
-import com.ichi2.utils.HashUtil
+import com.ichi2.utils.HashSetInit
 import com.ichi2.utils.JSONObject
 import com.ichi2.utils.KotlinCleanup
 import timber.log.Timber
@@ -89,7 +89,7 @@ class Model : JSONObject {
     @KotlinCleanup("filter")
     fun nonEmptyFields(sfld: Array<String>): Set<String> {
         val fieldNames = fieldsNames
-        val nonemptyFields: MutableSet<String> = HashUtil.HashSetInit(sfld.size)
+        val nonemptyFields: MutableSet<String> = HashSetInit(sfld.size)
         for (i in sfld.indices) {
             if (!TextUtils.isEmpty(sfld[i].trim { it <= ' ' })) {
                 nonemptyFields.add(fieldNames[i])

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Model.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Model.kt
@@ -20,7 +20,6 @@ import android.text.TextUtils
 import androidx.annotation.CheckResult
 import com.ichi2.libanki.template.ParsedNode
 import com.ichi2.libanki.template.TemplateError
-import com.ichi2.utils.HashSetInit
 import com.ichi2.utils.JSONObject
 import com.ichi2.utils.KotlinCleanup
 import timber.log.Timber
@@ -89,13 +88,7 @@ class Model : JSONObject {
     @KotlinCleanup("filter")
     fun nonEmptyFields(sfld: Array<String>): Set<String> {
         val fieldNames = fieldsNames
-        val nonemptyFields: MutableSet<String> = HashSetInit(sfld.size)
-        for (i in sfld.indices) {
-            if (!TextUtils.isEmpty(sfld[i].trim { it <= ' ' })) {
-                nonemptyFields.add(fieldNames[i])
-            }
-        }
-        return nonemptyFields
+        return sfld.indices.filter { i -> !TextUtils.isEmpty(sfld[i].trim { it <= ' ' }) }.map { i -> fieldNames[i] }.toSet()
     }
 
     /**

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Models.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Models.kt
@@ -25,7 +25,7 @@ import com.ichi2.anki.exception.ConfirmModSchemaException
 import com.ichi2.libanki.template.ParsedNode
 import com.ichi2.libanki.template.TemplateError
 import com.ichi2.libanki.utils.TimeManager.time
-import com.ichi2.utils.HashUtil.HashMapInit
+import com.ichi2.utils.HashMapInit
 import com.ichi2.utils.JSONArray
 import com.ichi2.utils.JSONObject
 import com.ichi2.utils.KotlinCleanup
@@ -791,9 +791,9 @@ class Models(col: Collection) : ModelManager(col) {
         mChanged = true
     }
 
-    val templateNames: HashMap<Long, HashMap<Int, String>>
+    val templateNames: Map<Long, Map<Int, String>>
         get() {
-            val result = HashMapInit<Long, HashMap<Int, String>>(
+            val result = HashMapInit<Long, Map<Int, String>>(
                 mModels!!.size
             )
             for (m in mModels!!.values) {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Utils.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Utils.kt
@@ -35,8 +35,6 @@ import com.ichi2.anki.CollectionHelper
 import com.ichi2.anki.R
 import com.ichi2.compat.CompatHelper.Companion.compat
 import com.ichi2.libanki.Consts.FIELD_SEPARATOR
-import com.ichi2.utils.HashMapInit
-import com.ichi2.utils.HashSetInit
 import com.ichi2.utils.ImportUtils.isValidPackageName
 import com.ichi2.utils.JSONArray
 import com.ichi2.utils.JSONException
@@ -724,7 +722,7 @@ object Utils {
             throw IOException("Failed to create target directory: $targetDirectory")
         }
         if (zipEntryToFilenameMap == null) {
-            zipEntryToFilenameMap = HashMapInit(0)
+            zipEntryToFilenameMap = mapOf()
         }
         for (requestedEntry in zipEntries) {
             val ze = zipFile.getEntry(requestedEntry)
@@ -1126,15 +1124,6 @@ object Utils {
      * @return The set of non empty field values.
      */
     @KotlinCleanup("remove TextUtils at least. Maybe .filter { }")
-    fun nonEmptyFields(fields: Map<String, String>): Set<String> {
-        val nonempty_fields: MutableSet<String> = HashSetInit(fields.size)
-        for (kv in fields.entries) {
-            var value = kv.value
-            value = stripHTMLMedia(value).trim { it <= ' ' }
-            if (!TextUtils.isEmpty(value)) {
-                nonempty_fields.add(kv.key)
-            }
-        }
-        return nonempty_fields
-    }
+    fun nonEmptyFields(fields: Map<String, String>) =
+        fields.entries.filter { kv -> !TextUtils.isEmpty(stripHTMLMedia(kv.value).trim()) }.map { it.key }.toSet()
 }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Utils.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Utils.kt
@@ -35,8 +35,8 @@ import com.ichi2.anki.CollectionHelper
 import com.ichi2.anki.R
 import com.ichi2.compat.CompatHelper.Companion.compat
 import com.ichi2.libanki.Consts.FIELD_SEPARATOR
-import com.ichi2.utils.HashUtil.HashMapInit
-import com.ichi2.utils.HashUtil.HashSetInit
+import com.ichi2.utils.HashMapInit
+import com.ichi2.utils.HashSetInit
 import com.ichi2.utils.ImportUtils.isValidPackageName
 import com.ichi2.utils.JSONArray
 import com.ichi2.utils.JSONException

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/importer/Anki2Importer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/importer/Anki2Importer.kt
@@ -34,7 +34,8 @@ import com.ichi2.libanki.Consts.QUEUE_TYPE_NEW
 import com.ichi2.libanki.Consts.QUEUE_TYPE_REV
 import com.ichi2.libanki.Storage.collection
 import com.ichi2.libanki.utils.TimeManager
-import com.ichi2.utils.HashUtil
+import com.ichi2.utils.HashMapInit
+import com.ichi2.utils.HashSetInit
 import com.ichi2.utils.KotlinCleanup
 import timber.log.Timber
 import java.io.BufferedInputStream
@@ -100,7 +101,7 @@ open class Anki2Importer(col: Collection?, file: String) : Importer(col!!, file)
     }
 
     private fun _import() {
-        mDecks = HashUtil.HashMapInit(src.decks.count())
+        mDecks = HashMapInit(src.decks.count())
         try {
             // Use transactions for performance and rollbacks in case of error
             dst.db.database.beginTransaction()
@@ -170,8 +171,8 @@ open class Anki2Importer(col: Collection?, file: String) : Importer(col!!, file)
     private fun _importNotes() {
         val noteCount = dst.noteCount()
         // build guid -> (id,mod,mid) hash & map of existing note ids
-        mNotes = HashUtil.HashMapInit(noteCount)
-        val existing: MutableSet<Long> = HashUtil.HashSetInit(noteCount)
+        mNotes = HashMapInit(noteCount)
+        val existing: MutableSet<Long> = HashSetInit(noteCount)
         dst.db.query("select id, guid, mod, mid from notes").use { cur ->
             while (cur.moveToNext()) {
                 val id = cur.getLong(0)
@@ -367,7 +368,7 @@ open class Anki2Importer(col: Collection?, file: String) : Importer(col!!, file)
      */
     /** Prepare index of schema hashes.  */
     private fun _prepareModels() {
-        mModelMap = HashUtil.HashMapInit(src.models.count())
+        mModelMap = HashMapInit(src.models.count())
     }
 
     /** Return local id for remote MID.  */
@@ -486,8 +487,8 @@ open class Anki2Importer(col: Collection?, file: String) : Importer(col!!, file)
          * Java: guid -> ord -> cid
          */
         val nbCard = dst.cardCount()
-        val cardsByGuid: MutableMap<String, MutableMap<Int, Long>> = HashUtil.HashMapInit(nbCard)
-        val existing: MutableSet<Long> = HashUtil.HashSetInit(nbCard)
+        val cardsByGuid: MutableMap<String, MutableMap<Int, Long>> = HashMapInit(nbCard)
+        val existing: MutableSet<Long> = HashSetInit(nbCard)
         dst.db.query(
             "select f.guid, c.ord, c.id from cards c, notes f " +
                 "where c.nid = f.id"

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/importer/AnkiPackageImporter.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/importer/AnkiPackageImporter.kt
@@ -27,7 +27,7 @@ import com.ichi2.anki.exception.ImportExportException
 import com.ichi2.libanki.Collection
 import com.ichi2.libanki.Storage
 import com.ichi2.libanki.Utils
-import com.ichi2.utils.HashUtil.HashMapInit
+import com.ichi2.utils.HashMapInit
 import com.ichi2.utils.KotlinCleanup
 import org.apache.commons.compress.archivers.zip.ZipFile
 import timber.log.Timber

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/importer/AnkiPackageImporter.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/importer/AnkiPackageImporter.kt
@@ -27,7 +27,6 @@ import com.ichi2.anki.exception.ImportExportException
 import com.ichi2.libanki.Collection
 import com.ichi2.libanki.Storage
 import com.ichi2.libanki.Utils
-import com.ichi2.utils.HashMapInit
 import com.ichi2.utils.KotlinCleanup
 import org.apache.commons.compress.archivers.zip.ZipFile
 import timber.log.Timber
@@ -83,8 +82,7 @@ class AnkiPackageImporter(col: Collection?, file: String?) : Anki2Importer(col!!
                 // The filename that we extract should be collection.anki2
                 // Importing collection.anki21 fails due to some media regexes expecting collection.anki2.
                 // We follow how Anki does it and fix the problem here.
-                val mediaToFileNameMap = HashMapInit<String, String>(1)
-                mediaToFileNameMap[colname] = CollectionHelper.COLLECTION_FILENAME
+                val mediaToFileNameMap = mapOf(colname to CollectionHelper.COLLECTION_FILENAME)
                 Utils.unzipFiles(mZip!!, tempDir.absolutePath, arrayOf(colname, "media"), mediaToFileNameMap)
                 colname = CollectionHelper.COLLECTION_FILENAME
             } catch (e: IOException) {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Sched.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Sched.kt
@@ -34,6 +34,11 @@ import com.ichi2.libanki.sched.Counts.Queue
 import com.ichi2.libanki.sched.Counts.Queue.*
 import com.ichi2.libanki.stats.Stats.Companion.SECONDS_PER_DAY
 import com.ichi2.utils.*
+import com.ichi2.utils.Assert.that
+import com.ichi2.utils.HashMapInit
+import com.ichi2.utils.JSONException
+import com.ichi2.utils.JSONObject
+import com.ichi2.utils.KotlinCleanup
 import com.ichi2.utils.SyncStatus.Companion.ignoreDatabaseModification
 import timber.log.Timber
 import java.util.*
@@ -154,7 +159,7 @@ class Sched(col: Collection) : SchedV2(col) {
         col.decks.checkIntegrity()
         val allDecksSorted = col.decks.allSorted()
         @KotlinCleanup("input should be non-null")
-        val lims = HashUtil.HashMapInit<String?, Array<Int>>(allDecksSorted.size)
+        val lims = HashMapInit<String?, Array<Int>>(allDecksSorted.size)
         val deckNodes = ArrayList<DeckDueTreeNode>(allDecksSorted.size)
         for (deck in allDecksSorted) {
             if (isCancelled(collectionTask)) {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.kt
@@ -43,6 +43,7 @@ import com.ichi2.libanki.stats.Stats
 import com.ichi2.libanki.utils.Time
 import com.ichi2.libanki.utils.TimeManager
 import com.ichi2.utils.*
+import com.ichi2.utils.HashMapInit
 import net.ankiweb.rsdroid.BackendFactory
 import net.ankiweb.rsdroid.RustCleanup
 import timber.log.Timber
@@ -400,7 +401,7 @@ open class SchedV2(col: Collection) : AbstractSched(col) {
         cancelListener: CancelListener? = null
     ): Int {
         var tot = 0
-        val pcounts = HashUtil.HashMapInit<Long, Int>(col.decks.count())
+        val pcounts = HashMapInit<Long, Int>(col.decks.count())
         // for each of the active decks
         for (did in col.decks.active()) {
             if (isCancelled(cancelListener)) return -1
@@ -453,7 +454,7 @@ open class SchedV2(col: Collection) : AbstractSched(col) {
         _checkDay()
         col.decks.checkIntegrity()
         val allDecksSorted = col.decks.allSorted()
-        val lims = HashUtil.HashMapInit<String?, Array<Int>>(allDecksSorted.size)
+        val lims = HashMapInit<String?, Array<Int>>(allDecksSorted.size)
         val deckNodes = ArrayList<DeckDueTreeNode>(allDecksSorted.size)
         val childMap = col.decks.childMap()
         for (deck in allDecksSorted) {
@@ -2382,7 +2383,7 @@ end)  """
             return
         }
         // determine nid ordering
-        val due = HashUtil.HashMapInit<Long?, Long>(nids.size)
+        val due = HashMapInit<Long?, Long>(nids.size)
         if (shuffle) {
             Collections.shuffle(nids)
         }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.kt
@@ -2383,13 +2383,10 @@ end)  """
             return
         }
         // determine nid ordering
-        val due = HashMapInit<Long?, Long>(nids.size)
         if (shuffle) {
             Collections.shuffle(nids)
         }
-        for (c in nids.indices) {
-            due[nids[c]] = (start + c * step).toLong()
-        }
+        val due = nids.indices.associate { c -> nids[c] to (start + c * step).toLong() }
         val high = start + step * (nids.size - 1)
         // shift?
         if (shift) {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/stats/AdvancedStatistics.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/stats/AdvancedStatistics.kt
@@ -29,7 +29,7 @@ import com.ichi2.libanki.DeckManager
 import com.ichi2.libanki.stats.Stats.AxisType
 import com.ichi2.libanki.utils.Time
 import com.ichi2.libanki.utils.TimeManager.time
-import com.ichi2.utils.HashUtil.HashMapInit
+import com.ichi2.utils.HashMapInit
 import timber.log.Timber
 import java.util.*
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sync/FullSyncer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sync/FullSyncer.kt
@@ -30,7 +30,7 @@ import com.ichi2.libanki.sync.Syncer.ConnectionResultType
 import com.ichi2.libanki.sync.Syncer.ConnectionResultType.ARBITRARY_STRING
 import com.ichi2.libanki.sync.Syncer.ConnectionResultType.OVERWRITE_ERROR
 import com.ichi2.libanki.sync.Syncer.ConnectionResultType.SUCCESS
-import com.ichi2.utils.HashUtil
+import com.ichi2.utils.HashMapInit
 import com.ichi2.utils.KotlinCleanup
 import com.ichi2.utils.VersionUtils.pkgVersionName
 import okhttp3.Response
@@ -49,7 +49,7 @@ class FullSyncer(col: Collection?, hkey: String?, con: Connection, hostNum: Host
     private val mCon: Connection
 
     init {
-        postVars = HashUtil.HashMapInit(2)
+        postVars = HashMapInit(2)
         postVars["k"] = hkey
         postVars["v"] = String.format(Locale.US, "ankidroid,%s,%s", pkgVersionName, Utils.platDesc())
         @KotlinCleanup("move to constructor")

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sync/FullSyncer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sync/FullSyncer.kt
@@ -30,7 +30,6 @@ import com.ichi2.libanki.sync.Syncer.ConnectionResultType
 import com.ichi2.libanki.sync.Syncer.ConnectionResultType.ARBITRARY_STRING
 import com.ichi2.libanki.sync.Syncer.ConnectionResultType.OVERWRITE_ERROR
 import com.ichi2.libanki.sync.Syncer.ConnectionResultType.SUCCESS
-import com.ichi2.utils.HashMapInit
 import com.ichi2.utils.KotlinCleanup
 import com.ichi2.utils.VersionUtils.pkgVersionName
 import okhttp3.Response
@@ -49,9 +48,10 @@ class FullSyncer(col: Collection?, hkey: String?, con: Connection, hostNum: Host
     private val mCon: Connection
 
     init {
-        postVars = HashMapInit(2)
-        postVars["k"] = hkey
-        postVars["v"] = String.format(Locale.US, "ankidroid,%s,%s", pkgVersionName, Utils.platDesc())
+        postVars = mutableMapOf(
+            "k" to hkey,
+            "v" to String.format(Locale.US, "ankidroid,%s,%s", pkgVersionName, Utils.platDesc())
+        )
         @KotlinCleanup("move to constructor")
         mCol = col
         mCon = con

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sync/HttpSyncer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sync/HttpSyncer.kt
@@ -27,7 +27,6 @@ import com.ichi2.anki.web.CustomSyncServer
 import com.ichi2.anki.web.HttpFetcher
 import com.ichi2.async.Connection
 import com.ichi2.libanki.Utils
-import com.ichi2.utils.HashMapInit
 import com.ichi2.utils.KotlinCleanup
 import okhttp3.HttpUrl
 import okhttp3.HttpUrl.Companion.toHttpUrl
@@ -329,7 +328,7 @@ open class HttpSyncer(
         @KotlinCleanup("move to constructor")
         this.con = con
         @KotlinCleanup("combined declaration and initialization")
-        postVars = HashMapInit(0) // New map is created each time it is filled. No need to allocate room
+        postVars = mutableMapOf() // New map is created each time it is filled. No need to allocate room
         @KotlinCleanup("move to constructor")
         mHostNum = hostNum
     }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sync/HttpSyncer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sync/HttpSyncer.kt
@@ -27,7 +27,7 @@ import com.ichi2.anki.web.CustomSyncServer
 import com.ichi2.anki.web.HttpFetcher
 import com.ichi2.async.Connection
 import com.ichi2.libanki.Utils
-import com.ichi2.utils.HashUtil.HashMapInit
+import com.ichi2.utils.HashMapInit
 import com.ichi2.utils.KotlinCleanup
 import okhttp3.HttpUrl
 import okhttp3.HttpUrl.Companion.toHttpUrl

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sync/RemoteMediaServer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sync/RemoteMediaServer.kt
@@ -23,7 +23,7 @@ import com.ichi2.anki.web.CustomSyncServer
 import com.ichi2.async.Connection
 import com.ichi2.libanki.Collection
 import com.ichi2.libanki.Utils
-import com.ichi2.utils.HashUtil.HashMapInit
+import com.ichi2.utils.HashMapInit
 import com.ichi2.utils.JSONArray
 import com.ichi2.utils.JSONObject
 import com.ichi2.utils.VersionUtils.pkgVersionName

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sync/RemoteMediaServer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sync/RemoteMediaServer.kt
@@ -23,7 +23,6 @@ import com.ichi2.anki.web.CustomSyncServer
 import com.ichi2.async.Connection
 import com.ichi2.libanki.Collection
 import com.ichi2.libanki.Utils
-import com.ichi2.utils.HashMapInit
 import com.ichi2.utils.JSONArray
 import com.ichi2.utils.JSONObject
 import com.ichi2.utils.VersionUtils.pkgVersionName
@@ -49,9 +48,10 @@ class RemoteMediaServer(
     @Throws(UnknownHttpResponseException::class, MediaSyncException::class)
     fun begin(): JSONObject {
         return try {
-            postVars = HashMapInit(2)
-            postVars["k"] = hKey
-            postVars["v"] = String.format(Locale.US, "ankidroid,%s,%s", pkgVersionName, Utils.platDesc())
+            postVars = mutableMapOf(
+                "k" to hKey,
+                "v" to String.format(Locale.US, "ankidroid,%s,%s", pkgVersionName, Utils.platDesc())
+            )
             val resp = req("begin", getInputStream(Utils.jsonToString(JSONObject())))
             val jresp = JSONObject(resp.body!!.string())
             val ret = dataOnly(jresp, JSONObject::class.java)
@@ -66,8 +66,7 @@ class RemoteMediaServer(
     @Throws(UnknownHttpResponseException::class, MediaSyncException::class)
     fun mediaChanges(lastUsn: Int): JSONArray {
         return try {
-            postVars = HashMapInit(1)
-            postVars["sk"] = checksumKey
+            postVars = mutableMapOf("sk" to checksumKey)
             val resp = req(
                 "mediaChanges",
                 getInputStream(Utils.jsonToString(JSONObject().put("lastUsn", lastUsn)))

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sync/RemoteServer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sync/RemoteServer.kt
@@ -21,7 +21,7 @@ import com.ichi2.anki.exception.UnknownHttpResponseException
 import com.ichi2.async.Connection
 import com.ichi2.libanki.Consts
 import com.ichi2.libanki.Utils
-import com.ichi2.utils.HashUtil.HashMapInit
+import com.ichi2.utils.HashMapInit
 import com.ichi2.utils.JSONException
 import com.ichi2.utils.JSONObject
 import com.ichi2.utils.VersionUtils.pkgVersionName

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sync/RemoteServer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sync/RemoteServer.kt
@@ -21,7 +21,6 @@ import com.ichi2.anki.exception.UnknownHttpResponseException
 import com.ichi2.async.Connection
 import com.ichi2.libanki.Consts
 import com.ichi2.libanki.Utils
-import com.ichi2.utils.HashMapInit
 import com.ichi2.utils.JSONException
 import com.ichi2.utils.JSONObject
 import com.ichi2.utils.VersionUtils.pkgVersionName
@@ -40,7 +39,7 @@ class RemoteServer(
     @Throws(UnknownHttpResponseException::class)
     fun hostKey(user: String?, pw: String?): Response? {
         return try {
-            postVars = HashMapInit(0)
+            postVars = mutableMapOf()
             val credentials = JSONObject()
             credentials.put("u", user)
             credentials.put("p", pw)
@@ -53,9 +52,10 @@ class RemoteServer(
 
     @Throws(UnknownHttpResponseException::class)
     fun meta(): Response {
-        postVars = HashMapInit(2)
-        postVars["k"] = hKey
-        postVars["s"] = checksumKey
+        postVars = mutableMapOf(
+            "k" to hKey,
+            "s" to checksumKey
+        )
         val meta = JSONObject()
         meta.put("v", Consts.SYNC_VER)
         meta.put("cv", String.format(Locale.US, "ankidroid,%s,%s", pkgVersionName, Utils.platDesc()))

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sync/Syncer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sync/Syncer.kt
@@ -32,7 +32,7 @@ import com.ichi2.libanki.Collection
 import com.ichi2.libanki.sched.AbstractDeckTreeNode
 import com.ichi2.libanki.sync.Syncer.ConnectionResultType.*
 import com.ichi2.libanki.utils.TimeManager.time
-import com.ichi2.utils.HashUtil.HashMapInit
+import com.ichi2.utils.HashMapInit
 import com.ichi2.utils.JSONArray
 import com.ichi2.utils.JSONException
 import com.ichi2.utils.JSONObject

--- a/AnkiDroid/src/main/java/com/ichi2/themes/HtmlColors.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/themes/HtmlColors.kt
@@ -16,7 +16,7 @@
 
 package com.ichi2.themes
 
-import com.ichi2.utils.HashUtil.HashMapInit
+import com.ichi2.utils.HashMapInit
 import com.ichi2.utils.KotlinCleanup
 import timber.log.Timber
 import java.util.*

--- a/AnkiDroid/src/main/java/com/ichi2/ui/AppCompatPreferenceActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/ui/AppCompatPreferenceActivity.kt
@@ -31,7 +31,7 @@ import com.ichi2.anki.AnkiDroidApp
 import com.ichi2.anki.CollectionHelper
 import com.ichi2.anki.receiver.SdCardReceiver
 import com.ichi2.libanki.Collection
-import com.ichi2.utils.HashUtil
+import com.ichi2.utils.HashMapInit
 import com.ichi2.utils.KotlinCleanup
 import timber.log.Timber
 import java.util.*
@@ -56,7 +56,7 @@ abstract class AppCompatPreferenceActivity<PreferenceHack : AppCompatPreferenceA
     protected lateinit var pref: PreferenceHack
 
     abstract inner class AbstractPreferenceHack : SharedPreferences {
-        val mValues: MutableMap<String, String> = HashUtil.HashMapInit(30) // At most as many as in cacheValues
+        val mValues: MutableMap<String, String> = HashMapInit(30) // At most as many as in cacheValues
         val mSummaries: MutableMap<String, String?> = HashMap()
         protected val listeners: MutableList<SharedPreferences.OnSharedPreferenceChangeListener> = LinkedList()
 

--- a/AnkiDroid/src/main/java/com/ichi2/utils/HashUtil.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/HashUtil.kt
@@ -15,24 +15,12 @@
  ****************************************************************************************/
 package com.ichi2.utils
 
-import java.util.HashMap
-import java.util.HashSet
+/**
+ * @param size Number of elements expected in the hash structure
+ * @return Initial capacity for the hash structure. Copied from HashMap code
+ */
+private fun capacity(size: Int) = ((size / .75f).toInt() + 1).coerceAtLeast(16)
 
-object HashUtil {
-    /**
-     * @param size Number of elements expected in the hash structure
-     * @return Initial capacity for the hash structure. Copied from HashMap code
-     */
-    private fun capacity(size: Int): Int {
-        return Math.max((size / .75f).toInt() + 1, 16)
-    }
+fun <T> HashSetInit(size: Int) = HashSet<T>(capacity(size))
 
-    fun <T> HashSetInit(size: Int): HashSet<T> {
-        return HashSet(capacity(size))
-    }
-
-    @KotlinCleanup("return mutableMap")
-    fun <T, U> HashMapInit(size: Int): HashMap<T, U> {
-        return HashMap(capacity(size))
-    }
-}
+fun <T, U> HashMapInit(size: Int) = HashMap<T, U>(capacity(size))

--- a/AnkiDroid/src/main/java/com/wildplot/android/parsing/TopLevelParser.kt
+++ b/AnkiDroid/src/main/java/com/wildplot/android/parsing/TopLevelParser.kt
@@ -15,7 +15,6 @@
  ****************************************************************************************/
 package com.wildplot.android.parsing
 
-import com.ichi2.utils.HashMapInit
 import com.wildplot.android.rendering.interfaces.Function2D
 import com.wildplot.android.rendering.interfaces.Function3D
 import java.util.regex.Pattern
@@ -23,7 +22,10 @@ import java.util.regex.Pattern
 class TopLevelParser(expressionString: String, parserRegister: HashMap<String, TopLevelParser>) :
     Function2D, Function3D, Cloneable {
     private val parserRegister: HashMap<String, TopLevelParser>
-    private val varMap = HashMapInit<String, Double>(2) // Number form initVarMap
+    private val varMap = mapOf(
+        "e" to Math.E,
+        "pi" to Math.PI
+    )
     var x = 0.0
     var y = 0.0
     private val expression: Expression
@@ -33,18 +35,12 @@ class TopLevelParser(expressionString: String, parserRegister: HashMap<String, T
     private var yName = "y"
 
     init {
-        initVarMap()
         this.parserRegister = parserRegister
         this.expressionString = expressionString
         val isValidExpressionString = initExpressionString()
         expression = Expression(this.expressionString, this)
         isValid =
             expression.expressionType != Expression.ExpressionType.INVALID && isValidExpressionString
-    }
-
-    private fun initVarMap() {
-        varMap["e"] = Math.E
-        varMap["pi"] = Math.PI
     }
 
     private fun initExpressionString(): Boolean {

--- a/AnkiDroid/src/main/java/com/wildplot/android/parsing/TopLevelParser.kt
+++ b/AnkiDroid/src/main/java/com/wildplot/android/parsing/TopLevelParser.kt
@@ -15,7 +15,7 @@
  ****************************************************************************************/
 package com.wildplot.android.parsing
 
-import com.ichi2.utils.HashUtil.HashMapInit
+import com.ichi2.utils.HashMapInit
 import com.wildplot.android.rendering.interfaces.Function2D
 import com.wildplot.android.rendering.interfaces.Function3D
 import java.util.regex.Pattern

--- a/AnkiDroid/src/test/java/com/ichi2/anki/servicemodel/PreferenceUpgradeServiceTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/servicemodel/PreferenceUpgradeServiceTest.kt
@@ -29,7 +29,6 @@ import com.ichi2.anki.servicelayer.RemovedPreferences
 import com.ichi2.anki.web.CustomSyncServer
 import com.ichi2.libanki.Consts
 import com.ichi2.testutils.EmptyApplication
-import com.ichi2.utils.HashSetInit
 import org.hamcrest.CoreMatchers.equalTo
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.lessThan
@@ -122,13 +121,10 @@ class PreferenceUpgradeServiceTest : RobolectricTest() {
     @Test
     fun note_editor_toolbar_button_text() {
         // add two example toolbar buttons
-        val buttons = HashSetInit<String>(2)
-
-        var values = arrayOf(0, "<h1>", "</h1>")
-        buttons.add(TextUtils.join(Consts.FIELD_SEPARATOR, values))
-
-        values = arrayOf(1, "<p>", "</p>")
-        buttons.add(TextUtils.join(Consts.FIELD_SEPARATOR, values))
+        val buttons = setOf(
+            TextUtils.join(Consts.FIELD_SEPARATOR, arrayOf(0, "<h1>", "</h1>")),
+            TextUtils.join(Consts.FIELD_SEPARATOR, arrayOf(1, "<p>", "</p>"))
+        )
 
         mPrefs.edit {
             putStringSet("note_editor_custom_buttons", buttons)
@@ -137,7 +133,7 @@ class PreferenceUpgradeServiceTest : RobolectricTest() {
         // now update it and check it
         PreferenceUpgrade.UpdateNoteEditorToolbarPrefs().performUpgrade(mPrefs)
 
-        val set = mPrefs.getStringSet("note_editor_custom_buttons", HashSetInit<String>(0)) as Set<String?>
+        val set = mPrefs.getStringSet("note_editor_custom_buttons", setOf()) as Set<String?>
         val toolbarButtons = CustomToolbarButton.fromStringSet(set)
 
         assertEquals("Set size", 2, set.size)

--- a/AnkiDroid/src/test/java/com/ichi2/anki/servicemodel/PreferenceUpgradeServiceTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/servicemodel/PreferenceUpgradeServiceTest.kt
@@ -29,7 +29,7 @@ import com.ichi2.anki.servicelayer.RemovedPreferences
 import com.ichi2.anki.web.CustomSyncServer
 import com.ichi2.libanki.Consts
 import com.ichi2.testutils.EmptyApplication
-import com.ichi2.utils.HashUtil
+import com.ichi2.utils.HashSetInit
 import org.hamcrest.CoreMatchers.equalTo
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.lessThan
@@ -122,7 +122,7 @@ class PreferenceUpgradeServiceTest : RobolectricTest() {
     @Test
     fun note_editor_toolbar_button_text() {
         // add two example toolbar buttons
-        val buttons = HashUtil.HashSetInit<String>(2)
+        val buttons = HashSetInit<String>(2)
 
         var values = arrayOf(0, "<h1>", "</h1>")
         buttons.add(TextUtils.join(Consts.FIELD_SEPARATOR, values))
@@ -137,7 +137,7 @@ class PreferenceUpgradeServiceTest : RobolectricTest() {
         // now update it and check it
         PreferenceUpgrade.UpdateNoteEditorToolbarPrefs().performUpgrade(mPrefs)
 
-        val set = mPrefs.getStringSet("note_editor_custom_buttons", HashUtil.HashSetInit<String>(0)) as Set<String?>
+        val set = mPrefs.getStringSet("note_editor_custom_buttons", HashSetInit<String>(0)) as Set<String?>
         val toolbarButtons = CustomToolbarButton.fromStringSet(set)
 
         assertEquals("Set size", 2, set.size)


### PR DESCRIPTION
Now that HashUtil methods are not used in Java anymore (at least once #12301 is merged. But my two commits can be reviewed independently of #12301), I can make them return Kotlin type instead of java type. This ensure better typing as far as nullability goes.

Working on them, I also cleaned every usage of those methods that can be replaced by map/associate/filter.

I believe this PR should be rebased