### PR TITLE
fix(docs): fix link to remove ktlint override

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -85,7 +85,8 @@ subprojects {
 
         ktlint {
             // remove version override when ktlint gradle plugin releases with 0.45+ transitive
-            // check here https://github.com/JLLeitschuh/ktlint-gradle/blob/ddd465e28d77b879384886e1eef5666ebe518b4d/plugin/gradle/libs.versions.toml#L3
+            // check for "ktlint" here:
+            // https://github.com/JLLeitschuh/ktlint-gradle/blob/master/plugin/gradle/libs.versions.toml
             version = "0.45.2"
             disabledRules = ["no-wildcard-imports"]
         }


### PR DESCRIPTION
We linked to a permalink (commit reference), change to the live file

As of writing, the library was 0.43.2: override is still needed

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
