### PR TITLE
tests: check if all preferences fragments don't throw on creation

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.kt
@@ -307,6 +307,7 @@ open class AnkiDroidApp : Application() {
         @JvmField
         var TESTING_SCOPED_STORAGE = false
         const val XML_CUSTOM_NAMESPACE = "http://arbitrary.app.namespace/com.ichi2.anki"
+        const val ANDROID_NAMESPACE = "http://schemas.android.com/apk/res/android"
 
         // Tag for logging messages.
         const val TAG = "AnkiDroid"

--- a/AnkiDroid/src/test/java/com/ichi2/anki/ReviewerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/ReviewerTest.kt
@@ -22,6 +22,7 @@ import androidx.test.core.app.ActivityScenario
 import com.ichi2.anki.AbstractFlashcardViewer.Companion.RESULT_DEFAULT
 import com.ichi2.anki.cardviewer.ViewerCommand
 import com.ichi2.anki.exception.ConfirmModSchemaException
+import com.ichi2.anki.preferences.PreferenceUtils
 import com.ichi2.anki.reviewer.ActionButtonStatus
 import com.ichi2.libanki.Card
 import com.ichi2.libanki.Consts
@@ -29,7 +30,6 @@ import com.ichi2.libanki.Model
 import com.ichi2.libanki.ModelManager
 import com.ichi2.libanki.utils.TimeManager
 import com.ichi2.testutils.MockTime
-import com.ichi2.testutils.PreferenceUtils
 import com.ichi2.testutils.assertThrowsSubclass
 import com.ichi2.utils.JSONArray
 import org.hamcrest.MatcherAssert.assertThat

--- a/AnkiDroid/src/test/java/com/ichi2/anki/preferences/PreferenceUtils.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/preferences/PreferenceUtils.kt
@@ -13,13 +13,11 @@
  You should have received a copy of the GNU General Public License along with
  this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package com.ichi2.testutils
+package com.ichi2.anki.preferences
 
 import android.content.Context
 import androidx.lifecycle.Lifecycle
 import androidx.test.core.app.ActivityScenario
-import com.ichi2.anki.preferences.CustomButtonsSettingsFragment
-import com.ichi2.anki.preferences.Preferences
 import java.util.concurrent.atomic.AtomicReference
 
 object PreferenceUtils {

--- a/AnkiDroid/src/test/java/com/ichi2/anki/preferences/PreferencesTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/preferences/PreferencesTest.kt
@@ -15,7 +15,10 @@
  */
 package com.ichi2.anki.preferences
 
+import androidx.fragment.app.commitNow
+import androidx.test.core.app.ActivityScenario
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.ichi2.anki.R
 import com.ichi2.anki.RobolectricTest
 import com.ichi2.anki.exception.ConfirmModSchemaException
 import com.ichi2.anki.preferences.Preferences.Companion.getDayOffset
@@ -53,6 +56,20 @@ class PreferencesTest : RobolectricTest() {
         for (i in 0..23) {
             preferences.setDayOffset(i)
             assertThat(getDayOffset(col), equalTo(i))
+        }
+    }
+
+    /** checks if any of the Preferences fragments throws while being created */
+    @Test
+    fun fragmentsDoNotThrowOnCreation() {
+        val activityScenario = ActivityScenario.launch(Preferences::class.java)
+
+        activityScenario.onActivity { activity ->
+            PreferenceUtils.getAllPreferencesFragments(activity).forEach {
+                activity.supportFragmentManager.commitNow {
+                    add(R.id.settings_container, it)
+                }
+            }
         }
     }
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/reviewer/ActionButtonStatusTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/reviewer/ActionButtonStatusTest.kt
@@ -18,7 +18,7 @@ package com.ichi2.anki.reviewer
 import android.content.SharedPreferences
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.ichi2.anki.RobolectricTest
-import com.ichi2.testutils.PreferenceUtils
+import com.ichi2.anki.preferences.PreferenceUtils
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.containsInAnyOrder
 import org.junit.Test


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
Depending on the changes, a preferences fragment throws on creation, which sould be only seen while running the app, so here's a test for it

## Approach
On the commits

## How Has This Been Tested?

this is a test

## Learning (optional, can help others)

Use `.commitNow` if you are looping fragments, as `commit` is async


## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
