### PR TITLE
chore: remove redundant '@JvmStatic' annotations

### DIFF
--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/ContentProviderTest.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/ContentProviderTest.kt
@@ -1296,7 +1296,7 @@ class ContentProviderTest : InstrumentedTest() {
 
     companion object {
         @Parameterized.Parameters
-        @JvmStatic
+        @JvmStatic // required for initParameters
         fun initParameters(): Collection<Array<Any>> {
             // This does one run with schedVersion injected as 1, and one run as 2
             return Arrays.asList(*arrayOf(arrayOf(1), arrayOf(2)))

--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/InstrumentedTest.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/InstrumentedTest.kt
@@ -49,7 +49,6 @@ abstract class InstrumentedTest {
          * https://github.com/react-native-community/react-native-device-info/blob/bb505716ff50e5900214fcbcc6e6434198010d95/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceModule.java#L185
          * @return boolean true if the execution environment is most likely an emulator
          */
-        @JvmStatic
         fun isEmulator(): Boolean {
             return (
                 Build.BRAND.startsWith("generic") && Build.DEVICE.startsWith("generic") ||

--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/LayoutValidationTest.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/LayoutValidationTest.kt
@@ -83,7 +83,7 @@ class LayoutValidationTest : InstrumentedTest() {
             InvocationTargetException::class,
             InstantiationException::class
         )
-        @JvmStatic
+        @JvmStatic // required for initParameters
         fun initParameters(): Collection<Array<Any>> {
             val ctor: Constructor<*> = com.ichi2.anki.R.layout::class.java.declaredConstructors[0]
             ctor.isAccessible = true // Required for at least API 16, maybe later.

--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/testutil/DatabaseUtils.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/testutil/DatabaseUtils.kt
@@ -48,7 +48,6 @@ object DatabaseUtils {
      * @param positionParam The start position for filling the window.
      * @param window The window to fill.
      */
-    @JvmStatic
     fun cursorFillWindow(
         cursor: Cursor,
         positionParam: Int,

--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/testutil/MockReviewerUi.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/testutil/MockReviewerUi.kt
@@ -29,7 +29,6 @@ class MockReviewerUi : ReviewerUi {
     }
 
     companion object {
-        @JvmStatic
         fun displayingAnswer(): ReviewerUi {
             val mockReviewerUi = MockReviewerUi()
             mockReviewerUi.isDisplayingAnswer = true

--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/testutil/TestEnvironment.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/testutil/TestEnvironment.kt
@@ -18,7 +18,6 @@ package com.ichi2.anki.testutil
 import java.util.*
 
 object TestEnvironment {
-    @JvmStatic
     fun isDisplayingDefaultEnglishStrings(): Boolean {
         return "en-US" == Locale.getDefault().toLanguageTag()
     }

--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/testutil/ThreadUtils.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/testutil/ThreadUtils.kt
@@ -16,7 +16,6 @@
 package com.ichi2.anki.testutil
 
 object ThreadUtils {
-    @JvmStatic
     fun sleep(timeMs: Int) {
         try {
             Thread.sleep(timeMs.toLong())

--- a/AnkiDroid/src/main/java/com/ichi2/anim/ActivityTransitionAnimation.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anim/ActivityTransitionAnimation.kt
@@ -11,7 +11,6 @@ import com.ichi2.anki.R
 import kotlinx.parcelize.Parcelize
 
 object ActivityTransitionAnimation {
-    @JvmStatic
     fun slide(activity: Activity, direction: Direction?) {
         when (direction) {
             Direction.START -> if (isRightToLeft(activity)) {
@@ -38,7 +37,6 @@ object ActivityTransitionAnimation {
         }
     }
 
-    @JvmStatic
     fun getAnimationOptions(activity: Activity, direction: Direction?): ActivityOptionsCompat {
         return when (direction) {
             Direction.START -> if (isRightToLeft(activity)) ActivityOptionsCompat.makeCustomAnimation(activity, R.anim.slide_right_in, R.anim.slide_right_out) else ActivityOptionsCompat.makeCustomAnimation(activity, R.anim.slide_left_in, R.anim.slide_left_out)

--- a/AnkiDroid/src/main/java/com/ichi2/anim/ViewAnimation.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anim/ViewAnimation.kt
@@ -80,7 +80,6 @@ object ViewAnimation {
         FADE_IN(0f),
         FADE_OUT(1f);
     }
-    @JvmStatic
     fun fade(type: Fade, duration: Int, offset: Int) =
         AlphaAnimation(type.originalAlpha, 1.0f - type.originalAlpha).apply {
             this.duration = duration.toLong()

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
@@ -2198,7 +2198,6 @@ abstract class AbstractFlashcardViewer :
         const val ANSWER_ORDINAL_2 = 6
         const val ANSWER_ORDINAL_3 = 7
         const val ANSWER_ORDINAL_4 = 8
-        @JvmStatic
         fun getSignalFromUrl(url: String): Int {
             when (url) {
                 "signal:typefocus" -> return TYPE_FOCUS
@@ -2635,7 +2634,6 @@ abstract class AbstractFlashcardViewer :
         const val INITIAL_HIDE_DELAY = 200
         // I don't see why we don't do this by intent.
         /** to be sent to and from the card editor  */
-        @JvmStatic
         @set:VisibleForTesting(otherwise = VisibleForTesting.NONE)
         var editorCard: Card? = null
         @JvmField

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.kt
@@ -315,7 +315,6 @@ open class AnkiDroidApp : Application() {
         // Singleton instance of this class.
         // Note: this may not be initialized if AnkiDroid is run via BackupManager
         @KotlinCleanup("replace comment with javadoc")
-        @JvmStatic
         lateinit var instance: AnkiDroidApp
             private set
 
@@ -369,14 +368,12 @@ open class AnkiDroidApp : Application() {
          * @return A SharedPreferences object for this instance of the app.
          */
         @Suppress("deprecation") // TODO Tracked in https://github.com/ankidroid/Anki-Android/issues/5019
-        @JvmStatic
         fun getSharedPrefs(context: Context?): SharedPreferences {
             return android.preference.PreferenceManager.getDefaultSharedPreferences(context)
         }
 
         val cacheStorageDirectory: String
             get() = instance.cacheDir.absolutePath
-        @JvmStatic
         val appResources: Resources
             get() = instance.resources
         val isSdCardMounted: Boolean
@@ -389,7 +386,6 @@ open class AnkiDroidApp : Application() {
          * @param remoteContext The base context offered by attachBase() to be passed to super.attachBase().
          * Can be modified here to set correct GUI language.
          */
-        @JvmStatic
         fun updateContextWithLanguage(remoteContext: Context): Context {
             return try {
                 val preferences: SharedPreferences

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiFont.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiFont.kt
@@ -59,7 +59,6 @@ class AnkiFont private constructor(val name: String, private val family: String,
          * @param fromAssets True if the font is to be found in assets of application
          * @return A new AnkiFont object or null if the file can't be interpreted as typeface.
          */
-        @JvmStatic
         fun createAnkiFont(ctx: Context, filePath: String, fromAssets: Boolean): AnkiFont? {
             var path = filePath
             val fontFile = File(path)
@@ -114,7 +113,6 @@ class AnkiFont private constructor(val name: String, private val family: String,
             return createdFont
         }
 
-        @JvmStatic
         fun getTypeface(ctx: Context, path: String): Typeface? {
             return try {
                 if (path.startsWith(fAssetPathPrefix)) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiSerialization.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiSerialization.kt
@@ -26,7 +26,6 @@ object AnkiSerialization {
     /**
      * @return singleton of {@link ObjectMapper} used to bind json to java classes
      */
-    @JvmStatic
     val objectMapper: ObjectMapper by lazy {
         ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
     }
@@ -34,7 +33,6 @@ object AnkiSerialization {
     /**
      * @return singleton of {@link JsonFactory} used for json stream processing
      */
-    @JvmStatic
     val factory: JsonFactory
         get() = objectMapper.factory
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/BackupManager.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/BackupManager.kt
@@ -197,7 +197,6 @@ open class BackupManager {
         val isActivated: Boolean
             get() = true
 
-        @JvmStatic
         fun getBackupDirectory(ankidroidDir: File): File {
             val directory = File(ankidroidDir, BACKUP_SUFFIX)
             if (!directory.isDirectory && !directory.mkdirs()) {
@@ -218,7 +217,6 @@ open class BackupManager {
             return directory
         }
 
-        @JvmStatic
         fun performBackupInBackground(path: String, time: Time): Boolean {
             return BackupManager().performBackupInBackground(path, BACKUP_INTERVAL, time)
         }
@@ -232,7 +230,6 @@ open class BackupManager {
             return colFile.length() + MIN_FREE_SPACE * 1024 * 1024
         }
 
-        @JvmStatic
         fun enoughDiscSpace(path: String?): Boolean {
             return getFreeDiscSpace(path) >= MIN_FREE_SPACE * 1024 * 1024
         }
@@ -255,7 +252,6 @@ open class BackupManager {
          * @param col Collection
          * @return whether the repair was successful
          */
-        @JvmStatic
         fun repairCollection(col: Collection): Boolean {
             val deckPath = col.path
             val deckFile = File(deckPath)
@@ -336,7 +332,6 @@ open class BackupManager {
          * @param fileName String with pattern "collection-yyyy-MM-dd-HH-mm.colpkg"
          * @return Its dateformat parsable string or null if it doesn't match naming pattern
          */
-        @JvmStatic
         fun getBackupTimeString(fileName: String): String? {
             return backupNameRegex.matchEntire(fileName)?.groupValues?.get(1)
         }
@@ -344,7 +339,6 @@ open class BackupManager {
         /**
          * @return date in string if it matches backup naming pattern or null if not
          */
-        @JvmStatic
         fun parseBackupTimeString(timeString: String): Date? {
             return try {
                 legacyDateFormat.parse(timeString)
@@ -360,7 +354,6 @@ open class BackupManager {
         /**
          * @return date in fileName if it matches backup naming pattern or null if not
          */
-        @JvmStatic
         fun getBackupDate(fileName: String): Date? {
             return getBackupTimeString(fileName)?.let { parseBackupTimeString(it) }
         }
@@ -368,7 +361,6 @@ open class BackupManager {
         /**
          * @return filename with pattern collection-yyyy-MM-dd-HH-mm based on given time parameter
          */
-        @JvmStatic
         fun getNameForNewBackup(time: Time): String? {
             /** Changes in the file name pattern should be updated as well in
              * [getBackupTimeString] and [com.ichi2.anki.dialogs.DatabaseErrorDialog.onCreateDialog] */
@@ -382,7 +374,6 @@ open class BackupManager {
             return backupFilename
         }
 
-        @JvmStatic
         /**
          * @return Array of files with names which matches the backup name pattern,
          * in order of creation.
@@ -405,7 +396,6 @@ open class BackupManager {
          *
          * @return the most recent backup, or null if no backups exist
          */
-        @JvmStatic
         fun getLatestBackup(colFile: File): File? = getBackups(colFile).lastOrNull()
 
         /**
@@ -413,7 +403,6 @@ open class BackupManager {
          * @param colPath Path of collection file whose backups should be deleted
          * @param keepNumber How many files to keep
          */
-        @JvmStatic
         fun deleteDeckBackups(colPath: String, keepNumber: Int): Boolean {
             return deleteDeckBackups(getBackups(File(colPath)), keepNumber)
         }
@@ -429,7 +418,6 @@ open class BackupManager {
             return true
         }
 
-        @JvmStatic
         fun removeDir(dir: File): Boolean {
             if (dir.isDirectory) {
                 val files = dir.listFiles()
@@ -440,7 +428,6 @@ open class BackupManager {
             return dir.delete()
         }
 
-        @JvmStatic
         @VisibleForTesting(otherwise = VisibleForTesting.NONE)
         fun createInstance(): BackupManager {
             return BackupManager()

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -2655,7 +2655,6 @@ open class CardBrowser :
         private const val LAST_DECK_ID_KEY = "lastDeckId"
         const val CARD_NOT_AVAILABLE = -1
         @KotlinCleanup(".edit { }")
-        @JvmStatic
         fun clearLastDeckId() {
             val context: Context = AnkiDroidApp.instance
             context.getSharedPreferences(PERSISTENT_STATE_FILE, 0).edit().remove(LAST_DECK_ID_KEY).apply()
@@ -2676,7 +2675,6 @@ open class CardBrowser :
          * @param showFileNames Whether [sound:foo.mp3] should be rendered as " foo.mp3 " or  " "
          * @return The formatted string
          */
-        @JvmStatic
         @VisibleForTesting
         @CheckResult
         fun formatQAInternal(txt: String, showFileNames: Boolean): String {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardInfo.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardInfo.kt
@@ -292,7 +292,6 @@ class CardInfo : AnkiActivity() {
         }
 
         companion object {
-            @JvmStatic
             @CheckResult
             fun create(c: Card, collection: Collection): CardInfoModel {
                 val addedDate = c.id

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateBrowserAppearanceEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateBrowserAppearanceEditor.kt
@@ -183,7 +183,6 @@ class CardTemplateBrowserAppearanceEditor : AnkiActivity() {
         }
 
         companion object {
-            @JvmStatic
             @Contract("null -> null")
             fun fromIntent(intent: Intent?): Result? {
                 return if (intent == null) {
@@ -206,7 +205,6 @@ class CardTemplateBrowserAppearanceEditor : AnkiActivity() {
 
         /** Specified the card browser should use the default template formatter  */
         const val VALUE_USE_DEFAULT = ""
-        @JvmStatic
         @CheckResult
         fun getIntentFromTemplate(context: Context, template: JSONObject): Intent {
             val browserQuestionTemplate = template.getString("bqfmt")

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardUtils.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardUtils.kt
@@ -14,7 +14,6 @@ object CardUtils {
     /**
      * @return List of corresponding notes without duplicates, even if the input list has multiple cards of the same note.
      */
-    @JvmStatic
     fun getNotes(cards: Collection<Card>): Set<Note> {
         val notes: MutableSet<Note> = HashSetInit(cards.size)
         for (card in cards) {
@@ -26,7 +25,6 @@ object CardUtils {
     /**
      * @return All cards of all notes
      */
-    @JvmStatic
     fun getAllCards(notes: Set<Note>): List<Card> {
         val allCards: MutableList<Card> = ArrayList(notes.size)
         for (note in notes) {
@@ -35,7 +33,6 @@ object CardUtils {
         return allCards
     }
 
-    @JvmStatic
     fun markAll(notes: List<Note>, mark: Boolean) {
         for (note in notes) {
             if (mark) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CollectionHelper.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CollectionHelper.kt
@@ -282,7 +282,6 @@ open class CollectionHelper {
     }
 
     companion object {
-        @JvmStatic
         var instance: CollectionHelper = CollectionHelper()
             private set
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CollectionManager.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CollectionManager.kt
@@ -235,7 +235,6 @@ object CollectionManager {
         }
     }
 
-    @JvmStatic
     fun closeCollectionBlocking(save: Boolean = true) {
         runBlocking { ensureClosed(save = save) }
     }
@@ -246,7 +245,6 @@ object CollectionManager {
      * the collection while the reference is held. [withCol]
      * is a better alternative.
      */
-    @JvmStatic
     fun getColUnsafe(): Collection {
         return logUIHangs {
             blockForQueue {
@@ -293,7 +291,6 @@ object CollectionManager {
     /**
      * True if the collection is open. Unsafe, as it has the potential to race.
      */
-    @JvmStatic
     fun isOpenUnsafe(): Boolean {
         return logUIHangs {
             blockForQueue {
@@ -310,7 +307,6 @@ object CollectionManager {
      Use [col] as collection in tests.
      This collection persists only up to the next (direct or indirect) call to `ensureClosed`
      */
-    @JvmStatic
     fun setColForTests(col: Collection?) {
         blockForQueue {
             if (col == null) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CrashReportService.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CrashReportService.kt
@@ -57,7 +57,6 @@ object CrashReportService {
      * Temporary method to access the CoreConfigurationBuilder until all classes that require access
      *  to the CoreConfigurationBuilder are migrated to kotlin.
      */
-    @JvmStatic
     @KotlinCleanup("once EVERY class using this method gets migrated to kotlin remove it and expose mAcraCoreConfigBuilder with a private setter")
     fun getAcraCoreConfigBuilder(): CoreConfigurationBuilder {
         return mAcraCoreConfigBuilder
@@ -68,7 +67,6 @@ object CrashReportService {
      * The ACRA process needs a WebView for optimal UsageAnalytics values but it can't have the same
      * data directory. Analytics falls back to a sensible default if this is not set.
      */
-    @JvmStatic
     fun initialize(application: Application) {
         mApplication = application
         // Setup logging and crash reporting
@@ -141,7 +139,6 @@ object CrashReportService {
      * Set the reporting mode for ACRA based on the value of the FEEDBACK_REPORT_KEY preference
      * @param value value of FEEDBACK_REPORT_KEY preference
      */
-    @JvmStatic
     fun setAcraReportingMode(value: String) {
         val editor = AnkiDroidApp.getSharedPrefs(mApplication).edit()
         // Set the ACRA disable value
@@ -171,7 +168,6 @@ object CrashReportService {
      *
      * @param prefs SharedPreferences object the reporting state is persisted in
      */
-    @JvmStatic
     @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
     fun setDebugACRAConfig(prefs: SharedPreferences) {
         // Disable crash reporting
@@ -187,7 +183,6 @@ object CrashReportService {
      *
      * @param prefs SharedPreferences object the reporting state is persisted in
      */
-    @JvmStatic
     @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
     fun setProductionACRAConfig(prefs: SharedPreferences) {
         // Enable or disable crash reporting based on user setting
@@ -224,22 +219,18 @@ object CrashReportService {
     }
 
     /** Used when we don't have an exception to throw, but we know something is wrong and want to diagnose it  */
-    @JvmStatic
     fun sendExceptionReport(message: String?, origin: String?) {
         sendExceptionReport(ManuallyReportedException(message), origin, null)
     }
 
-    @JvmStatic
     fun sendExceptionReport(e: Throwable, origin: String?) {
         sendExceptionReport(e, origin, null)
     }
 
-    @JvmStatic
     fun sendExceptionReport(e: Throwable, origin: String?, additionalInfo: String?) {
         sendExceptionReport(e, origin, additionalInfo, false)
     }
 
-    @JvmStatic
     fun sendExceptionReport(e: Throwable, origin: String?, additionalInfo: String?, onlyIfSilent: Boolean) {
         sendAnalyticsException(e, false)
         AnkiDroidApp.sentExceptionReportHack = true
@@ -255,12 +246,10 @@ object CrashReportService {
         ACRA.getErrorReporter().handleException(e)
     }
 
-    @JvmStatic
     fun isProperServiceProcess(): Boolean {
         return ACRA.isACRASenderServiceProcess()
     }
 
-    @JvmStatic
     fun isAcraEnabled(context: Context, defaultValue: Boolean): Boolean {
         if (!AnkiDroidApp.getSharedPrefs(context).contains(ACRA.PREF_DISABLE_ACRA)) {
             // we shouldn't use defaultValue below, as it would be inverted which complicated understanding.
@@ -275,7 +264,6 @@ object CrashReportService {
      *
      * @param context the context leading to the directory with ACRA limiter data
      */
-    @JvmStatic
     fun deleteACRALimiterData(context: Context) {
         try {
             LimiterData().store(context)
@@ -284,7 +272,6 @@ object CrashReportService {
         }
     }
 
-    @JvmStatic
     fun onPreferenceChanged(ctx: Context, newValue: String) {
         setAcraReportingMode(newValue)
         // If the user changed error reporting, make sure future reports have a chance to post
@@ -297,7 +284,6 @@ object CrashReportService {
      * @return the status of the report, true if the report was sent, false if the report is already
      *  submitted
      */
-    @JvmStatic
     fun sendReport(ankiActivity: AnkiActivity): Boolean {
         val preferences = AnkiDroidApp.getSharedPrefs(ankiActivity)
         val reportMode = preferences.getString(FEEDBACK_REPORT_KEY, "")

--- a/AnkiDroid/src/main/java/com/ichi2/anki/InitialActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/InitialActivity.kt
@@ -27,7 +27,6 @@ import timber.log.Timber
 /** Utilities for launching the first activity (currently the DeckPicker)  */
 object InitialActivity {
     /** Returns null on success  */
-    @JvmStatic
     @CheckResult
     fun getStartupFailureType(context: Context): StartupFailure? {
 
@@ -59,7 +58,6 @@ object InitialActivity {
 
     /** @return Whether any preferences were upgraded
      */
-    @JvmStatic
     fun upgradePreferences(context: Context?, previousVersionCode: Long): Boolean {
         return PreferenceUpgradeService.upgradePreferences(context, previousVersionCode)
     }
@@ -76,7 +74,6 @@ object InitialActivity {
      * in practice, this doesn't occur due to CollectionHelper.getCol creating a new collection, and it's called before
      * this in the startup script
      */
-    @JvmStatic
     @CheckResult
     fun performSetupFromFreshInstallOrClearedPreferences(preferences: SharedPreferences): Boolean {
         if (!wasFreshInstall(preferences)) {
@@ -98,7 +95,6 @@ object InitialActivity {
         "" == preferences.getString("lastVersion", "")
 
     /** Sets the preference stating that the latest version has been applied  */
-    @JvmStatic
     fun setUpgradedToLatestVersion(preferences: SharedPreferences) {
         Timber.i("Marked prefs as upgraded to latest version: %s", pkgVersionName)
         preferences.edit().putString("lastVersion", pkgVersionName).apply()
@@ -109,7 +105,6 @@ object InitialActivity {
      * This is not called in the case of performSetupFromFreshInstall returning true.
      * So this should not use the default value
      */
-    @JvmStatic
     fun isLatestVersion(preferences: SharedPreferences): Boolean {
         return preferences.getString("lastVersion", "") == pkgVersionName
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/IntentHandler.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/IntentHandler.kt
@@ -149,7 +149,6 @@ class IntentHandler : Activity() {
             return !isInvalidViewIntent(intent)
         }
 
-        @JvmStatic
         @VisibleForTesting
         @CheckResult
         fun getLaunchType(intent: Intent): LaunchType {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/LanguageUtils.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/LanguageUtils.kt
@@ -28,7 +28,6 @@ object LanguageUtils {
      * Returns a Locale object constructed from an empty string if the input string is null, empty
      * or contains more than 3 fields separated by underscores.
      */
-    @JvmStatic
     fun localeFromStringIgnoringScriptAndExtensions(localeCodeStr: String): Locale {
         val localeCode = stripScriptAndExtensions(localeCodeStr)
         val fields = localeCode.split("_".toRegex()).toTypedArray()

--- a/AnkiDroid/src/main/java/com/ichi2/anki/LeakCanaryConfiguration.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/LeakCanaryConfiguration.kt
@@ -27,7 +27,6 @@ object LeakCanaryConfiguration {
     /**
      * Disable LeakCanary.
      */
-    @JvmStatic
     fun disable() {
         config = config.copy(
             dumpHeap = false,
@@ -42,7 +41,6 @@ object LeakCanaryConfiguration {
      * Sets the initial configuration for LeakCanary. This method can be used to match known library
      * leaks or leaks which have been already reported previously.
      */
-    @JvmStatic
     fun setInitialConfigFor(application: Application, knownMemoryLeaks: List<ReferenceMatcher> = emptyList()) {
         config = config.copy(referenceMatchers = AndroidReferenceMatchers.appDefaults + knownMemoryLeaks)
         // AppWatcher manual install if not already installed

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NotificationChannels.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NotificationChannels.kt
@@ -22,7 +22,6 @@ import android.content.res.Resources
 import com.ichi2.compat.CompatHelper
 
 object NotificationChannels {
-    @JvmStatic
     fun getId(channel: Channel?): String {
         return when (channel) {
             Channel.SYNC -> "Synchronization"
@@ -49,7 +48,6 @@ object NotificationChannels {
      * TODO should be called in response to {@link android.content.Intent#ACTION_LOCALE_CHANGED}
      * @param context the context for access to localized strings for channel names
      */
-    @JvmStatic
     fun setup(context: Context) {
         val res = context.resources
         val compat = CompatHelper.compat

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ReadText.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ReadText.kt
@@ -38,7 +38,6 @@ import java.util.*
 
 object ReadText {
     @get:VisibleForTesting(otherwise = VisibleForTesting.NONE)
-    @get:JvmStatic
     var textToSpeech: TextToSpeech? = null
         private set
     private val availableTtsLocales = ArrayList<Locale>()
@@ -245,7 +244,6 @@ object ReadText {
             TextToSpeech.LANG_AVAILABLE
     }
 
-    @JvmStatic
     fun initializeTts(context: Context, listener: ReadTextListener) {
         // Store weak reference to Activity to prevent memory leak
         flashCardViewer = WeakReference(context)
@@ -321,7 +319,6 @@ object ReadText {
      * No-op if the current instance of TextToSpeech was initialized by another Context
      * @param context The context used during [.initializeTts]
      */
-    @JvmStatic
     fun releaseTts(context: Context) {
         if (textToSpeech != null && flashCardViewer.get() === context) {
             textToSpeech!!.stop()
@@ -329,14 +326,12 @@ object ReadText {
         }
     }
 
-    @JvmStatic
     fun stopTts() {
         if (textToSpeech != null) {
             textToSpeech!!.stop()
         }
     }
 
-    @JvmStatic
     fun closeForTests() {
         if (textToSpeech != null) {
             textToSpeech!!.shutdown()

--- a/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsFragment.kt
@@ -714,7 +714,6 @@ class StudyOptionsFragment : Fragment(), Toolbar.OnMenuItemClickListener {
          * which shows the current deck's options. Set to true when programmatically
          * opening a new filtered deck for the first time.
          */
-        @JvmStatic
         fun newInstance(withDeckOptions: Boolean): StudyOptionsFragment {
             val f = StudyOptionsFragment()
             val args = Bundle()
@@ -723,7 +722,6 @@ class StudyOptionsFragment : Fragment(), Toolbar.OnMenuItemClickListener {
             return f
         }
 
-        @JvmStatic
         @VisibleForTesting
         fun formatDescription(desc: String?): Spanned {
             // #5715: In deck description, ignore what is in style and script tag

--- a/AnkiDroid/src/main/java/com/ichi2/anki/TemporaryModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/TemporaryModel.kt
@@ -315,7 +315,6 @@ class TemporaryModel(model: Model) {
          * @param bundle a Bundle that should contain persisted JSON under INTENT_MODEL_FILENAME key
          * @return re-hydrated TemporaryModel or null if there was a problem, null means should reload from database
          */
-        @JvmStatic
         fun fromBundle(bundle: Bundle): TemporaryModel? {
             val editedModelFileName = bundle.getString(INTENT_MODEL_FILENAME)
             // Bundle.getString is @Nullable, so we have to check.
@@ -339,7 +338,6 @@ class TemporaryModel(model: Model) {
          * Save the current model to a temp file in the application internal cache directory
          * @return String representing the absolute path of the saved file, or null if there was a problem
          */
-        @JvmStatic
         fun saveTempModel(context: Context, tempModel: JSONObject): String? {
             Timber.d("saveTempModel() saving tempModel")
             var tempModelFile: File
@@ -360,7 +358,6 @@ class TemporaryModel(model: Model) {
          * @return JSONObject holding the model, or null if there was a problem
          */
         @Throws(IOException::class)
-        @JvmStatic
         fun getTempModel(tempModelFileName: String): Model {
             Timber.d("getTempModel() fetching tempModel %s", tempModelFileName)
             try {
@@ -377,7 +374,6 @@ class TemporaryModel(model: Model) {
         /** Clear any temp model files saved into internal cache directory  */
         @Suppress("RECEIVER_NULLABILITY_MISMATCH_BASED_ON_JAVA_ANNOTATIONS")
         @KotlinCleanup("handle the nullability issue of listing files from cache dir")
-        @JvmStatic
         fun clearTempModelFiles(): Int {
             var deleteCount = 0
             for (c in AnkiDroidApp.instance.cacheDir.listFiles()) {
@@ -400,7 +396,6 @@ class TemporaryModel(model: Model) {
          * @param ord int representing an ordinal in the model, that might be an unsaved addition
          * @return boolean true if it is a pending addition from this editing session
          */
-        @JvmStatic
         fun isOrdinalPendingAdd(model: TemporaryModel, ord: Int): Boolean {
             for (i in model.templateChanges.indices) {
                 // commented out to make the code compile, why is this unused?

--- a/AnkiDroid/src/main/java/com/ichi2/anki/TtsParser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/TtsParser.kt
@@ -22,7 +22,6 @@ object TtsParser {
      * elements; in that case the function returns a single LocalisedText object containing the
      * text extracted from the whole HTML fragment, with the localeCode set to an empty string.
      */
-    @JvmStatic
     fun getTextsToRead(html: String, clozeReplacement: String): List<TTSTag> {
         val textsToRead: MutableList<TTSTag> = ArrayList()
         val elem = Jsoup.parseBodyFragment(html).body()

--- a/AnkiDroid/src/main/java/com/ichi2/anki/UIUtils.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/UIUtils.kt
@@ -14,27 +14,22 @@ import timber.log.Timber
 import java.util.*
 
 object UIUtils {
-    @JvmStatic
     fun showThemedToast(context: Context?, text: String?, shortLength: Boolean) {
         Toast.makeText(context, text, if (shortLength) Toast.LENGTH_SHORT else Toast.LENGTH_LONG).show()
     }
 
-    @JvmStatic
     fun showThemedToast(context: Context?, text: CharSequence?, shortLength: Boolean) {
         showThemedToast(context, text.toString(), shortLength)
     }
 
-    @JvmStatic
     fun showThemedToast(context: Context?, @StringRes textResource: Int, shortLength: Boolean) {
         Toast.makeText(context, textResource, if (shortLength) Toast.LENGTH_SHORT else Toast.LENGTH_LONG).show()
     }
 
-    @JvmStatic
     fun getDensityAdjustedValue(context: Context, value: Float): Float {
         return context.resources.displayMetrics.density * value
     }
 
-    @JvmStatic
     fun getDayStart(time: Time): Long {
         val cal = time.calendar()
         if (cal[Calendar.HOUR_OF_DAY] < 4) {
@@ -47,7 +42,6 @@ object UIUtils {
         return cal.timeInMillis
     }
 
-    @JvmStatic
     fun saveCollectionInBackground(syncIgnoresDatabaseModification: Boolean = false) {
         if (CollectionHelper.instance.colIsOpen()) {
             val listener: TaskListener<Void?, Void?> = object : TaskListener<Void?, Void?>() {
@@ -70,7 +64,6 @@ object UIUtils {
      * @param context Context to get resources and device specific display metrics.
      * @return A float value to represent px value which is equivalent to the passed dp value.
      */
-    @JvmStatic
     fun convertDpToPixel(dp: Float, context: Context): Float {
         return dp * (context.resources.displayMetrics.densityDpi.toFloat() / DisplayMetrics.DENSITY_DEFAULT)
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Whiteboard.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Whiteboard.kt
@@ -517,7 +517,6 @@ class Whiteboard(activity: AnkiActivity, handleMultiTouch: Boolean, inverted: Bo
     companion object {
         private const val TOUCH_TOLERANCE = 4f
         private var mWhiteboardMultiTouchMethods: WhiteboardMultiTouchMethods? = null
-        @JvmStatic
         fun createInstance(context: AnkiActivity, handleMultiTouch: Boolean, whiteboardMultiTouchMethods: WhiteboardMultiTouchMethods?): Whiteboard {
             val whiteboard = Whiteboard(context, handleMultiTouch, currentTheme.isNightMode)
             mWhiteboardMultiTouchMethods = whiteboardMultiTouchMethods

--- a/AnkiDroid/src/main/java/com/ichi2/anki/analytics/UsageAnalytics.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/analytics/UsageAnalytics.kt
@@ -53,7 +53,6 @@ object UsageAnalytics {
      *
      * @param context required to look up the analytics codes for the app
      */
-    @JvmStatic
     @Synchronized
     fun initialize(context: Context): GoogleAnalytics? {
         Timber.i("initialize()")
@@ -165,7 +164,6 @@ object UsageAnalytics {
      *
      * @param dryRun set to true if you want to log analytics hit but not dispatch
      */
-    @JvmStatic
     @Synchronized
     fun setDryRun(dryRun: Boolean) {
         Timber.i("setDryRun(): %s, warning dryRun is experimental", dryRun)
@@ -192,7 +190,6 @@ object UsageAnalytics {
      * @param object the result of Object.getClass().getSimpleName() will be used as the screen tag
      */
     @KotlinCleanup("rename object")
-    @JvmStatic
     fun sendAnalyticsScreenView(`object`: Any) {
         sendAnalyticsScreenView(`object`.javaClass.simpleName)
     }
@@ -218,7 +215,6 @@ object UsageAnalytics {
      * @param action   the action the user performed
      */
     @KotlinCleanup("remove when all callers are Kotlin")
-    @JvmStatic
     fun sendAnalyticsEvent(category: String, action: String) {
         sendAnalyticsEvent(category, action, Integer.MIN_VALUE, null)
     }
@@ -231,7 +227,6 @@ object UsageAnalytics {
      * @param value    A value for the event, Integer.MIN_VALUE signifies caller shouldn't send the value
      * @param label    A label for the event, may be null
      */
-    @JvmStatic
     fun sendAnalyticsEvent(category: String, action: String, value: Int = Int.MIN_VALUE, label: String? = null) {
         Timber.d("sendAnalyticsEvent() category/action/value/label: %s/%s/%s/%s", category, action, value, label)
         if (!optIn) {
@@ -253,12 +248,10 @@ object UsageAnalytics {
      * @param t     Throwable to send for analysis
      * @param fatal whether it was fatal or not
      */
-    @JvmStatic
     fun sendAnalyticsException(t: Throwable, fatal: Boolean) {
         sendAnalyticsException(getCause(t).toString(), fatal)
     }
 
-    @JvmStatic
     @KotlinCleanup("convert to sequence")
     fun getCause(t: Throwable): Throwable {
         var cause: Throwable?
@@ -308,7 +301,6 @@ object UsageAnalytics {
                 .apply()
         }
 
-    @JvmStatic
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)
     fun resetForTests() {
         sAnalytics = null

--- a/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/CardAppearance.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/CardAppearance.kt
@@ -77,7 +77,6 @@ class CardAppearance(private val customFonts: ReviewerCustomFonts, private val c
     companion object {
         private val nightModeClassRegex = Regex("\\.night(?:_m|M)ode\\b")
 
-        @JvmStatic
         fun create(customFonts: ReviewerCustomFonts, preferences: SharedPreferences): CardAppearance {
             val cardZoom = preferences.getInt("cardZoom", 100)
             val imageZoom = preferences.getInt("imageZoom", 100)
@@ -85,7 +84,6 @@ class CardAppearance(private val customFonts: ReviewerCustomFonts, private val c
             return CardAppearance(customFonts, cardZoom, imageZoom, centerVertically)
         }
 
-        @JvmStatic
         fun fixBoldStyle(content: String): String {
             // In order to display the bold style correctly, we have to change
             // font-weight to 700

--- a/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/CardHtml.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/CardHtml.kt
@@ -201,7 +201,6 @@ class CardHtml(
          * @param answerContent     The content from which to remove front side audio.
          * @return The content stripped of audio due to {{FrontSide}} inclusion.
          */
-        @JvmStatic
         fun removeFrontSideAudio(card: Card, answerContent: String): String {
             val answerFormat = getAnswerFormat(card)
             var newAnswerContent = answerContent
@@ -216,7 +215,6 @@ class CardHtml(
             return newAnswerContent
         }
 
-        @JvmStatic
         fun legacyGetTtsTags(card: Card, cardSide: Sound.SoundSide, context: Context): List<TTSTag>? {
             val cardSideContent: String = when {
                 Sound.SoundSide.QUESTION == cardSide -> card.q(true)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/Gesture.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/Gesture.kt
@@ -83,7 +83,6 @@ enum class TapGestureMode {
     NINE_POINT;
 
     companion object {
-        @JvmStatic
         fun fromPreference(preferences: SharedPreferences): TapGestureMode =
             when (preferences.getBoolean("gestureCornerTouch", false)) {
                 true -> NINE_POINT

--- a/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/HtmlGenerator.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/HtmlGenerator.kt
@@ -52,7 +52,6 @@ class HtmlGenerator(
     }
 
     companion object {
-        @JvmStatic
         fun createInstance(context: Context, typeAnswer: TypeAnswer, baseUrl: String): HtmlGenerator {
             val preferences = AnkiDroidApp.getSharedPrefs(context)
             val cardAppearance = CardAppearance.create(ReviewerCustomFonts(context), preferences)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/PreviewLayout.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/PreviewLayout.kt
@@ -74,7 +74,6 @@ class PreviewLayout(
     }
 
     companion object {
-        @JvmStatic
         fun createAndDisplay(activity: AnkiActivity, toggleAnswerHandler: View.OnClickListener): PreviewLayout {
             val buttonsLayout = activity.findViewById<FrameLayout>(R.id.preview_buttons_layout)
             val prevCard = activity.findViewById<ImageView>(R.id.preview_previous_flashcard)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/SoundPlayer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/SoundPlayer.kt
@@ -46,7 +46,6 @@ class SoundPlayer {
     class CardSoundConfig(val replayQuestion: Boolean, val autoplay: Boolean) {
 
         companion object {
-            @JvmStatic
             fun create(col: Collection, card: Card): CardSoundConfig {
                 val deckConfig = col.decks.confForDid(CardUtils.getDeckIdForCard(card))
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/TypeAnswer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/TypeAnswer.kt
@@ -231,7 +231,6 @@ class TypeAnswer(
         /** Regular expression in card data for a 'type answer' after processing has occurred */
         val PATTERN: Pattern = Pattern.compile("\\[\\[type:(.+?)]]")
 
-        @JvmStatic
         fun createInstance(preferences: SharedPreferences): TypeAnswer {
             return TypeAnswer(
                 useInputTag = preferences.getBoolean("useInputTag", false),
@@ -250,7 +249,6 @@ class TypeAnswer(
          * @param answer The content of the field the text typed by the user is compared to.
          * @return The correct answer text, with actual HTML and media references removed, and HTML entities unescaped.
          */
-        @JvmStatic
         fun cleanCorrectAnswer(answer: String?): String {
             if (answer.isNullOrEmpty()) return ""
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/contextmenu/AnkiCardContextMenu.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/contextmenu/AnkiCardContextMenu.kt
@@ -22,7 +22,6 @@ class AnkiCardContextMenu(context: Context) : SystemContextMenu(context) {
         get() = "com.ichi2.anki.AnkiCardContextMenuAction"
 
     companion object {
-        @JvmStatic
         fun ensureConsistentStateWithPreferenceStatus(context: Context, preferenceStatus: Boolean) {
             AnkiCardContextMenu(context).ensureConsistentStateWithPreferenceStatus(preferenceStatus)
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/contextmenu/CardBrowserContextMenu.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/contextmenu/CardBrowserContextMenu.kt
@@ -22,7 +22,6 @@ class CardBrowserContextMenu(context: Context) : SystemContextMenu(context) {
         get() = "com.ichi2.anki.CardBrowserContextMenuAction"
 
     companion object {
-        @JvmStatic
         fun ensureConsistentStateWithPreferenceStatus(context: Context, preferenceStatus: Boolean) {
             CardBrowserContextMenu(context).ensureConsistentStateWithPreferenceStatus(preferenceStatus)
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/CardBrowserMySearchesDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/CardBrowserMySearchesDialog.kt
@@ -102,7 +102,7 @@ class CardBrowserMySearchesDialog : AnalyticsDialogFragment() {
         const val CARD_BROWSER_MY_SEARCHES_TYPE_LIST = 0 // list searches dialog
         const val CARD_BROWSER_MY_SEARCHES_TYPE_SAVE = 1 // save searches dialog
         private var mySearchesDialogListener: MySearchesDialogListener? = null
-        @JvmStatic
+
         fun newInstance(
             savedFilters: HashMap<String, String>?,
             mySearchesDialogListener: MySearchesDialogListener?,

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/CardBrowserOrderDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/CardBrowserOrderDialog.kt
@@ -56,7 +56,7 @@ class CardBrowserOrderDialog : AnalyticsDialogFragment() {
 
     companion object {
         private var orderSingleChoiceDialogListener: SingleChoiceListener = null
-        @JvmStatic
+
         fun newInstance(
             order: Int,
             isOrderAsc: Boolean,

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DatabaseErrorDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DatabaseErrorDialog.kt
@@ -455,7 +455,6 @@ class DatabaseErrorDialog : AsyncDialogFragment() {
          *
          * @param dialogType An integer which specifies which of the sub-dialogs to show
          */
-        @JvmStatic
         fun newInstance(dialogType: Int): DatabaseErrorDialog {
             val f = DatabaseErrorDialog()
             val args = Bundle()

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckPickerAnalyticsOptInDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckPickerAnalyticsOptInDialog.kt
@@ -42,7 +42,6 @@ class DeckPickerAnalyticsOptInDialog : AnalyticsDialogFragment() {
     }
 
     companion object {
-        @JvmStatic
         fun newInstance(): DeckPickerAnalyticsOptInDialog {
             return DeckPickerAnalyticsOptInDialog()
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckPickerBackupNoSpaceLeftDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckPickerBackupNoSpaceLeftDialog.kt
@@ -41,7 +41,6 @@ class DeckPickerBackupNoSpaceLeftDialog : AnalyticsDialogFragment() {
     }
 
     companion object {
-        @JvmStatic
         fun newInstance(): DeckPickerBackupNoSpaceLeftDialog {
             return DeckPickerBackupNoSpaceLeftDialog()
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckPickerConfirmDeleteDeckDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckPickerConfirmDeleteDeckDialog.kt
@@ -47,7 +47,6 @@ class DeckPickerConfirmDeleteDeckDialog : AnalyticsDialogFragment() {
     }
 
     companion object {
-        @JvmStatic
         fun newInstance(dialogMessage: String?, deckId: DeckId): DeckPickerConfirmDeleteDeckDialog {
             val f = DeckPickerConfirmDeleteDeckDialog()
             val args = Bundle()

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckPickerNoSpaceLeftDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckPickerNoSpaceLeftDialog.kt
@@ -37,7 +37,6 @@ class DeckPickerNoSpaceLeftDialog : AnalyticsDialogFragment() {
     }
 
     companion object {
-        @JvmStatic
         fun newInstance(): DeckPickerNoSpaceLeftDialog {
             return DeckPickerNoSpaceLeftDialog()
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckPickerNoSpaceToDowngradeDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckPickerNoSpaceToDowngradeDialog.kt
@@ -50,7 +50,6 @@ class DeckPickerNoSpaceToDowngradeDialog(private val formatter: FileSizeFormatte
     }
 
     companion object {
-        @JvmStatic
         fun newInstance(formatter: FileSizeFormatter, collectionFile: File): DeckPickerNoSpaceToDowngradeDialog {
             return DeckPickerNoSpaceToDowngradeDialog(formatter, collectionFile)
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckSelectionDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckSelectionDialog.kt
@@ -356,7 +356,6 @@ open class DeckSelectionDialog : AnalyticsDialogFragment() {
              * @param filter A method deciding which deck to add
              * @return the list of all SelectableDecks from the collection satisfying filter
              */
-            @JvmStatic
             fun fromCollection(c: Collection, filter: FunctionalInterfaces.Filter<Deck> = FunctionalInterfaces.Filters.allowAll()): List<SelectableDeck> {
                 val all = c.decks.all()
                 val ret: MutableList<SelectableDeck> = ArrayList(all.size)
@@ -384,7 +383,6 @@ open class DeckSelectionDialog : AnalyticsDialogFragment() {
         /**
          * A dialog which handles selecting a deck
          */
-        @JvmStatic
         fun newInstance(title: String, summaryMessage: String?, keepRestoreDefaultButton: Boolean, decks: List<SelectableDeck>): DeckSelectionDialog {
             val f = DeckSelectionDialog()
             val args = Bundle()

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DialogHandler.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DialogHandler.kt
@@ -149,7 +149,6 @@ class DialogHandler(activity: AnkiActivity) : Handler(getDefaultLooper()) {
          * Store a persistent message to static variable
          * @param message Message to store
          */
-        @JvmStatic
         fun storeMessage(message: Message?) {
             Timber.d("Storing persistent message")
             sStoredMessage = message

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DiscardChangesDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DiscardChangesDialog.kt
@@ -21,7 +21,6 @@ import com.ichi2.anki.R
 
 class DiscardChangesDialog {
     companion object {
-        @JvmStatic
         fun showDialog(context: Context?, positiveMethod: () -> Unit): MaterialDialog {
             return MaterialDialog(context!!).show {
                 message(R.string.discard_unsaved_changes)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/HelpDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/HelpDialog.kt
@@ -47,7 +47,6 @@ object HelpDialog {
         ankiActivity.openUrl(Uri.parse(AnkiDroidApp.feedbackUrl))
     }
 
-    @JvmStatic
     fun createInstance(): DialogFragment {
         val exceptionReportItem = ExceptionReportItem(R.string.help_title_send_exception, R.drawable.ic_round_assignment_24, UsageAnalytics.Actions.EXCEPTION_REPORT)
         UsageAnalytics.sendAnalyticsEvent(UsageAnalytics.Category.LINK_CLICKED, UsageAnalytics.Actions.OPENED_HELPDIALOG)
@@ -97,7 +96,6 @@ object HelpDialog {
         return createInstance(ArrayList(listOf(*allItems)), R.string.help)
     }
 
-    @JvmStatic
     fun createInstanceForSupportAnkiDroid(context: Context?): DialogFragment {
         UsageAnalytics.sendAnalyticsEvent(UsageAnalytics.Category.LINK_CLICKED, UsageAnalytics.Actions.OPENED_SUPPORT_ANKIDROID)
         val rateAppItem = RateAppItem(R.string.help_item_support_rate_ankidroid, R.drawable.ic_star_black_24, UsageAnalytics.Actions.OPENED_RATE)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ImportDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ImportDialog.kt
@@ -101,7 +101,6 @@ class ImportDialog : AsyncDialogFragment() {
          * @param dialogMessageList An optional ArrayList of string(s) which can be used to show a custom message
          * or specify import path
          */
-        @JvmStatic
         fun newInstance(dialogType: Int, dialogMessageList: ArrayList<String>): ImportDialog {
             val f = ImportDialog()
             val args = Bundle()

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ImportFileSelectionFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ImportFileSelectionFragment.kt
@@ -32,7 +32,6 @@ import timber.log.Timber
 @NeedsTest("Restore backup dialog does not allow multiple files")
 class ImportFileSelectionFragment {
     companion object {
-        @JvmStatic
         @KotlinCleanup("convert importItems to java ArrayList")
         fun createInstance(@Suppress("UNUSED_PARAMETER") context: DeckPicker): RecursivePictureMenu {
             // this needs a deckPicker for now. See use of PICK_APKG_FILE
@@ -83,7 +82,6 @@ class ImportFileSelectionFragment {
         }
 
         // needs to be static for serialization
-        @JvmStatic
         fun openImportFilePicker(
             activity: AnkiActivity,
             requestCode: Int,

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/LocaleSelectionDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/LocaleSelectionDialog.kt
@@ -176,7 +176,6 @@ class LocaleSelectionDialog : AnalyticsDialogFragment() {
         /**
          * @param handler Marker interface to enforce the convention the caller implementing LocaleSelectionDialogHandler
          */
-        @JvmStatic
         fun newInstance(handler: LocaleSelectionDialogHandler): LocaleSelectionDialog {
             return LocaleSelectionDialog().apply {
                 mDialogHandler = handler

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/MediaCheckDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/MediaCheckDialog.kt
@@ -144,7 +144,6 @@ class MediaCheckDialog : AsyncDialogFragment() {
     companion object {
         const val DIALOG_CONFIRM_MEDIA_CHECK = 0
         const val DIALOG_MEDIA_CHECK_RESULTS = 1
-        @JvmStatic
         fun newInstance(dialogType: Int): MediaCheckDialog {
             val f = MediaCheckDialog()
             val args = Bundle()
@@ -153,7 +152,6 @@ class MediaCheckDialog : AsyncDialogFragment() {
             return f
         }
 
-        @JvmStatic
         fun newInstance(dialogType: Int, checkList: List<List<String?>?>): MediaCheckDialog {
             val f = MediaCheckDialog()
             val args = Bundle()

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ModelBrowserContextMenu.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ModelBrowserContextMenu.kt
@@ -31,7 +31,6 @@ class ModelBrowserContextMenu : AnalyticsDialogFragment() {
     companion object {
         private const val KEY_LABEL = "key_label"
 
-        @JvmStatic
         fun newInstance(label: String?): ModelBrowserContextMenu = ModelBrowserContextMenu().apply {
             arguments = bundleOf(KEY_LABEL to label)
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ModelEditorContextMenu.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ModelEditorContextMenu.kt
@@ -62,7 +62,6 @@ open class ModelEditorContextMenu : AnalyticsDialogFragment() {
         @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
         const val KEY_LABEL = "key_label"
 
-        @JvmStatic
         fun newInstance(label: String): ModelEditorContextMenu = ModelEditorContextMenu().apply {
             arguments = bundleOf(KEY_LABEL to label)
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/RecursivePictureMenu.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/RecursivePictureMenu.kt
@@ -193,7 +193,6 @@ class RecursivePictureMenu : DialogFragment() {
     }
 
     companion object {
-        @JvmStatic
         @CheckResult
         fun createInstance(itemList: ArrayList<Item?>?, @StringRes title: Int): RecursivePictureMenu {
             val helpDialog = RecursivePictureMenu()
@@ -204,7 +203,6 @@ class RecursivePictureMenu : DialogFragment() {
             return helpDialog
         }
 
-        @JvmStatic
         fun removeFrom(allItems: List<Item>, toRemove: Item?) {
             // Note: currently doesn't remove the top-level elements.
             for (i in allItems) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/RescheduleDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/RescheduleDialog.kt
@@ -23,7 +23,6 @@ import com.ichi2.libanki.sched.SchedV2
 import java.util.function.Consumer
 
 object RescheduleDialog : IntegerDialog() {
-    @JvmStatic
     @CheckResult
     fun rescheduleSingleCard(
         resources: Resources,
@@ -44,7 +43,6 @@ object RescheduleDialog : IntegerDialog() {
         return rescheduleDialog
     }
 
-    @JvmStatic
     @CheckResult
     fun rescheduleMultipleCards(resources: Resources, consumer: Consumer<Int>?, cardCount: Int): RescheduleDialog {
         val rescheduleDialog = RescheduleDialog

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ScopedStorageMigrationDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ScopedStorageMigrationDialog.kt
@@ -48,7 +48,6 @@ typealias OpenUri = (Uri) -> Unit
 object ScopedStorageMigrationDialog {
     @Suppress("Deprecation") // Material dialog neutral button deprecation
     @SuppressLint("CheckResult")
-    @JvmStatic
     fun showDialog(ctx: Context, openUri: OpenUri, initiateScopedStorage: Runnable): Dialog {
         return MaterialDialog(ctx).show {
             title(R.string.scoped_storage_title)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/SyncErrorDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/SyncErrorDialog.kt
@@ -268,7 +268,6 @@ class SyncErrorDialog : AsyncDialogFragment() {
          * @param dialogType An integer which specifies which of the sub-dialogs to show
          * @param dialogMessage A string which can be optionally used to set the dialog message
          */
-        @JvmStatic
         fun newInstance(dialogType: Int, dialogMessage: String?): SyncErrorDialog {
             val f = SyncErrorDialog()
             val args = Bundle()

--- a/AnkiDroid/src/main/java/com/ichi2/anki/model/WhiteboardPenColor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/model/WhiteboardPenColor.kt
@@ -29,7 +29,6 @@ class WhiteboardPenColor(val lightPenColor: Int?, val darkPenColor: Int?) {
     }
 
     companion object {
-        @JvmStatic
         @get:CheckResult
         val default: WhiteboardPenColor
             get() = WhiteboardPenColor(null, null)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/AudioView.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/AudioView.kt
@@ -336,7 +336,6 @@ class AudioView private constructor(context: Context, resPlay: Int, resPause: In
     }
 
     companion object {
-        @JvmStatic
         fun createRecorderInstance(
             context: Context,
             resPlay: Int,
@@ -359,7 +358,6 @@ class AudioView private constructor(context: Context, resPlay: Int, resPause: In
             }
         }
 
-        @JvmStatic
         fun generateTempAudioFile(context: Context): String? {
             val tempAudioPath: String?
             tempAudioPath = try {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/beolingus/parsing/BeolingusParser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/beolingus/parsing/BeolingusParser.kt
@@ -37,7 +37,6 @@ object BeolingusParser {
      * @param html HTML page from beolingus, with translation of the word we search
      * @return `"no"` or the pronunciation URL
      */
-    @JvmStatic
     @KotlinCleanup("AFTER fixing @KotlinCleanup in LoadPronunciationActivity see if wordToSearchFor can be made non null")
     fun getPronunciationAddressFromTranslation(@Language("HTML") html: String, wordToSearchFor: String?): String {
         val m = PRONUNCIATION_PATTERN.matcher(html)
@@ -57,7 +56,6 @@ object BeolingusParser {
     /**
      * @return `"no"`, or the http address of the mp3 file
      */
-    @JvmStatic
     fun getMp3AddressFromPronunciation(@Language("HTML") pronunciationPageHtml: String): String {
         // Only log the page if you need to work with the regex
         // Timber.d("pronunciationPageHtml is %s", pronunciationPageHtml);

--- a/AnkiDroid/src/main/java/com/ichi2/anki/noteeditor/CustomToolbarButton.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/noteeditor/CustomToolbarButton.kt
@@ -48,7 +48,6 @@ class CustomToolbarButton(var index: Int, var buttonText: ButtonText, val prefix
             return CustomToolbarButton(index, fields[1], fields[2], fields[3])
         }
 
-        @JvmStatic
         fun fromStringSet(hs: Set<String?>): ArrayList<CustomToolbarButton> {
             val buttons = ArrayList<CustomToolbarButton>(hs.size)
             for (s in hs) {
@@ -64,7 +63,6 @@ class CustomToolbarButton(var index: Int, var buttonText: ButtonText, val prefix
             return buttons
         }
 
-        @JvmStatic
         fun toStringSet(buttons: ArrayList<CustomToolbarButton>): Set<String> {
             val ret = HashSetInit<String>(buttons.size)
             for (b in buttons) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/noteeditor/FieldState.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/noteeditor/FieldState.kt
@@ -127,7 +127,6 @@ class FieldState private constructor(private val editor: NoteEditor) {
         var newModel: Model? = null
 
         companion object {
-            @JvmStatic
             fun refreshWithMap(newModel: Model?, modelChangeFieldMap: Map<Int, Int>?, replaceNewlines: Boolean): FieldChangeType {
                 val typeClass = FieldChangeType(Type.REFRESH_WITH_MAP, replaceNewlines)
                 typeClass.newModel = newModel
@@ -135,22 +134,18 @@ class FieldState private constructor(private val editor: NoteEditor) {
                 return typeClass
             }
 
-            @JvmStatic
             fun refresh(replaceNewlines: Boolean): FieldChangeType {
                 return fromType(Type.REFRESH, replaceNewlines)
             }
 
-            @JvmStatic
             fun refreshWithStickyFields(replaceNewlines: Boolean): FieldChangeType {
                 return fromType(Type.CLEAR_KEEP_STICKY, replaceNewlines)
             }
 
-            @JvmStatic
             fun changeFieldCount(replaceNewlines: Boolean): FieldChangeType {
                 return fromType(Type.CHANGE_FIELD_COUNT, replaceNewlines)
             }
 
-            @JvmStatic
             fun onActivityCreation(replaceNewlines: Boolean): FieldChangeType {
                 return fromType(Type.INIT, replaceNewlines)
             }
@@ -170,7 +165,6 @@ class FieldState private constructor(private val editor: NoteEditor) {
             return oldFields.size > 2
         }
 
-        @JvmStatic
         fun fromEditor(editor: NoteEditor): FieldState {
             return FieldState(editor)
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/Preferences.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/Preferences.kt
@@ -308,7 +308,6 @@ class Preferences : AnkiActivity(), SearchPreferenceResultListener {
         const val INITIAL_FRAGMENT_EXTRA = "initial_fragment"
 
         /** Returns the hour that the collection rolls over to the next day  */
-        @JvmStatic
         fun getDayOffset(col: Collection): Int {
             return when (col.schedVer()) {
                 2 -> col.get_config("rollover", DEFAULT_ROLLOVER_VALUE)!!

--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/SettingsFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/SettingsFragment.kt
@@ -80,7 +80,7 @@ abstract class SettingsFragment : PreferenceFragmentCompat() {
     }
 
     companion object {
-        @JvmStatic
+        @JvmStatic // Using protected members which are not @JvmStatic in the superclass companion is unsupported yet
         protected fun getSubscreenIntent(context: Context, fragmentClass: KClass<out SettingsFragment>): Intent {
             return Intent(context, Preferences::class.java)
                 .putExtra(Preferences.INITIAL_FRAGMENT_EXTRA, fragmentClass.jvmName)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/provider/CardContentProvider.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/provider/CardContentProvider.kt
@@ -110,7 +110,6 @@ class CardContentProvider : ContentProvider() {
         private val sDefaultNoteProjectionDBAccess = FlashCardsContract.Note.DEFAULT_PROJECTION.clone()
         private const val COL_NULL_ERROR_MSG = "AnkiDroid database inaccessible. Open AnkiDroid to see what's wrong."
 
-        @JvmStatic
         private fun sanitizeNoteProjection(projection: Array<String>?): Array<String> {
             if (projection == null || projection.size == 0) {
                 return sDefaultNoteProjectionDBAccess

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/AnswerButtons.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/AnswerButtons.kt
@@ -101,7 +101,6 @@ enum class AnswerButtons {
         fun canAnswerHard(numberOfButtons: Int): Boolean = numberOfButtons == 4
         fun canAnswerEasy(numberOfButtons: Int): Boolean = numberOfButtons >= 3
 
-        @JvmStatic
         fun getBackgroundColors(ctx: AnkiActivity): IntArray {
             val backgroundIds: IntArray =
                 if (ctx.animationEnabled()) {
@@ -122,7 +121,6 @@ enum class AnswerButtons {
             return Themes.getResFromAttr(ctx, backgroundIds)
         }
 
-        @JvmStatic
         fun getTextColors(ctx: Context): IntArray {
             return Themes.getColorFromAttr(
                 ctx,

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/AutomaticAnswer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/AutomaticAnswer.kt
@@ -193,13 +193,11 @@ class AutomaticAnswer(
     }
 
     companion object {
-        @JvmStatic
         @CheckResult
         fun defaultInstance(target: AutomaticallyAnswered): AutomaticAnswer {
             return AutomaticAnswer(target, AutomaticAnswerSettings())
         }
 
-        @JvmStatic
         @CheckResult
         fun createInstance(target: AutomaticallyAnswered, preferences: SharedPreferences, col: Collection): AutomaticAnswer {
             val settings = AutomaticAnswerSettings.createInstance(preferences, col)
@@ -244,7 +242,6 @@ class AutomaticAnswerSettings(
          * @return null if the deck is dynamic (use global settings),
          * or if "useGeneralTimeoutSettings" is set
          */
-        @JvmStatic
         fun queryDeckSpecificOptions(
             action: AutomaticAnswerAction,
             col: Collection,
@@ -269,7 +266,6 @@ class AutomaticAnswerSettings(
             return AutomaticAnswerSettings(action, useTimer, waitQuestionSecond, waitAnswerSecond)
         }
 
-        @JvmStatic
         fun queryFromPreferences(preferences: SharedPreferences, action: AutomaticAnswerAction): AutomaticAnswerSettings {
             val prefUseTimer: Boolean = preferences.getBoolean("timeoutAnswer", false)
             val prefWaitQuestionSecond: Int = preferences.getInt("timeoutQuestionSeconds", 60)
@@ -277,7 +273,6 @@ class AutomaticAnswerSettings(
             return AutomaticAnswerSettings(action, prefUseTimer, prefWaitQuestionSecond, prefWaitAnswerSecond)
         }
 
-        @JvmStatic
         fun createInstance(preferences: SharedPreferences, col: Collection): AutomaticAnswerSettings {
             // deck specific options take precedence over general (preference-based) options.
             // the action can only be set via preferences (but is stored in the collection).

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/Binding.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/Binding.kt
@@ -135,13 +135,10 @@ class Binding private constructor(val modifierKeys: ModifierKeys?, val keycode: 
         companion object {
             fun none(): ModifierKeys = ModifierKeys(shift = false, ctrl = false, alt = false)
 
-            @JvmStatic
             fun ctrl(): ModifierKeys = ModifierKeys(shift = false, ctrl = true, alt = false)
 
-            @JvmStatic
             fun shift(): ModifierKeys = ModifierKeys(shift = true, ctrl = false, alt = false)
 
-            @JvmStatic
             fun alt(): ModifierKeys = ModifierKeys(shift = false, ctrl = false, alt = true)
 
             /**
@@ -204,7 +201,6 @@ class Binding private constructor(val modifierKeys: ModifierKeys?, val keycode: 
         const val GAMEPAD_PREFIX = "🎮"
 
         /** This returns multiple bindings due to the "default" implementation not knowing what the keycode for a button is  */
-        @JvmStatic
         fun key(event: KeyEvent): List<Binding> {
             val modifiers = ModifierKeys(event.isShiftPressed, event.isCtrlPressed, event.isAltPressed)
             val ret: MutableList<Binding> = ArrayList()
@@ -231,7 +227,6 @@ class Binding private constructor(val modifierKeys: ModifierKeys?, val keycode: 
          * Specifies a unicode binding from an unknown input device
          * See [AppDefinedModifierKeys]
          */
-        @JvmStatic
         fun unicode(unicodeChar: Char): Binding =
             unicode(AppDefinedModifierKeys.allowShift(), unicodeChar)
 
@@ -240,10 +235,8 @@ class Binding private constructor(val modifierKeys: ModifierKeys?, val keycode: 
             return Binding(modifierKeys, null, unicodeChar, null)
         }
 
-        @JvmStatic
         fun keyCode(keyCode: Int): Binding = keyCode(ModifierKeys.none(), keyCode)
 
-        @JvmStatic
         fun keyCode(modifiers: ModifierKeys?, keyCode: Int): Binding =
             Binding(modifiers, keyCode, null, null)
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/CardSide.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/CardSide.kt
@@ -22,7 +22,6 @@ enum class CardSide {
     BOTH;
 
     companion object {
-        @JvmStatic
         fun fromAnswer(displayingAnswer: Boolean): CardSide =
             if (displayingAnswer) ANSWER else QUESTION
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/FullScreenMode.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/FullScreenMode.kt
@@ -33,20 +33,16 @@ enum class FullScreenMode(private val prefValue: String) {
 
     companion object {
         const val PREF_KEY = "fullscreenMode"
-        @JvmStatic
         val DEFAULT = BUTTONS_AND_MENU
 
-        @JvmStatic
         fun fromPreference(prefs: SharedPreferences): FullScreenMode {
             val value = prefs.getString(PREF_KEY, DEFAULT.prefValue)
             return enumValues<FullScreenMode>().firstOrNull { it.prefValue == value } ?: DEFAULT
         }
 
-        @JvmStatic
         fun isFullScreenReview(prefs: SharedPreferences): Boolean =
             fromPreference(prefs).isFullScreenReview()
 
-        @JvmStatic
         fun upgradeFromLegacyPreference(preferences: SharedPreferences) {
             if (!preferences.contains("fullscreenReview")) return
 
@@ -59,7 +55,6 @@ enum class FullScreenMode(private val prefValue: String) {
             preferences.edit().remove("fullscreenReview").apply()
         }
 
-        @JvmStatic
         fun setPreference(prefs: SharedPreferences, mode: FullScreenMode) {
             prefs.edit().putString(PREF_KEY, mode.getPreferenceValue()).apply()
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/MappableBinding.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/MappableBinding.kt
@@ -201,14 +201,12 @@ class MappableBinding(val binding: Binding, private val screen: Screen) {
         }
 
         @CheckResult
-        @JvmStatic
         fun fromPreference(prefs: SharedPreferences, command: ViewerCommand): MutableList<MappableBinding> {
             val value = prefs.getString(command.preferenceKey, null) ?: return command.defaultValue.toMutableList()
             return fromPreferenceString(value)
         }
 
         @CheckResult
-        @JvmStatic
         fun allMappings(prefs: SharedPreferences): MutableList<Pair<ViewerCommand, MutableList<MappableBinding>>> {
             return ViewerCommand.values().map {
                 Pair(it, fromPreference(prefs, it))

--- a/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/DebugInfoService.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/DebugInfoService.kt
@@ -27,7 +27,6 @@ import timber.log.Timber
 import java.util.function.Supplier
 
 object DebugInfoService {
-    @JvmStatic
     fun getDebugInfo(info: Context, col: Supplier<Collection>): String {
         var schedName = "Not found"
         try {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/DeckService.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/DeckService.kt
@@ -23,7 +23,6 @@ import com.ichi2.libanki.Utils
 import java.util.*
 
 object DeckService {
-    @JvmStatic
     fun shouldShowDefaultDeck(col: Collection): Boolean =
         defaultDeckHasCards(col) || hasChildren(col, Consts.DEFAULT_DECK_ID)
 
@@ -31,7 +30,6 @@ object DeckService {
     private fun hasChildren(col: Collection, did: DeckId) =
         col.decks.children(did).size > 0
 
-    @JvmStatic
     fun defaultDeckHasCards(col: Collection) =
         col.db.queryScalar("select 1 from cards where did = 1") != 0
 
@@ -44,7 +42,6 @@ object DeckService {
      * @param did Id of the deck to search
      * @return the number of cards in the supplied deck and child decks
      */
-    @JvmStatic
     fun countCardsInDeckTree(col: Collection, did: DeckId): Int {
         val children: TreeMap<String, Long> = col.decks.children(did)
         val dids = LongArray(children.size + 1)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/LanguageHintService.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/LanguageHintService.kt
@@ -36,7 +36,6 @@ import java.util.*
 typealias LanguageHint = Locale
 
 object LanguageHintService {
-    @JvmStatic
     @CheckResult
     fun getLanguageHintForField(field: JSONObject): LanguageHint? {
         if (!field.has("ad-hint-locale")) {
@@ -45,7 +44,6 @@ object LanguageHintService {
         return Locale.forLanguageTag(field.getString("ad-hint-locale"))
     }
 
-    @JvmStatic
     fun setLanguageHintForField(models: ModelManager, model: Model, fieldPos: Int, selectedLocale: Locale) {
         val field = model.getField(fieldPos)
         field.put("ad-hint-locale", selectedLocale.toLanguageTag())
@@ -54,7 +52,6 @@ object LanguageHintService {
         Timber.i("Set field locale to %s", selectedLocale)
     }
 
-    @JvmStatic
     fun EditText.applyLanguageHint(languageHint: LanguageHint?) {
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.N) return
         this.imeHintLocales = if (languageHint != null) LocaleList(languageHint) else null

--- a/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/NoteService.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/NoteService.kt
@@ -45,7 +45,6 @@ object NoteService {
      * @param model the model in JSOBObject format
      * @return a new note instance
      */
-    @JvmStatic
     fun createEmptyNote(model: JSONObject): MultimediaEditableNote? {
         try {
             val fieldsArray = model.getJSONArray("flds")
@@ -70,7 +69,6 @@ object NoteService {
         return null
     }
 
-    @JvmStatic
     fun updateMultimediaNoteFromFields(col: com.ichi2.libanki.Collection, fields: Array<String>, modelId: NoteTypeId, mmNote: MultimediaEditableNote) {
         for (i in fields.indices) {
             val value = fields[i]
@@ -99,7 +97,6 @@ object NoteService {
      * @param noteSrc
      * @param editorNoteDst
      */
-    @JvmStatic
     fun updateJsonNoteFromMultimediaNote(noteSrc: IMultimediaEditableNote?, editorNoteDst: Note) {
         if (noteSrc is MultimediaEditableNote) {
             val mmNote = noteSrc
@@ -118,7 +115,6 @@ object NoteService {
      *
      * @param field
      */
-    @JvmStatic
     fun importMediaToDirectory(col: com.ichi2.libanki.Collection, field: IField?) {
         var tmpMediaPath: String? = null
         when (field!!.type) {
@@ -157,7 +153,6 @@ object NoteService {
     /**
      * @param replaceNewlines Converts [FieldEditText.NEW_LINE] to HTML linebreaks
      */
-    @JvmStatic
     @VisibleForTesting
     @CheckResult
     fun getFieldsAsBundleForPreview(editFields: Collection<NoteField?>?, replaceNewlines: Boolean): Bundle {
@@ -177,7 +172,6 @@ object NoteService {
         return fields
     }
 
-    @JvmStatic
     fun convertToHtmlNewline(fieldData: String, replaceNewlines: Boolean): String {
         return if (!replaceNewlines) {
             fieldData
@@ -200,7 +194,6 @@ object NoteService {
         }
     }
 
-    @JvmStatic
     fun isMarked(note: Note): Boolean {
         return note.hasTag("marked")
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/PreferenceUpgradeService.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/PreferenceUpgradeService.kt
@@ -40,7 +40,6 @@ private typealias VersionIdentifier = Int
 private typealias LegacyVersionIdentifier = Long
 
 object PreferenceUpgradeService {
-    @JvmStatic
     fun upgradePreferences(context: Context?, previousVersionCode: LegacyVersionIdentifier): Boolean =
         upgradePreferences(AnkiDroidApp.getSharedPrefs(context), previousVersionCode)
 
@@ -60,7 +59,7 @@ object PreferenceUpgradeService {
      * Typically because the app has been run for the first time, or the preferences
      * have been deleted
      */
-    @JvmStatic
+    @JvmStatic // reqired for mockito for now
     fun setPreferencesUpToDate(preferences: SharedPreferences) {
         Timber.i("Marking preferences as up to date")
         PreferenceUpgrade.setPreferenceToLatestVersion(preferences)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/SearchService.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/SearchService.kt
@@ -37,7 +37,7 @@ class SearchService {
         companion object {
             @RustCleanup("error checking")
             @RustCleanup("i18n - we use an error message from the Rust")
-            @JvmStatic fun error(e: Exception): SearchCardsResult {
+            fun error(e: Exception): SearchCardsResult {
                 if (e !is InvalidSearchException) {
                     // temporary check to see we haven't missed a backend exception
                     CrashReportService.sendExceptionReport(e, "unexpected error type")
@@ -45,8 +45,8 @@ class SearchService {
                 val error = e.localizedMessage?.replace("net.ankiweb.rsdroid.exceptions.BackendInvalidInputException: ", "")
                 return SearchCardsResult(null, error)
             }
-            @JvmStatic fun success(result: List<CardBrowser.CardCache>) = SearchCardsResult(result, null)
-            @JvmStatic fun invalidResult() = SearchCardsResult(null, null)
+            fun success(result: List<CardBrowser.CardCache>) = SearchCardsResult(result, null)
+            fun invalidResult() = SearchCardsResult(null, null)
         }
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/services/BootService.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/services/BootService.kt
@@ -106,7 +106,6 @@ class BootService : BroadcastReceiver() {
          */
         private var sWasRun = false
 
-        @JvmStatic
         fun scheduleNotification(time: Time, context: Context) {
             val alarmManager = context.getSystemService(Context.ALARM_SERVICE) as AlarmManager
             val sp = AnkiDroidApp.getSharedPrefs(context)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/services/NotificationService.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/services/NotificationService.kt
@@ -37,7 +37,6 @@ class NotificationService : BroadcastReceiver() {
         /** The id of the notification for due cards.  */
         private const val WIDGET_NOTIFY_ID = 1
 
-        @JvmStatic
         fun triggerNotificationFor(context: Context) {
             Timber.i("NotificationService: OnStartCommand")
             val manager = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager

--- a/AnkiDroid/src/main/java/com/ichi2/anki/services/ReminderService.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/services/ReminderService.kt
@@ -174,7 +174,6 @@ class ReminderService : BroadcastReceiver() {
         const val EXTRA_DECK_OPTION_ID = "EXTRA_DECK_OPTION_ID"
         const val EXTRA_DECK_ID = "EXTRA_DECK_ID"
 
-        @JvmStatic
         fun getReviewDeckIntent(context: Context, deckId: DeckId): Intent {
             return Intent(context, IntentHandler::class.java).putExtra(EXTRA_DECK_ID, deckId)
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/stats/AnkiStatsTaskHandler.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/stats/AnkiStatsTaskHandler.kt
@@ -110,11 +110,9 @@ class AnkiStatsTaskHandler private constructor(
         }
 
     companion object {
-        @JvmStatic
         var instance: AnkiStatsTaskHandler? = null
             private set
         private val mutex = Mutex()
-        @JvmStatic
         @Synchronized
         fun getInstance(
             collection: Collection,
@@ -127,7 +125,6 @@ class AnkiStatsTaskHandler private constructor(
             return instance!!
         }
 
-        @JvmStatic
         suspend fun createReviewSummaryStatistics(
             col: Collection,
             view: TextView,

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/NoteTypeSpinnerUtils.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/NoteTypeSpinnerUtils.kt
@@ -31,7 +31,6 @@ import java.util.*
 
 /** Setup for a spinner which displays all note types */
 object NoteTypeSpinnerUtils {
-    @JvmStatic
     fun setupNoteTypeSpinner(context: Context, noteTypeSpinner: Spinner, col: com.ichi2.libanki.Collection): ArrayList<Long> {
         val models: List<Model> = col.models.all()
         Collections.sort(models, NamedJSONComparator.INSTANCE)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/web/HostNumFactory.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/web/HostNumFactory.kt
@@ -21,7 +21,6 @@ import com.ichi2.anki.AnkiDroidApp
 import com.ichi2.libanki.sync.HostNum
 
 object HostNumFactory {
-    @JvmStatic
     fun getInstance(context: Context?): HostNum {
         return PreferenceBackedHostNum.fromPreferences(AnkiDroidApp.getSharedPrefs(context))
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/web/HttpFetcher.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/web/HttpFetcher.kt
@@ -50,7 +50,6 @@ object HttpFetcher {
      * @param fakeUserAgent true if we should issue "fake" User-Agent header 'Mozilla/5.0' for compatibility
      * @return OkHttpClient.Builder ready for use or further configuration
      */
-    @JvmStatic
     fun getOkHttpBuilder(fakeUserAgent: Boolean): OkHttpClient.Builder {
         val clientBuilder = OkHttpClient.Builder()
         Tls12SocketFactory.enableTls12OnPreLollipop(clientBuilder)
@@ -85,7 +84,6 @@ object HttpFetcher {
         return clientBuilder
     }
 
-    @JvmStatic
     fun fetchThroughHttp(address: String?, encoding: String? = "utf-8"): String {
         Timber.d("fetching %s", address)
         var response: Response? = null
@@ -123,7 +121,6 @@ object HttpFetcher {
         }
     }
 
-    @JvmStatic
     fun downloadFileToSdCard(UrlToFile: String, context: Context, prefix: String?): String {
         var str = downloadFileToSdCardMethod(UrlToFile, context, prefix, "GET")
         if (str.startsWith("FAIL")) {
@@ -132,7 +129,6 @@ object HttpFetcher {
         return str
     }
 
-    @JvmStatic
     private fun downloadFileToSdCardMethod(UrlToFile: String, context: Context, prefix: String?, method: String): String {
         var response: Response? = null
         return try {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/web/PreferenceBackedHostNum.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/web/PreferenceBackedHostNum.kt
@@ -43,7 +43,6 @@ class PreferenceBackedHostNum(hostNum: Int?, private val preferences: SharedPref
     }
 
     companion object {
-        @JvmStatic
         fun fromPreferences(preferences: SharedPreferences): PreferenceBackedHostNum {
             val hostNum = getHostNum(preferences)
             return PreferenceBackedHostNum(hostNum, preferences)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/workarounds/FirefoxSnackbarWorkaround.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/workarounds/FirefoxSnackbarWorkaround.kt
@@ -34,7 +34,6 @@ import timber.log.Timber
  * Reported as fixed in Firefox Preview
  */
 object FirefoxSnackbarWorkaround {
-    @JvmStatic
     fun handledLaunchFromWebBrowser(intent: Intent?, context: Context): Boolean {
         if (intent == null) {
             Timber.w("FirefoxSnackbarWorkaround: No intent provided")

--- a/AnkiDroid/src/main/java/com/ichi2/async/CancelListener.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/async/CancelListener.kt
@@ -24,7 +24,6 @@ fun interface CancelListener {
          * @param cancelListener Either null or a cancel listener
          * @return whether the listener exists and is cancelled
          */
-        @JvmStatic
         fun isCancelled(cancelListener: CancelListener?): Boolean {
             return cancelListener != null && cancelListener.isCancelled()
         }

--- a/AnkiDroid/src/main/java/com/ichi2/async/CollectionLoader.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/async/CollectionLoader.kt
@@ -33,7 +33,6 @@ object CollectionLoader {
         fun execute(col: Collection?)
     }
 
-    @JvmStatic
     fun load(lifecycleOwner: LifecycleOwner, callback: Callback) {
         lifecycleOwner.lifecycleScope.launch {
             val col = withContext(Dispatchers.IO) {

--- a/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.kt
@@ -1189,7 +1189,6 @@ open class CollectionTask<Progress, Result>(val task: TaskDelegateBase<Progress,
     }
 
     companion object {
-        @JvmStatic
         @VisibleForTesting
         fun nonTaskUndo(col: Collection): Card? {
             val sched = col.sched

--- a/AnkiDroid/src/main/java/com/ichi2/async/Connection.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/async/Connection.kt
@@ -548,7 +548,6 @@ class Connection : BaseAsyncTask<Connection.Payload, Any, Connection.Payload>() 
             return sInstance
         }
 
-        @JvmStatic
         fun login(listener: TaskListener, data: Payload): Connection? {
             data.taskType = LOGIN
             return launchConnectionTask(listener, data)

--- a/AnkiDroid/src/main/java/com/ichi2/async/ProgressSender.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/async/ProgressSender.kt
@@ -20,7 +20,6 @@ fun interface ProgressSender<T> {
     fun doProgress(value: T?)
 
     companion object {
-        @JvmStatic
         fun <T> publishProgress(progress: ProgressSender<T>?, value: T) {
             progress?.doProgress(value)
         }

--- a/AnkiDroid/src/main/java/com/ichi2/async/TaskManager.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/async/TaskManager.kt
@@ -78,7 +78,6 @@ abstract class TaskManager {
             return previous
         }
 
-        @JvmStatic
         fun removeTask(task: CollectionTask<*, *>): Boolean {
             return sTaskManager.removeTaskConcrete(task)
         }
@@ -95,12 +94,10 @@ abstract class TaskManager {
          * @param task the task to execute
          * @return the newly created task
          */
-        @JvmStatic
         fun setLatestInstance(task: CollectionTask<*, *>) {
             sTaskManager.setLatestInstanceConcrete(task)
         }
 
-        @JvmStatic
         fun <Progress, Result> launchCollectionTask(task: TaskDelegateBase<Progress, Result>): Cancellable {
             return sTaskManager.launchCollectionTaskConcrete(task)
         }
@@ -128,7 +125,6 @@ abstract class TaskManager {
         /**
          * Block the current thread until the currently running CollectionTask instance (if any) has finished.
          */
-        @JvmStatic
         fun waitToFinish() {
             sTaskManager.waitToFinishConcrete()
         }
@@ -138,7 +134,6 @@ abstract class TaskManager {
          * @param timeoutSeconds timeout in seconds (or null to wait indefinitely)
          * @return whether or not the previous task was successful or not, OR if an exception occurred (for example: timeout)
          */
-        @JvmStatic
         fun waitToFinish(timeoutSeconds: Int?): Boolean {
             return sTaskManager.waitToFinishConcrete(timeoutSeconds)
         }

--- a/AnkiDroid/src/main/java/com/ichi2/compat/CompatHelper.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/CompatHelper.kt
@@ -45,19 +45,16 @@ class CompatHelper private constructor() {
         private val instance by lazy { CompatHelper() }
 
         /** Get the current Android API level.  */
-        @JvmStatic
         val sdkVersion: Int
             get() = Build.VERSION.SDK_INT
 
         /** Determine if the device is running API level 23 or higher.  */
-        @JvmStatic
         val isMarshmallow: Boolean
             get() = sdkVersion >= Build.VERSION_CODES.M
 
         /**
          * Main public method to get the compatibility class
          */
-        @JvmStatic
         val compat get() = instance.compatValue
 
         val isChromebook: Boolean
@@ -65,7 +62,6 @@ class CompatHelper private constructor() {
                 "chromium".equals(Build.BRAND, ignoreCase = true) || "chromium".equals(Build.MANUFACTURER, ignoreCase = true) ||
                     "novato_cheets".equals(Build.DEVICE, ignoreCase = true)
                 )
-        @JvmStatic
         val isKindle: Boolean
             get() = "amazon".equals(Build.BRAND, ignoreCase = true) || "amazon".equals(Build.MANUFACTURER, ignoreCase = true)
 

--- a/AnkiDroid/src/main/java/com/ichi2/compat/customtabs/CustomTabActivityHelper.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/customtabs/CustomTabActivityHelper.kt
@@ -146,7 +146,6 @@ class CustomTabActivityHelper : ServiceConnectionCallback {
          * @param uri the Uri to be opened.
          * @param fallback a CustomTabFallback to be used if Custom Tabs is not available.
          */
-        @JvmStatic
         fun openCustomTab(
             activity: Activity,
             customTabsIntent: CustomTabsIntent,
@@ -169,7 +168,6 @@ class CustomTabActivityHelper : ServiceConnectionCallback {
             }
         }
 
-        @JvmStatic
         @VisibleForTesting(otherwise = VisibleForTesting.NONE)
         fun resetFailed() {
             sCustomTabsFailed = false

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/DB.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/DB.kt
@@ -279,7 +279,6 @@ class DB(db: SupportSQLiteDatabase) {
         /**
          * Open a connection using the system framework.
          */
-        @JvmStatic
         fun withAndroidFramework(context: Context, path: String): DB {
             val db = AnkiSupportSQLiteDatabase.withFramework(
                 context,

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.kt
@@ -1066,7 +1066,6 @@ class Decks(private val col: Collection) : DeckManager() {
                 "}"
             )
         private val pathCache = HashMap<String, Array<String>>()
-        @JvmStatic
         fun path(name: String): Array<String> {
             if (!pathCache.containsKey(name)) {
                 pathCache[name] = name.split("::".toRegex()).toTypedArray()
@@ -1098,7 +1097,6 @@ class Decks(private val col: Collection) : DeckManager() {
      * **************************************
      */
         private val normalized = HashMap<String?, String>()
-        @JvmStatic
         @KotlinCleanup("nullability")
         fun normalizeName(name: String?): String? {
             if (!normalized.containsKey(name)) {
@@ -1123,7 +1121,6 @@ class Decks(private val col: Collection) : DeckManager() {
         }
 
         private val sParentCache = HashMap<String, String?>()
-        @JvmStatic
         fun parent(deckName: String): String? {
             // method parent, from sched's method deckDueList in python
             if (!sParentCache.containsKey(deckName)) {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/DecksV16.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/DecksV16.kt
@@ -683,7 +683,6 @@ class DecksV16(private val col: CollectionV16) :
 
     companion object {
 
-        @JvmStatic
         fun find_deck_in_tree(
             node: anki.decks.DeckTreeNode,
             deck_id: DeckId
@@ -700,28 +699,22 @@ class DecksV16(private val col: CollectionV16) :
             return Optional.empty()
         }
 
-        @JvmStatic
         fun path(name: str): ImmutableList<str> {
             return name.split("::")
         }
 
-        @JvmStatic
         fun _path(name: str) = path(name)
 
-        @JvmStatic
         fun basename(name: str): str {
             return path(name).last()
         }
 
-        @JvmStatic
         fun _basename(str: str) = basename(str)
 
-        @JvmStatic
         fun immediate_parent_path(name: str): MutableList<str> {
             return _path(name).dropLast(1).toMutableList()
         }
 
-        @JvmStatic
         fun immediate_parent(name: str): Optional<str> {
             val pp = immediate_parent_path(name)
             if (pp.isNotNullOrEmpty()) {
@@ -730,7 +723,6 @@ class DecksV16(private val col: CollectionV16) :
             return Optional.empty()
         }
 
-        @JvmStatic
         fun key(deck: DeckV16): ImmutableList<str> {
             return path(deck.name)
         }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/LaTeX.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/LaTeX.kt
@@ -57,12 +57,10 @@ object LaTeX {
      * Convert HTML with embedded latex tags to image links.
      * NOTE: _imgLink produces an alphanumeric filename so there is no need to escape the replacement string.
      */
-    @JvmStatic
     fun mungeQA(html: String, col: Collection, model: Model): String {
         return mungeQA(html, col.media, model)
     }
 
-    @JvmStatic
     fun convertHTML(html: String, media: Media, model: Model): String {
         val stringBuffer = StringBuffer()
         STANDARD_PATTERN.matcher(html).run {
@@ -74,7 +72,6 @@ object LaTeX {
         return stringBuffer.toString()
     }
 
-    @JvmStatic
     fun convertExpression(input: String, media: Media, model: Model): String {
         val stringBuffer = StringBuffer()
         EXPRESSION_PATTERN.matcher(input).run {
@@ -86,7 +83,6 @@ object LaTeX {
         return stringBuffer.toString()
     }
 
-    @JvmStatic
     fun convertMath(input: String, media: Media, model: Model): String {
         val stringBuffer = StringBuffer()
         MATH_PATTERN.matcher(input).run {
@@ -103,7 +99,6 @@ object LaTeX {
 
     // It's only goal is to allow testing with a different media manager.
     @VisibleForTesting
-    @JvmStatic
     fun mungeQA(html: String, m: Media, model: Model): String =
         arrayOf(::convertHTML, ::convertExpression, ::convertMath).fold(html) { input, transformer ->
             transformer(input, m, model)
@@ -113,7 +108,6 @@ object LaTeX {
      * Return an img link for LATEX.
      */
     @VisibleForTesting
-    @JvmStatic
     internal fun imgLink(latex: String, model: Model, m: Media): String {
         val txt = latexFromHtml(latex)
         val ext = if (model.optBoolean("latexsvg", false)) "svg" else "png"
@@ -128,6 +122,5 @@ object LaTeX {
     /**
      * Convert entities and fix newlines.
      */
-    @JvmStatic
     private fun latexFromHtml(latex: String): String = Utils.stripHTML(latex.replace("<br( /)?>|<div>".toRegex(), "\n"))
 }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Models.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Models.kt
@@ -882,7 +882,6 @@ class Models(col: Collection) : ModelManager(col) {
         }
 
         /** "Mapping of field name -> (ord, field).  */
-        @JvmStatic
         fun fieldMap(m: Model): Map<String, Pair<Int, JSONObject>> {
             val flds = m.getJSONArray("flds")
             // TreeMap<Integer, String> map = new TreeMap<Integer, String>();
@@ -896,7 +895,6 @@ class Models(col: Collection) : ModelManager(col) {
         /*
      * Templates ***********************************************************************************************
      */
-        @JvmStatic
         @KotlinCleanup("direct return and use scope function")
         fun newTemplate(name: String?): JSONObject {
             val t = JSONObject(defaultTemplate)

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Sound.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Sound.kt
@@ -496,7 +496,6 @@ class Sound {
         /** Extract SoundOrVideoTag instances from content where sound tags are in the form: [sound:filename.mp3]  */
         @CheckResult
         @KotlinCleanup("non-null param")
-        @JvmStatic
         fun extractTagsFromLegacyContent(content: String?): List<SoundOrVideoTag> {
             val matcher = SOUND_PATTERN.matcher(content!!)
             // While there is matches of the pattern for sound markers

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Storage.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Storage.kt
@@ -57,7 +57,6 @@ object Storage {
     /**
      * Helper method for when the collection can't be opened
      */
-    @JvmStatic
     @Throws(UnknownDatabaseVersionException::class)
     fun getDatabaseVersion(context: Context, path: String): Int {
         return try {
@@ -77,7 +76,6 @@ object Storage {
     /**
      *  Open a new or existing collection. Path must be unicode
      * */
-    @JvmStatic
     fun collection(
         context: Context,
         path: String,
@@ -172,7 +170,6 @@ object Storage {
         _updateIndices(db)
     }
 
-    @JvmStatic
     fun setUseInMemory(useInMemoryDatabase: Boolean) {
         isInMemory = useInMemoryDatabase
     }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Utils.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Utils.kt
@@ -228,7 +228,6 @@ object Utils {
      * @return The formatted, localized time string. The time is always an integer.
      * e.g. something like "3 seconds" or "1 year".
      */
-    @JvmStatic
     fun timeSpan(context: Context, time_s: Long): String {
         val time_x: Int // Time in unit x
         val res = context.resources
@@ -312,7 +311,6 @@ object Utils {
      * @param inputParam The HTML text to be cleaned.
      * @return The text without the aforementioned tags.
      </_any_tag_> */
-    @JvmStatic
     @KotlinCleanup("see if function body could be improved")
     fun stripHTML(inputParam: String): String {
         var s = inputParam
@@ -342,7 +340,6 @@ object Utils {
      * Strip HTML but keep media filenames
      */
     @KotlinCleanup("replacement: non-null")
-    @JvmStatic
     fun stripHTMLMedia(s: String, replacement: String? = " $1 "): String {
         val imgMatcher = imgPattern.matcher(s)
         return stripHTML(imgMatcher.replaceAll(replacement!!))
@@ -352,7 +349,6 @@ object Utils {
      * Strip sound but keep media filenames
      */
     @KotlinCleanup("replacement & s: non-null")
-    @JvmStatic
     fun stripSoundMedia(s: String?, replacement: String? = " $1 "): String {
         val soundMatcher = soundPattern.matcher(s!!)
         return soundMatcher.replaceAll(replacement!!)
@@ -401,7 +397,6 @@ object Utils {
     }
 
     /** Given a list of integers, return a string '(int1,int2,...)'.  */
-    @JvmStatic
     @KotlinCleanup("Use scope function on StringBuilder")
     fun ids2str(ids: LongArray?): String {
         val sb = StringBuilder()
@@ -428,7 +423,6 @@ object Utils {
     }
 
     /** Given a list of integers, return a string '(int1,int2,...)', in order given by the iterator.  */
-    @JvmStatic
     @KotlinCleanup("Use scope function on StringBuilder, simplify inner for loop")
     fun <T> ids2str(ids: Iterable<T>): String {
         val sb = StringBuilder(512)
@@ -471,7 +465,6 @@ object Utils {
 
     /** LIBANKI: not in libanki
      * Transform a collection of Long into an array of Long  */
-    @JvmStatic
     @KotlinCleanup("inline as .toLongArray() and remove")
     fun collection2Array(list: Collection<Long>): LongArray {
         val ar = LongArray(list.size)
@@ -508,7 +501,6 @@ object Utils {
     }
 
     /** return a base91-encoded 64bit random number  */
-    @JvmStatic
     fun guid64(): String {
         return base91(
             Random().nextInt((Math.pow(2.0, 61.0) - 1).toInt())
@@ -549,7 +541,6 @@ object Utils {
      * Fields
      * ***********************************************************************************************
      */
-    @JvmStatic
     fun joinFields(list: Array<String>): String {
         val result = StringBuilder(128)
         for (i in 0 until list.size - 1) {
@@ -561,7 +552,6 @@ object Utils {
         return result.toString()
     }
 
-    @JvmStatic
     @KotlinCleanup("ensure manual conversion is correct")
     fun splitFields(fields: String): Array<String> {
         // -1 ensures that we don't drop empty fields at the ends
@@ -578,7 +568,6 @@ object Utils {
      * @param data the string to generate hash from
      * @return A string of length 40 containing the hexadecimal representation of the MD5 checksum of data.
      */
-    @JvmStatic
     @KotlinCleanup("remove if check return empty string directly if data is null")
     fun checksum(data: String?): String {
         var result = ""
@@ -615,7 +604,6 @@ object Utils {
      * @param sortIdx An index of the field
      * @return The field at sortIdx, without html media, and the csum of the first field.
      */
-    @JvmStatic
     fun sfieldAndCsum(fields: Array<String>, sortIdx: Int): Pair<String, Long> {
         val firstStripped = stripHTMLMedia(fields[0])
         val sortStripped = if (sortIdx == 0) firstStripped else stripHTMLMedia(fields[sortIdx])
@@ -634,7 +622,6 @@ object Utils {
      * @param data the string to generate hash from. Html media should be removed
      * @return 32 bit unsigned number from first 8 digits of sha1 hash
      */
-    @JvmStatic
     fun fieldChecksumWithoutHtmlMedia(data: String?): Long {
         return java.lang.Long.valueOf(checksum(data).substring(0, 8), 16)
     }
@@ -644,7 +631,6 @@ object Utils {
      * @param file The file to be checked
      * @return A string of length 32 containing the hexadecimal representation of the SHA1 checksum of the file's contents.
      */
-    @JvmStatic
     fun fileChecksum(file: String?): String {
         val buffer = ByteArray(1024)
         var digest: ByteArray? = null
@@ -677,7 +663,6 @@ object Utils {
         return result
     }
 
-    @JvmStatic
     fun fileChecksum(file: File): String {
         return fileChecksum(file.absolutePath)
     }
@@ -690,7 +675,6 @@ object Utils {
      * @param is InputStream to convert
      * @return String version of the InputStream
      */
-    @JvmStatic
     fun convertStreamToString(`is`: InputStream?): String {
         var contentOfMyInputStream = ""
         try {
@@ -808,7 +792,6 @@ object Utils {
      * Does not close the provided stream
      * @throws IOException Rethrows exception after a set number of retries
      */
-    @JvmStatic
     @Throws(IOException::class)
     fun writeToFile(source: InputStream, destination: String) {
         // sometimes this fails and works on retries (hardware issue?)
@@ -933,7 +916,6 @@ object Utils {
      * 0 - file name
      * 1 - extension
      */
-    @JvmStatic
     fun splitFilename(filename: String): Array<String> {
         var name = filename
         var ext = ""
@@ -1011,7 +993,6 @@ object Utils {
      * @param sourceFile The source file
      * @param destFile The destination file, doesn't need to exist yet.
      */
-    @JvmStatic
     @Throws(IOException::class)
     fun copyFile(sourceFile: File?, destFile: File) {
         FileInputStream(sourceFile).use { source -> writeToFile(source, destFile.absolutePath) }
@@ -1027,7 +1008,6 @@ object Utils {
      * @return the json serialization of the object
      * @see org.json.JSONObject.toString
      */
-    @JvmStatic
     fun jsonToString(json: JSONObject): String {
         return json.toString().replace("\\\\/".toRegex(), "/")
     }
@@ -1042,7 +1022,6 @@ object Utils {
      * @return the json serialization of the object
      * @see org.json.JSONArray.toString
      */
-    @JvmStatic
     fun jsonToString(json: JSONArray): String {
         return json.toString().replace("\\\\/".toRegex(), "/")
     }
@@ -1067,7 +1046,6 @@ object Utils {
      * @param txt Text to be normalized
      * @return The input text in its NFC normalized form form.
     */
-    @JvmStatic
     fun nfcNormalized(txt: String): String {
         return if (!Normalizer.isNormalized(txt, Normalizer.Form.NFC)) {
             Normalizer.normalize(txt, Normalizer.Form.NFC)
@@ -1090,7 +1068,6 @@ object Utils {
     /**
      * Return a random float within the range of min and max.
      */
-    @JvmStatic
     fun randomFloatInRange(min: Float, max: Float): Float {
         val rand = Random()
         return rand.nextFloat() * (max - min) + min
@@ -1107,7 +1084,6 @@ object Utils {
      * @return whether there was a non-zero usn; in this case the list
      * should be saved before the upload.
      */
-    @JvmStatic
     fun markAsUploaded(ar: List<JSONObject>): Boolean {
         var changed = false
         for (obj in ar) {
@@ -1127,7 +1103,6 @@ object Utils {
      </T> */
     // Similar as Objects.equals. So deprecated starting at API Level 19 where this methods exists.
     @KotlinCleanup("remove")
-    @JvmStatic
     fun <T> equals(left: T?, right: T?): Boolean {
         return left === right || left != null && left == right
     }
@@ -1150,7 +1125,6 @@ object Utils {
      * @param fields A map from field name to field value
      * @return The set of non empty field values.
      */
-    @JvmStatic
     @KotlinCleanup("remove TextUtils at least. Maybe .filter { }")
     fun nonEmptyFields(fields: Map<String, String>): Set<String> {
         val nonempty_fields: MutableSet<String> = HashSetInit(fields.size)

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/backend/exception/DeckRenameException.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/backend/exception/DeckRenameException.kt
@@ -29,7 +29,6 @@ class DeckRenameException
         private const val FILTERED_NOSUBDECKS = 1
 
         /** Generates a {@link com.ichi2.libanki.backend.exception.DeckRenameException} with additional information in the message */
-        @JvmStatic
         fun filteredAncestor(deckName: String?, filteredAncestorName: String?): DeckRenameException {
             val ex = DeckRenameException(FILTERED_NOSUBDECKS)
             ex.mFilteredAncestorName = filteredAncestorName

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/hooks/ChessFilter.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/hooks/ChessFilter.kt
@@ -55,7 +55,6 @@ object ChessFilter {
         "    return '<div align=\"center\" width=\"100%%\"><table class=\"chess_board\" cellspacing=\"0\" cellpadding=\"0\"><tr>'+fentxt+'</tr></table></div>';" +
         "})('%s', %b)"
 
-    @JvmStatic
     fun fenToChessboard(text: String, context: Context?): String {
         if (!AnkiDroidApp.getSharedPrefs(context).getBoolean("convertFenText", false)) {
             return text

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/AbstractSched.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/AbstractSched.kt
@@ -191,7 +191,7 @@ abstract class AbstractSched(col: Collection) : BaseSched(col) {
          * @param card A card that just became a leech
          * @param activity An activity on which a message can be shown
          */
-        @JvmStatic
+        @JvmStatic // Using protected members which are not @JvmStatic in the superclass companion is unsupported yet
         protected fun leech(card: Card, activity: Activity?) {
             if (activity != null) {
                 val res = activity.resources

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sync/HostNum.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sync/HostNum.kt
@@ -40,7 +40,6 @@ open class HostNum(open var hostNum: Int?) {
     }
 
     companion object {
-        @JvmStatic
         fun getDefaultHostNum(): Int? {
             return Consts.DEFAULT_HOST_NUM
         }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sync/Tls12SocketFactory.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sync/Tls12SocketFactory.kt
@@ -111,7 +111,6 @@ class Tls12SocketFactory private constructor(
     companion object {
         private val TLS_V12_ONLY = arrayOf("TLSv1.2")
 
-        @JvmStatic
         fun enableTls12OnPreLollipop(client: OkHttpClient.Builder): OkHttpClient.Builder {
             if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP_MR1 && "Samsung" == Build.MANUFACTURER) {
                 try {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/template/FuriganaFilters.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/template/FuriganaFilters.kt
@@ -23,7 +23,6 @@ object FuriganaFilters {
     private val r = Pattern.compile(" ?([^ >]+?)\\[(.+?)]")
     private const val RUBY = "<ruby><rb>$1</rb><rt>$2</rt></ruby>"
 
-    @JvmStatic
     @Suppress("RECEIVER_NULLABILITY_MISMATCH_BASED_ON_JAVA_ANNOTATIONS")
     @KotlinCleanup("handle the nullability of match.group")
     private fun noSound(match: Matcher, replacement: String): String {
@@ -35,7 +34,6 @@ object FuriganaFilters {
         }
     }
 
-    @JvmStatic
     fun kanjiFilter(txt: String): String {
         val m = r.matcher(txt)
         val sb = StringBuffer()
@@ -46,7 +44,6 @@ object FuriganaFilters {
         return sb.toString()
     }
 
-    @JvmStatic
     fun kanaFilter(txt: String): String {
         val m = r.matcher(txt)
         val sb = StringBuffer()
@@ -57,7 +54,6 @@ object FuriganaFilters {
         return sb.toString()
     }
 
-    @JvmStatic
     fun furiganaFilter(txt: String): String {
         val m = r.matcher(txt)
         val sb = StringBuffer()

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/template/ParsedNodes.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/template/ParsedNodes.kt
@@ -80,7 +80,6 @@ class ParsedNodes : ParsedNode {
          * @param nodes A list of nodes to put in a tree
          * @return The list of node, as compactly as possible.
          */
-        @JvmStatic
         fun create(nodes: List<ParsedNode>): ParsedNode {
             @KotlinCleanup("replace with when")
             return if (nodes.isEmpty()) {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/template/TemplateFilters.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/template/TemplateFilters.kt
@@ -61,7 +61,6 @@ object TemplateFilters {
      * @param tag The entire content of the tag.
      * @return Result of filter on current txt.
      */
-    @JvmStatic
     @KotlinCleanup("maybe change var to val")
     fun apply_filter(txtInput: String, filterInput: String, field_name: String, tag: String): String {
         // Timber.d("Models.get():: Processing field: modifier=%s, extra=%s, tag=%s, txt=%s", mod, extra, tag, txt);

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/utils/Time.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/utils/Time.kt
@@ -90,14 +90,12 @@ abstract class Time {
     }
 
     companion object {
-        @JvmStatic
         fun calendar(timeInMS: Long): Calendar {
             val calendar = Calendar.getInstance()
             calendar.timeInMillis = timeInMS
             return calendar
         }
 
-        @JvmStatic
         fun gregorianCalendar(timeInMS: Long): GregorianCalendar {
             val calendar = GregorianCalendar()
             calendar.timeInMillis = timeInMS
@@ -107,7 +105,6 @@ abstract class Time {
         /**
          * Calculate the UTC offset
          */
-        @JvmStatic
         fun utcOffset(): Double {
             // Okay to use real time, as the result does not depends on time at all here
             val cal = Calendar.getInstance()

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/utils/TimeManager.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/utils/TimeManager.kt
@@ -31,7 +31,6 @@ object TimeManager {
     /**
      * Executes the provided functionality, returning [timeOverride] while in the code block
      */
-    @JvmStatic
     @VisibleForTesting
     fun <T : Time> withMockInstance(timeOverride: T, f: ((T) -> Unit)) {
         try {

--- a/AnkiDroid/src/main/java/com/ichi2/preferences/IncrementerNumberRangePreferenceCompat.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/preferences/IncrementerNumberRangePreferenceCompat.kt
@@ -117,7 +117,6 @@ class IncrementerNumberRangePreferenceCompat : NumberRangePreferenceCompat {
         }
 
         companion object {
-            @JvmStatic
             fun newInstance(key: String?): IncrementerNumberRangeDialogFragmentCompat {
                 val fragment = IncrementerNumberRangeDialogFragmentCompat()
                 val b = Bundle(1)

--- a/AnkiDroid/src/main/java/com/ichi2/preferences/NumberRangePreferenceCompat.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/preferences/NumberRangePreferenceCompat.kt
@@ -191,7 +191,6 @@ constructor(
         }
 
         companion object {
-            @JvmStatic
             fun newInstance(key: String?): NumberRangeDialogFragmentCompat {
                 val fragment = NumberRangeDialogFragmentCompat()
                 val b = Bundle(1)

--- a/AnkiDroid/src/main/java/com/ichi2/preferences/PreferenceExtensions.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/preferences/PreferenceExtensions.kt
@@ -28,7 +28,6 @@ object PreferenceExtensions {
      *
      * Defect #5828 - This is potentially not thread safe and could cause another preference commit to fail.
      */
-    @JvmStatic
     @CheckResult // Not truly an error as this has a side effect, but you should use a "set" API for perf.
     fun getOrSetString(target: SharedPreferences, key: String, supplier: Supplier<String>): String {
         if (target.contains(key)) {

--- a/AnkiDroid/src/main/java/com/ichi2/preferences/StepsPreference.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/preferences/StepsPreference.kt
@@ -113,7 +113,6 @@ class StepsPreference : android.preference.EditTextPreference, AutoFocusable {
          * @param a JSONArray representation of steps.
          * @return The steps as a space-separated string.
          */
-        @JvmStatic
         fun convertFromJSON(a: JSONArray): String {
             val sb = StringBuilder()
             for (s in a.stringIterable()) {
@@ -129,7 +128,6 @@ class StepsPreference : android.preference.EditTextPreference, AutoFocusable {
          * @param steps String representation of steps.
          * @return The steps as a JSONArray or null if the steps are not valid.
          */
-        @JvmStatic
         fun convertToJSON(steps: String): JSONArray? {
             val stepsAr = JSONArray()
             val stepsTrim = steps.trim { it <= ' ' }

--- a/AnkiDroid/src/main/java/com/ichi2/preferences/TimePreference.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/preferences/TimePreference.kt
@@ -52,12 +52,10 @@ class TimePreference(context: Context?, attrs: AttributeSet?) : android.preferen
 
     companion object {
         const val DEFAULT_VALUE = "00:00"
-        @JvmStatic
         fun parseHours(time: String): Int {
             return time.split(":".toRegex()).toTypedArray()[0].toInt()
         }
 
-        @JvmStatic
         fun parseMinutes(time: String): Int {
             return time.split(":".toRegex()).toTypedArray()[1].toInt()
         }

--- a/AnkiDroid/src/main/java/com/ichi2/themes/HtmlColors.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/themes/HtmlColors.kt
@@ -55,7 +55,6 @@ object HtmlColors {
      * #777777 is the grey color</span> This is done with a state machine with 2 states: - 0: within content - 1: within
      * a tag
      */
-    @JvmStatic
     fun invertColors(text: String?): String {
         val sb = StringBuffer()
         val m1 = fHtmlColorPattern.matcher(text!!)

--- a/AnkiDroid/src/main/java/com/ichi2/themes/StyledProgressDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/themes/StyledProgressDialog.kt
@@ -51,7 +51,6 @@ class StyledProgressDialog(context: Context?) : Dialog(context!!) {
 
     @Suppress("Deprecation") // ProgressDialog deprecation
     companion object {
-        @JvmStatic
         fun show(
             context: Context,
             title: CharSequence?,
@@ -75,7 +74,6 @@ class StyledProgressDialog(context: Context?) : Dialog(context!!) {
         }
 
         @Suppress("unused")
-        @JvmStatic
         private fun animationEnabled(context: Context): Boolean {
             return if (context is AnkiActivity) {
                 context.animationEnabled()

--- a/AnkiDroid/src/main/java/com/ichi2/themes/Themes.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/themes/Themes.kt
@@ -47,7 +47,6 @@ object Themes {
     /**
      * Sets theme to [currentTheme]
      */
-    @JvmStatic
     fun setTheme(context: Context) {
         context.setTheme(currentTheme.resId)
     }
@@ -65,7 +64,6 @@ object Themes {
      * on `Day` or `Night` theme according to system's current mode
      * Otherwise, updates to the selected theme.
      */
-    @JvmStatic
     fun updateCurrentTheme() {
         val prefs = AnkiDroidApp.getSharedPrefs(AnkiDroidApp.instance.applicationContext)
 
@@ -83,7 +81,6 @@ object Themes {
     /**
      * #8150: Fix icons not appearing in Note Editor due to MIUI 12's "force dark" mode
      */
-    @JvmStatic
     fun disableXiaomiForceDarkMode(context: Context) {
         // Setting a theme is an additive operation, so this adds a single property.
         context.setTheme(R.style.ThemeOverlay_Xiaomi)
@@ -103,14 +100,14 @@ object Themes {
         return attrs
     }
 
-    @JvmStatic
+    @JvmStatic // tests failed when removing, maybe try later
     @ColorInt
     fun getColorFromAttr(context: Context?, colorAttr: Int): Int {
         val attrs = intArrayOf(colorAttr)
         return getColorFromAttr(context!!, attrs)[0]
     }
 
-    @JvmStatic
+    @JvmStatic // tests failed when removing, maybe try later
     @ColorInt
     fun getColorFromAttr(context: Context, attrs: IntArray): IntArray {
         val ta = context.obtainStyledAttributes(attrs)
@@ -132,7 +129,6 @@ object Themes {
     /**
      * @return if current selected theme is `Follow system`
      */
-    @JvmStatic
     fun themeFollowsSystem(): Boolean {
         val prefs = AnkiDroidApp.getSharedPrefs(AnkiDroidApp.instance.applicationContext)
         return prefs.getString(APP_THEME_KEY, FOLLOW_SYSTEM_MODE) == FOLLOW_SYSTEM_MODE

--- a/AnkiDroid/src/main/java/com/ichi2/ui/ActionBarOverflow.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/ui/ActionBarOverflow.kt
@@ -35,7 +35,6 @@ object ActionBarOverflow {
     private var sNativeIsActionButton: Method? = null
     private var sAndroidXIsActionButton: Method? = null
 
-    @JvmStatic
     @VisibleForTesting
     fun setupMethods(accessor: PrivateMethodAccessor) {
         // Note: Multiple of these can succeed.
@@ -76,7 +75,6 @@ object ActionBarOverflow {
      * the MenuItem.
      * @return `true` if the MenuItem is visible on the ActionBar. `false` if not. `null if unknown`
      */
-    @JvmStatic
     fun isActionButton(item: MenuItem): Boolean? {
         return if (sNativeClassRef != null && sNativeClassRef!!.isInstance(item)) {
             tryInvokeMethod(item, sNativeIsActionButton)
@@ -103,14 +101,12 @@ object ActionBarOverflow {
         }
     }
 
-    @JvmStatic
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)
     fun hasUsableMethod(): Boolean {
         return sNativeIsActionButton != null ||
             sAndroidXIsActionButton != null
     }
 
-    @JvmStatic
     @CheckResult
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)
     fun getPrivateMethodOnlyHandleExceptions(className: String?, methodName: String?): Pair<Class<*>?, Method?> {

--- a/AnkiDroid/src/main/java/com/ichi2/ui/AnimationUtil.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/ui/AnimationUtil.kt
@@ -27,7 +27,6 @@ object AnimationUtil {
     /** This is a fast animation - We don't want the user incorrectly selecting the current position
      * for the next collapse operation  */
     private const val DURATION_MILLIS = 200
-    @JvmStatic
     fun collapseView(view: View, animationEnabled: Boolean) {
         view.animate().cancel()
         if (!animationEnabled) {
@@ -56,7 +55,6 @@ object AnimationUtil {
         view.startAnimation(set)
     }
 
-    @JvmStatic
     fun expandView(view: View, enableAnimation: Boolean) {
         view.animate().cancel()
         if (!enableAnimation) {

--- a/AnkiDroid/src/main/java/com/ichi2/ui/BadgeDrawableBuilder.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/ui/BadgeDrawableBuilder.kt
@@ -64,7 +64,6 @@ class BadgeDrawableBuilder(private val resources: Resources) {
     }
 
     companion object {
-        @JvmStatic
         fun removeBadge(menuItem: MenuItem) {
             if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
                 return

--- a/AnkiDroid/src/main/java/com/ichi2/ui/OnGestureListener.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/ui/OnGestureListener.kt
@@ -71,7 +71,6 @@ class OnGestureListener(
     }
 
     companion object {
-        @JvmStatic
         fun createInstance(view: View, consumer: Consumer<Gesture>): OnGestureListener {
             val gestureMapper = GestureMapper()
             gestureMapper.init(AnkiDroidApp.getSharedPrefs(view.context))

--- a/AnkiDroid/src/main/java/com/ichi2/upgrade/Upgrade.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/upgrade/Upgrade.kt
@@ -6,7 +6,7 @@ import com.ichi2.utils.JSONException
 import timber.log.Timber
 
 object Upgrade {
-    @JvmStatic
+    @JvmStatic // tests fail if removed: CardBrowserTest
     fun upgradeJSONIfNecessary(col: Collection, name: String, defaultValue: Boolean): Boolean {
         var value = defaultValue
         try {

--- a/AnkiDroid/src/main/java/com/ichi2/utils/AdaptionUtil.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/AdaptionUtil.kt
@@ -33,7 +33,6 @@ import java.util.*
 object AdaptionUtil {
     private var sHasRunWebBrowserCheck = false
     private var sHasWebBrowser = true
-    @JvmStatic
     fun hasWebBrowser(context: Context): Boolean {
         if (sHasRunWebBrowserCheck) {
             return sHasWebBrowser
@@ -43,7 +42,6 @@ object AdaptionUtil {
         return sHasWebBrowser
     }
 
-    @JvmStatic
     val isUserATestClient: Boolean
         get() = try {
             ActivityManager.isUserAMonkey() ||
@@ -143,7 +141,6 @@ object AdaptionUtil {
     }
 
     /** See: https://en.wikipedia.org/wiki/Vivo_(technology_company)  */
-    @JvmStatic
     val isVivo: Boolean
         get() {
             val manufacturer = Build.MANUFACTURER ?: return false
@@ -155,7 +152,6 @@ object AdaptionUtil {
      * is imported.
      * https://stackoverflow.com/questions/28550370/how-to-detect-whether-android-app-is-running-ui-test-with-espresso
      */
-    @JvmStatic
     val isRunningAsUnitTest: Boolean
         get() {
             try {

--- a/AnkiDroid/src/main/java/com/ichi2/utils/AndroidUiUtils.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/AndroidUiUtils.kt
@@ -25,7 +25,6 @@ import android.view.inputmethod.InputMethodManager
 import androidx.core.content.ContextCompat
 
 object AndroidUiUtils {
-    @JvmStatic
     fun isRunningOnTv(context: Context?): Boolean {
         val uiModeManager = ContextCompat.getSystemService(context!!, UiModeManager::class.java)
             ?: return false
@@ -38,7 +37,6 @@ object AndroidUiUtils {
      * @param view The EditText which requires the focus to be set.
      * @param window The window where the view is present.
      */
-    @JvmStatic
     fun setFocusAndOpenKeyboard(view: View, window: Window) {
         view.requestFocus()
         window.setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_ALWAYS_VISIBLE)
@@ -49,7 +47,6 @@ object AndroidUiUtils {
      * @param view The View which requires the focus to be set (typically an EditText).
      * @param runnable The Optional Runnable that will be executed at the end.
      */
-    @JvmStatic
     fun setFocusAndOpenKeyboard(view: View, runnable: Runnable? = null) {
         //  Required on some Android 9, 10 devices to show keyboard: https://stackoverflow.com/a/7784904
         view.postDelayed({

--- a/AnkiDroid/src/main/java/com/ichi2/utils/Assert.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/Assert.kt
@@ -27,7 +27,6 @@ object Assert {
         }
     }
 
-    @JvmStatic
     @Contract("false, _, _ -> fail")
     fun that(condition: Boolean, message: String?, vararg args: Any?) {
         if (!condition) {

--- a/AnkiDroid/src/main/java/com/ichi2/utils/AssetHelper.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/AssetHelper.kt
@@ -48,7 +48,6 @@ object AssetHelper {
      * @param path path of the file to guess its MIME type.
      * @return MIME type guessed from file extension or "text/plain".
      */
-    @JvmStatic
     fun guessMimeType(path: String?): String {
         val mimeType = URLConnection.guessContentTypeFromName(path)
         return mimeType ?: "text/plain"

--- a/AnkiDroid/src/main/java/com/ichi2/utils/BitmapUtil.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/BitmapUtil.kt
@@ -30,7 +30,6 @@ import java.io.FileInputStream
 import java.lang.Exception
 
 object BitmapUtil {
-    @JvmStatic
     fun decodeFile(theFile: File, IMAGE_MAX_SIZE: Int): Bitmap? {
         var bmp: Bitmap? = null
         try {
@@ -75,7 +74,6 @@ object BitmapUtil {
         return bmp
     }
 
-    @JvmStatic
     fun freeImageView(imageView: ImageView?) {
         // This code behaves differently on various OS builds. That is why put into try catch.
         try {

--- a/AnkiDroid/src/main/java/com/ichi2/utils/BundleUtils.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/BundleUtils.kt
@@ -29,7 +29,6 @@ object BundleUtils {
      * @param key the key to use
      * @return the long value, or null if not found
      */
-    @JvmStatic
     fun getNullableLong(bundle: Bundle?, key: String): Long? {
         return if (bundle == null || !bundle.containsKey(key)) {
             null

--- a/AnkiDroid/src/main/java/com/ichi2/utils/CheckCameraPermission.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/CheckCameraPermission.kt
@@ -23,7 +23,6 @@ import java.lang.Exception
 import java.util.*
 
 object CheckCameraPermission {
-    @JvmStatic
     fun manifestContainsPermission(context: Context): Boolean {
         try {
             val requestedPermissions = context.packageManager

--- a/AnkiDroid/src/main/java/com/ichi2/utils/ClipboardUtil.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/ClipboardUtil.kt
@@ -27,7 +27,6 @@ object ClipboardUtil {
     @JvmField
     val IMAGE_MIME_TYPES = arrayOf("image/gif", "image/png", "image/jpg", "image/jpeg")
 
-    @JvmStatic
     fun hasImage(clipboard: ClipboardManager?): Boolean {
         return clipboard
             ?.takeIf { it.hasPrimaryClip() }
@@ -36,7 +35,6 @@ object ClipboardUtil {
             ?: false
     }
 
-    @JvmStatic
     fun hasImage(description: ClipDescription?): Boolean {
         return description
             ?.run { IMAGE_MIME_TYPES.any { hasMimeType(it) } }
@@ -49,24 +47,20 @@ object ClipboardUtil {
         ?.takeIf { it.itemCount > 0 }
         ?.getItemAt(0)
 
-    @JvmStatic
     fun getImageUri(clipboard: ClipboardManager?): Uri? {
         return getFirstItem(clipboard)?.uri
     }
 
-    @JvmStatic
     @CheckResult
     fun getText(clipboard: ClipboardManager?): CharSequence? {
         return getFirstItem(clipboard)?.text
     }
 
-    @JvmStatic
     @CheckResult
     fun getPlainText(clipboard: ClipboardManager?, context: Context): CharSequence? {
         return getFirstItem(clipboard)?.coerceToText(context)
     }
 
-    @JvmStatic
     @CheckResult
     fun getDescriptionLabel(clipboard: ClipData?): CharSequence? {
         return clipboard

--- a/AnkiDroid/src/main/java/com/ichi2/utils/CollectionUtils.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/CollectionUtils.kt
@@ -22,7 +22,6 @@ object CollectionUtils {
      * @param it An iterator returning things to add to C
      * @param <T> Type of elements to copy from iterator to collection
      */
-    @JvmStatic
     @KotlinCleanup("replace with Kotlin extension: MutableCollections.addAll")
     fun <T> addAll(c: MutableCollection<T>, it: Iterable<T>) {
         for (elt in it) {

--- a/AnkiDroid/src/main/java/com/ichi2/utils/Computation.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/Computation.kt
@@ -55,11 +55,11 @@ class Computation<out ComputedType : Any> {
         @JvmField val OK: Computation<*> = Computation(Any())
 
         /** A strongly typed error return value */
-        @JvmStatic fun <ComputedType : Any> err(): Computation<ComputedType> {
+        fun <ComputedType : Any> err(): Computation<ComputedType> {
             return Computation()
         }
 
-        @JvmStatic fun <ComputedType : Any> ok(value: ComputedType): Computation<ComputedType> {
+        fun <ComputedType : Any> ok(value: ComputedType): Computation<ComputedType> {
             return Computation(value)
         }
     }

--- a/AnkiDroid/src/main/java/com/ichi2/utils/ContentResolverUtil.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/ContentResolverUtil.kt
@@ -29,7 +29,6 @@ import java.util.*
 
 object ContentResolverUtil {
     /** Obtains the filename from the url. Throws if all methods return exception  */
-    @JvmStatic
     @CheckResult
     fun getFileName(contentResolver: ContentResolver, uri: Uri): String {
         try {

--- a/AnkiDroid/src/main/java/com/ichi2/utils/DiffEngine.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/DiffEngine.kt
@@ -64,14 +64,12 @@ open class DiffEngine {
             return "<span class=\"typeGood\">" + escapeHtml(s) + "</span>"
         }
 
-        @JvmStatic
         @CheckResult
         fun wrapMissing(s: String?): String {
             return "<span class=\"typeMissed\">" + escapeHtml(s) + "</span>"
         }
 
         /** Prevents combining marks not getting highlighted properly if a span starts with them, by adding a "&nbsp;" before them (#10665) */
-        @JvmStatic
         fun escapeLoneMarks(s: String): String {
             if (s[0].category.code.startsWith("M"))
                 return "\\xa0$s"

--- a/AnkiDroid/src/main/java/com/ichi2/utils/DisplayUtils.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/DisplayUtils.kt
@@ -24,7 +24,6 @@ import android.view.WindowManager
 object DisplayUtils {
 
     @Suppress("DEPRECATION") // #9333: defaultDisplay & getSize
-    @JvmStatic
     fun getDisplayDimensions(wm: WindowManager): Point {
         val display = wm.defaultDisplay
         val point = Point()
@@ -32,7 +31,6 @@ object DisplayUtils {
         return point
     }
 
-    @JvmStatic
     fun getDisplayDimensions(context: Context): Point {
         val wm = context.getSystemService(Context.WINDOW_SERVICE) as WindowManager
         return getDisplayDimensions(wm)
@@ -41,7 +39,6 @@ object DisplayUtils {
     /** Allow the window to be resized when an input method is shown,
      * so that its contents are not covered by the input method */
     @Suppress("DEPRECATION") // 7110: SOFT_INPUT_ADJUST_RESIZE
-    @JvmStatic
     fun resizeWhenSoftInputShown(window: Window) {
         window.setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_ADJUST_RESIZE)
     }

--- a/AnkiDroid/src/main/java/com/ichi2/utils/ExceptionUtil.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/ExceptionUtil.kt
@@ -24,7 +24,6 @@ import java.io.PrintWriter
 import java.io.StringWriter
 
 object ExceptionUtil {
-    @JvmStatic
     fun containsMessage(e: Throwable?, needle: String?): Boolean {
         if (e == null) {
             return false
@@ -37,7 +36,6 @@ object ExceptionUtil {
     }
 
     @CheckResult
-    @JvmStatic
     fun getExceptionMessage(e: Throwable?): String {
         return getExceptionMessage(e, "\n")
     }
@@ -59,7 +57,6 @@ object ExceptionUtil {
     }
 
     /** Whether the exception is, or contains a cause of a given type  */
-    @JvmStatic
     @KotlinCleanup("convert to containsCause<T>(ex)")
     fun <T> containsCause(ex: Throwable, clazz: Class<T>): Boolean {
         if (clazz.isInstance(ex)) {
@@ -69,7 +66,6 @@ object ExceptionUtil {
         return containsCause(cause, clazz)
     }
 
-    @JvmStatic
     fun getFullStackTrace(ex: Throwable): String {
         val sw = StringWriter()
         ex.printStackTrace(PrintWriter(sw))

--- a/AnkiDroid/src/main/java/com/ichi2/utils/ExifUtil.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/ExifUtil.kt
@@ -27,7 +27,6 @@ import java.io.File
 import java.lang.Exception
 
 object ExifUtil {
-    @JvmStatic
     fun rotateFromCamera(theFile: File, _bmp: Bitmap): Bitmap {
         var bmp = _bmp
         return try {

--- a/AnkiDroid/src/main/java/com/ichi2/utils/FileUtil.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/FileUtil.kt
@@ -28,7 +28,6 @@ import java.util.*
 
 object FileUtil {
     /** Gets the free disk space given a file  */
-    @JvmStatic
     fun getFreeDiskSpace(file: File, defaultValue: Long): Long {
         return try {
             StatFs(file.parentFile?.path).availableBytes
@@ -46,7 +45,6 @@ object FileUtil {
      * @return the internal file after copying the data across.
      * @throws IOException
      */
-    @JvmStatic
     @Throws(IOException::class)
     @KotlinCleanup("nonnull uri")
     fun internalizeUri(uri: Uri?, internalFile: File, contentResolver: ContentResolver): File {
@@ -69,7 +67,6 @@ object FileUtil {
     /**
      * @return Key: Filename; Value: extension including dot
      */
-    @JvmStatic
     fun getFileNameAndExtension(fileName: String?): Map.Entry<String, String>? {
         if (fileName == null) {
             return null
@@ -90,7 +87,6 @@ object FileUtil {
      * @param directory Abstract representation of the file/directory whose size needs to be calculated
      * @return Size of the directory in bytes
      */
-    @JvmStatic
     @Throws(IOException::class)
     fun getDirectorySize(directory: File): Long {
         var directorySize: Long = 0
@@ -113,8 +109,6 @@ object FileUtil {
      * @param file Abstract representation of the file/directory whose size needs to be calculated
      * @return Size of the File/Directory in bytes. 0 if the [File] does not exist
      */
-    @JvmStatic
-    @KotlinCleanup("remove JvmStatic once FileUtilTest is in Kotlin")
     fun getSize(file: File) = if (file.isDirectory) {
         getDirectorySize(file)
     } else {
@@ -127,7 +121,6 @@ object FileUtil {
      * @param dir Abstract representation of a directory
      * @throws IOException if dir is not a directory or could not be created
      */
-    @JvmStatic
     @Throws(IOException::class)
     fun ensureFileIsDirectory(dir: File) {
         if (dir.exists()) {
@@ -148,7 +141,6 @@ object FileUtil {
      * @return An array of abstract representations of the files / directories present in the directory represented
      * by dir
      */
-    @JvmStatic
     @Throws(IOException::class)
     fun listFiles(dir: File): Array<File> {
         return dir.listFiles()

--- a/AnkiDroid/src/main/java/com/ichi2/utils/FragmentFactoryUtils.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/FragmentFactoryUtils.kt
@@ -23,7 +23,6 @@ object FragmentFactoryUtils {
     /**
      * A convenience util method that instantiate a fragment using the passed activity [FragmentFactory]
      */
-    @JvmStatic
     inline fun <reified F : Fragment?> instantiate(activity: FragmentActivity, cls: Class<F>): F {
         val factory = activity.supportFragmentManager.fragmentFactory
         return factory.instantiate(activity.classLoader, cls.name) as F

--- a/AnkiDroid/src/main/java/com/ichi2/utils/HandlerUtils.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/HandlerUtils.kt
@@ -22,10 +22,8 @@ import android.os.Looper
 
 object HandlerUtils {
 
-    @JvmStatic
     fun getDefaultLooper(): Looper = Looper.getMainLooper()
 
-    @JvmStatic
     fun newHandler(): Handler = Handler(getDefaultLooper())
 
     /**
@@ -34,7 +32,6 @@ object HandlerUtils {
      *
      * @param r The Runnable that will be executed.
      */
-    @JvmStatic
     fun postOnNewHandler(r: Runnable): Handler {
         val newHandler = newHandler()
         newHandler.post(r)
@@ -53,7 +50,6 @@ object HandlerUtils {
      * @param delayMillis The delay (in milliseconds) until the Runnable
      *        will be executed.
      */
-    @JvmStatic
     fun postDelayedOnNewHandler(r: Runnable, delayMillis: Long): Handler {
         val newHandler = newHandler()
         newHandler.postDelayed(r, delayMillis)

--- a/AnkiDroid/src/main/java/com/ichi2/utils/HashUtil.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/HashUtil.kt
@@ -27,13 +27,11 @@ object HashUtil {
         return Math.max((size / .75f).toInt() + 1, 16)
     }
 
-    @JvmStatic
     fun <T> HashSetInit(size: Int): HashSet<T> {
         return HashSet(capacity(size))
     }
 
     @KotlinCleanup("return mutableMap")
-    @JvmStatic
     fun <T, U> HashMapInit(size: Int): HashMap<T, U> {
         return HashMap(capacity(size))
     }

--- a/AnkiDroid/src/main/java/com/ichi2/utils/HtmlUtils.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/HtmlUtils.kt
@@ -19,7 +19,6 @@ import android.text.TextUtils
 
 object HtmlUtils {
     // #5188 - compat.fromHtml converts newlines into spaces.
-    @JvmStatic
     fun convertNewlinesToHtml(html: String?): String? {
         if (html == null) {
             return null
@@ -29,7 +28,6 @@ object HtmlUtils {
         return withoutWindowsLineEndings.replace("\n", "<br/>")
     }
 
-    @JvmStatic
     fun escape(html: String): String {
         return TextUtils.htmlEncode(html)
     }

--- a/AnkiDroid/src/main/java/com/ichi2/utils/ImportUtils.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/ImportUtils.kt
@@ -59,7 +59,6 @@ object ImportUtils {
      * @param intent contains the file to import
      * @return null if successful, otherwise error message
      */
-    @JvmStatic
     fun handleFileImport(context: Context, intent: Intent): ImportResult {
         return FileImporter().handleFileImport(context, intent)
     }
@@ -71,7 +70,6 @@ object ImportUtils {
         return FileImporter().getFileCachedCopy(context, intent)
     }
 
-    @JvmStatic
     fun showImportUnsuccessfulDialog(activity: Activity, errorMessage: String?, exitActivity: Boolean) {
         FileImporter().showImportUnsuccessfulDialog(activity, errorMessage, exitActivity)
     }
@@ -81,7 +79,6 @@ object ImportUtils {
     }
 
     /** @return Whether the file is either a deck, or a collection package */
-    @JvmStatic
     @Contract("null -> false")
     fun isValidPackageName(filename: String?): Boolean {
         return FileImporter.isDeckPackage(filename) || isCollectionPackage(filename)
@@ -91,7 +88,6 @@ object ImportUtils {
      * Whether importUtils can handle the given intent
      * Caused by #6312 - A launcher was sending ACTION_VIEW instead of ACTION_MAIN
      */
-    @JvmStatic
     fun isInvalidViewIntent(intent: Intent): Boolean {
         return intent.data == null && intent.clipData == null
     }

--- a/AnkiDroid/src/main/java/com/ichi2/utils/IntentUtil.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/IntentUtil.kt
@@ -24,7 +24,7 @@ import timber.log.Timber
 import java.lang.Exception
 
 object IntentUtil {
-    @JvmStatic
+    @JvmStatic // (fixable) required due to structure of unit tests
     fun canOpenIntent(context: Context, intent: Intent): Boolean {
         return try {
             val packageManager = context.packageManager
@@ -35,7 +35,6 @@ object IntentUtil {
         }
     }
 
-    @JvmStatic
     fun tryOpenIntent(activity: AnkiActivity, intent: Intent) {
         try {
             if (canOpenIntent(activity, intent)) {

--- a/AnkiDroid/src/main/java/com/ichi2/utils/JSON.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/JSON.kt
@@ -23,7 +23,6 @@ object JSON {
     /**
      * Returns the input if it is a JSON-permissible value; throws otherwise.
      */
-    @JvmStatic
     @Throws(JSONException::class)
     fun checkDouble(d: Double): Double {
         if (java.lang.Double.isInfinite(d) || java.lang.Double.isNaN(d)) {
@@ -32,7 +31,6 @@ object JSON {
         return d
     }
 
-    @JvmStatic
     fun toString(value: Any?): String? {
         if (value is String) {
             return value

--- a/AnkiDroid/src/main/java/com/ichi2/utils/JSONObject.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/JSONObject.kt
@@ -348,7 +348,6 @@ open class JSONObject : org.json.JSONObject, Iterable<String?> {
          * @param obj A json object
          * @return Exactly the same object, with a different type.
          */
-        @JvmStatic
         fun objectToObject(obj: org.json.JSONObject?): JSONObject = obj as JSONObject
 
         @CheckResult

--- a/AnkiDroid/src/main/java/com/ichi2/utils/KeyUtils.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/KeyUtils.kt
@@ -18,13 +18,11 @@ package com.ichi2.utils
 import android.view.KeyEvent
 
 object KeyUtils {
-    @JvmStatic
     fun isDigit(event: KeyEvent): Boolean {
         val unicodeChar = event.getUnicodeChar(0)
         return unicodeChar >= '0'.code && unicodeChar <= '9'.code
     }
 
-    @JvmStatic
     fun getDigit(event: KeyEvent): Int {
         val unicodeChar = event.getUnicodeChar(0)
         return unicodeChar - '0'.code

--- a/AnkiDroid/src/main/java/com/ichi2/utils/KotlinCleanup.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/KotlinCleanup.kt
@@ -13,7 +13,6 @@
  *  You should have received a copy of the GNU General Public License along with
  *  this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-@file:KotlinCleanup("Remove most @JvmStatic annotations")
 @file:KotlinCleanup("Remove most @JvmField annotations")
 @file:KotlinCleanup(
     "Remove all TextUtils references then see if we can remove " +

--- a/AnkiDroid/src/main/java/com/ichi2/utils/LanguageUtil.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/LanguageUtil.kt
@@ -192,7 +192,6 @@ object LanguageUtil {
      *
      * @return The [Locale] for the given code
      */
-    @JvmStatic
     val locale: Locale
         get() = getLocale("")
 
@@ -201,7 +200,6 @@ object LanguageUtil {
      *
      * @return The [Locale] for the given code
      */
-    @JvmStatic
     fun getLocale(localeCode: String?): Locale {
         val prefs = AnkiDroidApp.getSharedPrefs(AnkiDroidApp.instance.baseContext)
         return getLocale(localeCode, prefs)
@@ -213,7 +211,6 @@ object LanguageUtil {
      * @param localeCode The locale code of the language
      * @return The [Locale] for the given code
      */
-    @JvmStatic
     fun getLocale(localeCode: String?, prefs: SharedPreferences): Locale {
         var tempLocaleCode = localeCode
         if (tempLocaleCode == null || TextUtils.isEmpty(tempLocaleCode)) {
@@ -239,23 +236,19 @@ object LanguageUtil {
         return locale
     }
 
-    @JvmStatic
     fun getShortDateFormatFromMs(ms: Long): String {
         return DateFormat.getDateInstance(DateFormat.SHORT, locale).format(Date(ms))
     }
 
-    @JvmStatic
     fun getShortDateFormatFromS(s: Long): String {
         return DateFormat.getDateInstance(DateFormat.SHORT, locale).format(Date(s * 1000L))
     }
 
-    @JvmStatic
     fun getLocaleCompat(resources: Resources): Locale? {
         return ConfigurationCompat.getLocales(resources.configuration)[0]
     }
 
     /** If locale is not provided, the current locale will be used. */
-    @JvmStatic
     fun setDefaultBackendLanguages(locale: String = "") {
         BackendFactory.defaultLanguages = listOf(localeToBackendCode(getLocale(locale)))
     }

--- a/AnkiDroid/src/main/java/com/ichi2/utils/MapUtil.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/MapUtil.kt
@@ -23,7 +23,6 @@ object MapUtil {
      * @param value value to get key for
      * @return key corresponding to the given value
      */
-    @JvmStatic
     fun <T, E> getKeyByValue(map: Map<T, E>, value: E): T? {
         for ((key, value1) in map) {
             if (value == value1) {

--- a/AnkiDroid/src/main/java/com/ichi2/utils/MethodLogger.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/MethodLogger.kt
@@ -51,7 +51,6 @@ object MethodLogger {
     /**
      * Logs the method being called.
      */
-    @JvmStatic
     fun log() {
         logInternal("")
     }

--- a/AnkiDroid/src/main/java/com/ichi2/utils/NoteFieldDecorator.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/NoteFieldDecorator.kt
@@ -62,7 +62,6 @@ object NoteFieldDecorator {
         "Nxfunl0701",
     )
 
-    @JvmStatic
     fun aplicaHuevo(fieldText: String?): String? {
         val revuelto = huevoRevuelto(fieldText)
         for (huevo in huevoOpciones) {

--- a/AnkiDroid/src/main/java/com/ichi2/utils/Permissions.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/Permissions.kt
@@ -22,12 +22,10 @@ import android.content.pm.PackageManager
 import androidx.core.content.ContextCompat
 
 object Permissions {
-    @JvmStatic
     fun canUseCamera(context: Context): Boolean {
         return hasPermission(context, Manifest.permission.CAMERA)
     }
 
-    @JvmStatic
     fun canRecordAudio(context: Context): Boolean {
         return hasPermission(context, Manifest.permission.RECORD_AUDIO)
     }
@@ -41,7 +39,7 @@ object Permissions {
      * @param context
      * @return
      */
-    @JvmStatic
+    @JvmStatic // unit tests were flaky - maybe remove later
     private fun hasStorageWriteAccessPermission(context: Context): Boolean {
         return hasPermission(context, Manifest.permission.WRITE_EXTERNAL_STORAGE)
     }
@@ -51,7 +49,7 @@ object Permissions {
      * @param context
      * @return
      */
-    @JvmStatic
+    @JvmStatic // unit tests were flaky - maybe remove later
     private fun hasStorageReadAccessPermission(context: Context): Boolean {
         return hasPermission(context, Manifest.permission.READ_EXTERNAL_STORAGE)
     }
@@ -61,12 +59,11 @@ object Permissions {
      * @param context
      * @return
      */
-    @JvmStatic
+    @JvmStatic // unit tests were flaky - maybe remove later
     fun hasStorageAccessPermission(context: Context): Boolean {
         return hasStorageReadAccessPermission(context) && hasStorageWriteAccessPermission(context)
     }
 
-    @JvmStatic
     fun canUseWakeLock(context: Context): Boolean {
         return hasPermission(context, Manifest.permission.WAKE_LOCK)
     }

--- a/AnkiDroid/src/main/java/com/ichi2/utils/StringUtil.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/StringUtil.kt
@@ -22,7 +22,6 @@ import java.util.*
 
 object StringUtil {
     /** Trims from the right hand side of a string  */
-    @JvmStatic
     @Contract("null -> null; !null -> !null")
     fun trimRight(s: String?): String? {
         if (s == null) return null
@@ -35,7 +34,6 @@ object StringUtil {
     }
 
     /** Converts the string to where the first letter is uppercase, and the rest of the string is lowercase  */
-    @JvmStatic
     @Contract("null -> null; !null -> !null")
     fun toTitleCase(s: String?): String? {
         if (s == null) return null

--- a/AnkiDroid/src/main/java/com/ichi2/utils/SyncStatus.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/SyncStatus.kt
@@ -29,7 +29,6 @@ enum class SyncStatus {
         private var sPauseCheckingDatabase = false
         private var sMarkedInMemory = false
 
-        @JvmStatic
         fun getSyncStatus(col: Collection, auth: SyncAuth?): SyncStatus {
             if (isDisabled) {
                 return BADGE_DISABLED
@@ -87,13 +86,11 @@ enum class SyncStatus {
 
         /** To be converted to Rust  */
         @KotlinCleanup("Convert these to @RustCleanup")
-        @JvmStatic
         fun markSyncCompleted() {
             sMarkedInMemory = false
             AnkiDroidApp.getSharedPrefs(AnkiDroidApp.instance).edit().putBoolean("changesSinceLastSync", false).apply()
         }
 
-        @JvmStatic
         fun ignoreDatabaseModification(runnable: Runnable) {
             sPauseCheckingDatabase = true
             try {

--- a/AnkiDroid/src/main/java/com/ichi2/utils/TagsUtil.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/TagsUtil.kt
@@ -19,7 +19,6 @@ package com.ichi2.utils
 import java.util.stream.Collectors
 
 object TagsUtil {
-    @JvmStatic
     fun getUpdatedTags(
         previous: List<String>,
         selected: List<String>,
@@ -41,7 +40,6 @@ object TagsUtil {
      * Utility method that decomposes a hierarchy tag into several parts.
      * Replace empty parts to "blank".
      */
-    @JvmStatic
     fun getTagParts(tag: String): List<String> {
         val parts = tag.split("::").asSequence()
         return parts.map {
@@ -54,7 +52,6 @@ object TagsUtil {
      * Utility that uniforms a hierarchy tag.
      * Remove trailing '::'.
      */
-    @JvmStatic
     fun getUniformedTag(tag: String): String {
         val parts = getTagParts(tag)
         return if (tag.endsWith("::") && parts.last() == blankSubstituent) {
@@ -67,7 +64,6 @@ object TagsUtil {
     /**
      * Utility method that gets the root part of a tag.
      */
-    @JvmStatic
     fun getTagRoot(tag: String): String {
         val parts = tag.split("::").asSequence()
         return parts.map {
@@ -79,7 +75,6 @@ object TagsUtil {
     /**
      * Utility method that gets the ancestors of a tag.
      */
-    @JvmStatic
     fun getTagAncestors(tag: String): List<String> {
         val parts = getTagParts(tag)
         return (0..parts.size - 2).asSequence().map {
@@ -92,7 +87,6 @@ object TagsUtil {
      * Used to sort all tags firstly in DFN order, secondly in dictionary order
      * Both lhs and rhs must be uniformed.
      */
-    @JvmStatic
     fun compareTag(lhs: String, rhs: String): Int {
         val lhsIt = lhs.split("::").asSequence().iterator()
         val rhsIt = rhs.split("::").asSequence().iterator()

--- a/AnkiDroid/src/main/java/com/ichi2/utils/TextViewUtil.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/TextViewUtil.kt
@@ -19,7 +19,6 @@ package com.ichi2.utils
 import android.widget.TextView
 
 object TextViewUtil {
-    @JvmStatic
     fun getTextSizeSp(first: TextView): Float {
         return first.textSize / first.resources.displayMetrics.scaledDensity
     }

--- a/AnkiDroid/src/main/java/com/ichi2/utils/ThreadUtil.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/ThreadUtil.kt
@@ -19,7 +19,6 @@ package com.ichi2.utils
 import timber.log.Timber
 
 object ThreadUtil {
-    @JvmStatic
     fun sleep(timeout: Int) {
         try {
             Thread.sleep(timeout.toLong())

--- a/AnkiDroid/src/main/java/com/ichi2/utils/UiUtil.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/UiUtil.kt
@@ -23,14 +23,12 @@ import android.text.style.StyleSpan
 import android.widget.Spinner
 
 object UiUtil {
-    @JvmStatic
     fun makeBold(s: String): Spannable {
         val str = SpannableStringBuilder(s)
         str.setSpan(StyleSpan(Typeface.BOLD), 0, s.length, Spannable.SPAN_EXCLUSIVE_EXCLUSIVE)
         return str
     }
 
-    @JvmStatic
     fun makeColored(s: String, color: Int): Spannable {
         val str = SpannableStringBuilder(s)
         str.setSpan(ForegroundColorSpan(color), 0, s.length, Spannable.SPAN_EXCLUSIVE_EXCLUSIVE)

--- a/AnkiDroid/src/main/java/com/ichi2/utils/UniqueArrayList.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/UniqueArrayList.kt
@@ -146,7 +146,6 @@ private constructor(
          * @param source the source collection that will be used to construct UniqueArrayList
          * @param comparator used to judge uniqueness
          */
-        @JvmStatic
         fun <E> from(source: List<E>, comparator: Comparator<in E>? = null): UniqueArrayList<E> {
             val set: Set<E> = if (comparator == null) {
                 HashSet()

--- a/AnkiDroid/src/main/java/com/ichi2/utils/VersionUtils.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/VersionUtils.kt
@@ -31,7 +31,6 @@ object VersionUtils {
     /**
      * Get package name as defined in the manifest.
      */
-    @JvmStatic
     val appName: String
         get() {
             var pkgName = AnkiDroidApp.TAG
@@ -48,7 +47,6 @@ object VersionUtils {
     /**
      * Get the package versionName as defined in the manifest.
      */
-    @JvmStatic
     val pkgVersionName: String
         get() {
             var pkgVersion = "?"
@@ -65,7 +63,6 @@ object VersionUtils {
     /**
      * Get the package versionCode as defined in the manifest.
      */
-    @JvmStatic
     val pkgVersionCode: Long
         get() {
             val context: Context = applicationInstance ?: return 0
@@ -100,7 +97,6 @@ object VersionUtils {
      * Return whether the package version code is set to that for release version
      * @return whether build number in manifest version code is '3'
      */
-    @JvmStatic
     val isReleaseVersion: Boolean
         get() {
             val versionCode = java.lang.Long.toString(pkgVersionCode)

--- a/AnkiDroid/src/main/java/com/ichi2/utils/ViewGroupUtils.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/ViewGroupUtils.kt
@@ -25,7 +25,6 @@ import timber.log.Timber
 import java.util.ArrayList
 
 object ViewGroupUtils {
-    @JvmStatic
     fun getAllChildren(viewGroup: ViewGroup): List<View> {
         val childrenCount = viewGroup.childCount
         val views: MutableList<View> = ArrayList(childrenCount)
@@ -35,7 +34,6 @@ object ViewGroupUtils {
         return views
     }
 
-    @JvmStatic
     fun getAllChildrenRecursive(viewGroup: ViewGroup): MutableList<View> {
         val views: MutableList<View> = ArrayList()
         for (i in 0 until viewGroup.childCount) {
@@ -48,7 +46,6 @@ object ViewGroupUtils {
         return views
     }
 
-    @JvmStatic
     fun setRenderWorkaround(activity: Activity) {
         if (AnkiDroidApp.getSharedPrefs(activity).getBoolean("softwareRender", false)) {
             Timber.i("ViewGroupUtils::setRenderWorkaround - software render requested, altering Views...")

--- a/AnkiDroid/src/main/java/com/ichi2/utils/WebViewDebugging.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/WebViewDebugging.kt
@@ -24,7 +24,6 @@ import androidx.annotation.UiThread
 
 object WebViewDebugging {
     private var sHasSetDataDirectory = false
-    @JvmStatic
     @UiThread
     fun initializeDebugging(sharedPrefs: SharedPreferences) {
         // DEFECT: We might be able to cache this value: check what happens on WebView Renderer crash
@@ -40,14 +39,12 @@ object WebViewDebugging {
     }
 
     /** Throws IllegalStateException if a WebView has been initialized  */
-    @JvmStatic
     @RequiresApi(api = Build.VERSION_CODES.P)
     fun setDataDirectorySuffix(suffix: String) {
         WebView.setDataDirectorySuffix(suffix)
         sHasSetDataDirectory = true
     }
 
-    @JvmStatic
     fun hasSetDataDirectory(): Boolean {
         // Implicitly truth requires API >= P
         return sHasSetDataDirectory

--- a/AnkiDroid/src/main/java/com/ichi2/widget/WidgetStatus.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/widget/WidgetStatus.kt
@@ -42,7 +42,6 @@ object WidgetStatus {
      *             https://developer.android.com/guide/topics/appwidgets/#MetaData
      */
     @Suppress("deprecation") // #7108: AsyncTask
-    @JvmStatic
     fun update(context: Context?) {
         val preferences = AnkiDroidApp.getSharedPrefs(context)
         sSmallWidgetEnabled = preferences.getBoolean("widgetSmallEnabled", false)
@@ -58,7 +57,6 @@ object WidgetStatus {
     }
 
     /** Returns the status of each of the decks.  */
-    @JvmStatic
     @KotlinCleanup("make context non-null")
     fun fetchSmall(context: Context?): IntArray {
         return MetaDB.getWidgetSmallStatus(context!!)

--- a/AnkiDroid/src/main/java/com/wildplot/android/parsing/TopLevelParser.kt
+++ b/AnkiDroid/src/main/java/com/wildplot/android/parsing/TopLevelParser.kt
@@ -133,7 +133,6 @@ class TopLevelParser(expressionString: String, parserRegister: HashMap<String, T
     }
 
     companion object {
-        @JvmStatic
         fun stringHasValidBrackets(string: String): Boolean {
             val finalBracketCheck = string.replace("\\(".toRegex(), "").length - string.replace(
                 "\\)".toRegex(),

--- a/AnkiDroid/src/test/java/com/ichi2/anim/ActivityTransitionAnimationTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anim/ActivityTransitionAnimationTest.kt
@@ -45,7 +45,7 @@ class ActivityTransitionAnimationTest {
     }
 
     companion object {
-        @JvmStatic
+        @JvmStatic // used in @MethodSource
         fun getInverseTransition_returns_inverse_direction_args(): Stream<Arguments> {
             return Stream.of(
                 Arguments.of(Direction.START, Direction.END),

--- a/AnkiDroid/src/test/java/com/ichi2/anki/AbstractFlashcardViewerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/AbstractFlashcardViewerTest.kt
@@ -268,7 +268,7 @@ class AbstractFlashcardViewerTest : RobolectricTest() {
         return multimediaController
     }
     companion object {
-        @JvmStatic
+        @JvmStatic // required for @MethodSource
         fun getSignalFromUrlTest_args(): Stream<Arguments> {
             return Stream.of(
                 Arguments.of("signal:show_answer", SHOW_ANSWER),

--- a/AnkiDroid/src/test/java/com/ichi2/anki/ActivityStartupUnderBackupTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/ActivityStartupUnderBackupTest.kt
@@ -107,7 +107,7 @@ $stackTrace"""
 
     companion object {
         @ParameterizedRobolectricTestRunner.Parameters(name = "{1}")
-        @JvmStatic
+        @JvmStatic // required for initParameters
         fun initParameters(): Collection<Array<Any>> {
             return ActivityList.allActivitiesAndIntents().stream().map { x: ActivityLaunchParam -> arrayOf(x, x.simpleName) }.collect(Collectors.toList())
         }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/DeckPickerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/DeckPickerTest.kt
@@ -47,7 +47,7 @@ class DeckPickerTest : RobolectricTest() {
 
     companion object {
         @ParameterizedRobolectricTestRunner.Parameters
-        @JvmStatic
+        @JvmStatic // required for initParameters
         fun initParameters(): Collection<String> {
             return Arrays.asList("normal", "xlarge")
         }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/InitialActivityWithConflictTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/InitialActivityWithConflictTest.kt
@@ -59,20 +59,17 @@ class InitialActivityWithConflictTest : RobolectricTest() {
     }
 
     companion object {
-        @JvmStatic
         fun setupForDatabaseConflict() {
             grantWritePermissions()
             ShadowEnvironment.setExternalStorageState("mounted")
         }
 
-        @JvmStatic
         fun setupForValid(context: Context) {
             grantWritePermissions()
             ShadowEnvironment.setExternalStorageState("mounted")
             BackupManagerTestUtilities.setupSpaceForBackup(context)
         }
 
-        @JvmStatic
         fun setupForDefault() {
             revokeWritePermissions()
             ShadowEnvironment.setExternalStorageState("removed")

--- a/AnkiDroid/src/test/java/com/ichi2/anki/LocaleLinting.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/LocaleLinting.kt
@@ -49,7 +49,7 @@ class LocaleLinting(private val locale: Locale) : RobolectricTest() {
 
     companion object {
         @Parameters(name = "{0}")
-        @JvmStatic
+        @JvmStatic // required for initParameters
         @Suppress("unused")
         fun initParameters(): Collection<Locale> {
             return LanguageUtil.APP_LANGUAGES.map(::toLocale)

--- a/AnkiDroid/src/test/java/com/ichi2/anki/ModelFieldEditorTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/ModelFieldEditorTest.kt
@@ -132,7 +132,7 @@ class ModelFieldEditorTest(private val forbiddenCharacter: String) : Robolectric
         private val sForbiddenCharacters = arrayOf("#", "^", "/", " ", "\t")
         @ParameterizedRobolectricTestRunner.Parameters(name = "\"{0}\"")
         @Suppress("unused")
-        @JvmStatic
+        @JvmStatic // required: Parameters
         fun forbiddenCharacters(): Collection<*> {
             return listOf(*sForbiddenCharacters)
         }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/ReviewerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/ReviewerTest.kt
@@ -409,7 +409,7 @@ class ReviewerTest : RobolectricTest() {
     }
 
     companion object {
-        @JvmStatic
+        @JvmStatic // required for initParameters
         @ParameterizedRobolectricTestRunner.Parameters(name = "SchedV{0}")
         fun initParameters(): Collection<Array<Any>> {
             // This does one run with schedVersion injected as 1, and one run as 2
@@ -420,7 +420,6 @@ class ReviewerTest : RobolectricTest() {
             return startReviewer(testClass, Reviewer::class.java)
         }
 
-        @JvmStatic
         fun <T : Reviewer?> startReviewer(testClass: RobolectricTest, clazz: Class<T>): T {
             val reviewer = startActivityNormallyOpenCollectionWithIntent(testClass, clazz, Intent())
             waitForAsyncTasksToComplete()

--- a/AnkiDroid/src/test/java/com/ichi2/anki/RobolectricTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/RobolectricTest.kt
@@ -217,7 +217,6 @@ open class RobolectricTest : CollectionGetter {
         private var mBackground = true
 
         // Robolectric needs a manual advance with the new PAUSED looper mode
-        @JvmStatic
         fun advanceRobolectricLooper() {
             if (!mBackground) {
                 return
@@ -244,7 +243,6 @@ open class RobolectricTest : CollectionGetter {
         }
 
         // Robolectric needs some help sometimes in form of a manual kick, then a wait, to stabilize UI activity
-        @JvmStatic
         fun advanceRobolectricLooperWithSleep() {
             if (!mBackground) {
                 return
@@ -259,12 +257,12 @@ open class RobolectricTest : CollectionGetter {
         }
 
         /** This can probably be implemented in a better manner  */
-        @JvmStatic
+        @JvmStatic // Using protected members which are not @JvmStatic in the superclass companion is unsupported yet
         protected fun waitForAsyncTasksToComplete() {
             advanceRobolectricLooperWithSleep()
         }
 
-        @JvmStatic
+        @JvmStatic // Using protected members which are not @JvmStatic in the superclass companion is unsupported yet
         protected fun <T : AnkiActivity?> startActivityNormallyOpenCollectionWithIntent(testClass: RobolectricTest, clazz: Class<T>?, i: Intent?): T {
             val controller = Robolectric.buildActivity(clazz, i)
                 .create().start().resume().visible()

--- a/AnkiDroid/src/test/java/com/ichi2/anki/TestUtils.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/TestUtils.kt
@@ -25,7 +25,6 @@ import java.security.MessageDigest
 open class TestUtils {
     /** get the MD5 checksum (in hex) for the given filename  */
     companion object {
-        @JvmStatic
         @Throws(Exception::class)
         fun getMD5(filename: String): String {
             val md = MessageDigest.getInstance("MD5")

--- a/AnkiDroid/src/test/java/com/ichi2/anki/WhiteboardDefaultForegroundColorTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/WhiteboardDefaultForegroundColorTest.kt
@@ -45,7 +45,7 @@ class WhiteboardDefaultForegroundColorTest : RobolectricTest() {
 
     companion object {
         @ParameterizedRobolectricTestRunner.Parameters
-        @JvmStatic
+        @JvmStatic // required for initParameters
         fun initParameters(): Collection<Array<Any>> {
             return mutableListOf((arrayOf(true, Color.WHITE)), arrayOf(false, Color.BLACK))
         }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/analytics/AnalyticsConstantsTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/analytics/AnalyticsConstantsTest.kt
@@ -104,7 +104,7 @@ object AnalyticsConstantsTest {
         }
 
         companion object {
-            @JvmStatic
+            @JvmStatic // required for Parameters
             @Parameterized.Parameters
             fun addAnalyticsConstants(): List<String> {
                 return listOfConstantFields

--- a/AnkiDroid/src/test/java/com/ichi2/anki/cardviewer/GestureProcessorTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/cardviewer/GestureProcessorTest.kt
@@ -56,7 +56,7 @@ class GestureProcessorTest : ViewerCommand.CommandProcessor {
 
     companion object {
         @BeforeClass
-        @JvmStatic
+        @JvmStatic // required for @BeforeClass
         fun before() {
             mockkStatic(ViewConfiguration::class)
             every { ViewConfiguration.get(any()) } answers { mockk(relaxed = true) }
@@ -64,7 +64,7 @@ class GestureProcessorTest : ViewerCommand.CommandProcessor {
             AnkiDroidApp.internalSetInstanceValue(mockk(relaxed = true))
         }
 
-        @JvmStatic
+        @JvmStatic // required for @AfterClass
         @AfterClass
         fun after() {
             unmockkStatic(ViewConfiguration::class)

--- a/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/utils/RecursivePictureMenuUtil.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/utils/RecursivePictureMenuUtil.kt
@@ -24,7 +24,6 @@ import java.util.*
 
 class RecursivePictureMenuUtil {
     companion object {
-        @JvmStatic
         @CheckResult
         fun getRecyclerViewFor(menu: RecursivePictureMenu): RecyclerView {
             val dialog = Objects.requireNonNull(menu.dialog) as MaterialDialog

--- a/AnkiDroid/src/test/java/com/ichi2/anki/preferences/PreferenceUtils.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/preferences/PreferenceUtils.kt
@@ -67,7 +67,6 @@ object PreferenceUtils {
         return fragments.distinctBy { it::class } // and remove any repeated fragments
     }
 
-    @JvmStatic
     fun getAllCustomButtonKeys(context: Context): Set<String> {
         val ret = AtomicReference<Set<String>>()
         val i = CustomButtonsSettingsFragment.getSubscreenIntent(context)

--- a/AnkiDroid/src/test/java/com/ichi2/anki/preferences/PreferencesSimpleTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/preferences/PreferencesSimpleTest.kt
@@ -35,7 +35,7 @@ class PreferencesSimpleTest {
     }
 
     companion object {
-        @JvmStatic
+        @JvmStatic // required for @MethodSource
         fun buildCategorySummary_LTR_Test_args(): Stream<Arguments> {
             return Stream.of(
                 Arguments.of(arrayOf(""), ""),

--- a/AnkiDroid/src/test/java/com/ichi2/anki/reviewer/GestureMapperTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/reviewer/GestureMapperTest.kt
@@ -66,13 +66,13 @@ class GestureMapperTest {
 
     companion object {
         @BeforeClass
-        @JvmStatic
+        @JvmStatic // required for @BeforeClass
         fun before() {
             mockkStatic(ViewConfiguration::class)
             every { ViewConfiguration.get(any()) } answers { mock(ViewConfiguration::class.java) }
         }
 
-        @JvmStatic
+        @JvmStatic // required for @AfterClass
         @AfterClass
         fun after() {
             unmockkStatic(ViewConfiguration::class)

--- a/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/MigrateUserDataJvmTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/MigrateUserDataJvmTest.kt
@@ -40,7 +40,7 @@ class MigrateUserDataJvmTest {
         private lateinit var missingDir: String
 
         @BeforeClass
-        @JvmStatic
+        @JvmStatic // required for @BeforeClass
         fun initClass() {
             sourceDir = createTransientDirectory().canonicalPath
             destDir = createTransientDirectory().canonicalPath

--- a/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/MoveFileTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/MoveFileTest.kt
@@ -41,7 +41,7 @@ class MoveFileTest(private val attemptRename: Boolean) : RobolectricTest(), Oper
     companion object {
         @Suppress("unused")
         @Parameters(name = "attemptRename = {0}")
-        @JvmStatic
+        @JvmStatic // required for initParameters
         fun initParameters(): Collection<Array<Any>> {
             return listOf(arrayOf(true), arrayOf(false))
         }

--- a/AnkiDroid/src/test/java/com/ichi2/compat/CompatDeleteFileTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/compat/CompatDeleteFileTest.kt
@@ -35,7 +35,7 @@ class CompatDeleteFileTest(
     @Suppress("unused") private val unitTestDescription: String
 ) {
     companion object {
-        @JvmStatic
+        @JvmStatic // required for Parameters
         @Parameterized.Parameters(name = "{1}")
         fun data(): Iterable<Array<Any>> = sequence {
             yield(arrayOf(CompatV21(), "CompatV21"))

--- a/AnkiDroid/src/test/java/com/ichi2/compat/Test21And26.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/compat/Test21And26.kt
@@ -38,7 +38,7 @@ import java.io.IOException
 @RunWith(Parameterized::class)
 abstract class Test21And26 {
     companion object {
-        @JvmStatic
+        @JvmStatic // required for Parameters
         @Parameterized.Parameters(name = "{1}")
 
         fun data(): Iterable<Array<Any>> = sequence {
@@ -48,14 +48,14 @@ abstract class Test21And26 {
 
         lateinit var staticCompat: Compat
         @BeforeClass
-        @JvmStatic
+        @JvmStatic // required for @BeforeClass
         fun setupClass() {
             mockkObject(CompatHelper)
             every { CompatHelper.compat } answers { staticCompat }
         }
 
         @AfterClass
-        @JvmStatic
+        @JvmStatic // required for @AfterClass
         fun tearDownClass() {
             unmockkObject(CompatHelper)
         }

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/TextNoteExporterTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/TextNoteExporterTest.kt
@@ -87,7 +87,7 @@ class TextNoteExporterTest(
     }
 
     companion object {
-        @JvmStatic
+        @JvmStatic // required: Parameters
         @ParameterizedRobolectricTestRunner.Parameters(name = "{index} id:{0}\ttags:{1}\thtml:{2}")
         fun data(): Iterable<Array<Any>> {
             val data: MutableList<Array<Any>> = ArrayList()

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/sched/AbstractSchedTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/sched/AbstractSchedTest.kt
@@ -521,7 +521,7 @@ mw.col.sched.extendLimits(1, 0)
     companion object {
         @Suppress("unused")
         @ParameterizedRobolectricTestRunner.Parameters(name = "SchedV{0}")
-        @JvmStatic
+        @JvmStatic // required for initParameters
         @KotlinCleanup("fix array init")
         fun initParameters(): Collection<Array<Any>> {
             // This does one run with schedVersion injected as 1, and one run as 2

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/sched/SchedV2Test.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/sched/SchedV2Test.kt
@@ -1903,7 +1903,6 @@ open class SchedV2Test : RobolectricTest() {
          * @param addRev Determines whether to count the identifier of `revCount`.
          * @return
          */
-        @JvmStatic
         @KotlinCleanup("reduce code")
         fun expectedTree(col: Collection, addRev: Boolean): List<TreeNode<DeckDueTreeNode>> {
             // deck IDs are based on the collection time. Changed to being hardcoded during Kotlin conversion.

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/template/TokenizerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/template/TokenizerTest.kt
@@ -385,7 +385,6 @@ class TokenizerTest : RobolectricTest() {
     }
 
     companion object {
-        @JvmStatic
         fun new_to_legacy_template(template: String): String {
             return "   " + ALT_HANDLEBAR_DIRECTIVE + new_to_legacy(template)
         }

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/utils/EnumMirrorTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/utils/EnumMirrorTest.kt
@@ -26,7 +26,6 @@ package com.ichi2.libanki.utils
 //    }
 //
 //    companion object {
-//        @JvmStatic
 //        @Suppress("deprecation")
 //        @RustCleanup("remove suppress on BuiltinSortKind")
 //        @Parameterized.Parameters(name = "{0}")

--- a/AnkiDroid/src/test/java/com/ichi2/preferences/TimePreferenceTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/preferences/TimePreferenceTest.kt
@@ -33,7 +33,7 @@ class TimePreferenceTest(private val parsableHour: String, private val expectedH
     }
 
     companion object {
-        @JvmStatic
+        @JvmStatic // required for Parameters
         @Parameterized.Parameters
         fun data(): Collection<Array<Any>> {
             return Arrays.asList(

--- a/AnkiDroid/src/test/java/com/ichi2/testutils/AnkiAssert.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/testutils/AnkiAssert.kt
@@ -67,12 +67,10 @@ object AnkiAssert {
         assertListEquals(expected.toList(), actual)
     }
 
-    @JvmStatic
     fun without_unicode_isolation(s: String): String {
         return s.replace("\u2068", "").replace("\u2069", "")
     }
 
-    @JvmStatic
     @KotlinCleanup("scope function")
     fun checkRevIvl(c: Card, targetIvl: Int): Boolean {
         val minMax = SchedV2._fuzzIvlRange(targetIvl)

--- a/AnkiDroid/src/test/java/com/ichi2/testutils/BackendEmulatingOpenConflict.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/testutils/BackendEmulatingOpenConflict.kt
@@ -39,12 +39,10 @@ class BackendEmulatingOpenConflict(context: Context) : Backend(context) {
     }
 
     companion object {
-        @JvmStatic
         fun enable() {
             BackendFactory.setOverride() { context, _, _ -> BackendEmulatingOpenConflict(context) }
         }
 
-        @JvmStatic
         fun disable() {
             BackendFactory.setOverride(null)
         }

--- a/AnkiDroid/src/test/java/com/ichi2/testutils/BackupManagerTestUtilities.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/testutils/BackupManagerTestUtilities.kt
@@ -23,7 +23,6 @@ import java.io.File
 import java.lang.IllegalStateException
 
 object BackupManagerTestUtilities {
-    @JvmStatic
     fun setupSpaceForBackup(context: Context) {
         val currentAnkiDroidDirectory = CollectionHelper.getCurrentAnkiDroidDirectory(context)
 
@@ -34,7 +33,6 @@ object BackupManagerTestUtilities {
         assertTrue(enoughDiscSpace(currentAnkiDroidDirectory))
     }
 
-    @JvmStatic
     fun reset() {
         ShadowStatFs.reset()
     }

--- a/AnkiDroid/src/test/java/com/ichi2/testutils/DbUtils.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/testutils/DbUtils.kt
@@ -22,7 +22,6 @@ import com.ichi2.libanki.Storage
 
 object DbUtils {
     /** performs a query on an unopened collection  */
-    @JvmStatic
     fun performQuery(context: Context, query: String) {
         check(!Storage.isInMemory) { "cannot use performQuery in memory" }
         var db: DB? = null

--- a/AnkiDroid/src/test/java/com/ichi2/testutils/IntentAssert.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/testutils/IntentAssert.kt
@@ -21,13 +21,11 @@ import org.hamcrest.MatcherAssert.assertThat
 import kotlin.test.assertNotNull
 
 object IntentAssert {
-    @JvmStatic
     fun doesNotHaveExtra(intent: Intent, extraKey: String?) {
         val keySet = assertNotNull(intent.extras).keySet()
         assertThat(String.format("Intent should not have extra '%s'", extraKey), keySet, not(hasItem(extraKey)))
     }
 
-    @JvmStatic
     fun hasExtra(intent: Intent, extraKey: String?, value: Long) {
         val keySet = assertNotNull(intent.extras).keySet()
         assertThat(String.format("Intent should have extra '%s'", extraKey), keySet, hasItem(extraKey))

--- a/AnkiDroid/src/test/java/com/ichi2/testutils/JsonUtils.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/testutils/JsonUtils.kt
@@ -27,14 +27,12 @@ object JsonUtils {
      * COULD_BE_BETTER: This would be much better as a Matcher for JSON
      * COULD_BE_BETTER: Only handles one level of ordering
      */
-    @JvmStatic
     fun JSONObject.toOrderedString(): String {
         val stringer = JSONStringer()
         writeTo(stringer)
         return stringer.toString()
     }
 
-    @JvmStatic
     fun JSONArray.toOrderedString(): String {
         val stringer = JSONStringer()
         writeTo(stringer)

--- a/AnkiDroid/src/test/java/com/ichi2/testutils/KeyEventUtils.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/testutils/KeyEventUtils.kt
@@ -23,21 +23,18 @@ import org.mockito.kotlin.mock
 
 class KeyEventUtils {
     companion object {
-        @JvmStatic
         fun getVKey(): KeyEvent = mock {
             on { keyCode } doReturn KeyEvent.KEYCODE_V
             on { unicodeChar } doReturn 'v'.code
             on { getUnicodeChar(ArgumentMatchers.anyInt()) } doReturn 'v'.code
         }
 
-        @JvmStatic
         fun getInvalid(): KeyEvent = mock {
             on { keyCode } doReturn 0
             on { unicodeChar } doReturn 0
             on { getUnicodeChar(ArgumentMatchers.anyInt()) } doReturn 0
         }
 
-        @JvmStatic
         fun leftShift(): KeyEvent = mock {
             on { keyCode } doReturn KeyEvent.KEYCODE_SHIFT_LEFT
             on { unicodeChar } doReturn 0

--- a/AnkiDroid/src/test/java/com/ichi2/testutils/MockTime.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/testutils/MockTime.kt
@@ -83,7 +83,6 @@ open class MockTime(initTime: Long, private val step: Int = 0) : Time() {
          * @param second, From 0 to 59
          * @return the time stamp of this instant in GMT calendar
          */
-        @JvmStatic
         @KotlinCleanup("After Kotlin Conversion, use default argument and remove this")
         fun timeStamp(year: Int, month: Int, date: Int, hourOfDay: Int, minute: Int, second: Int): Long {
             return timeStamp(year, month, date, hourOfDay, minute, second, 0)
@@ -100,7 +99,6 @@ open class MockTime(initTime: Long, private val step: Int = 0) : Time() {
          * @param milliseconds, from 0 to 999
          * @return the time stamp of this instant in GMT calendar
          */
-        @JvmStatic
         @SuppressLint("DirectGregorianInstantiation")
         fun timeStamp(year: Int, month: Int, date: Int, hourOfDay: Int, minute: Int, second: Int, milliseconds: Int): Long {
             val timeZone = TimeZone.getTimeZone("GMT")

--- a/AnkiDroid/src/test/java/com/ichi2/testutils/ShadowStatFs.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/testutils/ShadowStatFs.kt
@@ -36,7 +36,6 @@ object ShadowStatFs {
      *
      * @see [markAsNonEmpty]
      */
-    @JvmStatic
     fun registerStats(path: File, blockCount: Int, freeBlocks: Int, availableBlocks: Int) {
         RobolectricStats.registerStats(path, blockCount, freeBlocks, availableBlocks)
         // call canonicalFile so this works on macOS
@@ -51,10 +50,8 @@ object ShadowStatFs {
      *
      * @param path path to the file
      */
-    @JvmStatic
     fun markAsNonEmpty(path: File) = registerStats(path, 100, 20, 10000)
 
     @Resetter
-    @JvmStatic
     fun reset() = RobolectricStats.reset()
 }

--- a/AnkiDroid/src/test/java/com/ichi2/utils/CreateTempDir.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/utils/CreateTempDir.kt
@@ -19,7 +19,6 @@ import java.io.File
 
 class CreateTempDir {
     companion object {
-        @JvmStatic
         fun tempDir(dirName: String): File {
             val path: String? = System.getProperty("java.io.tmpdir")
             val tempDir = path + dirName + System.nanoTime()

--- a/AnkiDroid/src/test/java/com/ichi2/utils/FileOperation.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/utils/FileOperation.kt
@@ -21,13 +21,11 @@ import java.util.*
 
 class FileOperation {
     companion object {
-        @JvmStatic
         fun getFileResource(name: String): String {
             val resource = Objects.requireNonNull(FileOperation::class.java.classLoader).getResource(name)
             return (File(resource.path).path)
         }
 
-        @JvmStatic
         fun getFileContentsBytes(exportedFile: File): ByteArray {
             val f = RandomAccessFile(exportedFile, "r")
             val b = ByteArray(f.length().toInt())
@@ -35,7 +33,6 @@ class FileOperation {
             return b
         }
 
-        @JvmStatic
         fun getFileContents(exportedFile: File): String {
             return String(getFileContentsBytes(exportedFile))
         }

--- a/AnkiDroid/src/test/java/com/ichi2/utils/ListUtil.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/utils/ListUtil.kt
@@ -72,7 +72,6 @@ class ListUtil {
          * @param actuals Object list or list of arrays (multi-dimensional array) with
          * actual values
          */
-        @JvmStatic
         fun assertListEquals(expected: List<Any?>?, actuals: List<Any?>?) {
             assertListEquals(null, expected, actuals)
         }

--- a/AnkiDroid/src/test/java/com/ichi2/utils/ResourceLoader.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/utils/ResourceLoader.kt
@@ -45,7 +45,6 @@ object ResourceLoader {
         }
     }
 
-    @JvmStatic
     fun getTempCollection(context: Context, name: String): String {
         return getTempFilePath(context, name, "collection.anki2")
     }

--- a/AnkiDroid/src/test/java/com/ichi2/utils/StrictMock.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/utils/StrictMock.kt
@@ -27,7 +27,6 @@ inline fun <reified T> strictMock(): T {
 
 class StrictMock {
     companion object {
-        @JvmStatic
         fun <T> strictMock(clazz: Class<T>): T {
             return Mockito.mock(clazz, ThrowingAnswer())
         }

--- a/AnkiDroid/src/test/java/com/ichi2/utils/TagsUtilTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/utils/TagsUtilTest.kt
@@ -50,7 +50,7 @@ class TagsUtilTest {
 
         companion object {
             // suppressed to have a symmetry in all parameters, listOf(...) should be all you need.
-            @JvmStatic
+            @JvmStatic // required for Parameters
             @Parameterized.Parameters
             fun data(): Collection<Array<Any>> {
                 return listOf(

--- a/AnkiDroid/src/test/java/com/ichi2/utils/UnzipFile.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/utils/UnzipFile.kt
@@ -22,7 +22,6 @@ import java.lang.Exception
 
 class UnzipFile {
     companion object {
-        @JvmStatic
         fun unzip(exportedFile: File?, destDir: String) {
             try {
                 val zipFile = ZipFile(exportedFile)

--- a/AnkiDroid/src/test/java/com/wildplot/android/rendering/PieChartParameterizedTest.kt
+++ b/AnkiDroid/src/test/java/com/wildplot/android/rendering/PieChartParameterizedTest.kt
@@ -94,7 +94,7 @@ class PieChartParameterizedTest {
         }
 
         @Parameterized.Parameters
-        @JvmStatic
+        @JvmStatic // required for Parameters
         fun data(): Collection<Array<Any>> {
             return createParametersCollection(
                 asList(

--- a/api/src/main/java/com/ichi2/anki/api/NoteInfo.kt
+++ b/api/src/main/java/com/ichi2/anki/api/NoteInfo.kt
@@ -34,7 +34,7 @@ class NoteInfo {
          * @param cursor from a query to FlashCardsContract.Note.CONTENT_URI
          * @return a NoteInfo object or null if the cursor was not valid
          */
-        @JvmStatic
+        @JvmStatic // API Project
         fun buildFromCursor(cursor: Cursor): NoteInfo? {
             return try {
                 val idIndex = cursor.getColumnIndexOrThrow(FlashCardsContract.Note._ID)

--- a/api/src/main/java/com/ichi2/anki/api/Utils.kt
+++ b/api/src/main/java/com/ichi2/anki/api/Utils.kt
@@ -37,18 +37,15 @@ internal object Utils {
     private const val FIELD_SEPARATOR = '\u001f'.toString()
 
     // TODO: Add contract for null -> null and non-null to non-null.
-    @JvmStatic
     fun joinFields(list: Array<String>?): String? {
         return if (list != null) TextUtils.join("\u001f", list) else null
     }
 
-    @JvmStatic
     fun splitFields(fields: String): Array<String> {
         return fields.split(FIELD_SEPARATOR.toRegex()).dropLastWhile { it.isEmpty() }
             .toTypedArray()
     }
 
-    @JvmStatic
     fun joinTags(tags: Set<String?>?): String {
         if (tags == null || tags.isEmpty()) {
             return ""
@@ -59,12 +56,10 @@ internal object Utils {
         return TextUtils.join(" ", tags)
     }
 
-    @JvmStatic
     fun splitTags(tags: String): Array<String> {
         return tags.trim { it <= ' ' }.split("\\s+".toRegex()).toTypedArray()
     }
 
-    @JvmStatic
     fun fieldChecksum(data: String): Long {
         val strippedData = stripHTMLMedia(data)
         return try {

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/utils/LintUtils.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/utils/LintUtils.kt
@@ -11,7 +11,6 @@ object LintUtils {
      * @param allowedClasses  the list of classes where the checks should be ignored
      * @return true if this is a class where the checks should not be applied, false otherwise
      */
-    @JvmStatic
     fun isAnAllowedClass(classes: List<UClass>, vararg allowedClasses: String): Boolean {
         var isInAllowedClass = false
         for (i in classes.indices) {


### PR DESCRIPTION
We're no longer in Java, so only a few annotations are still necessary.

These are mostly test methods (`@Parameters/@MethodSource`), a few which are useful for mocks, and a small number which cause tests to fail if they're removed for no reasonable reason

This is a potentially flaky commit, hopefully the reduction in code causes a reduction in compile times which makes this worthwhile

This was a mostly automated process, adding comments manually if removing the annotation failed tests

It did not modify the API project public classes

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
