### PR TITLE
Fix nullable type bug with NoteEditor menu item

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
@@ -2053,9 +2053,10 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
             }
 
             // Removes paste as plain text from ContextMenu in NoteEditor
-            val item: MenuItem = menu.findItem(android.R.id.pasteAsPlainText)
-            if (menu.contains(item) && menu.contains(menu.findItem(android.R.id.paste))) {
-                item.setVisible(false)
+            val item: MenuItem? = menu.findItem(android.R.id.pasteAsPlainText)
+            val platformPasteMenuItem: MenuItem? = menu.findItem(android.R.id.paste)
+            if (item != null && platformPasteMenuItem != null) {
+                item.isVisible = false
             }
 
             val initialSize = menu.size()


### PR DESCRIPTION
## Purpose / Description

This fixes the type nullability for the "pasteAsPlainText" menu item when retrieving it with  `menu.findItem()`(which can return null).

## Fixes

Fixes #12316 

## How Has This Been Tested?

Ran the tests.

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
