### PR TITLE
chore: remove redundant '@JvmField' annotations

### DIFF
--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/ContentProviderTest.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/ContentProviderTest.kt
@@ -64,7 +64,7 @@ import kotlin.test.junit.JUnitAsserter.assertNotNull
 @KotlinCleanup("try to replace try{query database...}finally{cursor.close()} with databaseQuery.use { cursor -> ...}")
 @RunWith(Parameterized::class)
 class ContentProviderTest : InstrumentedTest() {
-    @JvmField
+    @JvmField // required for Parameter
     @Parameterized.Parameter
     @KotlinCleanup("lateinit")
     var schedVersion = 0

--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/LayoutValidationTest.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/LayoutValidationTest.kt
@@ -31,11 +31,11 @@ import java.util.concurrent.atomic.AtomicReference
 
 @RunWith(Parameterized::class)
 class LayoutValidationTest : InstrumentedTest() {
-    @JvmField
+    @JvmField // required for Parameter
     @Parameterized.Parameter
     var resourceId = 0
 
-    @JvmField
+    @JvmField // required for Parameter
     @Parameterized.Parameter(1)
     var name: String? = null
     @Test

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
@@ -155,7 +155,6 @@ abstract class AbstractFlashcardViewer :
     private var mDoubleTapTimeInterval = DEFAULT_DOUBLE_TAP_TIME_INTERVAL
 
     // Android WebView
-    @JvmField
     var automaticAnswer = AutomaticAnswer.defaultInstance(this)
     protected var typeAnswer: TypeAnswer? = null
 
@@ -180,7 +179,6 @@ abstract class AbstractFlashcardViewer :
         private set
     private var mCardFrame: FrameLayout? = null
     private var mTouchLayer: FrameLayout? = null
-    @JvmField
     protected var answerField: FixedEditText? = null
     protected var flipCardLayout: LinearLayout? = null
     protected var easeButtonsLayout: LinearLayout? = null
@@ -192,7 +190,6 @@ abstract class AbstractFlashcardViewer :
     internal var easeButton3: EaseButton? = null
     @KotlinCleanup("internal for AnkiDroidJsApi")
     internal var easeButton4: EaseButton? = null
-    @JvmField
     protected var topBarLayout: RelativeLayout? = null
     private val mClipboard: ClipboardManager? = null
     private var mPreviousAnswerIndicator: PreviousAnswerIndicator? = null
@@ -207,7 +204,6 @@ abstract class AbstractFlashcardViewer :
      * A record of the last time the "show answer" or ease buttons were pressed. We keep track
      * of this time to ignore accidental button presses.
      */
-    @JvmField
     @VisibleForTesting
     protected var lastClickTime: Long = 0
 
@@ -255,7 +251,6 @@ abstract class AbstractFlashcardViewer :
     /** Preference: Whether the user wants press back twice to return to the main screen"  */
     private var mExitViaDoubleTapBack = false
 
-    @JvmField
     @VisibleForTesting
     val mOnRenderProcessGoneDelegate = OnRenderProcessGoneDelegate(this)
     protected val mTTS = TTS()
@@ -2632,7 +2627,6 @@ abstract class AbstractFlashcardViewer :
         /** to be sent to and from the card editor  */
         @set:VisibleForTesting(otherwise = VisibleForTesting.NONE)
         var editorCard: Card? = null
-        @JvmField
         internal var displayAnswer = false
         const val DOUBLE_TAP_TIME_INTERVAL = "doubleTapTimeInterval"
         const val DEFAULT_DOUBLE_TAP_TIME_INTERVAL = 200

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.kt
@@ -282,7 +282,6 @@ open class AnkiDroidApp : Application() {
 
     companion object {
         /** Running under instrumentation. a "/androidTest" directory will be created which contains a test collection  */
-        @JvmField
         var INSTRUMENTATION_TESTING = false
 
         /**
@@ -304,7 +303,6 @@ open class AnkiDroidApp : Application() {
          *
          * TODO: Should be removed once app is fully functional under Scoped Storage
          */
-        @JvmField
         var TESTING_SCOPED_STORAGE = false
         const val XML_CUSTOM_NAMESPACE = "http://arbitrary.app.namespace/com.ichi2.anki"
         const val ANDROID_NAMESPACE = "http://schemas.android.com/apk/res/android"

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -117,8 +117,8 @@ open class CardBrowser :
     override fun onDeckSelected(deck: SelectableDeck?) {
         deck?.let {
             val deckId = deck.deckId
-            mDeckSpinnerSelection!!.initializeActionBarDeckSpinner(this.supportActionBar!!)
-            mDeckSpinnerSelection!!.selectDeckById(deckId, true)
+            deckSpinnerSelection!!.initializeActionBarDeckSpinner(this.supportActionBar!!)
+            deckSpinnerSelection!!.selectDeckById(deckId, true)
             selectDeckAndSave(deckId)
         }
     }
@@ -136,17 +136,17 @@ open class CardBrowser :
     @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
     val mCards = CardCollection<CardCache>()
     @JvmField
-    var mDeckSpinnerSelection: DeckSpinnerSelection? = null
+    var deckSpinnerSelection: DeckSpinnerSelection? = null
 
     @KotlinCleanup("move to onCreate and make lateinit")
     @JvmField
     @VisibleForTesting
-    var mCardsListView: ListView? = null
+    var cardsListView: ListView? = null
     private var mSearchView: CardBrowserSearchView? = null
 
     @JvmField
     @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
-    var mCardsAdapter: MultiColumnListAdapter? = null
+    var cardsAdapter: MultiColumnListAdapter? = null
 
     private var mSearchTerms: String = ""
     private var mRestrictOnDeck: String? = null
@@ -453,7 +453,7 @@ open class CardBrowser :
         selectedCardIds.run { // to prevent computing selectedCardIds multiple times
             if (isEmpty()) {
                 endMultiSelectMode()
-                mCardsAdapter!!.notifyDataSetChanged()
+                cardsAdapter!!.notifyDataSetChanged()
             } else {
                 if (contains(reviewerCardId)) {
                     mReloadRequired = true
@@ -558,7 +558,7 @@ open class CardBrowser :
         // conf saved may still have this bug.
         mOrderAsc = upgradeJSONIfNecessary(col, "sortBackwards", false)
         mCards.reset()
-        mCardsListView = findViewById(R.id.card_browser_list)
+        cardsListView = findViewById(R.id.card_browser_list)
         // Create a spinner for column 1
         val cardsColumn1Spinner = findViewById<Spinner>(R.id.browser_column1_spinner)
         val column1Adapter = ArrayAdapter.createFromResource(
@@ -575,9 +575,9 @@ open class CardBrowser :
                     mColumn1Index = pos
                     AnkiDroidApp.getSharedPrefs(AnkiDroidApp.instance.baseContext).edit()
                         .putInt("cardBrowserColumn1", mColumn1Index).apply()
-                    val fromMap = mCardsAdapter!!.fromMapping
+                    val fromMap = cardsAdapter!!.fromMapping
                     fromMap[0] = COLUMN1_KEYS[mColumn1Index]
-                    mCardsAdapter!!.fromMapping = fromMap
+                    cardsAdapter!!.fromMapping = fromMap
                 }
             }
 
@@ -604,9 +604,9 @@ open class CardBrowser :
                     mColumn2Index = pos
                     AnkiDroidApp.getSharedPrefs(AnkiDroidApp.instance.baseContext).edit()
                         .putInt("cardBrowserColumn2", mColumn2Index).apply()
-                    val fromMap = mCardsAdapter!!.fromMapping
+                    val fromMap = cardsAdapter!!.fromMapping
                     fromMap[1] = COLUMN2_KEYS[mColumn2Index]
-                    mCardsAdapter!!.fromMapping = fromMap
+                    cardsAdapter!!.fromMapping = fromMap
                 }
             }
 
@@ -619,7 +619,7 @@ open class CardBrowser :
         val sflCustomFont = preferences.getString("browserEditorFont", "")
         val columnsContent = arrayOf(COLUMN1_KEYS[mColumn1Index], COLUMN2_KEYS[mColumn2Index])
         // make a new list adapter mapping the data in mCards to column1 and column2 of R.layout.card_item_browser
-        mCardsAdapter = MultiColumnListAdapter(
+        cardsAdapter = MultiColumnListAdapter(
             this,
             R.layout.card_item_browser,
             columnsContent, intArrayOf(R.id.card_sfld, R.id.card_column2),
@@ -627,13 +627,13 @@ open class CardBrowser :
             sflCustomFont
         )
         // link the adapter to the main mCardsListView
-        mCardsListView!!.adapter = mCardsAdapter
+        cardsListView!!.adapter = cardsAdapter
         // make the items (e.g. question & answer) render dynamically when scrolling
-        mCardsListView!!.setOnScrollListener(RenderOnScroll())
+        cardsListView!!.setOnScrollListener(RenderOnScroll())
         // set the spinner index
         cardsColumn1Spinner.setSelection(mColumn1Index)
         cardsColumn2Spinner.setSelection(mColumn2Index)
-        mCardsListView!!.setOnItemClickListener { _: AdapterView<*>?, view: View?, position: Int, _: Long ->
+        cardsListView!!.setOnItemClickListener { _: AdapterView<*>?, view: View?, position: Int, _: Long ->
             if (isInMultiSelectMode) {
                 // click on whole cell triggers select
                 val cb = view!!.findViewById<CheckBox>(R.id.card_checkbox)
@@ -647,7 +647,7 @@ open class CardBrowser :
             }
         }
         @KotlinCleanup("helper function for min/max range")
-        mCardsListView!!.setOnItemLongClickListener { _: AdapterView<*>?, view: View?, position: Int, _: Long ->
+        cardsListView!!.setOnItemLongClickListener { _: AdapterView<*>?, view: View?, position: Int, _: Long ->
             if (isInMultiSelectMode) {
                 var hasChanged = false
                 for (
@@ -656,7 +656,7 @@ open class CardBrowser :
                         position
                     )
                 ) {
-                    val card = mCardsListView!!.getItemAtPosition(i) as CardCache
+                    val card = cardsListView!!.getItemAtPosition(i) as CardCache
 
                     // Add to the set of checked cards
                     hasChanged = hasChanged or mCheckedCards.add(card)
@@ -674,33 +674,33 @@ open class CardBrowser :
                 cb.toggle()
                 onCheck(position, view)
                 recenterListView(view)
-                mCardsAdapter!!.notifyDataSetChanged()
+                cardsAdapter!!.notifyDataSetChanged()
             }
             true
         }
         window.setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_ALWAYS_HIDDEN)
         val deckId = col.decks.selected()
-        mDeckSpinnerSelection = DeckSpinnerSelection(
+        deckSpinnerSelection = DeckSpinnerSelection(
             this, col, findViewById(R.id.toolbar_spinner),
             showAllDecks = true, alwaysShowDefault = false, showFilteredDecks = true
         )
         inCardsMode = AnkiDroidApp.getSharedPrefs(this).getBoolean("inCardsMode", true)
         isTruncated = AnkiDroidApp.getSharedPrefs(this).getBoolean("isTruncated", false)
-        mDeckSpinnerSelection!!.initializeActionBarDeckSpinner(this.supportActionBar!!)
+        deckSpinnerSelection!!.initializeActionBarDeckSpinner(this.supportActionBar!!)
         selectDeckAndSave(deckId)
 
         // If a valid value for last deck exists then use it, otherwise use libanki selected deck
         if (lastDeckId != null && lastDeckId == ALL_DECKS_ID) {
             selectAllDecks()
         } else if (lastDeckId != null && col.decks.get(lastDeckId!!, false) != null) {
-            mDeckSpinnerSelection!!.selectDeckById(lastDeckId!!, false)
+            deckSpinnerSelection!!.selectDeckById(lastDeckId!!, false)
         } else {
-            mDeckSpinnerSelection!!.selectDeckById(col.decks.selected(), false)
+            deckSpinnerSelection!!.selectDeckById(col.decks.selected(), false)
         }
     }
 
     fun selectDeckAndSave(deckId: DeckId) {
-        mDeckSpinnerSelection!!.selectDeckById(deckId, true)
+        deckSpinnerSelection!!.selectDeckById(deckId, true)
         mRestrictOnDeck = if (deckId == ALL_DECKS_ID) {
             ""
         } else {
@@ -776,7 +776,7 @@ open class CardBrowser :
 
     @VisibleForTesting
     fun selectAllDecks() {
-        mDeckSpinnerSelection!!.selectAllDecks()
+        deckSpinnerSelection!!.selectAllDecks()
         mRestrictOnDeck = ""
         saveLastDeckId(ALL_DECKS_ID)
         searchCards()
@@ -786,11 +786,11 @@ open class CardBrowser :
      * We use the Card ID to specify the preview target  */
     private fun openNoteEditorForCard(cardId: CardId) {
         mCurrentCardId = cardId
-        sCardBrowserCard = col.getCard(mCurrentCardId)
+        cardBrowserCard = col.getCard(mCurrentCardId)
         // start note editor using the card we just loaded
         val editCard = Intent(this, NoteEditor::class.java)
             .putExtra(NoteEditor.EXTRA_CALLER, NoteEditor.CALLER_CARDBROWSER_EDIT)
-            .putExtra(NoteEditor.EXTRA_CARD_ID, sCardBrowserCard!!.id)
+            .putExtra(NoteEditor.EXTRA_CARD_ID, cardBrowserCard!!.id)
         launchActivityForResultWithAnimation(editCard, onEditCardActivityResult, ActivityTransitionAnimation.Direction.START)
         // #6432 - FIXME - onCreateOptionsMenu crashes if receiving an activity result from edit card when in multiselect
         endMultiSelectMode()
@@ -1265,7 +1265,7 @@ open class CardBrowser :
         }
 
         isTruncated = newTruncateValue
-        mCardsAdapter!!.notifyDataSetChanged()
+        cardsAdapter!!.notifyDataSetChanged()
     }
 
     protected fun deleteSelectedNote() {
@@ -1278,7 +1278,7 @@ open class CardBrowser :
         )
         mCheckedCards.clear()
         endMultiSelectMode()
-        mCardsAdapter!!.notifyDataSetChanged()
+        cardsAdapter!!.notifyDataSetChanged()
     }
 
     @VisibleForTesting
@@ -1518,7 +1518,7 @@ open class CardBrowser :
         }
         // clear the existing card list
         mCards.reset()
-        mCardsAdapter!!.notifyDataSetChanged()
+        cardsAdapter!!.notifyDataSetChanged()
         val query = searchText!!
         val order = if (mOrder == CARD_ORDER_NONE) NoOrdering() else UseCollectionOrdering()
         launchCatchingTask {
@@ -1565,16 +1565,16 @@ open class CardBrowser :
     protected open fun numCardsToRender(): Int {
         return ceil(
             (
-                mCardsListView!!.height /
+                cardsListView!!.height /
                     TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, 20f, resources.displayMetrics)
                 ).toDouble()
         ).toInt() + 5
     }
 
     private fun updateList() {
-        if (colIsOpen() && mCardsAdapter != null) {
-            mCardsAdapter!!.notifyDataSetChanged()
-            mDeckSpinnerSelection!!.notifyDataSetChanged()
+        if (colIsOpen() && cardsAdapter != null) {
+            cardsAdapter!!.notifyDataSetChanged()
+            deckSpinnerSelection!!.notifyDataSetChanged()
             onSelectionChanged()
             updatePreviewMenuItem()
         }
@@ -1603,7 +1603,7 @@ open class CardBrowser :
     /** Returns the decks which are valid targets for "Change Deck"  */
     @get:VisibleForTesting
     val validDecksForChangeDeck: List<Deck>
-        get() = mDeckSpinnerSelection!!.dropDownDecks
+        get() = deckSpinnerSelection!!.dropDownDecks
             .filterNot { d -> Decks.isDynamic(d) }
 
     @RustCleanup("this isn't how Desktop Anki does it")
@@ -1736,7 +1736,7 @@ open class CardBrowser :
         Timber.d("CardBrowser - saveEditedCard()")
         val updatedCard: Card = withProgress {
             withCol {
-                updateCard(this, sCardBrowserCard!!, isFromReviewer = false, false)
+                updateCard(this, cardBrowserCard!!, isFromReviewer = false, false)
             }
         }
         updateCardInList(updatedCard)
@@ -1747,7 +1747,7 @@ open class CardBrowser :
             browser.hideProgressBar()
             browser.searchCards()
             browser.endMultiSelectMode()
-            browser.mCardsAdapter!!.notifyDataSetChanged()
+            browser.cardsAdapter!!.notifyDataSetChanged()
             browser.invalidateOptionsMenu() // maybe the availability of undo changed
             if (!result!!.succeeded()) {
                 Timber.i("changeDeckHandler failed, not offering undo")
@@ -1863,7 +1863,7 @@ open class CardBrowser :
             // reload whole view
             browser.forceRefreshSearch()
             browser.endMultiSelectMode()
-            browser.mCardsAdapter!!.notifyDataSetChanged()
+            browser.cardsAdapter!!.notifyDataSetChanged()
             browser.updatePreviewMenuItem()
             browser.invalidateOptionsMenu() // maybe the availability of undo changed
         }
@@ -1875,13 +1875,13 @@ open class CardBrowser :
     }
 
     private fun autoScrollTo(newPosition: Int) {
-        mCardsListView!!.setSelectionFromTop(newPosition, mOldCardTopOffset)
+        cardsListView!!.setSelectionFromTop(newPosition, mOldCardTopOffset)
         mPostAutoScroll = true
     }
 
     private fun calculateTopOffset(cardPosition: Int): Int {
-        val firstVisiblePosition = mCardsListView!!.firstVisiblePosition
-        val v = mCardsListView!!.getChildAt(cardPosition - firstVisiblePosition)
+        val firstVisiblePosition = cardsListView!!.firstVisiblePosition
+        val v = cardsListView!!.getChildAt(cardPosition - firstVisiblePosition)
         return v?.top ?: 0
     }
 
@@ -1918,7 +1918,7 @@ open class CardBrowser :
         override fun actualOnProgressUpdate(context: CardBrowser, value: Int) {
             // Note: This is called every time a card is rendered.
             // It blocks the long-click callback while the task is running, so usage of the task should be minimized
-            context.mCardsAdapter!!.notifyDataSetChanged()
+            context.cardsAdapter!!.notifyDataSetChanged()
         }
 
         override fun actualOnPreExecute(context: CardBrowser) {
@@ -1938,7 +1938,7 @@ open class CardBrowser :
                     Timber.e(e, "failed to hide cards")
                 }
                 context.hideProgressBar()
-                context.mCardsAdapter!!.notifyDataSetChanged()
+                context.cardsAdapter!!.notifyDataSetChanged()
                 Timber.d("Completed doInBackgroundRenderBrowserQA Successfully")
             } else {
                 // Might want to do something more proactive here like show a message box?
@@ -2216,7 +2216,7 @@ open class CardBrowser :
             mActionBarTitle!!.text = String.format(LanguageUtil.getLocaleCompat(resources), "%d", checkedCardCount())
         } finally {
             if (colIsOpen()) {
-                mCardsAdapter?.notifyDataSetChanged()
+                cardsAdapter?.notifyDataSetChanged()
             }
         }
     }
@@ -2237,7 +2237,7 @@ open class CardBrowser :
                 props.reload()
             }
         }
-        mCardsAdapter!!.notifyDataSetChanged()
+        cardsAdapter!!.notifyDataSetChanged()
     }
 
     private val allCardIds: LongArray
@@ -2462,13 +2462,13 @@ open class CardBrowser :
      * adjust so that the vertical position of the given view is maintained
      */
     private fun recenterListView(view: View) {
-        val position = mCardsListView!!.getPositionForView(view)
+        val position = cardsListView!!.getPositionForView(view)
         // Get the current vertical position of the top of the selected view
         val top = view.top
         // Post to event queue with some delay to give time for the UI to update the layout
         postDelayedOnNewHandler({
             // Scroll to the same vertical position before the layout was changed
-            mCardsListView!!.setSelectionFromTop(position, top)
+            cardsListView!!.setSelectionFromTop(position, top)
         }, 10)
     }
 
@@ -2485,7 +2485,7 @@ open class CardBrowser :
         // show title and hide spinner
         mActionBarTitle!!.visibility = View.VISIBLE
         mActionBarTitle!!.text = checkedCardCount().toString()
-        mDeckSpinnerSelection!!.setSpinnerVisibility(View.GONE)
+        deckSpinnerSelection!!.setSpinnerVisibility(View.GONE)
         // reload the actionbar using the multi-select mode actionbar
         invalidateOptionsMenu()
     }
@@ -2498,13 +2498,13 @@ open class CardBrowser :
         mCheckedCards.clear()
         isInMultiSelectMode = false
         // If view which was originally selected when entering multi-select is visible then maintain its position
-        val view = mCardsListView!!.getChildAt(mLastSelectedPosition - mCardsListView!!.firstVisiblePosition)
+        val view = cardsListView!!.getChildAt(mLastSelectedPosition - cardsListView!!.firstVisiblePosition)
         view?.let { recenterListView(it) }
         // update adapter to remove check boxes
-        mCardsAdapter!!.notifyDataSetChanged()
+        cardsAdapter!!.notifyDataSetChanged()
         // update action bar
         invalidateOptionsMenu()
-        mDeckSpinnerSelection!!.setSpinnerVisibility(View.VISIBLE)
+        deckSpinnerSelection!!.setSpinnerVisibility(View.VISIBLE)
         mActionBarTitle!!.visibility = View.GONE
     }
 
@@ -2621,7 +2621,7 @@ open class CardBrowser :
 
     companion object {
         @JvmField
-        var sCardBrowserCard: Card? = null
+        var cardBrowserCard: Card? = null
 
         /**
          * Argument key to add on change deck dialog,

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -135,16 +135,13 @@ open class CardBrowser :
      * When the list is changed, the position member of its elements should get changed. */
     @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
     val mCards = CardCollection<CardCache>()
-    @JvmField
     var deckSpinnerSelection: DeckSpinnerSelection? = null
 
     @KotlinCleanup("move to onCreate and make lateinit")
-    @JvmField
     @VisibleForTesting
     var cardsListView: ListView? = null
     private var mSearchView: CardBrowserSearchView? = null
 
-    @JvmField
     @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
     var cardsAdapter: MultiColumnListAdapter? = null
 
@@ -2620,7 +2617,6 @@ open class CardBrowser :
     }
 
     companion object {
-        @JvmField
         var cardBrowserCard: Card? = null
 
         /**

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplatePreviewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplatePreviewer.kt
@@ -103,7 +103,7 @@ open class CardTemplatePreviewer : AbstractFlashcardViewer() {
 
     override fun onResume() {
         super.onResume()
-        if (mCurrentCard == null || mOrdinal < 0) {
+        if (currentCard == null || mOrdinal < 0) {
             Timber.e("CardTemplatePreviewer started with empty card list or invalid index")
             closeCardTemplatePreviewer()
         }
@@ -250,13 +250,13 @@ open class CardTemplatePreviewer : AbstractFlashcardViewer() {
             } else if (mEditedModel != null) { // bare note type (not coming from note editor), or new card template
                 Timber.d("onCreate() CardTemplatePreviewer started with edited model and template index, displaying blank to preview formatting")
                 currentCard = getDummyCard(mEditedModel!!, mOrdinal)
-                if (mCurrentCard == null) {
+                if (currentCard == null) {
                     showThemedToast(applicationContext, getString(R.string.invalid_template), false)
                     closeCardTemplatePreviewer()
                 }
             }
         }
-        if (mCurrentCard == null) {
+        if (currentCard == null) {
             showThemedToast(applicationContext, getString(R.string.invalid_template), false)
             closeCardTemplatePreviewer()
             return
@@ -276,18 +276,18 @@ open class CardTemplatePreviewer : AbstractFlashcardViewer() {
         assert(mNoteEditorBundle != null)
         currentCard = getDummyCard(mEditedModel, templateIndex, getBundleEditFields(mNoteEditorBundle))
         // example: a basic card with no fields provided
-        if (mCurrentCard == null) {
+        if (currentCard == null) {
             return null
         }
         val newDid = mNoteEditorBundle!!.getLong("did")
         if (col.decks.isDyn(newDid)) {
-            mCurrentCard!!.oDid = mCurrentCard!!.did
+            currentCard!!.oDid = currentCard!!.did
         }
-        mCurrentCard!!.did = newDid
-        val currentNote = mCurrentCard!!.note()
+        currentCard!!.did = newDid
+        val currentNote = currentCard!!.note()
         val tagsList = mNoteEditorBundle!!.getStringArrayList("tags")
         NoteUtils.setTags(currentNote, tagsList)
-        return mCurrentCard
+        return currentCard
     }
 
     private fun getLabels(fieldValues: MutableList<String>) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplatePreviewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplatePreviewer.kt
@@ -65,7 +65,6 @@ open class CardTemplatePreviewer : AbstractFlashcardViewer() {
         private set
     private var mAllFieldsNull = true
     private var mCardType: String? = null
-    @JvmField
     protected var previewLayout: PreviewLayout? = null
     override fun onCreate(savedInstanceState: Bundle?) {
         if (showedActivityFailedScreen(savedInstanceState)) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplatePreviewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplatePreviewer.kt
@@ -66,7 +66,7 @@ open class CardTemplatePreviewer : AbstractFlashcardViewer() {
     private var mAllFieldsNull = true
     private var mCardType: String? = null
     @JvmField
-    protected var mPreviewLayout: PreviewLayout? = null
+    protected var previewLayout: PreviewLayout? = null
     override fun onCreate(savedInstanceState: Bundle?) {
         if (showedActivityFailedScreen(savedInstanceState)) {
             return
@@ -139,28 +139,28 @@ open class CardTemplatePreviewer : AbstractFlashcardViewer() {
 
     override fun initLayout() {
         super.initLayout()
-        mTopBarLayout!!.visibility = View.GONE
+        topBarLayout!!.visibility = View.GONE
         findViewById<View>(R.id.answer_options_layout).visibility = View.GONE
-        mPreviewLayout = createAndDisplay(this, mToggleAnswerHandler)
-        mPreviewLayout!!.setOnPreviousCard { onPreviousTemplate() }
-        mPreviewLayout!!.setOnNextCard { onNextTemplate() }
-        mPreviewLayout!!.hideNavigationButtons()
-        mPreviewLayout!!.setPrevButtonEnabled(false)
+        previewLayout = createAndDisplay(this, mToggleAnswerHandler)
+        previewLayout!!.setOnPreviousCard { onPreviousTemplate() }
+        previewLayout!!.setOnNextCard { onNextTemplate() }
+        previewLayout!!.hideNavigationButtons()
+        previewLayout!!.setPrevButtonEnabled(false)
     }
 
     override fun displayCardQuestion() {
         super.displayCardQuestion()
         mShowingAnswer = false
-        mPreviewLayout!!.setShowingAnswer(false)
+        previewLayout!!.setShowingAnswer(false)
     }
 
     override fun displayCardAnswer() {
         if (mAllFieldsNull && mCardType != null && mCardType == getString(R.string.basic_typing_model_name)) {
-            mAnswerField!!.setText(getString(R.string.basic_answer_sample_text_user))
+            answerField!!.setText(getString(R.string.basic_answer_sample_text_user))
         }
         super.displayCardAnswer()
         mShowingAnswer = true
-        mPreviewLayout!!.setShowingAnswer(true)
+        previewLayout!!.setShowingAnswer(true)
     }
 
     override fun hideEaseButtons() {
@@ -205,8 +205,8 @@ open class CardTemplatePreviewer : AbstractFlashcardViewer() {
     private fun onTemplateIndexChanged() {
         val prevBtnEnabled = isPrevBtnEnabled(templateIndex)
         val nextBtnEnabled = isNextBtnEnabled(templateIndex)
-        mPreviewLayout!!.setPrevButtonEnabled(prevBtnEnabled)
-        mPreviewLayout!!.setNextButtonEnabled(nextBtnEnabled)
+        previewLayout!!.setPrevButtonEnabled(prevBtnEnabled)
+        previewLayout!!.setNextButtonEnabled(nextBtnEnabled)
         setCurrentCardFromNoteEditorBundle(col)
         displayCardQuestion()
     }
@@ -238,7 +238,7 @@ open class CardTemplatePreviewer : AbstractFlashcardViewer() {
             if (toPreview != null) {
                 mTemplateCount = col.findTemplates(toPreview.note()).size
                 if (mTemplateCount >= 2) {
-                    mPreviewLayout!!.showNavigationButtons()
+                    previewLayout!!.showNavigationButtons()
                 }
             }
         } else {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -196,7 +196,7 @@ open class DeckPicker :
 
     @JvmField
     @VisibleForTesting
-    var mDueTree: List<TreeNode<AbstractDeckTreeNode>>? = null
+    var dueTree: List<TreeNode<AbstractDeckTreeNode>>? = null
 
     @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
     var searchDecksIcon: MenuItem? = null
@@ -901,7 +901,7 @@ open class DeckPicker :
             mSyncOnResume = false
         } else if (colIsOpen()) {
             selectNavigationItem(R.id.nav_decks)
-            if (mDueTree == null) {
+            if (dueTree == null) {
                 updateDeckList(true)
             }
             updateDeckList()
@@ -1079,7 +1079,7 @@ open class DeckPicker :
             // update DB
             col.decks.collapse(did)
             // update stored state
-            findInDeckTree(mDueTree!! as List<TreeNode<DeckDueTreeNode>>, did)?.run {
+            findInDeckTree(dueTree!! as List<TreeNode<DeckDueTreeNode>>, did)?.run {
                 collapsed = !collapsed
             }
             renderPage()
@@ -2246,7 +2246,7 @@ open class DeckPicker :
     }
 
     fun renderPage() {
-        if (mDueTree == null) {
+        if (dueTree == null) {
             // mDueTree may be set back to null when the activity restart.
             // We may need to recompute it.
             updateDeckList()
@@ -2254,7 +2254,7 @@ open class DeckPicker :
         }
 
         // Check if default deck is the only available and there are no cards
-        val isEmpty = mDueTree!!.size == 1 && mDueTree!![0].value.did == 1L && col.isEmpty
+        val isEmpty = dueTree!!.size == 1 && dueTree!![0].value.did == 1L && col.isEmpty
         if (animationDisabled()) {
             mDeckPickerContent.visibility = if (isEmpty) View.GONE else View.VISIBLE
             mNoDecksPlaceholder.visibility = if (isEmpty) View.VISIBLE else View.GONE
@@ -2293,7 +2293,7 @@ open class DeckPicker :
             // We're done here
             return
         }
-        mDeckListAdapter.buildDeckList(mDueTree!!, col, currentFilter)
+        mDeckListAdapter.buildDeckList(dueTree!!, col, currentFilter)
 
         // Set the "x due in y minutes" subtitle
         try {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -194,7 +194,6 @@ open class DeckPicker :
     @VisibleForTesting
     var optionsMenuState: OptionsMenuState? = null
 
-    @JvmField
     @VisibleForTesting
     var dueTree: List<TreeNode<AbstractDeckTreeNode>>? = null
 
@@ -2236,7 +2235,7 @@ open class DeckPicker :
             showCollectionErrorDialog()
             return
         }
-        mDueTree = result.map { x -> x.unsafeCastToType() }
+        dueTree = result.map { x -> x.unsafeCastToType() }
         renderPage()
         // Update the mini statistics bar as well
         launchCatchingTask {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/FieldEditLine.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/FieldEditLine.kt
@@ -254,8 +254,7 @@ class FieldEditLine : FrameLayout {
         }
 
         companion object {
-            // required field that makes Parcelables from a Parcel
-            @JvmField
+            @JvmField // required field that makes Parcelables from a Parcel
             val CREATOR: Parcelable.Creator<SavedState> = object : ClassLoaderCreator<SavedState> {
                 override fun createFromParcel(`in`: Parcel, loader: ClassLoader): SavedState {
                     return SavedState(`in`, loader)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/FieldEditText.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/FieldEditText.kt
@@ -269,7 +269,7 @@ class FieldEditText : FixedEditText, NoteService.NoteField {
         }
 
         companion object {
-            @JvmField
+            @JvmField // required field that makes Parcelables from a Parcel
             val CREATOR: Parcelable.Creator<SavedState> = object : Parcelable.Creator<SavedState> {
                 override fun createFromParcel(source: Parcel): SavedState {
                     return SavedState(source)
@@ -292,7 +292,6 @@ class FieldEditText : FixedEditText, NoteService.NoteField {
     }
 
     companion object {
-        @JvmField
         val NEW_LINE: String = Objects.requireNonNull(System.getProperty("line.separator"))
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
@@ -327,7 +327,7 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
                 addNote =
                     true
             CALLER_CARDBROWSER_EDIT -> {
-                mCurrentEditedCard = CardBrowser.sCardBrowserCard
+                mCurrentEditedCard = CardBrowser.cardBrowserCard
                 if (mCurrentEditedCard == null) {
                     finishWithoutAnimation()
                     return

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Previewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Previewer.kt
@@ -151,7 +151,7 @@ class Previewer : AbstractFlashcardViewer() {
 
     override fun initLayout() {
         super.initLayout()
-        mTopBarLayout!!.visibility = View.GONE
+        topBarLayout!!.visibility = View.GONE
         findViewById<View>(R.id.answer_options_layout).visibility = View.GONE
         previewLayout = PreviewLayout.createAndDisplay(this, mToggleAnswerHandler)
         previewLayout!!.setOnNextCard { changePreviewedCard(true) }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
@@ -211,7 +211,7 @@ open class Reviewer : AbstractFlashcardViewer() {
     @NeedsTest("is not hidden if flag is on app bar and fullscreen is enabled")
     protected val flagToDisplay: Int
         get() {
-            val actualValue = mCurrentCard!!.userFlag()
+            val actualValue = currentCard!!.userFlag()
             if (actualValue == CardMarker.FLAG_NONE) {
                 return CardMarker.FLAG_NONE
             }
@@ -260,7 +260,7 @@ open class Reviewer : AbstractFlashcardViewer() {
     }
 
     private fun onMarkChanged() {
-        if (mCurrentCard == null) {
+        if (currentCard == null) {
             return
         }
         mCardMarker!!.displayMark(shouldDisplayMark())
@@ -297,7 +297,7 @@ open class Reviewer : AbstractFlashcardViewer() {
     }
 
     private fun onFlagChanged() {
-        if (mCurrentCard == null) {
+        if (currentCard == null) {
             return
         }
         mCardMarker!!.displayFlag(flagToDisplay)
@@ -399,7 +399,7 @@ open class Reviewer : AbstractFlashcardViewer() {
             }
             R.id.action_mark_card -> {
                 Timber.i("Reviewer:: Mark button pressed")
-                onMark(mCurrentCard)
+                onMark(currentCard)
             }
             R.id.action_replay -> {
                 Timber.i("Reviewer:: Replay audio button pressed (from menu)")
@@ -488,35 +488,35 @@ open class Reviewer : AbstractFlashcardViewer() {
             }
             R.id.action_flag_zero -> {
                 Timber.i("Reviewer:: No flag")
-                onFlag(mCurrentCard, CardMarker.FLAG_NONE)
+                onFlag(currentCard, CardMarker.FLAG_NONE)
             }
             R.id.action_flag_one -> {
                 Timber.i("Reviewer:: Flag one")
-                onFlag(mCurrentCard, CardMarker.FLAG_RED)
+                onFlag(currentCard, CardMarker.FLAG_RED)
             }
             R.id.action_flag_two -> {
                 Timber.i("Reviewer:: Flag two")
-                onFlag(mCurrentCard, CardMarker.FLAG_ORANGE)
+                onFlag(currentCard, CardMarker.FLAG_ORANGE)
             }
             R.id.action_flag_three -> {
                 Timber.i("Reviewer:: Flag three")
-                onFlag(mCurrentCard, CardMarker.FLAG_GREEN)
+                onFlag(currentCard, CardMarker.FLAG_GREEN)
             }
             R.id.action_flag_four -> {
                 Timber.i("Reviewer:: Flag four")
-                onFlag(mCurrentCard, CardMarker.FLAG_BLUE)
+                onFlag(currentCard, CardMarker.FLAG_BLUE)
             }
             R.id.action_flag_five -> {
                 Timber.i("Reviewer:: Flag five")
-                onFlag(mCurrentCard, CardMarker.FLAG_PINK)
+                onFlag(currentCard, CardMarker.FLAG_PINK)
             }
             R.id.action_flag_six -> {
                 Timber.i("Reviewer:: Flag six")
-                onFlag(mCurrentCard, CardMarker.FLAG_TURQUOISE)
+                onFlag(currentCard, CardMarker.FLAG_TURQUOISE)
             }
             R.id.action_flag_seven -> {
                 Timber.i("Reviewer:: Flag seven")
-                onFlag(mCurrentCard, CardMarker.FLAG_PURPLE)
+                onFlag(currentCard, CardMarker.FLAG_PURPLE)
             }
             R.id.action_card_info -> {
                 Timber.i("Card Viewer:: Card Info")
@@ -660,10 +660,10 @@ open class Reviewer : AbstractFlashcardViewer() {
 
     private fun showRescheduleCardDialog() {
         val runnable = Consumer { days: Int ->
-            val cardIds = listOf(mCurrentCard!!.id)
+            val cardIds = listOf(currentCard!!.id)
             RescheduleCards(cardIds, days).runWithHandler(scheduleCollectionTaskHandler(R.plurals.reschedule_cards_dialog_acknowledge))
         }
-        val dialog = rescheduleSingleCard(resources, mCurrentCard!!, runnable)
+        val dialog = rescheduleSingleCard(resources, currentCard!!, runnable)
         showDialogFragment(dialog)
     }
 
@@ -677,7 +677,7 @@ open class Reviewer : AbstractFlashcardViewer() {
         dialog.setArgs(title, message)
         val confirm = Runnable {
             Timber.i("NoteEditor:: ResetProgress button pressed")
-            val cardIds = listOf(mCurrentCard!!.id)
+            val cardIds = listOf(currentCard!!.id)
             ResetCards(cardIds).runWithHandler(scheduleCollectionTaskHandler(R.plurals.reset_cards_dialog_acknowledge))
         }
         dialog.setConfirm(confirm)
@@ -695,16 +695,16 @@ open class Reviewer : AbstractFlashcardViewer() {
 
     @NeedsTest("Starting animation from swipe is inverse to the finishing one")
     protected fun openCardInfo(fromGesture: Gesture? = null) {
-        if (mCurrentCard == null) {
+        if (currentCard == null) {
             showThemedToast(this, getString(R.string.multimedia_editor_something_wrong), true)
             return
         }
         val intent = if (BackendFactory.defaultLegacySchema) {
             Intent(this, CardInfo::class.java).apply {
-                putExtra("cardId", mCurrentCard!!.id)
+                putExtra("cardId", currentCard!!.id)
             }
         } else {
-            com.ichi2.anki.pages.CardInfo.getIntent(this, mCurrentCard!!.id)
+            com.ichi2.anki.pages.CardInfo.getIntent(this, currentCard!!.id)
         }
         val animation = getAnimationTransitionFromGesture(fromGesture)
         intent.putExtra(FINISH_ANIMATION_EXTRA, getInverseTransition(animation) as Parcelable)
@@ -752,7 +752,7 @@ open class Reviewer : AbstractFlashcardViewer() {
         mActionButtons.setCustomButtonsStatus(menu)
         var alpha = if (super.controlBlocked !== ReviewerUi.ControlBlock.SLOW) Themes.ALPHA_ICON_ENABLED_LIGHT else Themes.ALPHA_ICON_DISABLED_LIGHT
         val markCardIcon = menu.findItem(R.id.action_mark_card)
-        if (mCurrentCard != null && isMarked(mCurrentCard!!.note())) {
+        if (currentCard != null && isMarked(currentCard!!.note())) {
             markCardIcon.setTitle(R.string.menu_unmark_note).setIcon(R.drawable.ic_star_white)
         } else {
             markCardIcon.setTitle(R.string.menu_mark_note).setIcon(R.drawable.ic_star_border_white)
@@ -762,8 +762,8 @@ open class Reviewer : AbstractFlashcardViewer() {
         // 1643 - currently null on a TV
         val flag_icon = menu.findItem(R.id.action_flag)
         if (flag_icon != null) {
-            if (mCurrentCard != null) {
-                when (mCurrentCard!!.userFlag()) {
+            if (currentCard != null) {
+                when (currentCard!!.userFlag()) {
                     1 -> flag_icon.setIcon(R.drawable.ic_flag_red)
                     2 -> flag_icon.setIcon(R.drawable.ic_flag_orange)
                     3 -> flag_icon.setIcon(R.drawable.ic_flag_green)
@@ -1032,7 +1032,7 @@ open class Reviewer : AbstractFlashcardViewer() {
 
         // Show next review time
         if (shouldShowNextReviewTime()) {
-            fun nextIvlStr(button: Int) = sched!!.nextIvlStr(this, mCurrentCard!!, button)
+            fun nextIvlStr(button: Int) = sched!!.nextIvlStr(this, currentCard!!, button)
 
             easeButton1!!.nextTime = nextIvlStr(Consts.BUTTON_ONE)
             easeButton2!!.nextTime = nextIvlStr(Consts.BUTTON_TWO)
@@ -1046,7 +1046,7 @@ open class Reviewer : AbstractFlashcardViewer() {
     }
 
     val buttonCount: Int
-        get() = sched!!.answerButtons(mCurrentCard!!)
+        get() = sched!!.answerButtons(currentCard!!)
 
     override fun automaticShowQuestion(action: AutomaticAnswerAction) {
         // explicitly do not call super
@@ -1071,10 +1071,10 @@ open class Reviewer : AbstractFlashcardViewer() {
     }
 
     protected fun updateScreenCounts() {
-        if (mCurrentCard == null) return
+        if (currentCard == null) return
         super.updateActionBar()
         val actionBar = supportActionBar
-        val counts = sched!!.counts(mCurrentCard!!)
+        val counts = sched!!.counts(currentCard!!)
         if (actionBar != null) {
             if (mPrefShowETA) {
                 mEta = sched!!.eta(counts, false)
@@ -1087,7 +1087,7 @@ open class Reviewer : AbstractFlashcardViewer() {
         if (mPrefHideDueCount) {
             mRevCount = SpannableString("???")
         }
-        when (sched!!.countIdx(mCurrentCard!!)) {
+        when (sched!!.countIdx(currentCard!!)) {
             Counts.Queue.NEW -> mNewCount!!.setSpan(UnderlineSpan(), 0, mNewCount!!.length, 0)
             Counts.Queue.LRN -> mLrnCount!!.setSpan(UnderlineSpan(), 0, mLrnCount!!.length, 0)
             Counts.Queue.REV -> mRevCount!!.setSpan(UnderlineSpan(), 0, mRevCount!!.length, 0)
@@ -1112,7 +1112,7 @@ open class Reviewer : AbstractFlashcardViewer() {
 
     override fun displayCardQuestion() {
         // show timer, if activated in the deck's preferences
-        answerTimer.setupForCard(mCurrentCard!!)
+        answerTimer.setupForCard(currentCard!!)
         delayedHide(100)
         super.displayCardQuestion()
     }
@@ -1201,11 +1201,11 @@ open class Reviewer : AbstractFlashcardViewer() {
                 return true
             }
             ViewerCommand.UNSET_FLAG -> {
-                onFlag(mCurrentCard, CardMarker.FLAG_NONE)
+                onFlag(currentCard, CardMarker.FLAG_NONE)
                 return true
             }
             ViewerCommand.MARK -> {
-                onMark(mCurrentCard)
+                onMark(currentCard)
                 return true
             }
             ViewerCommand.ADD_NOTE -> {
@@ -1221,12 +1221,12 @@ open class Reviewer : AbstractFlashcardViewer() {
     }
 
     private fun toggleFlag(@FlagDef flag: Int) {
-        if (mCurrentCard!!.userFlag() == flag) {
+        if (currentCard!!.userFlag() == flag) {
             Timber.i("Toggle flag: unsetting flag")
-            onFlag(mCurrentCard, CardMarker.FLAG_NONE)
+            onFlag(currentCard, CardMarker.FLAG_NONE)
         } else {
             Timber.i("Toggle flag: Setting flag to %d", flag)
-            onFlag(mCurrentCard, flag)
+            onFlag(currentCard, flag)
         }
     }
 
@@ -1403,7 +1403,7 @@ open class Reviewer : AbstractFlashcardViewer() {
     }
 
     override val currentCardId: CardId?
-        get() = mCurrentCard!!.id
+        get() = currentCard!!.id
 
     override fun onWindowFocusChanged(hasFocus: Boolean) {
         super.onWindowFocusChanged(hasFocus)
@@ -1421,21 +1421,21 @@ open class Reviewer : AbstractFlashcardViewer() {
      */
     @KotlinCleanup("mCurrentCard handling")
     private fun suspendNoteAvailable(): Boolean {
-        return if (mCurrentCard == null || isControlBlocked()) {
+        return if (currentCard == null || isControlBlocked()) {
             false
         } else col.db.queryScalar(
             "select 1 from cards where nid = ? and id != ? and queue != " + Consts.QUEUE_TYPE_SUSPENDED + " limit 1",
-            mCurrentCard!!.nid, mCurrentCard!!.id
+            currentCard!!.nid, currentCard!!.id
         ) == 1
         // whether there exists a sibling not buried.
     }
     @KotlinCleanup("mCurrentCard handling")
     private fun buryNoteAvailable(): Boolean {
-        return if (mCurrentCard == null || isControlBlocked()) {
+        return if (currentCard == null || isControlBlocked()) {
             false
         } else col.db.queryScalar(
             "select 1 from cards where nid = ? and id != ? and queue >=  " + Consts.QUEUE_TYPE_NEW + " limit 1",
-            mCurrentCard!!.nid, mCurrentCard!!.id
+            currentCard!!.nid, currentCard!!.id
         ) == 1
         // Whether there exists a sibling which is neither suspended nor buried
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
@@ -118,7 +118,7 @@ open class Reviewer : AbstractFlashcardViewer() {
 
     // Whiteboard
     @JvmField
-    var mPrefWhiteboard = false
+    var prefWhiteboard = false
 
     @get:CheckResult
     @get:VisibleForTesting(otherwise = VisibleForTesting.NONE)
@@ -352,8 +352,8 @@ open class Reviewer : AbstractFlashcardViewer() {
         // Load the first card and start reviewing. Uses the answer card
         // task to load a card, but since we send null
         // as the card to answer, no card will be answered.
-        mPrefWhiteboard = MetaDB.getWhiteboardState(this, parentDid)
-        if (mPrefWhiteboard) {
+        prefWhiteboard = MetaDB.getWhiteboardState(this, parentDid)
+        if (prefWhiteboard) {
             // DEFECT: Slight inefficiency here, as we set the database using these methods
             val whiteboardVisibility = MetaDB.getWhiteboardVisibility(this, parentDid)
             setWhiteboardEnabledState(true)
@@ -530,13 +530,13 @@ open class Reviewer : AbstractFlashcardViewer() {
     }
 
     public override fun toggleWhiteboard() {
-        mPrefWhiteboard = !mPrefWhiteboard
-        Timber.i("Reviewer:: Whiteboard enabled state set to %b", mPrefWhiteboard)
+        prefWhiteboard = !prefWhiteboard
+        Timber.i("Reviewer:: Whiteboard enabled state set to %b", prefWhiteboard)
         // Even though the visibility is now stored in its own setting, we want it to be dependent
         // on the enabled status
-        setWhiteboardEnabledState(mPrefWhiteboard)
-        setWhiteboardVisibility(mPrefWhiteboard)
-        if (!mPrefWhiteboard) {
+        setWhiteboardEnabledState(prefWhiteboard)
+        setWhiteboardVisibility(prefWhiteboard)
+        if (!prefWhiteboard) {
             mColorPalette!!.visibility = View.GONE
         }
         refreshActionBar()
@@ -560,20 +560,20 @@ open class Reviewer : AbstractFlashcardViewer() {
 
     override fun updateForNewCard() {
         super.updateForNewCard()
-        if (mPrefWhiteboard && whiteboard != null) {
+        if (prefWhiteboard && whiteboard != null) {
             whiteboard!!.clear()
         }
     }
 
     override fun unblockControls() {
-        if (mPrefWhiteboard && whiteboard != null) {
+        if (prefWhiteboard && whiteboard != null) {
             whiteboard!!.isEnabled = true
         }
         super.unblockControls()
     }
 
     public override fun blockControls(quick: Boolean) {
-        if (mPrefWhiteboard && whiteboard != null) {
+        if (prefWhiteboard && whiteboard != null) {
             whiteboard!!.isEnabled = false
         }
         super.blockControls(quick)
@@ -805,7 +805,7 @@ open class Reviewer : AbstractFlashcardViewer() {
         val hide_whiteboard_icon = menu.findItem(R.id.action_hide_whiteboard)
         val change_pen_color_icon = menu.findItem(R.id.action_change_whiteboard_pen_color)
         // White board button
-        if (mPrefWhiteboard) {
+        if (prefWhiteboard) {
             // Configure the whiteboard related items in the action bar
             toggle_whiteboard_icon.setTitle(R.string.disable_whiteboard)
             // Always allow "Disable Whiteboard", even if "Enable Whiteboard" is disabled
@@ -1132,8 +1132,8 @@ open class Reviewer : AbstractFlashcardViewer() {
         }
 
         // can't move this into onCreate due to mTopBarLayout
-        val mark = mTopBarLayout!!.findViewById<ImageView>(R.id.mark_icon)
-        val flag = mTopBarLayout!!.findViewById<ImageView>(R.id.flag_icon)
+        val mark = topBarLayout!!.findViewById<ImageView>(R.id.mark_icon)
+        val flag = topBarLayout!!.findViewById<ImageView>(R.id.flag_icon)
         mCardMarker = CardMarker(mark, flag)
     }
 
@@ -1157,7 +1157,7 @@ open class Reviewer : AbstractFlashcardViewer() {
 
     override fun initControls() {
         super.initControls()
-        if (mPrefWhiteboard) {
+        if (prefWhiteboard) {
             setWhiteboardVisibility(mShowWhiteboard)
         }
         if (mShowRemainingCardCount) {
@@ -1251,7 +1251,7 @@ open class Reviewer : AbstractFlashcardViewer() {
 
     override fun onCardEdited(card: Card?) {
         super.onCardEdited(card)
-        if (mPrefWhiteboard && whiteboard != null) {
+        if (prefWhiteboard && whiteboard != null) {
             whiteboard!!.clear()
         }
         if (!isDisplayingAnswer) {
@@ -1277,7 +1277,7 @@ open class Reviewer : AbstractFlashcardViewer() {
     }
 
     private fun setWhiteboardEnabledState(state: Boolean) {
-        mPrefWhiteboard = state
+        prefWhiteboard = state
         MetaDB.storeWhiteboardState(this, parentDid, state)
         if (state && whiteboard == null) {
             createWhiteboard()

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
@@ -117,7 +117,6 @@ open class Reviewer : AbstractFlashcardViewer() {
     private var mPrefHideDueCount = false
 
     // Whiteboard
-    @JvmField
     var prefWhiteboard = false
 
     @get:CheckResult
@@ -144,7 +143,6 @@ open class Reviewer : AbstractFlashcardViewer() {
     private var mOverflowMenuIsOpen = false
     private lateinit var mToolbar: Toolbar
 
-    @JvmField
     @VisibleForTesting
     protected val mProcessor = PeripheralKeymap(this, this)
     private val mOnboarding = Onboarding.Reviewer(this)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/TypeAnswer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/TypeAnswer.kt
@@ -227,7 +227,6 @@ class TypeAnswer(
     }
 
     companion object {
-        @JvmField
         /** Regular expression in card data for a 'type answer' after processing has occurred */
         val PATTERN: Pattern = Pattern.compile("\\[\\[type:(.+?)]]")
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DatabaseErrorDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DatabaseErrorDialog.kt
@@ -447,7 +447,6 @@ class DatabaseErrorDialog : AsyncDialogFragment() {
         const val INCOMPATIBLE_DB_VERSION = 10
 
         // public flag which lets us distinguish between inaccessible and corrupt database
-        @JvmField
         var databaseCorruptFlag = false
 
         /**

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/HelpDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/HelpDialog.kt
@@ -136,7 +136,8 @@ object HelpDialog {
         private constructor(`in`: Parcel?) : super(`in`!!)
 
         companion object {
-            @JvmField val CREATOR: Parcelable.Creator<RateAppItem?> = object : Parcelable.Creator<RateAppItem?> {
+            @JvmField // required field that makes Parcelables from a Parcel
+            val CREATOR: Parcelable.Creator<RateAppItem?> = object : Parcelable.Creator<RateAppItem?> {
                 override fun createFromParcel(`in`: Parcel): RateAppItem {
                     return RateAppItem(`in`)
                 }
@@ -179,7 +180,8 @@ object HelpDialog {
         }
 
         companion object {
-            @JvmField val CREATOR: Parcelable.Creator<LinkItem?> = object : Parcelable.Creator<LinkItem?> {
+            @JvmField // required field that makes Parcelables from a Parcel
+            val CREATOR: Parcelable.Creator<LinkItem?> = object : Parcelable.Creator<LinkItem?> {
                 override fun createFromParcel(`in`: Parcel): LinkItem {
                     return LinkItem(`in`)
                 }
@@ -222,7 +224,8 @@ object HelpDialog {
         }
 
         companion object {
-            @JvmField val CREATOR: Parcelable.Creator<FunctionItem?> = object : Parcelable.Creator<FunctionItem?> {
+            @JvmField // required field that makes Parcelables from a Parcel
+            val CREATOR: Parcelable.Creator<FunctionItem?> = object : Parcelable.Creator<FunctionItem?> {
                 override fun createFromParcel(`in`: Parcel): FunctionItem {
                     return FunctionItem(`in`)
                 }
@@ -256,8 +259,8 @@ object HelpDialog {
         override fun remove(toRemove: RecursivePictureMenu.Item?) {}
 
         companion object {
-
-            @JvmField val CREATOR: Parcelable.Creator<ExceptionReportItem?> = object : Parcelable.Creator<ExceptionReportItem?> {
+            @JvmField // required field that makes Parcelables from a Parcel
+            val CREATOR: Parcelable.Creator<ExceptionReportItem?> = object : Parcelable.Creator<ExceptionReportItem?> {
                 override fun createFromParcel(`in`: Parcel): ExceptionReportItem {
                     return ExceptionReportItem(`in`)
                 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/RecursivePictureMenu.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/RecursivePictureMenu.kt
@@ -180,7 +180,8 @@ class RecursivePictureMenu : DialogFragment() {
         }
 
         companion object {
-            @JvmField val CREATOR: Parcelable.Creator<ItemHeader?> = object : Parcelable.Creator<ItemHeader?> {
+            @JvmField // required field that makes Parcelables from a Parcel
+            val CREATOR: Parcelable.Creator<ItemHeader?> = object : Parcelable.Creator<ItemHeader?> {
                 override fun createFromParcel(parcel: Parcel): ItemHeader {
                     return ItemHeader(parcel)
                 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/noteeditor/Toolbar.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/noteeditor/Toolbar.kt
@@ -367,8 +367,8 @@ class Toolbar : FrameLayout {
      * If not, at the end of the string
      */
     data class StringFormat(
-        @JvmField var result: String = "",
-        @JvmField var selectionStart: Int = 0,
-        @JvmField var selectionEnd: Int = 0
+        var result: String = "",
+        var selectionStart: Int = 0,
+        var selectionEnd: Int = 0
     )
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/ActionButtons.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/ActionButtons.kt
@@ -78,11 +78,9 @@ class ActionButtons(reviewerUi: ReviewerUi) {
     }
 
     companion object {
-        @JvmField
         @IdRes
         val RES_FLAG = R.id.action_flag
 
-        @JvmField
         @IdRes
         val RES_MARK = R.id.action_mark_card
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/stats/OverviewStatsBuilder.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/stats/OverviewStatsBuilder.kt
@@ -37,49 +37,30 @@ class OverviewStatsBuilder(private val webView: WebView, private val col: Collec
         var forecastTotalReviews = 0
         var forecastAverageReviews = 0.0
         var forecastDueTomorrow = 0
-        @JvmField
         var reviewsPerDayOnAll = 0.0
-        @JvmField
         var reviewsPerDayOnStudyDays = 0.0
-        @JvmField
         var allDays = 0
-        @JvmField
         var daysStudied = 0
-        @JvmField
         var timePerDayOnAll = 0.0
-        @JvmField
         var timePerDayOnStudyDays = 0.0
-        @JvmField
         var totalTime = 0.0
-        @JvmField
         var totalReviews = 0
-        @JvmField
         var newCardsPerDay = 0.0
-        @JvmField
         var totalNewCards = 0
-        @JvmField
         var averageInterval = 0.0
-        @JvmField
         var longestInterval = 0.0
         lateinit var newCardsOverview: AnswerButtonsOverview
         lateinit var youngCardsOverview: AnswerButtonsOverview
         lateinit var matureCardsOverview: AnswerButtonsOverview
 
-        @JvmField
         var totalCards: Long = 0
-        @JvmField
         var totalNotes: Long = 0
-        @JvmField
         var lowestEase = 0.0
-        @JvmField
         var averageEase = 0.0
-        @JvmField
         var highestEase = 0.0
 
         class AnswerButtonsOverview {
-            @JvmField
             var total = 0
-            @JvmField
             var correct = 0
             val percentage: Double
                 get() = if (correct == 0) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/stats/StatsMetaInfo.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/stats/StatsMetaInfo.kt
@@ -22,40 +22,22 @@ import com.ichi2.libanki.stats.Stats.AxisType
  * Interface between Stats.java and AdvancedStatistics.java
  */
 class StatsMetaInfo {
-    @JvmField
     var dynamicAxis = false
-    @JvmField
     var hasColoredCumulative = false
-    @JvmField
     var type: AxisType? = null
-    @JvmField
     var title = 0
-    @JvmField
     var backwards = false
-    @JvmField
     var valueLabels: IntArray? = null
-    @JvmField
     var colors: IntArray? = null
-    @JvmField
     var axisTitles: IntArray? = null
-    @JvmField
     var maxCards = 0
-    @JvmField
     var maxElements = 0
-    @JvmField
     var firstElement = 0.0
-    @JvmField
     var lastElement = 0.0
-    @JvmField
     var zeroIndex = 0
-    @JvmField
     var cumulative: Array<DoubleArray>? = null
-    @JvmField
     var mcount = 0.0
-    @JvmField
     var seriesList: Array<DoubleArray>? = null
-    @JvmField
     var isStatsCalculated = false
-    @JvmField
     var isDataAvailable = false
 }

--- a/AnkiDroid/src/main/java/com/ichi2/async/Connection.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/async/Connection.kt
@@ -489,7 +489,6 @@ class Connection : BaseAsyncTask<Connection.Payload, Any, Connection.Payload>() 
         var taskType = 0
         var resultType: Syncer.ConnectionResultType? = null
         var result: Array<Any?> = arrayOf()
-        @JvmField
         var success = true
         var returnType = 0
         var exception: Exception? = null

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/AnkiPackageExporter.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/AnkiPackageExporter.kt
@@ -32,14 +32,12 @@ import timber.log.Timber
 import java.io.*
 
 @KotlinCleanup("lots in this file")
-open class Exporter(@JvmField protected val col: Collection, protected val did: DeckId?) {
+open class Exporter(protected val col: Collection, protected val did: DeckId?) {
 
     /**
      * If set exporter will export only this deck, otherwise will export all cards
      */
-    @JvmField
     protected var count = 0
-    @JvmField
     protected var includeHTML = false
 
     /**

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/AnkiPackageExporter.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/AnkiPackageExporter.kt
@@ -38,9 +38,9 @@ open class Exporter(@JvmField protected val col: Collection, protected val did: 
      * If set exporter will export only this deck, otherwise will export all cards
      */
     @JvmField
-    protected var mCount = 0
+    protected var count = 0
     @JvmField
-    protected var mIncludeHTML = false
+    protected var includeHTML = false
 
     /**
      * An exporter for the whole collection of decks
@@ -61,13 +61,13 @@ open class Exporter(@JvmField protected val col: Collection, protected val did: 
         } else {
             Utils.list2ObjectArray(col.decks.cids(did, true))
         }
-        mCount = cids.size
+        count = cids.size
         return cids
     }
 
     fun processText(input: String): String {
         var text = input
-        if (!mIncludeHTML) {
+        if (!includeHTML) {
             text = stripHTML(text)
         }
         text = escapeText(text)
@@ -276,7 +276,7 @@ open class AnkiExporter(col: Collection, did: DeckId?, val includeSched: Boolean
         Timber.d("Cleanup")
         dst.crt = col.crt
         // todo: tags?
-        mCount = dst.cardCount()
+        count = dst.cardCount()
         dst.setMod()
         postExport()
         dst.close()
@@ -370,7 +370,7 @@ class AnkiPackageExporter : AnkiExporter {
     @Throws(IOException::class)
     private fun exportVerbatim(z: ZipFile, context: Context): JSONObject {
         // close our deck & write it into the zip file, and reopen
-        mCount = col.cardCount()
+        count = col.cardCount()
         col.close()
         if (!_v2sched) {
             z.write(col.path, CollectionHelper.COLLECTION_FILENAME)

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Consts.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Consts.kt
@@ -112,7 +112,6 @@ object Consts {
     const val SYNC_MAX_BYTES = (2.5 * 1024 * 1024).toInt()
     const val SYNC_MAX_FILES = 25
 
-    @JvmField
     val DEFAULT_HOST_NUM: Int? = null
 
     const val SYNC_VER = 10
@@ -146,7 +145,7 @@ object Consts {
 
     /** Default dconf - can't be removed  */
     const val DEFAULT_DECK_CONFIG_ID: Long = 1
-    @JvmField
+
     val FIELD_SEPARATOR = Character.toString('\u001f')
 
     /** Time duration for toast **/

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/StdModels.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/StdModels.kt
@@ -61,7 +61,6 @@ class StdModels(
 
     companion object {
         // / create the standard models
-        @JvmField
         val BASIC_MODEL = StdModels(
             { mm: ModelManager, name: String ->
                 val m = mm.newModel(name)

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/TextCardExporter.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/TextCardExporter.kt
@@ -21,7 +21,7 @@ import java.util.*
 
 class TextCardExporter(col: Collection, did: DeckId?, includeHTML: Boolean) : Exporter(col, did) {
     init {
-        mIncludeHTML = includeHTML
+        this.includeHTML = includeHTML
     }
     constructor(col: Collection, includeHTML: Boolean) : this(col, null, includeHTML)
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/TextNoteExporter.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/TextNoteExporter.kt
@@ -28,7 +28,7 @@ class TextNoteExporter(
     includeHTML: Boolean
 ) : Exporter(col, did) {
     init {
-        mIncludeHTML = includeHTML
+        this.includeHTML = includeHTML
     }
 
     constructor(
@@ -66,7 +66,7 @@ class TextNoteExporter(
                 data.add(TextUtils.join("\t", row))
             }
         }
-        mCount = data.size
+        count = data.size
         val out = TextUtils.join("\n", data)
         BufferedWriter(
             OutputStreamWriter(

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Utils.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Utils.kt
@@ -59,7 +59,6 @@ import kotlin.collections.Collection
 @KotlinCleanup("see if we can switch to standalone functions and properties and remove Utils container")
 object Utils {
     // Used to format doubles with English's decimal separator system
-    @JvmField
     val ENGLISH_LOCALE = Locale("en_US")
     const val CHUNK_SIZE = 32768
     private const val TIME_MINUTE_LONG: Long = 60 // seconds

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.kt
@@ -53,45 +53,32 @@ import java.util.*
 @KotlinCleanup("much to do - keep in line with libAnki")
 @SuppressLint("VariableNamingDetector") // mCurrentCard: complex setter
 open class SchedV2(col: Collection) : AbstractSched(col) {
-    @JvmField
     protected val mQueueLimit = 50
-    @JvmField
     protected var mReportLimit = 99999
     private val mDynReportLimit = 99999
     override var reps = 0
         protected set
     protected var haveQueues = false
-    @JvmField
     protected var mHaveCounts = false
-    @JvmField
     protected var mToday: Int? = null
     @KotlinCleanup("replace Sched.getDayCutoff() with dayCutoff")
     final override var dayCutoff: Long = 0
     private var mLrnCutoff: Long = 0
-    @JvmField
     protected var mNewCount = 0
-    @JvmField
     @VisibleForTesting(otherwise = VisibleForTesting.PROTECTED)
     internal var mLrnCount = 0
-    @JvmField
     protected var mRevCount = 0
     private var mNewCardModulus = 0
 
     // Queues
-    @JvmField
     protected val mNewQueue = SimpleCardQueue(this)
-    @JvmField
     protected val mLrnQueue = LrnCardQueue(this)
-    @JvmField
     protected val mLrnDayQueue = SimpleCardQueue(this)
-    @JvmField
     protected val mRevQueue = SimpleCardQueue(this)
     private var mNewDids = LinkedList<Long>()
-    @JvmField
     protected var mLrnDids = LinkedList<Long>()
 
     // Not in libanki
-    @JvmField
     protected var mContextReference: WeakReference<Activity>? = null
 
     fun interface LimitMethod {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sync/HttpSyncer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sync/HttpSyncer.kt
@@ -82,7 +82,6 @@ open class HttpSyncer(
     var nextSendR: Long = 1024
     protected var checksumKey: String
     protected val con: Connection?
-    @JvmField
     protected var postVars: MutableMap<String, Any?>
 
     @Volatile

--- a/AnkiDroid/src/main/java/com/ichi2/themes/Themes.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/themes/Themes.kt
@@ -38,10 +38,7 @@ object Themes {
     private const val DAY_THEME_KEY = "dayTheme"
     private const val NIGHT_THEME_KEY = "nightTheme"
 
-    @JvmField
     var currentTheme: Theme = Theme.fallback
-
-    @JvmField
     var systemIsInNightMode: Boolean = false
 
     /**

--- a/AnkiDroid/src/main/java/com/ichi2/ui/CheckBoxTriStates.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/ui/CheckBoxTriStates.kt
@@ -200,7 +200,7 @@ class CheckBoxTriStates : AppCompatCheckBox {
         }
 
         companion object {
-            @JvmField
+            @JvmField // required field that makes Parcelables from a Parcel
             val CREATOR: Parcelable.Creator<SavedState> = object : Parcelable.Creator<SavedState> {
                 override fun createFromParcel(`in`: Parcel): SavedState {
                     return SavedState(`in`)

--- a/AnkiDroid/src/main/java/com/ichi2/ui/RtlCompliantActionProvider.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/ui/RtlCompliantActionProvider.kt
@@ -27,7 +27,6 @@ import com.ichi2.anki.R
  * An Rtl version of a normal action view, where the drawable is mirrored
  */
 class RtlCompliantActionProvider(context: Context) : ActionProviderCompat(context) {
-    @JvmField
     @VisibleForTesting
     val mActivity: Activity
 

--- a/AnkiDroid/src/main/java/com/ichi2/utils/ClipboardUtil.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/ClipboardUtil.kt
@@ -24,7 +24,6 @@ import androidx.annotation.CheckResult
 
 object ClipboardUtil {
     // JPEG is sent via pasted content
-    @JvmField
     val IMAGE_MIME_TYPES = arrayOf("image/gif", "image/png", "image/jpg", "image/jpeg")
 
     fun hasImage(clipboard: ClipboardManager?): Boolean {

--- a/AnkiDroid/src/main/java/com/ichi2/utils/Computation.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/Computation.kt
@@ -51,8 +51,8 @@ class Computation<out ComputedType : Any> {
     }
 
     companion object {
-        @JvmField val ERR: Computation<*> = Computation<Any>()
-        @JvmField val OK: Computation<*> = Computation(Any())
+        val ERR: Computation<*> = Computation<Any>()
+        val OK: Computation<*> = Computation(Any())
 
         /** A strongly typed error return value */
         fun <ComputedType : Any> err(): Computation<ComputedType> {

--- a/AnkiDroid/src/main/java/com/ichi2/utils/DeckComparator.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/DeckComparator.kt
@@ -23,7 +23,6 @@ class DeckComparator : Comparator<JSONObject> {
     }
 
     companion object {
-        @JvmField
         val INSTANCE = DeckComparator()
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/utils/DeckNameComparator.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/DeckNameComparator.kt
@@ -33,7 +33,6 @@ class DeckNameComparator : Comparator<String> {
     }
 
     companion object {
-        @JvmField
         val INSTANCE = DeckNameComparator()
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/utils/JSONObject.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/JSONObject.kt
@@ -333,7 +333,6 @@ open class JSONObject : org.json.JSONObject, Iterable<String?> {
     }
 
     companion object {
-        @JvmField
         val NULL: Any? = org.json.JSONObject.NULL
 
         /**

--- a/AnkiDroid/src/main/java/com/ichi2/utils/KotlinCleanup.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/KotlinCleanup.kt
@@ -13,7 +13,6 @@
  *  You should have received a copy of the GNU General Public License along with
  *  this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-@file:KotlinCleanup("Remove most @JvmField annotations")
 @file:KotlinCleanup(
     "Remove all TextUtils references then see if we can remove " +
         "@RunWith(AndroidJUnit4::class) to speed up tests (if no other Android references)"

--- a/AnkiDroid/src/main/java/com/ichi2/utils/LanguageUtil.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/LanguageUtil.kt
@@ -33,7 +33,6 @@ object LanguageUtil {
     /** A list of all languages supported by AnkiDroid
      * Please modify LanguageUtilsTest if changing
      * Please note 'yue' is special, it is 'yu' on CrowdIn, and mapped in import specially to 'yue' */
-    @JvmField
     val APP_LANGUAGES = arrayOf(
         "af", // Afrikaans / Afrikaans
         "am", // Amharic / አማርኛ

--- a/AnkiDroid/src/main/java/com/ichi2/utils/NamedJSONComparator.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/NamedJSONComparator.kt
@@ -26,7 +26,6 @@ class NamedJSONComparator : Comparator<JSONObject> {
     }
 
     companion object {
-        @JvmField
         val INSTANCE = NamedJSONComparator()
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/utils/Triple.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/Triple.kt
@@ -16,4 +16,4 @@
 
 package com.ichi2.utils
 
-class Triple<First, Second, Triple> constructor(@JvmField val first: First, @JvmField val second: Second, @JvmField val third: Triple)
+class Triple<First, Second, Triple> constructor(val first: First, val second: Second, val third: Triple)

--- a/AnkiDroid/src/main/java/com/wildplot/android/rendering/graphics/wrapper/ColorWrap.kt
+++ b/AnkiDroid/src/main/java/com/wildplot/android/rendering/graphics/wrapper/ColorWrap.kt
@@ -58,27 +58,13 @@ class ColorWrap {
 
     companion object {
         val red = ColorWrap(Color.RED)
-
-        @JvmField
         val RED = ColorWrap(Color.RED)
-
-        @JvmField
         val BLACK = ColorWrap(Color.BLACK)
-
-        @JvmField
         val black = ColorWrap(Color.BLACK)
-
-        @JvmField
         val GREEN = ColorWrap(Color.GREEN)
         val green = ColorWrap(Color.GREEN)
-
-        @JvmField
         val LIGHT_GRAY = ColorWrap(Color.LTGRAY)
-
-        @JvmField
         val WHITE = ColorWrap(Color.WHITE)
-
-        @JvmField
         val white = ColorWrap(Color.WHITE)
     }
 }

--- a/AnkiDroid/src/main/java/com/wildplot/android/rendering/graphics/wrapper/RectangleWrap.kt
+++ b/AnkiDroid/src/main/java/com/wildplot/android/rendering/graphics/wrapper/RectangleWrap.kt
@@ -19,13 +19,9 @@ package com.wildplot.android.rendering.graphics.wrapper
 import android.graphics.Rect
 
 class RectangleWrap(rect: Rect) {
-    @JvmField
     val x: Int
-    @JvmField
     val y: Int
-    @JvmField
     var width: Int
-    @JvmField
     var height: Int
 
     constructor(width: Int, height: Int) : this(Rect(0, 0, width, height)) {}

--- a/AnkiDroid/src/test/java/com/ichi2/anki/AbstractFlashcardViewerCommandTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/AbstractFlashcardViewerCommandTest.kt
@@ -190,16 +190,15 @@ class AbstractFlashcardViewerCommandTest : RobolectricTest() {
         return c
     }
 
-    private class CommandTestCardViewer(currentCard: Card?) : Reviewer() {
+    private class CommandTestCardViewer(private var currentCardOverride: Card?) : Reviewer() {
         var lastFlag = 0
             private set
 
-        // we don't have getCol() here and we don't need the additional sound processing.
         override var currentCard: Card?
-            get() = super.currentCard
+            get() = currentCardOverride
             set(card) {
-                mCurrentCard = card
                 // we don't have getCol() here and we don't need the additional sound processing.
+                currentCardOverride = card
             }
 
         override fun setTitle() {
@@ -222,11 +221,7 @@ class AbstractFlashcardViewerCommandTest : RobolectricTest() {
 
         override fun onFlag(card: Card?, @FlagDef flag: Int) {
             lastFlag = flag
-            mCurrentCard!!.setUserFlag(flag)
-        }
-
-        init {
-            this@CommandTestCardViewer.currentCard = currentCard
+            currentCard!!.setUserFlag(flag)
         }
     }
 }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/AbstractFlashcardViewerKeyboardInputTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/AbstractFlashcardViewerKeyboardInputTest.kt
@@ -110,7 +110,7 @@ class AbstractFlashcardViewerKeyboardInputTest : RobolectricTest() {
 
         companion object {
             fun create(): KeyboardInputTestCardViewer {
-                sDisplayAnswer = false
+                displayAnswer = false
                 return KeyboardInputTestCardViewer()
             }
         }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/AbstractFlashcardViewerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/AbstractFlashcardViewerTest.kt
@@ -64,12 +64,12 @@ class AbstractFlashcardViewerTest : RobolectricTest() {
             }
         val hintLocale: String?
             get() {
-                val imeHintLocales = mAnswerField!!.imeHintLocales ?: return null
+                val imeHintLocales = answerField!!.imeHintLocales ?: return null
                 return imeHintLocales.toLanguageTags()
             }
 
         fun hasAutomaticAnswerQueued(): Boolean {
-            return mAutomaticAnswer.timeoutHandler.hasMessages(0)
+            return automaticAnswer.timeoutHandler.hasMessages(0)
         }
     }
 
@@ -196,22 +196,22 @@ class AbstractFlashcardViewerTest : RobolectricTest() {
     fun automaticAnswerDisabledProperty() {
         val controller = getViewerController(true, false)
         val viewer = controller.get()
-        assertThat("not disabled initially", viewer.mAutomaticAnswer.isDisabled, equalTo(false))
+        assertThat("not disabled initially", viewer.automaticAnswer.isDisabled, equalTo(false))
         controller.pause()
-        assertThat("disabled after pause", viewer.mAutomaticAnswer.isDisabled, equalTo(true))
+        assertThat("disabled after pause", viewer.automaticAnswer.isDisabled, equalTo(true))
         controller.resume()
-        assertThat("enabled after resume", viewer.mAutomaticAnswer.isDisabled, equalTo(false))
+        assertThat("enabled after resume", viewer.automaticAnswer.isDisabled, equalTo(false))
     }
 
     @Test
     fun noAutomaticAnswerAfterRenderProcessGoneAndPaused_issue9632() {
         val controller = getViewerController(true, false)
         val viewer = controller.get()
-        viewer.mAutomaticAnswer = AutomaticAnswer(viewer, AutomaticAnswerSettings(AutomaticAnswerAction.BURY_CARD, true, 5, 5))
+        viewer.automaticAnswer = AutomaticAnswer(viewer, AutomaticAnswerSettings(AutomaticAnswerAction.BURY_CARD, true, 5, 5))
         viewer.executeCommand(ViewerCommand.SHOW_ANSWER)
         assertThat("messages after flipping card", viewer.hasAutomaticAnswerQueued(), equalTo(true))
         controller.pause()
-        assertThat("disabled after pause", viewer.mAutomaticAnswer.isDisabled, equalTo(true))
+        assertThat("disabled after pause", viewer.automaticAnswer.isDisabled, equalTo(true))
         assertThat("no auto answer after pause", viewer.hasAutomaticAnswerQueued(), equalTo(false))
         viewer.mOnRenderProcessGoneDelegate.onRenderProcessGone(viewer.webView!!, mock(RenderProcessGoneDetail::class.java))
         assertThat("no auto answer after onRenderProcessGone when paused", viewer.hasAutomaticAnswerQueued(), equalTo(false))

--- a/AnkiDroid/src/test/java/com/ichi2/anki/AbstractFlashcardViewerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/AbstractFlashcardViewerTest.kt
@@ -110,9 +110,9 @@ class AbstractFlashcardViewerTest : RobolectricTest() {
 
         waitForAsyncTasksToComplete()
 
-        AbstractFlashcardViewer.editorCard = viewer.mCurrentCard
+        AbstractFlashcardViewer.editorCard = viewer.currentCard
 
-        val note = viewer.mCurrentCard!!.note()
+        val note = viewer.currentCard!!.note()
         note.setField(1, "David")
 
         viewer.saveEditedCard()
@@ -137,9 +137,9 @@ class AbstractFlashcardViewerTest : RobolectricTest() {
 
         waitForAsyncTasksToComplete()
 
-        AbstractFlashcardViewer.editorCard = viewer.mCurrentCard
+        AbstractFlashcardViewer.editorCard = viewer.currentCard
 
-        val note = viewer.mCurrentCard!!.note()
+        val note = viewer.currentCard!!.note()
         note.setField(1, "David")
 
         viewer.saveEditedCard()

--- a/AnkiDroid/src/test/java/com/ichi2/anki/ActivityStartupUnderBackupTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/ActivityStartupUnderBackupTest.kt
@@ -24,7 +24,6 @@ import com.ichi2.testutils.ActivityList
 import com.ichi2.testutils.ActivityList.ActivityLaunchParam
 import com.ichi2.testutils.EmptyApplication
 import com.ichi2.utils.ExceptionUtil.getFullStackTrace
-import com.ichi2.utils.KotlinCleanup
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
 import org.junit.Assert
@@ -39,15 +38,14 @@ import java.util.stream.Collectors
 
 @RunWith(ParameterizedRobolectricTestRunner::class)
 @Config(application = EmptyApplication::class) // no point in Application init if we don't use it
-@KotlinCleanup("See if we can combine Parameter and JvmField")
 class ActivityStartupUnderBackupTest : RobolectricTest() {
     @ParameterizedRobolectricTestRunner.Parameter
-    @JvmField
+    @JvmField // required for Parameter
     var mLauncher: ActivityLaunchParam? = null
 
     // Only used for display, but needs to be defined
     @ParameterizedRobolectricTestRunner.Parameter(1)
-    @JvmField
+    @JvmField // required for Parameter
     var mActivityName: String? = null
     @Before
     fun before() {

--- a/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.kt
@@ -706,7 +706,7 @@ class CardBrowserTest : RobolectricTest() {
         val cardBrowser = getBrowserWithNotes(2)
 
         val renderOnScroll = cardBrowser.RenderOnScroll()
-        renderOnScroll.onScroll(cardBrowser.mCardsListView!!, 0, 0, 2)
+        renderOnScroll.onScroll(cardBrowser.cardsListView!!, 0, 0, 2)
     }
 
     @Test
@@ -716,8 +716,8 @@ class CardBrowserTest : RobolectricTest() {
         cardBrowser.isTruncated = true
 
         // Testing whether each card is truncated and ellipsized
-        for (i in 0 until (cardBrowser.mCardsListView!!.childCount)) {
-            val row = cardBrowser.mCardsAdapter!!.getView(i, null, cardBrowser.mCardsListView!!)
+        for (i in 0 until (cardBrowser.cardsListView!!.childCount)) {
+            val row = cardBrowser.cardsAdapter!!.getView(i, null, cardBrowser.cardsListView!!)
             val column1 = row.findViewById<FixedTextView>(R.id.card_sfld)
             val column2 = row.findViewById<FixedTextView>(R.id.card_column2)
 
@@ -734,8 +734,8 @@ class CardBrowserTest : RobolectricTest() {
         cardBrowser.isTruncated = false
 
         // Testing whether each card is expanded and not ellipsized
-        for (i in 0 until (cardBrowser.mCardsListView!!.childCount)) {
-            val row = cardBrowser.mCardsAdapter!!.getView(i, null, cardBrowser.mCardsListView!!)
+        for (i in 0 until (cardBrowser.cardsListView!!.childCount)) {
+            val row = cardBrowser.cardsAdapter!!.getView(i, null, cardBrowser.cardsListView!!)
             val column1 = row.findViewById<FixedTextView>(R.id.card_sfld)
             val column2 = row.findViewById<FixedTextView>(R.id.card_column2)
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/DeckPickerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/DeckPickerTest.kt
@@ -42,7 +42,7 @@ import kotlin.test.assertNull
 @KotlinCleanup("replace `when` usages")
 class DeckPickerTest : RobolectricTest() {
     @ParameterizedRobolectricTestRunner.Parameter
-    @JvmField
+    @JvmField // required for Parameter
     var mQualifiers: String? = null
 
     companion object {

--- a/AnkiDroid/src/test/java/com/ichi2/anki/DeckPickerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/DeckPickerTest.kt
@@ -201,7 +201,7 @@ class DeckPickerTest : RobolectricTest() {
         val deckPicker = super.startActivityNormallyOpenCollectionWithIntent(
             DeckPicker::class.java, Intent()
         )
-        assertEquals(10, deckPicker.mDueTree!![0].value.newCount.toLong())
+        assertEquals(10, deckPicker.dueTree!![0].value.newCount.toLong())
     }
 
     @Test

--- a/AnkiDroid/src/test/java/com/ichi2/anki/ReviewerKeyboardInputTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/ReviewerKeyboardInputTest.kt
@@ -245,7 +245,7 @@ class ReviewerKeyboardInputTest : RobolectricTest() {
         }
 
         fun displayAnswerForTest() {
-            sDisplayAnswer = true
+            displayAnswer = true
         }
 
         override fun answerFieldIsFocused(): Boolean {
@@ -419,7 +419,7 @@ class ReviewerKeyboardInputTest : RobolectricTest() {
             @CheckResult
             fun displayingAnswer(): KeyboardInputTestReviewer {
                 val keyboardInputTestReviewer = KeyboardInputTestReviewer()
-                sDisplayAnswer = true
+                displayAnswer = true
                 keyboardInputTestReviewer.mProcessor.setup()
                 return keyboardInputTestReviewer
             }
@@ -427,7 +427,7 @@ class ReviewerKeyboardInputTest : RobolectricTest() {
             @CheckResult
             fun displayingQuestion(): KeyboardInputTestReviewer {
                 val keyboardInputTestReviewer = KeyboardInputTestReviewer()
-                sDisplayAnswer = false
+                displayAnswer = false
                 keyboardInputTestReviewer.mProcessor.setup()
                 return keyboardInputTestReviewer
             }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/ReviewerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/ReviewerTest.kt
@@ -201,26 +201,26 @@ class ReviewerTest : RobolectricTest() {
 
         waitForAsyncTasksToComplete()
 
-        equalFirstField(cards[0], reviewer.mCurrentCard!!)
+        equalFirstField(cards[0], reviewer.currentCard!!)
         reviewer.answerCard(Consts.BUTTON_ONE)
         waitForAsyncTasksToComplete()
 
-        equalFirstField(cards[1], reviewer.mCurrentCard!!)
+        equalFirstField(cards[1], reviewer.currentCard!!)
         reviewer.answerCard(Consts.BUTTON_ONE)
         waitForAsyncTasksToComplete()
 
         undo(reviewer)
         waitForAsyncTasksToComplete()
 
-        equalFirstField(cards[1], reviewer.mCurrentCard!!)
+        equalFirstField(cards[1], reviewer.currentCard!!)
         reviewer.answerCard(col.sched.goodNewButton)
         waitForAsyncTasksToComplete()
 
-        equalFirstField(cards[2], reviewer.mCurrentCard!!)
+        equalFirstField(cards[2], reviewer.currentCard!!)
         time.addM(2)
         reviewer.answerCard(col.sched.goodNewButton)
         advanceRobolectricLooperWithSleep()
-        equalFirstField(cards[0], reviewer.mCurrentCard!!) // This failed in #6898 because this card was not in the queue
+        equalFirstField(cards[0], reviewer.currentCard!!) // This failed in #6898 because this card was not in the queue
     }
 
     @Test
@@ -281,7 +281,7 @@ class ReviewerTest : RobolectricTest() {
 
     private fun assertCurrentOrdIsNot(r: Reviewer, @Suppress("SameParameterValue") i: Int) {
         waitForAsyncTasksToComplete()
-        val ord = r.mCurrentCard!!.ord
+        val ord = r.currentCard!!.ord
 
         assertThat("Unexpected card ord", ord + 1, not(equalTo(i)))
     }
@@ -319,7 +319,7 @@ class ReviewerTest : RobolectricTest() {
 
     private fun assertCurrentOrdIs(r: Reviewer, i: Int) {
         waitForAsyncTasksToComplete()
-        val ord = r.mCurrentCard!!.ord
+        val ord = r.currentCard!!.ord
 
         assertThat("Unexpected card ord", ord + 1, equalTo(i))
     }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/ReviewerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/ReviewerTest.kt
@@ -48,7 +48,7 @@ import kotlin.test.junit5.JUnit5Asserter.assertNotNull
 
 @RunWith(ParameterizedRobolectricTestRunner::class)
 class ReviewerTest : RobolectricTest() {
-    @JvmField
+    @JvmField // required for Parameter
     @ParameterizedRobolectricTestRunner.Parameter
     var schedVersion = 0
     @Before

--- a/AnkiDroid/src/test/java/com/ichi2/anki/ReviewerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/ReviewerTest.kt
@@ -262,7 +262,7 @@ class ReviewerTest : RobolectricTest() {
     private fun toggleWhiteboard(reviewer: ReviewerForMenuItems) {
         reviewer.toggleWhiteboard()
 
-        assumeTrue("Whiteboard should now be enabled", reviewer.mPrefWhiteboard)
+        assumeTrue("Whiteboard should now be enabled", reviewer.prefWhiteboard)
 
         advanceRobolectricLooperWithSleep()
     }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/RobolectricTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/RobolectricTest.kt
@@ -82,8 +82,7 @@ open class RobolectricTest : CollectionGetter {
         return true
     }
 
-    @Rule
-    @JvmField // required for Rule
+    @get:Rule
     val mTaskScheduler = TaskSchedulerRule()
 
     @Before

--- a/AnkiDroid/src/test/java/com/ichi2/anki/RobolectricTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/RobolectricTest.kt
@@ -83,7 +83,7 @@ open class RobolectricTest : CollectionGetter {
     }
 
     @Rule
-    @JvmField
+    @JvmField // required for Rule
     val mTaskScheduler = TaskSchedulerRule()
 
     @Before

--- a/AnkiDroid/src/test/java/com/ichi2/anki/TestCardTemplatePreviewer.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/TestCardTemplatePreviewer.kt
@@ -22,7 +22,7 @@ class TestCardTemplatePreviewer : CardTemplatePreviewer() {
         private set
 
     fun disableDoubleClickPrevention() {
-        mLastClickTime = (AnkiDroidApp.getSharedPrefs(baseContext).getInt(DOUBLE_TAP_TIME_INTERVAL, DEFAULT_DOUBLE_TAP_TIME_INTERVAL) * -2).toLong()
+        lastClickTime = (AnkiDroidApp.getSharedPrefs(baseContext).getInt(DOUBLE_TAP_TIME_INTERVAL, DEFAULT_DOUBLE_TAP_TIME_INTERVAL) * -2).toLong()
     }
 
     override fun displayCardAnswer() {
@@ -36,18 +36,18 @@ class TestCardTemplatePreviewer : CardTemplatePreviewer() {
     }
 
     fun nextButtonVisible(): Boolean {
-        return mPreviewLayout!!.nextCard.visibility != View.GONE
+        return previewLayout!!.nextCard.visibility != View.GONE
     }
 
     fun previousButtonVisible(): Boolean {
-        return mPreviewLayout!!.prevCard.visibility != View.GONE
+        return previewLayout!!.prevCard.visibility != View.GONE
     }
 
     fun previousButtonEnabled(): Boolean {
-        return mPreviewLayout!!.prevCard.isEnabled
+        return previewLayout!!.prevCard.isEnabled
     }
 
     fun nextButtonEnabled(): Boolean {
-        return mPreviewLayout!!.nextCard.isEnabled
+        return previewLayout!!.nextCard.isEnabled
     }
 }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/WhiteboardDefaultForegroundColorTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/WhiteboardDefaultForegroundColorTest.kt
@@ -26,11 +26,11 @@ import org.robolectric.ParameterizedRobolectricTestRunner
 @RunWith(ParameterizedRobolectricTestRunner::class)
 class WhiteboardDefaultForegroundColorTest : RobolectricTest() {
     @ParameterizedRobolectricTestRunner.Parameter
-    @JvmField
+    @JvmField // required for Parameter
     var mIsInverted = false
 
     @ParameterizedRobolectricTestRunner.Parameter(1)
-    @JvmField
+    @JvmField // required for Parameter
     var mExpectedResult = 0
     @Test
     fun testDefaultForegroundColor() {

--- a/AnkiDroid/src/test/java/com/ichi2/anki/multimediacard/AudioPlayerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/multimediacard/AudioPlayerTest.kt
@@ -38,7 +38,7 @@ class AudioPlayerTest : RobolectricTest() {
     private lateinit var file: File
 
     @Rule
-    @JvmField
+    @JvmField // required for Rule
     var temporaryDirectory = TemporaryFolder()
 
     @Before

--- a/AnkiDroid/src/test/java/com/ichi2/anki/multimediacard/AudioPlayerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/multimediacard/AudioPlayerTest.kt
@@ -37,8 +37,7 @@ class AudioPlayerTest : RobolectricTest() {
     private lateinit var audioPlayer: AudioPlayer
     private lateinit var file: File
 
-    @Rule
-    @JvmField // required for Rule
+    @get:Rule
     var temporaryDirectory = TemporaryFolder()
 
     @Before

--- a/AnkiDroid/src/test/java/com/ichi2/anki/services/NoteServiceTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/services/NoteServiceTest.kt
@@ -39,7 +39,6 @@ import java.io.File
 import java.io.FileWriter
 import java.io.IOException
 
-@KotlinCleanup("See if we can remove JvmField from Rule")
 @KotlinCleanup("have Model constructor accent @Language('JSON')")
 @KotlinCleanup("fix typo: testimage -> test_image")
 @KotlinCleanup("Add scope functions")
@@ -54,11 +53,11 @@ class NoteServiceTest : RobolectricTest() {
 
     // temporary directory to test importMediaToDirectory function
     @Rule
-    @JvmField
+    @JvmField // required for Rule
     var directory = TemporaryFolder()
 
     @Rule
-    @JvmField
+    @JvmField // required for Rule
     var directory2 = TemporaryFolder()
 
     // tests if the text fields of the notes are the same after calling updateJsonNoteFromMultimediaNote

--- a/AnkiDroid/src/test/java/com/ichi2/anki/services/NoteServiceTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/services/NoteServiceTest.kt
@@ -52,12 +52,10 @@ class NoteServiceTest : RobolectricTest() {
     }
 
     // temporary directory to test importMediaToDirectory function
-    @Rule
-    @JvmField // required for Rule
+    @get:Rule
     var directory = TemporaryFolder()
 
-    @Rule
-    @JvmField // required for Rule
+    @get:Rule
     var directory2 = TemporaryFolder()
 
     // tests if the text fields of the notes are the same after calling updateJsonNoteFromMultimediaNote

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/DecksTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/DecksTest.kt
@@ -282,7 +282,6 @@ class DecksTest : RobolectricTest() {
 
     companion object {
         // Used in other class to populate decks.
-        @JvmField
         @Suppress("SpellCheckingInspection")
         val TEST_DECKS = arrayOf(
             "scxipjiyozczaaczoawo",

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/FinderTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/FinderTest.kt
@@ -437,7 +437,7 @@ class FinderTest : RobolectricTest() {
         val cb = super.startActivityNormallyOpenCollectionWithIntent(
             CardBrowser::class.java, Intent()
         )
-        cb.mDeckSpinnerSelection!!.updateDeckPosition(currentDid)
+        cb.deckSpinnerSelection!!.updateDeckPosition(currentDid)
         advanceRobolectricLooperWithSleep()
         assertEquals(1L, cb.cardCount.toLong())
     }

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/sched/AbstractSchedTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/sched/AbstractSchedTest.kt
@@ -42,7 +42,7 @@ import kotlin.test.assertNull
 @RunWith(ParameterizedRobolectricTestRunner::class)
 class AbstractSchedTest : RobolectricTest() {
     @ParameterizedRobolectricTestRunner.Parameter
-    @JvmField
+    @JvmField // required for Parameter
     var schedVersion = 0
     @Before
     override fun setUp() {

--- a/AnkiDroid/src/test/java/com/ichi2/utils/FileUtilTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/utils/FileUtilTest.kt
@@ -32,8 +32,7 @@ import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
 class FileUtilTest {
-    @JvmField // required for Rule
-    @Rule
+    @get:Rule
     var temporaryDirectory = TemporaryFolder()
     private var testDirectorySize: Long = 0
     @Throws(Exception::class)

--- a/AnkiDroid/src/test/java/com/ichi2/utils/FileUtilTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/utils/FileUtilTest.kt
@@ -32,7 +32,7 @@ import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
 class FileUtilTest {
-    @JvmField
+    @JvmField // required for Rule
     @Rule
     var temporaryDirectory = TemporaryFolder()
     private var testDirectorySize: Long = 0

--- a/AnkiDroid/src/test/java/com/ichi2/utils/TagsUtilTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/utils/TagsUtilTest.kt
@@ -26,19 +26,19 @@ class TagsUtilTest {
     @RunWith(Parameterized::class)
     class GetUpdatedTagsTest {
         @Parameterized.Parameter(0)
-        @JvmField
+        @JvmField // required for Parameter
         var previous: List<String>? = null
 
         @Parameterized.Parameter(1)
-        @JvmField
+        @JvmField // required for Parameter
         var selected: List<String>? = null
 
         @Parameterized.Parameter(2)
-        @JvmField
+        @JvmField // required for Parameter
         var indeterminate: List<String>? = null
 
         @Parameterized.Parameter(3)
-        @JvmField
+        @JvmField // required for Parameter
         var updated: List<String>? = null
         @Test
         fun test() {

--- a/api/src/main/java/com/ichi2/anki/FlashCardsContract.kt
+++ b/api/src/main/java/com/ichi2/anki/FlashCardsContract.kt
@@ -210,14 +210,14 @@ object FlashCardsContract {
          *
          * For examples on how to use the URI for queries see class description.
          */
-        @JvmField
+        @JvmField // required for Java API
         val CONTENT_URI = Uri.withAppendedPath(AUTHORITY_URI, "notes")
 
         /**
          * The content:// style URI for notes, but with a direct SQL query to the notes table instead of accepting
          * a query in the libanki browser search syntax like the main URI #CONTENT_URI does.
          */
-        @JvmField
+        @JvmField // required for Java API
         val CONTENT_URI_V2 = Uri.withAppendedPath(AUTHORITY_URI, "notes_v2")
 
         /**
@@ -337,7 +337,7 @@ object FlashCardsContract {
          * The content:// style URI for model. If the it is appended by the model's ID, this
          * note can be directly accessed. See class description above for further details.
          */
-        @JvmField
+        @JvmField // required for Java API
         val CONTENT_URI = Uri.withAppendedPath(AUTHORITY_URI, "models")
         const val CURRENT_MODEL_ID = "current"
 
@@ -877,9 +877,9 @@ object FlashCardsContract {
      * ```
      */
     object Deck {
-        @JvmField
+        @JvmField // required for Java API
         val CONTENT_ALL_URI = Uri.withAppendedPath(AUTHORITY_URI, "decks")
-        @JvmField
+        @JvmField // required for Java API
         val CONTENT_SELECTED_URI = Uri.withAppendedPath(AUTHORITY_URI, "selected_deck")
 
         /**
@@ -946,7 +946,7 @@ object FlashCardsContract {
         /**
          * Content Uri for the MEDIA row of the CardContentProvider
          */
-        @JvmField
+        @JvmField // required for Java API
         val CONTENT_URI = Uri.withAppendedPath(AUTHORITY_URI, "media")
 
         /**

--- a/api/src/main/java/com/ichi2/anki/api/Basic2Model.kt
+++ b/api/src/main/java/com/ichi2/anki/api/Basic2Model.kt
@@ -5,15 +5,15 @@ package com.ichi2.anki.api
  * Definitions of the basic with reverse model
  */
 object Basic2Model {
-    @JvmField
+    @JvmField // required for Java API
     val FIELDS = arrayOf("Front", "Back")
     // List of card names that will be used in AnkiDroid (one for each direction of learning)
-    @JvmField
+    @JvmField // required for Java API
     val CARD_NAMES = arrayOf("Card 1", "Card 2")
     // Template for the question of each card
-    @JvmField
+    @JvmField // required for Java API
     val QFMT = arrayOf("{{Front}}", "{{Back}}")
-    @JvmField
+    @JvmField // required for Java API
     val AFMT = arrayOf(
         "{{FrontSide}}\n\n<hr id=\"answer\">\n\n{{Back}}",
         "{{FrontSide}}\n\n<hr id=\"answer\">\n\n{{Front}}"

--- a/api/src/main/java/com/ichi2/anki/api/BasicModel.kt
+++ b/api/src/main/java/com/ichi2/anki/api/BasicModel.kt
@@ -6,15 +6,15 @@ package com.ichi2.anki.api
  */
 internal class BasicModel {
     companion object {
-        @JvmField
+        @JvmField // required for API
         var FIELDS = arrayOf("Front", "Back")
         // List of card names that will be used in AnkiDroid (one for each direction of learning)
-        @JvmField
+        @JvmField // required for API
         val CARD_NAMES = arrayOf("Card 1")
         // Template for the question of each card
-        @JvmField
+        @JvmField // required for API
         val QFMT = arrayOf("{{Front}}")
-        @JvmField
+        @JvmField // required for API
         val AFMT = arrayOf("{{FrontSide}}\n\n<hr id=\"answer\">\n\n{{Back}}")
     }
 }

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/rules/CopyrightHeaderExists.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/CopyrightHeaderExists.kt
@@ -63,7 +63,6 @@ class CopyrightHeaderExists : Detector(), SourceCodeScanner {
             "https://softwarefreedom.org/resources/2007/gpl-non-gpl-collaboration.html#x1-40002.2 + or " +
             "\"//noinspection MissingCopyrightHeader <reason>\" may be added as the first line of the file."
         private val implementation = Implementation(CopyrightHeaderExists::class.java, EnumSet.of(Scope.JAVA_FILE, Scope.TEST_SOURCES))
-        @JvmField
         val ISSUE: Issue = Issue.create(
             ID,
             DESCRIPTION,

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/rules/DirectCalendarInstanceUsage.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/DirectCalendarInstanceUsage.kt
@@ -25,7 +25,6 @@ class DirectCalendarInstanceUsage : Detector(), SourceCodeScanner {
         private const val EXPLANATION = "Manually creating Calendar instances means time cannot be controlled " +
             "during testing. Calendar instances must be obtained through the collection's getTime() method"
         private val implementation = Implementation(DirectCalendarInstanceUsage::class.java, Scope.JAVA_FILE_SCOPE)
-        @JvmField
         val ISSUE: Issue = Issue.create(
             ID,
             DESCRIPTION,

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/rules/DirectDateInstantiation.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/DirectDateInstantiation.kt
@@ -23,7 +23,6 @@ class DirectDateInstantiation : Detector(), SourceCodeScanner {
         private const val EXPLANATION = "Creating Date instances directly means dates cannot be controlled during" +
             " testing, so it is not allowed. Use the collection's getTime() method instead"
         private val implementation = Implementation(DirectDateInstantiation::class.java, Scope.JAVA_FILE_SCOPE)
-        @JvmField
         val ISSUE: Issue = Issue.create(
             ID,
             DESCRIPTION,

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/rules/DirectGregorianInstantiation.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/DirectGregorianInstantiation.kt
@@ -25,7 +25,6 @@ class DirectGregorianInstantiation : Detector(), SourceCodeScanner {
         private const val EXPLANATION = "Creating GregorianCalendar instances directly is not allowed, as it " +
             "prevents control of time during testing. Use the collection's getTime() method instead"
         private val implementation = Implementation(DirectGregorianInstantiation::class.java, Scope.JAVA_FILE_SCOPE)
-        @JvmField
         val ISSUE: Issue = Issue.create(
             ID,
             DESCRIPTION,

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/rules/DirectSnackbarMakeUsage.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/DirectSnackbarMakeUsage.kt
@@ -40,7 +40,6 @@ class DirectSnackbarMakeUsage : Detector(), SourceCodeScanner {
             "you should use SnackbarsKt.showSnackbar " +
             "in place of the library Snackbar.make(...).show()"
         private val implementation = Implementation(DirectSnackbarMakeUsage::class.java, Scope.JAVA_FILE_SCOPE)
-        @JvmField
         val ISSUE: Issue = Issue.create(
             ID,
             DESCRIPTION,

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/rules/DirectSystemCurrentTimeMillisUsage.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/DirectSystemCurrentTimeMillisUsage.kt
@@ -23,7 +23,6 @@ class DirectSystemCurrentTimeMillisUsage : Detector(), SourceCodeScanner {
         private const val EXPLANATION = "Using time directly means time values cannot be controlled during testing. " +
             "Time values like System.currentTimeMillis() must be obtained through the Time obtained from a Collection"
         private val implementation = Implementation(DirectSystemCurrentTimeMillisUsage::class.java, Scope.JAVA_FILE_SCOPE)
-        @JvmField
         val ISSUE: Issue = Issue.create(
             ID,
             DESCRIPTION,

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/rules/DirectSystemTimeInstantiation.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/DirectSystemTimeInstantiation.kt
@@ -30,7 +30,6 @@ class DirectSystemTimeInstantiation : Detector(), SourceCodeScanner {
         private val implementation = Implementation(
             DirectSystemTimeInstantiation::class.java, Scope.JAVA_FILE_SCOPE
         )
-        @JvmField
         val ISSUE: Issue = Issue.create(
             ID,
             DESCRIPTION,

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/rules/DirectToastMakeTextUsage.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/DirectToastMakeTextUsage.kt
@@ -38,7 +38,6 @@ class DirectToastMakeTextUsage : Detector(), SourceCodeScanner {
         private const val EXPLANATION = "To improve code consistency within the codebase you should use UIUtils.showThemedToast in place" +
             " of the library Toast.makeText(...).show(). This ensures also that the toast is actually displayed after being created"
         private val implementation = Implementation(DirectToastMakeTextUsage::class.java, Scope.JAVA_FILE_SCOPE)
-        @JvmField
         val ISSUE: Issue = Issue.create(
             ID,
             DESCRIPTION,

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/rules/DuplicateCrowdInStrings.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/DuplicateCrowdInStrings.kt
@@ -168,7 +168,6 @@ class DuplicateCrowdInStrings : ResourceXmlDetector() {
         /**
          * Whether there are any duplicate strings, including capitalization adjustments.
          */
-        @JvmField
         var ISSUE: Issue = Issue.create(
             ID,
             "Duplicate Strings (CrowdIn)",

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/rules/DuplicateTextInPreferencesXml.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/DuplicateTextInPreferencesXml.kt
@@ -21,7 +21,6 @@ class DuplicateTextInPreferencesXml : ResourceXmlDetector() {
         private const val EXPLANATION = "Use different strings for the title and summary of a preference to better " +
             "explain what that preference is for"
         private val implementation = Implementation(DuplicateTextInPreferencesXml::class.java, Scope.RESOURCE_FILE_SCOPE)
-        @JvmField
         val ISSUE: Issue = Issue.create(
             ID,
             DESCRIPTION,

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/rules/FixedPreferencesTitleLength.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/FixedPreferencesTitleLength.kt
@@ -48,7 +48,6 @@ class FixedPreferencesTitleLength : ResourceXmlDetector(), XmlScanner {
         private const val EXPLANATION_MAX_LENGTH = "Preference Title should contain maxLength attribute " +
             "because it fixes translated string length"
         private val implementation = Implementation(FixedPreferencesTitleLength::class.java, Scope.RESOURCE_FILE_SCOPE)
-        @JvmField
         val ISSUE_TITLE_LENGTH: Issue = Issue.create(
             ID_TITLE_LENGTH,
             DESCRIPTION_TITLE_LENGTH,
@@ -58,7 +57,6 @@ class FixedPreferencesTitleLength : ResourceXmlDetector(), XmlScanner {
             Constants.ANKI_XML_SEVERITY,
             implementation
         )
-        @JvmField
         val ISSUE_MAX_LENGTH: Issue = Issue.create(
             ID_MAX_LENGTH,
             DESCRIPTION_MAX_LENGTH,

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/rules/HardcodedPreferenceKey.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/HardcodedPreferenceKey.kt
@@ -35,7 +35,6 @@ class HardcodedPreferenceKey : ResourceXmlDetector() {
         val DESCRIPTION = "Preference key should not be hardcoded"
         private const val EXPLANATION = "Extract the key to a resources XML so it can be reused"
         private val implementation = Implementation(HardcodedPreferenceKey::class.java, Scope.RESOURCE_FILE_SCOPE)
-        @JvmField
         val ISSUE: Issue = Issue.create(
             ID,
             DESCRIPTION,

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/rules/InvalidStringFormatDetector.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/InvalidStringFormatDetector.kt
@@ -46,7 +46,6 @@ class InvalidStringFormatDetector : ResourceXmlDetector() {
         /**
          * Whether the string or plural resource that is being used has all the translations
          * **/
-        @JvmField
         val ISSUE = Issue.create(
             "InvalidStringFormat",
             "The String format is invalid",

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/rules/JUnitNullAssertionDetector.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/JUnitNullAssertionDetector.kt
@@ -60,7 +60,6 @@ class JUnitNullAssertionDetector : Detector(), SourceCodeScanner {
             "afterwards. Use JUnitAsserter if passing in a message, kotlin.test top level functions otherwise"
         private val implementation = Implementation(JUnitNullAssertionDetector::class.java, JAVA_FILE_SCOPE)
 
-        @JvmField
         val ISSUE: Issue = Issue.create(
             ID,
             DESCRIPTION,

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/rules/KotlinMigrationBrokenEmails.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/KotlinMigrationBrokenEmails.kt
@@ -65,7 +65,6 @@ class KotlinMigrationBrokenEmails : Detector(), SourceCodeScanner {
             "Check all comments to see if this also affected emails.\n" +
             "This can be fixed before conversion by changing the comments from /** to /* if appropriate"
         private val implementation = Implementation(KotlinMigrationBrokenEmails::class.java, EnumSet.of(Scope.JAVA_FILE, Scope.TEST_SOURCES))
-        @JvmField
         val ISSUE: Issue = Issue.create(
             ID,
             DESCRIPTION,

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/rules/KotlinMigrationFixLineBreaks.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/KotlinMigrationFixLineBreaks.kt
@@ -67,7 +67,6 @@ class KotlinMigrationFixLineBreaks : Detector(), SourceCodeScanner {
             "Please check the relevant piece of code.\n" +
             "And change instances of <br></br> to a newline: Kotlin supports Markdown formatting."
         private val implementation = Implementation(KotlinMigrationFixLineBreaks::class.java, EnumSet.of(Scope.JAVA_FILE, Scope.TEST_SOURCES))
-        @JvmField
         val ISSUE: Issue = Issue.create(
             ID,
             DESCRIPTION,

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/rules/NonPositionalFormatSubstitutions.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/NonPositionalFormatSubstitutions.kt
@@ -45,7 +45,6 @@ class NonPositionalFormatSubstitutions : ResourceXmlDetector() {
         /**
          * Whether there are any duplicate strings, including capitalization adjustments.
          */
-        @JvmField
         val ISSUE = Issue.create(
             "NonPositionalFormatSubstitutions",
             "Multiple substitutions specified in non-positional format",

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/rules/PrintStackTraceUsage.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/PrintStackTraceUsage.kt
@@ -32,7 +32,6 @@ class PrintStackTraceUsage : Detector(), SourceCodeScanner {
         val DESCRIPTION = "Use Timber to log exceptions (typically Timber.w if non-fatal)"
         private const val EXPLANATION = "AnkiDroid exclusively uses Timber for logging exceptions. See: https://github.com/ankidroid/Anki-Android/wiki/Code-style#logging"
         private val implementation = Implementation(PrintStackTraceUsage::class.java, Scope.JAVA_FILE_SCOPE)
-        @JvmField
         val ISSUE: Issue = Issue.create(
             ID,
             DESCRIPTION,

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/rules/VariableNamingDetector.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/VariableNamingDetector.kt
@@ -61,7 +61,6 @@ class VariableNamingDetector : Detector(), Detector.UastScanner {
 
     companion object {
         private val IMPLEMENTATION = Implementation(VariableNamingDetector::class.java, JAVA_FILE_SCOPE)
-        @JvmField
         val ISSUE = Issue.create(
             id = "VariableNamingDetector",
             briefDescription = "Variable name should not use field prefixes.",

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/utils/Constants.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/utils/Constants.kt
@@ -13,7 +13,6 @@ object Constants {
      * A special [Category] which groups the Lint issues related to the usage of the new SystemTime class as a
      * sub category for [Category.CORRECTNESS].
      */
-    @JvmField
     val ANKI_TIME_CATEGORY: Category = create(Category.CORRECTNESS, "AnkiTime", 10)
 
     /**
@@ -24,7 +23,6 @@ object Constants {
     /**
      * The severity for the Lint issues used by all rules related to the restrictions introduced by SystemTime.
      */
-    @JvmField
     val ANKI_TIME_SEVERITY = Severity.FATAL
 
     /**
@@ -48,7 +46,6 @@ object Constants {
      * A special [Category] which groups the Lint issues related to Code Style as a
      * sub category for [Category.COMPLIANCE].
      */
-    @JvmField
     val ANKI_CODE_STYLE_CATEGORY: Category = create(Category.COMPLIANCE, "CodeStyle", 10)
 
     /**
@@ -59,7 +56,6 @@ object Constants {
     /**
      * The severity for the Lint issues used by rules related to Code Style.
      */
-    @JvmField
     val ANKI_CODE_STYLE_SEVERITY = Severity.FATAL
 
     /**


### PR DESCRIPTION
We're no longer in Java, so only a few annotations are still necessary.

These are mostly test methods (`@Parameter/@Rule`),
This is a potentially flaky commit, hopefully the reduction in code causes a reduction in compile times

It did not modify the API project public classes

## Learning

Much easier than fixing `@JvmStatic` 

Except it triggered some variable naming lint issues

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
