### PR TITLE
perf: Fix initial `@RunInBackground` instances in tests

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/HelpDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/HelpDialog.kt
@@ -21,7 +21,6 @@ import android.os.Parcel
 import android.os.Parcelable
 import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
-import androidx.fragment.app.DialogFragment
 import com.ichi2.anki.AnkiActivity
 import com.ichi2.anki.AnkiDroidApp
 import com.ichi2.anki.CrashReportService
@@ -48,7 +47,7 @@ object HelpDialog {
     }
 
     @JvmStatic
-    fun createInstance(): DialogFragment {
+    fun createInstance(): RecursivePictureMenu {
         val exceptionReportItem = ExceptionReportItem(R.string.help_title_send_exception, R.drawable.ic_round_assignment_24, UsageAnalytics.Actions.EXCEPTION_REPORT)
         UsageAnalytics.sendAnalyticsEvent(UsageAnalytics.Category.LINK_CLICKED, UsageAnalytics.Actions.OPENED_HELPDIALOG)
         val allItems = arrayOf<RecursivePictureMenu.Item>(
@@ -98,7 +97,7 @@ object HelpDialog {
     }
 
     @JvmStatic
-    fun createInstanceForSupportAnkiDroid(context: Context?): DialogFragment {
+    fun createInstanceForSupportAnkiDroid(context: Context?): RecursivePictureMenu {
         UsageAnalytics.sendAnalyticsEvent(UsageAnalytics.Category.LINK_CLICKED, UsageAnalytics.Actions.OPENED_SUPPORT_ANKIDROID)
         val rateAppItem = RateAppItem(R.string.help_item_support_rate_ankidroid, R.drawable.ic_star_black_24, UsageAnalytics.Actions.OPENED_RATE)
         val allItems = arrayOf(

--- a/AnkiDroid/src/test/java/com/ichi2/anki/AbstractFlashcardViewerKeyboardInputTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/AbstractFlashcardViewerKeyboardInputTest.kt
@@ -35,7 +35,6 @@ class AbstractFlashcardViewerKeyboardInputTest : RobolectricTest() {
     }
 
     @Test
-    @RunInBackground
     fun enterShowsAnswer() {
         val underTest = KeyboardInputTestCardViewer.create()
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/ReviewerNoParamTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/ReviewerNoParamTest.kt
@@ -163,7 +163,6 @@ class ReviewerNoParamTest : RobolectricTest() {
     }
 
     @Test
-    @RunInBackground
     fun defaultDrawerConflictIsTrueIfGesturesEnabled() {
         enableGestureSetting()
         enableGesture(SWIPE_RIGHT)
@@ -206,7 +205,6 @@ class ReviewerNoParamTest : RobolectricTest() {
     }
 
     @Test
-    @RunInBackground
     fun drawerConflictsIfUp() {
         enableGestureSetting()
         disableConflictGestures()
@@ -217,7 +215,6 @@ class ReviewerNoParamTest : RobolectricTest() {
     }
 
     @Test
-    @RunInBackground
     fun drawerConflictsIfDown() {
         enableGestureSetting()
         disableConflictGestures()
@@ -228,7 +225,6 @@ class ReviewerNoParamTest : RobolectricTest() {
     }
 
     @Test
-    @RunInBackground
     fun drawerConflictsIfRight() {
         enableGestureSetting()
         disableConflictGestures()

--- a/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/utils/HelpDialogTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/utils/HelpDialogTest.kt
@@ -23,6 +23,7 @@ import com.ichi2.anki.dialogs.HelpDialog.createInstance
 import com.ichi2.anki.dialogs.HelpDialog.createInstanceForSupportAnkiDroid
 import com.ichi2.anki.dialogs.RecursivePictureMenu
 import com.ichi2.anki.dialogs.utils.RecursivePictureMenuUtil.Companion.getRecyclerViewFor
+import com.ichi2.testutils.EmptyApplication
 import com.ichi2.utils.IntentUtil
 import io.mockk.every
 import io.mockk.mockkStatic
@@ -31,8 +32,10 @@ import org.hamcrest.MatcherAssert
 import org.hamcrest.Matchers
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
 
 @RunWith(AndroidJUnit4::class)
+@Config(application = EmptyApplication::class)
 class HelpDialogTest : RobolectricTest() {
     @Test
     fun testMenuDoesNotCrash() {

--- a/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/utils/HelpDialogTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/utils/HelpDialogTest.kt
@@ -19,8 +19,7 @@ import android.annotation.SuppressLint
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.ichi2.anki.AnkiDroidApp
 import com.ichi2.anki.RobolectricTest
-import com.ichi2.anki.dialogs.HelpDialog.createInstance
-import com.ichi2.anki.dialogs.HelpDialog.createInstanceForSupportAnkiDroid
+import com.ichi2.anki.dialogs.HelpDialog
 import com.ichi2.anki.dialogs.RecursivePictureMenu
 import com.ichi2.anki.dialogs.utils.RecursivePictureMenuUtil.Companion.getRecyclerViewFor
 import com.ichi2.testutils.EmptyApplication
@@ -39,7 +38,7 @@ import org.robolectric.annotation.Config
 class HelpDialogTest : RobolectricTest() {
     @Test
     fun testMenuDoesNotCrash() {
-        val dialog = createInstance() as RecursivePictureMenu
+        val dialog = HelpDialog.createInstance()
         openDialogFragment(dialog)
         val v = getRecyclerViewFor(dialog)
         MatcherAssert.assertThat(v.adapter!!.itemCount, Matchers.equalTo(4))
@@ -47,7 +46,7 @@ class HelpDialogTest : RobolectricTest() {
 
     @Test
     fun testMenuSupportAnkiDroidDoesNotCrash() {
-        val dialog = createInstanceForSupportAnkiDroid(targetContext) as RecursivePictureMenu
+        val dialog = HelpDialog.createInstanceForSupportAnkiDroid(targetContext)
         openDialogFragment(dialog)
         val v = getRecyclerViewFor(dialog)
         // to make the test more flexible, calculate the expected menu items count by actually
@@ -64,7 +63,7 @@ class HelpDialogTest : RobolectricTest() {
     fun testMenuSupportAnkiDroidShowsRateWhenPossible() {
         mockkStatic(IntentUtil::canOpenIntent)
         every { IntentUtil.canOpenIntent(targetContext, any()) } returns true
-        val dialog = createInstanceForSupportAnkiDroid(targetContext) as RecursivePictureMenu
+        val dialog = HelpDialog.createInstanceForSupportAnkiDroid(targetContext)
         openDialogFragment(dialog)
         val v = getRecyclerViewFor(dialog)
         // 6 because the option to rate the app is possible on the device

--- a/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/utils/HelpDialogTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/utils/HelpDialogTest.kt
@@ -19,7 +19,6 @@ import android.annotation.SuppressLint
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.ichi2.anki.AnkiDroidApp
 import com.ichi2.anki.RobolectricTest
-import com.ichi2.anki.RunInBackground
 import com.ichi2.anki.dialogs.HelpDialog.createInstance
 import com.ichi2.anki.dialogs.HelpDialog.createInstanceForSupportAnkiDroid
 import com.ichi2.anki.dialogs.RecursivePictureMenu
@@ -36,7 +35,6 @@ import org.junit.runner.RunWith
 @RunWith(AndroidJUnit4::class)
 class HelpDialogTest : RobolectricTest() {
     @Test
-    @RunInBackground
     fun testMenuDoesNotCrash() {
         val dialog = createInstance() as RecursivePictureMenu
         openDialogFragment(dialog)
@@ -45,7 +43,6 @@ class HelpDialogTest : RobolectricTest() {
     }
 
     @Test
-    @RunInBackground
     fun testMenuSupportAnkiDroidDoesNotCrash() {
         val dialog = createInstanceForSupportAnkiDroid(targetContext) as RecursivePictureMenu
         openDialogFragment(dialog)
@@ -61,7 +58,6 @@ class HelpDialogTest : RobolectricTest() {
     }
 
     @Test
-    @RunInBackground
     fun testMenuSupportAnkiDroidShowsRateWhenPossible() {
         mockkStatic(IntentUtil::canOpenIntent)
         every { IntentUtil.canOpenIntent(targetContext, any()) } returns true


### PR DESCRIPTION
## Pull Request template

## Purpose / Description

https://github.com/ankidroid/Anki-Android/blob/65e33fc3912bb98dd3a76b993181c2c928b9252e/AnkiDroid/src/test/java/com/ichi2/anki/RunInBackground.kt#L18-L23

## Approach
* Fix the instances which passed unit tests after removing `@RunInBackground` without a code change
* Then do some incidental refactoring

## How Has This Been Tested?

Test only

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
