### PR TITLE
ci: mark Stale issues as 'not_planned'

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -23,4 +23,5 @@ jobs:
         stale-pr-message: 'Hello 👋, this PR has been opened for more than 2 months with no activity on it. If you think this is a mistake please comment and ping a maintainer to get this merged ASAP! Thanks for contributing! You have 7 days until this gets closed automatically'
         exempt-issue-labels: 'Keep Open'
         exempt-pr-labels: 'Keep Open'
+        close-issue-reason: 'not_planned'
 


### PR DESCRIPTION
GitHub introduced 'not_planned' as a close reason for stale issues:

![image](https://user-images.githubusercontent.com/62114487/188744901-987b07ad-52cc-48f6-b42a-f542982c9ce8.png)

https://github.blog/changelog/2022-05-19-the-new-github-issues-may-19th-update/

docs: https://github.com/actions/stale#close-issue-reason

## How Has This Been Tested?

⚠️ Untested

## Learning
docs: https://github.com/actions/stale#close-issue-reason

Added in https://github.com/actions/stale/releases/tag/v5.1.0

https://github.blog/changelog/2022-05-19-the-new-github-issues-may-19th-update/


## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
