### PR TITLE
Cleanup FlashCardContract for new api release

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -29,6 +29,12 @@ android {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
+    kotlinOptions {
+        // enable explicit api mode for additional checks related to the public api
+        // see https://kotlinlang.org/docs/whatsnew14.html#explicit-api-mode-for-library-authors
+        // TODO When we finish cleaning up the api module we should move from warning to strict.
+        freeCompilerArgs += '-Xexplicit-api=warning'
+    }
 }
 
 apply from: "../lint.gradle"

--- a/api/src/main/java/com/ichi2/anki/FlashCardsContract.kt
+++ b/api/src/main/java/com/ichi2/anki/FlashCardsContract.kt
@@ -84,16 +84,15 @@ import android.net.Uri
  * --------------------------------------------------------------------------------------------------------------------
  * ```
  */
-// TODO @KotlinCleanup("fix ide lint issue")
-// TODO @KotlinCleanup("improve api types, see https://kotlinlang.org/docs/whatsnew14.html#explicit-api-mode-for-library-authors")
-object FlashCardsContract {
-    const val AUTHORITY = "com.ichi2.anki.flashcards"
-    const val READ_WRITE_PERMISSION = "com.ichi2.anki.permission.READ_WRITE_DATABASE"
+public object FlashCardsContract {
+    public const val AUTHORITY: String = "com.ichi2.anki.flashcards"
+    public const val READ_WRITE_PERMISSION: String = "com.ichi2.anki.permission.READ_WRITE_DATABASE"
 
     /**
      * A content:// style uri to the authority for the flash card provider
      */
-    val AUTHORITY_URI = Uri.parse("content://" + AUTHORITY)
+    @JvmField // required for Java API
+    public val AUTHORITY_URI: Uri = Uri.parse("content://$AUTHORITY")
 
     /**
      * The Notes can be accessed by
@@ -189,7 +188,7 @@ object FlashCardsContract {
      * --------------------------------------------------------------------------------------------------------------------
      * ```
      */
-    object Note {
+    public object Note {
         /**
          * The content:// style URI for notes. If the it is appended by the note's ID, this
          * note can be directly accessed, e.g.
@@ -211,33 +210,41 @@ object FlashCardsContract {
          * For examples on how to use the URI for queries see class description.
          */
         @JvmField // required for Java API
-        val CONTENT_URI = Uri.withAppendedPath(AUTHORITY_URI, "notes")
+        public val CONTENT_URI: Uri = Uri.withAppendedPath(AUTHORITY_URI, "notes")
 
         /**
          * The content:// style URI for notes, but with a direct SQL query to the notes table instead of accepting
          * a query in the libanki browser search syntax like the main URI #CONTENT_URI does.
          */
         @JvmField // required for Java API
-        val CONTENT_URI_V2 = Uri.withAppendedPath(AUTHORITY_URI, "notes_v2")
+        public val CONTENT_URI_V2: Uri = Uri.withAppendedPath(AUTHORITY_URI, "notes_v2")
 
         /**
          * This is the ID of the note. It is the same as the note ID in Anki. This ID can be
          * used for accessing the data of a note using the URI
          * "content://com.ichi2.anki.flashcards/notes/&lt;ID&gt;/data
          */
-        const val _ID = "_id"
-        const val GUID = "guid"
-        const val MID = "mid"
-        const val ALLOW_EMPTY = "allow_empty"
-        const val MOD = "mod"
-        const val USN = "usn"
-        const val TAGS = "tags"
-        const val FLDS = "flds"
-        const val SFLD = "sfld"
-        const val CSUM = "csum"
-        const val FLAGS = "flags"
-        const val DATA = "data"
-        val DEFAULT_PROJECTION = arrayOf(
+        @Suppress("ObjectPropertyName")
+        public const val _ID: String = "_id"
+        // field is part of the default projection available to the clients
+        @Suppress("MemberVisibilityCanBePrivate")
+        public const val GUID: String = "guid"
+        public const val MID: String = "mid"
+        public const val ALLOW_EMPTY: String = "allow_empty"
+        public const val MOD: String = "mod"
+        // field is part of the default projection available to the clients
+        @Suppress("MemberVisibilityCanBePrivate")
+        public const val USN: String = "usn"
+        public const val TAGS: String = "tags"
+        public const val FLDS: String = "flds"
+        // field is part of the default projection available to the clients
+        @Suppress("MemberVisibilityCanBePrivate")
+        public const val SFLD: String = "sfld"
+        public const val CSUM: String = "csum"
+        public const val FLAGS: String = "flags"
+        public const val DATA: String = "data"
+        @JvmField // required for Java API
+        public val DEFAULT_PROJECTION: Array<String> = arrayOf(
             _ID,
             GUID,
             MID,
@@ -254,17 +261,17 @@ object FlashCardsContract {
         /**
          * MIME type used for a note.
          */
-        const val CONTENT_ITEM_TYPE = "vnd.android.cursor.item/vnd.com.ichi2.anki.note"
+        public const val CONTENT_ITEM_TYPE: String = "vnd.android.cursor.item/vnd.com.ichi2.anki.note"
 
         /**
          * MIME type used for notes.
          */
-        const val CONTENT_TYPE = "vnd.android.cursor.dir/vnd.com.ichi2.anki.note"
+        public const val CONTENT_TYPE: String = "vnd.android.cursor.dir/vnd.com.ichi2.anki.note"
 
         /**
          * Used only by bulkInsert() to specify which deck the notes should be placed in
          */
-        const val DECK_ID_QUERY_PARAM = "deckId"
+        public const val DECK_ID_QUERY_PARAM: String = "deckId"
     }
 
     /**
@@ -332,38 +339,40 @@ object FlashCardsContract {
      *      Uri.withAppendedPath(FlashCardsContract.Model.CONTENT_URI, FlashCardsContract.Model.CURRENT_MODEL_ID);
      * ```
      */
-    object Model {
+    public object Model {
         /**
          * The content:// style URI for model. If the it is appended by the model's ID, this
          * note can be directly accessed. See class description above for further details.
          */
         @JvmField // required for Java API
-        val CONTENT_URI = Uri.withAppendedPath(AUTHORITY_URI, "models")
-        const val CURRENT_MODEL_ID = "current"
+        public val CONTENT_URI: Uri = Uri.withAppendedPath(AUTHORITY_URI, "models")
+        public const val CURRENT_MODEL_ID: String = "current"
 
         /**
          * This is the ID of the model. It is the same as the note ID in Anki. This ID can be
          * used for accessing the data of the model using the URI
          * "content://com.ichi2.anki.flashcards/models/&lt;ID&gt;
          */
-        const val _ID = "_id"
-        const val NAME = "name"
-        const val FIELD_NAME = "field_name"
-        const val FIELD_NAMES = "field_names"
-        const val NUM_CARDS = "num_cards"
-        const val CSS = "css"
-        const val SORT_FIELD_INDEX = "sort_field_index"
-        const val TYPE = "type"
-        const val LATEX_POST = "latex_post"
-        const val LATEX_PRE = "latex_pre"
-        const val NOTE_COUNT = "note_count"
+        @Suppress("ObjectPropertyName")
+        public const val _ID: String = "_id"
+        public const val NAME: String = "name"
+        public const val FIELD_NAME: String = "field_name"
+        public const val FIELD_NAMES: String = "field_names"
+        public const val NUM_CARDS: String = "num_cards"
+        public const val CSS: String = "css"
+        public const val SORT_FIELD_INDEX: String = "sort_field_index"
+        public const val TYPE: String = "type"
+        public const val LATEX_POST: String = "latex_post"
+        public const val LATEX_PRE: String = "latex_pre"
+        public const val NOTE_COUNT: String = "note_count"
 
         /**
          * The deck ID that is selected by default when adding new notes with this model.
          * This is only used when the "Deck for new cards" preference is set to "Decide by note type"
          */
-        const val DECK_ID = "deck_id"
-        val DEFAULT_PROJECTION = arrayOf(
+        public const val DECK_ID: String = "deck_id"
+        @JvmField // required for Java API
+        public val DEFAULT_PROJECTION: Array<String> = arrayOf(
             _ID,
             NAME,
             FIELD_NAMES,
@@ -379,12 +388,12 @@ object FlashCardsContract {
         /**
          * MIME type used for a model.
          */
-        const val CONTENT_ITEM_TYPE = "vnd.android.cursor.item/vnd.com.ichi2.anki.model"
+        public const val CONTENT_ITEM_TYPE: String = "vnd.android.cursor.item/vnd.com.ichi2.anki.model"
 
         /**
          * MIME type used for model.
          */
-        const val CONTENT_TYPE = "vnd.android.cursor.dir/vnd.com.ichi2.anki.model"
+        public const val CONTENT_TYPE: String = "vnd.android.cursor.dir/vnd.com.ichi2.anki.model"
     }
 
     /**
@@ -394,12 +403,12 @@ object FlashCardsContract {
      * reverse card allowing review in the "reverse" direction (e.g dog -&gt; 犬). When a Note is inserted, a Card will
      * be generated for each active CardTemplate which is defined.
      */
-    object CardTemplate {
+    public object CardTemplate {
         /**
          * MIME type used for data.
          */
-        const val CONTENT_TYPE = "vnd.android.cursor.dir/vnd.com.ichi2.anki.model.template"
-        const val CONTENT_ITEM_TYPE = "vnd.android.cursor.item/vnd.com.ichi2.anki.model.template"
+        public const val CONTENT_TYPE: String = "vnd.android.cursor.dir/vnd.com.ichi2.anki.model.template"
+        public const val CONTENT_ITEM_TYPE: String = "vnd.android.cursor.item/vnd.com.ichi2.anki.model.template"
 
         /**
          * Row ID. This is a virtual ID which actually does not exist in AnkiDroid's data base.
@@ -408,48 +417,50 @@ object FlashCardsContract {
          * reliably over subsequent queries. Especially if the number of cards or fields changes,
          * the _ID will change too.
          */
-        const val _ID = "_id"
+        @Suppress("ObjectPropertyName")
+        public const val _ID: String = "_id"
 
         /**
          * This is the ID of the model that this row belongs to (i.e. [Model._ID]).
          */
-        const val MODEL_ID = "model_id"
+        public const val MODEL_ID: String = "model_id"
 
         /**
          * This is the ordinal / index of the card template (from 0 to number of cards - 1).
          */
-        const val ORD = "ord"
+        public const val ORD: String = "ord"
 
         /**
          * The template name e.g. "Card 1".
          */
-        const val NAME = "card_template_name"
+        public const val NAME: String = "card_template_name"
 
         /**
          * The definition of the template for the question
          */
-        const val QUESTION_FORMAT = "question_format"
+        public const val QUESTION_FORMAT: String = "question_format"
 
         /**
          * The definition of the template for the answer
          */
-        const val ANSWER_FORMAT = "answer_format"
+        public const val ANSWER_FORMAT: String = "answer_format"
 
         /**
          * Optional alternative definition of the template for the question when rendered with the browser
          */
-        const val BROWSER_QUESTION_FORMAT = "browser_question_format"
+        public const val BROWSER_QUESTION_FORMAT: String = "browser_question_format"
 
         /**
          * Optional alternative definition of the template for the answer when rendered with the browser
          */
-        const val BROWSER_ANSWER_FORMAT = "browser_answer_format"
-        const val CARD_COUNT = "card_count"
+        public const val BROWSER_ANSWER_FORMAT: String = "browser_answer_format"
+        public const val CARD_COUNT: String = "card_count"
 
         /**
          * Default columns that are returned when querying the ...models/#/templates URI.
          */
-        val DEFAULT_PROJECTION = arrayOf(
+        @JvmField // required for Java API
+        public val DEFAULT_PROJECTION: Array<String> = arrayOf(
             _ID,
             MODEL_ID,
             ORD,
@@ -547,54 +558,55 @@ object FlashCardsContract {
      *      } while (cur.moveToNext());
      * ```
      */
-    object Card {
+    public object Card {
         /**
          * This is the ID of the note that this card belongs to (i.e. [Note._ID]).
          */
-        const val NOTE_ID = "note_id"
+        public const val NOTE_ID: String = "note_id"
 
         /**
          * This is the ordinal of the card. A note has 1..n cards. The ordinal can also be used
          * to directly access a card as describe in the class description.
          */
-        const val CARD_ORD = "ord"
+        public const val CARD_ORD: String = "ord"
 
         /**
          * The card's name.
          */
-        const val CARD_NAME = "card_name"
+        public const val CARD_NAME: String = "card_name"
 
         /**
          * The name of the deck that this card is part of.
          */
-        const val DECK_ID = "deck_id"
+        public const val DECK_ID: String = "deck_id"
 
         /**
          * The question for this card.
          */
-        const val QUESTION = "question"
+        public const val QUESTION: String = "question"
 
         /**
          * The answer for this card.
          */
-        const val ANSWER = "answer"
+        public const val ANSWER: String = "answer"
 
         /**
          * Simplified version of the question, without card styling (CSS).
          */
-        const val QUESTION_SIMPLE = "question_simple"
+        public const val QUESTION_SIMPLE: String = "question_simple"
 
         /**
          * Simplified version of the answer, without card styling (CSS).
          */
-        const val ANSWER_SIMPLE = "answer_simple"
+        public const val ANSWER_SIMPLE: String = "answer_simple"
 
         /**
          * Purified version of the answer. In case the ANSWER contains any additional elements
          * (like a duplicate of the question) this is removed for ANSWER_PURE
          */
-        const val ANSWER_PURE = "answer_pure"
-        val DEFAULT_PROJECTION = arrayOf(
+        public const val ANSWER_PURE: String = "answer_pure"
+        @JvmField // required for Java API
+        public val DEFAULT_PROJECTION: Array<String> = arrayOf(
             NOTE_ID,
             CARD_ORD,
             CARD_NAME,
@@ -606,12 +618,12 @@ object FlashCardsContract {
         /**
          * MIME type used for a card.
          */
-        const val CONTENT_ITEM_TYPE = "vnd.android.cursor.item/vnd.com.ichi2.anki.card"
+        public const val CONTENT_ITEM_TYPE: String = "vnd.android.cursor.item/vnd.com.ichi2.anki.card"
 
         /**
          * MIME type used for cards.
          */
-        const val CONTENT_TYPE = "vnd.android.cursor.dir/vnd.com.ichi2.anki.card"
+        public const val CONTENT_TYPE: String = "vnd.android.cursor.dir/vnd.com.ichi2.anki.card"
     }
 
     /**
@@ -626,7 +638,7 @@ object FlashCardsContract {
      * --------------------------------------------------------------------------------------------------------------------
      * long  | deckID | The deck, that was last selected    | The deckID of the deck from which the scheduled cards should be pulled.
      *       |        | for reviewing by the user in the    |
-     *       |        | Deckchooser dialog of the App       |
+     *       |        | Deck chooser dialog of the App      |
      * --------------------------------------------------------------------------------------------------------------------
      * int   | limit  | 1                                   | The maximum number of cards (rows) that will be returned. In case
      *       |        |                                     | the deck has fewer scheduled cards, the returned number of cards will be
@@ -721,56 +733,58 @@ object FlashCardsContract {
      *      int updateCount = cr.update(reviewInfoUri, values, null, null);
      * ```
      */
-    object ReviewInfo {
-        val CONTENT_URI = Uri.withAppendedPath(AUTHORITY_URI, "schedule")
+    public object ReviewInfo {
+        @JvmField // required for Java API
+        public val CONTENT_URI: Uri = Uri.withAppendedPath(AUTHORITY_URI, "schedule")
 
         /**
          * This is the ID of the note that this card belongs to (i.e. [Note._ID]).
          */
-        const val NOTE_ID = "note_id"
+        public const val NOTE_ID: String = "note_id"
 
         /**
          * This is the ordinal of the card. A note has 1..n cards. The ordinal can also be used
          * to directly access a card as describe in the class description.
          */
-        const val CARD_ORD = "ord"
+        public const val CARD_ORD: String = "ord"
 
         /**
          * This is the number of ease modes. It can take a value between 2 and 4.
          */
-        const val BUTTON_COUNT = "button_count"
+        public const val BUTTON_COUNT: String = "button_count"
 
         /**
          * This is a JSONArray containing the next review times for all buttons.
          */
-        const val NEXT_REVIEW_TIMES = "next_review_times"
+        public const val NEXT_REVIEW_TIMES: String = "next_review_times"
 
         /**
          * The names of the media files in the question and answer
          */
-        const val MEDIA_FILES = "media_files"
+        public const val MEDIA_FILES: String = "media_files"
 
         /*
          * Ease of an answer. Is not set when requesting the scheduled cards.
          * Can take values of AbstractFlashcardViewer e.g. EASE_1
          */
-        const val EASE = "answer_ease"
+        public const val EASE: String = "answer_ease"
 
         /*
          * Time it took to answer the card (in ms)
          */
-        const val TIME_TAKEN = "time_taken"
+        public const val TIME_TAKEN: String = "time_taken"
 
         /**
          * Write-only field, allows burying of a card when set to 1
          */
-        const val BURY = "buried"
+        public const val BURY: String = "buried"
 
         /**
          * Write-only field, allows suspending of a card when set to 1
          */
-        const val SUSPEND = "suspended"
-        val DEFAULT_PROJECTION = arrayOf(
+        public const val SUSPEND: String = "suspended"
+        @JvmField // required for Java API
+        public val DEFAULT_PROJECTION: Array<String> = arrayOf(
             NOTE_ID,
             CARD_ORD,
             BUTTON_COUNT,
@@ -781,7 +795,7 @@ object FlashCardsContract {
         /**
          * MIME type used for ReviewInfo.
          */
-        const val CONTENT_TYPE = "vnd.android.cursor.dir/vnd.com.ichi2.anki.review_info"
+        public const val CONTENT_TYPE: String = "vnd.android.cursor.dir/vnd.com.ichi2.anki.review_info"
     }
 
     /**
@@ -876,42 +890,43 @@ object FlashCardsContract {
      *      cr.update(selectDeckUri, values, null, null);
      * ```
      */
-    object Deck {
+    public object Deck {
         @JvmField // required for Java API
-        val CONTENT_ALL_URI = Uri.withAppendedPath(AUTHORITY_URI, "decks")
+        public val CONTENT_ALL_URI: Uri = Uri.withAppendedPath(AUTHORITY_URI, "decks")
         @JvmField // required for Java API
-        val CONTENT_SELECTED_URI = Uri.withAppendedPath(AUTHORITY_URI, "selected_deck")
+        public val CONTENT_SELECTED_URI: Uri = Uri.withAppendedPath(AUTHORITY_URI, "selected_deck")
 
         /**
          * The name of the Deck
          */
-        const val DECK_NAME = "deck_name"
+        public const val DECK_NAME: String = "deck_name"
 
         /**
          * The unique identifier of the Deck
          */
-        const val DECK_ID = "deck_id"
+        public const val DECK_ID: String = "deck_id"
 
         /**
          * The number of cards in the Deck
          */
-        const val DECK_COUNTS = "deck_count"
+        public const val DECK_COUNTS: String = "deck_count"
 
         /**
          * The options of the Deck
          */
-        const val OPTIONS = "options"
+        public const val OPTIONS: String = "options"
 
         /**
          * 1 if dynamic (AKA filtered) deck
          */
-        const val DECK_DYN = "deck_dyn"
+        public const val DECK_DYN: String = "deck_dyn"
 
         /**
          * Deck description
          */
-        const val DECK_DESC = "deck_desc"
-        val DEFAULT_PROJECTION = arrayOf(
+        public const val DECK_DESC: String = "deck_desc"
+        @JvmField // required for Java API
+        public val DEFAULT_PROJECTION: Array<String> = arrayOf(
             DECK_NAME,
             DECK_ID,
             DECK_COUNTS,
@@ -923,7 +938,7 @@ object FlashCardsContract {
         /**
          * MIME type used for Deck.
          */
-        const val CONTENT_TYPE = "vnd.android.cursor.dir/vnd.com.ichi2.anki.deck"
+        public const val CONTENT_TYPE: String = "vnd.android.cursor.dir/vnd.com.ichi2.anki.deck"
     }
 
     /**
@@ -942,21 +957,21 @@ object FlashCardsContract {
      *      Uri insertedFile = cr.insert(AnkiMedia.CONTENT_URI, cv);
      * ```
      */
-    object AnkiMedia {
+    public object AnkiMedia {
         /**
          * Content Uri for the MEDIA row of the CardContentProvider
          */
         @JvmField // required for Java API
-        val CONTENT_URI = Uri.withAppendedPath(AUTHORITY_URI, "media")
+        public val CONTENT_URI: Uri = Uri.withAppendedPath(AUTHORITY_URI, "media")
 
         /**
          * Uri.toString() which points to the media file that is to be inserted.
          */
-        const val FILE_URI = "file_uri"
+        public const val FILE_URI: String = "file_uri"
 
         /**
          * The preferred name for the file that will be inserted/copied into collection.media
          */
-        const val PREFERRED_NAME = "preferred_name"
+        public const val PREFERRED_NAME: String = "preferred_name"
     }
 }

--- a/api/src/main/java/com/ichi2/anki/api/AddContentApi.kt
+++ b/api/src/main/java/com/ichi2/anki/api/AddContentApi.kt
@@ -726,8 +726,8 @@ public class AddContentApi(context: Context) {
     }
 
     public companion object {
-        public const val READ_WRITE_PERMISSION = FlashCardsContract.READ_WRITE_PERMISSION
-        public const val DEFAULT_DECK_ID = 1L
+        public const val READ_WRITE_PERMISSION: String = FlashCardsContract.READ_WRITE_PERMISSION
+        public const val DEFAULT_DECK_ID: Long = 1L
         private const val TEST_TAG = "PREVIEW_NOTE"
         private const val PROVIDER_SPEC_META_DATA_KEY = "com.ichi2.anki.provider.spec"
         private const val DEFAULT_PROVIDER_SPEC_VALUE = 1 // for when meta-data key does not exist


### PR DESCRIPTION
## Purpose / Description

Part of #12310.

This cleanup includes:

- fixing ide lint issues
- adding extra `@JvmField` annotations to replicate the initial static fields in java, the targets were `Uri`s and the projection arrays(without the annotations these would have ended in the final bytecode as private static field + getter method)
- as I said when I migrated the class, I enabled the [explicit api mode](https://kotlinlang.org/docs/whatsnew14.html#explicit-api-mode-for-library-authors) as this is a library project and I think would be a good addition going forward. I made the violations as warnings for now( to be able to suppress them for the other api classes) and fixed them for `FlashCardContract`. When we finish cleaning up the api module we should move from warning to strict.
This included specifying the visibility modifiers and the actual properties types(nothing to note here as we have only strings, not null Uris and not null arrays of not null strings)
- added some @ Suppress annotations for naming(_ID)  and properties not being used(I'm assuming not used but replicating upstream?)

## How Has This Been Tested?

Ran checks and tests.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
