### PR TITLE
Replace the title of the note-adding screen ("Add note") with "Add"

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
@@ -377,7 +377,7 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
         setNote(mEditorNote, FieldChangeType.onActivityCreation(shouldReplaceNewlines()))
         if (addNote) {
             mNoteTypeSpinner!!.onItemSelectedListener = SetNoteTypeListener()
-            setTitle(R.string.menu_add_note)
+            setTitle(R.string.menu_add)
             // set information transferred by intent
             var contents: String? = null
             val tags = intent.getStringArrayExtra(EXTRA_TAGS)


### PR DESCRIPTION
## Pull Request template

## Purpose / Description

The title of the note-adding screen should have already be replaced with "Add" as a conclusion of the discussion in #10853, but it is still "Add note".
![image](https://user-images.githubusercontent.com/10436072/188901915-d449b865-076f-4d1c-b2f7-4f595bb2c3d3.png)

## Fixes
fixes #12335



## How Has This Been Tested?

1. Build an APK file and install it in my device
2. Open the app
3. Tap the floating action button ("+")
4. Tap "Add"
5. Check if the title of the screen is changed
 
![image](https://user-images.githubusercontent.com/10436072/188901668-2503de12-eaa7-4d04-b526-e6dee7c19028.png)

## Learning (optional, can help others)
The counterpart screen of Anki Desktop
![image](https://user-images.githubusercontent.com/10436072/188903050-9fbe9bdd-76e1-4e36-b7ee-cdaa831774ad.png)

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
