### PR TITLE
docs: add NeedsTest for onCreateDialog

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckPickerContextMenu.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckPickerContextMenu.kt
@@ -27,6 +27,7 @@ import com.ichi2.anki.*
 import com.ichi2.anki.StudyOptionsFragment.StudyOptionsListener
 import com.ichi2.anki.analytics.AnalyticsDialogFragment
 import com.ichi2.anki.dialogs.customstudy.CustomStudyDialog
+import com.ichi2.annotations.NeedsTest
 import com.ichi2.libanki.Collection
 import com.ichi2.libanki.DeckId
 import com.ichi2.utils.BundleUtils.requireLong
@@ -47,6 +48,7 @@ class DeckPickerContextMenu(private val collection: Collection) : AnalyticsDialo
     /** The selected deck for the context menu */
     val deckId get() = requireArguments().requireLong("did")
 
+    @NeedsTest("Ensure clicking an item results in correct action executed. See: #11788/#11790")
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
         super.onCreate(savedInstanceState)
         val title = collection.decks.name(deckId)


### PR DESCRIPTION
NeedsTest for regression fixed in #11788

- Fixes #11790 - transforms to `NeedsTest` - better to not have individual issues to add tests to functionality as it unnecessarily cogs up GitHub

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
