### PR TITLE
[GSoC] Show Avg Ease in note mode

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidJsAPI.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidJsAPI.kt
@@ -463,7 +463,7 @@ open class AnkiDroidJsAPI(private val activity: AbstractFlashcardViewer) {
     fun ankiSearchCardWithCallback(query: String) {
         val cards = try {
             runBlocking {
-                searchForCards(query, SortOrder.UseCollectionOrdering())
+                searchForCards(query, SortOrder.UseCollectionOrdering(), true)
             }
         } catch (exc: Exception) {
             activity.webView!!.evaluateJavascript(

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -2289,14 +2289,17 @@ open class CardBrowser :
         private var mQa: Pair<String, String>? = null
         override var position: Int
 
-        constructor(id: Long, col: com.ichi2.libanki.Collection, position: Int) : super(col, id) {
+        private val inCardMode: Boolean
+        constructor(id: Long, col: com.ichi2.libanki.Collection, position: Int, inCardMode: Boolean) : super(col, id) {
             this.position = position
+            this.inCardMode = inCardMode
         }
 
         constructor(cache: CardCache, position: Int) : super(cache) {
             isLoaded = cache.isLoaded
             mQa = cache.mQa
             this.position = position
+            this.inCardMode = cache.inCardMode
         }
 
         /** clear all values except ID. */
@@ -2342,13 +2345,7 @@ open class CardBrowser :
                 Column.TAGS -> card.note().stringTags()
                 Column.CARD -> card.template().optString("name")
                 Column.DUE -> card.dueString
-                Column.EASE -> {
-                    if (card.type == Consts.CARD_TYPE_NEW) {
-                        AnkiDroidApp.instance.getString(R.string.card_browser_interval_new_card)
-                    } else {
-                        "${card.factor / 10}%"
-                    }
-                }
+                Column.EASE -> if (inCardMode) getEaseForCards() else getAvgEaseForNotes()
                 Column.CHANGED -> LanguageUtil.getShortDateFormatFromS(card.mod)
                 Column.CREATED -> LanguageUtil.getShortDateFormatFromMs(card.note().id)
                 Column.EDITED -> LanguageUtil.getShortDateFormatFromS(card.note().mod)
@@ -2369,6 +2366,24 @@ open class CardBrowser :
                     mQa!!.second
                 }
                 else -> null
+            }
+        }
+
+        private fun getEaseForCards(): String {
+            return if (card.type == Consts.CARD_TYPE_NEW) {
+                AnkiDroidApp.instance.getString(R.string.card_browser_interval_new_card)
+            } else {
+                "${card.factor / 10}%"
+            }
+        }
+
+        private fun getAvgEaseForNotes(): String {
+            val avgEase = card.avgEaseOfNote()
+
+            return if (avgEase == null) {
+                AnkiDroidApp.instance.getString(R.string.card_browser_interval_new_card)
+            } else {
+                "$avgEase%"
             }
         }
 
@@ -2702,12 +2717,15 @@ open class CardBrowser :
 suspend fun searchForCards(
     query: String,
     order: SortOrder,
-    inCardsMode: Boolean = true
+    inCardsMode: Boolean
 ): MutableList<CardBrowser.CardCache> {
     return withCol {
         (if (inCardsMode) findCards(query, order) else findOneCardByNote(query)).asSequence()
-            .mapIndexed { idx, cid ->
-                CardBrowser.CardCache(cid, col, idx)
-            }.toMutableList()
+            .toCardCache(col, inCardsMode)
+            .toMutableList()
     }
+}
+
+private fun Sequence<CardId>.toCardCache(col: com.ichi2.libanki.Collection, isInCardMode: Boolean): Sequence<CardBrowser.CardCache> {
+    return this.mapIndexed { idx, cid -> CardBrowser.CardCache(cid, col, idx, isInCardMode) }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/NoteService.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/NoteService.kt
@@ -28,9 +28,11 @@ import com.ichi2.anki.FieldEditText
 import com.ichi2.anki.multimediacard.IMultimediaEditableNote
 import com.ichi2.anki.multimediacard.fields.*
 import com.ichi2.anki.multimediacard.impl.MultimediaEditableNote
+import com.ichi2.libanki.Consts
 import com.ichi2.libanki.Note
 import com.ichi2.libanki.NoteTypeId
 import com.ichi2.libanki.exception.EmptyMediaException
+import com.ichi2.utils.CollectionUtils.average
 import com.ichi2.utils.JSONException
 import com.ichi2.utils.JSONObject
 import net.ankiweb.rsdroid.BackendFactory
@@ -196,6 +198,17 @@ object NoteService {
 
     fun isMarked(note: Note): Boolean {
         return note.hasTag("marked")
+    }
+
+    //  TODO: should make a direct SQL query to do this
+    /**
+     * returns the average ease of all the non-new cards in the note,
+     * or if all the cards in the note are new, returns null
+     */
+    fun avgEase(note: Note): Int? {
+        val nonNewCards = note.cards().filter { it.type != Consts.CARD_TYPE_NEW }
+
+        return nonNewCards.average { it.factor }?.let { it / 10 }?.toInt()
     }
 
     interface NoteField {

--- a/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.kt
@@ -486,7 +486,7 @@ open class CollectionTask<Progress, Result>(val task: TaskDelegateBase<Progress,
                 Timber.d("The search found %d cards", searchResult_.size)
                 var position = 0
                 for (cid in searchResult_) {
-                    val card = CardCache(cid, col, position++)
+                    val card = CardCache(cid, col, position++, true)
                     searchResult.add(card)
                 }
             } else {
@@ -500,7 +500,7 @@ open class CollectionTask<Progress, Result>(val task: TaskDelegateBase<Progress,
                 Timber.d("The search found %d notes", searchResult_.size)
                 var position = 0
                 for (nid in searchResult_) {
-                    val card = CardCache(Note(col, nid).firstCard().id, col, position++)
+                    val card = CardCache(Note(col, nid).firstCard().id, col, position++, false)
                     searchResult.add(card)
                 }
             }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Card.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Card.kt
@@ -23,6 +23,7 @@ import androidx.annotation.VisibleForTesting
 import com.ichi2.anki.AnkiDroidApp
 import com.ichi2.anki.CollectionHelper
 import com.ichi2.anki.R
+import com.ichi2.anki.servicelayer.NoteService.avgEase
 import com.ichi2.async.CancelListener
 import com.ichi2.libanki.Consts.CARD_QUEUE
 import com.ichi2.libanki.Consts.CARD_TYPE
@@ -458,6 +459,8 @@ open class Card : Cloneable {
         }
         return LanguageUtil.getShortDateFormatFromS(date)
     } // In Anki Desktop, a card with oDue <> 0 && oDid == 0 is not marked as dynamic.
+
+    fun avgEaseOfNote() = avgEase(note())
 
     /** Non libAnki  */
     val isInDynamicDeck: Boolean

--- a/AnkiDroid/src/main/java/com/ichi2/utils/CollectionUtils.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/CollectionUtils.kt
@@ -42,4 +42,12 @@ object CollectionUtils {
             }
         }
     }
+
+    /**
+     * Return the average of the elements in the iterable,
+     * or null if the iterable is empty.
+     */
+    fun <T> Iterable<T>.average(f: (T) -> Int): Double? {
+        return this.map(f).average().let { if (it.isNaN()) null else it }
+    }
 }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/services/NoteServiceTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/services/NoteServiceTest.kt
@@ -22,6 +22,7 @@ import com.ichi2.anki.multimediacard.fields.ImageField
 import com.ichi2.anki.multimediacard.fields.MediaClipField
 import com.ichi2.anki.servicelayer.NoteService
 import com.ichi2.libanki.Collection
+import com.ichi2.libanki.Consts
 import com.ichi2.libanki.Model
 import com.ichi2.libanki.Note
 import com.ichi2.testutils.createTransientFile
@@ -239,5 +240,35 @@ class NoteServiceTest : RobolectricTest() {
         NoteService.importMediaToDirectory(testCol!!, field)
 
         assertThat("Image temporary file should have been deleted after importing", file, not(anExistingFile()))
+    }
+
+    @Test
+    fun testAvgEase() {
+        // basic case: no cards are new
+        val note = addNoteUsingModelName("Cloze", "{{c1::Hello}}{{c2::World}}{{c3::foo}}{{c4::bar}}", "extra")
+        // factor for cards: 3000, 1500, 1000, 750
+        for ((i, card) in note.cards().withIndex()) {
+            card.type = Consts.CARD_TYPE_REV
+            card.factor = 3000 / (i + 1)
+            card.flush()
+        }
+        // avg ease = (3000/10 + 1500/10 + 100/10 + 750/10) / 4 = [156.25] = 156
+        assertEquals(156, NoteService.avgEase(note))
+
+        // test case: one card is new
+        note.cards()[2].apply {
+            type = Consts.CARD_TYPE_NEW
+            flush()
+        }
+        // avg ease = (3000/10 + 1500/10 + 750/10) / 3 = [175] = 175
+        assertEquals(175, NoteService.avgEase(note))
+
+        // test case: all cards are new
+        for (card in note.cards()) {
+            card.type = Consts.CARD_TYPE_NEW
+            card.flush()
+        }
+        // no cards are rev, so avg ease cannot be calculated
+        assertEquals(null, NoteService.avgEase(note))
     }
 }


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
Follow up to #12035. User can now switch to showing just one card per note, but, the columns still show data for the card alone. As mentioned in the Anki Docs [here](https://docs.ankiweb.net/browsing.html#columns), a few columns display slightly different data in notes mode. This PR tackles displaying avg ease.

## Approach
Create a function for a `Card` to return the average ease of its note, and if `inCardsMode` is not true, (i.e. browser is in notes mode), we return the avg ease to the column header.

## How Has This Been Tested?

Manually on mobile device, Unit test added as well

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
