### PR TITLE
fix: Replace the name of note-adding shortcut ("Add note") with "Add"

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/NavigationDrawerActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NavigationDrawerActivity.kt
@@ -434,14 +434,14 @@ abstract class NavigationDrawerActivity :
                 .setIntent(intentReviewCards)
                 .build()
 
-            // Add Note Shortcut
+            // Add Shortcut
             val intentAddNote = Intent(context, NoteEditor::class.java)
             intentAddNote.action = Intent.ACTION_VIEW
             intentAddNote.flags = Intent.FLAG_ACTIVITY_CLEAR_TASK
             intentAddNote.putExtra(NoteEditor.EXTRA_CALLER, NoteEditor.CALLER_DECKPICKER)
             val NoteEditorShortcut = ShortcutInfo.Builder(context, "noteEditorShortcutId")
-                .setShortLabel(context.getString(R.string.menu_add_note))
-                .setLongLabel(context.getString(R.string.menu_add_note))
+                .setShortLabel(context.getString(R.string.menu_add))
+                .setLongLabel(context.getString(R.string.menu_add))
                 .setIcon(Icon.createWithResource(context, R.drawable.ankidroid_logo))
                 .setIntent(intentAddNote)
                 .build()


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
The name of the note-adding shortcut should have already be replaced with "Add" as a conclusion of the discussion in https://github.com/ankidroid/Anki-Android/pull/10853, but it is still "Add note".

## Fixes
fixes #12347

## Approach
- Replace the strings of "menu_add_note" with "menu_add" on NavigationDrawerActivity.kt
- Replace their comment ("Add Note Shortcut") with "Add Shortcut"

## How Has This Been Tested?

1. Build an APK file and install it on my physical device
2. Open the app
3. [GET STARTED]>[OK]>[ALLOW]
4. Close the app
5. Long press the app's icon (then, the app's shortcuts are shown)
6. Check if the name of the note-adding shortcut has been changed
![image](https://user-images.githubusercontent.com/10436072/189182167-df068e83-9b8d-4a2f-84b3-cdae8bf37015.png)



## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
