### PR TITLE
Adding kotlin-test-junit to androidTestImplementation

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -349,6 +349,7 @@ dependencies {
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'
     androidTestImplementation 'androidx.test:rules:1.4.0'
     androidTestImplementation "org.jetbrains.kotlin:kotlin-test:$kotlin_version"
+    androidTestImplementation "org.jetbrains.kotlin:kotlin-test-junit:$kotlin_version"
 }
 
 android {


### PR DESCRIPTION
Following https://stackoverflow.com/a/55218573/414269 It ensures the IDE don't show error on `import kotlin.test.junit.JUnitAsserter.assertNotNull`