### PR TITLE
Make custom sync server preferences easier to understand

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/SettingsFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/SettingsFragment.kt
@@ -19,14 +19,13 @@ import android.content.Context
 import android.content.Intent
 import android.os.Bundle
 import androidx.annotation.XmlRes
+import androidx.core.os.bundleOf
 import androidx.preference.Preference
 import androidx.preference.PreferenceFragmentCompat
 import com.ichi2.anki.CollectionHelper
 import com.ichi2.anki.analytics.UsageAnalytics
 import com.ichi2.libanki.Collection
-import com.ichi2.preferences.IncrementerNumberRangePreferenceCompat
-import com.ichi2.preferences.NumberRangePreferenceCompat
-import com.ichi2.preferences.SeekBarPreferenceCompat
+import com.ichi2.preferences.DialogFragmentProvider
 import kotlin.reflect.KClass
 import kotlin.reflect.jvm.jvmName
 
@@ -64,14 +63,9 @@ abstract class SettingsFragment : PreferenceFragmentCompat() {
     // `getTargetFragment()`, which throws if `setTargetFragment()` isn't used before.
     // While this isn't fixed on upstream, suppress the deprecation warning
     override fun onDisplayPreferenceDialog(preference: Preference) {
-        val dialogFragment = when (preference) {
-            is IncrementerNumberRangePreferenceCompat -> IncrementerNumberRangePreferenceCompat.IncrementerNumberRangeDialogFragmentCompat.newInstance(preference.getKey())
-            is NumberRangePreferenceCompat -> NumberRangePreferenceCompat.NumberRangeDialogFragmentCompat.newInstance(preference.getKey())
-            is SeekBarPreferenceCompat -> SeekBarPreferenceCompat.SeekBarDialogFragmentCompat.newInstance(preference.getKey())
-            else -> null
-        }
-
-        if (dialogFragment != null) {
+        if (preference is DialogFragmentProvider) {
+            val dialogFragment = preference.makeDialogFragment()
+            dialogFragment.arguments = bundleOf("key" to preference.key)
             dialogFragment.setTargetFragment(this, 0)
             dialogFragment.show(parentFragmentManager, "androidx.preference.PreferenceFragment.DIALOG")
         } else {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/SyncSettingsFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/SyncSettingsFragment.kt
@@ -57,10 +57,17 @@ class SyncSettingsFragment : SettingsFragment() {
         // Custom sync server
         requirePreference<Preference>(R.string.custom_sync_server_key).setSummaryProvider {
             val preferences = AnkiDroidApp.getSharedPrefs(requireContext())
-            if (!CustomSyncServer.isEnabled(preferences)) {
-                getString(R.string.disabled)
+            val collectionSyncUrl = CustomSyncServer.getCollectionSyncUrlIfSetAndEnabledOrNull(preferences)
+            val mediaSyncUrl = CustomSyncServer.getMediaSyncUrlIfSetAndEnabledOrNull(preferences)
+
+            if (collectionSyncUrl == null && mediaSyncUrl == null) {
+                getString(R.string.custom_sync_server_summary_none_of_the_two_servers_used)
             } else {
-                CustomSyncServer.getCollectionSyncUrl(preferences) ?: ""
+                getString(
+                    R.string.custom_sync_server_summary_both_or_either_of_the_two_servers_used,
+                    collectionSyncUrl ?: getString(R.string.custom_sync_server_summary_placeholder_default),
+                    mediaSyncUrl ?: getString(R.string.custom_sync_server_summary_placeholder_default)
+                )
             }
         }
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/PreferenceUpgradeService.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/PreferenceUpgradeService.kt
@@ -87,6 +87,7 @@ object PreferenceUpgradeService {
                 yield(UpgradeGesturesToControls())
                 yield(UpgradeDayAndNightThemes())
                 yield(UpgradeCustomCollectionSyncUrl())
+                yield(UpgradeCustomSyncServerEnabled())
             }
 
             /** Returns a list of preference upgrade classes which have not been applied */
@@ -386,6 +387,26 @@ object PreferenceUpgradeService {
                 preferences.edit {
                     remove(RemovedPreferences.PREFERENCE_CUSTOM_SYNC_BASE)
                     if (newUrl != null) putString(CustomSyncServer.PREFERENCE_CUSTOM_COLLECTION_SYNC_URL, newUrl)
+                }
+            }
+        }
+
+        internal class UpgradeCustomSyncServerEnabled : PreferenceUpgrade(8) {
+            override fun upgrade(preferences: SharedPreferences) {
+                val customSyncServerEnabled = preferences.getBoolean(RemovedPreferences.PREFERENCE_ENABLE_CUSTOM_SYNC_SERVER, false)
+                val customCollectionSyncUrl = preferences.getString(CustomSyncServer.PREFERENCE_CUSTOM_COLLECTION_SYNC_URL, null)
+                val customMediaSyncUrl = preferences.getString(CustomSyncServer.PREFERENCE_CUSTOM_MEDIA_SYNC_URL, null)
+
+                preferences.edit {
+                    remove(RemovedPreferences.PREFERENCE_ENABLE_CUSTOM_SYNC_SERVER)
+                    putBoolean(
+                        CustomSyncServer.PREFERENCE_CUSTOM_COLLECTION_SYNC_SERVER_ENABLED,
+                        customSyncServerEnabled && !customCollectionSyncUrl.isNullOrEmpty()
+                    )
+                    putBoolean(
+                        CustomSyncServer.PREFERENCE_CUSTOM_MEDIA_SYNC_SERVER_ENABLED,
+                        customSyncServerEnabled && !customMediaSyncUrl.isNullOrEmpty()
+                    )
                 }
             }
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/PreferenceUpgradeService.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/PreferenceUpgradeService.kt
@@ -192,8 +192,8 @@ object PreferenceUpgradeService {
          */
         internal class RemoveLegacyMediaSyncUrl : PreferenceUpgrade(3) {
             override fun upgrade(preferences: SharedPreferences) {
-                val mediaSyncUrl = CustomSyncServer.getMediaSyncUrl(preferences) ?: return
-                if (mediaSyncUrl.startsWith("https://msync.ankiweb.net")) {
+                val mediaSyncUrl = preferences.getString(CustomSyncServer.PREFERENCE_CUSTOM_MEDIA_SYNC_URL, null)
+                if (mediaSyncUrl?.startsWith("https://msync.ankiweb.net") == true) {
                     preferences.edit { remove(CustomSyncServer.PREFERENCE_CUSTOM_MEDIA_SYNC_URL) }
                 }
             }
@@ -394,4 +394,5 @@ object PreferenceUpgradeService {
 
 object RemovedPreferences {
     const val PREFERENCE_CUSTOM_SYNC_BASE = "syncBaseUrl"
+    const val PREFERENCE_ENABLE_CUSTOM_SYNC_SERVER = "useCustomSyncServer"
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/web/CustomSyncServer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/web/CustomSyncServer.kt
@@ -20,36 +20,31 @@ import android.content.Context
 import android.content.SharedPreferences
 import android.system.Os
 import com.ichi2.anki.AnkiDroidApp
+import com.ichi2.preferences.VersatileTextWithASwitchPreference
 import net.ankiweb.rsdroid.BackendFactory
 import timber.log.Timber
 
 object CustomSyncServer {
     const val PREFERENCE_CUSTOM_COLLECTION_SYNC_URL = "customCollectionSyncUrl"
     const val PREFERENCE_CUSTOM_MEDIA_SYNC_URL = "syncMediaUrl"
-    const val PREFERENCE_ENABLE_CUSTOM_SYNC_SERVER = "useCustomSyncServer"
 
-    fun getCollectionSyncUrl(preferences: SharedPreferences): String? {
-        return preferences.getString(PREFERENCE_CUSTOM_COLLECTION_SYNC_URL, null)
-    }
-
-    fun getMediaSyncUrl(preferences: SharedPreferences): String? {
-        return preferences.getString(PREFERENCE_CUSTOM_MEDIA_SYNC_URL, null)
-    }
+    const val PREFERENCE_CUSTOM_COLLECTION_SYNC_SERVER_ENABLED =
+        PREFERENCE_CUSTOM_COLLECTION_SYNC_URL + VersatileTextWithASwitchPreference.SWITCH_SUFFIX
+    const val PREFERENCE_CUSTOM_MEDIA_SYNC_SERVER_ENABLED =
+        PREFERENCE_CUSTOM_MEDIA_SYNC_URL + VersatileTextWithASwitchPreference.SWITCH_SUFFIX
 
     fun getCollectionSyncUrlIfSetAndEnabledOrNull(preferences: SharedPreferences): String? {
-        if (!isEnabled(preferences)) return null
-        val collectionSyncUrl = getCollectionSyncUrl(preferences)
+        val enabled = preferences.getBoolean(PREFERENCE_CUSTOM_COLLECTION_SYNC_SERVER_ENABLED, false)
+        if (!enabled) return null
+        val collectionSyncUrl = preferences.getString(PREFERENCE_CUSTOM_COLLECTION_SYNC_URL, null)
         return if (collectionSyncUrl.isNullOrEmpty()) null else collectionSyncUrl
     }
 
     fun getMediaSyncUrlIfSetAndEnabledOrNull(preferences: SharedPreferences): String? {
-        if (!isEnabled(preferences)) return null
-        val mediaSyncUrl = getMediaSyncUrl(preferences)
+        val enabled = preferences.getBoolean(PREFERENCE_CUSTOM_MEDIA_SYNC_SERVER_ENABLED, false)
+        if (!enabled) return null
+        val mediaSyncUrl = preferences.getString(PREFERENCE_CUSTOM_MEDIA_SYNC_URL, null)
         return if (mediaSyncUrl.isNullOrEmpty()) null else mediaSyncUrl
-    }
-
-    fun isEnabled(userPreferences: SharedPreferences): Boolean {
-        return userPreferences.getBoolean(PREFERENCE_ENABLE_CUSTOM_SYNC_SERVER, false)
     }
 
     fun handleSyncServerPreferenceChange(context: Context) {

--- a/AnkiDroid/src/main/java/com/ichi2/preferences/HtmlHelpPreference.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/preferences/HtmlHelpPreference.kt
@@ -1,0 +1,68 @@
+/*
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.preferences
+
+import android.content.Context
+import android.text.method.LinkMovementMethod
+import android.util.AttributeSet
+import android.widget.TextView
+import androidx.core.text.parseAsHtml
+import androidx.preference.Preference
+import androidx.preference.PreferenceViewHolder
+import com.ichi2.anki.R
+
+/**
+ * Non-clickable preference that shows help text.
+ *
+ * The summary is parsed as a format string containing HTML,
+ * and may contain up to three format specifiers as understood by `Sting.format()`,
+ * arguments for which can be specified using XML attributes such as `app:substitution1`.
+ *
+ *     <com.ichi2.preferences.HtmlHelpPreference
+ *         android:summary="@string/format_string"
+ *         app:substitution1="@string/substitution1"
+ *         />
+ *
+ * The summary HTML can contain all tags that TextViews can display,
+ * including new lines and links. Raw HTML can be entered using the CDATA tag, e.g.
+ *
+ *     <string name="format_string"><![CDATA[<b>Hello, %s</b>]]></string>
+ */
+class HtmlHelpPreference(context: Context, attrs: AttributeSet?) : Preference(context, attrs) {
+    init {
+        isSelectable = false
+        isPersistent = false
+    }
+
+    private val substitutions = context.usingStyledAttributes(attrs, R.styleable.HtmlHelpPreference) {
+        arrayOf(
+            getString(R.styleable.HtmlHelpPreference_substitution1),
+            getString(R.styleable.HtmlHelpPreference_substitution2),
+            getString(R.styleable.HtmlHelpPreference_substitution3),
+        )
+    }
+
+    override fun getSummary() = super.getSummary()
+        .toString()
+        .format(*substitutions)
+        .parseAsHtml()
+
+    override fun onBindViewHolder(holder: PreferenceViewHolder) {
+        super.onBindViewHolder(holder)
+        val summary = holder.findViewById(android.R.id.summary) as TextView
+        summary.movementMethod = LinkMovementMethod.getInstance()
+        summary.maxHeight = Int.MAX_VALUE
+    }
+}

--- a/AnkiDroid/src/main/java/com/ichi2/preferences/IncrementerNumberRangePreferenceCompat.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/preferences/IncrementerNumberRangePreferenceCompat.kt
@@ -18,7 +18,6 @@
 package com.ichi2.preferences
 
 import android.content.Context
-import android.os.Bundle
 import android.util.AttributeSet
 import android.view.Gravity
 import android.view.View
@@ -29,7 +28,7 @@ import android.widget.LinearLayout
 import com.ichi2.anki.R
 
 /** Marker class to be used in preferences */
-class IncrementerNumberRangePreferenceCompat : NumberRangePreferenceCompat {
+class IncrementerNumberRangePreferenceCompat : NumberRangePreferenceCompat, DialogFragmentProvider {
     constructor(context: Context, attrs: AttributeSet?, defStyleAttr: Int, defStyleRes: Int) : super(context, attrs, defStyleAttr, defStyleRes)
     constructor(context: Context, attrs: AttributeSet?, defStyleAttr: Int) : super(context, attrs, defStyleAttr)
     constructor(context: Context, attrs: AttributeSet?) : super(context, attrs)
@@ -115,15 +114,7 @@ class IncrementerNumberRangePreferenceCompat : NumberRangePreferenceCompat {
             mLastValidEntry = numberRangePreference.getValidatedRangeFromInt(value)
             editText.setText(mLastValidEntry.toString())
         }
-
-        companion object {
-            fun newInstance(key: String?): IncrementerNumberRangeDialogFragmentCompat {
-                val fragment = IncrementerNumberRangeDialogFragmentCompat()
-                val b = Bundle(1)
-                b.putString(ARG_KEY, key)
-                fragment.arguments = b
-                return fragment
-            }
-        }
     }
+
+    override fun makeDialogFragment() = IncrementerNumberRangeDialogFragmentCompat()
 }

--- a/AnkiDroid/src/main/java/com/ichi2/preferences/NumberRangePreferenceCompat.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/preferences/NumberRangePreferenceCompat.kt
@@ -18,7 +18,6 @@
 package com.ichi2.preferences
 
 import android.content.Context
-import android.os.Bundle
 import android.text.InputFilter
 import android.text.InputType
 import android.text.TextUtils
@@ -41,7 +40,7 @@ constructor(
     attrs: AttributeSet? = null,
     defStyleAttr: Int = R.attr.editTextPreferenceStyle,
     defStyleRes: Int = R.style.Preference_DialogPreference_EditTextPreference
-) : EditTextPreference(context, attrs, defStyleAttr, defStyleRes) {
+) : EditTextPreference(context, attrs, defStyleAttr, defStyleRes), DialogFragmentProvider {
 
     var defaultValue: String? = null
 
@@ -189,15 +188,7 @@ constructor(
                 numberRangePreference.setValue(newValue)
             }
         }
-
-        companion object {
-            fun newInstance(key: String?): NumberRangeDialogFragmentCompat {
-                val fragment = NumberRangeDialogFragmentCompat()
-                val b = Bundle(1)
-                b.putString(ARG_KEY, key)
-                fragment.arguments = b
-                return fragment
-            }
-        }
     }
+
+    override fun makeDialogFragment() = NumberRangeDialogFragmentCompat()
 }

--- a/AnkiDroid/src/main/java/com/ichi2/preferences/PreferenceUtil.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/preferences/PreferenceUtil.kt
@@ -19,9 +19,28 @@ import android.content.res.TypedArray
 import android.util.AttributeSet
 import androidx.annotation.AttrRes
 import androidx.annotation.StyleRes
+import androidx.fragment.app.DialogFragment
+import androidx.fragment.app.Fragment
+import androidx.preference.PreferenceFragmentCompat
 import kotlin.contracts.ExperimentalContracts
 import kotlin.contracts.InvocationKind
 import kotlin.contracts.contract
+
+/**
+ * By implementing this interface, a preference can specify which dialog fragment is opened on click.
+ * The library does this in a slightly roundabout way, requiring that
+ * a third party is aware of all the combinations of preferences and their dialogs;
+ * see [PreferenceFragmentCompat.onDisplayPreferenceDialog].
+ */
+interface DialogFragmentProvider {
+
+    /**
+     * @return A DialogFragment to show.
+     *   The dialog must have a zero-parameter constructor.
+     *   Any arguments set via [Fragment.setArguments] may get overridden.
+     */
+    fun makeDialogFragment(): DialogFragment
+}
 
 /**
  * Run a [block] on a [TypedArray] receiver that is recycled at the end.

--- a/AnkiDroid/src/main/java/com/ichi2/preferences/PreferenceUtil.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/preferences/PreferenceUtil.kt
@@ -1,0 +1,45 @@
+/*
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.preferences
+
+import android.content.Context
+import android.content.res.TypedArray
+import android.util.AttributeSet
+import androidx.annotation.AttrRes
+import androidx.annotation.StyleRes
+import kotlin.contracts.ExperimentalContracts
+import kotlin.contracts.InvocationKind
+import kotlin.contracts.contract
+
+/**
+ * Run a [block] on a [TypedArray] receiver that is recycled at the end.
+ * @return The return value of the block.
+ *
+ * @see android.content.res.Resources.Theme.obtainStyledAttributes
+ * @see androidx.core.content.withStyledAttributes
+ */
+@OptIn(ExperimentalContracts::class)
+inline fun <T> Context.usingStyledAttributes(
+    set: AttributeSet?,
+    attrs: IntArray,
+    @AttrRes defStyleAttr: Int = 0,
+    @StyleRes defStyleRes: Int = 0,
+    block: TypedArray.() -> T
+): T {
+    contract { callsInPlace(block, InvocationKind.EXACTLY_ONCE) }
+
+    val typedArray = obtainStyledAttributes(set, attrs, defStyleAttr, defStyleRes)
+    return typedArray.block().also { typedArray.recycle() }
+}

--- a/AnkiDroid/src/main/java/com/ichi2/preferences/SeekBarPreferenceCompat.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/preferences/SeekBarPreferenceCompat.kt
@@ -37,7 +37,6 @@ import android.widget.TextView
 import androidx.annotation.StringRes
 import androidx.appcompat.app.AlertDialog
 import androidx.core.content.withStyledAttributes
-import androidx.core.os.bundleOf
 import androidx.preference.DialogPreference
 import androidx.preference.PreferenceDialogFragmentCompat
 import com.ichi2.anki.AnkiDroidApp
@@ -51,7 +50,7 @@ constructor(
     attrs: AttributeSet? = null,
     defStyleAttr: Int = R.attr.dialogPreferenceStyle,
     defStyleRes: Int = R.style.Preference_DialogPreference
-) : DialogPreference(context, attrs, defStyleAttr, defStyleRes) {
+) : DialogPreference(context, attrs, defStyleAttr, defStyleRes), DialogFragmentProvider {
 
     private var suffix: String
     private var default: Int
@@ -262,13 +261,7 @@ constructor(
                 LinearLayout.LayoutParams.WRAP_CONTENT, weight
             )
         }
-
-        companion object {
-            fun newInstance(key: String): SeekBarDialogFragmentCompat {
-                return SeekBarDialogFragmentCompat().apply {
-                    arguments = bundleOf(ARG_KEY to key)
-                }
-            }
-        }
     }
+
+    override fun makeDialogFragment() = SeekBarDialogFragmentCompat()
 }

--- a/AnkiDroid/src/main/java/com/ichi2/preferences/VersatileTextPreference.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/preferences/VersatileTextPreference.kt
@@ -1,0 +1,85 @@
+/*
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.preferences
+
+import android.content.Context
+import android.content.DialogInterface
+import android.util.AttributeSet
+import android.view.View
+import android.widget.EditText
+import androidx.appcompat.app.AlertDialog
+import androidx.appcompat.widget.AppCompatEditText
+import androidx.core.widget.addTextChangedListener
+import androidx.preference.EditTextPreference
+import androidx.preference.EditTextPreferenceDialogFragmentCompat
+import kotlin.jvm.Throws
+
+/**
+ * A drop-in alternative to [EditTextPreference] with some extra functionality.
+ *
+ *   * It supports changing input type via `android:inputType` XML attribute,
+ *     which can help the keyboard app with choosing a more suitable keyboard layout.
+ *     For the list of available input types, see [TextView.getInputType].
+ *
+ *   * If [continuousValidator] is set, the dialog uses it to prevent user
+ *     from entering invalid data. On each text change, the validator is run;
+ *     if it throws, the Ok button gets disabled.
+ */
+open class VersatileTextPreference(context: Context, attrs: AttributeSet?) :
+    EditTextPreference(context, attrs), DialogFragmentProvider {
+
+    fun interface Validator {
+        @Throws(Exception::class) fun validate(value: String)
+    }
+
+    val referenceEditText = AppCompatEditText(context, attrs)
+
+    var continuousValidator: Validator? = null
+
+    override fun makeDialogFragment() = VersatileTextPreferenceDialogFragment()
+}
+
+open class VersatileTextPreferenceDialogFragment : EditTextPreferenceDialogFragmentCompat() {
+
+    private val versatileTextPreference get() = preference as VersatileTextPreference
+
+    protected lateinit var editText: EditText
+
+    // This changes input type first, as it resets the cursor,
+    // And only then calls super, which sets up text and moves the cursor to end.
+    //
+    // Positive button isn't present in a dialog until it is shown, which happens around onStart;
+    // for simplicity, obtain it in the listener itself.
+    override fun onBindDialogView(contentView: View) {
+        editText = contentView.findViewById(android.R.id.edit)!!
+        editText.inputType = versatileTextPreference.referenceEditText.inputType
+
+        super.onBindDialogView(contentView)
+
+        versatileTextPreference.continuousValidator?.let { validator ->
+            editText.addTextChangedListener(afterTextChanged = {
+                val alertDialog = dialog as AlertDialog
+                val positiveButton = alertDialog.getButton(DialogInterface.BUTTON_POSITIVE)
+
+                positiveButton?.isEnabled = try {
+                    validator.validate(editText.text.toString())
+                    true
+                } catch (e: Exception) {
+                    false
+                }
+            })
+        }
+    }
+}

--- a/AnkiDroid/src/main/java/com/ichi2/preferences/VersatileTextWithASwitchPreference.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/preferences/VersatileTextWithASwitchPreference.kt
@@ -1,0 +1,100 @@
+/*
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.preferences
+
+import android.content.Context
+import android.util.AttributeSet
+import androidx.appcompat.widget.SwitchCompat
+import androidx.core.content.edit
+import androidx.preference.EditTextPreference
+import androidx.preference.PreferenceViewHolder
+import com.ichi2.anki.R
+
+/**
+ * A combination of an EditTextPreference and a SwitchPreference.
+ * It mostly looks like a SwitchPreference, but the switch and the title can be clicked separately.
+ * If some text is set, it is possible to have the switch either of on off.
+ * However, if text is null or empty, the switch can only be in the off state.
+ *
+ * The text value is stored with the key of the preference.
+ * The key of the switch is suffixed with [SWITCH_SUFFIX].
+ *
+ * Notes on behavior:
+ *   * If text is present, tapping on the switch toggles it.
+ *   * If text is empty, tapping on the switch will open the dialog, as if the title was tapped.
+ *   * If the dialog is closed with Cancel, no changes happen.
+ *   * If the dialog is closed with Ok, and text is present, the switch will be set to on.
+ *   * If the dialog is closed with Ok, and text is empty, the switch will be set to off.
+ *
+ * The preference inherits from [VersatileTextPreference] and supports any attributes it does,
+ * including the regular [EditTextPreference] attributes.
+ */
+class VersatileTextWithASwitchPreference(context: Context, attrs: AttributeSet?) :
+    VersatileTextPreference(context, attrs), DialogFragmentProvider {
+
+    init { widgetLayoutResource = R.layout.preference_widget_switch_with_separator }
+
+    private val preferences get() = sharedPreferences!!
+
+    private val switchKey get() = key + SWITCH_SUFFIX
+
+    private val canBeSwitchedOn get() = !text.isNullOrEmpty()
+
+    // * If there is no text, we make the switch not focusable and not clickable.
+    //   This is exactly how SwitchPreference sets up its widget;
+    //   if you tap on the switch, it will behave as if you tapped on the preference itself.
+    // * If there is text, the switch can be tapped separately.
+    override fun onBindViewHolder(holder: PreferenceViewHolder) {
+        super.onBindViewHolder(holder)
+
+        val switch = holder.findViewById(R.id.switch_widget) as SwitchCompat
+
+        switch.isFocusable = canBeSwitchedOn
+        switch.isClickable = canBeSwitchedOn
+
+        switch.isChecked = preferences.getBoolean(switchKey, false)
+
+        switch.setOnCheckedChangeListener { _, checked ->
+            preferences.edit { putBoolean(switchKey, checked) }
+        }
+    }
+
+    fun onDialogClosedAndNewTextSet() {
+        preferences.edit { putBoolean(switchKey, canBeSwitchedOn) }
+    }
+
+    override fun makeDialogFragment() = VersatileTextWithASwitchPreferenceDialogFragment()
+
+    companion object {
+        const val SWITCH_SUFFIX = "_switch"
+    }
+}
+
+class VersatileTextWithASwitchPreferenceDialogFragment : VersatileTextPreferenceDialogFragment() {
+
+    // This replicates what the overridden method does, which is needed as we want to catch
+    // the event when the Ok button was pressed and the change listener approved the new value.
+    override fun onDialogClosed(positiveResult: Boolean) {
+        if (positiveResult) {
+            val preference = preference as VersatileTextWithASwitchPreference
+            val newText = editText.text.toString()
+
+            if (preference.callChangeListener(newText)) {
+                preference.text = newText
+                preference.onDialogClosedAndNewTextSet()
+            }
+        }
+    }
+}

--- a/AnkiDroid/src/main/res/layout/preference_widget_switch_with_separator.xml
+++ b/AnkiDroid/src/main/res/layout/preference_widget_switch_with_separator.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:orientation="horizontal"
+    >
+
+    <View
+        android:layout_width="1dp"
+        android:layout_height="match_parent"
+        android:background="#66888888"
+        android:layout_marginVertical="16dp"
+        />
+
+    <androidx.appcompat.widget.SwitchCompat
+        android:id="@+id/switch_widget"
+        android:layout_width="wrap_content"
+        android:layout_height="match_parent"
+        android:paddingStart="16dp"
+        android:background="@null"
+        />
+</LinearLayout>

--- a/AnkiDroid/src/main/res/values/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values/10-preferences.xml
@@ -206,6 +206,19 @@
     <string name="advanced_forecast_stats_mc_n_iterations_title" maxLength="41">Number of iterations of the simulation</string>
     <!-- Custom sync server settings -->
     <string name="custom_sync_server_title" maxLength="41">Custom sync server</string>
+    <string name="custom_sync_server_help"><![CDATA[
+        As an alternative to synchronizing with AnkiWeb,
+        you may use your own servers for synchronization.
+        You may specify either collection or media server, or both.
+        If not set, the default AnkiWeb servers will be used instead.
+        For example, you could use the sync server built into Anki
+        Desktop to sync the collection when you only have a local network,
+        and AnkiWeb to sync media when you have general internet access.
+        <a href="%s">Learn more</a>
+        <br>
+        <br>Note: unlike in previous AnkiDroid versions,
+        you must specify the full custom sync URL,
+        for example: https://example.com:8080/sync/.]]></string>
     <string name="custom_sync_server_enable_title" maxLength="41">Use custom sync server</string>
     <string name="custom_sync_server_enable_summary">If you don\'t want to use the proprietary AnkiWeb service you can specify an alternative server here</string>
     <string name="custom_sync_server_base_url_title" maxLength="41">Sync url</string>

--- a/AnkiDroid/src/main/res/values/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values/10-preferences.xml
@@ -206,6 +206,16 @@
     <string name="advanced_forecast_stats_mc_n_iterations_title" maxLength="41">Number of iterations of the simulation</string>
     <!-- Custom sync server settings -->
     <string name="custom_sync_server_title" maxLength="41">Custom sync server</string>
+    <string name="custom_sync_server_summary_none_of_the_two_servers_used"
+        comment="This summary is shown when neither of the two custom sync servers are used,
+        which is the default.">Not used</string>
+    <string name="custom_sync_server_summary_both_or_either_of_the_two_servers_used"
+        comment="This summary is shown when either or both custom sync servers are used.
+        The placeholders read either “default” or the custom URL.">Collection: %1$s\nMedia: %2$s</string>
+    <string name="custom_sync_server_summary_placeholder_default"
+        comment="This is shown in Custom sync server summary when either of the two sync servers
+        is not used. E.g. “Collection: default” would mean that the default server,
+        that is AnkiWeb, will be used for synchronization.">default</string>
     <string name="custom_sync_server_help"><![CDATA[
         As an alternative to synchronizing with AnkiWeb,
         you may use your own servers for synchronization.
@@ -219,12 +229,8 @@
         <br>Note: unlike in previous AnkiDroid versions,
         you must specify the full custom sync URL,
         for example: https://example.com:8080/sync/.]]></string>
-    <string name="custom_sync_server_enable_title" maxLength="41">Use custom sync server</string>
-    <string name="custom_sync_server_enable_summary">If you don\'t want to use the proprietary AnkiWeb service you can specify an alternative server here</string>
     <string name="custom_sync_server_base_url_title" maxLength="41">Sync url</string>
-    <string name="custom_sync_server_base_url_invalid">Sync url invalid</string>
     <string name="custom_sync_server_media_url_title" maxLength="41">Media sync url</string>
-    <string name="custom_sync_server_media_url_invalid">Media sync url invalid</string>
     <!-- Key Bindings -->
     <string name="keyboard">Keyboard</string>
     <string name="bluetooth">Bluetooth</string>

--- a/AnkiDroid/src/main/res/values/attrs.xml
+++ b/AnkiDroid/src/main/res/values/attrs.xml
@@ -42,6 +42,12 @@
         <attr name="summaryFormat" format="string"/>
     </declare-styleable>
 
+    <declare-styleable name="HtmlHelpPreference">
+        <attr name="substitution1" format="string" />
+        <attr name="substitution2" format="string" />
+        <attr name="substitution3" format="string" />
+    </declare-styleable>
+
     <declare-styleable name="HeaderPreference">
         <!-- String array of entries to join in order to build the preference summary -->
         <attr name="summaryEntries" format="reference"/>

--- a/AnkiDroid/src/main/res/values/constants.xml
+++ b/AnkiDroid/src/main/res/values/constants.xml
@@ -165,6 +165,7 @@
     <string name="link_distributions">https://apps.ankiweb.net/#download</string>
     <string name="link_ankiweb_lost_email_instructions">https://github.com/ankidroid/Anki-Android/wiki/FAQ#forgotten-ankiweb-email-instructions</string>
     <string name="link_scoped_storage_faq">https://github.com/ankidroid/Anki-Android/wiki/Storage-Migration-FAQ</string>
+    <string name="link_custom_sync_server_help_learn_more_en">https://docs.ankidroid.org/#_custom_sync_server</string>
 
     <string-array name="leech_action_values">
         <item>0</item>

--- a/AnkiDroid/src/main/res/values/preferences.xml
+++ b/AnkiDroid/src/main/res/values/preferences.xml
@@ -85,7 +85,6 @@
     <string name="show_large_answer_buttons_preference">showLargeAnswerButtons</string>
     <!-- Custom sync server -->
     <string name="pref_custom_sync_server_screen_key">customSyncServerScreen</string>
-    <string name="custom_sync_server_enable_key">useCustomSyncServer</string>
     <string name="custom_sync_server_collection_url_key">customCollectionSyncUrl</string>
     <string name="custom_sync_server_media_url_key">syncMediaUrl</string>
     <!-- Advanced -->

--- a/AnkiDroid/src/main/res/xml/preferences_custom_sync_server.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_custom_sync_server.xml
@@ -11,19 +11,14 @@
         android:summary="@string/custom_sync_server_help"
         app:substitution1="@string/link_custom_sync_server_help_learn_more_en"
         search:ignore="true" />
-    <SwitchPreference
-        android:key="@string/custom_sync_server_enable_key"
-        android:title="@string/custom_sync_server_enable_title"
-        android:summary="@string/custom_sync_server_enable_summary"
-        android:defaultValue="false"/>
-    <EditTextPreference
-        android:dependency="@string/custom_sync_server_enable_key"
+    <com.ichi2.preferences.VersatileTextWithASwitchPreference
         android:key="@string/custom_sync_server_collection_url_key"
         android:title="@string/custom_sync_server_base_url_title"
+        android:inputType="textUri"
         app:useSimpleSummaryProvider="true" />
-    <EditTextPreference
-        android:dependency="@string/custom_sync_server_enable_key"
+    <com.ichi2.preferences.VersatileTextWithASwitchPreference
         android:key="@string/custom_sync_server_media_url_key"
         android:title="@string/custom_sync_server_media_url_title"
+        android:inputType="textUri"
         app:useSimpleSummaryProvider="true" />
 </PreferenceScreen>

--- a/AnkiDroid/src/main/res/xml/preferences_custom_sync_server.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_custom_sync_server.xml
@@ -4,8 +4,13 @@
 <!-- Advanced Preferences -->
 <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:search="http://schemas.android.com/apk/com.bytehamster.lib.preferencesearch"
     android:title="@string/custom_sync_server_title"
     android:key="@string/pref_custom_sync_server_screen_key">
+    <com.ichi2.preferences.HtmlHelpPreference
+        android:summary="@string/custom_sync_server_help"
+        app:substitution1="@string/link_custom_sync_server_help_learn_more_en"
+        search:ignore="true" />
     <SwitchPreference
         android:key="@string/custom_sync_server_enable_key"
         android:title="@string/custom_sync_server_enable_title"

--- a/AnkiDroid/src/test/java/com/ichi2/anki/servicemodel/PreferenceUpgradeServiceTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/servicemodel/PreferenceUpgradeServiceTest.kt
@@ -111,12 +111,12 @@ class PreferenceUpgradeServiceTest : RobolectricTest() {
     }
 
     @Test
-    fun check_custom_media_sync_url() {
-        var syncURL = "https://msync.ankiweb.net"
+    fun `Legacy custom media sync URL is removed during upgrade`() {
+        val syncURL = "https://msync.ankiweb.net"
         mPrefs.edit { putString(CustomSyncServer.PREFERENCE_CUSTOM_MEDIA_SYNC_URL, syncURL) }
-        assertThat("Preference of custom media sync url is set to ($syncURL).", CustomSyncServer.getMediaSyncUrl(mPrefs).equals(syncURL))
+        assertThat(mPrefs.getString(CustomSyncServer.PREFERENCE_CUSTOM_MEDIA_SYNC_URL, null), equalTo(syncURL))
         PreferenceUpgrade.RemoveLegacyMediaSyncUrl().performUpgrade(mPrefs)
-        assertThat("Preference of custom media sync url is removed.", CustomSyncServer.getMediaSyncUrl(mPrefs).equals(null))
+        assertThat(mPrefs.getString(CustomSyncServer.PREFERENCE_CUSTOM_MEDIA_SYNC_URL, null), equalTo(null))
     }
 
     @Test

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/sync/HttpSyncerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/sync/HttpSyncerTest.kt
@@ -97,14 +97,14 @@ class HttpSyncerTest {
     private fun setCustomServerWithNoUrl() {
         val userPreferences = AnkiDroidApp.getSharedPrefs(AnkiDroidApp.instance)
         userPreferences.edit {
-            putBoolean(CustomSyncServer.PREFERENCE_ENABLE_CUSTOM_SYNC_SERVER, true)
+            putBoolean(CustomSyncServer.PREFERENCE_CUSTOM_COLLECTION_SYNC_SERVER_ENABLED, true)
         }
     }
 
     private fun setCustomServer(s: String) {
         val userPreferences = AnkiDroidApp.getSharedPrefs(AnkiDroidApp.instance)
         userPreferences.edit {
-            putBoolean(CustomSyncServer.PREFERENCE_ENABLE_CUSTOM_SYNC_SERVER, true)
+            putBoolean(CustomSyncServer.PREFERENCE_CUSTOM_COLLECTION_SYNC_SERVER_ENABLED, true)
             putString(CustomSyncServer.PREFERENCE_CUSTOM_COLLECTION_SYNC_URL, s)
         }
     }

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/sync/RemoteMediaServerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/sync/RemoteMediaServerTest.kt
@@ -19,6 +19,7 @@ package com.ichi2.libanki.sync
 import androidx.core.content.edit
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.ichi2.anki.AnkiDroidApp
+import com.ichi2.anki.web.CustomSyncServer
 import com.ichi2.utils.KotlinCleanup
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
@@ -93,15 +94,17 @@ class RemoteMediaServerTest {
     }
 
     private fun setCustomServerWithNoUrl() {
-        val userPreferences = AnkiDroidApp.getSharedPrefs(AnkiDroidApp.instance)
-        userPreferences.edit { putBoolean("useCustomSyncServer", true) }
+        AnkiDroidApp.getSharedPrefs(AnkiDroidApp.instance)
+            .edit {
+                putBoolean(CustomSyncServer.PREFERENCE_CUSTOM_MEDIA_SYNC_SERVER_ENABLED, true)
+            }
     }
 
     private fun setCustomMediaServer(s: String) {
         AnkiDroidApp.getSharedPrefs(AnkiDroidApp.instance)
             .edit {
-                putBoolean("useCustomSyncServer", true)
-                putString("syncMediaUrl", s)
+                putBoolean(CustomSyncServer.PREFERENCE_CUSTOM_MEDIA_SYNC_SERVER_ENABLED, true)
+                putString(CustomSyncServer.PREFERENCE_CUSTOM_MEDIA_SYNC_URL, s)
             }
     }
 


### PR DESCRIPTION
This implements my own suggestion from the point 2 in Remaining issues in #12112 nearly verbatim, except I added a note about Sync url preference expecting the full URL as discussed in #12269. @dobefore What do you think?

<img src="https://user-images.githubusercontent.com/1710718/189485689-53f04b2a-de2f-4084-a0ec-ac947c8506b0.png" width=250> <img src="https://user-images.githubusercontent.com/1710718/189485686-aea5d070-9320-4e76-903e-15ef853d9d3a.png" width=250> <img src="https://user-images.githubusercontent.com/1710718/189485688-56ba32eb-f29d-475c-83a6-a7a780487abb.png" width=250> 

https://user-images.githubusercontent.com/1710718/189485733-83b66dcf-eb76-43d5-b062-9910e4b25b17.mp4

As usual, please see the commits for individual changes.

Note that in the first commit there's a link to the fragment https://docs.ankidroid.org/#_custom_sync_server which doesn't exist yet. I suppose the docs will have to be amended for the new release, and this section could be added later.

Also note that Accessibility scanner complains about two things; not sure if this is actionable.

  * Help preference summary: Link text. Consider using more descriptive text in the link. The link “Learn more” may not independently convey the link's purpose.
  * Sync url preference switch widget: Item descriptions. Multiple items have the same description. This clickable item's speakable text: "OFF" is identical to that of 1 other item(s).

Edit: The test [pass](https://github.com/oakkitten/Anki-Android/actions/runs/3028050757) in my repo.

## How Has This Been Tested?

Manually tested on my Xiaomi Mi A2 (Android 11) and Motorola Moto G 1st Gen (Android 6).
Added a unit test for preference migration.

## Checklist

- [ ] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [x] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)