### PR TITLE
Fix Filter sheet item colors not updating

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/FilterSheetBottomFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/FilterSheetBottomFragment.kt
@@ -224,10 +224,10 @@ class FilterSheetBottomFragment :
              */
             private fun unselect(item: Flags) {
                 flagSearchItems.remove(item.flagNode)
+                setUnselectedColor()
                 if (flagSearchItems.isNotEmpty()) {
                     return
                 }
-                setUnselectedColor()
                 filterHeaderFlags.setTextColor(getColorFromAttr(R.attr.filterItemTextColor))
                 filterIconFlags.setColorFilter(getColorFromAttr(R.attr.filterItemTextColor))
                 flagToggleIcon.setColorFilter(getColorFromAttr(R.attr.filterItemTextColor))
@@ -239,10 +239,10 @@ class FilterSheetBottomFragment :
             private fun select(item: Flags) {
                 val wasNotEmpty = flagSearchItems.isNotEmpty()
                 flagSearchItems.add(item.flagNode)
+                setSelectedColor()
                 if (wasNotEmpty) {
                     return
                 }
-                setSelectedColor()
                 filterHeaderFlags.setTextColor(getColorFromAttr(R.attr.filterItemTextColorSelected))
                 filterIconFlags.setColorFilter(getColorFromAttr(R.attr.filterItemTextColorSelected))
                 flagToggleIcon.setColorFilter(getColorFromAttr(R.attr.filterItemTextColorSelected))
@@ -268,7 +268,7 @@ class FilterSheetBottomFragment :
             }
 
             /**
-             * Update the section header to indicate some of its content is selected.
+             * Update the filter item to indicate it is selected.
              */
             private fun setSelectedColor() {
                 itemView.setBackgroundColor(getColorFromAttr(R.attr.filterItemBackgroundSelected))
@@ -276,7 +276,7 @@ class FilterSheetBottomFragment :
             }
 
             /**
-             * Update the section header to indicate none of its content is selected.
+             * Update the filter item to indicate it is not selected anymore.
              */
             private fun setUnselectedColor() {
                 itemView.setBackgroundColor(getColorFromAttr(R.attr.filterItemBackground))


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
in #12145, filters were made persistent, but an oversight from me lead the colors to not be updated when needed. This small refactor fixes it.

## Approach
Move the function calls to set colors above return statement.

## How Has This Been Tested?
On my device

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
