### PR TITLE
NF: depends of junit5

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -334,6 +334,7 @@ dependencies {
     testImplementation 'androidx.test.ext:junit:1.1.3'
     testImplementation "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
     testImplementation "org.jetbrains.kotlin:kotlin-test:$kotlin_version"
+    testImplementation "org.jetbrains.kotlin:kotlin-test-junit5:$kotlin_version"
     testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:$coroutines_version"
     testImplementation "io.mockk:mockk:1.12.7"
     testImplementation 'org.apache.commons:commons-exec:1.3' // obtaining the OS


### PR DESCRIPTION
This ensures that the IDE don't complain about missing imports in classes such as BackupManagerSimpleTest.kt