### PR TITLE
[GSoC] Show Avg Interval in Notes Mode (follow up to #12035)

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/NoteService.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/NoteService.kt
@@ -217,6 +217,16 @@ object NoteService {
 
     fun totalReviews(note: Note) = note.cards().sumOf { it.reps }
 
+    /**
+     * Returns the average interval of all the non-new and non-learning cards in the note,
+     * or if all the cards in the note are new or learning, returns null
+     */
+    fun avgInterval(note: Note): Int? {
+        val nonNewOrLearningCards = note.cards().filter { it.type != Consts.CARD_TYPE_NEW && it.type != Consts.CARD_TYPE_LRN }
+
+        return nonNewOrLearningCards.average { it.ivl }?.toInt()
+    }
+
     interface NoteField {
         val ord: Int
 
@@ -228,3 +238,5 @@ object NoteService {
 fun Card.totalLapsesOfNote() = NoteService.totalLapses(note())
 
 fun Card.totalReviewsForNote() = NoteService.totalReviews(note())
+
+fun Card.avgIntervalOfNote() = NoteService.avgInterval(note())


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
Continuation of #12035. Adds functionality to see average interval of note in notes mode of browser.

## Approach
Create a function to average the intervals of non-new and non-learning cards

## How Has This Been Tested?

Unit Test added and tested on device.

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
