### PR TITLE
[GSoC] Show number of cards in Notes Mode (follow up to #12035)

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -2320,7 +2320,7 @@ open class CardBrowser :
                 Column.SFLD -> card.note().sFld
                 Column.DECK -> col.decks.name(card.did)
                 Column.TAGS -> card.note().stringTags()
-                Column.CARD -> card.template().optString("name")
+                Column.CARD -> if (inCardMode) card.template().optString("name") else "${card.note().numberOfCards()}"
                 Column.DUE -> card.dueString
                 Column.EASE -> if (inCardMode) getEaseForCards() else getAvgEaseForNotes()
                 Column.CHANGED -> LanguageUtil.getShortDateFormatFromS(card.mod)


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
Continuation of #12035. Follow upstream to show number of cards on the `Card` option of browser.

## Approach
use `note().numberOfCards` to show number of cards for that note

## How Has This Been Tested?

Manually on device.

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
