### PR TITLE
[GSoC] Show total lapses of note of card in notes mode (follow up to #12035)

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -64,6 +64,7 @@ import com.ichi2.anki.servicelayer.SchedulerService.RepositionCards
 import com.ichi2.anki.servicelayer.SchedulerService.RescheduleCards
 import com.ichi2.anki.servicelayer.SchedulerService.ResetCards
 import com.ichi2.anki.servicelayer.UndoService.Undo
+import com.ichi2.anki.servicelayer.totalLapsesOfNote
 import com.ichi2.anki.snackbar.showSnackbar
 import com.ichi2.anki.widgets.DeckDropDownAdapter.SubtitleListener
 import com.ichi2.async.*
@@ -2331,7 +2332,7 @@ open class CardBrowser :
                     Consts.CARD_TYPE_LRN -> AnkiDroidApp.instance.getString(R.string.card_browser_interval_learning_card)
                     else -> Utils.roundedTimeSpanUnformatted(AnkiDroidApp.instance, card.ivl * Stats.SECONDS_PER_DAY)
                 }
-                Column.LAPSES -> card.lapses.toString()
+                Column.LAPSES -> (if (inCardMode) card.lapses else card.totalLapsesOfNote()).toString()
                 Column.NOTE_TYPE -> card.model().optString("name")
                 Column.REVIEWS -> card.reps.toString()
                 Column.QUESTION -> {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/NoteService.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/NoteService.kt
@@ -28,6 +28,7 @@ import com.ichi2.anki.FieldEditText
 import com.ichi2.anki.multimediacard.IMultimediaEditableNote
 import com.ichi2.anki.multimediacard.fields.*
 import com.ichi2.anki.multimediacard.impl.MultimediaEditableNote
+import com.ichi2.libanki.Card
 import com.ichi2.libanki.Consts
 import com.ichi2.libanki.Note
 import com.ichi2.libanki.NoteTypeId
@@ -211,6 +212,9 @@ object NoteService {
         return nonNewCards.average { it.factor }?.let { it / 10 }?.toInt()
     }
 
+    //  TODO: should make a direct SQL query to do this
+    fun totalLapses(note: Note) = note.cards().sumOf { it.lapses }
+
     interface NoteField {
         val ord: Int
 
@@ -218,3 +222,5 @@ object NoteService {
         val fieldText: String?
     }
 }
+
+fun Card.totalLapsesOfNote() = NoteService.totalLapses(note())


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
Continuation of #12035. Show total lapses of the note in notes mode

## Approach
Show sum of lapses of all cards in notes mode.

## How Has This Been Tested?
Manually on device.

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
