### PR TITLE
Set Basic2Model as internal to follow original visibility

### DIFF
--- a/api/src/main/java/com/ichi2/anki/api/Basic2Model.kt
+++ b/api/src/main/java/com/ichi2/anki/api/Basic2Model.kt
@@ -4,7 +4,7 @@ package com.ichi2.anki.api
 /**
  * Definitions of the basic with reverse model
  */
-object Basic2Model {
+internal object Basic2Model {
     @JvmField // required for Java API
     val FIELDS = arrayOf("Front", "Back")
     // List of card names that will be used in AnkiDroid (one for each direction of learning)
@@ -12,9 +12,9 @@ object Basic2Model {
     val CARD_NAMES = arrayOf("Card 1", "Card 2")
     // Template for the question of each card
     @JvmField // required for Java API
-    val QFMT = arrayOf("{{Front}}", "{{Back}}")
+    internal val QFMT = arrayOf("{{Front}}", "{{Back}}")
     @JvmField // required for Java API
-    val AFMT = arrayOf(
+    internal val AFMT = arrayOf(
         "{{FrontSide}}\n\n<hr id=\"answer\">\n\n{{Back}}",
         "{{FrontSide}}\n\n<hr id=\"answer\">\n\n{{Front}}"
     )


### PR DESCRIPTION
## Purpose / Description

This class was package protected from its creation and not part of the public API(see the last commit before being migrated to kotlin: 66b7ea6) so I set its visibility to _internal_(the two properties were also package protected initially). 

Note that the interoperability related to internal is not great and this will end up as public in the java code.
We could move the properties of this object in `AddContentApi` as there's a single usage of `Basic2Model` in `addNewBasic2Model()`.

## How Has This Been Tested?

Nothing really to test.

