### PR TITLE
More cleanups for AddContentApi

### DIFF
--- a/api/src/main/java/com/ichi2/anki/api/AddContentApi.kt
+++ b/api/src/main/java/com/ichi2/anki/api/AddContentApi.kt
@@ -373,8 +373,7 @@ class AddContentApi(context: Context) {
      * Get the ID for the note type / model which is currently in use
      * @return id for current model, or &lt;0 if there was a problem
      */
-    // TODO: Kotlin Cleanup - val or fun - likely needs JvmField either way.
-    val currentModelId: Long
+    public val currentModelId: Long
         get() {
             // Get the current model
             val uri = Uri.withAppendedPath(Model.CONTENT_URI, Model.CURRENT_MODEL_ID)
@@ -409,8 +408,7 @@ class AddContentApi(context: Context) {
      * Get a map of all model ids and names
      * @return map of (id, name) pairs
      */
-    // TODO: Kotlin Cleanup - val or fun - likely needs JvmField either way.
-    val modelList: Map<Long, String>?
+    public val modelList: Map<Long, String>?
         get() = getModelList(1)
 
     /**
@@ -466,8 +464,7 @@ class AddContentApi(context: Context) {
      * Get the name of the selected deck
      * @return deck name or null if there was a problem
      */
-    // TODO: Kotlin Cleanup - val or fun - likely needs JvmField either way.
-    val selectedDeckName: String?
+    public val selectedDeckName: String?
         get() {
             val selectedDeckQuery = mResolver.query(
                 Deck.CONTENT_SELECTED_URI,
@@ -487,8 +484,7 @@ class AddContentApi(context: Context) {
      * Get a list of all the deck id / name pairs
      * @return Map of (id, name) pairs, or null if there was a problem
      */
-    // TODO: Kotlin Cleanup - val or fun - likely needs JvmField either way.
-    val deckList: Map<Long, String>?
+    public val deckList: Map<Long, String>?
         get() {
             // Get the current model
             val allDecksQuery =
@@ -525,9 +521,8 @@ class AddContentApi(context: Context) {
      *
      * @return the spec version number or -1 if AnkiDroid is not installed.
      */
-    // TODO: Kotlin Cleanup - val or fun - likely needs JvmField either way.
     @Suppress("deprecation") // API33 symbol required until minSdkVersion >= 33
-    val apiHostSpecVersion: Int
+    public val apiHostSpecVersion: Int
         get() {
             // PackageManager#resolveContentProvider docs suggest flags should be 0 (but that gives null metadata)
             // GET_META_DATA seems to work anyway

--- a/api/src/main/java/com/ichi2/anki/api/AddContentApi.kt
+++ b/api/src/main/java/com/ichi2/anki/api/AddContentApi.kt
@@ -46,7 +46,7 @@ import java.util.*
  * this may be extended to all operations at a later date.
  */
 // TODO: High Priority: Kotlin Cleanup: fix nullability of all public methods
-class AddContentApi(context: Context) {
+public class AddContentApi(context: Context) {
     private val mContext: Context = context.applicationContext
     private val mResolver: ContentResolver = mContext.contentResolver
 
@@ -59,7 +59,7 @@ class AddContentApi(context: Context) {
      * @param tags tags to include in the new note
      * @return note id or null if the note could not be added
      */
-    fun addNote(modelId: Long, deckId: Long, fields: Array<String>, tags: Set<String?>?): Long? {
+    public fun addNote(modelId: Long, deckId: Long, fields: Array<String>, tags: Set<String?>?): Long? {
         val noteUri = addNoteInternal(modelId, deckId, fields, tags) ?: return null
         return noteUri.lastPathSegment!!.toLong()
     }
@@ -103,7 +103,7 @@ class AddContentApi(context: Context) {
      * @param tagsList List of tags (one per note) (may be null)
      * @return The number of notes added (&lt;0 means there was a problem)
      */
-    fun addNotes(
+    public fun addNotes(
         modelId: Long,
         deckId: Long,
         fieldsList: List<Array<String>?>,
@@ -156,7 +156,7 @@ class AddContentApi(context: Context) {
      * @return the correctly formatted String for the media file to be placed in the desired field of a Card, or null
      * if unsuccessful.
      */
-    fun addMediaFromUri(
+    public fun addMediaFromUri(
         fileUri: Uri,
         preferredName: String,
         mimeType: String
@@ -187,7 +187,7 @@ class AddContentApi(context: Context) {
      * @param key the first field of a note
      * @return a list of duplicate notes
      */
-    fun findDuplicateNotes(mid: Long, key: String): List<NoteInfo?> {
+    public fun findDuplicateNotes(mid: Long, key: String): List<NoteInfo?> {
         val notes = compat.findDuplicateNotes(mid, listOf(key))
         return if (notes!!.size() == 0) {
             emptyList<NoteInfo>()
@@ -201,7 +201,7 @@ class AddContentApi(context: Context) {
      * @param keys list of keys
      * @return a SparseArray with a list of duplicate notes for each key
      */
-    fun findDuplicateNotes(mid: Long, keys: List<String?>): SparseArray<MutableList<NoteInfo?>>? {
+    public fun findDuplicateNotes(mid: Long, keys: List<String?>): SparseArray<MutableList<NoteInfo?>>? {
         return compat.findDuplicateNotes(mid, keys)
     }
 
@@ -210,7 +210,7 @@ class AddContentApi(context: Context) {
      * @param mid id of the model to be used
      * @return number of notes that exist with that model ID or -1 if there was a problem
      */
-    fun getNoteCount(mid: Long): Int = compat.queryNotes(mid)?.use { cursor -> cursor.count } ?: 0
+    public fun getNoteCount(mid: Long): Int = compat.queryNotes(mid)?.use { cursor -> cursor.count } ?: 0
 
     /**
      * Set the tags for a given note
@@ -219,7 +219,7 @@ class AddContentApi(context: Context) {
      * @return true if noteId was found, otherwise false
      * @throws SecurityException if READ_WRITE_PERMISSION not granted (e.g. due to install order bug)
      */
-    fun updateNoteTags(noteId: Long, tags: Set<String?>?): Boolean {
+    public fun updateNoteTags(noteId: Long, tags: Set<String?>?): Boolean {
         return updateNote(noteId, null, tags)
     }
 
@@ -230,7 +230,7 @@ class AddContentApi(context: Context) {
      * @return true if noteId was found, otherwise false
      * @throws SecurityException if READ_WRITE_PERMISSION not granted (e.g. due to install order bug)
      */
-    fun updateNoteFields(noteId: Long, fields: Array<String>?): Boolean {
+    public fun updateNoteFields(noteId: Long, fields: Array<String>?): Boolean {
         return updateNote(noteId, fields, null)
     }
 
@@ -239,7 +239,7 @@ class AddContentApi(context: Context) {
      * @param noteId the ID of the note to find
      * @return object containing the contents of note with noteID or null if there was a problem
      */
-    fun getNote(noteId: Long): NoteInfo? {
+    public fun getNote(noteId: Long): NoteInfo? {
         val noteUri = Uri.withAppendedPath(Note.CONTENT_URI, noteId.toString())
         val query = mResolver.query(noteUri, PROJECTION, null, null, null) ?: return null
         return query.use { cursor ->
@@ -267,7 +267,7 @@ class AddContentApi(context: Context) {
      * @return list of front &amp; back pairs for each card which contain the card HTML, or null if there was a problem
      * @throws SecurityException if READ_WRITE_PERMISSION not granted (e.g. due to install order bug)
      */
-    fun previewNewNote(mid: Long, flds: Array<String>): Map<String, Map<String, String>>? {
+    public fun previewNewNote(mid: Long, flds: Array<String>): Map<String, Map<String, String>>? {
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M && !hasReadWritePermission()) {
             // avoid situation where addNote will pass, but deleteNote will fail
             throw SecurityException("previewNewNote requires full read-write-permission")
@@ -299,7 +299,7 @@ class AddContentApi(context: Context) {
      * @param name name of the model
      * @return the mid of the model which was created, or null if it could not be created
      */
-    fun addNewBasicModel(name: String?): Long? {
+    public fun addNewBasicModel(name: String?): Long? {
         return addNewCustomModel(
             name, BasicModel.FIELDS, BasicModel.CARD_NAMES, BasicModel.QFMT,
             BasicModel.AFMT, null, null, null
@@ -312,7 +312,7 @@ class AddContentApi(context: Context) {
      * @param name name of the model
      * @return the mid of the model which was created, or null if it could not be created
      */
-    fun addNewBasic2Model(name: String?): Long? {
+    public fun addNewBasic2Model(name: String?): Long? {
         return addNewCustomModel(
             name, Basic2Model.FIELDS, Basic2Model.CARD_NAMES, Basic2Model.QFMT,
             Basic2Model.AFMT, null, null, null
@@ -332,7 +332,7 @@ class AddContentApi(context: Context) {
      * @param sortf index of field to be used for sorting. Use null for unspecified (unsupported in provider spec v1)
      * @return the mid of the model which was created, or null if it could not be created
      */
-    fun addNewCustomModel(
+    public fun addNewCustomModel(
         name: String?,
         fields: Array<String>,
         cards: Array<String>,
@@ -389,7 +389,7 @@ class AddContentApi(context: Context) {
      * @param modelId the ID of the model to use
      * @return the names of all the fields, or null if the model doesn't exist or there was some other problem
      */
-    fun getFieldList(modelId: Long): Array<String>? {
+    public fun getFieldList(modelId: Long): Array<String>? {
         // Get the current model
         val uri = Uri.withAppendedPath(Model.CONTENT_URI, modelId.toString())
         val modelQuery = mResolver.query(uri, null, null, null, null) ?: return null
@@ -416,7 +416,7 @@ class AddContentApi(context: Context) {
      * @param minNumFields minimum number of fields to consider the model for inclusion
      * @return map of (id, name) pairs or null if there was a problem
      */
-    fun getModelList(minNumFields: Int): Map<Long, String>? {
+    public fun getModelList(minNumFields: Int): Map<Long, String>? {
         // Get the current model
         val allModelsQuery =
             mResolver.query(Model.CONTENT_URI, null, null, null, null)
@@ -442,14 +442,14 @@ class AddContentApi(context: Context) {
      * @param mid id of model
      * @return the name of the model, or null if no model was found
      */
-    fun getModelName(mid: Long): String? = modelList!![mid]
+    public fun getModelName(mid: Long): String? = modelList!![mid]
 
     /**
      * Create a new deck with specified name and save the reference to SharedPreferences for later
      * @param deckName name of the deck to add
      * @return id of the added deck, or null if the deck was not added
      */
-    fun addNewDeck(deckName: String?): Long? {
+    public fun addNewDeck(deckName: String?): Long? {
         // Create a new note
         val values = ContentValues().apply { put(Deck.DECK_NAME, deckName) }
         val newDeckUri = mResolver.insert(Deck.CONTENT_ALL_URI, values)
@@ -506,7 +506,7 @@ class AddContentApi(context: Context) {
      * @param did ID of deck
      * @return the name of the deck, or null if no deck was found
      */
-    fun getDeckName(did: Long): String? = deckList!![did]
+    public fun getDeckName(did: Long): String? = deckList!![did]
 
     /**
      * The API spec version of the installed AnkiDroid app. This is not the same as the AnkiDroid app version code.
@@ -725,9 +725,9 @@ class AddContentApi(context: Context) {
         }
     }
 
-    companion object {
-        const val READ_WRITE_PERMISSION = FlashCardsContract.READ_WRITE_PERMISSION
-        const val DEFAULT_DECK_ID = 1L
+    public companion object {
+        public const val READ_WRITE_PERMISSION = FlashCardsContract.READ_WRITE_PERMISSION
+        public const val DEFAULT_DECK_ID = 1L
         private const val TEST_TAG = "PREVIEW_NOTE"
         private const val PROVIDER_SPEC_META_DATA_KEY = "com.ichi2.anki.provider.spec"
         private const val DEFAULT_PROVIDER_SPEC_VALUE = 1 // for when meta-data key does not exist
@@ -745,7 +745,8 @@ class AddContentApi(context: Context) {
          * @return packageId of AnkiDroid if a supported version is not installed, otherwise null
          */
         @Suppress("deprecation") // deprecated symbol until minSdkVersion >= 33
-        fun getAnkiDroidPackageName(context: Context): String? {
+        @JvmStatic // required for API
+        public fun getAnkiDroidPackageName(context: Context): String? {
             val manager = context.packageManager
             return if (Build.VERSION.SDK_INT >= 33)
                 manager.resolveContentProvider(


### PR DESCRIPTION
## Purpose / Description

More cleanups for AddContentApi:
- fixed the todos inside the class by removing them, they were not aplicacable as the requested annotation is not needed.
- added the proper visibility modifiers for the class methods and properties following the original code(this is in anticipation of enabling `explicitApi` mode for this module). Plus on @ JvmStatic to replicate a static method from the original java code.

See how the file looked in the last commit as a [java file](https://github.com/ankidroid/Anki-Android/blob/f39b7fa10f9ecbd080f0beb33617308137fb27bb/api/src/main/java/com/ichi2/anki/api/AddContentApi.java). 

There's one todo left about the nullability in the methods signatures.

## How Has This Been Tested?

Ran checks.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
