### PR TITLE
Enable again sending error reports from launchCatchingTask

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CoroutineHelpers.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CoroutineHelpers.kt
@@ -57,10 +57,10 @@ suspend fun <T> FragmentActivity.runCatchingTask(
         exc.localizedMessage?.let { showSnackbar(it) }
     } catch (exc: BackendException) {
         Timber.e(exc, extraInfo)
-        showError(this, exc.localizedMessage!!)
+        showError(this, exc.localizedMessage!!, exc)
     } catch (exc: Exception) {
         Timber.e(exc, extraInfo)
-        showError(this, exc.toString())
+        showError(this, exc.toString(), exc)
     }
     return null
 }
@@ -100,11 +100,14 @@ fun Fragment.launchCatchingTask(
     block: suspend CoroutineScope.() -> Unit
 ): Job = requireActivity().launchCatchingTask(errorMessage, block)
 
-private fun showError(context: Context, msg: String) {
+private fun showError(context: Context, msg: String, exception: Throwable) {
     AlertDialog.Builder(context)
         .setTitle(R.string.vague_error)
         .setMessage(msg)
         .setPositiveButton(R.string.dialog_ok) { _, _ -> }
+        .setOnDismissListener {
+            CrashReportService.sendExceptionReport(exception, origin = context::class.java.simpleName)
+        }
         .show()
 }
 


### PR DESCRIPTION
## Purpose / Description

At one point we had two `CoroutineHelpers` files. In ad95d569f0 we removed one of the implementations(which was sending error reports), unfortunately the code in the  file remaining didn't send error reports. This PR fixes this.
With my changes, when an error happens, the user will see a dialog and when that dialog is dismissed(in any way) he will see the error reporting dialog(if it is enabled in settings).

## How Has This Been Tested?

Ran the checks, verify that the app prepares an error report when this is permitted in settings.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
