### PR TITLE
Remove config for JavaCompile in gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -72,17 +72,6 @@ subprojects {
             }
         }
 
-        // Deprecation is an error. Use @SuppressWarnings("deprecation") and justify in the PR if you must
-        project.tasks.withType(JavaCompile) {
-            options.compilerArgs << "-Xlint:deprecation" << "-Xlint:fallthrough" << "-Xmaxwarns" << "1000" << "-Werror"
-
-            // https://guides.gradle.org/performance/#compiling_java
-            // 1- fork improves things over time with repeated builds, doesn't harm CI single builds
-            options.fork = true
-            // 2- incremental will be the default in the future and can help now
-            options.incremental = true
-        }
-
         ktlint {
             // remove version override when ktlint gradle plugin releases with 0.45+ transitive
             // check for "ktlint" here:


### PR DESCRIPTION
Since we have completely shifted to Kotlin, this can be removed from build.gradle.