### PR TITLE
OpenCollective automation documentation / fail-fastness

### DIFF
--- a/.github/workflows/opencollective_notices.yml
+++ b/.github/workflows/opencollective_notices.yml
@@ -4,9 +4,11 @@ on:
     workflow_dispatch:
         inputs:
             startDate:
+                description: "earliest date to consider- YYYY-MM-DD, example '2022-06-01'"
                 required: true
                 type: string
             endDate:
+                description: "oldest date to consider. YYYY-MM-DD, example '2022-06-30'"
                 required: true
                 type: string
     # and in the future schedule...
@@ -22,6 +24,9 @@ jobs:
               with:
                   script: |
                       // First get the month we are working on and prepare our PR query range
+                      // Format for the dates is "YYYY-MM-DD", and an example is "2022-05-01" and "2022-05-31"
+                      // Getting inputs in github-script requires some fancy mode-switching to "github templating" syntax
+                      // https://stackoverflow.com/a/70999557/9910298
                       var inputs = ${{ toJSON(inputs) }}
                       let startDate = inputs['startDate'];
                       let endDate = inputs['endDate'];
@@ -57,17 +62,18 @@ jobs:
                       }
 
 
-                      // Now get the PRs for the month, iterating over pages if needed (100 per page limit)
+                      // Now get the PRs for the month, iterating over pages if needed (100 per page limit, pages are 1-based / start on 1)
+                      // https://docs.github.com/en/rest/guides/traversing-with-pagination
                       let result = await getPRPage(startDate, endDate, 1)
 
                       // How many pages? iterate until fetched page Math.ceil(total/per-page)
-                      console.log(`total count is: ${result.data.total_count}`);
+                      console.log(`First page fetched. Total count is: ${result.data.total_count}`);
                       const pageCount = Math.ceil(result.data.total_count / 100);
                       console.log(`Should get a total of ${pageCount} pages`);
                       for (let i = 2; i <= pageCount; i++) {
                         console.log(`fetching page ${i}`);
                         const pageResult = await getPRPage(startDate, endDate, i);
-                        console.log(`Got another page with ${pageResult.data.total_count} items`);
+                        console.log(`Got another page with ${pageResult.data.items.length} items`);
                         result.data.items = result.data.items.concat(pageResult.data.items);
                       }
 
@@ -75,12 +81,15 @@ jobs:
                       const uniqueContributorsWithPR = {}
                       result.data.items.forEach((pr, index) => {
                         console.log(`pr at index ${index} is ${pr.number} by ${pr.user.login} (title ${pr.title})`);
+                        // This will overwrite the contributor again and again, on purpose.
+                        // We only want to leave one comment, so simply remembering the last PR we saw for a contributor is sufficient.
                         uniqueContributorsWithPR[pr.user.login] = pr.number;
                       })
 
                       // For each author in the map, post a comment on the associated PR
+                      // Incidentally you cannot use arry.forEach() with async functions; it does not await. for or for...in is required.
                       for (const key of Object.keys(uniqueContributorsWithPR)) {
-                        // skip some users
+                        // skip some users, we don't allow bots to claim for their work, yet?
                         if (key === 'github-actions' || key.includes('dependabot')) {
                           console.log(`ignoring pr with bot user ${key}`);
                           continue;
@@ -89,6 +98,15 @@ jobs:
                         try {
                           await addComment(uniqueContributorsWithPR[key], key);
                         } catch (e) {
-                          console.log('what happend?' + e);
+                          // This implies, since there is no state with regard to comments already added or not,
+                          // that you will need to figure out the root cause and re-run the workflow, which will re-add comments
+                          // on any issues that processed successfully prior to the error.
+                          //
+                          // This is not ideal. However it should be rare, and adding state management (e.g, via labels) to a script
+                          // that is working, and is not expected to fail frequently on this step, just to avoid
+                          // duplicate comments (which themselves are not that tramuatic) is in my opinion not worth it.
+                          // But it is worth noting that the problem had been considered.
+                          console.log('failed to add comment to issue? ' + e);
+                          throw e;
                         }
                       }


### PR DESCRIPTION

## Pull Request template

## Purpose / Description

Based on the review from @david-allison (thank you!)

- documented input parameters
- documented parts of the code that may be non-obvious
- carefully note the considered non-solution on issue comment labeling errors + re-throw
_Describe the problem or feature and motivation_

## Fixes
No issue logged - I wanted to do the first batch of notices ASAP so merged, but also wanted feedback and to improve it, so here's a follow-on

## Approach
Almost entirely comments.
Only functional change is to re-throw the error if there are "could not add a comment" errors, explicitly opening us to maybe double-commenting if you re-run it after fixing error, but definitely not no-commenting.

## How Has This Been Tested?

re-ran it on my fork https://github.com/mikehardy/Anki-Android/pull/105#issuecomment-1251011689
https://github.com/mikehardy/Anki-Android/actions/runs/3082723280/jobs/4982771681

## Learning (optional, can help others)
sleeping on a solution and re-reading it makes it a lot more obvious where you were lazy and did not add documentation. Bad MikePast! no biscuit.

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
