### PR TITLE
Move to strict for explicit api mode in api module

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -32,8 +32,7 @@ android {
     kotlinOptions {
         // enable explicit api mode for additional checks related to the public api
         // see https://kotlinlang.org/docs/whatsnew14.html#explicit-api-mode-for-library-authors
-        // TODO When we finish cleaning up the api module we should move from warning to strict.
-        freeCompilerArgs += '-Xexplicit-api=warning'
+        freeCompilerArgs += '-Xexplicit-api=strict'
     }
 }
 

--- a/api/src/test/java/com/ichi2/anki/api/ApiUtilsTest.kt
+++ b/api/src/test/java/com/ichi2/anki/api/ApiUtilsTest.kt
@@ -21,7 +21,7 @@ import kotlin.test.assertNull
  */
 // TODO: @KotlinCleanup("replace Assert.assertEquals with kotlin.test.assertEquals")
 @RunWith(RobolectricTestRunner::class)
-class ApiUtilsTest {
+internal class ApiUtilsTest {
     @Test
     fun joinFieldsShouldJoinWhenListIsValid() {
         val fieldList = arrayOf<String>("A", "B", "C")


### PR DESCRIPTION
## Purpose / Description

After all visibility modifiers were added to the classes in the api module this PR enables strict mode(moving from warnings to errors). Also had to make `ApiUtilsTest` as internal as the api mode applies to all classes in that module.

## How Has This Been Tested?

Ran checks.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
