### PR TITLE
Fix crash due to probable race condition

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
@@ -1085,10 +1085,14 @@ open class Reviewer : AbstractFlashcardViewer() {
         if (mPrefHideDueCount) {
             mRevCount = SpannableString("???")
         }
-        when (sched!!.countIdx(currentCard!!)) {
-            Counts.Queue.NEW -> mNewCount!!.setSpan(UnderlineSpan(), 0, mNewCount!!.length, 0)
-            Counts.Queue.LRN -> mLrnCount!!.setSpan(UnderlineSpan(), 0, mLrnCount!!.length, 0)
-            Counts.Queue.REV -> mRevCount!!.setSpan(UnderlineSpan(), 0, mRevCount!!.length, 0)
+        // if this code is run as a card is being answered, currentCard may be non-null but
+        // the queues may be empty - we can't call countIdx() in such a case
+        if (counts.count() != 0) {
+            when (sched!!.countIdx(currentCard!!)) {
+                Counts.Queue.NEW -> mNewCount!!.setSpan(UnderlineSpan(), 0, mNewCount!!.length, 0)
+                Counts.Queue.LRN -> mLrnCount!!.setSpan(UnderlineSpan(), 0, mLrnCount!!.length, 0)
+                Counts.Queue.REV -> mRevCount!!.setSpan(UnderlineSpan(), 0, mRevCount!!.length, 0)
+            }
         }
         mTextBarNew.text = mNewCount
         mTextBarLearn.text = mLrnCount

--- a/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.kt
@@ -126,7 +126,7 @@ class CardBrowserTest : RobolectricTest() {
     }
 
     @Test
-    fun browserDoesNotFailWhenSelectingANonExistingCard() {
+    fun browserDoesNotFailWhenSelectingANonExistingCard() = runTest {
         // #5900
         val browser = getBrowserWithNotes(6)
         // Sometimes an async operation deletes a card, we clear the data and rerender it to simulate this
@@ -137,7 +137,7 @@ class CardBrowserTest : RobolectricTest() {
 
     @Test
     @Ignore("Not yet implemented, feature has performance implications in large collections, instead we remove selections")
-    fun selectionsAreCorrectWhenNonExistingCardIsRemoved() {
+    fun selectionsAreCorrectWhenNonExistingCardIsRemoved() = runTest {
         val browser = getBrowserWithNotes(7)
         browser.checkCardsAtPositions(1, 3, 5, 6)
         deleteCardAtPosition(browser, 2) // delete non-selected
@@ -154,7 +154,7 @@ class CardBrowserTest : RobolectricTest() {
     }
 
     @Test
-    fun canChangeDeckToRegularDeck() {
+    fun canChangeDeckToRegularDeck() = runTest {
         addDeck("Hello")
         val b = getBrowserWithNotes(5)
 
@@ -162,14 +162,14 @@ class CardBrowserTest : RobolectricTest() {
 
         for (d in decks) {
             if (d.getString("name") == "Hello") {
-                return
+                return@runTest
             }
         }
         fail("Added deck was not found in the Card Browser")
     }
 
     @Test
-    fun cannotChangeDeckToDynamicDeck() {
+    fun cannotChangeDeckToDynamicDeck() = runTest {
         // 5932 - dynamic decks are meant to have cards added to them through "Rebuild".
         addDynamicDeck("World")
         val b = getBrowserWithNotes(5)
@@ -182,7 +182,7 @@ class CardBrowserTest : RobolectricTest() {
     }
 
     @Test
-    fun changeDeckIntegrationTestDynamicAndNon() {
+    fun changeDeckIntegrationTestDynamicAndNon() = runTest {
         addDeck("Hello")
         addDynamicDeck("World")
 
@@ -223,7 +223,7 @@ class CardBrowserTest : RobolectricTest() {
     }
 
     @Test
-    fun changeDeckViaTaskIsHandledCorrectly() {
+    fun changeDeckViaTaskIsHandledCorrectly() = runTest {
         val dynId = addDynamicDeck("World")
         selectDefaultDeck()
         val b = getBrowserWithNotes(5)
@@ -239,7 +239,7 @@ class CardBrowserTest : RobolectricTest() {
     }
 
     @Test
-    fun flagsAreShownInBigDecksTest() {
+    fun flagsAreShownInBigDecksTest() = runTest {
         val numberOfNotes = 75
         val cardBrowser = getBrowserWithNotes(numberOfNotes)
 
@@ -752,7 +752,7 @@ class CardBrowserTest : RobolectricTest() {
     }
 
     @Test
-    fun checkCardsNotesMode() {
+    fun checkCardsNotesMode() = runTest {
         val cardBrowser = getBrowserWithNotes(3, true)
 
         // set browser to be in cards mode


### PR DESCRIPTION
Resuming the app would trigger a redraw of the counts, and this probably coincided with a card being automatically answered.

Closes #12453
