### PR TITLE
Fix night mode by bumping appcompat to 1.6.0-rc01

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -247,7 +247,7 @@ dependencies {
 
     implementation 'androidx.activity:activity-ktx:1.5.1'
     implementation 'androidx.annotation:annotation:1.4.0'
-    implementation 'androidx.appcompat:appcompat:1.5.1'
+    implementation 'androidx.appcompat:appcompat:1.6.0-rc01'
     implementation 'androidx.browser:browser:1.4.0'
     implementation "androidx.core:core-ktx:1.9.0"
     implementation 'androidx.exifinterface:exifinterface:1.3.3'

--- a/AnkiDroid/src/test/java/com/ichi2/anki/AnkiActivityTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/AnkiActivityTest.kt
@@ -1,0 +1,45 @@
+/*
+ *  Copyright (c) 2022 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki
+
+import android.content.Intent
+import android.content.res.Configuration
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.ichi2.themes.Theme
+import com.ichi2.themes.Themes
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.equalTo
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class AnkiActivityTest : RobolectricTest() {
+    @Test
+    fun themeChangeIsValid() {
+        // #12404 - fail to respond to day/night mode change
+        val activity = startActivityNormallyOpenCollectionWithIntent(
+            AnkiActivity::class.java, Intent()
+        )
+        assertThat(Themes.currentTheme, equalTo(Theme.LIGHT))
+
+        val newConfig = Configuration(activity.resources.configuration)
+        newConfig.uiMode = 33
+        activity.onConfigurationChanged(newConfig)
+
+        assertThat(Themes.currentTheme, equalTo(Theme.BLACK))
+    }
+}


### PR DESCRIPTION
Night mode changing is broken by https://github.com/ankidroid/Anki-Android/pull/12343. This PR is going to fix it by bumping `appcompat` to [appcompat:1.6.0-rc01](https://developer.android.google.cn/jetpack/androidx/releases/appcompat#1.6.0-rc01).

fix https://github.com/ankidroid/Anki-Android/issues/12404#issuecomment-1252331711