### PR TITLE
API 33 serializable bundle deprecation update

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/SharedDecksDownloadFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/SharedDecksDownloadFragment.kt
@@ -36,6 +36,7 @@ import androidx.core.content.FileProvider
 import androidx.fragment.app.Fragment
 import com.afollestad.materialdialogs.MaterialDialog
 import com.ichi2.anki.SharedDecksActivity.Companion.DOWNLOAD_FILE
+import com.ichi2.compat.CompatHelper.Companion.getSerializableCompat
 import com.ichi2.utils.ImportUtils
 import timber.log.Timber
 import java.io.File
@@ -85,7 +86,6 @@ class SharedDecksDownloadFragment : Fragment() {
         const val DOWNLOAD_COMPLETED_PROGRESS_PERCENTAGE = "100"
     }
 
-    @Suppress("deprecation") // getSerializable
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
@@ -94,7 +94,6 @@ class SharedDecksDownloadFragment : Fragment() {
         return inflater.inflate(R.layout.fragment_shared_decks_download, container, false)
     }
 
-    @Suppress("deprecation") // getSerializable
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
@@ -105,7 +104,7 @@ class SharedDecksDownloadFragment : Fragment() {
         mTryAgainButton = view.findViewById(R.id.try_again_deck_download)
         mCheckNetworkInfoText = view.findViewById(R.id.check_network_info_text)
 
-        val fileToBeDownloaded = arguments?.getSerializable(DOWNLOAD_FILE) as DownloadFile
+        val fileToBeDownloaded = requireArguments().getSerializableCompat<DownloadFile>(DOWNLOAD_FILE)!!
         mDownloadManager = (activity as SharedDecksActivity).downloadManager
 
         downloadFile(fileToBeDownloaded)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/TemporaryModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/TemporaryModel.kt
@@ -23,6 +23,7 @@ import com.ichi2.anki.CardTemplateEditor.CardTemplateFragment.SaveModelAndExitHa
 import com.ichi2.async.CollectionTask.SaveModel
 import com.ichi2.async.TaskManager
 import com.ichi2.compat.CompatHelper.Companion.compat
+import com.ichi2.compat.CompatHelper.Companion.getSerializableCompat
 import com.ichi2.libanki.Model
 import com.ichi2.libanki.NoteTypeId
 import com.ichi2.utils.JSONObject
@@ -54,13 +55,11 @@ class TemporaryModel(model: Model) {
         return outState
     }
 
-    @Suppress("deprecation") // getSerializable
     private fun loadTemplateChanges(bundle: Bundle) {
         try {
             @Suppress("UNCHECKED_CAST")
             @KotlinCleanup("use bundle.getSerializableWithCast() to improve nullability")
-            mTemplateChanges =
-                (bundle.getSerializable("mTemplateChanges") as ArrayList<Array<Any>>)
+            mTemplateChanges = bundle.getSerializableCompat("mTemplateChanges")!!
         } catch (e: ClassCastException) {
             Timber.e(e, "Unexpected cast failure")
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/activity/MultimediaEditFieldActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/activity/MultimediaEditFieldActivity.kt
@@ -34,6 +34,7 @@ import com.ichi2.anki.R
 import com.ichi2.anki.UIUtils
 import com.ichi2.anki.multimediacard.IMultimediaEditableNote
 import com.ichi2.anki.multimediacard.fields.*
+import com.ichi2.compat.CompatHelper.Companion.getSerializableCompat
 import com.ichi2.compat.CompatHelper.Companion.getSerializableExtraCompat
 import com.ichi2.utils.CheckCameraPermission
 import com.ichi2.utils.KotlinCleanup
@@ -457,9 +458,8 @@ class MultimediaEditFieldActivity : AnkiActivity(), OnRequestPermissionsResultCa
         const val IMAGE_LIMIT = 1024 * 1024 // 1MB in bytes
         @KotlinCleanup("see if we can make this non-null")
         @VisibleForTesting
-        @Suppress("deprecation") // getSerializable
         fun getFieldFromIntent(intent: Intent): IField? {
-            return intent.extras!!.getSerializable(EXTRA_FIELD) as IField?
+            return intent.extras!!.getSerializableCompat<IField>(EXTRA_FIELD)
         }
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/compat/Compat.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/Compat.kt
@@ -27,6 +27,7 @@ import android.media.AudioManager
 import android.media.AudioManager.OnAudioFocusChangeListener
 import android.media.MediaRecorder
 import android.net.Uri
+import android.os.Bundle
 import android.os.Parcelable
 import android.widget.TimePicker
 import androidx.annotation.IntDef
@@ -76,6 +77,7 @@ interface Compat {
     fun getMediaRecorder(context: Context): MediaRecorder
     fun <T : Serializable?> getSerializableExtra(intent: Intent, name: String, className: Class<T>): T?
     fun <T : Parcelable?> getParcelableExtra(intent: Intent, name: String, clazz: Class<T>): T?
+    fun <T : Serializable?> getSerializable(bundle: Bundle, name: String, clazz: Class<T>): T?
 
     @Throws(IOException::class)
     fun copyFile(source: String, target: String)

--- a/AnkiDroid/src/main/java/com/ichi2/compat/CompatHelper.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/CompatHelper.kt
@@ -17,6 +17,7 @@ package com.ichi2.compat
 
 import android.content.Intent
 import android.os.Build
+import android.os.Bundle
 import android.os.Parcelable
 import android.view.KeyCharacterMap.deviceHasKey
 import android.view.KeyEvent.*
@@ -82,6 +83,10 @@ class CompatHelper private constructor() {
 
         inline fun <reified T : Parcelable> Intent.getParcelableExtraCompat(name: String): T? {
             return compat.getParcelableExtra(this, name, T::class.java)
+        }
+
+        inline fun <reified T : Serializable> Bundle.getSerializableCompat(name: String): T? {
+            return compat.getSerializable(this, name, T::class.java)
         }
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/compat/CompatV21.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/CompatV21.kt
@@ -28,6 +28,7 @@ import android.media.AudioManager.OnAudioFocusChangeListener
 import android.media.MediaRecorder
 import android.media.ThumbnailUtils
 import android.net.Uri
+import android.os.Bundle
 import android.os.Environment
 import android.os.Parcelable
 import android.os.Vibrator
@@ -90,6 +91,19 @@ open class CompatV21 : Compat {
         } catch (e: IOException) {
             Timber.e(e, "copyFile() error copying source %s", source)
             throw e
+        }
+    }
+
+    override fun <T : Serializable?> getSerializable(
+        bundle: Bundle,
+        name: String,
+        clazz: Class<T>
+    ): T? {
+        return try {
+            @Suppress("UNCHECKED_CAST")
+            bundle.getSerializable(name) as? T?
+        } catch (e: Exception) {
+            null
         }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/compat/CompatV33.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/CompatV33.kt
@@ -18,6 +18,7 @@ package com.ichi2.compat
 
 import android.annotation.TargetApi
 import android.content.Intent
+import android.os.Bundle
 import android.os.Parcelable
 import java.io.Serializable
 
@@ -29,5 +30,9 @@ open class CompatV33 : CompatV31(), Compat {
 
     override fun <T : Parcelable?> getParcelableExtra(intent: Intent, name: String, clazz: Class<T>): T? {
         return intent.getParcelableExtra(name, clazz)
+    }
+
+    override fun <T : Serializable?> getSerializable(bundle: Bundle, name: String, clazz: Class<T>): T? {
+        return bundle.getSerializable(name, clazz)
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/utils/BundleUtils.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/BundleUtils.kt
@@ -16,6 +16,8 @@
 package com.ichi2.utils
 
 import android.os.Bundle
+import com.ichi2.compat.CompatHelper.Companion.getSerializableCompat
+import java.io.Serializable
 
 /**
  * Collection of useful methods to be used with [android.os.Bundle]
@@ -49,8 +51,8 @@ object BundleUtils {
         return getLong(key)
     }
 
-    @Suppress("deprecation") // getSerializable
+    @KotlinCleanup("inline this")
     inline fun <reified T> Bundle.getSerializableWithCast(key: String): T {
-        return getSerializable(key) as T
+        return getSerializableCompat<Serializable>(key) as T
     }
 }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/TemporaryModelTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/TemporaryModelTest.kt
@@ -18,6 +18,7 @@ package com.ichi2.anki
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.ichi2.anki.TemporaryModel.ChangeType.*
+import com.ichi2.compat.CompatHelper.Companion.getSerializableCompat
 import com.ichi2.libanki.Model
 import com.ichi2.utils.JSONObject
 import org.junit.Assert
@@ -56,7 +57,6 @@ class TemporaryModelTest : RobolectricTest() {
     }
 
     @Test
-    @Suppress("deprecation") // getSerializable
     fun testAddDeleteTracking() {
 
         // Assume you start with a 2 template model (like "Basic (and reversed)")
@@ -97,7 +97,7 @@ class TemporaryModelTest : RobolectricTest() {
 
         // Make sure we can resurrect these changes across lifecycle
         val outBundle = tempModel.toBundle()
-        assertTemplateChangesEqual(expected4, outBundle.getSerializable("mTemplateChanges"))
+        assertTemplateChangesEqual(expected4, outBundle.getSerializableCompat("mTemplateChanges"))
 
         // This is the hard part. We will delete a template we added so everything shifts.
         // The template currently at ordinal 1 was added as template 3 at the start before it slid down on the deletes


### PR DESCRIPTION
Fixes the deprecation of bundle.Serializable in new API33 or older versions


## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [x] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
