### PR TITLE
Uses kotlin list, map and set

### DIFF
--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/NoteEditorTest.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/NoteEditorTest.kt
@@ -28,7 +28,6 @@ import org.hamcrest.Matchers
 import org.junit.Assume
 import org.junit.Before
 import org.junit.Rule
-import java.util.ArrayList
 
 @KotlinCleanup("fix ide lint issues")
 abstract class NoteEditorTest protected constructor() {

--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/ContentProviderTest.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/ContentProviderTest.kt
@@ -49,6 +49,7 @@ import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
 import timber.log.Timber
 import java.util.*
+import kotlin.collections.*
 import kotlin.test.assertNotNull
 import kotlin.test.junit.JUnitAsserter.assertNotNull
 

--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/libanki/DBTest.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/libanki/DBTest.kt
@@ -33,6 +33,7 @@ import org.junit.runner.RunWith
 import java.io.File
 import java.io.FileOutputStream
 import java.util.*
+import kotlin.collections.*
 
 @RunWith(AndroidJUnit4::class)
 class DBTest : InstrumentedTest() {

--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/libanki/ImportTest.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/libanki/ImportTest.kt
@@ -35,6 +35,7 @@ import java.io.File
 import java.io.FileOutputStream
 import java.io.IOException
 import java.util.*
+import kotlin.collections.*
 
 @KotlinCleanup("is -> equalTo")
 @KotlinCleanup("IDE Lint")

--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/testutil/TestEnvironment.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/testutil/TestEnvironment.kt
@@ -16,6 +16,7 @@
 package com.ichi2.anki.testutil
 
 import java.util.*
+import kotlin.collections.*
 
 object TestEnvironment {
     fun isDisplayingDefaultEnglishStrings(): Boolean {

--- a/AnkiDroid/src/androidTest/java/com/ichi2/libanki/DBTest.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/libanki/DBTest.kt
@@ -24,6 +24,7 @@ import org.junit.Assume.assumeThat
 import org.junit.Test
 import org.junit.runner.RunWith
 import java.util.*
+import kotlin.collections.*
 
 @RunWith(AndroidJUnit4::class)
 class DBTest : InstrumentedTest() {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.kt
@@ -51,6 +51,7 @@ import timber.log.Timber.DebugTree
 import java.io.InputStream
 import java.util.*
 import java.util.regex.Pattern
+import kotlin.collections.*
 
 /**
  * Application class.

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiFont.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiFont.kt
@@ -9,6 +9,7 @@ import java.io.File
 import java.lang.RuntimeException
 import java.lang.StringBuilder
 import java.util.*
+import kotlin.collections.*
 
 class AnkiFont private constructor(val name: String, private val family: String, private val attributes: List<String>, val path: String) {
     private var mIsDefault = false

--- a/AnkiDroid/src/main/java/com/ichi2/anki/BackupManager.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/BackupManager.kt
@@ -35,6 +35,7 @@ import java.text.SimpleDateFormat
 import java.util.*
 import java.util.zip.ZipEntry
 import java.util.zip.ZipOutputStream
+import kotlin.collections.*
 
 open class BackupManager {
     /**

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -97,7 +97,7 @@ import java.lang.IllegalStateException
 import java.lang.StringBuilder
 import java.util.*
 import java.util.function.Consumer
-import kotlin.collections.ArrayList
+import kotlin.collections.*
 import kotlin.math.abs
 import kotlin.math.ceil
 import kotlin.math.max

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardInfo.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardInfo.kt
@@ -43,6 +43,7 @@ import timber.log.Timber
 import java.text.DateFormat
 import java.util.*
 import java.util.function.Function
+import kotlin.collections.*
 
 @RustCleanup("Remove this whole activity and use the new Anki page once the new backend is the default")
 class CardInfo : AnkiActivity() {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplatePreviewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplatePreviewer.kt
@@ -309,7 +309,7 @@ open class CardTemplatePreviewer : AbstractFlashcardViewer() {
         for (fieldOrd in noteFields.keySet()) {
             ret[fieldOrd.toInt()] = noteFields.getString(fieldOrd)
         }
-        return ArrayList(listOf(*ret))
+        return ret.map { it!! }.toMutableList()
     }
 
     /**

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardUtils.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardUtils.kt
@@ -6,6 +6,7 @@ import com.ichi2.libanki.Card
 import com.ichi2.libanki.Note
 import com.ichi2.utils.HashUtil.HashSetInit
 import java.util.*
+import kotlin.collections.*
 
 /**
  * Utilities for working on multiple cards

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CrashReportService.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CrashReportService.kt
@@ -36,6 +36,7 @@ import org.acra.config.*
 import org.acra.sender.HttpSender
 import timber.log.Timber
 import java.util.*
+import kotlin.collections.*
 import kotlin.collections.HashMap
 
 object CrashReportService {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckOptions.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckOptions.kt
@@ -52,6 +52,7 @@ import com.ichi2.ui.AppCompatPreferenceActivity
 import com.ichi2.utils.*
 import timber.log.Timber
 import java.util.*
+import kotlin.collections.*
 
 @NeedsTest("onCreate - to be done after preference migration (5019)")
 @KotlinCleanup("lateinit wherever possible")

--- a/AnkiDroid/src/main/java/com/ichi2/anki/FieldEditLine.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/FieldEditLine.kt
@@ -41,6 +41,7 @@ import com.ichi2.ui.AnimationUtil.collapseView
 import com.ichi2.ui.AnimationUtil.expandView
 import com.ichi2.utils.KotlinCleanup
 import java.util.*
+import kotlin.collections.*
 
 @KotlinCleanup("check which properties could be made not nullable")
 class FieldEditLine : FrameLayout {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/FieldEditText.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/FieldEditText.kt
@@ -47,6 +47,7 @@ import com.ichi2.utils.ClipboardUtil.hasImage
 import com.ichi2.utils.KotlinCleanup
 import timber.log.Timber
 import java.util.*
+import kotlin.collections.*
 import kotlin.math.max
 import kotlin.math.min
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/LanguageUtils.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/LanguageUtils.kt
@@ -17,6 +17,7 @@
 package com.ichi2.anki
 
 import java.util.*
+import kotlin.collections.*
 
 object LanguageUtils {
     /**

--- a/AnkiDroid/src/main/java/com/ichi2/anki/MediaRegistration.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/MediaRegistration.kt
@@ -50,15 +50,15 @@ class MediaRegistration(private val context: Context) {
         val fd = openInputStreamWithURI(uri)
         val fileNameAndExtension = getFileNameAndExtension(filename)
         fileName = if (checkFilename(fileNameAndExtension!!)) {
-            String.format("%s-name", fileNameAndExtension.key)
+            String.format("%s-name", fileNameAndExtension.first)
         } else {
-            fileNameAndExtension.key
+            fileNameAndExtension.first
         }
         var clipCopy: File
         var bytesWritten: Long
         openInputStreamWithURI(uri).use { copyFd ->
             // no conversion to jpg in cases of gif and jpg and if png image with alpha channel
-            if (shouldConvertToJPG(fileNameAndExtension.value, copyFd)) {
+            if (shouldConvertToJPG(fileNameAndExtension.second, copyFd)) {
                 clipCopy = File.createTempFile(fileName, ".jpg")
                 bytesWritten = CompatHelper.compat.copyFile(fd, clipCopy.absolutePath)
                 // return null if jpg conversion false.
@@ -66,7 +66,7 @@ class MediaRegistration(private val context: Context) {
                     return null
                 }
             } else {
-                clipCopy = File.createTempFile(fileName, fileNameAndExtension.value)
+                clipCopy = File.createTempFile(fileName, fileNameAndExtension.second)
                 bytesWritten = CompatHelper.compat.copyFile(fd, clipCopy.absolutePath)
             }
         }
@@ -122,8 +122,8 @@ class MediaRegistration(private val context: Context) {
         return true
     }
 
-    private fun checkFilename(fileNameAndExtension: Map.Entry<String, String>): Boolean {
-        return fileNameAndExtension.key.length <= 3
+    private fun checkFilename(fileNameAndExtension: Pair<String, String>): Boolean {
+        return fileNameAndExtension.first.length <= 3
     }
 
     fun onImagePaste(uri: Uri): String? {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ModelFieldEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ModelFieldEditor.kt
@@ -58,6 +58,7 @@ import java.lang.NumberFormatException
 import java.lang.RuntimeException
 import java.util.*
 import kotlin.Throws
+import kotlin.collections.*
 
 class ModelFieldEditor : AnkiActivity(), LocaleSelectionDialogHandler {
     // Position of the current field selected

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NavigationDrawerActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NavigationDrawerActivity.kt
@@ -51,6 +51,7 @@ import com.ichi2.utils.KotlinCleanup
 import net.ankiweb.rsdroid.BackendFactory
 import timber.log.Timber
 import java.util.*
+import kotlin.collections.*
 
 @KotlinCleanup("lateinit if possible")
 @KotlinCleanup("IDE-lint")

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
@@ -93,6 +93,7 @@ import net.ankiweb.rsdroid.BackendFactory
 import timber.log.Timber
 import java.util.*
 import java.util.function.Consumer
+import kotlin.collections.*
 import kotlin.math.max
 import kotlin.math.min
 import kotlin.math.roundToInt

--- a/AnkiDroid/src/main/java/com/ichi2/anki/OnboardingUtils.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/OnboardingUtils.kt
@@ -23,6 +23,7 @@ import androidx.core.content.edit
 import com.ichi2.anki.IntroductionActivity.Companion.INTRODUCTION_SLIDES_SHOWN
 import timber.log.Timber
 import java.util.*
+import kotlin.collections.*
 import kotlin.collections.HashSet
 
 class OnboardingUtils {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ReadText.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ReadText.kt
@@ -36,6 +36,7 @@ import com.ichi2.utils.iconAttr
 import timber.log.Timber
 import java.lang.ref.WeakReference
 import java.util.*
+import kotlin.collections.*
 
 object ReadText {
     @get:VisibleForTesting(otherwise = VisibleForTesting.NONE)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/TtsParser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/TtsParser.kt
@@ -6,6 +6,7 @@ import com.ichi2.libanki.template.TemplateFilters
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Element
 import java.util.*
+import kotlin.collections.*
 
 /**
  * Parse card sides, extracting text snippets that should be read using a text-to-speech engine.

--- a/AnkiDroid/src/main/java/com/ichi2/anki/UIUtils.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/UIUtils.kt
@@ -8,6 +8,7 @@ import android.widget.Toast
 import androidx.annotation.StringRes
 import com.ichi2.libanki.utils.Time
 import java.util.*
+import kotlin.collections.*
 
 object UIUtils {
     fun showThemedToast(context: Context?, text: String?, shortLength: Boolean) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/ViewerCommand.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/ViewerCommand.kt
@@ -31,6 +31,7 @@ import com.ichi2.anki.reviewer.MappableBinding.Companion.toPreferenceString
 import java.util.*
 import java.util.function.BiFunction
 import java.util.stream.Collectors
+import kotlin.collections.*
 
 /** Abstraction: Discuss moving many of these to 'Reviewer'  */
 enum class ViewerCommand(val resourceId: Int) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DatabaseErrorDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DatabaseErrorDialog.kt
@@ -41,6 +41,7 @@ import java.io.File
 import java.io.IOException
 import java.text.SimpleDateFormat
 import java.util.*
+import kotlin.collections.*
 
 class DatabaseErrorDialog : AsyncDialogFragment() {
     private lateinit var mRepairValues: IntArray

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckSelectionDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckSelectionDialog.kt
@@ -52,6 +52,7 @@ import kotlinx.parcelize.Parcelize
 import timber.log.Timber
 import java.util.*
 import java.util.Objects.requireNonNull
+import kotlin.collections.*
 
 /**
  * "Deck Search": A dialog allowing the user to select a deck from a list of decks.

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/HelpDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/HelpDialog.kt
@@ -37,6 +37,7 @@ import com.ichi2.utils.IntentUtil.tryOpenIntent
 import com.ichi2.utils.KotlinCleanup
 import java.io.Serializable
 import java.util.*
+import kotlin.collections.*
 
 object HelpDialog {
     private fun openManual(ankiActivity: AnkiActivity) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/InsertFieldDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/InsertFieldDialog.kt
@@ -27,6 +27,7 @@ import com.afollestad.materialdialogs.list.customListAdapter
 import com.ichi2.anki.CardTemplateEditor
 import com.ichi2.anki.R
 import java.util.*
+import kotlin.collections.*
 
 /**
  * Dialog fragment used to show the fields that the user can insert in the card editor. This

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/LocaleSelectionDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/LocaleSelectionDialog.kt
@@ -39,6 +39,7 @@ import com.ichi2.ui.RecyclerSingleTouchAdapter
 import com.ichi2.utils.DisplayUtils.resizeWhenSoftInputShown
 import com.ichi2.utils.TypedFilter
 import java.util.*
+import kotlin.collections.*
 
 /** Locale selection dialog. Note: this must be dismissed onDestroy if not called from an activity implementing LocaleSelectionDialogHandler  */
 class LocaleSelectionDialog : AnalyticsDialogFragment() {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/MediaCheckDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/MediaCheckDialog.kt
@@ -14,6 +14,7 @@ import com.afollestad.materialdialogs.MaterialDialog
 import com.afollestad.materialdialogs.customview.customView
 import com.ichi2.anki.R
 import java.util.*
+import kotlin.collections.*
 
 class MediaCheckDialog : AsyncDialogFragment() {
     interface MediaCheckDialogListener {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/RecursivePictureMenu.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/RecursivePictureMenu.kt
@@ -34,6 +34,7 @@ import com.ichi2.anki.AnkiActivity
 import com.ichi2.anki.R
 import com.ichi2.anki.analytics.UsageAnalytics
 import java.util.*
+import kotlin.collections.*
 
 /** A Dialog displaying The various options for "Help" in a nested structure  */
 class RecursivePictureMenu : DialogFragment() {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/customstudy/CustomStudyDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/customstudy/CustomStudyDialog.kt
@@ -57,6 +57,7 @@ import com.ichi2.utils.JSONObject
 import com.ichi2.utils.KotlinCleanup
 import timber.log.Timber
 import java.util.*
+import kotlin.collections.*
 
 class CustomStudyDialog(private val collection: Collection, private val customStudyListener: CustomStudyListener?) : AnalyticsDialogFragment(), TagsDialogListener {
     interface CustomStudyListener : CreateCustomStudySessionListener.Callback {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/tags/TagsArrayAdapter.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/tags/TagsArrayAdapter.kt
@@ -29,6 +29,7 @@ import com.ichi2.ui.CheckBoxTriStates.State.*
 import com.ichi2.utils.TagsUtil
 import com.ichi2.utils.TypedFilter
 import java.util.*
+import kotlin.collections.*
 
 /**
  * @param tags A reference to the {@link TagsList} passed.

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/tags/TagsDialogListener.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/tags/TagsDialogListener.kt
@@ -20,7 +20,6 @@ import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentManager
 import androidx.fragment.app.FragmentResultListener
 import com.ichi2.utils.KotlinCleanup
-import java.util.ArrayList
 
 @KotlinCleanup("make selectedTags and indeterminateTags non-null")
 interface TagsDialogListener {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/tags/TagsList.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/tags/TagsList.kt
@@ -22,6 +22,7 @@ import com.ichi2.utils.TagsUtil.getTagRoot
 import com.ichi2.utils.UniqueArrayList
 import com.ichi2.utils.UniqueArrayList.Companion.from
 import java.util.*
+import kotlin.collections.*
 
 /**
  * A container class that keeps track of tags and their status, handling of tags are done in a case insensitive matter

--- a/AnkiDroid/src/main/java/com/ichi2/anki/jsaddons/NpmUtils.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/jsaddons/NpmUtils.kt
@@ -20,6 +20,7 @@ import timber.log.Timber
 import java.net.URLEncoder
 import java.util.*
 import java.util.regex.Pattern
+import kotlin.collections.*
 
 object NpmUtils {
     /**

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/activity/PickStringDialogFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/activity/PickStringDialogFragment.kt
@@ -28,6 +28,7 @@ import android.widget.ArrayAdapter
 import androidx.fragment.app.DialogFragment
 import com.ichi2.utils.KotlinCleanup
 import java.util.*
+import kotlin.collections.*
 
 /**
  * This dialog fragment support a choice from a list of strings.

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/impl/MultimediaEditableNote.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/impl/MultimediaEditableNote.kt
@@ -24,6 +24,7 @@ import com.ichi2.anki.multimediacard.fields.IField
 import com.ichi2.libanki.NoteTypeId
 import org.acra.util.IOUtils
 import java.util.*
+import kotlin.collections.*
 
 /**
  * Implementation of the editable note.

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/language/LanguageListerBase.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/language/LanguageListerBase.kt
@@ -20,6 +20,7 @@
 package com.ichi2.anki.multimediacard.language
 
 import java.util.*
+import kotlin.collections.*
 
 /**
  * This is some sort of tool, which translates from languages in a user readable form to a code, used to invoke some

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/language/LanguageListerBeolingus.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/language/LanguageListerBeolingus.kt
@@ -19,6 +19,7 @@
 package com.ichi2.anki.multimediacard.language
 
 import java.util.*
+import kotlin.collections.*
 
 /**
  * This one lister services in beolingus. It is used to load pronunciation.

--- a/AnkiDroid/src/main/java/com/ichi2/anki/noteeditor/CustomToolbarButton.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/noteeditor/CustomToolbarButton.kt
@@ -21,6 +21,7 @@ import com.ichi2.libanki.Consts
 import com.ichi2.utils.HashUtil.HashSetInit
 import timber.log.Timber
 import java.util.*
+import kotlin.collections.*
 
 typealias ButtonText = String
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/noteeditor/FieldState.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/noteeditor/FieldState.kt
@@ -30,6 +30,7 @@ import com.ichi2.utils.JSONObject
 import com.ichi2.utils.KotlinCleanup
 import com.ichi2.utils.MapUtil.getKeyByValue
 import java.util.*
+import kotlin.collections.*
 
 /** Responsible for recreating EditFieldLines after NoteEditor operations
  * This primarily exists so we can use saved instance state to repopulate the dynamically created FieldEditLine

--- a/AnkiDroid/src/main/java/com/ichi2/anki/noteeditor/Toolbar.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/noteeditor/Toolbar.kt
@@ -45,6 +45,7 @@ import com.ichi2.utils.ViewGroupUtils
 import com.ichi2.utils.ViewGroupUtils.getAllChildrenRecursive
 import timber.log.Timber
 import java.util.*
+import kotlin.collections.*
 import kotlin.math.ceil
 
 /**

--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/GeneralSettingsFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/GeneralSettingsFragment.kt
@@ -27,6 +27,7 @@ import com.ichi2.utils.LanguageUtil
 import com.ichi2.utils.LanguageUtil.getSystemLocale
 import kotlinx.coroutines.runBlocking
 import java.util.*
+import kotlin.collections.*
 
 class GeneralSettingsFragment : SettingsFragment() {
     override val preferenceResource: Int

--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/Preferences.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/Preferences.kt
@@ -48,6 +48,7 @@ import com.ichi2.utils.AdaptionUtil
 import com.ichi2.utils.getInstanceFromClassName
 import timber.log.Timber
 import java.util.*
+import kotlin.collections.*
 
 /**
  * Preferences dialog.

--- a/AnkiDroid/src/main/java/com/ichi2/anki/provider/CardContentProvider.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/provider/CardContentProvider.kt
@@ -49,6 +49,7 @@ import timber.log.Timber
 import java.io.File
 import java.io.IOException
 import java.util.*
+import kotlin.collections.*
 import kotlin.collections.ArrayList
 
 /**

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/Binding.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/Binding.kt
@@ -25,6 +25,7 @@ import com.ichi2.compat.CompatHelper
 import com.ichi2.utils.StringUtil
 import timber.log.Timber
 import java.util.*
+import kotlin.collections.*
 
 class Binding private constructor(val modifierKeys: ModifierKeys?, val keycode: Int?, val unicodeCharacter: Char?, val gesture: Gesture?) {
     constructor(gesture: Gesture?) : this(null, null, null, gesture)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/MappableBinding.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/MappableBinding.kt
@@ -24,6 +24,7 @@ import com.ichi2.anki.cardviewer.Gesture
 import com.ichi2.anki.cardviewer.ViewerCommand
 import timber.log.Timber
 import java.util.*
+import kotlin.collections.*
 import kotlin.collections.ArrayList
 
 /**

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/PeripheralKeymap.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/PeripheralKeymap.kt
@@ -23,7 +23,6 @@ import com.ichi2.anki.cardviewer.ViewerCommand
 import com.ichi2.anki.reviewer.Binding.Companion.key
 import com.ichi2.anki.reviewer.CardSide.Companion.fromAnswer
 import com.ichi2.anki.reviewer.MappableBinding.Companion.fromPreference
-import java.util.HashMap
 
 /** Accepts peripheral input, mapping via various keybinding strategies,
  * and converting them to commands for the Reviewer.  */

--- a/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/DeckService.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/DeckService.kt
@@ -21,6 +21,7 @@ import com.ichi2.libanki.Consts
 import com.ichi2.libanki.DeckId
 import com.ichi2.libanki.Utils
 import java.util.*
+import kotlin.collections.*
 
 object DeckService {
     fun shouldShowDefaultDeck(col: Collection): Boolean =

--- a/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/LanguageHintService.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/LanguageHintService.kt
@@ -25,6 +25,7 @@ import com.ichi2.libanki.ModelManager
 import com.ichi2.utils.JSONObject
 import timber.log.Timber
 import java.util.*
+import kotlin.collections.*
 
 /**
  * The language that a keyboard should open with when an [EditText] is selected

--- a/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/SchedulerService.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/SchedulerService.kt
@@ -27,6 +27,7 @@ import com.ichi2.utils.Computation
 import timber.log.Timber
 import java.util.*
 import java.util.concurrent.CancellationException
+import kotlin.collections.*
 import kotlin.collections.ArrayList
 import com.ichi2.libanki.Collection as AnkiCollection
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/stats/OverviewStatsBuilder.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/stats/OverviewStatsBuilder.kt
@@ -26,6 +26,7 @@ import com.ichi2.libanki.stats.Stats
 import com.ichi2.libanki.stats.Stats.AxisType
 import com.ichi2.themes.Themes.getColorFromAttr
 import java.util.*
+import kotlin.collections.*
 import kotlin.math.roundToInt
 import kotlin.math.roundToLong
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/NoteTypeSpinnerUtils.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/NoteTypeSpinnerUtils.kt
@@ -28,6 +28,7 @@ import com.ichi2.libanki.Model
 import com.ichi2.themes.Themes.getColorFromAttr
 import com.ichi2.utils.NamedJSONComparator
 import java.util.*
+import kotlin.collections.*
 
 /** Setup for a spinner which displays all note types */
 object NoteTypeSpinnerUtils {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/widgets/DeckAdapter.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/widgets/DeckAdapter.kt
@@ -39,6 +39,7 @@ import com.ichi2.utils.KotlinCleanup
 import com.ichi2.utils.TypedFilter
 import net.ankiweb.rsdroid.BackendFactory
 import java.util.*
+import kotlin.collections.*
 
 @KotlinCleanup("lots to do")
 class DeckAdapter(private val layoutInflater: LayoutInflater, context: Context) : RecyclerView.Adapter<DeckAdapter.ViewHolder>(), Filterable {

--- a/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.kt
@@ -47,6 +47,7 @@ import java.io.IOException
 import java.util.*
 import java.util.concurrent.CancellationException
 import java.util.concurrent.ExecutionException
+import kotlin.collections.*
 
 /**
  * This is essentially an AsyncTask with some more logging. It delegates to TaskDelegate the actual business logic.

--- a/AnkiDroid/src/main/java/com/ichi2/async/Connection.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/async/Connection.kt
@@ -48,7 +48,8 @@ import com.ichi2.utils.Permissions
 import okhttp3.Response
 import timber.log.Timber
 import java.io.IOException
-import java.util.Arrays
+import java.util.*
+import kotlin.collections.*
 
 @Suppress("DEPRECATION") // #7108: AsyncTask
 @KotlinCleanup("Simplify null comparison, !! -> ?.")

--- a/AnkiDroid/src/main/java/com/ichi2/async/SingleTaskManager.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/async/SingleTaskManager.kt
@@ -20,6 +20,7 @@ import com.ichi2.utils.ThreadUtil.sleep
 import timber.log.Timber
 import java.util.*
 import java.util.concurrent.TimeUnit
+import kotlin.collections.*
 
 /**
  * This class consists essentially in executing each received TaskDelegate in the order in which they are received.

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Card.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Card.kt
@@ -38,6 +38,7 @@ import net.ankiweb.rsdroid.RustCleanup
 import timber.log.Timber
 import java.util.*
 import java.util.concurrent.CancellationException
+import kotlin.collections.*
 
 /**
  * A Card is the ultimate entity subject to review; it encapsulates the scheduling parameters (from which to derive

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.kt
@@ -66,6 +66,7 @@ import java.util.*
 import java.util.concurrent.LinkedBlockingDeque
 import java.util.function.Consumer
 import java.util.regex.Pattern
+import kotlin.collections.*
 import kotlin.math.max
 import kotlin.random.Random
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/DB.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/DB.kt
@@ -37,7 +37,6 @@ import org.intellij.lang.annotations.Language
 import timber.log.Timber
 import java.lang.Exception
 import java.lang.RuntimeException
-import java.util.ArrayList
 import kotlin.Throws
 
 /**

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/DeckManager.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/DeckManager.kt
@@ -26,6 +26,7 @@ import com.ichi2.utils.KotlinCleanup
 import net.ankiweb.rsdroid.RustCleanup
 import org.intellij.lang.annotations.Language
 import java.util.*
+import kotlin.collections.*
 
 abstract class DeckManager {
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.kt
@@ -39,6 +39,7 @@ import timber.log.Timber
 import java.text.Normalizer
 import java.util.*
 import java.util.regex.Pattern
+import kotlin.collections.*
 
 // fixmes:
 // - make sure users can't set grad interval < 1

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/DecksV16.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/DecksV16.kt
@@ -53,6 +53,7 @@ import net.ankiweb.rsdroid.exceptions.BackendDeckIsFilteredException
 import net.ankiweb.rsdroid.exceptions.BackendNotFoundException
 import timber.log.Timber
 import java.util.*
+import kotlin.collections.*
 
 data class DeckNameId(val name: String, val id: DeckId)
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Finder.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Finder.kt
@@ -33,6 +33,7 @@ import timber.log.Timber
 import java.text.Normalizer
 import java.util.*
 import java.util.regex.Pattern
+import kotlin.collections.*
 
 @RustCleanup("remove this once Java backend is gone")
 class Finder(private val col: Collection) {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Media.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Media.kt
@@ -34,6 +34,7 @@ import java.util.regex.Pattern
 import java.util.zip.ZipEntry
 import java.util.zip.ZipFile
 import java.util.zip.ZipOutputStream
+import kotlin.collections.*
 import kotlin.math.min
 
 /**

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Models.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Models.kt
@@ -32,6 +32,7 @@ import com.ichi2.utils.KotlinCleanup
 import timber.log.Timber
 import java.util.*
 import java.util.regex.Pattern
+import kotlin.collections.*
 
 @KotlinCleanup("IDE Lint")
 @KotlinCleanup("Lots to do")

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/PythonTypes.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/PythonTypes.kt
@@ -17,6 +17,7 @@
 package com.ichi2.libanki
 
 import java.util.*
+import kotlin.collections.*
 
 /*
  * We can't use private typealiases until

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Sound.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Sound.kt
@@ -40,6 +40,7 @@ import timber.log.Timber
 import java.lang.ref.WeakReference
 import java.util.*
 import java.util.regex.Pattern
+import kotlin.collections.*
 
 @KotlinCleanup("IDE Lint")
 // NICE_TO_HAVE: Abstract, then add tests for #6111

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Tags.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Tags.kt
@@ -24,6 +24,7 @@ import com.ichi2.libanki.utils.TimeManager
 import com.ichi2.utils.JSONObject
 import java.util.*
 import java.util.regex.Pattern
+import kotlin.collections.*
 
 /**
  * Anki maintains a cache of used tags so it can quickly present a list of tags

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/TemplateManager.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/TemplateManager.kt
@@ -31,7 +31,6 @@ import com.ichi2.utils.JSONObject
 import net.ankiweb.rsdroid.RustCleanup
 import net.ankiweb.rsdroid.exceptions.BackendTemplateException
 import timber.log.Timber
-import java.util.*
 
 private typealias Union<A, B> = Pair<A, B>
 private typealias TemplateReplacementList = MutableList<Union<str?, TemplateManager.TemplateReplacement?>>
@@ -164,7 +163,7 @@ class TemplateManager {
             Timber.w(".fields() is obsolete, use .note() or .card()")
             if (_fields == null) {
                 // fields from note
-                val fields = _note.items().map { Pair(it[0], it[1]) }.toMap().toMutableMap()
+                val fields = _note.items().map { Pair(it[0]!!, it[1]!!) }.toMap().toMutableMap()
 
                 // add (most) special fields
                 fields["Tags"] = _note.stringTags().trim()

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/TextCardExporter.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/TextCardExporter.kt
@@ -18,6 +18,7 @@ import java.io.IOException
 import java.io.OutputStreamWriter
 import java.nio.charset.StandardCharsets
 import java.util.*
+import kotlin.collections.*
 
 class TextCardExporter(col: Collection, did: DeckId?, includeHTML: Boolean) : Exporter(col, did) {
     init {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/UndoAction.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/UndoAction.kt
@@ -23,6 +23,7 @@ import com.ichi2.anki.R
 import com.ichi2.utils.LanguageUtil.getLocaleCompat
 import timber.log.Timber
 import java.util.*
+import kotlin.collections.*
 
 abstract class UndoAction
 /**

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Utils.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Utils.kt
@@ -52,6 +52,7 @@ import java.text.Normalizer
 import java.util.*
 import java.util.regex.Matcher
 import java.util.regex.Pattern
+import kotlin.collections.*
 import kotlin.collections.Collection
 
 @KotlinCleanup("IDE Lint")

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/hooks/ChessFilter.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/hooks/ChessFilter.kt
@@ -21,6 +21,7 @@ import com.ichi2.anki.AnkiDroidApp
 import timber.log.Timber
 import java.util.*
 import java.util.regex.Pattern
+import kotlin.collections.*
 
 object ChessFilter {
     private val fFenPattern = Pattern.compile("\\[fen ?([^]]*)]([^\\[]+)\\[/fen]")

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/importer/AnkiPackageImporter.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/importer/AnkiPackageImporter.kt
@@ -36,6 +36,7 @@ import java.io.File
 import java.io.FileNotFoundException
 import java.io.IOException
 import java.util.*
+import kotlin.collections.*
 
 class AnkiPackageImporter(col: Collection?, file: String?) : Anki2Importer(col!!, file!!) {
     @KotlinCleanup("lateinit")

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/AbstractDeckTreeNode.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/AbstractDeckTreeNode.kt
@@ -20,6 +20,7 @@ import com.ichi2.libanki.DeckId
 import com.ichi2.libanki.Decks
 import java.lang.UnsupportedOperationException
 import java.util.*
+import kotlin.collections.*
 
 /**
  * Holds the data for a single node (row) in the deck due tree (the user-visible list

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/CardQueue.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/CardQueue.kt
@@ -21,6 +21,7 @@ import com.ichi2.libanki.CardId
 import com.ichi2.libanki.Collection
 import com.ichi2.utils.KotlinCleanup
 import java.util.*
+import kotlin.collections.*
 
 abstract class CardQueue<T : Card.Cache?>( // We need to store mSched and not queue, because during initialization of sched, when CardQueues are initialized
     // sched.getCol is null.

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/DeckDueTreeNode.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/DeckDueTreeNode.kt
@@ -21,6 +21,7 @@ import com.ichi2.libanki.Decks
 import com.ichi2.utils.KotlinCleanup
 import net.ankiweb.rsdroid.RustCleanup
 import java.util.*
+import kotlin.collections.*
 import kotlin.math.max
 import kotlin.math.min
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Sched.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Sched.kt
@@ -37,6 +37,7 @@ import com.ichi2.utils.*
 import com.ichi2.utils.SyncStatus.Companion.ignoreDatabaseModification
 import timber.log.Timber
 import java.util.*
+import kotlin.collections.*
 
 @KotlinCleanup("IDE Lint")
 @KotlinCleanup("cleanup: use formatted string for all queries")

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.kt
@@ -48,6 +48,7 @@ import net.ankiweb.rsdroid.RustCleanup
 import timber.log.Timber
 import java.lang.ref.WeakReference
 import java.util.*
+import kotlin.collections.*
 
 @KotlinCleanup("IDE Lint")
 @KotlinCleanup("much to do - keep in line with libAnki")

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/stats/AdvancedStatistics.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/stats/AdvancedStatistics.kt
@@ -32,6 +32,7 @@ import com.ichi2.libanki.utils.TimeManager.time
 import com.ichi2.utils.HashUtil.HashMapInit
 import timber.log.Timber
 import java.util.*
+import kotlin.collections.*
 
 /**
  * Display forecast statistics based on a simulation of future reviews.

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/stats/Stats.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/stats/Stats.kt
@@ -31,6 +31,7 @@ import com.ichi2.libanki.utils.Time.Companion.gregorianCalendar
 import com.ichi2.utils.KotlinCleanup
 import timber.log.Timber
 import java.util.*
+import kotlin.collections.*
 
 class Stats(private val col: com.ichi2.libanki.Collection, did: Long) {
     enum class AxisType(val days: Int, val descriptionId: Int) {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sync/MediaSyncer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sync/MediaSyncer.kt
@@ -30,6 +30,7 @@ import com.ichi2.libanki.sync.Syncer.ConnectionResultType
 import timber.log.Timber
 import java.io.IOException
 import java.util.*
+import kotlin.collections.*
 
 /**
  * About conflicts:

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sync/RemoteMediaServer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sync/RemoteMediaServer.kt
@@ -34,6 +34,7 @@ import java.io.FileInputStream
 import java.io.IOException
 import java.util.*
 import java.util.zip.ZipFile
+import kotlin.collections.*
 
 class RemoteMediaServer(
     private val col: Collection?,

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sync/RemoteServer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sync/RemoteServer.kt
@@ -29,6 +29,7 @@ import okhttp3.Response
 import timber.log.Timber
 import java.io.IOException
 import java.util.*
+import kotlin.collections.*
 
 class RemoteServer(
     con: Connection,

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sync/Syncer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sync/Syncer.kt
@@ -40,6 +40,7 @@ import com.ichi2.utils.KotlinCleanup
 import timber.log.Timber
 import java.io.IOException
 import java.util.*
+import kotlin.collections.*
 
 @KotlinCleanup("IDE-lint")
 class Syncer(

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sync/UnifiedTrustManager.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sync/UnifiedTrustManager.kt
@@ -24,6 +24,7 @@ import java.security.cert.X509Certificate
 import java.util.*
 import javax.net.ssl.TrustManagerFactory
 import javax.net.ssl.X509TrustManager
+import kotlin.collections.*
 
 // https://stackoverflow.com/questions/27562666/programmatically-add-a-certificate-authority-while-keeping-android-system-ssl-ce
 // Changes:

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/template/ParsedNode.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/template/ParsedNode.kt
@@ -24,6 +24,7 @@ import com.ichi2.libanki.template.TemplateError.*
 import com.ichi2.utils.KotlinCleanup
 import timber.log.Timber
 import java.util.*
+import kotlin.collections.*
 
 /**
  * Represents a template, allow to check in linear time which card is empty/render card.

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/template/ParsedNodes.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/template/ParsedNodes.kt
@@ -18,6 +18,7 @@ package com.ichi2.libanki.template
 import androidx.annotation.VisibleForTesting
 import com.ichi2.utils.KotlinCleanup
 import java.util.*
+import kotlin.collections.*
 
 @KotlinCleanup("fix hashCode issue suppression")
 @Suppress("EqualsOrHashCode")

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/template/Replacement.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/template/Replacement.kt
@@ -25,6 +25,7 @@ import com.ichi2.utils.KotlinCleanup
 import java.lang.StringBuilder
 import java.util.*
 import kotlin.Throws
+import kotlin.collections.*
 
 @KotlinCleanup("IDE Lint")
 class Replacement(

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/template/TemplateFilters.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/template/TemplateFilters.kt
@@ -29,6 +29,7 @@ import java.lang.Exception
 import java.util.*
 import java.util.regex.Matcher
 import java.util.regex.Pattern
+import kotlin.collections.*
 
 /**
  * Port template_filters.rs

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/utils/PythonExtensions.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/utils/PythonExtensions.kt
@@ -20,6 +20,7 @@ import android.text.TextUtils
 import com.ichi2.utils.JSONArray
 import com.ichi2.utils.JSONObject
 import java.util.*
+import kotlin.collections.*
 
 fun <T> MutableList<T>.append(value: T) {
     this.add(value)

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/utils/TimeManager.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/utils/TimeManager.kt
@@ -19,6 +19,7 @@ package com.ichi2.libanki.utils
 import android.annotation.SuppressLint
 import androidx.annotation.VisibleForTesting
 import java.util.*
+import kotlin.collections.*
 
 /** Singleton providing an instance of [Time].
  * Used for tests to mock the time provider

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/utils/TimeUtils.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/utils/TimeUtils.kt
@@ -17,6 +17,7 @@ package com.ichi2.libanki.utils
 
 import java.text.SimpleDateFormat
 import java.util.*
+import kotlin.collections.*
 
 object TimeUtils {
     fun getTimestamp(time: Time): String {

--- a/AnkiDroid/src/main/java/com/ichi2/preferences/ControlPreference.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/preferences/ControlPreference.kt
@@ -37,6 +37,7 @@ import com.ichi2.anki.reviewer.MappableBinding.Companion.fromGesture
 import com.ichi2.anki.reviewer.MappableBinding.Companion.toPreferenceString
 import com.ichi2.ui.KeyPicker
 import java.util.*
+import kotlin.collections.*
 
 /**
  * A preference which allows mapping of inputs to actions (example: keys -> commands)

--- a/AnkiDroid/src/main/java/com/ichi2/themes/HtmlColors.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/themes/HtmlColors.kt
@@ -22,6 +22,7 @@ import timber.log.Timber
 import java.util.*
 import java.util.regex.Matcher
 import java.util.regex.Pattern
+import kotlin.collections.*
 
 @KotlinCleanup("for better possibly-null handling")
 object HtmlColors {

--- a/AnkiDroid/src/main/java/com/ichi2/ui/AppCompatPreferenceActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/ui/AppCompatPreferenceActivity.kt
@@ -35,6 +35,7 @@ import com.ichi2.utils.HashUtil
 import com.ichi2.utils.KotlinCleanup
 import timber.log.Timber
 import java.util.*
+import kotlin.collections.*
 import kotlin.collections.HashMap
 
 /**

--- a/AnkiDroid/src/main/java/com/ichi2/utils/AdaptionUtil.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/AdaptionUtil.kt
@@ -29,6 +29,7 @@ import android.provider.Settings
 import com.ichi2.anki.AnkiDroidApp
 import timber.log.Timber
 import java.util.*
+import kotlin.collections.*
 
 object AdaptionUtil {
     private var sHasRunWebBrowserCheck = false

--- a/AnkiDroid/src/main/java/com/ichi2/utils/CheckCameraPermission.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/CheckCameraPermission.kt
@@ -21,6 +21,7 @@ import android.content.pm.PackageManager
 import timber.log.Timber
 import java.lang.Exception
 import java.util.*
+import kotlin.collections.*
 
 object CheckCameraPermission {
     @Suppress("deprecation") // getPackageInfo

--- a/AnkiDroid/src/main/java/com/ichi2/utils/ContentResolverUtil.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/ContentResolverUtil.kt
@@ -26,6 +26,7 @@ import java.io.File
 import java.lang.Exception
 import java.lang.IllegalStateException
 import java.util.*
+import kotlin.collections.*
 
 object ContentResolverUtil {
     /** Obtains the filename from the url. Throws if all methods return exception  */

--- a/AnkiDroid/src/main/java/com/ichi2/utils/DatabaseChangeDecorator.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/DatabaseChangeDecorator.kt
@@ -21,6 +21,7 @@ import androidx.sqlite.db.SupportSQLiteDatabase
 import androidx.sqlite.db.SupportSQLiteStatement
 import net.ankiweb.rsdroid.RustCleanup
 import java.util.*
+import kotlin.collections.*
 
 /** Detects any database modifications and notifies the sync status of the application  */
 @RustCleanup("After migrating to new backend, can use backend call instead of this class.")

--- a/AnkiDroid/src/main/java/com/ichi2/utils/FileUtil.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/FileUtil.kt
@@ -24,7 +24,6 @@ import timber.log.Timber
 import java.io.File
 import java.io.IOException
 import java.io.InputStream
-import java.util.*
 
 object FileUtil {
     /** Gets the free disk space given a file  */
@@ -67,14 +66,14 @@ object FileUtil {
     /**
      * @return Key: Filename; Value: extension including dot
      */
-    fun getFileNameAndExtension(fileName: String?): Map.Entry<String, String>? {
+    fun getFileNameAndExtension(fileName: String?): Pair<String, String>? {
         if (fileName == null) {
             return null
         }
         val index = fileName.lastIndexOf(".")
         return if (index < 1) {
             null
-        } else AbstractMap.SimpleEntry(fileName.substring(0, index), fileName.substring(index))
+        } else Pair(fileName.substring(0, index), fileName.substring(index))
     }
 
     /**

--- a/AnkiDroid/src/main/java/com/ichi2/utils/HashUtil.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/HashUtil.kt
@@ -15,7 +15,6 @@
  ****************************************************************************************/
 package com.ichi2.utils
 
-import java.util.HashMap
 import java.util.HashSet
 
 object HashUtil {

--- a/AnkiDroid/src/main/java/com/ichi2/utils/HashUtil.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/HashUtil.kt
@@ -15,8 +15,6 @@
  ****************************************************************************************/
 package com.ichi2.utils
 
-import java.util.HashSet
-
 object HashUtil {
     /**
      * @param size Number of elements expected in the hash structure

--- a/AnkiDroid/src/main/java/com/ichi2/utils/ImportUtils.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/ImportUtils.kt
@@ -46,6 +46,7 @@ import java.net.URLEncoder
 import java.util.*
 import java.util.zip.ZipException
 import java.util.zip.ZipInputStream
+import kotlin.collections.*
 import kotlin.collections.ArrayList
 
 object ImportUtils {

--- a/AnkiDroid/src/main/java/com/ichi2/utils/LanguageUtil.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/LanguageUtil.kt
@@ -25,6 +25,7 @@ import net.ankiweb.rsdroid.BackendFactory
 import timber.log.Timber
 import java.text.DateFormat
 import java.util.*
+import kotlin.collections.*
 
 /**
  * Utility call for proving language related functionality.

--- a/AnkiDroid/src/main/java/com/ichi2/utils/NoteFieldDecorator.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/NoteFieldDecorator.kt
@@ -19,6 +19,7 @@
 package com.ichi2.utils
 
 import java.util.*
+import kotlin.collections.*
 
 object NoteFieldDecorator {
     private val random = Random()

--- a/AnkiDroid/src/main/java/com/ichi2/utils/StringUtil.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/StringUtil.kt
@@ -19,6 +19,7 @@ package com.ichi2.utils
 
 import org.jetbrains.annotations.Contract
 import java.util.*
+import kotlin.collections.*
 
 object StringUtil {
     /** Trims from the right hand side of a string  */

--- a/AnkiDroid/src/main/java/com/ichi2/utils/UniqueArrayList.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/UniqueArrayList.kt
@@ -18,6 +18,7 @@ package com.ichi2.utils
 import androidx.annotation.RequiresApi
 import org.apache.commons.collections4.list.SetUniqueList
 import java.util.*
+import kotlin.collections.*
 
 /**
  * A collection of items that doesn't allow duplicate items, and allows fast random access, lookup, maintaining order, and sorting.

--- a/AnkiDroid/src/main/java/com/ichi2/utils/ViewGroupUtils.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/ViewGroupUtils.kt
@@ -22,7 +22,6 @@ import android.view.View
 import android.view.ViewGroup
 import com.ichi2.anki.AnkiDroidApp
 import timber.log.Timber
-import java.util.ArrayList
 
 object ViewGroupUtils {
     fun getAllChildren(viewGroup: ViewGroup): List<View> {

--- a/AnkiDroid/src/main/java/com/wildplot/android/rendering/DrawableContainer.kt
+++ b/AnkiDroid/src/main/java/com/wildplot/android/rendering/DrawableContainer.kt
@@ -18,6 +18,7 @@ package com.wildplot.android.rendering
 import com.wildplot.android.rendering.graphics.wrapper.GraphicsWrap
 import com.wildplot.android.rendering.interfaces.Drawable
 import java.util.*
+import kotlin.collections.*
 
 class DrawableContainer(private val isOnFrame: Boolean, private val isCritical: Boolean) : Drawable {
     private val drawableVector = Vector<Drawable>()

--- a/AnkiDroid/src/main/java/com/wildplot/android/rendering/MultiScreenPart.kt
+++ b/AnkiDroid/src/main/java/com/wildplot/android/rendering/MultiScreenPart.kt
@@ -18,6 +18,7 @@ package com.wildplot.android.rendering
 
 import com.wildplot.android.rendering.interfaces.Drawable
 import java.util.*
+import kotlin.collections.*
 
 /**
  * This class is used to store information for a certain plot in a multi-plot sheet.

--- a/AnkiDroid/src/main/java/com/wildplot/android/rendering/PlotSheet.kt
+++ b/AnkiDroid/src/main/java/com/wildplot/android/rendering/PlotSheet.kt
@@ -23,6 +23,7 @@ import com.wildplot.android.rendering.interfaces.Drawable
 import com.wildplot.android.rendering.interfaces.Legendable
 import timber.log.Timber
 import java.util.*
+import kotlin.collections.*
 
 /**
  * This is a sheet that is used to plot mathematical functions including coordinate systems and optional extras like

--- a/AnkiDroid/src/test/java/com/ichi2/anki/AbstractFlashcardViewerSoundRenderTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/AbstractFlashcardViewerSoundRenderTest.kt
@@ -27,6 +27,7 @@ import org.hamcrest.Matchers.nullValue
 import org.junit.Test
 import org.junit.runner.RunWith
 import java.util.*
+import kotlin.collections.*
 
 /** Tests Sound Rendering - should be extracted from the GUI at some point */
 @RustCleanup("doesn't work with V16")

--- a/AnkiDroid/src/test/java/com/ichi2/anki/AbstractFlashcardViewerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/AbstractFlashcardViewerTest.kt
@@ -38,6 +38,7 @@ import org.robolectric.android.controller.ActivityController
 import org.robolectric.shadows.ShadowToast
 import java.util.*
 import java.util.stream.Stream
+import kotlin.collections.*
 
 @RequiresApi(api = Build.VERSION_CODES.O) // getImeHintLocales, toLanguageTags, onRenderProcessGone, RenderProcessGoneDetail
 @RunWith(AndroidJUnit4::class)

--- a/AnkiDroid/src/test/java/com/ichi2/anki/ActivityStartupMetaTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/ActivityStartupMetaTest.kt
@@ -28,6 +28,7 @@ import org.junit.runner.RunWith
 import java.util.*
 import java.util.stream.Collectors
 import kotlin.Throws
+import kotlin.collections.*
 
 @RunWith(AndroidJUnit4::class)
 class ActivityStartupMetaTest : RobolectricTest() {

--- a/AnkiDroid/src/test/java/com/ichi2/anki/DeckPickerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/DeckPickerTest.kt
@@ -34,6 +34,7 @@ import org.robolectric.RuntimeEnvironment
 import java.io.File
 import java.lang.Exception
 import java.util.*
+import kotlin.collections.*
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/LocaleLinting.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/LocaleLinting.kt
@@ -32,6 +32,7 @@ import org.robolectric.RuntimeEnvironment
 import org.robolectric.annotation.Config
 import timber.log.Timber
 import java.util.*
+import kotlin.collections.*
 
 /**
  * Linting to ensure that all locales have valid strings

--- a/AnkiDroid/src/test/java/com/ichi2/anki/ReviewerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/ReviewerTest.kt
@@ -44,6 +44,7 @@ import org.robolectric.ParameterizedRobolectricTestRunner
 import timber.log.Timber
 import java.lang.Exception
 import java.util.*
+import kotlin.collections.*
 import kotlin.test.junit5.JUnit5Asserter.assertNotNull
 
 @RunWith(ParameterizedRobolectricTestRunner::class)

--- a/AnkiDroid/src/test/java/com/ichi2/anki/analytics/AnalyticsConstantsTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/analytics/AnalyticsConstantsTest.kt
@@ -23,6 +23,7 @@ import org.junit.runners.Parameterized
 import java.lang.RuntimeException
 import java.util.*
 import kotlin.Throws
+import kotlin.collections.*
 import kotlin.reflect.full.memberProperties
 import kotlin.reflect.jvm.javaField
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/RecursivePictureMenuUtilTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/RecursivePictureMenuUtilTest.kt
@@ -22,7 +22,6 @@ import com.ichi2.anki.RobolectricTest
 import com.ichi2.anki.analytics.UsageAnalytics
 import com.ichi2.anki.dialogs.utils.FragmentTestActivity
 import com.ichi2.anki.dialogs.utils.RecursivePictureMenuUtil
-import java.util.ArrayList
 
 open class RecursivePictureMenuUtilTest : RobolectricTest() {
     var activity: FragmentTestActivity? = null

--- a/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/tags/TagsDialogTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/tags/TagsDialogTest.kt
@@ -44,6 +44,7 @@ import org.mockito.kotlin.whenever
 import java.util.*
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.atomic.AtomicReference
+import kotlin.collections.*
 
 @RunWith(AndroidJUnit4::class)
 class TagsDialogTest {

--- a/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/tags/TagsListTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/tags/TagsListTest.kt
@@ -24,6 +24,7 @@ import org.junit.Test
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito
 import java.util.*
+import kotlin.collections.*
 
 // suppressed to have a symmetry in all tests, Arrays.asList(...) should be all you need.
 @KotlinCleanup("Use kotlin functions instead of Arrays.asList")

--- a/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/utils/RecursivePictureMenuUtil.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/utils/RecursivePictureMenuUtil.kt
@@ -21,6 +21,7 @@ import com.afollestad.materialdialogs.MaterialDialog
 import com.afollestad.materialdialogs.list.getRecyclerView
 import com.ichi2.anki.dialogs.RecursivePictureMenu
 import java.util.*
+import kotlin.collections.*
 
 class RecursivePictureMenuUtil {
     companion object {

--- a/AnkiDroid/src/test/java/com/ichi2/anki/reviewer/ActionButtonStatusTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/reviewer/ActionButtonStatusTest.kt
@@ -27,6 +27,7 @@ import org.mockito.Mockito.*
 import org.mockito.invocation.InvocationOnMock
 import org.mockito.kotlin.whenever
 import java.util.*
+import kotlin.collections.*
 
 @RunWith(AndroidJUnit4::class)
 class ActionButtonStatusTest : RobolectricTest() {

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/AnkiPackageExporterTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/AnkiPackageExporterTest.kt
@@ -32,6 +32,7 @@ import java.io.File
 import java.io.IOException
 import java.io.PrintWriter
 import java.util.*
+import kotlin.collections.*
 
 @RunWith(AndroidJUnit4::class)
 @KotlinCleanup("IDE Lint")

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/CardTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/CardTest.kt
@@ -29,6 +29,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.annotation.Config
 import java.util.*
+import kotlin.collections.*
 import kotlin.test.assertNotNull
 
 @RunWith(AndroidJUnit4::class)

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/CollectionTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/CollectionTest.kt
@@ -26,6 +26,7 @@ import org.junit.Ignore
 import org.junit.Test
 import org.junit.runner.RunWith
 import java.util.*
+import kotlin.collections.*
 
 @RunWith(AndroidJUnit4::class)
 class CollectionTest : RobolectricTest() {

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/FinderTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/FinderTest.kt
@@ -41,6 +41,7 @@ import org.junit.runner.RunWith
 import org.robolectric.annotation.Config
 import timber.log.Timber
 import java.util.*
+import kotlin.collections.*
 
 @RunWith(AndroidJUnit4::class)
 class FinderTest : RobolectricTest() {

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/ModelTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/ModelTest.kt
@@ -35,6 +35,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.annotation.Config
 import java.util.*
+import kotlin.collections.*
 
 @RunWith(AndroidJUnit4::class)
 @KotlinCleanup("improve kotlin code where possible")

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/StorageTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/StorageTest.kt
@@ -28,6 +28,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import java.util.*
 import java.util.stream.Collectors
+import kotlin.collections.*
 import kotlin.math.min
 
 /** Regression test for Rust  */

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/TextCardExporterTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/TextCardExporterTest.kt
@@ -24,6 +24,7 @@ import java.io.File
 import java.io.IOException
 import java.util.*
 import kotlin.Throws
+import kotlin.collections.*
 
 @KotlinCleanup("lateinit")
 @RunWith(AndroidJUnit4::class)

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/TextNoteExporterTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/TextNoteExporterTest.kt
@@ -27,6 +27,7 @@ import java.io.File
 import java.io.IOException
 import java.util.*
 import kotlin.Throws
+import kotlin.collections.*
 
 @KotlinCleanup("lateinit wherever possible")
 @KotlinCleanup("IDE-lint")

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/UtilsTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/UtilsTest.kt
@@ -29,6 +29,7 @@ import java.io.IOException
 import java.lang.Exception
 import java.util.*
 import kotlin.Throws
+import kotlin.collections.*
 
 @RunWith(AndroidJUnit4::class)
 class UtilsTest {

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/sched/SchedV2Test.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/sched/SchedV2Test.kt
@@ -62,6 +62,7 @@ import java.time.Instant
 import java.time.ZoneOffset
 import java.util.*
 import kotlin.Throws
+import kotlin.collections.*
 import kotlin.math.roundToLong
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull

--- a/AnkiDroid/src/test/java/com/ichi2/preferences/TimePreferenceTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/preferences/TimePreferenceTest.kt
@@ -22,6 +22,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
 import java.util.*
+import kotlin.collections.*
 
 @RunWith(Parameterized::class)
 class TimePreferenceTest(private val parsableHour: String, private val expectedHour: Int) {

--- a/AnkiDroid/src/test/java/com/ichi2/testutils/FileUtil.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/testutils/FileUtil.kt
@@ -21,6 +21,7 @@ import com.ichi2.anki.model.DiskFile
 import org.acra.util.IOUtils
 import java.io.File
 import java.util.*
+import kotlin.collections.*
 
 object FileUtil {
     /**

--- a/AnkiDroid/src/test/java/com/ichi2/testutils/MockTime.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/testutils/MockTime.kt
@@ -19,6 +19,7 @@ import android.annotation.SuppressLint
 import com.ichi2.libanki.utils.Time
 import com.ichi2.utils.KotlinCleanup
 import java.util.*
+import kotlin.collections.*
 
 /** @param [step] Number of milliseconds between each call.
  * @param [time]: Time since epoch in MS. */

--- a/AnkiDroid/src/test/java/com/ichi2/utils/FileOperation.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/utils/FileOperation.kt
@@ -18,6 +18,7 @@ package com.ichi2.utils
 import java.io.File
 import java.io.RandomAccessFile
 import java.util.*
+import kotlin.collections.*
 
 class FileOperation {
     companion object {

--- a/AnkiDroid/src/test/java/com/ichi2/utils/FileUtilTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/utils/FileUtilTest.kt
@@ -26,7 +26,6 @@ import org.junit.rules.TemporaryFolder
 import java.io.File
 import java.io.IOException
 import java.lang.Exception
-import java.util.ArrayList
 import kotlin.Throws
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue

--- a/AnkiDroid/src/test/java/com/ichi2/utils/FileUtilTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/utils/FileUtilTest.kt
@@ -15,9 +15,9 @@
  */
 package com.ichi2.utils
 
-import org.acra.util.IOUtils.*
+import org.acra.util.IOUtils.writeStringToFile
 import org.hamcrest.CoreMatchers
-import org.hamcrest.MatcherAssert.*
+import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.core.IsEqual.equalTo
 import org.junit.Assert.assertThrows
 import org.junit.Rule
@@ -25,8 +25,6 @@ import org.junit.Test
 import org.junit.rules.TemporaryFolder
 import java.io.File
 import java.io.IOException
-import java.lang.Exception
-import kotlin.Throws
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
@@ -144,15 +142,15 @@ class FileUtilTest {
     @Test
     fun testFileNameNormal() {
         val fileNameAndExtension = FileUtil.getFileNameAndExtension("abc.jpg")
-        assertThat(fileNameAndExtension!!.key, equalTo("abc"))
-        assertThat(fileNameAndExtension.value, equalTo(".jpg"))
+        assertThat(fileNameAndExtension!!.first, equalTo("abc"))
+        assertThat(fileNameAndExtension.second, equalTo(".jpg"))
     }
 
     @Test
     fun testFileNameTwoDot() {
         val fileNameAndExtension = FileUtil.getFileNameAndExtension("a.b.c")
-        assertThat(fileNameAndExtension!!.key, equalTo("a.b"))
-        assertThat(fileNameAndExtension.value, equalTo(".c"))
+        assertThat(fileNameAndExtension!!.first, equalTo("a.b"))
+        assertThat(fileNameAndExtension.second, equalTo(".c"))
     }
 
     @Test

--- a/AnkiDroid/src/test/java/com/ichi2/utils/JSONArrayTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/utils/JSONArrayTest.kt
@@ -33,6 +33,7 @@ import java.lang.Boolean.FALSE
 import java.lang.Boolean.TRUE
 import java.lang.Double.*
 import java.util.*
+import kotlin.collections.*
 import kotlin.test.assertNull
 
 /**

--- a/AnkiDroid/src/test/java/com/ichi2/utils/JSONObjectTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/utils/JSONObjectTest.kt
@@ -52,6 +52,7 @@ import org.robolectric.annotation.Config
 import java.math.BigDecimal
 import java.math.BigInteger
 import java.util.*
+import kotlin.collections.*
 
 /**
  * This black box test was written without inspecting the non-free org.json sourcecode.

--- a/AnkiDroid/src/test/java/com/ichi2/utils/LanguageUtilsTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/utils/LanguageUtilsTest.kt
@@ -29,6 +29,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.annotation.Config
 import java.util.*
+import kotlin.collections.*
 
 @RunWith(AndroidJUnit4::class)
 @Config(application = EmptyApplication::class)

--- a/AnkiDroid/src/test/java/com/ichi2/utils/TagsUtilTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/utils/TagsUtilTest.kt
@@ -20,6 +20,7 @@ import org.junit.experimental.runners.Enclosed
 import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
 import java.util.*
+import kotlin.collections.*
 
 @RunWith(Enclosed::class)
 class TagsUtilTest {

--- a/AnkiDroid/src/test/java/com/ichi2/utils/UniqueArrayListTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/utils/UniqueArrayListTest.kt
@@ -26,6 +26,7 @@ import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.mockStatic
 import org.mockito.Mockito.never
 import java.util.*
+import kotlin.collections.*
 
 class UniqueArrayListTest {
     private val mDupData = listOf(

--- a/AnkiDroid/src/test/java/com/wildplot/android/rendering/PieChartParameterizedTest.kt
+++ b/AnkiDroid/src/test/java/com/wildplot/android/rendering/PieChartParameterizedTest.kt
@@ -24,6 +24,7 @@ import org.mockito.MockitoAnnotations
 import org.mockito.kotlin.whenever
 import java.util.*
 import java.util.Arrays.asList
+import kotlin.collections.*
 
 @RunWith(Parameterized::class)
 class PieChartParameterizedTest {

--- a/api/src/main/java/com/ichi2/anki/api/AddContentApi.kt
+++ b/api/src/main/java/com/ichi2/anki/api/AddContentApi.kt
@@ -37,6 +37,7 @@ import com.ichi2.anki.FlashCardsContract.Model
 import com.ichi2.anki.FlashCardsContract.Note
 import java.io.File
 import java.util.*
+import kotlin.collections.*
 
 /**
  * API which can be used to add and query notes,cards,decks, and models to AnkiDroid

--- a/api/src/main/java/com/ichi2/anki/api/NoteInfo.kt
+++ b/api/src/main/java/com/ichi2/anki/api/NoteInfo.kt
@@ -19,6 +19,7 @@ package com.ichi2.anki.api
 import android.database.Cursor
 import com.ichi2.anki.FlashCardsContract
 import java.util.*
+import kotlin.collections.*
 
 /**
  * Representation of the contents of a note in AnkiDroid.

--- a/api/src/test/java/com/ichi2/anki/api/ApiUtilsTest.kt
+++ b/api/src/test/java/com/ichi2/anki/api/ApiUtilsTest.kt
@@ -6,7 +6,6 @@ import org.junit.Assert.*
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
-import java.util.HashSet
 import kotlin.test.assertNull
 
 /**

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/rules/CopyrightHeaderExists.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/CopyrightHeaderExists.kt
@@ -25,6 +25,7 @@ import org.jetbrains.uast.UClass
 import org.jetbrains.uast.UElement
 import java.util.*
 import java.util.regex.Pattern
+import kotlin.collections.*
 
 /**
  * Ensures that a GPLv3-compatible copyright header exists in all files.

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/rules/DuplicateCrowdInStrings.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/DuplicateCrowdInStrings.kt
@@ -46,6 +46,7 @@ import com.ichi2.anki.lint.utils.StringFormatDetector
 import org.w3c.dom.Element
 import org.w3c.dom.Node
 import java.util.*
+import kotlin.collections.*
 
 class DuplicateCrowdInStrings : ResourceXmlDetector() {
     /*

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/rules/FixedPreferencesTitleLength.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/FixedPreferencesTitleLength.kt
@@ -24,6 +24,7 @@ import com.google.common.annotations.VisibleForTesting
 import com.ichi2.anki.lint.utils.Constants
 import org.w3c.dom.Element
 import java.util.*
+import kotlin.collections.*
 
 class FixedPreferencesTitleLength : ResourceXmlDetector(), XmlScanner {
     companion object {

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/rules/InvalidStringFormatDetector.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/InvalidStringFormatDetector.kt
@@ -33,6 +33,7 @@ import org.w3c.dom.Element
 import org.w3c.dom.Node
 import java.util.*
 import java.util.regex.Pattern
+import kotlin.collections.*
 
 /**
  * Fix for "Linting Error - String format should be valid."

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/rules/KotlinMigrationBrokenEmails.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/KotlinMigrationBrokenEmails.kt
@@ -24,6 +24,7 @@ import com.ichi2.anki.lint.utils.Constants
 import org.jetbrains.uast.UClass
 import java.util.*
 import java.util.regex.Pattern
+import kotlin.collections.*
 
 @Beta
 class KotlinMigrationBrokenEmails : Detector(), SourceCodeScanner {

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/rules/KotlinMigrationFixLineBreaks.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/KotlinMigrationFixLineBreaks.kt
@@ -25,6 +25,7 @@ import com.ichi2.anki.lint.utils.Constants
 import org.jetbrains.uast.UClass
 import java.util.*
 import java.util.regex.Pattern
+import kotlin.collections.*
 
 @Beta
 class KotlinMigrationFixLineBreaks : Detector(), SourceCodeScanner {


### PR DESCRIPTION
This improve typing.

It's not ideal as this depends on the fact that when we import both java.utils.* and kotlin.collections.* the typing of kotlin is used to resolve the ambiguity. And that's harder to enforce than forbidding wilcard imports. But requires less change.

As far as I understand, I can't just use a linter to check that we don't use java.utils.ArrayList for examples, because kotlin uses java's array list except with better typing; and anyway we also uses java file from android API