### PR TITLE
Implement new backend for note types activity

### DIFF
--- a/.idea/dictionaries/davidallison.xml
+++ b/.idea/dictionaries/davidallison.xml
@@ -9,6 +9,7 @@
       <w>DOWNGRADABLE</w>
       <w>Glosbe</w>
       <w>NONINFRINGEMENT</w>
+      <w>Notetypes</w>
       <w>Pictogrammers</w>
       <w>SuperMemo</w>
       <w>Unbury</w>
@@ -68,6 +69,7 @@
       <w>misclicks</w>
       <w>munge</w>
       <w>mutliselect</w>
+      <w>notetypes</w>
       <w>numpad</w>
       <w>onboarding</w>
       <w>optin</w>

--- a/AnkiDroid/src/main/AndroidManifest.xml
+++ b/AnkiDroid/src/main/AndroidManifest.xml
@@ -232,6 +232,12 @@
             android:configChanges="keyboardHidden|orientation|locale|screenSize|uiMode"
             />
         <activity
+            android:name=".notetype.ManageNotetypes"
+            android:label="@string/model_browser_label"
+            android:exported="false"
+            android:configChanges="keyboardHidden|orientation|locale|screenSize|uiMode"
+            />
+        <activity
             android:name=".ModelFieldEditor"
             android:label="@string/model_editor_label"
             android:configChanges="keyboardHidden|orientation|locale|screenSize|uiMode"

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CoroutineHelpers.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CoroutineHelpers.kt
@@ -27,6 +27,8 @@ import anki.collection.Progress
 import com.afollestad.materialdialogs.MaterialDialog
 import com.afollestad.materialdialogs.callbacks.onCancel
 import com.afollestad.materialdialogs.callbacks.onDismiss
+import com.ichi2.anki.CollectionManager.TR
+import com.ichi2.anki.CollectionManager.withCol
 import com.ichi2.anki.snackbar.showSnackbar
 import com.ichi2.libanki.Collection
 import kotlinx.coroutines.*

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CoroutineHelpers.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CoroutineHelpers.kt
@@ -317,3 +317,21 @@ suspend fun AnkiActivity.userAcceptsSchemaChange(col: Collection): Boolean {
         }
     }
 }
+
+suspend fun AnkiActivity.userAcceptsSchemaChange(): Boolean {
+    if (withCol { schemaChanged() }) {
+        return true
+    }
+    val hasAcceptedSchemaChange = suspendCoroutine { coroutine ->
+        MaterialDialog(this).show {
+            message(text = TR.deckConfigWillRequireFullSync())
+            positiveButton(R.string.dialog_ok) { coroutine.resume(true) }
+            negativeButton(R.string.dialog_cancel) { coroutine.resume(false) }
+            onCancel { coroutine.resume(false) }
+        }
+    }
+    if (hasAcceptedSchemaChange) {
+        withCol { modSchemaNoCheck() }
+    }
+    return hasAcceptedSchemaChange
+}

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -79,6 +79,7 @@ import com.ichi2.anki.dialogs.customstudy.CustomStudyDialog.CustomStudyListener
 import com.ichi2.anki.dialogs.customstudy.CustomStudyDialogFactory
 import com.ichi2.anki.exception.ConfirmModSchemaException
 import com.ichi2.anki.export.ActivityExportingDelegate
+import com.ichi2.anki.notetype.ManageNotetypes
 import com.ichi2.anki.pages.CsvImporter
 import com.ichi2.anki.preferences.AdvancedSettingsFragment
 import com.ichi2.anki.receiver.SdCardReceiver
@@ -800,7 +801,12 @@ open class DeckPicker :
             }
             R.id.action_model_browser_open -> {
                 Timber.i("DeckPicker:: Model browser button pressed")
-                val noteTypeBrowser = Intent(this, ModelBrowser::class.java)
+                val manageNoteTypesTarget = if (!BackendFactory.defaultLegacySchema) {
+                    ManageNotetypes::class.java
+                } else {
+                    ModelBrowser::class.java
+                }
+                val noteTypeBrowser = Intent(this, manageNoteTypesTarget)
                 startActivityForResultWithAnimation(noteTypeBrowser, 0, START)
                 return true
             }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/notetype/ManageNotetypes.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/notetype/ManageNotetypes.kt
@@ -1,0 +1,312 @@
+/****************************************************************************************
+ * Copyright (c) 2022 lukstbit <52494258+lukstbit@users.noreply.github.com>             *
+ *                                                                                      *
+ * This program is free software; you can redistribute it and/or modify it under        *
+ * the terms of the GNU General Public License as published by the Free Software        *
+ * Foundation; either version 3 of the License, or (at your option) any later           *
+ * version.                                                                             *
+ *                                                                                      *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *                                                                                      *
+ * You should have received a copy of the GNU General Public License along with         *
+ * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ ****************************************************************************************/
+package com.ichi2.anki.notetype
+
+import android.annotation.SuppressLint
+import android.content.Intent
+import android.os.Bundle
+import android.view.View
+import android.widget.AdapterView
+import android.widget.ArrayAdapter
+import android.widget.EditText
+import android.widget.Spinner
+import androidx.activity.result.ActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.appcompat.app.ActionBar
+import androidx.core.widget.addTextChangedListener
+import androidx.recyclerview.widget.RecyclerView
+import anki.notetypes.StockNotetype
+import anki.notetypes.copy
+import com.afollestad.materialdialogs.MaterialDialog
+import com.afollestad.materialdialogs.WhichButton
+import com.afollestad.materialdialogs.actions.getActionButton
+import com.afollestad.materialdialogs.customview.customView
+import com.afollestad.materialdialogs.input.getInputField
+import com.afollestad.materialdialogs.input.input
+import com.google.android.material.floatingactionbutton.FloatingActionButton
+import com.ichi2.anim.ActivityTransitionAnimation
+import com.ichi2.anki.*
+import com.ichi2.anki.CollectionManager.withCol
+import com.ichi2.anki.snackbar.showSnackbar
+import com.ichi2.libanki.*
+import com.ichi2.libanki.backend.BackendUtils.from_json_bytes
+import com.ichi2.libanki.backend.BackendUtils.to_json_bytes
+import com.ichi2.libanki.utils.TimeManager.time
+import com.ichi2.libanki.utils.set
+
+// TODO when the new backend becomes the default delete the old implementation ModelBrowser and its
+//  related classes
+class ManageNotetypes : AnkiActivity() {
+    private lateinit var actionBar: ActionBar
+    private lateinit var noteTypesList: RecyclerView
+    private val notetypesAdapter: NotetypesAdapter by lazy {
+        NotetypesAdapter(
+            this@ManageNotetypes,
+            onShowFields = {
+                launchForChanges<ModelFieldEditor>(
+                    mapOf(
+                        "title" to it.name,
+                        "noteTypeID" to it.id,
+                    )
+                )
+            },
+            onEditCards = { launchForChanges<CardTemplateEditor>(mapOf("modelId" to it.id)) },
+            onRename = ::renameNotetype,
+            onDelete = ::deleteNotetype,
+        )
+    }
+    private val outsideChangesLauncher =
+        registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result: ActivityResult ->
+            if (result.resultCode == RESULT_OK) {
+                launchCatchingTask { runAndRefreshAfter() }
+            }
+        }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        if (showedActivityFailedScreen(savedInstanceState)) {
+            return
+        }
+        super.onCreate(savedInstanceState)
+        setTitle(R.string.model_browser_label)
+        setContentView(R.layout.activity_manage_note_types)
+        actionBar = enableToolbar()
+        noteTypesList = findViewById<RecyclerView?>(R.id.note_types_list).apply {
+            adapter = notetypesAdapter
+        }
+        findViewById<FloatingActionButton>(R.id.note_type_add).setOnClickListener {
+            launchCatchingTask { addNewNotetype() }
+        }
+        launchCatchingTask { runAndRefreshAfter() } // shows the initial note types list
+    }
+
+    @SuppressLint("CheckResult")
+    private fun renameNotetype(noteTypeUiModel: NoteTypeUiModel) {
+        launchCatchingTask {
+            val allNotetypes = mutableListOf<NotetypeBasicUiModel>()
+            allNotetypes.addAll(
+                withProgress {
+                    withCol { newBackend.getNotetypeNames().map { it.toUiModel() } }
+                }
+            )
+            val dialog = MaterialDialog(this@ManageNotetypes).show {
+                title(R.string.rename_model)
+                input(
+                    prefill = noteTypeUiModel.name,
+                    waitForPositiveButton = false,
+                    callback = { dialog, text ->
+                        dialog.getActionButton(WhichButton.POSITIVE).isEnabled =
+                            text.isNotEmpty() && !allNotetypes.map { it.name }
+                            .contains(text.toString())
+                    }
+                )
+                positiveButton(R.string.rename) {
+                    launchCatchingTask {
+                        runAndRefreshAfter {
+                            val initialNotetype = newBackend.getNotetype(noteTypeUiModel.id)
+                            val renamedNotetype = initialNotetype.copy {
+                                this.name = it.getInputField().text.toString()
+                            }
+                            newBackend.updateNotetype(renamedNotetype)
+                        }
+                    }
+                }
+                negativeButton(R.string.dialog_cancel)
+            }
+            // start with the button disabled as dialog shows the initial name
+            dialog.getActionButton(WhichButton.POSITIVE).isEnabled = false
+        }
+    }
+
+    private fun deleteNotetype(noteTypeUiModel: NoteTypeUiModel) {
+        launchCatchingTask {
+            val messageResourceId: Int? = if (userAcceptsSchemaChange()) {
+                withProgress {
+                    withCol {
+                        if (newBackend.getNotetypeNames().size <= 1) {
+                            return@withCol null
+                        }
+                        R.string.model_delete_warning
+                    }
+                }
+            } else {
+                return@launchCatchingTask
+            }
+            if (messageResourceId == null) {
+                showSnackbar(getString(R.string.toast_last_model))
+                return@launchCatchingTask
+            }
+            MaterialDialog(this@ManageNotetypes).show {
+                title(R.string.model_browser_delete)
+                message(res = messageResourceId)
+                positiveButton(R.string.dialog_ok) {
+                    launchCatchingTask {
+                        runAndRefreshAfter { newBackend.removeNotetype(noteTypeUiModel.id) }
+                    }
+                }
+                negativeButton(R.string.dialog_cancel)
+            }
+        }
+    }
+
+    private suspend fun addNewNotetype() {
+        val optionsToDisplay = withProgress {
+            withCol {
+                val standardNotetypesModels = StockNotetype.Kind.values()
+                    .filter { it != StockNotetype.Kind.UNRECOGNIZED }
+                    .map {
+                        val stockNotetype = from_json_bytes(newBackend.getStockNotetypeLegacy(it))
+                        NotetypeBasicUiModel(
+                            id = it.number.toLong(),
+                            name = stockNotetype.get("name") as String,
+                            isStandard = true
+                        )
+                    }
+                mutableListOf<NotetypeBasicUiModel>().apply {
+                    addAll(standardNotetypesModels)
+                    addAll(newBackend.getNotetypeNames().map { it.toUiModel() })
+                }
+            }
+        }
+        val dialog = MaterialDialog(this).show {
+            customView(R.layout.dialog_new_note_type, horizontalPadding = true)
+            positiveButton(R.string.dialog_ok) { dialog ->
+                val newName =
+                    dialog.view.findViewById<EditText>(R.id.notetype_new_name).text.toString()
+                val selectedPosition =
+                    dialog.view.findViewById<Spinner>(R.id.notetype_new_type).selectedItemPosition
+                if (selectedPosition == AdapterView.INVALID_POSITION) return@positiveButton
+                val selectedOption = optionsToDisplay[selectedPosition]
+                if (selectedOption.isStandard) {
+                    addStandardNotetype(newName, selectedOption)
+                } else {
+                    cloneStandardNotetype(newName, selectedOption)
+                }
+            }
+            negativeButton(R.string.dialog_cancel)
+        }
+        dialog.initializeViewsWith(optionsToDisplay)
+    }
+
+    private fun MaterialDialog.initializeViewsWith(optionsToDisplay: List<NotetypeBasicUiModel>) {
+        val addPrefixStr = resources.getString(R.string.model_browser_add_add)
+        val clonePrefixStr = resources.getString(R.string.model_browser_add_clone)
+        val nameInput = view.findViewById<EditText>(R.id.notetype_new_name)
+        nameInput.addTextChangedListener { editableText ->
+            val currentName = editableText?.toString() ?: ""
+            getActionButton(WhichButton.POSITIVE).isEnabled =
+                currentName.isNotEmpty() && !optionsToDisplay.map { it.name }.contains(currentName)
+        }
+        view.findViewById<Spinner>(R.id.notetype_new_type).apply {
+            onItemSelectedListener = object : AdapterView.OnItemSelectedListener {
+                override fun onItemSelected(av: AdapterView<*>?, rv: View?, index: Int, id: Long) {
+                    val selectedNotetype = optionsToDisplay[index]
+                    nameInput.setText(randomizeName(selectedNotetype.name))
+                }
+
+                override fun onNothingSelected(widget: AdapterView<*>?) {
+                    nameInput.setText("")
+                }
+            }
+            adapter = ArrayAdapter(
+                this@ManageNotetypes,
+                android.R.layout.simple_list_item_1,
+                android.R.id.text1,
+                optionsToDisplay.map {
+                    String.format(
+                        if (it.isStandard) addPrefixStr else clonePrefixStr,
+                        it.name,
+                    )
+                }
+            ).apply {
+                setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item)
+            }
+        }
+    }
+
+    private fun addStandardNotetype(newName: String, selectedOption: NotetypeBasicUiModel) {
+        launchCatchingTask {
+            runAndRefreshAfter {
+                val kind = StockNotetype.Kind.forNumber(selectedOption.id.toInt())
+                val updatedStandardNotetype =
+                    from_json_bytes(newBackend.getStockNotetypeLegacy(kind)).apply {
+                        set("name", newName)
+                    }
+                newBackend.addNotetypeLegacy(to_json_bytes(updatedStandardNotetype))
+            }
+        }
+    }
+
+    private fun cloneStandardNotetype(newName: String, model: NotetypeBasicUiModel) {
+        launchCatchingTask {
+            runAndRefreshAfter {
+                val targetNotetype = newBackend.getNotetype(model.id)
+                val newNotetype = targetNotetype.copy {
+                    id = 0
+                    name = newName
+                }
+                newBackend.addNotetype(newNotetype)
+            }
+        }
+    }
+
+    /**
+     * Run the provided block on the [Collection](also displaying progress) and then refresh the list
+     * of note types to show the changes. This method expects to be called from the main thread.
+     *
+     * @param action the action to run before the notetypes refresh, if not provided simply refresh
+     */
+    private suspend fun runAndRefreshAfter(action: com.ichi2.libanki.Collection.() -> Unit = {}) {
+        val updatedNotetypes = withProgress {
+            withCol {
+                action()
+                newBackend.getNotetypeNameIdUseCount().map { it.toUiModel() }
+            }
+        }
+        notetypesAdapter.submitList(updatedNotetypes)
+        actionBar.subtitle = resources.getQuantityString(
+            R.plurals.model_browser_types_available,
+            updatedNotetypes.size,
+            updatedNotetypes.size
+        )
+    }
+
+    private inline fun <reified T : AnkiActivity> launchForChanges(extras: Map<String, Any>) {
+        val targetIntent = Intent(this@ManageNotetypes, T::class.java).apply {
+            extras.forEach { toExtra(it) }
+        }
+        launchActivityForResultWithAnimation(
+            targetIntent,
+            outsideChangesLauncher,
+            ActivityTransitionAnimation.Direction.START
+        )
+    }
+
+    private fun Intent.toExtra(newExtra: Map.Entry<String, Any>) {
+        when (newExtra.value) {
+            is String -> putExtra(newExtra.key, newExtra.value as String)
+            is Long -> putExtra(newExtra.key, newExtra.value as Long)
+            else -> throw IllegalArgumentException("Unexpected value type: ${newExtra.value}")
+        }
+    }
+
+    /**
+     * Takes the current timestamp from [Collection] and appends it to the end of the new note
+     * type to dissuade the user from reusing names(which are technically not unique however).
+     */
+    private fun randomizeName(currentName: String): String {
+        return "$currentName-${Utils.checksum(time.intTimeMS().toString()).substring(0, 5)}"
+    }
+}

--- a/AnkiDroid/src/main/java/com/ichi2/anki/notetype/NotetypeAdapter.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/notetype/NotetypeAdapter.kt
@@ -1,0 +1,99 @@
+/****************************************************************************************
+ * Copyright (c) 2022 lukstbit <52494258+lukstbit@users.noreply.github.com>             *
+ *                                                                                      *
+ * This program is free software; you can redistribute it and/or modify it under        *
+ * the terms of the GNU General Public License as published by the Free Software        *
+ * Foundation; either version 3 of the License, or (at your option) any later           *
+ * version.                                                                             *
+ *                                                                                      *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *                                                                                      *
+ * You should have received a copy of the GNU General Public License along with         *
+ * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ ****************************************************************************************/
+package com.ichi2.anki.notetype
+
+import android.content.Context
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.Button
+import android.widget.TextView
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
+import androidx.recyclerview.widget.RecyclerView
+import com.ichi2.anki.R
+
+private val notetypeNamesAndCountDiff =
+    object : DiffUtil.ItemCallback<NoteTypeUiModel>() {
+        override fun areItemsTheSame(
+            oldItem: NoteTypeUiModel,
+            newItem: NoteTypeUiModel
+        ): Boolean =
+            oldItem.id == newItem.id && oldItem.name == newItem.name && oldItem.useCount == newItem.useCount
+
+        override fun areContentsTheSame(
+            oldItem: NoteTypeUiModel,
+            newItem: NoteTypeUiModel
+        ): Boolean =
+            oldItem.id == newItem.id && oldItem.name == newItem.name && oldItem.useCount == newItem.useCount
+    }
+
+internal class NotetypesAdapter(
+    context: Context,
+    private val onShowFields: (NoteTypeUiModel) -> Unit,
+    private val onEditCards: (NoteTypeUiModel) -> Unit,
+    private val onRename: (NoteTypeUiModel) -> Unit,
+    private val onDelete: (NoteTypeUiModel) -> Unit,
+) : ListAdapter<NoteTypeUiModel, NotetypeViewHolder>(notetypeNamesAndCountDiff) {
+    private val layoutInflater = LayoutInflater.from(context)
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): NotetypeViewHolder {
+        return NotetypeViewHolder(
+            rowView = layoutInflater.inflate(R.layout.item_manage_note_type, parent, false),
+            onDelete = onDelete,
+            onRename = onRename,
+            onEditCards = onEditCards,
+            onShowFields = onShowFields,
+        )
+    }
+
+    override fun onBindViewHolder(holder: NotetypeViewHolder, position: Int) {
+        holder.bind(getItem(position))
+    }
+}
+
+internal class NotetypeViewHolder(
+    rowView: View,
+    onShowFields: (NoteTypeUiModel) -> Unit,
+    onEditCards: (NoteTypeUiModel) -> Unit,
+    onRename: (NoteTypeUiModel) -> Unit,
+    onDelete: (NoteTypeUiModel) -> Unit,
+) : RecyclerView.ViewHolder(rowView) {
+    val name: TextView = rowView.findViewById(R.id.note_name)
+    val useCount: TextView = rowView.findViewById(R.id.note_use_count)
+    private val btnDelete: Button = rowView.findViewById(R.id.note_delete)
+    private val btnRename: Button = rowView.findViewById(R.id.note_rename)
+    private val btnEditCards: Button = rowView.findViewById(R.id.note_edit_cards)
+    private var noteTypeUiModel: NoteTypeUiModel? = null
+    private val resources = rowView.context.resources
+
+    init {
+        rowView.setOnClickListener { noteTypeUiModel?.let(onShowFields) }
+        btnEditCards.setOnClickListener { noteTypeUiModel?.let(onEditCards) }
+        btnDelete.setOnClickListener { noteTypeUiModel?.let(onDelete) }
+        btnRename.setOnClickListener { noteTypeUiModel?.let(onRename) }
+    }
+
+    fun bind(noteTypeUiModel: NoteTypeUiModel) {
+        this.noteTypeUiModel = noteTypeUiModel
+        name.text = noteTypeUiModel.name
+        useCount.text = resources.getQuantityString(
+            R.plurals.model_browser_of_type,
+            noteTypeUiModel.useCount,
+            noteTypeUiModel.useCount
+        )
+    }
+}

--- a/AnkiDroid/src/main/java/com/ichi2/anki/notetype/NotetypeUiModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/notetype/NotetypeUiModel.kt
@@ -1,0 +1,44 @@
+/****************************************************************************************
+ * Copyright (c) 2022 lukstbit <52494258+lukstbit@users.noreply.github.com>             *
+ *                                                                                      *
+ * This program is free software; you can redistribute it and/or modify it under        *
+ * the terms of the GNU General Public License as published by the Free Software        *
+ * Foundation; either version 3 of the License, or (at your option) any later           *
+ * version.                                                                             *
+ *                                                                                      *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *                                                                                      *
+ * You should have received a copy of the GNU General Public License along with         *
+ * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ ****************************************************************************************/
+package com.ichi2.anki.notetype
+
+import anki.notetypes.NotetypeNameId
+import anki.notetypes.NotetypeNameIdUseCount
+
+/**
+ * Data holder class which contains the data to display a single note type in [ManageNotetypes]'s
+ * list of notetypes.
+ */
+internal data class NoteTypeUiModel(
+    val id: Long,
+    val name: String,
+    val useCount: Int,
+)
+
+internal fun NotetypeNameIdUseCount.toUiModel(): NoteTypeUiModel =
+    NoteTypeUiModel(id, name, useCount)
+
+/**
+ * Simplest data holder class which contains only the id and name of a notetype.
+ */
+internal data class NotetypeBasicUiModel(
+    val id: Long,
+    val name: String,
+    val isStandard: Boolean = false
+)
+
+internal fun NotetypeNameId.toUiModel(isStandard: Boolean = false): NotetypeBasicUiModel =
+    NotetypeBasicUiModel(id, name, isStandard)

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/ModelsV16.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/ModelsV16.kt
@@ -25,7 +25,13 @@
 
 package com.ichi2.libanki
 
+import anki.collection.OpChanges
+import anki.collection.OpChangesWithId
+import anki.notetypes.Notetype
+import anki.notetypes.NotetypeNameId
+import anki.notetypes.NotetypeNameIdUseCount
 import anki.notetypes.StockNotetype
+import com.google.protobuf.ByteString
 import com.ichi2.anki.R
 import com.ichi2.libanki.Consts.MODEL_CLOZE
 import com.ichi2.libanki.Utils.checksum
@@ -687,4 +693,36 @@ fun CollectionV16.getNotetypeNamesRaw(input: ByteArray): ByteArray {
 
 fun CollectionV16.getFieldNamesRaw(input: ByteArray): ByteArray {
     return backend.getFieldNamesRaw(input)
+}
+
+fun CollectionV16.updateNotetype(updatedNotetype: Notetype): OpChanges {
+    return backend.updateNotetype(input = updatedNotetype)
+}
+
+fun CollectionV16.removeNotetype(notetypeId: Long): OpChanges {
+    return backend.removeNotetype(ntid = notetypeId)
+}
+
+fun CollectionV16.addNotetype(newNotetype: Notetype): OpChangesWithId {
+    return backend.addNotetype(input = newNotetype)
+}
+
+fun CollectionV16.getNotetypeNameIdUseCount(): List<NotetypeNameIdUseCount> {
+    return backend.getNotetypeNamesAndCounts()
+}
+
+fun CollectionV16.getNotetype(notetypeId: Long): Notetype {
+    return backend.getNotetype(ntid = notetypeId)
+}
+
+fun CollectionV16.getNotetypeNames(): List<NotetypeNameId> {
+    return backend.getNotetypeNames()
+}
+
+fun CollectionV16.addNotetypeLegacy(json: ByteString): OpChangesWithId {
+    return backend.addNotetypeLegacy(json = json)
+}
+
+fun CollectionV16.getStockNotetypeLegacy(kind: StockNotetype.Kind): ByteString {
+    return backend.getStockNotetypeLegacy(kind = kind)
 }

--- a/AnkiDroid/src/main/res/layout/activity_manage_note_types.xml
+++ b/AnkiDroid/src/main/res/layout/activity_manage_note_types.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.coordinatorlayout.widget.CoordinatorLayout android:id="@+id/root_layout"
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:fitsSystemWindows="true">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:orientation="vertical">
+
+        <include layout="@layout/toolbar" />
+
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/note_types_list"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:clipToPadding="false"
+            android:paddingBottom="104dp"
+            app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+            tools:listitem="@layout/item_manage_note_type" />
+    </LinearLayout>
+
+    <com.google.android.material.floatingactionbutton.FloatingActionButton
+        android:id="@+id/note_type_add"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="bottom|end"
+        android:layout_marginBottom="32dp"
+        android:layout_marginEnd="32dp"
+        app:fabSize="normal"
+        app:srcCompat="@drawable/ic_add_white"
+        app:backgroundTint="?attr/fab_normal"
+        tools:ignore="HardcodedText" />
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/AnkiDroid/src/main/res/layout/dialog_new_note_type.xml
+++ b/AnkiDroid/src/main/res/layout/dialog_new_note_type.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical">
+
+    <TextView
+        android:text="Type"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        tools:ignore="HardcodedText" />
+
+    <Spinner
+        android:id="@+id/notetype_new_type"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content" />
+
+    <TextView
+        android:text="Name"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        tools:ignore="HardcodedText" />
+
+    <EditText
+        android:id="@+id/notetype_new_name"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:inputType="text" />
+</LinearLayout>

--- a/AnkiDroid/src/main/res/layout/item_manage_note_type.xml
+++ b/AnkiDroid/src/main/res/layout/item_manage_note_type.xml
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.cardview.widget.CardView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:foreground="?android:attr/selectableItemBackground"
+    style="?cardViewStyle"
+    android:layout_margin="8dp" >
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical">
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:padding="16dp">
+
+            <TextView
+                android:id="@+id/note_name"
+                tools:text="Basic (and reversed card)"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:textAppearance="?attr/textAppearanceHeadline6" />
+            <TextView
+                android:id="@+id/note_use_count"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="8dp"
+                android:textAppearance="?attr/textAppearanceBody2"
+                android:textColor="?android:attr/textColorSecondary"
+                tools:text="912 notes"/>
+        </LinearLayout>
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content" >
+            <Button
+                android:id="@+id/note_edit_cards"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                style="?attr/borderlessButtonStyle"
+                android:text="@string/model_browser_template"
+                app:layout_constraintTop_toTopOf="parent"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintEnd_toStartOf="@id/note_rename"
+                app:layout_constraintHorizontal_chainStyle="packed"
+                app:layout_constraintHorizontal_bias="0.0" />
+
+            <Button
+                android:id="@+id/note_rename"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                style="?attr/borderlessButtonStyle"
+                android:text="@string/model_browser_rename"
+                app:layout_constraintTop_toTopOf="parent"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintStart_toEndOf="@id/note_edit_cards"
+                app:layout_constraintEnd_toStartOf="@id/note_delete" />
+
+            <Button
+                android:id="@+id/note_delete"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                style="?attr/borderlessButtonStyle"
+                android:text="@string/dialog_positive_delete"
+                app:layout_constraintTop_toTopOf="parent"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent" />
+        </androidx.constraintlayout.widget.ConstraintLayout>
+    </LinearLayout>
+</androidx.cardview.widget.CardView>

--- a/AnkiDroid/src/test/java/com/ichi2/testutils/ActivityList.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/testutils/ActivityList.kt
@@ -25,6 +25,7 @@ import com.ichi2.anki.CardTemplateBrowserAppearanceEditor.Companion.INTENT_ANSWE
 import com.ichi2.anki.CardTemplateBrowserAppearanceEditor.Companion.INTENT_QUESTION_FORMAT
 import com.ichi2.anki.multimediacard.activity.LoadPronunciationActivity
 import com.ichi2.anki.multimediacard.activity.MultimediaEditFieldActivity
+import com.ichi2.anki.notetype.ManageNotetypes
 import com.ichi2.anki.pages.PagesActivity
 import com.ichi2.anki.preferences.Preferences
 import com.ichi2.anki.services.ReminderService.Companion.getReviewDeckIntent
@@ -75,6 +76,7 @@ object ActivityList {
             get(PagesActivity::class.java),
             get(LoginActivity::class.java),
             get(IntroductionActivity::class.java),
+            get(ManageNotetypes::class.java),
         )
     }
 


### PR DESCRIPTION
This PR enables the new backend for viewing and changing notetypes. With the new implementation:

- add new activity for new backend implementation, ManageNotetypes(the old activity ModelBrowser would be deleted when the new backend becomes the default)
- full support for coroutines(and with progress) with all backend calls
- improve UI for the notes types list by using CardView(ideally we would use the material cards but we don't currently inherit from the material themes)
- fix some of the UX reported issues, like providing a uniform add action(by using the platform FloatingActionButton) and stop using the hard to discover context menu in favor of in layout actions for each item
- enable some checks for the notes types names when renaming or adding new entries
- introduce some UI model classes to better isolate the backend from the UI code
- other changes to streamline the UI and avoid pitfalls of the previous code(like double dialogs, issues with backstack, performance)

What's not implemented:
- ~~the old code in ModelBrowser had two options when adding a new notetype: add and clone. I looked at the code and I don't understand the difference between them so in my implementation I only did clone. Some advice here would be welcomed~~
- ~~no tests(can we use the new backed in tests?)~~(-> in a new PR)

Some images:

<img src="https://user-images.githubusercontent.com/52494258/191796411-a23db5e6-1496-4a4d-8f1d-e69c65a04941.png" width="280px" height="600px"/><img src="https://user-images.githubusercontent.com/52494258/191796408-1960939e-179d-4eb8-a7e9-a43b99c4ed2f.png" width="280px" height="600px"/>
<img src="https://user-images.githubusercontent.com/52494258/191796421-b0c4d672-a5fd-4792-80f7-8b2de37818c5.png" width="280px" height="600px"/><img src="https://user-images.githubusercontent.com/52494258/191796416-7f545eac-0565-4c44-978d-5ae3872b4134.png" width="280px" height="600px"/>
<img src="https://user-images.githubusercontent.com/52494258/191796394-d69b9ccc-2329-4f78-96ac-783d73200de0.png" width="280px" height="600px"/><img src="https://user-images.githubusercontent.com/52494258/191796413-b4a6d0c5-9b03-4dde-be66-ee1355cfc6a0.png" width="280px" height="600px"/>
<img src="https://user-images.githubusercontent.com/52494258/191796424-5f1b3109-2afe-4941-bb30-ec1cb81e1598.png" width="280px" height="600px"/>


## How Has This Been Tested?

Ran all checks, manually tested the features.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
