### PR TITLE
removed NoteEditor redundant pin

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
@@ -1324,9 +1324,15 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
                 // Use media editor button if not changing note type
                 mediaButton!!.setBackgroundResource(icons[0])
                 setMMButtonListener(mediaButton, i)
-                // toggle sticky button
-                toggleStickyButton!!.setBackgroundResource(icons[2])
-                setToggleStickyButtonListener(toggleStickyButton, i)
+
+                // toggle button
+                // fixed issue #12475 - removed the unnecessary pin
+                if (addNote) {
+                    toggleStickyButton!!.setBackgroundResource(icons[2])
+                    setToggleStickyButtonListener(toggleStickyButton, i)
+                } else {
+                    toggleStickyButton!!.setBackgroundResource(0)
+                }
             }
             if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
                 previous.lastViewInTabOrder!!.nextFocusForwardId = R.id.CardEditorTagButton


### PR DESCRIPTION
## Purpose / Description
The NoteEditor had a pin to alter changes in the filed but it is redundant because pinning any field would have no benefit. Refer to issue https://github.com/ankidroid/Anki-Android/issues/12475 

## Fixes
removed the pin option whenever you edit the note. But it remains attached when a new note is added.

## How Has This Been Tested?
Manually tested it on emulator . Works fine for me.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code