### PR TITLE
Add semi-functional delete button in previewer

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/Previewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Previewer.kt
@@ -159,11 +159,25 @@ class Previewer : AbstractFlashcardViewer() {
     }
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
-        if (item.itemId == R.id.action_edit) {
-            editCard()
-            return true
+        when (item.itemId) {
+            R.id.action_edit -> {
+                editCard()
+                return true
+            }
+            R.id.action_delete -> {
+                deleteCard()
+                return true
+            }
         }
         return super.onOptionsItemSelected(item)
+    }
+
+    private fun deleteCard() {
+
+        // Arrows are not updated
+        // If the last card is deleted, previewer doesn't switch to previous card
+        // setResult should be called before previewer closes (if any card is deleted)
+        showDeleteNoteDialog()
     }
 
     override fun onBackPressed() {

--- a/AnkiDroid/src/main/res/menu/previewer.xml
+++ b/AnkiDroid/src/main/res/menu/previewer.xml
@@ -22,4 +22,9 @@
         android:icon="@drawable/ic_mode_edit_white"
         android:title="@string/cardeditor_title_edit_card"
         ankidroid:showAsAction="ifRoom"/>
+    <item
+        android:id="@+id/action_delete"
+        android:icon="@drawable/ic_delete_white"
+        android:title="@string/card_editor_title_delete_card"
+        ankidroid:showAsAction="ifRoom" />
 </menu>

--- a/AnkiDroid/src/main/res/values/02-strings.xml
+++ b/AnkiDroid/src/main/res/values/02-strings.xml
@@ -93,6 +93,7 @@
 
     <!-- Card editor -->
     <string name="cardeditor_title_edit_card">Edit note</string>
+    <string name="card_editor_title_delete_card">Delete note</string>
     <string name="discard_unsaved_changes">Close and lose current input?</string>
     <string name="note_editor_no_cards_created">No cards created. Please fill in more fields</string>
     <string name="note_editor_no_first_field">The first field is empty</string>


### PR DESCRIPTION
## Purpose / Description
Adds a delete button to the previewer **[WIP]**

## Fixes
Closes #10321 **[WIP]**

## Approach
Currently the already available `showDeleteNoteDialog()` method is used.
However, this method is not flexible enough to fit in this scenario.

My guess is that `TaskManager.launchCollectionTask()` is more appropriate for this case.
It was mainly avoided earlier because of the complicated inheritance it involves.
Now it looks like the only option.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration (SDK version(s), emulator or physical, etc)

Just run on the emulator so far. With the dialog method, there are several problems:
- The arrows in previewer do not get updated.
- If the last card (index-wise) is deleted, the previewer does not go back to the previous card.
- Previous Activities are not updated with the result

## Learning (optional, can help others)
- Much of the hardwork is already done. Focus on finding internal APIs rather than writing your own.
- Patiently understand the inheritance where relevant.

## Checklist
_Please, go through these checks before submitting the PR._

- [ ] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas
- [ ] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
