### PR TITLE
Fix layout preview rendering for card_multimedia_editline.xml

### DIFF
--- a/AnkiDroid/src/main/res/layout/card_multimedia_editline.xml
+++ b/AnkiDroid/src/main/res/layout/card_multimedia_editline.xml
@@ -41,7 +41,7 @@
         android:layout_marginEnd="16dp"
         app:layout_constraintEnd_toStartOf="@id/id_expand_button"
         app:layout_constraintTop_toTopOf="parent"
-        tools:background="@drawable/ic_attachment_black_24dp"/>
+        tools:background="@drawable/ic_attachment_black"/>
 
     <ImageButton
         android:id="@+id/id_expand_button"


### PR DESCRIPTION
## Purpose / Description

`ic_attachment_black_24dp` was added as `tools:background` in e7dc7d3d but the file never existed in the codebase. This resulted in an error which prevented the `card_multimedia_editline` layout to render in the IDE's design panel. Fixed it by using the actual icon used by the ImageButton.

## How Has This Been Tested?
Verified that the layout is rendered in the design pane in the IDE.
