### PR TITLE
Coroutines migration UpdateValuesFromDeck

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsFragment.kt
@@ -565,9 +565,7 @@ class StudyOptionsFragment : Fragment(), Toolbar.OnMenuItemClickListener {
      * @param result the new DeckStudyData using which UI is to be rebuilt
      */
     // TODO: Make this a suspend function and move string operations and db-query to a background dispatcher
-    @Suppress("SENSELESS_COMPARISON", "UNNECESSARY_NOT_NULL_ASSERTION")
     private fun rebuildUi(result: DeckStudyData?, refreshDecklist: Boolean) {
-        val activity = requireActivity() // TODO: Remove [activity], was introduced to copy TaskListener.onPostExecute code as it is
         dismissProgressDialog()
         if (result != null) {
 
@@ -626,7 +624,7 @@ class StudyOptionsFragment : Fragment(), Toolbar.OnMenuItemClickListener {
                     mButtonStart!!.visibility = View.GONE
                 }
                 mTextCongratsMessage!!.visibility = View.VISIBLE
-                mTextCongratsMessage!!.text = col!!.sched.finishedMsg(activity!!)
+                mTextCongratsMessage!!.text = col!!.sched.finishedMsg(requireActivity())
             } else {
                 mCurrentContentView = CONTENT_STUDY_OPTIONS
                 mDeckInfoLayout!!.visibility = View.VISIBLE

--- a/AnkiDroid/src/main/java/com/ichi2/async/CollectionOperations.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/async/CollectionOperations.kt
@@ -108,6 +108,8 @@ fun deleteMedia(
     return unused.size
 }
 
+// TODO: Once [com.ichi2.async.CollectionTask.RebuildCram] and [com.ichi2.async.CollectionTask.EmptyCram]
+// are migrated to Coroutines, move this function to [com.ichi2.anki.StudyOptionsFragment]
 fun updateValuesFromDeck(
     col: Collection,
     reset: Boolean

--- a/AnkiDroid/src/main/java/com/ichi2/async/CollectionOperations.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/async/CollectionOperations.kt
@@ -15,6 +15,7 @@
  ****************************************************************************************/
 
 package com.ichi2.async
+import com.ichi2.anki.StudyOptionsFragment
 import com.ichi2.libanki.Card
 import com.ichi2.libanki.Collection
 import com.ichi2.libanki.Note
@@ -105,4 +106,28 @@ fun deleteMedia(
         }
     }
     return unused.size
+}
+
+fun updateValuesFromDeck(
+    col: Collection,
+    reset: Boolean
+): StudyOptionsFragment.DeckStudyData? {
+    Timber.d("doInBackgroundUpdateValuesFromDeck")
+    return try {
+        val sched = col.sched
+        if (reset) {
+            // reset actually required because of counts, which is used in getCollectionTaskListener
+            sched.resetCounts()
+        }
+        val counts = sched.counts()
+        val totalNewCount = sched.totalNewForCurrentDeck()
+        val totalCount = sched.cardCount()
+        StudyOptionsFragment.DeckStudyData(
+            counts.new, counts.lrn, counts.rev, totalNewCount,
+            totalCount, sched.eta(counts)
+        )
+    } catch (e: RuntimeException) {
+        Timber.e(e, "doInBackgroundUpdateValuesFromDeck - an error occurred")
+        null
+    }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.kt
@@ -409,24 +409,7 @@ open class CollectionTask<Progress, Result>(val task: TaskDelegateBase<Progress,
 
     class UpdateValuesFromDeck(private val reset: Boolean) : TaskDelegate<Void, DeckStudyData?>() {
         override fun task(col: Collection, collectionTask: ProgressSenderAndCancelListener<Void>): DeckStudyData? {
-            Timber.d("doInBackgroundUpdateValuesFromDeck")
-            return try {
-                val sched = col.sched
-                if (reset) {
-                    // reset actually required because of counts, which is used in getCollectionTaskListener
-                    sched.resetCounts()
-                }
-                val counts = sched.counts()
-                val totalNewCount = sched.totalNewForCurrentDeck()
-                val totalCount = sched.cardCount()
-                DeckStudyData(
-                    counts.new, counts.lrn, counts.rev, totalNewCount,
-                    totalCount, sched.eta(counts)
-                )
-            } catch (e: RuntimeException) {
-                Timber.e(e, "doInBackgroundUpdateValuesFromDeck - an error occurred")
-                null
-            }
+            return updateValuesFromDeck(col, reset)
         }
     }
 
@@ -434,7 +417,7 @@ open class CollectionTask<Progress, Result>(val task: TaskDelegateBase<Progress,
         override fun task(col: Collection, collectionTask: ProgressSenderAndCancelListener<Void>): DeckStudyData? {
             Timber.d("doInBackgroundRebuildCram")
             col.sched.rebuildDyn(col.decks.selected())
-            return UpdateValuesFromDeck(true).execTask(col, collectionTask)
+            return updateValuesFromDeck(col, true)
         }
     }
 
@@ -442,7 +425,7 @@ open class CollectionTask<Progress, Result>(val task: TaskDelegateBase<Progress,
         override fun task(col: Collection, collectionTask: ProgressSenderAndCancelListener<Void>): DeckStudyData? {
             Timber.d("doInBackgroundEmptyCram")
             col.sched.emptyDyn(col.decks.selected())
-            return UpdateValuesFromDeck(true).execTask(col, collectionTask)
+            return updateValuesFromDeck(col, true)
         }
     }
 


### PR DESCRIPTION
## Fixes
Fixes a part of #7108

## How Has This Been Tested?
Unit tests and Pixel 4a API 30 Emulator and Realme 6i API 30

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

## Note
try-catch from the updateValuesFromDeck  is left as it was because the same function is still being used by EmptyCram  and RebuildCram. Once they are also migrated we can let launchCatchingTask to handle this.
