### PR TITLE
Export selected cards from Browser

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/BackendImporting.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/BackendImporting.kt
@@ -18,12 +18,12 @@
 
 package com.ichi2.anki
 
+import anki.import_export.ExportLimit
 import anki.import_export.ImportResponse
 import com.afollestad.materialdialogs.MaterialDialog
 import com.ichi2.anki.CollectionManager.withCol
 import com.ichi2.anki.pages.PagesActivity
 import com.ichi2.libanki.CollectionV16
-import com.ichi2.libanki.DeckId
 import com.ichi2.libanki.exportAnkiPackage
 import com.ichi2.libanki.exportCollectionPackage
 import com.ichi2.libanki.importAnkiPackage
@@ -98,7 +98,7 @@ suspend fun AnkiActivity.exportApkg(
     apkgPath: String,
     withScheduling: Boolean,
     withMedia: Boolean,
-    deckId: DeckId?
+    limit: ExportLimit
 ) {
     withProgress(
         extractProgress = {
@@ -108,7 +108,7 @@ suspend fun AnkiActivity.exportApkg(
         },
     ) {
         withCol {
-            newBackend.exportAnkiPackage(apkgPath, withScheduling, withMedia, deckId)
+            newBackend.exportAnkiPackage(apkgPath, withScheduling, withMedia, limit)
         }
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -57,6 +57,7 @@ import com.ichi2.anki.dialogs.tags.TagsDialogFactory
 import com.ichi2.anki.dialogs.tags.TagsDialogListener
 import com.ichi2.anki.export.ActivityExportingDelegate
 import com.ichi2.anki.receiver.SdCardReceiver
+import com.ichi2.anki.servicelayer.CardService.selectedNoteIds
 import com.ichi2.anki.servicelayer.NoteService.isMarked
 import com.ichi2.anki.servicelayer.SchedulerService.NextCard
 import com.ichi2.anki.servicelayer.SchedulerService.RepositionCards
@@ -1370,10 +1371,7 @@ open class CardBrowser :
             val msg = resources.getQuantityString(R.plurals.confirm_apkg_export_selected_cards, selectedCardIds.size, selectedCardIds.size)
             mExportingDelegate.showExportDialog(msg, selectedCardIds, inCardsMode)
         } else {
-            val selectedNoteIds = getNotes(
-                selectedCardIds.map { col.getCard(it) }
-            ).map { it.id }
-
+            val selectedNoteIds = selectedNoteIds(selectedCardIds, col)
             val msg = resources.getQuantityString(R.plurals.confirm_apkg_export_selected_notes, selectedNoteIds.size, selectedNoteIds.size)
             mExportingDelegate.showExportDialog(msg, selectedNoteIds, inCardsMode)
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ExportDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ExportDialog.kt
@@ -57,6 +57,23 @@ class ExportDialog(private val listener: ExportDialogListener) : AnalyticsDialog
         return this
     }
 
+    /**
+     * @param ids A list of longs which specifies the card/note ids to be exported
+     * @param isCardList A boolean which specifies whether the list of ids is a list of card ids or note ids
+     * @param dialogMessage A string which can be used to show a custom message or specify import path
+     */
+    fun withArguments(dialogMessage: String, ids: List<Long>, isCardList: Boolean): ExportDialog {
+        val args = this.arguments ?: Bundle()
+        args.putString("dialogMessage", dialogMessage)
+        if (isCardList) {
+            args.putLongArray("cardIds", ids.toLongArray())
+        } else {
+            args.putLongArray("noteIds", ids.toLongArray())
+        }
+        this.arguments = args
+        return this
+    }
+
     @SuppressLint("CheckResult")
     override fun onCreateDialog(savedInstanceState: Bundle?): MaterialDialog {
         super.onCreate(savedInstanceState)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ExportDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ExportDialog.kt
@@ -28,7 +28,8 @@ import com.ichi2.utils.contentNullable
 
 class ExportDialog(private val listener: ExportDialogListener) : AnalyticsDialogFragment() {
     interface ExportDialogListener {
-        fun exportApkg(path: String?, did: DeckId?, includeSched: Boolean, includeMedia: Boolean)
+        fun exportColAsApkg(path: String?, includeSched: Boolean, includeMedia: Boolean)
+        fun exportDeckAsApkg(path: String?, did: DeckId, includeSched: Boolean, includeMedia: Boolean)
         fun dismissAllDialogFragments()
     }
 
@@ -73,7 +74,11 @@ class ExportDialog(private val listener: ExportDialogListener) : AnalyticsDialog
             title(R.string.export)
             contentNullable(requireArguments().getString("dialogMessage"))
             positiveButton(android.R.string.ok) {
-                listener.exportApkg(null, did, mIncludeSched, mIncludeMedia)
+                if (did != null) {
+                    listener.exportDeckAsApkg(null, did, mIncludeSched, mIncludeMedia)
+                } else {
+                    listener.exportColAsApkg(null, mIncludeSched, mIncludeMedia)
+                }
                 dismissAllDialogFragments()
             }
             negativeButton(android.R.string.cancel) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/export/ActivityExportingDelegate.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/export/ActivityExportingDelegate.kt
@@ -91,17 +91,8 @@ class ActivityExportingDelegate(private val activity: AnkiActivity, private val 
             val newFileName = colPath.name.replace(".anki2", "$timeStampSuffix.colpkg")
             File(exportDir, newFileName)
         }
-        val exportListener = ExportListener(activity, mDialogsFactory)
         if (BackendFactory.defaultLegacySchema) {
-            TaskManager.launchCollectionTask(
-                ExportApkg(
-                    exportPath.path,
-                    did,
-                    includeSched,
-                    includeMedia
-                ),
-                exportListener
-            )
+            exportApkgLegacy(exportPath, did, includeSched, includeMedia)
         } else {
             activity.launchCatchingTask {
                 if (did == null && includeSched) {
@@ -113,6 +104,19 @@ class ActivityExportingDelegate(private val activity: AnkiActivity, private val 
                 activity.showAsyncDialogFragment(dialog)
             }
         }
+    }
+
+    private fun exportApkgLegacy(exportPath: File, did: DeckId?, includeSched: Boolean, includeMedia: Boolean) {
+        val exportListener = ExportListener(activity, mDialogsFactory)
+        TaskManager.launchCollectionTask(
+            ExportApkg(
+                exportPath.path,
+                did,
+                includeSched,
+                includeMedia
+            ),
+            exportListener
+        )
     }
 
     override fun dismissAllDialogFragments() {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/export/ActivityExportingDelegate.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/export/ActivityExportingDelegate.kt
@@ -68,6 +68,16 @@ class ActivityExportingDelegate(private val activity: AnkiActivity, private val 
         activity.showDialogFragment(mDialogsFactory.newExportDialog().withArguments(msg, did))
     }
 
+    /**
+     * Show the export dialog in the Browser to export selected cards or notes
+     * @param msg the message to show in the dialog
+     * @param ids the selected card/note ids
+     * @param isCardList true if the ids are card ids, false if they are note ids
+     */
+    fun showExportDialog(msg: String, ids: List<Long>, isCardList: Boolean) {
+        activity.showDialogFragment(mDialogsFactory.newExportDialog().withArguments(msg, ids, isCardList))
+    }
+
     private fun getTimeStampSuffix() =
         "-" + run {
             collectionSupplier.get()

--- a/AnkiDroid/src/main/java/com/ichi2/anki/export/ActivityExportingDelegate.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/export/ActivityExportingDelegate.kt
@@ -94,14 +94,14 @@ class ActivityExportingDelegate(private val activity: AnkiActivity, private val 
         if (BackendFactory.defaultLegacySchema) {
             exportApkgLegacy(exportPath, did, includeSched, includeMedia)
         } else {
-            activity.launchCatchingTask {
-                if (did == null && includeSched) {
+            if (did == null && includeSched) {
+                activity.launchCatchingTask {
                     activity.exportColpkg(exportPath.path, includeMedia)
-                } else {
-                    activity.exportApkg(exportPath.path, includeSched, includeMedia, did)
+                    val dialog = mDialogsFactory.newExportCompleteDialog().withArguments(exportPath.path)
+                    activity.showAsyncDialogFragment(dialog)
                 }
-                val dialog = mDialogsFactory.newExportCompleteDialog().withArguments(exportPath.path)
-                activity.showAsyncDialogFragment(dialog)
+            } else {
+                exportNewBackendApkg(exportPath, includeSched, includeMedia, did)
             }
         }
     }
@@ -117,6 +117,15 @@ class ActivityExportingDelegate(private val activity: AnkiActivity, private val 
             ),
             exportListener
         )
+    }
+
+    // Only for new backend schema
+    private fun exportNewBackendApkg(exportPath: File, includeSched: Boolean, includeMedia: Boolean, did: DeckId?) {
+        activity.launchCatchingTask {
+            activity.exportApkg(exportPath.path, includeSched, includeMedia, did)
+            val dialog = mDialogsFactory.newExportCompleteDialog().withArguments(exportPath.path)
+            activity.showAsyncDialogFragment(dialog)
+        }
     }
 
     override fun dismissAllDialogFragments() {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/export/ActivityExportingDelegate.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/export/ActivityExportingDelegate.kt
@@ -24,6 +24,9 @@ import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.core.app.ShareCompat
 import androidx.core.content.FileProvider
+import anki.generic.Empty
+import anki.import_export.ExportLimit
+import anki.import_export.exportLimit
 import com.google.android.material.snackbar.Snackbar
 import com.ichi2.anki.*
 import com.ichi2.anki.UIUtils.showThemedToast
@@ -98,7 +101,8 @@ class ActivityExportingDelegate(private val activity: AnkiActivity, private val 
                     activity.showAsyncDialogFragment(dialog)
                 }
             } else {
-                exportNewBackendApkg(exportPath, false, includeMedia, null)
+                val limit = exportLimit { this.wholeCollection = Empty.getDefaultInstance() }
+                exportNewBackendApkg(exportPath, false, includeMedia, limit)
             }
         }
     }
@@ -119,7 +123,8 @@ class ActivityExportingDelegate(private val activity: AnkiActivity, private val 
         if (BackendFactory.defaultLegacySchema) {
             exportApkgLegacy(exportPath, did, includeSched, includeMedia)
         } else {
-            exportNewBackendApkg(exportPath, includeSched, includeMedia, did)
+            val limit = exportLimit { this.deckId = did }
+            exportNewBackendApkg(exportPath, includeSched, includeMedia, limit)
         }
     }
 
@@ -137,9 +142,9 @@ class ActivityExportingDelegate(private val activity: AnkiActivity, private val 
     }
 
     // Only for new backend schema
-    private fun exportNewBackendApkg(exportPath: File, includeSched: Boolean, includeMedia: Boolean, did: DeckId?) {
+    private fun exportNewBackendApkg(exportPath: File, includeSched: Boolean, includeMedia: Boolean, limit: ExportLimit) {
         activity.launchCatchingTask {
-            activity.exportApkg(exportPath.path, includeSched, includeMedia, did)
+            activity.exportApkg(exportPath.path, includeSched, includeMedia, limit)
             val dialog = mDialogsFactory.newExportCompleteDialog().withArguments(exportPath.path)
             activity.showAsyncDialogFragment(dialog)
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/export/ActivityExportingDelegate.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/export/ActivityExportingDelegate.kt
@@ -65,14 +65,17 @@ class ActivityExportingDelegate(private val activity: AnkiActivity, private val 
         activity.showDialogFragment(mDialogsFactory.newExportDialog().withArguments(msg, did))
     }
 
+    private fun getTimeStampSuffix() =
+        "-" + run {
+            collectionSupplier.get()
+            TimeUtils.getTimestamp(TimeManager.time)
+        }
+
     override fun exportApkg(path: String?, did: DeckId?, includeSched: Boolean, includeMedia: Boolean) {
         val exportDir = File(activity.externalCacheDir, "export")
         exportDir.mkdirs()
         val exportPath: File
-        val timeStampSuffix = "-" + run {
-            collectionSupplier.get()
-            TimeUtils.getTimestamp(TimeManager.time)
-        }
+        val timeStampSuffix = getTimeStampSuffix()
         exportPath = if (path != null) {
             // filename has been explicitly specified
             File(exportDir, path)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/export/ActivityExportingDelegate.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/export/ActivityExportingDelegate.kt
@@ -143,6 +143,15 @@ class ActivityExportingDelegate(private val activity: AnkiActivity, private val 
         }
     }
 
+    /**
+     * Export selected cards or notes using the new backend
+     * TODO: Once new backend is default, exportColAsApkg and exportDeckAsApkg can be merged into this function
+     */
+    override fun exportSelectedAsApkg(path: String?, limit: ExportLimit, includeSched: Boolean, includeMedia: Boolean) {
+        val exportPath = getExportFileName(limit, path, includeSched)
+        exportNewBackendApkg(exportPath, includeSched, includeMedia, limit)
+    }
+
     private fun exportApkgLegacy(exportPath: File, did: DeckId?, includeSched: Boolean, includeMedia: Boolean) {
         val exportListener = ExportListener(activity, mDialogsFactory)
         TaskManager.launchCollectionTask(

--- a/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/CardService.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/CardService.kt
@@ -1,0 +1,32 @@
+/*
+ *  Copyright (c) 2022 Akshit Sinha <akshitsinha3@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.servicelayer
+
+import com.ichi2.anki.CardUtils
+
+object CardService {
+    /**
+     * get unique note ids from a list of card ids
+     * @param selectedCardIds list of card ids
+     * can do better with performance here
+     * TODO: blocks the UI, should be fixed
+     */
+    fun selectedNoteIds(selectedCardIds: List<Long>, col: com.ichi2.libanki.Collection) =
+        CardUtils.getNotes(
+            selectedCardIds.map { col.getCard(it) }
+        ).map { it.id }
+}

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/BackendImportExport.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/BackendImportExport.kt
@@ -16,9 +16,8 @@
 
 package com.ichi2.libanki
 
-import anki.generic.Empty
+import anki.import_export.ExportLimit
 import anki.import_export.ImportResponse
-import anki.import_export.exportLimit
 import net.ankiweb.rsdroid.Backend
 
 /**
@@ -108,15 +107,8 @@ fun CollectionV16.exportAnkiPackage(
     outPath: String,
     withScheduling: Boolean,
     withMedia: Boolean,
-    deckId: DeckId?,
+    limit: ExportLimit,
     legacy: Boolean = true,
 ) {
-    val limit = exportLimit {
-        if (deckId != null) {
-            this.deckId = deckId
-        } else {
-            this.wholeCollection = Empty.getDefaultInstance()
-        }
-    }
     backend.exportAnkiPackage(outPath, withScheduling, withMedia, legacy, limit)
 }

--- a/AnkiDroid/src/main/res/menu/card_browser_multiselect.xml
+++ b/AnkiDroid/src/main/res/menu/card_browser_multiselect.xml
@@ -96,6 +96,9 @@
         android:title="@string/card_editor_preview_card"/>
 
     <item
+        android:id="@+id/action_export_selected" />
+
+    <item
         ankidroid:showAsAction="ifRoom"
         android:id="@+id/action_select_all"
         android:title="@string/card_browser_select_all"

--- a/AnkiDroid/src/main/res/values/02-strings.xml
+++ b/AnkiDroid/src/main/res/values/02-strings.xml
@@ -174,6 +174,14 @@
     <string name="export_include_media">Include media</string>
     <string name="confirm_apkg_export">Export collection as Anki package?</string>
     <string name="confirm_apkg_export_deck">Export “%s” as apkg file?</string>
+    <plurals name="confirm_apkg_export_selected_cards">
+        <item quantity="one">Export selected card as apkg file?</item>
+        <item quantity="other">Export %d selected cards as apkg file?</item>
+    </plurals>
+    <plurals name="confirm_apkg_export_selected_notes">
+        <item quantity="one">Export selected note as apkg file?</item>
+        <item quantity="other">Export %d selected notes as apkg file?</item>
+    </plurals>
     <string name="export_in_progress">Exporting Anki package file…</string>
     <string name="export_success_title">Collection exported successfully</string>
     <string name="export_send_no_handlers">No applications available to handle apkg. Saving...</string>

--- a/AnkiDroid/src/main/res/values/07-cardbrowser.xml
+++ b/AnkiDroid/src/main/res/values/07-cardbrowser.xml
@@ -75,6 +75,14 @@
     <string name="card_browser_search_all_decks">Search all decks</string>
     <string name="card_browser_unknown_deck_name">Unknown</string>
     <string name="card_browser_truncate" comment="allows users to show less of a field value">Truncate content</string>
+    <plurals name="card_browser_export_cards">
+        <item quantity="one">Export card</item>
+        <item quantity="other">Export cards</item>
+    </plurals>
+    <plurals name="card_browser_export_notes">
+        <item quantity="one">Export note</item>
+        <item quantity="other">Export notes</item>
+    </plurals>
 
     <plurals name="card_browser_cards_deleted">
         <item quantity="one">%d card deleted</item>


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
Add functionality to be able to select cards/notes in the browser and export them from the browser themselves

## Fixes
Fixes #8045

## Approach
With the new backend (see https://github.com/ankidroid/Anki-Android/pull/8159#issuecomment-1186151840), exporting selected cards and notes is supported. This PR handles the UI of exporting selected cards, and adds this case to utilise the functionality being provided by collectionV16.

## How Has This Been Tested?
### Exporting

https://user-images.githubusercontent.com/86671025/192843998-dce39526-6bc3-4358-96cc-3a20f287e1f1.mp4
### Importing

https://user-images.githubusercontent.com/86671025/192843979-3e780d71-76fb-4ca7-9da9-6222aebde173.mp4


## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
