### PR TITLE
MultimediaEditFieldActivity cleaning

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
@@ -60,6 +60,7 @@ import com.ichi2.anki.dialogs.tags.TagsDialogListener
 import com.ichi2.anki.exception.ConfirmModSchemaException
 import com.ichi2.anki.multimediacard.IMultimediaEditableNote
 import com.ichi2.anki.multimediacard.activity.MultimediaEditFieldActivity
+import com.ichi2.anki.multimediacard.activity.MultimediaEditFieldActivityExtra
 import com.ichi2.anki.multimediacard.fields.*
 import com.ichi2.anki.multimediacard.impl.MultimediaEditableNote
 import com.ichi2.anki.noteeditor.CustomToolbarButton
@@ -1499,11 +1500,9 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
     }
 
     private fun startMultimediaFieldEditor(index: Int, note: IMultimediaEditableNote?) {
-        val field = note!!.getField(index)
+        val field = note!!.getField(index)!!
         val editCard = Intent(this@NoteEditor, MultimediaEditFieldActivity::class.java)
-        editCard.putExtra(MultimediaEditFieldActivity.EXTRA_FIELD_INDEX, index)
-        editCard.putExtra(MultimediaEditFieldActivity.EXTRA_FIELD, field)
-        editCard.putExtra(MultimediaEditFieldActivity.EXTRA_WHOLE_NOTE, note)
+        editCard.putExtra(MultimediaEditFieldActivity.EXTRA_MULTIMEDIA_EDIT_FIELD_ACTIVITY, MultimediaEditFieldActivityExtra(index, field, note))
         startActivityForResultWithoutAnimation(editCard, REQUEST_MULTIMEDIA_EDIT)
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/activity/MultimediaEditFieldActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/activity/MultimediaEditFieldActivity.kt
@@ -223,10 +223,7 @@ class MultimediaEditFieldActivity : AnkiActivity(), OnRequestPermissionsResultCa
                 }
             }
         }
-        if (bChangeToText) {
-            mField = null
-        }
-        saveAndExit()
+        saveAndExit(bChangeToText)
     }
 
     protected fun toAudioRecordingField() {
@@ -328,9 +325,9 @@ class MultimediaEditFieldActivity : AnkiActivity(), OnRequestPermissionsResultCa
     }
 
     @KotlinCleanup("scope function")
-    private fun saveAndExit() {
+    private fun saveAndExit(ignoreField: Boolean = false) {
         val resultData = Intent()
-        resultData.putExtra(EXTRA_RESULT_FIELD, mField)
+        resultData.putExtra(EXTRA_RESULT_FIELD, if (ignoreField) null else mField)
         resultData.putExtra(EXTRA_RESULT_FIELD_INDEX, mFieldIndex)
         setResult(RESULT_OK, resultData)
         finishWithoutAnimation()

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/activity/MultimediaEditFieldActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/activity/MultimediaEditFieldActivity.kt
@@ -34,7 +34,6 @@ import com.ichi2.anki.R
 import com.ichi2.anki.UIUtils
 import com.ichi2.anki.multimediacard.IMultimediaEditableNote
 import com.ichi2.anki.multimediacard.fields.*
-import com.ichi2.compat.CompatHelper.Companion.getSerializableExtraCompat
 import com.ichi2.utils.CheckCameraPermission
 import com.ichi2.utils.KotlinCleanup
 import com.ichi2.utils.Permissions
@@ -79,14 +78,15 @@ class MultimediaEditFieldActivity : AnkiActivity(), OnRequestPermissionsResultCa
         val mainView = findViewById<View>(android.R.id.content)
         enableToolbar(mainView)
         val intent = this.intent
-        mField = getFieldFromIntent(intent)
-        mNote = intent.getSerializableExtraCompat<IMultimediaEditableNote>(EXTRA_WHOLE_NOTE)
-        mFieldIndex = intent.getIntExtra(EXTRA_FIELD_INDEX, 0)
-        if (mField == null) {
+        val extras = getFieldFromIntent(intent)
+        if (extras == null) {
             UIUtils.showThemedToast(this, getString(R.string.multimedia_editor_failed), false)
             finishCancel()
             return
         }
+        mFieldIndex = extras.first
+        mField = extras.second
+        mNote = extras.third
         recreateEditingUi(ChangeUIRequest.init(mField!!), controllerBundle)
     }
 
@@ -448,18 +448,16 @@ class MultimediaEditFieldActivity : AnkiActivity(), OnRequestPermissionsResultCa
     companion object {
         const val EXTRA_RESULT_FIELD = "edit.field.result.field"
         const val EXTRA_RESULT_FIELD_INDEX = "edit.field.result.field.index"
-        const val EXTRA_FIELD_INDEX = "multim.card.ed.extra.field.index"
-        const val EXTRA_FIELD = "multim.card.ed.extra.field"
-        const val EXTRA_WHOLE_NOTE = "multim.card.ed.extra.whole.note"
+        const val EXTRA_MULTIMEDIA_EDIT_FIELD_ACTIVITY = "multim.card.ed.extra"
         private const val BUNDLE_KEY_SHUT_OFF = "key.edit.field.shut.off"
         private const val REQUEST_AUDIO_PERMISSION = 0
         private const val REQUEST_CAMERA_PERMISSION = 1
         const val IMAGE_LIMIT = 1024 * 1024 // 1MB in bytes
         @KotlinCleanup("see if we can make this non-null")
         @VisibleForTesting
-        @Suppress("deprecation") // getSerializable
-        fun getFieldFromIntent(intent: Intent): IField? {
-            return intent.extras!!.getSerializable(EXTRA_FIELD) as IField?
-        }
+        @Suppress("deprecation", "UNCHECKED_CAST") // getSerializable
+        fun getFieldFromIntent(intent: Intent) = intent.extras!!.getSerializable(EXTRA_MULTIMEDIA_EDIT_FIELD_ACTIVITY) as MultimediaEditFieldActivityExtra?
     }
 }
+
+typealias MultimediaEditFieldActivityExtra = Triple<Int, IField, IMultimediaEditableNote>

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/activity/MultimediaEditFieldActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/activity/MultimediaEditFieldActivity.kt
@@ -44,8 +44,8 @@ import java.text.DecimalFormat
 @KotlinCleanup("IDE-based lint")
 @KotlinCleanup("lateinit")
 class MultimediaEditFieldActivity : AnkiActivity(), OnRequestPermissionsResultCallback {
-    private var mField: IField? = null
-    private var mNote: IMultimediaEditableNote? = null
+    private lateinit var mField: IField
+    private lateinit var mNote: IMultimediaEditableNote
     private var mFieldIndex = 0
 
     @get:VisibleForTesting
@@ -87,7 +87,7 @@ class MultimediaEditFieldActivity : AnkiActivity(), OnRequestPermissionsResultCa
         mFieldIndex = extras.first
         mField = extras.second
         mNote = extras.third
-        recreateEditingUi(ChangeUIRequest.init(mField!!), controllerBundle)
+        recreateEditingUi(ChangeUIRequest.init(mField), controllerBundle)
     }
 
     private fun finishCancel() {
@@ -125,9 +125,9 @@ class MultimediaEditFieldActivity : AnkiActivity(), OnRequestPermissionsResultCa
     /** Sets various properties required for IFieldController to be in a valid state  */
     @KotlinCleanup("scope function")
     private fun setupUIController(fieldController: IFieldController, savedInstanceState: Bundle?) {
-        fieldController.setField(mField!!)
+        fieldController.setField(mField)
         fieldController.setFieldIndex(mFieldIndex)
-        fieldController.setNote(mNote!!)
+        fieldController.setNote(mNote)
         fieldController.setEditingActivity(this)
         fieldController.loadInstanceState(savedInstanceState)
     }
@@ -156,13 +156,13 @@ class MultimediaEditFieldActivity : AnkiActivity(), OnRequestPermissionsResultCa
     }
 
     override fun onCreateOptionsMenu(menu: Menu): Boolean {
-        Timber.d("onCreateOptionsMenu() - mField.getType() = %s", mField!!.type)
+        Timber.d("onCreateOptionsMenu() - mField.getType() = %s", mField.type)
         // Inflate the menu; this adds items to the action bar if it is present.
         menuInflater.inflate(R.menu.activity_edit_text, menu)
-        menu.findItem(R.id.multimedia_edit_field_to_text).isVisible = mField!!.type !== EFieldType.TEXT
-        menu.findItem(R.id.multimedia_edit_field_to_audio).isVisible = mField!!.type !== EFieldType.AUDIO_RECORDING
-        menu.findItem(R.id.multimedia_edit_field_to_audio_clip).isVisible = mField!!.type !== EFieldType.MEDIA_CLIP
-        menu.findItem(R.id.multimedia_edit_field_to_image).isVisible = mField!!.type !== EFieldType.IMAGE
+        menu.findItem(R.id.multimedia_edit_field_to_text).isVisible = mField.type !== EFieldType.TEXT
+        menu.findItem(R.id.multimedia_edit_field_to_audio).isVisible = mField.type !== EFieldType.AUDIO_RECORDING
+        menu.findItem(R.id.multimedia_edit_field_to_audio_clip).isVisible = mField.type !== EFieldType.MEDIA_CLIP
+        menu.findItem(R.id.multimedia_edit_field_to_image).isVisible = mField.type !== EFieldType.IMAGE
         return true
     }
 
@@ -196,12 +196,12 @@ class MultimediaEditFieldActivity : AnkiActivity(), OnRequestPermissionsResultCa
     protected fun done() {
         fieldController!!.onDone()
         var bChangeToText = false
-        if (mField!!.type === EFieldType.IMAGE) {
-            if (mField!!.imagePath == null) {
+        if (mField.type === EFieldType.IMAGE) {
+            if (mField.imagePath == null) {
                 bChangeToText = true
             }
             if (!bChangeToText) {
-                val f = File(mField!!.imagePath!!)
+                val f = File(mField.imagePath!!)
                 if (!f.exists()) {
                     bChangeToText = true
                 } else {
@@ -212,12 +212,12 @@ class MultimediaEditFieldActivity : AnkiActivity(), OnRequestPermissionsResultCa
                     }
                 }
             }
-        } else if (mField!!.type === EFieldType.AUDIO_RECORDING) {
-            if (mField!!.audioPath == null) {
+        } else if (mField.type === EFieldType.AUDIO_RECORDING) {
+            if (mField.audioPath == null) {
                 bChangeToText = true
             }
             if (!bChangeToText) {
-                val f = File(mField!!.audioPath!!)
+                val f = File(mField.audioPath!!)
                 if (!f.exists()) {
                     bChangeToText = true
                 }
@@ -227,28 +227,28 @@ class MultimediaEditFieldActivity : AnkiActivity(), OnRequestPermissionsResultCa
     }
 
     protected fun toAudioRecordingField() {
-        if (mField!!.type !== EFieldType.AUDIO_RECORDING) {
+        if (mField.type !== EFieldType.AUDIO_RECORDING) {
             val request = ChangeUIRequest.uiChange(AudioRecordingField())
             recreateEditingUi(request)
         }
     }
 
     protected fun toAudioClipField() {
-        if (mField!!.type !== EFieldType.MEDIA_CLIP) {
+        if (mField.type !== EFieldType.MEDIA_CLIP) {
             val request = ChangeUIRequest.uiChange(MediaClipField())
             recreateEditingUi(request)
         }
     }
 
     protected fun toImageField() {
-        if (mField!!.type !== EFieldType.IMAGE) {
+        if (mField.type !== EFieldType.IMAGE) {
             val request = ChangeUIRequest.uiChange(ImageField())
             recreateEditingUi(request)
         }
     }
 
     protected fun toTextField() {
-        if (mField!!.type !== EFieldType.TEXT) {
+        if (mField.type !== EFieldType.TEXT) {
             val request = ChangeUIRequest.uiChange(TextField())
             recreateEditingUi(request)
         }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/NoteEditorTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/NoteEditorTest.kt
@@ -35,7 +35,6 @@ import com.ichi2.libanki.Note
 import com.ichi2.testutils.AnkiAssert.assertDoesNotThrow
 import com.ichi2.utils.KotlinCleanup
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.runTest
 import net.ankiweb.rsdroid.BackendFactory
 import net.ankiweb.rsdroid.RustCleanup
 import org.hamcrest.MatcherAssert.assertThat
@@ -88,7 +87,7 @@ class NoteEditorTest : RobolectricTest() {
         // Assert
         val intent = shadowOf(n).nextStartedActivityForResult
         val actualField = MultimediaEditFieldActivity.getFieldFromIntent(intent.intent)!!
-        assertThat("Provided value should be the updated value", actualField.formattedValue, equalTo("Good Afternoon"))
+        assertThat("Provided value should be the updated value", actualField.second.formattedValue, equalTo("Good Afternoon"))
     }
 
     @Test

--- a/AnkiDroid/src/test/java/com/ichi2/anki/multimediacard/activity/MultimediaEditFieldActivityTestBase.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/multimediacard/activity/MultimediaEditFieldActivityTestBase.kt
@@ -45,7 +45,7 @@ abstract class MultimediaEditFieldActivityTestBase : RobolectricTest() {
         app.grantPermissions(Manifest.permission.RECORD_AUDIO)
     }
 
-    protected fun getControllerForField(field: IField?, note: IMultimediaEditableNote?, fieldIndex: Int): IFieldController {
+    protected fun getControllerForField(field: IField, note: IMultimediaEditableNote, fieldIndex: Int): IFieldController {
         val intent = Intent(Intent.ACTION_VIEW)
         intent.putExtra(MultimediaEditFieldActivity.EXTRA_FIELD_INDEX, fieldIndex)
         intent.putExtra(MultimediaEditFieldActivity.EXTRA_FIELD, field)

--- a/AnkiDroid/src/test/java/com/ichi2/anki/multimediacard/activity/MultimediaEditFieldActivityTestBase.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/multimediacard/activity/MultimediaEditFieldActivityTestBase.kt
@@ -47,9 +47,7 @@ abstract class MultimediaEditFieldActivityTestBase : RobolectricTest() {
 
     protected fun getControllerForField(field: IField, note: IMultimediaEditableNote, fieldIndex: Int): IFieldController {
         val intent = Intent(Intent.ACTION_VIEW)
-        intent.putExtra(MultimediaEditFieldActivity.EXTRA_FIELD_INDEX, fieldIndex)
-        intent.putExtra(MultimediaEditFieldActivity.EXTRA_FIELD, field)
-        intent.putExtra(MultimediaEditFieldActivity.EXTRA_WHOLE_NOTE, note)
+        intent.putExtra(MultimediaEditFieldActivity.EXTRA_MULTIMEDIA_EDIT_FIELD_ACTIVITY, MultimediaEditFieldActivityExtra(fieldIndex, field, note))
         return getControllerForIntent(intent)
     }
 


### PR DESCRIPTION
I realized that three values are always saved and loaded together, and all sets or non sets in the extras together.
So I grouped them, so that typing indicates that they should appear together as far as nullability is concerned, which allows them to become lateinit