### PR TITLE
[GSoC] Migrated ConfRemove to Coroutines

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.kt
@@ -643,30 +643,6 @@ open class CollectionTask<Progress, Result>(val task: TaskDelegateBase<Progress,
         }
     }
 
-    class ConfRemove(private val conf: DeckConfig) : TaskDelegate<Void, Boolean>() {
-        override fun task(col: Collection, collectionTask: ProgressSenderAndCancelListener<Void>): Boolean {
-            Timber.d("doInBackgroundConfRemove")
-            return try {
-                // Note: We do the actual removing of the options group in the main thread so that we
-                // can ask the user to confirm if they're happy to do a full sync, and just do the resorting here
-
-                // When a conf is deleted, all decks using it revert to the default conf.
-                // Cards must be reordered according to the default conf.
-                val order = conf.getJSONObject("new").getInt("order")
-                val defaultOrder = col.decks.getConf(1)!!.getJSONObject("new").getInt("order")
-                if (order != defaultOrder) {
-                    conf.getJSONObject("new").put("order", defaultOrder)
-                    col.sched.resortConf(conf)
-                }
-                col.save()
-                true
-            } catch (e: JSONException) {
-                Timber.w(e)
-                false
-            }
-        }
-    }
-
     @KotlinCleanup("fix `val changed = execTask()!!`")
     class ConfSetSubdecks(private val deck: Deck, private val conf: DeckConfig) : TaskDelegate<Void, Boolean>() {
         override fun task(col: Collection, collectionTask: ProgressSenderAndCancelListener<Void>): Boolean {


### PR DESCRIPTION
Return from the ConfRemove is not required because anyway ConfChangeHandler don't used it as well. Any exceptions will be handled by CoroutineExceptionHandler.

## Fixes
Fixes a part of #7108

## How Has This Been Tested?
Unit tests

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
