### PR TITLE
[GSoC] Migrated EmptyCram to Coroutines

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -2473,7 +2473,17 @@ open class DeckPicker :
 
     fun emptyFiltered(did: DeckId) {
         col.decks.select(did)
-        TaskManager.launchCollectionTask(EmptyCram(), simpleProgressListener())
+        launchCatchingTask {
+            withProgress {
+                withCol {
+                    Timber.d("doInBackgroundEmptyCram")
+                    sched.emptyDyn(decks.selected())
+                    updateValuesFromDeck(this, true)
+                }
+            }
+            updateDeckList()
+            if (fragmented) loadStudyOptionsFragment(false)
+        }
     }
 
     override fun onAttachedToWindow() {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsFragment.kt
@@ -307,11 +307,7 @@ class StudyOptionsFragment : Fragment(), Toolbar.OnMenuItemClickListener {
             }
             R.id.action_empty -> {
                 Timber.i("StudyOptionsFragment:: empty cram deck button pressed")
-                mProgressDialog = show(
-                    requireActivity(), null,
-                    resources.getString(R.string.empty_filtered_deck), false
-                )
-                TaskManager.launchCollectionTask(EmptyCram(), getCollectionTaskListener(true))
+                launchCatchingTask { emptyCram() }
                 return true
             }
             R.id.action_rename -> {
@@ -328,6 +324,18 @@ class StudyOptionsFragment : Fragment(), Toolbar.OnMenuItemClickListener {
             }
             else -> return false
         }
+    }
+
+    @VisibleForTesting
+    suspend fun emptyCram() {
+        val result = requireActivity().withProgress(resources.getString(R.string.empty_filtered_deck)) {
+            withCol {
+                Timber.d("doInBackgroundEmptyCram")
+                sched.emptyDyn(decks.selected())
+                updateValuesFromDeck(this, true)
+            }
+        }
+        rebuildUi(result, true)
     }
 
     fun configureToolbar() {

--- a/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.kt
@@ -415,14 +415,6 @@ open class CollectionTask<Progress, Result>(val task: TaskDelegateBase<Progress,
         }
     }
 
-    class EmptyCram : TaskDelegate<Void, DeckStudyData?>() {
-        override fun task(col: Collection, collectionTask: ProgressSenderAndCancelListener<Void>): DeckStudyData? {
-            Timber.d("doInBackgroundEmptyCram")
-            col.sched.emptyDyn(col.decks.selected())
-            return updateValuesFromDeck(col, true)
-        }
-    }
-
     @KotlinCleanup("Use StringBuilder to concatenate the strings")
     class ImportAdd(private val pathList: List<String>) : TaskDelegate<String, Triple<List<AnkiPackageImporter>?, Boolean, String?>>() {
         override fun task(col: Collection, collectionTask: ProgressSenderAndCancelListener<String>): Triple<List<AnkiPackageImporter>?, Boolean, String?> {


### PR DESCRIPTION
Both implementations run the task within withProgress and run post-operation tasks from their respective handlers from previous implementations.

## Fixes
Fixes a part of #7108


## How Has This Been Tested?
Unit tests and pixel 4a API 30 Emulator

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
