### PR TITLE
Replace usages of String.format in with string templating

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/Info.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Info.kt
@@ -84,7 +84,7 @@ class Info : AnkiActivity() {
         // Apply Theme colors
         val typedArray = theme.obtainStyledAttributes(intArrayOf(android.R.attr.colorBackground, android.R.attr.textColor))
         val backgroundColor = typedArray.getColor(0, -1)
-        val textColor = String.format("#%06X", 0xFFFFFF and typedArray.getColor(1, -1)) // Color to hex string
+        val textColor = String.format("#%06X".format(0xFFFFFF and typedArray.getColor(1, -1)), ) // Color to hex string
         mWebView!!.setBackgroundColor(backgroundColor)
         setRenderWorkaround(this)
         when (type) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Info.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Info.kt
@@ -84,7 +84,7 @@ class Info : AnkiActivity() {
         // Apply Theme colors
         val typedArray = theme.obtainStyledAttributes(intArrayOf(android.R.attr.colorBackground, android.R.attr.textColor))
         val backgroundColor = typedArray.getColor(0, -1)
-        val textColor = String.format("#%06X".format(0xFFFFFF and typedArray.getColor(1, -1)), ) // Color to hex string
+        val textColor = String.format("#%06X", 0xFFFFFF and typedArray.getColor(1, -1)) // Color to hex string
         mWebView!!.setBackgroundColor(backgroundColor)
         setRenderWorkaround(this)
         when (type) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/MediaRegistration.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/MediaRegistration.kt
@@ -50,7 +50,7 @@ class MediaRegistration(private val context: Context) {
         val fd = openInputStreamWithURI(uri)
         val fileNameAndExtension = getFileNameAndExtension(filename)
         fileName = if (checkFilename(fileNameAndExtension!!)) {
-            String.format("%s-name", fileNameAndExtension.key)
+            "${fileNameAndExtension.key}-name"
         } else {
             fileNameAndExtension.key
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/CardAppearance.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/CardAppearance.kt
@@ -28,12 +28,12 @@ class CardAppearance(private val customFonts: ReviewerCustomFonts, private val c
     fun appendCssStyle(style: StringBuilder) {
         // Zoom cards
         if (cardZoom != 100) {
-            style.append(String.format("body { zoom: %s }\n", cardZoom / 100.0))
+            style.append("body { zoom: ${cardZoom / 100.0} }\n")
         }
 
         // Zoom images
         if (imageZoom != 100) {
-            style.append(String.format("img { zoom: %s }\n", imageZoom / 100.0))
+            style.append("img { zoom: ${imageZoom / 100.0} }\n")
         }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/AudioField.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/AudioField.kt
@@ -54,7 +54,7 @@ abstract class AudioField : FieldBase(), IField {
                 return ""
             }
             val file = File(audioPath!!)
-            return if (file.exists()) String.format("[sound:%s]", file.name) else ""
+            return if (file.exists()) "[sound:${file.name}]" else ""
         }
 
     override fun setFormattedString(col: Collection, value: String) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/provider/CardContentProvider.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/provider/CardContentProvider.kt
@@ -211,7 +211,7 @@ class CardContentProvider : ContentProvider() {
                 val query = selection ?: ""
                 val noteIds = col.findNotes(query)
                 if (noteIds.isNotEmpty()) {
-                    val sel = String.format("id in (%s)", TextUtils.join(",", noteIds))
+                    val sel = "id in (${TextUtils.join(",", noteIds)})"
                     val sql = SQLiteQueryBuilder.buildQueryString(false, "notes", proj, sel, null, null, order, null)
                     col.db.database.query(sql)
                 } else {
@@ -843,12 +843,12 @@ class CardContentProvider : ContentProvider() {
                     while (idx < numCards) {
                         val cardName = context!!.resources.getString(R.string.card_n_name, idx + 1)
                         val t = Models.newTemplate(cardName)
-                        t.put("qfmt", String.format("{{%s}}", allFields[0]))
+                        t.put("qfmt", "{{${allFields[0]}}}")
                         var answerField: String? = allFields[0]
                         if (allFields.size > 1) {
                             answerField = allFields[1]
                         }
-                        t.put("afmt", String.format("{{FrontSide}}\\n\\n<hr id=answer>\\n\\n{{%s}}", answerField))
+                        t.put("afmt", "{{FrontSide}}\\n\\n<hr id=answer>\\n\\n{{$answerField}}")
                         mm.addTemplateInNewModel(newModel, t)
                         idx++
                     }
@@ -1250,7 +1250,7 @@ class CardContentProvider : ContentProvider() {
     }
 
     private fun throwSecurityException(methodName: String, uri: Uri) {
-        val msg = String.format("Permission not granted for: %s", getLogMessage(methodName, uri))
+        val msg = "Permission not granted for: ${getLogMessage(methodName, uri)}"
         Timber.e("%s", msg)
         throw SecurityException(msg)
     }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Card.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Card.kt
@@ -392,11 +392,11 @@ open class Card : Cloneable {
                 if (SKIP_PRINT.contains(f.name)) {
                     continue
                 }
-                members.add(String.format("'%s': %s", f.name, f[this]))
+                members.add("'${f.name}': ${f[this]}")
             } catch (e: IllegalAccessException) {
-                members.add(String.format("'%s': %s", f.name, "N/A"))
+                members.add("'${f.name}': N/A")
             } catch (e: IllegalArgumentException) {
-                members.add(String.format("'%s': %s", f.name, "N/A"))
+                members.add("'${f.name}': N/A")
             }
         }
         return TextUtils.join(",  ", members)

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/template/TemplateFilters.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/template/TemplateFilters.kt
@@ -147,7 +147,7 @@ object TemplateFilters {
                 m.group(2)
             }
             if ("c" == m.group(1)) {
-                buf = String.format("<span class=cloze>%s</span>", buf)
+                buf = "<span class=cloze>$buf</span>"
             }
             m.appendReplacement(repl, Matcher.quoteReplacement(buf!!))
         }

--- a/AnkiDroid/src/main/java/com/ichi2/utils/ContentResolverUtil.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/ContentResolverUtil.kt
@@ -45,7 +45,7 @@ object ContentResolverUtil {
         if (filename != null) {
             return filename
         }
-        throw IllegalStateException(String.format("Unable to obtain valid filename from uri: %s", uri))
+        throw IllegalStateException("Unable to obtain valid filename from uri: $uri")
     }
 
     @CheckResult

--- a/AnkiDroid/src/main/java/com/ichi2/utils/NoteFieldDecorator.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/NoteFieldDecorator.kt
@@ -67,7 +67,7 @@ object NoteFieldDecorator {
         for (huevo in huevoOpciones) {
             if (huevo.equals(revuelto, ignoreCase = true)) {
                 val decoration = huevoDecorations[getRandomIndex(huevoDecorations.size)]
-                return String.format("%s%s %s %s%s", decoration, decoration, fieldText, decoration, decoration)
+                return "$decoration$decoration $fieldText $decoration$decoration"
             }
         }
         return fieldText

--- a/api/src/main/java/com/ichi2/anki/api/AddContentApi.kt
+++ b/api/src/main/java/com/ichi2/anki/api/AddContentApi.kt
@@ -616,7 +616,7 @@ public class AddContentApi(context: Context) {
             val modelFieldList = getFieldList(modelId) ?: return null
             val duplicates = SparseArray<MutableList<NoteInfo?>>()
             // Loop through each item in fieldsArray looking for an existing note, and add it to the duplicates array
-            val queryFormat = String.format("%s:\"%%s\" note:\"%s\"", modelFieldList[0], modelName)
+            val queryFormat = "${modelFieldList[0]}:\"%%s\" note:\"$modelName\""
             for (outputPos in keys.indices) {
                 val selection = String.format(queryFormat, keys[outputPos])
                 val query = mResolver.query(

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/rules/DuplicateCrowdInStrings.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/DuplicateCrowdInStrings.kt
@@ -133,7 +133,7 @@ class DuplicateCrowdInStrings : ResourceXmlDetector() {
                     firstLocation = location
                 } else {
                     prevLocation.secondary = location
-                    location.message = String.format("Duplicates value in `%s`. Add a `comment` attribute on both strings to explain this duplication", names[0])
+                    location.message = "Duplicates value in `${names[0]}`. Add a `comment` attribute on both strings to explain this duplication"
                     location.setSelfExplanatory(false)
                     if (string != prevString) {
                         caseVaries = true
@@ -147,11 +147,11 @@ class DuplicateCrowdInStrings : ResourceXmlDetector() {
             }
             val nameValues: MutableList<String> = ArrayList()
             for (name in names) {
-                nameValues.add(String.format("`%s`", name))
+                nameValues.add("`$name`")
             }
             val nameList = formatList(nameValues, nameValues.size, sort = true, useConjunction = false)
             // we use both quotes and code styling here so it appears in the console quoted
-            var message = String.format("Duplicate string value \"`%s`\", used in %s", prevString, nameList)
+            var message = "Duplicate string value \"`$prevString`\", used in $nameList"
             if (caseVaries) {
                 message += ". Use `android:inputType` or `android:capitalize` " +
                     "to treat these as the same and avoid string duplication."


### PR DESCRIPTION
## Purpose / Description
Replaced basic usages of String.format with Kotlin string templates

## Fixes
Fixes #11449 

## Approach
Replace `String.format("%s", x)` with `"$x"`

## How Has This Been Tested?

Passed all unit tests

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
