### PR TITLE
[GSoC] Migrated CollectionTask.Reset to Coroutines

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.kt
@@ -496,13 +496,6 @@ open class CollectionTask<Progress, Result>(val task: TaskDelegateBase<Progress,
         }
     }
 
-    class Reset : TaskDelegate<Void, Void?>() {
-        override fun task(col: Collection, collectionTask: ProgressSenderAndCancelListener<Void>): Void? {
-            col.sched.reset()
-            return null
-        }
-    }
-
     companion object {
         @JvmStatic
         @VisibleForTesting

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.kt
@@ -25,10 +25,9 @@ import android.database.SQLException
 import android.database.sqlite.SQLiteConstraintException
 import android.text.TextUtils
 import androidx.annotation.VisibleForTesting
+import com.ichi2.anki.CollectionManager
 import com.ichi2.async.CancelListener
 import com.ichi2.async.CancelListener.Companion.isCancelled
-import com.ichi2.async.CollectionTask.Reset
-import com.ichi2.async.TaskManager
 import com.ichi2.libanki.*
 import com.ichi2.libanki.Collection
 import com.ichi2.libanki.Consts.BUTTON_TYPE
@@ -44,6 +43,9 @@ import com.ichi2.libanki.stats.Stats
 import com.ichi2.libanki.utils.Time
 import com.ichi2.libanki.utils.TimeManager
 import com.ichi2.utils.*
+import kotlinx.coroutines.DelicateCoroutinesApi
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.launch
 import net.ankiweb.rsdroid.BackendFactory
 import net.ankiweb.rsdroid.RustCleanup
 import org.json.JSONArray
@@ -145,7 +147,8 @@ open class SchedV2(col: Collection) : AbstractSched(col) {
             }
             if (!mHaveCounts) {
                 // Need to reset queues once counts are reset
-                TaskManager.launchCollectionTask(Reset())
+                @OptIn(DelicateCoroutinesApi::class)
+                GlobalScope.launch { CollectionManager.withCol { sched.reset() } }
             }
             return card
         }


### PR DESCRIPTION
Previous implementation launches a CollectionTask without any handler. Which means it never gets cancelled or result of the operation is not used anywhere (succeed or fail). Also Reset was never cancelled anywhere.

Keeping in mind this behaviour, GlobalScope as a scope for this job can be used.

## Fixes
Fixes a part of #7108

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration (SDK version(s), emulator or physical, etc)

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
