### PR TITLE
NF: check media is a triple

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -1343,7 +1343,7 @@ open class DeckPicker :
         showAsyncDialogFragment(MediaCheckDialog.newInstance(dialogType))
     }
 
-    override fun showMediaCheckDialog(dialogType: Int, checkList: List<List<String>>) {
+    override fun showMediaCheckDialog(dialogType: Int, checkList: MediaCheckResult) {
         showAsyncDialogFragment(MediaCheckDialog.newInstance(dialogType, checkList))
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DialogHandler.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DialogHandler.kt
@@ -21,6 +21,7 @@ import android.os.Message
 import androidx.annotation.VisibleForTesting
 import com.ichi2.anki.*
 import com.ichi2.anki.analytics.UsageAnalytics
+import com.ichi2.libanki.MediaCheckResult
 import com.ichi2.libanki.utils.TimeManager
 import com.ichi2.utils.HandlerUtils.getDefaultLooper
 import com.ichi2.utils.NetworkUtils
@@ -61,10 +62,12 @@ class DialogHandler(activity: AnkiActivity) : Handler(getDefaultLooper()) {
             // Media check results
             val id = msgData.getInt("dialogType")
             if (id != MediaCheckDialog.DIALOG_CONFIRM_MEDIA_CHECK) {
-                val checkList: MutableList<List<String>> = ArrayList(3)
-                checkList.add(msgData.getStringArrayList("nohave")!!)
-                checkList.add(msgData.getStringArrayList("unused")!!)
-                checkList.add(msgData.getStringArrayList("invalid")!!)
+                val checkList =
+                    MediaCheckResult(
+                        msgData.getStringArrayList("nohave")!!,
+                        msgData.getStringArrayList("unused")!!,
+                        msgData.getStringArrayList("invalid")!!
+                    )
                 deckPicker.showMediaCheckDialog(id, checkList)
             }
         } else if (msg.what == MSG_SHOW_DATABASE_ERROR_DIALOG) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/MediaCheckDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/MediaCheckDialog.kt
@@ -13,12 +13,12 @@ import android.widget.TextView
 import com.afollestad.materialdialogs.MaterialDialog
 import com.afollestad.materialdialogs.customview.customView
 import com.ichi2.anki.R
-import java.util.*
+import com.ichi2.libanki.MediaCheckResult
 
 class MediaCheckDialog : AsyncDialogFragment() {
     interface MediaCheckDialogListener {
         fun showMediaCheckDialog(dialogType: Int)
-        fun showMediaCheckDialog(dialogType: Int, checkList: List<List<String>>)
+        fun showMediaCheckDialog(dialogType: Int, checkList: MediaCheckResult)
         fun mediaCheck()
         fun deleteUnused(unused: List<String>)
         fun dismissAllDialogFragments()
@@ -152,12 +152,12 @@ class MediaCheckDialog : AsyncDialogFragment() {
             return f
         }
 
-        fun newInstance(dialogType: Int, checkList: List<List<String?>?>): MediaCheckDialog {
+        fun newInstance(dialogType: Int, checkList: MediaCheckResult): MediaCheckDialog {
             val f = MediaCheckDialog()
             val args = Bundle()
-            args.putStringArrayList("nohave", ArrayList(checkList[0]!!.toMutableList()))
-            args.putStringArrayList("unused", ArrayList(checkList[1]!!.toMutableList()))
-            args.putStringArrayList("invalid", ArrayList(checkList[2]!!.toMutableList()))
+            args.putStringArrayList("nohave", ArrayList(checkList.noHave.toMutableList()))
+            args.putStringArrayList("unused", ArrayList(checkList.unused.toMutableList()))
+            args.putStringArrayList("invalid", ArrayList(checkList.invalid.toMutableList()))
             args.putInt("dialogType", dialogType)
             f.arguments = args
             return f

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/BackendMedia.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/BackendMedia.kt
@@ -48,9 +48,9 @@ class BackendMedia(val col: CollectionV16, server: Boolean) : Media(col, server)
     // markFileAdd
 
     // FIXME: this also provides trash count, but UI can not handle it yet
-    override fun check(): List<List<String>> {
+    override fun check(): MediaCheckResult {
         val out = col.backend.checkMedia()
-        return listOf(out.missingList, out.unusedList, listOf())
+        return MediaCheckResult(out.missingList, out.unusedList, listOf())
     }
 
     // FIXME: this currently removes files immediately, as the UI does not expose a way

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Media.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Media.kt
@@ -296,11 +296,11 @@ create table meta (dirMod int, lastUsn int); insert into meta values (0, 0);"""
      *
      * @return A list containing three lists of files (missingFiles, unusedFiles, invalidFiles)
      */
-    open fun check(): List<List<String>> {
+    open fun check(): MediaCheckResult {
         return check(null)
     }
 
-    private fun check(local: Array<File>?): List<List<String>> {
+    private fun check(local: Array<File>?): MediaCheckResult {
         val mdir = File(dir())
         // gather all media references in NFC form
         val allRefs: MutableSet<String> = HashSet()
@@ -383,12 +383,7 @@ create table meta (dirMod int, lastUsn int); insert into meta values (0, 0);"""
             Timber.w(ignored)
             _deleteDB()
         }
-        @KotlinCleanup("return listOf")
-        val result: MutableList<List<String>> = ArrayList(3)
-        result.add(noHave)
-        result.add(unused)
-        result.add(invalid)
-        return result
+        return MediaCheckResult(noHave, unused, invalid)
     }
 
     private fun _normalizeNoteRefs(nid: Long) {
@@ -1002,3 +997,5 @@ create table meta (dirMod int, lastUsn int); insert into meta values (0, 0);"""
         }
     }
 }
+
+data class MediaCheckResult(val noHave: List<String>, val unused: List<String>, val invalid: List<String>)


### PR DESCRIPTION
It's always a triple. That's similar to tuples as Python has.  Right now, anyway, upstream uses neither tuple nor list but a protobuf.

I may have used a dataclass but don't want to be far from how upstream used to be.


(I also ensured there is no import changes)