### PR TITLE
Simplify media check dialog

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -798,7 +798,7 @@ open class DeckPicker :
             }
             R.id.action_check_media -> {
                 Timber.i("DeckPicker:: Check media button pressed")
-                showMediaCheckDialog(MediaCheckDialog.DIALOG_CONFIRM_MEDIA_CHECK)
+                showMediaCheckDialog(DialogMediaCheckResults())
                 return true
             }
             R.id.action_empty_cards -> {
@@ -1339,12 +1339,12 @@ open class DeckPicker :
         showAsyncDialogFragment(newFragment)
     }
 
-    override fun showMediaCheckDialog(dialogType: Int) {
-        showAsyncDialogFragment(MediaCheckDialog.newInstance(dialogType))
+    override fun showMediaCheckDialog(dialog: MediaCheckDialog) {
+        showAsyncDialogFragment(MediaCheckDialog.newInstance(dialog))
     }
 
-    override fun showMediaCheckDialog(dialogType: Int, checkList: List<List<String>>) {
-        showAsyncDialogFragment(MediaCheckDialog.newInstance(dialogType, checkList))
+    override fun showMediaCheckDialog(dialog: MediaCheckDialog, checkList: List<List<String>>) {
+        showAsyncDialogFragment(MediaCheckDialog.newInstance(dialog, checkList))
     }
 
     /**
@@ -1488,7 +1488,7 @@ open class DeckPicker :
         if (hasStorageAccessPermission(this)) {
             launchCatchingTask {
                 val result = withProgress(resources.getString(R.string.check_media_message)) { checkMedia() }
-                showMediaCheckDialog(MediaCheckDialog.DIALOG_MEDIA_CHECK_RESULTS, result)
+                showMediaCheckDialog(DialogMediaCheckResults(), result)
             }
         } else {
             requestStoragePermission()

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -1340,7 +1340,7 @@ open class DeckPicker :
     }
 
     override fun showMediaCheckDialog(dialog: MediaCheckDialog) {
-        showAsyncDialogFragment(MediaCheckDialog.newInstance(dialog))
+        showAsyncDialogFragment(dialog)
     }
 
     override fun showMediaCheckDialog(dialog: MediaCheckDialog, checkList: List<List<String>>) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DialogHandler.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DialogHandler.kt
@@ -65,7 +65,7 @@ class DialogHandler(activity: AnkiActivity) : Handler(getDefaultLooper()) {
                 checkList.add(msgData.getStringArrayList("nohave")!!)
                 checkList.add(msgData.getStringArrayList("unused")!!)
                 checkList.add(msgData.getStringArrayList("invalid")!!)
-                deckPicker.showMediaCheckDialog(id, checkList)
+                deckPicker.showMediaCheckDialog(DialogMediaCheckResults(), checkList)
             }
         } else if (msg.what == MSG_SHOW_DATABASE_ERROR_DIALOG) {
             // Database error dialog

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/MediaCheckDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/MediaCheckDialog.kt
@@ -51,11 +51,6 @@ abstract class MediaCheckDialog : AsyncDialogFragment() {
     companion object {
         const val DIALOG_CONFIRM_MEDIA_CHECK = 0
 
-        fun newInstance(dialog: MediaCheckDialog) =
-            dialog.apply {
-                arguments = Bundle()
-            }
-
         fun newInstance(dialog: MediaCheckDialog, checkList: List<List<String?>?>) =
             dialog.apply {
                 arguments = Bundle().apply {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/MediaCheckDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/MediaCheckDialog.kt
@@ -15,8 +15,8 @@ import com.ichi2.anki.R
 
 abstract class MediaCheckDialog : AsyncDialogFragment() {
     interface MediaCheckDialogListener {
-        fun showMediaCheckDialog(dialogType: Int)
-        fun showMediaCheckDialog(dialogType: Int, checkList: List<List<String>>)
+        fun showMediaCheckDialog(dialog: MediaCheckDialog)
+        fun showMediaCheckDialog(dialog: MediaCheckDialog, checkList: List<List<String>>)
         fun mediaCheck()
         fun deleteUnused(unused: List<String>)
         fun dismissAllDialogFragments()
@@ -50,22 +50,14 @@ abstract class MediaCheckDialog : AsyncDialogFragment() {
 
     companion object {
         const val DIALOG_CONFIRM_MEDIA_CHECK = 0
-        const val DIALOG_MEDIA_CHECK_RESULTS = 1
 
-        private fun mediaCheckDialog(dialogType: Int) =
-            when (dialogType) {
-                DIALOG_CONFIRM_MEDIA_CHECK -> DialogConfirmMediaCheck()
-                DIALOG_MEDIA_CHECK_RESULTS -> DialogMediaCheckResults()
-                else -> throw java.lang.RuntimeException("$dialogType is not a Media Check type")
-            }
-
-        fun newInstance(dialogType: Int) =
-            mediaCheckDialog(dialogType).apply {
+        fun newInstance(dialog: MediaCheckDialog) =
+            dialog.apply {
                 arguments = Bundle()
             }
 
-        fun newInstance(dialogType: Int, checkList: List<List<String?>?>) =
-            mediaCheckDialog(dialogType).apply {
+        fun newInstance(dialog: MediaCheckDialog, checkList: List<List<String?>?>) =
+            dialog.apply {
                 arguments = Bundle().apply {
                     putStringArrayList("nohave", ArrayList(checkList[0]!!.toMutableList()))
                     putStringArrayList("unused", ArrayList(checkList[1]!!.toMutableList()))
@@ -85,12 +77,12 @@ class DialogConfirmMediaCheck() : MediaCheckDialog() {
         return dialog.show {
             message(text = notificationMessage)
             positiveButton(R.string.dialog_ok) {
-                (activity as MediaCheckDialog.MediaCheckDialogListener).mediaCheck()
-                (activity as MediaCheckDialog.MediaCheckDialogListener?)
+                (activity as MediaCheckDialogListener).mediaCheck()
+                (activity as MediaCheckDialogListener?)
                     ?.dismissAllDialogFragments()
             }
             negativeButton(R.string.dialog_cancel) {
-                (activity as MediaCheckDialog.MediaCheckDialogListener?)
+                (activity as MediaCheckDialogListener?)
                     ?.dismissAllDialogFragments()
             }
             cancelable(true)


### PR DESCRIPTION
I was looking at the media check dialog because of the manage space activity. It seemed to be actually two distinct classes depending on a parameter checked everywhere. So instead, lets split into two distinct classes, implemented the same way.