### PR TITLE
[KotlinCleanup] - turn set/hasTemporaryMedia into a property

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/MediaRegistration.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/MediaRegistration.kt
@@ -83,7 +83,7 @@ class MediaRegistration(private val context: Context) {
             return null
         }
         val field = ImageField()
-        field.setHasTemporaryMedia(true)
+        field.hasTemporaryMedia = true
         field.extraImagePathRef = tempFilePath
         return field.formattedValue
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/AudioField.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/AudioField.kt
@@ -27,11 +27,8 @@ import java.util.regex.Pattern
 /**
  * Implementation of Audio field types
  */
-@KotlinCleanup("want name & hasTemporaryMedia to be a property in the interface rather than a getter/setter")
 abstract class AudioField : FieldBase(), IField {
     private var mAudioPath: String? = null
-    protected var currentName: String? = null
-    private var currentHasTemporaryMedia = false
 
     override var imagePath: String? = null
 
@@ -44,11 +41,7 @@ abstract class AudioField : FieldBase(), IField {
 
     override var text: String? = null
 
-    override var hasTemporaryMedia: Boolean
-        get() = currentHasTemporaryMedia
-        set(value) {
-            currentHasTemporaryMedia = value
-        }
+    override var hasTemporaryMedia: Boolean = false
 
     @KotlinCleanup("get() can be simplified with a scope function")
     override val formattedValue: String

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/AudioField.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/AudioField.kt
@@ -31,7 +31,7 @@ import java.util.regex.Pattern
 abstract class AudioField : FieldBase(), IField {
     private var mAudioPath: String? = null
     protected var currentName: String? = null
-    protected var currentHasTemporaryMedia = false
+    private var currentHasTemporaryMedia = false
 
     override var imagePath: String? = null
 
@@ -44,8 +44,11 @@ abstract class AudioField : FieldBase(), IField {
 
     override var text: String? = null
 
-    abstract override fun setHasTemporaryMedia(hasTemporaryMedia: Boolean)
-    abstract override fun hasTemporaryMedia(): Boolean
+    override var hasTemporaryMedia: Boolean
+        get() = currentHasTemporaryMedia
+        set(value) {
+            currentHasTemporaryMedia = value
+        }
 
     @KotlinCleanup("get() can be simplified with a scope function")
     override val formattedValue: String

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/AudioRecordingField.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/AudioRecordingField.kt
@@ -11,11 +11,7 @@ class AudioRecordingField : AudioField() {
     override val isModified: Boolean
         get() = thisModified
 
-    override var name: String?
-        get() = currentName
-        set(value) {
-            currentName = value
-        }
+    override var name: String? = null
 
     companion object {
         private const val serialVersionUID = 5033819217738174719L

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/AudioRecordingField.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/AudioRecordingField.kt
@@ -11,14 +11,6 @@ class AudioRecordingField : AudioField() {
     override val isModified: Boolean
         get() = thisModified
 
-    override fun setHasTemporaryMedia(hasTemporaryMedia: Boolean) {
-        currentHasTemporaryMedia = hasTemporaryMedia
-    }
-
-    override fun hasTemporaryMedia(): Boolean {
-        return currentHasTemporaryMedia
-    }
-
     override var name: String?
         get() = currentName
         set(value) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicAudioRecordingFieldController.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicAudioRecordingFieldController.kt
@@ -70,7 +70,7 @@ class BasicAudioRecordingFieldController : FieldControllerBase(), IFieldControll
                 // currentFilePath.setText("Recording done, you can preview it. Hit save after finish");
                 // FIXME is this okay if it is still null?
                 mField.audioPath = mTempAudioPath
-                mField.setHasTemporaryMedia(true)
+                mField.hasTemporaryMedia = true
             }
         })
         layout.addView(mAudioView, LinearLayout.LayoutParams.MATCH_PARENT)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicImageFieldController.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicImageFieldController.kt
@@ -650,7 +650,7 @@ class BasicImageFieldController : FieldControllerBase(), IFieldController {
     private fun setTemporaryMedia(imagePath: String) {
         mField.apply {
             this.imagePath = imagePath
-            setHasTemporaryMedia(true)
+            hasTemporaryMedia = true
         }
     }
 
@@ -689,7 +689,7 @@ class BasicImageFieldController : FieldControllerBase(), IFieldController {
             showSomethingWentWrong()
             return false
         }
-        mField.setHasTemporaryMedia(true)
+        mField.hasTemporaryMedia = true
         return true
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicMediaClipFieldController.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicMediaClipFieldController.kt
@@ -165,7 +165,7 @@ class BasicMediaClipFieldController : FieldControllerBase(), IFieldController {
                 CompatHelper.compat.copyFile(inputStream!!, clipCopy.absolutePath)
 
                 // If everything worked, hand off the information
-                mField.setHasTemporaryMedia(true)
+                mField.hasTemporaryMedia = true
                 mField.audioPath = clipCopy.absolutePath
                 tvAudioClip.text = clipCopy.name
                 tvAudioClip.visibility = View.VISIBLE

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicTextFieldController.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicTextFieldController.kt
@@ -157,7 +157,7 @@ class BasicTextFieldController : FieldControllerBase(), IFieldController, Dialog
                 val af: AudioField = AudioRecordingField()
                 af.audioPath = pronouncePath
                 // This is done to delete the file later.
-                af.setHasTemporaryMedia(true)
+                af.hasTemporaryMedia = true
                 mActivity.handleFieldChanged(af)
             } catch (e: Exception) {
                 Timber.w(e)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/IField.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/IField.kt
@@ -19,7 +19,6 @@
 package com.ichi2.anki.multimediacard.fields
 
 import com.ichi2.libanki.Collection
-import com.ichi2.utils.KotlinCleanup
 import java.io.Serializable
 
 /**
@@ -44,14 +43,8 @@ interface IField : Serializable {
 
     /**
      * Mark if the current media path is temporary and if it should be deleted once the media has been processed.
-     *
-     * @param hasTemporaryMedia True if the media is temporary, False if it is existing media.
-     * @return
      */
-    @KotlinCleanup("turn set/hasTemporaryMedia into a property")
-    fun setHasTemporaryMedia(hasTemporaryMedia: Boolean)
-
-    fun hasTemporaryMedia(): Boolean
+    var hasTemporaryMedia: Boolean
 
     var name: String?
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/ImageField.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/ImageField.kt
@@ -34,7 +34,6 @@ import java.io.File
 class ImageField : FieldBase(), IField {
     @get:JvmName("getImagePath_unused")
     var extraImagePathRef: String? = null
-    private var mHasTemporaryMedia = false
     private var mName: String? = null
 
     override val type: EFieldType = EFieldType.IMAGE
@@ -53,11 +52,7 @@ class ImageField : FieldBase(), IField {
 
     override var text: String? = null
 
-    override var hasTemporaryMedia: Boolean
-        get() = mHasTemporaryMedia
-        set(value) {
-            mHasTemporaryMedia = value
-        }
+    override var hasTemporaryMedia: Boolean = false
 
     override var name: String?
         get() = mName

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/ImageField.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/ImageField.kt
@@ -53,13 +53,11 @@ class ImageField : FieldBase(), IField {
 
     override var text: String? = null
 
-    override fun setHasTemporaryMedia(hasTemporaryMedia: Boolean) {
-        mHasTemporaryMedia = hasTemporaryMedia
-    }
-
-    override fun hasTemporaryMedia(): Boolean {
-        return mHasTemporaryMedia
-    }
+    override var hasTemporaryMedia: Boolean
+        get() = mHasTemporaryMedia
+        set(value) {
+            mHasTemporaryMedia = value
+        }
 
     override var name: String?
         get() = mName

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/MediaClipField.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/MediaClipField.kt
@@ -10,14 +10,6 @@ class MediaClipField : AudioField() {
 
     override val isModified: Boolean = false
 
-    override fun setHasTemporaryMedia(hasTemporaryMedia: Boolean) {
-        currentHasTemporaryMedia = hasTemporaryMedia
-    }
-
-    override fun hasTemporaryMedia(): Boolean {
-        return currentHasTemporaryMedia
-    }
-
     override var name: String? = null
 
     companion object {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/TextField.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/TextField.kt
@@ -44,11 +44,7 @@ class TextField : FieldBase(), IField {
             setThisModified()
         }
 
-    override fun setHasTemporaryMedia(hasTemporaryMedia: Boolean) {}
-    override fun hasTemporaryMedia(): Boolean {
-        // TODO Auto-generated method stub
-        return false
-    }
+    override var hasTemporaryMedia: Boolean = false
 
     override var name: String?
         get() = mName

--- a/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/NoteService.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/NoteService.kt
@@ -130,7 +130,7 @@ object NoteService {
                 if (inFile.exists() && inFile.length() > 0) {
                     val fname = col.media.addFile(inFile)
                     val outFile = File(col.media.dir(), fname)
-                    if (field.hasTemporaryMedia() && outFile.absolutePath != tmpMediaPath) {
+                    if (field.hasTemporaryMedia && outFile.absolutePath != tmpMediaPath) {
                         // Delete original
                         inFile.delete()
                     }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/services/NoteServiceTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/services/NoteServiceTest.kt
@@ -218,7 +218,7 @@ class NoteServiceTest : RobolectricTest() {
 
         val field = MediaClipField()
         field.audioPath = file.absolutePath
-        field.setHasTemporaryMedia(true)
+        field.hasTemporaryMedia = true
 
         NoteService.importMediaToDirectory(testCol!!, field)
 
@@ -232,7 +232,7 @@ class NoteServiceTest : RobolectricTest() {
 
         val field = ImageField()
         field.extraImagePathRef = file.absolutePath
-        field.setHasTemporaryMedia(true)
+        field.hasTemporaryMedia = true
 
         NoteService.importMediaToDirectory(testCol!!, field)
 


### PR DESCRIPTION

## Pull Request template

## Purpose / Description
demand -
  1. replace setHasTemporaryMedia(), hasTemporaryMedia() to property

modify -
  1. replace with `var hasTemporaryMedia:Boolean` in IField.kt, and the following class relay on this property


## Fixes
1. A small step towards getting #10489 out of the way
2. Limit the mutability of `currentHasTemporaryMedia` in `AudioField`, exposing multiple mutable point might cause unexpected result.

## Approach
Refactored the code to be more Kotlin-y.

## How Has This Been Tested?
Since changing interface affects on its children classes, I simply choose
`./gradlew jacocoTestReport`
to check all the tests works fine.

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
