### PR TITLE
Fix 0 bytes file output when exporting collection

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ExportCompleteDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ExportCompleteDialog.kt
@@ -16,12 +16,12 @@
 
 package com.ichi2.anki.dialogs
 
+import android.annotation.SuppressLint
 import android.os.Bundle
 import androidx.core.os.bundleOf
 import com.afollestad.materialdialogs.MaterialDialog
+import com.afollestad.materialdialogs.list.listItems
 import com.ichi2.anki.R
-import com.ichi2.themes.Themes
-import java.io.File
 
 class ExportCompleteDialog(private val listener: ExportCompleteDialogListener) : AsyncDialogFragment() {
     interface ExportCompleteDialogListener {
@@ -29,7 +29,7 @@ class ExportCompleteDialog(private val listener: ExportCompleteDialogListener) :
         fun shareFile(path: String) // path of the file to be shared
         fun saveExportFile(exportPath: String)
     }
-    val exportPath
+    private val exportPath
         get() = requireArguments().getString("exportPath")!!
 
     fun withArguments(exportPath: String): ExportCompleteDialog {
@@ -37,23 +37,30 @@ class ExportCompleteDialog(private val listener: ExportCompleteDialogListener) :
         return this
     }
 
+    @SuppressLint("CheckResult")
     override fun onCreateDialog(savedInstanceState: Bundle?): MaterialDialog {
         super.onCreate(savedInstanceState)
+        val options = listOf(
+            getString(R.string.export_select_save_app),
+            getString(R.string.export_select_share_app),
+        )
         return MaterialDialog(requireActivity()).show {
             title(text = notificationTitle)
             message(text = notificationMessage)
-            icon(Themes.getResFromAttr(context, R.attr.dialogSendIcon))
-            positiveButton(R.string.export_send_button) {
+            listItems(items = options, waitForPositiveButton = false) { _, index, _ ->
                 listener.dismissAllDialogFragments()
-                listener.shareFile(exportPath)
+                when (index) {
+                    0 -> listener.saveExportFile(exportPath)
+                    1 -> listener.shareFile(exportPath)
+                }
             }
             negativeButton(R.string.dialog_cancel) { listener.dismissAllDialogFragments() }
         }
     }
 
     override val notificationTitle: String
-        get() = res().getString(R.string.export_successful_title)
+        get() = res().getString(R.string.export_success_title)
 
     override val notificationMessage: String
-        get() = res().getString(R.string.export_successful, File(exportPath).name)
+        get() = res().getString(R.string.export_success_message)
 }

--- a/AnkiDroid/src/main/res/values/02-strings.xml
+++ b/AnkiDroid/src/main/res/values/02-strings.xml
@@ -176,12 +176,11 @@
     <string name="confirm_apkg_export">Export collection as Anki package?</string>
     <string name="confirm_apkg_export_deck">Export “%s” as apkg file?</string>
     <string name="export_in_progress">Exporting Anki package file…</string>
-    <string name="export_successful_title">Send Anki package?</string>
-    <string name="export_send_button">Send</string>
+    <string name="export_success_title">Collection exported successfully</string>
     <string name="export_send_no_handlers">No applications available to handle apkg. Saving...</string>
     <string name="export_save_apkg_successful">Successfully saved Anki package</string>
     <string name="export_save_apkg_unsuccessful">Save Anki package failed</string>
-    <string name="export_successful">File “%s” was exported. Do you want to send it with another app?</string>
+    <string name="export_success_message">You may choose a file location to save it, or share it with another application.</string>
     <string name="export_share_title">Send Anki package using</string>
     <string name="export_email_subject">AnkiDroid exported flashcards: %s</string>
     <string name="export_email_text">
@@ -195,6 +194,8 @@
         ]]>
     </string>
     <string name="export_unsuccessful">Error exporting apkg file</string>
+    <string name="export_select_save_app">Select where to save file</string>
+    <string name="export_select_share_app">Select application for sharing</string>
     <string name="study_options" comment="Name for a preference category in Filtered deck (aka Cram deck, aka Custom study) options">Options</string>
     <string name="menu__deck_options">Deck options</string>
     <string name="menu__study_options" comment="Menu item that opens options for a Filtered deck (aka Cram deck, aka Custom study)">Study options</string>


### PR DESCRIPTION
## Purpose / Description

This bug appeared in 8f18dc3d1 which fixed the deprecation of the neutral button. The code tried to present to the user in the same intent chooser both an activity to save the file(Intent.ACTION_CREATE_DOCUMENT) and activities to share the file(Intent.ACTION_SEND). This doesn't work because the Intent.ACTION_CREATE_DOCUMENT expects to be called with `startActivityForResult` as it returns the uri to the newly created empty(0 bytes) file and expects the caller to actually write to that handle(while ACTION_SEND is more of a fire and forget type).

My changes fix this by providing to the user two options when it's finally time to handle the exported collection:
- Select where to save file
  uses Intent.ACTION_CREATE_DOCUMENT to create and write to a file in a location selected by the user
- Select application for sharing
  uses INTENT.ACTION_SEND to let the user to choose an app to share the exported collection

See the difference in UI(before and after):

<img src="https://user-images.githubusercontent.com/52494258/193571076-7b3c63ed-e596-4343-8589-1804536248d0.png" width="400px" height="350px" />

<details close><summary>First UI iteration</summary><img src ="https://user-images.githubusercontent.com/52494258/193572008-aa6be63a-24e5-4157-959f-fe0ab7ac0274.png" width="350px" height="350px" /></details>

Current UI:

<img src="https://user-images.githubusercontent.com/52494258/193870467-7c8eb1c6-50bf-46ed-89c6-c0ee2eb74cf5.png" width="400px" height="350px" />

Open for suggestions on wording in the strings used.

## Fixes

Fixes #12490

## How Has This Been Tested?

Ran the test, manually checked the functionality.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
