### PR TITLE
[KotlinCleanup] Made card arg in onCardEdited not null.

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
@@ -418,7 +418,7 @@ abstract class AbstractFlashcardViewer :
             showProgressBar()
             closeReviewer(RESULT_NO_MORE_CARDS, true)
         }
-        onCardEdited(currentCard)
+        onCardEdited(currentCard!!)
         if (displayAnswer) {
             mSoundPlayer.resetSounds() // load sounds from scratch, to expose any edit changes
             mAnswerSoundsAdded = false // causes answer sounds to be reloaded
@@ -430,9 +430,8 @@ abstract class AbstractFlashcardViewer :
         hideProgressBar()
     }
 
-    @KotlinCleanup("nullability")
     /** Operation after a card has been updated due to being edited. Called before display[Question/Answer]  */
-    protected open fun onCardEdited(card: Card?) {
+    protected open fun onCardEdited(card: Card) {
         // intentionally blank
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
@@ -1251,7 +1251,7 @@ open class Reviewer : AbstractFlashcardViewer() {
         }
     }
 
-    override fun onCardEdited(card: Card?) {
+    override fun onCardEdited(card: Card) {
         super.onCardEdited(card)
         if (prefWhiteboard && whiteboard != null) {
             whiteboard!!.clear()
@@ -1259,7 +1259,7 @@ open class Reviewer : AbstractFlashcardViewer() {
         if (!isDisplayingAnswer) {
             // Editing the card may reuse mCurrentCard. If so, the scheduler won't call startTimer() to reset the timer
             // QUESTIONABLE(legacy code): Only perform this if editing the question
-            card!!.startTimer()
+            card.startTimer()
         }
     }
 


### PR DESCRIPTION
## How Has This Been Tested?
- Tested on a physical device
- Tests

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented on your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [x] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)