### PR TITLE
Fixed #12251 : Keyboard not shown when focusing HTML input/contenteditable elements

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
@@ -1060,7 +1060,6 @@ abstract class AbstractFlashcardViewer :
         webView.settings.allowFileAccess = true
 
         // Problems with focus and input tags is the reason we keep the old type answer mechanism for old Androids.
-        webView.isFocusableInTouchMode = typeAnswer!!.useInputTag
         webView.isScrollbarFadingEnabled = true
         Timber.d("Focusable = %s, Focusable in touch mode = %s", webView.isFocusable, webView.isFocusableInTouchMode)
         webView.webViewClient = CardViewerWebClient(mAssetLoader, this)


### PR DESCRIPTION
## Fixes

Fixed #12251 : Keyboard not shown when focusing HTML input/contenteditable elements

## How Has This Been Tested?

Emulator Pixel 3a Api-29 Android 10 
Physical Device Poco M2 Pro Android 12

https://user-images.githubusercontent.com/76530270/194285811-12be6324-2262-4fbf-b618-e66d4694e593.mp4


## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [x] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
