### PR TITLE
[GSoC] Migrated CollectionTask.Reorder to Coroutines

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckOptions.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckOptions.kt
@@ -180,7 +180,17 @@ class DeckOptions :
                                 val oldOrder = mOptions.getJSONObject("new").getInt("order")
                                 if (oldOrder != newOrder) {
                                     mOptions.getJSONObject("new").put("order", newOrder)
-                                    TaskManager.launchCollectionTask(CollectionTask.Reorder(mOptions), confChangeHandler())
+                                    launch(getCoroutineExceptionHandler(this@DeckOptions)) {
+                                        preConfChange()
+                                        try {
+                                            withCol {
+                                                Timber.d("doInBackground - reorder")
+                                                sched.resortConf(mOptions)
+                                            }
+                                        } finally {
+                                            postConfChange()
+                                        }
+                                    }
                                 }
                                 mOptions.getJSONObject("new").put("order", value.toInt())
                             }

--- a/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.kt
@@ -573,14 +573,6 @@ open class CollectionTask<Progress, Result>(val task: TaskDelegateBase<Progress,
         }
     }
 
-    class Reorder(private val conf: DeckConfig) : TaskDelegate<Void, Boolean>() {
-        override fun task(col: Collection, collectionTask: ProgressSenderAndCancelListener<Void>): Boolean {
-            Timber.d("doInBackgroundReorder")
-            col.sched.resortConf(conf)
-            return true
-        }
-    }
-
     @KotlinCleanup("fix `val changed = execTask()!!`")
     class ConfSetSubdecks(private val deck: Deck, private val conf: DeckConfig) : TaskDelegate<Void, Boolean>() {
         override fun task(col: Collection, collectionTask: ProgressSenderAndCancelListener<Void>): Boolean {


### PR DESCRIPTION
Since the launch is taking place from inside a AppCompatPreferenceActivity which is not a lifecycleOwner. And launchCatchingTask can only happen from a lifecycleOwner, so a custom CoroutineScope implementation is required which cancels any job (launched from this activity) when the activity gets destroyed and that is achieved by extending 'AppCompatPreferenceActivity: CoroutineScope by MainScope' and calling cancel in onDestroy.

MainScope delegates the CoroutineScope implementation with having Main dispatcher as default for launch{} calls. This is the reason why coroutine is launched using launch{} instead of launchCatchingTask{}

Reference: https://github.com/ankidroid/Anki-Android/pull/12534

## Fixes
Fixes a part of #7108

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
