### PR TITLE
NF: refactor DeckOption conf change handler

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckOptions.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckOptions.kt
@@ -19,7 +19,9 @@
 package com.ichi2.anki
 
 import android.app.AlarmManager
-import android.content.*
+import android.content.Context
+import android.content.Intent
+import android.content.SharedPreferences
 import android.content.res.Configuration
 import android.os.Bundle
 import android.preference.CheckBoxPreference
@@ -39,6 +41,7 @@ import com.ichi2.async.TaskListenerWithContext
 import com.ichi2.async.TaskManager
 import com.ichi2.async.changeDeckConfiguration
 import com.ichi2.compat.CompatHelper
+import com.ichi2.libanki.Collection
 import com.ichi2.libanki.Consts
 import com.ichi2.libanki.DeckConfig
 import com.ichi2.libanki.utils.Time
@@ -146,6 +149,17 @@ class DeckOptions :
             return DeckConfig.parseTimerOpt(options, true)
         }
 
+        suspend fun confChangeHandler(block: Collection.() -> Unit) {
+            preConfChange()
+            try {
+                withCol(block)
+            } finally {
+                // need to call postConfChange in finally because if withCol{} throws an exception,
+                // postConfChange would never get called and progress-bar will never get dismissed
+                postConfChange()
+            }
+        }
+
         fun preConfChange() {
             val res = deckOptionsActivity.resources
             progressDialog = StyledProgressDialog.show(
@@ -181,14 +195,9 @@ class DeckOptions :
                                 if (oldOrder != newOrder) {
                                     mOptions.getJSONObject("new").put("order", newOrder)
                                     launch(getCoroutineExceptionHandler(this@DeckOptions)) {
-                                        preConfChange()
-                                        try {
-                                            withCol {
-                                                Timber.d("doInBackground - reorder")
-                                                sched.resortConf(mOptions)
-                                            }
-                                        } finally {
-                                            postConfChange()
+                                        confChangeHandler {
+                                            Timber.d("doInBackground - reorder")
+                                            sched.resortConf(mOptions)
                                         }
                                     }
                                 }
@@ -238,9 +247,9 @@ class DeckOptions :
                                 val newConfId: Long = (value as String).toLong()
                                 mOptions = col.decks.getConf(newConfId)!!
                                 launch(getCoroutineExceptionHandler(this@DeckOptions)) {
-                                    preConfChange()
-                                    withCol { changeDeckConfiguration(deck, mOptions, this) }
-                                    postConfChange()
+                                    confChangeHandler {
+                                        changeDeckConfiguration(deck, mOptions, this)
+                                    }
                                 }
                             }
                             "confRename" -> {
@@ -251,18 +260,11 @@ class DeckOptions :
                             }
                             "confReset" -> if (value as Boolean) {
                                 launch(getCoroutineExceptionHandler(this@DeckOptions)) {
-                                    preConfChange()
                                     // reset configuration
-                                    try {
-                                        withCol {
-                                            Timber.d("doInBackgroundConfReset")
-                                            decks.restoreToDefault(mOptions)
-                                            save()
-                                        }
-                                    } finally {
-                                        // need to call postConfChange in finally because if withCol{} throws an exception,
-                                        // postConfChange would never get called and progress-bar will never get dismissed
-                                        postConfChange()
+                                    confChangeHandler {
+                                        Timber.d("doInBackgroundConfReset")
+                                        decks.restoreToDefault(mOptions)
+                                        save()
                                     }
                                 }
                             }
@@ -418,26 +420,21 @@ class DeckOptions :
                 col.decks.remConf(mOptions.getLong("id"))
                 // Run the CPU intensive re-sort operation in a background thread
                 launch(getCoroutineExceptionHandler(this@DeckOptions)) {
-                    preConfChange()
                     val conf = mOptions
-                    try {
-                        withCol {
-                            // Note: We do the actual removing of the options group in the main thread so that we
-                            // can ask the user to confirm if they're happy to do a full sync, and just do the resorting here
+                    confChangeHandler {
+                        // Note: We do the actual removing of the options group in the main thread so that we
+                        // can ask the user to confirm if they're happy to do a full sync, and just do the resorting here
 
-                            // When a conf is deleted, all decks using it revert to the default conf.
-                            // Cards must be reordered according to the default conf.
-                            val order = conf.getJSONObject("new").getInt("order")
-                            val defaultOrder =
-                                col.decks.getConf(1)!!.getJSONObject("new").getInt("order")
-                            if (order != defaultOrder) {
-                                conf.getJSONObject("new").put("order", defaultOrder)
-                                col.sched.resortConf(conf)
-                            }
-                            col.save()
+                        // When a conf is deleted, all decks using it revert to the default conf.
+                        // Cards must be reordered according to the default conf.
+                        val order = conf.getJSONObject("new").getInt("order")
+                        val defaultOrder =
+                            col.decks.getConf(1)!!.getJSONObject("new").getInt("order")
+                        if (order != defaultOrder) {
+                            conf.getJSONObject("new").put("order", defaultOrder)
+                            col.sched.resortConf(conf)
                         }
-                    } finally {
-                        postConfChange()
+                        col.save()
                     }
                 }
                 deck.put("conf", 1)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckOptions.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckOptions.kt
@@ -149,14 +149,17 @@ class DeckOptions :
             return DeckConfig.parseTimerOpt(options, true)
         }
 
-        suspend fun confChangeHandler(block: Collection.() -> Unit) {
-            preConfChange()
-            try {
-                withCol(block)
-            } finally {
-                // need to call postConfChange in finally because if withCol{} throws an exception,
-                // postConfChange would never get called and progress-bar will never get dismissed
-                postConfChange()
+        fun confChangeHandler(timbering: String, block: Collection.() -> Unit) {
+            launch(getCoroutineExceptionHandler(this@DeckOptions)) {
+                preConfChange()
+                Timber.d(timbering)
+                try {
+                    withCol(block)
+                } finally {
+                    // need to call postConfChange in finally because if withCol{} throws an exception,
+                    // postConfChange would never get called and progress-bar will never get dismissed
+                    postConfChange()
+                }
             }
         }
 
@@ -194,11 +197,8 @@ class DeckOptions :
                                 val oldOrder = mOptions.getJSONObject("new").getInt("order")
                                 if (oldOrder != newOrder) {
                                     mOptions.getJSONObject("new").put("order", newOrder)
-                                    launch(getCoroutineExceptionHandler(this@DeckOptions)) {
-                                        confChangeHandler {
-                                            Timber.d("doInBackground - reorder")
-                                            sched.resortConf(mOptions)
-                                        }
+                                    confChangeHandler("doInBackground - reorder") {
+                                        sched.resortConf(mOptions)
                                     }
                                 }
                                 mOptions.getJSONObject("new").put("order", value.toInt())
@@ -246,10 +246,8 @@ class DeckOptions :
                             "deckConf" -> {
                                 val newConfId: Long = (value as String).toLong()
                                 mOptions = col.decks.getConf(newConfId)!!
-                                launch(getCoroutineExceptionHandler(this@DeckOptions)) {
-                                    confChangeHandler {
-                                        changeDeckConfiguration(deck, mOptions, this)
-                                    }
+                                confChangeHandler("change Deck configuration") {
+                                    changeDeckConfiguration(deck, mOptions, this)
                                 }
                             }
                             "confRename" -> {
@@ -259,13 +257,10 @@ class DeckOptions :
                                 }
                             }
                             "confReset" -> if (value as Boolean) {
-                                launch(getCoroutineExceptionHandler(this@DeckOptions)) {
-                                    // reset configuration
-                                    confChangeHandler {
-                                        Timber.d("doInBackgroundConfReset")
-                                        decks.restoreToDefault(mOptions)
-                                        save()
-                                    }
+                                // reset configuration
+                                confChangeHandler("doInBackgroundConfReset") {
+                                    decks.restoreToDefault(mOptions)
+                                    save()
                                 }
                             }
                             "confAdd" -> {
@@ -419,23 +414,21 @@ class DeckOptions :
                 // Remove options group, asking user to confirm full sync if necessary
                 col.decks.remConf(mOptions.getLong("id"))
                 // Run the CPU intensive re-sort operation in a background thread
-                launch(getCoroutineExceptionHandler(this@DeckOptions)) {
-                    val conf = mOptions
-                    confChangeHandler {
-                        // Note: We do the actual removing of the options group in the main thread so that we
-                        // can ask the user to confirm if they're happy to do a full sync, and just do the resorting here
+                val conf = mOptions
+                confChangeHandler("Remove configuration") {
+                    // Note: We do the actual removing of the options group in the main thread so that we
+                    // can ask the user to confirm if they're happy to do a full sync, and just do the resorting here
 
-                        // When a conf is deleted, all decks using it revert to the default conf.
-                        // Cards must be reordered according to the default conf.
-                        val order = conf.getJSONObject("new").getInt("order")
-                        val defaultOrder =
-                            col.decks.getConf(1)!!.getJSONObject("new").getInt("order")
-                        if (order != defaultOrder) {
-                            conf.getJSONObject("new").put("order", defaultOrder)
-                            col.sched.resortConf(conf)
-                        }
-                        col.save()
+                    // When a conf is deleted, all decks using it revert to the default conf.
+                    // Cards must be reordered according to the default conf.
+                    val order = conf.getJSONObject("new").getInt("order")
+                    val defaultOrder =
+                        col.decks.getConf(1)!!.getJSONObject("new").getInt("order")
+                    if (order != defaultOrder) {
+                        conf.getJSONObject("new").put("order", defaultOrder)
+                        col.sched.resortConf(conf)
                     }
+                    col.save()
                 }
                 deck.put("conf", 1)
             }


### PR DESCRIPTION
@divyansh-dxn 
While looking at #12592 I realized some code were repeated a lot. I'd love your opinion about this refactoring.
Once this last PR is merged, we can even remove the pre/post parts and just keep a single function there. 

Actually, I realize that if we had done it first, it would have made PR even simpler to review, since in this case, the launchCollectionTask would be replaced by a more or less similar call, with something that does the UI and then inside does the background change