### PR TITLE
Transform MigrateUserData as a service

### DIFF
--- a/AnkiDroid/src/main/AndroidManifest.xml
+++ b/AnkiDroid/src/main/AndroidManifest.xml
@@ -408,6 +408,10 @@
 
         <!-- Service to perform web API queries -->
         <service android:name="com.ichi2.widget.AnkiDroidWidgetSmall$UpdateService" />
+        <!-- Service to move user data (i.e. media) to scoped storage -->
+        <service android:name="com.ichi2.anki.servicelayer.scopedstorage.MigrateUserData"
+            android:exported="false"
+            android:permission=""/>
 
         <!-- small widget -->
         <receiver

--- a/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/ScopedStorageService.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/ScopedStorageService.kt
@@ -27,7 +27,7 @@ import com.ichi2.anki.model.DiskFile
 import com.ichi2.anki.model.RelativeFilePath
 import com.ichi2.anki.servicelayer.ScopedStorageService.isLegacyStorage
 import com.ichi2.anki.servicelayer.scopedstorage.MigrateEssentialFiles
-import com.ichi2.anki.servicelayer.scopedstorage.MigrateUserData
+import com.ichi2.anki.servicelayer.scopedstorage.migrateuserdata.MigrateUserData
 import com.ichi2.utils.FileUtil.getParentsAndSelfRecursive
 import com.ichi2.utils.FileUtil.isDescendantOf
 import timber.log.Timber

--- a/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/ScopedStorageService.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/ScopedStorageService.kt
@@ -28,6 +28,7 @@ import com.ichi2.anki.model.RelativeFilePath
 import com.ichi2.anki.servicelayer.ScopedStorageService.isLegacyStorage
 import com.ichi2.anki.servicelayer.scopedstorage.MigrateEssentialFiles
 import com.ichi2.anki.servicelayer.scopedstorage.migrateuserdata.MigrateUserData
+import com.ichi2.anki.servicelayer.scopedstorage.migrateuserdata.UserDataMigrationPreferences
 import com.ichi2.utils.FileUtil.getParentsAndSelfRecursive
 import com.ichi2.utils.FileUtil.isDescendantOf
 import timber.log.Timber
@@ -260,43 +261,6 @@ object ScopedStorageService {
         // If the current AnkiDroid directory isn't a sub directory of the app-specific external or internal storage
         // directories, then it must be in a legacy storage directory
         return true
-    }
-
-    /**
-     * Preferences relating to whether a user data scoped storage migration is taking place
-     * This refers to the [MigrateUserData] operation of copying media which can take a long time.
-     *
-     * @param source The path of the source directory. Check [migrationInProgress] before use.
-     * @param destination The path of the destination directory. Check [migrationInProgress] before use.
-     */
-    class UserDataMigrationPreferences private constructor(val source: String, val destination: String) {
-        /**  Whether a scoped storage migration is in progress */
-        val migrationInProgress = source.isNotEmpty()
-        val sourceFile get() = File(source)
-        val destinationFile get() = File(destination)
-        companion object {
-            /**
-             * @throws IllegalStateException If either [PREF_MIGRATION_SOURCE] or [PREF_MIGRATION_DESTINATION] is set (but not both)
-             * It is a logic bug if only one is set
-             */
-            fun createInstance(preferences: SharedPreferences): UserDataMigrationPreferences {
-                fun getValue(key: String) = preferences.getString(key, "")!!
-
-                return UserDataMigrationPreferences(
-                    source = getValue(PREF_MIGRATION_SOURCE),
-                    destination = getValue(PREF_MIGRATION_DESTINATION)
-                ).also {
-                    // ensure that both are set, or both are empty
-                    if (it.source.isEmpty() != it.destination.isEmpty()) {
-                        // throw if there's a mismatch + list the key -> value pairs
-                        val message =
-                            "'$PREF_MIGRATION_SOURCE': '${getValue(PREF_MIGRATION_SOURCE)}'; " +
-                                "'$PREF_MIGRATION_DESTINATION': '${getValue(PREF_MIGRATION_DESTINATION)}'"
-                        throw IllegalStateException("Expected either all or no migration directories set. $message")
-                    }
-                }
-            }
-        }
     }
 
     private data class DirectoryToExternalDirectory(val ancestorDirectory: File, val externalDirectory: File)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/scopedstorage/DeleteEmptyDirectory.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/scopedstorage/DeleteEmptyDirectory.kt
@@ -17,13 +17,15 @@
 package com.ichi2.anki.servicelayer.scopedstorage
 
 import com.ichi2.anki.model.Directory
+import com.ichi2.anki.servicelayer.scopedstorage.migrateuserdata.MigrateUserData.*
+import com.ichi2.anki.servicelayer.scopedstorage.migrateuserdata.operationCompleted
 import com.ichi2.compat.CompatHelper
 import timber.log.Timber
 import java.io.FileNotFoundException
 import java.io.IOException
 
-data class DeleteEmptyDirectory(val directory: Directory) : MigrateUserData.Operation() {
-    override fun execute(context: MigrateUserData.MigrationContext): List<MigrateUserData.Operation> {
+data class DeleteEmptyDirectory(val directory: Directory) : Operation() {
+    override fun execute(context: MigrationContext): List<Operation> {
         val directoryContainsFiles =
             try {
                 directory.hasFiles()
@@ -31,7 +33,7 @@ data class DeleteEmptyDirectory(val directory: Directory) : MigrateUserData.Oper
                 return noFile(ex)
             }
         if (directoryContainsFiles) {
-            context.reportError(this, MigrateUserData.DirectoryNotEmptyException(directory))
+            context.reportError(this, DirectoryNotEmptyException(directory))
             return operationCompleted()
         }
 
@@ -45,7 +47,7 @@ data class DeleteEmptyDirectory(val directory: Directory) : MigrateUserData.Oper
         return operationCompleted()
     }
 
-    private fun noFile(ex: IOException): List<MigrateUserData.Operation> {
+    private fun noFile(ex: IOException): List<Operation> {
         if (!directory.directory.exists()) {
             // If the directory is already deleted, the goal of the operation is reached,
             // hence we do not have to throw.

--- a/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/scopedstorage/MigrateEssentialFiles.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/scopedstorage/MigrateEssentialFiles.kt
@@ -27,7 +27,11 @@ import com.ichi2.anki.model.Directory
 import com.ichi2.anki.servicelayer.*
 import com.ichi2.anki.servicelayer.ScopedStorageService.PREF_MIGRATION_DESTINATION
 import com.ichi2.anki.servicelayer.ScopedStorageService.PREF_MIGRATION_SOURCE
+import com.ichi2.anki.servicelayer.scopedstorage.MigrateEssentialFiles.Companion.PRIORITY_FILES
+import com.ichi2.anki.servicelayer.scopedstorage.MigrateEssentialFiles.Companion.SAFETY_MARGIN_BYTES
+import com.ichi2.anki.servicelayer.scopedstorage.MigrateEssentialFiles.Companion.migrateEssentialFiles
 import com.ichi2.anki.servicelayer.scopedstorage.MigrateEssentialFiles.UserActionRequiredException
+import com.ichi2.anki.servicelayer.scopedstorage.migrateuserdata.NumberOfBytes
 import com.ichi2.annotations.NeedsTest
 import com.ichi2.compat.CompatHelper
 import com.ichi2.libanki.Collection

--- a/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/scopedstorage/MoveConflictedFile.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/scopedstorage/MoveConflictedFile.kt
@@ -21,10 +21,11 @@ import androidx.annotation.VisibleForTesting
 import com.ichi2.anki.model.Directory
 import com.ichi2.anki.model.DiskFile
 import com.ichi2.anki.model.RelativeFilePath
-import com.ichi2.anki.servicelayer.scopedstorage.MigrateUserData.*
+import com.ichi2.anki.servicelayer.scopedstorage.migrateuserdata.MigrateUserData.*
+import com.ichi2.anki.servicelayer.scopedstorage.migrateuserdata.NumberOfBytes
+import com.ichi2.anki.servicelayer.scopedstorage.migrateuserdata.operationCompleted
 import com.ichi2.compat.CompatHelper
 import java.io.File
-import java.lang.IllegalStateException
 
 /**
  * Moves a file from [sourceFile] to [proposedDestinationFile].

--- a/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/scopedstorage/MoveDirectory.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/scopedstorage/MoveDirectory.kt
@@ -18,7 +18,10 @@ package com.ichi2.anki.servicelayer.scopedstorage
 
 import androidx.annotation.VisibleForTesting
 import com.ichi2.anki.model.Directory
-import com.ichi2.anki.servicelayer.scopedstorage.MigrateUserData.Operation
+import com.ichi2.anki.servicelayer.scopedstorage.migrateuserdata.MigrateUserData.MigrationContext
+import com.ichi2.anki.servicelayer.scopedstorage.migrateuserdata.MigrateUserData.Operation
+import com.ichi2.anki.servicelayer.scopedstorage.migrateuserdata.onRetryExecute
+import com.ichi2.anki.servicelayer.scopedstorage.migrateuserdata.operationCompleted
 import com.ichi2.compat.CompatHelper
 import timber.log.Timber
 import java.io.File
@@ -31,8 +34,8 @@ import java.io.File
  *
  */
 
-data class MoveDirectory(val source: Directory, val destination: File) : MigrateUserData.Operation() {
-    override fun execute(context: MigrateUserData.MigrationContext): List<MigrateUserData.Operation> {
+data class MoveDirectory(val source: Directory, val destination: File) : Operation() {
+    override fun execute(context: MigrationContext): List<Operation> {
 
         // This seems unlikely to happen. Both paths need to be on the same mount point
         // We use directory.exists() to ensure that this operation doesn't occur twice. renameTo
@@ -60,7 +63,7 @@ data class MoveDirectory(val source: Directory, val destination: File) : Migrate
      * Create an empty directory at destination.
      * Return whether it was successful.
      */
-    internal fun createDirectory(context: MigrateUserData.MigrationContext): Boolean {
+    internal fun createDirectory(context: MigrationContext): Boolean {
         Timber.d("creating directory '$destination'")
         createDirectory(destination)
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/scopedstorage/MoveDirectory.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/scopedstorage/MoveDirectory.kt
@@ -14,14 +14,14 @@
  *  this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package com.ichi2.anki.servicelayer.scopedstorage
+package com.ichi2.anki.servicelayer.scopedstorage.migrateuserdata
 
 import androidx.annotation.VisibleForTesting
 import com.ichi2.anki.model.Directory
+import com.ichi2.anki.servicelayer.scopedstorage.DeleteEmptyDirectory
+import com.ichi2.anki.servicelayer.scopedstorage.MoveDirectoryContent
 import com.ichi2.anki.servicelayer.scopedstorage.migrateuserdata.MigrateUserData.MigrationContext
 import com.ichi2.anki.servicelayer.scopedstorage.migrateuserdata.MigrateUserData.Operation
-import com.ichi2.anki.servicelayer.scopedstorage.migrateuserdata.onRetryExecute
-import com.ichi2.anki.servicelayer.scopedstorage.migrateuserdata.operationCompleted
 import com.ichi2.compat.CompatHelper
 import timber.log.Timber
 import java.io.File

--- a/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/scopedstorage/MoveDirectoryContent.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/scopedstorage/MoveDirectoryContent.kt
@@ -18,6 +18,9 @@ package com.ichi2.anki.servicelayer.scopedstorage
 
 import androidx.annotation.VisibleForTesting
 import com.ichi2.anki.model.Directory
+import com.ichi2.anki.servicelayer.scopedstorage.migrateuserdata.MigrateUserData.MigrationContext
+import com.ichi2.anki.servicelayer.scopedstorage.migrateuserdata.MigrateUserData.Operation
+import com.ichi2.anki.servicelayer.scopedstorage.migrateuserdata.operationCompleted
 import com.ichi2.compat.CompatHelper
 import com.ichi2.compat.FileStream
 import java.io.File
@@ -30,7 +33,7 @@ import java.io.IOException
  * This is different than [MoveFile], [MoveDirectory] and [MoveFileOrDirectory] where destination is the new path of the copied element.
  * Because in this case, there is not a single destination path.
  */
-class MoveDirectoryContent private constructor(val source: FileStream, val destination: File) : MigrateUserData.Operation() {
+class MoveDirectoryContent private constructor(val source: FileStream, val destination: File) : Operation() {
     companion object {
         /**
          * Return a [MoveDirectoryContent], moving the content of [source] to [destination].
@@ -48,7 +51,7 @@ class MoveDirectoryContent private constructor(val source: FileStream, val desti
             MoveDirectoryContent(CompatHelper.compat.contentOfDirectory(source.directory), destination)
     }
 
-    override fun execute(context: MigrateUserData.MigrationContext): List<MigrateUserData.Operation> {
+    override fun execute(context: MigrationContext): List<Operation> {
         try {
             val hasNext = source.hasNext() // can throw an IOException
             if (!hasNext) {
@@ -69,7 +72,7 @@ class MoveDirectoryContent private constructor(val source: FileStream, val desti
      * @returns An operation to move file or directory [sourceFile] to [destination]
      */
     @VisibleForTesting
-    internal fun toMoveOperation(sourceFile: File): MigrateUserData.Operation {
+    internal fun toMoveOperation(sourceFile: File): Operation {
         return MoveFileOrDirectory(sourceFile, File(destination, sourceFile.name))
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/scopedstorage/MoveFile.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/scopedstorage/MoveFile.kt
@@ -19,8 +19,9 @@ package com.ichi2.anki.servicelayer.scopedstorage
 import androidx.annotation.VisibleForTesting
 import com.ichi2.anki.model.Directory
 import com.ichi2.anki.model.DiskFile
-import com.ichi2.anki.servicelayer.scopedstorage.MigrateUserData.EquivalentFileException
-import com.ichi2.anki.servicelayer.scopedstorage.MigrateUserData.Operation
+import com.ichi2.anki.servicelayer.scopedstorage.migrateuserdata.MigrateUserData
+import com.ichi2.anki.servicelayer.scopedstorage.migrateuserdata.MigrateUserData.*
+import com.ichi2.anki.servicelayer.scopedstorage.migrateuserdata.operationCompleted
 import com.ichi2.compat.CompatHelper
 import timber.log.Timber
 import java.io.File
@@ -28,20 +29,26 @@ import java.io.File
 /**
  * [Operation] which safely moves a file at path `sourceFile` to path `destinationFile`.
  *
- * Note: thrown exceptions are passed to the context via [MigrateUserData.MigrationContext.reportError]
+ * Note: thrown exceptions are passed to the context via [MigrationContext.reportError]
  *
- * @throws MigrateUserData.FileConflictException If the source and destination exist and are different
- * @throws MigrateUserData.EquivalentFileException sourceFile == destinationFile
- * @throws MigrateUserData.MissingDirectoryException if source or destination's directory is missing
+ * @throws FileConflictException If the source and destination exist and are different
+ * @throws EquivalentFileException sourceFile == destinationFile
+ * @throws MissingDirectoryException if source or destination's directory is missing
  * @throws IllegalStateException File copy failed
  * @throws java.io.IOException Unknown file operation failed
  */
 internal data class MoveFile(val sourceFile: DiskFile, val destinationFile: File) : Operation() {
-    override fun execute(context: MigrateUserData.MigrationContext): List<Operation> {
+    override fun execute(context: MigrationContext): List<Operation> {
         val destinationExists = destinationFile.exists()
 
         if (destinationExists && destinationFile.isDirectory) {
-            context.reportError(this, MigrateUserData.FileDirectoryConflictException(sourceFile, Directory.createInstanceUnsafe(destinationFile)))
+            context.reportError(
+                this,
+                MigrateUserData.FileDirectoryConflictException(
+                    sourceFile,
+                    Directory.createInstanceUnsafe(destinationFile)
+                )
+            )
             return operationCompleted()
         }
 
@@ -57,7 +64,13 @@ internal data class MoveFile(val sourceFile: DiskFile, val destinationFile: File
             // user requesting the file
             Timber.d("file already moved to $destinationFile")
             if (sourceFile.file.exists()) {
-                context.reportError(this, MigrateUserData.FileConflictException(sourceFile, DiskFile.createInstance(destinationFile)!!))
+                context.reportError(
+                    this,
+                    MigrateUserData.FileConflictException(
+                        sourceFile,
+                        DiskFile.createInstance(destinationFile)!!
+                    )
+                )
             }
             return operationCompleted()
         }
@@ -100,10 +113,10 @@ internal data class MoveFile(val sourceFile: DiskFile, val destinationFile: File
      * * Deletes source, if it has same content as destination but distinct path
      * * If source and destination deleted: report 0 progress (this is a no-op)
      *
-     * @throws MigrateUserData.EquivalentFileException sourceFile == destinationFile
-     * @throws MigrateUserData.MissingDirectoryException if source or destination's directory is missing
+     * @throws EquivalentFileException sourceFile == destinationFile
+     * @throws MissingDirectoryException if source or destination's directory is missing
      */
-    private fun handledEquivalentFileContent(destinationExists: Boolean, context: MigrateUserData.MigrationContext): Boolean {
+    private fun handledEquivalentFileContent(destinationExists: Boolean, context: MigrationContext): Boolean {
         if (!sourceFile.contentEquals(destinationFile)) {
             return false
         }
@@ -130,10 +143,10 @@ internal data class MoveFile(val sourceFile: DiskFile, val destinationFile: File
     }
 
     /**
-     * @throws MigrateUserData.MissingDirectoryException if source or destination's directory is missing
+     * @throws MissingDirectoryException if source or destination's directory is missing
      */
     private fun ensureParentDirectoriesExist() {
-        val exceptionBuilder = MigrateUserData.DirectoryValidator()
+        val exceptionBuilder = DirectoryValidator()
         exceptionBuilder.tryCreate("source - parent dir", sourceFile.file.parentFile!!)
         exceptionBuilder.tryCreate("destination - parent dir", destinationFile.parentFile!!)
         exceptionBuilder.throwIfNecessary()

--- a/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/scopedstorage/MoveFileOrDirectory.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/scopedstorage/MoveFileOrDirectory.kt
@@ -20,6 +20,7 @@ import com.ichi2.anki.model.Directory
 import com.ichi2.anki.model.DiskFile
 import com.ichi2.anki.servicelayer.scopedstorage.migrateuserdata.MigrateUserData.*
 import com.ichi2.anki.servicelayer.scopedstorage.migrateuserdata.MigrateUserData.Operation
+import com.ichi2.anki.servicelayer.scopedstorage.migrateuserdata.MoveDirectory
 import com.ichi2.anki.servicelayer.scopedstorage.migrateuserdata.operationCompleted
 import org.apache.commons.io.FileUtils.isSymlink
 import timber.log.Timber

--- a/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/scopedstorage/MoveFileOrDirectory.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/scopedstorage/MoveFileOrDirectory.kt
@@ -18,6 +18,9 @@ package com.ichi2.anki.servicelayer.scopedstorage
 
 import com.ichi2.anki.model.Directory
 import com.ichi2.anki.model.DiskFile
+import com.ichi2.anki.servicelayer.scopedstorage.migrateuserdata.MigrateUserData.*
+import com.ichi2.anki.servicelayer.scopedstorage.migrateuserdata.MigrateUserData.Operation
+import com.ichi2.anki.servicelayer.scopedstorage.migrateuserdata.operationCompleted
 import org.apache.commons.io.FileUtils.isSymlink
 import timber.log.Timber
 import java.io.File
@@ -41,9 +44,9 @@ data class MoveFileOrDirectory(
     val sourceFile: File,
     /** Destination: known to exist */
     val destination: File
-) : MigrateUserData.Operation() {
+) : Operation() {
 
-    override fun execute(context: MigrateUserData.MigrationContext): List<MigrateUserData.Operation> {
+    override fun execute(context: MigrationContext): List<Operation> {
         when {
             sourceFile.isFile -> {
                 val fileToCreate = DiskFile.createInstanceUnsafe(sourceFile)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/scopedstorage/migrateuserdata/MigrateUserData.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/scopedstorage/migrateuserdata/MigrateUserData.kt
@@ -14,7 +14,7 @@
  *  this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package com.ichi2.anki.servicelayer.scopedstorage
+package com.ichi2.anki.servicelayer.scopedstorage.migrateuserdata
 
 import android.content.SharedPreferences
 import androidx.annotation.VisibleForTesting
@@ -22,8 +22,11 @@ import com.ichi2.anki.model.Directory
 import com.ichi2.anki.model.DiskFile
 import com.ichi2.anki.model.RelativeFilePath
 import com.ichi2.anki.servicelayer.ScopedStorageService.UserDataMigrationPreferences
-import com.ichi2.anki.servicelayer.scopedstorage.MigrateUserData.Operation
-import com.ichi2.anki.servicelayer.scopedstorage.MigrateUserData.SingleRetryDecorator
+import com.ichi2.anki.servicelayer.scopedstorage.MigrateEssentialFiles
+import com.ichi2.anki.servicelayer.scopedstorage.MoveConflictedFile
+import com.ichi2.anki.servicelayer.scopedstorage.MoveFileOrDirectory
+import com.ichi2.anki.servicelayer.scopedstorage.migrateuserdata.MigrateUserData.Operation
+import com.ichi2.anki.servicelayer.scopedstorage.migrateuserdata.MigrateUserData.SingleRetryDecorator
 import com.ichi2.async.ProgressSenderAndCancelListener
 import com.ichi2.async.TaskDelegate
 import com.ichi2.compat.CompatHelper

--- a/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/scopedstorage/migrateuserdata/MigrateUserData.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/scopedstorage/migrateuserdata/MigrateUserData.kt
@@ -21,7 +21,6 @@ import androidx.annotation.VisibleForTesting
 import com.ichi2.anki.model.Directory
 import com.ichi2.anki.model.DiskFile
 import com.ichi2.anki.model.RelativeFilePath
-import com.ichi2.anki.servicelayer.ScopedStorageService.UserDataMigrationPreferences
 import com.ichi2.anki.servicelayer.scopedstorage.MigrateEssentialFiles
 import com.ichi2.anki.servicelayer.scopedstorage.MoveConflictedFile
 import com.ichi2.anki.servicelayer.scopedstorage.MoveFileOrDirectory

--- a/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/scopedstorage/migrateuserdata/MigrateUserDataService.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/scopedstorage/migrateuserdata/MigrateUserDataService.kt
@@ -16,10 +16,12 @@
 
 package com.ichi2.anki.servicelayer.scopedstorage.migrateuserdata
 
+import android.content.Context
 import android.content.Intent
 import com.ichi2.anki.R
 import com.ichi2.anki.UIUtils.showThemedToast
-import com.ichi2.anki.servicelayer.ScopedStorageService
+import com.ichi2.anki.servicelayer.ScopedStorageService.PREF_MIGRATION_DESTINATION
+import com.ichi2.anki.servicelayer.ScopedStorageService.PREF_MIGRATION_SOURCE
 
 class MigrateUserDataService : android.app.Service() {
 
@@ -30,8 +32,8 @@ class MigrateUserDataService : android.app.Service() {
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
         super.onStartCommand(intent, flags, startId)
-        val source = intent!!.getStringExtra(ScopedStorageService.PREF_MIGRATION_SOURCE)
-        val destination = intent.getStringExtra(ScopedStorageService.PREF_MIGRATION_DESTINATION)
+        val source = intent!!.getStringExtra(PREF_MIGRATION_SOURCE)
+        val destination = intent.getStringExtra(PREF_MIGRATION_DESTINATION)
         val migrateUserData = MigrateUserData.createInstance(
             UserDataMigrationPreferences.createInstance(
                 source!!,
@@ -53,3 +55,11 @@ class MigrateUserDataService : android.app.Service() {
         showThemedToast(this, getString(R.string.migration_done), shortLength = false)
     }
 }
+
+fun Context.startMigrateUserDataService(source: String, destination: String) =
+    this.startActivity(
+        Intent(this, MigrateUserDataService::class.java).apply {
+            putExtra(PREF_MIGRATION_SOURCE, source)
+            putExtra(PREF_MIGRATION_DESTINATION, destination)
+        }
+    )

--- a/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/scopedstorage/migrateuserdata/MigrateUserDataService.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/scopedstorage/migrateuserdata/MigrateUserDataService.kt
@@ -1,0 +1,55 @@
+/*
+ *  Copyright (c) 2022 Arthur Milchior <arthur@milchior.fr>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.servicelayer.scopedstorage.migrateuserdata
+
+import android.content.Intent
+import com.ichi2.anki.R
+import com.ichi2.anki.UIUtils.showThemedToast
+import com.ichi2.anki.servicelayer.ScopedStorageService
+
+class MigrateUserDataService : android.app.Service() {
+
+    /**
+     * Thread executing the migration.
+     */
+    lateinit var thread: Thread
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        super.onStartCommand(intent, flags, startId)
+        val source = intent!!.getStringExtra(ScopedStorageService.PREF_MIGRATION_SOURCE)
+        val destination = intent.getStringExtra(ScopedStorageService.PREF_MIGRATION_DESTINATION)
+        val migrateUserData = MigrateUserData.createInstance(
+            UserDataMigrationPreferences.createInstance(
+                source!!,
+                destination!!
+            )
+        )
+        thread = Thread {
+            migrateUserData.run()
+            stopSelf()
+        }
+        return START_REDELIVER_INTENT
+    }
+
+    // TODO: Allow to fetch information on the state of the migration
+    override fun onBind(intent: Intent?): Nothing? = null
+
+    override fun onDestroy() {
+        super.onDestroy()
+        showThemedToast(this, getString(R.string.migration_done), shortLength = false)
+    }
+}

--- a/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/scopedstorage/migrateuserdata/UserDataMigrationPreferences.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/scopedstorage/migrateuserdata/UserDataMigrationPreferences.kt
@@ -54,10 +54,12 @@ class UserDataMigrationPreferences private constructor(val source: String, val d
         fun createInstance(preferences: SharedPreferences): UserDataMigrationPreferences {
             fun getValue(key: String) = preferences.getString(key, "")!!
 
-            return UserDataMigrationPreferences(
+            return createInstance(
                 source = getValue(PREF_MIGRATION_SOURCE),
                 destination = getValue(PREF_MIGRATION_DESTINATION)
-            ).also { it.check() }
+            )
         }
+
+        fun createInstance(source: String, destination: String) = UserDataMigrationPreferences(source, destination).also { it.check() }
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/scopedstorage/migrateuserdata/UserDataMigrationPreferences.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/scopedstorage/migrateuserdata/UserDataMigrationPreferences.kt
@@ -34,6 +34,18 @@ class UserDataMigrationPreferences private constructor(val source: String, val d
     val migrationInProgress = source.isNotEmpty()
     val sourceFile get() = File(source)
     val destinationFile get() = File(destination)
+    // Throws if migration can't occur as expected.
+    fun check() {
+        // ensure that both are set, or both are empty
+        if (source.isEmpty() != destination.isEmpty()) {
+            // throw if there's a mismatch + list the key -> value pairs
+            val message =
+                "'$PREF_MIGRATION_SOURCE': '$source'; " +
+                    "'$PREF_MIGRATION_DESTINATION': '$destination'"
+            throw IllegalStateException("Expected either all or no migration directories set. $message")
+        }
+    }
+
     companion object {
         /**
          * @throws IllegalStateException If either [PREF_MIGRATION_SOURCE] or [PREF_MIGRATION_DESTINATION] is set (but not both)
@@ -45,18 +57,7 @@ class UserDataMigrationPreferences private constructor(val source: String, val d
             return UserDataMigrationPreferences(
                 source = getValue(PREF_MIGRATION_SOURCE),
                 destination = getValue(PREF_MIGRATION_DESTINATION)
-            ).also {
-                // ensure that both are set, or both are empty
-                if (it.source.isEmpty() != it.destination.isEmpty()) {
-                    // throw if there's a mismatch + list the key -> value pairs
-                    val message =
-                        "'$PREF_MIGRATION_SOURCE': '${getValue(PREF_MIGRATION_SOURCE)}'; " +
-                            "'$PREF_MIGRATION_DESTINATION': '${getValue(
-                                PREF_MIGRATION_DESTINATION
-                            )}'"
-                    throw IllegalStateException("Expected either all or no migration directories set. $message")
-                }
-            }
+            ).also { it.check() }
         }
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/scopedstorage/migrateuserdata/UserDataMigrationPreferences.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/scopedstorage/migrateuserdata/UserDataMigrationPreferences.kt
@@ -1,0 +1,62 @@
+/*
+ *  Copyright (c) 2022 David Allison <davidallisongithub@gmail.com>
+ *  Copyright (c) 2022 Arthur Milchior <arthur@milchior.fr>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.servicelayer.scopedstorage.migrateuserdata
+
+import android.content.SharedPreferences
+import com.ichi2.anki.servicelayer.ScopedStorageService.PREF_MIGRATION_DESTINATION
+import com.ichi2.anki.servicelayer.ScopedStorageService.PREF_MIGRATION_SOURCE
+import java.io.File
+
+/**
+ * Preferences relating to whether a user data scoped storage migration is taking place
+ * This refers to the [MigrateUserData] operation of copying media which can take a long time.
+ *
+ * @param source The path of the source directory. Check [migrationInProgress] before use.
+ * @param destination The path of the destination directory. Check [migrationInProgress] before use.
+ */
+class UserDataMigrationPreferences private constructor(val source: String, val destination: String) {
+    /**  Whether a scoped storage migration is in progress */
+    val migrationInProgress = source.isNotEmpty()
+    val sourceFile get() = File(source)
+    val destinationFile get() = File(destination)
+    companion object {
+        /**
+         * @throws IllegalStateException If either [PREF_MIGRATION_SOURCE] or [PREF_MIGRATION_DESTINATION] is set (but not both)
+         * It is a logic bug if only one is set
+         */
+        fun createInstance(preferences: SharedPreferences): UserDataMigrationPreferences {
+            fun getValue(key: String) = preferences.getString(key, "")!!
+
+            return UserDataMigrationPreferences(
+                source = getValue(PREF_MIGRATION_SOURCE),
+                destination = getValue(PREF_MIGRATION_DESTINATION)
+            ).also {
+                // ensure that both are set, or both are empty
+                if (it.source.isEmpty() != it.destination.isEmpty()) {
+                    // throw if there's a mismatch + list the key -> value pairs
+                    val message =
+                        "'$PREF_MIGRATION_SOURCE': '${getValue(PREF_MIGRATION_SOURCE)}'; " +
+                            "'$PREF_MIGRATION_DESTINATION': '${getValue(
+                                PREF_MIGRATION_DESTINATION
+                            )}'"
+                    throw IllegalStateException("Expected either all or no migration directories set. $message")
+                }
+            }
+        }
+    }
+}

--- a/AnkiDroid/src/main/res/values/01-core.xml
+++ b/AnkiDroid/src/main/res/values/01-core.xml
@@ -226,4 +226,5 @@
     </plurals>
 
     <string name="copy_note_type_name" comment="The new name of a copied note type">%s copy</string>
+    <string name="migration_done">Update is done. You can sync again.</string>
 </resources>

--- a/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/DeleteEmptyDirectoryTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/DeleteEmptyDirectoryTest.kt
@@ -17,6 +17,7 @@
 package com.ichi2.anki.servicelayer.scopedstorage
 
 import com.ichi2.anki.model.Directory
+import com.ichi2.anki.servicelayer.scopedstorage.migrateuserdata.MigrateUserData.DirectoryNotEmptyException
 import com.ichi2.compat.Test21And26
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.hasSize
@@ -52,7 +53,7 @@ class DeleteEmptyDirectoryTest : Test21And26(), OperationTest {
         val next = DeleteEmptyDirectory(toDelete).execute(executionContext)
 
         assertThat("exception expected", executionContext.exceptions, hasSize(1))
-        assertThat(executionContext.exceptions.single(), instanceOf(MigrateUserData.DirectoryNotEmptyException::class.java))
+        assertThat(executionContext.exceptions.single(), instanceOf(DirectoryNotEmptyException::class.java))
         assertThat("no more operations", next, hasSize(0))
     }
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/ExecutorTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/ExecutorTest.kt
@@ -16,8 +16,9 @@
 
 package com.ichi2.anki.servicelayer.scopedstorage
 
-import com.ichi2.anki.servicelayer.scopedstorage.MigrateUserData.Executor
-import com.ichi2.anki.servicelayer.scopedstorage.MigrateUserData.Operation
+import com.ichi2.anki.servicelayer.scopedstorage.migrateuserdata.MigrateUserData.*
+import com.ichi2.anki.servicelayer.scopedstorage.migrateuserdata.MigrateUserData.Executor
+import com.ichi2.anki.servicelayer.scopedstorage.migrateuserdata.MigrateUserData.Operation
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
 import org.hamcrest.Matchers.hasSize
@@ -172,7 +173,7 @@ class ExecutorTest {
         val isBlocked = Semaphore(1).apply { acquire() }
         // Semaphore that can be acquired after operation start executing
         var isExecuting = Semaphore(1).apply { acquire() }
-        override fun execute(context: MigrateUserData.MigrationContext): List<Operation> {
+        override fun execute(context: MigrationContext): List<Operation> {
             isExecuting.release()
             isBlocked.acquireInTwoSeconds()
             return emptyList()

--- a/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/ExecutorTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/ExecutorTest.kt
@@ -1,3 +1,4 @@
+
 /*
  *  Copyright (c) 2022 David Allison <davidallisongithub@gmail.com>
  *
@@ -17,8 +18,6 @@
 package com.ichi2.anki.servicelayer.scopedstorage
 
 import com.ichi2.anki.servicelayer.scopedstorage.migrateuserdata.MigrateUserData.*
-import com.ichi2.anki.servicelayer.scopedstorage.migrateuserdata.MigrateUserData.Executor
-import com.ichi2.anki.servicelayer.scopedstorage.migrateuserdata.MigrateUserData.Operation
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
 import org.hamcrest.Matchers.hasSize

--- a/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/MockExecutor.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/MockExecutor.kt
@@ -16,8 +16,8 @@
 
 package com.ichi2.anki.servicelayer.scopedstorage
 
-import com.ichi2.anki.servicelayer.scopedstorage.MigrateUserData.MigrationContext
-import com.ichi2.anki.servicelayer.scopedstorage.MigrateUserData.Operation
+import com.ichi2.anki.servicelayer.scopedstorage.migrateuserdata.MigrateUserData.MigrationContext
+import com.ichi2.anki.servicelayer.scopedstorage.migrateuserdata.MigrateUserData.Operation
 
 /**
  * Functionality:

--- a/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/MockMigrationContext.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/MockMigrationContext.kt
@@ -16,16 +16,21 @@
 
 package com.ichi2.anki.servicelayer.scopedstorage
 
-open class MockMigrationContext : MigrateUserData.MigrationContext() {
+import com.ichi2.anki.servicelayer.scopedstorage.migrateuserdata.MigrateUserData.*
+import com.ichi2.anki.servicelayer.scopedstorage.migrateuserdata.MigrateUserData.MigrationContext
+import com.ichi2.anki.servicelayer.scopedstorage.migrateuserdata.MigrateUserData.Operation
+import com.ichi2.anki.servicelayer.scopedstorage.migrateuserdata.NumberOfBytes
+
+open class MockMigrationContext : MigrationContext() {
     /** set [logExceptions] to populate this property */
     val errors = mutableListOf<ReportedError>()
     val exceptions get() = errors.map { it.exception }
     var logExceptions: Boolean = false
     val progress = mutableListOf<NumberOfBytes>()
     /** A list of tasks which were passed into [execSafe] */
-    val executed = mutableListOf<MigrateUserData.Operation>()
+    val executed = mutableListOf<Operation>()
 
-    override fun reportError(throwingOperation: MigrateUserData.Operation, ex: Exception) {
+    override fun reportError(throwingOperation: Operation, ex: Exception) {
         if (!logExceptions) {
             throw ex
         }
@@ -36,11 +41,11 @@ open class MockMigrationContext : MigrateUserData.MigrationContext() {
         progress.add(transferred)
     }
 
-    data class ReportedError(val operation: MigrateUserData.Operation, val exception: Exception)
+    data class ReportedError(val operation: Operation, val exception: Exception)
 
     override fun execSafe(
-        operation: MigrateUserData.Operation,
-        op: (MigrateUserData.Operation) -> Unit
+        operation: Operation,
+        op: (Operation) -> Unit
     ) {
         this.executed.add(operation)
         super.execSafe(operation, op)
@@ -48,15 +53,15 @@ open class MockMigrationContext : MigrateUserData.MigrationContext() {
 }
 
 /**
- * A [MockMigrationContext] which will call [MigrateUserData.Operation.retryOperations] once on
+ * A [MockMigrationContext] which will call [Operation.retryOperations] once on
  * a failed operation, if any `retryOperations` are available.
  *
  * If a second failure occurs, or if no `retryOperations` are available, it will throw
  */
-class RetryMigrationContext(val retry: (List<MigrateUserData.Operation>) -> Unit) : MockMigrationContext() {
+class RetryMigrationContext(val retry: (List<Operation>) -> Unit) : MockMigrationContext() {
     var retryCount = 0
 
-    override fun reportError(throwingOperation: MigrateUserData.Operation, ex: Exception) {
+    override fun reportError(throwingOperation: Operation, ex: Exception) {
         val opsForRetry = throwingOperation.retryOperations
         if (!opsForRetry.any()) {
             throw ex

--- a/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/MockMigrationContextTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/MockMigrationContextTest.kt
@@ -16,7 +16,8 @@
 
 package com.ichi2.anki.servicelayer.scopedstorage
 
-import com.ichi2.anki.servicelayer.scopedstorage.MigrateUserData.Operation
+import com.ichi2.anki.servicelayer.scopedstorage.migrateuserdata.MigrateUserData.*
+import com.ichi2.anki.servicelayer.scopedstorage.migrateuserdata.MigrateUserData.Operation
 import com.ichi2.testutils.TestException
 import com.ichi2.testutils.assertThrows
 import org.hamcrest.CoreMatchers.equalTo
@@ -40,7 +41,7 @@ class MockMigrationContextTest {
     }
 
     class OperationWhichThrowsIfUsed : Operation() {
-        override fun execute(context: MigrateUserData.MigrationContext): List<Operation> =
+        override fun execute(context: MigrationContext): List<Operation> =
             throw TestException("should not be called")
 
         override val retryOperations: List<Operation>

--- a/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/MoveConflictedFileTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/MoveConflictedFileTest.kt
@@ -20,7 +20,7 @@ package com.ichi2.anki.servicelayer.scopedstorage
 import com.ichi2.anki.model.Directory
 import com.ichi2.anki.model.DiskFile
 import com.ichi2.anki.model.RelativeFilePath
-import com.ichi2.anki.servicelayer.scopedstorage.MigrateUserData.FileConflictResolutionFailedException
+import com.ichi2.anki.servicelayer.scopedstorage.migrateuserdata.MigrateUserData.*
 import com.ichi2.compat.Test21And26
 import com.ichi2.testutils.*
 import org.hamcrest.CoreMatchers.*
@@ -31,7 +31,6 @@ import org.junit.Test
 import org.mockito.kotlin.*
 import java.io.File
 import java.io.IOException
-import java.lang.IllegalStateException
 
 class MoveConflictedFileTest : Test21And26(), OperationTest {
 
@@ -165,8 +164,8 @@ class MoveConflictedFileTest : Test21And26(), OperationTest {
 
         var op = params.createOperation()
         op = spy(op) {
-            doAnswer<List<MigrateUserData.Operation>> { answer ->
-                val context = answer.arguments[1] as MigrateUserData.MigrationContext
+            doAnswer<List<Operation>> { answer ->
+                val context = answer.arguments[1] as MigrationContext
                 context.reportError(this.mock, TestException("testing"))
                 emptyList()
             }.whenever(it).moveFile(any(), any())

--- a/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/MoveDirectoryContentTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/MoveDirectoryContentTest.kt
@@ -18,7 +18,8 @@ package com.ichi2.anki.servicelayer.scopedstorage
 
 import android.annotation.SuppressLint
 import com.ichi2.anki.model.Directory
-import com.ichi2.anki.servicelayer.scopedstorage.MigrateUserData.Operation
+import com.ichi2.anki.servicelayer.scopedstorage.migrateuserdata.MigrateUserData.*
+import com.ichi2.anki.servicelayer.scopedstorage.migrateuserdata.MigrateUserData.Operation
 import com.ichi2.compat.Test21And26
 import com.ichi2.testutils.*
 import org.hamcrest.MatcherAssert.assertThat
@@ -146,7 +147,7 @@ class MoveDirectoryContentTest : Test21And26(), OperationTest {
                     return@doAnswer object : Operation() {
                         // Create a file in `source` and then execute the original operation.
                         // It ensures a file is added after some files where already copied.
-                        override fun execute(context: MigrateUserData.MigrationContext): List<Operation> {
+                        override fun execute(context: MigrationContext): List<Operation> {
                             new_file_name = toDoBetweenTwoFilesMove(source).name
                             return operation.execute()
                         }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/MoveDirectoryTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/MoveDirectoryTest.kt
@@ -17,7 +17,8 @@
 package com.ichi2.anki.servicelayer.scopedstorage
 
 import com.ichi2.anki.model.Directory
-import com.ichi2.anki.servicelayer.scopedstorage.MigrateUserData.Operation
+import com.ichi2.anki.servicelayer.scopedstorage.migrateuserdata.MigrateUserData.*
+import com.ichi2.anki.servicelayer.scopedstorage.migrateuserdata.MigrateUserData.Operation
 import com.ichi2.compat.Test21And26
 import com.ichi2.testutils.*
 import org.hamcrest.CoreMatchers.equalTo
@@ -215,7 +216,7 @@ class MoveDirectoryTest : Test21And26(), OperationTest {
                     return@doAnswer object : Operation() {
                         // Create a file in `source` and then execute the original operation.
                         // It ensures a file is added after some files where already copied.
-                        override fun execute(context: MigrateUserData.MigrationContext): List<Operation> {
+                        override fun execute(context: MigrationContext): List<Operation> {
                             new_file_name = toDoBetweenTwoFilesMove(source).name
                             return operation.execute()
                         }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/MoveDirectoryTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/MoveDirectoryTest.kt
@@ -17,8 +17,9 @@
 package com.ichi2.anki.servicelayer.scopedstorage
 
 import com.ichi2.anki.model.Directory
-import com.ichi2.anki.servicelayer.scopedstorage.migrateuserdata.MigrateUserData.*
+import com.ichi2.anki.servicelayer.scopedstorage.migrateuserdata.MigrateUserData.MigrationContext
 import com.ichi2.anki.servicelayer.scopedstorage.migrateuserdata.MigrateUserData.Operation
+import com.ichi2.anki.servicelayer.scopedstorage.migrateuserdata.MoveDirectory
 import com.ichi2.compat.Test21And26
 import com.ichi2.testutils.*
 import org.hamcrest.CoreMatchers.equalTo

--- a/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/MoveFileOrDirectoryTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/MoveFileOrDirectoryTest.kt
@@ -16,6 +16,7 @@
 
 package com.ichi2.anki.servicelayer.scopedstorage
 
+import com.ichi2.anki.servicelayer.scopedstorage.migrateuserdata.MoveDirectory
 import com.ichi2.testutils.createTransientDirectory
 import com.ichi2.testutils.createTransientFile
 import org.hamcrest.CoreMatchers.equalTo
@@ -49,7 +50,12 @@ class MoveFileOrDirectoryTest : OperationTest {
         val nextOperations = moveFromAndExecute(directory)
         assertThat("Only one operation should be next", nextOperations, hasSize(1))
         val nextOperation = nextOperations[0]
-        assertThat("A file as input should return a file operation", nextOperation, instanceOf(MoveDirectory::class.java))
+        assertThat(
+            "A file as input should return a file operation", nextOperation,
+            instanceOf(
+                MoveDirectory::class.java
+            )
+        )
         val moveDirectory = nextOperation as MoveDirectory
         assertThat("Move file source should be file", moveDirectory.source.directory, equalTo(directory))
         assertThat("Destination file source should be file", moveDirectory.destination, equalTo(File(destinationDir, directory.name)))

--- a/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/MoveFileTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/MoveFileTest.kt
@@ -18,8 +18,8 @@ package com.ichi2.anki.servicelayer.scopedstorage
 
 import com.ichi2.anki.RobolectricTest
 import com.ichi2.anki.model.DiskFile
-import com.ichi2.anki.servicelayer.scopedstorage.MigrateUserData.*
-import com.ichi2.anki.servicelayer.scopedstorage.MigrateUserData.MissingDirectoryException.MissingFile
+import com.ichi2.anki.servicelayer.scopedstorage.migrateuserdata.MigrateUserData.*
+import com.ichi2.anki.servicelayer.scopedstorage.migrateuserdata.MigrateUserData.MissingDirectoryException.MissingFile
 import com.ichi2.testutils.*
 import org.hamcrest.CoreMatchers.*
 import org.hamcrest.MatcherAssert.assertThat

--- a/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/OperationTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/OperationTest.kt
@@ -17,7 +17,8 @@
 
 package com.ichi2.anki.servicelayer.scopedstorage
 
-import com.ichi2.anki.servicelayer.scopedstorage.MigrateUserData.Operation
+import com.ichi2.anki.servicelayer.scopedstorage.migrateuserdata.MigrateUserData.*
+import com.ichi2.anki.servicelayer.scopedstorage.migrateuserdata.MigrateUserData.Operation
 import com.ichi2.compat.CompatHelper
 import com.ichi2.testutils.TestException
 import com.ichi2.testutils.createTransientDirectory
@@ -102,7 +103,7 @@ interface OperationTest {
 
 /** A move operation which fails */
 class FailMove : Operation() {
-    override fun execute(context: MigrateUserData.MigrationContext): List<Operation> {
+    override fun execute(context: MigrationContext): List<Operation> {
         throw TestException("should fail but not crash")
     }
 }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/ScopedStorageMigrationIntegrationTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/ScopedStorageMigrationIntegrationTest.kt
@@ -19,7 +19,9 @@ package com.ichi2.anki.servicelayer.scopedstorage
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.ichi2.anki.RobolectricTest
 import com.ichi2.anki.model.Directory
-import com.ichi2.anki.servicelayer.scopedstorage.MigrateUserData.*
+import com.ichi2.anki.servicelayer.scopedstorage.migrateuserdata.MigrateUserData
+import com.ichi2.anki.servicelayer.scopedstorage.migrateuserdata.MigrateUserData.*
+import com.ichi2.anki.servicelayer.scopedstorage.migrateuserdata.NumberOfBytes
 import com.ichi2.async.ProgressSenderAndCancelListener
 import com.ichi2.exceptions.AggregateException
 import com.ichi2.testutils.*

--- a/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/migrateuserdata/MigrateUserDataJvmTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/migrateuserdata/MigrateUserDataJvmTest.kt
@@ -14,12 +14,13 @@
  *  this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package com.ichi2.anki.servicelayer.scopedstorage
+package com.ichi2.anki.servicelayer.scopedstorage.migrateuserdata
 
 import android.content.SharedPreferences
 import com.ichi2.anki.servicelayer.ScopedStorageService
-import com.ichi2.anki.servicelayer.scopedstorage.MigrateUserData.MissingDirectoryException
-import com.ichi2.anki.servicelayer.scopedstorage.MigrateUserDataJvmTest.SourceType.*
+import com.ichi2.anki.servicelayer.scopedstorage.migrateuserdata.MigrateUserData.Companion.createInstance
+import com.ichi2.anki.servicelayer.scopedstorage.migrateuserdata.MigrateUserData.MissingDirectoryException
+import com.ichi2.anki.servicelayer.scopedstorage.migrateuserdata.MigrateUserDataJvmTest.SourceType.*
 import com.ichi2.testutils.assertThrows
 import com.ichi2.testutils.createTransientDirectory
 import org.hamcrest.CoreMatchers.*
@@ -51,7 +52,7 @@ class MigrateUserDataJvmTest {
     @Test
     fun valid_instance_if_directories_exist() {
         val preferences = getScopedStorageMigrationPreferences(source = VALID_DIR, destination = VALID_DIR)
-        val data = MigrateUserData.createInstance(preferences)
+        val data = createInstance(preferences)
 
         assertThat("a valid task instance should be created", data, notNullValue())
 
@@ -62,14 +63,14 @@ class MigrateUserDataJvmTest {
     @Test
     fun no_instance_if_not_migrating() {
         val preferences = getScopedStorageMigrationPreferences(source = NOT_SET, destination = NOT_SET)
-        val data = MigrateUserData.createInstance(preferences)
+        val data = createInstance(preferences)
         assertThat("a valid task instance should not be created as we are not migrating", data, nullValue())
     }
 
     @Test
     fun error_if_settings_are_bad() {
         val preferences = getScopedStorageMigrationPreferences(source = NOT_SET, destination = VALID_DIR)
-        val exception = assertThrows<IllegalStateException> { MigrateUserData.createInstance(preferences) }
+        val exception = assertThrows<IllegalStateException> { createInstance(preferences) }
 
         assertThat(exception.message, equalTo("Expected either all or no migration directories set. 'migrationSourcePath': ''; 'migrationDestinationPath': '$destDir'"))
     }
@@ -77,14 +78,14 @@ class MigrateUserDataJvmTest {
     @Test
     fun error_if_source_does_not_exist() {
         val preferences = getScopedStorageMigrationPreferences(source = MISSING_DIR, destination = VALID_DIR)
-        val exception = assertThrows<MissingDirectoryException> { MigrateUserData.createInstance(preferences) }
+        val exception = assertThrows<MissingDirectoryException> { createInstance(preferences) }
         assertThat(exception.directories.single().file.canonicalPath, equalTo(missingDir))
     }
 
     @Test
     fun error_if_destination_does_not_exist() {
         val preferences = getScopedStorageMigrationPreferences(source = VALID_DIR, destination = MISSING_DIR)
-        val exception = assertThrows<MissingDirectoryException> { MigrateUserData.createInstance(preferences) }
+        val exception = assertThrows<MissingDirectoryException> { createInstance(preferences) }
         assertThat(exception.directories.single().file.canonicalPath, equalTo(missingDir))
     }
 


### PR DESCRIPTION
MigrateUserData used to be a TaskDelegate, to use with AsyncTask.

Not only, we do not want to use AsyncTask anymore. But more importantly, that would block the app, which is really not what we want. Instead, it should be a worker or a service. Since it should still work when the app closes, a service seems more appropriate. 
Since the service is supposed to have a single task running at the same time, I created the task directly and did not use a runner, contrary to the example of https://developer.android.com/guide/components/services

Since it's my first Service, I'd welcome strongly any feedback.
In particular, I don't yet know how to check whether a service is running; so that the DeckPicker, when AnkiDroid is started, can check whether the task is still running or whether a new task must be started
