### PR TITLE
Change the order of audio-related items on action menu of study screen

### DIFF
--- a/AnkiDroid/src/main/res/menu/reviewer.xml
+++ b/AnkiDroid/src/main/res/menu/reviewer.xml
@@ -98,16 +98,6 @@
         android:title="@string/menu_edit_tags"
         ankidroid:showAsAction="never"/>
     <item
-        android:id="@+id/action_replay"
-        android:title="@string/replay_audio"
-        android:icon="@drawable/ic_play_circle_white"
-        ankidroid:showAsAction="ifRoom"/>
-    <item
-        android:id="@+id/action_toggle_mic_tool_bar"
-        android:title="@string/menu_toggle_mic_tool_bar"
-        android:icon="@drawable/ic_action_mic"
-        ankidroid:showAsAction="never"/>
-    <item
         android:id="@+id/action_bury"
         android:title="@string/menu_bury"
         android:icon="@drawable/ic_flip_to_back_white"/>
@@ -131,12 +121,22 @@
         <menu/>
     </item>
     <item
-        android:id="@+id/action_open_deck_options"
-        android:icon="@drawable/ic_tune_white"
-        android:title="@string/menu__deck_options" />
+        android:id="@+id/action_replay"
+        android:title="@string/replay_audio"
+        android:icon="@drawable/ic_play_circle_white"
+        ankidroid:showAsAction="ifRoom"/>
+    <item
+        android:id="@+id/action_toggle_mic_tool_bar"
+        android:title="@string/menu_toggle_mic_tool_bar"
+        android:icon="@drawable/ic_action_mic"
+        ankidroid:showAsAction="never"/>
     <item
         android:id="@+id/action_select_tts"
         android:title="@string/select_tts"
         android:icon="@drawable/ic_language_white"
         android:visible="false" />
+    <item
+        android:id="@+id/action_open_deck_options"
+        android:icon="@drawable/ic_tune_white"
+        android:title="@string/menu__deck_options" />
 </menu>


### PR DESCRIPTION

## Pull Request template

## Purpose / Description
To group the audio-related items at the lower position (as on Anki Desktop) and to place "Deck options" at the bottom of the menu
![image](https://user-images.githubusercontent.com/10436072/194856895-7e129db1-d5bf-4e97-b472-e6e97dfd637b.png)![image](https://user-images.githubusercontent.com/10436072/194855899-6e2777d9-ba6c-4b21-ba37-ade5d5ed98be.png)


## Fixes
n/a

## Approach
Change the order of the items on reviewer.xml

## How Has This Been Tested?
Checked on my physical device
![image](https://user-images.githubusercontent.com/10436072/194855292-710e9a0d-dec5-4aef-9868-11318675dfe7.png)


## Learning (optional, can help others)
n/a

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
