### PR TITLE
Cleanup: Refactor `LintUtils.isAnAllowedClass` to not use `var`

### DIFF
--- a/lint-rules/src/main/java/com/ichi2/anki/lint/utils/LintUtils.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/utils/LintUtils.kt
@@ -27,16 +27,6 @@ object LintUtils {
      * @return true if this is a class where the checks should not be applied, false otherwise
      */
     fun isAnAllowedClass(classes: List<UClass>, vararg allowedClasses: String): Boolean {
-        var isInAllowedClass = false
-        for (i in classes.indices) {
-            val className = classes[i].name!!
-            for (allowedClass in allowedClasses) {
-                if (className == allowedClass) {
-                    isInAllowedClass = true
-                    break
-                }
-            }
-        }
-        return isInAllowedClass
+        return classes.any { uClass -> uClass.name!! in allowedClasses }
     }
 }


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
Similar to #12593 
Ended up reducing the function to a one-liner with the power of kotlin

```kotlin
fun isAnAllowedClass(classes: List<UClass>, vararg allowedClasses: String): Boolean {
        var isInAllowedClass = false
        for (i in classes.indices) {
            val className = classes[i].name!!
            for (allowedClass in allowedClasses) {
                if (className == allowedClass) {
                    isInAllowedClass = true
                    break
                }
            }
        }
        return isInAllowedClass
}
```

ends up as 
```kotlin
fun isAnAllowedClass(classes: List<UClass>, vararg allowedClasses: String): Boolean {
       return classes.any { it.name!! in allowedClasses }
}
```

and for more readability, you can write it as
```kotlin
fun isAnAllowedClass(classes: List<UClass>, vararg allowedClasses: String): Boolean {
     return classes.any { uClass -> uClass.name!! in allowedClasses }
}
```

## Fixes
Relevant to #11450 

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [x] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
