### PR TITLE
Fix: getAllModelsAndNotesCount is now cancelled co-operatively

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/ModelBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ModelBrowser.kt
@@ -47,7 +47,7 @@ import com.ichi2.utils.displayKeyboard
 import com.ichi2.widget.WidgetStatus.update
 import kotlinx.coroutines.Job
 import timber.log.Timber
-import java.util.ArrayList
+import java.util.*
 
 @KotlinCleanup("Try converting variables to be non-null wherever possible + Standard in-IDE cleanup")
 @NeedsTest("add tests to ensure changes(renames & deletions) to the list of note types are visible in the UI")
@@ -166,9 +166,7 @@ class ModelBrowser : AnkiActivity() {
             // Pair of list of models and corresponding notesCount
             Timber.d("doInBackgroundLoadModels: Started")
             val allModelsAndNotesCount = withProgress {
-                withCol {
-                    getAllModelsAndNotesCount(this)
-                }
+                getAllModelsAndNotesCount()
             }
             Timber.d("doInBackgroundLoadModels: Completed, refreshing UI")
             mModels = ArrayList(allModelsAndNotesCount.first)

--- a/AnkiDroid/src/test/java/com/ichi2/async/CountModelsTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/async/CountModelsTest.kt
@@ -26,14 +26,11 @@ class CountModelsTest : RobolectricTest() {
 
     @Test
     fun testModelsCount() = runTest {
-        val initialCount = modelCount
+        val initialCount = getAllModelsAndNotesCount().first.size /** number of models in the collection */
 
         addNonClozeModel("testModel", arrayOf("front", "back"), qfmt = "{{front}}", afmt = "{{FrontSide}}\n\n<hr id=answer>\n\n{{ back }}")
 
-        val finalCount = modelCount
+        val finalCount = getAllModelsAndNotesCount().first.size
         assertEquals(initialCount + 1, finalCount)
     }
-
-    /** Returns the number of models in the collection */
-    private val modelCount get() = getAllModelsAndNotesCount(col).first.size
 }


### PR DESCRIPTION

## Purpose / Description
Fixes the issue that the function would keep continuing even if the coroutine was cancelled.
This is a continuation to the PR where cancellation had got removed unnoticed https://github.com/ankidroid/Anki-Android/pull/12541

## Approach
Made the function suspend and use withCol{} internally whenever collection access is required.

## How Has This Been Tested?
YET_TO_BE_DONE

## Documentation followed
https://developer.android.com/kotlin/coroutines/coroutines-best-practices#coroutine-cancellable

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
