### PR TITLE
chore: remove 'welcome dialog'

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -587,36 +587,17 @@ open class DeckPicker :
         }
     }
 
+    /**
+     * precondition: [hasStorageAccessPermission] should return false
+     */
     fun requestStoragePermission() {
-        fun showStoragePermissionDialog() {
-            val storagePermissions = arrayOf(
-                Manifest.permission.WRITE_EXTERNAL_STORAGE,
-                Manifest.permission.READ_EXTERNAL_STORAGE
-            )
-            ActivityCompat.requestPermissions(this, storagePermissions, REQUEST_STORAGE_PERMISSION)
-        }
-
-        val sharedPrefs = AnkiDroidApp.getSharedPrefs(this)
-        val welcomeDialogDismissed = sharedPrefs.getBoolean("welcomeDialogDismissed", false)
-        if (welcomeDialogDismissed) {
-            // DEFECT #5847: This fails if the activity is killed.
-            // Even if the dialog is showing, we want to show it again.
-            showStoragePermissionDialog()
-            return
-        }
-
-        Timber.i("Displaying initial permission request dialog")
-        // Request storage permission if we don't have it (e.g. on Android 6.0+)
-        MaterialDialog(this).show {
-            title(R.string.collection_load_welcome_request_permissions_title)
-            message(R.string.collection_load_welcome_request_permissions_details)
-            positiveButton(R.string.dialog_ok) {
-                sharedPrefs.edit { putBoolean("welcomeDialogDismissed", true) }
-                showStoragePermissionDialog()
-            }
-            cancelable(false)
-            cancelOnTouchOutside(false)
-        }
+        // DEFECT #5847: This fails if the activity is killed.
+        // Even if the dialog is showing, we want to show it again.
+        val storagePermissions = arrayOf(
+            Manifest.permission.WRITE_EXTERNAL_STORAGE,
+            Manifest.permission.READ_EXTERNAL_STORAGE
+        )
+        ActivityCompat.requestPermissions(this, storagePermissions, REQUEST_STORAGE_PERMISSION)
     }
 
     override fun onCreateOptionsMenu(menu: Menu): Boolean {

--- a/AnkiDroid/src/main/res/values/03-dialogs.xml
+++ b/AnkiDroid/src/main/res/values/03-dialogs.xml
@@ -164,9 +164,6 @@
     <!-- Multimedia - Audio View -->
     <string name="multimedia_editor_audio_permission_denied">Audio recording permission denied</string>
 
-    <!-- Initial collection load -->
-    <string name="collection_load_welcome_request_permissions_title">Welcome to AnkiDroid!</string>
-    <string name="collection_load_welcome_request_permissions_details">AnkiDroid requires storage permission, which we use exclusively to store your AnkiDroid collection, flashcard media and backups. Our code is open-source, written by volunteers, and trusted by millions.\n\nIf you have any questions, please access our in-app manual or visit our support forums.\n\nThank you for trying AnkiDroid!\n—AnkiDroid Development Team</string>
     <string name="mutimedia_editor_assertion_failed">Unknown error occurred displaying Advanced Editor</string>
 
     <!-- Database Integrity Check -->


### PR DESCRIPTION
Due to Scoped Storage, we will no longer need this dialog It was added because people were complaining about the storage permission prompt, and this will no longer be shown

We remove this now to remove the burden on translators and a step for developers to test a new version of the app.

Later, we'll remove this function entirely.

See: issue #5304 - scoped storage

## How Has This Been Tested?

* On-device: S21 (Android 12). Cleared data, deleted `/AnkiDroid` and ran the app
* Unit tests pass
* Didn't try instrumented/lint tests. CI ahoy!


## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
