### PR TITLE
fix: 'RescheduleDialog' memory leak

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -50,8 +50,8 @@ import com.ichi2.anki.dialogs.CardBrowserOrderDialog.Companion.newInstance
 import com.ichi2.anki.dialogs.DeckSelectionDialog.Companion.newInstance
 import com.ichi2.anki.dialogs.DeckSelectionDialog.DeckSelectionListener
 import com.ichi2.anki.dialogs.DeckSelectionDialog.SelectableDeck
-import com.ichi2.anki.dialogs.RescheduleDialog.rescheduleMultipleCards
-import com.ichi2.anki.dialogs.RescheduleDialog.rescheduleSingleCard
+import com.ichi2.anki.dialogs.RescheduleDialog.Companion.rescheduleMultipleCards
+import com.ichi2.anki.dialogs.RescheduleDialog.Companion.rescheduleSingleCard
 import com.ichi2.anki.dialogs.tags.TagsDialog
 import com.ichi2.anki.dialogs.tags.TagsDialogFactory
 import com.ichi2.anki.dialogs.tags.TagsDialogListener

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
@@ -60,7 +60,7 @@ import com.ichi2.anki.Whiteboard.OnPaintColorChangeListener
 import com.ichi2.anki.cardviewer.Gesture
 import com.ichi2.anki.cardviewer.ViewerCommand
 import com.ichi2.anki.dialogs.ConfirmationDialog
-import com.ichi2.anki.dialogs.RescheduleDialog.rescheduleSingleCard
+import com.ichi2.anki.dialogs.RescheduleDialog.Companion.rescheduleSingleCard
 import com.ichi2.anki.multimediacard.AudioView
 import com.ichi2.anki.multimediacard.AudioView.Companion.createRecorderInstance
 import com.ichi2.anki.multimediacard.AudioView.Companion.generateTempAudioFile

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/RescheduleDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/RescheduleDialog.kt
@@ -22,58 +22,83 @@ import com.ichi2.libanki.Card
 import com.ichi2.libanki.sched.SchedV2
 import java.util.function.Consumer
 
-object RescheduleDialog : IntegerDialog() {
-    @CheckResult
-    fun rescheduleSingleCard(
-        resources: Resources,
-        currentCard: Card,
-        consumer: Consumer<Int>?
-    ): RescheduleDialog {
-        val rescheduleDialog = RescheduleDialog
-        val content = getContentString(resources, currentCard)
-        rescheduleDialog.setArgs(
-            title = resources.getQuantityString(R.plurals.reschedule_cards_dialog_title_new, 1, 1),
-            prompt = resources.getString(R.string.reschedule_card_dialog_message),
-            digits = 4,
-            content = content
-        )
-        if (consumer != null) {
-            rescheduleDialog.setCallbackRunnable(consumer)
-        }
-        return rescheduleDialog
-    }
+// a memory leak was caused when this was a singleton object.
+class RescheduleDialog : IntegerDialog() {
 
-    @CheckResult
-    fun rescheduleMultipleCards(resources: Resources, consumer: Consumer<Int>?, cardCount: Int): RescheduleDialog {
-        val rescheduleDialog = RescheduleDialog
-        rescheduleDialog.setArgs(
-            resources.getQuantityString(R.plurals.reschedule_cards_dialog_title_new, cardCount, cardCount),
-            resources.getString(R.string.reschedule_card_dialog_message),
-            4
-        )
-        if (consumer != null) {
-            rescheduleDialog.setCallbackRunnable(consumer)
-        }
-        return rescheduleDialog
-    }
-
-    private fun getContentString(resources: Resources, currentCard: Card): String? {
-        if (currentCard.isNew) {
-            return resources.getString(R.string.reschedule_card_dialog_new_card_warning)
+    companion object {
+        @CheckResult
+        fun rescheduleSingleCard(
+            resources: Resources,
+            currentCard: Card,
+            consumer: Consumer<Int>?
+        ): RescheduleDialog {
+            val rescheduleDialog = RescheduleDialog()
+            val content = getContentString(resources, currentCard)
+            rescheduleDialog.setArgs(
+                title = resources.getQuantityString(
+                    R.plurals.reschedule_cards_dialog_title_new,
+                    1,
+                    1
+                ),
+                prompt = resources.getString(R.string.reschedule_card_dialog_message),
+                digits = 4,
+                content = content
+            )
+            if (consumer != null) {
+                rescheduleDialog.setCallbackRunnable(consumer)
+            }
+            return rescheduleDialog
         }
 
-        // #5595 - Help a user reschedule cards by showing them the current interval.
-        // DEFECT: We should be able to calculate this for all card types - not yet performed for non-review or dynamic cards
-        if (!currentCard.isReview) {
-            return null
+        @CheckResult
+        fun rescheduleMultipleCards(
+            resources: Resources,
+            consumer: Consumer<Int>?,
+            cardCount: Int
+        ): RescheduleDialog {
+            val rescheduleDialog = RescheduleDialog()
+            rescheduleDialog.setArgs(
+                resources.getQuantityString(
+                    R.plurals.reschedule_cards_dialog_title_new,
+                    cardCount,
+                    cardCount
+                ),
+                resources.getString(R.string.reschedule_card_dialog_message),
+                4
+            )
+            if (consumer != null) {
+                rescheduleDialog.setCallbackRunnable(consumer)
+            }
+            return rescheduleDialog
         }
-        val message = resources.getString(R.string.reschedule_card_dialog_warning_ease_reset, SchedV2.RESCHEDULE_FACTOR / 10)
-        return if (currentCard.isInDynamicDeck) {
-            message
-        } else """
+
+        private fun getContentString(resources: Resources, currentCard: Card): String? {
+            if (currentCard.isNew) {
+                return resources.getString(R.string.reschedule_card_dialog_new_card_warning)
+            }
+
+            // #5595 - Help a user reschedule cards by showing them the current interval.
+            // DEFECT: We should be able to calculate this for all card types - not yet performed for non-review or dynamic cards
+            if (!currentCard.isReview) {
+                return null
+            }
+            val message = resources.getString(
+                R.string.reschedule_card_dialog_warning_ease_reset,
+                SchedV2.RESCHEDULE_FACTOR / 10
+            )
+            return if (currentCard.isInDynamicDeck) {
+                message
+            } else """
      $message
      
-     ${resources.getQuantityString(R.plurals.reschedule_card_dialog_interval, currentCard.ivl, currentCard.ivl)}
-        """.trimIndent()
+     ${
+            resources.getQuantityString(
+                R.plurals.reschedule_card_dialog_interval,
+                currentCard.ivl,
+                currentCard.ivl
+            )
+            }
+            """.trimIndent()
+        }
     }
 }


### PR DESCRIPTION
* Open Reviewer
* Select "Reschedule - Reschedule in X Days"
* Close the dialog
* Close the reviewer
* Memory leak

```
┬───
│ GC Root: Thread object
│
├─ android.os.HandlerThread instance
│    Leaking: NO (PathClassLoader↓ is not leaking)
│    Thread name: 'queued-work-looper'
│    ↓ Thread.contextClassLoader
├─ dalvik.system.PathClassLoader instance
│    Leaking: NO (RescheduleDialog↓ is not leaking and A ClassLoader is never
│    leaking)
│    ↓ ClassLoader.runtimeInternalObjects
├─ java.lang.Object[] array
│    Leaking: NO (RescheduleDialog↓ is not leaking)
│    ↓ Object[138]
├─ com.ichi2.anki.dialogs.RescheduleDialog class
│    Leaking: NO (a class is never leaking)
│    ↓ static RescheduleDialog.INSTANCE
│                              ~~~~~~~~
╰→ com.ichi2.anki.dialogs.RescheduleDialog instance
​     Leaking: YES (ObjectWatcher was watching this because com.ichi2.anki.
​     dialogs.RescheduleDialog received Fragment#onDestroy() callback and
​     Fragment#mFragmentManager is null)
​     Retaining 441.8 kB in 8621 objects
​     key = 6ecff083-09a1-49d5-b6e1-4ee164adc808
​     watchDurationMillis = 7610
​     retainedDurationMillis = 2610

METADATA

Build.VERSION.SDK_INT: 31
Build.MANUFACTURER: samsung
LeakCanary version: 2.9.1
App process name: com.ichi2.anki
Class count: 27339
Instance count: 275020
Primitive array count: 175923
Object array count: 37489
Thread count: 39
Heap total bytes: 33095716
Bitmap count: 4
Bitmap total bytes: 2456268
Large bitmap count: 0
Large bitmap total bytes: 0
Db 1: open /[storage/emulated/0/AnkiDroid/collection.media.ad.db2](http://storage/emulated/0/AnkiDroid/collection.media.ad.db2)
Db 2: open /[data/user/0/com.ichi2.anki/databases/ankidroid.db](http://data/user/0/com.ichi2.anki/databases/ankidroid.db)
Stats: LruCache[maxSize=3000,hits=149077,misses=254380,hitRate=36%]
RandomAccess[bytes=12942025,reads=254380,travel=86358031520,range=39630243,size=
49293954]
Analysis duration: 79725 ms
```

## How Has This Been Tested?

* re-tested on my device. Only one remains: `TaskManager.sInstance`

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
