### PR TITLE
fix(test): we need notification permission on tests that measure screen

### DIFF
--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/DeckPickerTest.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/DeckPickerTest.kt
@@ -19,6 +19,7 @@ package com.ichi2.anki
 
 import android.Manifest
 import android.annotation.SuppressLint
+import android.os.Build
 import androidx.recyclerview.widget.RecyclerView
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.Espresso.pressBack
@@ -48,7 +49,11 @@ class DeckPickerTest {
 
     @get:Rule
     val mRuntimePermissionRule: GrantPermissionRule =
-        GrantPermissionRule.grant(Manifest.permission.WRITE_EXTERNAL_STORAGE)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            GrantPermissionRule.grant(Manifest.permission.WRITE_EXTERNAL_STORAGE, Manifest.permission.POST_NOTIFICATIONS)
+        } else {
+            GrantPermissionRule.grant(Manifest.permission.WRITE_EXTERNAL_STORAGE)
+        }
 
     @Ignore("This test appears to be flaky everywhere")
     @Test


### PR DESCRIPTION

## Pull Request template

## Purpose / Description

otherwise the API33 "post notifications" permission dialog pops up and screen measurements fails

## Fixes

Unlogged, but running `./gradlew jacocoTestReport` locally while verifying other PRs was failing for me because I happened to have an API33 emulator up at the time

## Approach

Conditionally grant the permission

## How Has This Been Tested?

Failed before the change, re-ran the tests, passed after the change

## Learning (optional, can help others)
_Describe the research stage_

_Links to blog posts, patterns, libraries or addons used to solve this problem_

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x ] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
