### PR TITLE
test(perf): avoid OOM while running big batches of commit tests

### DIFF
--- a/tools/test-commits.sh
+++ b/tools/test-commits.sh
@@ -14,6 +14,7 @@ first_commit="$1"
 while :; do
     echo "testing $(git log --pretty=oneline -1)"
     ./gradlew -q clean uninstallPlayDebug jacocoTestReport :api:lintRelease :AnkiDroid:lintPlayRelease ktlintCheck
+    ./gradlew --stop
     [ $(git rev-parse HEAD) = $first_commit ] && break
     git checkout HEAD^
 done


### PR DESCRIPTION

## Pull Request template

## Purpose / Description

TIL that you can still kill a machine with 64GB+64GB RAM+Swap if you run enough Kotlin on it. Thanks gradle.

## Fixes

Nothing logged, but my laptop definitely knew it

```
Oct 13 13:58:43 bistromath systemd-oomd[6489]: Killed /user.slice/user-1000.slice/user@1000.service/app.slice/app-org.gnome.Terminal.slice/vte-spawn-0eaf5a40-aeed-40d9-92fd-28a19a40d3fa.scope due to memory pressure for /user.slice/user-1000.slice/user@1000.service being 76.59% > 50.00% for > 20s with reclaim activity
Oct 13 13:58:43 bistromath systemd-oomd[6489]: Killed /user.slice/user-1000.slice/user@1000.service/app.slice/app-org.gnome.Terminal.slice/vte-spawn-32aaa1a7-320f-46f8-afb9-49c2447a2b2a.scope due to memory pressure for /user.slice/user-1000.slice/user@1000.service being 65.84% > 50.00% for > 20s with reclaim activity
```

## Approach
kill gradle daemons while running commit checks on PRs, in between each commit check

## How Has This Been Tested?

I am a crash test dummy, and I volunteered myself to crash and show the problem, now I am no longer consuming RAM like a champion Nathan's hot dog eating contest competitor

## Learning (optional, can help others)

Did you know that Bill Gates never actually said 640k should be enough for anyone? I'm a bit disappointed.

https://www.wired.com/1997/01/did-gates-really-say-640k-is-enough-for-anyone/

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas
- [ ] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
