### PR TITLE
NF: MigrateUserData limit its use of TaskListener

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/scopedstorage/migrateuserdata/MigrateUserData.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/scopedstorage/migrateuserdata/MigrateUserData.kt
@@ -35,6 +35,12 @@ import timber.log.Timber
 import java.io.File
 
 typealias NumberOfBytes = Long
+/**
+ * Function that is executed when one file is migrated, with the number of bytes moved.
+ * Called with 0 when the file is already present in destination (i.e. successful move with no byte copied)
+ * Not called for directories.
+ */
+typealias MigrationProgressListener = (NumberOfBytes) -> Unit
 
 /**
  * Migrating user data (images, backups etc..) to scoped storage
@@ -150,6 +156,11 @@ open class MigrateUserData protected constructor(val source: Directory, val dest
      */
     abstract class MigrationContext {
         abstract fun reportError(throwingOperation: Operation, ex: Exception)
+
+        /**
+         * Called on each successful file migrated
+         * @param transferred The number of bytes of the transferred file
+         */
         abstract fun reportProgress(transferred: NumberOfBytes)
         /**
          * Whether [File#renameTo] should be attempted
@@ -364,9 +375,11 @@ open class MigrateUserData protected constructor(val source: Directory, val dest
 
     /**
      * Abstracts the decision of what to do when an exception occurs when migrating a file.
-     * Provides progress notifications
+     * Provides progress notifications.
+     * @param executor The executor that will do the migration.
+     * @param progressReportParam A function, called for each file that is migrated, with the number of bytes of the file.
      */
-    open class UserDataMigrationContext(private val executor: Executor, val source: Directory, val progressReportParam: ((NumberOfBytes) -> Unit)) : MigrationContext() {
+    open class UserDataMigrationContext(private val executor: Executor, val source: Directory, val progressReportParam: MigrationProgressListener) : MigrationContext() {
         val successfullyCompleted: Boolean get() = loggedExceptions.isEmpty()
 
         /**
@@ -498,7 +511,11 @@ open class MigrateUserData protected constructor(val source: Directory, val dest
     }
 
     @VisibleForTesting
-    internal open fun initializeContext(progress: ((NumberOfBytes) -> Unit)) =
+    /**
+     * @return A User data migration context, executing the migration of [source] on [executor].
+     * Calling [collectionTask::doProgress] on each migrated file, with the number of bytes migrated.
+     */
+    internal open fun initializeContext(progress: (MigrationProgressListener)) =
         UserDataMigrationContext(executor, source, progress)
 
     /**

--- a/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/scopedstorage/migrateuserdata/MigrateUserData.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/scopedstorage/migrateuserdata/MigrateUserData.kt
@@ -467,7 +467,7 @@ open class MigrateUserData protected constructor(val source: Directory, val dest
      */
     override fun task(col: Collection, collectionTask: ProgressSenderAndCancelListener<NumberOfBytes>): Boolean {
 
-        val context = initializeContext(collectionTask)
+        val context = initializeContext(collectionTask::doProgress)
 
         // define the function here, so we can execute it on retry
         fun moveRemainingFiles() {
@@ -498,8 +498,8 @@ open class MigrateUserData protected constructor(val source: Directory, val dest
     }
 
     @VisibleForTesting
-    internal open fun initializeContext(collectionTask: ProgressSenderAndCancelListener<NumberOfBytes>) =
-        UserDataMigrationContext(executor, source, collectionTask::doProgress)
+    internal open fun initializeContext(progress: ((NumberOfBytes) -> Unit)) =
+        UserDataMigrationContext(executor, source, progress)
 
     /**
      * Returns migration operations for the top level items in /AnkiDroid/

--- a/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/ScopedStorageMigrationIntegrationTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/ScopedStorageMigrationIntegrationTest.kt
@@ -21,7 +21,7 @@ import com.ichi2.anki.RobolectricTest
 import com.ichi2.anki.model.Directory
 import com.ichi2.anki.servicelayer.scopedstorage.migrateuserdata.MigrateUserData
 import com.ichi2.anki.servicelayer.scopedstorage.migrateuserdata.MigrateUserData.*
-import com.ichi2.anki.servicelayer.scopedstorage.migrateuserdata.NumberOfBytes
+import com.ichi2.anki.servicelayer.scopedstorage.migrateuserdata.MigrationProgressListener
 import com.ichi2.exceptions.AggregateException
 import com.ichi2.testutils.*
 import net.ankiweb.rsdroid.BackendFactory
@@ -217,7 +217,7 @@ private class MigrateUserDataTester
 private constructor(source: Directory, destination: Directory, val filesToMigrateCount: Int) :
     MigrateUserData(source, destination) {
 
-    override fun initializeContext(progress: ((NumberOfBytes) -> Unit)): UserDataMigrationContext {
+    override fun initializeContext(progress: MigrationProgressListener): UserDataMigrationContext {
         return super.initializeContext(progress).apply {
             attemptRename = false
         }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/ScopedStorageMigrationIntegrationTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/ScopedStorageMigrationIntegrationTest.kt
@@ -22,7 +22,6 @@ import com.ichi2.anki.model.Directory
 import com.ichi2.anki.servicelayer.scopedstorage.migrateuserdata.MigrateUserData
 import com.ichi2.anki.servicelayer.scopedstorage.migrateuserdata.MigrateUserData.*
 import com.ichi2.anki.servicelayer.scopedstorage.migrateuserdata.NumberOfBytes
-import com.ichi2.async.ProgressSenderAndCancelListener
 import com.ichi2.exceptions.AggregateException
 import com.ichi2.testutils.*
 import net.ankiweb.rsdroid.BackendFactory
@@ -218,8 +217,8 @@ private class MigrateUserDataTester
 private constructor(source: Directory, destination: Directory, val filesToMigrateCount: Int) :
     MigrateUserData(source, destination) {
 
-    override fun initializeContext(collectionTask: ProgressSenderAndCancelListener<NumberOfBytes>): UserDataMigrationContext {
-        return super.initializeContext(collectionTask).apply {
+    override fun initializeContext(progress: ((NumberOfBytes) -> Unit)): UserDataMigrationContext {
+        return super.initializeContext(progress).apply {
             attemptRename = false
         }
     }


### PR DESCRIPTION
When using a Worker or a thread, we won't have a task listener as argument. 
That may not be entirely ideal, but that 's a good compromise, I believe, between avoiding to rewrite too much, and ensuring that moving to a worker remains simple