### PR TITLE
Correct `testChannelCreation`

### DIFF
--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/NotificationChannelTest.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/NotificationChannelTest.kt
@@ -28,7 +28,8 @@ import com.ichi2.anki.NotificationChannels
 import com.ichi2.anki.NotificationChannels.getId
 import com.ichi2.compat.CompatHelper.Companion.sdkVersion
 import com.ichi2.utils.KotlinCleanup
-import org.junit.Assert.assertEquals
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.greaterThanOrEqualTo
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -84,10 +85,10 @@ class NotificationChannelTest : InstrumentedTest() {
                 expectedChannels += 1
             }
         }
-        assertEquals(
-            "Incorrect channel count",
+        assertThat(
+            "Not as many channels as expected.",
             expectedChannels,
-            channels.size
+            greaterThanOrEqualTo(channels.size)
         )
         for (channel in NotificationChannels.Channel.values()) {
             assertNotNull(


### PR DESCRIPTION
Channels are never deleted. So if this test is run on an AnkiDroid version that has more channels in previous installation, the test fails. It is very rare, because it requires that you add a channel and then remove it. However, this can occur:
* during development time, when you regularly change branch
* when doing bisect