### PR TITLE
Export has less nullability

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -275,7 +275,7 @@ open class DeckPicker :
     private val mImportAddListener = ImportAddListener(this)
 
     @KotlinCleanup("Migrate from Triple to Kotlin class")
-    private class ImportAddListener(deckPicker: DeckPicker?) : TaskListenerWithContext<DeckPicker, String, Triple<List<AnkiPackageImporter>?, Boolean, String?>?>(deckPicker) {
+    private class ImportAddListener(deckPicker: DeckPicker) : TaskListenerWithContext<DeckPicker, String, Triple<List<AnkiPackageImporter>?, Boolean, String?>?>(deckPicker) {
         override fun actualOnPostExecute(context: DeckPicker, result: Triple<List<AnkiPackageImporter>?, Boolean, String?>?) {
             if (context.mProgressDialog != null && context.mProgressDialog!!.isShowing) {
                 context.mProgressDialog!!.dismiss()
@@ -336,7 +336,7 @@ open class DeckPicker :
         return ImportReplaceListener(this)
     }
 
-    private class ImportReplaceListener(deckPicker: DeckPicker?) : TaskListenerWithContext<DeckPicker, String, Computation<*>?>(deckPicker) {
+    private class ImportReplaceListener(deckPicker: DeckPicker) : TaskListenerWithContext<DeckPicker, String, Computation<*>?>(deckPicker) {
         override fun actualOnPostExecute(context: DeckPicker, result: Computation<*>?) {
             Timber.i("Import: Replace Task Completed")
             if (context.mProgressDialog != null && context.mProgressDialog!!.isShowing) {
@@ -1286,7 +1286,7 @@ open class DeckPicker :
         return UndoTaskListener(isReview, this)
     }
 
-    private class UndoTaskListener(private val isReview: Boolean, deckPicker: DeckPicker?) : TaskListenerWithContext<DeckPicker, Unit, Computation<NextCard<*>>?>(deckPicker) {
+    private class UndoTaskListener(private val isReview: Boolean, deckPicker: DeckPicker) : TaskListenerWithContext<DeckPicker, Unit, Computation<NextCard<*>>?>(deckPicker) {
         override fun actualOnCancelled(context: DeckPicker) {
             context.hideProgressBar()
         }
@@ -2138,7 +2138,7 @@ open class DeckPicker :
         return UpdateDeckListListener(this)
     }
 
-    private class UpdateDeckListListener<T : AbstractDeckTreeNode>(private val deckPicker: DeckPicker?) : TaskListenerWithContext<DeckPicker, Void, List<TreeNode<T>>?>(deckPicker) {
+    private class UpdateDeckListListener<T : AbstractDeckTreeNode>(deckPicker: DeckPicker) : TaskListenerWithContext<DeckPicker, Void, List<TreeNode<T>>?>(deckPicker) {
         override fun actualOnPreExecute(context: DeckPicker) {
             if (!context.colIsOpen()) {
                 context.showProgressBar()

--- a/AnkiDroid/src/main/java/com/ichi2/anki/export/ExportListener.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/export/ExportListener.kt
@@ -22,7 +22,8 @@ import com.ichi2.async.TaskListenerWithContext
 import com.ichi2.themes.StyledProgressDialog
 import timber.log.Timber
 
-internal class ExportListener(activity: AnkiActivity?, private val dialogsFactory: ExportDialogsFactory) : TaskListenerWithContext<AnkiActivity, Void, Pair<Boolean, String?>?>(activity) {
+internal class ExportListener(activity: AnkiActivity, private val dialogsFactory: ExportDialogsFactory) :
+    TaskListenerWithContext<AnkiActivity, Void, Pair<Boolean, String?>?>(activity) {
     @Suppress("Deprecation")
     private var mProgressDialog: android.app.ProgressDialog? = null
     override fun actualOnPreExecute(context: AnkiActivity) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/export/ExportListener.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/export/ExportListener.kt
@@ -23,7 +23,7 @@ import com.ichi2.themes.StyledProgressDialog
 import timber.log.Timber
 
 internal class ExportListener(activity: AnkiActivity, private val dialogsFactory: ExportDialogsFactory) :
-    TaskListenerWithContext<AnkiActivity, Void, Pair<Boolean, String?>?>(activity) {
+    TaskListenerWithContext<AnkiActivity, Void, Pair<Boolean, String?>>(activity) {
     @Suppress("Deprecation")
     private var mProgressDialog: android.app.ProgressDialog? = null
     override fun actualOnPreExecute(context: AnkiActivity) {
@@ -33,14 +33,14 @@ internal class ExportListener(activity: AnkiActivity, private val dialogsFactory
         )
     }
 
-    override fun actualOnPostExecute(context: AnkiActivity, result: Pair<Boolean, String?>?) {
+    override fun actualOnPostExecute(context: AnkiActivity, result: Pair<Boolean, String?>) {
         if (mProgressDialog != null && mProgressDialog!!.isShowing) {
             mProgressDialog!!.dismiss()
         }
 
         // If boolean and string are both set, we are signalling an error message
         // instead of a successful result.
-        if (result!!.first == true && result.second != null) {
+        if (result.first && result.second != null) {
             Timber.w("Export Failed: %s", result.second)
             context.showSimpleMessageDialog(result.second)
         } else {

--- a/AnkiDroid/src/main/java/com/ichi2/async/SingleTaskManager.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/async/SingleTaskManager.kt
@@ -82,7 +82,7 @@ class SingleTaskManager : TaskManager() {
     @Suppress("DEPRECATION")
     override fun <Progress, Result> launchCollectionTaskConcrete(
         task: TaskDelegateBase<Progress, Result>,
-        listener: TaskListener<in Progress, in Result?>?
+        listener: TaskListener<in Progress, in Result>?
     ): Cancellable {
         // Start new task
         return CollectionTask(task, listener, mLatestInstance).apply {

--- a/AnkiDroid/src/main/java/com/ichi2/async/TaskListenerWithContext.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/async/TaskListenerWithContext.kt
@@ -19,7 +19,7 @@ import java.lang.ref.WeakReference
 
 /** Similar to task listener, but if the context disappear, no action are executed.
  * We ensure that the context can't disappear during the execution of the methods. */
-abstract class TaskListenerWithContext<CTX, Progress, Result> protected constructor(context: CTX?) :
+abstract class TaskListenerWithContext<CTX, Progress, Result> protected constructor(context: CTX) :
     TaskListener<Progress, Result>() where CTX : Any {
     private val mContext: WeakReference<CTX>
     override fun onPreExecute() {

--- a/AnkiDroid/src/main/java/com/ichi2/async/TaskManager.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/async/TaskManager.kt
@@ -36,7 +36,7 @@ abstract class TaskManager {
     protected abstract fun setLatestInstanceConcrete(task: CollectionTask<*, *>)
     abstract fun <Progress, Result> launchCollectionTaskConcrete(
         task: TaskDelegateBase<Progress, Result>,
-        listener: TaskListener<in Progress, in Result?>?
+        listener: TaskListener<in Progress, in Result>?
     ): Cancellable
 
     abstract fun waitToFinishConcrete()
@@ -117,7 +117,7 @@ abstract class TaskManager {
          */
         fun <Progress, Result> launchCollectionTask(
             task: TaskDelegateBase<Progress, Result>,
-            listener: TaskListener<in Progress, in Result?>?
+            listener: TaskListener<in Progress, in Result>?
         ): Cancellable {
             return sTaskManager.launchCollectionTaskConcrete(task, listener)
         }

--- a/AnkiDroid/src/test/java/com/ichi2/async/ForegroundTaskManager.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/async/ForegroundTaskManager.kt
@@ -32,7 +32,7 @@ class ForegroundTaskManager(private val colGetter: CollectionGetter) : TaskManag
     protected override fun setLatestInstanceConcrete(task: CollectionTask<*, *>) {}
     override fun <Progress, Result> launchCollectionTaskConcrete(
         task: TaskDelegateBase<Progress, Result>,
-        listener: TaskListener<in Progress, in Result?>?
+        listener: TaskListener<in Progress, in Result>?
     ): Cancellable {
         return executeTaskWithListener(task, listener, colGetter)
     }
@@ -62,7 +62,7 @@ class ForegroundTaskManager(private val colGetter: CollectionGetter) : TaskManag
 
     class EmptyTask<Progress, Result>(
         task: TaskDelegateBase<Progress, Result>?,
-        listener: TaskListener<in Progress, in Result?>?
+        listener: TaskListener<in Progress, in Result>?
     ) : CollectionTask<Progress, Result>(
         task!!, listener, null
     )
@@ -71,7 +71,7 @@ class ForegroundTaskManager(private val colGetter: CollectionGetter) : TaskManag
         @KotlinCleanup("getCol should be allowed to return null: maybe getColSafe here?")
         fun <Progress, Result> executeTaskWithListener(
             task: TaskDelegateBase<Progress, Result>,
-            listener: TaskListener<in Progress, in Result?>?,
+            listener: TaskListener<in Progress, in Result>?,
             colGetter: CollectionGetter
         ): Cancellable {
             listener?.onPreExecute()


### PR DESCRIPTION
Working on improving notification for Scoped storage. For this I want to improve nullability. This concerns the one after Export message too. 

Also, using a sealed enum for various case help to notice that some of the code (at least timbers) clearly didn't make sens and was not as intended.

This is blocked by #12660