### PR TITLE
Add `migrate` in DeckPicker

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -86,6 +86,7 @@ import com.ichi2.anki.receiver.SdCardReceiver
 import com.ichi2.anki.servicelayer.DeckService
 import com.ichi2.anki.servicelayer.SchedulerService.NextCard
 import com.ichi2.anki.servicelayer.ScopedStorageService.isLegacyStorage
+import com.ichi2.anki.servicelayer.ScopedStorageService.migrateEssentialFiles
 import com.ichi2.anki.servicelayer.ScopedStorageService.userMigrationIsInProgress
 import com.ichi2.anki.servicelayer.UndoService.Undo
 import com.ichi2.anki.snackbar.showSnackbar
@@ -117,7 +118,9 @@ import com.ichi2.utils.*
 import com.ichi2.utils.NetworkUtils.isActiveNetworkMetered
 import com.ichi2.utils.Permissions.hasStorageAccessPermission
 import com.ichi2.widget.WidgetStatus
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.withContext
 import net.ankiweb.rsdroid.BackendFactory
 import net.ankiweb.rsdroid.RustCleanup
 import org.intellij.lang.annotations.Language
@@ -2757,6 +2760,35 @@ open class DeckPicker :
     }
 
     /**
+     * Do the whole migration.
+     * Blocks the UI until essential files are migrated.
+     * Change the preferences related to storage
+     * Migrate the user data in a service
+     */
+    fun migrate() {
+        if (userMigrationIsInProgress(this) || !isLegacyStorage(this)) {
+            // This should not ever occurs.
+            return
+        }
+        launchCatchingTask {
+            withProgress(getString(R.string.start_migration_progress_message)) {
+                withContext(Dispatchers.IO) {
+                    migrateEssentialFiles(baseContext)
+                }
+            }
+            showSnackbar(R.string.migration_part_1_done_resume)
+            startMigrateUserDataService()
+        }
+    }
+
+    /**
+     * Start migrating the user data. Assumes that
+     */
+    fun startMigrateUserDataService() {
+        // TODO
+    }
+
+    /**
      * Show a dialog that explains no sync can occur during migration.
      */
     private fun warnNoSyncDuringMigration() {
@@ -2815,10 +2847,6 @@ open class DeckPicker :
             ) { _, _ ->
                 setMigrationWasLastPostponedAtToNow()
             }.addScopedStorageLearnMoreLinkAndShow(message)
-    }
-
-    fun migrate() {
-        // TODO: Implement
     }
 
     // Scoped Storage migration

--- a/AnkiDroid/src/main/res/values/02-strings.xml
+++ b/AnkiDroid/src/main/res/values/02-strings.xml
@@ -414,6 +414,9 @@
     <string name="migration_update_request_dialog_download_warning">If you uninstall AnkiDroid, you will need to download your full collection again.</string>
     <string name="migration_update_request">Android storage access policy requires us to change where we store your collection. When your data is migrated AnkiDroid will be faster and your data will be more secure.
     You will not be able to sync during the storage migration.</string>
+    <string name="start_migration_progress_message">Starting storage migration. You may resume using AnkiDroid shortly.</string>
+    <string name="migration_part_1_done_resume">You may resume using AnkiDroid.
+\nStorage migration will continue in the background.</string>
     <!--  JS Addons  -->
     <string name="not_valid_js_addon">%s is not a valid javascript addon package</string>
     <string name="could_not_create_dir">Could not create directory %s</string>


### PR DESCRIPTION
It suspend during the important part of the migration and then call a function to start the service. This one is TODO for the moment.
We'll need this as a separate function since we'll need to start the service also if the service is not working and we still have work to do