### PR TITLE
Kotlin Cleanup: Changed to scope function in DeckPickerTest

### DIFF
--- a/AnkiDroid/src/test/java/com/ichi2/anki/DeckPickerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/DeckPickerTest.kt
@@ -58,7 +58,6 @@ class DeckPickerTest : RobolectricTest() {
 
     @Test
     fun verifyCodeMessages() {
-        // getResourceString() is the wrapper for targetContext.getString(resource)
         val codeResponsePairs = hashMapOf(
             407 to getResourceString(R.string.sync_error_407_proxy_required),
             409 to getResourceString(R.string.sync_error_409),

--- a/AnkiDroid/src/test/java/com/ichi2/anki/DeckPickerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/DeckPickerTest.kt
@@ -58,7 +58,6 @@ class DeckPickerTest : RobolectricTest() {
 
     @Test
     fun verifyCodeMessages() {
-        // Scope function:
         HashMap<Int, String>().let {
             val context = targetContext
             it[407] = context.getString(R.string.sync_error_407_proxy_required)

--- a/AnkiDroid/src/test/java/com/ichi2/anki/DeckPickerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/DeckPickerTest.kt
@@ -58,22 +58,21 @@ class DeckPickerTest : RobolectricTest() {
 
     @Test
     fun verifyCodeMessages() {
-        HashMap<Int, String>().let {
-            // HashMap object will now be referenced by "it"
-            val context = targetContext
-            it[407] = context.getString(R.string.sync_error_407_proxy_required)
-            it[409] = context.getString(R.string.sync_error_409)
-            it[413] = context.getString(R.string.sync_error_413_collection_size)
-            it[500] = context.getString(R.string.sync_error_500_unknown)
-            it[501] = context.getString(R.string.sync_error_501_upgrade_required)
-            it[502] = context.getString(R.string.sync_error_502_maintenance)
-            it[503] = context.getString(R.string.sync_too_busy)
-            it[504] = context.getString(R.string.sync_error_504_gateway_timeout)
-            ActivityScenario.launch(DeckPicker::class.java).use { scenario ->
-                scenario.onActivity { deckPicker: DeckPicker ->
-                    for ((key, value) in it) {
-                        assertEquals(deckPicker.rewriteError(key), value)
-                    }
+        // getResourceString() is the wrapper for targetContext.getString(resource)
+        val codeResponsePairs = hashMapOf(
+            407 to getResourceString(R.string.sync_error_407_proxy_required),
+            409 to getResourceString(R.string.sync_error_409),
+            413 to getResourceString(R.string.sync_error_413_collection_size),
+            500 to getResourceString(R.string.sync_error_500_unknown),
+            501 to getResourceString(R.string.sync_error_501_upgrade_required),
+            502 to getResourceString(R.string.sync_error_502_maintenance),
+            503 to getResourceString(R.string.sync_too_busy),
+            504 to getResourceString(R.string.sync_error_504_gateway_timeout)
+        )
+        ActivityScenario.launch(DeckPicker::class.java).use { scenario ->
+            scenario.onActivity { deckPicker: DeckPicker ->
+                for ((key, value) in codeResponsePairs) {
+                    assertEquals(deckPicker.rewriteError(key), value)
                 }
             }
         }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/DeckPickerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/DeckPickerTest.kt
@@ -15,7 +15,6 @@ import com.ichi2.libanki.Storage
 import com.ichi2.libanki.exception.UnknownDatabaseVersionException
 import com.ichi2.testutils.*
 import com.ichi2.testutils.AnkiActivityUtils.getDialogFragment
-import com.ichi2.utils.KotlinCleanup
 import com.ichi2.utils.ResourceLoader
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import net.ankiweb.rsdroid.BackendFactory
@@ -59,21 +58,22 @@ class DeckPickerTest : RobolectricTest() {
 
     @Test
     fun verifyCodeMessages() {
-        @KotlinCleanup("use scope function")
-        val codeResponsePairs: MutableMap<Int, String> = HashMap()
-        val context = targetContext
-        codeResponsePairs[407] = context.getString(R.string.sync_error_407_proxy_required)
-        codeResponsePairs[409] = context.getString(R.string.sync_error_409)
-        codeResponsePairs[413] = context.getString(R.string.sync_error_413_collection_size)
-        codeResponsePairs[500] = context.getString(R.string.sync_error_500_unknown)
-        codeResponsePairs[501] = context.getString(R.string.sync_error_501_upgrade_required)
-        codeResponsePairs[502] = context.getString(R.string.sync_error_502_maintenance)
-        codeResponsePairs[503] = context.getString(R.string.sync_too_busy)
-        codeResponsePairs[504] = context.getString(R.string.sync_error_504_gateway_timeout)
-        ActivityScenario.launch(DeckPicker::class.java).use { scenario ->
-            scenario.onActivity { deckPicker: DeckPicker ->
-                for ((key, value) in codeResponsePairs) {
-                    assertEquals(deckPicker.rewriteError(key), value)
+        // Scope function:
+        HashMap<Int, String>().let {
+            val context = targetContext
+            it[407] = context.getString(R.string.sync_error_407_proxy_required)
+            it[409] = context.getString(R.string.sync_error_409)
+            it[413] = context.getString(R.string.sync_error_413_collection_size)
+            it[500] = context.getString(R.string.sync_error_500_unknown)
+            it[501] = context.getString(R.string.sync_error_501_upgrade_required)
+            it[502] = context.getString(R.string.sync_error_502_maintenance)
+            it[503] = context.getString(R.string.sync_too_busy)
+            it[504] = context.getString(R.string.sync_error_504_gateway_timeout)
+            ActivityScenario.launch(DeckPicker::class.java).use { scenario ->
+                scenario.onActivity { deckPicker: DeckPicker ->
+                    for ((key, value) in it) {
+                        assertEquals(deckPicker.rewriteError(key), value)
+                    }
                 }
             }
         }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/DeckPickerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/DeckPickerTest.kt
@@ -59,6 +59,7 @@ class DeckPickerTest : RobolectricTest() {
     @Test
     fun verifyCodeMessages() {
         HashMap<Int, String>().let {
+            // HashMap object will now be referenced by "it"
             val context = targetContext
             it[407] = context.getString(R.string.sync_error_407_proxy_required)
             it[409] = context.getString(R.string.sync_error_409)


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
Fix `@KotlinCleanup` tag for better code styling.

## Fixes
Related to #10489 

## Approach
~This code changes from using a variable representation to a scoped function. This helps to enhance readability. The variable is referenced within scope by `it`.~
Originally, the intention was to switch from a variable representation to a scoped function. Further suggestions have instead favored switching to `useHashMapOf` to make things more Kotlin-like.
`getResourceString` is favored over `targetContext.getString` for its simplicity.

## How Has This Been Tested?
This has been tested both as an individual test file and as part of the entire gradle test suite, including testing with incorrect values to ensure they are caught:
- `./gradlew AnkiDroid:testPlayDebugUnitTest --tests com.ichi2.anki.DeckPickerTest.verifyCodeMessages`
- `./gradlew AnkiDroid:testPlayDebugUnitTest --tests com.ichi2.anki.DeckPickerTest`
- `./gradlew jacocoTestReport`

## Learning (optional, can help others)
[This](https://kotlinlang.org/docs/scope-functions.html) is Kotlin's Scope Function reference.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- ~[ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)~
- ~[ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)~
