### PR TITLE
NF: save last successful export

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ExportDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ExportDialog.kt
@@ -31,7 +31,7 @@ import com.ichi2.utils.contentNullable
 
 class ExportDialog(private val listener: ExportDialogListener) : AnalyticsDialogFragment() {
     interface ExportDialogListener {
-        fun exportColAsApkg(path: String?, includeSched: Boolean, includeMedia: Boolean)
+        fun exportColAsApkgOrColpkg(path: String?, includeSched: Boolean, includeMedia: Boolean)
         fun exportDeckAsApkg(path: String?, did: DeckId, includeSched: Boolean, includeMedia: Boolean)
         fun exportSelectedAsApkg(path: String?, limit: ExportLimit, includeSched: Boolean, includeMedia: Boolean)
         fun dismissAllDialogFragments()
@@ -110,7 +110,7 @@ class ExportDialog(private val listener: ExportDialogListener) : AnalyticsDialog
                     }
                     listener.exportSelectedAsApkg(null, limit, mIncludeSched, mIncludeMedia)
                 } else {
-                    listener.exportColAsApkg(null, mIncludeSched, mIncludeMedia)
+                    listener.exportColAsApkgOrColpkg(null, mIncludeSched, mIncludeMedia)
                 }
                 dismissAllDialogFragments()
             }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/export/ActivityExportingDelegate.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/export/ActivityExportingDelegate.kt
@@ -105,11 +105,11 @@ class ActivityExportingDelegate(private val activity: AnkiActivity, private val 
         }
     }
 
-    override fun exportColAsApkg(path: String?, includeSched: Boolean, includeMedia: Boolean) {
+    override fun exportColAsApkgOrColpkg(path: String?, includeSched: Boolean, includeMedia: Boolean) {
         val exportPath = getExportFileName(path, "All Decks", includeSched)
 
         if (BackendFactory.defaultLegacySchema) {
-            exportApkgLegacy(exportPath, null, includeSched, includeMedia)
+            exportApkgOrColpkgLegacy(exportPath, null, includeSched, includeMedia)
         } else {
             if (includeSched) {
                 activity.launchCatchingTask {
@@ -129,7 +129,7 @@ class ActivityExportingDelegate(private val activity: AnkiActivity, private val 
         val exportPath = getExportFileName(path, deckName, includeSched)
 
         if (BackendFactory.defaultLegacySchema) {
-            exportApkgLegacy(exportPath, did, includeSched, includeMedia)
+            exportApkgOrColpkgLegacy(exportPath, did, includeSched, includeMedia)
         } else {
             val limit = exportLimit { this.deckId = did }
             exportNewBackendApkg(exportPath, includeSched, includeMedia, limit)
@@ -146,9 +146,9 @@ class ActivityExportingDelegate(private val activity: AnkiActivity, private val 
         exportNewBackendApkg(exportPath, includeSched, includeMedia, limit)
     }
 
-    private fun exportApkgLegacy(exportPath: File, did: DeckId?, includeSched: Boolean, includeMedia: Boolean) {
+    private fun exportApkgOrColpkgLegacy(exportPath: File, did: DeckId?, includeSched: Boolean, includeMedia: Boolean) {
         activity.launchCatchingTask {
-            val apkgPath = exportPath.path
+            val exportPkgPath = exportPath.path
             activity.withProgress(activity.resources.getString(R.string.export_in_progress)) {
                 withCol {
                     val exporter = if (did == null) {
@@ -156,10 +156,10 @@ class ActivityExportingDelegate(private val activity: AnkiActivity, private val 
                     } else {
                         AnkiPackageExporter(this, did, includeSched, includeMedia)
                     }
-                    exporter.exportInto(apkgPath, context)
+                    exporter.exportInto(exportPkgPath, context)
                 }
             }
-            val dialog = mDialogsFactory.newExportCompleteDialog().withArguments(apkgPath)
+            val dialog = mDialogsFactory.newExportCompleteDialog().withArguments(exportPkgPath)
             activity.showAsyncDialogFragment(dialog)
         }
     }


### PR DESCRIPTION
We save MOD and date. We intend to take it into account if sync is not activated.

MOD because if there was no change since last export, it's clear we don't risk loosing data.

Actual time because that will ensure we can know how much time of review/card creation can be lost.