### PR TITLE
Fix crash when user aborts file selection while exporting

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/export/ActivityExportingDelegate.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/export/ActivityExportingDelegate.kt
@@ -15,6 +15,7 @@
  */
 package com.ichi2.anki.export
 
+import android.app.Activity
 import android.content.ClipData
 import android.content.Intent
 import android.net.Uri
@@ -283,6 +284,12 @@ class ActivityExportingDelegate(private val activity: AnkiActivity, private val 
         fragmentManager.fragmentFactory = mDialogsFactory
         mSaveFileLauncher = activity.registerForActivityResult(
             ActivityResultContracts.StartActivityForResult()
-        ) { result: ActivityResult -> saveFileCallback(result) }
+        ) { result: ActivityResult ->
+            if (result.resultCode == Activity.RESULT_OK) {
+                saveFileCallback(result)
+            } else {
+                Timber.i("The file selection for the exported collection was cancelled")
+            }
+        }
     }
 }


### PR DESCRIPTION
## Purpose / Description

We didn't handle the user cancelling the file selection(like hitting back) when trying to export the collection.

## Fixes
Fixes #12676

## How Has This Been Tested?

Minor change.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
