### PR TITLE
Replaces usages of `MaterialDialog` with `AlertDialog` on most preferences classes

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/AboutFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/AboutFragment.kt
@@ -28,9 +28,9 @@ import android.view.ViewGroup
 import android.widget.Button
 import android.widget.ImageView
 import android.widget.TextView
+import androidx.appcompat.app.AlertDialog
 import androidx.core.text.parseAsHtml
 import androidx.fragment.app.Fragment
-import com.afollestad.materialdialogs.MaterialDialog
 import com.google.android.material.snackbar.Snackbar
 import com.ichi2.anki.*
 import com.ichi2.anki.servicelayer.DebugInfoService
@@ -38,6 +38,7 @@ import com.ichi2.anki.snackbar.showSnackbar
 import com.ichi2.utils.IntentUtil
 import com.ichi2.utils.VersionUtils.appName
 import com.ichi2.utils.VersionUtils.pkgVersionName
+import com.ichi2.utils.show
 
 class AboutFragment : Fragment() {
     override fun onCreateView(
@@ -140,26 +141,24 @@ class AboutFragment : Fragment() {
          * Shows a dialog to confirm if developer options should be enabled or not
          */
         fun showEnableDevOptionsDialog(context: Context) {
-            MaterialDialog(context).show {
-                title(R.string.dev_options_enabled_pref)
-                icon(R.drawable.ic_warning_black)
-                message(R.string.dev_options_warning)
-                positiveButton(R.string.dialog_ok) { enableDevOptions(context) }
-                // Reset click count if user has cancelled the action
-                negativeButton(R.string.dialog_cancel) { clickCount = 0 }
-                // avoid dismissing the dialog, as there is a high chance the user
-                // taps outside the dialog while trying to unlock the secret
-                cancelOnTouchOutside(false)
+            AlertDialog.Builder(context).show {
+                setTitle(R.string.dev_options_enabled_pref)
+                setIcon(R.drawable.ic_warning_black)
+                setMessage(R.string.dev_options_warning)
+                setPositiveButton(R.string.dialog_ok) { _, _ -> enableDevOptions() }
+                setNegativeButton(R.string.dialog_cancel) { _, _ -> clickCount = 0 }
+                setCancelable(false)
             }
         }
 
         /**
          * Enables developer options for the user and shows it on [HeaderFragment]
          */
-        fun enableDevOptions(context: Context) {
-            val message = context.getString(R.string.dev_options_enabled_msg)
-            UIUtils.showThemedToast(context, message, true)
+        fun enableDevOptions() {
             preferencesActivity.setDevOptionsEnabled(true)
+            preferencesActivity.showSnackbar(R.string.dev_options_enabled_msg) {
+                setAction(R.string.undo) { preferencesActivity.setDevOptionsEnabled(false) }
+            }
         }
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/AdvancedSettingsFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/AdvancedSettingsFragment.kt
@@ -20,16 +20,17 @@ import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageManager
 import androidx.annotation.StringRes
+import androidx.appcompat.app.AlertDialog
 import androidx.preference.EditTextPreference
 import androidx.preference.Preference
 import androidx.preference.SwitchPreference
-import com.afollestad.materialdialogs.MaterialDialog
 import com.ichi2.anki.*
 import com.ichi2.anki.CollectionManager.withCol
 import com.ichi2.anki.exception.StorageAccessException
 import com.ichi2.anki.provider.CardContentProvider
 import com.ichi2.anki.snackbar.showSnackbar
 import com.ichi2.compat.CompatHelper
+import com.ichi2.utils.show
 import net.ankiweb.rsdroid.BackendFactory
 import net.ankiweb.rsdroid.RustCleanup
 import timber.log.Timber
@@ -57,12 +58,10 @@ class AdvancedSettingsFragment : SettingsFragment() {
                     true
                 } catch (e: StorageAccessException) {
                     Timber.e(e, "Could not initialize directory: %s", newPath)
-                    MaterialDialog(requireContext()).show {
-                        title(R.string.dialog_collection_path_not_dir)
-                        positiveButton(R.string.dialog_ok) {
-                            dismiss()
-                        }
-                        negativeButton(R.string.reset_custom_buttons) {
+                    AlertDialog.Builder(requireContext()).show {
+                        setTitle(R.string.dialog_collection_path_not_dir)
+                        setPositiveButton(R.string.dialog_ok) { _, _ -> }
+                        setNegativeButton(R.string.reset_custom_buttons) { _, _ ->
                             text = CollectionHelper.getDefaultAnkiDroidDirectory(requireContext())
                         }
                     }
@@ -79,16 +78,16 @@ class AdvancedSettingsFragment : SettingsFragment() {
 
         // Configure "Reset languages" preference
         requirePreference<Preference>(R.string.pref_reset_languages_key).setOnPreferenceClickListener {
-            MaterialDialog(requireContext()).show {
-                title(R.string.reset_languages)
-                icon(R.drawable.ic_warning_black)
-                message(R.string.reset_languages_question)
-                positiveButton(R.string.dialog_ok) {
+            AlertDialog.Builder(requireContext()).show {
+                setTitle(R.string.reset_languages)
+                setIcon(R.drawable.ic_warning_black)
+                setMessage(R.string.reset_languages_question)
+                setPositiveButton(R.string.dialog_ok) { _, _ ->
                     if (MetaDB.resetLanguages(requireContext())) {
                         showSnackbar(R.string.reset_confirmation)
                     }
                 }
-                negativeButton(R.string.dialog_cancel)
+                setNegativeButton(R.string.dialog_cancel) { _, _ -> }
             }
             true
         }
@@ -178,12 +177,12 @@ class AdvancedSettingsFragment : SettingsFragment() {
         val prefTitleString = getString(prefTitle)
         val dialogTitle = getString(R.string.experimental_pref_confirmation, prefTitleString)
 
-        MaterialDialog(requireContext()).show {
-            title(text = dialogTitle)
-            message(message)
-            positiveButton(R.string.dialog_ok) { onConfirm() }
-            negativeButton(R.string.dialog_cancel) { onCancel() }
-            cancelOnTouchOutside(false) // to avoid `onCancel` not being triggered on outside cancels
+        AlertDialog.Builder(requireContext()).show {
+            setTitle(dialogTitle)
+            message?.let { setMessage(it) }
+            setPositiveButton(R.string.dialog_ok) { _, _ -> onConfirm() }
+            setNegativeButton(R.string.dialog_cancel) { _, _ -> onCancel() }
+            setCancelable(false) // to avoid `onCancel` not being triggered on outside cancels
         }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/DevOptionsFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/DevOptionsFragment.kt
@@ -16,12 +16,13 @@
 package com.ichi2.anki.preferences
 
 import android.content.Context
+import androidx.appcompat.app.AlertDialog
 import androidx.preference.Preference
 import androidx.preference.SwitchPreference
-import com.afollestad.materialdialogs.MaterialDialog
 import com.ichi2.anki.*
 import com.ichi2.anki.analytics.UsageAnalytics
 import com.ichi2.anki.snackbar.showSnackbar
+import com.ichi2.utils.show
 import timber.log.Timber
 
 /**
@@ -83,12 +84,12 @@ class DevOptionsFragment : SettingsFragment() {
      * Shows dialog to confirm if developer options should be disabled
      */
     private fun showDisableDevOptionsDialog() {
-        MaterialDialog(requireContext()).show {
-            title(R.string.disable_dev_options)
-            positiveButton(R.string.dialog_ok) {
+        AlertDialog.Builder(requireContext()).show {
+            setTitle(R.string.disable_dev_options)
+            setPositiveButton(R.string.dialog_ok) { _, _ ->
                 disableDevOptions()
             }
-            negativeButton(R.string.dialog_cancel)
+            setNegativeButton(R.string.dialog_cancel) { _, _ -> }
         }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/SyncSettingsFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/SyncSettingsFragment.kt
@@ -15,8 +15,8 @@
  */
 package com.ichi2.anki.preferences
 
+import androidx.appcompat.app.AlertDialog
 import androidx.preference.Preference
-import com.afollestad.materialdialogs.MaterialDialog
 import com.google.android.material.snackbar.Snackbar
 import com.ichi2.anki.AnkiDroidApp
 import com.ichi2.anki.CollectionManager.withCol
@@ -24,6 +24,7 @@ import com.ichi2.anki.R
 import com.ichi2.anki.customSyncBase
 import com.ichi2.anki.launchCatchingTask
 import com.ichi2.anki.snackbar.showSnackbar
+import com.ichi2.utils.show
 
 /**
  * Fragment with preferences related to syncing
@@ -40,16 +41,16 @@ class SyncSettingsFragment : SettingsFragment() {
 
         // Configure force full sync option
         requirePreference<Preference>(R.string.force_full_sync_key).setOnPreferenceClickListener {
-            MaterialDialog(requireContext()).show {
-                title(R.string.force_full_sync_title)
-                message(R.string.force_full_sync_summary)
-                positiveButton(R.string.dialog_ok) {
+            AlertDialog.Builder(requireContext()).show {
+                setTitle(R.string.force_full_sync_title)
+                setMessage(R.string.force_full_sync_summary)
+                setPositiveButton(R.string.dialog_ok) { _, _ ->
                     launchCatchingTask {
                         withCol { modSchemaNoCheck() }
                         showSnackbar(R.string.force_full_sync_confirmation, Snackbar.LENGTH_SHORT)
                     }
                 }
-                negativeButton(R.string.dialog_cancel)
+                setNegativeButton(R.string.dialog_cancel) { _, _ -> }
             }
             true
         }

--- a/AnkiDroid/src/main/java/com/ichi2/utils/AlertDialogFacade.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/AlertDialogFacade.kt
@@ -1,0 +1,122 @@
+/*
+ *  Copyright (c) 2023 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+@file:Suppress("unused")
+
+package com.ichi2.utils
+
+import android.content.DialogInterface
+import android.content.DialogInterface.OnClickListener
+import androidx.annotation.DrawableRes
+import androidx.annotation.StringRes
+import androidx.appcompat.app.AlertDialog
+import com.ichi2.themes.Themes
+
+/** Wraps [DialogInterface.OnClickListener] as we don't need the `which` parameter */
+typealias DialogInterfaceListener = (DialogInterface) -> Unit
+
+fun DialogInterfaceListener.toClickListener(): OnClickListener {
+    return OnClickListener { dialog: DialogInterface, _ -> this(dialog) }
+}
+
+/*
+ * Allows easier transformations from [MaterialDialog] to [AlertDialog].
+ * Inline this file when material dialog is removed
+ */
+fun AlertDialog.Builder.title(@StringRes stringRes: Int? = null, text: String? = null): AlertDialog.Builder {
+    if (stringRes == null && text == null) {
+        throw IllegalArgumentException("either `stringRes` or `title` must be set")
+    }
+    return if (stringRes != null) {
+        setTitle(stringRes)
+    } else {
+        setTitle(text)
+    }
+}
+
+fun AlertDialog.Builder.message(@StringRes stringRes: Int? = null, text: CharSequence? = null): AlertDialog.Builder {
+    if (stringRes == null && text == null) {
+        throw IllegalArgumentException("either `stringRes` or `title` must be set")
+    }
+    return if (stringRes != null) {
+        setMessage(stringRes)
+    } else {
+        setMessage(text)
+    }
+}
+
+/**
+ * Shows an icon to the left of the dialog title.
+ */
+fun AlertDialog.Builder.iconAttr(
+    @DrawableRes res: Int
+) = apply {
+    return this.setIcon(Themes.getResFromAttr(this.context, res))
+}
+
+fun AlertDialog.Builder.positiveButton(
+    @StringRes stringRes: Int? = null,
+    text: CharSequence? = null,
+    click: DialogInterfaceListener? = null
+): AlertDialog.Builder {
+    if (stringRes == null && text == null) {
+        throw IllegalArgumentException("either `stringRes` or `title` must be set")
+    }
+    return if (stringRes != null) {
+        this.setPositiveButton(stringRes, click?.toClickListener())
+    } else {
+        this.setPositiveButton(text, click?.toClickListener())
+    }
+}
+
+fun AlertDialog.Builder.neutralButton(
+    @StringRes stringRes: Int? = null,
+    text: CharSequence? = null,
+    click: DialogInterfaceListener? = null
+): AlertDialog.Builder {
+    if (stringRes == null && text == null) {
+        throw IllegalArgumentException("either `stringRes` or `title` must be set")
+    }
+    return if (stringRes != null) {
+        this.setNeutralButton(stringRes, click?.toClickListener())
+    } else {
+        this.setNeutralButton(text, click?.toClickListener())
+    }
+}
+
+fun AlertDialog.Builder.negativeButton(
+    @StringRes stringRes: Int? = null,
+    text: CharSequence? = null,
+    click: DialogInterfaceListener? = null
+): AlertDialog.Builder {
+    if (stringRes == null && text == null) {
+        throw IllegalArgumentException("either `stringRes` or `title` must be set")
+    }
+    return if (stringRes != null) {
+        this.setNegativeButton(stringRes, click?.toClickListener())
+    } else {
+        this.setNegativeButton(text, click?.toClickListener())
+    }
+}
+
+/**
+ * Executes the provided block, then creates an [AlertDialog] with the arguments supplied
+ * and immediately displays the dialog
+ */
+inline fun AlertDialog.Builder.show(block: AlertDialog.Builder.() -> Unit): AlertDialog.Builder = apply {
+    this.block()
+    this.show()
+}


### PR DESCRIPTION
## Pull Request template

## Fixes
Fixes #12669
Related #13315

## Approach
Replaces most usages of `MaterialDialog` with `AlertDialog` on preferences classes, except Custom sync server preferences as they are handled on #12367

`Controls` screen preferences haven't been changed

## How Has This Been Tested?

Open each one of the changed dialogs on their respective preferences

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
