### PR TITLE
Documenting and cleaning backup manager

### DIFF
--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/libanki/MediaTest.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/libanki/MediaTest.kt
@@ -61,7 +61,7 @@ class MediaTest : InstrumentedTest() {
     fun testAdd() {
         // open new empty collection
         val dir = testDir
-        BackupManager.removeDir(dir)
+        BackupManager.removeDirOrFile(dir)
         assertTrue(dir.mkdirs())
         val path = File(dir, "foo.jpg")
         var os = FileOutputStream(path, false)
@@ -84,7 +84,7 @@ class MediaTest : InstrumentedTest() {
     fun testAddEmptyFails() {
         // open new empty collection
         val dir = testDir
-        BackupManager.removeDir(dir)
+        BackupManager.removeDirOrFile(dir)
         assertTrue(dir.mkdirs())
         val path = File(dir, "foo.jpg")
         assertTrue(path.createNewFile())

--- a/AnkiDroid/src/main/java/com/ichi2/anki/BackupManager.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/BackupManager.kt
@@ -234,15 +234,15 @@ open class BackupManager {
             return colFile.length() + MIN_FREE_SPACE * 1024 * 1024
         }
 
-        fun enoughDiscSpace(path: String?): Boolean {
+        fun enoughDiscSpace(path: String): Boolean {
             return getFreeDiscSpace(path) >= MIN_FREE_SPACE * 1024 * 1024
         }
 
         /**
          * Get free disc space in bytes from path to Collection
          */
-        fun getFreeDiscSpace(path: String?): Long {
-            return getFreeDiscSpace(File(path!!))
+        fun getFreeDiscSpace(path: String): Long {
+            return getFreeDiscSpace(File(path))
         }
 
         private fun getFreeDiscSpace(file: File): Long {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/BackupManager.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/BackupManager.kt
@@ -407,11 +407,11 @@ open class BackupManager {
          * @param colPath Path of collection file whose backups should be deleted
          * @param keepNumber How many files to keep
          */
-        fun deleteColBackups(colPath: String, keepNumber: Int): Boolean {
-            return deleteColBackups(getBackups(File(colPath)), keepNumber)
+        fun deleteColBackups(colPath: String, keepNumber: Int) {
+            deleteColBackups(getBackups(File(colPath)), keepNumber)
         }
 
-        private fun deleteColBackups(backups: Array<File>, keepNumber: Int): Boolean {
+        private fun deleteColBackups(backups: Array<File>, keepNumber: Int) {
             for (i in 0 until backups.size - keepNumber) {
                 if (!backups[i].delete()) {
                     Timber.e("deleteColBackups() failed to delete %s", backups[i].absolutePath)
@@ -419,7 +419,6 @@ open class BackupManager {
                     Timber.i("deleteColBackups: backup file %s deleted.", backups[i].absolutePath)
                 }
             }
-            return true
         }
 
         fun removeDir(dir: File): Boolean {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CollectionHelper.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CollectionHelper.kt
@@ -260,8 +260,8 @@ open class CollectionHelper {
 
                 // We currently use the same directory as the collection for VACUUM/ANALYZE due to the SQLite APIs
                 val collectionFile = File(getCollectionPath(context))
-                val freeSpace = FileUtil.getFreeDiskSpace(collectionFile, -1)
-                if (freeSpace == -1L) {
+                val freeSpace = FileUtil.getFreeDiskSpace(collectionFile)
+                if (freeSpace == null) {
                     Timber.w("Error obtaining free space for '%s'", collectionFile.path)
                     val readableFileSize = Formatter.formatFileSize(context, requiredSpaceInBytes)
                     return fromError(

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -1122,7 +1122,9 @@ open class DeckPicker :
                 Timber.i("Android 8/8.1 detected, software render preference already exists.")
             }
         }
-        if (!BackupManager.enoughDiscSpace(CollectionHelper.getCurrentAnkiDroidDirectory(this))) {
+        // If we can't measure free space, let the user use the app.
+        val enoughDiscSpace = BackupManager.enoughDiscSpace(CollectionHelper.getCurrentAnkiDroidDirectory(this)) ?: true
+        if (!enoughDiscSpace) {
             Timber.i("Not enough space to do backup")
             showDialogFragment(DeckPickerNoSpaceLeftDialog.newInstance())
         } else if (preferences.getBoolean("noSpaceLeft", false)) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -1129,7 +1129,7 @@ open class DeckPicker :
             showDialogFragment(DeckPickerNoSpaceLeftDialog.newInstance())
         } else if (preferences.getBoolean("noSpaceLeft", false)) {
             Timber.i("No space left")
-            showDialogFragment(DeckPickerBackupNoSpaceLeftDialog.newInstance())
+            showDialogFragment(DeckPickerBackupNoSpaceLeftDialog())
             preferences.edit { remove("noSpaceLeft") }
         } else if (InitialActivity.performSetupFromFreshInstallOrClearedPreferences(preferences)) {
             onFinishedStartup()

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -1049,7 +1049,7 @@ open class DeckPicker :
     private fun onFinishedStartup() {
         // create backup in background if needed
         if (BackendFactory.defaultLegacySchema) {
-            BackupManager.performBackupInBackground(col.path, TimeManager.time)
+            BackupManager().performBackupInBackground(col.path)
         } else {
             // new code triggers backup in updateDeckList()
         }
@@ -1123,7 +1123,7 @@ open class DeckPicker :
             }
         }
         // If we can't measure free space, let the user use the app.
-        val enoughDiscSpace = BackupManager.enoughDiscSpace(CollectionHelper.getCurrentAnkiDroidDirectory(this)) ?: true
+        val enoughDiscSpace = BackupManager.enoughFreeSpaceToUseAnkiDroid(CollectionHelper.getCurrentAnkiDroidDirectory(this)) ?: true
         if (!enoughDiscSpace) {
             Timber.i("Not enough space to do backup")
             showDialogFragment(DeckPickerNoSpaceLeftDialog.newInstance())

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DatabaseErrorDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DatabaseErrorDialog.kt
@@ -368,7 +368,7 @@ class DatabaseErrorDialog : AsyncDialogFragment() {
                 res().getString(R.string.access_collection_failed_message, res().getString(R.string.link_help))
             }
             DIALOG_DB_ERROR -> res().getString(R.string.answering_error_message)
-            DIALOG_REPAIR_COLLECTION -> res().getString(R.string.repair_deck_dialog, BackupManager.BROKEN_COLLECTIONS_SUFFIX)
+            DIALOG_REPAIR_COLLECTION -> res().getString(R.string.repair_deck_dialog, BackupManager.BROKEN_COLLECTIONS_DIRECTORY)
             DIALOG_RESTORE_BACKUP -> res().getString(R.string.backup_restore_no_backups)
             DIALOG_NEW_COLLECTION -> res().getString(R.string.backup_del_collection_question)
             DIALOG_CONFIRM_DATABASE_CHECK -> res().getString(R.string.check_db_warning)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckPickerBackupNoSpaceLeftDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckPickerBackupNoSpaceLeftDialog.kt
@@ -28,10 +28,15 @@ class DeckPickerBackupNoSpaceLeftDialog : AnalyticsDialogFragment() {
     override fun onCreateDialog(savedInstanceState: Bundle?): MaterialDialog {
         super.onCreate(savedInstanceState)
         val res = resources
+        // If we show this dialog, we assume we are able to measure the free space
         val space = BackupManager.getFreeDiscSpace(CollectionHelper.getCollectionPath(requireActivity()))
+        val message = if (space != null)
+            res.getString(R.string.sd_space_warning, space / 1024 / 1024)
+        else
+            res.getString(R.string.sd_space_warning_unknown)
         return MaterialDialog(requireActivity()).show {
             title(R.string.sd_card_almost_full_title)
-            message(text = res.getString(R.string.sd_space_warning, space / 1024 / 1024))
+            message(text = message)
             positiveButton(R.string.dialog_ok) {
                 (activity as DeckPicker).finishWithoutAnimation()
             }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckPickerBackupNoSpaceLeftDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckPickerBackupNoSpaceLeftDialog.kt
@@ -44,10 +44,4 @@ class DeckPickerBackupNoSpaceLeftDialog : AnalyticsDialogFragment() {
             setOnCancelListener { (activity as DeckPicker).finishWithoutAnimation() }
         }
     }
-
-    companion object {
-        fun newInstance(): DeckPickerBackupNoSpaceLeftDialog {
-            return DeckPickerBackupNoSpaceLeftDialog()
-        }
-    }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.kt
@@ -216,7 +216,7 @@ open class CollectionTask<Progress, Result>(val task: TaskDelegateBase<Progress,
             // extract the deck from the zip file
             val dir = File(File(colPath).parentFile, "tmpzip")
             if (dir.exists()) {
-                BackupManager.removeDir(dir)
+                BackupManager.removeDirOrFile(dir)
             }
             // from anki2.py
             var colname = "collection.anki21"
@@ -314,7 +314,7 @@ open class CollectionTask<Progress, Result>(val task: TaskDelegateBase<Progress,
                     }
                     zip.close()
                     // delete tmp dir
-                    BackupManager.removeDir(dir)
+                    BackupManager.removeDirOrFile(dir)
                     Computation.OK
                 } catch (e: RuntimeException) {
                     Timber.e(e, "doInBackgroundImportReplace - RuntimeException")

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/importer/AnkiPackageImporter.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/importer/AnkiPackageImporter.kt
@@ -19,7 +19,7 @@ package com.ichi2.libanki.importer
 import android.text.format.Formatter
 import com.fasterxml.jackson.core.JsonToken
 import com.ichi2.anki.AnkiSerialization.factory
-import com.ichi2.anki.BackupManager.Companion.removeDir
+import com.ichi2.anki.BackupManager.Companion.removeDirOrFile
 import com.ichi2.anki.CollectionHelper
 import com.ichi2.anki.CrashReportService
 import com.ichi2.anki.R
@@ -160,7 +160,7 @@ class AnkiPackageImporter(col: Collection?, file: String?) : Anki2Importer(col!!
 
             // Clean up our temporary files
             if (tempDir.exists()) {
-                removeDir(tempDir)
+                removeDirOrFile(tempDir)
             }
         }
         publishProgress(100, 100, 100)

--- a/AnkiDroid/src/main/java/com/ichi2/utils/FileUtil.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/FileUtil.kt
@@ -28,7 +28,9 @@ import java.io.InputStream
 import java.util.*
 
 object FileUtil {
-    /** Gets the free disk space given a file  */
+    /**
+     * @param defaultValue: value to return if free space can not be measured.
+     * @return the free disk space of the system containing [file]  */
     fun getFreeDiskSpace(file: File): Long? {
         return try {
             StatFs(file.parentFile?.path).availableBytes

--- a/AnkiDroid/src/main/java/com/ichi2/utils/FileUtil.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/FileUtil.kt
@@ -29,12 +29,12 @@ import java.util.*
 
 object FileUtil {
     /** Gets the free disk space given a file  */
-    fun getFreeDiskSpace(file: File, defaultValue: Long): Long {
+    fun getFreeDiskSpace(file: File): Long? {
         return try {
             StatFs(file.parentFile?.path).availableBytes
         } catch (e: IllegalArgumentException) {
             Timber.e(e, "Free space could not be retrieved")
-            defaultValue
+            null
         }
     }
     /** Returns the current download Directory */

--- a/AnkiDroid/src/main/res/values/09-backup.xml
+++ b/AnkiDroid/src/main/res/values/09-backup.xml
@@ -20,6 +20,7 @@
 --><resources>
 
     <string name="backup_deck_no_space_left">Backup not saved. Not enough space left on SD card. Lower the backup depth or remove some other files.</string>
+    <string name="sd_space_warning_unknown">Not enough space left.\nFree some space to avoid data loss.</string>
     <string name="sd_space_warning">Less than %d MB space on your SD card left.\nFree some space to avoid data loss.</string>
     <string name="backup_restore">Restore from backup</string>
     <string name="backup_new_collection">New collection</string>

--- a/AnkiDroid/src/test/java/com/ichi2/anki/BackupManagerIntegrationTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/BackupManagerIntegrationTest.kt
@@ -18,11 +18,10 @@ package com.ichi2.anki
 import android.annotation.SuppressLint
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.ichi2.async.CollectionTask.ImportReplace
-import com.ichi2.libanki.utils.TimeManager
 import com.ichi2.testutils.AnkiAssert
 import com.ichi2.testutils.BackupManagerTestUtilities
-import org.hamcrest.MatcherAssert.*
-import org.hamcrest.Matchers.*
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.equalTo
 import org.junit.Ignore
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -52,9 +51,8 @@ class BackupManagerIntegrationTest : RobolectricTest() {
             BackupManagerTestUtilities.setupSpaceForBackup(targetContext)
             assertThat(
                 "Backup should work",
-                BackupManager.performBackupInBackground(
-                    col.path,
-                    TimeManager.time
+                BackupManager().performBackupInBackground(
+                    col.path
                 ),
                 equalTo(true)
             )

--- a/AnkiDroid/src/test/java/com/ichi2/anki/BackupManagerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/BackupManagerTest.kt
@@ -104,7 +104,7 @@ open class BackupManagerTest {
     /** Returns a spy of BackupManager which would pass  */
     private fun getPassingBackupManagerSpy(backupFileMock: File?): BackupManager {
         val spy = spy(BackupManager.createInstance())
-        doReturn(true).whenever(spy).hasFreeDiscSpace(any())
+        doReturn(true).whenever(spy).hasFreeDiscSpaceForDatabaseBackup(any())
         doReturn(false).whenever(spy).collectionIsTooSmallToBeValid(any())
         doNothing().whenever(spy).performBackupInNewThread(any(), any())
         doReturn(null).whenever(spy).getLastBackupDate(any())

--- a/AnkiDroid/src/test/java/com/ichi2/testutils/Backup.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/testutils/Backup.kt
@@ -19,7 +19,6 @@ package com.ichi2.testutils
 import android.annotation.SuppressLint
 import com.ichi2.anki.BackupManager
 import com.ichi2.anki.RobolectricTest
-import com.ichi2.libanki.utils.TimeManager
 import java.io.File
 
 @Suppress("unused")
@@ -37,7 +36,6 @@ object Backup {
     fun create(col: com.ichi2.libanki.Collection) {
         BackupManagerTestUtilities.setupSpaceForBackup(col.context)
         val path = col.path
-        val time = TimeManager.time
         col.close()
 
         val originalBackupCount = getBackupCount(path)
@@ -48,7 +46,7 @@ object Backup {
 
         val backupManager = BackupManager.createInstance()
 
-        if (!backupManager.performBackupInBackground(path, 0, time)) {
+        if (!backupManager.performBackupInBackground(path, 0)) {
             throw IllegalStateException("failed to create backup")
         }
 

--- a/AnkiDroid/src/test/java/com/ichi2/testutils/BackupManagerTestUtilities.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/testutils/BackupManagerTestUtilities.kt
@@ -16,7 +16,7 @@
 package com.ichi2.testutils
 
 import android.content.Context
-import com.ichi2.anki.BackupManager.Companion.enoughDiscSpace
+import com.ichi2.anki.BackupManager.Companion.enoughFreeSpaceToUseAnkiDroid
 import com.ichi2.anki.CollectionHelper
 import org.junit.Assert.assertTrue
 import java.io.File
@@ -30,7 +30,7 @@ object BackupManagerTestUtilities {
             ?: throw IllegalStateException("currentAnkiDroidDirectory had no parent")
         ShadowStatFs.markAsNonEmpty(path)
 
-        val enoughDiscSpace = enoughDiscSpace(currentAnkiDroidDirectory)
+        val enoughDiscSpace = enoughFreeSpaceToUseAnkiDroid(currentAnkiDroidDirectory)
         assertNotNull(enoughDiscSpace)
         assertTrue(enoughDiscSpace)
     }

--- a/AnkiDroid/src/test/java/com/ichi2/testutils/BackupManagerTestUtilities.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/testutils/BackupManagerTestUtilities.kt
@@ -20,7 +20,7 @@ import com.ichi2.anki.BackupManager.Companion.enoughDiscSpace
 import com.ichi2.anki.CollectionHelper
 import org.junit.Assert.assertTrue
 import java.io.File
-import java.lang.IllegalStateException
+import kotlin.test.assertNotNull
 
 object BackupManagerTestUtilities {
     fun setupSpaceForBackup(context: Context) {
@@ -30,7 +30,9 @@ object BackupManagerTestUtilities {
             ?: throw IllegalStateException("currentAnkiDroidDirectory had no parent")
         ShadowStatFs.markAsNonEmpty(path)
 
-        assertTrue(enoughDiscSpace(currentAnkiDroidDirectory))
+        val enoughDiscSpace = enoughDiscSpace(currentAnkiDroidDirectory)
+        assertNotNull(enoughDiscSpace)
+        assertTrue(enoughDiscSpace)
     }
 
     fun reset() {


### PR DESCRIPTION
I need to consider free space to decide whether to offer to export the collection before storage migration.
Lots of the related functions are in the BackupManager. So I went, read it, clarify names which are not entirely clear, document it, and while I'm at it, improving some functions. 

In particular, some functions have default values that are absolutely not explicit; now it's explicitly documented what occurs when we don't know how much space there remains on disk