### PR TITLE
Make whiteboard related items grouped

### DIFF
--- a/AnkiDroid/src/main/res/menu/reviewer.xml
+++ b/AnkiDroid/src/main/res/menu/reviewer.xml
@@ -3,6 +3,13 @@
     android:layoutDirection="locale">
 
     <item
+        android:id="@+id/action_undo"
+        android:enabled="false"
+        android:icon="@drawable/ic_undo_white"
+        android:title="@string/undo"
+        ankidroid:actionProviderClass="com.ichi2.ui.RtlCompliantActionProvider"
+        ankidroid:showAsAction="always"/>
+    <item
         android:id="@+id/action_clear_whiteboard"
         android:title="@string/clear_whiteboard"
         android:icon="@drawable/ic_clear_white"
@@ -21,12 +28,16 @@
         android:visible="false"
         ankidroid:showAsAction="ifRoom"/>
     <item
-        android:id="@+id/action_undo"
-        android:enabled="false"
-        android:icon="@drawable/ic_undo_white"
-        android:title="@string/undo"
-        ankidroid:actionProviderClass="com.ichi2.ui.RtlCompliantActionProvider"
-        ankidroid:showAsAction="always"/>
+        android:id="@+id/action_save_whiteboard"
+        android:title="@string/save_whiteboard"
+        android:icon="@drawable/ic_save_white"
+        android:visible="false"
+        ankidroid:showAsAction="never"/>
+    <item
+        android:id="@+id/action_toggle_whiteboard"
+        android:title="@string/enable_whiteboard"
+        android:icon="@drawable/ic_gesture_white"
+        ankidroid:showAsAction="never"/>
     <item
         android:id="@+id/action_flag"
         android:title="@string/menu_flag_card"
@@ -66,17 +77,6 @@
                 android:icon="@drawable/ic_flag_purple"/>
         </menu>
     </item>
-    <item
-        android:id="@+id/action_save_whiteboard"
-        android:title="@string/save_whiteboard"
-        android:icon="@drawable/ic_save_white"
-        android:visible="false"
-        ankidroid:showAsAction="never"/>
-    <item
-        android:id="@+id/action_toggle_whiteboard"
-        android:title="@string/enable_whiteboard"
-        android:icon="@drawable/ic_gesture_white"
-        ankidroid:showAsAction="never"/>
     <item
         android:id="@+id/action_edit"
         android:icon="@drawable/ic_mode_edit_white"


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
On action menu of Study screen, the group of whiteboard-related item is divided by the other items. This PR is to fix it.
![image](https://user-images.githubusercontent.com/10436072/196009970-ad13d3b0-140d-43a8-8d49-98e0ecea2492.png)
## Fixes
Fixes #12672

## Approach
Change the order of the items on [AnkiDroid/src/main/res/menu/reviewer.xml](https://github.com/snowtimeglass/Anki-Android/pull/7/commits/ba1549dec3d6e44a9b32fc27477ecc2ca0784903#diff-7bbb2a2db563216b3008620948f5af3cf4d4c702426a2719159a115258790484) as follows.

- Move "Undo ~" above "Clear whiteboard"  (i.e. move "Undo ~" to the top of the menu)

- Move "Save whiteboard" and "Disable/Enable whiteboard" above "Flag card" (i.e. move "Flag card" item below the group of whiteboard-related items)

## How Has This Been Tested?
Checked on physical device
![image](https://user-images.githubusercontent.com/10436072/196014894-27f5838f-d2e9-476d-964c-545119b57498.png)
![image](https://user-images.githubusercontent.com/10436072/196014897-cddd0101-7518-4c42-9339-7d36c7be0622.png)



## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
