### PR TITLE
Replaced String.format() with string template in Anki2Importer

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/importer/Anki2Importer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/importer/Anki2Importer.kt
@@ -255,10 +255,9 @@ open class Anki2Importer(col: Collection?, file: String) : Importer(col!!, file)
                                     update.add(arrayOf(nid, guid, mid, mod, usn, tags, flds, sfld, csum, flag, data))
                                     dirty.add(nid)
                                 } else {
-                                    dupesIgnored.add(
-                                            "${mCol.models.get(oldMid)!!.getString("name")}: " +
-                                                    "${flds.replace('\u001f', ',')}"
-                                    )
+                                    val modelName = mCol.models.get(oldMid)!!.getString("name")
+                                    val commaSeparatedFields = flds.replace('\u001f', ',')
+                                    dupesIgnored.add("$modelName: $commaSeparatedFields")
                                     mIgnoredGuids!!.add(guid)
                                 }
                             }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/importer/Anki2Importer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/importer/Anki2Importer.kt
@@ -256,11 +256,8 @@ open class Anki2Importer(col: Collection?, file: String) : Importer(col!!, file)
                                     dirty.add(nid)
                                 } else {
                                     dupesIgnored.add(
-                                        String.format(
-                                            "%s: %s",
-                                            mCol.models.get(oldMid)!!.getString("name"),
-                                            flds.replace('\u001f', ',')
-                                        )
+                                            "${mCol.models.get(oldMid)!!.getString("name")}: " +
+                                                    "${flds.replace('\u001f', ',')}"
                                     )
                                     mIgnoredGuids!!.add(guid)
                                 }


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
Replaced basic usages of String.format with Kotlin string templates

## Fixes
Fixes https://github.com/ankidroid/Anki-Android/issues/11449

## Approach
Replace `String.format("%s", x)` with `"$x"`

## How Has This Been Tested?

Passed all unit tests

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
