### PR TITLE
Replaced String.format() with string template in Collection

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.kt
@@ -26,7 +26,6 @@ import android.content.ContentValues
 import android.content.Context
 import android.content.res.Resources
 import android.database.sqlite.SQLiteDatabaseLockedException
-import android.text.TextUtils
 import androidx.annotation.CheckResult
 import androidx.annotation.VisibleForTesting
 import anki.search.SearchNode
@@ -2142,21 +2141,20 @@ open class Collection(
         }
     }
 
-    fun log(vararg argsParam: Any?) {
-        val args = argsParam.toMutableList()
-        if (!debugLog) {
-            return
-        }
-        val trace = Thread.currentThread().stackTrace[3]
-        // Overwrite any args that need special handling for an appropriate string representation
-        for (i in 0 until args.size) {
-            if (args[i] is LongArray) {
-                args[i] = Arrays.toString(args[i] as LongArray?)
-            }
-        }
-        val s = "[" + TimeManager.time.intTime() + "] " + trace.fileName + ":" + trace.methodName + "(): " +
-                TextUtils.join(",  ", args)
-        writeLog(s)
+    fun log(vararg objects: Any?) {
+        if (!debugLog) return
+
+        val unixTime = TimeManager.time.intTime()
+
+        val outerTraceElement = Thread.currentThread().stackTrace[3]
+        val fileName = outerTraceElement.fileName
+        val methodName = outerTraceElement.methodName
+
+        val objectsString = objects
+            .map { if (it is LongArray) Arrays.toString(it) else it }
+            .joinToString(", ")
+
+        writeLog("[$unixTime] $fileName:$methodName() $objectsString")
     }
 
     private fun writeLog(s: String) {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.kt
@@ -2154,10 +2154,8 @@ open class Collection(
                 args[i] = Arrays.toString(args[i] as LongArray?)
             }
         }
-        val s = String.format(
-            "[%s] %s:%s(): %s", TimeManager.time.intTime(), trace.fileName, trace.methodName,
-            TextUtils.join(",  ", args)
-        )
+        val s = "[${TimeManager.time.intTime()}] ${trace.fileName}:${trace.methodName}(): " +
+                "${TextUtils.join(",  ", args)}"
         writeLog(s)
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.kt
@@ -2154,8 +2154,8 @@ open class Collection(
                 args[i] = Arrays.toString(args[i] as LongArray?)
             }
         }
-        val s = "[${TimeManager.time.intTime()}] ${trace.fileName}:${trace.methodName}(): " +
-                "${TextUtils.join(",  ", args)}"
+        val s = "[" + TimeManager.time.intTime() + "] " + trace.fileName + ":" + trace.methodName + "(): " +
+                TextUtils.join(",  ", args)
         writeLog(s)
     }
 


### PR DESCRIPTION
## Purpose / Description
Replaced basic usages of String.format with Kotlin string templates

## Fixes
Related to https://github.com/ankidroid/Anki-Android/issues/11449

## Approach
Replace `String.format("%s", x)` with `"$x"`

## How Has This Been Tested?

Passed all unit tests

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
