### PR TITLE
Fix options group not updating in deck options

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckOptions.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckOptions.kt
@@ -244,8 +244,8 @@ class DeckOptions :
                             // TODO: Extract out deckConf, confReset, remConf and confSetSubdecks to a function. They are overall similar.
                             "deckConf" -> {
                                 val newConfId: Long = (value as String).toLong()
-                                mOptions = col.decks.getConf(newConfId)!!
                                 confChangeHandler("change Deck configuration") {
+                                    mOptions = decks.getConf(newConfId)!!
                                     changeDeckConfiguration(deck, mOptions, this)
                                 }
                             }


### PR DESCRIPTION
## Purpose / Description

There's a visibility issue in DeckOptions, although the mOptions field is assigned a new value, in confChangeHandler the old value(before the assignment) appears. I'm not sure exactly why this happens(I'm assuming this has something to do with the generated java lambdas under the hood).

I fixed it by moving the mOptions assignment inside the lambda(also makes sense as the required Collection reference is in scope there).

## Fixes

Fixes #12622

## How Has This Been Tested?

Ran the checks, manually verified the app.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
