### PR TITLE
NF: remove toLong and toInt from equal assertions

### DIFF
--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/ContentProviderTest.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/ContentProviderTest.kt
@@ -345,7 +345,7 @@ class ContentProviderTest : InstrumentedTest() {
         model = col.models.get(modelId)
         // Test the field is as expected
         val fieldId = ContentUris.parseId(fieldUri!!)
-        assertEquals("Check field id", initialFieldCount.toLong(), fieldId)
+        assertEquals("Check field id", initialFieldCount, fieldId)
         assertNotNull("Check model", model)
         val fldsArr = model!!.getJSONArray("flds")
         assertEquals(
@@ -389,7 +389,7 @@ class ContentProviderTest : InstrumentedTest() {
         cursor = cr.query(FlashCardsContract.Note.CONTENT_URI_V2, null, "mid=0", null, null)
         assertNotNull(cursor)
         try {
-            assertEquals("Check number of results", 0, cursor.count.toLong())
+            assertEquals("Check number of results", 0, cursor.count)
         } finally {
             cursor.close()
         }
@@ -1103,7 +1103,7 @@ class ContentProviderTest : InstrumentedTest() {
             put(FlashCardsContract.ReviewInfo.TIME_TAKEN, timeTaken)
         }
         val updateCount = cr.update(reviewInfoUri, values, null, null)
-        assertEquals("Check if update returns 1", 1, updateCount.toLong())
+        assertEquals("Check if update returns 1", 1, updateCount)
         try {
             Thread.currentThread().join(500)
         } catch (e: Exception) { /* do nothing */
@@ -1154,7 +1154,7 @@ class ContentProviderTest : InstrumentedTest() {
             put(FlashCardsContract.ReviewInfo.BURY, bury)
         }
         val updateCount = cr.update(reviewInfoUri, values, null, null)
-        assertEquals("Check if update returns 1", 1, updateCount.toLong())
+        assertEquals("Check if update returns 1", 1, updateCount)
 
         // verify that it did get buried
         // -----------------------------
@@ -1206,7 +1206,7 @@ class ContentProviderTest : InstrumentedTest() {
             put(FlashCardsContract.ReviewInfo.SUSPEND, suspend)
         }
         val updateCount = cr.update(reviewInfoUri, values, null, null)
-        assertEquals("Check if update returns 1", 1, updateCount.toLong())
+        assertEquals("Check if update returns 1", 1, updateCount)
 
         // verify that it did get suspended
         // --------------------------------
@@ -1234,7 +1234,7 @@ class ContentProviderTest : InstrumentedTest() {
         // make sure the tag is what we expect initially
         // ---------------------------------------------
         val tagList: List<String> = note.tags
-        assertEquals("only one tag", 1, tagList.size.toLong())
+        assertEquals("only one tag", 1, tagList.size)
         assertEquals("check tag value", TEST_TAG, tagList[0])
 
         // update tags
@@ -1248,13 +1248,13 @@ class ContentProviderTest : InstrumentedTest() {
         val values = ContentValues()
         values.put(FlashCardsContract.Note.TAGS, "$TEST_TAG $tag2")
         val updateCount = cr.update(updateNoteUri, values, null, null)
-        assertEquals("updateCount is 1", 1, updateCount.toLong())
+        assertEquals("updateCount is 1", 1, updateCount)
 
         // lookup the note now and verify tags
         // -----------------------------------
         val noteAfterUpdate = col.getNote(noteId)
         val newTagList: List<String> = noteAfterUpdate.tags
-        assertEquals("two tags", 2, newTagList.size.toLong())
+        assertEquals("two tags", 2, newTagList.size)
         assertEquals("check first tag", TEST_TAG, newTagList[0])
         assertEquals("check second tag", tag2, newTagList[1])
     }

--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/libanki/ImportTest.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/libanki/ImportTest.kt
@@ -97,7 +97,7 @@ class ImportTest : InstrumentedTest() {
         var expected = listOf("foo.mp3")
         var actual = File(empty.media.dir()).list()!!.toMutableList()
         actual.retainAll(expected)
-        assertEquals(expected.size.toLong(), actual.size.toLong())
+        assertEquals(expected.size, actual.size)
         // and importing again will not duplicate, as the file content matches
         empty.remCards(empty.db.queryLongList("select id from cards"))
         imp = Anki2Importer(empty, testCol.path)
@@ -105,7 +105,7 @@ class ImportTest : InstrumentedTest() {
         expected = listOf("foo.mp3")
         actual = mutableListOf(*File(empty.media.dir()).list()!!)
         actual.retainAll(expected)
-        assertEquals(expected.size.toLong(), actual.size.toLong())
+        assertEquals(expected.size, actual.size)
         n = empty.getNote(empty.db.queryLongScalar("select id from notes"))
         assertTrue("foo.mp3" in n.fields[0])
         // if the local file content is different, and import should trigger a rename
@@ -118,7 +118,7 @@ class ImportTest : InstrumentedTest() {
         expected = listOf("foo.mp3", String.format("foo_%s.mp3", mid))
         actual = mutableListOf(*File(empty.media.dir()).list()!!)
         actual.retainAll(expected)
-        assertEquals(expected.size.toLong(), actual.size.toLong())
+        assertEquals(expected.size, actual.size)
         n = empty.getNote(empty.db.queryLongScalar("select id from notes"))
         assertTrue(n.fields[0].contains("_"))
         // if the localized media file already exists, we rewrite the note and media
@@ -131,7 +131,7 @@ class ImportTest : InstrumentedTest() {
         expected = listOf("foo.mp3", String.format("foo_%s.mp3", mid))
         actual = mutableListOf(*File(empty.media.dir()).list()!!)
         actual.retainAll(expected)
-        assertEquals(expected.size.toLong(), actual.size.toLong())
+        assertEquals(expected.size, actual.size)
         n = empty.getNote(empty.db.queryLongScalar("select id from notes"))
         assertTrue(n.fields[0].contains("_"))
         empty.close()
@@ -149,12 +149,12 @@ class ImportTest : InstrumentedTest() {
             ).list()!!
         )
         actual.retainAll(expected)
-        assertEquals(actual.size.toLong(), expected.size.toLong())
+        assertEquals(actual.size, expected.size)
         imp.run()
         expected = listOf("foo.wav")
         actual = mutableListOf(*File(testCol.media.dir()).list()!!)
         actual.retainAll(expected)
-        assertEquals(expected.size.toLong(), actual.size.toLong())
+        assertEquals(expected.size, actual.size)
         // import again should be idempotent in terms of media
         testCol.remCards(testCol.db.queryLongList("select id from cards"))
         imp = AnkiPackageImporter(testCol, apkg)
@@ -162,7 +162,7 @@ class ImportTest : InstrumentedTest() {
         expected = listOf("foo.wav")
         actual = mutableListOf(*File(testCol.media.dir()).list()!!)
         actual.retainAll(expected)
-        assertEquals(expected.size.toLong(), actual.size.toLong())
+        assertEquals(expected.size, actual.size)
         // but if the local file has different data, it will rename
         testCol.remCards(testCol.db.queryLongList("select id from cards"))
         val os = FileOutputStream(File(testCol.media.dir(), "foo.wav"), false)
@@ -170,7 +170,7 @@ class ImportTest : InstrumentedTest() {
         os.close()
         imp = AnkiPackageImporter(testCol, apkg)
         imp.run()
-        assertEquals(2, File(testCol.media.dir()).list()!!.size.toLong())
+        assertEquals(2, File(testCol.media.dir()).list()!!.size)
     }
 
     @Test
@@ -189,7 +189,7 @@ class ImportTest : InstrumentedTest() {
         imp.setDupeOnSchemaChange(true)
         imp.run()
         // collection should contain the note we imported
-        assertEquals(1, testCol.noteCount().toLong())
+        assertEquals(1, testCol.noteCount())
         // the front template should contain the text added in the 2nd package
         val tcid = testCol.findCards("")[0]
         val tnote = testCol.getCard(tcid).note()
@@ -215,7 +215,7 @@ class ImportTest : InstrumentedTest() {
         assertEquals(0, imp.added)
         assertEquals(0, imp.updated)
         // importing a newer note should update
-        assertEquals(1, testCol.noteCount().toLong())
+        assertEquals(1, testCol.noteCount())
         assertTrue(testCol.db.queryString("select flds from notes").startsWith("hello"))
         tmp = Shared.getTestFilePath(testContext, "update2.apkg")
         imp = AnkiPackageImporter(testCol, tmp)

--- a/AnkiDroid/src/test/java/com/ichi2/anki/DeckPickerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/DeckPickerTest.kt
@@ -200,7 +200,7 @@ class DeckPickerTest : RobolectricTest() {
         val deckPicker = super.startActivityNormallyOpenCollectionWithIntent(
             DeckPicker::class.java, Intent()
         )
-        assertEquals(10, deckPicker.dueTree!![0].value.newCount.toLong())
+        assertEquals(10, deckPicker.dueTree!![0].value.newCount)
     }
 
     @Test

--- a/AnkiDroid/src/test/java/com/ichi2/anki/TemporaryModelTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/TemporaryModelTest.kt
@@ -45,7 +45,7 @@ class TemporaryModelTest : RobolectricTest() {
         Assert.assertEquals(JSONObject("{\"foo\": \"bar\"}").toString(), tempModel.toString())
 
         // Make sure clearing works
-        Assert.assertEquals(1, TemporaryModel.clearTempModelFiles().toLong())
+        Assert.assertEquals(1, TemporaryModel.clearTempModelFiles())
         Timber.i("The following logged NoSuchFileException is an expected part of verifying a file delete.")
         try {
             TemporaryModel.getTempModel(tempModelPath)
@@ -140,7 +140,7 @@ class TemporaryModelTest : RobolectricTest() {
         if (actual !is ArrayList<*>) {
             Assert.fail("actual array null or not the correct type")
         }
-        Assert.assertEquals("arrays didn't have the same length?", expected.size.toLong(), (actual as ArrayList<Array<Any?>?>).size.toLong())
+        Assert.assertEquals("arrays didn't have the same length?", expected.size, (actual as ArrayList<Array<Any?>?>).size)
         for (i in expected.indices) {
             if (actual[i] !is Array<Any?>) {
                 Assert.fail("actual array does not contain Object[] entries")

--- a/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/tags/TagsDialogTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/tags/TagsDialogTest.kt
@@ -63,7 +63,7 @@ class TagsDialogTest {
             MatcherAssert.assertThat(dialog, IsNull.notNullValue())
             val body = dialog!!.getCustomView()
             val optionsGroup = body.findViewById<RadioGroup>(R.id.tags_dialog_options_radiogroup)
-            Assert.assertEquals(optionsGroup.visibility.toLong(), View.VISIBLE.toLong())
+            Assert.assertEquals(optionsGroup.visibility, View.VISIBLE)
             val expectedOption = 1
             optionsGroup.getChildAt(expectedOption).performClick()
             dialog.getActionButton(WhichButton.POSITIVE).callOnClick()
@@ -94,12 +94,12 @@ class TagsDialogTest {
             )
             val body = dialog!!.getCustomView()
             val optionsGroup = body.findViewById<RadioGroup>(R.id.tags_dialog_options_radiogroup)
-            Assert.assertEquals(optionsGroup.visibility.toLong(), View.VISIBLE.toLong())
+            Assert.assertEquals(optionsGroup.visibility, View.VISIBLE)
             val expectedOption = 2
             optionsGroup.getChildAt(expectedOption).performClick()
             dialog.getActionButton(WhichButton.POSITIVE).callOnClick()
             ListUtil.assertListEquals(ArrayList(), returnedList.get())
-            Assert.assertEquals(expectedOption.toLong(), returnedOption.get().toLong())
+            Assert.assertEquals(expectedOption, returnedOption.get())
         }
     }
 
@@ -131,7 +131,7 @@ class TagsDialogTest {
             recycler.layout(0, 0, 100, 1000)
             val lastItem = RecyclerViewUtils.viewHolderAt<TagsArrayAdapter.ViewHolder>(recycler, 4)
             val newTagItemItem = RecyclerViewUtils.viewHolderAt<TagsArrayAdapter.ViewHolder>(recycler, 2)
-            Assert.assertEquals(5, recycler.adapter!!.itemCount.toLong())
+            Assert.assertEquals(5, recycler.adapter!!.itemCount)
             Assert.assertEquals(tag, newTagItemItem.text)
             Assert.assertTrue(newTagItemItem.isChecked)
             Assert.assertNotEquals(tag, lastItem.text)
@@ -166,7 +166,7 @@ class TagsDialogTest {
             recycler.layout(0, 0, 100, 1000)
             val lastItem = RecyclerViewUtils.viewHolderAt<TagsArrayAdapter.ViewHolder>(recycler, 3)
             val newTagItemItem = RecyclerViewUtils.viewHolderAt<TagsArrayAdapter.ViewHolder>(recycler, 2)
-            Assert.assertEquals(4, recycler.adapter!!.itemCount.toLong())
+            Assert.assertEquals(4, recycler.adapter!!.itemCount)
             Assert.assertEquals(tag, newTagItemItem.text)
             Assert.assertTrue(newTagItemItem.isChecked)
             Assert.assertNotEquals(tag, lastItem.text)
@@ -262,7 +262,7 @@ class TagsDialogTest {
             //   - football    [ ]
             //   - tennis      [x]
             // - book          [ ]
-            Assert.assertEquals(8, recycler.adapter!!.itemCount.toLong())
+            Assert.assertEquals(8, recycler.adapter!!.itemCount)
             Assert.assertEquals("fruit", getItem(0).text)
             Assert.assertEquals("fruit::apple", getItem(1).text)
             Assert.assertEquals("fruit::pear", getItem(2).text)
@@ -303,7 +303,7 @@ class TagsDialogTest {
             //     - tennis    [x]
             recycler.measure(0, 0)
             recycler.layout(0, 0, 100, 1000)
-            Assert.assertEquals(7, recycler.adapter!!.itemCount.toLong())
+            Assert.assertEquals(7, recycler.adapter!!.itemCount)
             val item0 = RecyclerViewUtils.viewHolderAt<TagsArrayAdapter.ViewHolder>(recycler, 0)
             val item1 = RecyclerViewUtils.viewHolderAt<TagsArrayAdapter.ViewHolder>(recycler, 1)
             val item2 = RecyclerViewUtils.viewHolderAt<TagsArrayAdapter.ViewHolder>(recycler, 2)
@@ -353,7 +353,7 @@ class TagsDialogTest {
             //     - careless  [x]
             recycler.measure(0, 0)
             recycler.layout(0, 0, 100, 1000)
-            Assert.assertEquals(3, recycler.adapter!!.itemCount.toLong())
+            Assert.assertEquals(3, recycler.adapter!!.itemCount)
             val item0 = RecyclerViewUtils.viewHolderAt<TagsArrayAdapter.ViewHolder>(recycler, 0)
             val item1 = RecyclerViewUtils.viewHolderAt<TagsArrayAdapter.ViewHolder>(recycler, 1)
             val item2 = RecyclerViewUtils.viewHolderAt<TagsArrayAdapter.ViewHolder>(recycler, 2)
@@ -399,7 +399,7 @@ class TagsDialogTest {
             //     - tennis    [x]
             recycler.measure(0, 0)
             recycler.layout(0, 0, 100, 1000)
-            Assert.assertEquals(5, recycler.adapter!!.itemCount.toLong())
+            Assert.assertEquals(5, recycler.adapter!!.itemCount)
             val item0 = RecyclerViewUtils.viewHolderAt<TagsArrayAdapter.ViewHolder>(recycler, 0)
             val item1 = RecyclerViewUtils.viewHolderAt<TagsArrayAdapter.ViewHolder>(recycler, 1)
             val item2 = RecyclerViewUtils.viewHolderAt<TagsArrayAdapter.ViewHolder>(recycler, 2)
@@ -442,7 +442,7 @@ class TagsDialogTest {
             // v common     [ ]
             //   v sport    [ ]
             //     - tennis [ ]
-            Assert.assertEquals(3, recycler.adapter!!.itemCount.toLong())
+            Assert.assertEquals(3, recycler.adapter!!.itemCount)
 
             adapter.filter.filter("")
             updateLayout()
@@ -450,7 +450,7 @@ class TagsDialogTest {
             //   - speak    [ ]
             //   v sport    [ ]
             //     - tennis [ ]
-            Assert.assertEquals(4, recycler.adapter!!.itemCount.toLong())
+            Assert.assertEquals(4, recycler.adapter!!.itemCount)
         }
     }
 
@@ -498,7 +498,7 @@ class TagsDialogTest {
             //     v football  [ ]
             //       - small   [ ]
             //     - tennis    [ ]
-            Assert.assertEquals(7, recycler.adapter!!.itemCount.toLong())
+            Assert.assertEquals(7, recycler.adapter!!.itemCount)
 
             getItem(2).mCheckBoxView.performClick()
             updateLayout()

--- a/AnkiDroid/src/test/java/com/ichi2/anki/multimediacard/AudioRecorderAndroidTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/multimediacard/AudioRecorderAndroidTest.kt
@@ -74,6 +74,6 @@ class AudioRecorderAndroidTest : RobolectricTest() {
         val recordingHandler = InitHandlerWithError()
         mAudioRecorder.setOnRecordingInitializedHandler(recordingHandler)
         mAudioRecorder.startRecording(targetContext, "testpath")
-        Assert.assertEquals("Initialization handler should run twice", 2, recordingHandler.timesRun.toLong())
+        Assert.assertEquals("Initialization handler should run twice", 2, recordingHandler.timesRun)
     }
 }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/stats/OverviewStatsBuilderTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/stats/OverviewStatsBuilderTest.kt
@@ -21,7 +21,7 @@ import com.ichi2.anki.RobolectricTest
 import com.ichi2.anki.stats.OverviewStatsBuilder.OverviewStats.AnswerButtonsOverview
 import com.ichi2.libanki.stats.Stats
 import com.ichi2.utils.KotlinCleanup
-import junit.framework.TestCase.*
+import junit.framework.TestCase.assertEquals
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.annotation.Config
@@ -32,7 +32,7 @@ class OverviewStatsBuilderTest : RobolectricTest() {
     @Test
     fun testGetPercentage() {
         val testAnswerButtonsOverview = AnswerButtonsOverview()
-        assertEquals(testAnswerButtonsOverview.percentage.toInt(), 0)
+        assertEquals(testAnswerButtonsOverview.percentage, 0.0)
 
         testAnswerButtonsOverview.correct = 15
         testAnswerButtonsOverview.total = 50

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/DecksTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/DecksTest.kt
@@ -70,13 +70,13 @@ class DecksTest : RobolectricTest() {
         val col = col
         val decks = col.decks
         // we start with a standard col
-        assertEquals(1, decks.allSortedNames().size.toLong())
+        assertEquals(1, decks.allSortedNames().size)
         // it should have an id of 1
         assertNotNull(decks.name(1))
         // create a new col
         val parentId = addDeck("new deck")
         assertNotEquals(parentId, 0)
-        assertEquals(2, decks.allSortedNames().size.toLong())
+        assertEquals(2, decks.allSortedNames().size)
         // should get the same id
         assertEquals(parentId, addDeck("new deck"))
         // we start with the default col selected
@@ -105,8 +105,8 @@ class DecksTest : RobolectricTest() {
         n.setItem("Front", "abc")
         col.addNote(n)
 
-        assertEquals(decks.id_for_name("new deck")!!.toLong(), parentId)
-        assertEquals(decks.id_for_name("  New Deck  ")!!.toLong(), parentId)
+        assertEquals(decks.id_for_name("new deck")!!, parentId)
+        assertEquals(decks.id_for_name("  New Deck  ")!!, parentId)
         assertNull(decks.id_for_name("Not existing deck"))
         assertNull(decks.id_for_name("new deck::not either"))
     }
@@ -122,9 +122,9 @@ class DecksTest : RobolectricTest() {
         col.addNote(note)
         val c = note.cards()[0]
         assertEquals(deck1, c.did)
-        assertEquals(1, col.cardCount().toLong())
+        assertEquals(1, col.cardCount())
         col.decks.rem(deck1)
-        assertEquals(0, col.cardCount().toLong())
+        assertEquals(0, col.cardCount())
         // if we try to get it, we get the default
         assertEquals("[no deck]", col.decks.name(c.did))
     }

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/FinderTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/FinderTest.kt
@@ -30,9 +30,7 @@ import com.ichi2.testutils.AnkiAssert
 import net.ankiweb.rsdroid.BackendFactory
 import org.hamcrest.CoreMatchers.equalTo
 import org.hamcrest.MatcherAssert.assertThat
-import org.hamcrest.Matchers.greaterThan
-import org.hamcrest.Matchers.hasItem
-import org.hamcrest.Matchers.hasSize
+import org.hamcrest.Matchers.*
 import org.junit.Assert.*
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -436,7 +434,7 @@ class FinderTest : RobolectricTest() {
         )
         cb.deckSpinnerSelection!!.updateDeckPosition(currentDid)
         advanceRobolectricLooperWithSleep()
-        assertEquals(1L, cb.cardCount.toLong())
+        assertEquals(1, cb.cardCount)
     }
 
     @Test

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/MediaTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/MediaTest.kt
@@ -50,7 +50,7 @@ class MediaTest : RobolectricTest() {
     fun test_strings() {
         val col = col
         val mid = col.models.current()!!.getLong("id")
-        assertEquals(0, col.media.filesInStr(mid, "aoeu").size.toLong())
+        assertEquals(0, col.media.filesInStr(mid, "aoeu").size)
         assertEqualsArrayList(arrayOf("foo.jpg"), col.media.filesInStr(mid, "aoeu<img src='foo.jpg'>ao"))
         assertEqualsArrayList(arrayOf("foo.jpg"), col.media.filesInStr(mid, "aoeu<img src='foo.jpg' style='test'>ao"))
         assertEqualsArrayList(arrayOf("foo.jpg", "bar.jpg"), col.media.filesInStr(mid, "aoeu<img src='foo.jpg'><img src=\"bar.jpg\">ao"))

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/TextNoteExporterTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/TextNoteExporterTest.kt
@@ -64,7 +64,7 @@ class TextNoteExporterTest(
         val exportedFile = File.createTempFile("export", ".txt")
         exporter.doExport(exportedFile.absolutePath)
         val lines = FileOperation.getFileContents(exportedFile).split("\n".toRegex()).toTypedArray()
-        Assert.assertEquals(noteList.size.toLong(), lines.size.toLong())
+        Assert.assertEquals(noteList.size, lines.size)
         for (i in noteList.indices) {
             val note = noteList[i]
             val line = lines[i]

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/sched/AbstractSchedTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/sched/AbstractSchedTest.kt
@@ -167,8 +167,8 @@ class AbstractSchedTest : RobolectricTest() {
                 `is`(lessThanOrEqualTo(nbNote * 2 - i))
             ) // Maximal number potentially shown,
             // because decrementing does not consider burying sibling
-            assertEquals(0, counts.lrn.toLong())
-            assertEquals(0, counts.rev.toLong())
+            assertEquals(0, counts.lrn)
+            assertEquals(0, counts.rev)
             assertEquals(notes[i]!!.firstCard().id, card.id)
             assertEquals(Consts.QUEUE_TYPE_NEW, card.queue)
             sched.answerCard(card, sched.answerButtons(card))

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/sched/SchedV2Test.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/sched/SchedV2Test.kt
@@ -57,11 +57,8 @@ import org.junit.Ignore
 import org.junit.Test
 import org.junit.platform.commons.util.CollectionUtils
 import org.junit.runner.RunWith
-import java.lang.Exception
 import java.time.Instant
 import java.time.ZoneOffset
-import java.util.*
-import kotlin.Throws
 import kotlin.math.roundToLong
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
@@ -346,14 +343,14 @@ open class SchedV2Test : RobolectricTest() {
     fun test_new_v2() {
         val col = colV2
         col.reset()
-        Assert.assertEquals(0, col.sched.newCount().toLong())
+        Assert.assertEquals(0, col.sched.newCount())
         // add a note
         val note = col.newNote()
         note.setItem("Front", "one")
         note.setItem("Back", "two")
         col.addNote(note)
         col.reset()
-        Assert.assertEquals(1, col.sched.newCount().toLong())
+        Assert.assertEquals(1, col.sched.newCount())
         // fetch it
         val c = card!!
         assertNotNull(c)
@@ -409,7 +406,7 @@ open class SchedV2Test : RobolectricTest() {
         col.decks.setConf(col.decks.get(deck2), c2)
         col.reset()
         // both confs have defaulted to a limit of 20
-        Assert.assertEquals(20, col.sched.newCount().toLong())
+        Assert.assertEquals(20, col.sched.newCount())
         // first card we get comes from parent
         val c = card!!
         Assert.assertEquals(1, c.did)
@@ -418,13 +415,13 @@ open class SchedV2Test : RobolectricTest() {
         conf1.getJSONObject("new").put("perDay", 10)
         col.decks.save(conf1)
         col.reset()
-        Assert.assertEquals(10, col.sched.newCount().toLong())
+        Assert.assertEquals(10, col.sched.newCount())
         // if we limit child to 4, we should get 9
         val conf2 = col.decks.confForDid(deck2)
         conf2.getJSONObject("new").put("perDay", 4)
         col.decks.save(conf2)
         col.reset()
-        Assert.assertEquals(9, col.sched.newCount().toLong())
+        Assert.assertEquals(9, col.sched.newCount())
     }
 
     @Test
@@ -474,8 +471,8 @@ open class SchedV2Test : RobolectricTest() {
         // fail it
         col.sched.answerCard(c, BUTTON_ONE)
         // it should have three reps left to graduation
-        Assert.assertEquals(3, (c.left % 1000).toLong())
-        ifV2 { Assert.assertEquals(3, (c.left / 1000).toLong()) }
+        Assert.assertEquals(3, (c.left % 1000))
+        ifV2 { Assert.assertEquals(3, (c.left / 1000)) }
         // it should be due in 30 seconds
         val t = Math.round((c.due - time.intTime()).toFloat()).toLong()
         MatcherAssert.assertThat(t, Matchers.greaterThanOrEqualTo(25L))
@@ -489,14 +486,14 @@ open class SchedV2Test : RobolectricTest() {
             dueIn,
             Matchers.lessThanOrEqualTo((180 * 1.25).toLong())
         )
-        Assert.assertEquals(2, (c.left % 1000).toLong())
-        ifV2 { Assert.assertEquals(2, (c.left / 1000).toLong()) }
+        Assert.assertEquals(2, (c.left % 1000))
+        ifV2 { Assert.assertEquals(2, (c.left / 1000)) }
         // check log is accurate
         val log = col.db.database.query("select * from revlog order by id desc")
         Assert.assertTrue(log.moveToFirst())
-        Assert.assertEquals(3, log.getInt(3).toLong())
-        Assert.assertEquals(-180, log.getInt(4).toLong())
-        Assert.assertEquals(-30, log.getInt(5).toLong())
+        Assert.assertEquals(3, log.getInt(3))
+        Assert.assertEquals(-180, log.getInt(4))
+        Assert.assertEquals(-30, log.getInt(5))
         // pass again
         col.sched.answerCard(c, BUTTON_THREE)
         // it should be due in 10 minutes
@@ -506,8 +503,8 @@ open class SchedV2Test : RobolectricTest() {
             dueIn,
             Matchers.lessThanOrEqualTo((600 * 1.25).toLong())
         )
-        Assert.assertEquals(1, (c.left % 1000).toLong())
-        ifV2 { Assert.assertEquals(1, (c.left / 1000).toLong()) }
+        Assert.assertEquals(1, (c.left % 1000))
+        ifV2 { Assert.assertEquals(1, (c.left / 1000)) }
         // the next pass should graduate the card
         Assert.assertEquals(QUEUE_TYPE_LRN, c.queue)
         Assert.assertEquals(CARD_TYPE_LRN, c.type)
@@ -632,8 +629,8 @@ open class SchedV2Test : RobolectricTest() {
         // pass it
         col.sched.answerCard(c, BUTTON_THREE)
         // two reps to graduate, 1 more today
-        Assert.assertEquals(3, (c.left % 1000).toLong())
-        ifV2 { Assert.assertEquals(1, (c.left / 1000).toLong()) }
+        Assert.assertEquals(3, (c.left % 1000))
+        ifV2 { Assert.assertEquals(1, (c.left / 1000)) }
         Assert.assertEquals(Counts(0, 1, 0), col.sched.counts())
         c = card!!
         Assert.assertEquals(Stats.SECONDS_PER_DAY, col.sched.nextIvl(c, BUTTON_THREE))
@@ -804,8 +801,8 @@ open class SchedV2Test : RobolectricTest() {
         var tree = col.sched.deckDueTree()[parentIndex]
         // (('parent', 1514457677462, 5, 0, 0, (('child', 1514457677463, 5, 0, 0, ()),)))
         Assert.assertEquals("parent", tree.value.fullDeckName)
-        Assert.assertEquals(5, tree.value.revCount.toLong()) // paren, tree.review_count)t
-        Assert.assertEquals(10, tree.children[0].value.revCount.toLong())
+        Assert.assertEquals(5, tree.value.revCount) // paren, tree.review_count)t
+        Assert.assertEquals(10, tree.children[0].value.revCount)
 
         // .counts() should match
         col.decks.select(child.getLong("id"))
@@ -817,8 +814,8 @@ open class SchedV2Test : RobolectricTest() {
         col.sched.answerCard(c, BUTTON_THREE)
         Assert.assertEquals(Counts(0, 0, 9), col.sched.counts())
         tree = col.sched.deckDueTree()[parentIndex]
-        Assert.assertEquals(4, tree.value.revCount.toLong())
-        Assert.assertEquals(9, tree.children[0].value.revCount.toLong())
+        Assert.assertEquals(4, tree.value.revCount)
+        Assert.assertEquals(9, tree.children[0].value.revCount)
     }
 
     @Test
@@ -971,19 +968,19 @@ open class SchedV2Test : RobolectricTest() {
         // new cards
         // //////////////////////////////////////////////////////////////////////////////////////////////////
         Assert.assertEquals(30, col.sched.nextIvl(c, BUTTON_ONE))
-        Assert.assertEquals(((30 + 180) / 2).toLong(), col.sched.nextIvl(c, BUTTON_TWO))
+        Assert.assertEquals(((30 + 180) / 2), col.sched.nextIvl(c, BUTTON_TWO))
         Assert.assertEquals(180, col.sched.nextIvl(c, BUTTON_THREE))
         Assert.assertEquals(4 * Stats.SECONDS_PER_DAY, col.sched.nextIvl(c, BUTTON_FOUR))
         col.sched.answerCard(c, BUTTON_ONE)
         // cards in learning
         // //////////////////////////////////////////////////////////////////////////////////////////////////
         Assert.assertEquals(30, col.sched.nextIvl(c, BUTTON_ONE))
-        Assert.assertEquals(((30 + 180) / 2).toLong(), col.sched.nextIvl(c, BUTTON_TWO))
+        Assert.assertEquals(((30 + 180) / 2), col.sched.nextIvl(c, BUTTON_TWO))
         Assert.assertEquals(180, col.sched.nextIvl(c, BUTTON_THREE))
         Assert.assertEquals(4 * Stats.SECONDS_PER_DAY, col.sched.nextIvl(c, BUTTON_FOUR))
         col.sched.answerCard(c, BUTTON_THREE)
         Assert.assertEquals(30, col.sched.nextIvl(c, BUTTON_ONE))
-        ifV2 { Assert.assertEquals(((180 + 600) / 2).toLong(), col.sched.nextIvl(c, BUTTON_TWO)) }
+        ifV2 { Assert.assertEquals(((180 + 600) / 2), col.sched.nextIvl(c, BUTTON_TWO)) }
         ifV3 { Assert.assertEquals(180, col.sched.nextIvl(c, BUTTON_TWO)) }
         Assert.assertEquals(600, col.sched.nextIvl(c, BUTTON_THREE))
         Assert.assertEquals(4 * Stats.SECONDS_PER_DAY, col.sched.nextIvl(c, BUTTON_FOUR))
@@ -1152,7 +1149,7 @@ open class SchedV2Test : RobolectricTest() {
         Assert.assertEquals(Counts(0, 0, 1), col.sched.counts())
         // grab it and check estimates
         c = card!!
-        Assert.assertEquals(4, col.sched.answerButtons(c).toLong())
+        Assert.assertEquals(4, col.sched.answerButtons(c))
         Assert.assertEquals(600, col.sched.nextIvl(c, BUTTON_ONE))
         Assert.assertEquals(
             Math.round(75 * 1.2) * Stats.SECONDS_PER_DAY,
@@ -1273,11 +1270,11 @@ open class SchedV2Test : RobolectricTest() {
         c = card!!
         Assert.assertEquals(600, col.sched.nextIvl(c, BUTTON_ONE))
         ifV2 {
-            Assert.assertEquals(2, col.sched.answerButtons(c).toLong())
+            Assert.assertEquals(2, col.sched.answerButtons(c))
             Assert.assertEquals(0, col.sched.nextIvl(c, BUTTON_TWO))
         }
         ifV3 {
-            Assert.assertEquals(4, col.sched.answerButtons(c).toLong())
+            Assert.assertEquals(4, col.sched.answerButtons(c))
             Assert.assertEquals(900, col.sched.nextIvl(c, BUTTON_TWO))
         }
         // failing it will push its due time back
@@ -1328,7 +1325,7 @@ open class SchedV2Test : RobolectricTest() {
         note.setItem("Front", "1")
         note.setItem("Back", "1")
         col.addNote(note)
-        Assert.assertEquals(3, col.cardCount().toLong())
+        Assert.assertEquals(3, col.cardCount())
         col.reset()
         // ordinals should arrive in order
         val sched = col.sched
@@ -1546,19 +1543,19 @@ open class SchedV2Test : RobolectricTest() {
         note.model().put("did", addDeck("foo::baz"))
         col.addNote(note)
         col.reset()
-        Assert.assertEquals(5, col.decks.allSortedNames().size.toLong())
+        Assert.assertEquals(5, col.decks.allSortedNames().size)
         val tree = col.sched.deckDueTree()[0]
         Assert.assertEquals("Default", tree.value.lastDeckNameComponent)
         // sum of child and parent
         Assert.assertEquals(1, tree.value.did)
-        Assert.assertEquals(1, tree.value.revCount.toLong())
-        Assert.assertEquals(1, tree.value.newCount.toLong())
+        Assert.assertEquals(1, tree.value.revCount)
+        Assert.assertEquals(1, tree.value.newCount)
         // child count is just review
         val (value) = tree.children[0]
         Assert.assertEquals("1", value.lastDeckNameComponent)
         Assert.assertEquals(default1, value.did)
-        Assert.assertEquals(1, value.revCount.toLong())
-        Assert.assertEquals(0, value.newCount.toLong())
+        Assert.assertEquals(1, value.revCount)
+        Assert.assertEquals(0, value.newCount)
         // code should not fail if a card has an invalid deck
         c.did = 12345
         c.flush()
@@ -1864,7 +1861,7 @@ open class SchedV2Test : RobolectricTest() {
             Matchers.lessThanOrEqualTo((expected * 1.25).toLong())
         )
         val ivl = col.db.queryLongScalar("select ivl from revlog")
-        Assert.assertEquals((-5.5 * 60).toLong(), ivl)
+        Assert.assertEquals((-5.5 * 60), ivl)
     }
 
     @Test
@@ -1888,9 +1885,9 @@ open class SchedV2Test : RobolectricTest() {
             sched.answerCard(card, BUTTON_ONE)
         }
         advanceRobolectricLooperWithSleep()
-        Assert.assertEquals(1, sched.lrnCount().toLong())
+        Assert.assertEquals(1, sched.lrnCount())
         card = sched.card
-        Assert.assertEquals(1, sched.counts(card!!).lrn.toLong())
+        Assert.assertEquals(1, sched.counts(card!!).lrn)
         advanceRobolectricLooperWithSleep()
         sched.answerCard(card, BUTTON_ONE)
         AnkiAssert.assertDoesNotThrow { col.undo() }

--- a/AnkiDroid/src/test/java/com/ichi2/utils/FileUtilTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/utils/FileUtilTest.kt
@@ -121,7 +121,7 @@ class FileUtilTest {
         for (testDirChild in testDirChildren) {
             assertTrue(expectedChildren.contains(testDirChild))
         }
-        assertEquals(expectedChildren.size.toLong(), testDirChildren.size.toLong())
+        assertEquals(expectedChildren.size, testDirChildren.size)
 
         // Create invalid input
         assertThrows(IOException::class.java) { FileUtil.listFiles(File(testDir, "file1.txt")) }

--- a/AnkiDroid/src/test/java/com/ichi2/utils/JSONObjectTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/utils/JSONObjectTest.kt
@@ -923,7 +923,7 @@ class JSONObjectTest {
         correctJsonObjectBasicCopy.putOpt("boolean_key", true)
         correctJsonObjectBasicCopy.putOpt("object_key", mCorrectJsonBasic)
 
-        Assert.assertEquals(6, correctJsonObjectBasicCopy.getInt("int_key").toLong())
+        Assert.assertEquals(6, correctJsonObjectBasicCopy.getInt("int_key"))
         Assert.assertEquals(2L, correctJsonObjectBasicCopy.getLong("long_key"))
         Assert.assertEquals(2.0, correctJsonObjectBasicCopy.getDouble("double_key"), 1e-10)
         Assert.assertTrue(correctJsonObjectBasicCopy.getBoolean("boolean_key"))

--- a/AnkiDroid/src/test/java/com/ichi2/utils/TagsUtilTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/utils/TagsUtilTest.kt
@@ -143,8 +143,8 @@ class TagsUtilTest {
             assertTrue(TagsUtil.compareTag("aaa::bbbb", "aaa::bbb::trailing") > 0)
             assertTrue(TagsUtil.compareTag("aaa::bbbz::foo", "aaa::bbb::bar") > 0)
             assertTrue(TagsUtil.compareTag("aaa::bbb9::foo", "aaa::bbb::bar") > 0)
-            assertEquals(0, TagsUtil.compareTag("aaa::bbb", "aaa::bbb").toLong())
-            assertEquals(0, TagsUtil.compareTag("aAa::bbb", "aaa::bBb").toLong())
+            assertEquals(0, TagsUtil.compareTag("aaa::bbb", "aaa::bbb"))
+            assertEquals(0, TagsUtil.compareTag("aAa::bbb", "aaa::bBb"))
         }
     }
 }

--- a/AnkiDroid/src/test/java/com/ichi2/utils/UniqueArrayListTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/utils/UniqueArrayListTest.kt
@@ -115,14 +115,14 @@ class UniqueArrayListTest {
         val list = mutableListOf("TarekkMA", "TarekkMA", "TarekkmA", "tarekkma")
         val uniqueList = UniqueArrayList.from(list, String.CASE_INSENSITIVE_ORDER)
 
-        assertEquals(1, uniqueList.size.toLong())
+        assertEquals(1, uniqueList.size)
         assertEquals("TarekkMA", uniqueList[0])
 
         uniqueList.clear()
         list.reverse()
         uniqueList.addAll(list)
 
-        assertEquals(1, uniqueList.size.toLong())
+        assertEquals(1, uniqueList.size)
         assertEquals("tarekkma", uniqueList[0])
     }
 
@@ -368,11 +368,11 @@ class UniqueArrayListTest {
         val longs = listOf(1L, 1L, 2L, 3L, 4L, 1L, 5L, 1L, 6L, 7L, 8L, 9L, 10L, 11L, 1L, 12L, 13L)
         val uniqueList = UniqueArrayList.from(longs)
 
-        assertNotEquals(-1, uniqueList.indexOf(1L).toLong())
+        assertNotEquals(-1, uniqueList.indexOf(1L))
         uniqueList.remove(1L)
-        assertEquals(-1, uniqueList.indexOf(1L).toLong())
+        assertEquals(-1, uniqueList.indexOf(1L))
         uniqueList[10] = 1L
-        assertEquals(10, uniqueList.indexOf(1L).toLong())
+        assertEquals(10, uniqueList.indexOf(1L))
     }
 
     @Test
@@ -380,11 +380,11 @@ class UniqueArrayListTest {
         val longs = listOf(1L, 1L, 2L, 3L, 4L, 1L, 5L, 1L, 6L, 7L, 8L, 9L, 10L, 11L, 1L, 12L, 13L)
         val uniqueList = UniqueArrayList.from(longs)
 
-        assertNotEquals(-1, uniqueList.indexOf(1L).toLong())
+        assertNotEquals(-1, uniqueList.indexOf(1L))
         uniqueList.removeAt(0 /*index of 1L*/)
-        assertEquals(-1, uniqueList.indexOf(1L).toLong())
+        assertEquals(-1, uniqueList.indexOf(1L))
         uniqueList[10] = 1L
-        assertEquals(10, uniqueList.indexOf(1L).toLong())
+        assertEquals(10, uniqueList.indexOf(1L))
     }
 
     @Test
@@ -412,17 +412,17 @@ class UniqueArrayListTest {
         val longs = listOf(1L, 1L, 2L, 3L, 4L, 1L, 5L, 1L, 6L, 7L, 8L, 9L, 10L, 11L, 1L, 12L, 13L)
         val uniqueList = UniqueArrayList.from(longs)
 
-        assertEquals(0, uniqueList.indexOf(1L).toLong())
-        assertEquals(5, uniqueList.indexOf(6L).toLong())
-        assertEquals(12, uniqueList.indexOf(13L).toLong())
-        assertEquals(9, uniqueList.indexOf(10L).toLong())
-        assertEquals(2, uniqueList.indexOf(3L).toLong())
+        assertEquals(0, uniqueList.indexOf(1L))
+        assertEquals(5, uniqueList.indexOf(6L))
+        assertEquals(12, uniqueList.indexOf(13L))
+        assertEquals(9, uniqueList.indexOf(10L))
+        assertEquals(2, uniqueList.indexOf(3L))
 
-        assertEquals(0, uniqueList.lastIndexOf(1L).toLong())
-        assertEquals(5, uniqueList.lastIndexOf(6L).toLong())
-        assertEquals(12, uniqueList.lastIndexOf(13L).toLong())
-        assertEquals(9, uniqueList.lastIndexOf(10L).toLong())
-        assertEquals(2, uniqueList.lastIndexOf(3L).toLong())
+        assertEquals(0, uniqueList.lastIndexOf(1L))
+        assertEquals(5, uniqueList.lastIndexOf(6L))
+        assertEquals(12, uniqueList.lastIndexOf(13L))
+        assertEquals(9, uniqueList.lastIndexOf(10L))
+        assertEquals(2, uniqueList.lastIndexOf(3L))
     }
 
     @Test
@@ -501,9 +501,9 @@ class UniqueArrayListTest {
         val longs = listOf(1L, 1L, 2L, 3L, 4L, 1L, 5L, 1L, 6L, 7L, 8L, 9L, 10L, 11L, 1L, 12L, 13L)
         val uniqueList = UniqueArrayList.from(longs)
 
-        assertNotEquals(2, uniqueList.size.toLong())
+        assertNotEquals(2, uniqueList.size)
         uniqueList.retainAll(listOf(1L, 3L))
-        assertEquals(2, uniqueList.size.toLong())
+        assertEquals(2, uniqueList.size)
         assertEquals(listOf(1L, 3L), uniqueList)
     }
 


### PR DESCRIPTION
Mostly fixes bug: #11965, except for examples such as https://github.com/ankidroid/Anki-Android/blob/main/AnkiDroid/src/test/java/com/ichi2/anki/DeckPickerTest.kt#L160 where, if you remove the toLong you get the error message:
> java.lang.AssertionError: expected: java.lang.Integer<20800301> but was: java.lang.Long<20800301>
