### PR TITLE
fix: crash showing error if activity is  destroyed

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CoroutineHelpers.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CoroutineHelpers.kt
@@ -261,7 +261,7 @@ private suspend fun monitorProgress(
     extractProgress: ProgressContext.() -> Unit,
     updateUi: ProgressContext.() -> Unit,
 ) {
-    var state = ProgressContext(Progress.getDefaultInstance())
+    val state = ProgressContext(Progress.getDefaultInstance())
     while (true) {
         state.progress = backend.latestProgress()
         state.extractProgress()


### PR DESCRIPTION
`showError` could crash if the activity was destroyed. 

In this case, we don't have much we can do, so we ignore the error.

## Fixes
Fixes #12718

## Approach
Ignore the exception

## How Has This Been Tested?
Untested

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
