### PR TITLE
Fixed a crash on images exceed 1MB

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/activity/MultimediaEditFieldActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/activity/MultimediaEditFieldActivity.kt
@@ -194,7 +194,6 @@ class MultimediaEditFieldActivity : AnkiActivity(), OnRequestPermissionsResultCa
 
     @KotlinCleanup("rename: bChangeToText")
     protected fun done() {
-        fieldController!!.onDone()
         var bChangeToText = false
         if (mField.type === EFieldType.IMAGE) {
             if (mField.imagePath == null) {
@@ -223,6 +222,7 @@ class MultimediaEditFieldActivity : AnkiActivity(), OnRequestPermissionsResultCa
                 }
             }
         }
+        fieldController!!.onDone()
         saveAndExit(bChangeToText)
     }
 


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
This PR fixes an issue which causes the app to crash when adding images that exceeded the size limit(1MB)

## Fixes
Fixes #12730 

## Approach
Moving the call of `MultimediaEditFieldActivity::done()` to somewhere after FileCropDialog is created.

## How Has This Been Tested?
The fix has been tested on OnePlus 7 Pro with Android 11 without issue.
To perform a test, add an image that exceeds 1MB to the card and select crop in the crop suggesting dialog and observe if the app crashes.


## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [X] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [X] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
