### PR TITLE
Fix permission missing crash when sharing exported collection

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/export/ActivityExportingDelegate.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/export/ActivityExportingDelegate.kt
@@ -205,8 +205,8 @@ class ActivityExportingDelegate(private val activity: AnkiActivity, private val 
                 )
             )
             .intent.apply {
-                clipData = ClipData.newRawUri(attachment.name, uri)
-                addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+                clipData = ClipData.newUri(activity.contentResolver, attachment.name, uri)
+                addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION or Intent.FLAG_GRANT_WRITE_URI_PERMISSION)
             }
         val shareFileIntent = Intent.createChooser(
             sendIntent,


### PR DESCRIPTION
## Purpose / Description

An attempt to fix issue #12675, on the emulator and lower versions devices it works. Don't have access to a Samsung device with the mentioned api version(12). Ideally this would be merged before a new alpha release so it can be tested.
If this doesn't work I'll revert the commit and look at other options. 

## Fixes

I'll manually close issue #12675, if working.

## How Has This Been Tested?
Ran the tests, manually verified the flow on an emulator.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
