### PR TITLE
build: support JDK11 and JDK17 (the two LTSs) and JDK18

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -102,11 +102,11 @@ subprojects {
 ext {
 
     jvmVersion = Jvm.current().javaVersion.majorVersion
-    if (jvmVersion != "11" && jvmVersion != "14" && jvmVersion != "16") {
+    if (jvmVersion != "11" && jvmVersion != "17" && jvmVersion != "18") {
         println "\n\n\n"
         println "**************************************************************************************************************"
         println "\n\n\n"
-        println "ERROR: AnkiDroid builds with JVM version 11, 14, or 16."
+        println "ERROR: AnkiDroid builds with JVM version 11, 17 or 18."
         println "  Incompatible major version detected: '" + jvmVersion + "'"
         println "\n\n\n"
         println "**************************************************************************************************************"


### PR DESCRIPTION
## Pull Request template

## Purpose / Description

JDK14 and JDK16 where interim releases before the JDK17 LTS, no need to support them since 17 works fine. 18 appears to work fine as well.

https://en.wikipedia.org//wiki/Java_version_history#Release_table

## Fixes
Nothing logged, just looking at build/CI/release infra

## How Has This Been Tested?

Tested JDK 11, 17 and 18 locally with

`/bin/nice -n 19 ./gradlew clean jacocoTestReport :api:lintRelease :AnkiDroid:lintPlayRelease ktlintCheck lint-rules:test`

## Learning (optional, can help others)

I've been doing Java long enough I'm still sort of surprised to see their version numbers (finally!) shake loose and development continue. But I guess we're on Kotlin so :shrug: :laughing: 

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
