### PR TITLE
fix all types of sorting when browser options are set to "notes"

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -2763,7 +2763,7 @@ suspend fun searchForCards(
     inCardsMode: Boolean
 ): MutableList<CardBrowser.CardCache> {
     return withCol {
-        (if (inCardsMode) findCards(query, order) else findOneCardByNote(query)).asSequence()
+        (if (inCardsMode) findCards(query, order) else findNotes(query, order)).asSequence()
             .toCardCache(col, inCardsMode)
             .toMutableList()
     }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.kt
@@ -1234,7 +1234,7 @@ open class Collection(
      * @param order only used in overridden V16 findNotes() method
      * */
     open fun findNotes(query: String, order: SortOrder = SortOrder.NoOrdering()): List<Long> {
-        return Finder(this).findNotes(query)
+        return Finder(this).findNotes(query, order)
     }
 
     fun findReplace(nids: List<Long?>, src: String, dst: String): Int {


### PR DESCRIPTION

## Purpose / Description
Fixes all types of sorting when browser options are set to "notes".

## Fixes
Fixes #12742 

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)