### PR TITLE
GitHub cache clear

### DIFF
--- a/.github/workflows/tests_emulator.yml
+++ b/.github/workflows/tests_emulator.yml
@@ -125,8 +125,10 @@ jobs:
           emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           sdcard-path-or-size: 100M
           disable-animations: true
-          # Give the emulator a little time to run and do first boot stuff before taking snapshot
+          # Restart zygote to win a config race / Give emulator time to run and do first boot stuff before taking snapshot
           script: |
+            $ANDROID_HOME/platform-tools/adb shell su root "setprop ctl.restart zygote"
+            sleep 10
             sleep $FIRST_BOOT_DELAY
             echo "First boot warmup completed."
 
@@ -144,8 +146,6 @@ jobs:
           script: |
             $ANDROID_HOME/platform-tools/adb logcat '*:D' > adb-log.txt &
             sleep 5
-            $ANDROID_HOME/platform-tools/adb shell su root "setprop ctl.restart zygote"
-            sleep 10
             ./gradlew uninstallAll jacocoAndroidTestReport --daemon
 
       - name: Compress Emulator Log

--- a/.github/workflows/tests_emulator.yml
+++ b/.github/workflows/tests_emulator.yml
@@ -67,6 +67,7 @@ jobs:
           # Builds on other branches will only read from main branch cache writes
           # Comment this and the with: above out for performance testing on a branch
           cache-read-only: ${{ github.ref != 'refs/heads/main' }}
+          gradle-home-cache-cleanup: true
 
       - name: Warm Gradle Cache
         # This makes sure we fetch gradle network resources with a retry

--- a/.github/workflows/tests_emulator.yml
+++ b/.github/workflows/tests_emulator.yml
@@ -106,7 +106,11 @@ jobs:
           sdcard-path-or-size: 100M
           disable-animations: true
           # Give the emulator a little time to run and do first boot stuff before taking snapshot
-          script: echo "Generated AVD snapshot for caching."
+          script: |
+            touch adb-log.txt
+            $ANDROID_HOME/platform-tools/adb logcat '*:D' >> adb-log.txt &
+            adb logcat --clear
+            echo "Generated AVD snapshot for caching."
 
         # This step is separate so pure install time may be calculated as a step
       - name: Emulator Snapshot After Firstboot Warmup
@@ -127,9 +131,12 @@ jobs:
           disable-animations: true
           # Restart zygote to win a config race / Give emulator time to run and do first boot stuff before taking snapshot
           script: |
+            touch adb-log.txt
+            $ANDROID_HOME/platform-tools/adb logcat '*:D' >> adb-log.txt &
             $ANDROID_HOME/platform-tools/adb shell su root "setprop ctl.restart zygote"
             sleep 10
             sleep $FIRST_BOOT_DELAY
+            adb logcat --clear
             echo "First boot warmup completed."
 
       - name: Run Emulator Tests
@@ -144,7 +151,8 @@ jobs:
           sdcard-path-or-size: 100M
           disable-animations: true
           script: |
-            $ANDROID_HOME/platform-tools/adb logcat '*:D' > adb-log.txt &
+            touch adb-log.txt
+            $ANDROID_HOME/platform-tools/adb logcat '*:D' >> adb-log.txt &
             sleep 5
             ./gradlew uninstallAll jacocoAndroidTestReport --daemon
 

--- a/.github/workflows/tests_emulator.yml
+++ b/.github/workflows/tests_emulator.yml
@@ -2,6 +2,11 @@ name: Emulator Tests
 
 on:
   workflow_dispatch:
+    inputs:
+      clearCaches:
+        description: "Clear workflow caches where possible"
+        required: false
+        type: boolean
   pull_request:
     branches:
       - '**'
@@ -82,6 +87,17 @@ jobs:
           key: avd-${{ matrix.api-level }}-${{ matrix.arch }}-${{matrix.target}}-v1-${{ hashFiles('~/.android/avd/**/snapshots/**') }}
           restore-keys: |
             avd-${{ matrix.api-level }}-${{ matrix.arch }}-${{matrix.target}}-v1
+
+      - name: Clear Caches Optionally
+        if: "${{ github.event.inputs.clearCaches != '' }}"
+        shell: bash
+        run: |
+          du -sk ~/.gradle
+          du -sk ~/.android
+          rm -fr ~/.gradle
+          rm -fr ~/.android
+          du -sk ~/.gradle
+          du -sk ~/.android
 
       - name: Warm Gradle Cache
         # This makes sure we fetch gradle network resources with a retry

--- a/.github/workflows/tests_emulator.yml
+++ b/.github/workflows/tests_emulator.yml
@@ -69,15 +69,6 @@ jobs:
           cache-read-only: ${{ github.ref != 'refs/heads/main' }}
           gradle-home-cache-cleanup: true
 
-      - name: Warm Gradle Cache
-        # This makes sure we fetch gradle network resources with a retry
-        uses: nick-invision/retry@v2
-        with:
-          timeout_minutes: 15
-          retry_wait_seconds: 60
-          max_attempts: 3
-          command: ./gradlew packagePlayDebug packagePlayDebugAndroidTest --daemon
-
         # This appears to be 'Cache Size: ~1230 MB (1290026823 B)' based on watching action logs
         # Repo limit is 10GB; branch caches are independent; branches may read default branch cache.
         # We don't want branches to evict main branch snapshot, so save on main, read-only all else
@@ -91,6 +82,15 @@ jobs:
           key: avd-${{ matrix.api-level }}-${{ matrix.arch }}-${{matrix.target}}-v1-${{ hashFiles('~/.android/avd/**/snapshots/**') }}
           restore-keys: |
             avd-${{ matrix.api-level }}-${{ matrix.arch }}-${{matrix.target}}-v1
+
+      - name: Warm Gradle Cache
+        # This makes sure we fetch gradle network resources with a retry
+        uses: nick-invision/retry@v2
+        with:
+          timeout_minutes: 15
+          retry_wait_seconds: 60
+          max_attempts: 3
+          command: ./gradlew packagePlayDebug packagePlayDebugAndroidTest --daemon
 
       - name: AVD Boot and Snapshot Creation
         # Only generate a snapshot for saving if we are on main branch with a cache miss


### PR DESCRIPTION
## Pull Request template

## Purpose / Description

1) emulator tests have become pretty flaky (again): https://github.com/ankidroid/Anki-Android/actions/workflows/tests_emulator.yml
2) the desugar library is giving me trouble but works if you clear gradle cache #12665 

I believe the emulator can be optimized a bit by doing the zygote race workaround only during snapshot generation, and I think a fresh snapshot could help (it doesn't ever sit for the required "github caches expire after a week of no access" week where it would be a cache miss and refresh.

And I believe a gradle cache clean would allow the desugar library bump to go in

So I want a way to purge those caches and get fresh cache contents

## Fixes
Related #12665 (or 12164)

## Approach
This should have no effect after this is merged *until you run the emulator test on main manually with cache clear input set to true*

## How Has This Been Tested?

Workflows unfortunately always require merge + test

## Learning (optional, can help others)

Detecting whether an optional input is present or not is tricky: https://stackoverflow.com/a/71050123/9910298

Windows "bash" in workflow actions is git bash, which has rm, and...this code should work on windows as well, even though this is just a macOS runner https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsshell

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
