### PR TITLE
fix(test): correctly rebuild AVD snapshot if we cleared it

### DIFF
--- a/.github/workflows/tests_emulator.yml
+++ b/.github/workflows/tests_emulator.yml
@@ -111,7 +111,7 @@ jobs:
       - name: AVD Boot and Snapshot Creation
         # Only generate a snapshot for saving if we are on main branch with a cache miss
         # Comment the if out to generate snapshots on branch for performance testing
-        if: steps.avd-cache.outputs.cache-hit != 'true' && github.ref == 'refs/heads/main'
+        if: "${{ github.event.inputs.clearCaches != '' || (steps.avd-cache.outputs.cache-hit != 'true' && github.ref == 'refs/heads/main') }}"
         uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: ${{ matrix.api-level }}
@@ -133,7 +133,7 @@ jobs:
         # Only generate a snapshot for saving if we are on main branch with a cache miss
         # Switch the if statements via comment if generating snapshots for performance testing
         # if: matrix.first-boot-delay != '0'
-        if: steps.avd-cache.outputs.cache-hit != 'true' && github.ref == 'refs/heads/main'
+        if: "${{ github.event.inputs.clearCaches != '' || (steps.avd-cache.outputs.cache-hit != 'true' && github.ref == 'refs/heads/main') }}"
         env:
           FIRST_BOOT_DELAY: ${{ matrix.first-boot-delay }}
         uses: reactivecircus/android-emulator-runner@v2


### PR DESCRIPTION

## Pull Request template

## Purpose / Description

missed the inclusion of the new optional manual input var to recreate after deleting

## Approach
Work on workflow files, push them and test after merging a PR because you can't test locally really, and it's all really slow

## How Has This Been Tested?

You can't. But I'm testing after the fact by watching the automated runs, and the manual runs with the box ticked, and the manual runs without the box ticked

## Learning (optional, can help others)
yaml / github expression syntax is arcane

