### PR TITLE
fix(test): ensure we can have a non-primary cache hit when clearing cache

### DIFF
--- a/.github/workflows/tests_emulator.yml
+++ b/.github/workflows/tests_emulator.yml
@@ -6,7 +6,7 @@ on:
       clearCaches:
         description: "Clear workflow caches where possible"
         required: false
-        type: boolean
+        type: string
   pull_request:
     branches:
       - '**'
@@ -84,7 +84,7 @@ jobs:
           path: |
             ~/.android/avd/*
             ~/.android/adb*
-          key: avd-${{ matrix.api-level }}-${{ matrix.arch }}-${{matrix.target}}-v1-${{ hashFiles('~/.android/avd/**/snapshots/**') }}
+          key: avd-${{ matrix.api-level }}-${{ matrix.arch }}-${{matrix.target}}-v1-${{ github.event.inputs.clearCaches }}
           restore-keys: |
             avd-${{ matrix.api-level }}-${{ matrix.arch }}-${{matrix.target}}-v1
 


### PR DESCRIPTION
## Pull Request template

## Purpose / Description

- previous cache key was generating empty final var every run, so was useless anyway
- new key will be empty nearly all the time (when not specified) so matches previous behavior
- new key will have a value when clearing cache, so will generate new caches for AVD

## Approach
Caches are immutable, so if a primary cache key is a hit, **the cache will not be updated**

This was failing the final testing scenario of the work to allow AVD cache clear / rebuild - the rebuild was happening when I did a manual run with the input to clear cache, but it was not actually uploading the fresh AVD snapshot because of a primary key hit.

## How Has This Been Tested?

I can't without merging it to main, then running it

## Learning (optional, can help others)
It's all subtle, this CI / cache business.

Here's your cache update link: https://github.com/actions/cache/blob/main/workarounds.md#update-a-cache
