### PR TITLE
fix(test): allow cache clearing in lint + unit test workflows as well

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,6 +2,11 @@ name: Code Quality Checks
 
 on:
   workflow_dispatch:
+    inputs:
+      clearCaches:
+        description: "Clear workflow caches where possible"
+        required: false
+        type: string
   pull_request:
     branches:
       - '**'
@@ -62,6 +67,15 @@ jobs:
           # Builds on other branches will only read from main branch cache writes
           # Comment this and the with: above out for performance testing on a branch
           cache-read-only: ${{ github.ref != 'refs/heads/main' }}
+          gradle-home-cache-cleanup: true
+
+      - name: Clear Caches Optionally
+        if: "${{ github.event.inputs.clearCaches != '' }}"
+        shell: bash
+        run: |
+          du -sk ~/.gradle
+          rm -fr ~/.gradle
+          du -sk ~/.gradle || echo ~/.gradle is gone
 
       - name: Warm Gradle Cache
         # This makes sure we fetch gradle network resources with a retry

--- a/.github/workflows/tests_unit.yml
+++ b/.github/workflows/tests_unit.yml
@@ -2,6 +2,11 @@ name: Unit Tests
 
 on:
   workflow_dispatch:
+    inputs:
+      clearCaches:
+        description: "Clear workflow caches where possible"
+        required: false
+        type: string
   pull_request:
     branches:
       - '**'
@@ -76,6 +81,15 @@ jobs:
           # Builds on other branches will only read from main branch cache writes
           # Comment this and the with: above out for performance testing on a branch
           cache-read-only: ${{ github.ref != 'refs/heads/main' }}
+          gradle-home-cache-cleanup: true
+
+      - name: Clear Caches Optionally
+        if: "${{ github.event.inputs.clearCaches != '' }}"
+        shell: bash
+        run: |
+          du -sk ~/.gradle
+          rm -fr ~/.gradle
+          du -sk ~/.gradle || echo ~/.gradle is gone
 
       - name: Gradle Dependency Download
         uses: nick-invision/retry@v2


### PR DESCRIPTION

## Pull Request template

## Purpose / Description

with these, I may be able to get desugar PR through CI since it passes locally now after deleting my local caches

## Fixes
Related #12749 (test results etc)

## Approach
Same approach as the other cache clearing work, but this time I do not have to worry about cache key stuff (that was only for the emulator snapshot, which is not in play here)

## How Has This Been Tested?

Can't really test, we'll see when it runs...

## Learning (optional, can help others)
github workflows are great but developing them is slow
