### PR TITLE
test(coverage): switch to recommended codecov uploader action

### DIFF
--- a/.github/workflows/tests_emulator.yml
+++ b/.github/workflows/tests_emulator.yml
@@ -184,12 +184,6 @@ jobs:
           name: ${{ matrix.api-level }}-${{ matrix.arch }}-${{matrix.target}}-${{matrix.first-boot-delay}}-${{matrix.iteration}}-adb_logs
           path: adb-log.txt.gz
 
-      - name: Submit Coverage
-        # This can fail on timeouts etc, wrap with retry
-        uses: nick-invision/retry@v2
+      - uses: codecov/codecov-action@v3
         with:
-          timeout_minutes: 10
-          retry_wait_seconds: 60
-          continue_on_error: true #12501
-          max_attempts: 3
-          command: curl https://codecov.io/bash -o codecov.sh && bash ./codecov.sh 
+          verbose: true

--- a/.github/workflows/tests_unit.yml
+++ b/.github/workflows/tests_unit.yml
@@ -110,13 +110,6 @@ jobs:
         with:
           arguments: --stop
 
-      - name: Submit Coverage
-        # This can fail on timeouts etc, wrap with retry
-        uses: nick-invision/retry@v2
+      - uses: codecov/codecov-action@v3
         with:
-          timeout_minutes: 10
-          retry_wait_seconds: 60
-          max_attempts: 3
-          continue_on_error: true #12501
-          shell: bash
-          command: curl https://codecov.io/bash -o codecov.sh && bash ./codecov.sh
+          verbose: true


### PR DESCRIPTION
## Pull Request template

## Purpose / Description

We are downloading the bash uploader then using it, dynamically, but codecov recommends using an ecosystem-specific (that is: github specific) uploader, which they provide

https://about.codecov.io/blog/codecov-uploader-deprecation-plan/

> Ecosystem specific Uploaders
> Codecov provides a series of wrappers for our uploader including
> 
> [Codecov Bitrise Step](https://www.bitrise.io/integrations/steps/codecov) (v3)
> [Codecov CircleCI Orb](https://circleci.com/developer/orbs/orb/codecov/codecov) (v2)
> [Codecov GitHub Action](https://github.com/marketplace/actions/codecov) (v2)


## Fixes

CI system deprecation

## Approach
Do the thing people recommend that you do

## How Has This Been Tested?

The PR unit and emulator tests will upload or not, on this PR
But I've made this change in other repos and it works fine

## Learning (optional, can help others)
The only constant is change

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
