### PR TITLE
Move unrelated code from CollectionTask

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
@@ -72,7 +72,7 @@ import com.ichi2.anki.servicelayer.LanguageHintService.applyLanguageHint
 import com.ichi2.anki.servicelayer.NoteService.isMarked
 import com.ichi2.anki.servicelayer.SchedulerService.*
 import com.ichi2.anki.servicelayer.TaskListenerBuilder
-import com.ichi2.anki.servicelayer.UndoService.Undo
+import com.ichi2.anki.servicelayer.Undo
 import com.ichi2.anki.snackbar.SnackbarBuilder
 import com.ichi2.anki.snackbar.showSnackbar
 import com.ichi2.annotations.NeedsTest

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -63,7 +63,7 @@ import com.ichi2.anki.servicelayer.SchedulerService.NextCard
 import com.ichi2.anki.servicelayer.SchedulerService.RepositionCards
 import com.ichi2.anki.servicelayer.SchedulerService.RescheduleCards
 import com.ichi2.anki.servicelayer.SchedulerService.ResetCards
-import com.ichi2.anki.servicelayer.UndoService.Undo
+import com.ichi2.anki.servicelayer.Undo
 import com.ichi2.anki.servicelayer.avgIntervalOfNote
 import com.ichi2.anki.servicelayer.totalLapsesOfNote
 import com.ichi2.anki.servicelayer.totalReviewsForNote

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -91,7 +91,7 @@ import com.ichi2.anki.servicelayer.ScopedStorageService.getBestDefaultRootDirect
 import com.ichi2.anki.servicelayer.ScopedStorageService.isLegacyStorage
 import com.ichi2.anki.servicelayer.ScopedStorageService.migrateEssentialFiles
 import com.ichi2.anki.servicelayer.ScopedStorageService.userMigrationIsInProgress
-import com.ichi2.anki.servicelayer.UndoService.Undo
+import com.ichi2.anki.servicelayer.Undo
 import com.ichi2.anki.snackbar.showSnackbar
 import com.ichi2.anki.stats.AnkiStatsTaskHandler
 import com.ichi2.anki.web.CustomSyncServer

--- a/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsFragment.kt
@@ -37,7 +37,7 @@ import com.ichi2.anim.ActivityTransitionAnimation.slide
 import com.ichi2.anki.CollectionManager.withCol
 import com.ichi2.anki.dialogs.customstudy.CustomStudyDialog
 import com.ichi2.anki.servicelayer.ComputeResult
-import com.ichi2.anki.servicelayer.UndoService.Undo
+import com.ichi2.anki.servicelayer.Undo
 import com.ichi2.anki.snackbar.showSnackbar
 import com.ichi2.annotations.NeedsTest
 import com.ichi2.async.CollectionTask.*

--- a/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/Undo.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/Undo.kt
@@ -22,19 +22,17 @@ import com.ichi2.async.CollectionTask
 import com.ichi2.utils.Computation
 import timber.log.Timber
 
-class UndoService {
-    class Undo : ActionAndNextCard() {
-        override fun execute(): ComputeResult {
-            return try {
-                val card = col.db.executeInTransaction {
-                    CollectionTask.nonTaskUndo(col)
-                }
-                Computation.ok(NextCard.withNoResult(card))
-            } catch (e: RuntimeException) {
-                Timber.e(e, "doInBackgroundUndo - RuntimeException on undoing")
-                CrashReportService.sendExceptionReport(e, "doInBackgroundUndo")
-                Computation.err()
+class Undo : ActionAndNextCard() {
+    override fun execute(): ComputeResult {
+        return try {
+            val card = col.db.executeInTransaction {
+                CollectionTask.nonTaskUndo(col)
             }
+            Computation.ok(NextCard.withNoResult(card))
+        } catch (e: RuntimeException) {
+            Timber.e(e, "doInBackgroundUndo - RuntimeException on undoing")
+            CrashReportService.sendExceptionReport(e, "doInBackgroundUndo")
+            Computation.err()
         }
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.kt
@@ -19,7 +19,6 @@
 package com.ichi2.async
 
 import android.content.Context
-import androidx.annotation.VisibleForTesting
 import com.fasterxml.jackson.core.JsonToken
 import com.ichi2.anki.*
 import com.ichi2.anki.AnkiSerialization.factory
@@ -380,28 +379,6 @@ open class CollectionTask<Progress, Result>(val task: TaskDelegateBase<Progress,
         override fun task(col: Collection, collectionTask: ProgressSenderAndCancelListener<Void>): Void? {
             col.sched.reset()
             return null
-        }
-    }
-
-    companion object {
-        @JvmStatic
-        @VisibleForTesting
-        fun nonTaskUndo(col: Collection): Card? {
-            val sched = col.sched
-            val card = col.undo()
-            if (card == null) {
-                /* multi-card action undone, no action to take here */
-                Timber.d("Multi-select undo succeeded")
-            } else {
-                // cid is actually a card id.
-                // a review was undone,
-                /* card review undone, set up to review that card again */
-                Timber.d("Single card review undo succeeded")
-                card.startTimer()
-                col.reset()
-                sched.deferReset(card)
-            }
-            return card
         }
     }
 }

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/sched/AbstractSchedTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/sched/AbstractSchedTest.kt
@@ -18,7 +18,7 @@ package com.ichi2.libanki.sched
 import com.ichi2.anki.RobolectricTest
 import com.ichi2.anki.exception.ConfirmModSchemaException
 import com.ichi2.anki.servicelayer.Undo
-import com.ichi2.async.CollectionTask.Companion.nonTaskUndo
+import com.ichi2.anki.servicelayer.Undo.Companion.nonTaskUndo
 import com.ichi2.libanki.*
 import com.ichi2.libanki.utils.TimeManager.time
 import com.ichi2.testutils.AnkiAssert

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/sched/AbstractSchedTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/sched/AbstractSchedTest.kt
@@ -17,7 +17,7 @@ package com.ichi2.libanki.sched
 
 import com.ichi2.anki.RobolectricTest
 import com.ichi2.anki.exception.ConfirmModSchemaException
-import com.ichi2.anki.servicelayer.UndoService.Undo
+import com.ichi2.anki.servicelayer.Undo
 import com.ichi2.async.CollectionTask.Companion.nonTaskUndo
 import com.ichi2.libanki.*
 import com.ichi2.libanki.utils.TimeManager.time


### PR DESCRIPTION
## Purpose / Description

Moves the nonTaskUndo() method from CollectionTask to eliminate unrelated code and make it easier to delete the class. Also deletes the UndoService wrapper class for Undo as it was unused and not really needed.

## How Has This Been Tested?

Ran the tests.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
