### PR TITLE
Migrate the DeleteField task to coroutine

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.kt
@@ -335,24 +335,6 @@ open class CollectionTask<Progress, Result>(val task: TaskDelegateBase<Progress,
     }
 
     /**
-     * Deletes the given field in the given model
-     */
-    class DeleteField(private val model: Model, private val field: JSONObject) : TaskDelegate<Void, Boolean>() {
-        override fun task(col: Collection, collectionTask: ProgressSenderAndCancelListener<Void>): Boolean {
-            Timber.d("doInBackGroundDeleteField")
-            try {
-                col.models.remField(model, field)
-                col.save()
-            } catch (e: ConfirmModSchemaException) {
-                // Should never be reached
-                e.log()
-                return false
-            }
-            return true
-        }
-    }
-
-    /**
      * Repositions the given field in the given model
      */
     class RepositionField(private val model: Model, private val field: JSONObject, private val index: Int) : TaskDelegate<Void, Boolean>() {


### PR DESCRIPTION
## Purpose / Description

Part of #7108. The minimum amount of work to migrate this task to coroutine to remove it from CollectionTask. There's no need for extra refactoring or TODOs as the enclosing class, ModelFieldEditor, will be removed in the future.

## How Has This Been Tested?

Ran the tests, manually verified the app.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
