### PR TITLE
Remove "SD cards" from strings Fix #12777

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -1805,7 +1805,7 @@ open class DeckPicker :
                             showSyncErrorMessage(joinSyncMessages(dialogMessage, syncMessage))
                         }
                         ConnectionResultType.SD_ACCESS_ERROR -> {
-                            dialogMessage = res.getString(R.string.sync_write_access_error)
+                            dialogMessage = res.getString(R.string.sync_write_access_error_on_storage)
                             showSyncErrorMessage(joinSyncMessages(dialogMessage, syncMessage))
                         }
                         ConnectionResultType.FINISH_ERROR -> {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckPickerBackupNoSpaceLeftDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckPickerBackupNoSpaceLeftDialog.kt
@@ -30,8 +30,8 @@ class DeckPickerBackupNoSpaceLeftDialog : AnalyticsDialogFragment() {
         val res = resources
         val space = BackupManager.getFreeDiscSpace(CollectionHelper.getCollectionPath(requireActivity()))
         return MaterialDialog(requireActivity()).show {
-            title(R.string.sd_card_almost_full_title)
-            message(text = res.getString(R.string.sd_space_warning, space / 1024 / 1024))
+            title(R.string.storage_almost_full_title)
+            message(text = res.getString(R.string.storage_warning, space / 1024 / 1024))
             positiveButton(R.string.dialog_ok) {
                 (activity as DeckPicker).finishWithoutAnimation()
             }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckPickerNoSpaceLeftDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckPickerNoSpaceLeftDialog.kt
@@ -26,8 +26,8 @@ class DeckPickerNoSpaceLeftDialog : AnalyticsDialogFragment() {
     override fun onCreateDialog(savedInstanceState: Bundle?): MaterialDialog {
         super.onCreate(savedInstanceState)
         return MaterialDialog(requireActivity()).show {
-            title(R.string.sd_card_full_title)
-            message(R.string.backup_deck_no_space_left)
+            title(R.string.storage_full_title)
+            message(R.string.backup_deck_no_storage_left)
             cancelable(true)
             positiveButton(R.string.dialog_ok) {
                 (activity as DeckPicker).startLoadingCollection()

--- a/AnkiDroid/src/main/res/values/03-dialogs.xml
+++ b/AnkiDroid/src/main/res/values/03-dialogs.xml
@@ -97,7 +97,11 @@
     </plurals>
 
     <string name="sd_card_full_title">SD card full</string>
+    <!-- New key for above string (to avoid term SD card)-->
+    <string name="storage_full_title">Storage full</string>
     <string name="sd_card_almost_full_title">SD card almost full</string>
+    <!-- New key for above string (to avoid term SD card)-->
+    <string name="storage_almost_full_title">Storage almost full</string>
     <string name="no_space_to_downgrade_title">No space</string>
     <string name="no_space_to_downgrade_content">AnkiDroid needs %s free storage space to continue. Please clear some space</string>
 

--- a/AnkiDroid/src/main/res/values/03-dialogs.xml
+++ b/AnkiDroid/src/main/res/values/03-dialogs.xml
@@ -97,10 +97,8 @@
     </plurals>
 
     <string name="sd_card_full_title">SD card full</string>
-    <!-- New key for above string (to avoid term SD card)-->
     <string name="storage_full_title">Storage full</string>
     <string name="sd_card_almost_full_title">SD card almost full</string>
-    <!-- New key for above string (to avoid term SD card)-->
     <string name="storage_almost_full_title">Storage almost full</string>
     <string name="no_space_to_downgrade_title">No space</string>
     <string name="no_space_to_downgrade_content">AnkiDroid needs %s free storage space to continue. Please clear some space</string>

--- a/AnkiDroid/src/main/res/values/03-dialogs.xml
+++ b/AnkiDroid/src/main/res/values/03-dialogs.xml
@@ -96,9 +96,7 @@
         <item quantity="other">Files imported: %1$d\nTotal cards imported: %2$d</item>
     </plurals>
 
-    <string name="sd_card_full_title">SD card full</string>
     <string name="storage_full_title">Storage full</string>
-    <string name="sd_card_almost_full_title">SD card almost full</string>
     <string name="storage_almost_full_title">Storage almost full</string>
     <string name="no_space_to_downgrade_title">No space</string>
     <string name="no_space_to_downgrade_content">AnkiDroid needs %s free storage space to continue. Please clear some space</string>

--- a/AnkiDroid/src/main/res/values/04-network.xml
+++ b/AnkiDroid/src/main/res/values/04-network.xml
@@ -64,7 +64,7 @@
     <string name="sync_remote_db_error">The downloaded database was corrupt. Please try again.</string>
     <string name="sync_overwrite_error">Your current collection couldn’t be overwritten by the downloaded file</string>
     <string name="sync_connection_error">Connection timed out. Either your internet connection is experiencing problems, or you have a very large file in your media folder.</string>
-    <string name="sync_write_access_error_on_storage">The downloaded file couldn’t be saved to your storage. Either the storage is mounted read-only or there isn’t enough space.</string>
+    <string name="sync_write_access_error_on_storage">The downloaded file couldn’t be saved to your storage. Either the storage is read-only or there isn’t enough space.</string>
     <string name="sync_error_invalid_sync_server">The Custom Sync Server in Advanced Settings is invalid (%s). Please enter a valid server, or disable the setting.</string>
     <string name="sync_deletions_message">Syncing deletions…</string>
     <string name="sync_small_objects_message">Syncing small objects…</string>

--- a/AnkiDroid/src/main/res/values/04-network.xml
+++ b/AnkiDroid/src/main/res/values/04-network.xml
@@ -65,7 +65,6 @@
     <string name="sync_overwrite_error">Your current collection couldn’t be overwritten by the downloaded file</string>
     <string name="sync_connection_error">Connection timed out. Either your internet connection is experiencing problems, or you have a very large file in your media folder.</string>
     <string name="sync_write_access_error">The downloaded file couldn’t be saved to the SD card. Either the card is mounted read-only or there isn’t enough space.</string>
-    <!-- New key for above string (to avoid term SD Card)-->
     <string name="sync_write_access_error_on_storage">The downloaded file couldn’t be saved to your storage. Either the storage is mounted read-only or there isn’t enough space.</string>
     <string name="sync_error_invalid_sync_server">The Custom Sync Server in Advanced Settings is invalid (%s). Please enter a valid server, or disable the setting.</string>
     <string name="sync_deletions_message">Syncing deletions…</string>

--- a/AnkiDroid/src/main/res/values/04-network.xml
+++ b/AnkiDroid/src/main/res/values/04-network.xml
@@ -64,7 +64,6 @@
     <string name="sync_remote_db_error">The downloaded database was corrupt. Please try again.</string>
     <string name="sync_overwrite_error">Your current collection couldn’t be overwritten by the downloaded file</string>
     <string name="sync_connection_error">Connection timed out. Either your internet connection is experiencing problems, or you have a very large file in your media folder.</string>
-    <string name="sync_write_access_error">The downloaded file couldn’t be saved to the SD card. Either the card is mounted read-only or there isn’t enough space.</string>
     <string name="sync_write_access_error_on_storage">The downloaded file couldn’t be saved to your storage. Either the storage is mounted read-only or there isn’t enough space.</string>
     <string name="sync_error_invalid_sync_server">The Custom Sync Server in Advanced Settings is invalid (%s). Please enter a valid server, or disable the setting.</string>
     <string name="sync_deletions_message">Syncing deletions…</string>

--- a/AnkiDroid/src/main/res/values/04-network.xml
+++ b/AnkiDroid/src/main/res/values/04-network.xml
@@ -65,6 +65,8 @@
     <string name="sync_overwrite_error">Your current collection couldn’t be overwritten by the downloaded file</string>
     <string name="sync_connection_error">Connection timed out. Either your internet connection is experiencing problems, or you have a very large file in your media folder.</string>
     <string name="sync_write_access_error">The downloaded file couldn’t be saved to the SD card. Either the card is mounted read-only or there isn’t enough space.</string>
+    <!-- New key for above string (to avoid term SD Card)-->
+    <string name="sync_write_access_error_on_storage">The downloaded file couldn’t be saved to your storage. Either the storage is mounted read-only or there isn’t enough space.</string>
     <string name="sync_error_invalid_sync_server">The Custom Sync Server in Advanced Settings is invalid (%s). Please enter a valid server, or disable the setting.</string>
     <string name="sync_deletions_message">Syncing deletions…</string>
     <string name="sync_small_objects_message">Syncing small objects…</string>

--- a/AnkiDroid/src/main/res/values/09-backup.xml
+++ b/AnkiDroid/src/main/res/values/09-backup.xml
@@ -21,7 +21,6 @@
 
     <string name="backup_deck_no_space_left">Backup not saved. Not enough space left on SD card. Lower the backup depth or remove some other files.</string>
     <string name="backup_deck_no_storage_left">Backup not saved. Not enough space left on Storage. Lower the backup depth or remove some other files.</string>
-    <string name="sd_space_warning">Less than %d MB space on your SD card left.\nFree some space to avoid data loss.</string>
     <string name="storage_warning">Less than %d MB space on your storage left.\nFree some space to avoid data loss.</string>
     <string name="backup_restore">Restore from backup</string>
     <string name="backup_new_collection">New collection</string>

--- a/AnkiDroid/src/main/res/values/09-backup.xml
+++ b/AnkiDroid/src/main/res/values/09-backup.xml
@@ -18,8 +18,7 @@
 ~ You should have received a copy of the GNU General Public License along with
 ~ this program.  If not, see <http://www.gnu.org/licenses/>.
 --><resources>
-
-    <string name="backup_deck_no_space_left">Backup not saved. Not enough space left on SD card. Lower the backup depth or remove some other files.</string>
+    
     <string name="backup_deck_no_storage_left">Backup not saved. Not enough space left on Storage. Lower the backup depth or remove some other files.</string>
     <string name="storage_warning">Less than %d MB space on your storage left.\nFree some space to avoid data loss.</string>
     <string name="backup_restore">Restore from backup</string>

--- a/AnkiDroid/src/main/res/values/09-backup.xml
+++ b/AnkiDroid/src/main/res/values/09-backup.xml
@@ -18,8 +18,8 @@
 ~ You should have received a copy of the GNU General Public License along with
 ~ this program.  If not, see <http://www.gnu.org/licenses/>.
 --><resources>
-    
-    <string name="backup_deck_no_storage_left">Backup not saved. Not enough space left on Storage. Lower the backup depth or remove some other files.</string>
+
+    <string name="backup_deck_no_storage_left">Backup not saved. Not enough space left on your storage. Lower the backup depth or remove some other files.</string>
     <string name="storage_warning">Less than %d MB space on your storage left.\nFree some space to avoid data loss.</string>
     <string name="backup_restore">Restore from backup</string>
     <string name="backup_new_collection">New collection</string>

--- a/AnkiDroid/src/main/res/values/09-backup.xml
+++ b/AnkiDroid/src/main/res/values/09-backup.xml
@@ -20,7 +20,11 @@
 --><resources>
 
     <string name="backup_deck_no_space_left">Backup not saved. Not enough space left on SD card. Lower the backup depth or remove some other files.</string>
+    <!-- New key for above string (to avoid term SD card)-->
+    <string name="backup_deck_no_storage_left">Backup not saved. Not enough space left on Storage. Lower the backup depth or remove some other files.</string>
     <string name="sd_space_warning">Less than %d MB space on your SD card left.\nFree some space to avoid data loss.</string>
+    <!-- New key for above string (to avoid term SD Card)-->
+    <string name="storage_warning">Less than %d MB space on your storage left.\nFree some space to avoid data loss.</string>
     <string name="backup_restore">Restore from backup</string>
     <string name="backup_new_collection">New collection</string>
     <string name="backup_del_collection">Delete collection and create new one</string>

--- a/AnkiDroid/src/main/res/values/09-backup.xml
+++ b/AnkiDroid/src/main/res/values/09-backup.xml
@@ -20,10 +20,8 @@
 --><resources>
 
     <string name="backup_deck_no_space_left">Backup not saved. Not enough space left on SD card. Lower the backup depth or remove some other files.</string>
-    <!-- New key for above string (to avoid term SD card)-->
     <string name="backup_deck_no_storage_left">Backup not saved. Not enough space left on Storage. Lower the backup depth or remove some other files.</string>
     <string name="sd_space_warning">Less than %d MB space on your SD card left.\nFree some space to avoid data loss.</string>
-    <!-- New key for above string (to avoid term SD Card)-->
     <string name="storage_warning">Less than %d MB space on your storage left.\nFree some space to avoid data loss.</string>
     <string name="backup_restore">Restore from backup</string>
     <string name="backup_new_collection">New collection</string>


### PR DESCRIPTION
As intended, I have followed the first preference as suggested by @mikehardy  and @Arthur-Milchior  and made the following changes.

Changes include creating new keys for the strings as follows:

    <string name="backup_deck_no_space_left">Backup not saved. Not enough space left on SD card. Lower the backup depth or remove some other files.</string>
    <string name="sd_space_warning">Less than %d MB space on your SD card left.\nFree some space to avoid data loss.</string>
    <string name="sync_write_access_error">The downloaded file couldn’t be saved to the SD card. Either the card is mounted read-only or there isn’t enough space.</string>
    <string name="sd_card_full_title">SD card full</string>
    <string name="sd_card_almost_full_title">SD card almost full</string>
    
    
The term "SD Card" is now Storage for the users on the applications.