### PR TITLE
Migrate the RepositionField task to coroutine

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/ModelFieldEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ModelFieldEditor.kt
@@ -357,11 +357,10 @@ class ModelFieldEditor : AnkiActivity(), LocaleSelectionDialogHandler {
                     if (pos < 1 || pos > mFieldsLabels.size) {
                         showThemedToast(this@ModelFieldEditor, resources.getString(R.string.toast_out_of_range), true)
                     } else {
-                        val listener = changeFieldHandler()
                         // Input is valid, now attempt to modify
                         try {
                             collection.modSchema()
-                            TaskManager.launchCollectionTask(RepositionField(mModel, mNoteFields.getJSONObject(currentPos), pos - 1), listener)
+                            repositionField(pos - 1)
                         } catch (e: ConfirmModSchemaException) {
                             e.log()
 
@@ -371,13 +370,7 @@ class ModelFieldEditor : AnkiActivity(), LocaleSelectionDialogHandler {
                             val confirm = Runnable {
                                 try {
                                     collection.modSchemaNoCheck()
-                                    TaskManager.launchCollectionTask(
-                                        RepositionField(
-                                            mModel,
-                                            mNoteFields.getJSONObject(currentPos), pos - 1
-                                        ),
-                                        listener
-                                    )
+                                    repositionField(pos - 1)
                                 } catch (e1: JSONException) {
                                     throw RuntimeException(e1)
                                 }
@@ -391,6 +384,13 @@ class ModelFieldEditor : AnkiActivity(), LocaleSelectionDialogHandler {
             }
                 .displayKeyboard(_fieldNameInput)
         }
+    }
+
+    private fun repositionField(index: Int) {
+        TaskManager.launchCollectionTask(
+            RepositionField(mModel, mNoteFields.getJSONObject(currentPos), index),
+            changeFieldHandler()
+        )
     }
 
     // ----------------------------------------------------------------------------

--- a/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.kt
@@ -22,7 +22,6 @@ import android.content.Context
 import com.fasterxml.jackson.core.JsonToken
 import com.ichi2.anki.*
 import com.ichi2.anki.AnkiSerialization.factory
-import com.ichi2.anki.exception.ConfirmModSchemaException
 import com.ichi2.anki.exception.ImportExportException
 import com.ichi2.libanki.*
 import com.ichi2.libanki.Collection
@@ -33,7 +32,6 @@ import com.ichi2.libanki.sched.TreeNode
 import com.ichi2.utils.Computation
 import com.ichi2.utils.KotlinCleanup
 import org.apache.commons.compress.archivers.zip.ZipFile
-import org.json.JSONObject
 import timber.log.Timber
 import java.io.File
 import java.io.FileNotFoundException
@@ -330,24 +328,6 @@ open class CollectionTask<Progress, Result>(val task: TaskDelegateBase<Progress,
                 }
             }
             return Computation.OK
-        }
-    }
-
-    /**
-     * Repositions the given field in the given model
-     */
-    class RepositionField(private val model: Model, private val field: JSONObject, private val index: Int) : TaskDelegate<Void, Boolean>() {
-        override fun task(col: Collection, collectionTask: ProgressSenderAndCancelListener<Void>): Boolean {
-            Timber.d("doInBackgroundRepositionField")
-            try {
-                col.models.moveField(model, field, index)
-                col.save()
-            } catch (e: ConfirmModSchemaException) {
-                e.log()
-                // Should never be reached
-                return false
-            }
-            return true
         }
     }
 


### PR DESCRIPTION
## Purpose / Description

~~Blocked by #12781 so the task hander could also be deleted(first two commits are from that PR).~~

Part of https://github.com/ankidroid/Anki-Android/issues/7108. The minimum amount of work to migrate this task to coroutine to remove it from CollectionTask. There's no need for extra refactoring or TODOs as the enclosing class, ModelFieldEditor, will be removed in the future.

## How Has This Been Tested?

Ran the tests, manually verified the app.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
