### PR TITLE
Capitalize the first letter of ”yes” of alert dialog button

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -2532,7 +2532,7 @@ open class DeckPicker :
         private fun confirmCancel(deckPicker: DeckPicker, task: Cancellable) {
             MaterialDialog(deckPicker).show {
                 message(R.string.confirm_cancel)
-                positiveButton(R.string.yes) {
+                positiveButton(R.string.dialog_yes) {
                     actualOnPreExecute(deckPicker)
                 }
                 negativeButton(R.string.dialog_no) {

--- a/AnkiDroid/src/main/res/values/01-core.xml
+++ b/AnkiDroid/src/main/res/values/01-core.xml
@@ -18,7 +18,6 @@
 ~ You should have received a copy of the GNU General Public License along with
 ~ this program.  If not, see <http://www.gnu.org/licenses/>.
 --><resources>
-    <string name="yes">yes</string>
     <!-- Navigation drawer items-->
     <string name="decks">Decks</string>
     <string name="card_browser" comment="The usage of card browser inside the app (note the casing)">Card browser</string>

--- a/AnkiDroid/src/main/res/values/03-dialogs.xml
+++ b/AnkiDroid/src/main/res/values/03-dialogs.xml
@@ -109,6 +109,7 @@
     <string name="dialog_ok">OK</string>
     <string name="dialog_confirm">Confirm</string>
     <string name="dialog_no">No</string>
+    <stringname="dialog_yes">Yes</string>
     <string name="dialog_continue">Continue</string>
     <string name="dialog_processing">Processing...</string>
     <string name="dialog_positive_create" comment="Create a new collection, probably erasing the previous one, may be necessary in case of error.">Create</string>

--- a/AnkiDroid/src/main/res/values/03-dialogs.xml
+++ b/AnkiDroid/src/main/res/values/03-dialogs.xml
@@ -109,7 +109,7 @@
     <string name="dialog_ok">OK</string>
     <string name="dialog_confirm">Confirm</string>
     <string name="dialog_no">No</string>
-    <stringname="dialog_yes">Yes</string>
+    <string name="dialog_yes">Yes</string>
     <string name="dialog_continue">Continue</string>
     <string name="dialog_processing">Processing...</string>
     <string name="dialog_positive_create" comment="Create a new collection, probably erasing the previous one, may be necessary in case of error.">Create</string>


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
Capitalize the first letter of ”yes” of alert dialog button of "Empty cards" feature
![image](https://user-images.githubusercontent.com/10436072/200163214-2ad51384-bc81-464b-9ee0-8593427e4fac.png)


## Fixes
Fixes #12788

## Approach
- Create a new string of "Yes" for alert dialog on 03-dialog.xml
- Replace the current string ("yes") with the new one above ("Yes") on Deckpicker.kt
- Remove the current string ("yes") on 01-core.xml

## How Has This Been Tested?
Checked on a physical device
![image](https://user-images.githubusercontent.com/10436072/200163309-fdc5ebba-e729-4540-9111-23e96c768849.png)


## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
