### PR TITLE
fix "yes" and "no" actions in Empty Cards alert dialog

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -2533,10 +2533,10 @@ open class DeckPicker :
             MaterialDialog(deckPicker).show {
                 message(R.string.confirm_cancel)
                 positiveButton(R.string.yes) {
-                    actualOnPreExecute(deckPicker)
+                    task.safeCancel()
                 }
                 negativeButton(R.string.dialog_no) {
-                    task.safeCancel()
+                    actualOnPreExecute(deckPicker)
                 }
             }
         }


### PR DESCRIPTION
## Purpose / Description
fix "yes" and "no" actions in Empty Cards alert dialog which appears to be switched.

## Fixes
Fixes #12790