### PR TITLE
Unbury without loop

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/BaseSched.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/BaseSched.kt
@@ -155,7 +155,7 @@ abstract class BaseSched(val col: Collection) {
     /**
      * Unbury all buried cards in all decks. Only used for tests.
      */
-    fun unburyCards() {
+    open fun unburyCards() {
         for (did in col.decks.allIds()) {
             unburyCardsForDeck(did)
         }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/BaseSched.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/BaseSched.kt
@@ -113,7 +113,8 @@ abstract class BaseSched(val col: Collection) {
 
     /**
      * Unbury cards.
-     * @param type Which kind of cards should be unburied.
+     * @param type Which kind of cards should be unburied. See [UnburyType]
+     * @param did: the deck whose cards must be unburied
      */
     open fun unburyCardsForDeck(did: DeckId, type: UnburyType = UnburyType.ALL) {
         val mode = when (type) {
@@ -124,8 +125,24 @@ abstract class BaseSched(val col: Collection) {
         col.newBackend.backend.unburyDeck(deckId = did, mode = mode)
     }
 
+    /**
+     * Parameter to describe what kind of cards must be unburied.
+     */
     enum class UnburyType {
-        ALL, MANUAL, SIBLINGS
+        /**
+         * Represents all buried cards
+         */
+        ALL,
+
+        /**
+         * Represents cards that have been buried explicitly by the user using the reviewer
+         */
+        MANUAL,
+
+        /**
+         * Represents cards that were buried because they are the siblings of a reviewed cards.
+         */
+        SIBLINGS
     }
 
     /**

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.kt
@@ -2211,7 +2211,7 @@ end)  """
      * Unbury the cards of deck [did] and its descendants.
      * @param type See [UnburyType]
      */
-     override fun unburyCardsForDeck(did: Long, type: UnburyType) {
+    override fun unburyCardsForDeck(did: Long, type: UnburyType) {
         if (!BackendFactory.defaultLegacySchema) {
             super.unburyCardsForDeck(did, type)
             return
@@ -2224,22 +2224,30 @@ end)  """
     /**
      * Unbury the cards of some decks.
      * @param type See [UnburyType]
-     * @param allDecks the decks from which cards should be unburied.
+     * @param allDecks the decks from which cards should be unburied. If None, unbury for all decks.
      * Only cards directly in a deck of this lists are considered, not subdecks.
      */
-    fun unburyCardsForDeck(type: UnburyType, allDecks: List<Long>) {
+    fun unburyCardsForDeck(type: UnburyType, allDecks: List<Long>?) {
         @Language("SQL")
         val queue = when (type) {
             UnburyType.ALL -> queueIsBuriedSnippet()
             UnburyType.MANUAL -> "queue = " + Consts.QUEUE_TYPE_MANUALLY_BURIED
             UnburyType.SIBLINGS -> "queue = " + Consts.QUEUE_TYPE_SIBLING_BURIED
         }
-        val sids = Utils.ids2str(allDecks)
-        col.log(col.db.queryLongList("select id from cards where $queue and did in $sids"))
+        val deckConstraint = if (allDecks == null) {
+            ""
+        } else {
+            " and did in " + Utils.ids2str(allDecks)
+        }
+        col.log(col.db.queryLongList("select id from cards where $queue $deckConstraint"))
         col.db.execute(
-            "update cards set mod=?,usn=?, " + _restoreQueueSnippet() + " where " + queue + " and did in " + sids,
+            "update cards set mod=?,usn=?, " + _restoreQueueSnippet() + " where " + queue + deckConstraint,
             time.intTime(), col.usn()
         )
+    }
+
+    override fun unburyCards() {
+        unburyCardsForDeck(UnburyType.ALL, null)
     }
 
     /**

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.kt
@@ -46,6 +46,7 @@ import com.ichi2.libanki.utils.TimeManager
 import com.ichi2.utils.*
 import net.ankiweb.rsdroid.BackendFactory
 import net.ankiweb.rsdroid.RustCleanup
+import org.intellij.lang.annotations.Language
 import org.json.JSONArray
 import org.json.JSONException
 import org.json.JSONObject
@@ -2188,6 +2189,9 @@ end)  """
     }
 
     // Overridden: V1 also remove from dyns and lrn
+    /**
+     * Bury all cards with id in cids. Set as manual bury if [manual]
+     */
     @VisibleForTesting
     override fun buryCards(cids: LongArray, manual: Boolean) {
         if (!BackendFactory.defaultLegacySchema) {
@@ -2203,7 +2207,11 @@ end)  """
         )
     }
 
-    override fun unburyCardsForDeck(did: Long, type: UnburyType) {
+    /**
+     * Unbury the cards of deck [did] and its descendants.
+     * @param type See [UnburyType]
+     */
+     override fun unburyCardsForDeck(did: Long, type: UnburyType) {
         if (!BackendFactory.defaultLegacySchema) {
             super.unburyCardsForDeck(did, type)
             return
@@ -2213,9 +2221,15 @@ end)  """
         unburyCardsForDeck(type, dids)
     }
 
+    /**
+     * Unbury the cards of some decks.
+     * @param type See [UnburyType]
+     * @param allDecks the decks from which cards should be unburied. If [null], then default to active decks.
+     * Only cards directly in a deck of this lists are considered, not subdecks.
+     */
     fun unburyCardsForDeck(type: UnburyType, allDecks: List<Long>?) {
-        val queue: String
-        queue = when (type) {
+        @Language("SQL")
+        val queue = when (type) {
             UnburyType.ALL -> queueIsBuriedSnippet()
             UnburyType.MANUAL -> "queue = " + Consts.QUEUE_TYPE_MANUALLY_BURIED
             UnburyType.SIBLINGS -> "queue = " + Consts.QUEUE_TYPE_SIBLING_BURIED

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.kt
@@ -2224,17 +2224,17 @@ end)  """
     /**
      * Unbury the cards of some decks.
      * @param type See [UnburyType]
-     * @param allDecks the decks from which cards should be unburied. If [null], then default to active decks.
+     * @param allDecks the decks from which cards should be unburied.
      * Only cards directly in a deck of this lists are considered, not subdecks.
      */
-    fun unburyCardsForDeck(type: UnburyType, allDecks: List<Long>?) {
+    fun unburyCardsForDeck(type: UnburyType, allDecks: List<Long>) {
         @Language("SQL")
         val queue = when (type) {
             UnburyType.ALL -> queueIsBuriedSnippet()
             UnburyType.MANUAL -> "queue = " + Consts.QUEUE_TYPE_MANUALLY_BURIED
             UnburyType.SIBLINGS -> "queue = " + Consts.QUEUE_TYPE_SIBLING_BURIED
         }
-        val sids = Utils.ids2str(allDecks ?: col.decks.active())
+        val sids = Utils.ids2str(allDecks)
         col.log(col.db.queryLongList("select id from cards where $queue and did in $sids"))
         col.db.execute(
             "update cards set mod=?,usn=?, " + _restoreQueueSnippet() + " where " + queue + " and did in " + sids,


### PR DESCRIPTION
AnkiDroid takes minutes to start on my collection. That's because `unburyCards` iterate over each deck and unbury in them one by one instead of just doing a single unbury query.

I'd love your review @dae, since you introduced this implementation in 3c32c7669a95d03b23566e359e3c5e65d4c9a3e4 , removing the more efficient implementation in schedV1 and V2. If there was a reason to do so, I fail to see them, so I may be breaking some things I don't know about.
Also, I'm confused about why the comment states " Only used for tests." which is false as can indicate android studio.

I'm only doing the correction for V2, since I don't have access to V3. But I'd clearly appreciate for V3 not to do an explicit loop, otherwise this will be very slow again.

Simultaneously, I'm adding comment on unbury functions. And I'm removing a feature that was never actually used (having unbury default to the list of active decks)