### PR TITLE
Migrate the ImportAdd task to coroutine

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CoroutineHelpers.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CoroutineHelpers.kt
@@ -32,6 +32,7 @@ import com.ichi2.anki.snackbar.showSnackbar
 import com.ichi2.libanki.Collection
 import com.ichi2.utils.*
 import kotlinx.coroutines.*
+import kotlinx.coroutines.channels.Channel
 import net.ankiweb.rsdroid.Backend
 import net.ankiweb.rsdroid.BackendException
 import net.ankiweb.rsdroid.exceptions.BackendInterruptedException
@@ -255,7 +256,7 @@ suspend fun <T> Fragment.withProgress(@StringRes messageId: Int, block: suspend 
     requireActivity().withProgress(messageId, block)
 
 @Suppress("Deprecation") // ProgressDialog deprecation
-private suspend fun <T> withProgressDialog(
+suspend fun <T> withProgressDialog(
     context: Activity,
     onCancel: (() -> Unit)?,
     op: suspend (android.app.ProgressDialog) -> T
@@ -366,4 +367,23 @@ suspend fun AnkiActivity.userAcceptsSchemaChange(): Boolean {
         withCol { modSchemaNoCheck() }
     }
     return hasAcceptedSchemaChange
+}
+
+/**
+ * Create a [Channel] and provide it to the supplied action. There is no need to close the channel,
+ * it will be automatically closed on exceptions in the supplied action or when the function
+ * finishes normally.
+ *
+ * This is used as an alternative to the deprecated ProgressCallback class to enable communication
+ * between the (coroutines) background tasks and the UI(mainly for progress updates).
+ *
+ * @param action the action to run with the provided [Channel] as a parameter
+ */
+suspend fun<T, R> withChannel(action: suspend (Channel<T>) -> R): R {
+    val channel = Channel<T>()
+    return try {
+        action(channel)
+    } finally {
+        channel.close()
+    }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -1665,15 +1665,15 @@ open class DeckPicker :
         }
     }
 
-    private fun importAddPostTask(result: ImporterData?) {
-        if (mProgressDialog != null && mProgressDialog!!.isShowing) {
-            mProgressDialog!!.dismiss()
+    private fun importAddPostTask(result: ImporterData) {
+        mProgressDialog?.apply {
+            if (isShowing) dismiss()
         }
         // If result.errFlag and result are both set, we are signalling
         // some files were imported successfully & some errors occurred.
         // If result.impList is null & result.errList is set
         // we are signalling all the files which were selected threw error
-        if (result!!.impList == null && result.errList != null) {
+        if (result.impList == null && result.errList != null) {
             Timber.w("Import: Add Failed: %s", result.errList)
             showSimpleMessageDialog(result.errList)
         } else {
@@ -1687,7 +1687,7 @@ open class DeckPicker :
             for (data in result.impList!!) {
                 // Check if mLog is not null or empty
                 // If mLog is not null or empty that indicates an error has occurred.
-                if (data.log.isNullOrEmpty()) {
+                if (data.log.isEmpty()) {
                     fileCount += 1
                     totalCardCount += data.cardCount
                 } else { errorMsg += data.fileName + "\n" + data.log[0] + "\n" }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -80,6 +80,7 @@ import com.ichi2.anki.dialogs.customstudy.CustomStudyDialog
 import com.ichi2.anki.dialogs.customstudy.CustomStudyDialog.CustomStudyListener
 import com.ichi2.anki.dialogs.customstudy.CustomStudyDialogFactory
 import com.ichi2.anki.exception.ConfirmModSchemaException
+import com.ichi2.anki.exception.ImportExportException
 import com.ichi2.anki.export.ActivityExportingDelegate
 import com.ichi2.anki.export.ExportType
 import com.ichi2.anki.notetype.ManageNotetypes
@@ -109,6 +110,8 @@ import com.ichi2.compat.CompatHelper.Companion.sdkVersion
 import com.ichi2.libanki.*
 import com.ichi2.libanki.Collection
 import com.ichi2.libanki.Collection.CheckDatabaseResult
+import com.ichi2.libanki.importer.AnkiPackageImporter
+import com.ichi2.libanki.importer.ImportAddProgress
 import com.ichi2.libanki.sched.AbstractDeckTreeNode
 import com.ichi2.libanki.sched.DeckDueTreeNode
 import com.ichi2.libanki.sched.TreeNode
@@ -1607,9 +1610,99 @@ open class DeckPicker :
     override fun importAdd(importPath: List<String>) {
         Timber.d("importAdd() for file %s", importPath)
         if (BackendFactory.defaultLegacySchema) {
-            TaskManager.launchCollectionTask(ImportAdd(importPath), importAddListener())
+            importAddLegacy(importPath)
         } else {
             importApkgs(importPath)
+        }
+    }
+
+    private fun importAddLegacy(pathList: List<String>) {
+        launchCatchingTask {
+            val importerData = withProgressDialog(this@DeckPicker, null) { progressDialog ->
+                Timber.d("doInBackgroundImportAdd")
+                @Suppress("DEPRECATION")
+                progressDialog.setMessage(resources.getString(R.string.import_title))
+                withChannel { progressChannel ->
+                    launch {
+                        for (importAddProgress: ImportAddProgress in progressChannel) {
+                            // TODO the current code doesn't show the name of the file currently
+                            //  being imported. This filename is available in Anki2Importer to be
+                            //  passed in, but the displayed string needs to be modified as we are
+                            //  combining all data into a single string(this makes it difficult for
+                            //  the UI to show long filenames correctly)
+                            @Suppress("DEPRECATION")
+                            progressDialog.setMessage(
+                                getString(
+                                    R.string.import_progress,
+                                    importAddProgress.notesDone,
+                                    importAddProgress.cardsDone,
+                                    importAddProgress.postProcess
+                                )
+                            )
+                        }
+                    }
+                    withCol {
+                        val impList = arrayListOf<AnkiPackageImporter>()
+                        val errBuilder = StringBuilder()
+
+                        for (path in pathList) {
+                            val imp = AnkiPackageImporter(this, path)
+                            imp.setProgressCallback(progressChannel)
+                            try {
+                                imp.run()
+                                impList.add(imp)
+                            } catch (e: ImportExportException) {
+                                Timber.w(e)
+                                errBuilder.append(File(path).name, "\n", e.message, "\n")
+                            }
+                        }
+                        val errList = if (errBuilder.isEmpty()) null else errBuilder.toString()
+                        ImporterData(if (impList.isEmpty()) null else impList, errList)
+                    }
+                }
+            }
+            importAddPostTask(importerData)
+        }
+    }
+
+    private fun importAddPostTask(result: ImporterData?) {
+        if (mProgressDialog != null && mProgressDialog!!.isShowing) {
+            mProgressDialog!!.dismiss()
+        }
+        // If result.errFlag and result are both set, we are signalling
+        // some files were imported successfully & some errors occurred.
+        // If result.impList is null & result.errList is set
+        // we are signalling all the files which were selected threw error
+        if (result!!.impList == null && result.errList != null) {
+            Timber.w("Import: Add Failed: %s", result.errList)
+            showSimpleMessageDialog(result.errList)
+        } else {
+            Timber.i("Import: Add succeeded")
+
+            var fileCount = 0
+            var totalCardCount = 0
+
+            var errorMsg = ""
+
+            for (data in result.impList!!) {
+                // Check if mLog is not null or empty
+                // If mLog is not null or empty that indicates an error has occurred.
+                if (data.log.isNullOrEmpty()) {
+                    fileCount += 1
+                    totalCardCount += data.cardCount
+                } else { errorMsg += data.fileName + "\n" + data.log[0] + "\n" }
+            }
+
+            var dialogMsg = resources.getQuantityString(R.plurals.import_complete_message, fileCount, fileCount, totalCardCount)
+            if (result.errList != null) {
+                errorMsg += result.errList
+            }
+            if (errorMsg.isNotEmpty()) {
+                dialogMsg += "\n\n" + resources.getString(com.ichi2.anki.R.string.import_stats_error, errorMsg)
+            }
+
+            showSimpleMessageDialog(dialogMsg)
+            updateDeckList()
         }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Import.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Import.kt
@@ -140,68 +140,6 @@ private class ImportReplaceListener(deckPicker: DeckPicker) : TaskListenerWithCo
     }
 }
 
-fun DeckPicker.importAddListener(): TaskListenerWithContext<DeckPicker, String, ImporterData?> =
-    ImportAddListener(this)
-
-private class ImportAddListener(deckPicker: DeckPicker) : TaskListenerWithContext<DeckPicker, String, ImporterData?>(deckPicker) {
-    override fun actualOnPostExecute(context: DeckPicker, result: ImporterData?) {
-        if (context.mProgressDialog != null && context.mProgressDialog!!.isShowing) {
-            context.mProgressDialog!!.dismiss()
-        }
-        // If result.errFlag and result are both set, we are signalling
-        // some files were imported successfully & some errors occurred.
-        // If result.impList is null & result.errList is set
-        // we are signalling all the files which were selected threw error
-        if (result!!.impList == null && result.errList != null) {
-            Timber.w("Import: Add Failed: %s", result.errList)
-            context.showSimpleMessageDialog(result.errList)
-        } else {
-            Timber.i("Import: Add succeeded")
-
-            var fileCount = 0
-            var totalCardCount = 0
-
-            var errorMsg = ""
-
-            for (data in result.impList!!) {
-                // Check if mLog is not null or empty
-                // If mLog is not null or empty that indicates an error has occurred.
-                if (data.log.isEmpty()) {
-                    fileCount += 1
-                    totalCardCount += data.cardCount
-                } else { errorMsg += data.fileName + "\n" + data.log[0] + "\n" }
-            }
-
-            var dialogMsg = context.resources.getQuantityString(R.plurals.import_complete_message, fileCount, fileCount, totalCardCount)
-            if (result.errList != null) {
-                errorMsg += result.errList
-            }
-            if (errorMsg.isNotEmpty()) {
-                dialogMsg += "\n\n" + context.resources.getString(R.string.import_stats_error, errorMsg)
-            }
-
-            context.showSimpleMessageDialog(dialogMsg)
-            context.updateDeckList()
-        }
-    }
-
-    override fun actualOnPreExecute(context: DeckPicker) {
-        if (context.mProgressDialog == null || !context.mProgressDialog!!.isShowing) {
-            context.mProgressDialog = StyledProgressDialog.show(
-                context,
-                context.resources.getString(R.string.import_title),
-                null,
-                false
-            )
-        }
-    }
-
-    override fun actualOnProgressUpdate(context: DeckPicker, value: String) {
-        @Suppress("Deprecation")
-        context.mProgressDialog!!.setMessage(value)
-    }
-}
-
 /**
  * @param impList: List of packages to import
  * @param errList: a string describing the errors. Null if no error.

--- a/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.kt
@@ -22,11 +22,9 @@ import android.content.Context
 import com.fasterxml.jackson.core.JsonToken
 import com.ichi2.anki.*
 import com.ichi2.anki.AnkiSerialization.factory
-import com.ichi2.anki.exception.ImportExportException
 import com.ichi2.libanki.*
 import com.ichi2.libanki.Collection
 import com.ichi2.libanki.Collection.CheckDatabaseResult
-import com.ichi2.libanki.importer.AnkiPackageImporter
 import com.ichi2.utils.Computation
 import com.ichi2.utils.KotlinCleanup
 import org.apache.commons.compress.archivers.zip.ZipFile
@@ -160,31 +158,6 @@ open class CollectionTask<Progress, Result>(val task: TaskDelegateBase<Progress,
                 CollectionHelper.instance.closeCollection(true, "Check Database Completed")
                 Pair(true, result)
             }
-        }
-    }
-
-    class ImportAdd(private val pathList: List<String>) : TaskDelegate<String, ImporterData>() {
-        override fun task(col: Collection, collectionTask: ProgressSenderAndCancelListener<String>): ImporterData {
-            Timber.d("doInBackgroundImportAdd")
-            val res = AnkiDroidApp.instance.baseContext.resources
-
-            var impList = arrayListOf<AnkiPackageImporter>()
-            val errBuilder = StringBuilder()
-
-            for (path in pathList) {
-                val imp = AnkiPackageImporter(col, path)
-                imp.setProgressCallback(TaskManager.ProgressCallback(collectionTask, res))
-                try {
-                    imp.run()
-                    impList.add(imp)
-                } catch (e: ImportExportException) {
-                    Timber.w(e)
-                    errBuilder.append(File(path).name, "\n", e.message, "\n")
-                }
-            }
-
-            val errList = if (errBuilder.isEmpty()) null else errBuilder.toString()
-            return ImporterData(if (impList.isEmpty()) null else impList, errList)
         }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/importer/Anki2Importer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/importer/Anki2Importer.kt
@@ -863,7 +863,13 @@ open class Anki2Importer(col: Collection?, file: String) : Importer(col!!, file)
      * @param postProcess Percentage of remaining tasks complete.
      */
     protected fun publishProgress(notesDone: Int, cardsDone: Int, postProcess: Int) {
-        progress?.publishProgress(res.getString(R.string.import_progress, notesDone, cardsDone, postProcess))
+        progress?.trySend(
+            ImportAddProgress(
+                notesDone = notesDone,
+                cardsDone = cardsDone,
+                postProcess = postProcess
+            )
+        )
     }
 
     /* The methods below are only used for testing. */
@@ -883,3 +889,16 @@ open class Anki2Importer(col: Collection?, file: String) : Importer(col!!, file)
         mDupeOnSchemaChange = false
     }
 }
+
+/**
+ * Data class which holds the intermediary status of the import add operation.
+ *
+ * @property notesDone Percentage of notes complete.
+ * @property cardsDone Percentage of cards complete.
+ * @property postProcess Percentage of remaining tasks complete.
+ */
+data class ImportAddProgress(
+    val notesDone: Int,
+    val cardsDone: Int,
+    val postProcess: Int
+)

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/importer/Importer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/importer/Importer.kt
@@ -19,10 +19,10 @@ package com.ichi2.libanki.importer
 import android.content.Context
 import android.content.res.Resources
 import com.ichi2.anki.exception.ImportExportException
-import com.ichi2.async.TaskManager
 import com.ichi2.libanki.Collection
 import com.ichi2.libanki.utils.TimeManager.time
 import com.ichi2.utils.KotlinCleanup
+import kotlinx.coroutines.channels.SendChannel
 import java.io.File
 
 abstract class Importer(col: Collection, protected var file: String) {
@@ -42,7 +42,7 @@ abstract class Importer(col: Collection, protected var file: String) {
     protected lateinit var dst: Collection
     protected lateinit var src: Collection
     protected val context: Context
-    protected var progress: TaskManager.ProgressCallback<String>? = null
+    protected var progress: SendChannel<ImportAddProgress>? = null
 
     @Throws(ImportExportException::class)
     abstract fun run()
@@ -67,7 +67,7 @@ abstract class Importer(col: Collection, protected var file: String) {
      * The methods below are not in LibAnki.
      * ***********************************************************
      */
-    fun setProgressCallback(progressCallback: TaskManager.ProgressCallback<String>?) {
+    fun setProgressCallback(progressCallback: SendChannel<ImportAddProgress>?) {
         progress = progressCallback
     }
 


### PR DESCRIPTION
## Purpose / Description

Part of https://github.com/ankidroid/Anki-Android/issues/7108. The minimum amount of work to migrate this task to coroutine to remove it from CollectionTask. There's no need for extra refactoring or TODOs as the changed code is on the legacy pathway and will be removed when the new backend becomes the default..

## How Has This Been Tested?

Ran the tests, manually verified the import feature.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
