### PR TITLE
CropException fix

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicImageFieldController.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicImageFieldController.kt
@@ -212,7 +212,12 @@ class BasicImageFieldController : FieldControllerBase(), IFieldController {
                 // cropImage can give us more information. Not sure it is actionable so for now just log it.
                 val error: String = cropResult.error?.toString() ?: "Error info not available"
                 Timber.w(error, "cropImage threw an error")
-                CrashReportService.sendExceptionReport(error, "cropImage threw an error")
+                // condition can be removed if #12768 get fixed by Canhub
+                if (cropResult.error is CropException.Cancellation) {
+                    Timber.i("CropException caught, seemingly nothing to do ", error)
+                } else {
+                    CrashReportService.sendExceptionReport(error, "cropImage threw an error")
+                }
             }
         }
     }


### PR DESCRIPTION
## Pull Request template
Preventing the report generation due to the crop Exception that was generated when back was pressed.

## Purpose / Description
This PR will fix the report generation issue that was arising due to Canhub's `CropException` . The report was generated when we used to enter the crop image option and pressed back without doing anything. This issue was reported by some user and I found it on ACRA and then reproduced it, also the same was reported by other users as well. The reports are of no action to take on as the Exception is put by Canhub Dev. and can be countered by catching it, they have knowingly put it there but it is of no relevance to us

## Fixes
Fixes #12768


## How Has This Been Tested?
After committing the changes the exception is no more reported

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration (SDK version(s), emulator or physical, etc) : - Can be reproduced by going through the issue mentioned above.


## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [x] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
