### PR TITLE
Dependency updates 20221111

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -340,7 +340,10 @@ dependencies {
     testImplementation 'org.apache.commons:commons-exec:1.3' // obtaining the OS
 
     // debugImplementation required vs testImplementation: https://issuetracker.google.com/issues/128612536
-    debugImplementation "androidx.fragment:fragment-testing:$fragments_version"
+    debugImplementation("androidx.fragment:fragment-testing:$fragments_version") {
+        // exclude transitive androidx.test:core dep: https://github.com/android/android-test/issues/1587
+        exclude group: 'androidx.test', module: 'core'
+    }
 
     // May need a resolution strategy for support libs to our versions
     androidTestImplementation "androidx.test.espresso:espresso-core:$espresso_version"

--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -319,7 +319,7 @@ dependencies {
     // Cannot use debugImplementation since classes need to be imported in AnkiDroidApp
     // and there's no no-op version for release build. Usage has been disabled for release
     // build via AnkiDroidApp.
-    implementation 'com.squareup.leakcanary:leakcanary-android:2.9.1'
+    implementation 'com.squareup.leakcanary:leakcanary-android:2.10'
 
     api project(":api")
 

--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -262,7 +262,7 @@ dependencies {
     implementation 'androidx.webkit:webkit:1.5.0'
     // Note: the design support library can be quite buggy, so test everything thoroughly before updating it
     implementation 'com.google.android.material:material:1.7.0'
-    implementation 'com.fasterxml.jackson.core:jackson-databind:2.13.4.2'
+    implementation 'com.fasterxml.jackson.core:jackson-databind:2.14.0'
     implementation 'com.vanniktech:android-image-cropper:4.5.0'
     implementation 'org.nanohttpd:nanohttpd:2.3.1'
 

--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -330,8 +330,8 @@ dependencies {
     testImplementation 'net.lachlanmckee:timber-junit-rule:1.0.1'
     // robolectricDownloader.gradle *may* need a new SDK jar entry if they release one or if we change targetSdk. Instructions in that gradle file.
     testImplementation "org.robolectric:robolectric:4.8.2"
-    testImplementation 'androidx.test:core:1.4.0'
-    testImplementation 'androidx.test.ext:junit:1.1.3'
+    testImplementation "androidx.test:core:$androidx_test_version"
+    testImplementation "androidx.test.ext:junit:$androidx_test_junit_version"
     testImplementation "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
     testImplementation "org.jetbrains.kotlin:kotlin-test:$kotlin_version"
     testImplementation "org.jetbrains.kotlin:kotlin-test-junit5:$kotlin_version"
@@ -343,12 +343,13 @@ dependencies {
     debugImplementation "androidx.fragment:fragment-testing:$fragments_version"
 
     // May need a resolution strategy for support libs to our versions
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
-    androidTestImplementation('androidx.test.espresso:espresso-contrib:3.4.0') {
+    androidTestImplementation "androidx.test.espresso:espresso-core:$espresso_version"
+    androidTestImplementation("androidx.test.espresso:espresso-contrib:$espresso_version") {
         exclude module: "protobuf-lite"
     }
-    androidTestImplementation 'androidx.test.ext:junit:1.1.3'
-    androidTestImplementation 'androidx.test:rules:1.4.0'
+    androidTestImplementation "androidx.test:core:$androidx_test_version"
+    androidTestImplementation "androidx.test.ext:junit:$androidx_test_junit_version"
+    androidTestImplementation "androidx.test:rules:$androidx_test_version"
     androidTestImplementation "org.jetbrains.kotlin:kotlin-test:$kotlin_version"
     androidTestImplementation "org.jetbrains.kotlin:kotlin-test-junit:$kotlin_version"
 }

--- a/build.gradle
+++ b/build.gradle
@@ -14,6 +14,9 @@ buildscript {
     ext.junit_version = '5.9.1'
     ext.coroutines_version = '1.6.4'
     ext.fragments_version = "1.5.4"
+    ext.espresso_version = '3.4.0'
+    ext.androidx_test_version = '1.4.0'
+    ext.androidx_test_junit_version = '1.1.3'
 
     repositories {
         google()

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompilerExecutionStrategy
 
 buildscript {
     // The version for the Kotlin plugin and dependencies
-    ext.kotlin_version = '1.7.20'
+    ext.kotlin_version = '1.7.21'
     ext.lint_version = '30.3.1'
     ext.acra_version = '5.9.6'
     ext.ankidroid_backend_version = '0.1.15-anki2.1.54' // this is parsed in tools/setup-anki-backend.sh

--- a/build.gradle
+++ b/build.gradle
@@ -14,9 +14,9 @@ buildscript {
     ext.junit_version = '5.9.1'
     ext.coroutines_version = '1.6.4'
     ext.fragments_version = "1.5.4"
-    ext.espresso_version = '3.4.0'
-    ext.androidx_test_version = '1.4.0'
-    ext.androidx_test_junit_version = '1.1.3'
+    ext.espresso_version = '3.5.0'
+    ext.androidx_test_version = '1.5.0'
+    ext.androidx_test_junit_version = '1.1.4'
 
     repositories {
         google()


### PR DESCRIPTION

Had to untangle a transitive dep collision for androidx.test:core between fragment-testing and the regular testing deps

Solved it by first parameterizing the versions (so the change was easier to see), then excluding the core test dep from fragment-testing's dependency

Works with the previous androidx.test:core versions, works with the new/current ones

See https://github.com/android/android-test/issues/1587
