### PR TITLE
Fix regression on marshmallow due to gradient usage

### DIFF
--- a/AnkiDroid/src/main/res/drawable/horizontal_gradient_separator.xml
+++ b/AnkiDroid/src/main/res/drawable/horizontal_gradient_separator.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<shape xmlns:android="http://schemas.android.com/apk/res/android">
-    <gradient
-        android:centerColor="@color/intro_center_separator"
-        android:endColor="?android:attr/colorBackground"
-        android:startColor="?android:attr/colorBackground" />
-
-</shape>

--- a/AnkiDroid/src/main/res/layout/introduction_layout.xml
+++ b/AnkiDroid/src/main/res/layout/introduction_layout.xml
@@ -58,9 +58,9 @@
 
     <View
         android:id="@+id/title_divider"
-        android:layout_width="160dp"
+        android:layout_width="100dp"
         android:layout_height="2dp"
-        android:background="@drawable/horizontal_gradient_separator"
+        android:background="#dddddd"
         app:layout_constraintBottom_toTopOf="@+id/remember_more"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent" />
@@ -90,6 +90,7 @@
         android:textSize="18sp"
         app:layout_constraintBottom_toTopOf="@+id/get_started"
         app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.0"
         app:layout_constraintStart_toStartOf="parent" />
 
     <com.google.android.material.button.MaterialButton

--- a/AnkiDroid/src/main/res/values/colors.xml
+++ b/AnkiDroid/src/main/res/values/colors.xml
@@ -141,7 +141,5 @@
     <color name="popup_background_theme_dark">#434343</color>
     <color name="popup_background_theme_black">#252525</color>
 
-    <color name="intro_center_separator">#dddddd</color>
-
 </resources>
 


### PR DESCRIPTION
From #12588 

 _Even worse, with current main as of 20221114 at least, on a fresh install on Android 6 emulator it just crashed for me with a problem doing a linear gradient in the view XML_

The issue was introduced in f4cd5c06d01f930ed5d37d89d4d214a42d17fece. Surprisingly it works on a lower version but not marshmallow. I simply reverted the commit as the UI changes from that commit, although nice, affect app startup which is critical.

## How Has This Been Tested?

Manually verified the app startup on lollipop, marshmallow and the latest versions.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
