### PR TITLE
Fix missing sync menu item badge in marshmallow

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -702,12 +702,12 @@ open class DeckPicker :
                 BadgeDrawableBuilder.removeBadge(menuItem)
             }
             SyncIconState.PendingChanges -> {
-                BadgeDrawableBuilder(resources)
+                BadgeDrawableBuilder(this)
                     .withColor(ContextCompat.getColor(this@DeckPicker, R.color.badge_warning))
                     .replaceBadge(menuItem)
             }
             SyncIconState.FullSync, SyncIconState.NotLoggedIn -> {
-                BadgeDrawableBuilder(resources)
+                BadgeDrawableBuilder(this)
                     .withText('!')
                     .withColor(ContextCompat.getColor(this@DeckPicker, R.color.badge_error))
                     .replaceBadge(menuItem)

--- a/AnkiDroid/src/main/java/com/ichi2/ui/BadgeDrawableBuilder.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/ui/BadgeDrawableBuilder.kt
@@ -16,15 +16,15 @@
 
 package com.ichi2.ui
 
-import android.content.res.Resources
+import android.content.Context
 import android.graphics.drawable.Drawable
 import android.os.Build
 import android.view.MenuItem
-import androidx.vectordrawable.graphics.drawable.VectorDrawableCompat
+import androidx.core.content.ContextCompat
 import com.ichi2.anki.R
 import timber.log.Timber
 
-class BadgeDrawableBuilder(private val resources: Resources) {
+class BadgeDrawableBuilder(private val context: Context) {
     private var mChar = '\u0000'
     private var mColor: Int? = null
     fun withText(c: Char): BadgeDrawableBuilder {
@@ -51,7 +51,7 @@ class BadgeDrawableBuilder(private val resources: Resources) {
             badge.setText(mChar)
         }
         if (mColor != null) {
-            val badgeDrawable: Drawable? = VectorDrawableCompat.create(resources, R.drawable.badge_drawable, null)
+            val badgeDrawable: Drawable? = ContextCompat.getDrawable(context, R.drawable.badge_drawable)
             if (badgeDrawable == null) {
                 Timber.w("Unable to find badge_drawable - not drawing badge")
                 return


### PR DESCRIPTION
## Purpose / Description

~~Built on top of #12840 to make the app able to start on marshmallow to actually test things.~~

The sync button badge was not showing in marshmallow(I presume it wasn't showing in upper versions, like nougat but I didn't test it). The issue was that the badge drawable was loaded through VectorDrawableCompat but the drawable itself wasn't a vector drawable(it's a simple ShapeDrawable). Reverted to use the ContextCompat.getDrawable() to initialize the normal, non vector badge drawable.

## Fixes
Fixes #12825

## How Has This Been Tested?

Manually verified that the badge appears in marshmallow, also API levels 31 and 33.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
