### PR TITLE
Fix menu item crash when Reschedule set to appear in toolbar

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
@@ -1505,13 +1505,12 @@ open class Reviewer : AbstractFlashcardViewer() {
 
     /**
      * Inner class which implements the submenu for the Schedule button
-     *
-     * NOTE: this action provider doesn't handle the menu item being shown directly in the toolbar,
-     * if the menu item is set to appear in the toolbar, the onCreateActionView(MenuItem) needs to be
-     * overridden. See one of its siblings([BuryProvider] or [SuspendProvider]) for an example of an
-     * implementation.
      */
     internal inner class ScheduleProvider(context: Context) : ActionProviderCompat(context), SubMenuProvider {
+
+        override fun onCreateActionView(forItem: MenuItem): View {
+            return createActionViewWith(context, forItem, R.menu.reviewer_schedule, ::onMenuItemClick) { true }
+        }
 
         override fun hasSubMenu(): Boolean {
             return true


### PR DESCRIPTION
## Purpose / Description

Leftover work from fixing issues with the suspend and bury menu items in the reviewer. The reschedule menu item was changed to use the proper method when being setup. The menu item now appears:

![Screenshot_20221118_152708](https://user-images.githubusercontent.com/52494258/202715926-14fb56c2-9547-4e0c-8c6e-a70615938c3d.png)


## Fixes
Fixes #12843

## How Has This Been Tested?

Ran the tests, manually verified the app on lollipop and the latest version.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
