### PR TITLE
Make undo button work in StudyOptions

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsActivity.kt
@@ -60,6 +60,10 @@ class StudyOptionsActivity : NavigationDrawerActivity(), StudyOptionsListener, C
         if (drawerToggle.onOptionsItemSelected(item)) {
             return true
         }
+        if (item.itemId == android.R.id.home) {
+            closeStudyOptions()
+            return true
+        }
         return super.onOptionsItemSelected(item)
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsActivity.kt
@@ -60,13 +60,6 @@ class StudyOptionsActivity : NavigationDrawerActivity(), StudyOptionsListener, C
         if (drawerToggle.onOptionsItemSelected(item)) {
             return true
         }
-        if (item.itemId == android.R.id.home) {
-            closeStudyOptions()
-            return true
-        }
-        if (item.itemId == R.id.action_undo) {
-            return currentFragment?.undo() ?: false
-        }
         return super.onOptionsItemSelected(item)
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsActivity.kt
@@ -64,6 +64,9 @@ class StudyOptionsActivity : NavigationDrawerActivity(), StudyOptionsListener, C
             closeStudyOptions()
             return true
         }
+        if (item.itemId == R.id.action_undo) {
+            return currentFragment?.undo() ?: false
+        }
         return super.onOptionsItemSelected(item)
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsFragment.kt
@@ -31,6 +31,7 @@ import androidx.annotation.VisibleForTesting
 import androidx.appcompat.content.res.AppCompatResources
 import androidx.appcompat.widget.Toolbar
 import androidx.core.text.HtmlCompat
+import androidx.core.view.MenuItemCompat
 import androidx.fragment.app.Fragment
 import com.ichi2.anim.ActivityTransitionAnimation
 import com.ichi2.anim.ActivityTransitionAnimation.slide
@@ -48,6 +49,7 @@ import com.ichi2.libanki.Collection
 import com.ichi2.libanki.Consts
 import com.ichi2.libanki.Decks
 import com.ichi2.libanki.Utils
+import com.ichi2.ui.RtlCompliantActionProvider
 import com.ichi2.utils.FragmentFactoryUtils.instantiate
 import com.ichi2.utils.HtmlUtils.convertNewlinesToHtml
 import com.ichi2.utils.KotlinCleanup
@@ -270,7 +272,6 @@ class StudyOptionsFragment : Fragment(), Toolbar.OnMenuItemClickListener {
     }
 
     override fun onMenuItemClick(item: MenuItem): Boolean {
-        Timber.i("onMenuItemClick - Toolbar")
         when (item.itemId) {
             R.id.action_undo -> {
                 Timber.i("StudyOptionsFragment:: Undo button pressed")
@@ -389,6 +390,11 @@ class StudyOptionsFragment : Fragment(), Toolbar.OnMenuItemClickListener {
             }
             // Switch on or off unbury depending on if there are cards to unbury
             menu.findItem(R.id.action_unbury).isVisible = col != null && col!!.sched.haveBuried()
+            // Set the proper click target for the undo button's ActionProvider
+            val undoActionProvider: RtlCompliantActionProvider? = MenuItemCompat.getActionProvider(
+                menu.findItem(R.id.action_undo)
+            ) as? RtlCompliantActionProvider
+            undoActionProvider?.clickHandler = { _, menuItem -> onMenuItemClick(menuItem) }
             // Switch on or off undo depending on whether undo is available
             if (col == null || !col!!.undoAvailable()) {
                 menu.findItem(R.id.action_undo).isVisible = false

--- a/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsFragment.kt
@@ -31,7 +31,6 @@ import androidx.annotation.VisibleForTesting
 import androidx.appcompat.content.res.AppCompatResources
 import androidx.appcompat.widget.Toolbar
 import androidx.core.text.HtmlCompat
-import androidx.core.view.MenuItemCompat
 import androidx.fragment.app.Fragment
 import com.ichi2.anim.ActivityTransitionAnimation
 import com.ichi2.anim.ActivityTransitionAnimation.slide
@@ -49,7 +48,6 @@ import com.ichi2.libanki.Collection
 import com.ichi2.libanki.Consts
 import com.ichi2.libanki.Decks
 import com.ichi2.libanki.Utils
-import com.ichi2.ui.RtlCompliantActionProvider
 import com.ichi2.utils.FragmentFactoryUtils.instantiate
 import com.ichi2.utils.HtmlUtils.convertNewlinesToHtml
 import com.ichi2.utils.KotlinCleanup
@@ -272,6 +270,7 @@ class StudyOptionsFragment : Fragment(), Toolbar.OnMenuItemClickListener {
     }
 
     override fun onMenuItemClick(item: MenuItem): Boolean {
+        Timber.i("onMenuItemClick - Toolbar")
         when (item.itemId) {
             R.id.action_undo -> {
                 Timber.i("StudyOptionsFragment:: Undo button pressed")
@@ -390,11 +389,6 @@ class StudyOptionsFragment : Fragment(), Toolbar.OnMenuItemClickListener {
             }
             // Switch on or off unbury depending on if there are cards to unbury
             menu.findItem(R.id.action_unbury).isVisible = col != null && col!!.sched.haveBuried()
-            // Set the proper click target for the undo button's ActionProvider
-            val undoActionProvider: RtlCompliantActionProvider? = MenuItemCompat.getActionProvider(
-                menu.findItem(R.id.action_undo)
-            ) as? RtlCompliantActionProvider
-            undoActionProvider?.clickHandler = { _, menuItem -> onMenuItemClick(menuItem) }
             // Switch on or off undo depending on whether undo is available
             if (col == null || !col!!.undoAvailable()) {
                 menu.findItem(R.id.action_undo).isVisible = false

--- a/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsFragment.kt
@@ -253,23 +253,28 @@ class StudyOptionsFragment : Fragment(), Toolbar.OnMenuItemClickListener {
             openReviewer()
         }
     }
+    fun undo(): Boolean {
+        Timber.i("StudyOptionsFragment:: Undo button pressed")
+        if (BackendFactory.defaultLegacySchema) {
+            Undo().runWithHandler(mUndoListener)
+        } else {
+            launchCatchingTask {
+                if (requireActivity().backendUndoAndShowPopup()) {
+                    openReviewer()
+                } else {
+                    Undo().runWithHandler(mUndoListener)
+                }
+            }
+        }
+        return true
+    }
 
     override fun onMenuItemClick(item: MenuItem): Boolean {
+        Timber.i("onMenuItemClick - Toolbar")
         when (item.itemId) {
             R.id.action_undo -> {
                 Timber.i("StudyOptionsFragment:: Undo button pressed")
-                if (BackendFactory.defaultLegacySchema) {
-                    Undo().runWithHandler(mUndoListener)
-                } else {
-                    launchCatchingTask {
-                        if (requireActivity().backendUndoAndShowPopup()) {
-                            openReviewer()
-                        } else {
-                            Undo().runWithHandler(mUndoListener)
-                        }
-                    }
-                }
-                return true
+                return undo()
             }
             R.id.action_deck_or_study_options -> {
                 Timber.i("StudyOptionsFragment:: Deck or study options button pressed")

--- a/AnkiDroid/src/main/java/com/ichi2/ui/RtlCompliantActionProvider.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/ui/RtlCompliantActionProvider.kt
@@ -30,6 +30,15 @@ class RtlCompliantActionProvider(context: Context) : ActionProviderCompat(contex
     @VisibleForTesting
     val mActivity: Activity
 
+    /**
+     * The action to perform when clicking the associated menu item. By default this delegates to
+     * the activity's [Activity.onOptionsItemSelected] callback, but a custom action can be set and
+     * used instead.
+     */
+    var clickHandler: (Activity, MenuItem) -> Unit = { activity, menuItem ->
+        activity.onOptionsItemSelected(menuItem)
+    }
+
     override fun onCreateActionView(forItem: MenuItem): View {
         val actionView = ImageButton(context, null, R.attr.actionButtonStyle)
         TooltipCompat.setTooltipText(actionView, forItem.title)
@@ -42,7 +51,7 @@ class RtlCompliantActionProvider(context: Context) : ActionProviderCompat(contex
             if (!forItem.isEnabled) {
                 return@setOnClickListener
             }
-            mActivity.onOptionsItemSelected(forItem)
+            clickHandler(mActivity, forItem)
         }
         return actionView
     }

--- a/AnkiDroid/src/main/java/com/ichi2/ui/RtlCompliantActionProvider.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/ui/RtlCompliantActionProvider.kt
@@ -30,15 +30,6 @@ class RtlCompliantActionProvider(context: Context) : ActionProviderCompat(contex
     @VisibleForTesting
     val mActivity: Activity
 
-    /**
-     * The action to perform when clicking the associated menu item. By default this delegates to
-     * the activity's [Activity.onOptionsItemSelected] callback, but a custom action can be set and
-     * used instead.
-     */
-    var clickHandler: (Activity, MenuItem) -> Unit = { activity, menuItem ->
-        activity.onOptionsItemSelected(menuItem)
-    }
-
     override fun onCreateActionView(forItem: MenuItem): View {
         val actionView = ImageButton(context, null, R.attr.actionButtonStyle)
         TooltipCompat.setTooltipText(actionView, forItem.title)
@@ -51,7 +42,7 @@ class RtlCompliantActionProvider(context: Context) : ActionProviderCompat(contex
             if (!forItem.isEnabled) {
                 return@setOnClickListener
             }
-            clickHandler(mActivity, forItem)
+            mActivity.onOptionsItemSelected(forItem)
         }
         return actionView
     }


### PR DESCRIPTION
## Purpose / Description

The Undo button in `StudyOptionsFragment` does not work. This issue occurred after creating `RTLActionProvider`, which allows icons to be mirrored for right-to-left languages. This fix makes this undo button work as expected. However, it still does not allow the user to undo the last card in a deck from `StudyOptions`. 

## Fixes

Fixes #12277, I wouldn't say "fixes" because I know this is not an ideal code change. **[Edit: I'm saying it fixes it - Mike H]**

## Approach

I struggled to fix this problem for a long time, and finally threw in the towel on being able to solve it "correctly". I understand my code is not exactly desirable, but I wanted to share my findings and the things I tried to help save others time if they make a cleaner fix in the future.

The Undo button is inflated from `StudyOptionsFragment`, which is hosted by `StudyOptionsActivity`. `RTLActionProvider` takes in an Activity. So, when the Undo button is pressed, `RTLActionProvider` calls `onOptionsItemSelected` on `StudyOptionsActivity`. This doesn't do anything, because the activity has no knowledge of the options in its fragment. All other uses of `RTL...` use Activities, which is why they work as expected.

Changing `RTLActionProvider` to instead use a Fragment is not trivial, because Frags aren't aware of Context.

It was suggested to use `MenuHost/MenuProvider` to redo the menu/actions system. I struggled with this because the menu in `StudyOptionsFragment` uses a `Toolbar` and I couldn't figure out how to set up the actions correctly with `MH/MP` instead (Due to my own skill level). It seemed to me like that would still not solve the underlying issue, though perhaps if the `SOActivity` and `SOFragment` menus were coupled in this way it would work. I struggled finding resources on it because it is a relatively new feature.

My approach here is the simple and "hacky" one: Just make the Activity call the method on the Fragment when it detects an options item click. This feels like bad encapsulation: the Activity shouldn't call down the chain to a function on the Fragment. However I could be wrong here.

## How Has This Been Tested?

- [x] Jacoco Unit Tests
- [x] KTLint checks

1. Open a deck
2. Review any number of cards (except ALL cards)
3. Navigate back to DeckPicker
4. Use the three numbers to the right of the deck name to open StudyOptions
5. Tapping undo button in top menu undoes the last card review, and returns to the Reviewer on that same card

![studyoptions_undo](https://user-images.githubusercontent.com/38815390/202835800-fb973e4d-d890-46f5-b34f-cc208029f061.gif)

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] ~UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)~
- [x] ~UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)~
