### PR TITLE
Use "Undo" instead of "Undo %s" for the item of "Undo" if there is no string of undone target

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
@@ -748,7 +748,11 @@ open class Reviewer : AbstractFlashcardViewer() {
         undoIcon.setEnabled(undoEnabled).iconAlpha = alphaUndo
         undoIcon.actionView!!.isEnabled = undoEnabled
         if (colIsOpen()) { // Required mostly because there are tests where `col` is null
-            undoIcon.title = resources.getString(R.string.studyoptions_congrats_undo, col.undoName(resources))
+            if (col.undoName(resources) !="") {
+                undoIcon.title = resources.getString(R.string.studyoptions_congrats_undo, col.undoName(resources))
+            } else {
+                undoIcon.title = resources.getString(R.string.undo)
+            }    
         }
         if (undoEnabled) {
             mOnboarding.onUndoButtonEnabled()

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
@@ -748,9 +748,15 @@ open class Reviewer : AbstractFlashcardViewer() {
         undoIcon.setEnabled(undoEnabled).iconAlpha = alphaUndo
         undoIcon.actionView!!.isEnabled = undoEnabled
         if (colIsOpen()) { // Required mostly because there are tests where `col` is null
-            if (col.undoName(resources) !="") {
+            if (col.undoAvailable()) {
+                // We arrive here if the last action which can be undone is retained.
+                //  e.g. Undo Bury, Undo Change Deck, Undo Update Note   
                 undoIcon.title = resources.getString(R.string.studyoptions_congrats_undo, col.undoName(resources))
             } else {
+                // We arrive here if the last action which can be undone isn't retained. 
+                // In this case, there is no object word for the verb, "Undo", 
+                // so in some languages such as Japanese, which have postpositional particle with the object,
+                // we need to use the string for just "Undo" instead of the string for "Undo %s".
                 undoIcon.title = resources.getString(R.string.undo)
             }    
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
@@ -750,15 +750,15 @@ open class Reviewer : AbstractFlashcardViewer() {
         if (colIsOpen()) { // Required mostly because there are tests where `col` is null
             if (col.undoAvailable()) {
                 // We arrive here if the last action which can be undone is retained.
-                //  e.g. Undo Bury, Undo Change Deck, Undo Update Note   
+                //  e.g. Undo Bury, Undo Change Deck, Undo Update Note
                 undoIcon.title = resources.getString(R.string.studyoptions_congrats_undo, col.undoName(resources))
             } else {
-                // We arrive here if the last action which can be undone isn't retained. 
-                // In this case, there is no object word for the verb, "Undo", 
-                // so in some languages such as Japanese, which have postpositional particle with the object,
+                // We arrive here if the last action which can be undone isn't retained.
+                // In this case, there is no object word for the verb, "Undo",
+                // so in some languages such as Japanese, which have pre/postpositional particle with the object,
                 // we need to use the string for just "Undo" instead of the string for "Undo %s".
                 undoIcon.title = resources.getString(R.string.undo)
-            }    
+            }
         }
         if (undoEnabled) {
             mOnboarding.onUndoButtonEnabled()


### PR DESCRIPTION


## Pull Request template

## Purpose / Description
Use just "Undo" instead of "Undo %s" for the item of "Undo" if there is no string of undone target.
![image](https://user-images.githubusercontent.com/10436072/202884903-3234acd0-de6d-411f-9895-9989499c056f.png)
![image](https://user-images.githubusercontent.com/10436072/202880860-3784d168-8e09-43ae-a02a-b96ce8cd4f2f.png)

https://github.com/ankidroid/Anki-Android/blob/9ac9e6e3047184d79a4044129254f2ee96a4f8bc/AnkiDroid/src/main/res/values/01-core.xml#L76
https://github.com/ankidroid/Anki-Android/blob/9ac9e6e3047184d79a4044129254f2ee96a4f8bc/AnkiDroid/src/main/res/values-ja/01-core.xml#L92
https://github.com/ankidroid/Anki-Android/blob/9ac9e6e3047184d79a4044129254f2ee96a4f8bc/AnkiDroid/src/main/res/values/01-core.xml#L74
https://github.com/ankidroid/Anki-Android/blob/9ac9e6e3047184d79a4044129254f2ee96a4f8bc/AnkiDroid/src/main/res/values-ja/01-core.xml#L90
## Fixes
Fixes #12853

## Approach
Separate cases by presence/absence of string of undone target on Reviewer.kt

## How Has This Been Tested?
Checked on a physical device
![image](https://user-images.githubusercontent.com/10436072/202884961-7580870a-adae-4bac-a7a3-99363c23be81.png)

![image](https://user-images.githubusercontent.com/10436072/202884257-0054e6ff-2add-4c1a-964c-e340e0f4cb65.png)




## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
