### PR TITLE
Make the title of Drawing screen translated

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DrawingActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DrawingActivity.kt
@@ -43,6 +43,7 @@ class DrawingActivity : AnkiActivity() {
             return
         }
         super.onCreate(savedInstanceState)
+        setTitle(R.string.drawing)
         setContentView(R.layout.activity_drawing)
         enableToolbar()
         mColorPalette = findViewById(R.id.whiteboard_editor)


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
The title of Drawing screen is written in the system language even if the language of AnkiDroid settings is changed to another one. This PR is to fix it.
![image](https://user-images.githubusercontent.com/10436072/202897457-2e743053-7438-4de6-b1f5-b0bdb3617b6f.png)


## Fixes
Fixes #12856


## How Has This Been Tested?
Checked on a physical device
![image](https://user-images.githubusercontent.com/10436072/202897242-a7374b59-d56c-43a1-a44a-c0690f3da5ac.png)


## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
