### PR TITLE
Fix for the translation issue of the estimated studying time on Reviewer screen

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
@@ -1030,7 +1030,7 @@ open class Reviewer : AbstractFlashcardViewer() {
         if (actionBar != null) {
             if (mPrefShowETA) {
                 mEta = sched!!.eta(counts, false)
-                actionBar.subtitle = Utils.remainingTime(AnkiDroidApp.instance, (mEta * 60).toLong())
+                actionBar.subtitle = Utils.remainingTime(this, (mEta * 60).toLong())
             }
         }
         mNewCount = SpannableString(counts.new.toString())


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
The estimated studying time on Reviewer screen is translated on language change.
 
## Fixes
Fixes #12888

## Approach
Switching the context passed into the Util method from Application to Activity context seemed to resolve the issue.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration (SDK version(s), emulator or physical, etc)

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [x] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)


https://user-images.githubusercontent.com/76740999/204138731-d8b2e8c0-1c72-47dc-bbd6-357f48b2a604.mp4




