### PR TITLE
Fix prettier throwing errors

### DIFF
--- a/pre-commit
+++ b/pre-commit
@@ -55,8 +55,14 @@ runPrettier () {
         return 0
     fi
 
-    # Run prettier over all Javascript files
-    npx --yes prettier --ignore-unknown --write AnkiDroid/**/*.js
+    CHANGED_JS_FILES="$(git --no-pager diff --name-status --no-color --cached | awk '$1 != "D" && $2 ~ /\.js/ { print $2 }')"
+        if [ -z "$CHANGED_JS_FILES" ]; then
+            echo "No Javascript staged files. Hence, skipping pre-commit Prettier run."
+            return 0
+        fi;
+
+    # Prettify changed files
+    echo "$CHANGED_JS_FILES" | xargs npx prettier --ignore-unknown --write
 
     echo "Completed npx prettier run."
     echo "$CHANGED_JS_FILES" | while read -r file; do

--- a/pre-commit
+++ b/pre-commit
@@ -67,5 +67,5 @@ runPrettier () {
 }
 
 runKtlint
-runPrettier
+runPrettier || :; # || to avoid cancelling the commit if there is an error with Prettier
 echo "Completed the pre-commit hook."


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
idk why, but prettier is always being runned even if there isn't a javascript file being edited so it got my commits cancelled repeatedly

## Fixes
Fixes #12850

## Approach
try catch the error

## How Has This Been Tested?

trying a commit with no internet and without prettier installed (but with npx installed)

## Learning (optional, can help others)
_Describe the research stage_

_Links to blog posts, patterns, libraries or addons used to solve this problem_

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
