### PR TITLE
Show more stats while downloading a shared deck

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/SharedDecksDownloadFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/SharedDecksDownloadFragment.kt
@@ -67,8 +67,8 @@ class SharedDecksDownloadFragment : Fragment() {
     private lateinit var mImportDeckButton: Button
     private lateinit var mDownloadPercentageText: TextView
     private lateinit var mDownloadProgressBar: ProgressBar
-    private lateinit var mDownloadTimeLeftText: TextView
-    private lateinit var mDownloadSpeedText: TextView
+    private lateinit var downloadTimeLeftText: TextView
+    private lateinit var downloadSpeedText: TextView
     private lateinit var mCheckNetworkInfoText: TextView
 
     /**
@@ -106,8 +106,8 @@ class SharedDecksDownloadFragment : Fragment() {
 
         mDownloadPercentageText = view.findViewById(R.id.download_percentage)
         mDownloadProgressBar = view.findViewById(R.id.download_progress)
-        mDownloadTimeLeftText = view.findViewById(R.id.download_time_left)
-        mDownloadSpeedText = view.findViewById(R.id.download_speed)
+        downloadTimeLeftText = view.findViewById(R.id.download_time_left)
+        downloadSpeedText = view.findViewById(R.id.download_speed)
         mCancelButton = view.findViewById(R.id.cancel_shared_decks_download)
         mImportDeckButton = view.findViewById(R.id.import_shared_deck_button)
         mTryAgainButton = view.findViewById(R.id.try_again_deck_download)
@@ -378,7 +378,7 @@ class SharedDecksDownloadFragment : Fragment() {
                 val estimatedTimeInHours = estimatedTimeRemainingInSeconds / 3600
                 resources.getQuantityString(R.plurals.time_left_hours, estimatedTimeInHours, estimatedTimeInHours)
             }
-            mDownloadTimeLeftText.text = estimatedTimeRemainingText
+            downloadTimeLeftText.text = estimatedTimeRemainingText
             // don't use averageSpeedInBytesPerMillis to calculate averageSpeedInBytesPerSecond
             // as that would make the minimum non-zero value of averageSpeedInBytesPerSecond at
             // least 1000
@@ -392,7 +392,7 @@ class SharedDecksDownloadFragment : Fragment() {
                 val averageSpeedInMBPerSecond = averageSpeedInBytesPerSecond / (1024 * 1024)
                 resources.getQuantityString(R.plurals.download_speed_mbs_per_second, averageSpeedInMBPerSecond, averageSpeedInMBPerSecond)
             }
-            mDownloadSpeedText.text = averageSpeedText
+            downloadSpeedText.text = averageSpeedText
             mDownloadProgressBar.progress = downloadProgress.toInt()
 
             val columnIndexForStatus = it.getColumnIndex(DownloadManager.COLUMN_STATUS)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/SharedDecksDownloadFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/SharedDecksDownloadFragment.kt
@@ -59,7 +59,8 @@ class SharedDecksDownloadFragment : Fragment() {
     private var mHandler: Handler = Handler(Looper.getMainLooper())
     private var mIsProgressCheckerRunning = false
 
-    private var timeQuantumPassed = 0
+    // number of times download progress has been checked
+    private var mNumIterations = 0
 
     private lateinit var mCancelButton: Button
     private lateinit var mTryAgainButton: Button
@@ -161,7 +162,7 @@ class SharedDecksDownloadFragment : Fragment() {
         Timber.d("Download ID -> $mDownloadId")
         Timber.d("File name -> $mFileName")
         view?.findViewById<TextView>(R.id.downloading_title)?.text = getString(R.string.downloading_file, mFileName)
-        timeQuantumPassed = 0
+        mNumIterations = 0
         startDownloadProgressChecker()
     }
 
@@ -338,7 +339,7 @@ class SharedDecksDownloadFragment : Fragment() {
                 return
             }
 
-            ++timeQuantumPassed
+            ++mNumIterations
 
             // Calculate download progress and display it in the ProgressBar.
             val downloadedBytes = it.getLong(it.getColumnIndex(DownloadManager.COLUMN_BYTES_DOWNLOADED_SO_FAR))
@@ -355,7 +356,7 @@ class SharedDecksDownloadFragment : Fragment() {
             }
             mDownloadPercentageText.text = getString(R.string.percentage, percentageValue)
 
-            val totalTimePassedInMillis = timeQuantumPassed * DOWNLOAD_PROGRESS_CHECK_DELAY
+            val totalTimePassedInMillis = mNumIterations * DOWNLOAD_PROGRESS_CHECK_DELAY
             val averageSpeedInBytesPerMillis = downloadedBytes / totalTimePassedInMillis
             val estimatedTimeRemainingInMillis = if (downloadProgressIntValue == 0 || downloadProgressIntValue == 100) {
                 0 // no useful estimate can be provided when nothing has been downloaded or when

--- a/AnkiDroid/src/main/java/com/ichi2/anki/SharedDecksDownloadFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/SharedDecksDownloadFragment.kt
@@ -357,7 +357,10 @@ class SharedDecksDownloadFragment : Fragment() {
 
             val totalTimePassedInMillis = timeQuantumPassed * DOWNLOAD_PROGRESS_CHECK_DELAY
             val averageSpeedInBytesPerMillis = downloadedBytes / totalTimePassedInMillis
-            val estimatedTimeRemainingInMillis = if (averageSpeedInBytesPerMillis != 0L) {
+            val estimatedTimeRemainingInMillis = if (downloadProgressIntValue == 0 || downloadProgressIntValue == 100) {
+                0 // no useful estimate can be provided when nothing has been downloaded or when
+                // download has finished
+            } else if (averageSpeedInBytesPerMillis != 0L) {
                 (totalBytes - downloadedBytes) / averageSpeedInBytesPerMillis
             } else {
                 0 // used to indicate no valid value

--- a/AnkiDroid/src/main/java/com/ichi2/anki/SharedDecksDownloadFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/SharedDecksDownloadFragment.kt
@@ -60,7 +60,7 @@ class SharedDecksDownloadFragment : Fragment() {
     private var mIsProgressCheckerRunning = false
 
     // number of times download progress has been checked
-    private var mNumIterations = 0
+    private var numIterations = 0
 
     private lateinit var mCancelButton: Button
     private lateinit var mTryAgainButton: Button
@@ -162,7 +162,7 @@ class SharedDecksDownloadFragment : Fragment() {
         Timber.d("Download ID -> $mDownloadId")
         Timber.d("File name -> $mFileName")
         view?.findViewById<TextView>(R.id.downloading_title)?.text = getString(R.string.downloading_file, mFileName)
-        mNumIterations = 0
+        numIterations = 0
         startDownloadProgressChecker()
     }
 
@@ -339,7 +339,7 @@ class SharedDecksDownloadFragment : Fragment() {
                 return
             }
 
-            ++mNumIterations
+            ++numIterations
 
             // Calculate download progress and display it in the ProgressBar.
             val downloadedBytes = it.getLong(it.getColumnIndex(DownloadManager.COLUMN_BYTES_DOWNLOADED_SO_FAR))
@@ -356,7 +356,7 @@ class SharedDecksDownloadFragment : Fragment() {
             }
             mDownloadPercentageText.text = getString(R.string.percentage, percentageValue)
 
-            val totalTimePassedInMillis = mNumIterations * DOWNLOAD_PROGRESS_CHECK_DELAY
+            val totalTimePassedInMillis = numIterations * DOWNLOAD_PROGRESS_CHECK_DELAY
             val averageSpeedInBytesPerMillis = downloadedBytes / totalTimePassedInMillis
             val estimatedTimeRemainingInMillis = if (downloadProgressIntValue == 0 || downloadProgressIntValue == 100) {
                 0 // no useful estimate can be provided when nothing has been downloaded or when

--- a/AnkiDroid/src/main/res/layout/fragment_shared_decks_download.xml
+++ b/AnkiDroid/src/main/res/layout/fragment_shared_decks_download.xml
@@ -37,7 +37,7 @@
         app:layout_constraintTop_toBottomOf="@id/downloading_title" />
     
     <com.ichi2.ui.FixedTextView
-        android:id="@+id/download_percentage"
+        android:id="@+id/download_stats"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:textSize="20sp"
@@ -45,7 +45,7 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toBottomOf="@id/download_dialog_info_text"
-        tools:text="100 %" />
+        tools:text="66 %, 42 seconds left (7 MBs/second)" />
 
     <ProgressBar
         android:id="@+id/download_progress"
@@ -57,7 +57,7 @@
         android:scaleY="4"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/download_percentage"
+        app:layout_constraintTop_toBottomOf="@id/download_stats"
         style="@style/Widget.AppCompat.ProgressBar.Horizontal" />
 
     <com.ichi2.ui.FixedTextView

--- a/AnkiDroid/src/main/res/layout/fragment_shared_decks_download.xml
+++ b/AnkiDroid/src/main/res/layout/fragment_shared_decks_download.xml
@@ -37,7 +37,7 @@
         app:layout_constraintTop_toBottomOf="@id/downloading_title" />
     
     <com.ichi2.ui.FixedTextView
-        android:id="@+id/download_stats"
+        android:id="@+id/download_percentage"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:textSize="20sp"
@@ -45,7 +45,7 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toBottomOf="@id/download_dialog_info_text"
-        tools:text="66 %, 42 seconds left (7 MBs/second)" />
+        tools:text="66 %" />
 
     <ProgressBar
         android:id="@+id/download_progress"
@@ -57,8 +57,31 @@
         android:scaleY="4"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/download_stats"
+        app:layout_constraintTop_toBottomOf="@id/download_percentage"
         style="@style/Widget.AppCompat.ProgressBar.Horizontal" />
+
+
+    <com.ichi2.ui.FixedTextView
+        android:id="@+id/download_time_left"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:textSize="20sp"
+        android:layout_marginTop="24dp"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/download_progress"
+        tools:text="42 seconds left" />
+
+    <com.ichi2.ui.FixedTextView
+        android:id="@+id/download_speed"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:textSize="20sp"
+        android:layout_marginTop="24dp"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/download_time_left"
+        tools:text="7 MB/s" />
 
     <com.ichi2.ui.FixedTextView
         android:id="@+id/check_network_info_text"

--- a/AnkiDroid/src/main/res/values/02-strings.xml
+++ b/AnkiDroid/src/main/res/values/02-strings.xml
@@ -368,6 +368,32 @@
 
     <!-- %% is required to display % symbol. Reference: https://stackoverflow.com/a/16834358 -->
     <string name="percentage">%s%%</string>
+
+    <plurals name="time_left_seconds">
+        <item quantity="one">%d second left</item>
+        <item quantity="other">%d seconds left</item>
+    </plurals>
+    <plurals name="time_left_minutes">
+        <item quantity="one">%d minute left</item>
+        <item quantity="other">%d minutes left</item>
+    </plurals>
+    <plurals name="time_left_hours">
+        <item quantity="one">%d hour left</item>
+        <item quantity="other">%d hours left</item>
+    </plurals>
+
+    <plurals name="download_speed_bytes_per_second">
+        <item quantity="one">%d byte/second</item>
+        <item quantity="other">%d bytes/second</item>
+    </plurals>
+    <plurals name="download_speed_kbs_per_second">
+        <item quantity="one">%d KB/second</item>
+        <item quantity="other">%d KBs/second</item>
+    </plurals>
+    <plurals name="download_speed_mbs_per_second">
+        <item quantity="one">%d MB/second</item>
+        <item quantity="other">%d MBs/second</item>
+    </plurals>
     
     <string name="download_deck">Download deck</string>
     <string name="try_again">Try Again</string>


### PR DESCRIPTION
## Purpose / Description
Instead of just showing the progress in percentage, the download screen now shows an estimate of the time remaining along with average download speed in the appropriate units.

## Fixes
Fixes https://github.com/ankidroid/Anki-Android/issues/12899

## Approach
This solves issue #12899 directly by adding the asked for stats on the download screen.

## How Has This Been Tested?
This has been tested on a physical as well as several virtual android devices. Just launch Anki and try to download a shared deck via the "Get shared deck" button. On the download screen one can see an estimate of the remaining time as well as the average download speed.

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
