### PR TITLE
Fix app crashing if deck from shortcut does not exist anymore

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
@@ -301,7 +301,7 @@ open class Reviewer : AbstractFlashcardViewer() {
         // TODO delete deck shortcut if the deck does not exist anymore
         // TODO don't start reviewing the default deck if a shortcut for a deleted deck is launched
         if (col.decks.get(did, _default = false) == null) {
-            Timber.d("selectDeckFromExtra() deckId '%d' doesn't exist", did)
+            Timber.w("selectDeckFromExtra() deckId '%d' doesn't exist", did)
             return
         }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
@@ -297,6 +297,14 @@ open class Reviewer : AbstractFlashcardViewer() {
         val did = extras.getLong("deckId", Long.MIN_VALUE)
         Timber.d("selectDeckFromExtra() with deckId = %d", did)
 
+        // deckId does not exist, load default (#12910)
+        // TODO delete deck shortcut if the deck does not exist anymore
+        // TODO don't start reviewing the default deck if a shortcut for a deleted deck is launched
+        if (col.decks.get(did, _default = false) == null) {
+            Timber.d("selectDeckFromExtra() deckId '%d' doesn't exist", did)
+            return
+        }
+
         // Clear the undo history when selecting a new deck
         if (col.decks.selected() != did) {
             col.clearUndo()


### PR DESCRIPTION
## Fixes
Fixes #12910

## Approach
Return early if the deck does not exist anymore (col.decks.select(did) was doing the crashes)

## How Has This Been Tested?

1. Long press a deck
2. Create shortcut
3. Delete the deck
4. Open the shortcut
5. Don't see any crashes

Reviewer.kt is too big and clumped, if I may say so, to me to deal with it right now so I left some TODOs. Not crashing is already some progress to me 😁

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
