### PR TITLE
Fix hang when syncing media with new schema

### DIFF
--- a/.github/workflows/tests_unit.yml
+++ b/.github/workflows/tests_unit.yml
@@ -99,6 +99,10 @@ jobs:
           max_attempts: 3
           command: ./gradlew robolectricSdkDownload --daemon
 
+      - name: Switch to new schema (Linux)
+        if: matrix.os == 'ubuntu-latest'
+        run: echo "legacy_schema = false" >> local.properties
+
       - name: Run Unit Tests
         uses: gradle/gradle-build-action@v2
         with:

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Sync.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Sync.kt
@@ -249,7 +249,8 @@ private suspend fun handleMediaSync(
         .setPositiveButton("Background") { _, _ -> }
         .show()
     try {
-        CollectionManager.getBackend().withProgress(
+        val backend = CollectionManager.getBackend()
+        backend.withProgress(
             extractProgress = {
                 if (progress.hasMediaSync()) {
                     text =
@@ -260,9 +261,7 @@ private suspend fun handleMediaSync(
                 dialog.setMessage(text)
             },
         ) {
-            withCol {
-                newBackend.syncMedia(auth)
-            }
+            backend.syncMedia(auth)
         }
     } finally {
         dialog.dismiss()

--- a/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/DeckPickerContextMenuTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/DeckPickerContextMenuTest.kt
@@ -30,6 +30,7 @@ import com.ichi2.anki.R
 import com.ichi2.anki.RobolectricTest
 import com.ichi2.libanki.utils.TimeManager
 import com.ichi2.testutils.assertThrows
+import net.ankiweb.rsdroid.BackendFactory
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.containsInAnyOrder
 import org.hamcrest.Matchers.not
@@ -108,8 +109,13 @@ class DeckPickerContextMenuTest : RobolectricTest() {
             openContextMenuAndSelectItem(recyclerView, 3)
 
             val deckOptions = shadowOf(this).nextStartedActivity!!
-            assertEquals("com.ichi2.anki.DeckOptionsActivity", deckOptions.component!!.className)
-            assertEquals(deckId, deckOptions.getLongExtra("did", 1))
+            if (BackendFactory.defaultLegacySchema) {
+                assertEquals(
+                    "com.ichi2.anki.DeckOptionsActivity",
+                    deckOptions.component!!.className
+                )
+                assertEquals(deckId, deckOptions.getLongExtra("did", 1))
+            }
         }
     }
 


### PR DESCRIPTION
Also fixes a failing unit test with the new schema, and adds the new schema to CI. I originally had the Ubuntu runner checking both new and old schemas, but that makes it run slower, so I've switched it so that the Ubuntu one only checks new schema, and the other two check legacy.