### PR TITLE
Migrate the CheckDatabase task to coroutine

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CoroutineHelpers.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CoroutineHelpers.kt
@@ -33,6 +33,7 @@ import com.ichi2.anki.CollectionManager.withCol
 import com.ichi2.anki.snackbar.showSnackbar
 import com.ichi2.libanki.Collection
 import kotlinx.coroutines.*
+import kotlinx.coroutines.channels.Channel
 import net.ankiweb.rsdroid.Backend
 import net.ankiweb.rsdroid.BackendException
 import net.ankiweb.rsdroid.exceptions.BackendInterruptedException
@@ -242,7 +243,7 @@ suspend fun <T> Fragment.withProgress(@StringRes messageId: Int, block: suspend 
     requireActivity().withProgress(messageId, block)
 
 @Suppress("Deprecation") // ProgressDialog deprecation
-private suspend fun <T> withProgressDialog(
+suspend fun <T> withProgressDialog(
     context: Activity,
     onCancel: (() -> Unit)?,
     op: suspend (android.app.ProgressDialog) -> T
@@ -353,4 +354,23 @@ suspend fun AnkiActivity.userAcceptsSchemaChange(): Boolean {
         withCol { modSchemaNoCheck() }
     }
     return hasAcceptedSchemaChange
+}
+
+/**
+ * Create a [Channel] and provide it to the supplied action. There is no need to close the channel,
+ * it will be automatically closed on exceptions in the supplied action or when the function
+ * finishes normally.
+ *
+ * This is used as an alternative to the deprecated ProgressCallback class to enable communication
+ * between the (coroutines) background tasks and the UI(mainly for progress updates).
+ *
+ * @param action the action to run with the provided [Channel] as a parameter
+ */
+suspend fun<T, R> withChannel(action: suspend (Channel<T>) -> R): R {
+    val channel = Channel<T>()
+    return try {
+        action(channel)
+    } finally {
+        channel.close()
+    }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -1474,14 +1474,14 @@ open class DeckPicker :
     }
 
     private fun handleDatabaseCheckLegacy() {
-        TaskManager.launchCollectionTask(
-            object : TaskDelegate<String, Pair<Boolean, CheckDatabaseResult?>>() {
-                override fun task(col: Collection, collectionTask: ProgressSenderAndCancelListener<String>): Pair<Boolean, CheckDatabaseResult?> {
-                    return checkDatabase(col, collectionTask)
-                }
-            },
-            CheckDatabaseListener()
-        )
+        launchCatchingTask {
+            withProgressDialog(this@DeckPicker, null) { progressDialog ->
+                @Suppress("DEPRECATION")
+                progressDialog.setMessage(getString(R.string.check_db_message))
+                val result = withCol { checkDatabase(this) }
+                checkDatabasePostTask(result)
+            }
+        }
     }
 
     private fun checkDatabasePostTask(result: Pair<Boolean, CheckDatabaseResult?>?) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -1467,10 +1467,21 @@ open class DeckPicker :
     private fun performIntegrityCheck() {
         Timber.i("performIntegrityCheck()")
         if (BackendFactory.defaultLegacySchema) {
-            TaskManager.launchCollectionTask(CheckDatabase(), CheckDatabaseListener())
+            handleDatabaseCheckLegacy()
         } else {
             handleDatabaseCheck()
         }
+    }
+
+    private fun handleDatabaseCheckLegacy() {
+        TaskManager.launchCollectionTask(
+            object : TaskDelegate<String, Pair<Boolean, CheckDatabaseResult?>>() {
+                override fun task(col: Collection, collectionTask: ProgressSenderAndCancelListener<String>): Pair<Boolean, CheckDatabaseResult?> {
+                    return checkDatabase(col, collectionTask)
+                }
+            },
+            CheckDatabaseListener()
+        )
     }
 
     /**

--- a/AnkiDroid/src/main/java/com/ichi2/async/CollectionOperations.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/async/CollectionOperations.kt
@@ -424,17 +424,19 @@ fun changeDeckMulti(
 
 fun checkDatabase(
     col: Collection,
-    collectionTask: ProgressSenderAndCancelListener<String>,
+    /* collectionTask: ProgressSenderAndCancelListener<String>, */
 ): Pair<Boolean, Collection.CheckDatabaseResult?> {
     Timber.d("doInBackgroundCheckDatabase")
     // Don't proceed if collection closed
-    val result = col.fixIntegrity(TaskManager.ProgressCallback(collectionTask, AnkiDroidApp.appResources))
+    // TaskManager.ProgressCallback(collectionTask, AnkiDroidApp.appResources)
+    val result = col.fixIntegrity(null)
     return if (result.failed) {
         // we can fail due to a locked database, which requires knowledge of the failure.
         Pair(false, result)
     } else {
         // Close the collection and we restart the app to reload
-        CollectionHelper.instance.closeCollection(true, "Check Database Completed")
+        // CollectionHelper.instance.closeCollection(true, "Check Database Completed")
+        col.close(save = true)
         Pair(true, result)
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/async/CollectionOperations.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/async/CollectionOperations.kt
@@ -23,6 +23,7 @@ import com.ichi2.libanki.*
 import com.ichi2.libanki.Collection
 import com.ichi2.utils.Computation
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.channels.SendChannel
 import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.withContext
 import net.ankiweb.rsdroid.BackendFactory
@@ -424,12 +425,11 @@ fun changeDeckMulti(
 
 fun checkDatabase(
     col: Collection,
-    /* collectionTask: ProgressSenderAndCancelListener<String>, */
+    progressCallback: SendChannel<Collection.FixIntegrityProgress>
 ): Pair<Boolean, Collection.CheckDatabaseResult?> {
     Timber.d("doInBackgroundCheckDatabase")
     // Don't proceed if collection closed
-    // TaskManager.ProgressCallback(collectionTask, AnkiDroidApp.appResources)
-    val result = col.fixIntegrity(null)
+    val result = col.fixIntegrity(progressCallback)
     return if (result.failed) {
         // we can fail due to a locked database, which requires knowledge of the failure.
         Pair(false, result)

--- a/AnkiDroid/src/main/java/com/ichi2/async/CollectionOperations.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/async/CollectionOperations.kt
@@ -421,3 +421,20 @@ fun changeDeckMulti(
         return@executeInTransaction Computation.ok(cards)
     }
 }
+
+fun checkDatabase(
+    col: Collection,
+    collectionTask: ProgressSenderAndCancelListener<String>,
+): Pair<Boolean, Collection.CheckDatabaseResult?> {
+    Timber.d("doInBackgroundCheckDatabase")
+    // Don't proceed if collection closed
+    val result = col.fixIntegrity(TaskManager.ProgressCallback(collectionTask, AnkiDroidApp.appResources))
+    return if (result.failed) {
+        // we can fail due to a locked database, which requires knowledge of the failure.
+        Pair(false, result)
+    } else {
+        // Close the collection and we restart the app to reload
+        CollectionHelper.instance.closeCollection(true, "Check Database Completed")
+        Pair(true, result)
+    }
+}

--- a/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.kt
@@ -25,7 +25,6 @@ import com.ichi2.anki.AnkiSerialization.factory
 import com.ichi2.anki.exception.ImportExportException
 import com.ichi2.libanki.*
 import com.ichi2.libanki.Collection
-import com.ichi2.libanki.Collection.CheckDatabaseResult
 import com.ichi2.libanki.importer.AnkiPackageImporter
 import com.ichi2.utils.Computation
 import com.ichi2.utils.KotlinCleanup
@@ -145,22 +144,6 @@ open class CollectionTask<Progress, Result>(val task: TaskDelegateBase<Progress,
     override fun onCancelled() {
         TaskManager.removeTask(this)
         listener?.onCancelled()
-    }
-
-    class CheckDatabase : TaskDelegate<String, Pair<Boolean, CheckDatabaseResult?>>() {
-        override fun task(col: Collection, collectionTask: ProgressSenderAndCancelListener<String>): Pair<Boolean, CheckDatabaseResult?> {
-            Timber.d("doInBackgroundCheckDatabase")
-            // Don't proceed if collection closed
-            val result = col.fixIntegrity(TaskManager.ProgressCallback(collectionTask, AnkiDroidApp.appResources))
-            return if (result.failed) {
-                // we can fail due to a locked database, which requires knowledge of the failure.
-                Pair(false, result)
-            } else {
-                // Close the collection and we restart the app to reload
-                CollectionHelper.instance.closeCollection(true, "Check Database Completed")
-                Pair(true, result)
-            }
-        }
     }
 
     class ImportAdd(private val pathList: List<String>) : TaskDelegate<String, ImporterData>() {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.kt
@@ -1484,13 +1484,13 @@ open class Collection(
 
     /** Fix possible problems and rebuild caches.  */
     @KotlinCleanup("Convert FunctionThrowable to ::method (as it was done in the Java)")
-    fun fixIntegrity(progressCallback: TaskManager.ProgressCallback<String>): CheckDatabaseResult {
+    fun fixIntegrity(@Suppress("UNUSED_PARAMETER") progressCallback: TaskManager.ProgressCallback<String>?): CheckDatabaseResult {
         var file = File(path)
         val result = CheckDatabaseResult(file.length())
-        val currentTask = intArrayOf(1)
+        @Suppress("UNUSED_VARIABLE") val currentTask = intArrayOf(1)
         // a few fixes are in all-models loops, the rest are one-offs
-        val totalTasks = models.all().size * 4 + 27
-        val notifyProgress = Runnable { fixIntegrityProgress(progressCallback, currentTask[0]++, totalTasks) }
+        @Suppress("UNUSED_VARIABLE") val totalTasks = models.all().size * 4 + 27
+        val notifyProgress = Runnable { /* fixIntegrityProgress(progressCallback, currentTask[0]++, totalTasks) */ }
         val executeIntegrityTask = Consumer { function: FunctionalInterfaces.FunctionThrowable<Runnable, List<String?>?> ->
             // DEFECT: notifyProgress will lag if an exception is thrown.
             try {

--- a/AnkiDroid/src/test/java/com/ichi2/async/CheckDatabaseTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/async/CheckDatabaseTest.kt
@@ -17,24 +17,18 @@ package com.ichi2.async
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.ichi2.anki.RobolectricTest
-import com.ichi2.libanki.Collection
 import com.ichi2.testutils.CollectionUtils
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.mockito.kotlin.mock
 
 @RunWith(AndroidJUnit4::class)
 class CheckDatabaseTest : RobolectricTest() {
     @Test
     fun checkDatabaseWithLockedCollectionReturnsLocked() {
         lockDatabase()
-        val result = object : TaskDelegate<String, Pair<Boolean, Collection.CheckDatabaseResult?>>() {
-            override fun task(col: Collection, collectionTask: ProgressSenderAndCancelListener<String>): Pair<Boolean, Collection.CheckDatabaseResult?> {
-                return checkDatabase(col, collectionTask)
-            }
-        }.execTask(col, mock())
+        val result = checkDatabase(col)
         assertThat("The result should specify a failure", result.first, equalTo(false))
         val checkDbResult = result.second!!
         assertThat("The result should specify the database was locked", checkDbResult.databaseLocked)

--- a/AnkiDroid/src/test/java/com/ichi2/async/CheckDatabaseTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/async/CheckDatabaseTest.kt
@@ -22,13 +22,14 @@ import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.mockito.kotlin.mock
 
 @RunWith(AndroidJUnit4::class)
 class CheckDatabaseTest : RobolectricTest() {
     @Test
     fun checkDatabaseWithLockedCollectionReturnsLocked() {
         lockDatabase()
-        val result = checkDatabase(col)
+        val result = checkDatabase(col, mock())
         assertThat("The result should specify a failure", result.first, equalTo(false))
         val checkDbResult = result.second!!
         assertThat("The result should specify the database was locked", checkDbResult.databaseLocked)

--- a/AnkiDroid/src/test/java/com/ichi2/async/CheckDatabaseTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/async/CheckDatabaseTest.kt
@@ -17,7 +17,7 @@ package com.ichi2.async
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.ichi2.anki.RobolectricTest
-import com.ichi2.async.CollectionTask.CheckDatabase
+import com.ichi2.libanki.Collection
 import com.ichi2.testutils.CollectionUtils
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
@@ -30,7 +30,11 @@ class CheckDatabaseTest : RobolectricTest() {
     @Test
     fun checkDatabaseWithLockedCollectionReturnsLocked() {
         lockDatabase()
-        val result = CheckDatabase().execTask(col, mock())
+        val result = object : TaskDelegate<String, Pair<Boolean, Collection.CheckDatabaseResult?>>() {
+            override fun task(col: Collection, collectionTask: ProgressSenderAndCancelListener<String>): Pair<Boolean, Collection.CheckDatabaseResult?> {
+                return checkDatabase(col, collectionTask)
+            }
+        }.execTask(col, mock())
         assertThat("The result should specify a failure", result.first, equalTo(false))
         val checkDbResult = result.second!!
         assertThat("The result should specify the database was locked", checkDbResult.databaseLocked)


### PR DESCRIPTION
## Purpose / Description

Part of https://github.com/ankidroid/Anki-Android/issues/7108. The minimum amount of work to migrate this task to coroutine to remove it from CollectionTask. There's no need for extra refactoring or TODOs as the changed code is on the legacy pathway and will be removed when the new backend becomes the default.

## How Has This Been Tested?

Ran the tests, manually verified the check database feature.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
