### PR TITLE
Enable extra CI checks using  the new backend

### DIFF
--- a/.github/workflows/tests_unit.yml
+++ b/.github/workflows/tests_unit.yml
@@ -39,12 +39,18 @@ concurrency:
 
 jobs:
   unit:
-    name: JUnit Tests
+    name: JUnit Tests (${{ matrix.os}}, legacy_schema = ${{ matrix.legacy_schema }})
     timeout-minutes: 40
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
+        legacy_schema: [true, false]
+        exclude:
+          - os: macos-latest
+            legacy_schema: false
+          - os: windows-latest
+            legacy_schema: false
     runs-on: ${{ matrix.os }}
     #env:
     #  CODACY_TOKEN: ${{ secrets.CODACY_TOKEN }}
@@ -99,9 +105,8 @@ jobs:
           max_attempts: 3
           command: ./gradlew robolectricSdkDownload --daemon
 
-      - name: Switch to new schema (Linux)
-        if: matrix.os == 'ubuntu-latest'
-        run: echo "legacy_schema = false" >> local.properties
+      - name: Set legacy schema property
+        run: echo "legacy_schema = ${{ matrix.legacy_schema }}" >> local.properties
 
       - name: Run Unit Tests
         uses: gradle/gradle-build-action@v2

--- a/.github/workflows/tests_unit.yml
+++ b/.github/workflows/tests_unit.yml
@@ -49,8 +49,6 @@ jobs:
         exclude:
           - os: macos-latest
             legacy_schema: false
-          - os: windows-latest
-            legacy_schema: false
     runs-on: ${{ matrix.os }}
     #env:
     #  CODACY_TOKEN: ${{ secrets.CODACY_TOKEN }}

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/CollectionPersistentTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/CollectionPersistentTest.kt
@@ -18,6 +18,7 @@ package com.ichi2.libanki
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.ichi2.anki.RobolectricTest
+import net.ankiweb.rsdroid.BackendFactory
 import org.hamcrest.Matchers.equalTo
 import org.hamcrest.Matchers.not
 import org.junit.Test
@@ -32,8 +33,10 @@ class CollectionPersistentTest : RobolectricTest() {
 
     @Test
     fun beforeUploadDbIsV11() {
-        assumeThat(col.queryVer(), not(equalTo(11)))
-        col.beforeUpload()
-        assumeThat(Storage.getDatabaseVersion(targetContext, col.path), equalTo(11))
+        if (BackendFactory.defaultLegacySchema) {
+            assumeThat(col.queryVer(), not(equalTo(11)))
+            col.beforeUpload()
+            assumeThat(Storage.getDatabaseVersion(targetContext, col.path), equalTo(11))
+        }
     }
 }


### PR DESCRIPTION
## Purpose / Description

Introduces a new matrix variable for jobs so we get to test the old code as well as run tests for the new backend. At the moment I enabled the new backend just for Ubuntu. Also because this PR introduces two different configurations for Ubuntu CI runner, I changed the name of the job to mention both the os and the legacy schema value so reviewers/contributors can see more easily  in which situations the PR fails.

## Fixes

Fixes #12920 

## How Has This Been Tested?

Ran on my fork.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
