### PR TITLE
Forward-port github workflows to macos-12

### DIFF
--- a/.github/workflows/sync_translations.yml
+++ b/.github/workflows/sync_translations.yml
@@ -48,7 +48,7 @@ jobs:
 
       - name: Pull translation updates from crowdin
         run: |
-          ./tools/update-localizations.py
+          python ./tools/update-localizations.py
           git push --set-upstream origin +i18n_sync
           echo "The results of the sync are on the i18n_sync branch, PR them from there for merge."
           echo "https://github.com/ankidroid/Anki-Android/compare/i18n_sync?expand=1"

--- a/tools/update-localizations.py
+++ b/tools/update-localizations.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 # Copyright (c) 2010 norbert.nagold@gmail.com


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
`macos-latest` will become macos-12 shortly and I don't think this will have any effects other than to alter the python interpreter (as I discovered in other repos...) so just making sure we resolve to python3 as that is required for our i18n work

## Fixes
No fix, but related: https://github.com/ankidroid/Anki-Android/pull/12927#issuecomment-1337441422

## Approach
- For local machines use the `#!/usr/bin/env python3` she-bang style to resolve pyrhon3 from PATH
- For CI use the `python` interpreter directly to call script as documented by setup-python action

## How Has This Been Tested?

Untested! But github actions are like that ;-) - hard to test them. Change it tiny though and I will repair it if it breaks when I do an i18n sync

## Learning (optional, can help others)
https://unix.stackexchange.com/questions/12736/how-does-usr-bin-env-know-which-program-to-use/12751#12751
https://github.com/actions/setup-python#readme


## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
