### PR TITLE
Add option to sync media only on unmetered connections

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -1578,9 +1578,12 @@ open class DeckPicker :
         /** Nested function that makes the connection to
          * the sync server and starts syncing the data */
         fun doSync() {
-            val syncMediaPrefValue = preferences.getString("syncFetchMedia", "always")
-            val syncMedia = syncMediaPrefValue == "always" ||
-                (syncMediaPrefValue == "only_wifi" && !isActiveNetworkMetered())
+            val alwaysValue = getString(R.string.sync_media_always_value)
+            val onlyWifiValue = getString(R.string.sync_media_only_wifi_value)
+
+            val syncMediaPrefValue = preferences.getString(getString(R.string.sync_fetch_media_key), alwaysValue)
+            val syncMedia = syncMediaPrefValue == alwaysValue ||
+                (syncMediaPrefValue == onlyWifiValue && !isActiveNetworkMetered())
 
             if (!BackendFactory.defaultLegacySchema) {
                 handleNewSync(conflict, syncMedia)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -1578,7 +1578,10 @@ open class DeckPicker :
         /** Nested function that makes the connection to
          * the sync server and starts syncing the data */
         fun doSync() {
-            val syncMedia = preferences.getBoolean("syncFetchesMedia", true)
+            val syncMediaPrefValue = preferences.getString("syncFetchMedia", "always")
+            val syncMedia = syncMediaPrefValue == "always" ||
+                (syncMediaPrefValue == "only_wifi" && !isActiveNetworkMetered())
+
             if (!BackendFactory.defaultLegacySchema) {
                 handleNewSync(conflict, syncMedia)
             } else {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -1575,20 +1575,22 @@ open class DeckPicker :
             showSyncErrorDialog(SyncErrorDialog.DIALOG_USER_NOT_LOGGED_IN_SYNC)
             return
         }
+
+        fun shouldFetchMedia(): Boolean {
+            val always = getString(R.string.sync_media_always_value)
+            val onlyIfUnmetered = getString(R.string.sync_media_only_unmetered_value)
+            val shouldFetchMedia = preferences.getString(getString(R.string.sync_fetch_media_key), always)
+            return shouldFetchMedia == always ||
+                (shouldFetchMedia == onlyIfUnmetered && !isActiveNetworkMetered())
+        }
+
         /** Nested function that makes the connection to
          * the sync server and starts syncing the data */
         fun doSync() {
-            val alwaysValue = getString(R.string.sync_media_always_value)
-            val onlyUnmeteredValue = getString(R.string.sync_media_only_unmetered_value)
-
-            val syncMediaPrefValue = preferences.getString(getString(R.string.sync_fetch_media_key), alwaysValue)
-            val syncMedia = syncMediaPrefValue == alwaysValue ||
-                (syncMediaPrefValue == onlyUnmeteredValue && !isActiveNetworkMetered())
-
             if (!BackendFactory.defaultLegacySchema) {
-                handleNewSync(conflict, syncMedia)
+                handleNewSync(conflict, shouldFetchMedia())
             } else {
-                val data = arrayOf(hkey, syncMedia, conflict, HostNumFactory.getInstance(baseContext))
+                val data = arrayOf(hkey, shouldFetchMedia(), conflict, HostNumFactory.getInstance(baseContext))
                 Connection.sync(mSyncListener, Connection.Payload(data))
             }
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -1579,11 +1579,11 @@ open class DeckPicker :
          * the sync server and starts syncing the data */
         fun doSync() {
             val alwaysValue = getString(R.string.sync_media_always_value)
-            val onlyWifiValue = getString(R.string.sync_media_only_wifi_value)
+            val onlyUnmeteredValue = getString(R.string.sync_media_only_unmetered_value)
 
             val syncMediaPrefValue = preferences.getString(getString(R.string.sync_fetch_media_key), alwaysValue)
             val syncMedia = syncMediaPrefValue == alwaysValue ||
-                (syncMediaPrefValue == onlyWifiValue && !isActiveNetworkMetered())
+                (syncMediaPrefValue == onlyUnmeteredValue && !isActiveNetworkMetered())
 
             if (!BackendFactory.defaultLegacySchema) {
                 handleNewSync(conflict, syncMedia)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/PreferenceUpgradeService.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/PreferenceUpgradeService.kt
@@ -88,6 +88,7 @@ object PreferenceUpgradeService {
                 yield(UpgradeDayAndNightThemes())
                 yield(UpgradeCustomCollectionSyncUrl())
                 yield(UpgradeCustomSyncServerEnabled())
+                yield(UpgradeFetchMedia())
             }
 
             /** Returns a list of preference upgrade classes which have not been applied */
@@ -408,6 +409,14 @@ object PreferenceUpgradeService {
                         customSyncServerEnabled && !customMediaSyncUrl.isNullOrEmpty()
                     )
                 }
+            }
+        }
+
+        internal class UpgradeFetchMedia : PreferenceUpgrade(9) {
+            override fun upgrade(preferences: SharedPreferences) {
+                val fetchMediaSwitch = preferences.getBoolean("syncFetchesMedia", true)
+                val status = if (fetchMediaSwitch) "always" else "never"
+                preferences.edit { this.putString("syncFetchMedia", status) }
             }
         }
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/PreferenceUpgradeService.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/PreferenceUpgradeService.kt
@@ -414,10 +414,10 @@ object PreferenceUpgradeService {
 
         internal class UpgradeFetchMedia : PreferenceUpgrade(9) {
             override fun upgrade(preferences: SharedPreferences) {
-                val fetchMediaSwitch = preferences.getBoolean(RemovedPreferences.SYNC_FETCH_MEDIA, true)
+                val fetchMediaSwitch = preferences.getBoolean(RemovedPreferences.SYNC_FETCHES_MEDIA, true)
                 val status = if (fetchMediaSwitch) "always" else "never"
                 preferences.edit {
-                    remove(RemovedPreferences.SYNC_FETCH_MEDIA)
+                    remove(RemovedPreferences.SYNC_FETCHES_MEDIA)
                     putString("syncFetchMedia", status)
                 }
             }
@@ -428,5 +428,5 @@ object PreferenceUpgradeService {
 object RemovedPreferences {
     const val PREFERENCE_CUSTOM_SYNC_BASE = "syncBaseUrl"
     const val PREFERENCE_ENABLE_CUSTOM_SYNC_SERVER = "useCustomSyncServer"
-    const val SYNC_FETCH_MEDIA = "syncFetchesMedia"
+    const val SYNC_FETCHES_MEDIA = "syncFetchesMedia"
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/PreferenceUpgradeService.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/PreferenceUpgradeService.kt
@@ -414,9 +414,12 @@ object PreferenceUpgradeService {
 
         internal class UpgradeFetchMedia : PreferenceUpgrade(9) {
             override fun upgrade(preferences: SharedPreferences) {
-                val fetchMediaSwitch = preferences.getBoolean("syncFetchesMedia", true)
+                val fetchMediaSwitch = preferences.getBoolean(RemovedPreferences.SYNC_FETCH_MEDIA, true)
                 val status = if (fetchMediaSwitch) "always" else "never"
-                preferences.edit { this.putString("syncFetchMedia", status) }
+                preferences.edit {
+                    remove(RemovedPreferences.SYNC_FETCH_MEDIA)
+                    putString("syncFetchMedia", status)
+                }
             }
         }
     }
@@ -425,4 +428,5 @@ object PreferenceUpgradeService {
 object RemovedPreferences {
     const val PREFERENCE_CUSTOM_SYNC_BASE = "syncBaseUrl"
     const val PREFERENCE_ENABLE_CUSTOM_SYNC_SERVER = "useCustomSyncServer"
+    const val SYNC_FETCH_MEDIA = "syncFetchesMedia"
 }

--- a/AnkiDroid/src/main/res/values/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values/10-preferences.xml
@@ -107,7 +107,7 @@
     <string name="automatic_sync_choice" maxLength="41">Automatic synchronization</string>
     <string name="automatic_sync_choice_summ">Sync automatically on app start/exit if the last sync was more than 10
         minutes ago.</string>
-    <string name="sync_media_always">Always</string>
+    <string name="sync_media_always" comment="Option to always fetch media when syncing">Always</string>
     <string name="sync_media_only_wifi">Only on Wi-Fi</string>
     <string name="sync_media_never">Never</string>
     <string name="sync_status_badge" maxLength="41">Display synchronization status</string>

--- a/AnkiDroid/src/main/res/values/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values/10-preferences.xml
@@ -107,8 +107,9 @@
     <string name="automatic_sync_choice" maxLength="41">Automatic synchronization</string>
     <string name="automatic_sync_choice_summ">Sync automatically on app start/exit if the last sync was more than 10
         minutes ago.</string>
-    <string name="only_wifi">Only on Wi-Fi</string>
-    <string name="never">Never</string>
+    <string name="sync_media_always">Always</string>
+    <string name="sync_media_only_wifi">Only on Wi-Fi</string>
+    <string name="sync_media_never">Never</string>
     <string name="sync_status_badge" maxLength="41">Display synchronization status</string>
     <string name="sync_status_badge_summ">Change the sync icon when changes can be uploaded</string>
     <string name="metered_sync_title" maxLength="41">Allow sync on metered connections</string>

--- a/AnkiDroid/src/main/res/values/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values/10-preferences.xml
@@ -102,12 +102,13 @@
     <string name="tts_summ">Reads out question and answer if no sound file is included</string>
     <!-- Sync -->
     <string name="sync_fetch_missing_media" maxLength="41">Fetch media on sync</string>
-    <string name="sync_fetch_missing_media_summ">Automatically fetch missing media when syncing</string>
     <string name="sync_account" maxLength="41">AnkiWeb account</string>
     <string name="sync_account_summ_logged_out">Not logged in</string>
     <string name="automatic_sync_choice" maxLength="41">Automatic synchronization</string>
     <string name="automatic_sync_choice_summ">Sync automatically on app start/exit if the last sync was more than 10
         minutes ago.</string>
+    <string name="only_wifi">Only on Wi-Fi</string>
+    <string name="never">Never</string>
     <string name="sync_status_badge" maxLength="41">Display synchronization status</string>
     <string name="sync_status_badge_summ">Change the sync icon when changes can be uploaded</string>
     <string name="metered_sync_title" maxLength="41">Allow sync on metered connections</string>

--- a/AnkiDroid/src/main/res/values/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values/10-preferences.xml
@@ -108,7 +108,7 @@
     <string name="automatic_sync_choice_summ">Sync automatically on app start/exit if the last sync was more than 10
         minutes ago.</string>
     <string name="sync_media_always" comment="Option to always fetch media when syncing">Always</string>
-    <string name="sync_media_only_wifi">Only on Wi-Fi</string>
+    <string name="sync_media_only_unmetered">Only on unmetered connections</string>
     <string name="sync_media_never">Never</string>
     <string name="sync_status_badge" maxLength="41">Display synchronization status</string>
     <string name="sync_status_badge_summ">Change the sync icon when changes can be uploaded</string>

--- a/AnkiDroid/src/main/res/values/11-arrays.xml
+++ b/AnkiDroid/src/main/res/values/11-arrays.xml
@@ -54,7 +54,7 @@
 
     <!-- override_font_labels -->
     <string name="override_font_if_missing">When no font specified on flashcards</string>
-    <string name="override_font_always">Always</string>
+    <string name="override_font_always" comment="Option to always override font">Always</string>
 
     <!-- theme labels -->
     <string name="theme_follow_system">Follow system</string>

--- a/AnkiDroid/src/main/res/values/constants.xml
+++ b/AnkiDroid/src/main/res/values/constants.xml
@@ -251,9 +251,9 @@
     </string-array>
 
     <string-array name="sync_media_entries">
-        <item>@string/override_font_always</item>
-        <item>@string/only_wifi</item>
-        <item>@string/never</item>
+        <item>@string/sync_media_always</item>
+        <item>@string/sync_media_only_wifi</item>
+        <item>@string/sync_media_never</item>
     </string-array>
 
     <string name="sync_media_always_value">always</string>

--- a/AnkiDroid/src/main/res/values/constants.xml
+++ b/AnkiDroid/src/main/res/values/constants.xml
@@ -250,6 +250,22 @@
         <item>4</item>
     </string-array>
 
+    <string-array name="sync_media_entries">
+        <item>@string/override_font_always</item>
+        <item>@string/only_wifi</item>
+        <item>@string/never</item>
+    </string-array>
+
+    <string name="sync_media_always_value">always</string>
+    <string name="sync_media_only_wifi_value">only_wifi</string>
+    <string name="sync_media_never_value">never</string>
+
+    <string-array name="sync_media_values">
+        <item>@string/sync_media_always_value</item>
+        <item>@string/sync_media_only_wifi_value</item>
+        <item>@string/sync_media_never_value</item>
+    </string-array>
+
     <!-- Preferences headers summaries -->
     <string-array name="general_summary_entries">
         <item>@string/language</item>

--- a/AnkiDroid/src/main/res/values/constants.xml
+++ b/AnkiDroid/src/main/res/values/constants.xml
@@ -252,17 +252,17 @@
 
     <string-array name="sync_media_entries">
         <item>@string/sync_media_always</item>
-        <item>@string/sync_media_only_wifi</item>
+        <item>@string/sync_media_only_unmetered</item>
         <item>@string/sync_media_never</item>
     </string-array>
 
     <string name="sync_media_always_value">always</string>
-    <string name="sync_media_only_wifi_value">only_wifi</string>
+    <string name="sync_media_only_unmetered_value">only_unmetered</string>
     <string name="sync_media_never_value">never</string>
 
     <string-array name="sync_media_values">
         <item>@string/sync_media_always_value</item>
-        <item>@string/sync_media_only_wifi_value</item>
+        <item>@string/sync_media_only_unmetered_value</item>
         <item>@string/sync_media_never_value</item>
     </string-array>
 

--- a/AnkiDroid/src/main/res/values/preferences.xml
+++ b/AnkiDroid/src/main/res/values/preferences.xml
@@ -23,7 +23,7 @@
     <!-- Sync -->
     <string name="pref_sync_screen_key">syncScreen</string>
     <string name="sync_account_key">syncAccount</string>
-    <string name="sync_fetch_missing_media_key">syncFetchesMedia</string>
+    <string name="sync_fetch_media_key">syncFetchMedia</string>
     <string name="automatic_sync_choice_key">automaticSyncMode</string>
     <string name="force_full_sync_key">force_full_sync</string>
     <string name="sync_status_badge_key">showSyncStatusBadge</string>

--- a/AnkiDroid/src/main/res/xml/preferences_sync.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_sync.xml
@@ -15,6 +15,7 @@
   ~  this program.  If not, see <http://www.gnu.org/licenses/>.
   -->
 <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:search="http://schemas.android.com/apk/com.bytehamster.lib.preferencesearch"
     android:title="@string/pref_cat_sync"
     android:key="@string/pref_sync_screen_key">
@@ -27,11 +28,13 @@
             android:targetClass="com.ichi2.anki.MyAccount"
             android:targetPackage="com.ichi2.anki" />
     </Preference>
-    <SwitchPreference
-        android:defaultValue="true"
-        android:key="@string/sync_fetch_missing_media_key"
-        android:summary="@string/sync_fetch_missing_media_summ"
-        android:title="@string/sync_fetch_missing_media" />
+    <ListPreference
+        android:defaultValue="@string/sync_media_always_value"
+        android:entries="@array/sync_media_entries"
+        android:entryValues="@array/sync_media_values"
+        android:key="@string/sync_fetch_media_key"
+        android:title="@string/sync_fetch_missing_media"
+        app:useSimpleSummaryProvider="true"/>
     <SwitchPreference
         android:defaultValue="false"
         android:key="@string/automatic_sync_choice_key"

--- a/AnkiDroid/src/test/java/com/ichi2/anki/servicemodel/PreferenceUpgradeServiceTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/servicemodel/PreferenceUpgradeServiceTest.kt
@@ -199,4 +199,17 @@ class PreferenceUpgradeServiceTest : RobolectricTest() {
         assertThat(CustomSyncServer.getCollectionSyncUrlIfSetAndEnabledOrNull(mPrefs), equalTo("http://foo/sync/"))
         assertThat(CustomSyncServer.getMediaSyncUrlIfSetAndEnabledOrNull(mPrefs), equalTo(null))
     }
+
+    @Test
+    fun `Fetch media pref's values are converted to 'always' if enabled and 'never' if disabled`() {
+        // enabled -> always
+        mPrefs.edit { putBoolean(RemovedPreferences.SYNC_FETCH_MEDIA, true) }
+        PreferenceUpgrade.UpgradeFetchMedia().performUpgrade(mPrefs)
+        assertThat(mPrefs.getString("syncFetchMedia", null), equalTo("always"))
+
+        // disabled -> never
+        mPrefs.edit { putBoolean(RemovedPreferences.SYNC_FETCH_MEDIA, false) }
+        PreferenceUpgrade.UpgradeFetchMedia().performUpgrade(mPrefs)
+        assertThat(mPrefs.getString("syncFetchMedia", null), equalTo("never"))
+    }
 }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/servicemodel/PreferenceUpgradeServiceTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/servicemodel/PreferenceUpgradeServiceTest.kt
@@ -203,12 +203,12 @@ class PreferenceUpgradeServiceTest : RobolectricTest() {
     @Test
     fun `Fetch media pref's values are converted to 'always' if enabled and 'never' if disabled`() {
         // enabled -> always
-        mPrefs.edit { putBoolean(RemovedPreferences.SYNC_FETCH_MEDIA, true) }
+        mPrefs.edit { putBoolean(RemovedPreferences.SYNC_FETCHES_MEDIA, true) }
         PreferenceUpgrade.UpgradeFetchMedia().performUpgrade(mPrefs)
         assertThat(mPrefs.getString("syncFetchMedia", null), equalTo("always"))
 
         // disabled -> never
-        mPrefs.edit { putBoolean(RemovedPreferences.SYNC_FETCH_MEDIA, false) }
+        mPrefs.edit { putBoolean(RemovedPreferences.SYNC_FETCHES_MEDIA, false) }
         PreferenceUpgrade.UpgradeFetchMedia().performUpgrade(mPrefs)
         assertThat(mPrefs.getString("syncFetchMedia", null), equalTo("never"))
     }


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
This converts the Fetch media on sync SwitchPreference to a ListPreference with the options "Always, "Only on Wi-Fi" and "Never"

## Fixes
Fixes #12932

## Approach
This converts the Fetch media on sync SwitchPreference to a ListPreference with the options "Always, "Only on Wi-Fi" and "Never"

## How Has This Been Tested?

Unit test. And by installing an old version of the app then installing this new one

## Learning (optional, can help others)
_Describe the research stage_

Mostly I tried to understand the code by reading other PRs after using git blame on `preferences_sync.xml`. 

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
