### PR TITLE
Make Collection calls async on preferences' fragments

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CoroutineHelpers.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CoroutineHelpers.kt
@@ -140,6 +140,20 @@ fun Fragment.launchCatchingTask(
     }
 }
 
+/** Launches a [CollectionManager.withCol] job while catching its errors with [launchCatchingTask] */
+fun <T> FragmentActivity.launchWithCol(block: Collection.() -> T): Job {
+    return launchCatchingTask {
+        withCol { block() }
+    }
+}
+
+/** See [FragmentActivity.launchWithCol] */
+fun <T> Fragment.launchWithCol(block: Collection.() -> T): Job {
+    return launchCatchingTask {
+        withCol { block() }
+    }
+}
+
 private fun showError(context: Context, msg: String, exception: Throwable) {
     try {
         MaterialDialog(context).show {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/AppearanceSettingsFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/AppearanceSettingsFragment.kt
@@ -21,10 +21,7 @@ import androidx.activity.result.contract.ActivityResultContracts
 import androidx.preference.ListPreference
 import androidx.preference.Preference
 import androidx.preference.SwitchPreference
-import com.ichi2.anki.AnkiDroidApp
-import com.ichi2.anki.CollectionHelper
-import com.ichi2.anki.R
-import com.ichi2.anki.UIUtils
+import com.ichi2.anki.*
 import com.ichi2.anki.cardviewer.GestureProcessor
 import com.ichi2.anki.reviewer.FullScreenMode
 import com.ichi2.anki.snackbar.showSnackbar
@@ -44,7 +41,6 @@ class AppearanceSettingsFragment : SettingsFragment() {
         get() = "prefs.appearance"
 
     override fun initSubscreen() {
-        val col = col!!
         // Show error toast if the user tries to disable answer button without gestures on
         requirePreference<Preference>(R.string.answer_buttons_position_preference).setOnPreferenceChangeListener() { _, newValue: Any ->
             val prefs = AnkiDroidApp.getSharedPrefs(requireContext())
@@ -164,18 +160,22 @@ class AppearanceSettingsFragment : SettingsFragment() {
         // Represents the collection pref "estTime": i.e.
         // whether the buttons should indicate the duration of the interval if we click on them.
         requirePreference<SwitchPreference>(R.string.show_estimates_preference).apply {
-            isChecked = col.get_config_boolean("estTimes")
-            setOnPreferenceChangeListener { newValue ->
-                col.set_config("estTimes", newValue)
+            launchWithCol {
+                isChecked = get_config_boolean("estTimes")
+                setOnPreferenceChangeListener { newValue ->
+                    set_config("estTimes", newValue)
+                }
             }
         }
         // Show progress
         // Represents the collection pref "dueCounts": i.e.
         // whether the remaining number of cards should be shown.
         requirePreference<SwitchPreference>(R.string.show_progress_preference).apply {
-            isChecked = col.get_config_boolean("dueCounts")
-            setOnPreferenceChangeListener { newValue ->
-                col.set_config("dueCounts", newValue)
+            launchWithCol {
+                isChecked = get_config_boolean("dueCounts")
+                setOnPreferenceChangeListener { newValue ->
+                    set_config("dueCounts", newValue)
+                }
             }
         }
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/GeneralSettingsFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/GeneralSettingsFragment.kt
@@ -17,9 +17,7 @@ package com.ichi2.anki.preferences
 
 import androidx.preference.ListPreference
 import androidx.preference.SwitchPreference
-import com.ichi2.anki.CollectionManager
-import com.ichi2.anki.CrashReportService
-import com.ichi2.anki.R
+import com.ichi2.anki.*
 import com.ichi2.anki.contextmenu.AnkiCardContextMenu
 import com.ichi2.anki.contextmenu.CardBrowserContextMenu
 import com.ichi2.annotations.NeedsTest
@@ -35,7 +33,6 @@ class GeneralSettingsFragment : SettingsFragment() {
         get() = "prefs.general"
 
     override fun initSubscreen() {
-        val col = col!!
         // Build languages
         initializeLanguageDialog()
 
@@ -44,18 +41,22 @@ class GeneralSettingsFragment : SettingsFragment() {
         // if true, then add note to current decks, otherwise let the note type's configuration decide
         // Note that "addToCur" is a boolean while USE_CURRENT is "0" or "1"
         requirePreference<ListPreference>(R.string.deck_for_new_cards_key).apply {
-            setValueIndex(if (col.get_config("addToCur", true)!!) 0 else 1)
-            setOnPreferenceChangeListener { newValue ->
-                col.set_config("addToCur", "0" == newValue)
+            launchWithCol {
+                setValueIndex(if (get_config("addToCur", true)!!) 0 else 1)
+                setOnPreferenceChangeListener { newValue ->
+                    set_config("addToCur", "0" == newValue)
+                }
             }
         }
         // Paste PNG
         // Represents in the collection's pref "pastePNG" , i.e.
         // whether to convert clipboard uri to png format or not.
         requirePreference<SwitchPreference>(R.string.paste_png_key).apply {
-            isChecked = col.get_config("pastePNG", false)!!
-            setOnPreferenceChangeListener { newValue ->
-                col.set_config("pastePNG", newValue)
+            launchWithCol {
+                isChecked = get_config("pastePNG", false)!!
+                setOnPreferenceChangeListener { newValue ->
+                    set_config("pastePNG", newValue)
+                }
             }
         }
         // Error reporting mode

--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/SettingsFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/SettingsFragment.kt
@@ -22,9 +22,7 @@ import androidx.annotation.XmlRes
 import androidx.core.os.bundleOf
 import androidx.preference.Preference
 import androidx.preference.PreferenceFragmentCompat
-import com.ichi2.anki.CollectionHelper
 import com.ichi2.anki.analytics.UsageAnalytics
-import com.ichi2.libanki.Collection
 import com.ichi2.preferences.DialogFragmentProvider
 import kotlin.reflect.KClass
 import kotlin.reflect.jvm.jvmName
@@ -44,9 +42,6 @@ abstract class SettingsFragment : PreferenceFragmentCompat() {
         addPreferencesFromResource(preferenceResource)
         initSubscreen()
     }
-
-    protected val col: Collection?
-        get() = CollectionHelper.instance.getCol(requireContext())
 
     abstract fun initSubscreen()
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/SyncSettingsFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/SyncSettingsFragment.kt
@@ -20,7 +20,7 @@ import com.afollestad.materialdialogs.MaterialDialog
 import com.google.android.material.snackbar.Snackbar
 import com.ichi2.anki.AnkiDroidApp
 import com.ichi2.anki.R
-import com.ichi2.anki.UIUtils.showThemedToast
+import com.ichi2.anki.launchWithCol
 import com.ichi2.anki.snackbar.showSnackbar
 import com.ichi2.anki.web.CustomSyncServer
 
@@ -43,12 +43,10 @@ class SyncSettingsFragment : SettingsFragment() {
                 title(R.string.force_full_sync_title)
                 message(R.string.force_full_sync_summary)
                 positiveButton(R.string.dialog_ok) {
-                    if (col == null) {
-                        showThemedToast(requireContext(), R.string.directory_inaccessible, false)
-                        return@positiveButton
+                    launchWithCol {
+                        modSchemaNoCheck()
+                        showSnackbar(R.string.force_full_sync_confirmation, Snackbar.LENGTH_SHORT)
                     }
-                    col!!.modSchemaNoCheck()
-                    showSnackbar(R.string.force_full_sync_confirmation, Snackbar.LENGTH_SHORT)
                 }
                 negativeButton(R.string.dialog_cancel)
             }


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
UI/Main thread got blocked by a Collection call while I was doing some tests, so I finally made the calls to Collection async on preferences

## Approach
On the commits

## How Has This Been Tested?

1. Go to Settings
2. Test if the changed fragments work normally (Appearance, General, Sync, Reviewing) by tapping and changing settings

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
