### PR TITLE
Fix manage space activity on parallel and debug builds

### DIFF
--- a/AnkiDroid/src/main/AndroidManifest.xml
+++ b/AnkiDroid/src/main/AndroidManifest.xml
@@ -83,10 +83,12 @@
         android:resizeableActivity="true"
         android:supportsRtl="true"
         android:theme="@style/Theme_Light"
-        android:manageSpaceActivity=".ui.windows.managespace.ManageSpaceActivity"
+        android:manageSpaceActivity="com.ichi2.anki.ui.windows.managespace.ManageSpaceActivity"
         >
+        <!-- Probably because of a bug on the framework,
+        the full package path is needed for manageSpaceActivity -->
         <activity
-            android:name=".ui.windows.managespace.ManageSpaceActivity"
+            android:name="com.ichi2.anki.ui.windows.managespace.ManageSpaceActivity"
             android:exported="true"
             android:theme="@android:style/Theme.Translucent.NoTitleBar"/>
         <activity android:name=".DrawingActivity"


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
_Describe the problem or feature and motivation_

## Fixes
Fixes #12953

## Approach
Set the absolute path on the Manifest for the manage space activity

## How Has This Been Tested?

1. Install one of the parallel builds (can be found at the releases page or by running ./tools/parallel-package-name.sh com.ichi2.anki.a AnkiDroid.A then installing the app)
2. Go to the app settings > Storage

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
