### PR TITLE
Make possible to disable leak canary on local.properties

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -34,6 +34,7 @@ android {
         buildConfigField "Boolean", "LEGACY_SCHEMA", "true"
         buildConfigField "String", "ACRA_URL", '"https://ankidroid.org/acra/report"'
         buildConfigField "String", "BACKEND_VERSION", "\"$ankidroid_backend_version\""
+        buildConfigField "Boolean", "ENABLE_LEAK_CANARY", "false"
 
         // The version number is of the form:
         // <major>.<minor>.<maintenance>[dev|alpha<build>|beta<build>|]
@@ -92,6 +93,12 @@ android {
                 // allow overriding default schema version
                 if (localProperties["legacy_schema"] != null) {
                     buildConfigField "Boolean", "LEGACY_SCHEMA", localProperties["legacy_schema"]
+                }
+                // allow disabling leak canary
+                if (localProperties["enable_leak_canary"] != null) {
+                    buildConfigField "Boolean", "ENABLE_LEAK_CANARY", localProperties["enable_leak_canary"]
+                } else {
+                    buildConfigField "Boolean", "ENABLE_LEAK_CANARY", "true"
                 }
             } else {
                 testCoverageEnabled true

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.kt
@@ -119,9 +119,12 @@ open class AnkiDroidApp : Application() {
         if (BuildConfig.DEBUG) {
             // Enable verbose error logging and do method tracing to put the Class name as log tag
             Timber.plant(DebugTree())
-            LeakCanaryConfiguration.setInitialConfigFor(this)
         } else {
             Timber.plant(ProductionCrashReportingTree())
+        }
+        if (BuildConfig.ENABLE_LEAK_CANARY) {
+            LeakCanaryConfiguration.setInitialConfigFor(this)
+        } else {
             LeakCanaryConfiguration.disable()
         }
         Timber.tag(TAG)


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
Leak canary can be pretty annoying while testing some things, so this adds an option to disable it with local.properties

## Fixes
Fixes _Link to the issues._

## Approach
Add a local property to disable leak canary

## How Has This Been Tested?

Install the app and see if LeakCanary shows up

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
