### PR TITLE
Make "Undo" item's title for whiteboard mode

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
@@ -765,7 +765,7 @@ open class Reviewer : AbstractFlashcardViewer() {
                 // We arrive here if the first stroke for whiteboard is done.
                 // We stay here even if the first stroke is undone.
                 //  (This works as a safeguard against unintentional undo
-                //   for before-whiteboard actions by consective tappings.)
+                //   for pre-whiteboard actions by consective tappings.)
                 // We leave here if whiteboard is inactive ("Disable whiteboard" or "Hide whiteboard")
                 //  or is reset ("Clear whiteboard")
                 val lastStroke = resources.getString(R.string.undo_action_whiteboard_last_stroke)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
@@ -744,7 +744,7 @@ open class Reviewer : AbstractFlashcardViewer() {
         // Undo button
         @DrawableRes val undoIconId: Int
         val undoEnabled: Boolean
-        if (mShowWhiteboard && whiteboard != null && whiteboard!!.isUndoModeActive) {
+        if (mShowWhiteboard && whiteboard != null && whiteboard?.isUndoModeActive == true) {
             // Whiteboard is here and strokes have been added at some point
             undoIconId = R.drawable.eraser
             undoEnabled = !whiteboard!!.undoEmpty()

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
@@ -760,7 +760,11 @@ open class Reviewer : AbstractFlashcardViewer() {
         undoIcon.setEnabled(undoEnabled).iconAlpha = alphaUndo
         undoIcon.actionView!!.isEnabled = undoEnabled
         if (colIsOpen()) { // Required mostly because there are tests where `col` is null
-            if (col.undoAvailable()) {
+            if (mShowWhiteboard && whiteboard != null && whiteboard!!.isUndoModeActive) {
+                // We arrive here if whiteboard is shown and one or more strokes are retained
+                val lastStroke = resources.getString(R.string.undo_action_whiteboard_last_stroke)
+                undoIcon.title = resources.getString(R.string.studyoptions_congrats_undo, lastStroke)
+            } else if (col.undoAvailable()) {
                 // We arrive here if the last action which can be undone is retained.
                 //  e.g. Undo Bury, Undo Change Deck, Undo Update Note
                 undoIcon.title = resources.getString(R.string.studyoptions_congrats_undo, col.undoName(resources))

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
@@ -761,7 +761,13 @@ open class Reviewer : AbstractFlashcardViewer() {
         undoIcon.actionView!!.isEnabled = undoEnabled
         if (colIsOpen()) { // Required mostly because there are tests where `col` is null
             if (mShowWhiteboard && whiteboard != null && whiteboard!!.isUndoModeActive) {
-                // We arrive here if whiteboard is shown and one or more strokes are retained
+                // Show undo title for whiteboard mode
+                // We arrive here if the first stroke for whiteboard is done.
+                // We stay here even if the first stroke is undone. 
+                //  (This works as a safeguard against unintentional undo 
+                //   for before-whiteboard actions by consective tappings.)
+                // We leave here if whiteboard is inactive ("Disable whiteboard" or "Hide whiteboard")
+                //  or is reset ("Clear whiteboard")
                 val lastStroke = resources.getString(R.string.undo_action_whiteboard_last_stroke)
                 undoIcon.title = resources.getString(R.string.studyoptions_congrats_undo, lastStroke)
             } else if (col.undoAvailable()) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
@@ -749,7 +749,6 @@ open class Reviewer : AbstractFlashcardViewer() {
             undoIconId = R.drawable.eraser
             undoEnabled = true
         } else {
-            // We can arrive here even if whiteboard is enabled if no stroke has ever been made
             undoIconId = R.drawable.ic_undo_white
             undoEnabled = colIsOpen() && col.undoAvailable()
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
@@ -744,15 +744,12 @@ open class Reviewer : AbstractFlashcardViewer() {
         // Undo button
         @DrawableRes val undoIconId: Int
         val undoEnabled: Boolean
-        if (mShowWhiteboard && whiteboard != null && whiteboard?.isUndoModeActive == true) {
-            // We arrive here if the first stroke of whiteboard is done.
-            // We leave here when whiteboard is inactive (by "Disable whiteboard" or "Hide whiteboard")
-            //  or is reset (by "Clear whiteboard")
+        val whiteboardShowsStrokesToUndo = mShowWhiteboard && whiteboard?.undoEmpty() == false
+        if (whiteboardShowsStrokesToUndo) {
             undoIconId = R.drawable.eraser
-            undoEnabled = !whiteboard!!.undoEmpty()
+            undoEnabled = true
         } else {
-            // We can arrive here even if `mShowWhiteboard &&
-            // mWhiteboard != null` if no stroke had ever been made
+            // We can arrive here even if whiteboard is enabled if no stroke has ever been made
             undoIconId = R.drawable.ic_undo_white
             undoEnabled = colIsOpen() && col.undoAvailable()
         }
@@ -762,14 +759,12 @@ open class Reviewer : AbstractFlashcardViewer() {
         undoIcon.setEnabled(undoEnabled).iconAlpha = alphaUndo
         undoIcon.actionView!!.isEnabled = undoEnabled
         if (colIsOpen()) { // Required mostly because there are tests where `col` is null
-            if (undoIconId == R.drawable.eraser) {
+            if (whiteboardShowsStrokesToUndo) {
                 undoIcon.title = resources.getString(R.string.undo_action_whiteboard_last_stroke)
             } else if (col.undoAvailable()) {
-                // We arrive here if the last action which can be undone is retained.
-                //  e.g. Undo Bury, Undo Change Deck, Undo Update Note
                 undoIcon.title = resources.getString(R.string.studyoptions_congrats_undo, col.undoName(resources))
+                //  e.g. Undo Bury, Undo Change Deck, Undo Update Note
             } else {
-                // We arrive here if the last action which can be undone isn't retained.
                 // In this case, there is no object word for the verb, "Undo",
                 // so in some languages such as Japanese, which have pre/postpositional particle with the object,
                 // we need to use the string for just "Undo" instead of the string for "Undo %s".

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
@@ -745,7 +745,9 @@ open class Reviewer : AbstractFlashcardViewer() {
         @DrawableRes val undoIconId: Int
         val undoEnabled: Boolean
         if (mShowWhiteboard && whiteboard != null && whiteboard?.isUndoModeActive == true) {
-            // Whiteboard is here and strokes have been added at some point
+            // We arrive here if the first stroke of whiteboard is done.
+            // We leave here when whiteboard is inactive (by "Disable whiteboard" or "Hide whiteboard")
+            //  or is reset (by "Clear whiteboard")
             undoIconId = R.drawable.eraser
             undoEnabled = !whiteboard!!.undoEmpty()
         } else {
@@ -761,13 +763,6 @@ open class Reviewer : AbstractFlashcardViewer() {
         undoIcon.actionView!!.isEnabled = undoEnabled
         if (colIsOpen()) { // Required mostly because there are tests where `col` is null
             if (undoIconId == R.drawable.eraser) {
-                // Show undo title for whiteboard mode
-                // We arrive here if the first stroke for whiteboard is done.
-                // We stay here even if the first stroke is undone.
-                //  (This works as a safeguard against unintentional undo
-                //   for pre-whiteboard actions by consective tappings.)
-                // We leave here if whiteboard is inactive ("Disable whiteboard" or "Hide whiteboard")
-                //  or is reset ("Clear whiteboard")
                 val lastStroke = resources.getString(R.string.undo_action_whiteboard_last_stroke)
                 undoIcon.title = resources.getString(R.string.studyoptions_congrats_undo, lastStroke)
             } else if (col.undoAvailable()) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
@@ -744,8 +744,8 @@ open class Reviewer : AbstractFlashcardViewer() {
         // Undo button
         @DrawableRes val undoIconId: Int
         val undoEnabled: Boolean
-        val whiteboardShowsStrokesToUndo = mShowWhiteboard && whiteboard?.undoEmpty() == false
-        if (whiteboardShowsStrokesToUndo) {
+        val whiteboardIsShownAndHasStrokes = mShowWhiteboard && whiteboard?.undoEmpty() == false
+        if (whiteboardIsShownAndHasStrokes) {
             undoIconId = R.drawable.eraser
             undoEnabled = true
         } else {
@@ -759,7 +759,7 @@ open class Reviewer : AbstractFlashcardViewer() {
         undoIcon.setEnabled(undoEnabled).iconAlpha = alphaUndo
         undoIcon.actionView!!.isEnabled = undoEnabled
         if (colIsOpen()) { // Required mostly because there are tests where `col` is null
-            if (whiteboardShowsStrokesToUndo) {
+            if (whiteboardIsShownAndHasStrokes) {
                 undoIcon.title = resources.getString(R.string.undo_action_whiteboard_last_stroke)
             } else if (col.undoAvailable()) {
                 undoIcon.title = resources.getString(R.string.studyoptions_congrats_undo, col.undoName(resources))

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
@@ -763,8 +763,8 @@ open class Reviewer : AbstractFlashcardViewer() {
             if (mShowWhiteboard && whiteboard != null && whiteboard!!.isUndoModeActive) {
                 // Show undo title for whiteboard mode
                 // We arrive here if the first stroke for whiteboard is done.
-                // We stay here even if the first stroke is undone. 
-                //  (This works as a safeguard against unintentional undo 
+                // We stay here even if the first stroke is undone.
+                //  (This works as a safeguard against unintentional undo
                 //   for before-whiteboard actions by consective tappings.)
                 // We leave here if whiteboard is inactive ("Disable whiteboard" or "Hide whiteboard")
                 //  or is reset ("Clear whiteboard")

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
@@ -760,7 +760,7 @@ open class Reviewer : AbstractFlashcardViewer() {
         undoIcon.setEnabled(undoEnabled).iconAlpha = alphaUndo
         undoIcon.actionView!!.isEnabled = undoEnabled
         if (colIsOpen()) { // Required mostly because there are tests where `col` is null
-            if (mShowWhiteboard && whiteboard != null && whiteboard!!.isUndoModeActive) {
+            if (undoIconId == R.drawable.eraser) {
                 // Show undo title for whiteboard mode
                 // We arrive here if the first stroke for whiteboard is done.
                 // We stay here even if the first stroke is undone.

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
@@ -763,8 +763,7 @@ open class Reviewer : AbstractFlashcardViewer() {
         undoIcon.actionView!!.isEnabled = undoEnabled
         if (colIsOpen()) { // Required mostly because there are tests where `col` is null
             if (undoIconId == R.drawable.eraser) {
-                val lastStroke = resources.getString(R.string.undo_action_whiteboard_last_stroke)
-                undoIcon.title = resources.getString(R.string.studyoptions_congrats_undo, lastStroke)
+                undoIcon.title = resources.getString(R.string.undo_action_whiteboard_last_stroke)
             } else if (col.undoAvailable()) {
                 // We arrive here if the last action which can be undone is retained.
                 //  e.g. Undo Bury, Undo Change Deck, Undo Update Note

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Whiteboard.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Whiteboard.kt
@@ -68,12 +68,6 @@ class Whiteboard(activity: AnkiActivity, handleMultiTouch: Boolean, inverted: Bo
     var isCurrentlyDrawing = false
         private set
 
-    /**
-     * @return true if the undo queue has had any strokes added to it since the last clear
-     */
-    var isUndoModeActive = false
-        private set
-
     @get:CheckResult
     @get:VisibleForTesting
     var foregroundColor = 0
@@ -179,7 +173,6 @@ class Whiteboard(activity: AnkiActivity, handleMultiTouch: Boolean, inverted: Bo
      * Clear the whiteboard.
      */
     fun clear() {
-        isUndoModeActive = false
         mBitmap.eraseColor(0)
         mUndo.clear()
         invalidate()
@@ -254,7 +247,6 @@ class Whiteboard(activity: AnkiActivity, handleMultiTouch: Boolean, inverted: Bo
         val action = if (pm.length > 0) DrawPath(Path(mPath), paint) else DrawPoint(mX, mY, paint)
         action.apply(mCanvas)
         mUndo.add(action)
-        isUndoModeActive = true
         // kill the path so we don't double draw
         mPath.reset()
         if (mUndo.size() == 1) {

--- a/AnkiDroid/src/main/res/values/01-core.xml
+++ b/AnkiDroid/src/main/res/values/01-core.xml
@@ -76,7 +76,7 @@
     <string name="undo">Undo</string>
     <string name="undo_action_review">last review</string>
     <string name="undo_action_change_deck_multi">change decks</string>
-    <string name="undo_action_whiteboard_last_stroke">Undo stroke</string>
+    <string name="undo_action_whiteboard_last_stroke" comment="One of the display patterns of "Undo" item on the action menu in Reviewer. It is shown as the title of the item when the whiteboard (handwriting) feature is enabled and visible and has any strokes (handwritten lines)">Undo stroke</string>
     <string name="move_all_to_deck">Move all to deck</string>
     <string name="unbury">Unbury</string>
     <string name="rename_deck">Rename deck</string>

--- a/AnkiDroid/src/main/res/values/01-core.xml
+++ b/AnkiDroid/src/main/res/values/01-core.xml
@@ -76,7 +76,7 @@
     <string name="undo">Undo</string>
     <string name="undo_action_review">last review</string>
     <string name="undo_action_change_deck_multi">change decks</string>
-    <string name="undo_action_whiteboard_last_stroke" comment="One of the display patterns of "Undo" item on the action menu in Reviewer. It is shown as the title of the item when the whiteboard (handwriting) feature is enabled and visible and has any strokes (handwritten lines)">Undo stroke</string>
+    <string name="undo_action_whiteboard_last_stroke" comment="One of the display patterns of 'Undo' item on the action menu in Reviewer. It is shown as the title of the item when the whiteboard (handwriting) feature is enabled and visible and has any strokes (handwritten lines)">Undo stroke</string>
     <string name="move_all_to_deck">Move all to deck</string>
     <string name="unbury">Unbury</string>
     <string name="rename_deck">Rename deck</string>

--- a/AnkiDroid/src/main/res/values/01-core.xml
+++ b/AnkiDroid/src/main/res/values/01-core.xml
@@ -76,6 +76,7 @@
     <string name="undo">Undo</string>
     <string name="undo_action_review">last review</string>
     <string name="undo_action_change_deck_multi">change decks</string>
+    <string name="undo_action_whiteboard_last_stroke">Stroke</string>
     <string name="move_all_to_deck">Move all to deck</string>
     <string name="unbury">Unbury</string>
     <string name="rename_deck">Rename deck</string>

--- a/AnkiDroid/src/main/res/values/01-core.xml
+++ b/AnkiDroid/src/main/res/values/01-core.xml
@@ -76,7 +76,7 @@
     <string name="undo">Undo</string>
     <string name="undo_action_review">last review</string>
     <string name="undo_action_change_deck_multi">change decks</string>
-    <string name="undo_action_whiteboard_last_stroke">Stroke</string>
+    <string name="undo_action_whiteboard_last_stroke">Undo Stroke</string>
     <string name="move_all_to_deck">Move all to deck</string>
     <string name="unbury">Unbury</string>
     <string name="rename_deck">Rename deck</string>

--- a/AnkiDroid/src/main/res/values/01-core.xml
+++ b/AnkiDroid/src/main/res/values/01-core.xml
@@ -76,7 +76,7 @@
     <string name="undo">Undo</string>
     <string name="undo_action_review">last review</string>
     <string name="undo_action_change_deck_multi">change decks</string>
-    <string name="undo_action_whiteboard_last_stroke">Undo Stroke</string>
+    <string name="undo_action_whiteboard_last_stroke">Undo stroke</string>
     <string name="move_all_to_deck">Move all to deck</string>
     <string name="unbury">Unbury</string>
     <string name="rename_deck">Rename deck</string>


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
"Undo" item's title isn't switched to one for whiteboard mode though its action itself and its icon are done.
![image](https://user-images.githubusercontent.com/10436072/206902935-6c5de6ac-e98d-4f19-ae46-7bdea974fc90.png)

## Fixes
Fixes #12960

## Approach
Make a new string for "Undo" item's title for whiteboard mode

## How Has This Been Tested?
Checked on a physical device
![image](https://user-images.githubusercontent.com/10436072/206904550-362a0b51-6944-412f-a2d6-4fd37792e7c9.png)

https://user-images.githubusercontent.com/10436072/206904451-9fa0ca93-1b34-43e3-bbe7-a089d3039cbc.mp4


## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
