### PR TITLE
bug fix for deck export

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/export/ActivityExportingDelegate.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/export/ActivityExportingDelegate.kt
@@ -126,7 +126,7 @@ class ActivityExportingDelegate(private val activity: AnkiActivity, private val 
     }
 
     override fun exportDeckAsApkg(path: String?, did: DeckId, includeSched: Boolean, includeMedia: Boolean) {
-        val deckName = collectionSupplier.get().decks.current().getString("name")
+        val deckName = collectionSupplier.get().decks.name(did)
         val exportPath = getExportFileName(path, deckName, includeSched)
 
         if (BackendFactory.defaultLegacySchema) {


### PR DESCRIPTION
## Pull Request template
This PR fixes the export deck bug

## Purpose / Description


## Fixes
Fixes #12966
Closes #12966

## Approach
Select the exact deck before calling the export method

## How Has This Been Tested?
1. Long press a deck other than the default deck you were studying 
2. Press export deck
3. This particular deck will be exported

## Learning (optional, can help others)
_Describe the research stage_

_Links to blog posts, patterns, libraries or addons used to solve this problem_

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
