### PR TITLE
Changed the color of the zero count

### DIFF
--- a/AnkiDroid/src/main/res/values/theme_black.xml
+++ b/AnkiDroid/src/main/res/values/theme_black.xml
@@ -47,7 +47,7 @@
         <item name="newCountColor">@color/material_blue_700</item>
         <item name="learnCountColor">@color/material_red_400</item>
         <item name="reviewCountColor">@color/material_green_400</item>
-        <item name="zeroCountColor">#202020</item>
+        <item name="zeroCountColor">#808080</item>
         <!-- Reviewer colors -->
         <item name="topBarColor">@color/theme_black_primary</item>
         <item name="maxTimerColor">@color/material_red_300</item>

--- a/AnkiDroid/src/main/res/values/theme_dark.xml
+++ b/AnkiDroid/src/main/res/values/theme_dark.xml
@@ -56,7 +56,7 @@
         <item name="newCountColor">@color/material_indigo_200</item>
         <item name="learnCountColor">@color/material_red_200</item>
         <item name="reviewCountColor">@color/material_green_200</item>
-        <item name="zeroCountColor">#202020</item>
+        <item name="zeroCountColor">#808080</item>
         <!-- Reviewer colors -->
         <item name="topBarColor">@color/theme_dark_primary_light</item>
         <item name="maxTimerColor">@color/material_red_300</item>


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
In dark and black mode the count zero wasn't visible.

## Fixes
Fixes #12952

## Approach
Changed the color of the zero count in the dark and black mode.

## How Has This Been Tested?

SDK: Android Tiramisu
Emulator: Pixel 6

## Screenshots
Dark mode:
![Anki-Android – theme_black xml  Anki-Android AnkiDroid main  13 12 2022 10_14_17](https://user-images.githubusercontent.com/109673982/207276589-143cf7b7-987a-469d-82c8-e73f93874611.png)

Black mode:
![grafik](https://user-images.githubusercontent.com/109673982/207276038-e7d92a53-b498-4c9b-ac9c-c48cc619d9d4.png)

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [x] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
