### PR TITLE
Add CI job to append a special label to PRs made by new contributors

### DIFF
--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -150,3 +150,35 @@ jobs:
                 break;
               }
             }
+
+  add_new_contributor_label:
+    if: github.event.action == 'opened'
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v6
+        with:
+          script: |
+            const creator = context.payload.sender.login
+            const opts = github.rest.issues.listForRepo.endpoint.merge({
+              ...context.issue,
+              creator,
+              state: 'all'
+            })
+            const issues = await github.paginate(opts)
+            for (const issue of issues) {
+              if (issue.number === context.issue.number) {
+                continue
+              }
+              if (issue.pull_request) {
+                return // creator is already a contributor
+              }
+            }
+            await github.rest.issues.addLabels({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo
+              labels: ['New contributor']
+            })


### PR DESCRIPTION
## Purpose / Description

Adds a new label to make it easier for reviewers to spot PRs made by new developers. In the original issue the request was made for `New developer`, I choose `New contributor` as a more(maybe) inclusive label(but I can revert this no issues). The code is basically a copy of an example from the `actions/github-script` [documentation](https://github.com/actions/github-script#welcome-a-first-time-contributor) with the end changed to add the desired label instead of creating a comment.

## Fixes
Fixes #12944 

## How Has This Been Tested?

As mentioned above, should work but I wasn't able to test it, I'll keep a look out for this in future PRs.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
