### PR TITLE
Added Add-Card Option in DeckPickerContextMenu

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckPickerContextMenu.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckPickerContextMenu.kt
@@ -68,6 +68,7 @@ class DeckPickerContextMenu(private val collection: Collection) : AnalyticsDialo
             val did = deckId
             val dyn = collection.decks.isDyn(did)
             val contextMenuOptions = ArrayList<DeckPickerContextMenuOption>(11) // init with our fixed list size for performance
+            contextMenuOptions.add(DeckPickerContextMenuOption.ADD_CARD)
             contextMenuOptions.add(DeckPickerContextMenuOption.BROWSE_CARDS)
             if (dyn) {
                 contextMenuOptions.add(DeckPickerContextMenuOption.CUSTOM_STUDY_REBUILD)
@@ -146,6 +147,12 @@ class DeckPickerContextMenu(private val collection: Collection) : AnalyticsDialo
                 val intent = Intent(activity, CardBrowser::class.java)
                 (activity as DeckPicker).startActivityForResultWithAnimation(intent, NavigationDrawerActivity.REQUEST_BROWSE_CARDS, ActivityTransitionAnimation.Direction.START)
             }
+            DeckPickerContextMenuOption.ADD_CARD -> {
+                Timber.i("Add selected")
+                collection.decks.select(deckId)
+                (activity as DeckPicker).addNote()
+                (activity as AnkiActivity).dismissAllDialogFragments()
+            }
         }
     }
 
@@ -160,7 +167,8 @@ class DeckPickerContextMenu(private val collection: Collection) : AnalyticsDialo
         CUSTOM_STUDY_EMPTY(7, R.string.empty_cram_label),
         CREATE_SUBDECK(8, R.string.create_subdeck),
         CREATE_SHORTCUT(9, R.string.create_shortcut),
-        BROWSE_CARDS(10, R.string.browse_cards);
+        BROWSE_CARDS(10, R.string.browse_cards),
+        ADD_CARD(11, R.string.menu_add);
 
         companion object {
             fun fromId(targetId: Int): DeckPickerContextMenuOption {

--- a/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/DeckPickerContextMenuTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/DeckPickerContextMenuTest.kt
@@ -58,13 +58,26 @@ class DeckPickerContextMenuTest : RobolectricTest() {
     }
 
     @Test
+    fun addCards() = runTest {
+        startActivityNormallyOpenCollectionWithIntent(DeckPicker::class.java, Intent()).run {
+            addDeck("Deck 1")
+            updateDeckList()
+            assertEquals(1, visibleDeckCount)
+
+            openContextMenuAndSelectItem(recyclerView, 0)
+
+            assertDialogTitleEquals("Add")
+        }
+    }
+
+    @Test
     fun testBrowseCards() = runTest {
         startActivityNormallyOpenCollectionWithIntent(DeckPicker::class.java, Intent()).run {
             val deckId = addDeck("Deck 1")
             updateDeckList()
             assertEquals(1, visibleDeckCount)
 
-            openContextMenuAndSelectItem(recyclerView, 0)
+            openContextMenuAndSelectItem(recyclerView, 1)
 
             val browser = shadowOf(this).nextStartedActivity!!
             assertEquals("com.ichi2.anki.CardBrowser", browser.component!!.className)
@@ -80,7 +93,7 @@ class DeckPickerContextMenuTest : RobolectricTest() {
             updateDeckList()
             assertEquals(1, visibleDeckCount)
 
-            openContextMenuAndSelectItem(recyclerView, 1)
+            openContextMenuAndSelectItem(recyclerView, 2)
 
             assertDialogTitleEquals("Rename deck")
         }
@@ -93,7 +106,7 @@ class DeckPickerContextMenuTest : RobolectricTest() {
             updateDeckList()
             assertEquals(1, visibleDeckCount)
 
-            openContextMenuAndSelectItem(recyclerView, 2)
+            openContextMenuAndSelectItem(recyclerView, 3)
 
             assertDialogTitleEquals("Create subdeck")
         }
@@ -106,7 +119,7 @@ class DeckPickerContextMenuTest : RobolectricTest() {
             updateDeckList()
             assertEquals(1, visibleDeckCount)
 
-            openContextMenuAndSelectItem(recyclerView, 3)
+            openContextMenuAndSelectItem(recyclerView, 4)
 
             val deckOptions = shadowOf(this).nextStartedActivity!!
             if (BackendFactory.defaultLegacySchema) {
@@ -126,7 +139,7 @@ class DeckPickerContextMenuTest : RobolectricTest() {
             updateDeckList()
             assertEquals(1, visibleDeckCount)
 
-            openContextMenuAndSelectItem(recyclerView, 7)
+            openContextMenuAndSelectItem(recyclerView, 8)
 
             assertThat(col.decks.allIds(), not(containsInAnyOrder(deckId)))
         }
@@ -139,7 +152,7 @@ class DeckPickerContextMenuTest : RobolectricTest() {
             updateDeckList()
             assertEquals(1, visibleDeckCount)
 
-            openContextMenuAndSelectItem(recyclerView, 6)
+            openContextMenuAndSelectItem(recyclerView, 7)
 
             assertEquals(
                 "Deck 1",
@@ -161,7 +174,7 @@ class DeckPickerContextMenuTest : RobolectricTest() {
 
             assertTrue(col.sched.haveBuried(deckId))
 
-            openContextMenuAndSelectItem(recyclerView, 6)
+            openContextMenuAndSelectItem(recyclerView, 7)
 
             assertFalse(col.sched.haveBuried(deckId))
         }
@@ -174,7 +187,7 @@ class DeckPickerContextMenuTest : RobolectricTest() {
             updateDeckList()
             assertEquals(1, visibleDeckCount)
 
-            openContextMenuAndSelectItem(recyclerView, 4)
+            openContextMenuAndSelectItem(recyclerView, 5)
 
             assertDialogTitleEquals("Custom study")
         }
@@ -187,7 +200,7 @@ class DeckPickerContextMenuTest : RobolectricTest() {
             updateDeckList()
             assertEquals(1, visibleDeckCount)
 
-            openContextMenuAndSelectItem(recyclerView, 5)
+            openContextMenuAndSelectItem(recyclerView, 6)
 
             assertDialogTitleEquals("Export")
         }
@@ -205,11 +218,11 @@ class DeckPickerContextMenuTest : RobolectricTest() {
             updateDeckList()
             assertEquals(1, visibleDeckCount)
 
-            openContextMenuAndSelectItem(recyclerView, 2) // Empty
+            openContextMenuAndSelectItem(recyclerView, 3) // Empty
 
             assertTrue(allCardsInSameDeck(cardIds, 1))
 
-            openContextMenuAndSelectItem(recyclerView, 1) // Rebuild
+            openContextMenuAndSelectItem(recyclerView, 2) // Rebuild
 
             assertTrue(allCardsInSameDeck(cardIds, deckId))
         }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/DeckPickerContextMenuTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/DeckPickerContextMenuTest.kt
@@ -59,10 +59,11 @@ class DeckPickerContextMenuTest : RobolectricTest() {
         startActivityNormallyOpenCollectionWithIntent(DeckPicker::class.java, Intent()).run {
             val models = col.models
             val didA = addDeck("Test")
+            updateDeckList()
             val basic = models.byName(AnkiDroidApp.appResources.getString(R.string.basic_model_name))
             basic!!.put("did", didA)
             addNoteUsingBasicModel("Front", "Back")
-            updateDeckList()
+            
             assertEquals(1, visibleDeckCount)
 
             openContextMenuAndSelectItem(recyclerView, 0)

--- a/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/DeckPickerContextMenuTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/DeckPickerContextMenuTest.kt
@@ -58,17 +58,16 @@ class DeckPickerContextMenuTest : RobolectricTest() {
     fun addCards() = runTest {
         startActivityNormallyOpenCollectionWithIntent(DeckPicker::class.java, Intent()).run {
             val models = col.models
-            val didA = addDeck("Test")
+            val didA = addDeck("Deck 1")
             updateDeckList()
+            col.decks.select(didA)
             val basic = models.byName(AnkiDroidApp.appResources.getString(R.string.basic_model_name))
             basic!!.put("did", didA)
             addNoteUsingBasicModel("Front", "Back")
-            
             assertEquals(1, visibleDeckCount)
-
             openContextMenuAndSelectItem(recyclerView, 0)
+            assertEquals(1, col.cardCount(didA))
 
-            assertDialogTitleEquals("Add")
         }
     }
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/DeckPickerContextMenuTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/DeckPickerContextMenuTest.kt
@@ -67,7 +67,6 @@ class DeckPickerContextMenuTest : RobolectricTest() {
             assertEquals(1, visibleDeckCount)
             openContextMenuAndSelectItem(recyclerView, 0)
             assertEquals(1, col.cardCount(didA))
-
         }
     }
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/DeckPickerContextMenuTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/DeckPickerContextMenuTest.kt
@@ -24,10 +24,7 @@ import androidx.recyclerview.widget.RecyclerView
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.afollestad.materialdialogs.MaterialDialog
 import com.afollestad.materialdialogs.internal.rtl.RtlTextView
-import com.ichi2.anki.DeckPicker
-import com.ichi2.anki.IntroductionActivity
-import com.ichi2.anki.R
-import com.ichi2.anki.RobolectricTest
+import com.ichi2.anki.*
 import com.ichi2.libanki.utils.TimeManager
 import com.ichi2.testutils.assertThrows
 import net.ankiweb.rsdroid.BackendFactory

--- a/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/DeckPickerContextMenuTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/DeckPickerContextMenuTest.kt
@@ -60,7 +60,11 @@ class DeckPickerContextMenuTest : RobolectricTest() {
     @Test
     fun addCards() = runTest {
         startActivityNormallyOpenCollectionWithIntent(DeckPicker::class.java, Intent()).run {
-            addDeck("Deck 1")
+            val models = col.models
+            val didA = addDeck("Test")
+            val basic = models.byName(AnkiDroidApp.appResources.getString(R.string.basic_model_name))
+            basic!!.put("did", didA)
+            addNoteUsingBasicModel("Front", "Back")
             updateDeckList()
             assertEquals(1, visibleDeckCount)
 


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
This adds the Add-Card option to the DeckPickerContextMenu

## Fixes
Fixes #12962 

## Screenshot

![Anki-Android – DeckPickerContextMenu kt  Anki-Android AnkiDroid main  14 12 2022 11_57_05](https://user-images.githubusercontent.com/109673982/207593850-b8552aa6-bf9a-4fdb-8748-977d764cc0ab.png)

## How Has This Been Tested?

SDK: Android Tiramisu
Emulator: Pixel 6

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [x] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
