### PR TITLE
Added enable button to the snackbar to enable gestures

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/AppearanceSettingsFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/AppearanceSettingsFragment.kt
@@ -18,6 +18,8 @@ package com.ichi2.anki.preferences
 import android.os.Build
 import android.provider.MediaStore
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.core.view.accessibility.AccessibilityEventCompat.setAction
+import androidx.fragment.app.commit
 import androidx.preference.ListPreference
 import androidx.preference.Preference
 import androidx.preference.SwitchPreference
@@ -26,6 +28,7 @@ import com.ichi2.anki.CollectionHelper
 import com.ichi2.anki.R
 import com.ichi2.anki.UIUtils
 import com.ichi2.anki.cardviewer.GestureProcessor
+import com.ichi2.anki.preferences.ControlsSettingsFragment.Companion.enableGestures
 import com.ichi2.anki.reviewer.FullScreenMode
 import com.ichi2.anki.snackbar.showSnackbar
 import com.ichi2.libanki.Utils
@@ -51,9 +54,11 @@ class AppearanceSettingsFragment : SettingsFragment() {
             if (prefs.getBoolean(GestureProcessor.PREF_KEY, false) || newValue != "none") {
                 true
             } else {
-                // TODO add a button on the snackbar that leads directly to the
-                // Controls fragment and highlight the gesture preference
-                showSnackbar(R.string.full_screen_error_gestures)
+                showSnackbar(R.string.full_screen_error_gestures) {
+                    setAction(R.string.enable) {
+                        openControlsSettingsFragmentEnableGestures()
+                    }
+                }
                 false
             }
         }
@@ -62,9 +67,11 @@ class AppearanceSettingsFragment : SettingsFragment() {
             if (prefs.getBoolean(GestureProcessor.PREF_KEY, false) || FullScreenMode.FULLSCREEN_ALL_GONE.getPreferenceValue() != newValue) {
                 true
             } else {
-                // TODO add a button on the snackbar that leads directly to the
-                // Controls fragment and highlight the gesture preference
-                showSnackbar(R.string.full_screen_error_gestures)
+                showSnackbar(R.string.full_screen_error_gestures) {
+                    setAction(R.string.enable) {
+                        openControlsSettingsFragmentEnableGestures()
+                    }
+                }
                 false
             }
         }
@@ -178,6 +185,14 @@ class AppearanceSettingsFragment : SettingsFragment() {
                 col.set_config("dueCounts", newValue)
             }
         }
+    }
+
+    private fun openControlsSettingsFragmentEnableGestures() {
+        (requireActivity() as Preferences).supportFragmentManager.commit {
+            replace(R.id.settings_container, ControlsSettingsFragment())
+            addToBackStack(null)
+        }
+        enableGestures = true
     }
 
     /** Returns a list of the names of the installed custom fonts */

--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/ControlsSettingsFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/ControlsSettingsFragment.kt
@@ -16,9 +16,11 @@
 package com.ichi2.anki.preferences
 
 import androidx.preference.PreferenceCategory
+import androidx.preference.SwitchPreference
 import com.ichi2.anki.R
 import com.ichi2.anki.cardviewer.ViewerCommand
 import com.ichi2.anki.reviewer.MappableBinding.Companion.toPreferenceString
+import com.ichi2.anki.snackbar.showSnackbar
 import com.ichi2.preferences.ControlPreference
 
 class ControlsSettingsFragment : SettingsFragment() {
@@ -29,6 +31,12 @@ class ControlsSettingsFragment : SettingsFragment() {
 
     override fun initSubscreen() {
         val commandMappingCategory = requirePreference<PreferenceCategory>(R.string.controls_command_mapping_cat_key)
+        if (enableGestures) {
+            enableGestures = false
+            showSnackbar(R.string.enabled_gestures)
+            scrollToPreference(R.string.gestures_preference.toString())
+            requirePreference<SwitchPreference>(R.string.gestures_preference).isChecked = true
+        }
         addAllControlPreferencesToCategory(commandMappingCategory)
     }
 
@@ -42,5 +50,8 @@ class ControlsSettingsFragment : SettingsFragment() {
             }
             category.addPreference(preference)
         }
+    }
+    companion object {
+        var enableGestures: Boolean = false
     }
 }

--- a/AnkiDroid/src/main/res/values/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values/10-preferences.xml
@@ -21,6 +21,8 @@
     <!-- generic strings -->
     <string name="disabled">Disabled</string>
     <string name="enabled">Enabled</string>
+    <string name="enable">Enable</string>
+    <string name="enabled_gestures">Enabled gestures</string>
     <string name="pref_summary_seconds">%s s</string>
     <string name="pref_summary_minutes">%s min</string>
     <string comment="Percentage value of a preference. %s represents the number to be replaced. Use \%% to represent a single percent sign (%)"


### PR DESCRIPTION
## Purpose / Description
Added enable button to the snackbar to enable gestures .

## Fixes
Fixes #12940 

## Approach
Added enable button to the snackbar to enable gestures by using scroll to preference.

## How Has This Been Tested?

Tested on google emulator.

## Learning (optional, can help others)
_Describe the research stage_

_Links to blog posts, patterns, libraries or addons used to solve this problem_

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
