### PR TITLE
Added a switch preference in developer options to enable/disable leakCanary

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.kt
@@ -116,7 +116,9 @@ open class AnkiDroidApp : Application() {
             }
         }
         CrashReportService.initialize(this)
-        if (BuildConfig.DEBUG) {
+
+        val leakKeyValue = getSharedPrefs(this).getBoolean(R.string.pref_leak_canary_key.toString(), true)
+        if (BuildConfig.DEBUG && leakKeyValue) {
             // Enable verbose error logging and do method tracing to put the Class name as log tag
             Timber.plant(DebugTree())
             LeakCanaryConfiguration.setInitialConfigFor(this)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -2526,7 +2526,7 @@ open class DeckPicker :
             @Suppress("Deprecation")
             context.mProgressDialog = android.app.ProgressDialog(context).apply {
                 progress = mNumberOfCards
-                setTitle(R.string.emtpy_cards_finding)
+                setTitle(R.string.empty_cards_finding)
                 setCancelable(true)
                 show()
                 setOnCancelListener(onCancel)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/LeakCanaryConfiguration.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/LeakCanaryConfiguration.kt
@@ -33,7 +33,7 @@ object LeakCanaryConfiguration {
             retainedVisibleThreshold = 0,
             referenceMatchers = AndroidReferenceMatchers.appDefaults,
             computeRetainedHeapSize = false,
-            maxStoredHeapDumps = 0,
+            maxStoredHeapDumps = 0
         )
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/DevOptionsFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/DevOptionsFragment.kt
@@ -86,6 +86,14 @@ class DevOptionsFragment : SettingsFragment() {
                 true
             }
         }
+        // Enable / Disable Leak Canary
+        requirePreference<SwitchPreference>(R.string.pref_leak_canary_key).setOnPreferenceChangeListener { newValue ->
+            if (newValue == true) {
+                LeakCanaryConfiguration.setInitialConfigFor(requireActivity().application)
+            } else {
+                LeakCanaryConfiguration.disable()
+            }
+        }
     }
 
     /**

--- a/AnkiDroid/src/main/res/values/03-dialogs.xml
+++ b/AnkiDroid/src/main/res/values/03-dialogs.xml
@@ -151,7 +151,7 @@
     <string name="tags_dialog_option_due_cards" comment="Name of cards that are already been reviewed in the past, and that should be reviewed again">Due</string>
 
     <!-- Empty cards -->
-    <string name="emtpy_cards_finding">Finding empty cards…</string>
+    <string name="empty_cards_finding">Finding empty cards…</string>
     <string name="confirm_cancel">Do you want to cancel?</string>
     <string name="empty_cards_none">No empty cards</string>
     <string name="empty_cards_count">Cards to delete: %d</string>

--- a/AnkiDroid/src/main/res/values/preferences.xml
+++ b/AnkiDroid/src/main/res/values/preferences.xml
@@ -134,6 +134,7 @@
     <string name="pref_reset_onboarding_key">resetOnboarding</string>
     <string name="pref_rust_backend_key">useRustBackend</string>
     <string name="pref_scoped_storage_key">useScopedStorage</string>
+    <string name="pref_leak_canary_key">enableDisableLeakCanary</string>
     <string name="dev_options_enabled_by_user_key">devOptionsEnabledByUser</string>
     <!-- Messages displayed after the user enabled developer options, and warned remaining messages will be in English -->
     <string name="dev_options_enabled_msg">Enabled developer options</string>

--- a/AnkiDroid/src/main/res/xml/preferences_dev_options.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_dev_options.xml
@@ -30,6 +30,12 @@
         android:key="@string/html_javascript_debugging_key"
         android:summary="@string/html_javascript_debugging_summ"
         android:title="@string/html_javascript_debugging"/>
+    <SwitchPreference
+        android:key="@string/pref_leak_canary_key"
+        android:defaultValue="true"
+        android:summaryOn="Disable Leak canary"
+        android:summaryOff="Enable Leak canary"
+        android:title="Enable/Disable leak canary"/>
     <Preference
         android:title="Trigger test crash"
         android:summary="Touch here for an immediate test crash"


### PR DESCRIPTION
## Purpose / Description

- Added switch preference in developer options to enable/disable leak canary.
- Fix typo in string in 03-dialogs.xml.

## Fixes
Fixes #12957

## Approach
Added switch preference in developer options.

## How Has This Been Tested?

- Tested on google emulator
- AnkiDroid Version = 2.16alpha91

## Learning (optional, can help others)
_Describe the research stage_

_Links to blog posts, patterns, libraries or addons used to solve this problem_

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)


https://user-images.githubusercontent.com/76740999/207885160-8bb44e1b-611d-4034-8f21-6a433b70d5cf.mp4



