### PR TITLE
Stop handling language changes manually

### DIFF
--- a/AnkiDroid/src/main/AndroidManifest.xml
+++ b/AnkiDroid/src/main/AndroidManifest.xml
@@ -417,6 +417,15 @@
             android:theme="@style/Theme.AppCompat.NoActionBar"
             android:configChanges="keyboardHidden|screenSize" />
 
+
+        <service
+            android:name="androidx.appcompat.app.AppLocalesMetadataHolderService"
+            android:enabled="false"
+            android:exported="false">
+            <meta-data
+                android:name="autoStoreLocales"
+                android:value="true" />
+        </service>
         <!-- Service to perform web API queries -->
         <service android:name="com.ichi2.widget.AnkiDroidWidgetSmall$UpdateService" />
 

--- a/AnkiDroid/src/main/AndroidManifest.xml
+++ b/AnkiDroid/src/main/AndroidManifest.xml
@@ -92,16 +92,16 @@
         <activity android:name=".DrawingActivity"
             android:label="@string/drawing"
             android:exported="false"
-            android:configChanges="keyboardHidden|locale|orientation|screenSize|uiMode"
+            android:configChanges="keyboardHidden|orientation|screenSize|uiMode"
             />
         <activity
             android:name="com.ichi2.anki.pages.PagesActivity"
-            android:configChanges="keyboardHidden|orientation|screenSize|locale|uiMode"
+            android:configChanges="keyboardHidden|orientation|screenSize|uiMode"
             android:exported="true"
             android:theme="@android:style/Theme.Translucent.NoTitleBar"/>
         <activity
             android:name="com.ichi2.anki.IntentHandler"
-            android:configChanges="keyboardHidden|orientation|screenSize|locale|uiMode"
+            android:configChanges="keyboardHidden|orientation|screenSize|uiMode"
             android:theme="@android:style/Theme.Translucent.NoTitleBar"
             android:exported="true"
             >
@@ -191,13 +191,13 @@
             android:name="com.ichi2.anki.DeckPicker"
             android:theme="@style/Theme_Dark_Compat.Launcher"
             android:exported="false"
-            android:configChanges="keyboardHidden|orientation|screenSize|locale|uiMode"
+            android:configChanges="keyboardHidden|orientation|screenSize|uiMode"
             />
         <activity
             android:name="com.ichi2.anki.StudyOptionsActivity"
             android:label="StudyOptions"
             android:exported="false"
-            android:configChanges="keyboardHidden|locale|orientation|screenSize|uiMode"
+            android:configChanges="keyboardHidden|orientation|screenSize|uiMode"
             android:parentActivityName=".DeckPicker"
             >
         </activity>
@@ -221,7 +221,7 @@
             android:label="@string/card_browser"
             android:theme="@style/Theme_Dark_Compat.Launcher"
             android:exported="true"
-            android:configChanges="keyboardHidden|orientation|locale|screenSize|uiMode"
+            android:configChanges="keyboardHidden|orientation|screenSize|uiMode"
             android:parentActivityName=".DeckPicker"
             >
             <intent-filter android:label="@string/card_browser">
@@ -236,24 +236,24 @@
             android:name=".ModelBrowser"
             android:label="@string/model_browser_label"
             android:exported="false"
-            android:configChanges="keyboardHidden|orientation|locale|screenSize|uiMode"
+            android:configChanges="keyboardHidden|orientation|screenSize|uiMode"
             />
         <activity
             android:name=".notetype.ManageNotetypes"
             android:label="@string/model_browser_label"
             android:exported="false"
-            android:configChanges="keyboardHidden|orientation|locale|screenSize|uiMode"
+            android:configChanges="keyboardHidden|orientation|screenSize|uiMode"
             />
         <activity
             android:name=".ModelFieldEditor"
             android:label="@string/model_editor_label"
-            android:configChanges="keyboardHidden|orientation|locale|screenSize|uiMode"
+            android:configChanges="keyboardHidden|orientation|screenSize|uiMode"
             />
         <activity
             android:name="com.ichi2.anki.Reviewer"
             android:exported="true"
             android:theme="@style/Theme_Dark_Compat.Launcher"
-            android:configChanges="keyboardHidden|orientation|locale|screenSize|uiMode"
+            android:configChanges="keyboardHidden|orientation|screenSize|uiMode"
             android:windowSoftInputMode="adjustResize"
             android:parentActivityName=".DeckPicker">
             <intent-filter>
@@ -264,20 +264,20 @@
         <activity
             android:name="com.ichi2.anki.VideoPlayer"
             android:exported="false"
-            android:configChanges="keyboardHidden|orientation|locale|screenSize|uiMode"
+            android:configChanges="keyboardHidden|orientation|screenSize|uiMode"
             android:theme="@android:style/Theme.NoTitleBar.Fullscreen"
             />
         <activity
             android:name="com.ichi2.anki.MyAccount"
             android:label="@string/menu_my_account"
             android:exported="false"
-            android:configChanges="keyboardHidden|orientation|locale|screenSize|uiMode"
+            android:configChanges="keyboardHidden|orientation|screenSize|uiMode"
             />
         <activity
             android:name="com.ichi2.anki.preferences.Preferences"
             android:label="@string/settings"
             android:exported="false"
-            android:configChanges="keyboardHidden|orientation|locale|screenSize|uiMode"
+            android:configChanges="keyboardHidden|orientation|screenSize|uiMode"
             android:theme="@style/Theme_Light"
             >
             <intent-filter>
@@ -288,21 +288,21 @@
             android:name="com.ichi2.anki.DeckOptionsActivity"
             android:label="@string/deckpreferences_title"
             android:exported="false"
-            android:configChanges="keyboardHidden|orientation|locale|screenSize|uiMode"
+            android:configChanges="keyboardHidden|orientation|screenSize|uiMode"
             android:theme="@style/Theme_Light"
             />
         <activity
             android:name=".FilteredDeckOptions"
             android:label="@string/deckpreferences_title"
             android:exported="false"
-            android:configChanges="keyboardHidden|orientation|locale|screenSize|uiMode"
+            android:configChanges="keyboardHidden|orientation|screenSize|uiMode"
             android:theme="@style/Theme_Light"
             />
         <activity
             android:name="com.ichi2.anki.Info"
             android:label="@string/pref_cat_about_title"
             android:exported="false"
-            android:configChanges="locale|uiMode"
+            android:configChanges="uiMode"
             />
 
         <activity-alias
@@ -322,7 +322,7 @@
             android:label="@string/fact_adder_intent_title"
             android:theme="@style/Theme_Dark_Compat.Launcher"
             android:exported="true"
-            android:configChanges="keyboardHidden|orientation|locale|screenSize|uiMode"
+            android:configChanges="keyboardHidden|orientation|screenSize|uiMode"
             >
             <intent-filter>
                 <action android:name="org.openintents.action.CREATE_FLASHCARD" />
@@ -337,7 +337,7 @@
         <activity
             android:name="com.canhub.cropper.CropImageActivity"
             android:exported="true"
-            android:configChanges="keyboardHidden|orientation|locale|screenSize|uiMode"
+            android:configChanges="keyboardHidden|orientation|screenSize|uiMode"
             android:theme="@style/Base.Theme.AppCompat" />
         <activity
             android:name="com.ichi2.anki.analytics.AnkiDroidCrashReportDialog"
@@ -350,7 +350,7 @@
         <activity
             android:name="com.ichi2.anki.Statistics"
             android:exported="false"
-            android:configChanges="keyboardHidden|orientation|locale|screenSize|uiMode"
+            android:configChanges="keyboardHidden|orientation|screenSize|uiMode"
             android:parentActivityName=".DeckPicker"
             >
         </activity>
@@ -358,33 +358,33 @@
             android:name="com.ichi2.anki.Previewer"
             android:label="@string/preview_title"
             android:exported="false"
-            android:configChanges="locale|uiMode"
+            android:configChanges="uiMode"
             />
         <activity
             android:name="com.ichi2.anki.CardTemplatePreviewer"
             android:label="@string/preview_title"
             android:exported="false"
-            android:configChanges="locale|uiMode"
+            android:configChanges="uiMode"
             />
         <activity
             android:name=".multimediacard.activity.MultimediaEditFieldActivity"
             android:label="@string/title_activity_edit_text"
             android:exported="false"
-            android:configChanges="keyboardHidden|orientation|locale|screenSize|uiMode"
+            android:configChanges="keyboardHidden|orientation|screenSize|uiMode"
             >
         </activity>
         <activity
             android:name="com.ichi2.anki.multimediacard.activity.LoadPronunciationActivity"
             android:label="@string/multimedia_editor_text_field_editing_say"
             android:exported="false"
-            android:configChanges="keyboardHidden|orientation|locale|screenSize|uiMode"
+            android:configChanges="keyboardHidden|orientation|screenSize|uiMode"
             >
         </activity>
         <activity
             android:name="com.ichi2.anki.CardTemplateEditor"
             android:label="@string/title_activity_template_editor"
             android:exported="false"
-            android:configChanges="keyboardHidden|orientation|locale|screenSize|uiMode"
+            android:configChanges="keyboardHidden|orientation|screenSize|uiMode"
             android:windowSoftInputMode="stateAlwaysHidden|adjustPan"
             >
         </activity>
@@ -392,30 +392,30 @@
             android:name=".CardTemplateBrowserAppearanceEditor"
             android:label="@string/card_template_browser_appearance_title"
             android:exported="false"
-            android:configChanges="keyboardHidden|orientation|locale|screenSize|uiMode"
+            android:configChanges="keyboardHidden|orientation|screenSize|uiMode"
             />
         <activity
             android:name=".CardInfo"
             android:label="@string/card_info_title"
             android:exported="false"
-            android:configChanges="keyboardHidden|orientation|locale|screenSize|uiMode"
+            android:configChanges="keyboardHidden|orientation|screenSize|uiMode"
             />
         <activity
             android:name=".SharedDecksActivity"
-            android:configChanges="keyboardHidden|orientation|screenSize|locale|uiMode"
+            android:configChanges="keyboardHidden|orientation|screenSize|uiMode"
             android:label="@string/download_deck"
             android:theme="@style/Theme.MaterialComponents.NoActionBar" />
         <activity
             android:name="com.ichi2.anki.LoginActivity"
             android:label="@string/menu_my_account"
             android:exported="false"
-            android:configChanges="keyboardHidden|orientation|locale|screenSize|uiMode"
+            android:configChanges="keyboardHidden|orientation|screenSize|uiMode"
             />
 
         <activity android:name=".IntroductionActivity"
             android:exported="false"
             android:theme="@style/Theme.AppCompat.NoActionBar"
-            android:configChanges="keyboardHidden|screenSize|locale" />
+            android:configChanges="keyboardHidden|screenSize" />
 
         <!-- Service to perform web API queries -->
         <service android:name="com.ichi2.widget.AnkiDroidWidgetSmall$UpdateService" />

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiActivity.kt
@@ -7,7 +7,6 @@ import android.app.Activity
 import android.app.NotificationManager
 import android.app.PendingIntent
 import android.content.ActivityNotFoundException
-import android.content.Context
 import android.content.Intent
 import android.content.res.Configuration
 import android.graphics.BitmapFactory
@@ -102,10 +101,6 @@ open class AnkiActivity : AppCompatActivity, SimpleMessageDialogListener, Collec
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O_MR1) {
             window.navigationBarColor = ContextCompat.getColor(this, R.color.transparent)
         }
-    }
-
-    override fun attachBaseContext(base: Context) {
-        super.attachBaseContext(AnkiDroidApp.updateContextWithLanguage(base))
     }
 
     override fun onStart() {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.kt
@@ -44,7 +44,6 @@ import com.ichi2.compat.CompatHelper
 import com.ichi2.libanki.Utils
 import com.ichi2.themes.Themes
 import com.ichi2.utils.*
-import com.ichi2.utils.LanguageUtil.getCurrentLanguage
 import net.ankiweb.rsdroid.BackendFactory
 import timber.log.Timber
 import timber.log.Timber.DebugTree
@@ -353,7 +352,7 @@ open class AnkiDroidApp : Application() {
         val feedbackUrl: String
             get() = // TODO actually this can be done by translating "link_help" string for each language when the App is
                 // properly translated
-                when (getSharedPrefs(instance).getCurrentLanguage()) {
+                when (LanguageUtil.getCurrentLocaleTag()) {
                     "ja" -> appResources.getString(R.string.link_help_ja)
                     "zh" -> appResources.getString(R.string.link_help_zh)
                     "ar" -> appResources.getString(R.string.link_help_ar)
@@ -367,7 +366,7 @@ open class AnkiDroidApp : Application() {
         val manualUrl: String
             get() = // TODO actually this can be done by translating "link_manual" string for each language when the App is
                 // properly translated
-                when (getSharedPrefs(instance).getCurrentLanguage()) {
+                when (LanguageUtil.getCurrentLocaleTag()) {
                     "ja" -> appResources.getString(R.string.link_manual_ja)
                     "zh" -> appResources.getString(R.string.link_manual_zh)
                     "ar" -> appResources.getString(R.string.link_manual_ar)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.kt
@@ -25,9 +25,7 @@ import android.content.SharedPreferences
 import android.content.res.Configuration
 import android.content.res.Resources
 import android.net.Uri
-import android.os.Build
 import android.os.Environment
-import android.os.LocaleList
 import android.system.Os
 import android.util.Log
 import android.webkit.CookieManager
@@ -47,12 +45,10 @@ import com.ichi2.libanki.Utils
 import com.ichi2.themes.Themes
 import com.ichi2.utils.*
 import com.ichi2.utils.LanguageUtil.getCurrentLanguage
-import com.ichi2.utils.LanguageUtil.getLanguage
 import net.ankiweb.rsdroid.BackendFactory
 import timber.log.Timber
 import timber.log.Timber.DebugTree
 import java.io.InputStream
-import java.util.*
 import java.util.regex.Pattern
 
 /**
@@ -65,18 +61,7 @@ open class AnkiDroidApp : Application() {
     private var mWebViewError: Throwable? = null
     private val mNotifications = MutableLiveData<Void?>()
 
-    @KotlinCleanup("can move analytics here now")
-    override fun attachBaseContext(base: Context) {
-        // update base context with preferred app language before attach
-        // possible since API 17, only supported way since API 25
-        // for API < 17 we update the configuration directly
-        super.attachBaseContext(updateContextWithLanguage(base))
-
-        // DO NOT INIT A WEBVIEW HERE (Moving Analytics to this method)
-        // Crashes only on a Physical API 19 Device - #7135
-        // After we move past API 19, we're good to go.
-    }
-
+    @KotlinCleanup("analytics can be moved to attachBaseContext()")
     /**
      * On application creation.
      */
@@ -353,66 +338,6 @@ open class AnkiDroidApp : Application() {
             get() = instance.resources
         val isSdCardMounted: Boolean
             get() = Environment.MEDIA_MOUNTED == Environment.getExternalStorageState()
-
-        /**
-         * Returns a Context with the correct, saved language, to be attached using attachBase().
-         * For old APIs directly sets language using deprecated functions
-         *
-         * @param remoteContext The base context offered by attachBase() to be passed to super.attachBase().
-         * Can be modified here to set correct GUI language.
-         */
-        fun updateContextWithLanguage(remoteContext: Context): Context {
-            return try {
-                // sInstance (returned by getInstance() ) set during application OnCreate()
-                // if getInstance() is null, the method is called during applications attachBaseContext()
-                // and preferences need mBase directly (is provided by remoteContext during attachBaseContext())
-                val preferences = if (isInitialized) {
-                    getSharedPrefs(instance.baseContext)
-                } else {
-                    getSharedPrefs(remoteContext)
-                }
-                val langConfig =
-                    getLanguageConfig(remoteContext.resources.configuration, preferences)
-                remoteContext.createConfigurationContext(langConfig)
-            } catch (e: Exception) {
-                Timber.e(e, "failed to update context with new language")
-                // during AnkiDroidApp.attachBaseContext() ACRA is not initialized, so the exception report will not be sent
-                sendExceptionReport(e, "AnkiDroidApp.updateContextWithLanguage")
-                remoteContext
-            }
-        }
-
-        /**
-         * Creates and returns a new configuration with the chosen GUI language that is saved in the preferences
-         *
-         * @param remoteConfig The configuration of the remote context to set the language for
-         * @param prefs
-         */
-        private fun getLanguageConfig(
-            remoteConfig: Configuration,
-            prefs: SharedPreferences
-        ): Configuration {
-            val newConfig = Configuration(remoteConfig)
-            val newLocale = LanguageUtil.getLocale(prefs.getLanguage(), prefs)
-            Timber.d("AnkiDroidApp::getLanguageConfig - setting locale to %s", newLocale)
-            // API level >=24
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
-                // Build list of locale strings, separated by commas: newLocale as first element
-                var strLocaleList = newLocale.toLanguageTag()
-                // if Anki locale from settings is no equal to system default, add system default as second item
-                // LocaleList must not contain language tags twice, will crash otherwise!
-                if (!strLocaleList.contains(Locale.getDefault().toLanguageTag())) {
-                    strLocaleList = strLocaleList + "," + Locale.getDefault().toLanguageTag()
-                }
-                val newLocaleList = LocaleList.forLanguageTags(strLocaleList)
-                // first element of setLocales() is automatically setLocal()
-                newConfig.setLocales(newLocaleList)
-            } else {
-                // API level >=17 but <24
-                newConfig.setLocale(newLocale)
-            }
-            return newConfig
-        }
 
         fun getMarketIntent(context: Context): Intent {
             val uri =

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.kt
@@ -137,7 +137,7 @@ open class CardTemplateEditor : AnkiActivity(), DeckSelectionListener {
 
     public override fun onSaveInstanceState(outState: Bundle) {
         with(outState) {
-            putAll(tempModel!!.toBundle())
+            tempModel?.let { putAll(it.toBundle()) }
             putLong(EDITOR_MODEL_ID, mModelId)
             putLong(EDITOR_NOTE_ID, mNoteId)
             putInt(EDITOR_START_ORD_ID, mStartingOrdId)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/analytics/AnkiDroidCrashReportDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/analytics/AnkiDroidCrashReportDialog.kt
@@ -18,7 +18,6 @@ package com.ichi2.anki.analytics
 
 import android.annotation.SuppressLint
 import android.app.AlertDialog
-import android.content.Context
 import android.content.DialogInterface
 import android.os.Bundle
 import android.view.View
@@ -40,10 +39,6 @@ class AnkiDroidCrashReportDialog : CrashReportDialog(), DialogInterface.OnClickL
     private var mAlwaysReportCheckBox: CheckBox? = null
     private var mUserComment: EditText? = null
     private var mHelper: CrashReportDialogHelper? = null
-
-    override fun attachBaseContext(base: Context) {
-        super.attachBaseContext(AnkiDroidApp.updateContextWithLanguage(base))
-    }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/GeneralSettingsFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/GeneralSettingsFragment.kt
@@ -15,6 +15,8 @@
  */
 package com.ichi2.anki.preferences
 
+import androidx.appcompat.app.AppCompatDelegate
+import androidx.core.os.LocaleListCompat
 import androidx.preference.ListPreference
 import androidx.preference.SwitchPreference
 import com.ichi2.anki.*
@@ -83,15 +85,20 @@ class GeneralSettingsFragment : SettingsFragment() {
     private fun initializeLanguagePref() {
         val sortedLanguages = LanguageUtil.APP_LANGUAGES.toSortedMap(java.lang.String.CASE_INSENSITIVE_ORDER)
         val systemLocale = getSystemLocale()
-
         requirePreference<ListPreference>(R.string.pref_language_key).apply {
             entries = arrayOf(getStringByLocale(R.string.language_system, systemLocale), *sortedLanguages.keys.toTypedArray())
-            entryValues = arrayOf("$systemLocale", *sortedLanguages.values.toTypedArray())
-            setOnPreferenceChangeListener { newValue ->
-                LanguageUtil.setDefaultBackendLanguages(newValue as String)
+            entryValues = arrayOf(LanguageUtil.DEFAULT_LANGUAGE_TAG, *sortedLanguages.values.toTypedArray())
+            setOnPreferenceChangeListener { selectedLanguage ->
+                LanguageUtil.setDefaultBackendLanguages(selectedLanguage as String)
                 runBlocking { CollectionManager.discardBackend() }
 
-                requireActivity().recreate()
+                val localeCode = if (selectedLanguage != LanguageUtil.DEFAULT_LANGUAGE_TAG) {
+                    selectedLanguage
+                } else {
+                    null
+                }
+                val localeList = LocaleListCompat.forLanguageTags(localeCode)
+                AppCompatDelegate.setApplicationLocales(localeList)
             }
         }
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/Preferences.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/Preferences.kt
@@ -288,11 +288,6 @@ class Preferences :
         result.highlight(fragmentToHighlight as PreferenceFragmentCompat)
     }
 
-    @VisibleForTesting(otherwise = VisibleForTesting.NONE)
-    public override fun attachBaseContext(base: Context) {
-        super.attachBaseContext(base)
-    }
-
     companion object {
         /** Key of the language preference  */
         const val LANGUAGE = "language"

--- a/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/PreferenceUpgradeService.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/PreferenceUpgradeService.kt
@@ -19,7 +19,9 @@ import android.content.Context
 import android.content.SharedPreferences
 import android.view.KeyEvent
 import androidx.annotation.VisibleForTesting
+import androidx.appcompat.app.AppCompatDelegate
 import androidx.core.content.edit
+import androidx.core.os.LocaleListCompat
 import com.ichi2.anki.AnkiDroidApp
 import com.ichi2.anki.cardviewer.Gesture
 import com.ichi2.anki.cardviewer.ViewerCommand
@@ -33,6 +35,8 @@ import com.ichi2.libanki.Consts
 import com.ichi2.themes.Themes
 import com.ichi2.utils.HashUtil.HashSetInit
 import timber.log.Timber
+import java.util.*
+import kotlin.collections.ArrayList
 
 private typealias VersionIdentifier = Int
 private typealias LegacyVersionIdentifier = Long
@@ -84,6 +88,7 @@ object PreferenceUpgradeService {
                 yield(UpgradeGesturesToControls())
                 yield(UpgradeDayAndNightThemes())
                 yield(UpgradeFetchMedia())
+                yield(UpgradeAppLocale())
             }
 
             /** Returns a list of preference upgrade classes which have not been applied */
@@ -362,6 +367,40 @@ object PreferenceUpgradeService {
                     remove(RemovedPreferences.SYNC_FETCHES_MEDIA)
                     putString("syncFetchMedia", status)
                 }
+            }
+        }
+
+        internal class UpgradeAppLocale : PreferenceUpgrade(10) {
+            override fun upgrade(preferences: SharedPreferences) {
+                fun getLocale(localeCode: String): Locale {
+                    // Language separators are '_' or '-' at different times in display/resource fetch
+                    val locale: Locale = if (localeCode.contains("_") || localeCode.contains("-")) {
+                        try {
+                            val localeParts = localeCode.split("[_-]".toRegex(), 2).toTypedArray()
+                            Locale(localeParts[0], localeParts[1])
+                        } catch (e: ArrayIndexOutOfBoundsException) {
+                            Timber.w(e, "getLocale variant split fail, using code '%s' raw.", localeCode)
+                            Locale(localeCode)
+                        }
+                    } else {
+                        Locale(localeCode) // guaranteed to be non null
+                    }
+                    return locale
+                }
+                // 1. upgrade value from `locale.toString()` to `locale.toLanguageTag()`,
+                // because the new API uses language tags
+                val languagePrefValue = preferences.getString("language", "")!!
+                val languageTag = if (languagePrefValue.isNotEmpty()) {
+                    getLocale(languagePrefValue).toLanguageTag()
+                } else {
+                    null
+                }
+                preferences.edit {
+                    putString("language", languageTag ?: "")
+                }
+                // 2. Set the locale with the new AndroidX API
+                val localeList = LocaleListCompat.forLanguageTags(languageTag)
+                AppCompatDelegate.setApplicationLocales(localeList)
             }
         }
     }

--- a/AnkiDroid/src/main/java/com/ichi2/ui/AppCompatPreferenceActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/ui/AppCompatPreferenceActivity.kt
@@ -27,7 +27,6 @@ import androidx.annotation.LayoutRes
 import androidx.appcompat.app.ActionBar
 import androidx.appcompat.app.AppCompatDelegate
 import androidx.appcompat.widget.Toolbar
-import com.ichi2.anki.AnkiDroidApp
 import com.ichi2.anki.CollectionHelper
 import com.ichi2.anki.receiver.SdCardReceiver
 import com.ichi2.libanki.Collection
@@ -187,10 +186,6 @@ abstract class AppCompatPreferenceActivity<PreferenceHack : AppCompatPreferenceA
         } else {
             finish()
         }
-    }
-
-    override fun attachBaseContext(base: Context) {
-        super.attachBaseContext(AnkiDroidApp.updateContextWithLanguage(base))
     }
 
     override fun onPostCreate(savedInstanceState: Bundle?) {

--- a/AnkiDroid/src/test/java/com/ichi2/anki/preferences/PreferencesTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/preferences/PreferencesTest.kt
@@ -15,6 +15,8 @@
  */
 package com.ichi2.anki.preferences
 
+import android.content.Context
+import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.commitNow
 import androidx.test.core.app.ActivityScenario
 import androidx.test.ext.junit.runners.AndroidJUnit4
@@ -24,6 +26,7 @@ import com.ichi2.anki.exception.ConfirmModSchemaException
 import com.ichi2.anki.preferences.Preferences.Companion.getDayOffset
 import com.ichi2.anki.preferences.Preferences.Companion.setDayOffset
 import com.ichi2.preferences.HeaderPreference
+import com.ichi2.testutils.getJavaMethodAsAccessible
 import kotlinx.coroutines.runBlocking
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
@@ -40,7 +43,12 @@ class PreferencesTest : RobolectricTest() {
     override fun setUp() {
         super.setUp()
         preferences = Preferences()
-        preferences.attachBaseContext(targetContext)
+        val attachBaseContext = getJavaMethodAsAccessible(
+            AppCompatActivity::class.java,
+            "attachBaseContext",
+            Context::class.java
+        )
+        attachBaseContext.invoke(preferences, targetContext)
     }
 
     @Test

--- a/AnkiDroid/src/test/java/com/ichi2/anki/servicemodel/PreferenceUpgradeServiceTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/servicemodel/PreferenceUpgradeServiceTest.kt
@@ -27,6 +27,7 @@ import com.ichi2.anki.servicelayer.PreferenceUpgradeService.PreferenceUpgrade
 import com.ichi2.anki.servicelayer.RemovedPreferences
 import com.ichi2.libanki.Consts
 import com.ichi2.utils.HashUtil
+import com.ichi2.utils.LanguageUtil
 import org.hamcrest.CoreMatchers.equalTo
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.lessThan
@@ -34,6 +35,8 @@ import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
+import java.util.*
+import kotlin.test.assertNotNull
 
 @RunWith(AndroidJUnit4::class)
 class PreferenceUpgradeServiceTest : RobolectricTest() {
@@ -170,5 +173,39 @@ class PreferenceUpgradeServiceTest : RobolectricTest() {
         mPrefs.edit { putBoolean(RemovedPreferences.SYNC_FETCHES_MEDIA, false) }
         PreferenceUpgrade.UpgradeFetchMedia().performUpgrade(mPrefs)
         assertThat(mPrefs.getString("syncFetchMedia", null), equalTo("never"))
+    }
+
+    // ############################
+    // ##### UpgradeAppLocale #####
+    // ############################
+    @Test
+    fun `Language preference value is updated to use language tags`() {
+        val upgradeAppLocale = PreferenceUpgrade.UpgradeAppLocale()
+        for (languageTag in LanguageUtil.APP_LANGUAGES.values) {
+            mPrefs.edit {
+                putString("language", Locale.forLanguageTag(languageTag).toString())
+            }
+            upgradeAppLocale.performUpgrade(mPrefs)
+            val correctLanguage = mPrefs.getString("language", null)
+            assertThat(languageTag, equalTo(correctLanguage))
+            assertThat(LanguageUtil.getCurrentLocaleTag(), equalTo(languageTag))
+        }
+    }
+
+    @Test
+    fun `Language preference value is set to system default correctly if it hasn't been set`() {
+        PreferenceUpgrade.UpgradeAppLocale().performUpgrade(mPrefs)
+
+        assertNotNull(mPrefs.getString("language", null))
+        assertThat(LanguageUtil.getCurrentLocaleTag(), equalTo(""))
+    }
+
+    @Test
+    fun `Language preference value is set to system default correctly`() {
+        mPrefs.edit { putString("language", "") }
+        PreferenceUpgrade.UpgradeAppLocale().performUpgrade(mPrefs)
+
+        assertThat(mPrefs.getString("language", null), equalTo(""))
+        assertThat(LanguageUtil.getCurrentLocaleTag(), equalTo(""))
     }
 }

--- a/AnkiDroid/src/test/java/com/ichi2/testutils/ReflectionUtils.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/testutils/ReflectionUtils.kt
@@ -17,6 +17,7 @@
 package com.ichi2.testutils
 
 import java.lang.reflect.Field
+import java.lang.reflect.Method
 import kotlin.reflect.KCallable
 import kotlin.reflect.full.createType
 
@@ -30,6 +31,17 @@ inline fun <reified T> KCallable<*>.isType() = returnType == T::class.createType
  */
 fun getJavaFieldAsAccessible(clazz: Class<*>, fieldName: String): Field {
     return clazz.getDeclaredField(fieldName).apply {
+        isAccessible = true
+    }
+}
+
+/**
+ * @param clazz Java class to get the field
+ * @param methodName name of the method
+ * @return a [Field] object with `isAccessible` set to true
+ */
+fun getJavaMethodAsAccessible(clazz: Class<*>, methodName: String, vararg parameterTypes: Class<*>): Method {
+    return clazz.getDeclaredMethod(methodName, *parameterTypes).apply {
         isAccessible = true
     }
 }

--- a/AnkiDroid/src/test/java/com/ichi2/utils/LanguageUtilsTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/utils/LanguageUtilsTest.kt
@@ -15,16 +15,11 @@
  */
 package com.ichi2.utils
 
-import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.common.collect.Sets
-import com.ichi2.anki.AnkiDroidApp
 import com.ichi2.testutils.EmptyApplication
-import com.ichi2.utils.LanguageUtil.getLocale
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers
-import org.hamcrest.Matchers.equalTo
-import org.hamcrest.Matchers.oneOf
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.annotation.Config
@@ -52,61 +47,6 @@ class LanguageUtilsTest {
             actual,
             Matchers.contains(*CURRENT_LANGUAGES)
         )
-    }
-
-    @Test
-    @Config(qualifiers = "en")
-    fun localeTwoLetterCodeResolves() {
-        assertThat(
-            "A locale with a 3-letter code resolves correctly",
-            getLocale("af").displayLanguage,
-            equalTo("Afrikaans")
-        )
-    }
-
-    @Test
-    @Config(qualifiers = "en")
-    fun localeThreeLetterCodeResolves() {
-        assertThat(
-            "A locale with a 3-letter code resolves correctly",
-            getLocale("fil").displayLanguage,
-            equalTo("Filipino")
-        )
-    }
-
-    @Test
-    @Config(qualifiers = "en")
-    fun localeTwoLetterRegionalVariantResolves() {
-        assertThat(
-            "A locale with a 2-letter code and regional variant resolves correctly",
-            getLocale("pt-BR").displayName,
-            equalTo("Portuguese (Brazil)")
-        )
-        assertThat(
-            "A locale with a 2-letter code and regional variant resolves correctly",
-            getLocale("pt_BR").displayName,
-            equalTo("Portuguese (Brazil)")
-        )
-    }
-
-    @Test
-    @Config(qualifiers = "en")
-    fun localeThreeLetterRegionalVariantResolves() {
-        assertThat(
-            "A locale with a 2-letter code and regional variant resolves correctly",
-            getLocale("yue-TW").displayName,
-            oneOf("yue (Taiwan)", "Cantonese (Taiwan)")
-        )
-        assertThat(
-            "A locale with a 2-letter code and regional variant resolves correctly",
-            getLocale("yue_TW").displayName,
-            oneOf("yue (Taiwan)", "Cantonese (Taiwan)")
-        )
-    }
-
-    private fun getLocale(localeCode: String): Locale {
-        val prefs = AnkiDroidApp.getSharedPrefs(ApplicationProvider.getApplicationContext())
-        return getLocale(localeCode, prefs)
     }
 
     companion object {


### PR DESCRIPTION
## Purpose / Description

Adds support to SDK ≥ 33 new language settings configuration and simplifies language change handling

## Fixes
Fixes #7173
Fixes #8865
Fixes #13046

## Approach

The commits splitting is only to help reviewers and myself. This probably needs to be squashed

1. Stop handling language changes manually (#12832) by removing it from the manifest
    - `locale` manual handling was added ~10 years ago and Android's API has changed a lot since then 
2. Upgrade the previous language scheme of `locale.toString()` to `locale.toLanguageTag` because the new API takes languageTags
3. Use Android's new API for setting and storing locales (reference: https://developer.android.com/guide/topics/resources/app-languages)
4. Refactor a part of `LanguageUtil`

## How Has This Been Tested?

Run on SDK 33 emulator and on my phone (Android 12, Samsung One UI 4.1)
1. Go to settings > general
2. Try changing language

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [X] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
