### PR TITLE
made MediaCheckResult parcelable

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/MediaCheckDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/MediaCheckDialog.kt
@@ -15,6 +15,10 @@ import com.afollestad.materialdialogs.customview.customView
 import com.ichi2.anki.R
 import com.ichi2.libanki.MediaCheckResult
 
+private const val CHECK_LIST = "checkList"
+
+private const val DIALOG_TYPE = "dialogType"
+
 class MediaCheckDialog : AsyncDialogFragment() {
     interface MediaCheckDialogListener {
         fun showMediaCheckDialog(dialogType: Int)
@@ -28,7 +32,7 @@ class MediaCheckDialog : AsyncDialogFragment() {
         super.onCreate(savedInstanceState)
         val dialog = MaterialDialog(requireActivity())
         dialog.title(text = notificationTitle)
-        return when (requireArguments().getInt("dialogType")) {
+        return when (requireArguments().getInt(DIALOG_TYPE)) {
             DIALOG_CONFIRM_MEDIA_CHECK -> {
                 dialog.show {
                     message(text = notificationMessage)
@@ -114,7 +118,7 @@ class MediaCheckDialog : AsyncDialogFragment() {
 
     override val notificationMessage: String
         get() {
-            return when (requireArguments().getInt("dialogType")) {
+            return when (requireArguments().getInt(DIALOG_TYPE)) {
                 DIALOG_CONFIRM_MEDIA_CHECK -> resources.getString(R.string.check_media_warning)
                 DIALOG_MEDIA_CHECK_RESULTS -> resources.getString(R.string.check_media_acknowledge)
                 else -> resources.getString(R.string.app_name)
@@ -123,7 +127,7 @@ class MediaCheckDialog : AsyncDialogFragment() {
 
     override val notificationTitle: String
         get() {
-            return if (requireArguments().getInt("dialogType") == DIALOG_CONFIRM_MEDIA_CHECK) {
+            return if (requireArguments().getInt(DIALOG_TYPE) == DIALOG_CONFIRM_MEDIA_CHECK) {
                 resources.getString(R.string.check_media_title)
             } else resources.getString(R.string.app_name)
         }
@@ -136,7 +140,7 @@ class MediaCheckDialog : AsyncDialogFragment() {
             b.putStringArrayList("nohave", requireArguments().getStringArrayList("nohave"))
             b.putStringArrayList("unused", requireArguments().getStringArrayList("unused"))
             b.putStringArrayList("invalid", requireArguments().getStringArrayList("invalid"))
-            b.putInt("dialogType", requireArguments().getInt("dialogType"))
+            b.putInt(DIALOG_TYPE, requireArguments().getInt(DIALOG_TYPE))
             msg.data = b
             return msg
         }
@@ -147,21 +151,16 @@ class MediaCheckDialog : AsyncDialogFragment() {
         fun newInstance(dialogType: Int): MediaCheckDialog {
             val f = MediaCheckDialog()
             val args = Bundle()
-            args.putInt("dialogType", dialogType)
+            args.putInt(DIALOG_TYPE, dialogType)
             f.arguments = args
             return f
         }
 
-        // TODO Instead of putting string arrays into the bundle,
-        //   make MediaCheckResult parcelable with @Parcelize and put it instead.
-        // TODO Extract keys to constants
         fun newInstance(dialogType: Int, checkList: MediaCheckResult): MediaCheckDialog {
             val f = MediaCheckDialog()
             val args = Bundle()
-            args.putStringArrayList("nohave", ArrayList(checkList.missingFileNames))
-            args.putStringArrayList("unused", ArrayList(checkList.unusedFileNames))
-            args.putStringArrayList("invalid", ArrayList(checkList.invalidFileNames))
-            args.putInt("dialogType", dialogType)
+            args.putParcelable(CHECK_LIST, checkList)
+            args.putInt(DIALOG_TYPE, dialogType)
             f.arguments = args
             return f
         }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Media.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Media.kt
@@ -20,6 +20,7 @@ package com.ichi2.libanki
 import android.database.Cursor
 import android.database.SQLException
 import android.net.Uri
+import android.os.Parcelable
 import android.text.TextUtils
 import androidx.annotation.VisibleForTesting
 import com.ichi2.anki.CrashReportService
@@ -29,6 +30,7 @@ import com.ichi2.utils.*
 import com.ichi2.utils.HashUtil.HashMapInit
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ensureActive
+import kotlinx.parcelize.Parcelize
 import net.ankiweb.rsdroid.BackendFactory
 import org.json.JSONArray
 import org.json.JSONObject
@@ -1032,9 +1034,9 @@ create table meta (dirMod int, lastUsn int); insert into meta values (0, 0);"""
         }
     }
 }
-
+@Parcelize
 data class MediaCheckResult(
     val missingFileNames: List<String>,
     val unusedFileNames: List<String>,
     val invalidFileNames: List<String>,
-)
+) : Parcelable


### PR DESCRIPTION
## Pull Request template
 made MediaCheckResult parcelable with @Parcelize and used it instead of Array...

## Purpose / Description
TODO

## Fixes
Fixes _Link to the issues._

## Approach
_How does this change address the problem?_

## How Has This Been Tested?
Tested on google emulator SDK 31

## Learning (optional, can help others)
_Describe the research stage_

_Links to blog posts, patterns, libraries or addons used to solve this problem_

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
