### PR TITLE
Fix typo in  new contributor label workflow

### DIFF
--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -179,6 +179,6 @@ jobs:
             await github.rest.issues.addLabels({
               issue_number: context.issue.number,
               owner: context.repo.owner,
-              repo: context.repo.repo
+              repo: context.repo.repo,
               labels: ['New contributor']
             })


### PR DESCRIPTION
## Purpose / Description

Embarrassing but I missed a comma, hopefully there's nothing else currently crashing this workflow.

## How Has This Been Tested?

Reviewed again the previous code.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
