### PR TITLE
Fix incorrect timezone in new schema

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ buildscript {
     ext.kotlin_version = '1.7.22'
     ext.lint_version = '30.3.1'
     ext.acra_version = '5.9.7'
-    ext.ankidroid_backend_version = '0.1.17-anki2.1.55' // this is parsed in tools/setup-anki-backend.sh
+    ext.ankidroid_backend_version = '0.1.18-anki2.1.55' // this is parsed in tools/setup-anki-backend.sh
     ext.hamcrest_version = '2.2'
     ext.junit_version = '5.9.1'
     ext.coroutines_version = '1.6.4'


### PR DESCRIPTION
Another day, another backend release :-(

Requires https://github.com/ankidroid/Anki-Android-Backend/pull/251

Closes #13022

You can test before/after with the new schema by logging the determined timezone:

```diff
diff --git a/AnkiDroid/src/main/java/com/ichi2/anki/stats/AnkiStatsTaskHandler.kt b/AnkiDroid/src/main/java/com/ichi2/anki/stats/AnkiStatsTaskHandler.kt
index 06c6c7339e..da8b3b5777 100644
--- a/AnkiDroid/src/main/java/com/ichi2/anki/stats/AnkiStatsTaskHandler.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/stats/AnkiStatsTaskHandler.kt
@@ -132,6 +132,7 @@ class AnkiStatsTaskHandler private constructor(
             var cards: Int
             var minutes: Int
             /* cards, excludes rescheduled cards https://github.com/ankidroid/Anki-Android/issues/8592 */
+            Timber.e("cutoff is %d", col.sched.dayCutoff)
             val query = "select sum(case when ease > 0 then 1 else 0 end), " +
                 "sum(time)/1000 from revlog where id > " + (col.sched.dayCutoff - Stats.SECONDS_PER_DAY) * 1000
             Timber.d("DeckPreviewStatistics query: %s", query)
```

If you check the resulting timestamp, you should find it's not 4am local time, but is after the backend update.