### PR TITLE
Make invisible expanders unclickable

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/widgets/DeckAdapter.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/widgets/DeckAdapter.kt
@@ -17,8 +17,6 @@
 package com.ichi2.anki.widgets
 
 import android.content.Context
-import android.graphics.Color
-import android.graphics.drawable.ColorDrawable
 import android.graphics.drawable.Drawable
 import android.view.LayoutInflater
 import android.view.View
@@ -252,7 +250,7 @@ class DeckAdapter(private val layoutInflater: LayoutInflater, context: Context) 
                 expander.contentDescription = expander.context.getString(R.string.collapse)
             }
         } else {
-            expander.visibility = View.INVISIBLE 
+            expander.visibility = View.INVISIBLE
             expander.importantForAccessibility = View.IMPORTANT_FOR_ACCESSIBILITY_NO
         }
         // Add some indenting for each nested level

--- a/AnkiDroid/src/main/java/com/ichi2/anki/widgets/DeckAdapter.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/widgets/DeckAdapter.kt
@@ -54,7 +54,6 @@ class DeckAdapter(private val layoutInflater: LayoutInflater, context: Context) 
     private val mDeckNameDynColor: Int
     private val mExpandImage: Drawable?
     private val mCollapseImage: Drawable?
-    private val mNoExpander: Drawable = ColorDrawable(Color.TRANSPARENT)
     private var currentDeckId: DeckId = 0
 
     // Listeners
@@ -253,7 +252,7 @@ class DeckAdapter(private val layoutInflater: LayoutInflater, context: Context) 
                 expander.contentDescription = expander.context.getString(R.string.collapse)
             }
         } else {
-            expander.setImageDrawable(mNoExpander)
+            expander.visibility = View.INVISIBLE 
             expander.importantForAccessibility = View.IMPORTANT_FOR_ACCESSIBILITY_NO
         }
         // Add some indenting for each nested level


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
Invisible expanders are unnecessarily clickable and prevent decks from opening.
![deckpicker2_600px](https://user-images.githubusercontent.com/10436072/209550945-54496c12-340b-43c3-a1b8-b02cc70b4fd0.gif)

## Fixes
Fixes #13034

## How Has This Been Tested?
Tested on a physical device (The debug info is written in #13034)



https://user-images.githubusercontent.com/10436072/209548750-2733cdcb-b65a-4d46-915c-d5c2ea653798.mp4






## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
