### PR TITLE
Fix compress format and extension format.

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/Whiteboard.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Whiteboard.kt
@@ -506,7 +506,7 @@ class Whiteboard(activity: AnkiActivity, handleMultiTouch: Boolean, inverted: Bo
         }
         draw(canvas)
         val baseFileName = "Whiteboard" + TimeUtils.getTimestamp(time!!)
-        return CompatHelper.compat.saveImage(context, bitmap, baseFileName, "png", Bitmap.CompressFormat.PNG, 95)
+        return CompatHelper.compat.saveImage(context, bitmap, baseFileName, "jpg", Bitmap.CompressFormat.JPEG, 95)
     }
 
     @KotlinCleanup("fun interface & use SAM on callers")

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Whiteboard.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Whiteboard.kt
@@ -506,8 +506,7 @@ class Whiteboard(activity: AnkiActivity, handleMultiTouch: Boolean, inverted: Bo
         }
         draw(canvas)
         val baseFileName = "Whiteboard" + TimeUtils.getTimestamp(time!!)
-        // TODO: Fix inconsistent CompressFormat 'JPEG' and file extension 'png'
-        return CompatHelper.compat.saveImage(context, bitmap, baseFileName, "png", Bitmap.CompressFormat.JPEG, 95)
+        return CompatHelper.compat.saveImage(context, bitmap, baseFileName, "png", Bitmap.CompressFormat.PNG, 95)
     }
 
     @KotlinCleanup("fun interface & use SAM on callers")


### PR DESCRIPTION
## Purpose / Description
Fix compress format and extension.

## Fixes
Fixes _Link to the issues._

## Approach
When the image is imported from gallery, it is imported as JPEG with extension jpg, but when imported as drawing it is imported as JPEG, but to my surprise with extension PNG, so I think TODO is added to fix this inconsistency in compress format and extension.
Fixed this inconsistency by changing the extension to JPG when imported from drawing.

## How Has This Been Tested?

Tested on google emulator

## Before


https://user-images.githubusercontent.com/76740999/210334748-babbf6d2-175a-4ff6-96d9-9baa3ea98c88.mp4


## After

https://user-images.githubusercontent.com/76740999/210334753-c70d98a4-a7ef-44a3-9400-aecfacafe605.mp4



## Learning (optional, can help others)
_Describe the research stage_

_Links to blog posts, patterns, libraries or addons used to solve this problem_

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
