### PR TITLE
fixes the super. call with correct one

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/SimpleMessageDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/SimpleMessageDialog.kt
@@ -28,8 +28,7 @@ class SimpleMessageDialog : AsyncDialogFragment() {
     }
 
     override fun onCreateDialog(savedInstanceState: Bundle?): MaterialDialog {
-        // FIXME this should be super.onCreateDialog(Bundle), no?
-        super.onCreate(savedInstanceState)
+        super.onCreateDialog(savedInstanceState)
         return MaterialDialog(requireActivity()).show {
             title(text = notificationTitle)
             contentNullable(notificationMessage)


### PR DESCRIPTION
## Pull Request template
FIXME
## Purpose / Description
onCreate(savedInstanceState: Bundle?) function is called to perform other initialization tasks for the Fragment and should not be called from the onCreateDialog function.

## Fixes
Fixes _Link to the issues._

## Approach
_How does this change address the problem?_

## How Has This Been Tested?
Tested on google emulator (API 28)

## Learning (optional, can help others)
_Describe the research stage_

_Links to blog posts, patterns, libraries or addons used to solve this problem_

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
