### PR TITLE
To find the screen size in API 30

### DIFF
--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/TestUtils.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/TestUtils.kt
@@ -20,7 +20,6 @@ import android.app.Activity
 import android.content.res.Configuration
 import android.os.Build
 import android.view.View
-import androidx.annotation.RequiresApi
 import androidx.test.espresso.UiController
 import androidx.test.espresso.ViewAction
 import androidx.test.platform.app.InstrumentationRegistry
@@ -75,14 +74,15 @@ object TestUtils {
      */
     @Suppress("deprecation") // #9333: getDefaultDisplay & getMetrics
     val isScreenSw600dp: Boolean
-        @RequiresApi(Build.VERSION_CODES.R)
         get() {
-            activityInstance!!.baseContext.display
-            val bounds = activityInstance!!.windowManager.currentWindowMetrics.bounds
-            val widthDp = bounds.width() / Configuration.DENSITY_DPI_UNDEFINED
-            val heightDp = bounds.height() / Configuration.DENSITY_DPI_UNDEFINED
-            val screenSw = Math.min(widthDp, heightDp)
-            return screenSw >= 600
+            return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+                activityInstance!!.baseContext.display
+                val bounds = activityInstance!!.windowManager.currentWindowMetrics.bounds
+                val widthDp = bounds.width() / Configuration.DENSITY_DPI_UNDEFINED
+                val heightDp = bounds.height() / Configuration.DENSITY_DPI_UNDEFINED
+                val screenSw = Math.min(widthDp, heightDp)
+                screenSw >= 600
+            } else false
         }
 
     /**

--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/TestUtils.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/TestUtils.kt
@@ -17,8 +17,10 @@
 package com.ichi2.anki
 
 import android.app.Activity
-import android.util.DisplayMetrics
+import android.content.res.Configuration
+import android.os.Build
 import android.view.View
+import androidx.annotation.RequiresApi
 import androidx.test.espresso.UiController
 import androidx.test.espresso.ViewAction
 import androidx.test.platform.app.InstrumentationRegistry
@@ -73,11 +75,12 @@ object TestUtils {
      */
     @Suppress("deprecation") // #9333: getDefaultDisplay & getMetrics
     val isScreenSw600dp: Boolean
+        @RequiresApi(Build.VERSION_CODES.R)
         get() {
-            val displayMetrics = DisplayMetrics()
-            activityInstance!!.windowManager.defaultDisplay.getMetrics(displayMetrics)
-            val widthDp = displayMetrics.widthPixels / displayMetrics.density
-            val heightDp = displayMetrics.heightPixels / displayMetrics.density
+            activityInstance!!.baseContext.display
+            val bounds = activityInstance!!.windowManager.currentWindowMetrics.bounds
+            val widthDp = bounds.width() / Configuration.DENSITY_DPI_UNDEFINED
+            val heightDp = bounds.height() / Configuration.DENSITY_DPI_UNDEFINED
             val screenSw = Math.min(widthDp, heightDp)
             return screenSw >= 600
         }

--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/TestUtils.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/TestUtils.kt
@@ -19,6 +19,7 @@ package com.ichi2.anki
 import android.app.Activity
 import android.content.res.Configuration
 import android.os.Build
+import android.util.DisplayMetrics
 import android.view.View
 import androidx.test.espresso.UiController
 import androidx.test.espresso.ViewAction
@@ -75,14 +76,21 @@ object TestUtils {
     @Suppress("deprecation") // #9333: getDefaultDisplay & getMetrics
     val isScreenSw600dp: Boolean
         get() {
-            return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            return if (Build.VERSION.SDK_INT == Build.VERSION_CODES.R) {
                 activityInstance!!.baseContext.display
                 val bounds = activityInstance!!.windowManager.currentWindowMetrics.bounds
                 val widthDp = bounds.width() / Configuration.DENSITY_DPI_UNDEFINED
                 val heightDp = bounds.height() / Configuration.DENSITY_DPI_UNDEFINED
                 val screenSw = Math.min(widthDp, heightDp)
                 screenSw >= 600
-            } else false
+            } else {
+                val displayMetrics = DisplayMetrics()
+                activityInstance!!.windowManager.defaultDisplay.getMetrics(displayMetrics)
+                val widthDp = displayMetrics.widthPixels / displayMetrics.density
+                val heightDp = displayMetrics.heightPixels / displayMetrics.density
+                val screenSw = Math.min(widthDp, heightDp)
+                return screenSw >= 600
+            }
         }
 
     /**


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
Display/Size related deprecation in API 30

## Fixes
#9333 


## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)