### PR TITLE
Search box is filled with the required flag when `filter by flag`

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -548,7 +548,6 @@ open class CardBrowser :
 
     fun searchWithFilterQuery(filterQuery: String) {
         mSearchTerms = filterQuery
-
         mSearchView!!.setQuery(mSearchTerms, true)
         searchCards()
     }
@@ -1803,7 +1802,7 @@ open class CardBrowser :
             mSearchTerms.isNotEmpty() -> "$flagSearchTerm $mSearchTerms"
             else -> flagSearchTerm
         }
-        searchCards()
+        searchWithFilterQuery(mSearchTerms)
     }
 
     internal abstract class ListenerWithProgressBar<Progress, Result>(browser: CardBrowser) : TaskListenerWithContext<CardBrowser, Progress, Result>(browser) {


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
Search box is filled with the required flag when `filter by flag`.

## Fixes
Fixes #13087 

## Approach
 `searchWithFilterQuery()` is called to fill the search view.

## How Has This Been Tested?



https://user-images.githubusercontent.com/76740999/211275122-80f29657-cc9b-446d-a1e9-bf79b5cc0762.mp4




## Learning (optional, can help others)
_Describe the research stage_

_Links to blog posts, patterns, libraries or addons used to solve this problem_

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
