### PR TITLE
ci: debug identifier -> 'com.ichi2.anki.debug'

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -77,6 +77,7 @@ android {
     buildTypes {
         debug {
             debuggable true
+            applicationIdSuffix ".debug"
             splits.abi.universalApk = true // Build universal APK for debug always
             // Check Crash Reports page on developer wiki for info on ACRA testing
             // buildConfigField "String", "ACRA_URL", '"https://918f7f55-f238-436c-b34f-c8b5f1331fe5-bluemix.cloudant.com/acra-ankidroid/_design/acra-storage/_update/report"'
@@ -107,6 +108,7 @@ android {
             // make the icon red if in debug mode
             resValue 'color', 'anki_foreground_icon_color_0', "#FFFF0000"
             resValue 'color', 'anki_foreground_icon_color_1', "#FFFF0000"
+            resValue "string", "applicationId", "${defaultConfig.applicationId}${applicationIdSuffix}"
         }
         release {
             minifyEnabled true
@@ -115,6 +117,7 @@ android {
             signingConfig signingConfigs.release
             resValue 'color', 'anki_foreground_icon_color_0', "#FF29B6F6"
             resValue 'color', 'anki_foreground_icon_color_1', "#FF0288D1"
+            resValue "string", "applicationId", defaultConfig.applicationId
         }
     }
 

--- a/AnkiDroid/src/main/AndroidManifest.xml
+++ b/AnkiDroid/src/main/AndroidManifest.xml
@@ -40,7 +40,7 @@
     <uses-permission android:name="android.permission.CAMERA" />
     <uses-permission android:name="android.permission.GET_PACKAGE_SIZE" android:maxSdkVersion="25" />
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
-    <permission android:name="com.ichi2.anki.permission.READ_WRITE_DATABASE"
+    <permission android:name="${applicationId}.permission.READ_WRITE_DATABASE"
                 android:label="@string/read_write_permission_label"
                 android:description="@string/read_write_permission_description"
                 android:protectionLevel="dangerous"
@@ -517,7 +517,7 @@
 
         <provider
             android:name=".provider.CardContentProvider"
-            android:authorities="com.ichi2.anki.flashcards"
+            android:authorities="${applicationId}.flashcards"
             android:enabled="true"
             android:exported="true"
             >
@@ -526,7 +526,7 @@
 
         <provider
             android:name="androidx.core.content.FileProvider"
-            android:authorities="com.ichi2.anki.apkgfileprovider"
+            android:authorities="${applicationId}.apkgfileprovider"
             android:grantUriPermissions="true"
             android:exported="false"
             >

--- a/AnkiDroid/src/main/res/xml/preferences_sync.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_sync.xml
@@ -23,9 +23,10 @@
         android:key="@string/sync_account_key"
         android:summary="@string/sync_account_summ_logged_out"
         android:title="@string/sync_account" >
+        <!--suppress AndroidDomInspection: @string/applicationId works -->
         <intent
             android:targetClass="com.ichi2.anki.MyAccount"
-            android:targetPackage="com.ichi2.anki" />
+            android:targetPackage="@string/applicationId" />
     </Preference>
     <SwitchPreference
         android:defaultValue="true"

--- a/api/build.gradle
+++ b/api/build.gradle
@@ -22,6 +22,10 @@ android {
         buildConfigField "String", "AUTHORITY", '"com.ichi2.anki.flashcards"'
     }
     buildTypes {
+        debug {
+            buildConfigField "String", "READ_WRITE_PERMISSION", '"com.ichi2.anki.debug.permission.READ_WRITE_DATABASE"'
+            buildConfigField "String", "AUTHORITY", '"com.ichi2.anki.debug.flashcards"'
+        }
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'

--- a/api/build.gradle
+++ b/api/build.gradle
@@ -18,6 +18,8 @@ android {
         minSdkVersion 16
         //noinspection OldTargetApi
         targetSdkVersion 29
+        buildConfigField "String", "READ_WRITE_PERMISSION", '"com.ichi2.anki.permission.READ_WRITE_DATABASE"'
+        buildConfigField "String", "AUTHORITY", '"com.ichi2.anki.flashcards"'
     }
     buildTypes {
         release {

--- a/api/src/debug/AndroidManifest.xml
+++ b/api/src/debug/AndroidManifest.xml
@@ -1,0 +1,21 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.ichi2.anki.api">
+    <!--
+    In Anki-Android:AndroidManifest.xml 'applicationId' defines the permission/authority for the API
+
+    (com.ichi2.anki.permission.xxx)       - live    (Anki-Android)
+    (com.ichi2.anki.debug.permission.xxx) - disabled (Anki-Android:Dev)
+    (com.ichi2.anki.a.permission.xxx)     - disabled (Anki-Android:Parallel.A)
+
+    This caused a problem with integration test builds (androidTest)
+    These run under '.debug', but require a working API where we can test permissions
+
+    We need <uses-permission> to grant 'com.ichi2.anki.debug.permission.READ_WRITE_DATABASE'
+
+    The permission should not be in a 'release' build.
+    We can't define an 'androidTest' only manifest:
+    https://stackoverflow.com/questions/26244998/androidmanifest-in-androidtest-directory-being-ignored
+
+    So this exists in a 'debug' manifest, which is used by androidTest
+    -->
+    <uses-permission android:name="com.ichi2.anki.debug.permission.READ_WRITE_DATABASE"/>
+</manifest>

--- a/api/src/main/java/com/ichi2/anki/FlashCardsContract.kt
+++ b/api/src/main/java/com/ichi2/anki/FlashCardsContract.kt
@@ -7,6 +7,7 @@
 package com.ichi2.anki
 
 import android.net.Uri
+import com.ichi2.anki.api.BuildConfig
 
 /**
  * The contract between AnkiDroid and applications. Contains definitions for the supported URIs and
@@ -85,8 +86,8 @@ import android.net.Uri
  * ```
  */
 public object FlashCardsContract {
-    public const val AUTHORITY: String = "com.ichi2.anki.flashcards"
-    public const val READ_WRITE_PERMISSION: String = "com.ichi2.anki.permission.READ_WRITE_DATABASE"
+    public const val AUTHORITY: String = BuildConfig.AUTHORITY
+    public const val READ_WRITE_PERMISSION: String = BuildConfig.READ_WRITE_PERMISSION
 
     /**
      * A content:// style uri to the authority for the flash card provider

--- a/tools/parallel-package-name.sh
+++ b/tools/parallel-package-name.sh
@@ -7,13 +7,10 @@ NEW_ID=$1		# e.g. com.ichi2.anki.a
 NEW_NAME=$2		# e.g. AnkiDroid.A
 
 ROOT="AnkiDroid/src/main/"
-MANIFEST="AndroidManifest.xml"
 CONSTANTS="res/values/constants.xml"
 
 OLD_ID=com.ichi2.anki
 
 perl -pi -e "s/name=\"app_name\"(.*?)>.*?<\/string>/name=\"app_name\"\1>$NEW_NAME<\/string>/g" $ROOT$CONSTANTS
-perl -pi -e "s/applicationId \"$OLD_ID/applicationId \"$NEW_ID/g" AnkiDroid/build.gradle
-perl -pi -e "s/android:authorities=\"$OLD_ID/android:authorities=\"$NEW_ID/g" $ROOT$MANIFEST
-perl -pi -e "s/permission android:name=\"$OLD_ID.permission/permission android:name=\"$NEW_ID.permission/g" $ROOT$MANIFEST
-find $ROOT/res/xml -type f -exec perl -pi -e "s/android:targetPackage=\"$OLD_ID\"/android:targetPackage=\"$NEW_ID\"/g" {} \;
+# use .+? to fix reruns of script breaking the applicationId
+perl -pi -e "s/applicationId \".+?\"/applicationId \"$NEW_ID\"/g" AnkiDroid/build.gradle


### PR DESCRIPTION
Since we're moving to scoped storage, uninstalling the app will very likely delete user data.

In Debug/Dev, we want this to impact the dev's workflow as little as possible So we change the applicationId. This relays the expectation that a 'stable' anki should be using 'com.ichi2.anki' and an 'unstable/dev' AnkiDroid should be 'com.ichi2.anki.debug'. A developer should have two copies of the app, each with their own storage location.

## ⚠️ Review Goals

* I had a bug with `@string/applicationId` being marked as an IDE error. The code ran after a rebuild. I believe this is fine, but is a priority for review
* The perl regexes have been tested manually, and seemed fine
* Security review of API Logic

## API

As previously, define the API permissions/authority using the applicationId:
permission: 'com.ichi2.anki.debug.permission'. 
authority: 'com.ichi2.anki.debug.flashcards'. 

androidTest needs to access 'com.ichi2.anki.debug.flashcards' and have
'com.ichi2.anki.debug.permission'.

To resolve this, if the API is built in debug mode, the constants are modified:

**(api/build.gradle)**
* AUTHORITY = "com.ichi2.anki.debug.flashcards"
* READ_WRITE_PERMISSION = "com.ichi2.anki.debug.permission.READ_WRITE_DATABASE"

## Implementation:

### High level:
* Define variables in build.gradle
* Handle modifying them via parallel-package-name.sh

### Low level:
* Use 'applicationIdSuffix' for this
* Modifies `<provider android:authorities>` in AndroidManifest.xml
  * Required for installation on device
  * Use `applicationId`
* Modifies `<permission android:name` in AndroidManifest.xml
  * Not required - cleanup on parallel-package-name.sh
* Modifies `preferences_sync.xml`
  * via `resValue` in build.gradle
  * Fixes crash

Source for both: https://developer.android.com/studio/build/build-variants#build-types

**applicationIdSuffix:**
https://developer.android.com/reference/tools/gradle-api/7.3/com/android/build/api/dsl/ApplicationVariantDimension#applicationIdSuffix()

**@string/applicationId**
* syntax ref: https://stackoverflow.com/questions/27954215/changing-resvalue-in-variant

**manifestPlaceholders/${applicationId}**
https://developer.android.com/studio/build/manage-manifests

## Learning:
> By default, the build tools also provide your app's application ID in the ${applicationId} placeholder. The value always matches the final application ID for the current build, including changes by build variants. This is useful when you want to use a unique namespace for identifiers such as an intent action, even between your build variants.

https://developer.android.com/studio/build/manage-manifests
