### PR TITLE
Moved recording buttons outside the scroll view as it should always be on the screen.

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicAudioRecordingFieldController.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicAudioRecordingFieldController.kt
@@ -55,7 +55,6 @@ class BasicAudioRecordingFieldController : FieldControllerBase(), IFieldControll
             mTempAudioPath = generateTempAudioFile(mActivity)
         }
 
-        // FIXME: We should move this outside the scrollview as it should always be on the screen.
         mAudioView = createRecorderInstance(
             context = mActivity,
             resPlay = R.drawable.ic_play_arrow_white_24dp,

--- a/AnkiDroid/src/main/res/layout/multimedia_edit_field_activity.xml
+++ b/AnkiDroid/src/main/res/layout/multimedia_edit_field_activity.xml
@@ -19,17 +19,16 @@
             android:orientation="horizontal" >
         </LinearLayout>
 
+        <LinearLayout
+            android:id="@+id/LinearLayoutInScrollViewFieldEdit"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical" />
+
         <ScrollView
             android:id="@+id/scrollView1"
             android:layout_width="match_parent"
-            android:layout_height="match_parent" >
+            android:layout_height="match_parent" />
 
-            <LinearLayout
-                android:id="@+id/LinearLayoutInScrollViewFieldEdit"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:orientation="vertical" >
-            </LinearLayout>
-        </ScrollView>
     </LinearLayout>
 </androidx.coordinatorlayout.widget.CoordinatorLayout>


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
Move recording buttons outside scroll view as it should always be on the screen.

## Fixes
Fixes   `// FIXME: We should move this outside the scrollview as it should always be on the screen.`

## Approach
Fix layout issue.

## How Has This Been Tested?

## Before


https://user-images.githubusercontent.com/76740999/211755265-9e5f2d5b-a406-493a-9170-000fde8693eb.mp4




## After


https://user-images.githubusercontent.com/76740999/211755281-2d9557d6-dce2-4857-9a8a-929dbc3d14af.mp4





## Learning (optional, can help others)
_Describe the research stage_

_Links to blog posts, patterns, libraries or addons used to solve this problem_

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
