### PR TITLE
Default new users to a writable folder

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.kt
@@ -283,27 +283,6 @@ open class AnkiDroidApp : Application() {
     companion object {
         /** Running under instrumentation. a "/androidTest" directory will be created which contains a test collection  */
         var INSTRUMENTATION_TESTING = false
-
-        /**
-         * Toggles Scoped Storage functionality introduced in later commits
-         *
-         *
-         * Can be set to true or false only by altering the declaration itself.
-         * This restriction ensures that this flag will only be used by developers for testing
-         *
-         *
-         * Set to false by default, so won't migrate data or use new scoped dirs
-         *
-         *
-         * If true, enables data migration & use of scoped dirs in later commits
-         *
-         *
-         * Should be set to true for testing Scoped Storage
-         *
-         *
-         * TODO: Should be removed once app is fully functional under Scoped Storage
-         */
-        var TESTING_SCOPED_STORAGE = false
         const val XML_CUSTOM_NAMESPACE = "http://arbitrary.app.namespace/com.ichi2.anki"
         const val ANDROID_NAMESPACE = "http://schemas.android.com/apk/res/android"
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CollectionHelper.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CollectionHelper.kt
@@ -452,9 +452,7 @@ open class CollectionHelper {
         // TODO Tracked in https://github.com/ankidroid/Anki-Android/issues/5304
         @CheckResult
         fun getDefaultAnkiDroidDirectory(context: Context): String {
-            return if (AnkiDroidApp.TESTING_SCOPED_STORAGE) {
-                getAppSpecificExternalAnkiDroidDirectory(context)
-            } else legacyAnkiDroidDirectory
+            return getAppSpecificExternalAnkiDroidDirectory(context)
         }
 
         /**
@@ -466,7 +464,7 @@ open class CollectionHelper {
          *
          * @return Absolute path to the AnkiDroid directory in primary shared/external storage
          */
-        private val legacyAnkiDroidDirectory: String
+        val legacyAnkiDroidDirectory: String
             get() = File(Environment.getExternalStorageDirectory(), "AnkiDroid").absolutePath
 
         /**

--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/DevOptionsFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/DevOptionsFragment.kt
@@ -77,15 +77,6 @@ class DevOptionsFragment : SettingsFragment() {
             OnboardingUtils.reset(requireContext())
             true
         }
-        // Use scoped storage
-        requirePreference<Preference>(getString(R.string.pref_scoped_storage_key)).apply {
-            setDefaultValue(AnkiDroidApp.TESTING_SCOPED_STORAGE)
-            setOnPreferenceClickListener {
-                AnkiDroidApp.TESTING_SCOPED_STORAGE = true
-                (requireActivity() as Preferences).restartWithNewDeckPicker()
-                true
-            }
-        }
     }
 
     /**

--- a/AnkiDroid/src/main/res/values/preferences.xml
+++ b/AnkiDroid/src/main/res/values/preferences.xml
@@ -133,7 +133,6 @@
     <string name="pref_show_onboarding_key">showOnboarding</string>
     <string name="pref_reset_onboarding_key">resetOnboarding</string>
     <string name="pref_rust_backend_key">useRustBackend</string>
-    <string name="pref_scoped_storage_key">useScopedStorage</string>
     <string name="dev_options_enabled_by_user_key">devOptionsEnabledByUser</string>
     <!-- Messages displayed after the user enabled developer options, and warned remaining messages will be in English -->
     <string name="dev_options_enabled_msg">Enabled developer options</string>

--- a/AnkiDroid/src/main/res/xml/preferences_dev_options.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_dev_options.xml
@@ -48,10 +48,6 @@
         android:key="@string/pref_show_onboarding_key"
         android:defaultValue="false"/>
     <Preference
-        android:title="Enable Scoped Storage"
-        android:summary="UNSTABLE. DO NOT USE ON A COLLECTION YOU CARE ABOUT. REVERTED ON APP CLOSE"
-        android:key="@string/pref_scoped_storage_key"/>
-    <Preference
         android:title="@string/reset_onboarding"
         android:summary="@string/reset_onboarding_desc"
         android:key="@string/pref_reset_onboarding_key"/>

--- a/AnkiDroid/src/test/java/com/ichi2/anki/RobolectricTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/RobolectricTest.kt
@@ -288,7 +288,7 @@ open class RobolectricTest : CollectionGetter {
      * Returns an instance of [SharedPreferences] using the test context
      * @see [editPreferences] for editing
      */
-    protected fun getPreferences(): SharedPreferences {
+    fun getPreferences(): SharedPreferences {
         return AnkiDroidApp.getSharedPrefs(targetContext)
     }
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/ScopedStorageAnkiDroidTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/ScopedStorageAnkiDroidTest.kt
@@ -21,6 +21,7 @@ import com.ichi2.anki.AnkiDroidApp
 import com.ichi2.anki.CollectionHelper
 import com.ichi2.anki.RobolectricTest
 import com.ichi2.anki.servicelayer.scopedstorage.MigrateEssentialFiles
+import com.ichi2.anki.servicelayer.scopedstorage.setLegacyStorage
 import com.ichi2.libanki.Collection
 import com.ichi2.testutils.ShadowStatFs
 import com.ichi2.testutils.TestException
@@ -96,7 +97,10 @@ class ScopedStorageAnkiDroidTest : RobolectricTest() {
     /**
      * Accessing the collection ensure the creation of the collection.
      */
-    private fun setupCol(): Collection = col
+    private fun setupCol(): Collection {
+        setLegacyStorage()
+        return col
+    }
 
     private fun getBestRootDirectory(): File {
         val collectionPath = AnkiDroidApp.getSharedPrefs(targetContext).getString(CollectionHelper.PREF_COLLECTION_PATH, null)!!

--- a/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/MigrateEssentialFilesIntegrationTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/MigrateEssentialFilesIntegrationTest.kt
@@ -59,6 +59,8 @@ class MigrateEssentialFilesIntegrationTest : RobolectricTest() {
     override fun setUp() {
         super.setUp()
 
+        setLegacyStorage()
+
         // we need to access 'col' before we start
         col.basicCheck()
         destinationPath = File(Path(targetContext.getExternalFilesDir(null)!!.canonicalPath, "AnkiDroid-1").pathString)

--- a/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/ScopedStorageMigrationIntegrationTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/ScopedStorageMigrationIntegrationTest.kt
@@ -59,7 +59,10 @@ class ScopedStorageMigrationIntegrationTest : RobolectricTest() {
 
     @Test
     fun `Valid migration`() {
+        setLegacyStorage()
+
         underTest = MigrateUserDataTester.create()
+
         // use all the real components on a real collection.
         val inputDirectory = File(col.path).parentFile!!
         File(inputDirectory, "collection.media").addTempFile("image.jpg", "foo")
@@ -87,6 +90,7 @@ class ScopedStorageMigrationIntegrationTest : RobolectricTest() {
 
     @Test
     fun `Migration without space fails`() {
+        setLegacyStorage()
         // use all the real components on a real collection.
         val inputDirectory = File(col.path).parentFile!!
         File(inputDirectory, "collection.media").addTempFile("image.jpg", "foo")

--- a/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/Utils.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/Utils.kt
@@ -17,6 +17,8 @@
 package com.ichi2.anki.servicelayer.scopedstorage
 
 import androidx.annotation.CheckResult
+import androidx.core.content.edit
+import com.ichi2.anki.CollectionHelper
 import com.ichi2.anki.RobolectricTest
 import com.ichi2.anki.model.DiskFile
 import com.ichi2.anki.servicelayer.ScopedStorageService
@@ -46,6 +48,10 @@ private fun convertPathToMediaFile(media: Media, path: List<String>): File {
 
 /** A [File] reference to the AnkiDroid directory of the current collection */
 internal fun RobolectricTest.ankiDroidDirectory() = File(col.path).parentFile!!
+
+internal fun RobolectricTest.setLegacyStorage() {
+    getPreferences().edit { putString(CollectionHelper.PREF_COLLECTION_PATH, CollectionHelper.legacyAnkiDroidDirectory) }
+}
 
 /** Adds a file to collection.media which [Media] is not aware of */
 @CheckResult


### PR DESCRIPTION
## Fixes
Fixes #13093

## Approach
On the commits

I haven't changed the javadoc of `getDefaultAnkiDroidDirectory` because it is too long and spending time on it isn't the priority

## How Has This Been Tested?

1. Create a fresh install
2. Go to settings > Advanced
3. See if the folder is app-specific
4. See on the file manager as well if the legacy storage were not created and if the files are at the app-specific folder

And did the same thing with a parallel build created by running `./tools/parallel-package-name.sh com.ichi2.anki.a AnkiDroid.A`

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
