### PR TITLE
[KotlinCleanup] NoteEditorTest

### DIFF
--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/NoteEditorTest.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/NoteEditorTest.kt
@@ -23,12 +23,10 @@ import android.os.Build
 import androidx.test.ext.junit.rules.ActivityScenarioRule
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.rule.GrantPermissionRule
-import com.ichi2.utils.KotlinCleanup
 import org.hamcrest.Matchers
 import org.junit.Assume
 import org.junit.Before
 import org.junit.Rule
-import java.util.ArrayList
 
 abstract class NoteEditorTest protected constructor() {
     @get:Rule
@@ -60,27 +58,12 @@ abstract class NoteEditorTest protected constructor() {
             )
         }
     }
-
-    private val invalidSdksImpl: List<Int>
-        get() {
-            // TODO: Look into these assumptions and see if they can be diagnosed - both work on my emulators.
-            // If we fix them, we might be able to use instrumentation.sendKeyDownUpSync
-            /*
-             java.lang.AssertionError: Activity never becomes requested state "[DESTROYED]" (last lifecycle transition = "PAUSED")
-             at androidx.test.core.app.ActivityScenario.waitForActivityToBecomeAnyOf(ActivityScenario.java:301)
-              */
-            val invalid = Build.VERSION_CODES.N_MR1
-            val integers = ArrayList(listOf(invalid))
-            integers.addAll(invalidSdks!!)
-            return integers
-        }
-    protected open val invalidSdks: List<Int>?
-        get() = ArrayList()
+    protected open val invalidSdks: List<Int>? = emptyList()
+    private val invalidSdksImpl: List<Int> = listOf(Build.VERSION_CODES.N_MR1) + invalidSdks.orEmpty()
     protected val targetContext: Context
         get() = InstrumentationRegistry.getInstrumentation().targetContext
 
     init {
-        @KotlinCleanup("change to variable init")
         // Rules mean that we get a failure on API 25.
         // Even if we ignore the tests, the rules cause a failure.
         // We can't ignore the test in @BeforeClass ("Test run failed to complete. Expected 150 tests, received 149")


### PR DESCRIPTION
## Fixes
- Changed invalidSdksImpl to variable init

## How Has This Been Tested?
- Tests

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented on your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [x] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
