### PR TITLE
Fix getParcelableArrayList deprecation

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckSelectionDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckSelectionDialog.kt
@@ -39,6 +39,7 @@ import com.ichi2.anki.analytics.AnalyticsDialogFragment
 import com.ichi2.anki.dialogs.DeckSelectionDialog.DecksArrayAdapter.DecksFilter
 import com.ichi2.anki.dialogs.DeckSelectionDialog.SelectableDeck
 import com.ichi2.annotations.NeedsTest
+import com.ichi2.compat.CompatHelper.Companion.getParcelableArrayListCompat
 import com.ichi2.libanki.*
 import com.ichi2.libanki.Collection
 import com.ichi2.libanki.backend.exception.DeckRenameException
@@ -51,6 +52,7 @@ import kotlinx.parcelize.IgnoredOnParcel
 import kotlinx.parcelize.Parcelize
 import timber.log.Timber
 import java.util.*
+import kotlin.collections.ArrayList
 
 /**
  * "Deck Search": A dialog allowing the user to select a deck from a list of decks.
@@ -116,9 +118,8 @@ open class DeckSelectionDialog : AnalyticsDialogFragment() {
         return arguments.getString(SUMMARY_MESSAGE)
     }
 
-    @Suppress("deprecation") // getParcelableArrayList
-    private fun getDeckNames(arguments: Bundle) =
-        arguments.getParcelableArrayList<SelectableDeck>(DECK_NAMES)!! as ArrayList<SelectableDeck>
+    private fun getDeckNames(arguments: Bundle): ArrayList<SelectableDeck> =
+        arguments.getParcelableArrayListCompat(DECK_NAMES, SelectableDeck::class.java)!!
 
     private val title: String
         get() = requireArguments().getString(TITLE)!!

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/RecursivePictureMenu.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/RecursivePictureMenu.kt
@@ -33,13 +33,13 @@ import com.afollestad.materialdialogs.list.getRecyclerView
 import com.ichi2.anki.AnkiActivity
 import com.ichi2.anki.R
 import com.ichi2.anki.analytics.UsageAnalytics
+import com.ichi2.compat.CompatHelper.Companion.getParcelableArrayListCompat
 import java.util.*
 
 /** A Dialog displaying The various options for "Help" in a nested structure  */
 class RecursivePictureMenu : DialogFragment() {
-    @Suppress("deprecation") // getParcelableArrayList
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
-        val items: List<Item> = requireArguments().getParcelableArrayList("bundle")!!
+        val items: List<Item> = requireArguments().getParcelableArrayListCompat("bundle", Item::class.java)!!
         val title = requireContext().getString(requireArguments().getInt("titleRes"))
         val adapter: RecyclerView.Adapter<*> = object : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
             override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): RecyclerView.ViewHolder {

--- a/AnkiDroid/src/main/java/com/ichi2/compat/Compat.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/Compat.kt
@@ -27,6 +27,7 @@ import android.media.AudioManager
 import android.media.AudioManager.OnAudioFocusChangeListener
 import android.media.MediaRecorder
 import android.net.Uri
+import android.os.Bundle
 import android.os.Parcel
 import android.os.Parcelable
 import android.util.SparseArray
@@ -78,6 +79,7 @@ interface Compat {
     fun vibrate(context: Context, durationMillis: Long)
     fun getMediaRecorder(context: Context): MediaRecorder
     fun <T> readSparseArray(parcel: Parcel, loader: ClassLoader, clazz: Class<T>): SparseArray<T>?
+    fun <T : Parcelable> getParcelableArrayList(bundle: Bundle, key: String, clazz: Class<T>): ArrayList<T>?
 
     /**
      * Retrieve extended data from the intent.

--- a/AnkiDroid/src/main/java/com/ichi2/compat/CompatHelper.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/CompatHelper.kt
@@ -17,6 +17,7 @@ package com.ichi2.compat
 
 import android.content.Intent
 import android.os.Build
+import android.os.Bundle
 import android.os.Parcel
 import android.os.Parcelable
 import android.util.SparseArray
@@ -84,6 +85,10 @@ class CompatHelper private constructor() {
 
         inline fun <reified T : Parcelable> Intent.getParcelableExtraCompat(name: String): T? {
             return compat.getParcelableExtra(this, name, T::class.java)
+        }
+
+        inline fun <reified T : Parcelable> Bundle.getParcelableArrayListCompat(key: String, clazz: Class<T>): ArrayList<T>? {
+            return compat.getParcelableArrayList(this, key, clazz)
         }
 
         inline fun <reified T> Parcel.readSparseArrayCompat(loader: ClassLoader, clazz: Class<T>): SparseArray<T>? {

--- a/AnkiDroid/src/main/java/com/ichi2/compat/CompatV21.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/CompatV21.kt
@@ -28,6 +28,7 @@ import android.media.AudioManager.OnAudioFocusChangeListener
 import android.media.MediaRecorder
 import android.media.ThumbnailUtils
 import android.net.Uri
+import android.os.Bundle
 import android.os.Environment
 import android.os.Parcel
 import android.os.Parcelable
@@ -66,6 +67,10 @@ open class CompatV21 : Compat {
 
     override fun <T> readSparseArray(parcel: Parcel, loader: ClassLoader, clazz: Class<T>): SparseArray<T>? {
         return parcel.readSparseArray(loader)
+    }
+
+    override fun <T : Parcelable> getParcelableArrayList(bundle: Bundle, key: String, clazz: Class<T>): ArrayList<T>? {
+        return bundle.getParcelableArrayList(key)
     }
 
     override fun <T : Serializable?> getSerializableExtra(

--- a/AnkiDroid/src/main/java/com/ichi2/compat/CompatV33.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/CompatV33.kt
@@ -18,6 +18,7 @@ package com.ichi2.compat
 
 import android.annotation.TargetApi
 import android.content.Intent
+import android.os.Bundle
 import android.os.Parcel
 import android.os.Parcelable
 import android.util.SparseArray
@@ -25,6 +26,10 @@ import java.io.Serializable
 
 @TargetApi(33)
 open class CompatV33 : CompatV31(), Compat {
+    override fun <T : Parcelable> getParcelableArrayList(bundle: Bundle, key: String, clazz: Class<T>): ArrayList<T>? {
+        return bundle.getParcelableArrayList(key, clazz)
+    }
+
     override fun <T : Serializable?> getSerializableExtra(intent: Intent, name: String, className: Class<T>): T? {
         return intent.getSerializableExtra(name, className)
     }


### PR DESCRIPTION
## Purpose / Description
Fix getParcelableArrayList deprecation

## Fixes
Fixes part of #12364

## Approach
Added it to compat

## How Has This Been Tested?

Opened the browser and selected a deck

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
