### PR TITLE
Fix the command title for "Bury card" action

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/ViewerCommand.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/ViewerCommand.kt
@@ -44,7 +44,7 @@ enum class ViewerCommand(val resourceId: Int) {
     UNDO(R.string.undo),
     EDIT(R.string.cardeditor_title_edit_card),
     MARK(R.string.menu_mark_note),
-    BURY_CARD(R.string.menu_bury),
+    BURY_CARD(R.string.menu_bury_card),
     SUSPEND_CARD(R.string.menu_suspend_card),
     DELETE(R.string.menu_delete_note),
     PLAY_MEDIA(R.string.gesture_play),


### PR DESCRIPTION


## Pull Request template

## Purpose / Description
`[Settings]->[Controls]->[Bury]` sets the command (key, gesture) for the action of "Bury card", but its title is just `Bury` (in contrast to the titles of the similar actions, that is, `Bury note`, `Suspend card`, `Suspend note`). This commit changes the title to `Bury card`.
![image](https://user-images.githubusercontent.com/10436072/212531543-fc3e2ef8-720b-4f7a-a8d8-c62e0471ea98.png)


## Fixes
n/a

## Approach
Replace the current string with the other existing string

## How Has This Been Tested?
Checked on a physical device
![image](https://user-images.githubusercontent.com/10436072/212532268-45d25235-012d-44bc-b101-299753cab9e5.png)



## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] ~~You have commented your code, particularly in hard-to-understand areas~~
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] ~~UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)~~
