### PR TITLE
NF: `assertThrows` take a block.

### DIFF
--- a/AnkiDroid/src/test/java/com/ichi2/testutils/AnkiAssert.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/testutils/AnkiAssert.kt
@@ -51,9 +51,9 @@ object AnkiAssert {
         }
     }
 
-    fun <T : Throwable?> assertThrows(r: Runnable, clazz: Class<T>): T {
+    fun <T : Throwable?> assertThrows(clazz: Class<T>, block: () -> Unit): T {
         try {
-            r.run()
+            block()
             Assert.fail("Expected exception: " + clazz.simpleName + ". No exception thrown.")
         } catch (t: Throwable) {
             if (t.javaClass == clazz) {
@@ -96,8 +96,8 @@ object AnkiAssert {
  *
  * @see TestException if a test-only exception is needed
  * */
-inline fun <reified T : Throwable> assertThrows(r: Runnable): T =
-    AnkiAssert.assertThrows(r, T::class.java)
+inline fun <reified T : Throwable> assertThrows(noinline block: () -> Unit): T =
+    AnkiAssert.assertThrows(T::class.java, block)
 
 /**
  * [assertThrows], accepting subclasses of the exception type

--- a/AnkiDroid/src/test/java/com/ichi2/testutils/AnkiAssertTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/testutils/AnkiAssertTest.kt
@@ -15,20 +15,17 @@
  */
 package com.ichi2.testutils
 
-import org.hamcrest.MatcherAssert.*
+import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.*
 import org.junit.Assert
 import org.junit.Test
-import java.lang.AssertionError
-import java.lang.IllegalArgumentException
-import java.lang.IllegalStateException
 
 class AnkiAssertTest {
     // We're not going to use the class under test to verify that these are working.
     @Test
     fun assertThrowsNoException() {
         try {
-            AnkiAssert.assertThrows({}, IllegalStateException::class.java)
+            AnkiAssert.assertThrows(IllegalStateException::class.java) {}
             Assert.fail("No exception thrown")
         } catch (e: AssertionError) {
             assertThat(e.message, containsString("Expected exception: IllegalStateException"))
@@ -40,7 +37,7 @@ class AnkiAssertTest {
     fun assertThrowsWrongException() {
         val toThrow = IllegalArgumentException()
         try {
-            AnkiAssert.assertThrows({ throw toThrow }, IllegalStateException::class.java)
+            AnkiAssert.assertThrows(IllegalStateException::class.java) { throw toThrow }
             Assert.fail("No exception thrown")
         } catch (e: AssertionError) {
             assertThat(e.message, containsString("Expected 'IllegalStateException' got 'IllegalArgumentException'"))
@@ -53,7 +50,7 @@ class AnkiAssertTest {
     fun assertThrowsSameException() {
         val ex = IllegalStateException()
 
-        val exception = AnkiAssert.assertThrows({ throw ex }, IllegalStateException::class.java)
+        val exception = AnkiAssert.assertThrows(IllegalStateException::class.java) { throw ex }
 
         assertThat(exception, sameInstance(ex))
     }


### PR DESCRIPTION
This is slightly more readable. More importantly, I can use edit it later to use with suspend function.