### PR TITLE
[NeedsTest] Added tests to check if App Intro is displayed on a new startup.

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -160,8 +160,6 @@ const val POSTPONE_MIGRATION_INTERVAL_DAYS = 5L
  * * A custom image as a background can be added: [applyDeckPickerBackground]
  */
 @KotlinCleanup("lots to do")
-@NeedsTest("On a new startup, the App Intro is displayed")
-@NeedsTest("If the collection has been created, the app intro is not displayed")
 @NeedsTest("If the user selects 'Sync Profile' in the app intro, a sync starts immediately")
 open class DeckPicker :
     NavigationDrawerActivity(),
@@ -488,7 +486,8 @@ open class DeckPicker :
         Onboarding.DeckPicker(this, mRecyclerViewLayoutManager).onCreate()
     }
 
-    private fun hasShownAppIntro(): Boolean {
+    @VisibleForTesting
+    fun hasShownAppIntro(): Boolean {
         val prefs = AnkiDroidApp.getSharedPrefs(this)
 
         // if moving from 2.15 to 2.16 then we do not want to show the intro

--- a/AnkiDroid/src/test/java/com/ichi2/anki/DeckPickerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/DeckPickerTest.kt
@@ -623,4 +623,19 @@ class DeckPickerTest : RobolectricTest() {
             }
         }
     }
+
+    @Test
+    fun hasShownAppIntroTest() {
+        ActivityScenario.launch(DeckPicker::class.java).use { scenario ->
+            scenario.onActivity { deckPicker: DeckPicker ->
+                // Default
+                assertEquals(true, deckPicker.hasShownAppIntro())
+                // Set INTRODUCTION_SLIDES_SHOWN true to emulate app has shown introduction slides
+                AnkiDroidApp.getSharedPrefs(targetContext).edit {
+                    putBoolean(IntroductionActivity.INTRODUCTION_SLIDES_SHOWN, false)
+                }
+                assertEquals(false, deckPicker.hasShownAppIntro())
+            }
+        }
+    }
 }


### PR DESCRIPTION
## Purpose / Description
Added test to check if the app intro is displayed on a new startup.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

_Note: This is my first time writing tests on android._