### PR TITLE
Changed contrast for Tags and Cards options in Note Editor

### DIFF
--- a/AnkiDroid/src/main/res/drawable/border_dark.xml
+++ b/AnkiDroid/src/main/res/drawable/border_dark.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android" android:shape="rectangle" >
+    <solid android:color="@android:color/transparent" />
+    <stroke android:width="1dip" android:color="@android:color/darker_gray"/>
+    <padding android:bottom="10dp" android:left="10dp" android:right="10dp" android:top="10dp"/>
+</shape>

--- a/AnkiDroid/src/main/res/drawable/border_dark.xml
+++ b/AnkiDroid/src/main/res/drawable/border_dark.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<shape xmlns:android="http://schemas.android.com/apk/res/android" android:shape="rectangle" >
-    <solid android:color="@android:color/transparent" />
-    <stroke android:width="1dip" android:color="@android:color/darker_gray"/>
-    <padding android:bottom="10dp" android:left="10dp" android:right="10dp" android:top="10dp"/>
-</shape>

--- a/AnkiDroid/src/main/res/drawable/button_background_updated.xml
+++ b/AnkiDroid/src/main/res/drawable/button_background_updated.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android" android:shape="rectangle" >
+    <solid android:color="?attr/wideButtonBackgroundColor" />
+    <stroke android:width="1dip" android:color="?attr/largeButtonBorderColor"  />
+    <padding android:bottom="10dp" android:left="10dp" android:right="10dp" android:top="10dp"/>
+    <corners
+        android:topLeftRadius="5dp"
+        android:topRightRadius="5dp"
+        android:bottomLeftRadius="5dp"
+        android:bottomRightRadius="5dp"/>
+</shape>

--- a/AnkiDroid/src/main/res/layout/note_editor.xml
+++ b/AnkiDroid/src/main/res/layout/note_editor.xml
@@ -95,7 +95,7 @@
                         android:paddingEnd="15dip"
                         android:elevation="50dip"
                         android:layout_marginBottom="5dp"
-                        android:background="@drawable/border_dark"/>
+                        android:background="@drawable/button_background_updated"/>
                     <androidx.appcompat.widget.AppCompatButton
                         android:id="@+id/CardEditorCardsButton"
                         android:layout_width="match_parent"
@@ -106,7 +106,7 @@
                         android:paddingEnd="15dip"
                         android:elevation="50dip"
                         android:layout_marginBottom="5dp"
-                        android:background="@drawable/border_dark"/>
+                        android:background="@drawable/button_background_updated"/>
                  </LinearLayout>
         </ScrollView>
     </LinearLayout>

--- a/AnkiDroid/src/main/res/layout/note_editor.xml
+++ b/AnkiDroid/src/main/res/layout/note_editor.xml
@@ -95,7 +95,7 @@
                         android:paddingEnd="15dip"
                         android:elevation="50dip"
                         android:layout_marginBottom="5dp"
-                        android:background="@drawable/button_background"/>
+                        android:background="@drawable/border_dark"/>
                     <androidx.appcompat.widget.AppCompatButton
                         android:id="@+id/CardEditorCardsButton"
                         android:layout_width="match_parent"
@@ -106,7 +106,7 @@
                         android:paddingEnd="15dip"
                         android:elevation="50dip"
                         android:layout_marginBottom="5dp"
-                        android:background="@drawable/button_background"/>
+                        android:background="@drawable/border_dark"/>
                  </LinearLayout>
         </ScrollView>
     </LinearLayout>

--- a/AnkiDroid/src/main/res/values/attrs.xml
+++ b/AnkiDroid/src/main/res/values/attrs.xml
@@ -130,6 +130,8 @@
     <attr name="buttonShadowColor" format="color"/>
     <attr name="buttonRippleColor" format="color"/>
     <attr name="buttonForegroundColor" format="color"/>
+    <attr name="largeButtonBorderColor" format="color"/>
+    <attr name="wideButtonBackgroundColor" format="color"/>
     <!-- Images -->
     <attr name="navDrawerImage" format="integer"/>
     <attr name="attachFileImage" format="integer"/>

--- a/AnkiDroid/src/main/res/values/theme_black.xml
+++ b/AnkiDroid/src/main/res/values/theme_black.xml
@@ -98,6 +98,8 @@
         <item name="buttonShadowColor">#bdbdbd</item>
         <item name="buttonRippleColor">#BABABA</item>
         <item name="buttonForegroundColor">#757575</item>
+        <item name="largeButtonBorderColor">@color/white</item>
+        <item name="wideButtonBackgroundColor">@color/material_blue_grey_900</item>
         <!-- FAB -->
         <item name="fab_normal">#ff303030</item>
         <item name="fab_pressed">#c8303030</item> <!-- 55 less opacity than fab_normal -->

--- a/AnkiDroid/src/main/res/values/theme_black.xml
+++ b/AnkiDroid/src/main/res/values/theme_black.xml
@@ -99,7 +99,7 @@
         <item name="buttonRippleColor">#BABABA</item>
         <item name="buttonForegroundColor">#757575</item>
         <item name="largeButtonBorderColor">@color/white</item>
-        <item name="wideButtonBackgroundColor">@color/material_blue_grey_900</item>
+        <item name="wideButtonBackgroundColor">#303030</item>
         <!-- FAB -->
         <item name="fab_normal">#ff303030</item>
         <item name="fab_pressed">#c8303030</item> <!-- 55 less opacity than fab_normal -->

--- a/AnkiDroid/src/main/res/values/theme_dark.xml
+++ b/AnkiDroid/src/main/res/values/theme_dark.xml
@@ -107,7 +107,7 @@
         <item name="buttonRippleColor">#BABABA</item>
         <item name="buttonForegroundColor">#757575</item>
         <item name="largeButtonBorderColor">@color/white</item>
-        <item name="wideButtonBackgroundColor">@color/material_blue_grey_900</item>
+        <item name="wideButtonBackgroundColor">#909090</item>
         <!-- FAB -->
         <item name="fab_normal">@color/material_light_blue_700</item>
         <item name="fab_pressed">@color/material_light_blue_900</item>

--- a/AnkiDroid/src/main/res/values/theme_dark.xml
+++ b/AnkiDroid/src/main/res/values/theme_dark.xml
@@ -106,6 +106,8 @@
         <item name="buttonShadowColor">#bdbdbd</item>
         <item name="buttonRippleColor">#BABABA</item>
         <item name="buttonForegroundColor">#757575</item>
+        <item name="largeButtonBorderColor">@color/white</item>
+        <item name="wideButtonBackgroundColor">@color/material_blue_grey_900</item>
         <!-- FAB -->
         <item name="fab_normal">@color/material_light_blue_700</item>
         <item name="fab_pressed">@color/material_light_blue_900</item>

--- a/AnkiDroid/src/main/res/values/theme_light.xml
+++ b/AnkiDroid/src/main/res/values/theme_light.xml
@@ -122,7 +122,7 @@ APIs. It's visible when there aren't enough decks to fill the screen.
         <item name="buttonRippleColor">#595959</item>
         <item name="buttonForegroundColor">#D6D7D7</item>
         <item name="largeButtonBorderColor">@color/black</item>
-        <item name="wideButtonBackgroundColor">@color/material_blue_grey_100</item>
+        <item name="wideButtonBackgroundColor">#D3D3D3</item>
 
         <!-- FAB -->
         <item name="fab_normal">@color/material_light_blue_700</item>

--- a/AnkiDroid/src/main/res/values/theme_light.xml
+++ b/AnkiDroid/src/main/res/values/theme_light.xml
@@ -121,6 +121,9 @@ APIs. It's visible when there aren't enough decks to fill the screen.
         <item name="buttonShadowColor">#FFAAAAAA</item>
         <item name="buttonRippleColor">#595959</item>
         <item name="buttonForegroundColor">#D6D7D7</item>
+        <item name="largeButtonBorderColor">@color/black</item>
+        <item name="wideButtonBackgroundColor">@color/material_blue_grey_100</item>
+
         <!-- FAB -->
         <item name="fab_normal">@color/material_light_blue_700</item>
         <item name="fab_pressed">@color/material_light_blue_900</item>

--- a/AnkiDroid/src/main/res/values/theme_plain.xml
+++ b/AnkiDroid/src/main/res/values/theme_plain.xml
@@ -43,7 +43,7 @@
         <item name="buttonShadowColor">#FFAAAAAA</item>
         <item name="buttonRippleColor">#595959</item>
         <item name="buttonForegroundColor">#D6D7D7</item>
-        <item name="wideButtonBackgroundColor">@color/material_blue_grey_100</item>
+        <item name="wideButtonBackgroundColor">#D3D3D3</item>
 
         <!-- FAB -->
         <item name="fab_normal">@color/theme_plain_accent</item>

--- a/AnkiDroid/src/main/res/values/theme_plain.xml
+++ b/AnkiDroid/src/main/res/values/theme_plain.xml
@@ -43,6 +43,8 @@
         <item name="buttonShadowColor">#FFAAAAAA</item>
         <item name="buttonRippleColor">#595959</item>
         <item name="buttonForegroundColor">#D6D7D7</item>
+        <item name="wideButtonBackgroundColor">@color/material_blue_grey_100</item>
+
         <!-- FAB -->
         <item name="fab_normal">@color/theme_plain_accent</item>
         <item name="fab_pressed">#c8607d8b</item> <!-- 55 less opacity than fab_normal -->

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompilerExecutionStrategy
 
 buildscript {
     // The version for the Kotlin plugin and dependencies
-    ext.kotlin_version = '1.7.22'
+    ext.kotlin_version = '1.7.21'
     ext.lint_version = '30.3.1'
     ext.acra_version = '5.9.7'
     ext.ankidroid_backend_version = '0.1.18-anki2.1.55' // this is parsed in tools/setup-anki-backend.sh


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
Previously the contrast ratio of the text to the background of the Tags and Cards options in Note Editor was too high. By changing the background color, the options are more readable. 

## Fixes
included wideButtonBackgroundColor attr in each of the theme_xyz.xml files. Created another button background file for updated button border colors.

## Approach
Makes it easier to read the options.

## How Has This Been Tested?
UI changes made. No testcases written,

## Learning (optional, can help others)
_Describe the research stage_

_Links to blog posts, patterns, libraries or addons used to solve this problem_

## Checklist
_Please, go through these checks before submitting the PR._

- [ ] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas
- [ ] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
