### PR TITLE
Narendraanjana09/issue13147  Issue: Update Added Give folder permission in developer options

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/DevOptionsFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/DevOptionsFragment.kt
@@ -40,6 +40,7 @@ class DevOptionsFragment : SettingsFragment() {
     override val analyticsScreenNameConstant: String
         get() = "prefs.dev_options"
 
+    // this is used to launch the ACTION_OPEN_DOCUMENT_TREE intent to select folder from the device
     private var onFolderPermissionActivityResult = registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result: ActivityResult ->
         Timber.e("onFolderPermissionActivityResult: resultCode=${result.resultCode}")
         if (result.resultCode == Activity.RESULT_OK) {
@@ -51,6 +52,7 @@ class DevOptionsFragment : SettingsFragment() {
         }
     }
 
+    // after getting the uri of selected folder we are using this function to retains permission to read and write in the returned folder
     private fun askReadWriteFolderPermission(uri: Uri) {
         val contentResolver = requireActivity().applicationContext.contentResolver
         val takeFlags: Int = Intent.FLAG_GRANT_READ_URI_PERMISSION or
@@ -101,6 +103,7 @@ class DevOptionsFragment : SettingsFragment() {
             OnboardingUtils.reset(requireContext())
             true
         }
+        // For Give Folder Permission
         requirePreference<Preference>(getString(R.string.pref_give_folder_permission_key)).setOnPreferenceClickListener {
             val intent = Intent(Intent.ACTION_OPEN_DOCUMENT_TREE)
             try {

--- a/AnkiDroid/src/main/res/values/preferences.xml
+++ b/AnkiDroid/src/main/res/values/preferences.xml
@@ -132,6 +132,7 @@
     <string name="pref_lock_database_key">debug_lock_database</string>
     <string name="pref_show_onboarding_key">showOnboarding</string>
     <string name="pref_reset_onboarding_key">resetOnboarding</string>
+    <string name="pref_give_folder_permission_key">giveFolderPermission</string>
     <string name="pref_rust_backend_key">useRustBackend</string>
     <string name="dev_options_enabled_by_user_key">devOptionsEnabledByUser</string>
     <!-- Messages displayed after the user enabled developer options, and warned remaining messages will be in English -->

--- a/AnkiDroid/src/main/res/xml/preferences_dev_options.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_dev_options.xml
@@ -51,4 +51,8 @@
         android:title="@string/reset_onboarding"
         android:summary="@string/reset_onboarding_desc"
         android:key="@string/pref_reset_onboarding_key"/>
+    <Preference
+        android:title="Give folder permission"
+        android:summary="Read and Write permission for a folder"
+        android:key="@string/pref_give_folder_permission_key"/>
 </PreferenceScreen>


### PR DESCRIPTION
## Pull Request template
@Arthur-Milchior 

## Purpose / Description
This pull request aims to add a new option in the developer options called "Give folder permission" that allows the user to select a folder and grant the app permission to read and write to that folder.

## Fixes
Fixes #13147
https://github.com/ankidroid/Anki-Android/issues/13147

## Approach
This feature is implemented by adding a new option in the developer options screen that launches an intent with the action ACTION_OPEN_DOCUMENT_TREE. The result Uri is then used to grant the app read and write permissions to the selected folder by calling the takePersistableUriPermission() function on the ContentResolver with the URI of the folder and flags.

## How Has This Been Tested?
The changes have been tested on a physical device running Android 10 and Android 11. To test, I navigated to the developer options and selected the "Give folder permission" option. I then selected a folder and confirmed that the app had the necessary permissions to read and write to that folder.

## Learning (optional, can help others)
I researched the use of intents and the takePersistableUriPermission() function to grant permissions to a specific folder.

https://developer.android.com/training/data-storage/shared/documents-files#persist-permissions

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [x] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
