### PR TITLE
feat: Scoped Storage Migration Service, Notification & Deck Picker Implementation

### DIFF
--- a/AnkiDroid/src/main/AndroidManifest.xml
+++ b/AnkiDroid/src/main/AndroidManifest.xml
@@ -40,6 +40,7 @@
     <uses-permission android:name="android.permission.CAMERA" />
     <uses-permission android:name="android.permission.GET_PACKAGE_SIZE" android:maxSdkVersion="25" />
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <permission android:name="${applicationId}.permission.READ_WRITE_DATABASE"
                 android:label="@string/read_write_permission_label"
                 android:description="@string/read_write_permission_description"
@@ -421,6 +422,11 @@
 
         <!-- Service to perform web API queries -->
         <service android:name="com.ichi2.widget.AnkiDroidWidgetSmall$UpdateService" />
+
+        <service
+            android:name="com.ichi2.anki.services.MigrationService"
+            android:foregroundServiceType="dataSync"
+            />
 
         <!-- small widget -->
         <receiver

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -86,11 +86,14 @@ import com.ichi2.anki.preferences.AdvancedSettingsFragment
 import com.ichi2.anki.receiver.SdCardReceiver
 import com.ichi2.anki.servicelayer.DeckService
 import com.ichi2.anki.servicelayer.SchedulerService.NextCard
+import com.ichi2.anki.servicelayer.ScopedStorageService
 import com.ichi2.anki.servicelayer.ScopedStorageService.getBestDefaultRootDirectory
 import com.ichi2.anki.servicelayer.ScopedStorageService.isLegacyStorage
-import com.ichi2.anki.servicelayer.ScopedStorageService.migrateEssentialFiles
 import com.ichi2.anki.servicelayer.ScopedStorageService.userMigrationIsInProgress
 import com.ichi2.anki.servicelayer.Undo
+import com.ichi2.anki.servicelayer.scopedstorage.migrateuserdata.toMB
+import com.ichi2.anki.services.MigrationService
+import com.ichi2.anki.services.ServiceConnection
 import com.ichi2.anki.snackbar.showSnackbar
 import com.ichi2.anki.stats.AnkiStatsTaskHandler
 import com.ichi2.anki.web.CustomSyncServer
@@ -235,6 +238,15 @@ open class DeckPicker :
     @VisibleForTesting
     var createMenuJob: Job? = null
     private var loadDeckCounts: Job? = null
+
+    private val migrationService: ServiceConnection<MigrationService> = object : ServiceConnection<MigrationService>() {
+        override fun onServiceConnected(service: MigrationService) {
+            service.migrationCompletedListener = { onStorageMigrationCompleted() }
+        }
+        override fun onServiceDisconnected(service: MigrationService) {
+            service.migrationCompletedListener = null
+        }
+    }
 
     init {
         ChangeManager.subscribe(this)
@@ -507,10 +519,58 @@ open class DeckPicker :
     }
 
     /**
+     * The first call in showing dialogs for startup
+     *
+     * Attempts startup if storage permission has been acquired, else, it requests the permission
+     *
+     * If the migration is in progress, it starts the service if not running
+     *
+     * See: #5304
+     * @return true: Interrupt startup. `false`: continue as normal
+     */
+    open fun startingStorageMigrationInterruptsStartup(): Boolean {
+        val migrationStatus = ScopedStorageService.migrationStatus(this)
+        Timber.i("migration status: %s", migrationStatus)
+        when (migrationStatus) {
+            ScopedStorageService.Status.NEEDS_MIGRATION -> {
+                // TODO: we should propose a migration, but not yet (alpha users should opt in)
+                // If the migration was proposed too soon, don't show it again and startup normally.
+                // TODO: This logic needs thought
+                // showDialogThatOffersToMigrateStorage(onPostpone = {
+                //     // Unblocks the UI if opened from changing the deck path
+                //     updateDeckList()
+                //     invalidateOptionsMenu()
+                //     handleStartup(skipStorageMigration = true)
+                // })
+                return false // TODO: Allow startup normally
+            }
+            ScopedStorageService.Status.IN_PROGRESS -> {
+                startMigrateUserDataService()
+                return false
+            }
+            // If legacy storage is being used, ensure storage permission is obtained in order to access Legacy Directories
+            ScopedStorageService.Status.REQUIRES_PERMISSION -> {
+                requestStoragePermission()
+                return true
+            }
+            ScopedStorageService.Status.PERMISSION_FAILED -> {
+                // TODO: Handle "user reinstalled & kept data" scenario.
+                //  (Or edge case of permission removal)
+                return false
+            }
+            // App is already using Scoped Storage Directory for user data, no need to migrate & can proceed with startup
+            ScopedStorageService.Status.COMPLETED -> return false
+        }
+    }
+
+    /**
      * The first call in showing dialogs for startup - error or success.
      * Attempts startup if storage permission has been acquired, else, it requests the permission
      */
     fun handleStartup() {
+        if (startingStorageMigrationInterruptsStartup()) return
+
+        Timber.d("handleStartup: Continuing. unaffected by storage migration")
         if (hasStorageAccessPermission(this)) {
             val failure = InitialActivity.getStartupFailureType(this)
             mStartupError = if (failure == null) {
@@ -771,7 +831,7 @@ open class DeckPicker :
             }
             R.id.action_scoped_storage_migrate -> {
                 Timber.i("DeckPicker:: migrate button pressed")
-                showDialogThatOffersToMigrateStorage()
+                showDialogThatOffersToMigrateStorage(onPostpone = null)
                 return true
             }
             R.id.action_import -> {
@@ -936,6 +996,18 @@ open class DeckPicker :
         mFloatingActionMenu.isFABOpen = savedInstanceState.getBoolean("mIsFABOpen")
     }
 
+    fun onStorageMigrationCompleted() {
+        migrationService.unbind(this)
+        invalidateOptionsMenu() // reapply the sync icon
+    }
+
+    override fun onStart() {
+        super.onStart()
+        if (userMigrationIsInProgress(this)) {
+            migrationService.bind(this, MigrationService::class.java)
+        }
+    }
+
     override fun onPause() {
         Timber.d("onPause()")
         mActivityPaused = true
@@ -947,6 +1019,7 @@ open class DeckPicker :
     override fun onStop() {
         Timber.d("onStop()")
         super.onStop()
+        migrationService.unbind(this)
         if (colIsOpen()) {
             WidgetStatus.update(this)
             // Ignore the modification - a change in deck shouldn't trigger the icon for "pending changes".
@@ -2779,14 +2852,19 @@ open class DeckPicker :
             val elapsedMillisDuringEssentialFilesMigration = measureTimeMillis {
                 withProgress(getString(R.string.start_migration_progress_message)) {
                     withContext(Dispatchers.IO) {
-                        migrateEssentialFiles(baseContext)
+                        loadDeckCounts?.cancel()
+                        CollectionHelper.instance.closeCollection(false, "migration to scoped storage")
+                        ScopedStorageService.migrateEssentialFiles(baseContext)
+
+                        updateDeckList()
+                        handleStartup()
+                        startMigrateUserDataService()
                     }
                 }
             }
             if (elapsedMillisDuringEssentialFilesMigration > 800) {
                 showSnackbar(R.string.migration_part_1_done_resume)
             }
-            startMigrateUserDataService()
         }
     }
 
@@ -2794,16 +2872,26 @@ open class DeckPicker :
      * Start migrating the user data. Assumes that
      */
     fun startMigrateUserDataService() {
-        // TODO
+        // TODO: Handle lack of disk space - most common error
+        Timber.i("Starting Migrate User Data Service")
+        migrationService.startForeground(this, MigrationService::class.java)
     }
 
     /**
      * Show a dialog that explains no sync can occur during migration.
      */
     private fun warnNoSyncDuringMigration() {
-        // TODO: Fetch and display real numbers
+        // TODO: handle value updates
+        // Note: migrationService shouldn't be null in normal operation
+        val text = migrationService.instance?.let { service ->
+            return@let service.totalToTransfer?.let { totalToTransfer ->
+                "\n\n" + getString(R.string.migration_transferred_size, service.currentProgress.toMB().toFloat(), totalToTransfer.toMB().toFloat())
+            }
+        }
+        // TODO: maybe handle onStorageMigrationCompleted()
+        // TODO: sync_impossible_during_migration needs changing
         MaterialDialog(this).show {
-            message(text = resources.getString(R.string.sync_impossible_during_migration, 5))
+            message(text = resources.getString(R.string.sync_impossible_during_migration, 5) + text)
             positiveButton(res = R.string.dialog_ok)
             negativeButton(res = R.string.scoped_storage_learn_more) {
                 openUrl(R.string.link_scoped_storage_faq)
@@ -2845,7 +2933,8 @@ open class DeckPicker :
     /**
      * Show a dialog offering to migrate, postpone or learn more.
      */
-    fun showDialogThatOffersToMigrateStorage() {
+    fun showDialogThatOffersToMigrateStorage(onPostpone: (() -> Unit)?) {
+        Timber.i("Displaying dialog to migrate storage")
         if (userMigrationIsInProgress(baseContext)) {
             // This should not occur. We should have not called the function in this case.
             return
@@ -2872,6 +2961,7 @@ open class DeckPicker :
                 getString(R.string.scoped_storage_postpone)
             ) { _, _ ->
                 setMigrationWasLastPostponedAtToNow()
+                onPostpone?.invoke()
             }.addScopedStorageLearnMoreLinkAndShow(message)
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/ScopedStorageService.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/ScopedStorageService.kt
@@ -19,6 +19,8 @@ package com.ichi2.anki.servicelayer
 
 import android.content.Context
 import android.content.SharedPreferences
+import android.os.Build
+import android.os.Environment
 import androidx.annotation.VisibleForTesting
 import com.ichi2.anki.AnkiDroidApp
 import com.ichi2.anki.CollectionHelper
@@ -31,6 +33,7 @@ import com.ichi2.anki.servicelayer.scopedstorage.migrateuserdata.MigrateUserData
 import com.ichi2.anki.servicelayer.scopedstorage.migrateuserdata.UserDataMigrationPreferences
 import com.ichi2.utils.FileUtil.getParentsAndSelfRecursive
 import com.ichi2.utils.FileUtil.isDescendantOf
+import com.ichi2.utils.Permissions
 import timber.log.Timber
 import java.io.File
 
@@ -263,5 +266,31 @@ object ScopedStorageService {
         return true
     }
 
-    private data class DirectoryToExternalDirectory(val ancestorDirectory: File, val externalDirectory: File)
+    fun migrationStatus(context: Context): Status {
+        if (!isLegacyStorage(context) && !userMigrationIsInProgress(context)) {
+            return Status.COMPLETED
+        }
+
+        if (!Permissions.hasStorageAccessPermission(context)) {
+            return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q && !Environment.isExternalStorageLegacy()) {
+                Status.PERMISSION_FAILED
+            } else {
+                Status.REQUIRES_PERMISSION
+            }
+        }
+
+        if (userMigrationIsInProgress(context)) {
+            return Status.IN_PROGRESS
+        }
+
+        return Status.NEEDS_MIGRATION
+    }
+
+    enum class Status {
+        NEEDS_MIGRATION,
+        REQUIRES_PERMISSION,
+        PERMISSION_FAILED,
+        IN_PROGRESS,
+        COMPLETED
+    }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/scopedstorage/MigrateEssentialFiles.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/scopedstorage/MigrateEssentialFiles.kt
@@ -503,7 +503,7 @@ internal constructor(
         /**
          * A collection of [File] objects to be moved by [MigrateEssentialFiles]
          */
-        private fun iterateEssentialFiles(sourcePath: AnkiDroidDirectory) =
+        fun iterateEssentialFiles(sourcePath: AnkiDroidDirectory) =
             PRIORITY_FILES.flatMap { it.getEssentialFiles(sourcePath.directory.canonicalPath) }
 
         /**

--- a/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/scopedstorage/MoveDirectory.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/scopedstorage/MoveDirectory.kt
@@ -36,19 +36,6 @@ import java.io.File
 
 data class MoveDirectory(val source: Directory, val destination: File) : Operation() {
     override fun execute(context: MigrationContext): List<Operation> {
-
-        // This seems unlikely to happen. Both paths need to be on the same mount point
-        // We use directory.exists() to ensure that this operation doesn't occur twice. renameTo
-        // is likely to be expensive, so we use the creation of the target directory to mark
-        // that the rename previously failed
-        if (context.attemptRename && !destination.exists() && rename(source, destination)) {
-            Timber.d("successfully renamed '$source' to '$destination'")
-            return operationCompleted()
-        } else {
-            // mark in the context that rename should not be attempted again for any sub-operations
-            context.attemptRename = false
-        }
-
         if (!createDirectory(context)) {
             return operationCompleted()
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/scopedstorage/MoveFile.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/scopedstorage/MoveFile.kt
@@ -76,10 +76,14 @@ internal data class MoveFile(val sourceFile: DiskFile, val destinationFile: File
         }
 
         // attempt a quick rename
-        if (context.attemptRename && sourceFile.renameTo(destinationFile)) {
-            Timber.d("move successful from '$sourceFile' to '$destinationFile'")
-            context.reportProgress(destinationFile.length())
-            return operationCompleted()
+        if (context.attemptRename) {
+            if (sourceFile.renameTo(destinationFile)) {
+                Timber.d("fast move successful from '$sourceFile' to '$destinationFile'")
+                context.reportProgress(destinationFile.length())
+                return operationCompleted()
+            } else {
+                context.attemptRename = false
+            }
         }
 
         // copy the file, and delete the source.

--- a/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/scopedstorage/migrateuserdata/MigrateUserData.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/scopedstorage/migrateuserdata/MigrateUserData.kt
@@ -26,11 +26,8 @@ import com.ichi2.anki.servicelayer.scopedstorage.MoveConflictedFile
 import com.ichi2.anki.servicelayer.scopedstorage.MoveFileOrDirectory
 import com.ichi2.anki.servicelayer.scopedstorage.migrateuserdata.MigrateUserData.Operation
 import com.ichi2.anki.servicelayer.scopedstorage.migrateuserdata.MigrateUserData.SingleRetryDecorator
-import com.ichi2.async.ProgressSenderAndCancelListener
-import com.ichi2.async.TaskDelegate
 import com.ichi2.compat.CompatHelper
 import com.ichi2.exceptions.AggregateException
-import com.ichi2.libanki.Collection
 import timber.log.Timber
 import java.io.File
 
@@ -55,7 +52,7 @@ typealias MigrationProgressListener = (NumberOfBytes) -> Unit
  * This also handles preemption, allowing media files to skip the queue
  * (if they're required for review)
  */
-open class MigrateUserData protected constructor(val source: Directory, val destination: Directory) : TaskDelegate<NumberOfBytes, Boolean>() {
+open class MigrateUserData protected constructor(val source: Directory, val destination: Directory) {
     companion object {
         /**
          * Creates an instance of [MigrateUserData] if valid, returns null if a migration is not in progress, or throws if data is invalid
@@ -478,9 +475,9 @@ open class MigrateUserData protected constructor(val source: Directory, val dest
      * @throws AggregateException If multiple exceptions were thrown when executing
      * @throws RuntimeException Various other failings if only a single exception was thrown
      */
-    override fun task(col: Collection, collectionTask: ProgressSenderAndCancelListener<NumberOfBytes>): Boolean {
+    fun migrateFiles(progressListener: MigrationProgressListener): Boolean {
 
-        val context = initializeContext(collectionTask::doProgress)
+        val context = initializeContext(progressListener)
 
         // define the function here, so we can execute it on retry
         fun moveRemainingFiles() {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/scopedstorage/migrateuserdata/MigrateUserData.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/scopedstorage/migrateuserdata/MigrateUserData.kt
@@ -168,9 +168,12 @@ open class MigrateUserData protected constructor(val source: Directory, val dest
          */
         abstract fun reportProgress(transferred: NumberOfBytes)
         /**
-         * Whether [File#renameTo] should be attempted
+         * Whether [File#renameTo] should be attempted for files.
          *
-         * In scoped storage, this is typically false, as we may be moving between mount points
+         * This is not attempted for directories: very unlikely to work as we're copying across
+         * mount points.
+         * Android has internal logic which recovers renames from /storage/emulated
+         * But this hasn't worked for me for folders
          */
         var attemptRename: Boolean = true
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/scopedstorage/migrateuserdata/MigrateUserData.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/scopedstorage/migrateuserdata/MigrateUserData.kt
@@ -32,6 +32,14 @@ import timber.log.Timber
 import java.io.File
 
 typealias NumberOfBytes = Long
+
+fun NumberOfBytes.toKB(): Int {
+    return ((this / 1024).toInt())
+}
+
+fun NumberOfBytes.toMB(): Int {
+    return this.toKB() / 1024
+}
 /**
  * Function that is executed when one file is migrated, with the number of bytes moved.
  * Called with 0 when the file is already present in destination (i.e. successful move with no byte copied)
@@ -292,7 +300,9 @@ open class MigrateUserData protected constructor(val source: Directory, val dest
      */
     open class Executor(private val operations: ArrayDeque<Operation>) {
         /** Whether [terminate] was called. Once this is called, a new instance should be used */
-        private var terminated: Boolean = false
+        var terminated: Boolean = false
+            private set
+
         /**
          * A list of operations to be executed before [operations]
          * [operations] should only be executed if this list is clear
@@ -377,7 +387,7 @@ open class MigrateUserData protected constructor(val source: Directory, val dest
      * @param progressReportParam A function, called for each file that is migrated, with the number of bytes of the file.
      */
     open class UserDataMigrationContext(private val executor: Executor, val source: Directory, val progressReportParam: MigrationProgressListener) : MigrationContext() {
-        val successfullyCompleted: Boolean get() = loggedExceptions.isEmpty()
+        val successfullyCompleted: Boolean get() = loggedExceptions.isEmpty() && !executor.terminated
 
         /**
          * The reason that the the execution of the whole migration was terminated early

--- a/AnkiDroid/src/main/java/com/ichi2/anki/services/MigrationService.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/services/MigrationService.kt
@@ -1,0 +1,247 @@
+/*
+ *  Copyright (c) 2023 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.services
+
+import android.app.Service
+import android.content.Context
+import android.content.Intent
+import android.os.Binder
+import android.os.IBinder
+import androidx.core.app.NotificationCompat
+import androidx.core.app.NotificationManagerCompat
+import androidx.core.content.edit
+import com.ichi2.anki.*
+import com.ichi2.anki.servicelayer.ScopedStorageService.PREF_MIGRATION_DESTINATION
+import com.ichi2.anki.servicelayer.ScopedStorageService.PREF_MIGRATION_SOURCE
+import com.ichi2.anki.servicelayer.scopedstorage.MigrateEssentialFiles
+import com.ichi2.anki.servicelayer.scopedstorage.MoveConflictedFile
+import com.ichi2.anki.servicelayer.scopedstorage.migrateuserdata.MigrateUserData
+import com.ichi2.anki.servicelayer.scopedstorage.migrateuserdata.NumberOfBytes
+import com.ichi2.anki.servicelayer.scopedstorage.migrateuserdata.toKB
+import com.ichi2.anki.servicelayer.scopedstorage.migrateuserdata.toMB
+import com.ichi2.utils.FileUtil
+import com.ichi2.utils.Repeater
+import com.ichi2.utils.runOnUiThread
+import timber.log.Timber
+import java.io.File
+import kotlin.concurrent.thread
+
+/**
+ * A service which migrates the AnkiDroid collection from a legacy directory to an app-specific directory.
+ */
+class MigrationService : Service() {
+    private lateinit var migrateUserDataTask: MigrateUserData
+    private lateinit var migrateDataThread: Thread
+    private lateinit var notificationUpdater: Repeater
+    private var isStarted = false
+
+    /** the current progress (may be ahead of the notification) */
+    var currentProgress: NumberOfBytes = 0
+        private set
+
+    /** the current progress which is displayed on the notification */
+    var notificationDisplayedProgress: NumberOfBytes = 0
+        private set
+
+    /**
+     * The total bytes required to be transferred. 0 on error
+     * Note: currently this is recalculated each time the service is started
+     */
+    var totalToTransfer: NumberOfBytes? = null
+        private set
+
+    var migrationCompletedListener: (() -> Unit)? = null
+
+    private inner class MigrateUserDataProgressListener(val context: Context) {
+        private var notification: Notification? = null
+
+        fun initNotification(totalToTransfer: NumberOfBytes?) {
+            // startForeground must be called within 5 seconds. Otherwise a crash occurs:
+            // `Context.startForegroundService() did not then call Service.startForeground()`
+            val sourceSize = totalToTransfer ?: 0 // TODO: error handling
+            notification = Notification.createInstance(context, sourceSize).also {
+                Timber.i("Running in foreground with notification")
+                startForeground(it.id, it.build())
+            }
+
+            notificationUpdater = Repeater.createAndStart(delayMs = 2000L) {
+                notificationDisplayedProgress = currentProgress
+                notification?.notifyUpdate(currentProgress)
+            }
+        }
+
+        fun onProgressUpdate(value: NumberOfBytes?) {
+            /** @see notificationUpdater for where this is used */
+            currentProgress += value ?: 0
+        }
+
+        fun onResult(result: Boolean) {
+            if (result) {
+                Timber.i("Marking migration as completed")
+                AnkiDroidApp.getSharedPrefs(context).edit {
+                    remove(PREF_MIGRATION_DESTINATION)
+                    remove(PREF_MIGRATION_SOURCE)
+                }
+                migrationCompletedListener?.invoke()
+            }
+            notification?.notifyCompletion(result)
+
+            // display a toast to the user.
+            displayMigrationCompleted(result)
+            stopSelf()
+        }
+
+        private fun displayMigrationCompleted(result: Boolean) {
+            // TODO: This should be discussed
+            val message =
+                if (result) R.string.migration_successful_message else R.string.migration_failed_message
+
+            // fixes: "Can't toast on a thread that has not called Looper.prepare()"
+            runOnUiThread {
+                UIUtils.showThemedToast(context, message, true)
+            }
+        }
+    }
+
+    private class Notification private constructor(
+        private val context: Context,
+        private val manager: NotificationManagerCompat,
+        private val sourceSize: NumberOfBytes
+    ) {
+        private var notificationBuilder: NotificationCompat.Builder = NotificationCompat.Builder(
+            context,
+            Channel.SCOPED_STORAGE_MIGRATION.id
+        )
+            .setSmallIcon(R.drawable.ic_stat_notify)
+            .setContentTitle(context.resources.getString(R.string.migrating_data_message))
+            .setContentText(context.resources.getString(R.string.migration_transferred_size, 0f, sourceSize / 1024f))
+            .setPriority(NotificationCompat.PRIORITY_LOW)
+            .setOngoing(true)
+            .setSilent(true)
+            .setProgress(100, 0, false)
+
+        /** The id of the notification for in-progress user data migration. */
+        val id = 2
+
+        fun build() = this.notificationBuilder.build()
+        fun notifyUpdate(currentProgress: NumberOfBytes) {
+            Timber.v("update: %d", currentProgress)
+            notificationBuilder.setProgress(sourceSize.toKB(), currentProgress.toKB(), false)
+            notificationBuilder.setContentText(
+                context.resources.getString(
+                    R.string.migration_transferred_size,
+                    currentProgress.toMB().toFloat(), sourceSize.toMB().toFloat()
+                )
+            )
+            manager.notify(id, notificationBuilder.build())
+        }
+
+        fun notifyCompletion(result: Boolean) {
+            val titleRes = if (result) R.string.migration_successful_message else R.string.migration_failed_message
+            val notificationTitle = context.resources.getString(titleRes)
+            notificationBuilder.setContentTitle(notificationTitle)
+                .setProgress(0, 0, false)
+                .setOngoing(false)
+            manager.notify(id, notificationBuilder.build())
+        }
+
+        companion object {
+            fun createInstance(context: Context, sourceSize: NumberOfBytes): Notification {
+                val notificationManager = NotificationManagerCompat.from(context)
+                return Notification(context, notificationManager, sourceSize)
+            }
+        }
+    }
+
+    private fun getRestartBehavior() = START_STICKY
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        // If a service is called twice, onStartCommand is called twice
+        if (isStarted) {
+            Timber.v("rejected onStartCommand")
+            return getRestartBehavior()
+        }
+        isStarted = true
+        Timber.d("onStartCommand")
+
+        val migrateUserDataTask = try {
+            MigrateUserData.createInstance(AnkiDroidApp.getSharedPrefs(this))
+        } catch (e: MigrateUserData.MissingDirectoryException) {
+            // TODO: Log and handle - likely SD card removal
+            throw e
+        } catch (e: Exception) {
+            stopSelf()
+            return getRestartBehavior()
+        }
+
+        // a migration is not taking place
+        if (migrateUserDataTask == null) {
+            Timber.w("MigrationService started when a migration was not taking place")
+            stopSelf()
+            return getRestartBehavior()
+        }
+
+        this.migrateUserDataTask = migrateUserDataTask
+        this.migrateDataThread = thread(name = "Storage Migration") {
+            this.totalToTransfer = getRemainingTransferSize(migrateUserDataTask)
+            val listener = MigrateUserDataProgressListener(this)
+            listener.initNotification(totalToTransfer)
+            // TODO: Handle transient errors (lack of space)
+            val result = migrateUserDataTask.migrateFiles { bytesTransferred -> listener.onProgressUpdate(bytesTransferred) }
+            listener.onResult(result)
+        }
+
+        return getRestartBehavior()
+    }
+
+    override fun onDestroy() {
+        Timber.d("onDestroy")
+        if (::migrateUserDataTask.isInitialized) { migrateUserDataTask.executor.terminate() }
+        if (::notificationUpdater.isInitialized) { notificationUpdater.terminate() }
+        super.onDestroy()
+    }
+
+    private fun getRemainingTransferSize(
+        task: MigrateUserData,
+    ): NumberOfBytes? {
+        return try {
+            val ignoredFiles = MigrateEssentialFiles.iterateEssentialFiles(task.source) +
+                File(task.source.directory, MoveConflictedFile.CONFLICT_DIRECTORY)
+            val ignoredSpace = ignoredFiles.sumOf { FileUtil.getSize(it) }
+            val folderSize = FileUtil.DirectoryContentInformation.fromDirectory(task.source.directory).totalBytes
+            val remainingSpaceToMigrate = folderSize - ignoredSpace
+            Timber.d("folder size: %d, safe: %d, remaining: %d", folderSize, ignoredSpace, remainingSpaceToMigrate)
+            return remainingSpaceToMigrate
+        } catch (e: Exception) {
+            Timber.w(e, "Failed to get directory size")
+            null
+        }
+    }
+
+    /**
+     * Class used for the client Binder.  Because we know this service always
+     * runs in the same process as its clients, we don't need to deal with IPC.
+     *
+     * See: https://developer.android.com/guide/components/bound-services#Binder
+     */
+    inner class LocalBinder : Binder() {
+        @Suppress("unused")
+        fun getService(): MigrationService = this@MigrationService
+    }
+
+    override fun onBind(intent: Intent): IBinder = LocalBinder()
+}

--- a/AnkiDroid/src/main/java/com/ichi2/anki/services/MigrationService.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/services/MigrationService.kt
@@ -238,9 +238,9 @@ class MigrationService : Service() {
      *
      * See: https://developer.android.com/guide/components/bound-services#Binder
      */
-    inner class LocalBinder : Binder() {
+    inner class LocalBinder : Binder(), SimpleBinder<MigrationService> {
         @Suppress("unused")
-        fun getService(): MigrationService = this@MigrationService
+        override fun getService(): MigrationService = this@MigrationService
     }
 
     override fun onBind(intent: Intent): IBinder = LocalBinder()

--- a/AnkiDroid/src/main/java/com/ichi2/anki/services/ServiceConnection.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/services/ServiceConnection.kt
@@ -1,0 +1,94 @@
+/*
+ *  Copyright (c) 2023 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.services
+
+import android.app.Service
+import android.content.*
+import android.content.ServiceConnection
+import android.os.IBinder
+import androidx.core.content.ContextCompat
+import timber.log.Timber
+
+/**
+ * Simplifies the interface for binding to a running service
+ * Access the service via [instance].
+ *
+ *
+ * @param T The service to encapsulate. Note: service's [Service.onBind] must return a [SimpleBinder]
+ */
+abstract class ServiceConnection<T : Service> {
+    var instance: T? = null
+        private set
+
+    /** Whether [bind] was called and succeeded */
+    private var serviceBound = false
+
+    val connection = object : ServiceConnection {
+        override fun onServiceConnected(name: ComponentName, service: IBinder) {
+            if (service !is SimpleBinder<*>) {
+                throw IllegalStateException("$name must return a binder implementing SimpleBinder")
+            }
+            val binder = service as SimpleBinder<*>
+            Timber.d("%s connected", name.shortClassName)
+            @Suppress("UNCHECKED_CAST")
+            this@ServiceConnection.instance = (binder.getService() as T).also {
+                onServiceConnected(it)
+            }
+        }
+
+        override fun onServiceDisconnected(name: ComponentName) {
+            Timber.d("%s disconnected", name.shortClassName)
+            instance?.let {
+                onServiceDisconnected(it)
+                instance = null
+            }
+        }
+    }
+
+    fun startForeground(context: Context, clazz: Class<T>) {
+        ContextCompat.startForegroundService(context, Intent(context, clazz))
+        bind(context, clazz)
+    }
+
+    fun unbind(context: Context) {
+        instance?.let { onServiceDisconnected(it) }
+        if (serviceBound) {
+            context.unbindService(connection)
+        }
+        serviceBound = false
+    }
+
+    /**
+     * @param flags @see `Context.BindServiceFlags`
+     */
+    fun bind(context: Context, clazz: Class<T>, flags: Int = Context.BIND_AUTO_CREATE) {
+        Intent(context, clazz).also { intent ->
+            context.bindService(intent, connection, flags)
+            serviceBound = true
+        }
+    }
+
+    open fun onServiceConnected(service: T) {}
+    open fun onServiceDisconnected(service: T) {}
+}
+
+/**
+ * Marker interface to allow a [Service] to be usable with [ServiceConnection]
+ */
+interface SimpleBinder<T : Service> {
+    fun getService(): T
+}

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/importer/Anki2Importer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/importer/Anki2Importer.kt
@@ -695,7 +695,6 @@ open class Anki2Importer(col: Collection?, file: String) : Importer(col!!, file)
         return try {
             BufferedInputStream(FileInputStream(path), MEDIAPICKLIMIT * 2)
         } catch (e: IOException) {
-            Timber.w(e)
             null
         }
     }

--- a/AnkiDroid/src/main/java/com/ichi2/utils/FileUtil.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/FileUtil.kt
@@ -82,6 +82,27 @@ object FileUtil {
     }
 
     /**
+     * Calculates the size of a [File].
+     * If it is a file, returns the size.
+     * If the file does not exist, returns 0
+     * If the file is a directory, recursively explore the directory tree and summing the length of each
+     * file. The time taken to calculate directory size is proportional to the number of files in the directory
+     * and all of its sub-directories. See: [DirectoryContentInformation.fromDirectory]
+     * It is assumed that directory contains no symbolic links.
+     *
+     * @param file Abstract representation of the file/directory whose size needs to be calculated
+     * @return Size of the File/Directory in bytes. 0 if the [File] does not exist
+     */
+    fun getSize(file: File): Long {
+        if (file.isFile) {
+            return file.length()
+        } else if (!file.exists()) {
+            return 0L
+        }
+        return DirectoryContentInformation.fromDirectory(file).totalBytes
+    }
+
+    /**
      * Information about the content of a directory `d`.
      */
     data class DirectoryContentInformation(
@@ -100,6 +121,9 @@ object FileUtil {
         val numberOfFiles: Int
     ) {
         companion object {
+            /**
+             * @throws IOException [root] does not exist
+             */
             fun fromDirectory(root: File): DirectoryContentInformation {
                 var totalBytes = 0L
                 var numberOfDirectories = 0

--- a/AnkiDroid/src/main/java/com/ichi2/utils/HandlerUtils.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/HandlerUtils.kt
@@ -84,3 +84,11 @@ object HandlerUtils {
         )
     }
 }
+
+fun runOnUiThread(runnable: () -> Unit) {
+    Handler(Looper.getMainLooper()).apply {
+        post {
+            runnable()
+        }
+    }
+}

--- a/AnkiDroid/src/main/java/com/ichi2/utils/Repeater.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/Repeater.kt
@@ -1,0 +1,56 @@
+/*
+ *  Copyright (c) 2023 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.utils
+
+import com.ichi2.utils.HandlerUtils.newHandler
+import timber.log.Timber
+
+/**
+ * Schedules repeating events
+ * @param delayMs the interval to wait after the execution of [runnable] before the next call is made
+ * @param runnable Called once every [delayMs] until [terminate] is called
+ */
+class Repeater private constructor(val delayMs: Long, val runnable: () -> Unit) {
+    private var terminated = false
+
+    fun terminate() {
+        Timber.v("Terminated Repeater $this")
+        terminated = true
+    }
+
+    fun repeatDelayed() {
+        if (terminated) { return }
+        val handler = newHandler()
+        handler.postDelayed(
+            object : Runnable {
+                override fun run() {
+                    Timber.v("Executing $this")
+                    if (!terminated) {
+                        runnable()
+                        handler.postDelayed(this, delayMs)
+                    }
+                }
+            },
+            delayMs
+        )
+    }
+
+    companion object {
+        fun createAndStart(delayMs: Long, runnable: () -> Unit) =
+            Repeater(delayMs, runnable).also { it.repeatDelayed() }
+    }
+}

--- a/AnkiDroid/src/main/res/values/01-core.xml
+++ b/AnkiDroid/src/main/res/values/01-core.xml
@@ -235,4 +235,10 @@
         comment="Generic message about an unknown error, to be shown in snackbars and such"
         translatable="false"
         >@string/webview_crash_unknown</string>
+
+    <!-- Scoped Storage Migration -->
+    <string name="migrating_data_message">Migrating your data</string>
+    <string name="migration_successful_message">Migration successful</string>
+    <string name="migration_failed_message">Migration failed</string>
+    <string name="migration_transferred_size">Migrated %1$.0f MB of %2$.0f MB</string>
 </resources>

--- a/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/MoveDirectoryTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/MoveDirectoryTest.kt
@@ -65,48 +65,6 @@ class MoveDirectoryTest : Test21And26(), OperationTest {
     }
 
     @Test
-    fun test_fast_rename() {
-        val source = createTransientDirectory().withTempFile("tmp.txt")
-        val destinationFile = generateDestinationDirectoryRef()
-        executionContext.attemptRename = true
-
-        val ret = moveDirectory(source, destinationFile).execute()
-
-        assertThat("fast rename returns no operations", ret, empty())
-        assertThat("source directory should not exist", source.exists(), equalTo(false))
-        assertThat("destination directory should exist", destinationFile.exists(), equalTo(true))
-        assertThat("file should be copied", File(destinationFile, "tmp.txt").exists(), equalTo(true))
-    }
-
-    @Test
-    fun failed_rename_avoids_further_renames() {
-        // This is a performance optimization,
-        val source = createTransientDirectory().withTempFile("tmp.txt")
-        val destinationFile = generateDestinationDirectoryRef()
-        var renameCalled = 0
-
-        executionContext.logExceptions = true
-        // don't actually move the directory, or we'd have a problem
-        val moveDirectory = spy(moveDirectory(source, destinationFile)) {
-            doAnswer { renameCalled++; return@doAnswer false }.whenever(it).rename(any(), any())
-        }
-
-        assertThat("rename was true", executionContext.attemptRename, equalTo(true))
-
-        moveDirectory.execute()
-
-        assertThat("rename is now false", executionContext.attemptRename, equalTo(false))
-        assertThat("rename was called", renameCalled, equalTo(1))
-
-        moveDirectory.execute()
-
-        assertThat("rename was not called again", renameCalled, equalTo(1))
-
-        assertThat(executionContext.exceptions, hasSize(0))
-        assertThat("source was not copied", File(source, "tmp.txt").exists(), equalTo(true))
-    }
-
-    @Test
     fun a_move_failure_is_not_fatal() {
         val source = createTransientDirectory()
             .withTempFile("foo.txt")

--- a/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/ScopedStorageMigrationIntegrationTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/ScopedStorageMigrationIntegrationTest.kt
@@ -39,7 +39,7 @@ import kotlin.io.path.pathString
 import kotlin.test.fail
 
 // PERF: Some of these do not need a collection
-/** Test for [MigrateUserData.execTask] */
+/** Test for [MigrateUserData.migrateFiles] */
 @RunWith(AndroidJUnit4::class)
 class ScopedStorageMigrationIntegrationTest : RobolectricTest() {
 
@@ -210,7 +210,7 @@ class ScopedStorageMigrationIntegrationTest : RobolectricTest() {
     }
 
     private fun MigrateUserDataTester.execTask(): Boolean {
-        return this.execTask(mock(), mock())
+        return this.migrateFiles(mock())
     }
 }
 


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
This Pull Request implements the foreground service which performs the Scoped Storage Migration, and hooks it up to the Deck Picker

## Review Goals
* Ensure alpha users will not be placed in a bad position by this. This PR moves us to 'developers can test the migration', I'd rather keep this as too unstable for alpha, despite the amount of testing, given the impact.
* Question the `onStartCommand` isStarted logic
* Determine the TODOs which need to be moved to the Plan

This also contains a couple refactorings which could be split out if requested in the review.

## Fixes
Related #5304

## Approach
* Define a Service
* Define code to run a repeated task
* Define a Service Binder to abstract out the intricacies from DeckPicker
* Define an API which determines the state of the migration

## How Has This Been Tested?
⚠️ This needs more thorough testing. I'm submitting this PR to allow for this to occur. Once this testing is complete, we can allow 'GitHub alpha' users to use it.
* Tested on my test collection. All media transferred.

## Known Issues
* `Reviewer` is not tied in to the migration process yet
* `Media` is not blocked

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
