### PR TITLE
Added Button to reset directory path in AdvancedSettingFragment

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/AdvancedSettingsFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/AdvancedSettingsFragment.kt
@@ -71,6 +71,20 @@ class AdvancedSettingsFragment : SettingsFragment() {
             }
         }
 
+        // Reset Directory path to default path
+        requirePreference<Preference>(R.string.pref_reset_to_default_directory_path_key).setOnPreferenceClickListener {
+            val defaultPath = CollectionHelper.getDefaultAnkiDroidDirectory(requireContext())
+            requirePreference<EditTextPreference>(CollectionHelper.PREF_COLLECTION_PATH).text = defaultPath
+            try {
+                CollectionHelper.initializeAnkiDroidDirectory(defaultPath)
+                (requireActivity() as Preferences).restartWithNewDeckPicker()
+                true
+            } catch (e: StorageAccessException) {
+                Timber.e(e, "Could not initialize directory: %s", defaultPath)
+                false
+            }
+        }
+
         // Third party apps
         requirePreference<Preference>(R.string.thirdparty_apps_key).setOnPreferenceClickListener {
             (requireActivity() as AnkiActivity).openUrl(R.string.link_third_party_api_apps)

--- a/AnkiDroid/src/main/res/values/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values/10-preferences.xml
@@ -59,6 +59,7 @@
     <string name="card_browser_hide_media" maxLength="41">Display filenames in card browser</string>
     <string name="card_browser_hide_media_summary">Display media filenames in the card browser question/answer fields</string>
     <string name="col_path" maxLength="41">AnkiDroid directory</string>
+    <string name="resets_to_default_path" maxLength="41">Reset to default path</string>
     <string name="fullscreen_review" maxLength="41">Fullscreen mode</string>
     <string name="full_screen_off">Off</string>
     <string name="full_screen_system">Hide the system bars</string>
@@ -99,6 +100,7 @@
     <string name="double_scrolling_gap_summ">Double the scroll gap with eReader</string>
     <string name="swipe_sensitivity" maxLength="41">Swipe sensitivity</string>
     <string name="tts" maxLength="41">Text to speech</string>
+    <string name="default_directory_path_summ">Resets directory path to its default path</string>
     <string name="tts_summ">Reads out question and answer if no sound file is included</string>
     <!-- Sync -->
     <string name="sync_fetch_missing_media" maxLength="41">Fetch media on sync</string>

--- a/AnkiDroid/src/main/res/values/preferences.xml
+++ b/AnkiDroid/src/main/res/values/preferences.xml
@@ -91,6 +91,7 @@
     <string name="pref_advanced_screen_key">pref_screen_advanced</string>
     <string name="pref_cat_workarounds_key">category_workarounds</string>
     <string name="pref_ankidroid_directory_key">deckPath</string>
+    <string name="pref_reset_to_default_directory_path_key">set_to_default_deck_path</string>
     <string name="disable_hardware_render_key">softwareRender</string>
     <string name="safe_display_key">safeDisplay</string>
     <string name="use_input_tag_key">useInputTag</string>

--- a/AnkiDroid/src/main/res/xml/preferences_advanced.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_advanced.xml
@@ -32,6 +32,10 @@
             android:key="@string/pref_ankidroid_directory_key"
             android:title="@string/col_path"
             app1:useSimpleSummaryProvider="true"/>
+        <Preference
+            android:key="@string/pref_reset_to_default_directory_path_key"
+            android:summary="@string/default_directory_path_summ"
+            android:title="@string/resets_to_default_path"/>
         <com.ichi2.preferences.IncrementerNumberRangePreferenceCompat
             android:defaultValue="8"
             android:key="@string/pref_backup_max_key"


### PR DESCRIPTION
## Pull Request template
@Arthur-Milchior

## Purpose / Description
This pull request aims to add a new option in the "AdvancedSettingFragment" options called "Reset Directory Path" that allows the user to reset the directory path to default.

## Fixes
#13150

## Approach
This feature is implemented by adding a new option in the "AdvancedSettingFragment" screen that resets its directory path to default.

## How Has This Been Tested?

The changes have been tested on a physical device running Android 10 and Android 11. To test, I navigated to the 'AdvancedSettingFragment' and selected the "Reset to default path" option.

## Learning (optional, can help others)

## Checklist
_Please, go through these checks before submitting the PR._

- [ ] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented on your code, particularly in hard-to-understand areas
- [ ] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
