### PR TITLE
made data not null

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicMediaClipFieldController.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicMediaClipFieldController.kt
@@ -31,8 +31,6 @@ import com.ichi2.anki.R
 import com.ichi2.anki.UIUtils.showThemedToast
 import com.ichi2.compat.CompatHelper
 import com.ichi2.ui.FixedTextView
-import com.ichi2.utils.ExceptionUtil.executeSafe
-import com.ichi2.utils.KotlinCleanup
 import timber.log.Timber
 import java.io.File
 
@@ -94,16 +92,10 @@ class BasicMediaClipFieldController : FieldControllerBase(), IFieldController {
         mActivity.startActivityForResultWithoutAnimation(Intent.createChooser(i, chooserPrompt), resultCode)
     }
 
-    @KotlinCleanup("make data non-null")
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
-        if (resultCode != Activity.RESULT_CANCELED && requestCode == ACTIVITY_SELECT_AUDIO_CLIP) {
-            executeSafe(mActivity, "handleMediaSelection:unhandled") {
-                handleMediaSelection(data!!)
-            }
-        }
-        if (resultCode != Activity.RESULT_CANCELED && requestCode == ACTIVITY_SELECT_VIDEO_CLIP) {
-            executeSafe(mActivity, "handleMediaSelection:unhandled") {
-                handleMediaSelection(data!!)
+        if (resultCode != Activity.RESULT_CANCELED) {
+            when (requestCode) {
+                ACTIVITY_SELECT_AUDIO_CLIP, ACTIVITY_SELECT_VIDEO_CLIP -> data?.let { handleMediaSelection(it) }
             }
         }
     }


### PR DESCRIPTION

## Fixes
- Made data not null in the BasicMediaClipFieldController.kt file

## Approach
I moved the null check for "resultCode" and "requestCode" before calling the "handleMediaSelection" method to avoid unnecessary calls. 

## How Has This Been Tested?
- Tests

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [x] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
