### PR TITLE
fix(ScopedStorage): destination has empty file

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/scopedstorage/MoveFile.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/scopedstorage/MoveFile.kt
@@ -39,7 +39,7 @@ import java.io.File
  */
 internal data class MoveFile(val sourceFile: DiskFile, val destinationFile: File) : Operation() {
     override fun execute(context: MigrationContext): List<Operation> {
-        val destinationExists = destinationFile.exists()
+        var destinationExists = destinationFile.exists()
 
         if (destinationExists && destinationFile.isDirectory) {
             context.reportError(
@@ -54,6 +54,14 @@ internal data class MoveFile(val sourceFile: DiskFile, val destinationFile: File
 
         if (handledEquivalentFileContent(destinationExists, context)) {
             return operationCompleted()
+        }
+
+        // destination exists, does NOT match content, and is 0-length
+        // delete it and let the transfer occur again.
+        if (destinationExists && destinationFile.length() == 0L) {
+            // TODO: #13170 - extend this for when destinationFile is an exact subset of sourceFile
+            destinationExists = !destinationFile.delete()
+            Timber.w("(conflict) Deleted empty file in destination. Deletion result: %b", destinationExists)
         }
 
         // destination exists, and does NOT match content: throw an exception


### PR DESCRIPTION
Bug occurred with a test of a migration of the AnKing deck.

Likely due to a reset of the phone, an empty file was produced and the 'real' file went to the 'conflict' file in the source directory. This issue was theorised about, and was a personal TODO, let's get it fixed.

This fixes one part of #13170, and gets the logic in place for the remainder of the fix

```
DEST
e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855  paste-178541790495174.jpg
-rw-rw---- 1 u0_a148 ext_data_rw 0 2023-01-30 22:58 paste-178541790495174.jpg

SOURCE
c429ab2472c70d11254d4834bf4addc311447fe33c629ca07b7068eb6039d87d  paste-178541790495174.jpg
-rw-rw---- 1 u0_a141 media_rw 13052 2023-01-30 22:58 paste-178541790495174.jpg
```

## How Has This Been Tested?

Unit test added

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
