### PR TITLE
Enable "None" in the gesture list to be translated

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/ui/GesturePicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/ui/GesturePicker.kt
@@ -88,7 +88,7 @@ constructor(ctx: Context, attributeSet: AttributeSet? = null, defStyleAttr: Int 
 
     inner class GestureWrapper(val gesture: Gesture?) {
         override fun toString(): String {
-            return gesture?.toDisplayString(context) ?: "None"
+            return gesture?.toDisplayString(context) ?: resources.getString(R.string.gestures_none)
         }
 
         override fun equals(other: Any?): Boolean {

--- a/AnkiDroid/src/main/res/values/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values/10-preferences.xml
@@ -76,6 +76,7 @@
     <string name="gestures_corner_touch_summary">Allow touch gestures in screen corners</string>
     <string name="gestures_full_screen_nav_drawer" maxLength="41">Full screen navigation drawer</string>
     <string name="gestures_fullscreen_nav_drawer_summary">Open navigation drawer when swiped right from anywhere on the screen</string>
+    <string name="gestures_none" maxLength="41">None</string>
     <string name="gestures_swipe_up" maxLength="41">Swipe up</string>
     <string name="gestures_swipe_down" maxLength="41">Swipe down</string>
     <string name="gestures_swipe_left" maxLength="41">Swipe left</string>


### PR DESCRIPTION
 ## Pull Request template

## Purpose / Description
Currently, it is impossible to replace "None" in the gesture list with other languages.
![image](https://user-images.githubusercontent.com/10436072/215961661-9836ed81-4ce4-4e66-bca0-32e0c6354716.png)
(`Settings` -> `Controls` -> (`Enable gestures`) -> one of the items of `Command mapping` -> `Add gesture`　-> Open the dropdown list)

https://github.com/ankidroid/Anki-Android/blob/3c379007d2e7a8905808df3bd589e10ef39a08d2/AnkiDroid/src/main/java/com/ichi2/ui/GesturePicker.kt#L89-L91

This commit enables translating it  into other languages.

## Fixes
n/a

## Approach

 - Add a new string for "None" in the gesture list, in 10-preferences.xml

 - Use the translatable string instead of current untranslatable code, in GesturePicker.kt

## How Has This Been Tested?
Tested on a physical device
![image](https://user-images.githubusercontent.com/10436072/215964945-812d3724-4b24-478c-ad6f-8a3e65789e30.png)

Checked that the new string is surely reflected on the screen
![image](https://user-images.githubusercontent.com/10436072/215971935-60a9c5cf-fb4e-44c0-a546-80d4fec53a95.png)
![image](https://user-images.githubusercontent.com/10436072/215970496-ba2e454f-c3fc-4bf0-a615-9c3a07a887de.png)

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] ~~You have commented your code, particularly in hard-to-understand areas~~
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] ~~UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)~~
