### PR TITLE
Remove enableJetifier config

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -15,9 +15,6 @@ org.gradle.jvmargs=-Xmx2560M -Dfile.encoding=UTF-8
 # Android operating system, and which are packaged with your app's APK
 # https://developer.android.com/topic/libraries/support-library/androidx-rn
 android.useAndroidX=true
-# Automatically convert third-party libraries to use AndroidX
-# Needed until material dialogs is updated: https://github.com/ankidroid/Anki-Android/issues/5225
-android.enableJetifier=true
 
 # With de-coupled gradle sub-modules, they may run in parallel
 org.gradle.parallel=true


### PR DESCRIPTION
It should had been removed when #5225 was fixed, as it isn't necessary anymore

Doing Android Studio's check confirms that no dependencies needs it currently

## How Has This Been Tested?

Built the app

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
