### PR TITLE
alert user before resetting app bar buttons

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/CustomButtonsSettingsFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/CustomButtonsSettingsFragment.kt
@@ -31,6 +31,9 @@ class CustomButtonsSettingsFragment : SettingsFragment() {
         get() = "prefs.custom_buttons"
 
     override fun initSubscreen() {
+
+        //checking commit
+
         // Reset toolbar button customizations
         val resetCustomButtons = requirePreference<Preference>("reset_custom_buttons")
         resetCustomButtons.onPreferenceClickListener = Preference.OnPreferenceClickListener {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/CustomButtonsSettingsFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/CustomButtonsSettingsFragment.kt
@@ -18,6 +18,7 @@ package com.ichi2.anki.preferences
 import android.content.Context
 import android.content.Intent
 import androidx.annotation.VisibleForTesting
+import androidx.appcompat.app.AlertDialog
 import androidx.core.content.edit
 import androidx.preference.Preference
 import androidx.preference.PreferenceCategory
@@ -37,30 +38,40 @@ class CustomButtonsSettingsFragment : SettingsFragment() {
         // Reset toolbar button customizations
         val resetCustomButtons = requirePreference<Preference>("reset_custom_buttons")
         resetCustomButtons.onPreferenceClickListener = Preference.OnPreferenceClickListener {
-            AnkiDroidApp.getSharedPrefs(requireContext()).edit {
-                remove("customButtonUndo")
-                remove("customButtonScheduleCard")
-                remove("customButtonEditCard")
-                remove("customButtonTags")
-                remove("customButtonAddCard")
-                remove("customButtonReplay")
-                remove("customButtonCardInfo")
-                remove("customButtonSelectTts")
-                remove("customButtonDeckOptions")
-                remove("customButtonMarkCard")
-                remove("customButtonToggleMicToolBar")
-                remove("customButtonBury")
-                remove("customButtonSuspend")
-                remove("customButtonFlag")
-                remove("customButtonDelete")
-                remove("customButtonEnableWhiteboard")
-                remove("customButtonSaveWhiteboard")
-                remove("customButtonWhiteboardPenColor")
-                remove("customButtonClearWhiteboard")
-                remove("customButtonShowHideWhiteboard")
-            }
-            // #9263: refresh the screen to display the changes
-            refreshScreen()
+
+            //adding an alert dialog box------------------
+            AlertDialog.Builder(requireContext())
+                .setTitle("Confirm Reset")
+                .setMessage("Click 'RESET' to proceed with the reset changes.(You can change again later) ")
+                .setPositiveButton("RESET") { _, _ ->
+                    AnkiDroidApp.getSharedPrefs(requireContext()).edit {
+                        remove("customButtonUndo")
+                        remove("customButtonScheduleCard")
+                        remove("customButtonEditCard")
+                        remove("customButtonTags")
+                        remove("customButtonAddCard")
+                        remove("customButtonReplay")
+                        remove("customButtonCardInfo")
+                        remove("customButtonSelectTts")
+                        remove("customButtonDeckOptions")
+                        remove("customButtonMarkCard")
+                        remove("customButtonToggleMicToolBar")
+                        remove("customButtonBury")
+                        remove("customButtonSuspend")
+                        remove("customButtonFlag")
+                        remove("customButtonDelete")
+                        remove("customButtonEnableWhiteboard")
+                        remove("customButtonSaveWhiteboard")
+                        remove("customButtonWhiteboardPenColor")
+                        remove("customButtonClearWhiteboard")
+                        remove("customButtonShowHideWhiteboard")
+                    }
+                    // #9263: refresh the screen to display the changes
+                    refreshScreen()
+                }
+                .setNegativeButton("cancel") { _, _ ->
+
+                }.show()
             true
         }
     }


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
added alert dialog box before resetting the app bar buttons

## Fixes
added working alert dialog box for verification

## Approach
this asks the user for confirmation if they want to reset the button settings to default

## How Has This Been Tested?
video proof

https://user-images.githubusercontent.com/96579549/216095687-ebdb8844-b74f-4834-9a76-c573de014d76.mp4



## Learning (optional, can help others)
_Describe the research stage_

_Links to blog posts, patterns, libraries or addons used to solve this problem_

## Checklist
_Please, go through these checks before submitting the PR._

- [ ] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas
- [ ] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
