### PR TITLE
Allow to restore default value in AnkiDroid directory settings

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/AdvancedSettingsFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/AdvancedSettingsFragment.kt
@@ -22,6 +22,8 @@ import android.content.pm.PackageManager
 import androidx.annotation.StringRes
 import androidx.appcompat.app.AlertDialog
 import androidx.preference.*
+import androidx.preference.Preference
+import androidx.preference.SwitchPreference
 import com.ichi2.anki.*
 import com.ichi2.anki.CollectionManager.withCol
 import com.ichi2.anki.R
@@ -30,6 +32,7 @@ import com.ichi2.anki.provider.CardContentProvider
 import com.ichi2.anki.servicelayer.ScopedStorageService
 import com.ichi2.anki.snackbar.showSnackbar
 import com.ichi2.compat.CompatHelper
+import com.ichi2.preferences.EditTextPreferenceWithDefault
 import com.ichi2.utils.show
 import net.ankiweb.rsdroid.BackendFactory
 import net.ankiweb.rsdroid.RustCleanup
@@ -49,8 +52,9 @@ class AdvancedSettingsFragment : SettingsFragment() {
         removeUnnecessaryAdvancedPrefs()
 
         // Check that input is valid before committing change in the collection path
-        requirePreference<EditTextPreference>(CollectionHelper.PREF_COLLECTION_PATH).apply {
+        requirePreference<EditTextPreferenceWithDefault>(CollectionHelper.PREF_COLLECTION_PATH).apply {
             disableIfStorageMigrationInProgress()
+            setDefaultValue(CollectionHelper.getDefaultAnkiDroidDirectory(requireContext()))
             setOnPreferenceChangeListener { _, newValue: Any? ->
                 val newPath = newValue as String
                 try {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/PreferenceUtils.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/PreferenceUtils.kt
@@ -18,6 +18,7 @@ package com.ichi2.anki.preferences
 import androidx.annotation.StringRes
 import androidx.preference.Preference
 import androidx.preference.PreferenceFragmentCompat
+import com.ichi2.utils.getJavaFieldAsAccessible
 
 /**
  * Sets the callback to be invoked when this preference is changed by the user
@@ -49,4 +50,8 @@ inline fun <reified T : Preference> PreferenceFragmentCompat.requirePreference(k
 inline fun <reified T : Preference> PreferenceFragmentCompat.requirePreference(@StringRes resId: Int): T {
     val key = getString(resId)
     return requirePreference(key)
+}
+
+fun Preference.getDefaultValue(): Any? {
+    return getJavaFieldAsAccessible(Preference::class.java, "mDefaultValue").get(this)
 }

--- a/AnkiDroid/src/main/java/com/ichi2/preferences/EditTextPreferenceWithDefault.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/preferences/EditTextPreferenceWithDefault.kt
@@ -1,0 +1,58 @@
+/****************************************************************************************
+ * Copyright (c) 2023 Arthur Milchior <arthur@milchior.fr>                              *
+ *                                                                                      *
+ * This program is free software; you can redistribute it and/or modify it under        *
+ * the terms of the GNU General Public License as published by the Free Software        *
+ * Foundation; either version 3 of the License, or (at your option) any later           *
+ * version.                                                                             *
+ *                                                                                      *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *                                                                                      *
+ * You should have received a copy of the GNU General Public License along with         *
+ * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ ****************************************************************************************/
+
+package com.ichi2.preferences
+
+import android.app.Dialog
+import android.content.Context
+import android.content.DialogInterface
+import android.os.Bundle
+import android.util.AttributeSet
+import androidx.appcompat.app.AlertDialog
+import androidx.preference.EditTextPreference
+import androidx.preference.EditTextPreferenceDialogFragmentCompat
+import com.ichi2.anki.R
+import com.ichi2.anki.preferences.getDefaultValue
+
+/**
+ * Similar to EditTextPreference, but add an extra default button.
+ * The default value should be set explicitly.
+ */
+class EditTextPreferenceWithDefault(
+    context: Context,
+    attrs: AttributeSet? = null
+) : EditTextPreference(context, attrs), DialogFragmentProvider {
+
+    class EditTextPreferenceWithResetButtonDialogFragmentCompat(val preference: EditTextPreferenceWithDefault) : EditTextPreferenceDialogFragmentCompat() {
+
+        @Override
+        override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
+            val dialog = super.onCreateDialog(savedInstanceState) as AlertDialog
+            dialog.setButton(DialogInterface.BUTTON_NEUTRAL, getString(R.string.reset_custom_buttons)) {
+                    _: DialogInterface, _: Int ->
+                val defaultValue = preference.getDefaultValue() as String?
+                val changeSucceeded = preference.callChangeListener(defaultValue)
+                if (changeSucceeded) {
+                    preference.text = defaultValue
+                }
+            }
+
+            return dialog
+        }
+    }
+    override fun makeDialogFragment() =
+        EditTextPreferenceWithResetButtonDialogFragmentCompat(this)
+}

--- a/AnkiDroid/src/main/java/com/ichi2/utils/ReflectionUtils.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/ReflectionUtils.kt
@@ -15,6 +15,19 @@
  */
 package com.ichi2.utils
 
+import java.lang.reflect.Field
+
 inline fun <reified T> getInstanceFromClassName(javaClassName: String): T {
     return Class.forName(javaClassName).newInstance() as T
+}
+
+/**
+ * @param clazz Java class to get the field
+ * @param fieldName name of the field
+ * @return a [Field] object with `isAccessible` set to true
+ */
+fun getJavaFieldAsAccessible(clazz: Class<*>, fieldName: String): Field {
+    return clazz.getDeclaredField(fieldName).apply {
+        isAccessible = true
+    }
 }

--- a/AnkiDroid/src/main/res/xml/preferences_advanced.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_advanced.xml
@@ -27,7 +27,7 @@
     xmlns:search="http://schemas.android.com/apk/com.bytehamster.lib.preferencesearch"
     android:title="@string/pref_cat_advanced"
     android:key="@string/pref_advanced_screen_key">
-        <EditTextPreference
+        <com.ichi2.preferences.EditTextPreferenceWithDefault
             android:defaultValue="/sdcard/AnkiDroid"
             android:key="@string/pref_ankidroid_directory_key"
             android:title="@string/col_path"

--- a/AnkiDroid/src/test/java/com/ichi2/anki/preferences/PreferenceUtilsTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/preferences/PreferenceUtilsTest.kt
@@ -1,0 +1,43 @@
+/*
+ *  Copyright (c) 2023 Brayan Oliveira <brayandso.dev@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.ichi2.anki.preferences
+
+import androidx.preference.Preference
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.ichi2.anki.RobolectricTest
+import com.ichi2.testutils.EmptyApplication
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+import kotlin.test.assertEquals
+
+@RunWith(AndroidJUnit4::class)
+@Config(application = EmptyApplication::class)
+class PreferenceUtilsTest : RobolectricTest() {
+
+    /**
+     * check if the method works correctly and doesn't throw,
+     * just in case AOSP changes the field name, as this method uses reflection
+     */
+    @Test
+    fun getDefaultValue_test() {
+        val defaultValue = "foo"
+        val pref = Preference(targetContext).apply {
+            setDefaultValue(defaultValue)
+        }
+        assertEquals(defaultValue, pref.getDefaultValue())
+    }
+}


### PR DESCRIPTION
As suggested by @BrayanDSO in #13153, it's better to have the button in the dialog than to have an extra one.

Manually tested, it indeed put back the folder to its default value.

Ping @ParthTagalpallewar

Fix: #13150
![2023-02-05-081512_425x767_scrot](https://user-images.githubusercontent.com/357361/216806652-a77f1e62-b278-4157-b34d-152e45a20d6d.png)
