### PR TITLE
build(deps): revert apache commons-compress to API21-compatible version

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -283,7 +283,6 @@ dependencies {
     implementation 'androidx.sqlite:sqlite-framework:2.2.0'
     implementation 'androidx.swiperefreshlayout:swiperefreshlayout:1.1.0'
     implementation 'androidx.viewpager2:viewpager2:1.0.0'
-    // noinspection GradleDependency - pinned at 1.12 until API26 minSdkVersion (File.toPath usage)
     implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
     implementation 'androidx.webkit:webkit:1.5.0'
     // Note: the design support library can be quite buggy, so test everything thoroughly before updating it
@@ -325,7 +324,7 @@ dependencies {
     // io.github.java-diff-utils:java-diff-utils is the natural successor here, but requires API24, #7091
     implementation 'org.bitbucket.cowwoc:diff-match-patch:1.2'
     // noinspection GradleDependency - commons-compress 1.12 - later versions use `File.toPath`; API26 can remove?
-    implementation 'org.apache.commons:commons-compress:1.22' // #6419 - handle >2GB apkg files
+    implementation 'org.apache.commons:commons-compress:1.12' // #6419 - handle >2GB apkg files
     implementation 'org.apache.commons:commons-collections4:4.4' // SetUniqueList
     implementation 'commons-io:commons-io:2.11.0' // FileUtils.contentEquals
     implementation 'net.mikehardy:google-analytics-java7:2.0.13'


### PR DESCRIPTION

## Pull Request template

## Purpose / Description

This was my fault previously on a dependency updates run, I let it slip into a version range with a known incompatibility that I even left a comment for!

## Fixes
Unlogged - I chatted about it on discord quite a while back and at least one other person reproduced though. Finally getting around to fixing it

## Approach
Just reverts the version pin to the one in place before I incorrectly moved it to a version that requires minSdkVersion 26+

## How Has This Been Tested?

Start an API21 emulator and run `./gradlew jacocoAndroidTestReport` - that is enough to trigger the issue and to show it works with commons-compress at 1.12 again

## Learning (optional, can help others)
Even if I leave a comment for myself I sometimes just don't see it and make a mistake


## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
