### PR TITLE
Default path to a `files/` subfolder

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CollectionHelper.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CollectionHelper.kt
@@ -453,7 +453,7 @@ open class CollectionHelper {
         @CheckResult
         fun getDefaultAnkiDroidDirectory(context: Context): String {
             return if (!BuildConfig.LEGACY_STORAGE) {
-                getAppSpecificExternalAnkiDroidDirectory(context)
+                File(getAppSpecificExternalAnkiDroidDirectory(context), "AnkiDroid").absolutePath
             } else {
                 legacyAnkiDroidDirectory
             }


### PR DESCRIPTION
## Fixes
Fixes #13169

## Approach
Change the `getDefaultAnkiDroidDirectory` method

## How Has This Been Tested?

1. Installed the app
2. Check if the collection is on a subfolder of `files/` at the AnkIDroid directory preference

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
