### PR TITLE
Solve `onPreferenceStartFragment` warning

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/Preferences.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/Preferences.kt
@@ -32,6 +32,7 @@ import androidx.core.content.edit
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentManager
 import androidx.fragment.app.commit
+import androidx.preference.Preference
 import androidx.preference.PreferenceFragmentCompat
 import com.bytehamster.lib.preferencesearch.SearchConfiguration
 import com.bytehamster.lib.preferencesearch.SearchPreferenceFragment
@@ -51,7 +52,10 @@ import java.util.*
 /**
  * Preferences dialog.
  */
-class Preferences : AnkiActivity(), SearchPreferenceResultListener {
+class Preferences :
+    AnkiActivity(),
+    PreferenceFragmentCompat.OnPreferenceStartFragmentCallback,
+    SearchPreferenceResultListener {
     val searchConfiguration: SearchConfiguration by lazy { configureSearchBar() }
     lateinit var searchView: PreferencesSearchView
 
@@ -111,6 +115,21 @@ class Preferences : AnkiActivity(), SearchPreferenceResultListener {
         searchView.searchConfiguration = searchConfiguration
 
         return super.onCreateOptionsMenu(menu)
+    }
+
+    override fun onPreferenceStartFragment(
+        caller: PreferenceFragmentCompat,
+        pref: Preference
+    ): Boolean {
+        val fragment = supportFragmentManager.fragmentFactory.instantiate(
+            classLoader, pref.fragment!!
+        )
+        fragment.arguments = pref.extras
+        supportFragmentManager.commit {
+            replace(R.id.settings_container, fragment)
+            addToBackStack(null)
+        }
+        return true
     }
 
     /**


### PR DESCRIPTION
To solve the following warning

> PreferenceFragment      com.ichi2.anki.debug                 W  onPreferenceStartFragment is not implemented in the parent activity - attempting to use a fallback implementation. You should implement this method so that you can configure the new fragment that will be displayed, and set a transition between the fragments.

## Approach
Add `onPreferenceStartFragment` to `Preferences` activity, following https://developer.android.com/develop/ui/views/components/settings/organize-your-settings

## How Has This Been Tested?

- Go to settings
- Start opening the preference screens

## Learning (optional, can help others)
https://developer.android.com/develop/ui/views/components/settings/organize-your-settings

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
