### PR TITLE
Removed monochrome launcher from lint-release.

### DIFF
--- a/lint-release.xml
+++ b/lint-release.xml
@@ -63,9 +63,6 @@
     <issue id="ImplicitSamInstance" severity="fatal" />
     <issue id="DrawAllocation" severity="fatal" />
 
-    <!-- new with AGP7.4+, tracking in https://github.com/ankidroid/Anki-Android/issues/13197 -->
-    <issue id="MonochromeLauncherIcon" severity="ignore" />
-
     <!-- this is new with AGP7.1+, does not appear to create value -->
     <issue id="IntentFilterUniqueDataAttributes" severity="ignore" />
 


### PR DESCRIPTION
## Purpose / Description
Removes unused lint rule.

## Fixes
https://github.com/ankidroid/Anki-Android/issues/13197

## How Has This Been Tested?
I tried building the project & encountered no warnings or errors.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented on your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
