### PR TITLE
added check which rejects new notes with empty first field

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
@@ -698,6 +698,10 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
                 displayErrorSavingNote()
                 return
             }
+            if (getCurrentFieldText(0).isEmpty()) {
+                displayErrorSavingNote()
+                return
+            }
 
             // load all of the fields into the note
             for (f in mEditFields!!) {


### PR DESCRIPTION
## Pull Request template
Empty card issue

## Purpose / Description
Placed a check to not allow empty cards from getting saved by checking the first edit text field and showing a toast respectively

## Fixes
Fixes #13240

## Approach
Placed a check

## How Has This Been Tested?
Tested on OnePlus Nord CE
![Screenshot_40](https://user-images.githubusercontent.com/48384865/218307865-f4f8e545-c6cf-4082-bb98-3650e2245cbf.png)


## Learning (optional, can help others)
_Describe the research stage_

_Links to blog posts, patterns, libraries or addons used to solve this problem_

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
