### PR TITLE
Dynamically add cloze icon to note editor toolbar

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
@@ -1689,7 +1689,6 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
             toolbar.visibility = View.VISIBLE
         }
         toolbar.clearCustomItems()
-        val clozeIcon = toolbar.clozeIcon
         if (mEditorNote!!.model().isCloze) {
             val clozeFormatter = Toolbar.TextFormatter { s: String ->
                 val stringFormat = Toolbar.StringFormat()
@@ -1704,10 +1703,11 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
                 }
                 stringFormat
             }
-            clozeIcon!!.setOnClickListener { toolbar.onFormat(clozeFormatter) }
-            clozeIcon.visibility = View.VISIBLE
-        } else {
-            clozeIcon!!.visibility = View.GONE
+
+            val clozeDrawable = ResourcesCompat.getDrawable(resources, R.drawable.ic_cloze_black_24dp, null)
+            clozeDrawable!!.setTint(Themes.getColorFromAttr(this@NoteEditor, R.attr.toolbarIconColor))
+            val clozeButton = toolbar.insertItem(0, clozeDrawable, Runnable { toolbar.onFormat(clozeFormatter) })
+            clozeButton.contentDescription = resources.getString(R.string.insert_cloze)
         }
         val buttons = toolbarButtons
         for (b in buttons) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/noteeditor/Toolbar.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/noteeditor/Toolbar.kt
@@ -68,14 +68,6 @@ class Toolbar : FrameLayout {
     private val mCustomButtons: MutableList<View> = ArrayList()
     private val mRows: MutableList<LinearLayout> = ArrayList()
 
-    /**
-     * TODO HACK until API 21 - can be removed once tested.
-     *
-     * inside NoteEditor: use [insertItem] instead of accessing this
-     * and remove [R.id.note_editor_toolbar_button_cloze] from [R.layout.note_editor_toolbar]
-     */
-    var clozeIcon: View? = null
-        private set
     private var mStringPaint: Paint? = null
 
     constructor(context: Context) : super(context)
@@ -92,7 +84,6 @@ class Toolbar : FrameLayout {
         }
         mToolbar = findViewById(R.id.editor_toolbar_internal)
         mToolbarLayout = findViewById(R.id.toolbar_layout)
-        clozeIcon = findViewById(R.id.note_editor_toolbar_button_cloze)
         setupDefaultButtons()
     }
 

--- a/AnkiDroid/src/main/res/layout/note_editor_toolbar.xml
+++ b/AnkiDroid/src/main/res/layout/note_editor_toolbar.xml
@@ -99,16 +99,6 @@
             app:srcCompat="@drawable/ic_add_equation_black_24dp"
             android:tag="m"
             style="@style/note_editor_toolbar_button" />
-
-        <!-- We can't dynamically add this on API 16,
-         which is a shame, as we need the note editor to know the cloze ordinal
-         so make it invisible and bring it back and add the listener when appropriate -->
-        <androidx.appcompat.widget.AppCompatImageButton
-            android:id="@+id/note_editor_toolbar_button_cloze"
-            android:visibility="gone"
-            android:contentDescription="@string/insert_cloze"
-            app:srcCompat="@drawable/ic_cloze_black_24dp"
-            style="@style/note_editor_toolbar_button" />
     </LinearLayout>
     </LinearLayout>
 </HorizontalScrollView>


### PR DESCRIPTION
## Purpose / Description
This PR removes the workaround used  to dynamically hide/show the cloze button depending on the card type.

## Fixes
Fixes #7851

## Approach
As described in the TODO comment, toolbar.insertItem is used to insert the cloze button when it is needed.

## How Has This Been Tested?

Tested on physical Pixel 2 SDK 30 (Android 11).
- Button appears on Cloze card type and does not appear on Basic card type.
- Button adds cloze deletions with correct numbering and cursor position with both cursor and selection
- Button has correct color on Light, Plain, Dark, and Black themes.
- Accessibility text to speech reads button contentDescription

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
N/A because of small diff
- [X] You have performed a self-review of your own code
- [X] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
![Screenshot_20230213-020527](https://user-images.githubusercontent.com/8166212/218392877-5dfef244-2f78-42e0-9169-7c1d06392591.png)
- [X] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
Recommends larger clickable area for all the toolbar buttons, which I believe is out of scope for this PR. It also recommends the "Add toolbar item" button have a contentDescription set, which should be quite simple, but I did not want to pollute the PR with unrelated changes.