### PR TITLE
Improve accessibility and styling of note editor toolbar

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
@@ -44,6 +44,7 @@ import androidx.annotation.VisibleForTesting
 import androidx.appcompat.view.menu.MenuBuilder
 import androidx.appcompat.widget.AppCompatButton
 import androidx.appcompat.widget.PopupMenu
+import androidx.appcompat.widget.TooltipCompat
 import androidx.core.content.edit
 import androidx.core.content.res.ResourcesCompat
 import androidx.core.text.HtmlCompat
@@ -1708,6 +1709,7 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
             clozeDrawable!!.setTint(Themes.getColorFromAttr(this@NoteEditor, R.attr.toolbarIconColor))
             val clozeButton = toolbar.insertItem(0, clozeDrawable, Runnable { toolbar.onFormat(clozeFormatter) })
             clozeButton.contentDescription = resources.getString(R.string.insert_cloze)
+            TooltipCompat.setTooltipText(clozeButton, resources.getString(R.string.insert_cloze))
         }
         val buttons = toolbarButtons
         for (b in buttons) {
@@ -1720,6 +1722,7 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
             }
             val bmp = toolbar.createDrawableForString(text)
             val v = toolbar.insertItem(0, bmp, b.toFormatter())
+            v.contentDescription = text
 
             // Allow Ctrl + 1...Ctrl + 0 for item 10.
             v.tag = (visualIndex % 10).toString()
@@ -1733,7 +1736,9 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
         // Sets the add custom tag icon color.
         val drawable = ResourcesCompat.getDrawable(resources, R.drawable.ic_add_toolbar_icon, null)
         drawable!!.setTint(Themes.getColorFromAttr(this@NoteEditor, R.attr.toolbarIconColor))
-        toolbar.insertItem(0, drawable, Runnable { displayAddToolbarDialog() })
+        val addButton = toolbar.insertItem(0, drawable, Runnable { displayAddToolbarDialog() })
+        addButton.contentDescription = resources.getString(R.string.add_toolbar_item)
+        TooltipCompat.setTooltipText(addButton, resources.getString(R.string.add_toolbar_item))
     }
 
     private val toolbarButtons: ArrayList<CustomToolbarButton>

--- a/AnkiDroid/src/main/java/com/ichi2/anki/noteeditor/Toolbar.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/noteeditor/Toolbar.kt
@@ -105,7 +105,9 @@ class Toolbar : FrameLayout {
         findViewById<View>(R.id.note_editor_toolbar_button_title).setOnClickListener { displayInsertHeadingDialog() }
 
         val parentLayout = findViewById<LinearLayout>(R.id.editor_toolbar_internal)
-        CompatHelper.compat.addTooltipTextsFromContentDescription(parentLayout.children)
+        parentLayout.children.forEach { child ->
+            CompatHelper.compat.setTooltipTextByContentDescription(child)
+        }
     }
 
     /**

--- a/AnkiDroid/src/main/java/com/ichi2/anki/noteeditor/Toolbar.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/noteeditor/Toolbar.kt
@@ -26,6 +26,7 @@ import android.graphics.drawable.BitmapDrawable
 import android.graphics.drawable.Drawable
 import android.util.AttributeSet
 import android.util.DisplayMetrics
+import android.util.TypedValue
 import android.view.*
 import android.widget.FrameLayout
 import android.widget.LinearLayout
@@ -148,7 +149,7 @@ class Toolbar : FrameLayout {
         val context = context
         val button = AppCompatImageButton(context)
         button.id = id
-        button.background = drawable
+        button.setImageDrawable(drawable)
 
         /*
             Style didn't work
@@ -158,10 +159,13 @@ class Toolbar : FrameLayout {
         */
 
         // apply style
-        val margin = convertDpToPixel(8F, context).toInt()
-        val params = LinearLayout.LayoutParams(ViewGroup.LayoutParams.WRAP_CONTENT, ViewGroup.LayoutParams.WRAP_CONTENT)
+        val background = TypedValue()
+        context.theme.resolveAttribute(android.R.attr.selectableItemBackground, background, true)
+        button.setBackgroundResource(background.resourceId)
+        // Use layout size from R.style.note_editor_toolbar_button
+        val layoutSize = convertDpToPixel(44F, context).toInt()
+        val params = LinearLayout.LayoutParams(layoutSize, layoutSize)
         params.gravity = Gravity.CENTER
-        params.setMargins(margin, margin / 2, margin, margin / 2)
         button.layoutParams = params
         val twoDp = ceil((2 / context.resources.displayMetrics.density).toDouble()).toInt()
         button.setPadding(twoDp, twoDp, twoDp, twoDp)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/noteeditor/Toolbar.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/noteeditor/Toolbar.kt
@@ -34,7 +34,6 @@ import androidx.annotation.ColorInt
 import androidx.annotation.DrawableRes
 import androidx.annotation.IdRes
 import androidx.appcompat.widget.AppCompatImageButton
-import androidx.appcompat.widget.TooltipCompat
 import androidx.core.view.children
 import androidx.vectordrawable.graphics.drawable.VectorDrawableCompat
 import com.afollestad.materialdialogs.MaterialDialog
@@ -43,6 +42,7 @@ import com.ichi2.anki.AnkiDroidApp
 import com.ichi2.anki.NoteEditor
 import com.ichi2.anki.R
 import com.ichi2.anki.UIUtils.convertDpToPixel
+import com.ichi2.compat.CompatHelper
 import com.ichi2.libanki.Utils
 import com.ichi2.utils.ViewGroupUtils
 import com.ichi2.utils.ViewGroupUtils.getAllChildrenRecursive
@@ -104,16 +104,8 @@ class Toolbar : FrameLayout {
         findViewById<View>(R.id.note_editor_toolbar_button_font_size).setOnClickListener { displayFontSizeDialog() }
         findViewById<View>(R.id.note_editor_toolbar_button_title).setOnClickListener { displayInsertHeadingDialog() }
 
-        /**
-         * TODO Redundant workaround until API 26
-         * We can't use XML attributes to set tooltip text on API 21
-         * This method can be completely removed after a minSDKVersion bump to API 26 since it is
-         * redundant with the android:tooltipText attribute in [R.layout.note_editor_toolbar]
-         */
         val parentLayout = findViewById<LinearLayout>(R.id.editor_toolbar_internal)
-        for (button in parentLayout.children) {
-            TooltipCompat.setTooltipText(button, button.contentDescription)
-        }
+        CompatHelper.compat.addTooltipText(parentLayout.children)
     }
 
     /**

--- a/AnkiDroid/src/main/java/com/ichi2/anki/noteeditor/Toolbar.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/noteeditor/Toolbar.kt
@@ -105,7 +105,7 @@ class Toolbar : FrameLayout {
         findViewById<View>(R.id.note_editor_toolbar_button_title).setOnClickListener { displayInsertHeadingDialog() }
 
         val parentLayout = findViewById<LinearLayout>(R.id.editor_toolbar_internal)
-        CompatHelper.compat.addTooltipText(parentLayout.children)
+        CompatHelper.compat.addTooltipTextsFromContentDescription(parentLayout.children)
     }
 
     /**
@@ -168,8 +168,8 @@ class Toolbar : FrameLayout {
         context.theme.resolveAttribute(android.R.attr.selectableItemBackground, background, true)
         button.setBackgroundResource(background.resourceId)
         // Use layout size from R.style.note_editor_toolbar_button
-        val layoutSize = convertDpToPixel(44F, context).toInt()
-        val params = LinearLayout.LayoutParams(layoutSize, layoutSize)
+        val buttonSize = convertDpToPixel(44F, context).toInt()
+        val params = LinearLayout.LayoutParams(buttonSize, buttonSize)
         params.gravity = Gravity.CENTER
         button.layoutParams = params
         val twoDp = ceil((2 / context.resources.displayMetrics.density).toDouble()).toInt()

--- a/AnkiDroid/src/main/java/com/ichi2/anki/noteeditor/Toolbar.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/noteeditor/Toolbar.kt
@@ -34,6 +34,8 @@ import androidx.annotation.ColorInt
 import androidx.annotation.DrawableRes
 import androidx.annotation.IdRes
 import androidx.appcompat.widget.AppCompatImageButton
+import androidx.appcompat.widget.TooltipCompat
+import androidx.core.view.children
 import androidx.vectordrawable.graphics.drawable.VectorDrawableCompat
 import com.afollestad.materialdialogs.MaterialDialog
 import com.afollestad.materialdialogs.list.listItems
@@ -101,6 +103,17 @@ class Toolbar : FrameLayout {
         setupButtonWrappingText(R.id.note_editor_toolbar_button_horizontal_rule, "<hr>", "")
         findViewById<View>(R.id.note_editor_toolbar_button_font_size).setOnClickListener { displayFontSizeDialog() }
         findViewById<View>(R.id.note_editor_toolbar_button_title).setOnClickListener { displayInsertHeadingDialog() }
+
+        /**
+         * TODO Redundant workaround until API 26
+         * We can't use XML attributes to set tooltip text on API 21
+         * This method can be completely removed after a minSDKVersion bump to API 26 since it is
+         * redundant with the android:tooltipText attribute in [R.layout.note_editor_toolbar]
+         */
+        val parentLayout = findViewById<LinearLayout>(R.id.editor_toolbar_internal)
+        for (button in parentLayout.children) {
+            TooltipCompat.setTooltipText(button, button.contentDescription)
+        }
     }
 
     /**

--- a/AnkiDroid/src/main/java/com/ichi2/compat/Compat.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/Compat.kt
@@ -74,7 +74,7 @@ import java.io.*
  */
 interface Compat {
     fun setupNotificationChannel(context: Context)
-    fun addTooltipTextsFromContentDescription(views: Sequence<View>)
+    fun setTooltipTextByContentDescription(view: View)
     fun setTime(picker: TimePicker, hour: Int, minute: Int)
     fun getHour(picker: TimePicker): Int
     fun getMinute(picker: TimePicker): Int

--- a/AnkiDroid/src/main/java/com/ichi2/compat/Compat.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/Compat.kt
@@ -74,7 +74,7 @@ import java.io.*
  */
 interface Compat {
     fun setupNotificationChannel(context: Context)
-    fun addTooltipText(views: Sequence<View>)
+    fun addTooltipTextsFromContentDescription(views: Sequence<View>)
     fun setTime(picker: TimePicker, hour: Int, minute: Int)
     fun getHour(picker: TimePicker): Int
     fun getMinute(picker: TimePicker): Int

--- a/AnkiDroid/src/main/java/com/ichi2/compat/Compat.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/Compat.kt
@@ -31,6 +31,7 @@ import android.os.Bundle
 import android.os.Parcel
 import android.os.Parcelable
 import android.util.SparseArray
+import android.view.View
 import android.widget.TimePicker
 import androidx.annotation.IntDef
 import java.io.*
@@ -73,6 +74,7 @@ import java.io.*
  */
 interface Compat {
     fun setupNotificationChannel(context: Context)
+    fun addTooltipText(views: Sequence<View>)
     fun setTime(picker: TimePicker, hour: Int, minute: Int)
     fun getHour(picker: TimePicker): Int
     fun getMinute(picker: TimePicker): Int

--- a/AnkiDroid/src/main/java/com/ichi2/compat/CompatV21.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/CompatV21.kt
@@ -51,10 +51,8 @@ open class CompatV21 : Compat {
     }
 
     // Until API26, tooltips cannot be defined declaratively in layouts
-    override fun addTooltipTextsFromContentDescription(views: Sequence<View>) {
-        for (view in views) {
-            TooltipCompat.setTooltipText(view, view.contentDescription)
-        }
+    override fun setTooltipTextByContentDescription(view: View) {
+        TooltipCompat.setTooltipText(view, view.contentDescription)
     }
 
     // Until API 23 the methods have "current" in the name

--- a/AnkiDroid/src/main/java/com/ichi2/compat/CompatV21.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/CompatV21.kt
@@ -51,7 +51,7 @@ open class CompatV21 : Compat {
     }
 
     // Until API26, tooltips cannot be defined declaratively in layouts
-    override fun addTooltipText(views: Sequence<View>) {
+    override fun addTooltipTextsFromContentDescription(views: Sequence<View>) {
         for (view in views) {
             TooltipCompat.setTooltipText(view, view.contentDescription)
         }

--- a/AnkiDroid/src/main/java/com/ichi2/compat/CompatV21.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/CompatV21.kt
@@ -35,7 +35,9 @@ import android.os.Parcelable
 import android.os.Vibrator
 import android.provider.MediaStore
 import android.util.SparseArray
+import android.view.View
 import android.widget.TimePicker
+import androidx.appcompat.widget.TooltipCompat
 import com.ichi2.utils.KotlinCleanup
 import timber.log.Timber
 import java.io.*
@@ -46,6 +48,13 @@ import java.io.*
 open class CompatV21 : Compat {
     // Until API26, ignore notification channels
     override fun setupNotificationChannel(context: Context) { /* pre-API26, do nothing */
+    }
+
+    // Until API26, tooltips cannot be defined declaratively in layouts
+    override fun addTooltipText(views: Sequence<View>) {
+        for (view in views) {
+            TooltipCompat.setTooltipText(view, view.contentDescription)
+        }
     }
 
     // Until API 23 the methods have "current" in the name

--- a/AnkiDroid/src/main/java/com/ichi2/compat/CompatV26.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/CompatV26.kt
@@ -41,7 +41,7 @@ open class CompatV26 : CompatV23(), Compat {
         NotificationChannels.setup(context)
     }
 
-    override fun addTooltipTextsFromContentDescription(views: Sequence<View>) { /* Nothing to do API26+ */
+    override fun setTooltipTextByContentDescription(view: View) { /* Nothing to do API26+ */
     }
 
     @Suppress("DEPRECATION")

--- a/AnkiDroid/src/main/java/com/ichi2/compat/CompatV26.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/CompatV26.kt
@@ -41,7 +41,7 @@ open class CompatV26 : CompatV23(), Compat {
         NotificationChannels.setup(context)
     }
 
-    override fun addTooltipText(views: Sequence<View>) { /* Nothing to do API26+ */
+    override fun addTooltipTextsFromContentDescription(views: Sequence<View>) { /* Nothing to do API26+ */
     }
 
     @Suppress("DEPRECATION")

--- a/AnkiDroid/src/main/java/com/ichi2/compat/CompatV26.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/CompatV26.kt
@@ -23,6 +23,7 @@ import android.media.AudioManager
 import android.media.AudioManager.OnAudioFocusChangeListener
 import android.os.VibrationEffect
 import android.os.Vibrator
+import android.view.View
 import androidx.annotation.VisibleForTesting
 import com.ichi2.anki.NotificationChannels
 import com.ichi2.utils.KotlinCleanup
@@ -38,6 +39,9 @@ open class CompatV26 : CompatV23(), Compat {
      */
     override fun setupNotificationChannel(context: Context) {
         NotificationChannels.setup(context)
+    }
+
+    override fun addTooltipText(views: Sequence<View>) { /* Nothing to do API26+ */
     }
 
     @Suppress("DEPRECATION")

--- a/AnkiDroid/src/main/res/layout/note_editor_toolbar.xml
+++ b/AnkiDroid/src/main/res/layout/note_editor_toolbar.xml
@@ -54,6 +54,7 @@
             android:id="@+id/note_editor_toolbar_button_bold"
             app:srcCompat="@drawable/ic_format_bold_black_24dp"
             android:contentDescription="@string/format_insert_bold"
+            android:tooltipText="@string/format_insert_bold"
             android:tag="b"
             style="@style/note_editor_toolbar_button" />
 
@@ -61,6 +62,7 @@
             android:id="@+id/note_editor_toolbar_button_italic"
             app:srcCompat="@drawable/ic_format_italic_black_24dp"
             android:contentDescription="@string/format_insert_italic"
+            android:tooltipText="@string/format_insert_italic"
             android:tag="i"
             style="@style/note_editor_toolbar_button" />
 
@@ -68,6 +70,7 @@
             android:id="@+id/note_editor_toolbar_button_underline"
             app:srcCompat="@drawable/ic_format_underlined_black_24dp"
             android:contentDescription="@string/format_insert_underline"
+            android:tooltipText="@string/format_insert_underline"
             android:tag="u"
             style="@style/note_editor_toolbar_button" />
 
@@ -75,6 +78,7 @@
             android:id="@+id/note_editor_toolbar_button_horizontal_rule"
             app:srcCompat="@drawable/ic_horizontal_rule_black_24dp"
             android:contentDescription="@string/insert_horizontal_line"
+            android:tooltipText="@string/insert_horizontal_line"
             android:tag="r"
             style="@style/note_editor_toolbar_button" />
 
@@ -82,12 +86,14 @@
             android:id="@+id/note_editor_toolbar_button_title"
             app:srcCompat="@drawable/ic_format_title_black_24dp"
             android:contentDescription="@string/insert_heading"
+            android:tooltipText="@string/insert_heading"
             android:tag="h"
             style="@style/note_editor_toolbar_button" />
 
         <androidx.appcompat.widget.AppCompatImageButton
             android:id="@+id/note_editor_toolbar_button_font_size"
             android:contentDescription="@string/format_font_size"
+            android:tooltipText="@string/format_font_size"
             app:srcCompat="@drawable/ic_format_font_size_24dp"
             android:tag="f"
             style="@style/note_editor_toolbar_button" />
@@ -96,6 +102,7 @@
         <androidx.appcompat.widget.AppCompatImageButton
             android:id="@+id/note_editor_toolbar_button_insert_mathjax"
             android:contentDescription="@string/insert_mathjax"
+            android:tooltipText="@string/insert_mathjax"
             app:srcCompat="@drawable/ic_add_equation_black_24dp"
             android:tag="m"
             style="@style/note_editor_toolbar_button" />


### PR DESCRIPTION
## Purpose / Description
The toolbar buttons have some styling and accessibility inconsistencies:
- They have no tooltips for new users to understand their purpose
- Custom buttons added by insertItem have no click animation and have a smaller clickable area
- As briefly mentioned in #13244, the "Add toolbar item" button does not have a contentDescription set

## Fixes
I could not find any open issue for these problems.

## Approach
- Add tooltips to all buttons with the exception of custom toolbar buttons since they already have a long click action
- Add contentDescription to all buttons for accessibility. For custom toolbar buttons, the button text is used.
- Resize the layout of insertItem buttons to match the other buttons (see Before screenshot)
- Add background animation on insertItem buttons

## How Has This Been Tested?
Tested on physical Pixel 2 SDK 30 (Android 11).

- Long clicking buttons results in tooltip
- Adding multiple custom buttons does not break the style
- Accessibility text to speech reads button descriptions, including custom buttons
- Clicking buttons created by insertItem results in a background animation, just like the other buttons.

## Screenshots
### Before (Google Accessibility Scanner)
Note the size of the clickable area
![Screenshot_20230213-115840](https://user-images.githubusercontent.com/8166212/218522550-6fd0acbf-a392-4e5c-b187-8b01a34691b7.png)

### After (Showing click animation and tooltip)
![Screenshot_20230213-114707](https://user-images.githubusercontent.com/8166212/218522651-59b17146-e537-42a6-8285-28e4abce7a9d.png)


## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [X] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [X] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
