### PR TITLE
fix getPackageInfo deprecation

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/provider/CardContentProvider.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/provider/CardContentProvider.kt
@@ -27,7 +27,9 @@ import android.net.Uri
 import android.webkit.MimeTypeMap
 import com.ichi2.anki.*
 import com.ichi2.anki.exception.ConfirmModSchemaException
+import com.ichi2.compat.CompatHelper.Companion.getPackageInfoCompat
 import com.ichi2.compat.CompatHelper.Companion.isMarshmallow
+import com.ichi2.compat.PackageInfoFlagsCompat
 import com.ichi2.libanki.*
 import com.ichi2.libanki.Collection
 import com.ichi2.libanki.Consts.BUTTON_TYPE
@@ -1268,12 +1270,11 @@ class CardContentProvider : ContentProvider() {
 
     /** Returns true if the calling package is known to be "rogue" and should be blocked.
      * Calling package might be rogue if it has not declared #READ_WRITE_PERMISSION in its manifest, or if blacklisted  */
-    @Suppress("deprecation") // getPackageInfo
     private fun knownRogueClient(): Boolean {
         val pm = context!!.packageManager
         return try {
-            val callingPi = pm.getPackageInfo(callingPackage!!, PackageManager.GET_PERMISSIONS)
-            if (callingPi?.requestedPermissions == null) {
+            val callingPi = pm.getPackageInfoCompat(callingPackage!!, PackageInfoFlagsCompat.of(PackageManager.GET_PERMISSIONS.toLong()))
+            if (callingPi.requestedPermissions == null) {
                 false
             } else !listOf(*callingPi.requestedPermissions).contains(FlashCardsContract.READ_WRITE_PERMISSION)
         } catch (e: PackageManager.NameNotFoundException) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/provider/CardContentProvider.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/provider/CardContentProvider.kt
@@ -1273,7 +1273,7 @@ class CardContentProvider : ContentProvider() {
     private fun knownRogueClient(): Boolean {
         val pm = context!!.packageManager
         return try {
-            val callingPi = pm.getPackageInfoCompat(callingPackage!!, PackageInfoFlagsCompat.of(PackageManager.GET_PERMISSIONS.toLong()))
+            val callingPi = pm.getPackageInfoCompat(callingPackage!!, PackageInfoFlagsCompat.of(PackageManager.GET_PERMISSIONS.toLong())) ?: return false
             if (callingPi.requestedPermissions == null) {
                 false
             } else !listOf(*callingPi.requestedPermissions).contains(FlashCardsContract.READ_WRITE_PERMISSION)

--- a/AnkiDroid/src/main/java/com/ichi2/compat/Compat.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/Compat.kt
@@ -105,9 +105,11 @@ interface Compat {
      * installed on the system.
      *
      * @see PackageManager.getPackageInfo
+     * @throws NameNotFoundException if no such package is available to the caller.
+     * * Can be null: https://cs.android.com/android/platform/superproject/+/master:frameworks/base/services/core/java/com/android/server/pm/ComputerEngine.java;drc=c4ad8bc669e66262a00798b57132347a0d0aa2ac;bpv=1;bpt=1;l=1705?q=getPackageInfoInternal&ss=android&gsn=getPackageInfoInternalBody&gs=kythe%3A%2F%2Fandroid.googlesource.com%2Fplatform%2Fsuperproject%3Flang%3Djava%3Fpath%3Dcom.android.server.pm.ComputerEngine%23977e4a94695fef516f4b2d9fa73dea77cfaf06eff40c6fb3ec9bd80c6e18a08f
      */
     @Throws(NameNotFoundException::class)
-    fun getPackageInfo(packageManager: PackageManager, packageName: String, flags: PackageInfoFlagsCompat): PackageInfo
+    fun getPackageInfo(packageManager: PackageManager, packageName: String, flags: PackageInfoFlagsCompat): PackageInfo?
 
     /**
      * Copy file at path [source] to path [target]

--- a/AnkiDroid/src/main/java/com/ichi2/compat/Compat.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/Compat.kt
@@ -20,6 +20,9 @@ package com.ichi2.compat
 import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
+import android.content.pm.PackageInfo
+import android.content.pm.PackageManager
+import android.content.pm.PackageManager.NameNotFoundException
 import android.graphics.Bitmap
 import android.graphics.Bitmap.CompressFormat
 import android.media.AudioFocusRequest
@@ -96,6 +99,15 @@ interface Compat {
      * @return the value of an item previously added with putExtra(), or null if no [Parcelable] value was found.
      */
     fun <T : Parcelable?> getParcelableExtra(intent: Intent, name: String, clazz: Class<T>): T?
+
+    /**
+     * Retrieve overall information about an application package that is
+     * installed on the system.
+     *
+     * @see PackageManager.getPackageInfo
+     */
+    @Throws(NameNotFoundException::class)
+    fun getPackageInfo(packageManager: PackageManager, packageName: String, flags: PackageInfoFlagsCompat): PackageInfo
 
     /**
      * Copy file at path [source] to path [target]

--- a/AnkiDroid/src/main/java/com/ichi2/compat/CompatHelper.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/CompatHelper.kt
@@ -107,7 +107,7 @@ class CompatHelper private constructor() {
          * @throws NameNotFoundException if no such package is available to the caller.
          */
         @Throws(NameNotFoundException::class)
-        fun Context.getPackageInfoCompat(packageName: String, flags: PackageInfoFlagsCompat): PackageInfo =
+        fun Context.getPackageInfoCompat(packageName: String, flags: PackageInfoFlagsCompat): PackageInfo? =
             this.packageManager.getPackageInfoCompat(packageName, flags)
 
         /**
@@ -118,7 +118,7 @@ class CompatHelper private constructor() {
          * @throws NameNotFoundException if no such package is available to the caller.
          */
         @Throws(NameNotFoundException::class)
-        fun PackageManager.getPackageInfoCompat(packageName: String, flags: PackageInfoFlagsCompat): PackageInfo =
+        fun PackageManager.getPackageInfoCompat(packageName: String, flags: PackageInfoFlagsCompat): PackageInfo? =
             compat.getPackageInfo(this, packageName, flags)
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/compat/CompatHelper.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/CompatHelper.kt
@@ -15,7 +15,11 @@
  ****************************************************************************************/
 package com.ichi2.compat
 
+import android.content.Context
 import android.content.Intent
+import android.content.pm.PackageInfo
+import android.content.pm.PackageManager
+import android.content.pm.PackageManager.NameNotFoundException
 import android.os.Build
 import android.os.Bundle
 import android.os.Parcel
@@ -94,5 +98,27 @@ class CompatHelper private constructor() {
         inline fun <reified T> Parcel.readSparseArrayCompat(loader: ClassLoader, clazz: Class<T>): SparseArray<T>? {
             return compat.readSparseArray(this, loader, clazz)
         }
+
+        /**
+         * Retrieve overall information about an application package that is
+         * installed on the system.
+         *
+         * @see PackageManager.getPackageInfo
+         * @throws NameNotFoundException if no such package is available to the caller.
+         */
+        @Throws(NameNotFoundException::class)
+        fun Context.getPackageInfoCompat(packageName: String, flags: PackageInfoFlagsCompat): PackageInfo =
+            this.packageManager.getPackageInfoCompat(packageName, flags)
+
+        /**
+         * Retrieve overall information about an application package that is
+         * installed on the system.
+         *
+         * @see PackageManager.getPackageInfo
+         * @throws NameNotFoundException if no such package is available to the caller.
+         */
+        @Throws(NameNotFoundException::class)
+        fun PackageManager.getPackageInfoCompat(packageName: String, flags: PackageInfoFlagsCompat): PackageInfo =
+            compat.getPackageInfo(this, packageName, flags)
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/compat/CompatV21.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/CompatV21.kt
@@ -20,6 +20,8 @@ import android.annotation.SuppressLint
 import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
+import android.content.pm.PackageInfo
+import android.content.pm.PackageManager
 import android.graphics.Bitmap
 import android.graphics.Bitmap.CompressFormat
 import android.media.AudioFocusRequest
@@ -93,6 +95,10 @@ open class CompatV21 : Compat {
     ): T? {
         return intent.getParcelableExtra<T>(name)
     }
+
+    override fun getPackageInfo(packageManager: PackageManager, packageName: String, flags: PackageInfoFlagsCompat): PackageInfo =
+        packageManager.getPackageInfo(packageName, flags.value.toInt())
+
     // Until API 26 do the copy using streams
     @Throws(IOException::class)
     override fun copyFile(source: String, target: String) {

--- a/AnkiDroid/src/main/java/com/ichi2/compat/CompatV21.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/CompatV21.kt
@@ -96,7 +96,7 @@ open class CompatV21 : Compat {
         return intent.getParcelableExtra<T>(name)
     }
 
-    override fun getPackageInfo(packageManager: PackageManager, packageName: String, flags: PackageInfoFlagsCompat): PackageInfo =
+    override fun getPackageInfo(packageManager: PackageManager, packageName: String, flags: PackageInfoFlagsCompat): PackageInfo? =
         packageManager.getPackageInfo(packageName, flags.value.toInt())
 
     // Until API 26 do the copy using streams

--- a/AnkiDroid/src/main/java/com/ichi2/compat/CompatV33.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/CompatV33.kt
@@ -18,6 +18,8 @@ package com.ichi2.compat
 
 import android.annotation.TargetApi
 import android.content.Intent
+import android.content.pm.PackageInfo
+import android.content.pm.PackageManager
 import android.os.Bundle
 import android.os.Parcel
 import android.os.Parcelable
@@ -45,4 +47,7 @@ open class CompatV33 : CompatV31(), Compat {
     ): SparseArray<T>? {
         return parcel.readSparseArray(loader, clazz)
     }
+
+    override fun getPackageInfo(packageManager: PackageManager, packageName: String, flags: PackageInfoFlagsCompat): PackageInfo =
+        packageManager.getPackageInfo(packageName, PackageManager.PackageInfoFlags.of(flags.value))
 }

--- a/AnkiDroid/src/main/java/com/ichi2/compat/CompatV33.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/CompatV33.kt
@@ -48,6 +48,6 @@ open class CompatV33 : CompatV31(), Compat {
         return parcel.readSparseArray(loader, clazz)
     }
 
-    override fun getPackageInfo(packageManager: PackageManager, packageName: String, flags: PackageInfoFlagsCompat): PackageInfo =
+    override fun getPackageInfo(packageManager: PackageManager, packageName: String, flags: PackageInfoFlagsCompat): PackageInfo? =
         packageManager.getPackageInfo(packageName, PackageManager.PackageInfoFlags.of(flags.value))
 }

--- a/AnkiDroid/src/main/java/com/ichi2/compat/PackageManagerCompat.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/PackageManagerCompat.kt
@@ -1,0 +1,168 @@
+/*
+ *  Copyright (c) 2023 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  This file incorporates code under the following license:
+ *
+ *     Copyright (C) 2006 The Android Open Source Project
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ *     https://cs.android.com/android/platform/superproject/+/master:frameworks/base/core/java/android/content/pm/PackageManager.java;l=4955-4982;drc=6b291909ea085cc451201ce0e3da961f96523b45
+ */
+
+package com.ichi2.compat
+
+import android.content.pm.ApplicationInfo
+import android.content.pm.PackageInfo
+import androidx.annotation.LongDef
+import android.content.pm.PackageManager as AndroidPackageManager
+
+/*
+ * Provides [PackageInfoFlagsCompat] to Android versions before SDK 33,
+ * keeping a near consistent API for [Compat.getPackageInfo],
+ * constraining the flags to the correct values (or types when available)
+ *
+ * Allows for either long flags to be provided (new API), or int flags (old API).
+ * The old API is currently better as it means .toLong() isn't needed on constants provided
+ * to the API.
+ * For future: Can Kotlin can accept either the int or long in a `@LongDef`
+ */
+
+/**
+ * Flags class that wraps around the bitmask flags used in methods that retrieve package or
+ * application info.
+ */
+open class Flags protected constructor(val value: Long)
+
+/**
+ * Specific flags used for retrieving package info. Example:
+ * `PackageManager.getPackageInfo(packageName, PackageInfoFlags.of(0)`
+ */
+class PackageInfoFlagsCompat private constructor(@PackageInfoFlagsBits value: Long) : Flags(value) {
+    companion object {
+        fun of(@PackageInfoFlagsBits value: Long): PackageInfoFlagsCompat = PackageInfoFlagsCompat(value)
+
+        /** Helper property. Does not exist on Platform API */
+        val EMPTY = PackageInfoFlagsCompat(0)
+    }
+}
+
+/**
+ * Flag parameter to retrieve some information about all applications (even
+ * uninstalled ones) which have data directories. This state could have
+ * resulted if applications have been deleted with flag
+ * `DELETE_KEEP_DATA` with a possibility of being replaced or
+ * reinstalled in future.
+ *
+ *
+ * Note: this flag may cause less information about currently installed
+ * applications to be returned.
+ *
+ *
+ * Note: use of this flag requires the android.permission.QUERY_ALL_PACKAGES
+ * permission to see uninstalled packages.
+ */
+const val MATCH_UNINSTALLED_PACKAGES = 0x00002000 // API 24
+
+/**
+ * [PackageInfo] flag: return the signing certificates associated with
+ * this package.  Each entry is a signing certificate that the package
+ * has proven it is authorized to use, usually a past signing certificate from
+ * which it has rotated.
+ */
+const val GET_SIGNING_CERTIFICATES = 0x08000000 // API 28
+
+/**
+ * [PackageInfo] flag: include disabled components in the returned info.
+ */
+const val MATCH_DISABLED_COMPONENTS = 0x00000200 // API 24
+
+/**
+ * [PackageInfo] flag: include disabled components which are in
+ * that state only because of [.COMPONENT_ENABLED_STATE_DISABLED_UNTIL_USED]
+ * in the returned info.  Note that if you set this flag, applications
+ * that are in this disabled state will be reported as enabled.
+ */
+const val MATCH_DISABLED_UNTIL_USED_COMPONENTS = 0x00008000 // API 24
+
+/**
+ * Querying flag: include only components from applications that are marked
+ * with [ApplicationInfo.FLAG_SYSTEM].
+ */
+const val MATCH_SYSTEM_ONLY = 0x00100000 // API 24
+
+/**
+ * [PackageInfo] flag: include APEX packages that are currently
+ * installed. In APEX terminology, this corresponds to packages that are
+ * currently active, i.e. mounted and available to other processes of the OS.
+ * In particular, this flag alone will not match APEX files that are staged
+ * for activation at next reboot.
+ */
+const val MATCH_APEX = 0x40000000 // API 29
+
+/**
+ * [PackageInfo] flag: return all attributions declared in the package manifest
+ */
+const val GET_ATTRIBUTIONS = -0x80000000 // API 31
+
+@LongDef(
+    flag = true,
+    // prefix = ["GET_", "MATCH_"],
+    value = [
+        AndroidPackageManager.GET_ACTIVITIES.toLong(),
+        AndroidPackageManager.GET_CONFIGURATIONS.toLong(),
+        AndroidPackageManager.GET_GIDS.toLong(),
+        AndroidPackageManager.GET_INSTRUMENTATION.toLong(),
+        AndroidPackageManager.GET_META_DATA.toLong(),
+        AndroidPackageManager.GET_PERMISSIONS.toLong(),
+        AndroidPackageManager.GET_PROVIDERS.toLong(),
+        AndroidPackageManager.GET_RECEIVERS.toLong(),
+        AndroidPackageManager.GET_SERVICES.toLong(),
+        AndroidPackageManager.GET_SHARED_LIBRARY_FILES.toLong(),
+        GET_SIGNING_CERTIFICATES.toLong(),
+        AndroidPackageManager.GET_URI_PERMISSION_PATTERNS.toLong(),
+        MATCH_UNINSTALLED_PACKAGES.toLong(),
+        MATCH_DISABLED_COMPONENTS.toLong(),
+        MATCH_DISABLED_UNTIL_USED_COMPONENTS.toLong(),
+        MATCH_SYSTEM_ONLY.toLong(),
+        MATCH_APEX.toLong(),
+        GET_ATTRIBUTIONS.toLong()
+
+        // not handled: Deprecated & unused in our code
+        // PackageManager.GET_INTENT_FILTERS.toLong(),
+        // PackageManager.GET_SIGNATURES.toLong(),
+        // PackageManager.GET_DISABLED_COMPONENTS.toLong(),
+        // PackageManager.GET_DISABLED_UNTIL_USED_COMPONENTS.toLong(),
+        // PackageManager.GET_UNINSTALLED_PACKAGES.toLong(),
+
+        // not handled: values with @SystemApi
+        // PackageManager.MATCH_FACTORY_ONLY,
+        // PackageManager.MATCH_DEBUG_TRIAGED_MISSING,
+        // PackageManager.MATCH_INSTANT,
+        // PackageManager.MATCH_HIDDEN_UNTIL_INSTALLED_COMPONENTS,
+    ]
+)
+@Retention(AnnotationRetention.SOURCE)
+annotation class PackageInfoFlagsBits

--- a/AnkiDroid/src/main/java/com/ichi2/utils/AdaptionUtil.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/AdaptionUtil.kt
@@ -101,7 +101,7 @@ object AdaptionUtil {
     private fun isSystemApp(packageName: String?, pm: PackageManager): Boolean {
         return if (packageName != null) {
             try {
-                val info = pm.getPackageInfoCompat(packageName, PackageInfoFlagsCompat.EMPTY)
+                val info = pm.getPackageInfoCompat(packageName, PackageInfoFlagsCompat.EMPTY) ?: return false
                 info.applicationInfo != null &&
                     info.applicationInfo.flags and ApplicationInfo.FLAG_SYSTEM != 0
             } catch (e: PackageManager.NameNotFoundException) {

--- a/AnkiDroid/src/main/java/com/ichi2/utils/AdaptionUtil.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/AdaptionUtil.kt
@@ -27,6 +27,8 @@ import android.net.Uri
 import android.os.Build
 import android.provider.Settings
 import com.ichi2.anki.AnkiDroidApp
+import com.ichi2.compat.CompatHelper.Companion.getPackageInfoCompat
+import com.ichi2.compat.PackageInfoFlagsCompat
 import timber.log.Timber
 import java.util.*
 
@@ -96,12 +98,11 @@ object AdaptionUtil {
         return ri?.activityInfo != null && ri.activityInfo.exported
     }
 
-    @Suppress("deprecation") // getPackageInfo
     private fun isSystemApp(packageName: String?, pm: PackageManager): Boolean {
         return if (packageName != null) {
             try {
-                val info = pm.getPackageInfo(packageName, 0)
-                info?.applicationInfo != null &&
+                val info = pm.getPackageInfoCompat(packageName, PackageInfoFlagsCompat.EMPTY)
+                info.applicationInfo != null &&
                     info.applicationInfo.flags and ApplicationInfo.FLAG_SYSTEM != 0
             } catch (e: PackageManager.NameNotFoundException) {
                 Timber.w(e)

--- a/AnkiDroid/src/main/java/com/ichi2/utils/CheckCameraPermission.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/CheckCameraPermission.kt
@@ -18,16 +18,19 @@ package com.ichi2.utils
 
 import android.content.Context
 import android.content.pm.PackageManager
+import com.ichi2.compat.CompatHelper.Companion.getPackageInfoCompat
+import com.ichi2.compat.PackageInfoFlagsCompat
 import timber.log.Timber
 import java.lang.Exception
 import java.util.*
 
 object CheckCameraPermission {
-    @Suppress("deprecation") // getPackageInfo
     fun manifestContainsPermission(context: Context): Boolean {
         try {
-            val requestedPermissions = context.packageManager
-                .getPackageInfo(context.packageName, PackageManager.GET_PERMISSIONS).requestedPermissions
+            val requestedPermissions = context.getPackageInfoCompat(
+                context.packageName,
+                PackageInfoFlagsCompat.of(PackageManager.GET_PERMISSIONS.toLong())
+            ).requestedPermissions
             if (Arrays.toString(requestedPermissions).contains("android.permission.CAMERA")) {
                 return true
             }

--- a/AnkiDroid/src/main/java/com/ichi2/utils/CheckCameraPermission.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/CheckCameraPermission.kt
@@ -27,11 +27,11 @@ import java.util.*
 object CheckCameraPermission {
     fun manifestContainsPermission(context: Context): Boolean {
         try {
-            val requestedPermissions = context.getPackageInfoCompat(
+            val packageInfo = context.getPackageInfoCompat(
                 context.packageName,
                 PackageInfoFlagsCompat.of(PackageManager.GET_PERMISSIONS.toLong())
-            ).requestedPermissions
-            if (Arrays.toString(requestedPermissions).contains("android.permission.CAMERA")) {
+            ) ?: return false
+            if (Arrays.toString(packageInfo.requestedPermissions).contains("android.permission.CAMERA")) {
                 return true
             }
         } catch (e: Exception) {

--- a/AnkiDroid/src/main/java/com/ichi2/utils/VersionUtils.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/VersionUtils.kt
@@ -39,6 +39,10 @@ object VersionUtils {
             val context: Context = applicationInstance ?: return AnkiDroidApp.TAG
             try {
                 val pInfo = context.getPackageInfoCompat(context.packageName, PackageInfoFlagsCompat.EMPTY)
+                if (pInfo == null) {
+                    Timber.w("Couldn't find package named %s", context.packageName)
+                    return pkgName
+                }
                 pkgName = context.getString(pInfo.applicationInfo.labelRes)
             } catch (e: PackageManager.NameNotFoundException) {
                 Timber.e(e, "Couldn't find package named %s", context.packageName)
@@ -54,7 +58,7 @@ object VersionUtils {
             var pkgVersion = "?"
             val context: Context = applicationInstance ?: return pkgVersion
             try {
-                val pInfo = context.getPackageInfoCompat(context.packageName, PackageInfoFlagsCompat.EMPTY)
+                val pInfo = context.getPackageInfoCompat(context.packageName, PackageInfoFlagsCompat.EMPTY) ?: return pkgVersion
                 pkgVersion = pInfo.versionName
             } catch (e: PackageManager.NameNotFoundException) {
                 Timber.e(e, "Couldn't find package named %s", context.packageName)
@@ -70,6 +74,10 @@ object VersionUtils {
             val context: Context = applicationInstance ?: return 0
             try {
                 val pInfo = context.getPackageInfoCompat(context.packageName, PackageInfoFlagsCompat.EMPTY)
+                if (pInfo == null) {
+                    Timber.w("getPackageInfo failed")
+                    return 0
+                }
                 val versionCode = PackageInfoCompat.getLongVersionCode(pInfo)
                 Timber.d("getPkgVersionCode() is %s", versionCode)
                 return versionCode

--- a/AnkiDroid/src/main/java/com/ichi2/utils/VersionUtils.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/VersionUtils.kt
@@ -21,6 +21,8 @@ import android.content.pm.PackageManager
 import androidx.core.content.pm.PackageInfoCompat
 import com.ichi2.anki.AnkiDroidApp
 import com.ichi2.anki.CrashReportService
+import com.ichi2.compat.CompatHelper.Companion.getPackageInfoCompat
+import com.ichi2.compat.PackageInfoFlagsCompat
 import timber.log.Timber
 import java.lang.NullPointerException
 
@@ -31,13 +33,12 @@ object VersionUtils {
     /**
      * Get package name as defined in the manifest.
      */
-    @Suppress("deprecation") // getPackageInfo
     val appName: String
         get() {
             var pkgName = AnkiDroidApp.TAG
             val context: Context = applicationInstance ?: return AnkiDroidApp.TAG
             try {
-                val pInfo = context.packageManager.getPackageInfo(context.packageName, 0)
+                val pInfo = context.getPackageInfoCompat(context.packageName, PackageInfoFlagsCompat.EMPTY)
                 pkgName = context.getString(pInfo.applicationInfo.labelRes)
             } catch (e: PackageManager.NameNotFoundException) {
                 Timber.e(e, "Couldn't find package named %s", context.packageName)
@@ -48,13 +49,12 @@ object VersionUtils {
     /**
      * Get the package versionName as defined in the manifest.
      */
-    @Suppress("deprecation") // getPackageInfo
     val pkgVersionName: String
         get() {
             var pkgVersion = "?"
             val context: Context = applicationInstance ?: return pkgVersion
             try {
-                val pInfo = context.packageManager.getPackageInfo(context.packageName, 0)
+                val pInfo = context.getPackageInfoCompat(context.packageName, PackageInfoFlagsCompat.EMPTY)
                 pkgVersion = pInfo.versionName
             } catch (e: PackageManager.NameNotFoundException) {
                 Timber.e(e, "Couldn't find package named %s", context.packageName)
@@ -65,12 +65,11 @@ object VersionUtils {
     /**
      * Get the package versionCode as defined in the manifest.
      */
-    @Suppress("deprecation") // getPackageInfo
     val pkgVersionCode: Long
         get() {
             val context: Context = applicationInstance ?: return 0
             try {
-                val pInfo = context.packageManager.getPackageInfo(context.packageName, 0)
+                val pInfo = context.getPackageInfoCompat(context.packageName, PackageInfoFlagsCompat.EMPTY)
                 val versionCode = PackageInfoCompat.getLongVersionCode(pInfo)
                 Timber.d("getPkgVersionCode() is %s", versionCode)
                 return versionCode

--- a/AnkiDroid/src/main/java/com/ichi2/utils/VersionUtils.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/VersionUtils.kt
@@ -102,7 +102,7 @@ object VersionUtils {
      */
     val isReleaseVersion: Boolean
         get() {
-            val versionCode = java.lang.Long.toString(pkgVersionCode)
+            val versionCode = pkgVersionCode.toString()
             Timber.d("isReleaseVersion() versionCode: %s", versionCode)
             return versionCode[versionCode.length - 3] == '3'
         }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/ActivityStartupMetaTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/ActivityStartupMetaTest.kt
@@ -40,7 +40,7 @@ class ActivityStartupMetaTest : RobolectricTest() {
         // if this fails, you may need to add the missing activity to ActivityList.allActivitiesAndIntents()
 
         // we can't access this in a static context
-        val packageInfo = targetContext.getPackageInfoCompat(targetContext.packageName, PackageInfoFlagsCompat.of(PackageManager.GET_ACTIVITIES.toLong()))
+        val packageInfo = targetContext.getPackageInfoCompat(targetContext.packageName, PackageInfoFlagsCompat.of(PackageManager.GET_ACTIVITIES.toLong())) ?: throw IllegalStateException("getPackageInfo failed")
         val manifestActivities = packageInfo.activities
         val testedActivityClassNames = ActivityList.allActivitiesAndIntents().stream().map { obj: ActivityLaunchParam -> obj.className }.collect(Collectors.toSet())
         val manifestActivityNames = Arrays.stream(manifestActivities)

--- a/AnkiDroid/src/test/java/com/ichi2/anki/ActivityStartupMetaTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/ActivityStartupMetaTest.kt
@@ -18,6 +18,8 @@ package com.ichi2.anki
 import android.content.pm.ActivityInfo
 import android.content.pm.PackageManager
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.ichi2.compat.CompatHelper.Companion.getPackageInfoCompat
+import com.ichi2.compat.PackageInfoFlagsCompat
 import com.ichi2.testutils.ActivityList
 import com.ichi2.testutils.ActivityList.ActivityLaunchParam
 import com.ichi2.utils.KotlinCleanup
@@ -34,13 +36,11 @@ class ActivityStartupMetaTest : RobolectricTest() {
     @Test
     @Throws(PackageManager.NameNotFoundException::class)
     @KotlinCleanup("remove throws; remove stream(), remove : String")
-    @Suppress("deprecation") // getPackageInfo
     fun ensureAllActivitiesAreTested() {
         // if this fails, you may need to add the missing activity to ActivityList.allActivitiesAndIntents()
 
         // we can't access this in a static context
-        val pm = targetContext.packageManager
-        val packageInfo = pm.getPackageInfo(targetContext.packageName, PackageManager.GET_ACTIVITIES)
+        val packageInfo = targetContext.getPackageInfoCompat(targetContext.packageName, PackageInfoFlagsCompat.of(PackageManager.GET_ACTIVITIES.toLong()))
         val manifestActivities = packageInfo.activities
         val testedActivityClassNames = ActivityList.allActivitiesAndIntents().stream().map { obj: ActivityLaunchParam -> obj.className }.collect(Collectors.toSet())
         val manifestActivityNames = Arrays.stream(manifestActivities)


### PR DESCRIPTION
## Purpose / Description

Deprecated in API 33: https://developer.android.com/reference/android/content/pm/PackageManager#getPackageInfo(java.lang.String,%20int) 

I'm going to use this functionality in Scoped Storage, so I've prioritised fixing this deprecation. 


## Fixes
Fixes https://github.com/ankidroid/Anki-Android/pull/12548 (superseded)
  * Sincere & profuse apologies to @n1snt - I'm marking a concerted effort to get back into both maintenance and development to ensure this doesn't occur again.
  
Related https://github.com/ankidroid/Anki-Android/issues/12364

## Approach
⚠️ I'm unsure on this approach, and welcome alternate suggestions

`flags: Integer` was replaced with `flags: PackageInfoFlags` in API 33. This is likely because the `int` flags were expanded to be `long` flags.

In addition to this, an interface with a `@LongDef` was added to the constructor of `PackageInfoFlags` to allow for safer construction.

We define our own `PackageInfoFlags`, then `PackageInfoFlagsBits`, then reproduce the constants which are unavailable in lesser versions of the API. This **should** mean that `PackageInfoFlags` can be used by API 21 without issue and matches the API to the closest of our ability

I say **should** as for all the implementations I've seen in the Android codebase. 

Flags are tested using the standard `bit & flag == 0`, which is forwards-compatible with the addition of unknown flags.

## How Has This Been Tested?

Unit tested

## Learning (optional, can help others)
https://developer.android.com/reference/android/content/pm/PackageManager#getPackageInfo(java.lang.String,%20int)

https://cs.android.com/android/platform/superproject/+/master:frameworks/base/services/core/java/com/android/server/pm/ComputerEngine.java;drc=c4ad8bc669e66262a00798b57132347a0d0aa2ac;bpv=1;bpt=1;l=1705?q=getPackageInfoInternal&ss=android&gsn=getPackageInfoInternalBody&gs=kythe%3A%2F%2Fandroid.googlesource.com%2Fplatform%2Fsuperproject%3Flang%3Djava%3Fpath%3Dcom.android.server.pm.ComputerEngine%23977e4a94695fef516f4b2d9fa73dea77cfaf06eff40c6fb3ec9bd80c6e18a08f

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
