### PR TITLE
GitHub: Implement Bug Reporting Form

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report_form.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report_form.yml
@@ -1,0 +1,67 @@
+name: 🐞 Bug
+description: File a bug
+title: "[BUG]: "
+labels:  [Bug, "Needs Triage"]
+
+body:
+
+  - type: checkboxes
+    id: contact
+    attributes:
+      label: Checked for duplicates?
+      description: Quickly search our [open issues](https://github.com/ankidroid/Anki-Android/issues) to see if a similar issue exists
+      options:
+        - label: This issue is not a duplicate
+          required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: What are the steps to reproduce this bug?
+      description: Briefly explain what you did which caused this bug to occur
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected-behaviour
+    attributes:
+      label: Expected behaviour
+      description: Briefly describe what should have happened
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual-behaviour
+    attributes:
+      label: Actual behaviour
+      description: Briefly describe what happened
+    validations:
+      required: true
+
+  - type: textarea
+    id: debug-info
+    attributes:
+      label: Debug info
+      description: Refer to the [support page](https://ankidroid.org/docs/help.html) if you are unsure where to get the "debug info"
+      placeholder: AnkiDroid Debug Info (Starts with "AnkiDroid Version")
+    validations:
+      required: true
+
+  - type: textarea
+    id: extra_info
+    attributes:
+      label: (Optional) Anything else you want to share?
+      placeholder: List any extra information
+
+  - type: checkboxes
+    id: research
+    attributes:
+      label: Research
+      description: Confirm the points below
+      options:
+        - label: I am reporting a bug specific to AnkiDroid (Android app)
+          required: true
+        - label: I have checked the [manual](https://ankidroid.org/docs/manual.html) and the [FAQ](https://github.com/ankidroid/Anki-Android/wiki/FAQ) and could not find a solution to my issue
+          required: true
+        - label: (Optional) I have confirmed the issue is not resolved in the latest alpha release ([instructions](https://docs.ankidroid.org/manual.html#betaTesting))
+          required: false


### PR DESCRIPTION
## Pull Request template

See form at: https://github.com/david-allison/Anki-Android/issues/new?assignees=&labels=Bug&template=bug_reprot_form.yml&title=%5BBUG%5D%3A+

## Purpose / Description
See: #12214. It was proposed that the repo had a bug template. At the very least, the checkboxes are less confusing, and we can 'require' some input in the Debug Info

## Fixes
- Fixes: #12214
- Fixes: #12248 (Superseded)

## Approach
Based off `issue_template.md` with additional copy changes.

For now, we don't disable the previous template

## How Has This Been Tested?

See: https://github.com/david-allison/Anki-Android/issues/new?assignees=&labels=Bug&template=bug_reprot_form.yml&title=%5BBUG%5D%3A+

## Learning (optional, can help others)
See: #12248 for discussion

* `required` is currently the only available validation on forms

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
