### PR TITLE
Revert "Scheduler should be reloaded on full sync"

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/async/Connection.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/async/Connection.kt
@@ -324,7 +324,9 @@ class Connection : BaseAsyncTask<Connection.Payload, Any, Connection.Payload>() 
                             val ret = fullSyncServer.download()
                             if (SUCCESS == ret) {
                                 data.success = true
-                                col.reopen(afterFullSync = true)
+                                // Note: we don't set afterFullSync here, as that assumes the new schema
+                                // has already reopened the collection in the backend.
+                                col.reopen()
                             }
                             if (SUCCESS != ret) {
                                 Timber.w("Sync - fullsync - download failed")


### PR DESCRIPTION
This reverts commit 72acb72c1af78b2118ca5afedc8e6ec6ca6e5cef.

The afterFullSync path was intended for use with the new backend, where the backend automatically reopens the collection. I've added a comment as part of the revert.

My mistake - I tested the main fix in that PR quite thoroughly, and only added this change at the last minute.

Closes #13255