### PR TITLE
lint: enable 'MonochromeLauncherIcon'

### DIFF
--- a/lint-release.xml
+++ b/lint-release.xml
@@ -63,8 +63,7 @@
     <issue id="ImplicitSamInstance" severity="fatal" />
     <issue id="DrawAllocation" severity="fatal" />
 
-    <!-- new with AGP7.4+, tracking in https://github.com/ankidroid/Anki-Android/issues/13197 -->
-    <issue id="MonochromeLauncherIcon" severity="ignore" />
+    <issue id="MonochromeLauncherIcon" severity="fatal" />
 
     <!-- this is new with AGP7.1+, does not appear to create value -->
     <issue id="IntentFilterUniqueDataAttributes" severity="ignore" />


### PR DESCRIPTION
Lint no longer fails

partial revert of 0ca2e6c204aef9ae16242d932b87988f3c5a237f

Fixes #13197