### PR TITLE
Dependency updates 20220216

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -204,7 +204,12 @@ android {
     }
 
     compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
         coreLibraryDesugaringEnabled true
+    }
+    kotlinOptions {
+        jvmTarget = JavaVersion.VERSION_1_8
     }
     ndkVersion "22.0.7026061"
 }

--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -277,7 +277,7 @@ dependencies {
     implementation "androidx.fragment:fragment-ktx:$fragments_version"
     implementation "androidx.preference:preference-ktx:1.2.0"
     implementation 'androidx.recyclerview:recyclerview:1.2.1'
-    implementation 'androidx.sqlite:sqlite-framework:2.2.0'
+    implementation 'androidx.sqlite:sqlite-framework:2.3.0'
     implementation 'androidx.swiperefreshlayout:swiperefreshlayout:1.1.0'
     implementation 'androidx.viewpager2:viewpager2:1.0.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.4'

--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -271,7 +271,7 @@ dependencies {
     implementation 'androidx.activity:activity-ktx:1.6.1'
     implementation 'androidx.annotation:annotation:1.5.0'
     implementation 'androidx.appcompat:appcompat:1.6.0-rc01'
-    implementation 'androidx.browser:browser:1.4.0'
+    implementation 'androidx.browser:browser:1.5.0'
     implementation "androidx.core:core-ktx:1.9.0"
     implementation 'androidx.exifinterface:exifinterface:1.3.6'
     implementation "androidx.fragment:fragment-ktx:$fragments_version"

--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -270,7 +270,7 @@ dependencies {
 
     implementation 'androidx.activity:activity-ktx:1.6.1'
     implementation 'androidx.annotation:annotation:1.5.0'
-    implementation 'androidx.appcompat:appcompat:1.6.0-rc01'
+    implementation 'androidx.appcompat:appcompat:1.7.0-alpha02'
     implementation 'androidx.browser:browser:1.5.0'
     implementation "androidx.core:core-ktx:1.9.0"
     implementation 'androidx.exifinterface:exifinterface:1.3.6'

--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -273,7 +273,7 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.6.0-rc01'
     implementation 'androidx.browser:browser:1.4.0'
     implementation "androidx.core:core-ktx:1.9.0"
-    implementation 'androidx.exifinterface:exifinterface:1.3.5'
+    implementation 'androidx.exifinterface:exifinterface:1.3.6'
     implementation "androidx.fragment:fragment-ktx:$fragments_version"
     implementation "androidx.preference:preference-ktx:1.2.0"
     implementation 'androidx.recyclerview:recyclerview:1.2.1'

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/DB.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/DB.kt
@@ -105,7 +105,7 @@ class DB(db: SupportSQLiteDatabase) {
     }
 
     // Allows to avoid using new Object[]
-    fun query(@Language("SQL") query: String?, vararg selectionArgs: Any): Cursor {
+    fun query(@Language("SQL") query: String, vararg selectionArgs: Any): Cursor {
         return database.query(query, selectionArgs)
     }
 
@@ -115,7 +115,7 @@ class DB(db: SupportSQLiteDatabase) {
      * @param query The raw SQL query to use.
      * @return The integer result of the query.
      */
-    fun queryScalar(@Language("SQL") query: String?, vararg selectionArgs: Any): Int {
+    fun queryScalar(@Language("SQL") query: String, vararg selectionArgs: Any): Int {
         var cursor: Cursor? = null
         val scalar: Int
         try {
@@ -286,7 +286,7 @@ class DB(db: SupportSQLiteDatabase) {
                 SupportSQLiteOpenHelperCallback(1)
             )
             db.disableWriteAheadLogging()
-            db.query("PRAGMA synchronous = 2", null)
+            db.query("PRAGMA synchronous = 2")
             return DB(db)
         }
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Finder.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Finder.kt
@@ -60,7 +60,7 @@ class Finder(private val col: Collection) {
         val sql = _query(preds, order)
         Timber.v("Search query '%s' is compiled as '%s'.", query, sql)
         try {
-            col.db.database.query(sql, args).use { cur ->
+            col.db.database.query(sql, args ?: emptyArray()).use { cur ->
                 while (cur.moveToNext()) {
                     res.add(cur.getLong(0))
                 }
@@ -120,7 +120,7 @@ class Finder(private val col: Collection) {
             "select distinct(n.id) from cards c, notes n where c.nid=n.id and $preds"
         }
         try {
-            col.db.database.query(sql, args).use { cur ->
+            col.db.database.query(sql, args ?: emptyArray()).use { cur ->
                 while (cur.moveToNext()) {
                     res.add(cur.getLong(0))
                 }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/importer/Anki2Importer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/importer/Anki2Importer.kt
@@ -200,8 +200,7 @@ open class Anki2Importer(col: Collection?, file: String) : Importer(col!!, file)
         dst.db.database.beginTransaction()
         try {
             src.db.database.query(
-                "select id, guid, mid, mod, tags, flds, sfld, csum, flags, data  from notes",
-                null
+                "select id, guid, mid, mod, tags, flds, sfld, csum, flags, data  from notes"
             ).use { cur ->
                 // Counters for progress updates
                 val total = cur.count

--- a/AnkiDroid/src/main/java/com/ichi2/utils/DatabaseChangeDecorator.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/DatabaseChangeDecorator.kt
@@ -66,13 +66,19 @@ class DatabaseChangeDecorator(val wrapped: SupportSQLiteDatabase) : SupportSQLit
         return insert
     }
 
-    override fun delete(table: String, whereClause: String, whereArgs: Array<Any>): Int {
+    override fun delete(table: String, whereClause: String?, whereArgs: Array<out Any?>?): Int {
         val delete = wrapped.delete(table, whereClause, whereArgs)
         markDataAsChanged()
         return delete
     }
 
-    override fun update(table: String, conflictAlgorithm: Int, values: ContentValues, whereClause: String?, whereArgs: Array<Any>?): Int {
+    override fun update(
+        table: String,
+        conflictAlgorithm: Int,
+        values: ContentValues,
+        whereClause: String?,
+        whereArgs: Array<out Any?>?
+    ): Int {
         val update = wrapped.update(table, conflictAlgorithm, values, whereClause, whereArgs)
         markDataAsChanged()
         return update
@@ -85,7 +91,7 @@ class DatabaseChangeDecorator(val wrapped: SupportSQLiteDatabase) : SupportSQLit
     }
 
     @Throws(SQLException::class)
-    override fun execSQL(sql: String, bindArgs: Array<Any>) {
+    override fun execSQL(sql: String, bindArgs: Array<out Any?>) {
         wrapped.execSQL(sql, bindArgs)
         checkForChanges(sql)
     }

--- a/api/build.gradle
+++ b/api/build.gradle
@@ -41,6 +41,7 @@ android {
         // enable explicit api mode for additional checks related to the public api
         // see https://kotlinlang.org/docs/whatsnew14.html#explicit-api-mode-for-library-authors
         freeCompilerArgs += '-Xexplicit-api=strict'
+        jvmTarget = JavaVersion.VERSION_1_8
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompilerExecutionStrategy
 
 buildscript {
     // The version for the Kotlin plugin and dependencies
-    ext.kotlin_version = '1.7.22'
+    ext.kotlin_version = '1.8.10'
     ext.lint_version = '30.4.1'
     ext.acra_version = '5.9.7'
     ext.ankidroid_backend_version = '0.1.20-anki2.1.57'
@@ -93,11 +93,21 @@ subprojects {
 
          and we used "all" because we don't have downstream consumers
          https://docs.gradle.org/current/userguide/task_configuration_avoidance.html
+
+         Related to ExperimentalCoroutinesApi: this opt-in is added to enable usage of experimental
+            coroutines API, this targets all project modules with the exception of the "api" module,
+            which doesn't use coroutines so the annotation isn't not available. This would normally
+            result in a warning but we treat warnings as errors.
+            (see https://youtrack.jetbrains.com/issue/KT-28777/Using-experimental-coroutines-api-causes-unresolved-dependency)
         */
         tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
             kotlinOptions {
                 allWarningsAsErrors = fatalWarnings
-                freeCompilerArgs = ['-Xjvm-default=all']
+                def compilerArgs = ['-Xjvm-default=all']
+                if (project.name != "api") {
+                    compilerArgs += ['-opt-in=kotlinx.coroutines.ExperimentalCoroutinesApi']
+                }
+                freeCompilerArgs = compilerArgs
             }
         }
     }

--- a/lint-rules/build.gradle
+++ b/lint-rules/build.gradle
@@ -5,8 +5,8 @@ repositories {
     mavenCentral()
 }
 
-compileKotlin {
-    kotlinOptions.jvmTarget = JavaVersion.VERSION_11
+kotlin {
+    jvmToolchain(11)
 }
 
 dependencies {


### PR DESCRIPTION

This is not quite a standard dependency update PR - reviewer notes:

- yes, we're adopting an appcompat alpha, $deity help us
- pay close attention to the last commit - there is quite a bit of trouble harmonizing the build compatibility targets, I *think* this way is okay but I'm not sure if the spec of a jvmToolchain in the lint-rules repo will fail people that don't have JDK8 installed? If not then doing the source/target compatibility stuff is better if more verbose

I linked relevant sources online in the commit

This is rebased against main as of just now when I create this PR