### PR TITLE
`@Flaky`: block flaky tests from CI 

### DIFF
--- a/.idea/dictionaries/android.xml
+++ b/.idea/dictionaries/android.xml
@@ -40,6 +40,7 @@
       <w>snackbars</w>
       <w>sqldb</w>
       <w>stacktraces</w>
+      <w>testutils</w>
       <w>tracesql</w>
       <w>ungzip</w>
       <w>ungzipped</w>

--- a/AnkiDroid/src/test/java/com/ichi2/anki/ReviewerNoParamTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/ReviewerNoParamTest.kt
@@ -32,6 +32,8 @@ import com.ichi2.anki.reviewer.FullScreenMode.Companion.setPreference
 import com.ichi2.anki.reviewer.MappableBinding
 import com.ichi2.libanki.Consts
 import com.ichi2.libanki.DeckId
+import com.ichi2.testutils.Flaky
+import com.ichi2.testutils.OS
 import com.ichi2.themes.Theme
 import com.ichi2.themes.Themes.currentTheme
 import org.hamcrest.MatcherAssert.assertThat
@@ -163,6 +165,7 @@ class ReviewerNoParamTest : RobolectricTest() {
     }
 
     @Test
+    @Flaky(OS.LINUX, "hasDrawerSwipeConflicts was false")
     @RunInBackground
     fun defaultDrawerConflictIsTrueIfGesturesEnabled() {
         enableGestureSetting()

--- a/AnkiDroid/src/test/java/com/ichi2/anki/RobolectricTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/RobolectricTest.kt
@@ -42,6 +42,7 @@ import com.ichi2.libanki.backend.exception.DeckRenameException
 import com.ichi2.libanki.sched.Sched
 import com.ichi2.libanki.sched.SchedV2
 import com.ichi2.libanki.utils.TimeManager
+import com.ichi2.testutils.IgnoreFlakyTestsInCIRule
 import com.ichi2.testutils.MockTime
 import com.ichi2.testutils.TaskSchedulerRule
 import com.ichi2.utils.Computation
@@ -83,6 +84,10 @@ open class RobolectricTest : CollectionGetter {
 
     @get:Rule
     val mTaskScheduler = TaskSchedulerRule()
+
+    /** Allows [com.ichi2.testutils.Flaky] to annotate tests in subclasses */
+    @get:Rule
+    val ignoreFlakyTests = IgnoreFlakyTestsInCIRule()
 
     @Before
     @CallSuper

--- a/AnkiDroid/src/test/java/com/ichi2/testutils/IgnoreFlakyTestsInCIRule.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/testutils/IgnoreFlakyTestsInCIRule.kt
@@ -1,0 +1,88 @@
+/*
+ *  Copyright (c) 2023 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.testutils
+
+import org.hamcrest.CoreMatchers.not
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.equalTo
+import org.junit.Assume
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TestRule
+import org.junit.runner.Description
+import org.junit.runners.model.Statement
+import java.util.*
+
+/**
+ * An annotation which marks a test as flaky so it will be skipped if run under CI
+ * @param os The OS The test fails under (required)
+ * @param message The message to display when the test is skipped
+ */
+annotation class Flaky(val os: OS, val message: String = "")
+
+/**
+ * Ignores any matching test defined with `@Flaky` in CI
+ * @see Flaky
+ */
+class IgnoreFlakyTestsInCIRule : TestRule {
+    override fun apply(base: Statement, description: Description): Statement {
+        if (!isRunningUnderCI) return base
+        val annotation = description.getAnnotation(Flaky::class.java) ?: return base
+        if (!annotation.os.isRunning()) return base
+        return object : Statement() {
+            override fun evaluate() {
+                val message = if (annotation.message.isEmpty()) "Flaky test" else "Flaky test: " + annotation.message
+                Assume.assumeTrue(message, false)
+            }
+        }
+    }
+
+    companion object {
+        val isRunningUnderCI = System.getenv("CI") == "true"
+    }
+}
+
+enum class OS {
+    WINDOWS, MACOS, LINUX, ALL;
+    fun isRunning(): Boolean = this == ALL || this == currentOS
+
+    companion object {
+        val currentOS: OS by lazy {
+            val osName = System.getProperty("os.name")?.lowercase(Locale.ENGLISH) ?: throw IllegalStateException("Could not get OS name")
+            // values obtained by throwing an exception containing 'System.getProperty("os.name")'
+            with(osName) {
+                return@lazy when {
+                    startsWith("linux") -> LINUX // Linux
+                    startsWith("win") -> WINDOWS // Windows Server 2022
+                    startsWith("mac") -> MACOS // Mac OS X
+                    else -> throw IllegalStateException("Unknown OS: $osName")
+                }
+            }
+        }
+    }
+}
+
+class IgnoreFlakyTestsTest {
+    @get:Rule
+    val ignoreFlakyTests = IgnoreFlakyTestsInCIRule()
+
+    @Test
+    @Flaky(os = OS.ALL)
+    fun ensureFlakyTestsAreOnlyRunLocally() {
+        assertThat("Not running under CI", System.getenv("CI"), not(equalTo("true")))
+    }
+}


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
We lose a lot of time due to flaky tests, this is also a bad experience for new users

## Approach
Allow us to mark tests as flaky, these are skipped with a message. This may be for a single OS, or for all of them.

❗️Ignoring tests only on CI may be the wrong move, open to discussion here, but wanted the skeleton of the code in

## How Has This Been Tested?
Unit test

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
