### PR TITLE
tests: fix emulator tests on API 30

### DIFF
--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/DeckPickerTest.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/DeckPickerTest.kt
@@ -17,9 +17,7 @@
 
 package com.ichi2.anki
 
-import android.Manifest
 import android.annotation.SuppressLint
-import android.os.Build
 import androidx.recyclerview.widget.RecyclerView
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.Espresso.pressBack
@@ -28,13 +26,15 @@ import androidx.test.espresso.assertion.ViewAssertions
 import androidx.test.espresso.contrib.RecyclerViewActions
 import androidx.test.espresso.matcher.ViewMatchers.*
 import androidx.test.ext.junit.rules.ActivityScenarioRule
-import androidx.test.rule.GrantPermissionRule
 import com.ichi2.anki.TestUtils.activityInstance
 import com.ichi2.anki.TestUtils.clickChildViewWithId
 import com.ichi2.anki.TestUtils.isScreenSw600dp
 import com.ichi2.anki.TestUtils.wasBuiltOnCI
 import com.ichi2.anki.tests.InstrumentedTest.Companion.isEmulator
+import com.ichi2.anki.testutil.GrantStoragePermission.storagePermission
 import com.ichi2.anki.testutil.ThreadUtils.sleep
+import com.ichi2.anki.testutil.grantPermissions
+import com.ichi2.anki.testutil.notificationPermission
 import org.hamcrest.Matchers.instanceOf
 import org.junit.Assume.assumeFalse
 import org.junit.Assume.assumeTrue
@@ -48,12 +48,7 @@ class DeckPickerTest {
     val mActivityRule = ActivityScenarioRule(DeckPicker::class.java)
 
     @get:Rule
-    val mRuntimePermissionRule: GrantPermissionRule =
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-            GrantPermissionRule.grant(Manifest.permission.WRITE_EXTERNAL_STORAGE, Manifest.permission.POST_NOTIFICATIONS)
-        } else {
-            GrantPermissionRule.grant(Manifest.permission.WRITE_EXTERNAL_STORAGE)
-        }
+    val mRuntimePermissionRule = grantPermissions(storagePermission, notificationPermission)
 
     @Ignore("This test appears to be flaky everywhere")
     @Test

--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/NoteEditorTest.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/NoteEditorTest.kt
@@ -15,25 +15,24 @@
  */
 package com.ichi2.anki
 
-import android.Manifest
 import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
 import android.os.Build
 import androidx.test.ext.junit.rules.ActivityScenarioRule
 import androidx.test.platform.app.InstrumentationRegistry
-import androidx.test.rule.GrantPermissionRule
+import com.ichi2.anki.testutil.GrantStoragePermission
 import com.ichi2.utils.KotlinCleanup
 import org.hamcrest.Matchers
 import org.junit.Assume
 import org.junit.Before
 import org.junit.Rule
+import org.junit.rules.TestRule
 import java.util.ArrayList
 
 abstract class NoteEditorTest protected constructor() {
     @get:Rule
-    var runtimePermissionRule: GrantPermissionRule? =
-        GrantPermissionRule.grant(Manifest.permission.WRITE_EXTERNAL_STORAGE)
+    var runtimePermissionRule: TestRule? = GrantStoragePermission.instance
 
     @get:Rule
     var activityRule: ActivityScenarioRule<NoteEditor>? = ActivityScenarioRule(

--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/ACRATest.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/ACRATest.kt
@@ -16,19 +16,18 @@
  ****************************************************************************************/
 package com.ichi2.anki.tests
 
-import android.Manifest
 import android.annotation.SuppressLint
 import android.content.SharedPreferences
 import androidx.annotation.StringRes
 import androidx.core.content.edit
 import androidx.test.annotation.UiThreadTest
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import androidx.test.rule.GrantPermissionRule
 import com.ichi2.anki.AnkiDroidApp
 import com.ichi2.anki.CrashReportService
 import com.ichi2.anki.CrashReportService.FEEDBACK_REPORT_ALWAYS
 import com.ichi2.anki.CrashReportService.FEEDBACK_REPORT_ASK
 import com.ichi2.anki.R
+import com.ichi2.anki.testutil.GrantStoragePermission
 import org.acra.ACRA
 import org.acra.builder.ReportBuilder
 import org.acra.config.ACRAConfigurationException
@@ -48,8 +47,7 @@ import timber.log.Timber
 @SuppressLint("DirectSystemCurrentTimeMillisUsage")
 class ACRATest : InstrumentedTest() {
     @get:Rule
-    var runtimePermissionRule: GrantPermissionRule =
-        GrantPermissionRule.grant(Manifest.permission.WRITE_EXTERNAL_STORAGE)
+    var runtimePermissionRule = GrantStoragePermission.instance
     private var mApp: AnkiDroidApp? = null
     private val mDebugLogcatArguments = arrayOf("-t", "300", "-v", "long", "ACRA:S")
 

--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/CollectionTest.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/CollectionTest.kt
@@ -16,9 +16,8 @@
  ****************************************************************************************/
 package com.ichi2.anki.tests
 
-import android.Manifest
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import androidx.test.rule.GrantPermissionRule
+import com.ichi2.anki.testutil.GrantStoragePermission
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -30,8 +29,7 @@ import kotlin.test.junit.JUnitAsserter.assertNotNull
 @RunWith(AndroidJUnit4::class)
 class CollectionTest : InstrumentedTest() {
     @get:Rule
-    val runtimePermissionRule: GrantPermissionRule =
-        GrantPermissionRule.grant(Manifest.permission.WRITE_EXTERNAL_STORAGE)
+    val runtimePermissionRule = GrantStoragePermission.instance
 
     @Test
     fun testOpenCollection() {

--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/ContentProviderTest.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/ContentProviderTest.kt
@@ -18,18 +18,18 @@
  ****************************************************************************************/
 package com.ichi2.anki.tests
 
-import android.Manifest
 import android.content.ContentResolver
 import android.content.ContentUris
 import android.content.ContentValues
 import android.database.CursorWindow
 import android.net.Uri
-import androidx.test.rule.GrantPermissionRule
 import com.ichi2.anki.AbstractFlashcardViewer
 import com.ichi2.anki.CollectionHelper
 import com.ichi2.anki.FlashCardsContract
 import com.ichi2.anki.exception.ConfirmModSchemaException
 import com.ichi2.anki.testutil.DatabaseUtils.cursorFillWindow
+import com.ichi2.anki.testutil.GrantStoragePermission.storagePermission
+import com.ichi2.anki.testutil.grantPermissions
 import com.ichi2.async.TaskManager.Companion.waitToFinish
 import com.ichi2.libanki.*
 import com.ichi2.utils.BlocksSchemaUpgrade
@@ -67,10 +67,7 @@ class ContentProviderTest : InstrumentedTest() {
     var schedVersion = 0
 
     @get:Rule
-    var runtimePermissionRule: GrantPermissionRule? = GrantPermissionRule.grant(
-        Manifest.permission.WRITE_EXTERNAL_STORAGE,
-        FlashCardsContract.READ_WRITE_PERMISSION
-    )
+    var runtimePermissionRule = grantPermissions(storagePermission, FlashCardsContract.READ_WRITE_PERMISSION)
 
     // Whether tear down should be executed. I.e. if set up was not cancelled.
     private var mTearDown = false

--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/NotificationChannelTest.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/NotificationChannelTest.kt
@@ -15,16 +15,15 @@
  ****************************************************************************************/
 package com.ichi2.anki.tests
 
-import android.Manifest
 import android.app.NotificationManager
 import android.content.Context
 import android.os.Build
 import androidx.annotation.RequiresApi
 import androidx.test.annotation.UiThreadTest
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import androidx.test.rule.GrantPermissionRule
 import com.ichi2.anki.AnkiDroidApp
 import com.ichi2.anki.Channel
+import com.ichi2.anki.testutil.GrantStoragePermission
 import com.ichi2.compat.CompatHelper.Companion.sdkVersion
 import com.ichi2.utils.KotlinCleanup
 import org.hamcrest.MatcherAssert.assertThat
@@ -42,8 +41,7 @@ import kotlin.test.junit.JUnitAsserter.assertNotNull
 @KotlinCleanup("Enable JUnit 5 in androidTest and use JUnit5Asserter to match the standard tests")
 class NotificationChannelTest : InstrumentedTest() {
     @get:Rule
-    var runtimePermissionRule: GrantPermissionRule =
-        GrantPermissionRule.grant(Manifest.permission.WRITE_EXTERNAL_STORAGE)
+    var runtimePermissionRule = GrantStoragePermission.instance
     private var mCurrentAPI = -1
     private var mTargetAPI = -1
     @KotlinCleanup("lateinit")

--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/libanki/DBTest.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/libanki/DBTest.kt
@@ -16,14 +16,13 @@
  ****************************************************************************************/
 package com.ichi2.anki.tests.libanki
 
-import android.Manifest
 import android.database.sqlite.SQLiteDatabase
 import android.database.sqlite.SQLiteDatabaseCorruptException
 import androidx.sqlite.db.SupportSQLiteDatabase
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import androidx.test.rule.GrantPermissionRule
 import com.ichi2.anki.CollectionHelper
 import com.ichi2.anki.tests.InstrumentedTest
+import com.ichi2.anki.testutil.GrantStoragePermission
 import com.ichi2.libanki.DB
 import net.ankiweb.rsdroid.database.AnkiSupportSQLiteDatabase
 import org.junit.Assert
@@ -37,8 +36,7 @@ import java.util.*
 @RunWith(AndroidJUnit4::class)
 class DBTest : InstrumentedTest() {
     @get:Rule
-    var runtimePermissionRule: GrantPermissionRule =
-        GrantPermissionRule.grant(Manifest.permission.WRITE_EXTERNAL_STORAGE)
+    var runtimePermissionRule = GrantStoragePermission.instance
 
     @Test
     @Throws(Exception::class)

--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/libanki/HttpTest.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/libanki/HttpTest.kt
@@ -20,7 +20,8 @@ package com.ichi2.anki.tests.libanki
 import android.Manifest
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
-import androidx.test.rule.GrantPermissionRule
+import com.ichi2.anki.testutil.GrantStoragePermission.storagePermission
+import com.ichi2.anki.testutil.grantPermissions
 import com.ichi2.async.Connection
 import com.ichi2.libanki.sync.HostNum
 import com.ichi2.utils.NetworkUtils
@@ -33,8 +34,8 @@ import org.junit.runner.RunWith
 class HttpTest {
 
     @get:Rule
-    var runtimeStoragePermissionRule = GrantPermissionRule.grant(
-        Manifest.permission.WRITE_EXTERNAL_STORAGE,
+    var runtimeStoragePermissionRule = grantPermissions(
+        storagePermission,
         Manifest.permission.INTERNET,
         Manifest.permission.ACCESS_NETWORK_STATE
     )

--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/libanki/ImportTest.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/libanki/ImportTest.kt
@@ -15,12 +15,11 @@
  ****************************************************************************************/
 package com.ichi2.anki.tests.libanki
 
-import android.Manifest
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import androidx.test.rule.GrantPermissionRule
 import com.ichi2.anki.exception.ImportExportException
 import com.ichi2.anki.tests.InstrumentedTest
 import com.ichi2.anki.tests.Shared
+import com.ichi2.anki.testutil.GrantStoragePermission
 import com.ichi2.libanki.Collection
 import com.ichi2.libanki.importer.Anki2Importer
 import com.ichi2.libanki.importer.AnkiPackageImporter
@@ -45,8 +44,7 @@ class ImportTest : InstrumentedTest() {
     private lateinit var testCol: Collection
 
     @get:Rule
-    var runtimePermissionRule: GrantPermissionRule? =
-        GrantPermissionRule.grant(Manifest.permission.WRITE_EXTERNAL_STORAGE)
+    var runtimePermissionRule = GrantStoragePermission.instance
 
     // testAnki2Mediadupes() failed on Travis API=22 EMU_FLAVOR=default ABI=armeabi-v7a
     // com.ichi2.anki.tests.libanki.ImportTest > testAnki2Mediadupes[test(AVD) - 5.1.1] FAILED

--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/libanki/MediaTest.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/libanki/MediaTest.kt
@@ -15,11 +15,10 @@
  ****************************************************************************************/
 package com.ichi2.anki.tests.libanki
 
-import android.Manifest
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import androidx.test.rule.GrantPermissionRule
 import com.ichi2.anki.BackupManager
 import com.ichi2.anki.tests.InstrumentedTest
+import com.ichi2.anki.testutil.GrantStoragePermission
 import com.ichi2.libanki.Collection
 import com.ichi2.libanki.Media
 import com.ichi2.libanki.exception.EmptyMediaException
@@ -42,8 +41,7 @@ class MediaTest : InstrumentedTest() {
     private var mTestCol: Collection? = null
 
     @get:Rule
-    var runtimePermissionRule: GrantPermissionRule =
-        GrantPermissionRule.grant(Manifest.permission.WRITE_EXTERNAL_STORAGE)
+    var runtimePermissionRule = GrantStoragePermission.instance
 
     @Before
     @Throws(IOException::class)

--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/testutil/GrantPermissions.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/testutil/GrantPermissions.kt
@@ -1,0 +1,48 @@
+/*
+ *  Copyright (c) 2023 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.testutil
+
+import android.os.Build
+import androidx.test.platform.app.InstrumentationRegistry
+import androidx.test.rule.GrantPermissionRule
+import org.junit.rules.TestRule
+
+object GrantStoragePermission {
+    private val targetSdkVersion = InstrumentationRegistry.getInstrumentation().targetContext.applicationInfo.targetSdkVersion
+    val storagePermission = if (
+        targetSdkVersion >= Build.VERSION_CODES.R &&
+        Build.VERSION.SDK_INT >= Build.VERSION_CODES.R
+    )
+        null
+    else
+        android.Manifest.permission.WRITE_EXTERNAL_STORAGE
+
+    /**
+     * Storage is longer necessary for API 30+
+     * This specific rule is very common, so use a flyweight
+     */
+    val instance: TestRule = grantPermissions(storagePermission)
+}
+
+val notificationPermission = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU)
+    android.Manifest.permission.POST_NOTIFICATIONS else null
+
+/** Grants permissions, given some may be invalid */
+fun grantPermissions(vararg permissions: String?): TestRule {
+    val validPermissions = permissions.filterNotNull().toTypedArray()
+    return GrantPermissionRule.grant(*validPermissions)
+}


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
I bumped the emulator version for tests in https://github.com/ankidroid/Anki-Android/pull/13261. It got problematic as `WRITE_EXTERNAL_STORAGE` was denied, so the `GrantPermissionRule` rule failed

## Approach
* Define permission strings which may be null on certain APIs
* Define grantPermissions() which filters out these null strings

## How Has This Been Tested?
Tested on emulators: API 32 and 21

## Learning (optional, can help others)
* `GrantPermissionRule.grant` fails if strings are null or empty, but not if the list is empty
  * And if the permission is denied (not unreasonable) 

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
