### PR TITLE
ci: temporarily remove `creyD/prettier_action`

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -94,8 +94,9 @@ jobs:
           # "lintPlayDebug" doesn't test the API
           arguments: lintPlayDebug :api:lintDebug ktLintCheck lint-rules:test --daemon
 
-      - name: Prettify code
-        uses: creyD/prettier_action@v4.2
-        with:
-          prettier_options: --check AnkiDroid/**/*.js
-          dry: True
+# Disabled temporarily: #13296
+#      - name: Prettify code
+#        uses: creyD/prettier_action@v4.2
+#        with:
+#          prettier_options: --check AnkiDroid/**/*.js
+#          dry: True


### PR DESCRIPTION
The action is currently broken. We don't use it often.

To be reinstated when upstream has fixed the issue.

Issue #13296