### PR TITLE
Storage Migration: Notification to handle failure

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/AboutFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/AboutFragment.kt
@@ -15,10 +15,7 @@
  */
 package com.ichi2.anki.preferences
 
-import android.content.ClipData
-import android.content.ClipboardManager
 import android.content.Context
-import android.content.Context.CLIPBOARD_SERVICE
 import android.content.Intent
 import android.os.Bundle
 import android.text.method.LinkMovementMethod
@@ -36,8 +33,8 @@ import com.ichi2.anki.*
 import com.ichi2.anki.servicelayer.DebugInfoService
 import com.ichi2.anki.snackbar.showSnackbar
 import com.ichi2.utils.IntentUtil
-import com.ichi2.utils.VersionUtils.appName
 import com.ichi2.utils.VersionUtils.pkgVersionName
+import com.ichi2.utils.copyToClipboard
 import com.ichi2.utils.show
 
 class AboutFragment : Fragment() {
@@ -105,9 +102,7 @@ class AboutFragment : Fragment() {
      */
     private fun copyDebugInfo() {
         val debugInfo = DebugInfoService.getDebugInfo(requireContext()) { (requireActivity() as Preferences).col }
-        val clipboardManager = requireActivity().getSystemService(CLIPBOARD_SERVICE) as ClipboardManager?
-        if (clipboardManager != null) {
-            clipboardManager.setPrimaryClip(ClipData.newPlainText("$appName v$pkgVersionName", debugInfo))
+        if (requireContext().copyToClipboard(debugInfo)) {
             showSnackbar(
                 R.string.about_ankidroid_successfully_copied_debug,
                 Snackbar.LENGTH_SHORT

--- a/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/scopedstorage/migrateuserdata/MigrateUserData.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/scopedstorage/migrateuserdata/MigrateUserData.kt
@@ -18,6 +18,8 @@ package com.ichi2.anki.servicelayer.scopedstorage.migrateuserdata
 
 import android.content.SharedPreferences
 import androidx.annotation.VisibleForTesting
+import com.ichi2.anki.AnkiDroidApp
+import com.ichi2.anki.R
 import com.ichi2.anki.model.Directory
 import com.ichi2.anki.model.DiskFile
 import com.ichi2.anki.model.RelativeFilePath
@@ -512,7 +514,8 @@ open class MigrateUserData protected constructor(val source: Directory, val dest
         // otherwise, there were a few exceptions which didn't stop execution, throw these.
         if (!context.successfullyCompleted) {
             context.terminatedWith?.let { throw it }
-            throw AggregateException.raise("", context.loggedExceptions) // TODO
+            val migrationFailedMessage = AnkiDroidApp.instance.getString(R.string.migration_failed_message)
+            throw AggregateException.raise(migrationFailedMessage, context.loggedExceptions)
         }
 
         // we are successfully migrated here

--- a/AnkiDroid/src/main/java/com/ichi2/anki/services/MigrationService.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/services/MigrationService.kt
@@ -33,6 +33,7 @@ import com.ichi2.anki.servicelayer.scopedstorage.migrateuserdata.MigrateUserData
 import com.ichi2.anki.servicelayer.scopedstorage.migrateuserdata.NumberOfBytes
 import com.ichi2.anki.servicelayer.scopedstorage.migrateuserdata.toKB
 import com.ichi2.anki.servicelayer.scopedstorage.migrateuserdata.toMB
+import com.ichi2.compat.CompatHelper.Companion.compat
 import com.ichi2.utils.FileUtil
 import com.ichi2.utils.Repeater
 import com.ichi2.utils.runOnUiThread
@@ -115,6 +116,11 @@ class MigrationService : Service() {
                 UIUtils.showThemedToast(context, message, true)
             }
         }
+
+        fun onError(e: Exception) {
+            notificationUpdater.terminate()
+            notification?.notifyError(e)
+        }
     }
 
     private class Notification private constructor(
@@ -155,12 +161,27 @@ class MigrationService : Service() {
             val titleRes = if (result) R.string.migration_successful_message else R.string.migration_failed_message
             val notificationTitle = context.resources.getString(titleRes)
             notificationBuilder.setContentTitle(notificationTitle)
-                .setProgress(0, 0, false)
                 .setOngoing(false)
+                .hideProgressBar()
+            manager.notify(id, notificationBuilder.build())
+        }
+
+        fun notifyError(e: Exception) {
+            // TODO: Add a button for 'Get Help'
+            val copyIntent = IntentHandler.copyStringToClipboardIntent(this.context, e.toString())
+
+            val copyDebugIntent = compat.getImmutableActivityIntent(this.context, COPY_DEBUG, copyIntent, 0)
+            notificationBuilder.setContentTitle(context.getString(R.string.migration_failed_message))
+                .setContentText(e.toString())
+                .setOngoing(false)
+                .hideProgressBar()
+                .addAction(R.drawable.ic_star_notify, context.getString(R.string.feedback_copy_debug), copyDebugIntent)
+
             manager.notify(id, notificationBuilder.build())
         }
 
         companion object {
+            const val COPY_DEBUG: Int = 1
             fun createInstance(context: Context, sourceSize: NumberOfBytes): Notification {
                 val notificationManager = NotificationManagerCompat.from(context)
                 return Notification(context, notificationManager, sourceSize)
@@ -201,9 +222,13 @@ class MigrationService : Service() {
             this.totalToTransfer = getRemainingTransferSize(migrateUserDataTask)
             val listener = MigrateUserDataProgressListener(this)
             listener.initNotification(totalToTransfer)
-            // TODO: Handle transient errors (lack of space)
-            val result = migrateUserDataTask.migrateFiles { bytesTransferred -> listener.onProgressUpdate(bytesTransferred) }
-            listener.onResult(result)
+            try {
+                val result = migrateUserDataTask.migrateFiles { bytesTransferred -> listener.onProgressUpdate(bytesTransferred) }
+                listener.onResult(result)
+            } catch (e: Exception) {
+                CrashReportService.sendExceptionReport(e, "Storage Migration Failed")
+                listener.onError(e)
+            }
         }
 
         return getRestartBehavior()
@@ -246,3 +271,7 @@ class MigrationService : Service() {
 
     override fun onBind(intent: Intent): IBinder = LocalBinder()
 }
+
+/** Hides a progress bar if previously shown on a notification */
+private fun NotificationCompat.Builder.hideProgressBar(): NotificationCompat.Builder =
+    this.setProgress(0, 0, false)

--- a/AnkiDroid/src/main/java/com/ichi2/exceptions/AggregateException.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/exceptions/AggregateException.kt
@@ -26,6 +26,10 @@ import java.lang.RuntimeException
  */
 class AggregateException(message: String, val exceptions: List<Exception>) : RuntimeException(message) {
 
+    override fun toString(): String {
+        return "$message\n ${exceptions.joinToString(separator = "\n") { it.stackTraceToString() }}"
+    }
+
     companion object {
         /**
          * Returns an [AggregateException] containing the provided exceptions

--- a/AnkiDroid/src/main/java/com/ichi2/utils/ClipboardUtil.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/ClipboardUtil.kt
@@ -15,12 +15,14 @@
  */
 package com.ichi2.utils
 
+import android.app.Activity
 import android.content.ClipData
 import android.content.ClipDescription
 import android.content.ClipboardManager
 import android.content.Context
 import android.net.Uri
 import androidx.annotation.CheckResult
+import timber.log.Timber
 
 object ClipboardUtil {
     // JPEG is sent via pasted content
@@ -66,4 +68,24 @@ object ClipboardUtil {
             ?.description
             ?.label
     }
+}
+
+/**
+ * Copies the provided text to the clipboard (truncated if necessary)
+ * @return `true` if the clipboard is modified. `false` otherwise
+ */
+fun Context.copyToClipboard(text: String): Boolean {
+    val clipboardManager = this.getSystemService(Activity.CLIPBOARD_SERVICE) as? ClipboardManager
+    if (clipboardManager == null) {
+        Timber.w("Failed to obtain ClipboardManager")
+        return false
+    }
+
+    clipboardManager.setPrimaryClip(
+        ClipData.newPlainText(
+            "${VersionUtils.appName} v${VersionUtils.pkgVersionName}",
+            text
+        )
+    )
+    return true
 }

--- a/AnkiDroid/src/main/java/com/ichi2/utils/StringUtil.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/StringUtil.kt
@@ -19,6 +19,7 @@ package com.ichi2.utils
 
 import org.jetbrains.annotations.Contract
 import java.util.*
+import kotlin.math.min
 
 object StringUtil {
     /** Converts the string to where the first letter is uppercase, and the rest of the string is lowercase  */
@@ -29,4 +30,8 @@ object StringUtil {
 
         return s.substring(0, 1).uppercase(Locale.getDefault()) + s.substring(1).lowercase(Locale.getDefault())
     }
+}
+
+fun String.trimToLength(maxLength: Int): String {
+    return this.substring(0, min(this.length, maxLength))
 }


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
Handles a few TODOs. Previously a crash would have occurred


## Fixes
Issue #5304

## Approach
* Show a notification with a 'copy debug info'
  * Copies Exception + Stack trace to clipboard
* Submits a Crash Report

## How Has This Been Tested?

<details>
<summary>Manually by having `MoveFile` throw - debug info included</summary>

```
Migration failed
 java.lang.IllegalStateException: Testing
	at com.ichi2.anki.servicelayer.scopedstorage.MoveFile.execute(MoveFile.kt:42)
	at com.ichi2.anki.servicelayer.scopedstorage.migrateuserdata.MigrateUserData$Executor.executeOperationInternal$AnkiDroid_playDebug(MigrateUserData.kt:344)
	at com.ichi2.anki.servicelayer.scopedstorage.migrateuserdata.MigrateUserData$Executor$execute$1.invoke(MigrateUserData.kt:334)
	at com.ichi2.anki.servicelayer.scopedstorage.migrateuserdata.MigrateUserData$Executor$execute$1.invoke(MigrateUserData.kt:333)
	at com.ichi2.anki.servicelayer.scopedstorage.migrateuserdata.MigrateUserData$MigrationContext.execSafe(MigrateUserData.kt:187)
	at com.ichi2.anki.servicelayer.scopedstorage.migrateuserdata.MigrateUserData$Executor.execute(MigrateUserData.kt:333)
	at com.ichi2.anki.servicelayer.scopedstorage.migrateuserdata.MigrateUserData.migrateFiles$moveRemainingFiles(MigrateUserData.kt:500)
	at com.ichi2.anki.servicelayer.scopedstorage.migrateuserdata.MigrateUserData.migrateFiles(MigrateUserData.kt:509)
	at com.ichi2.anki.services.MigrationService$onStartCommand$1.invoke(MigrationService.kt:225)
	at com.ichi2.anki.services.MigrationService$onStartCommand$1.invoke(MigrationService.kt:220)
	at kotlin.concurrent.ThreadsKt$thread$thread$1.run(Thread.kt:30)

com.ichi2.anki.servicelayer.scopedstorage.migrateuserdata.MigrateUserData$DirectoryNotEmptyException: directory was not empty: /storage/emulated/0/AnkiDroid/backup
	at com.ichi2.anki.servicelayer.scopedstorage.DeleteEmptyDirectory.execute(DeleteEmptyDirectory.kt:36)
	at com.ichi2.anki.servicelayer.scopedstorage.migrateuserdata.MigrateUserData$SingleRetryDecorator.execute(MigrateUserData.kt:296)
	at com.ichi2.anki.servicelayer.scopedstorage.migrateuserdata.MigrateUserData$Executor.executeOperationInternal$AnkiDroid_playDebug(MigrateUserData.kt:344)
	at com.ichi2.anki.servicelayer.scopedstorage.migrateuserdata.MigrateUserData$Executor$execute$1.invoke(MigrateUserData.kt:334)
	at com.ichi2.anki.servicelayer.scopedstorage.migrateuserdata.MigrateUserData$Executor$execute$1.invoke(MigrateUserData.kt:333)
	at com.ichi2.anki.servicelayer.scopedstorage.migrateuserdata.MigrateUserData$MigrationContext.execSafe(MigrateUserData.kt:187)
	at com.ichi2.anki.servicelayer.scopedstorage.migrateuserdata.MigrateUserData$Executor.execute(MigrateUserData.kt:333)
	at com.ichi2.anki.servicelayer.scopedstorage.migrateuserdata.MigrateUserData.migrateFiles$moveRemainingFiles(MigrateUserData.kt:500)
	at com.ichi2.anki.servicelayer.scopedstorage.migrateuserdata.MigrateUserData.migrateFiles(MigrateUserData.kt:509)
	at com.ichi2.anki.services.MigrationService$onStartCommand$1.invoke(MigrationService.kt:225)
	at com.ichi2.anki.services.MigrationService$onStartCommand$1.invoke(MigrationService.kt:220)
	at kotlin.concurrent.ThreadsKt$thread$thread$1.run(Thread.kt:30)

```

</details>

![Screenshot 2023-02-19 at 02 08 37](https://user-images.githubusercontent.com/62114487/219908584-c5e21832-60ea-4814-b8c3-95c5d79d5164.png)
![Screenshot 2023-02-19 at 02 08 43](https://user-images.githubusercontent.com/62114487/219908586-c01b7aff-70b7-4ae5-a137-80043e6eaea9.png)



## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
