### PR TITLE
fix getParcelable deprecation

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicImageFieldController.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicImageFieldController.kt
@@ -60,6 +60,7 @@ import com.ichi2.anki.UIUtils
 import com.ichi2.anki.multimediacard.activity.MultimediaEditFieldActivity
 import com.ichi2.annotations.NeedsTest
 import com.ichi2.compat.CompatHelper
+import com.ichi2.compat.CompatHelper.Companion.getParcelableCompat
 import com.ichi2.ui.FixedEditText
 import com.ichi2.utils.BitmapUtil
 import com.ichi2.utils.ExifUtil
@@ -100,7 +101,6 @@ class BasicImageFieldController : FieldControllerBase(), IFieldController {
     @VisibleForTesting
     lateinit var registryToUse: ActivityResultRegistry
 
-    @Suppress("deprecation") // getParcelable
     override fun loadInstanceState(savedInstanceState: Bundle?) {
         if (savedInstanceState == null) {
             Timber.i("loadInstanceState but null so nothing to load")
@@ -110,7 +110,7 @@ class BasicImageFieldController : FieldControllerBase(), IFieldController {
         Timber.i("loadInstanceState loading saved state...")
         mViewModel = ImageViewModel.fromBundle(savedInstanceState)
         mPreviousImagePath = savedInstanceState.getString("mPreviousImagePath")
-        mPreviousImageUri = savedInstanceState.getParcelable("mPreviousImageUri")
+        mPreviousImageUri = savedInstanceState.getParcelableCompat<Uri>("mPreviousImageUri")
     }
 
     override fun saveInstanceState(): Bundle {

--- a/AnkiDroid/src/main/java/com/ichi2/compat/Compat.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/Compat.kt
@@ -88,6 +88,7 @@ interface Compat {
     fun <T> readSparseArray(parcel: Parcel, loader: ClassLoader, clazz: Class<T>): SparseArray<T>?
     fun <T : Parcelable> getParcelableArrayList(bundle: Bundle, key: String, clazz: Class<T>): ArrayList<T>?
     fun resolveService(packageManager: PackageManager, intent: Intent, flags: ResolveInfoFlagsCompat): ResolveInfo?
+    fun <T> getParcelable(bundle: Bundle, key: String?, clazz: Class<T>): T?
 
     /**
      * Retrieve extended data from the intent.

--- a/AnkiDroid/src/main/java/com/ichi2/compat/CompatHelper.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/CompatHelper.kt
@@ -148,6 +148,23 @@ class CompatHelper private constructor() {
         }
 
         /**
+         * Returns the value associated with the given key or `null` if:
+         *  * No mapping of the desired type exists for the given key.
+         *  * A `null` value is explicitly associated with the key.
+         *  * The object is not of type `T`.
+         *
+         * **Note: ** if the expected value is not a class provided by the Android platform,
+         * you must call [.setClassLoader] with the proper [ClassLoader] first.
+         * Otherwise, this method might throw an exception or return `null`.
+         *
+         * @param key a String, or `null`
+         * @return a Parcelable value, or `null`
+         */
+        inline fun <reified T> Bundle.getParcelableCompat(key: String): T? {
+            return compat.getParcelable(this, key, T::class.java)
+        }
+
+        /**
          * Read into an existing List object from the parcel at the current
          * dataPosition(), using the given class loader to load any enclosed
          * Parcelables.  If it is null, the default class loader is used.

--- a/AnkiDroid/src/main/java/com/ichi2/compat/CompatV21.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/CompatV21.kt
@@ -91,6 +91,10 @@ open class CompatV21 : Compat {
         return packageManager.resolveService(intent, flags.value.toInt())
     }
 
+    override fun <T> getParcelable(bundle: Bundle, key: String?, clazz: Class<T>): T? {
+        return bundle.getParcelable(key)
+    }
+
     override fun <T : Serializable?> getSerializableExtra(
         intent: Intent,
         name: String,

--- a/AnkiDroid/src/main/java/com/ichi2/compat/CompatV33.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/CompatV33.kt
@@ -76,4 +76,8 @@ open class CompatV33 : CompatV31(), Compat {
     ) {
         parcel.readList(outVal, classLoader, clazz)
     }
+
+    override fun <T> getParcelable(bundle: Bundle, key: String?, clazz: Class<T>): T? {
+        return bundle.getParcelable(key, clazz)
+    }
 }


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
_Describe the problem or feature and motivation_

## Fixes
part of https://github.com/ankidroid/Anki-Android/issues/12364

## Approach
_How does this change address the problem?_

## How Has This Been Tested?

I don't know how to test this

## Learning (optional, can help others)
_Describe the research stage_

_Links to blog posts, patterns, libraries or addons used to solve this problem_

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
