### PR TITLE
NF: remove trimRight method

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Sound.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Sound.kt
@@ -34,7 +34,6 @@ import com.ichi2.anki.ReadText
 import com.ichi2.compat.CompatHelper
 import com.ichi2.utils.DisplayUtils
 import com.ichi2.utils.KotlinCleanup
-import com.ichi2.utils.StringUtil.trimRight
 import net.ankiweb.rsdroid.BackendFactory.defaultLegacySchema
 import timber.log.Timber
 import java.lang.ref.WeakReference
@@ -588,7 +587,7 @@ class Sound {
             return if (hasURIScheme(trimmedSound)) {
                 trimmedSound
             } else {
-                soundDir + Uri.encode(trimRight(sound))
+                soundDir + Uri.encode(sound.trimEnd())
             }
         }
 

--- a/AnkiDroid/src/main/java/com/ichi2/utils/StringUtil.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/StringUtil.kt
@@ -21,18 +21,6 @@ import org.jetbrains.annotations.Contract
 import java.util.*
 
 object StringUtil {
-    /** Trims from the right hand side of a string  */
-    @Contract("null -> null; !null -> !null")
-    fun trimRight(s: String?): String? {
-        if (s == null) return null
-
-        var newLength = s.length
-        while (newLength > 0 && Character.isWhitespace(s[newLength - 1])) {
-            newLength--
-        }
-        return if (newLength < s.length) s.substring(0, newLength) else s
-    }
-
     /** Converts the string to where the first letter is uppercase, and the rest of the string is lowercase  */
     @Contract("null -> null; !null -> !null")
     fun toTitleCase(s: String?): String? {

--- a/AnkiDroid/src/test/java/com/ichi2/utils/StringUtilTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/utils/StringUtilTest.kt
@@ -16,35 +16,12 @@
 package com.ichi2.utils
 
 import com.ichi2.utils.StringUtil.toTitleCase
-import com.ichi2.utils.StringUtil.trimRight
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
 import org.hamcrest.Matchers.nullValue
-import org.hamcrest.Matchers.sameInstance
 import org.junit.Test
 
 class StringUtilTest {
-    @Test
-    fun trimRightNullIsSetToNull() {
-        assertThat(trimRight(null), nullValue())
-    }
-
-    @Test
-    fun trimRightWhiteSpaceIsBlankString() {
-        assertThat(trimRight(" "), equalTo(""))
-    }
-
-    @Test
-    fun trimRightOnlyTrimsRight() {
-        assertThat(trimRight(" a "), equalTo(" a"))
-    }
-
-    @Test
-    fun trimRightDoesNothingOnTrimmedString() {
-        val input = " foo"
-        assertThat(trimRight(input), sameInstance(input))
-    }
-
     @Test
     fun toTitleCase_null_is_null() {
         assertThat(toTitleCase(null), nullValue())


### PR DESCRIPTION
same as Kotlin's trimEnd

## How Has This Been Tested?

Made `trimRight` be like the below snippet and saw if it passed the tests the same way
```kotlin
fun trimRight(s: String?): String? {
        return s?.trimEnd()
    }
```