### PR TITLE
feat: Add "Backup Prompt" Dialog

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -56,6 +56,7 @@ import com.ichi2.anki.dialogs.tags.TagsDialog
 import com.ichi2.anki.dialogs.tags.TagsDialogFactory
 import com.ichi2.anki.dialogs.tags.TagsDialogListener
 import com.ichi2.anki.export.ActivityExportingDelegate
+import com.ichi2.anki.export.ExportType
 import com.ichi2.anki.receiver.SdCardReceiver
 import com.ichi2.anki.servicelayer.CardService.selectedNoteIds
 import com.ichi2.anki.servicelayer.NoteService.isMarked
@@ -1376,12 +1377,20 @@ open class CardBrowser :
         }
 
         if (inCardsMode) {
-            val msg = resources.getQuantityString(R.plurals.confirm_apkg_export_selected_cards, selectedCardIds.size, selectedCardIds.size)
-            mExportingDelegate.showExportDialog(msg, selectedCardIds, inCardsMode)
+            mExportingDelegate.showExportDialog(
+                ExportDialogParams(
+                    message = resources.getQuantityString(R.plurals.confirm_apkg_export_selected_cards, selectedCardIds.size, selectedCardIds.size),
+                    exportType = ExportType.ExportCards(selectedCardIds)
+                )
+            )
         } else {
             val selectedNoteIds = selectedNoteIds(selectedCardIds, col)
-            val msg = resources.getQuantityString(R.plurals.confirm_apkg_export_selected_notes, selectedNoteIds.size, selectedNoteIds.size)
-            mExportingDelegate.showExportDialog(msg, selectedNoteIds, inCardsMode)
+            mExportingDelegate.showExportDialog(
+                ExportDialogParams(
+                    message = resources.getQuantityString(R.plurals.confirm_apkg_export_selected_notes, selectedNoteIds.size, selectedNoteIds.size),
+                    exportType = ExportType.ExportNotes(selectedNoteIds)
+                )
+            )
         }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -79,6 +79,7 @@ import com.ichi2.anki.dialogs.customstudy.CustomStudyDialog.CustomStudyListener
 import com.ichi2.anki.dialogs.customstudy.CustomStudyDialogFactory
 import com.ichi2.anki.exception.ConfirmModSchemaException
 import com.ichi2.anki.export.ActivityExportingDelegate
+import com.ichi2.anki.export.ExportType
 import com.ichi2.anki.notetype.ManageNotetypes
 import com.ichi2.anki.pages.CsvImporter
 import com.ichi2.anki.preferences.AdvancedSettingsFragment
@@ -895,8 +896,12 @@ open class DeckPicker :
             }
             R.id.action_export -> {
                 Timber.i("DeckPicker:: Export collection button pressed")
-                val msg = resources.getString(R.string.confirm_apkg_export)
-                mExportingDelegate.showExportDialog(msg)
+                mExportingDelegate.showExportDialog(
+                    ExportDialogParams(
+                        message = resources.getString(R.string.confirm_apkg_export),
+                        exportType = ExportType.ExportCollection
+                    )
+                )
                 return true
             }
             else -> return super.onOptionsItemSelected(item)
@@ -2405,8 +2410,12 @@ open class DeckPicker :
     }
 
     fun exportDeck(did: DeckId) {
-        val msg = resources.getString(R.string.confirm_apkg_export_deck, col.decks.get(did).getString("name"))
-        mExportingDelegate.showExportDialog(msg, did)
+        mExportingDelegate.showExportDialog(
+            ExportDialogParams(
+                message = resources.getString(R.string.confirm_apkg_export_deck, col.decks.get(did).getString("name")),
+                exportType = ExportType.ExportDeck(did)
+            )
+        )
     }
 
     fun createIcon(context: Context, did: DeckId) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -896,16 +896,21 @@ open class DeckPicker :
             }
             R.id.action_export -> {
                 Timber.i("DeckPicker:: Export collection button pressed")
-                mExportingDelegate.showExportDialog(
-                    ExportDialogParams(
-                        message = resources.getString(R.string.confirm_apkg_export),
-                        exportType = ExportType.ExportCollection
-                    )
-                )
+                exportCollection(includeMedia = false)
                 return true
             }
             else -> return super.onOptionsItemSelected(item)
         }
+    }
+
+    fun exportCollection(includeMedia: Boolean) {
+        mExportingDelegate.showExportDialog(
+            ExportDialogParams(
+                message = resources.getString(R.string.confirm_apkg_export),
+                exportType = ExportType.ExportCollection,
+                includeMedia = includeMedia
+            )
+        )
     }
 
     @Deprecated("Deprecated in Java")
@@ -1136,6 +1141,8 @@ open class DeckPicker :
         } else {
             // new code triggers backup in updateDeckList()
         }
+
+        launchCatchingTask { BackupPromptDialog.showIfAvailable(this@DeckPicker) }
 
         // Force a full sync if flag was set in upgrade path, asking the user to confirm if necessary
         if (mRecommendFullSync) {
@@ -1630,7 +1637,7 @@ open class DeckPicker :
     override fun sync(conflict: ConflictResolution?) {
         val preferences = getSharedPrefs(baseContext)
 
-        if (userMigrationIsInProgress(this)) {
+        if (!canSync(this)) {
             warnNoSyncDuringMigration()
             return
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Sync.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Sync.kt
@@ -27,11 +27,13 @@ import com.ichi2.anim.ActivityTransitionAnimation
 import com.ichi2.anki.CollectionManager.TR
 import com.ichi2.anki.CollectionManager.withCol
 import com.ichi2.anki.dialogs.SyncErrorDialog
+import com.ichi2.anki.servicelayer.ScopedStorageService
 import com.ichi2.anki.snackbar.showSnackbar
 import com.ichi2.anki.web.HostNumFactory
 import com.ichi2.async.Connection
 import com.ichi2.libanki.createBackup
 import com.ichi2.libanki.sync.*
+import com.ichi2.libanki.utils.TimeManager
 import com.ichi2.preferences.VersatileTextWithASwitchPreference
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -104,6 +106,10 @@ suspend fun syncLogout(context: Context) {
  * or even that the ankiweb account is still valid.
  */
 fun isLoggedIn() = AnkiDroidApp.getSharedPrefs(AnkiDroidApp.instance).getString(SyncPreferences.HKEY, "")!!.isNotEmpty()
+
+fun millisecondsSinceLastSync(preferences: SharedPreferences) = TimeManager.time.intTimeMS() - preferences.getLong("lastSyncTime", 0)
+
+fun canSync(context: Context) = !ScopedStorageService.userMigrationIsInProgress(context)
 
 fun DeckPicker.handleNewSync(
     conflict: Connection.ConflictResolution?,

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/BackupPromptDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/BackupPromptDialog.kt
@@ -1,0 +1,204 @@
+/*
+ *  Copyright (c) 2023 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.dialogs
+
+import android.content.Context
+import android.os.Build
+import androidx.core.content.edit
+import com.afollestad.materialdialogs.MaterialDialog
+import com.afollestad.materialdialogs.WhichButton
+import com.afollestad.materialdialogs.actions.setActionButtonEnabled
+import com.afollestad.materialdialogs.checkbox.checkBoxPrompt
+import com.ichi2.anki.*
+import com.ichi2.anki.CollectionManager.withCol
+import com.ichi2.anki.servicelayer.ScopedStorageService
+import com.ichi2.compat.CompatHelper.Companion.getPackageInfoCompat
+import com.ichi2.compat.PackageInfoFlagsCompat
+import com.ichi2.libanki.utils.TimeManager
+import com.ichi2.utils.Permissions
+import timber.log.Timber
+
+/**
+ * Prompts a user to backup via either sync or 'export collection'
+ *
+ * If dismissed, it will not appear for a period of time (~2 weeks): [calculateNextTimeToShowDialog]
+ * After 2 dismissals, the user may hide the dialog permanently.
+ *
+ * This exists to inform the user their data is at risk when in a scoped folder.
+ *
+ * See [shouldShowDialog] for the criteria to display the dialog
+ */
+class BackupPromptDialog private constructor(private val windowContext: Context) {
+
+    private lateinit var materialDialog: MaterialDialog
+
+    /**
+     * After 2 dismissals, allow ignoring
+     * Note: this is 0-based - the dialog has not been dismissed on the first viewing
+     */
+    private val allowUserToPermanentlyDismissDialog: Boolean
+        get() = timesDialogDismissed > 1
+
+    /** Whether the user has selected 'don't show again' */
+    private var userCheckedDoNotShowAgain = false
+
+    private var timesDialogDismissed: Int
+        get() = AnkiDroidApp.getSharedPrefs(windowContext).getInt("backupPromptDismissedCount", 0)
+        set(value) = AnkiDroidApp.getSharedPrefs(windowContext).edit { putInt("backupPromptDismissedCount", value) }
+
+    private var dialogPermanentlyDismissed: Boolean
+        get() = AnkiDroidApp.getSharedPrefs(windowContext).getBoolean("backupPromptDisabled", false)
+        set(disablePermanently) {
+            AnkiDroidApp.getSharedPrefs(windowContext).edit {
+                putBoolean("backupPromptDisabled", disablePermanently)
+                if (disablePermanently) {
+                    remove("backupPromptDismissedCount")
+                    remove("timeToShowBackupDialog")
+                }
+            }
+        }
+
+    private var nextTimeToShowDialog: Long
+        get() = AnkiDroidApp.getSharedPrefs(windowContext).getLong("timeToShowBackupDialog", 0)
+        set(value) { AnkiDroidApp.getSharedPrefs(windowContext).edit { putLong("timeToShowBackupDialog", value) } }
+
+    private fun onDismiss() {
+        Timber.i("BackupPromptDialog dismissed")
+        if (userCheckedDoNotShowAgain) {
+            dialogPermanentlyDismissed = true
+        } else {
+            timesDialogDismissed += 1
+            nextTimeToShowDialog = calculateNextTimeToShowDialog()
+        }
+    }
+
+    private fun onBackup() {
+        nextTimeToShowDialog = calculateNextTimeToShowDialog()
+    }
+
+    private fun calculateNextTimeToShowDialog(): Long {
+        val now = TimeManager.time.intTimeMS()
+        val fixedDayCount = 12
+        val oneToFourDays = (1..4).random() // 13-16 days
+        return now + (fixedDayCount + oneToFourDays) * ONE_DAY_IN_MS
+    }
+
+    private fun build(isLoggedIn: Boolean, performBackup: () -> Unit) {
+        this.materialDialog = MaterialDialog(windowContext).apply {
+            icon(R.drawable.ic_baseline_backup_24)
+            title(R.string.backup_your_collection)
+            message(R.string.backup_collection_message)
+            positiveButton(if (isLoggedIn) R.string.button_sync else R.string.button_backup) {
+                Timber.i("User selected 'backup'")
+                onBackup()
+                performBackup()
+            }
+            if (allowUserToPermanentlyDismissDialog) {
+                checkBoxPrompt(R.string.button_do_not_show_again) { checked ->
+                    Timber.d("Don't show again checked: %b", checked)
+                    userCheckedDoNotShowAgain = checked
+                    setActionButtonEnabled(WhichButton.POSITIVE, !checked)
+                }
+            }
+            negativeButton(R.string.button_backup_later) { onDismiss() }
+            cancelable(false)
+        }
+    }
+
+    companion object {
+        private const val ONE_DAY_IN_MS = 1000 * 60 * 60 * 24
+
+        suspend fun showIfAvailable(deckPicker: DeckPicker) {
+            val backupPrompt = BackupPromptDialog(deckPicker)
+            if (!backupPrompt.shouldShowDialog()) {
+                return
+            }
+
+            val isLoggedIn = isLoggedIn()
+            backupPrompt.apply {
+                build(isLoggedIn) {
+                    if (isLoggedIn) {
+                        deckPicker.sync(conflict = null)
+                    } else {
+                        deckPicker.exportCollection(includeMedia = true)
+                    }
+                }
+                materialDialog.show()
+            }
+        }
+    }
+
+    private suspend fun shouldShowDialog(): Boolean = !userIsNewToAnkiDroid() && canProvideBackupOption() && timeToShowDialogAgain()
+
+    private fun userIsPreservingLegacyStorage(): Boolean {
+        // TODO: Confirm this is correct after 13261 is merged.
+        return Build.VERSION.SDK_INT >= Build.VERSION_CODES.R &&
+            Permissions.hasStorageAccessPermission(windowContext)
+    }
+
+    private fun canProvideBackupOption(): Boolean {
+        if (isLoggedIn()) {
+            // If we're unable to sync, there's no point in showing the dialog
+            if (!canSync(windowContext)) {
+                return false
+            }
+            // Show dialog to sync if user hasn't synced in a while
+            val preferences = AnkiDroidApp.getSharedPrefs(windowContext)
+            return millisecondsSinceLastSync(preferences) <= ONE_DAY_IN_MS * 7
+        }
+
+        // Non-legacy locations may be deleted by the user on uninstall
+        val collectionIsSafeAfterUninstall = ScopedStorageService.isLegacyStorage(windowContext)
+        if (!collectionIsSafeAfterUninstall) {
+            return true
+        }
+
+        // The user may have upgraded, in which it's unsafe to uninstall as Android
+        // will permanently revoke access to the legacy folder
+        // The collection won't be lost, but it will be inaccessible.
+        return this.userIsPreservingLegacyStorage()
+    }
+
+    private fun timeToShowDialogAgain(): Boolean =
+        nextTimeToShowDialog <= TimeManager.time.intTimeMS()
+
+    private suspend fun userIsNewToAnkiDroid(): Boolean {
+        // A user is new if the app was installed > 7 days ago  OR if they have no cards
+        val firstInstallTime = getFirstInstallTime() ?: 0
+        if (TimeManager.time.intTimeMS() - firstInstallTime >= ONE_DAY_IN_MS * 7) {
+            return false
+        }
+
+        // if for some reason the user has no cards after 7 days, don't bother
+        return withCol {
+            this.cardCount() == 0
+        }
+    }
+
+    /** The time at which the app was first installed. Units are as per [System.currentTimeMillis()]. */
+    private fun getFirstInstallTime(): Long? {
+        return try {
+            return windowContext.packageManager.getPackageInfoCompat(
+                windowContext.packageName,
+                PackageInfoFlagsCompat.of(0)
+            )?.firstInstallTime
+        } catch (exception: Exception) {
+            Timber.w("failed to get first install time")
+            null
+        }
+    }
+}

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/BackupPromptDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/BackupPromptDialog.kt
@@ -18,6 +18,7 @@ package com.ichi2.anki.dialogs
 
 import android.content.Context
 import android.os.Build
+import androidx.appcompat.app.AlertDialog
 import androidx.core.content.edit
 import com.afollestad.materialdialogs.MaterialDialog
 import com.afollestad.materialdialogs.WhichButton
@@ -29,7 +30,7 @@ import com.ichi2.anki.servicelayer.ScopedStorageService
 import com.ichi2.compat.CompatHelper.Companion.getPackageInfoCompat
 import com.ichi2.compat.PackageInfoFlagsCompat
 import com.ichi2.libanki.utils.TimeManager
-import com.ichi2.utils.Permissions
+import com.ichi2.utils.*
 import timber.log.Timber
 
 /**
@@ -79,10 +80,27 @@ class BackupPromptDialog private constructor(private val windowContext: Context)
     private fun onDismiss() {
         Timber.i("BackupPromptDialog dismissed")
         if (userCheckedDoNotShowAgain) {
-            dialogPermanentlyDismissed = true
+            permanentlyDismissDialog()
         } else {
             timesDialogDismissed += 1
             nextTimeToShowDialog = calculateNextTimeToShowDialog()
+        }
+    }
+
+    private fun permanentlyDismissDialog() {
+        val message = if (userIsPreservingLegacyStorage()) R.string.dismiss_backup_warning_upgrade else R.string.dismiss_backup_warning_new_user
+
+        AlertDialog.Builder(windowContext).show {
+            title(R.string.dismiss_backup_warning_title)
+            message(message)
+            iconAttr(R.attr.dialogErrorIcon)
+            positiveButton(R.string.dialog_cancel) {
+                dialogPermanentlyDismissed = true
+            }
+            negativeButton(R.string.button_disable_reminder) {
+                userCheckedDoNotShowAgain = false
+                onDismiss()
+            }
         }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DialogHandler.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DialogHandler.kt
@@ -22,7 +22,6 @@ import androidx.annotation.VisibleForTesting
 import com.ichi2.anki.*
 import com.ichi2.anki.analytics.UsageAnalytics
 import com.ichi2.libanki.MediaCheckResult
-import com.ichi2.libanki.utils.TimeManager
 import com.ichi2.utils.HandlerUtils.getDefaultLooper
 import com.ichi2.utils.NetworkUtils
 import timber.log.Timber
@@ -87,7 +86,7 @@ class DialogHandler(activity: AnkiActivity) : Handler(getDefaultLooper()) {
             val preferences = AnkiDroidApp.getSharedPrefs(mActivity.get())
             val res = mActivity.get()!!.resources
             val hkey = preferences.getString("hkey", "")
-            val millisecondsSinceLastSync = TimeManager.time.intTimeMS() - preferences.getLong("lastSyncTime", 0)
+            val millisecondsSinceLastSync = millisecondsSinceLastSync(preferences)
             val limited = millisecondsSinceLastSync < INTENT_SYNC_MIN_INTERVAL
             if (!limited && hkey!!.isNotEmpty() && NetworkUtils.isOnline) {
                 deckPicker.sync()

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ExportDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ExportDialog.kt
@@ -18,13 +18,17 @@ package com.ichi2.anki.dialogs
 
 import android.annotation.SuppressLint
 import android.os.Bundle
+import anki.cards.cardIds
 import anki.import_export.ExportLimit
 import anki.import_export.exportLimit
+import anki.notes.noteIds
 import com.afollestad.materialdialogs.MaterialDialog
 import com.afollestad.materialdialogs.list.listItemsMultiChoice
 import com.ichi2.anki.R
 import com.ichi2.anki.analytics.AnalyticsDialogFragment
-import com.ichi2.annotations.NeedsTest
+import com.ichi2.anki.dialogs.ExportDialogParams.Companion.toExportDialogParams
+import com.ichi2.anki.export.ExportType
+import com.ichi2.anki.export.ExportType.*
 import com.ichi2.libanki.DeckId
 import com.ichi2.utils.BundleUtils.getNullableLong
 import com.ichi2.utils.contentNullable
@@ -37,80 +41,36 @@ class ExportDialog(private val listener: ExportDialogListener) : AnalyticsDialog
         fun dismissAllDialogFragments()
     }
 
-    private var mIncludeSched = false
-    private var mIncludeMedia = false
+    private var includeSched = false
+    private var includeMedia = false
 
-    /**
-     * Creates a new instance of ExportDialog to export a deck of cards
-     *
-     * @param did A long which specifies the deck to be exported,
-     *            if did is null then the whole collection of decks will be exported
-     * @param dialogMessage A string which can be used to show a custom message or specify import path
-     */
-    fun withArguments(dialogMessage: String, did: DeckId? = null): ExportDialog {
-        val args = this.arguments ?: Bundle()
-        if (did != null) {
-            args.putLong("did", did)
-        }
-        args.putString("dialogMessage", dialogMessage)
-        this.arguments = args
-        return this
-    }
-
-    /**
-     * @param ids A list of longs which specifies the card/note ids to be exported
-     * @param isCardList A boolean which specifies whether the list of ids is a list of card ids or note ids
-     * @param dialogMessage A string which can be used to show a custom message or specify import path
-     */
-    fun withArguments(dialogMessage: String, ids: List<Long>, isCardList: Boolean): ExportDialog {
-        val args = this.arguments ?: Bundle()
-        args.putString("dialogMessage", dialogMessage)
-        if (isCardList) {
-            args.putLongArray("cardIds", ids.toLongArray())
-        } else {
-            args.putLongArray("noteIds", ids.toLongArray())
-        }
-        this.arguments = args
+    fun withArguments(data: ExportDialogParams): ExportDialog {
+        this.arguments = data.appendToBundle(this.arguments ?: Bundle())
         return this
     }
 
     @SuppressLint("CheckResult")
     override fun onCreateDialog(savedInstanceState: Bundle?): MaterialDialog {
         super.onCreate(savedInstanceState)
-        val res = resources
-        val did = getNullableLong(arguments, "did")
-        val cardIds = arguments?.getLongArray("cardIds")?.toList()
-        val noteIds = arguments?.getLongArray("noteIds")?.toList()
-        val checked: Array<Int>
-        @NeedsTest("Test that correct options are checked given different arguments")
-        if (did != null || cardIds == null || noteIds == null) {
-            mIncludeSched = false
-            checked = arrayOf()
-        } else {
-            mIncludeSched = true
-            checked = arrayOf(INCLUDE_SCHED)
-        }
-        val items = listOf(
-            res.getString(R.string.export_include_schedule),
-            res.getString(R.string.export_include_media)
-        )
+        val exportData = requireArguments().toExportDialogParams()
+        val initialSelection: Array<Int> = if (exportData.includeScheduling) arrayOf(INCLUDE_SCHED) else arrayOf()
+        includeSched = initialSelection.contains(INCLUDE_SCHED)
+
         return MaterialDialog(requireActivity()).show {
             title(R.string.export)
-            contentNullable(requireArguments().getString("dialogMessage"))
+            contentNullable(exportData.message)
             positiveButton(android.R.string.ok) {
-                if (did != null) {
-                    listener.exportDeckAsApkg(null, did, mIncludeSched, mIncludeMedia)
-                } else if (cardIds != null || noteIds != null) {
-                    val limit = exportLimit {
-                        if (cardIds != null) {
-                            this.cardIds = this.cardIds.toBuilder().addAllCids(cardIds).build()
-                        } else {
-                            this.noteIds = this.noteIds.toBuilder().addAllNoteIds(noteIds).build()
-                        }
+                when (val exportType = exportData.exportType) {
+                    is ExportDeck -> listener.exportDeckAsApkg(null, exportType.deckId, includeSched, includeMedia)
+                    is ExportCollection -> listener.exportColAsApkgOrColpkg(null, includeSched, includeMedia)
+                    is ExportNotes -> {
+                        val limit = exportLimit { this.noteIds = noteIds { this.noteIds.addAll(exportType.nodeIds) } }
+                        listener.exportSelectedAsApkg(null, limit, includeSched, includeMedia)
                     }
-                    listener.exportSelectedAsApkg(null, limit, mIncludeSched, mIncludeMedia)
-                } else {
-                    listener.exportColAsApkgOrColpkg(null, mIncludeSched, mIncludeMedia)
+                    is ExportCards -> {
+                        val limit = exportLimit { this.cardIds = cardIds { cids.addAll(exportType.cardIds) } }
+                        listener.exportSelectedAsApkg(null, limit, includeSched, includeMedia)
+                    }
                 }
                 dismissAllDialogFragments()
             }
@@ -119,13 +79,16 @@ class ExportDialog(private val listener: ExportDialogListener) : AnalyticsDialog
             }
             cancelable(true)
             listItemsMultiChoice(
-                items = items,
-                initialSelection = checked.toIntArray(),
+                items = listOf(
+                    resources.getString(R.string.export_include_schedule),
+                    resources.getString(R.string.export_include_media)
+                ),
+                initialSelection = initialSelection.toIntArray(),
                 allowEmptySelection = true,
                 waitForPositiveButton = false
             ) { _: MaterialDialog, ints: IntArray, _: List<CharSequence> ->
-                mIncludeMedia = ints.contains(INCLUDE_MEDIA)
-                mIncludeSched = ints.contains(INCLUDE_SCHED)
+                includeMedia = ints.contains(INCLUDE_MEDIA)
+                includeSched = ints.contains(INCLUDE_SCHED)
             }
         }
     }
@@ -137,5 +100,58 @@ class ExportDialog(private val listener: ExportDialogListener) : AnalyticsDialog
     companion object {
         private const val INCLUDE_SCHED = 0
         private const val INCLUDE_MEDIA = 1
+    }
+}
+
+/**
+ * @param message A dialog to display to the user when exporting
+ */
+class ExportDialogParams(val message: String, val exportType: ExportType) {
+    val includeScheduling: Boolean = when (this.exportType) {
+        is ExportNotes -> false
+        is ExportCards -> false
+        is ExportDeck -> false
+        is ExportCollection -> true
+    }
+
+    fun appendToBundle(bundle: Bundle): Bundle {
+        bundle.putString(MESSAGE, this.message)
+
+        when (this.exportType) {
+            is ExportNotes -> bundle.putLongArray(NOTE_IDS, this.exportType.nodeIds.toLongArray())
+            is ExportCards -> bundle.putLongArray(CARD_IDS, this.exportType.cardIds.toLongArray())
+            is ExportDeck -> bundle.putLong(DECK_ID, this.exportType.deckId)
+            is ExportCollection -> {}
+        }
+        return bundle
+    }
+
+    companion object {
+        private const val MESSAGE = "dialogMessage"
+        private const val DECK_ID = "did"
+        private const val CARD_IDS = "cardIds"
+        private const val NOTE_IDS = "noteIds"
+
+        private fun Bundle.toExportType(): ExportType {
+            val did = getNullableLong(DECK_ID)
+            val cardIds = getLongArray(CARD_IDS)
+            val noteIds = getLongArray(NOTE_IDS)
+
+            if (did != null) {
+                return ExportDeck(did)
+            }
+            if (cardIds != null) {
+                return ExportCards(cardIds.toList())
+            }
+            if (noteIds != null) {
+                return ExportNotes(noteIds.toList())
+            }
+            return ExportCollection
+        }
+
+        fun Bundle.toExportDialogParams(): ExportDialogParams = ExportDialogParams(
+            message = getString(MESSAGE)!!,
+            exportType = this.toExportType()
+        )
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/export/ActivityExportingDelegate.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/export/ActivityExportingDelegate.kt
@@ -35,6 +35,7 @@ import com.ichi2.anki.CollectionManager.withCol
 import com.ichi2.anki.UIUtils.showThemedToast
 import com.ichi2.anki.dialogs.ExportCompleteDialog.ExportCompleteDialogListener
 import com.ichi2.anki.dialogs.ExportDialog.ExportDialogListener
+import com.ichi2.anki.dialogs.ExportDialogParams
 import com.ichi2.anki.snackbar.showSnackbar
 import com.ichi2.compat.CompatHelper
 import com.ichi2.libanki.AnkiPackageExporter
@@ -62,22 +63,8 @@ class ActivityExportingDelegate(private val activity: AnkiActivity, private val 
     private val mSaveFileLauncher: ActivityResultLauncher<Intent>
     private lateinit var mExportFileName: String
 
-    fun showExportDialog(msg: String) {
-        activity.showDialogFragment(mDialogsFactory.newExportDialog().withArguments(msg))
-    }
-
-    fun showExportDialog(msg: String, did: DeckId) {
-        activity.showDialogFragment(mDialogsFactory.newExportDialog().withArguments(msg, did))
-    }
-
-    /**
-     * Show the export dialog in the Browser to export selected cards or notes
-     * @param msg the message to show in the dialog
-     * @param ids the selected card/note ids
-     * @param isCardList true if the ids are card ids, false if they are note ids
-     */
-    fun showExportDialog(msg: String, ids: List<Long>, isCardList: Boolean) {
-        activity.showDialogFragment(mDialogsFactory.newExportDialog().withArguments(msg, ids, isCardList))
+    fun showExportDialog(params: ExportDialogParams) {
+        activity.showDialogFragment(mDialogsFactory.newExportDialog().withArguments(params))
     }
 
     private fun getTimeStampSuffix() =

--- a/AnkiDroid/src/main/java/com/ichi2/anki/export/ExportType.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/export/ExportType.kt
@@ -1,0 +1,31 @@
+/*
+ *  Copyright (c) 2023 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.export
+
+import com.ichi2.libanki.CardId
+import com.ichi2.libanki.DeckId
+import com.ichi2.libanki.NoteId
+
+/**
+ * Ways that a user may export data
+ */
+sealed interface ExportType {
+    class ExportNotes(val nodeIds: List<NoteId>) : ExportType
+    class ExportCards(val cardIds: List<CardId>) : ExportType
+    class ExportDeck(val deckId: DeckId) : ExportType
+    object ExportCollection : ExportType
+}

--- a/AnkiDroid/src/main/java/com/ichi2/utils/BundleUtils.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/BundleUtils.kt
@@ -24,16 +24,15 @@ object BundleUtils {
     /**
      * Retrieves a [Long] value from a [Bundle] using a key, returns null if not found
      *
-     * @param bundle the bundle to look into
      * can be null to support nullable bundles like [androidx.fragment.app.Fragment.getArguments]
      * @param key the key to use
      * @return the long value, or null if not found
      */
-    fun getNullableLong(bundle: Bundle?, key: String): Long? {
-        return if (bundle == null || !bundle.containsKey(key)) {
+    fun Bundle.getNullableLong(key: String): Long? {
+        return if (!containsKey(key)) {
             null
         } else {
-            bundle.getLong(key)
+            getLong(key)
         }
     }
 

--- a/AnkiDroid/src/main/res/drawable/ic_baseline_backup_24.xml
+++ b/AnkiDroid/src/main/res/drawable/ic_baseline_backup_24.xml
@@ -1,0 +1,21 @@
+<!--
+  ~  Copyright (c) 2023 David Allison <davidallisongithub@gmail.com>
+  ~
+  ~  This program is free software; you can redistribute it and/or modify it under
+  ~  the terms of the GNU General Public License as published by the Free Software
+  ~  Foundation; either version 3 of the License, or (at your option) any later
+  ~  version.
+  ~
+  ~  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+  ~  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+  ~  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+  ~
+  ~  You should have received a copy of the GNU General Public License along with
+  ~  this program.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+
+<vector android:height="24dp" android:tint="?attr/toolbarIconColor"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="?attr/iconColor" android:pathData="M19.35,10.04C18.67,6.59 15.64,4 12,4 9.11,4 6.6,5.64 5.35,8.04 2.34,8.36 0,10.91 0,14c0,3.31 2.69,6 6,6h13c2.76,0 5,-2.24 5,-5 0,-2.64 -2.05,-4.78 -4.65,-4.96zM14,13v4h-4v-4H7l5,-5 5,5h-3z"/>
+</vector>

--- a/AnkiDroid/src/main/res/values/03-dialogs.xml
+++ b/AnkiDroid/src/main/res/values/03-dialogs.xml
@@ -272,4 +272,12 @@
     <!-- Deck selection dialog -->
     <string name="cannot_create_subdeck_for_all_decks">You cannot create a subdeck for all decks</string>
 
+    <!-- scoped storage -->
+    <string name="backup_your_collection">Backup your collection</string>
+    <string name="backup_collection_message">You haven\'t backed up your collection in a while. You should do this now to prevent data loss</string>
+    <string name="button_backup">Backup</string>
+    <string name="button_backup_later" comment="dismiss the 'Backup' dialog for around 2 weeks">Later</string>
+    <string name="button_do_not_show_again" comment="permanently dismisses a dialog">Don\'t show again</string>
+
+
 </resources>

--- a/AnkiDroid/src/main/res/values/03-dialogs.xml
+++ b/AnkiDroid/src/main/res/values/03-dialogs.xml
@@ -276,8 +276,17 @@
     <string name="backup_your_collection">Backup your collection</string>
     <string name="backup_collection_message">You haven\'t backed up your collection in a while. You should do this now to prevent data loss</string>
     <string name="button_backup">Backup</string>
+    <string name="button_disable_reminder">Disable reminder</string>
     <string name="button_backup_later" comment="dismiss the 'Backup' dialog for around 2 weeks">Later</string>
     <string name="button_do_not_show_again" comment="permanently dismisses a dialog">Don\'t show again</string>
 
+    <string name="dismiss_backup_warning_title">Data loss warning</string>
+    <string name="dismiss_backup_warning_new_user">
+        Due to Android privacy changes, your data and automated backups will be deleted from your phone if the app is uninstalled
+    </string>
+
+    <string name="dismiss_backup_warning_upgrade">
+        Due to Android privacy changes, your data and automated backups will be inaccessible if the app is uninstalled
+    </string>
 
 </resources>

--- a/AnkiDroid/src/test/java/com/ichi2/anki/export/ExportDialogParamsTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/export/ExportDialogParamsTest.kt
@@ -1,0 +1,38 @@
+/*
+ *  Copyright (c) 2023 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.export
+
+import com.ichi2.anki.dialogs.ExportDialogParams
+import com.ichi2.anki.export.ExportType.*
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.equalTo
+import org.junit.Test
+
+class ExportDialogParamsTest {
+    @Test
+    fun includeSchedulingDefaultValue() {
+        assertIncludeScheduling(ExportDeck(1), false)
+        assertIncludeScheduling(ExportCards(listOf(1, 2)), false)
+        assertIncludeScheduling(ExportNotes(listOf(1, 2)), false)
+        assertIncludeScheduling(ExportCollection, true)
+    }
+
+    private fun assertIncludeScheduling(type: ExportType, expected: Boolean) {
+        val includeScheduling = ExportDialogParams(message = "", exportType = type).includeScheduling
+        assertThat("${type.javaClass.simpleName}: includeScheduling", includeScheduling, equalTo(expected))
+    }
+}

--- a/AnkiDroid/src/test/java/com/ichi2/utils/BundleUtilsTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/utils/BundleUtilsTest.kt
@@ -16,6 +16,7 @@
 package com.ichi2.utils
 
 import android.os.Bundle
+import com.ichi2.utils.BundleUtils.getNullableLong
 import org.junit.Assert.assertEquals
 import org.junit.Test
 import org.mockito.Mockito.*
@@ -25,18 +26,12 @@ import kotlin.test.assertNull
 
 class BundleUtilsTest {
     @Test
-    fun test_GetNullableLong_NullBundle_ReturnsNull() {
-        val value = BundleUtils.getNullableLong(null, KEY)
-        assertNull(value)
-    }
-
-    @Test
     fun test_GetNullableLong_NotFound_ReturnsNull() {
         val b = mock(Bundle::class.java)
 
         whenever(b.containsKey(anyString())).thenReturn(false)
 
-        val value = BundleUtils.getNullableLong(b, KEY)
+        val value = b.getNullableLong(KEY)
 
         verify(b, times(0)).getLong(eq(KEY))
 
@@ -52,7 +47,7 @@ class BundleUtilsTest {
 
         whenever(b.getLong(anyString())).thenReturn(expected)
 
-        val value = BundleUtils.getNullableLong(b, KEY)
+        val value = b.getNullableLong(KEY)
 
         verify(b).getLong(eq(KEY))
 


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
Add a dialog to remind users to sync

This exists to:
* Ensure that users are aware their data is at risk after API 30 and the collection folder may be deleted on uninstall
* Encourage users to sync

## Approach
Firstly, refactor 'ExportDialog',  we want to add 'include media' functionality here and it needed work. This also fixes a bug in the `include scheduling` flag defaults

Then, implement a dialog

This is shown:
* If the user is NOT new to AnkiDroid
* And the collection is unsafe. Either:
  * Not syncing and collection is unsafe
  * Syncing and has not synced recently

This dialog is shown once every 13-16 days.

## How Has This Been Tested?

Manually

![Screenshot 2023-02-20 at 22 34 58](https://user-images.githubusercontent.com/62114487/220210331-4d5b6b1c-60ca-4b3a-8628-057434758418.png)
![Screenshot 2023-02-20 at 22 33 23](https://user-images.githubusercontent.com/62114487/220210357-3a4cf64e-70a7-4ff0-b9b7-24689c11a5c5.png)
![Screenshot 2023-02-21 at 00 17 20](https://user-images.githubusercontent.com/62114487/220216551-c48ffe79-c362-4dc8-a717-1e82bd916100.png)



## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
