### PR TITLE
Disable some advanced settings if migrating storage

### DIFF
--- a/AnkiDroid/src/main/res/values/02-strings.xml
+++ b/AnkiDroid/src/main/res/values/02-strings.xml
@@ -454,4 +454,9 @@
     <string name="toggle_browser_mode_help">Toggle Showing cards or notes in the browser</string>
     <string name="truncate_content_help">Truncate the height of each row of the Browser to show only first 3 lines of content</string>
     <string name="browser_options_dialog_heading">Browser Options</string>
+
+    <string name="functionality_disabled_during_storage_migration"
+        comment="Displayed when trying to access functionality which cannot be run while storage is being moved to a new location">
+        This functionality is unavailable during a storage migration
+    </string>
 </resources>


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
Migrating storage is a high-risk operation as it involves copying the user's media

Disable:
* AnkiDroid Directory
  * Corruption: Media from the one collection is moved to the other
* V3 Migration
  * High Risk: Disabling defensively

## Related
- #5304
- #13094

## Approach
Grey the preference and set a summary

<img width="427" alt="Screenshot 2023-02-24 at 19 58 39" src="https://user-images.githubusercontent.com/62114487/221279209-bcdbff78-1d21-47e5-a7ae-26c237f7152a.png">


## How Has This Been Tested?
Manually: API 33 emulator

## Learning
**Unused n this PR**

* If a preference is not disabled, the `click` handler won't stop the change/dialog event
* If disabled, the `click` handler doesn't fire

But we can handle the dialog event separately to catch this

On switch/checkbox preferences, all we need to do is override `setOnPreferenceChangeListener` AFTER it's been set conditionally

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
