### PR TITLE
Replaces usages of MaterialDialog with AlertDialog

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
@@ -1805,12 +1805,12 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
         editToolbarItemDialog: MaterialDialog
     ) {
         AlertDialog.Builder(this).show {
-            setTitle(R.string.remove_toolbar_item)
-            setPositiveButton(R.string.dialog_positive_delete) { _, _ ->
+            title(R.string.remove_toolbar_item)
+            positiveButton(R.string.dialog_positive_delete) {
                 editToolbarItemDialog.dismiss()
                 removeButton(button)
             }
-            setNegativeButton(R.string.dialog_cancel) { _, _ -> }
+            negativeButton(R.string.dialog_cancel)
         }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
@@ -41,6 +41,7 @@ import androidx.annotation.CheckResult
 import androidx.annotation.RequiresApi
 import androidx.annotation.StringRes
 import androidx.annotation.VisibleForTesting
+import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.view.menu.MenuBuilder
 import androidx.appcompat.widget.AppCompatButton
 import androidx.appcompat.widget.PopupMenu
@@ -90,6 +91,7 @@ import com.ichi2.libanki.Note.ClozeUtils
 import com.ichi2.libanki.Note.DupeOrEmpty
 import com.ichi2.themes.Themes
 import com.ichi2.utils.*
+import com.ichi2.utils.show
 import com.ichi2.widget.WidgetStatus
 import net.ankiweb.rsdroid.BackendFactory
 import org.json.JSONArray
@@ -1802,13 +1804,13 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
         button: CustomToolbarButton,
         editToolbarItemDialog: MaterialDialog
     ) {
-        MaterialDialog(this).show {
-            title(R.string.remove_toolbar_item)
-            positiveButton(R.string.dialog_positive_delete) {
+        AlertDialog.Builder(this).show {
+            setTitle(R.string.remove_toolbar_item)
+            setPositiveButton(R.string.dialog_positive_delete) { _, _ ->
                 editToolbarItemDialog.dismiss()
                 removeButton(button)
             }
-            negativeButton(R.string.dialog_cancel)
+            setNegativeButton(R.string.dialog_cancel) { _, _ -> }
         }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/pages/PageChromeClient.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/pages/PageChromeClient.kt
@@ -18,9 +18,10 @@ package com.ichi2.anki.pages
 import android.webkit.JsResult
 import android.webkit.WebChromeClient
 import android.webkit.WebView
-import com.afollestad.materialdialogs.MaterialDialog
+import androidx.appcompat.app.AlertDialog
 import com.ichi2.anki.R
 import com.ichi2.anki.UIUtils
+import com.ichi2.utils.show
 
 open class PageChromeClient : WebChromeClient() {
     override fun onJsAlert(
@@ -39,10 +40,10 @@ open class PageChromeClient : WebChromeClient() {
         message: String?,
         result: JsResult?
     ): Boolean {
-        MaterialDialog(view.context).show {
-            message?.let { message(text = message) }
-            positiveButton(R.string.dialog_ok) { result?.confirm() }
-            negativeButton(R.string.dialog_cancel) { result?.cancel() }
+        AlertDialog.Builder(view.context).show {
+            message?.let { setMessage(message) }
+            setPositiveButton(R.string.dialog_ok) { _, _ -> result?.confirm() }
+            setNegativeButton(R.string.dialog_cancel) { _, _ -> result?.cancel() }
         }
         return true
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/pages/PageChromeClient.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/pages/PageChromeClient.kt
@@ -21,6 +21,9 @@ import android.webkit.WebView
 import androidx.appcompat.app.AlertDialog
 import com.ichi2.anki.R
 import com.ichi2.anki.UIUtils
+import com.ichi2.utils.message
+import com.ichi2.utils.negativeButton
+import com.ichi2.utils.positiveButton
 import com.ichi2.utils.show
 
 open class PageChromeClient : WebChromeClient() {
@@ -41,9 +44,9 @@ open class PageChromeClient : WebChromeClient() {
         result: JsResult?
     ): Boolean {
         AlertDialog.Builder(view.context).show {
-            message?.let { setMessage(message) }
-            setPositiveButton(R.string.dialog_ok) { _, _ -> result?.confirm() }
-            setNegativeButton(R.string.dialog_cancel) { _, _ -> result?.cancel() }
+            message?.let { message(text = message) }
+            positiveButton(R.string.dialog_ok) { result?.confirm() }
+            negativeButton(R.string.dialog_cancel) { result?.cancel() }
         }
         return true
     }


### PR DESCRIPTION
## Purpose / Description
Replaces usages of MaterialDialog with AlertDialog in NoteEditor.kt,PageChromeClient.kt
## Fixes
Related to #13315 

## How Has This Been Tested?
Open each one of the changed dialogs on their respective preferences

