### PR TITLE
Replaces usages of MaterialDialog with AlertDialog for BasicImageFieldController.kt,ImportUtils.kt

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicImageFieldController.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicImageFieldController.kt
@@ -47,10 +47,10 @@ import android.widget.TextView
 import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.result.ActivityResultRegistry
 import androidx.annotation.VisibleForTesting
+import androidx.appcompat.app.AlertDialog
 import androidx.core.content.ContentResolverCompat
 import androidx.core.content.FileProvider
 import androidx.core.content.getSystemService
-import com.afollestad.materialdialogs.MaterialDialog
 import com.canhub.cropper.*
 import com.ichi2.anki.AnkiDroidApp
 import com.ichi2.anki.CrashReportService
@@ -62,11 +62,7 @@ import com.ichi2.annotations.NeedsTest
 import com.ichi2.compat.CompatHelper
 import com.ichi2.compat.CompatHelper.Companion.getParcelableCompat
 import com.ichi2.ui.FixedEditText
-import com.ichi2.utils.BitmapUtil
-import com.ichi2.utils.ExifUtil
-import com.ichi2.utils.FileUtil
-import com.ichi2.utils.KotlinCleanup
-import com.ichi2.utils.Permissions
+import com.ichi2.utils.*
 import timber.log.Timber
 import java.io.File
 import java.io.FileNotFoundException
@@ -669,16 +665,16 @@ class BasicImageFieldController : FieldControllerBase(), IFieldController {
             Timber.w("showCropDialog called with null URI or Path")
             return
         }
-        val dialog = MaterialDialog(mActivity)
-            .message(text = content)
-            .positiveButton(R.string.dialog_ok) {
+
+        AlertDialog.Builder(mActivity).show {
+            message(text = content)
+            positiveButton(R.string.dialog_ok) {
                 mViewModel = requestCrop(mViewModel)
             }
-            .negativeButton(R.string.dialog_no) {
+            negativeButton(R.string.dialog_no) {
                 negativeCallback?.invoke() // Using invoke since negativeCallback is nullable
             }
-
-        dialog.show()
+        }
     }
 
     private fun handleCropResult(result: CropImageView.CropResult) {

--- a/AnkiDroid/src/main/java/com/ichi2/utils/ImportUtils.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/ImportUtils.kt
@@ -26,7 +26,7 @@ import android.os.Message
 import android.provider.OpenableColumns
 import android.webkit.MimeTypeMap
 import androidx.annotation.CheckResult
-import com.afollestad.materialdialogs.MaterialDialog
+import androidx.appcompat.app.AlertDialog
 import com.ichi2.anki.AnkiActivity
 import com.ichi2.anki.AnkiDroidApp
 import com.ichi2.anki.CrashReportService
@@ -291,7 +291,7 @@ object ImportUtils {
         fun showImportUnsuccessfulDialog(activity: Activity, errorMessage: String?, exitActivity: Boolean) {
             Timber.e("showImportUnsuccessfulDialog() message %s", errorMessage)
             val title = activity.resources.getString(R.string.import_title_error)
-            MaterialDialog(activity).show {
+            AlertDialog.Builder(activity).show {
                 title(text = title)
                 message(text = errorMessage!!)
                 positiveButton(R.string.dialog_ok) {


### PR DESCRIPTION
## Purpose / Description
Replaces usages of MaterialDialog with AlertDialog in BasicImageFieldController.kt,ImportUtils.kt
## Fixes
Related to #13315 

## How Has This Been Tested?
Open each one of the changed dialogs on their respective preferences
