### PR TITLE
test: mark flaky windows tests

### DIFF
--- a/AnkiDroid/src/test/java/com/ichi2/anki/ReviewerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/ReviewerTest.kt
@@ -29,7 +29,9 @@ import com.ichi2.libanki.Consts
 import com.ichi2.libanki.Model
 import com.ichi2.libanki.ModelManager
 import com.ichi2.libanki.utils.TimeManager
+import com.ichi2.testutils.Flaky
 import com.ichi2.testutils.MockTime
+import com.ichi2.testutils.OS
 import com.ichi2.utils.deepClone
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.*
@@ -73,6 +75,7 @@ class ReviewerTest : RobolectricTest() {
 
     @Test
     @RunInBackground
+    @Flaky(os = OS.WINDOWS, "startUp: BackendCollectionAlreadyOpenException")
     fun exitCommandWorksAfterControlsAreBlocked() {
         ensureCollectionLoadIsSynchronous()
         ActivityScenario.launchActivityForResult(Reviewer::class.java).use { scenario ->
@@ -221,6 +224,7 @@ class ReviewerTest : RobolectricTest() {
     }
 
     @Test
+    @Flaky(os = OS.WINDOWS, "startReviewer: NullPointerException - baseDeckName")
     fun baseDeckName() {
         val models = col.models
 


### PR DESCRIPTION
- `com.ichi2.anki.ReviewerTest.baseDeckName[SchedV2]`
  - `NullPointerException`
- `com.ichi2.anki.ReviewerTest.exitCommandWorksAfterControlsAreBlocked[SchedV2]`
  - `CollectionAlreadyOpen`

https://github.com/ankidroid/Anki-Android/actions/runs/4265822001/jobs/7425612801

```
ReviewerTest > [SchedV2] > com.ichi2.anki.ReviewerTest.exitCommandWorksAfterControlsAreBlocked[SchedV2] FAILED
    net.ankiweb.rsdroid.exceptions.BackendInvalidInputException$BackendCollectionAlreadyOpenException: CollectionAlreadyOpen
        at net.ankiweb.rsdroid.exceptions.BackendInvalidInputException$Companion.fromInvalidInputError(BackendInvalidInputException.kt:34)
        at net.ankiweb.rsdroid.BackendException$Companion.fromError(BackendException.kt:114)
        at net.ankiweb.rsdroid.BackendKt.unpackResult(Backend.kt:323)
        at net.ankiweb.rsdroid.BackendKt.access$unpackResult(Backend.kt:1)
        at net.ankiweb.rsdroid.Backend$runMethodRaw$1.invoke(Backend.kt:130)
        at net.ankiweb.rsdroid.Backend$runMethodRaw$1.invoke(Backend.kt:129)
        at net.ankiweb.rsdroid.Backend.withBackend(Backend.kt:157)
        at net.ankiweb.rsdroid.Backend.runMethodRaw(Backend.kt:129)
        at anki.backend.GeneratedBackend.openCollectionRaw(GeneratedBackend.kt:26)
        at anki.backend.GeneratedBackend.openCollection(GeneratedBackend.kt:39)
        at net.ankiweb.rsdroid.Backend.openCollection(Backend.kt:109)
        at net.ankiweb.rsdroid.Backend.openCollection(Backend.kt:61)
        at com.ichi2.libanki.Storage.openDB$AnkiDroid_playDebug(Storage.kt:106)
        at com.ichi2.libanki.Collection.reopen(Collection.kt:459)
        at com.ichi2.libanki.Collection.reopen$default(Collection.kt:456)
        at com.ichi2.libanki.Collection.<init>(Collection.kt:190)
        at com.ichi2.libanki.Storage.collection(Storage.kt:88)
        at com.ichi2.anki.CollectionManager.ensureOpenInner(CollectionManager.kt:223)
        at com.ichi2.anki.CollectionManager.access$ensureOpenInner(CollectionManager.kt:36)
        at com.ichi2.anki.CollectionManager$getColUnsafe$1$1.invoke(CollectionManager.kt:276)
        at com.ichi2.anki.CollectionManager$getColUnsafe$1$1.invoke(CollectionManager.kt:275)
        at com.ichi2.anki.CollectionManager.blockForQueue(CollectionManager.kt:255)
        at com.ichi2.anki.CollectionManager.access$blockForQueue(CollectionManager.kt:36)
        at com.ichi2.anki.CollectionManager$getColUnsafe$1.invoke(CollectionManager.kt:275)
        at com.ichi2.anki.CollectionManager$getColUnsafe$1.invoke(CollectionManager.kt:274)
        at com.ichi2.anki.CollectionManager.logUIHangs(CollectionManager.kt:291)
        at com.ichi2.anki.CollectionManager.getColUnsafe(CollectionManager.kt:274)
        at com.ichi2.anki.CollectionHelper.getCol(CollectionHelper.kt:95)
        at com.ichi2.anki.RobolectricTest.getCol(RobolectricTest.kt:312)
        at com.ichi2.anki.ReviewerTest.setUp(ReviewerTest.kt:56)

ReviewerTest > [SchedV2] > com.ichi2.anki.ReviewerTest.baseDeckName[SchedV2] FAILED
    java.lang.NullPointerException
        at com.ichi2.anki.AbstractFlashcardViewer$NextCardHandler.onPostExecute(AbstractFlashcardViewer.kt:481)
        at com.ichi2.anki.AbstractFlashcardViewer$NextCardHandler.onPostExecute(AbstractFlashcardViewer.kt:447)
        at com.ichi2.anki.servicelayer.TaskListenerBuilder.replaceWith$lambda$1(AsyncLayerAdapter.kt:68)
        at com.ichi2.anki.servicelayer.AsyncLayerAdapterKt$toListener$1.onPostExecute(AsyncLayerAdapter.kt:48)
        at com.ichi2.async.CollectionTask.onPostExecute(CollectionTask.kt:[140](https://github.com/ankidroid/Anki-Android/actions/runs/4265822001/jobs/7425612801#step:10:141))
        at android.os.AsyncTask.finish(AsyncTask.java:755)
        at android.os.AsyncTask.access$900(AsyncTask.java:192)
        at android.os.AsyncTask$InternalHandler.handleMessage(AsyncTask.java:772)
        at android.os.Handler.dispatchMessage(Handler.java:107)
        at org.robolectric.shadows.ShadowPausedLooper$IdlingRunnable.run(ShadowPausedLooper.java:368)
        at org.robolectric.shadows.ShadowPausedLooper.executeOnLooper(ShadowPausedLooper.java:402)
        at org.robolectric.shadows.ShadowPausedLooper.idle(ShadowPausedLooper.java:93)
        at org.robolectric.shadows.ShadowPausedLooper.idleIfPaused(ShadowPausedLooper.java:[164](https://github.com/ankidroid/Anki-Android/actions/runs/4265822001/jobs/7425612801#step:10:165))
        at org.robolectric.android.controller.ActivityController.visible(ActivityController.java:222)
        at com.ichi2.anki.RobolectricTest$Companion.startActivityNormallyOpenCollectionWithIntent(RobolectricTest.kt:270)
        at com.ichi2.anki.RobolectricTest.startActivityNormallyOpenCollectionWithIntent(RobolectricTest.kt)
        at com.ichi2.anki.ReviewerTest$Companion.startReviewer(ReviewerTest.kt:420)
        at com.ichi2.anki.ReviewerTest$Companion.startReviewer(ReviewerTest.kt:416)
        at com.ichi2.anki.ReviewerTest.startReviewer(ReviewerTest.kt:363)
        at com.ichi2.anki.ReviewerTest.baseDeckName(ReviewerTest.kt:234)
```

## Approach
Add `@Flaky`

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
