### PR TITLE
refactor: Sound/Video

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/CardHtml.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/CardHtml.kt
@@ -21,6 +21,9 @@ import com.ichi2.anki.R
 import com.ichi2.anki.TtsParser
 import com.ichi2.anki.cardviewer.CardAppearance.Companion.hasUserDefinedNightMode
 import com.ichi2.libanki.*
+import com.ichi2.libanki.Sound.SingleSoundSide
+import com.ichi2.libanki.Sound.SingleSoundSide.ANSWER
+import com.ichi2.libanki.Sound.SingleSoundSide.QUESTION
 import com.ichi2.libanki.template.MathJax
 import com.ichi2.themes.HtmlColors
 import com.ichi2.themes.Themes.currentTheme
@@ -213,14 +216,10 @@ class CardHtml(
             return newAnswerContent
         }
 
-        fun legacyGetTtsTags(card: Card, cardSide: Sound.SoundSide, context: Context): List<TTSTag>? {
-            val cardSideContent: String = when {
-                Sound.SoundSide.QUESTION == cardSide -> card.q(true)
-                Sound.SoundSide.ANSWER == cardSide -> card.pureAnswer
-                else -> {
-                    Timber.w("Unrecognised cardSide")
-                    return null
-                }
+        fun legacyGetTtsTags(card: Card, cardSide: SingleSoundSide, context: Context): List<TTSTag> {
+            val cardSideContent: String = when (cardSide) {
+                QUESTION -> card.q(true)
+                ANSWER -> card.pureAnswer
             }
             return TtsParser.getTextsToRead(cardSideContent, context.getString(R.string.reviewer_tts_cloze_spoken_replacement))
         }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Sound.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Sound.kt
@@ -17,7 +17,6 @@
 
 package com.ichi2.libanki
 
-import android.app.Activity
 import android.content.Context
 import android.media.*
 import android.media.AudioManager.OnAudioFocusChangeListener
@@ -28,460 +27,163 @@ import android.webkit.MimeTypeMap
 import android.widget.VideoView
 import androidx.annotation.CheckResult
 import androidx.annotation.VisibleForTesting
-import com.ichi2.anki.AbstractFlashcardViewer
 import com.ichi2.anki.AnkiDroidApp
 import com.ichi2.anki.ReadText
 import com.ichi2.compat.CompatHelper
 import com.ichi2.libanki.Sound.OnErrorListener.ErrorHandling.CONTINUE_AUDIO
+import com.ichi2.libanki.Sound.SoundSide.*
 import com.ichi2.utils.DisplayUtils
-import com.ichi2.utils.KotlinCleanup
 import net.ankiweb.rsdroid.BackendFactory.defaultLegacySchema
+import org.intellij.lang.annotations.Language
 import timber.log.Timber
-import java.lang.ref.WeakReference
 import java.util.*
 import java.util.regex.Pattern
 
+private typealias SoundPath = String
 // NICE_TO_HAVE: Abstract, then add tests for #6111
 /**
- * Class used to parse, load and play sound files on AnkiDroid.
+ * Parses, loads and plays sound & video files
+ * Called `Sound` Anki uses `[sound:]` for both audio and video
  */
-@KotlinCleanup("IDE Lint")
-class Sound {
+class Sound(private val soundPlayer: SoundPlayer, private val soundDir: String) : SoundPlayer by soundPlayer {
     /**
-     * Media player used to play the sounds. It's Nullable and that it is set only if a sound is playing or paused, otherwise it is null.
+     * @param soundDir base path to the media files
      */
-    private var mMediaPlayer: MediaPlayer? = null
+    constructor(soundDir: String) : this(SoundPlayerImpl(), soundDir)
 
     /**
-     * It's used to store the Uri of the current Audio in case of running or pausing.
-     */
-    private var mCurrentAudioUri: Uri? = null
-
-    /**
-     * AudioManager to request/release audio focus
-     */
-    private var mAudioManager: AudioManager? = null
-
-    /**
-     * Weak reference to the activity which is attempting to play the sound
-     */
-    private var mCallingActivity: WeakReference<Activity?>? = null
-
-    @VisibleForTesting
-    fun getSounds(side: SoundSide): ArrayList<String>? {
-        if (side == SoundSide.QUESTION_AND_ANSWER) {
-            makeQuestionAnswerList()
-        }
-        return mSoundPaths[side]
-    }
-
-    /**
-     * Subset Flags: Flags that indicate the subset of sounds to involve
+     * The subset of sounds to involve
+     * @param int Used for serialisation
      */
     enum class SoundSide(val int: Int) {
         QUESTION(0), ANSWER(1), QUESTION_AND_ANSWER(2);
     }
 
-    /**
-     * Stores sounds for the current card, key is one of the subset flags. It is intended that it not contain empty lists, and code assumes this will be true.
-     */
-    private val mSoundPaths: HashMap<SoundSide, ArrayList<String>> = HashMap()
-    private var mAudioFocusRequest: AudioFocusRequest? = null
+    /** Sounds for the question/answer of a card */
+    // Stops code paths where QUESTION_AND_ANSWER is invalid
+    enum class SingleSoundSide {
+        QUESTION, ANSWER;
 
-    // Clears current sound paths; call before parseSounds() calls
+        fun toSoundSide(): SoundSide = when (this) {
+            QUESTION -> SoundSide.QUESTION
+            ANSWER -> SoundSide.ANSWER
+        }
+    }
+
+    /**
+     * Stores sounds for the current card. Maps from a side to paths paths
+     * Should be accessed via [getSounds]
+     */
+    private val soundPaths: MutableMap<SoundSide, MutableList<SoundPath>> = EnumMap(SoundSide::class.java)
+
+    /** Returns a non-empty list of sounds, or null if there are no values */
+    @VisibleForTesting
+    fun getSounds(side: SoundSide) = getSoundList(side).let {
+        if (!it.any()) null else it
+    }
+
+    private fun getSoundList(side: SoundSide): List<SoundPath> {
+        if (side == QUESTION_AND_ANSWER) {
+            return getSoundList(QUESTION) + getSoundList(ANSWER)
+        }
+        return soundPaths[side] ?: emptyList()
+    }
+
+    /**
+     * Clears current sound paths; call before [expandSounds] + [addSounds]
+     * is called for the next card
+     */
     fun resetSounds() {
-        mSoundPaths.clear()
+        soundPaths.clear()
     }
 
     /**
      * Stores entries to the filepaths for sounds, categorized as belonging to the front (question) or back (answer) of cards.
      * Note that all sounds embedded in the content will be given the same base categorization of question or answer.
      * Additionally, the result is to be sorted by the order of appearance on the card.
-     * @param soundDir -- base path to the media files
-     * @param tags -- the entries expected in display order
-     * @param qa -- the base categorization of the sounds in the content, SoundSide.SOUNDS_QUESTION or SoundSide.SOUNDS_ANSWER
+     * @param tags the entries expected in display order
+     * @param side the base categorization of the sounds in the content
      */
-    fun addSounds(soundDir: String, tags: List<SoundOrVideoTag>, qa: SoundSide) {
-        for ((filename) in tags) {
-            // Create appropriate list if needed; list must not be empty so long as code does no check
-            if (!mSoundPaths.containsKey(qa)) {
-                mSoundPaths[qa] = ArrayList(0)
-            }
-            val soundPath = getSoundPath(soundDir, filename)
-            // Construct the sound path and store it
-            Timber.d("Adding Sound to side: %s", qa)
-            mSoundPaths[qa]!!.add(soundPath)
-        }
+    fun addSounds(tags: List<SoundOrVideoTag>, side: SingleSoundSide) {
+        val soundPathCollection = soundPaths.getOrPut(side.toSoundSide()) { mutableListOf() }
+
+        Timber.d("Adding %d sounds to side: %s", tags.size, side)
+        val paths = tags.map { getSoundPath(soundDir, it.filename) }
+        soundPathCollection.addAll(paths)
     }
 
-    /**
-     * makeQuestionAnswerSoundList creates a single list of both the question and answer audio only if it does not
-     * already exist. It's intended for lazy evaluation, only in the rare cases when both sides are fully played
-     * together, which even when configured as supported may not be instigated
-     * @return True if a non-null list was created, or false otherwise
-     */
-    private fun makeQuestionAnswerList(): Boolean {
-        // if combined list already exists, don't recreate
-        if (mSoundPaths.containsKey(SoundSide.QUESTION_AND_ANSWER)) {
-            return false // combined list already exists
-        }
-
-        // make combined list only if necessary to avoid an empty combined list
-        if (mSoundPaths.containsKey(SoundSide.QUESTION) || mSoundPaths.containsKey(SoundSide.ANSWER)) {
-            // some list exists to place into combined list
-            mSoundPaths[SoundSide.QUESTION_AND_ANSWER] = ArrayList(0)
-        } else { // no need to make list
-            return false
-        }
-        val combinedSounds = mSoundPaths[SoundSide.QUESTION_AND_ANSWER]!!
-        if (mSoundPaths.containsKey(SoundSide.QUESTION)) {
-            combinedSounds.addAll(mSoundPaths[SoundSide.QUESTION]!!)
-        }
-        if (mSoundPaths.containsKey(SoundSide.ANSWER)) {
-            combinedSounds.addAll(mSoundPaths[SoundSide.ANSWER]!!)
-        }
-        return true
-    }
-
-    /**
-     * Plays the sounds for the indicated sides
-     * @param qa -- One of SoundSide.SOUNDS_QUESTION, SoundSide.SOUNDS_ANSWER, or SoundSide.SOUNDS_QUESTION_AND_ANSWER
-     */
-    fun playSounds(qa: SoundSide, errorListener: OnErrorListener?) {
+    /** Plays all the sounds for the indicated side(s)  */
+    fun playSounds(side: SoundSide, errorListener: OnErrorListener?) {
         // If there are sounds to play for the current card, start with the first one
-        if (mSoundPaths.containsKey(qa)) {
-            Timber.d("playSounds %s", qa)
-            playSoundInternal(
-                mSoundPaths[qa]!![0],
-                PlayAllCompletionListener(qa, errorListener),
-                null,
-                errorListener
-            )
-        } else if (qa == SoundSide.QUESTION_AND_ANSWER) {
-            if (makeQuestionAnswerList()) {
-                Timber.d("playSounds: playing both question and answer")
-                playSoundInternal(
-                    mSoundPaths[qa]!![0],
-                    PlayAllCompletionListener(qa, errorListener),
-                    null,
-                    errorListener
-                )
-            } else {
-                Timber.d("playSounds: No question answer list, not playing sound")
-            }
-        }
+        val soundPaths = getSounds(side) ?: return
+        Timber.d("playSounds: playing $side")
+        this.playSound(
+            soundPaths[0],
+            PlayAllCompletionListener(side, errorListener),
+            errorListener
+        )
     }
 
-    /**
-     * Returns length in milliseconds.
-     * @param qa -- One of SoundSide.SOUNDS_QUESTION, SoundSide.SOUNDS_ANSWER, or SoundSide.SOUNDS_QUESTION_AND_ANSWER
-     */
-    fun getSoundsLength(qa: SoundSide): Long {
-        var length: Long = 0
-        if (qa == SoundSide.QUESTION_AND_ANSWER && makeQuestionAnswerList() || mSoundPaths.containsKey(
-                qa
-            )
-        ) {
-            val metaRetriever = MediaMetadataRetriever()
-            for (uri_string in mSoundPaths[qa]!!) {
-                val soundUri = Uri.parse(uri_string)
+    /** Returns the total length of all sounds for the side in milliseconds */
+    fun getSoundsLength(side: SoundSide): Long {
+        val soundPaths = getSounds(side) ?: return 0
+        val metaRetriever = MediaMetadataRetriever()
+        val context = AnkiDroidApp.instance.applicationContext
+        return soundPaths
+            .map { Uri.parse(it) }
+            .sumOf { uri ->
                 try {
-                    metaRetriever.setDataSource(
-                        AnkiDroidApp.instance.applicationContext,
-                        soundUri
-                    )
-                    length += metaRetriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_DURATION)!!
-                        .toLong()
+                    metaRetriever.getDuration(context, uri)
                 } catch (e: Exception) {
-                    Timber.e(
+                    Timber.w(
                         e,
                         "metaRetriever - Error setting Data Source for mediaRetriever (media doesn't exist or forbidden?)."
                     )
+                    0
                 }
             }
-        }
-        return length
-    }
-
-    /**
-     * Plays the given sound or video and sets playAllListener if available on media player to start next media.
-     * If videoView is null and the media is a video, then a request is sent to start the VideoPlayer Activity
-     */
-    fun playSound(
-        soundPath: String,
-        playAllListener: OnCompletionListener?,
-        videoView: VideoView?,
-        errorListener: OnErrorListener?
-    ) {
-        Timber.d("Playing single sound")
-        val completionListener = SingleSoundCompletionListener(playAllListener)
-        playSoundInternal(soundPath, completionListener, videoView, errorListener)
-    }
-
-    /**
-     * Play or Pause the running sound. Called on pressing the content inside span tag.
-     */
-    @KotlinCleanup("?.let { }")
-    fun playOrPauseSound() {
-        mMediaPlayer ?: return
-        if (mMediaPlayer!!.isPlaying) {
-            mMediaPlayer!!.pause()
-        } else {
-            mMediaPlayer!!.start()
-        }
-    }
-
-    // When an audio finishes and I'm trying to replay it again, this method should check if the mMediaPlayer is null which means
-    // the audio finished to return true, so that I would be able to play the same sound again.
-    @KotlinCleanup("simplify property with ?. ")
-    val isCurrentAudioFinished: Boolean
-        get() = mMediaPlayer == null
-
-    /**
-     * Plays a sound without ensuring that the playAllListener will release the audio
-     */
-    @KotlinCleanup("remove timber - always true")
-    private fun playSoundInternal(
-        soundPath: String,
-        playAllListener: OnCompletionListener,
-        videoView: VideoView?,
-        errorListener: OnErrorListener?
-    ) {
-        Timber.d("Playing %s has listener? %b", soundPath, true)
-        val soundUri = Uri.parse(soundPath)
-        mCurrentAudioUri = soundUri
-        val errorHandler = errorListener
-            ?: OnErrorListener { _: MediaPlayer?, what: Int, extra: Int, _: String? ->
-                Timber.w("Media Error: (%d, %d). Calling OnCompletionListener", what, extra)
-                CONTINUE_AUDIO
-            }
-        if ("tts" == soundPath.substring(0, 3)) {
-            // TODO: give information about did
-//            ReadText.textToSpeech(soundPath.substring(4, soundPath.length()),
-//                    Integer.parseInt(soundPath.substring(3, 4)));
-            return
-        }
-
-        fun playMedia() {
-            // Check if the file extension is that of a known video format
-            val extension =
-                soundPath.substring(soundPath.lastIndexOf(".") + 1).lowercase(Locale.getDefault())
-            var isVideo = listOf(*VIDEO_WHITELIST).contains(extension)
-            if (!isVideo) {
-                val guessedType = MimeTypeMap.getSingleton().getMimeTypeFromExtension(extension)
-                isVideo = guessedType != null && guessedType.startsWith("video/")
-            }
-            // Also check that there is a video thumbnail, as some formats like mp4 can be audio only
-            isVideo = isVideo && hasVideoThumbnail(soundUri)
-            // No thumbnail: no video after all. (Or maybe not a video we can handle on the specific device.)
-            // If video file but no SurfaceHolder provided then ask AbstractFlashcardViewer to provide a VideoView
-            // holder
-            if (isVideo && videoView == null && mCallingActivity != null && mCallingActivity!!.get() != null) {
-                Timber.d("Requesting AbstractFlashcardViewer play video - no SurfaceHolder")
-                mediaCompletionListener = playAllListener
-                (mCallingActivity!!.get() as AbstractFlashcardViewer?)!!.playVideo(soundPath)
-                return
-            }
-            // Play media
-            try {
-                // Create media player
-                if (mMediaPlayer == null) {
-                    Timber.d("Creating media player for playback")
-                    mMediaPlayer = MediaPlayer()
-                } else {
-                    Timber.d("Resetting media for playback")
-                    mMediaPlayer!!.reset()
-                }
-                if (mAudioManager == null) {
-                    mAudioManager = AnkiDroidApp.instance.applicationContext.getSystemService(
-                        Context.AUDIO_SERVICE
-                    ) as AudioManager
-                }
-                // Provide a VideoView to the MediaPlayer if valid video file
-                if (isVideo && videoView != null) {
-                    mMediaPlayer!!.setDisplay(videoView.holder)
-                    mMediaPlayer!!.setOnVideoSizeChangedListener { _: MediaPlayer?, width: Int, height: Int ->
-                        configureVideo(
-                            videoView,
-                            width,
-                            height
-                        )
-                    }
-                }
-                mMediaPlayer!!.setOnErrorListener { mp: MediaPlayer?, which: Int, extra: Int ->
-                    val errorHandling = errorHandler.onError(
-                        mp,
-                        which,
-                        extra,
-                        soundPath
-                    )
-                    // returning false calls onComplete()
-                    return@setOnErrorListener when (errorHandling) {
-                        CONTINUE_AUDIO -> false
-                        OnErrorListener.ErrorHandling.RETRY_AUDIO -> {
-                            playMedia()
-                            true
-                        }
-                        OnErrorListener.ErrorHandling.STOP_AUDIO -> {
-                            stopSounds()
-                            true
-                        }
-                    }
-                }
-                // Setup the MediaPlayer
-                @KotlinCleanup("simplify with scope function on mediaPlayer")
-                mMediaPlayer!!.setDataSource(
-                    AnkiDroidApp.instance.applicationContext,
-                    soundUri
-                )
-                mMediaPlayer!!.setAudioAttributes(
-                    AudioAttributes.Builder()
-                        .setContentType(AudioAttributes.CONTENT_TYPE_MUSIC)
-                        .build()
-                )
-                mMediaPlayer!!.setOnPreparedListener {
-                    Timber.d("Starting media player")
-                    mMediaPlayer!!.start()
-                }
-                mMediaPlayer!!.setOnCompletionListener(playAllListener)
-                mMediaPlayer!!.prepareAsync()
-                Timber.d("Requesting audio focus")
-
-                // Set mAudioFocusRequest for API 26 and above.
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-                    mAudioFocusRequest =
-                        AudioFocusRequest.Builder(AudioManager.AUDIOFOCUS_GAIN_TRANSIENT_MAY_DUCK)
-                            .setOnAudioFocusChangeListener(afChangeListener)
-                            .build()
-                }
-                CompatHelper.compat.requestAudioFocus(mAudioManager!!, afChangeListener, mAudioFocusRequest)
-            } catch (e: Exception) {
-                Timber.e(e, "playSounds - Error reproducing sound %s", soundPath)
-                when (
-                    errorHandler.onError(
-                        mMediaPlayer,
-                        MediaPlayer.MEDIA_ERROR_UNSUPPORTED,
-                        0,
-                        soundPath
-                    )
-                ) {
-                    CONTINUE_AUDIO -> {
-                        Timber.d("Force playing next sound.")
-                        playAllListener.onCompletion(mMediaPlayer)
-                    }
-                    OnErrorListener.ErrorHandling.STOP_AUDIO -> stopSounds()
-                    OnErrorListener.ErrorHandling.RETRY_AUDIO -> playMedia()
-                }
-            }
-        }
-
-        playMedia()
-    }
-
-    @KotlinCleanup("simplify code with ?. or make uri non-null")
-    private fun hasVideoThumbnail(soundUri: Uri?): Boolean {
-        if (soundUri == null) {
-            return false
-        }
-        val path = soundUri.path ?: return false
-        return CompatHelper.compat.hasVideoThumbnail(path)
-    }
-
-    val currentAudioUri: String?
-        get() = if (mCurrentAudioUri == null) {
-            null
-        } else {
-            mCurrentAudioUri.toString()
-        }
-
-    fun notifyConfigurationChanged(videoView: VideoView) {
-        if (mMediaPlayer != null) {
-            configureVideo(videoView, mMediaPlayer!!.videoWidth, mMediaPlayer!!.videoHeight)
-        }
-    }
-
-    /** #5414 - Ensures playing a single sound performs cleanup  */
-    private inner class SingleSoundCompletionListener(private val userCallback: OnCompletionListener?) :
-        OnCompletionListener {
-        override fun onCompletion(mp: MediaPlayer) {
-            Timber.d("Single Sound completed")
-            if (userCallback != null) {
-                userCallback.onCompletion(mp)
-            } else {
-                releaseSound()
-            }
-        }
     }
 
     /**
      * Class used to play all sounds for a given card side
      */
     private inner class PlayAllCompletionListener(
-        /**
-         * Question/Answer
-         */
-        private val qa: SoundSide,
+        private val side: SoundSide,
         private val errorListener: OnErrorListener?
     ) : OnCompletionListener {
-        /**
-         * next sound to play (onCompletion() is first called after the first (0) has been played)
-         */
-        private var mNextToPlay = 1
+        /** Index of next sound to play inside `getSounds(side)` */
+        // this is a completion listener: [onCompletion] is first called after the first sound
+        private var nextIndexToPlay = 1
         override fun onCompletion(mp: MediaPlayer) {
-            // If there is still more sounds to play for the current card, play the next one
-            if (mSoundPaths.containsKey(qa) && mNextToPlay < mSoundPaths[qa]!!.size) {
+            val paths = getSounds(side) ?: emptyList() // emptyList -> stopSounds()
+            // If there are still more sounds to play for the current card, play the next one
+            if (nextIndexToPlay < paths.size) {
                 Timber.i("Play all: Playing next sound")
-                playSound(mSoundPaths[qa]!![mNextToPlay++], this, null, errorListener)
+                playSound(paths[nextIndexToPlay++], this, errorListener)
             } else {
                 Timber.i("Play all: Completed - releasing sound")
-                releaseSound()
+                soundPlayer.stopSounds()
             }
         }
     }
 
-    /**
-     * Releases the sound.
-     */
-    private fun releaseSound() {
-        Timber.d("Releasing sounds and abandoning audio focus")
-        if (mMediaPlayer != null) {
-            // Required to remove warning: "mediaplayer went away with unhandled events"
-            // https://stackoverflow.com/questions/9609479/android-mediaplayer-went-away-with-unhandled-events
-            mMediaPlayer!!.reset()
-            mMediaPlayer!!.release()
-            mMediaPlayer = null
+    override fun stopSounds() {
+        soundPlayer.stopSounds()
+        ReadText.stopTts() // TODO: Reconsider design
+    }
+
+    fun hasQuestion(): Boolean = getSounds(QUESTION) != null
+
+    fun hasAnswer(): Boolean = getSounds(ANSWER) != null
+
+    /** Handle a call to play audio which may be made while audio is already playing */
+    fun playAnotherSound(replacedUrl: String, errorListener: OnErrorListener) {
+        val suppliedAudioIsCurrentlyPlaying = replacedUrl == currentAudioUri && !isCurrentAudioFinished
+        if (suppliedAudioIsCurrentlyPlaying) {
+            playOrPauseSound()
+        } else {
+            playSound(replacedUrl, null, errorListener)
         }
-        if (mAudioManager != null) {
-            // mAudioFocusRequest was initialised for API 26 and above in playSoundInternal().
-            CompatHelper.compat.abandonAudioFocus(mAudioManager!!, afChangeListener, mAudioFocusRequest)
-            mAudioManager = null
-        }
-    }
-
-    /**
-     * Stops the playing sounds.
-     */
-    fun stopSounds() {
-        if (mMediaPlayer != null) {
-            mMediaPlayer!!.stop()
-            releaseSound()
-        }
-        ReadText.stopTts()
-    }
-
-    /**
-     * Set the context for the calling activity (necessary for playing videos)
-     */
-    fun setContext(activityRef: WeakReference<Activity?>?) {
-        mCallingActivity = activityRef
-    }
-
-    fun hasQuestion(): Boolean {
-        return mSoundPaths.containsKey(SoundSide.QUESTION)
-    }
-
-    fun hasAnswer(): Boolean {
-        return mSoundPaths.containsKey(SoundSide.ANSWER)
     }
 
     fun interface OnErrorListener {
@@ -511,29 +213,12 @@ class Sound {
         private val sUriPattern =
             Pattern.compile("^(([^:/?#]+):)?(//([^/?#]*))?([^?#]*)(\\?([^#]*))?(#(.*))?$")
 
-        /**
-         * OnCompletionListener so that external video player can notify to play next sound
-         */
-        var mediaCompletionListener: OnCompletionListener? = null
-            private set
-
-        /**
-         * Whitelist for video extensions
-         */
-        private val VIDEO_WHITELIST = arrayOf("3gp", "mp4", "webm", "mkv", "flv")
-
-        /**
-         * Listener to handle audio focus. Currently blank because we're not respecting losing focus from other apps.
-         */
-        private val afChangeListener = OnAudioFocusChangeListener { }
-
         /** Extract SoundOrVideoTag instances from content where sound tags are in the form: [sound:filename.mp3]  */
         @CheckResult
-        @KotlinCleanup("non-null param")
-        fun extractTagsFromLegacyContent(content: String?): List<SoundOrVideoTag> {
-            val matcher = SOUND_PATTERN.matcher(content!!)
+        fun extractTagsFromLegacyContent(content: String): List<SoundOrVideoTag> {
+            val matcher = SOUND_PATTERN.matcher(content)
             // While there is matches of the pattern for sound markers
-            val ret: MutableList<SoundOrVideoTag> = ArrayList()
+            val ret = mutableListOf<SoundOrVideoTag>()
             while (matcher.find()) {
                 // Get the sound file name
                 val sound = matcher.group(1)!!
@@ -569,6 +254,7 @@ class Sound {
                 // Construct the new content, appending the substring from the beginning of the content left until the
                 // beginning of the sound marker
                 // and then appending the html code to add the play button
+                @Language("HTML")
                 val button =
                     "<svg viewBox=\"0 0 64 64\"><circle cx=\"32\" cy=\"32\" r=\"29\" fill = \"lightgrey\"/>" +
                         "<path d=\"M56.502,32.301l-37.502,20.101l0.329,-40.804l37.173,20.703Z\" fill = \"" +
@@ -589,26 +275,6 @@ class Sound {
             // if/when tts support is considered complete, these comment lines serve no purpose
             stringBuilder.append(contentLeft)
             return stringBuilder.toString()
-        }
-
-        private fun configureVideo(videoView: VideoView, videoWidth: Int, videoHeight: Int) {
-            // get the display
-            val context = AnkiDroidApp.instance.applicationContext
-            // adjust the size of the video so it fits on the screen
-            val videoProportion = videoWidth.toFloat() / videoHeight.toFloat()
-            val point = DisplayUtils.getDisplayDimensions(context)
-            val screenWidth = point.x
-            val screenHeight = point.y
-            val screenProportion = screenWidth.toFloat() / screenHeight.toFloat()
-            val lp = videoView.layoutParams
-            if (videoProportion > screenProportion) {
-                lp.width = screenWidth
-                lp.height = (screenWidth.toFloat() / videoProportion).toInt()
-            } else {
-                lp.width = (videoProportion * screenHeight.toFloat()).toInt()
-                lp.height = screenHeight
-            }
-            videoView.layoutParams = lp
         }
 
         /**
@@ -634,4 +300,323 @@ class Sound {
             return uriMatcher.matches() && uriMatcher.group(2) != null
         }
     }
+}
+
+interface SoundPlayer {
+    /**
+     * Plays the given sound or video.
+     * Video requires a surface: [hasVideoSurface]
+     * [playVideoExternallyCallback] will be called if this is unavailable
+     */
+    fun playSound(
+        soundPath: String,
+        onCompletionListener: OnCompletionListener?,
+        errorListener: Sound.OnErrorListener?
+    )
+
+    val hasVideoSurface: Boolean
+
+    // When an audio finishes and I'm trying to replay it again, this method should check if the mMediaPlayer is null which means
+    // the audio finished to return true, so that I would be able to play the same sound again.
+    val isCurrentAudioFinished: Boolean
+
+    /**
+     * The Uri of the currently playing audio (or `null` if no audio playing)
+     */
+    val currentAudioUri: String?
+
+    /**
+     * Stops the playing sounds.
+     */
+    fun stopSounds()
+
+    /**
+     * Play or Pause the running sound. Called on pressing the content inside span tag.
+     */
+    fun playOrPauseSound()
+
+    /** @return Whether the video was handled externally. Only used if [hasVideoSurface] is false */
+    var playVideoExternallyCallback: ((soundPath: String, onCompletion: OnCompletionListener) -> Boolean)?
+}
+
+open class SoundPlayerImpl : SoundPlayer {
+    override val currentAudioUri: String?
+        get() = mCurrentAudioUri?.toString()
+
+    override val isCurrentAudioFinished: Boolean
+        get() = mMediaPlayer == null
+
+    /**
+     * Media player used to play the sounds. It's Nullable and that it is set only if a sound is playing or paused, otherwise it is null.
+     */
+    protected var mMediaPlayer: MediaPlayer? = null
+
+    private var mCurrentAudioUri: Uri? = null
+
+    /**
+     * AudioManager to request/release audio focus
+     */
+    private var mAudioManager: AudioManager? = null
+
+    private var mAudioFocusRequest: AudioFocusRequest? = null
+
+    override val hasVideoSurface: Boolean = false
+
+    /**
+     * Plays the given sound or video and sets playAllListener if available on media player to start next media.
+     * If videoView is null and the media is a video, then a request is sent to start the VideoPlayer Activity
+     */
+    override fun playSound(
+        soundPath: String,
+        onCompletionListener: OnCompletionListener?,
+        errorListener: Sound.OnErrorListener?
+    ) {
+        Timber.d("Playing single sound")
+        val completionListener = onCompletionListener ?: SingleSoundCompletionListener()
+        val errorHandler = errorListener
+            ?: Sound.OnErrorListener { _: MediaPlayer?, what: Int, extra: Int, _: String? ->
+                Timber.w("Media Error: (%d, %d). Calling OnCompletionListener", what, extra)
+                CONTINUE_AUDIO
+            }
+        playSoundInternal(soundPath, completionListener, errorHandler)
+    }
+
+    /**
+     * Plays a sound without ensuring that the playAllListener will release the audio
+     */
+    private fun playSoundInternal(
+        soundPath: String,
+        completionListener: OnCompletionListener,
+        errorHandler: Sound.OnErrorListener
+    ) {
+        Timber.d("Playing %s", soundPath)
+        val soundUri = Uri.parse(soundPath)
+        mCurrentAudioUri = soundUri
+
+        val context = AnkiDroidApp.instance.applicationContext
+
+        val isVideo = isVideo(soundPath)
+        if (isVideo && !hasVideoSurface && playVideoExternallyCallback?.invoke(soundPath, completionListener) == true) {
+            return
+        }
+        // Play media
+        fun playMedia() {
+            try {
+                // Create media player
+                if (mMediaPlayer == null) {
+                    Timber.d("Creating media player for playback")
+                    mMediaPlayer = MediaPlayer()
+                } else {
+                    Timber.d("Resetting media for playback")
+                    mMediaPlayer!!.reset()
+                }
+                val mediaPlayer = mMediaPlayer!!
+                mAudioManager =
+                    mAudioManager ?: context.getSystemService(Context.AUDIO_SERVICE) as AudioManager
+
+                if (isVideo) {
+                    prepareVideo(mediaPlayer)
+                }
+
+                mediaPlayer.setOnErrorListener { mp: MediaPlayer?, which: Int, extra: Int ->
+                    val errorHandling = errorHandler.onError(
+                        mp,
+                        which,
+                        extra,
+                        soundPath
+                    )
+                    // returning false calls onComplete()
+                    return@setOnErrorListener when (errorHandling) {
+                        CONTINUE_AUDIO -> false
+                        Sound.OnErrorListener.ErrorHandling.RETRY_AUDIO -> {
+                            playMedia()
+                            true
+                        }
+                        Sound.OnErrorListener.ErrorHandling.STOP_AUDIO -> {
+                            stopSounds()
+                            true
+                        }
+                    }
+                }
+                // Setup the MediaPlayer
+                mediaPlayer.setDataSource(context, soundUri)
+                mediaPlayer.setAudioAttributes(
+                    AudioAttributes.Builder()
+                        .setContentType(AudioAttributes.CONTENT_TYPE_MUSIC)
+                        .build()
+                )
+                mediaPlayer.setOnPreparedListener {
+                    Timber.d("Starting media player")
+                    it.start()
+                }
+                mediaPlayer.setOnCompletionListener(completionListener)
+                mediaPlayer.prepareAsync()
+                Timber.d("Requesting audio focus")
+
+                // Set mAudioFocusRequest for API 26 and above.
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                    mAudioFocusRequest =
+                        AudioFocusRequest.Builder(AudioManager.AUDIOFOCUS_GAIN_TRANSIENT_MAY_DUCK)
+                            .setOnAudioFocusChangeListener(audioFocusChangeListener)
+                            .build()
+                }
+                CompatHelper.compat.requestAudioFocus(
+                    mAudioManager!!,
+                    audioFocusChangeListener,
+                    mAudioFocusRequest
+                )
+            } catch (e: Exception) {
+                Timber.e(e, "playSounds - Error reproducing sound %s", soundPath)
+                when (
+                    errorHandler.onError(
+                        mMediaPlayer,
+                        MediaPlayer.MEDIA_ERROR_UNSUPPORTED,
+                        0,
+                        soundPath
+                    )
+                ) {
+                    CONTINUE_AUDIO -> {
+                        Timber.d("Force playing next sound.")
+                        completionListener.onCompletion(mMediaPlayer)
+                    }
+                    Sound.OnErrorListener.ErrorHandling.STOP_AUDIO -> stopSounds()
+                    Sound.OnErrorListener.ErrorHandling.RETRY_AUDIO -> playMedia()
+                }
+            }
+        }
+
+        playMedia()
+    }
+
+    open fun prepareVideo(mediaPlayer: MediaPlayer) {
+        // in the base class: playVideoExternallyCallback should have been called
+    }
+
+    override var playVideoExternallyCallback: ((soundPath: String, onCompletion: OnCompletionListener) -> Boolean)? = null
+
+    private fun isVideo(soundPath: String): Boolean {
+        // Check if the file extension is that of a known video format
+        val extension = soundPath.getFileExtension()
+        val isVideoExtension = listOf(*VIDEO_WHITELIST).contains(extension) || extension.isVideoMimeTypeExtension()
+        // Also check that there is a video thumbnail, as some formats like mp4 can be audio only
+        // No thumbnail: no video after all. (Or maybe not a video we can handle on the specific device.)
+        return isVideoExtension && CompatHelper.compat.hasVideoThumbnail(soundPath)
+    }
+
+    // TODO: This seems wrong
+    private fun String.getFileExtension() = substring(this.lastIndexOf(".") + 1).lowercase(Locale.getDefault())
+    private fun String.isVideoMimeTypeExtension(): Boolean {
+        val guessedType = MimeTypeMap.getSingleton().getMimeTypeFromExtension(this) ?: return false
+        return guessedType.startsWith("video/")
+    }
+
+    /**
+     * Releases the sound.
+     */
+    private fun releaseSound() {
+        Timber.d("Releasing sounds and abandoning audio focus")
+        mMediaPlayer?.let {
+            // Required to remove warning: "mediaplayer went away with unhandled events"
+            // https://stackoverflow.com/questions/9609479/android-mediaplayer-went-away-with-unhandled-events
+            it.reset()
+            it.release()
+            mMediaPlayer = null
+        }
+        mAudioManager?.let {
+            // mAudioFocusRequest was initialised for API 26 and above in playSoundInternal().
+            CompatHelper.compat.abandonAudioFocus(it, audioFocusChangeListener, mAudioFocusRequest)
+            mAudioManager = null
+        }
+    }
+
+    override fun stopSounds() {
+        mMediaPlayer?.let {
+            it.stop()
+            // TODO: Inefficient. Determine whether we want to release or stop, don't do both
+            // Ensure `currentAudioUri` etc... still work when we do this
+            releaseSound()
+        }
+    }
+
+    override fun playOrPauseSound() {
+        mMediaPlayer?.let {
+            if (it.isPlaying) {
+                it.pause()
+            } else {
+                it.start()
+            }
+        }
+    }
+
+    /** #5414 - Ensures playing a single sound performs cleanup  */
+    private inner class SingleSoundCompletionListener : OnCompletionListener {
+        override fun onCompletion(mp: MediaPlayer) {
+            Timber.d("Single Sound completed")
+            releaseSound()
+        }
+    }
+
+    companion object {
+        /**
+         * Whitelist for video extensions
+         */
+        private val VIDEO_WHITELIST = arrayOf("3gp", "mp4", "webm", "mkv", "flv")
+
+        /**
+         * Listener to handle audio focus. Currently blank because we're not respecting losing focus from other apps.
+         */
+        private val audioFocusChangeListener = OnAudioFocusChangeListener { }
+    }
+}
+
+class VideoPlayer(private val videoView: VideoView) : SoundPlayerImpl() {
+
+    // don't call out to external video players
+    override val hasVideoSurface = true
+
+    /** Plays the given video */
+    fun play(
+        path: String,
+        onCompletionListener: OnCompletionListener?,
+        onErrorListener: Sound.OnErrorListener?
+    ) = playSound(path, onCompletionListener, onErrorListener)
+    fun notifyConfigurationChanged() {
+        mMediaPlayer?.let {
+            configureVideo(videoView, it.videoWidth, it.videoHeight)
+        }
+    }
+
+    override fun prepareVideo(mediaPlayer: MediaPlayer) {
+        mediaPlayer.setDisplay(videoView.holder)
+        mediaPlayer.setOnVideoSizeChangedListener { _, width: Int, height: Int ->
+            configureVideo(videoView, width, height)
+        }
+    }
+
+    private fun configureVideo(videoView: VideoView, videoWidth: Int, videoHeight: Int) {
+        // get the display
+        val context = AnkiDroidApp.instance.applicationContext
+        // adjust the size of the video so it fits on the screen
+        val videoProportion = videoWidth.toFloat() / videoHeight.toFloat()
+        val point = DisplayUtils.getDisplayDimensions(context)
+        val screenWidth = point.x
+        val screenHeight = point.y
+        val screenProportion = screenWidth.toFloat() / screenHeight.toFloat()
+        val lp = videoView.layoutParams
+        if (videoProportion > screenProportion) {
+            lp.width = screenWidth
+            lp.height = (screenWidth.toFloat() / videoProportion).toInt()
+        } else {
+            lp.width = (videoProportion * screenHeight.toFloat()).toInt()
+            lp.height = screenHeight
+        }
+        videoView.layoutParams = lp
+    }
+}
+
+@Throws(Exception::class)
+private fun MediaMetadataRetriever.getDuration(context: Context, uri: Uri): Long {
+    this.setDataSource(context, uri)
+    val duration = this.extractMetadata(MediaMetadataRetriever.METADATA_KEY_DURATION)
+    return duration!!.toLong()
 }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/AbstractFlashcardViewerSoundRenderTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/AbstractFlashcardViewerSoundRenderTest.kt
@@ -35,7 +35,7 @@ class AbstractFlashcardViewerSoundRenderTest : RobolectricTest() {
 
     /** Call this after a valid card has been added */
     private val sounds by lazy {
-        val ret = super.startRegularActivity<ReviewerSoundAccessor>()
+        val ret = super.startRegularActivity<Reviewer>()
         assertThat("activity was started before it had cards", ret.isDestroyed, equalTo(false))
         ret
     }
@@ -149,17 +149,7 @@ class AbstractFlashcardViewerSoundRenderTest : RobolectricTest() {
         addNoteUsingModelName("NoFrontSide", front, back)
     }
 
-    class ReviewerSoundAccessor : Reviewer() {
-        fun a(): ArrayList<String>? {
-            return super.mSoundPlayer.getSounds(Sound.SoundSide.ANSWER)
-        }
-
-        fun q(): ArrayList<String>? {
-            return super.mSoundPlayer.getSounds(Sound.SoundSide.QUESTION)
-        }
-
-        fun qa(): ArrayList<String>? {
-            return super.mSoundPlayer.getSounds(Sound.SoundSide.QUESTION_AND_ANSWER)
-        }
-    }
+    fun Reviewer.a() = mSoundPlayer.getSounds(Sound.SoundSide.ANSWER)
+    fun Reviewer.q() = mSoundPlayer.getSounds(Sound.SoundSide.QUESTION)
+    fun Reviewer.qa() = mSoundPlayer.getSounds(Sound.SoundSide.QUESTION_AND_ANSWER)
 }


### PR DESCRIPTION

## Pull Request template


Summary: splits out sound playing + sound listing of sound files.
Splits out video

* Remove logic for only creating a list containing `QUESTION_AND_ANSWER` if requested
  * Instead, concat the two QUESTION and ANSWER lists when requested
* Split out 'playing' code into 'SoundPlayer'
* Split out video-related code into `VideoPlayer`
* remove 'videoView' parameter
* remove 'mBaseUrl' parameter
* define `SoundPlayer` interface + delegate to parameter
* remove legacy "tts" code
* extract `playAnotherSound()`
* cleanup VideoPlayer `null` path handling
* remove videoPlayer.onStop
* SingleSoundSide: ensures the wrong parameter can't be provided, cleaning up code paths

I was going to build on this for scoped storage, but consider this to be optional and only if it feels like there's an improvement

## How Has This Been Tested?
Unit Tests

Went through with an emulator:

* play auto
* play manual
* play two audio
* play one of two audio manually
* replay audio

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
