### PR TITLE
Reviewer: migrate requested files immediately

### DIFF
--- a/.idea/dictionaries/davidallison.xml
+++ b/.idea/dictionaries/davidallison.xml
@@ -3,6 +3,7 @@
     <words>
       <w>Aedict</w>
       <w>Affero</w>
+      <w>Awaitable</w>
       <w>Beolingus</w>
       <w>CROWDIN</w>
       <w>CrowdIn</w>

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
@@ -81,6 +81,7 @@ import com.ichi2.compat.CompatHelper.Companion.compat
 import com.ichi2.libanki.*
 import com.ichi2.libanki.Collection
 import com.ichi2.libanki.Consts.BUTTON_TYPE
+import com.ichi2.libanki.Sound.OnErrorListener.ErrorHandling
 import com.ichi2.libanki.Sound.SoundSide
 import com.ichi2.libanki.sched.AbstractSched
 import com.ichi2.libanki.sched.SchedV2
@@ -1539,9 +1540,8 @@ abstract class AbstractFlashcardViewer :
                 }
             } catch (e: Exception) {
                 Timber.w(e)
-                return@OnErrorListener false
             }
-            false
+            ErrorHandling.CONTINUE_AUDIO
         }
 
     /**

--- a/AnkiDroid/src/main/java/com/ichi2/anki/services/MigrationService.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/services/MigrationService.kt
@@ -270,6 +270,22 @@ class MigrationService : Service() {
     }
 
     override fun onBind(intent: Intent): IBinder = LocalBinder()
+
+    /**
+     * A file was expected at the provided location, but wasn't found
+     * If it exists in the old location, attempt to migrate it.
+     * Block until migrated.
+     *
+     * @return Whether the migration was successful (or unnecessary)
+     */
+    fun migrateFileImmediately(expectedFileLocation: File): Boolean {
+        try {
+            migrateUserDataTask.migrateFileImmediately(expectedFileLocation)
+        } catch (e: Exception) {
+            Timber.w(e, "Failed to migrate file")
+        }
+        return expectedFileLocation.exists()
+    }
 }
 
 /** Hides a progress bar if previously shown on a notification */

--- a/AnkiDroid/src/main/java/com/ichi2/anki/services/ServiceConnection.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/services/ServiceConnection.kt
@@ -30,7 +30,7 @@ import timber.log.Timber
  *
  * @param T The service to encapsulate. Note: service's [Service.onBind] must return a [SimpleBinder]
  */
-abstract class ServiceConnection<T : Service> {
+open class ServiceConnection<T : Service> {
     var instance: T? = null
         private set
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Sound.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Sound.kt
@@ -32,6 +32,7 @@ import com.ichi2.anki.AbstractFlashcardViewer
 import com.ichi2.anki.AnkiDroidApp
 import com.ichi2.anki.ReadText
 import com.ichi2.compat.CompatHelper
+import com.ichi2.libanki.Sound.OnErrorListener.ErrorHandling.CONTINUE_AUDIO
 import com.ichi2.utils.DisplayUtils
 import com.ichi2.utils.KotlinCleanup
 import net.ankiweb.rsdroid.BackendFactory.defaultLegacySchema
@@ -252,13 +253,16 @@ class Sound {
         val errorHandler = errorListener
             ?: OnErrorListener { _: MediaPlayer?, what: Int, extra: Int, _: String? ->
                 Timber.w("Media Error: (%d, %d). Calling OnCompletionListener", what, extra)
-                false
+                CONTINUE_AUDIO
             }
         if ("tts" == soundPath.substring(0, 3)) {
             // TODO: give information about did
 //            ReadText.textToSpeech(soundPath.substring(4, soundPath.length()),
 //                    Integer.parseInt(soundPath.substring(3, 4)));
-        } else {
+            return
+        }
+
+        fun playMedia() {
             // Check if the file extension is that of a known video format
             val extension =
                 soundPath.substring(soundPath.lastIndexOf(".") + 1).lowercase(Locale.getDefault())
@@ -305,12 +309,24 @@ class Sound {
                     }
                 }
                 mMediaPlayer!!.setOnErrorListener { mp: MediaPlayer?, which: Int, extra: Int ->
-                    errorHandler.onError(
+                    val errorHandling = errorHandler.onError(
                         mp,
                         which,
                         extra,
                         soundPath
                     )
+                    // returning false calls onComplete()
+                    return@setOnErrorListener when (errorHandling) {
+                        CONTINUE_AUDIO -> false
+                        OnErrorListener.ErrorHandling.RETRY_AUDIO -> {
+                            playMedia()
+                            true
+                        }
+                        OnErrorListener.ErrorHandling.STOP_AUDIO -> {
+                            stopSounds()
+                            true
+                        }
+                    }
                 }
                 // Setup the MediaPlayer
                 @KotlinCleanup("simplify with scope function on mediaPlayer")
@@ -341,18 +357,25 @@ class Sound {
                 CompatHelper.compat.requestAudioFocus(mAudioManager!!, afChangeListener, mAudioFocusRequest)
             } catch (e: Exception) {
                 Timber.e(e, "playSounds - Error reproducing sound %s", soundPath)
-                if (!errorHandler.onError(
+                when (
+                    errorHandler.onError(
                         mMediaPlayer,
                         MediaPlayer.MEDIA_ERROR_UNSUPPORTED,
                         0,
                         soundPath
                     )
                 ) {
-                    Timber.d("Force playing next sound.")
-                    playAllListener.onCompletion(mMediaPlayer)
+                    CONTINUE_AUDIO -> {
+                        Timber.d("Force playing next sound.")
+                        playAllListener.onCompletion(mMediaPlayer)
+                    }
+                    OnErrorListener.ErrorHandling.STOP_AUDIO -> stopSounds()
+                    OnErrorListener.ErrorHandling.RETRY_AUDIO -> playMedia()
                 }
             }
         }
+
+        playMedia()
     }
 
     @KotlinCleanup("simplify code with ?. or make uri non-null")
@@ -462,7 +485,18 @@ class Sound {
     }
 
     fun interface OnErrorListener {
-        fun onError(mp: MediaPlayer?, which: Int, extra: Int, path: String?): Boolean
+        fun onError(mp: MediaPlayer?, which: Int, extra: Int, path: String?): ErrorHandling
+
+        enum class ErrorHandling {
+            /** Stop playing audio */
+            STOP_AUDIO,
+
+            /** Continue to the next audio (if any) */
+            CONTINUE_AUDIO,
+
+            /** Retry the current audio */
+            RETRY_AUDIO
+        }
     }
 
     companion object {


### PR DESCRIPTION
## Purpose / Description
During a storage migration, we have some media in an old folder and others in the collection media folder.

Instead of handling the possibility of 2 folders, we immediately migrate requested files when requested by the reviewer/previewers

## Fixes
- Related: #5304

## Approach

When an image/sound file is requested, and is:
* not found
* inside the collection
* available for migration

Add a new task to prioritise it in the storage migration

Image migration: needs to be performed in `shouldInterceptRequest` as WebClient error handlers do not provide enough control to recover from

Sound: performed in the error handler to avoid impacting the fast path

## How Has This Been Tested?
API 31/33 emulator.


The migration performance hit is not noticeable in my testing

## Learning (optional, can help others)
Using `CountDownLatch` - constructor is very light

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
