### PR TITLE
build(ci): reduce PR stale timeout to 21 days

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -20,11 +20,11 @@ jobs:
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         stale-issue-message: 'Hello 👋, this issue has been opened for more than 3 months with no activity on it. If the issue is still here, please keep in mind that we need community support and help to fix it! Just comment something like _still searching for solutions_ and if you found one, please open a pull request! You have 7 days until this gets closed automatically'
-        stale-pr-message: 'Hello 👋, this PR has been opened for more than 1 month with no activity on it. If you think this is a mistake please comment and ping a maintainer to get this merged ASAP! Thanks for contributing! You have 7 days until this gets closed automatically'
+        stale-pr-message: 'Hello 👋, this PR has been opened for more than 3 weeks with no activity on it. If you think this is a mistake please comment and ping a maintainer to get this merged ASAP! Thanks for contributing! You have 7 days until this gets closed automatically'
         exempt-issue-labels: 'Keep Open'
         exempt-pr-labels: 'Keep Open'
         close-issue-reason: 'not_planned'
         days-before-issue-stale: 90
-        days-before-pr-stale: 30
+        days-before-pr-stale: 21
         only-pr-labels: 'Needs Author Reply'
 

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -20,7 +20,7 @@ jobs:
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         stale-issue-message: 'Hello 👋, this issue has been opened for more than 3 months with no activity on it. If the issue is still here, please keep in mind that we need community support and help to fix it! Just comment something like _still searching for solutions_ and if you found one, please open a pull request! You have 7 days until this gets closed automatically'
-        stale-pr-message: 'Hello 👋, this PR has been opened for more than 3 weeks with no activity on it. If you think this is a mistake please comment and ping a maintainer to get this merged ASAP! Thanks for contributing! You have 7 days until this gets closed automatically'
+        stale-pr-message: 'Hello 👋, this PR has had no activity for more than 3 weeks and needs a reply from the author. If you think this is a mistake please comment and ping a maintainer to get this merged ASAP! Thanks for contributing! You have 7 days until this gets closed automatically'
         exempt-issue-labels: 'Keep Open'
         exempt-pr-labels: 'Keep Open'
         close-issue-reason: 'not_planned'


### PR DESCRIPTION
Changes:
days-before-pr-stale: 30 -> 21

The agreed figure was 14, but reduce to this incrementally to provide users with appropriate time to fix their PRs without overburdening them

Large numeric jump: '3 weeks' reads better than a numeric number of days, and '4 weeks' wouldn't be a significant change from 30 days

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
