### PR TITLE
Replaces usages of MaterialDialog with AlertDialog for DeckoptionsActivity.kt,ControlPreference.kt,onRenderProcessGoneDelegate.kt

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckOptionsActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckOptionsActivity.kt
@@ -28,7 +28,7 @@ import android.preference.CheckBoxPreference
 import android.preference.ListPreference
 import android.preference.Preference
 import android.preference.PreferenceScreen
-import com.afollestad.materialdialogs.MaterialDialog
+import androidx.appcompat.app.AlertDialog
 import com.ichi2.anim.ActivityTransitionAnimation
 import com.ichi2.anim.ActivityTransitionAnimation.Direction.FADE
 import com.ichi2.anki.CollectionManager.withCol
@@ -52,6 +52,7 @@ import com.ichi2.themes.Themes
 import com.ichi2.themes.Themes.themeFollowsSystem
 import com.ichi2.themes.Themes.updateCurrentTheme
 import com.ichi2.ui.AppCompatPreferenceActivity
+import com.ichi2.utils.*
 import com.ichi2.utils.KotlinCleanup
 import com.ichi2.utils.NamedJSONComparator
 import kotlinx.coroutines.launch
@@ -297,7 +298,7 @@ class DeckOptionsActivity :
                                     e.log()
                                     // Libanki determined that a full sync will be required, so confirm with the user before proceeding
                                     // TODO : Use ConfirmationDialog DialogFragment -- not compatible with PreferenceActivity
-                                    MaterialDialog(this@DeckOptionsActivity).show {
+                                    AlertDialog.Builder(this@DeckOptionsActivity).show {
                                         message(R.string.full_sync_confirmation)
                                         positiveButton(R.string.dialog_ok) {
                                             col.modSchemaNoCheck()

--- a/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/OnRenderProcessGoneDelegate.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/OnRenderProcessGoneDelegate.kt
@@ -20,12 +20,13 @@ import android.os.Build
 import android.webkit.RenderProcessGoneDetail
 import android.webkit.WebView
 import androidx.annotation.RequiresApi
+import androidx.appcompat.app.AlertDialog
 import androidx.lifecycle.Lifecycle
-import com.afollestad.materialdialogs.MaterialDialog
 import com.ichi2.anki.AbstractFlashcardViewer
 import com.ichi2.anki.R
 import com.ichi2.anki.UIUtils.showThemedToast
 import com.ichi2.libanki.CardId
+import com.ichi2.utils.*
 import timber.log.Timber
 
 /**
@@ -129,14 +130,13 @@ open class OnRenderProcessGoneDelegate(val target: AbstractFlashcardViewer) {
         val cardInformation = java.lang.Long.toString(currentCardId)
         val res = target.resources
         val errorDetails = if (detail.didCrash()) res.getString(R.string.webview_crash_unknwon_detailed) else res.getString(R.string.webview_crash_oom_details)
-        MaterialDialog(target).show {
+        AlertDialog.Builder(target).show {
             title(R.string.webview_crash_loop_dialog_title)
             message(text = res.getString(R.string.webview_crash_loop_dialog_content, cardInformation, errorDetails))
             positiveButton(R.string.dialog_ok) {
                 onCloseRenderLoopDialog()
             }
             cancelable(false)
-            cancelOnTouchOutside(false)
         }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/preferences/ControlPreference.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/preferences/ControlPreference.kt
@@ -19,6 +19,7 @@ package com.ichi2.preferences
 import android.annotation.SuppressLint
 import android.content.Context
 import android.util.AttributeSet
+import androidx.appcompat.app.AlertDialog
 import androidx.preference.ListPreference
 import com.afollestad.materialdialogs.MaterialDialog
 import com.afollestad.materialdialogs.customview.customView
@@ -36,6 +37,7 @@ import com.ichi2.anki.reviewer.MappableBinding
 import com.ichi2.anki.reviewer.MappableBinding.Companion.fromGesture
 import com.ichi2.anki.reviewer.MappableBinding.Companion.toPreferenceString
 import com.ichi2.ui.KeyPicker
+import com.ichi2.utils.*
 import java.util.*
 
 /**
@@ -215,7 +217,7 @@ class ControlPreference : ListPreference {
     private fun showDialogToReplaceBinding(binding: MappableBinding, title: String, parentDialog: MaterialDialog) {
         val commandName = context.getString(getCommandWithBindingExceptThis(binding)!!.resourceId)
 
-        MaterialDialog(context).show {
+        AlertDialog.Builder(context).show {
             title(text = title)
             message(text = context.getString(R.string.bindings_already_bound, commandName))
             positiveButton(R.string.dialog_positive_replace) {


### PR DESCRIPTION
## Purpose / Description
Replaces usages of MaterialDialog with AlertDialog in DeckoptionsActivity.kt,ControlPreference.kt,onRenderProcessGoneDelegate.kt
## Fixes
Related to #13315 

## How Has This Been Tested?
Open each one of the changed dialogs on their respective preferences
