### PR TITLE
test: Reduce noise in test logging

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.kt
@@ -105,7 +105,11 @@ open class AnkiDroidApp : Application() {
         CrashReportService.initialize(this)
         if (BuildConfig.DEBUG) {
             // Enable verbose error logging and do method tracing to put the Class name as log tag
-            Timber.plant(DebugTree())
+            if (isRobolectric) {
+                Timber.plant(RobolectricDebugTree())
+            } else {
+                Timber.plant(DebugTree())
+            }
         } else {
             Timber.plant(ProductionCrashReportingTree())
         }
@@ -386,5 +390,15 @@ open class AnkiDroidApp : Application() {
                 }
                 return ExceptionUtil.getExceptionMessage(error)
             }
+    }
+
+    class RobolectricDebugTree : DebugTree() {
+        override fun log(priority: Int, tag: String?, message: String, t: Throwable?) {
+            // This is noisy in test environments
+            if (tag == "Backend\$checkMainThreadOp") {
+                return
+            }
+            super.log(priority, tag, message, t)
+        }
     }
 }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/RobolectricTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/RobolectricTest.kt
@@ -61,6 +61,7 @@ import org.robolectric.Shadows
 import org.robolectric.android.controller.ActivityController
 import org.robolectric.shadows.ShadowDialog
 import org.robolectric.shadows.ShadowLog
+import org.robolectric.shadows.ShadowMediaPlayer
 import timber.log.Timber
 import java.util.concurrent.locks.ReentrantLock
 import kotlin.concurrent.withLock
@@ -266,6 +267,13 @@ open class RobolectricTest : CollectionGetter {
 
         @JvmStatic // Using protected members which are not @JvmStatic in the superclass companion is unsupported yet
         protected fun <T : AnkiActivity?> startActivityNormallyOpenCollectionWithIntent(testClass: RobolectricTest, clazz: Class<T>?, i: Intent?): T {
+            if (AbstractFlashcardViewer::class.java.isAssignableFrom(clazz!!)) {
+                // fixes 'Don't know what to do with dataSource...' inside Sounds.kt
+                // solution from https://github.com/robolectric/robolectric/issues/4673
+                ShadowMediaPlayer.setMediaInfoProvider {
+                    ShadowMediaPlayer.MediaInfo(1, 0)
+                }
+            }
             val controller = Robolectric.buildActivity(clazz, i)
                 .create().start().resume().visible()
             advanceRobolectricLooperWithSleep()


### PR DESCRIPTION
## Purpose / Description
Lots of noise in test logs

## Fixes
Comment: https://github.com/ankidroid/Anki-Android/pull/13345#issuecomment-1445219437

## Approach
* Avoid 'Op on UI Thread'
   * Stop logging this one under Robolectric - embedded in `Anki-Android-Backend`
* Avoid 'Don't know what to do with dataSource..'
  * Answer from GitHub `https://github.com/robolectric/robolectric/issues/4673`

## How Has This Been Tested?
Test only

## Learning (optional, can help others)
Note: One gotcha with this shadow is that you need to either configure an exception or a [ShadowMediaPlayer.MediaInfo](https://robolectric.org/javadoc/3.8/org/robolectric/shadows/ShadowMediaPlayer.MediaInfo.html) instance for that data source (using [addException(DataSource, IOException)](https://robolectric.org/javadoc/3.8/org/robolectric/shadows/ShadowMediaPlayer.html#addException-org.robolectric.shadows.util.DataSource-java.io.IOException-) or [addMediaInfo(DataSource, MediaInfo)](https://robolectric.org/javadoc/3.8/org/robolectric/shadows/ShadowMediaPlayer.html#addMediaInfo-org.robolectric.shadows.util.DataSource-org.robolectric.shadows.ShadowMediaPlayer.MediaInfo-) respectively) before calling [setDataSource(org.robolectric.shadows.util.DataSource)](https://robolectric.org/javadoc/3.8/org/robolectric/shadows/ShadowMediaPlayer.html#setDataSource-org.robolectric.shadows.util.DataSource-), otherwise you’ll get an IllegalArgumentException.
> https://robolectric.org/javadoc/3.8/org/robolectric/shadows/ShadowMediaPlayer.html#addMediaInfo-org.robolectric.shadows.util.DataSource-org.robolectric.shadows.ShadowMediaPlayer.MediaInfo-

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
