### PR TITLE
DeckPicker: disable functionality during storage migration

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -1100,8 +1100,8 @@ open class DeckPicker :
         val autoSyncIsEnabled = preferences.getBoolean("automaticSyncMode", false)
         val syncIntervalPassed = TimeManager.time.intTimeMS() - lastSyncTime > AUTOMATIC_SYNC_MIN_INTERVAL
         val isNotBlockedByMeteredConnection = preferences.getBoolean(getString(R.string.metered_sync_key), false) || !isActiveNetworkMetered()
-
-        if (isLoggedIn() && autoSyncIsEnabled && NetworkUtils.isOnline && syncIntervalPassed && isNotBlockedByMeteredConnection) {
+        val isMigratingStorage = userMigrationIsInProgress(this)
+        if (isLoggedIn() && autoSyncIsEnabled && NetworkUtils.isOnline && syncIntervalPassed && isNotBlockedByMeteredConnection && !isMigratingStorage) {
             Timber.i("Triggering Automatic Sync")
             sync()
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -1450,6 +1450,10 @@ open class DeckPicker :
 
     // Show dialogs to deal with database loading issues etc
     open fun showDatabaseErrorDialog(id: Int) {
+        if (id == DatabaseErrorDialog.DIALOG_CONFIRM_DATABASE_CHECK && userMigrationIsInProgress(this)) {
+            showSnackbar(R.string.functionality_disabled_during_storage_migration, Snackbar.LENGTH_SHORT)
+            return
+        }
         val newFragment: AsyncDialogFragment = DatabaseErrorDialog.newInstance(id)
         showAsyncDialogFragment(newFragment)
     }
@@ -1561,6 +1565,12 @@ open class DeckPicker :
 
     // Callback method to handle database integrity check
     override fun integrityCheck() {
+        if (userMigrationIsInProgress(this)) {
+            // The only path which can still display this is a sync error, which shouldn't be possible
+            showSnackbar(R.string.functionality_disabled_during_storage_migration, Snackbar.LENGTH_SHORT)
+            return
+        }
+
         // #5852 - We were having issues with integrity checks where the users had run out of space.
         // display a dialog box if we don't have the space
         val status = CollectionIntegrityStorageCheck.createInstance(this)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -872,7 +872,7 @@ open class DeckPicker :
             }
             R.id.action_import -> {
                 Timber.i("DeckPicker:: Import button pressed")
-                showDialogFragment(ImportFileSelectionFragment.createInstance(this))
+                showImportDialog()
                 return true
             }
             R.id.action_new_filtered_deck -> {
@@ -926,6 +926,14 @@ open class DeckPicker :
             }
             else -> return super.onOptionsItemSelected(item)
         }
+    }
+
+    private fun showImportDialog() {
+        if (userMigrationIsInProgress(this)) {
+            showSnackbar(R.string.functionality_disabled_during_storage_migration, Snackbar.LENGTH_SHORT)
+            return
+        }
+        showDialogFragment(ImportFileSelectionFragment.createInstance(this))
     }
 
     fun exportCollection(includeMedia: Boolean) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DatabaseErrorDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DatabaseErrorDialog.kt
@@ -27,6 +27,7 @@ import com.afollestad.materialdialogs.actions.setActionButtonEnabled
 import com.afollestad.materialdialogs.list.listItems
 import com.afollestad.materialdialogs.list.listItemsSingleChoice
 import com.ichi2.anki.*
+import com.ichi2.anki.servicelayer.ScopedStorageService
 import com.ichi2.async.Connection
 import com.ichi2.libanki.Consts
 import com.ichi2.libanki.utils.TimeManager
@@ -109,7 +110,7 @@ class DatabaseErrorDialog : AsyncDialogFragment() {
                     // retry
                     options.add(res.getString(R.string.backup_retry_opening))
                     values.add(0)
-                } else {
+                } else if (!ScopedStorageService.userMigrationIsInProgress(requireContext())) {
                     // fix integrity
                     options.add(res.getString(R.string.check_db))
                     values.add(1)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/export/ActivityExportingDelegate.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/export/ActivityExportingDelegate.kt
@@ -36,6 +36,7 @@ import com.ichi2.anki.UIUtils.showThemedToast
 import com.ichi2.anki.dialogs.ExportCompleteDialog.ExportCompleteDialogListener
 import com.ichi2.anki.dialogs.ExportDialog.ExportDialogListener
 import com.ichi2.anki.dialogs.ExportDialogParams
+import com.ichi2.anki.servicelayer.ScopedStorageService
 import com.ichi2.anki.snackbar.showSnackbar
 import com.ichi2.compat.CompatHelper
 import com.ichi2.libanki.AnkiPackageExporter
@@ -64,6 +65,10 @@ class ActivityExportingDelegate(private val activity: AnkiActivity, private val 
     private lateinit var mExportFileName: String
 
     fun showExportDialog(params: ExportDialogParams) {
+        if (ScopedStorageService.userMigrationIsInProgress(activity)) {
+            activity.showSnackbar(R.string.functionality_disabled_during_storage_migration, Snackbar.LENGTH_SHORT)
+            return
+        }
         activity.showDialogFragment(mDialogsFactory.newExportDialog().withArguments(params))
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/MediaService.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/MediaService.kt
@@ -1,0 +1,39 @@
+/*
+ *  Copyright (c) 2023 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.servicelayer
+
+import com.google.android.material.snackbar.Snackbar
+import com.ichi2.anki.AnkiActivity
+import com.ichi2.anki.CollectionManager
+import com.ichi2.anki.R
+import com.ichi2.anki.snackbar.showSnackbar
+import com.ichi2.anki.withProgress
+import com.ichi2.libanki.MediaCheckResult
+
+suspend fun AnkiActivity.checkMedia(): MediaCheckResult? {
+    if (ScopedStorageService.userMigrationIsInProgress(this)) {
+        showSnackbar(
+            R.string.functionality_disabled_during_storage_migration,
+            Snackbar.LENGTH_SHORT
+        )
+        return null
+    }
+
+    return withProgress(R.string.check_media_message) {
+        CollectionManager.withCol { media.performFullCheck() }
+    }
+}


### PR DESCRIPTION
## Purpose / Description
A subset of functionality may be problematic while we are migrating storage.

## Fixes
- Related: https://github.com/ankidroid/Anki-Android/issues/13094
- Related: #5304

## Approach
* Show a snackbar when selected functionality is active
* Do not disable 'restore from backup' functionality
* ⚠️ DO not grey out the menu items
  * If they can be disabled with an explanation when clicked on, I'd support this - haven't looked into it

## How Has This Been Tested?
Manually: API 31 AOSP emulator

![Screenshot 2023-02-27 at 00 46 55](https://user-images.githubusercontent.com/62114487/221448511-f943e3a4-2e53-4532-be54-9aacd49f7354.png)
![Screenshot 2023-02-27 at 00 46 42](https://user-images.githubusercontent.com/62114487/221448518-dc55d429-480e-4cdf-9a88-63c26241c18d.png)

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)