### PR TITLE
Storage Migration: Sync before starting storage migration

### DIFF
--- a/.idea/dictionaries/android.xml
+++ b/.idea/dictionaries/android.xml
@@ -46,6 +46,7 @@
       <w>ungzip</w>
       <w>ungzipped</w>
       <w>ungzipping</w>
+      <w>unmetered</w>
       <w>untar</w>
       <w>vivo</w>
       <w>webview</w>

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiActivity.kt
@@ -121,7 +121,7 @@ open class AnkiActivity : AppCompatActivity, SimpleMessageDialogListener, Collec
             SIMPLE_NOTIFICATION_ID
         )
         // Show any pending dialogs which were stored persistently
-        dialogHandler.readMessage()
+        dialogHandler.executeMessage()
     }
 
     override fun onDestroy() {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -240,6 +240,8 @@ open class DeckPicker :
         callback = handleStoragePermissionsCheckForCheckMedia(WeakReference(this))
     )
 
+    private var migrateStorageAfterMediaSyncCompleted = false
+
     // stored for testing purposes
     @VisibleForTesting
     var createMenuJob: Job? = null
@@ -922,11 +924,13 @@ open class DeckPicker :
     public override fun onSaveInstanceState(savedInstanceState: Bundle) {
         super.onSaveInstanceState(savedInstanceState)
         savedInstanceState.putBoolean("mIsFABOpen", mFloatingActionMenu.isFABOpen)
+        savedInstanceState.putBoolean("migrateStorageAfterMediaSyncCompleted", migrateStorageAfterMediaSyncCompleted)
     }
 
     public override fun onRestoreInstanceState(savedInstanceState: Bundle) {
         super.onRestoreInstanceState(savedInstanceState)
         mFloatingActionMenu.isFABOpen = savedInstanceState.getBoolean("mIsFABOpen")
+        migrateStorageAfterMediaSyncCompleted = savedInstanceState.getBoolean("migrateStorageAfterMediaSyncCompleted")
     }
 
     fun onStorageMigrationCompleted() {
@@ -2420,6 +2424,8 @@ open class DeckPicker :
      * Migrate the user data in a service
      */
     fun migrate() {
+        migrateStorageAfterMediaSyncCompleted = false
+
         if (userMigrationIsInProgress(this) || !isLegacyStorage(this)) {
             // This should not ever occurs.
             return
@@ -2531,6 +2537,9 @@ open class DeckPicker :
 
     override fun onMediaSyncCompleted(data: SyncCompletion) {
         Timber.i("Media sync completed. Success: %b", data.isSuccess)
+        if (migrateStorageAfterMediaSyncCompleted) {
+            migrate()
+        }
     }
 }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -1512,21 +1512,13 @@ open class DeckPicker :
             return
         }
 
-        fun shouldFetchMedia(): Boolean {
-            val always = getString(R.string.sync_media_always_value)
-            val onlyIfUnmetered = getString(R.string.sync_media_only_unmetered_value)
-            val shouldFetchMedia = preferences.getString(getString(R.string.sync_fetch_media_key), always)
-            return shouldFetchMedia == always ||
-                (shouldFetchMedia == onlyIfUnmetered && !isActiveNetworkMetered())
-        }
-
         /** Nested function that makes the connection to
          * the sync server and starts syncing the data */
         fun doSync() {
             if (!BackendFactory.defaultLegacySchema) {
-                handleNewSync(conflict, shouldFetchMedia())
+                handleNewSync(conflict, shouldFetchMedia(preferences))
             } else {
-                val fetchMedia = shouldFetchMedia()
+                val fetchMedia = shouldFetchMedia(preferences)
                 val data = arrayOf(hkey, fetchMedia, conflict, HostNumFactory.getInstance(baseContext))
                 Connection.sync(createSyncListener(isFetchingMedia = fetchMedia), Connection.Payload(data))
             }
@@ -2513,12 +2505,7 @@ open class DeckPicker :
             .setPositiveButton(
                 getString(R.string.scoped_storage_migrate)
             ) { _, _ ->
-                if (!BuildConfig.ALLOW_UNSAFE_MIGRATION) {
-                    performMediaSyncBeforeStorageMigration()
-                } else {
-                    Timber.i("Performing unsafe storage migration")
-                    migrate()
-                }
+                performMediaSyncBeforeStorageMigration()
             }
             .setNegativeButton(
                 getString(R.string.scoped_storage_postpone)
@@ -2528,9 +2515,28 @@ open class DeckPicker :
     }
 
     private fun performMediaSyncBeforeStorageMigration() {
-        Timber.i("Syncing before storage migration")
-        migrateStorageAfterMediaSyncCompleted = true
-        sync()
+        // if we allow an unsafe migration, the 'sync required' dialog shows an unsafe migration confirmation dialog
+        val showUnsafeSyncDialog = (BuildConfig.ALLOW_UNSAFE_MIGRATION && !isLoggedIn())
+
+        if (shouldFetchMedia(getSharedPrefs(this)) && !showUnsafeSyncDialog) {
+            Timber.i("Syncing before storage migration")
+            migrateStorageAfterMediaSyncCompleted = true
+            sync()
+        } else {
+            Timber.i("media sync disabled: displaying dialog")
+            AlertDialog.Builder(this).show {
+                setTitle(R.string.media_sync_required_title)
+                iconAttr(R.attr.dialogErrorIcon)
+                setMessage(R.string.media_sync_unavailable_message)
+                setPositiveButton(getString(R.string.scoped_storage_migrate)) { _, _ ->
+                    Timber.i("Performing unsafe storage migration")
+                    migrate()
+                }
+                setNegativeButton(getString(R.string.scoped_storage_postpone)) { _, _ ->
+                    setMigrationWasLastPostponedAtToNow()
+                }
+            }
+        }
     }
 
     // Scoped Storage migration

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -165,6 +165,7 @@ open class DeckPicker :
     OnRequestPermissionsResultCallback,
     CustomStudyListener,
     ChangeManager.Subscriber,
+    SyncCompletionListener,
     ImportColpkgListener {
     // Short animation duration from system
     private var mShortAnimDuration = 0
@@ -1522,8 +1523,9 @@ open class DeckPicker :
             if (!BackendFactory.defaultLegacySchema) {
                 handleNewSync(conflict, shouldFetchMedia())
             } else {
-                val data = arrayOf(hkey, shouldFetchMedia(), conflict, HostNumFactory.getInstance(baseContext))
-                Connection.sync(createSyncListener(), Connection.Payload(data))
+                val fetchMedia = shouldFetchMedia()
+                val data = arrayOf(hkey, fetchMedia, conflict, HostNumFactory.getInstance(baseContext))
+                Connection.sync(createSyncListener(isFetchingMedia = fetchMedia), Connection.Payload(data))
             }
         }
         // Warn the user in case the connection is metered
@@ -2525,6 +2527,10 @@ open class DeckPicker :
     override fun onImportColpkg(colpkgPath: String?) {
         invalidateOptionsMenu()
         updateDeckList()
+    }
+
+    override fun onMediaSyncCompleted(data: SyncCompletion) {
+        Timber.i("Media sync completed. Success: %b", data.isSuccess)
     }
 }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -891,9 +891,13 @@ open class DeckPicker :
 
     override fun onResume() {
         Timber.d("onResume()")
+        // stop onResume() processing the message.
+        // we need to process the message after `loadDeckCounts` is added in refreshState
+        // As `loadDeckCounts` is cancelled in `migrate()`
+        val message = dialogHandler.popMessage()
         super.onResume()
         refreshState()
-        // Migration
+        message?.let { dialogHandler.sendStoredMessage(it) }
     }
 
     fun refreshState() {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -2430,6 +2430,12 @@ open class DeckPicker :
             // This should not ever occurs.
             return
         }
+
+        if (mActivityPaused) {
+            sendNotificationForAsyncOperation(MigrateStorageOnSyncSuccess(this.resources), Channel.SYNC)
+            return
+        }
+
         launchCatchingTask {
             val elapsedMillisDuringEssentialFilesMigration = measureTimeMillis {
                 withProgress(getString(R.string.start_migration_progress_message)) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Sync.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Sync.kt
@@ -330,6 +330,20 @@ private fun cancelMediaSync(backend: Backend) {
     backend.abortMediaSync()
 }
 
+/**
+ * Whether media should be fetched on sync. Options from preferences are:
+ * * Always
+ * * Only if unmetered
+ * * Never
+ */
+fun DeckPicker.shouldFetchMedia(preferences: SharedPreferences): Boolean {
+    val always = getString(R.string.sync_media_always_value)
+    val onlyIfUnmetered = getString(R.string.sync_media_only_unmetered_value)
+    val shouldFetchMedia = preferences.getString(getString(R.string.sync_fetch_media_key), always)
+    return shouldFetchMedia == always ||
+        (shouldFetchMedia == onlyIfUnmetered && !NetworkUtils.isActiveNetworkMetered())
+}
+
 private suspend fun handleMediaSync(
     deckPicker: DeckPicker,
     auth: SyncAuth

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Sync.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Sync.kt
@@ -63,6 +63,11 @@ object SyncPreferences {
     const val HOSTNUM = "hostNum"
 }
 
+data class SyncCompletion(val isSuccess: Boolean)
+interface SyncCompletionListener {
+    fun onMediaSyncCompleted(data: SyncCompletion)
+}
+
 fun DeckPicker.syncAuth(): SyncAuth? {
     val preferences = AnkiDroidApp.getSharedPrefs(this)
     val hkey = preferences.getString(SyncPreferences.HKEY, null)
@@ -356,9 +361,10 @@ private suspend fun handleMediaSync(
     } finally {
         dialog.dismiss()
     }
+    deckPicker.onMediaSyncCompleted(SyncCompletion(isSuccess = true))
 }
 
-fun DeckPicker.createSyncListener() = object : Connection.CancellableTaskListener {
+fun DeckPicker.createSyncListener(isFetchingMedia: Boolean) = object : Connection.CancellableTaskListener {
     private var mCurrentMessage: String? = null
     private var mCountUp: Long = 0
     private var mCountDown: Long = 0
@@ -726,6 +732,9 @@ fun DeckPicker.createSyncListener() = object : Connection.CancellableTaskListene
                     // fragment here is fine since we build a fresh fragment on resume anyway.
                     Timber.w(e, "Failed to load StudyOptionsFragment after sync.")
                 }
+            }
+            if (isFetchingMedia) {
+                onMediaSyncCompleted(SyncCompletion(isSuccess = true))
             }
         }
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DialogHandler.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DialogHandler.kt
@@ -102,6 +102,7 @@ abstract class DialogHandlerMessage protected constructor(val which: WhichDialog
                 WhichDialogHandler.MSG_SHOW_DATABASE_ERROR_DIALOG -> DatabaseErrorDialog.ShowDatabaseErrorDialog.fromMessage(message)
                 WhichDialogHandler.MSG_SHOW_FORCE_FULL_SYNC_DIALOG -> ForceFullSyncDialog.fromMessage(message)
                 WhichDialogHandler.MSG_DO_SYNC -> IntentHandler.Companion.DoSync()
+                WhichDialogHandler.MSG_MIGRATE_ON_SYNC_SUCCESS -> MigrateStorageOnSyncSuccess.MigrateOnSyncSuccessHandler()
             }
         }
     }
@@ -116,7 +117,9 @@ abstract class DialogHandlerMessage protected constructor(val which: WhichDialog
         MSG_SHOW_MEDIA_CHECK_COMPLETE_DIALOG(5),
         MSG_SHOW_DATABASE_ERROR_DIALOG(6),
         MSG_SHOW_FORCE_FULL_SYNC_DIALOG(7),
-        MSG_DO_SYNC(8);
+        MSG_DO_SYNC(8),
+        MSG_MIGRATE_ON_SYNC_SUCCESS(9)
+        ;
         companion object {
             fun fromInt(value: Int) = WhichDialogHandler.values().first { it.what == value }
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DialogHandler.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DialogHandler.kt
@@ -43,15 +43,28 @@ class DialogHandler(activity: AnkiActivity) : Handler(getDefaultLooper()) {
     }
 
     /**
-     * Read and handle Message which was stored via storeMessage()
+     * Returns the current message (if any) and stops further processing of it
      */
-    fun readMessage() {
+    fun popMessage(): Message? {
+        val toReturn = sStoredMessage
+        sStoredMessage = null
+        return toReturn
+    }
+
+    /**
+     * Read and handle Message which was stored via [storeMessage]
+     */
+    fun executeMessage() {
         Timber.d("Reading persistent message")
         if (sStoredMessage != null) {
-            Timber.i("Dispatching persistent message: %d", sStoredMessage!!.what)
-            sendMessage(sStoredMessage!!)
+            sendStoredMessage(sStoredMessage!!)
         }
         sStoredMessage = null
+    }
+
+    fun sendStoredMessage(message: Message) {
+        Timber.i("Dispatching persistent message: %d", message.what)
+        sendMessage(message)
     }
 
     companion object {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/widgets/DeckAdapter.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/widgets/DeckAdapter.kt
@@ -36,9 +36,11 @@ import com.ichi2.libanki.sched.TreeNode
 import com.ichi2.utils.KotlinCleanup
 import com.ichi2.utils.TypedFilter
 import net.ankiweb.rsdroid.BackendFactory
+import net.ankiweb.rsdroid.RustCleanup
 import java.util.*
 
 @KotlinCleanup("lots to do")
+@RustCleanup("synchronous col access")
 class DeckAdapter(private val layoutInflater: LayoutInflater, context: Context) : RecyclerView.Adapter<DeckAdapter.ViewHolder>(), Filterable {
     private val mDeckList: MutableList<TreeNode<AbstractDeckTreeNode>>
 

--- a/AnkiDroid/src/main/java/com/ichi2/async/AsyncOperation.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/async/AsyncOperation.kt
@@ -1,0 +1,50 @@
+/*
+ *  Copyright (c) 2023 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.async
+
+import com.ichi2.anki.Channel
+import com.ichi2.anki.DeckPicker
+import com.ichi2.anki.dialogs.DialogHandler
+import com.ichi2.anki.dialogs.DialogHandlerMessage
+
+abstract class AsyncOperation {
+    abstract val notificationMessage: String?
+    abstract val notificationTitle: String
+    abstract val handlerMessage: DialogHandlerMessage
+}
+
+fun DeckPicker.sendNotificationForAsyncOperation(operation: AsyncOperation, channel: Channel) {
+    // Store a persistent message instructing AnkiDroid to perform the operation
+    DialogHandler.storeMessage(operation.handlerMessage.toMessage())
+    // Show a basic notification to the user in the notification bar in the meantime
+    val title = operation.notificationTitle
+    val message = operation.notificationMessage
+    showSimpleNotification(title, message, channel)
+}
+
+@Suppress("unused")
+fun DeckPicker.performAsyncOperation(
+    operation: AsyncOperation,
+    channel: Channel
+) {
+    if (mActivityPaused) {
+        sendNotificationForAsyncOperation(operation, channel)
+        return
+    }
+
+    operation.handlerMessage.handleAsyncMessage(this)
+}

--- a/AnkiDroid/src/main/res/values/02-strings.xml
+++ b/AnkiDroid/src/main/res/values/02-strings.xml
@@ -451,4 +451,9 @@
         comment="Displayed when trying to access functionality which cannot be run while storage is being moved to a new location">
         This functionality is unavailable during a storage migration
     </string>
+
+    <string name="storage_migration_sync_notification"
+        comment="Appears on a notification after the user has opted into a storage migration and provided consent to sync
+        and AnkiDroid was minimised when the sync completed"
+        >Tap to start storage migration</string>
 </resources>

--- a/AnkiDroid/src/main/res/values/02-strings.xml
+++ b/AnkiDroid/src/main/res/values/02-strings.xml
@@ -402,10 +402,7 @@
     <string name="sync_impossible_during_migration">Sync is disabled until the migration is done.\n
         %1$d media files left to migrate.</string>
 
-    <string name="migration_warning_risk_of_data_loss_if_no_update">If you reinstall AnkiDroid, it will not be able to open your collection.</string>
-    <string name="migration_update_request_dialog_download_warning">If you uninstall AnkiDroid, you will need to download your full collection again.</string>
-    <string name="migration_update_request">Android storage access policy requires us to change where we store your collection. When your data is migrated AnkiDroid will be faster and your data will be more secure.
-    You will not be able to sync during the storage migration.</string>
+    <string name="migration_update_request_requires_media_sync" commnet="use HTML linebreaks in this string">AnkiDroid needs to migrate its storage to comply with Android 10 security policy.\n\nThis will improve media sync performance.&lt;br&gt;&lt;br&gt;During the migration you will be unable to sync and some settings will be disabled. A media sync will occur before the migration starts to keep your data safe.&lt;br&gt;&lt;br&gt;It is safe to use or close AnkiDroid during this process.</string>
     <string name="start_migration_progress_message">Starting storage migration. You may resume using AnkiDroid shortly.</string>
     <string name="migration_part_1_done_resume">You may resume using AnkiDroid.
 \nStorage migration will continue in the background.</string>
@@ -456,4 +453,8 @@
         comment="Appears on a notification after the user has opted into a storage migration and provided consent to sync
         and AnkiDroid was minimised when the sync completed"
         >Tap to start storage migration</string>
+
+
+    <string name="media_sync_required_title">Media Sync Required</string>
+    <string name="media_sync_required_message">You must sync before performing a storage migration</string>
 </resources>

--- a/AnkiDroid/src/main/res/values/02-strings.xml
+++ b/AnkiDroid/src/main/res/values/02-strings.xml
@@ -454,7 +454,6 @@
         and AnkiDroid was minimised when the sync completed"
         >Tap to start storage migration</string>
 
-
     <string name="media_sync_required_title">Media Sync Required</string>
-    <string name="media_sync_required_message">You must sync before performing a storage migration</string>
+    <string name="media_sync_unavailable_message">Media sync is disabled in the settings. Please sync and backup any media which hasn\'t been synced before continuing</string>
 </resources>


### PR DESCRIPTION
## Purpose / Description
If a user is going to perform a migration, they should be fully synced to ensure no data loss. We can't easily know if they're fully synced on the media side of things, so perform a sync and see.

When the user has performed a media sync, migrate.

The sync may complete while the user has the app closed.

In this case, `withProgress` may not execute (no window), so we conservatively pause the start of the migration until the AnkiDroid window has called `onResume`.

Also handle the case where the media sync cannot occur (via `AlertDialog` + migrate anyway). 


## Fixes
- Related: #5304
- Fixes #13382

## Approach
Define an `AsyncOperation`: similar to an `AsyncDialogFragment`, but not necessarily with a dialog

Define a `MigrateStorageAfterSync`
It passes this into `sync`, which calls it at the end of the operation

Define a `onSyncCompleted()` listener, as an interface so the sync functionality can be decoupled from `DeckPicker` in future.

Handle the activity lifecycle changes in `DeckPicker`, which required a minor rework of `DialogHandler` + `AnkiActivity`

## How Has This Been Tested?

![Screenshot 2023-03-07 at 00 11 31](https://user-images.githubusercontent.com/62114487/223300567-15cc5f8d-d7ef-47cb-8629-8ac9c6f9f068.png)
<img width="408" alt="Screenshot 2023-03-06 at 23 32 41" src="https://user-images.githubusercontent.com/62114487/223300572-2dd632bb-6474-4b72-a5f5-f1c941d0f6ab.png">
<img width="425" alt="Screenshot 2023-03-06 at 23 29 11" src="https://user-images.githubusercontent.com/62114487/223300575-efb9aec8-c1e4-435a-bae8-14902c08c040.png">

## Learning

`renderPage()` needs a lot of work for the new Backend

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
