### PR TITLE
Refactor: Legacy syncing

### DIFF
--- a/.idea/dictionaries/android.xml
+++ b/.idea/dictionaries/android.xml
@@ -25,6 +25,7 @@
       <w>gtxt</w>
       <w>instanceof</w>
       <w>keypress</w>
+      <w>librsdroid</w>
       <w>longclick</w>
       <w>mediaplayer</w>
       <w>nomedia</w>

--- a/.idea/dictionaries/anki.xml
+++ b/.idea/dictionaries/anki.xml
@@ -103,6 +103,10 @@
       <w>rsum</w>
       <w>sched</w>
       <w>sched's</w>
+      <w>schedv</w>
+      <w>schedv1</w>
+      <w>schedv2</w>
+      <w>schedv3</w>
       <w>scmhash</w>
       <w>sdids</w>
       <w>sfld</w>

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -37,9 +37,7 @@ import android.provider.Settings
 import android.util.TypedValue
 import android.view.*
 import android.view.View.OnLongClickListener
-import android.view.WindowManager.BadTokenException
 import android.widget.*
-import androidx.annotation.StringRes
 import androidx.annotation.VisibleForTesting
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.widget.SearchView
@@ -101,7 +99,6 @@ import com.ichi2.anki.widgets.DeckAdapter
 import com.ichi2.annotations.NeedsTest
 import com.ichi2.async.*
 import com.ichi2.async.CollectionTask.*
-import com.ichi2.async.Connection.CancellableTaskListener
 import com.ichi2.async.Connection.ConflictResolution
 import com.ichi2.compat.CompatHelper.Companion.sdkVersion
 import com.ichi2.libanki.*
@@ -112,8 +109,6 @@ import com.ichi2.libanki.sched.AbstractDeckTreeNode
 import com.ichi2.libanki.sched.DeckDueTreeNode
 import com.ichi2.libanki.sched.TreeNode
 import com.ichi2.libanki.sched.findInDeckTree
-import com.ichi2.libanki.sync.CustomSyncServerUrlException
-import com.ichi2.libanki.sync.Syncer.ConnectionResultType
 import com.ichi2.libanki.utils.TimeManager
 import com.ichi2.themes.StyledProgressDialog
 import com.ichi2.ui.BadgeDrawableBuilder
@@ -129,7 +124,6 @@ import org.json.JSONException
 import timber.log.Timber
 import java.io.File
 import java.lang.Runnable
-import kotlin.math.abs
 import kotlin.math.roundToLong
 import kotlin.system.measureTimeMillis
 
@@ -179,7 +173,7 @@ open class DeckPicker :
     private lateinit var mDeckPickerContent: RelativeLayout
 
     @Suppress("Deprecation") // TODO: Encapsulate ProgressDialog within a class to limit the use of deprecated functionality
-    private var mProgressDialog: android.app.ProgressDialog? = null
+    var mProgressDialog: android.app.ProgressDialog? = null
     private var mStudyoptionsFrame: View? = null // not lateInit - can be null
     @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
     lateinit var recyclerView: RecyclerView
@@ -188,7 +182,9 @@ open class DeckPicker :
     private val mSnackbarShowHideCallback = Snackbar.Callback()
     private lateinit var mExportingDelegate: ActivityExportingDelegate
     private lateinit var mNoDecksPlaceholder: LinearLayout
-    private lateinit var mPullToSyncWrapper: SwipeRefreshLayout
+    lateinit var mPullToSyncWrapper: SwipeRefreshLayout
+        private set
+
     private lateinit var mReviewSummaryTextView: TextView
 
     @KotlinCleanup("make lateinit, but needs more changes")
@@ -199,7 +195,8 @@ open class DeckPicker :
     private var mRecommendFullSync = false
 
     // flag keeping track of when the app has been paused
-    private var mActivityPaused = false
+    var mActivityPaused = false
+        private set
 
     // Flag to keep track of startup error
     private var mStartupError = false
@@ -1479,46 +1476,6 @@ open class DeckPicker :
         showAsyncDialogFragment(newFragment, Channel.SYNC)
     }
 
-    /**
-     * Show simple error dialog with just the message and OK button. Reload the activity when dialog closed.
-     */
-    private fun showSyncErrorMessage(message: String?) {
-        val title = resources.getString(R.string.sync_error)
-        showSimpleMessageDialog(title = title, message = message, reload = true)
-    }
-
-    /**
-     * Show a simple snackbar message or notification if the activity is not in foreground
-     * @param messageResource String resource for message
-     */
-    fun showSyncLogMessage(@StringRes messageResource: Int, syncMessage: String?) {
-        if (mActivityPaused) {
-            val res = AnkiDroidApp.appResources
-            showSimpleNotification(
-                res.getString(R.string.app_name),
-                res.getString(messageResource),
-                Channel.SYNC
-            )
-        } else {
-            if (syncMessage.isNullOrEmpty()) {
-                if (messageResource == R.string.youre_offline && !Connection.allowLoginSyncOnNoConnection) {
-                    // #6396 - Add a temporary "Try Anyway" button until we sort out `isOnline`
-                    showSnackbar(messageResource) {
-                        setAction(R.string.sync_even_if_offline) {
-                            Connection.allowLoginSyncOnNoConnection = true
-                            sync()
-                        }
-                    }
-                } else {
-                    showSnackbar(messageResource)
-                }
-            } else {
-                val res = AnkiDroidApp.appResources
-                showSimpleMessageDialog(title = res.getString(messageResource), message = syncMessage)
-            }
-        }
-    }
-
     fun showImportDialog(id: Int, messageList: ArrayList<String>) {
         Timber.d("showImportDialog() delegating to ImportDialog")
         if (messageList.isEmpty()) {
@@ -1691,7 +1648,7 @@ open class DeckPicker :
                 handleNewSync(conflict, shouldFetchMedia())
             } else {
                 val data = arrayOf(hkey, shouldFetchMedia(), conflict, HostNumFactory.getInstance(baseContext))
-                Connection.sync(mSyncListener, Connection.Payload(data))
+                Connection.sync(createSyncListener(), Connection.Payload(data))
             }
         }
         // Warn the user in case the connection is metered
@@ -1705,339 +1662,6 @@ open class DeckPicker :
         } else {
             doSync()
         }
-    }
-
-    private val mSyncListener: Connection.TaskListener = object : CancellableTaskListener {
-        private var mCurrentMessage: String? = null
-        private var mCountUp: Long = 0
-        private var mCountDown: Long = 0
-        private var mDialogDisplayFailure = false
-        override fun onDisconnected() {
-            showSyncLogMessage(R.string.youre_offline, "")
-        }
-
-        override fun onCancelled() {
-            showSyncLogMessage(R.string.sync_cancelled, "")
-            if (!mDialogDisplayFailure) {
-                mProgressDialog!!.dismiss()
-                // update deck list in case sync was cancelled during media sync and main sync was actually successful
-                updateDeckList()
-            }
-            // reset our display failure fate, just in case it is re-used
-            mDialogDisplayFailure = false
-        }
-
-        override fun onPreExecute() {
-            mCountUp = 0
-            mCountDown = 0
-            val syncStartTime = TimeManager.time.intTimeMS()
-            if (mProgressDialog == null || !mProgressDialog!!.isShowing) {
-                try {
-                    mProgressDialog = StyledProgressDialog.show(
-                        this@DeckPicker,
-                        resources.getString(R.string.sync_title),
-                        """
-                                ${resources.getString(R.string.sync_title)}
-                                ${resources.getString(R.string.sync_up_down_size, mCountUp, mCountDown)}
-                        """.trimIndent(),
-                        false
-                    )
-                } catch (e: BadTokenException) {
-                    // If we could not show the progress dialog to start even, bail out - user will get a message
-                    Timber.w(e, "Unable to display Sync progress dialog, Activity not valid?")
-                    mDialogDisplayFailure = true
-                    Connection.cancel()
-                    return
-                }
-
-                // Override the back key so that the user can cancel a sync which is in progress
-                mProgressDialog!!.setOnKeyListener { _: DialogInterface?, keyCode: Int, event: KeyEvent ->
-                    // Make sure our method doesn't get called twice
-                    if (event.action != KeyEvent.ACTION_DOWN) {
-                        return@setOnKeyListener true
-                    }
-                    if (keyCode == KeyEvent.KEYCODE_BACK && Connection.isCancellable &&
-                        !Connection.isCancelled
-                    ) {
-                        // If less than 2s has elapsed since sync started then don't ask for confirmation
-                        if (TimeManager.time.intTimeMS() - syncStartTime < 2000) {
-                            Connection.cancel()
-                            @Suppress("Deprecation")
-                            mProgressDialog!!.setMessage(getString(R.string.sync_cancel_message))
-                            return@setOnKeyListener true
-                        }
-                        // Show confirmation dialog to check if the user wants to cancel the sync
-                        AlertDialog.Builder(mProgressDialog!!.context).show {
-                            message(R.string.cancel_sync_confirm)
-                            cancelable(false)
-                            positiveButton(R.string.dialog_ok) {
-                                @Suppress("Deprecation")
-                                mProgressDialog!!.setMessage(getString(R.string.sync_cancel_message))
-                                Connection.cancel()
-                            }
-                            negativeButton(R.string.continue_sync)
-                        }
-                        return@setOnKeyListener true
-                    } else {
-                        return@setOnKeyListener false
-                    }
-                }
-            }
-
-            // Store the current time so that we don't bother the user with a sync prompt for another 10 minutes
-            // Note: getLs() in Libanki doesn't take into account the case when no changes were found, or sync cancelled
-            getSharedPrefs(baseContext).edit { putLong("lastSyncTime", syncStartTime) }
-        }
-
-        override fun onProgressUpdate(vararg values: Any?) {
-            val res = resources
-            if (values[0] is Int) {
-                val id = values[0] as Int
-                if (id != 0) {
-                    mCurrentMessage = res.getString(id)
-                }
-                if (values.size >= 3) {
-                    mCountUp = values[1] as Long
-                    mCountDown = values[2] as Long
-                }
-            } else if (values[0] is String) {
-                mCurrentMessage = values[0] as String
-                if (values.size >= 3) {
-                    mCountUp = values[1] as Long
-                    mCountDown = values[2] as Long
-                }
-            }
-            if (mProgressDialog != null && mProgressDialog!!.isShowing) {
-                @Suppress("Deprecation")
-                mProgressDialog!!.setMessage(
-                    """
-    $mCurrentMessage
-    
-                    """.trimIndent() +
-                        res
-                            .getString(R.string.sync_up_down_size, mCountUp / 1024, mCountDown / 1024)
-                )
-            }
-        }
-
-        override fun onPostExecute(data: Connection.Payload) {
-            mPullToSyncWrapper.isRefreshing = false
-            var dialogMessage: String? = ""
-            Timber.d("Sync Listener onPostExecute()")
-            val res = resources
-            try {
-                if (mProgressDialog != null && mProgressDialog!!.isShowing) {
-                    mProgressDialog!!.dismiss()
-                }
-            } catch (e: IllegalArgumentException) {
-                Timber.e(e, "Could not dismiss mProgressDialog. The Activity must have been destroyed while the AsyncTask was running")
-                CrashReportService.sendExceptionReport(e, "DeckPicker.onPostExecute", "Could not dismiss mProgressDialog")
-            }
-            val syncMessage = data.message
-            Timber.i("Sync Listener: onPostExecute: Data: %s", data.toString())
-            if (!data.success) {
-                val result = data.result
-                val resultType = data.resultType
-                if (resultType != null) {
-                    when (resultType) {
-                        ConnectionResultType.BAD_AUTH -> {
-                            // delete old auth information
-                            getSharedPrefs(baseContext).edit {
-                                putString("username", "")
-                                putString("hkey", "")
-                            }
-                            // then show not logged in dialog
-                            showSyncErrorDialog(SyncErrorDialog.DIALOG_USER_NOT_LOGGED_IN_SYNC)
-                        }
-                        ConnectionResultType.NO_CHANGES -> {
-                            SyncStatus.markSyncCompleted()
-                            // show no changes message, use false flag so we don't show "sync error" as the Dialog title
-                            showSyncLogMessage(R.string.sync_no_changes_message, "")
-                        }
-                        ConnectionResultType.CLOCK_OFF -> {
-                            val diff = result[0] as Long
-                            dialogMessage = when {
-                                diff >= 86100 -> {
-                                    // The difference if more than a day minus 5 minutes acceptable by ankiweb error
-                                    res.getString(
-                                        R.string.sync_log_clocks_unsynchronized,
-                                        diff,
-                                        res.getString(R.string.sync_log_clocks_unsynchronized_date)
-                                    )
-                                }
-                                abs(diff % 3600.0 - 1800.0) >= 1500.0 -> {
-                                    // The difference would be within limit if we adjusted the time by few hours
-                                    // It doesn't work for all timezones, but it covers most and it's a guess anyway
-                                    res.getString(
-                                        R.string.sync_log_clocks_unsynchronized,
-                                        diff,
-                                        res.getString(R.string.sync_log_clocks_unsynchronized_tz)
-                                    )
-                                }
-                                else -> {
-                                    res.getString(R.string.sync_log_clocks_unsynchronized, diff, "")
-                                }
-                            }
-                            showSyncErrorMessage(joinSyncMessages(dialogMessage, syncMessage))
-                        }
-                        ConnectionResultType.FULL_SYNC -> if (col.isEmpty) {
-                            // don't prompt user to resolve sync conflict if local collection empty
-                            sync(ConflictResolution.FULL_DOWNLOAD)
-                            // TODO: Also do reverse check to see if AnkiWeb collection is empty if Anki Desktop
-                            // implements it
-                        } else {
-                            // If can't be resolved then automatically then show conflict resolution dialog
-                            showSyncErrorDialog(SyncErrorDialog.DIALOG_SYNC_CONFLICT_RESOLUTION)
-                        }
-                        ConnectionResultType.BASIC_CHECK_FAILED -> {
-                            dialogMessage = res.getString(R.string.sync_basic_check_failed, res.getString(R.string.check_db))
-                            showSyncErrorDialog(SyncErrorDialog.DIALOG_SYNC_BASIC_CHECK_ERROR, joinSyncMessages(dialogMessage, syncMessage))
-                        }
-                        ConnectionResultType.DB_ERROR -> showSyncErrorDialog(SyncErrorDialog.DIALOG_SYNC_CORRUPT_COLLECTION, syncMessage)
-                        ConnectionResultType.OVERWRITE_ERROR -> {
-                            dialogMessage = res.getString(R.string.sync_overwrite_error)
-                            showSyncErrorMessage(joinSyncMessages(dialogMessage, syncMessage))
-                        }
-                        ConnectionResultType.REMOTE_DB_ERROR -> {
-                            dialogMessage = res.getString(R.string.sync_remote_db_error)
-                            showSyncErrorMessage(joinSyncMessages(dialogMessage, syncMessage))
-                        }
-                        ConnectionResultType.SD_ACCESS_ERROR -> {
-                            dialogMessage = res.getString(R.string.sync_write_access_error_on_storage)
-                            showSyncErrorMessage(joinSyncMessages(dialogMessage, syncMessage))
-                        }
-                        ConnectionResultType.FINISH_ERROR -> {
-                            dialogMessage = res.getString(R.string.sync_log_finish_error)
-                            showSyncErrorMessage(joinSyncMessages(dialogMessage, syncMessage))
-                        }
-                        ConnectionResultType.CONNECTION_ERROR -> {
-                            dialogMessage = res.getString(R.string.sync_connection_error)
-                            if (result[0] is Exception) {
-                                dialogMessage += """
-                                    
-                                    
-                                    ${(result[0] as Exception).localizedMessage}
-                                """.trimIndent()
-                            }
-                            showSyncErrorMessage(joinSyncMessages(dialogMessage, syncMessage))
-                        }
-                        ConnectionResultType.IO_EXCEPTION -> handleDbError()
-                        ConnectionResultType.GENERIC_ERROR -> {
-                            dialogMessage = res.getString(R.string.sync_generic_error)
-                            showSyncErrorMessage(joinSyncMessages(dialogMessage, syncMessage))
-                        }
-                        ConnectionResultType.OUT_OF_MEMORY_ERROR -> {
-                            dialogMessage = res.getString(R.string.error_insufficient_memory)
-                            showSyncErrorMessage(joinSyncMessages(dialogMessage, syncMessage))
-                        }
-                        ConnectionResultType.SANITY_CHECK_ERROR -> {
-                            dialogMessage = res.getString(R.string.sync_sanity_failed)
-                            showSyncErrorDialog(
-                                SyncErrorDialog.DIALOG_SYNC_SANITY_ERROR,
-                                joinSyncMessages(dialogMessage, syncMessage)
-                            )
-                        }
-                        ConnectionResultType.SERVER_ABORT -> // syncMsg has already been set above, no need to fetch it here.
-                            showSyncErrorMessage(joinSyncMessages(dialogMessage, syncMessage))
-                        ConnectionResultType.MEDIA_SYNC_SERVER_ERROR -> {
-                            dialogMessage = res.getString(R.string.sync_media_error_check)
-                            showSyncErrorDialog(
-                                SyncErrorDialog.DIALOG_MEDIA_SYNC_ERROR,
-                                joinSyncMessages(dialogMessage, syncMessage)
-                            )
-                        }
-                        ConnectionResultType.CUSTOM_SYNC_SERVER_URL -> {
-                            val url = if (result.isNotEmpty() && result[0] is CustomSyncServerUrlException) (result[0] as CustomSyncServerUrlException).url else "unknown"
-                            dialogMessage = res.getString(R.string.sync_error_invalid_sync_server, url)
-                            showSyncErrorMessage(joinSyncMessages(dialogMessage, syncMessage))
-                        }
-                        ConnectionResultType.NETWORK_ERROR -> {
-                            showSnackbar(R.string.check_network) {
-                                setAction(R.string.sync_even_if_offline) {
-                                    Connection.allowLoginSyncOnNoConnection = true
-                                    sync()
-                                }
-                            }
-                        }
-                        else -> {
-                            if (result.isNotEmpty() && result[0] is Int) {
-                                val code = result[0] as Int
-                                dialogMessage = rewriteError(code)
-                                if (dialogMessage == null) {
-                                    dialogMessage = res.getString(
-                                        R.string.sync_log_error_specific,
-                                        code.toString(),
-                                        result[1]
-                                    )
-                                }
-                            } else {
-                                dialogMessage = res.getString(R.string.sync_log_error_specific, (-1).toString(), resultType)
-                            }
-                            showSyncErrorMessage(joinSyncMessages(dialogMessage, syncMessage))
-                        }
-                    }
-                } else {
-                    dialogMessage = res.getString(R.string.sync_generic_error)
-                    showSyncErrorMessage(joinSyncMessages(dialogMessage, syncMessage))
-                }
-            } else {
-                Timber.i("Sync was successful")
-                if (data.data[2] != null && "" != data.data[2]) {
-                    Timber.i("Syncing had additional information")
-                    // There was a media error, so show it
-                    // Note: Do not log this data. May contain user email.
-                    val message = res.getString(R.string.sync_database_acknowledge) + "\n\n" + data.data[2]
-                    showSimpleMessageDialog(message)
-                } else if (data.data.isNotEmpty() && data.data[0] is ConflictResolution) {
-                    // A full sync occurred
-                    when (data.data[0] as ConflictResolution) {
-                        ConflictResolution.FULL_UPLOAD -> {
-                            Timber.i("Full Upload Completed")
-                            showSyncLogMessage(R.string.sync_log_uploading_message, syncMessage)
-                        }
-                        ConflictResolution.FULL_DOWNLOAD -> {
-                            Timber.i("Full Download Completed")
-                            showSyncLogMessage(R.string.backup_full_sync_from_server, syncMessage)
-                        }
-                    }
-                } else {
-                    Timber.i("Regular sync completed successfully")
-                    showSyncLogMessage(R.string.sync_database_acknowledge, syncMessage)
-                }
-                // Mark sync as completed - then refresh the sync icon
-                SyncStatus.markSyncCompleted()
-                invalidateOptionsMenu()
-                updateDeckList()
-                WidgetStatus.update(this@DeckPicker)
-                if (fragmented) {
-                    try {
-                        loadStudyOptionsFragment(false)
-                    } catch (e: IllegalStateException) {
-                        // Activity was stopped or destroyed when the sync finished. Losing the
-                        // fragment here is fine since we build a fresh fragment on resume anyway.
-                        Timber.w(e, "Failed to load StudyOptionsFragment after sync.")
-                    }
-                }
-            }
-        }
-    }
-
-    @VisibleForTesting
-    fun rewriteError(code: Int): String? {
-        val msg: String?
-        val res = resources
-        msg = when (code) {
-            407 -> res.getString(R.string.sync_error_407_proxy_required)
-            409 -> res.getString(R.string.sync_error_409)
-            413 -> res.getString(R.string.sync_error_413_collection_size)
-            500 -> res.getString(R.string.sync_error_500_unknown)
-            501 -> res.getString(R.string.sync_error_501_upgrade_required)
-            502 -> res.getString(R.string.sync_error_502_maintenance)
-            503 -> res.getString(R.string.sync_too_busy)
-            504 -> res.getString(R.string.sync_error_504_gateway_timeout)
-            else -> null
-        }
-        return msg
     }
 
     override fun loginToSyncServer() {
@@ -2074,7 +1698,7 @@ open class DeckPicker :
      * modify the filter settings before being shown the fragment. The fragment itself will handle
      * rebuilding the deck if the settings change.
      */
-    private fun loadStudyOptionsFragment(withDeckOptions: Boolean) {
+    fun loadStudyOptionsFragment(withDeckOptions: Boolean) {
         val details = StudyOptionsFragment.newInstance(withDeckOptions)
         supportFragmentManager.commit {
             replace(R.id.studyoptions_fragment, details)
@@ -2855,20 +2479,6 @@ open class DeckPicker :
         // 10 minutes in milliseconds.
         const val AUTOMATIC_SYNC_MIN_INTERVAL: Long = 600000
         private const val SWIPE_TO_SYNC_TRIGGER_DISTANCE = 400
-        fun joinSyncMessages(dialogMessage: String?, syncMessage: String?): String? {
-            // If both strings have text, separate them by a new line, otherwise return whichever has text
-            return if (!dialogMessage.isNullOrEmpty() && !syncMessage.isNullOrEmpty()) {
-                """
-     $dialogMessage
-     
-     $syncMessage
-                """.trimIndent()
-            } else if (!dialogMessage.isNullOrEmpty()) {
-                dialogMessage
-            } else {
-                syncMessage
-            }
-        }
 
         // Animation utility methods used by renderPage() method
         fun fadeIn(view: View?, duration: Int, translation: Float = 0f, startAction: Runnable? = Runnable { view!!.visibility = View.VISIBLE }): ViewPropertyAnimator {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NavigationDrawerActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NavigationDrawerActivity.kt
@@ -59,7 +59,8 @@ abstract class NavigationDrawerActivity :
     /**
      * Navigation Drawer
      */
-    protected var fragmented = false
+    var fragmented = false
+        protected set
     private var mNavButtonGoesBack = false
 
     // Navigation drawer list item entries

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Sync.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Sync.kt
@@ -19,10 +19,10 @@ package com.ichi2.anki
 import android.content.Context
 import android.content.DialogInterface
 import android.content.SharedPreferences
+import android.content.res.Resources
 import android.view.KeyEvent
 import android.view.WindowManager
 import androidx.annotation.StringRes
-import androidx.annotation.VisibleForTesting
 import androidx.appcompat.app.AlertDialog
 import androidx.core.content.edit
 import anki.sync.SyncAuth
@@ -660,7 +660,7 @@ fun DeckPicker.createSyncListener() = object : Connection.CancellableTaskListene
                     else -> {
                         if (result.isNotEmpty() && result[0] is Int) {
                             val code = result[0] as Int
-                            dialogMessage = rewriteError(code)
+                            dialogMessage = getMessageFromSyncErrorCode(resources, code)
                             if (dialogMessage == null) {
                                 dialogMessage = res.getString(
                                     R.string.sync_log_error_specific,
@@ -765,23 +765,16 @@ fun DeckPicker.showSyncLogMessage(@StringRes messageResource: Int, syncMessage: 
     }
 }
 
-@VisibleForTesting
-fun DeckPicker.rewriteError(code: Int): String? {
-    // PREF: Unit tests on this method can be sped up (remove 'DeckPicker' reference)
-    val msg: String?
-    val res = resources
-    msg = when (code) {
-        407 -> res.getString(R.string.sync_error_407_proxy_required)
-        409 -> res.getString(R.string.sync_error_409)
-        413 -> res.getString(R.string.sync_error_413_collection_size)
-        500 -> res.getString(R.string.sync_error_500_unknown)
-        501 -> res.getString(R.string.sync_error_501_upgrade_required)
-        502 -> res.getString(R.string.sync_error_502_maintenance)
-        503 -> res.getString(R.string.sync_too_busy)
-        504 -> res.getString(R.string.sync_error_504_gateway_timeout)
-        else -> null
-    }
-    return msg
+fun getMessageFromSyncErrorCode(res: Resources, code: Int): String? = when (code) {
+    407 -> res.getString(R.string.sync_error_407_proxy_required)
+    409 -> res.getString(R.string.sync_error_409)
+    413 -> res.getString(R.string.sync_error_413_collection_size)
+    500 -> res.getString(R.string.sync_error_500_unknown)
+    501 -> res.getString(R.string.sync_error_501_upgrade_required)
+    502 -> res.getString(R.string.sync_error_502_maintenance)
+    503 -> res.getString(R.string.sync_too_busy)
+    504 -> res.getString(R.string.sync_error_504_gateway_timeout)
+    else -> null
 }
 
 fun joinSyncMessages(dialogMessage: String?, syncMessage: String?): String? {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Sync.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Sync.kt
@@ -17,7 +17,12 @@
 package com.ichi2.anki
 
 import android.content.Context
+import android.content.DialogInterface
 import android.content.SharedPreferences
+import android.view.KeyEvent
+import android.view.WindowManager
+import androidx.annotation.StringRes
+import androidx.annotation.VisibleForTesting
 import androidx.appcompat.app.AlertDialog
 import androidx.core.content.edit
 import anki.sync.SyncAuth
@@ -35,6 +40,9 @@ import com.ichi2.libanki.createBackup
 import com.ichi2.libanki.sync.*
 import com.ichi2.libanki.utils.TimeManager
 import com.ichi2.preferences.VersatileTextWithASwitchPreference
+import com.ichi2.themes.StyledProgressDialog
+import com.ichi2.utils.*
+import com.ichi2.widget.WidgetStatus
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import net.ankiweb.rsdroid.Backend
@@ -42,6 +50,7 @@ import net.ankiweb.rsdroid.exceptions.BackendNetworkException
 import net.ankiweb.rsdroid.exceptions.BackendSyncException
 import timber.log.Timber
 import java.net.UnknownHostException
+import kotlin.math.abs
 
 object SyncPreferences {
     const val HKEY = "hkey"
@@ -340,5 +349,452 @@ private suspend fun handleMediaSync(
         }
     } finally {
         dialog.dismiss()
+    }
+}
+
+fun DeckPicker.createSyncListener() = object : Connection.CancellableTaskListener {
+    private var mCurrentMessage: String? = null
+    private var mCountUp: Long = 0
+    private var mCountDown: Long = 0
+    private var mDialogDisplayFailure = false
+    override fun onDisconnected() {
+        showSyncLogMessage(R.string.youre_offline, "")
+    }
+
+    override fun onCancelled() {
+        showSyncLogMessage(R.string.sync_cancelled, "")
+        if (!mDialogDisplayFailure) {
+            mProgressDialog!!.dismiss()
+            // update deck list in case sync was cancelled during media sync and main sync was actually successful
+            updateDeckList()
+        }
+        // reset our display failure fate, just in case it is re-used
+        mDialogDisplayFailure = false
+    }
+
+    override fun onPreExecute() {
+        mCountUp = 0
+        mCountDown = 0
+        val syncStartTime = TimeManager.time.intTimeMS()
+        if (mProgressDialog == null || !mProgressDialog!!.isShowing) {
+            try {
+                mProgressDialog = StyledProgressDialog.show(
+                    this@createSyncListener,
+                    resources.getString(R.string.sync_title),
+                    """
+                                ${resources.getString(R.string.sync_title)}
+                                ${resources.getString(R.string.sync_up_down_size, mCountUp, mCountDown)}
+                    """.trimIndent(),
+                    false
+                )
+            } catch (e: WindowManager.BadTokenException) {
+                // If we could not show the progress dialog to start even, bail out - user will get a message
+                Timber.w(e, "Unable to display Sync progress dialog, Activity not valid?")
+                mDialogDisplayFailure = true
+                Connection.cancel()
+                return
+            }
+
+            // Override the back key so that the user can cancel a sync which is in progress
+            mProgressDialog!!.setOnKeyListener { _: DialogInterface?, keyCode: Int, event: KeyEvent ->
+                // Make sure our method doesn't get called twice
+                if (event.action != KeyEvent.ACTION_DOWN) {
+                    return@setOnKeyListener true
+                }
+                if (keyCode == KeyEvent.KEYCODE_BACK && Connection.isCancellable &&
+                    !Connection.isCancelled
+                ) {
+                    // If less than 2s has elapsed since sync started then don't ask for confirmation
+                    if (TimeManager.time.intTimeMS() - syncStartTime < 2000) {
+                        Connection.cancel()
+                        @Suppress("Deprecation")
+                        mProgressDialog!!.setMessage(getString(R.string.sync_cancel_message))
+                        return@setOnKeyListener true
+                    }
+                    // Show confirmation dialog to check if the user wants to cancel the sync
+                    AlertDialog.Builder(mProgressDialog!!.context).show {
+                        message(R.string.cancel_sync_confirm)
+                        cancelable(false)
+                        positiveButton(R.string.dialog_ok) {
+                            @Suppress("Deprecation")
+                            mProgressDialog!!.setMessage(getString(R.string.sync_cancel_message))
+                            Connection.cancel()
+                        }
+                        negativeButton(R.string.continue_sync)
+                    }
+                    return@setOnKeyListener true
+                } else {
+                    return@setOnKeyListener false
+                }
+            }
+        }
+
+        // Store the current time so that we don't bother the user with a sync prompt for another 10 minutes
+        // Note: getLs() in Libanki doesn't take into account the case when no changes were found, or sync cancelled
+        AnkiDroidApp.getSharedPrefs(baseContext).edit { putLong("lastSyncTime", syncStartTime) }
+    }
+
+    override fun onProgressUpdate(vararg values: Any?) {
+        val res = resources
+        if (values[0] is Int) {
+            val id = values[0] as Int
+            if (id != 0) {
+                mCurrentMessage = res.getString(id)
+            }
+            if (values.size >= 3) {
+                mCountUp = values[1] as Long
+                mCountDown = values[2] as Long
+            }
+        } else if (values[0] is String) {
+            mCurrentMessage = values[0] as String
+            if (values.size >= 3) {
+                mCountUp = values[1] as Long
+                mCountDown = values[2] as Long
+            }
+        }
+        if (mProgressDialog != null && mProgressDialog!!.isShowing) {
+            @Suppress("Deprecation")
+            mProgressDialog!!.setMessage(
+                """
+    $mCurrentMessage
+    
+                """.trimIndent() +
+                    res
+                        .getString(R.string.sync_up_down_size, mCountUp / 1024, mCountDown / 1024)
+            )
+        }
+    }
+
+    override fun onPostExecute(data: Connection.Payload) {
+        mPullToSyncWrapper.isRefreshing = false
+        var dialogMessage: String? = ""
+        Timber.d("Sync Listener onPostExecute()")
+        val res = resources
+        try {
+            if (mProgressDialog != null && mProgressDialog!!.isShowing) {
+                mProgressDialog!!.dismiss()
+            }
+        } catch (e: IllegalArgumentException) {
+            Timber.e(e, "Could not dismiss mProgressDialog. The Activity must have been destroyed while the AsyncTask was running")
+            CrashReportService.sendExceptionReport(e, "DeckPicker.onPostExecute", "Could not dismiss mProgressDialog")
+        }
+        val syncMessage = data.message
+        Timber.i("Sync Listener: onPostExecute: Data: %s", data.toString())
+        if (!data.success) {
+            val result = data.result
+            val resultType = data.resultType
+            if (resultType != null) {
+                when (resultType) {
+                    Syncer.ConnectionResultType.BAD_AUTH -> {
+                        // delete old auth information
+                        AnkiDroidApp.getSharedPrefs(baseContext).edit {
+                            putString("username", "")
+                            putString("hkey", "")
+                        }
+                        // then show not logged in dialog
+                        showSyncErrorDialog(SyncErrorDialog.DIALOG_USER_NOT_LOGGED_IN_SYNC)
+                    }
+                    Syncer.ConnectionResultType.NO_CHANGES -> {
+                        SyncStatus.markSyncCompleted()
+                        // show no changes message, use false flag so we don't show "sync error" as the Dialog title
+                        showSyncLogMessage(R.string.sync_no_changes_message, "")
+                    }
+                    Syncer.ConnectionResultType.CLOCK_OFF -> {
+                        val diff = result[0] as Long
+                        dialogMessage = when {
+                            diff >= 86100 -> {
+                                // The difference if more than a day minus 5 minutes acceptable by ankiweb error
+                                res.getString(
+                                    R.string.sync_log_clocks_unsynchronized,
+                                    diff,
+                                    res.getString(R.string.sync_log_clocks_unsynchronized_date)
+                                )
+                            }
+                            abs(diff % 3600.0 - 1800.0) >= 1500.0 -> {
+                                // The difference would be within limit if we adjusted the time by few hours
+                                // It doesn't work for all timezones, but it covers most and it's a guess anyway
+                                res.getString(
+                                    R.string.sync_log_clocks_unsynchronized,
+                                    diff,
+                                    res.getString(R.string.sync_log_clocks_unsynchronized_tz)
+                                )
+                            }
+                            else -> {
+                                res.getString(R.string.sync_log_clocks_unsynchronized, diff, "")
+                            }
+                        }
+                        showSyncErrorMessage(
+                            joinSyncMessages(
+                                dialogMessage,
+                                syncMessage
+                            )
+                        )
+                    }
+                    Syncer.ConnectionResultType.FULL_SYNC -> if (col.isEmpty) {
+                        // don't prompt user to resolve sync conflict if local collection empty
+                        sync(Connection.ConflictResolution.FULL_DOWNLOAD)
+                        // TODO: Also do reverse check to see if AnkiWeb collection is empty if Anki Desktop
+                        // implements it
+                    } else {
+                        // If can't be resolved then automatically then show conflict resolution dialog
+                        showSyncErrorDialog(SyncErrorDialog.DIALOG_SYNC_CONFLICT_RESOLUTION)
+                    }
+                    Syncer.ConnectionResultType.BASIC_CHECK_FAILED -> {
+                        dialogMessage = res.getString(R.string.sync_basic_check_failed, res.getString(R.string.check_db))
+                        showSyncErrorDialog(
+                            SyncErrorDialog.DIALOG_SYNC_BASIC_CHECK_ERROR,
+                            joinSyncMessages(dialogMessage, syncMessage)
+                        )
+                    }
+                    Syncer.ConnectionResultType.DB_ERROR -> showSyncErrorDialog(SyncErrorDialog.DIALOG_SYNC_CORRUPT_COLLECTION, syncMessage)
+                    Syncer.ConnectionResultType.OVERWRITE_ERROR -> {
+                        dialogMessage = res.getString(R.string.sync_overwrite_error)
+                        showSyncErrorMessage(
+                            joinSyncMessages(
+                                dialogMessage,
+                                syncMessage
+                            )
+                        )
+                    }
+                    Syncer.ConnectionResultType.REMOTE_DB_ERROR -> {
+                        dialogMessage = res.getString(R.string.sync_remote_db_error)
+                        showSyncErrorMessage(
+                            joinSyncMessages(
+                                dialogMessage,
+                                syncMessage
+                            )
+                        )
+                    }
+                    Syncer.ConnectionResultType.SD_ACCESS_ERROR -> {
+                        dialogMessage = res.getString(R.string.sync_write_access_error_on_storage)
+                        showSyncErrorMessage(
+                            joinSyncMessages(
+                                dialogMessage,
+                                syncMessage
+                            )
+                        )
+                    }
+                    Syncer.ConnectionResultType.FINISH_ERROR -> {
+                        dialogMessage = res.getString(R.string.sync_log_finish_error)
+                        showSyncErrorMessage(
+                            joinSyncMessages(
+                                dialogMessage,
+                                syncMessage
+                            )
+                        )
+                    }
+                    Syncer.ConnectionResultType.CONNECTION_ERROR -> {
+                        dialogMessage = res.getString(R.string.sync_connection_error)
+                        if (result[0] is Exception) {
+                            dialogMessage += """
+                                    
+                                    
+                                    ${(result[0] as Exception).localizedMessage}
+                            """.trimIndent()
+                        }
+                        showSyncErrorMessage(
+                            joinSyncMessages(
+                                dialogMessage,
+                                syncMessage
+                            )
+                        )
+                    }
+                    Syncer.ConnectionResultType.IO_EXCEPTION -> handleDbError()
+                    Syncer.ConnectionResultType.GENERIC_ERROR -> {
+                        dialogMessage = res.getString(R.string.sync_generic_error)
+                        showSyncErrorMessage(
+                            joinSyncMessages(
+                                dialogMessage,
+                                syncMessage
+                            )
+                        )
+                    }
+                    Syncer.ConnectionResultType.OUT_OF_MEMORY_ERROR -> {
+                        dialogMessage = res.getString(R.string.error_insufficient_memory)
+                        showSyncErrorMessage(
+                            joinSyncMessages(
+                                dialogMessage,
+                                syncMessage
+                            )
+                        )
+                    }
+                    Syncer.ConnectionResultType.SANITY_CHECK_ERROR -> {
+                        dialogMessage = res.getString(R.string.sync_sanity_failed)
+                        showSyncErrorDialog(
+                            SyncErrorDialog.DIALOG_SYNC_SANITY_ERROR,
+                            joinSyncMessages(dialogMessage, syncMessage)
+                        )
+                    }
+                    Syncer.ConnectionResultType.SERVER_ABORT -> // syncMsg has already been set above, no need to fetch it here.
+                        showSyncErrorMessage(
+                            joinSyncMessages(
+                                dialogMessage,
+                                syncMessage
+                            )
+                        )
+                    Syncer.ConnectionResultType.MEDIA_SYNC_SERVER_ERROR -> {
+                        dialogMessage = res.getString(R.string.sync_media_error_check)
+                        showSyncErrorDialog(
+                            SyncErrorDialog.DIALOG_MEDIA_SYNC_ERROR,
+                            joinSyncMessages(dialogMessage, syncMessage)
+                        )
+                    }
+                    Syncer.ConnectionResultType.CUSTOM_SYNC_SERVER_URL -> {
+                        val url = if (result.isNotEmpty() && result[0] is CustomSyncServerUrlException) (result[0] as CustomSyncServerUrlException).url else "unknown"
+                        dialogMessage = res.getString(R.string.sync_error_invalid_sync_server, url)
+                        showSyncErrorMessage(
+                            joinSyncMessages(
+                                dialogMessage,
+                                syncMessage
+                            )
+                        )
+                    }
+                    Syncer.ConnectionResultType.NETWORK_ERROR -> {
+                        showSnackbar(R.string.check_network) {
+                            setAction(R.string.sync_even_if_offline) {
+                                Connection.allowLoginSyncOnNoConnection = true
+                                sync()
+                            }
+                        }
+                    }
+                    else -> {
+                        if (result.isNotEmpty() && result[0] is Int) {
+                            val code = result[0] as Int
+                            dialogMessage = rewriteError(code)
+                            if (dialogMessage == null) {
+                                dialogMessage = res.getString(
+                                    R.string.sync_log_error_specific,
+                                    code.toString(),
+                                    result[1]
+                                )
+                            }
+                        } else {
+                            dialogMessage = res.getString(R.string.sync_log_error_specific, (-1).toString(), resultType)
+                        }
+                        showSyncErrorMessage(
+                            joinSyncMessages(
+                                dialogMessage,
+                                syncMessage
+                            )
+                        )
+                    }
+                }
+            } else {
+                dialogMessage = res.getString(R.string.sync_generic_error)
+                showSyncErrorMessage(joinSyncMessages(dialogMessage, syncMessage))
+            }
+        } else {
+            Timber.i("Sync was successful")
+            if (data.data[2] != null && "" != data.data[2]) {
+                Timber.i("Syncing had additional information")
+                // There was a media error, so show it
+                // Note: Do not log this data. May contain user email.
+                val message = res.getString(R.string.sync_database_acknowledge) + "\n\n" + data.data[2]
+                showSimpleMessageDialog(message)
+            } else if (data.data.isNotEmpty() && data.data[0] is Connection.ConflictResolution) {
+                // A full sync occurred
+                when (data.data[0] as Connection.ConflictResolution) {
+                    Connection.ConflictResolution.FULL_UPLOAD -> {
+                        Timber.i("Full Upload Completed")
+                        showSyncLogMessage(R.string.sync_log_uploading_message, syncMessage)
+                    }
+                    Connection.ConflictResolution.FULL_DOWNLOAD -> {
+                        Timber.i("Full Download Completed")
+                        showSyncLogMessage(R.string.backup_full_sync_from_server, syncMessage)
+                    }
+                }
+            } else {
+                Timber.i("Regular sync completed successfully")
+                showSyncLogMessage(R.string.sync_database_acknowledge, syncMessage)
+            }
+            // Mark sync as completed - then refresh the sync icon
+            SyncStatus.markSyncCompleted()
+            invalidateOptionsMenu()
+            updateDeckList()
+            WidgetStatus.update(this@createSyncListener)
+            if (fragmented) {
+                try {
+                    loadStudyOptionsFragment(false)
+                } catch (e: IllegalStateException) {
+                    // Activity was stopped or destroyed when the sync finished. Losing the
+                    // fragment here is fine since we build a fresh fragment on resume anyway.
+                    Timber.w(e, "Failed to load StudyOptionsFragment after sync.")
+                }
+            }
+        }
+    }
+}
+
+/**
+ * Show simple error dialog with just the message and OK button. Reload the activity when dialog closed.
+ */
+private fun DeckPicker.showSyncErrorMessage(message: String?) {
+    val title = resources.getString(R.string.sync_error)
+    showSimpleMessageDialog(title = title, message = message, reload = true)
+}
+
+/**
+ * Show a simple snackbar message or notification if the activity is not in foreground
+ * @param messageResource String resource for message
+ */
+fun DeckPicker.showSyncLogMessage(@StringRes messageResource: Int, syncMessage: String?) {
+    if (mActivityPaused) {
+        val res = AnkiDroidApp.appResources
+        showSimpleNotification(
+            res.getString(R.string.app_name),
+            res.getString(messageResource),
+            Channel.SYNC
+        )
+    } else {
+        if (syncMessage.isNullOrEmpty()) {
+            if (messageResource == R.string.youre_offline && !Connection.allowLoginSyncOnNoConnection) {
+                // #6396 - Add a temporary "Try Anyway" button until we sort out `isOnline`
+                showSnackbar(messageResource) {
+                    setAction(R.string.sync_even_if_offline) {
+                        Connection.allowLoginSyncOnNoConnection = true
+                        sync()
+                    }
+                }
+            } else {
+                showSnackbar(messageResource)
+            }
+        } else {
+            val res = AnkiDroidApp.appResources
+            showSimpleMessageDialog(title = res.getString(messageResource), message = syncMessage)
+        }
+    }
+}
+
+@VisibleForTesting
+fun DeckPicker.rewriteError(code: Int): String? {
+    // PREF: Unit tests on this method can be sped up (remove 'DeckPicker' reference)
+    val msg: String?
+    val res = resources
+    msg = when (code) {
+        407 -> res.getString(R.string.sync_error_407_proxy_required)
+        409 -> res.getString(R.string.sync_error_409)
+        413 -> res.getString(R.string.sync_error_413_collection_size)
+        500 -> res.getString(R.string.sync_error_500_unknown)
+        501 -> res.getString(R.string.sync_error_501_upgrade_required)
+        502 -> res.getString(R.string.sync_error_502_maintenance)
+        503 -> res.getString(R.string.sync_too_busy)
+        504 -> res.getString(R.string.sync_error_504_gateway_timeout)
+        else -> null
+    }
+    return msg
+}
+
+fun joinSyncMessages(dialogMessage: String?, syncMessage: String?): String? {
+    // If both strings have text, separate them by a new line, otherwise return whichever has text
+    return if (!dialogMessage.isNullOrEmpty() && !syncMessage.isNullOrEmpty()) {
+        """
+     $dialogMessage
+     
+     $syncMessage
+        """.trimIndent()
+    } else if (!dialogMessage.isNullOrEmpty()) {
+        dialogMessage
+    } else {
+        syncMessage
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/SyncErrorDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/SyncErrorDialog.kt
@@ -21,8 +21,8 @@ import android.os.Bundle
 import android.os.Message
 import com.afollestad.materialdialogs.MaterialDialog
 import com.ichi2.anki.AnkiActivity
-import com.ichi2.anki.DeckPicker
 import com.ichi2.anki.R
+import com.ichi2.anki.joinSyncMessages
 import com.ichi2.async.Connection.ConflictResolution
 import com.ichi2.libanki.CollectionGetter
 import com.ichi2.utils.contentNullable
@@ -209,7 +209,7 @@ class SyncErrorDialog : AsyncDialogFragment() {
                 val syncMessage = requireArguments().getString("dialogMessage")
                 val repairUrl = getString(R.string.repair_deck)
                 val dialogMessage = getString(R.string.sync_corrupt_database, repairUrl)
-                DeckPicker.joinSyncMessages(dialogMessage, syncMessage)
+                joinSyncMessages(dialogMessage, syncMessage)
             }
             else -> requireArguments().getString("dialogMessage")
         }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/DeckPickerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/DeckPickerTest.kt
@@ -34,7 +34,6 @@ import org.robolectric.RuntimeEnvironment
 import java.io.File
 import kotlin.test.assertFailsWith
 import kotlin.test.assertNotNull
-import kotlin.test.assertNull
 
 @OptIn(ExperimentalCoroutinesApi::class)
 @RunWith(ParameterizedRobolectricTestRunner::class)
@@ -56,40 +55,6 @@ class DeckPickerTest : RobolectricTest() {
         RuntimeEnvironment.setQualifiers(mQualifiers)
         getPreferences().edit {
             putBoolean(IntroductionActivity.INTRODUCTION_SLIDES_SHOWN, true)
-        }
-    }
-
-    @Test
-    fun verifyCodeMessages() {
-        val codeResponsePairs = hashMapOf(
-            407 to getResourceString(R.string.sync_error_407_proxy_required),
-            409 to getResourceString(R.string.sync_error_409),
-            413 to getResourceString(R.string.sync_error_413_collection_size),
-            500 to getResourceString(R.string.sync_error_500_unknown),
-            501 to getResourceString(R.string.sync_error_501_upgrade_required),
-            502 to getResourceString(R.string.sync_error_502_maintenance),
-            503 to getResourceString(R.string.sync_too_busy),
-            504 to getResourceString(R.string.sync_error_504_gateway_timeout)
-        )
-        ActivityScenario.launch(DeckPicker::class.java).use { scenario ->
-            scenario.onActivity { deckPicker: DeckPicker ->
-                for ((key, value) in codeResponsePairs) {
-                    assertEquals(deckPicker.rewriteError(key), value)
-                }
-            }
-        }
-    }
-
-    @Test
-    fun verifyBadCodesNoMessage() {
-        ActivityScenario.launch(DeckPicker::class.java).use { scenario ->
-            scenario.onActivity { deckPicker: DeckPicker ->
-                assertNull(deckPicker.rewriteError(0))
-                assertNull(deckPicker.rewriteError(-1))
-                assertNull(deckPicker.rewriteError(1))
-                assertNull(deckPicker.rewriteError(Int.MIN_VALUE))
-                assertNull(deckPicker.rewriteError(Int.MAX_VALUE))
-            }
         }
     }
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/RobolectricTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/RobolectricTest.kt
@@ -42,6 +42,7 @@ import com.ichi2.libanki.backend.exception.DeckRenameException
 import com.ichi2.libanki.sched.Sched
 import com.ichi2.libanki.sched.SchedV2
 import com.ichi2.libanki.utils.TimeManager
+import com.ichi2.testutils.AndroidTest
 import com.ichi2.testutils.IgnoreFlakyTestsInCIRule
 import com.ichi2.testutils.MockTime
 import com.ichi2.testutils.TaskSchedulerRule
@@ -68,7 +69,7 @@ import kotlin.concurrent.withLock
 import kotlin.coroutines.CoroutineContext
 import kotlin.coroutines.EmptyCoroutineContext
 
-open class RobolectricTest : CollectionGetter {
+open class RobolectricTest : CollectionGetter, AndroidTest {
 
     @Suppress("PLATFORM_CLASS_MAPPED_TO_KOTLIN")
     private fun Any.wait(timeMs: Long) = (this as Object).wait(timeMs)
@@ -127,14 +128,13 @@ open class RobolectricTest : CollectionGetter {
         return false
     }
 
-    protected fun getHelperFactory(): SupportSQLiteOpenHelper.Factory {
+    protected fun getHelperFactory(): SupportSQLiteOpenHelper.Factory =
         if (useInMemoryDatabase()) {
             Timber.w("Using in-memory database for test. Collection should not be re-opened")
-            return InMemorySQLiteOpenHelperFactory()
+            InMemorySQLiteOpenHelperFactory()
         } else {
-            return FrameworkSQLiteOpenHelperFactory()
+            FrameworkSQLiteOpenHelperFactory()
         }
-    }
 
     @After
     @CallSuper
@@ -158,7 +158,7 @@ open class RobolectricTest : CollectionGetter {
             // If you don't tear down the database you'll get unexpected IllegalStateExceptions related to connections
             CollectionHelper.instance.closeCollection(false, "RobolectricTest: End")
         } catch (ex: BackendException) {
-            if ("CollectionNotOpen".equals(ex.message)) {
+            if ("CollectionNotOpen" == ex.message) {
                 Timber.w(ex, "Collection was already disposed - may have been a problem")
             } else {
                 throw ex
@@ -180,6 +180,7 @@ open class RobolectricTest : CollectionGetter {
      * Ensure that each task in backgrounds are executed immediately instead of being queued.
      * This may help debugging test without requiring to guess where `advanceRobolectricLooper` are needed.
      */
+    @Suppress("MemberVisibilityCanBePrivate")
     fun runTasksInForeground() {
         TaskManager.setTaskManager(ForegroundTaskManager(this))
         mBackground = false
@@ -193,7 +194,7 @@ open class RobolectricTest : CollectionGetter {
         mBackground = true
     }
 
-    protected fun clickDialogButton(button: WhichButton?, checkDismissed: Boolean) {
+    protected fun clickDialogButton(button: WhichButton?, @Suppress("SameParameterValue") checkDismissed: Boolean) {
         val dialog = ShadowDialog.getLatestDialog() as MaterialDialog
         dialog.getActionButton(button!!).performClick()
         if (checkDismissed) {
@@ -206,7 +207,7 @@ open class RobolectricTest : CollectionGetter {
      *
      * @param checkDismissed true if you want to check for dismissed, will return null even if dialog exists but has been dismissed
      */
-    protected fun getDialogText(checkDismissed: Boolean): String? {
+    protected fun getDialogText(@Suppress("SameParameterValue") checkDismissed: Boolean): String? {
         val dialog: MaterialDialog = ShadowDialog.getLatestDialog() as MaterialDialog
         if (checkDismissed && Shadows.shadowOf(dialog).hasBeenDismissed()) {
             Timber.e("The latest dialog has already been dismissed.")
@@ -290,7 +291,7 @@ open class RobolectricTest : CollectionGetter {
             } catch (e: IllegalStateException) {
                 if (e.message != null && e.message!!.startsWith("No instrumentation registered!")) {
                     // Explicitly ignore the inner exception - generates line noise
-                    throw IllegalStateException("Annotate class: '" + javaClass.simpleName + "' with '@RunWith(AndroidJUnit4.class)'")
+                    throw IllegalStateException("Annotate class: '${javaClass.simpleName}' with '@RunWith(AndroidJUnit4.class)'")
                 }
                 throw e
             }
@@ -308,7 +309,7 @@ open class RobolectricTest : CollectionGetter {
         return targetContext.getString(res)
     }
 
-    protected fun getQuantityString(res: Int, quantity: Int, vararg formatArgs: Any?): String {
+    protected fun getQuantityString(res: Int, quantity: Int, vararg formatArgs: Any): String {
         return targetContext.resources.getQuantityString(res, quantity, *formatArgs)
     }
 
@@ -363,7 +364,7 @@ open class RobolectricTest : CollectionGetter {
         return addNoteUsingModelName("Basic", front, back)
     }
 
-    protected fun addRevNoteUsingBasicModelDueToday(front: String, back: String): Note {
+    protected fun addRevNoteUsingBasicModelDueToday(@Suppress("SameParameterValue") front: String, @Suppress("SameParameterValue") back: String): Note {
         val note = addNoteUsingBasicModel(front, back)
         val card = note.firstCard()
         card.queue = Consts.QUEUE_TYPE_REV
@@ -376,7 +377,7 @@ open class RobolectricTest : CollectionGetter {
         return addNoteUsingModelName("Basic (and reversed card)", front, back)
     }
 
-    protected fun addNoteUsingBasicTypedModel(front: String, back: String): Note {
+    protected fun addNoteUsingBasicTypedModel(@Suppress("SameParameterValue") front: String, @Suppress("SameParameterValue") back: String): Note {
         return addNoteUsingModelName("Basic (type in the answer)", front, back)
     }
 
@@ -456,9 +457,9 @@ open class RobolectricTest : CollectionGetter {
             override fun onPostExecute(result: Result?) {
                 require(!(result == null || !result.succeeded())) { "Task failed" }
                 completed[0] = true
-                val RobolectricTest = ReentrantLock()
-                val condition = RobolectricTest.newCondition()
-                RobolectricTest.withLock { condition.signal() }
+                val robolectricTest = ReentrantLock()
+                val condition = robolectricTest.newCondition()
+                robolectricTest.withLock { condition.signal() }
                 // synchronized(this@RobolectricTest) { this@RobolectricTest.notify() }
             }
         }
@@ -551,6 +552,7 @@ open class RobolectricTest : CollectionGetter {
      * editPreferences { putString("key", value) }
      * ```
      */
+    @Suppress("MemberVisibilityCanBePrivate")
     fun editPreferences(action: SharedPreferences.Editor.() -> Unit) =
         getPreferences().edit(action = action)
 
@@ -604,7 +606,7 @@ open class RobolectricTest : CollectionGetter {
         context: CoroutineContext = EmptyCoroutineContext,
         dispatchTimeoutMs: Long = 60_000L,
         testBody: suspend TestScope.() -> Unit
-    ): TestResult {
+    ) {
         kotlinx.coroutines.test.runTest(context, dispatchTimeoutMs) {
             CollectionManager.setTestDispatcher(UnconfinedTestDispatcher(testScheduler))
             testBody()

--- a/AnkiDroid/src/test/java/com/ichi2/anki/SyncTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/SyncTest.kt
@@ -1,0 +1,62 @@
+/*
+ *  Copyright (c) 2023 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.ichi2.testutils.AndroidTest
+import com.ichi2.testutils.EmptyApplication
+import com.ichi2.testutils.getString
+import com.ichi2.testutils.targetContext
+import org.junit.Assert
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+import kotlin.test.assertNull
+
+@RunWith(AndroidJUnit4::class)
+@Config(application = EmptyApplication::class)
+class SyncTest : AndroidTest {
+
+    @Test
+    fun verifyCodeMessages() {
+        val codeResponsePairs = hashMapOf(
+            407 to getString(R.string.sync_error_407_proxy_required),
+            409 to getString(R.string.sync_error_409),
+            413 to getString(R.string.sync_error_413_collection_size),
+            500 to getString(R.string.sync_error_500_unknown),
+            501 to getString(R.string.sync_error_501_upgrade_required),
+            502 to getString(R.string.sync_error_502_maintenance),
+            503 to getString(R.string.sync_too_busy),
+            504 to getString(R.string.sync_error_504_gateway_timeout)
+        )
+
+        for ((key, value) in codeResponsePairs) {
+            Assert.assertEquals(getMessageFromSyncErrorCode(key), value)
+        }
+    }
+
+    @Test
+    fun verifyBadCodesNoMessage() {
+        assertNull(getMessageFromSyncErrorCode(0))
+        assertNull(getMessageFromSyncErrorCode(-1))
+        assertNull(getMessageFromSyncErrorCode(1))
+        assertNull(getMessageFromSyncErrorCode(Int.MIN_VALUE))
+        assertNull(getMessageFromSyncErrorCode(Int.MAX_VALUE))
+    }
+
+    private fun getMessageFromSyncErrorCode(key: Int) = getMessageFromSyncErrorCode(targetContext.resources, key)
+}

--- a/AnkiDroid/src/test/java/com/ichi2/testutils/AndroidTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/testutils/AndroidTest.kt
@@ -1,0 +1,61 @@
+/*
+ *  Copyright (c) 2023 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.testutils
+
+import android.content.Context
+import android.content.SharedPreferences
+import androidx.core.content.edit
+import androidx.test.core.app.ApplicationProvider
+import com.ichi2.anki.AnkiDroidApp
+
+/** Marker interface for classes annotated with `@RunWith(AndroidJUnit4.class)` */
+interface AndroidTest
+
+val AndroidTest.targetContext: Context
+    get() {
+        return try {
+            ApplicationProvider.getApplicationContext()
+        } catch (e: IllegalStateException) {
+            if (e.message != null && e.message!!.startsWith("No instrumentation registered!")) {
+                // Explicitly ignore the inner exception - generates line noise
+                throw IllegalStateException("Annotate class: '${javaClass.simpleName}' with '@RunWith(AndroidJUnit4.class)'")
+            }
+            throw e
+        }
+    }
+
+/**
+ * Returns an instance of [SharedPreferences] using the test context
+ * @see [editPreferences] for editing
+ */
+fun AndroidTest.getSharedPrefs(): SharedPreferences = AnkiDroidApp.getSharedPrefs(targetContext)
+
+fun AndroidTest.getString(res: Int): String = targetContext.getString(res)
+
+@Suppress("unused")
+fun AndroidTest.getQuantityString(res: Int, quantity: Int, vararg formatArgs: Any): String =
+    targetContext.resources.getQuantityString(res, quantity, *formatArgs)
+
+/**
+ * Allows editing of preferences, followed by a call to [apply][SharedPreferences.Editor.apply]:
+ *
+ * ```
+ * editPreferences { putString("key", value) }
+ * ```
+ */
+fun AndroidTest.editPreferences(action: SharedPreferences.Editor.() -> Unit) =
+    getSharedPrefs().edit(action = action)


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
A lot of `DeckPicker` was legacy sync related code. This extracts it.

If there's a "no", or a likelihood that this won't go through quickly, then I'll close this and rework #13356 - in the linked PR, I wanted the changes on the `DeckPicker` related to storage migrations to be obvious, but this isn't a 'must'.

* **Note:** This is 'legacy backend' refactoring - if there are immediate issues, let's close this.
* Speeds up a couple of tests
* Makes `DeckPicker` a little easier to navigate

## Fixes
Reduces code churn on #13356, isolates changes in `DeckPicker` to being `DeckPicker` related, rather than including syncing-related code

## Approach
* Extract `createSyncListener`, then extract associated functionality
* Speed up tests as they no longer need a `DeckPicker`

## How Has This Been Tested?
Manually

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
