### PR TITLE
refactor: DialogHandler

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiActivity.kt
@@ -482,7 +482,7 @@ open class AnkiActivity : AppCompatActivity, SimpleMessageDialogListener, Collec
         } catch (e: IllegalStateException) {
             Timber.w(e)
             // Store a persistent message to SharedPreferences instructing AnkiDroid to show dialog
-            DialogHandler.storeMessage(newFragment.dialogHandlerMessage)
+            DialogHandler.storeMessage(newFragment.dialogHandlerMessage?.toMessage())
             // Show a basic notification to the user in the notification bar in the meantime
             val title = newFragment.notificationTitle
             val message = newFragment.notificationMessage

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/AsyncDialogFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/AsyncDialogFragment.kt
@@ -15,7 +15,6 @@
  ****************************************************************************************/
 package com.ichi2.anki.dialogs
 
-import android.os.Message
 import com.ichi2.anki.analytics.AnalyticsDialogFragment
 
 abstract class AsyncDialogFragment : AnalyticsDialogFragment() {
@@ -25,5 +24,5 @@ abstract class AsyncDialogFragment : AnalyticsDialogFragment() {
        the onPostExecute() method of an AsyncTask */
     abstract val notificationMessage: String?
     abstract val notificationTitle: String
-    open val dialogHandlerMessage: Message? get() = null
+    open val dialogHandlerMessage: DialogHandlerMessage? get() = null
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DialogHandler.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DialogHandler.kt
@@ -21,15 +21,10 @@ import android.os.Message
 import androidx.annotation.VisibleForTesting
 import com.ichi2.anki.*
 import com.ichi2.anki.analytics.UsageAnalytics
-import com.ichi2.anki.dialogs.DatabaseErrorDialog.DatabaseErrorDialogType
-import com.ichi2.compat.CompatHelper.Companion.getParcelableCompat
-import com.ichi2.libanki.MediaCheckResult
 import com.ichi2.utils.HandlerUtils.getDefaultLooper
-import com.ichi2.utils.NetworkUtils
+import com.ichi2.utils.ImportUtils
 import timber.log.Timber
 import java.lang.ref.WeakReference
-import kotlin.math.max
-import kotlin.math.min
 
 /**
  * We're not allowed to commit fragment transactions from Loader.onLoadCompleted(),
@@ -38,75 +33,13 @@ import kotlin.math.min
  */
 class DialogHandler(activity: AnkiActivity) : Handler(getDefaultLooper()) {
     // Use weak reference to main activity to prevent leaking the activity when it's closed
-    val mActivity: WeakReference<AnkiActivity> = WeakReference(activity)
-    override fun handleMessage(msg: Message) {
-        val msgData = msg.data
-        val messageName = MESSAGE_NAME_LIST[msg.what]
-        UsageAnalytics.sendAnalyticsScreenView(messageName)
-        Timber.i("Handling Message: %s", messageName)
-
+    private val mActivity: WeakReference<AnkiActivity> = WeakReference(activity)
+    override fun handleMessage(message: Message) {
+        val msg = DialogHandlerMessage.fromMessage(message)
+        UsageAnalytics.sendAnalyticsScreenView(msg.analyticName)
+        Timber.i("Handling Message: %s", msg.analyticName)
         val deckPicker = mActivity.get() as DeckPicker
-        if (msg.what == MSG_SHOW_COLLECTION_LOADING_ERROR_DIALOG) {
-            // Collection could not be opened
-            deckPicker.showDatabaseErrorDialog(DatabaseErrorDialogType.DIALOG_LOAD_FAILED)
-        } else if (msg.what == MSG_SHOW_COLLECTION_IMPORT_REPLACE_DIALOG) {
-            // Handle import of collection package APKG
-            deckPicker.showImportDialog(ImportDialog.DIALOG_IMPORT_REPLACE_CONFIRM, msgData.getStringArrayList("importPath")!!)
-        } else if (msg.what == MSG_SHOW_COLLECTION_IMPORT_ADD_DIALOG) {
-            // Handle import of deck package APKG
-            deckPicker.showImportDialog(ImportDialog.DIALOG_IMPORT_ADD_CONFIRM, msgData.getStringArrayList("importPath")!!)
-        } else if (msg.what == MSG_SHOW_SYNC_ERROR_DIALOG) {
-            val id = msgData.getInt("dialogType")
-            val message = msgData.getString("dialogMessage")
-            deckPicker.showSyncErrorDialog(id, message)
-        } else if (msg.what == MSG_SHOW_MEDIA_CHECK_COMPLETE_DIALOG) {
-            // Media check results
-            val id = msgData.getInt("dialogType")
-            if (id != MediaCheckDialog.DIALOG_CONFIRM_MEDIA_CHECK) {
-                val checkList =
-                    MediaCheckResult(
-                        msgData.getStringArrayList("nohave")!!,
-                        msgData.getStringArrayList("unused")!!,
-                        msgData.getStringArrayList("invalid")!!
-                    )
-                deckPicker.showMediaCheckDialog(id, checkList)
-            }
-        } else if (msg.what == MSG_SHOW_DATABASE_ERROR_DIALOG) {
-            // Database error dialog
-            val errorDialogType = msgData.getParcelableCompat<DatabaseErrorDialogType>("dialog")!!
-            deckPicker.showDatabaseErrorDialog(errorDialogType)
-        } else if (msg.what == MSG_SHOW_FORCE_FULL_SYNC_DIALOG) {
-            // Confirmation dialog for forcing full sync
-            val dialog = ConfirmationDialog()
-            val confirm = Runnable {
-                // Bypass the check once the user confirms
-                CollectionHelper.instance.getCol(AnkiDroidApp.instance)!!.modSchemaNoCheck()
-            }
-            dialog.setConfirm(confirm)
-            dialog.setArgs(msgData.getString("message"))
-            mActivity.get()!!.showDialogFragment(dialog)
-        } else if (msg.what == MSG_DO_SYNC) {
-            val preferences = AnkiDroidApp.getSharedPrefs(mActivity.get())
-            val res = mActivity.get()!!.resources
-            val hkey = preferences.getString("hkey", "")
-            val millisecondsSinceLastSync = millisecondsSinceLastSync(preferences)
-            val limited = millisecondsSinceLastSync < INTENT_SYNC_MIN_INTERVAL
-            if (!limited && hkey!!.isNotEmpty() && NetworkUtils.isOnline) {
-                deckPicker.sync()
-            } else {
-                val err = res.getString(R.string.sync_error)
-                if (limited) {
-                    val remainingTimeInSeconds = max((INTENT_SYNC_MIN_INTERVAL - millisecondsSinceLastSync) / 1000, 1)
-                    // getQuantityString needs an int
-                    val remaining = min(Int.MAX_VALUE.toLong(), remainingTimeInSeconds).toInt()
-                    val message = res.getQuantityString(R.plurals.sync_automatic_sync_needs_more_time, remaining, remaining)
-                    mActivity.get()!!.showSimpleNotification(err, message, Channel.SYNC)
-                } else {
-                    mActivity.get()!!.showSimpleNotification(err, res.getString(R.string.youre_offline), Channel.SYNC)
-                }
-            }
-            mActivity.get()!!.finishWithoutAnimation()
-        }
+        msg.handleAsyncMessage(deckPicker)
     }
 
     /**
@@ -122,32 +55,7 @@ class DialogHandler(activity: AnkiActivity) : Handler(getDefaultLooper()) {
     }
 
     companion object {
-        const val INTENT_SYNC_MIN_INTERVAL = (
-            2 * 60000 // 2min minimum sync interval
-            ).toLong()
 
-        /**
-         * Handler messages
-         */
-        const val MSG_SHOW_COLLECTION_LOADING_ERROR_DIALOG = 0
-        const val MSG_SHOW_COLLECTION_IMPORT_REPLACE_DIALOG = 1
-        const val MSG_SHOW_COLLECTION_IMPORT_ADD_DIALOG = 2
-        const val MSG_SHOW_SYNC_ERROR_DIALOG = 3
-        const val MSG_SHOW_MEDIA_CHECK_COMPLETE_DIALOG = 5
-        const val MSG_SHOW_DATABASE_ERROR_DIALOG = 6
-        const val MSG_SHOW_FORCE_FULL_SYNC_DIALOG = 7
-        const val MSG_DO_SYNC = 8
-        val MESSAGE_NAME_LIST = arrayOf(
-            "CollectionLoadErrorDialog",
-            "ImportReplaceDialog",
-            "ImportAddDialog",
-            "SyncErrorDialog",
-            "ExportCompleteDialog",
-            "MediaCheckCompleteDialog",
-            "DatabaseErrorDialog",
-            "ForceFullSyncDialog",
-            "DoSyncDialog"
-        )
         private var sStoredMessage: Message? = null
 
         /**
@@ -162,6 +70,55 @@ class DialogHandler(activity: AnkiActivity) : Handler(getDefaultLooper()) {
         @VisibleForTesting(otherwise = VisibleForTesting.NONE)
         fun discardMessage() {
             sStoredMessage = null
+        }
+    }
+}
+
+/**
+ * A message which can be passed to [DialogHandler] for the [DeckPicker] to handle asynchronously
+ * once the app is restored.
+ *
+ * Restoration + handling is performed in [AnkiActivity.onResume].
+ * It is assumed that the [DeckPicker] will be the inheritor of AnkiActivity at this time.
+ * As this is provided as the intent from [AnkiActivity.showSimpleNotification]
+ */
+abstract class DialogHandlerMessage protected constructor(val which: WhichDialogHandler, val analyticName: String) {
+    val what = which.what
+    abstract fun handleAsyncMessage(deckPicker: DeckPicker)
+
+    protected fun emptyMessage(what: Int): Message = Message.obtain().apply { this.what = what }
+
+    // TODO: See if toMessage + fromMessage can be made parcelable
+    abstract fun toMessage(): Message
+
+    companion object {
+        fun fromMessage(message: Message): DialogHandlerMessage {
+            return when (WhichDialogHandler.fromInt(message.what)) {
+                WhichDialogHandler.MSG_SHOW_COLLECTION_LOADING_ERROR_DIALOG -> CollectionLoadingErrorDialog()
+                WhichDialogHandler.MSG_SHOW_COLLECTION_IMPORT_REPLACE_DIALOG -> ImportUtils.CollectionImportReplace.fromMessage(message)
+                WhichDialogHandler.MSG_SHOW_COLLECTION_IMPORT_ADD_DIALOG -> ImportUtils.CollectionImportAdd.fromMessage(message)
+                WhichDialogHandler.MSG_SHOW_SYNC_ERROR_DIALOG -> SyncErrorDialog.SyncErrorDialogMessageHandler.fromMessage(message)
+                WhichDialogHandler.MSG_SHOW_MEDIA_CHECK_COMPLETE_DIALOG -> MediaCheckDialog.MediaCheckCompleteDialog.fromMessage(message)
+                WhichDialogHandler.MSG_SHOW_DATABASE_ERROR_DIALOG -> DatabaseErrorDialog.ShowDatabaseErrorDialog.fromMessage(message)
+                WhichDialogHandler.MSG_SHOW_FORCE_FULL_SYNC_DIALOG -> ForceFullSyncDialog.fromMessage(message)
+                WhichDialogHandler.MSG_DO_SYNC -> IntentHandler.Companion.DoSync()
+            }
+        }
+    }
+
+    /** A list of unique values to be used in [DialogHandler]
+     * @param what Ensures that a [Message] is provided with a unique value */
+    enum class WhichDialogHandler(val what: Int) {
+        MSG_SHOW_COLLECTION_LOADING_ERROR_DIALOG(0),
+        MSG_SHOW_COLLECTION_IMPORT_REPLACE_DIALOG(1),
+        MSG_SHOW_COLLECTION_IMPORT_ADD_DIALOG(2),
+        MSG_SHOW_SYNC_ERROR_DIALOG(3),
+        MSG_SHOW_MEDIA_CHECK_COMPLETE_DIALOG(5),
+        MSG_SHOW_DATABASE_ERROR_DIALOG(6),
+        MSG_SHOW_FORCE_FULL_SYNC_DIALOG(7),
+        MSG_DO_SYNC(8);
+        companion object {
+            fun fromInt(value: Int) = WhichDialogHandler.values().first { it.what == value }
         }
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/MediaCheckDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/MediaCheckDialog.kt
@@ -9,8 +9,10 @@ import android.text.method.ScrollingMovementMethod
 import android.view.View
 import android.widget.LinearLayout
 import android.widget.TextView
+import androidx.core.os.bundleOf
 import com.afollestad.materialdialogs.MaterialDialog
 import com.afollestad.materialdialogs.customview.customView
+import com.ichi2.anki.DeckPicker
 import com.ichi2.anki.R
 import com.ichi2.libanki.MediaCheckResult
 
@@ -129,17 +131,14 @@ class MediaCheckDialog : AsyncDialogFragment() {
             }
         }
 
-    override val dialogHandlerMessage: Message
+    override val dialogHandlerMessage: MediaCheckCompleteDialog
         get() {
-            val msg = Message.obtain()
-            msg.what = DialogHandler.MSG_SHOW_MEDIA_CHECK_COMPLETE_DIALOG
-            val b = Bundle()
-            b.putStringArrayList("nohave", requireArguments().getStringArrayList("nohave"))
-            b.putStringArrayList("unused", requireArguments().getStringArrayList("unused"))
-            b.putStringArrayList("invalid", requireArguments().getStringArrayList("invalid"))
-            b.putInt("dialogType", requireArguments().getInt("dialogType"))
-            msg.data = b
-            return msg
+            val dialogType = requireArguments().getInt("dialogType")
+            val nohave = requireArguments().getStringArrayList("nohave")
+            val unused = requireArguments().getStringArrayList("unused")
+            val invalid = requireArguments().getStringArrayList("invalid")
+
+            return MediaCheckCompleteDialog(dialogType, nohave, unused, invalid)
         }
 
     companion object {
@@ -165,6 +164,42 @@ class MediaCheckDialog : AsyncDialogFragment() {
             args.putInt("dialogType", dialogType)
             f.arguments = args
             return f
+        }
+    }
+
+    class MediaCheckCompleteDialog(
+        private val dialogType: Int,
+        private val noHave: ArrayList<String>?,
+        private val unused: ArrayList<String>?,
+        private val invalid: ArrayList<String>?
+    ) : DialogHandlerMessage(WhichDialogHandler.MSG_SHOW_MEDIA_CHECK_COMPLETE_DIALOG, "MediaCheckCompleteDialog") {
+        override fun handleAsyncMessage(deckPicker: DeckPicker) {
+            // Media check results
+            val id = dialogType
+            if (id != MediaCheckDialog.DIALOG_CONFIRM_MEDIA_CHECK) {
+                val checkList = MediaCheckResult(noHave!!, unused!!, invalid!!)
+                deckPicker.showMediaCheckDialog(id, checkList)
+            }
+        }
+
+        override fun toMessage(): Message = Message.obtain().apply {
+            what = this@MediaCheckCompleteDialog.what
+            data = bundleOf(
+                "nohave" to noHave,
+                "unused" to unused,
+                "invalid" to invalid,
+                "dialogType" to dialogType
+            )
+        }
+
+        companion object {
+            fun fromMessage(message: Message): MediaCheckCompleteDialog {
+                val dialogType = message.data.getInt("dialogType")
+                val noHave = message.data.getStringArrayList("noHave")
+                val unused = message.data.getStringArrayList("unused")
+                val invalid = message.data.getStringArrayList("invalid")
+                return MediaCheckCompleteDialog(dialogType, noHave, unused, invalid)
+            }
         }
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/utils/ImportUtils.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/ImportUtils.kt
@@ -21,17 +21,16 @@ import android.content.ContentResolver
 import android.content.Context
 import android.content.Intent
 import android.net.Uri
-import android.os.Bundle
 import android.os.Message
 import android.provider.OpenableColumns
 import android.webkit.MimeTypeMap
 import androidx.annotation.CheckResult
 import androidx.appcompat.app.AlertDialog
-import com.ichi2.anki.AnkiActivity
-import com.ichi2.anki.AnkiDroidApp
-import com.ichi2.anki.CrashReportService
-import com.ichi2.anki.R
+import androidx.core.os.bundleOf
+import com.ichi2.anki.*
 import com.ichi2.anki.dialogs.DialogHandler
+import com.ichi2.anki.dialogs.DialogHandlerMessage
+import com.ichi2.anki.dialogs.ImportDialog
 import com.ichi2.compat.CompatHelper
 import org.apache.commons.compress.archivers.zip.ZipFile
 import org.jetbrains.annotations.Contract
@@ -368,23 +367,15 @@ object ImportUtils {
              */
             private fun sendShowImportFileDialogMsg(pathList: ArrayList<String>) {
                 // Get the filename from the path
-                val f = File(pathList.first())
-                val filename = f.name
+                val filename = File(pathList.first()).name
 
-                // Create a new message for DialogHandler so that we see the appropriate import dialog in DeckPicker
-                val handlerMessage = Message.obtain()
-                val msgData = Bundle()
-                msgData.putStringArrayList("importPath", pathList)
-                handlerMessage.data = msgData
-                if (isCollectionPackage(filename)) {
-                    // Show confirmation dialog asking to confirm import with replace when file called "collection.apkg"
-                    handlerMessage.what = DialogHandler.MSG_SHOW_COLLECTION_IMPORT_REPLACE_DIALOG
+                val dialogMessage = if (isCollectionPackage(filename)) {
+                    CollectionImportReplace(pathList)
                 } else {
-                    // Otherwise show confirmation dialog asking to confirm import with add
-                    handlerMessage.what = DialogHandler.MSG_SHOW_COLLECTION_IMPORT_ADD_DIALOG
+                    CollectionImportAdd(pathList)
                 }
                 // Store the message in AnkiDroidApp message holder, which is loaded later in AnkiActivity.onResume
-                DialogHandler.storeMessage(handlerMessage)
+                DialogHandler.storeMessage(dialogMessage.toMessage())
             }
 
             internal fun isDeckPackage(filename: String?): Boolean {
@@ -479,6 +470,48 @@ object ImportUtils {
                 CrashReportService.sendExceptionReport(e, "Import - invalid zip", "improve UI message here", true)
                 return ctx.getString(R.string.import_log_failed_unzip, e.localizedMessage)
             }
+        }
+    }
+
+    /** Show confirmation dialog asking to confirm import with replace when file called "collection.apkg" */
+    class CollectionImportReplace(private val pathList: ArrayList<String>) : DialogHandlerMessage(
+        which = WhichDialogHandler.MSG_SHOW_COLLECTION_IMPORT_REPLACE_DIALOG,
+        analyticName = "ImportReplaceDialog"
+    ) {
+        override fun handleAsyncMessage(deckPicker: DeckPicker) {
+            // Handle import of collection package APKG
+            deckPicker.showImportDialog(ImportDialog.DIALOG_IMPORT_REPLACE_CONFIRM, pathList)
+        }
+
+        override fun toMessage(): Message = Message.obtain().apply {
+            data = bundleOf("importPath" to pathList)
+            what = this@CollectionImportReplace.what
+        }
+
+        companion object {
+            fun fromMessage(message: Message): CollectionImportReplace =
+                CollectionImportReplace(message.data.getStringArrayList("importPath")!!)
+        }
+    }
+
+    /** Show confirmation dialog asking to confirm import with add */
+    class CollectionImportAdd(private val pathList: ArrayList<String>) : DialogHandlerMessage(
+        WhichDialogHandler.MSG_SHOW_COLLECTION_IMPORT_ADD_DIALOG,
+        "ImportAddDialog"
+    ) {
+        override fun handleAsyncMessage(deckPicker: DeckPicker) {
+            // Handle import of deck package APKG
+            deckPicker.showImportDialog(ImportDialog.DIALOG_IMPORT_ADD_CONFIRM, pathList)
+        }
+
+        override fun toMessage(): Message = Message.obtain().apply {
+            data = bundleOf("importPath" to pathList)
+            what = this@CollectionImportAdd.what
+        }
+
+        companion object {
+            fun fromMessage(message: Message): CollectionImportAdd =
+                CollectionImportAdd(message.data.getStringArrayList("importPath")!!)
         }
     }
 }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/DatabaseErrorDialogTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/DatabaseErrorDialogTest.kt
@@ -1,0 +1,38 @@
+/*
+ *  Copyright (c) 2023 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.dialogs
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.ichi2.anki.dialogs.DatabaseErrorDialog.DatabaseErrorDialogType
+import com.ichi2.anki.dialogs.DatabaseErrorDialog.ShowDatabaseErrorDialog
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.equalTo
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class DatabaseErrorDialogTest {
+
+    @Test
+    fun `ShowDatabaseErrorDialog serialization`() {
+        // concerns with 'bundleOf' + '@Parcelize'
+        val error = ShowDatabaseErrorDialog(DatabaseErrorDialogType.DIALOG_DB_ERROR)
+        val message = error.toMessage()
+        val deserialized = ShowDatabaseErrorDialog.fromMessage(message)
+        assertThat(deserialized.dialogType, equalTo(DatabaseErrorDialogType.DIALOG_DB_ERROR))
+    }
+}


### PR DESCRIPTION
Move serialisation + handling to classes instead of being spread around the codebase

Keep enum: `WhichDialogHandler` to ensure that we do not reuse int values

## Pull Request template

## Purpose / Description
* Our DialogHandler implementation split our two aspects of handling `Message`s (which isn't the easiest code to follow):
  * Serialisation around the codebase
  * Deserialisation + logic in `DialogHandler`  

## Related
* Makes #13356 easier to understand, as we add another handler (without a dialog) here
* #5075

## Approach
* Split out each `DialogHandler` into a class: containing the method and the serde of its parameters
* Document the class a little better
* Use an enum to ensure that no items have duplicated `what` integers, and all cases are handled

## How Has This Been Tested?
Unit test only

## Learning (optional, can help others)
Finally documenting our use of `Message`: The implicit assumption is that we launch all of the dialogs from `DeckPicker`, and the notification uses an intent of `DeckPicker`, so everything should work. This assumption occasionally breaks down

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
