### PR TITLE
fix: "Backup Dialog" icon on dark theme

### DIFF
--- a/AnkiDroid/src/main/res/drawable/ic_baseline_backup_24.xml
+++ b/AnkiDroid/src/main/res/drawable/ic_baseline_backup_24.xml
@@ -17,5 +17,5 @@
 <vector android:height="24dp" android:tint="?attr/toolbarIconColor"
     android:viewportHeight="24" android:viewportWidth="24"
     android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
-    <path android:fillColor="?attr/iconColor" android:pathData="M19.35,10.04C18.67,6.59 15.64,4 12,4 9.11,4 6.6,5.64 5.35,8.04 2.34,8.36 0,10.91 0,14c0,3.31 2.69,6 6,6h13c2.76,0 5,-2.24 5,-5 0,-2.64 -2.05,-4.78 -4.65,-4.96zM14,13v4h-4v-4H7l5,-5 5,5h-3z"/>
+    <path android:fillColor="#FFFFFF" android:pathData="M19.35,10.04C18.67,6.59 15.64,4 12,4 9.11,4 6.6,5.64 5.35,8.04 2.34,8.36 0,10.91 0,14c0,3.31 2.69,6 6,6h13c2.76,0 5,-2.24 5,-5 0,-2.64 -2.05,-4.78 -4.65,-4.96zM14,13v4h-4v-4H7l5,-5 5,5h-3z"/>
 </vector>


### PR DESCRIPTION
## Purpose / Description
Icon was invisible on the Dark Theme

## Fixes
- Fixes #13372

## Approach
Remove reference to color and use a tintable color instead

## How Has This Been Tested?

<img width="381" alt="Screenshot 2023-03-01 at 01 42 58" src="https://user-images.githubusercontent.com/62114487/222023215-d30aa9ac-2bb8-437f-8c02-f808a1990bcb.png">

Also tested on other themes

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
