### PR TITLE
Issue template: Use "render: text" for debug info

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report_form.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report_form.yml
@@ -44,6 +44,7 @@ body:
       label: Debug info
       description: Refer to the [support page](https://ankidroid.org/docs/help.html) if you are unsure where to get the "debug info"
       placeholder: AnkiDroid Debug Info (Starts with "AnkiDroid Version")
+      render: text
     validations:
       required: true
 


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
Render debug info as block text

## How Has This Been Tested?

[Tested on cloned repo](https://github.com/doozan/Anki-Android/issues/new?assignees=&labels=Bug%2CNeeds+Triage&template=bug_report_form.yml&title=%5BBUG%5D%3A+)
[Sample issue](https://github.com/doozan/Anki-Android/issues/4)

## Learning (optional, can help others)
https://gh-community.github.io/issue-template-feedback/structured/#codeblock-rendering-for-contributor-submitted-text

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
