### PR TITLE
fix: Disable "force full sync" preference when user is not logged in

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/SyncSettingsFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/SyncSettingsFragment.kt
@@ -39,8 +39,8 @@ class SyncSettingsFragment : SettingsFragment() {
         // AnkiWeb Account
         updateSyncAccountSummary()
 
-        // Enable/disable force full sync
-        updateForceFullSync()
+        // Enable/disable force full sync if the user is logged in or not
+        updateForceFullSyncEnabledState()
 
         // Configure force full sync option
         requirePreference<Preference>(R.string.force_full_sync_key).setOnPreferenceClickListener {
@@ -76,7 +76,7 @@ class SyncSettingsFragment : SettingsFragment() {
             .ifEmpty { getString(R.string.sync_account_summ_logged_out) }
     }
 
-    private fun updateForceFullSync() {
+    private fun updateForceFullSyncEnabledState() {
         val isLoggedIn = Preferences.hasAnkiWebAccount(AnkiDroidApp.getSharedPrefs(requireContext()))
         requirePreference<Preference>(R.string.force_full_sync_key).isEnabled = isLoggedIn
     }
@@ -85,7 +85,7 @@ class SyncSettingsFragment : SettingsFragment() {
     override fun onResume() {
         // Trigger a summary update in case the user logged in/out on MyAccount activity
         updateSyncAccountSummary()
-        updateForceFullSync()
+        updateForceFullSyncEnabledState()
         super.onResume()
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/SyncSettingsFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/SyncSettingsFragment.kt
@@ -39,6 +39,9 @@ class SyncSettingsFragment : SettingsFragment() {
         // AnkiWeb Account
         updateSyncAccountSummary()
 
+        // Enable/disable force full sync
+        updateForceFullSync()
+
         // Configure force full sync option
         requirePreference<Preference>(R.string.force_full_sync_key).setOnPreferenceClickListener {
             AlertDialog.Builder(requireContext()).show {
@@ -73,10 +76,16 @@ class SyncSettingsFragment : SettingsFragment() {
             .ifEmpty { getString(R.string.sync_account_summ_logged_out) }
     }
 
+    private fun updateForceFullSync() {
+        val isLoggedIn = Preferences.hasAnkiWebAccount(AnkiDroidApp.getSharedPrefs(requireContext()))
+        requirePreference<Preference>(R.string.force_full_sync_key).isEnabled = isLoggedIn
+    }
+
     // TODO trigger the summary change from MyAccount.kt once it is migrated to a fragment
     override fun onResume() {
         // Trigger a summary update in case the user logged in/out on MyAccount activity
         updateSyncAccountSummary()
+        updateForceFullSync()
         super.onResume()
     }
 }


### PR DESCRIPTION
## Purpose / Description

Disabled "force full sync" preference when user is not logged in.

## Fixes
Fixes #13374 

## Approach
First checked if the user is logged in or not and enabled/disabled the preference accordingly.

## How Has This Been Tested?

## Before



https://user-images.githubusercontent.com/76740999/222242830-ca0e7a55-ce50-47aa-a1de-bc7a5fff981e.mp4



## After




https://user-images.githubusercontent.com/76740999/222242855-9e45aded-4261-401c-af71-45bc9dabd0c0.mp4




## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
