### PR TITLE
fix: Set iconColor in theme_dark.xml

### DIFF
--- a/AnkiDroid/src/main/res/values/theme_dark.xml
+++ b/AnkiDroid/src/main/res/values/theme_dark.xml
@@ -132,6 +132,7 @@
         <item name="popupBackgroundColor">@color/popup_background_theme_dark</item>
         <item name="editTextDisabled">@color/material_grey_500</item>
         <item name="overflowAndPopupMenuIconColor">#9effffff</item>
+        <item name="iconColor">?android:attr/textColor</item>
         <!-- StatusBar -->
         <item name="android:statusBarColor">@color/theme_dark_primary</item>
         <item name="android:windowLightStatusBar" tools:targetApi="m">false</item>


### PR DESCRIPTION
## Purpose / Description
Set iconColor in theme_dark.xml.

## Fixes
Fixes #13383
Fixes #13372
Closes #13373

## Approach

Added an attribute iconColor in theme_dark.xml .

## How Has This Been Tested?

## Before

![bef](https://user-images.githubusercontent.com/76740999/222463841-931245e4-76ac-4108-8e9a-40f9a978f3c7.png)


## After


![af](https://user-images.githubusercontent.com/76740999/222463873-0699954f-7870-4839-9ba0-8524535ac3a6.png)



## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
