### PR TITLE
test(Windows): previewWorksAfterSort is flaky

### DIFF
--- a/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.kt
@@ -348,6 +348,7 @@ class CardBrowserTest : RobolectricTest() {
     }
 
     @Test
+    @Flaky(os = OS.WINDOWS, "IllegalStateException: Card '1596783600440' not found")
     fun previewWorksAfterSort() {
         // #7286
         val cid1 = addNoteUsingBasicModel("Hello", "World").cards()[0].id


### PR DESCRIPTION
```
CardBrowserTest > previewWorksAfterSort FAILED
    java.lang.IllegalStateException: Card '1596783600440' not found
        at com.ichi2.anki.CardBrowser.getPropertiesForCardId(CardBrowser.kt:2662)
        at com.ichi2.anki.CardBrowserTest.previewWorksAfterSort(CardBrowserTest.kt:358)
```

https://github.com/ankidroid/Anki-Android/actions/runs/4318941121/jobs/7537826151