### PR TITLE
test: mark flaky tests

### DIFF
--- a/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.kt
@@ -107,6 +107,7 @@ class CardBrowserTest : RobolectricTest() {
     }
 
     @Test
+    @Flaky(os = OS.WINDOWS, "Index 0 out of bounds for length 0")
     fun browserIsInMultiSelectModeWhenSelectingOne() {
         val browser = browserWithMultipleNotes
         selectOneOfManyCards(browser)


### PR DESCRIPTION
`browserIsInMultiSelectModeWhenSelectingOne`

```
CardBrowserTest > browserIsInMultiSelectModeWhenSelectingOne FAILED
    java.lang.IndexOutOfBoundsException: Index 0 out of bounds for length 0
        at java.base/jdk.internal.util.Preconditions.outOfBounds(Preconditions.java:64)
        at java.base/jdk.internal.util.Preconditions.outOfBoundsCheckIndex(Preconditions.java:70)
        at java.base/jdk.internal.util.Preconditions.checkIndex(Preconditions.java:248)
        at java.base/java.util.Objects.checkIndex(Objects.java:372)
        at java.base/java.util.ArrayList.get(ArrayList.java:459)
        at com.ichi2.anki.CardBrowser$CardCollection.get(CardBrowser.kt:2291)
        at com.ichi2.anki.CardBrowser.saveScrollingState(CardBrowser.kt:1935)
        at com.ichi2.anki.CardBrowser.onCollectionLoaded$lambda$16(CardBrowser.kt:689)
        at com.ichi2.anki.CardBrowserTest.selectOneOfManyCards(CardBrowserTest.kt:663)
        at com.ichi2.anki.CardBrowserTest.selectOneOfManyCards(CardBrowserTest.kt:647)
        at com.ichi2.anki.CardBrowserTest.browserIsInMultiSelectModeWhenSelectingOne(CardBrowserTest.kt:112)
```

https://github.com/ankidroid/Anki-Android/actions/runs/4325913119/jobs/7552674557
