### PR TITLE
Scoped Storage: Handle storage being revoked

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiActivity.kt
@@ -452,7 +452,9 @@ open class AnkiActivity : AppCompatActivity, SimpleMessageDialogListener, Collec
      * @param newFragment  the DialogFragment you want to show
      */
     open fun showDialogFragment(newFragment: DialogFragment) {
-        showDialogFragment(this, newFragment)
+        runOnUiThread {
+            showDialogFragment(this, newFragment)
+        }
     }
 
     /**

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CollectionHelper.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CollectionHelper.kt
@@ -533,6 +533,9 @@ open class CollectionHelper {
             return File(getCurrentAnkiDroidDirectory(context), COLLECTION_FILENAME).absolutePath
         }
 
+        /** A temporary override for [getCurrentAnkiDroidDirectory] */
+        var ankiDroidDirectoryOverride: String? = null
+
         /**
          * @return the absolute path to the AnkiDroid directory.
          */
@@ -545,6 +548,8 @@ open class CollectionHelper {
                     getDefaultAnkiDroidDirectory(context),
                     "androidTest"
                 ).absolutePath
+            } else if (ankiDroidDirectoryOverride != null) {
+                ankiDroidDirectoryOverride!!
             } else {
                 PreferenceExtensions.getOrSetString(
                     preferences,

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CollectionHelper.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CollectionHelper.kt
@@ -22,6 +22,7 @@ import android.os.Environment
 import android.text.format.Formatter
 import androidx.annotation.CheckResult
 import androidx.annotation.VisibleForTesting
+import androidx.core.content.edit
 import com.ichi2.anki.AnkiDroidFolder.DeleteOnUninstall
 import com.ichi2.anki.exception.StorageAccessException
 import com.ichi2.anki.preferences.Preferences
@@ -550,6 +551,18 @@ open class CollectionHelper {
                     PREF_COLLECTION_PATH
                 ) { getDefaultAnkiDroidDirectory(context) }
             }
+        }
+
+        /**
+         * Resets the AnkiDroid directory to the [getDefaultAnkiDroidDirectory]
+         * Note: if [android.R.attr.preserveLegacyExternalStorage] is in use
+         * this will represent a change from `/AnkiDroid` to `/Android/data/...`
+         */
+        fun resetAnkiDroidDirectory(context: Context) {
+            val preferences = AnkiDroidApp.getSharedPrefs(context)
+            val directory = getDefaultAnkiDroidDirectory(context)
+            Timber.d("resetting AnkiDroid directory to %s", directory)
+            preferences.edit { putString(PREF_COLLECTION_PATH, directory) }
         }
 
         /** Fetches additional collection data not required for

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ImportFileSelectionFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ImportFileSelectionFragment.kt
@@ -30,7 +30,7 @@ import timber.log.Timber
 @NeedsTest("Selecting COLPKG does not allow multiple files")
 @NeedsTest("Restore backup dialog does not allow multiple files")
 class ImportFileSelectionFragment {
-    data class ImportOptions(val importColpkg: Boolean = true, val importApkg: Boolean = true, val importTextFile: Boolean = true)
+    data class ImportOptions(val importColpkg: Boolean, val importApkg: Boolean, val importTextFile: Boolean)
 
     companion object {
         fun createInstance(@Suppress("UNUSED_PARAMETER") context: DeckPicker, options: ImportOptions): RecursivePictureMenu {

--- a/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.kt
@@ -194,7 +194,7 @@ open class CollectionTask<Progress, Result>(val task: TaskDelegateBase<Progress,
             Timber.d("doInBackgroundImportReplace")
             val res = AnkiDroidApp.instance.baseContext.resources
             val context = col.context
-            val colPath = CollectionHelper.getCollectionPath(context)
+            val colPath = col.path
             // extract the deck from the zip file
             val dir = File(File(colPath).parentFile, "tmpzip")
             if (dir.exists()) {

--- a/AnkiDroid/src/main/res/values/01-core.xml
+++ b/AnkiDroid/src/main/res/values/01-core.xml
@@ -243,4 +243,14 @@
     <string name="migration_successful_message">Migration successful</string>
     <string name="migration_failed_message">Migration failed</string>
     <string name="migration_transferred_size">Migrated %1$.0f MB of %2$.0f MB</string>
+
+    <string name="directory_inaccessible_after_uninstall" comment="Dialog title if AnkiDroid can't access the collection once the app is installed">Inaccessible collection</string>
+    <string name="directory_inaccessible_after_uninstall_summary" comment="the parameter is the path to the AnkiDroid folder. Typically /storage/emulated/0/AnkiDroid">We are unable to access your collection after AnkiDroid is uninstalled due to a change in Play Store Policy\n\nYour data is safe and can be restored. It is located at\n%s\n\nSelect an option below to restore:</string>
+    <string name="restore_data_from_ankiweb">Restore from AnkiWeb (recommended)</string>
+    <string name="install_non_play_store_ankidroid_recommended">Restore folder access (recommended)</string>
+    <string name="install_non_play_store_ankidroid">Restore folder access (advanced)</string>
+    <string name="restore_data_from_backup">Restore from .colpkg backup (advanced)</string>
+    <string name="create_new_collection">Create a new collection</string>
+
+    <string name="new_unsafe_collection">The new collection will be deleted from your phone if you uninstall AnkiDroid</string>
 </resources>

--- a/AnkiDroid/src/main/res/values/constants.xml
+++ b/AnkiDroid/src/main/res/values/constants.xml
@@ -163,6 +163,7 @@
     <string name="link_distributions">https://apps.ankiweb.net/#download</string>
     <string name="link_ankiweb_lost_email_instructions">https://github.com/ankidroid/Anki-Android/wiki/FAQ#forgotten-ankiweb-email-instructions</string>
     <string name="link_scoped_storage_faq">https://github.com/ankidroid/Anki-Android/wiki/Storage-Migration-FAQ</string>
+    <string name="link_install_non_play_store_install">https://github.com/ankidroid/Anki-Android/wiki/Full-Storage-Access</string>
     <string name="link_custom_sync_server_help_learn_more_en">https://docs.ankidroid.org/#_custom_sync_server</string>
 
     <string-array name="leech_action_values">


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
If a user uninstalls and selects 'keep data', the user retains access to their preferences, so we retain `deckPath` and can use it to determine if their collection is no longer accessible

If a user uninstalls AnkiDroid, `preserveLegacyExternalStorage` no longer works.

This means they have a deckPath of `/storage/emulated/0/AnkiDroid` which can no longer be accessed.

Their data exists, but cannot be accessed unless:
* They restore from AnkiWeb
* They have a colpkg
* They manually copy the folder over
* They install a non-Google-Play copy

Provide a dialog with options:
* Restore from AnkiWeb
* Restore folder access
   (https://github.com/ankidroid/Anki-Android/wiki/Full-Storage-Access)
* Restore backup (⚠️ Hidden - Not Implemented)
* Get Help (Link to: Google Group)
* Delete collection and create a new one

## Fixes
Related: #5304

## Approach

![Screenshot 2023-03-04 at 03 07 40](https://user-images.githubusercontent.com/62114487/222872922-3e1cfee1-bcbc-4bb7-a0c7-324a89fb1108.png)
![Screenshot 2023-03-04 at 03 09 18](https://user-images.githubusercontent.com/62114487/222872919-8fec0f9a-8314-4ec6-b841-41367c3a5e13.png)


## How Has This Been Tested?
API 31 emulator, manually with the provided shell script

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
