### PR TITLE
add tool: enable/disable scoped storage

### DIFF
--- a/tools/storage/set_scoped_storage.sh
+++ b/tools/storage/set_scoped_storage.sh
@@ -1,0 +1,43 @@
+#/bin/bash
+# enable/disable scoped storage: ./set_scoped_storage.sh [limited/full]
+
+
+function help() {
+    echo "\nPossible arguments:"
+    echo "limited\t\tEquivalent to a fresh install. /AnkiDroid/ is inaccessible"
+    echo "full\t\tEquivalent to an upgrade from targetSdkVersion 29 to 30. /AnkiDroid/ is accessible\n"
+}
+
+# This should be run when a single AOSP emulator is open.
+# Errors are suppressed by default. Remove > /dev/null
+if [ "$1" = "full" ]; then
+    adb shell pm grant com.ichi2.anki.debug android.permission.READ_EXTERNAL_STORAGE
+    adb shell pm grant com.ichi2.anki.debug android.permission.WRITE_EXTERNAL_STORAGE
+    adb shell am compat disable FORCE_ENABLE_SCOPED_STORAGE com.ichi2.anki.debug   > /dev/null
+    adb shell am compat disable DEFAULT_SCOPED_STORAGE com.ichi2.anki.debug  > /dev/null # fails on Play store
+    if [ $? == '0' ]; then
+        echo "scoped storage disabled: preserving storage access"
+    else
+        echo "something went wrong: edit script to display errors"
+    fi
+elif [ "$1" = "limited" ]; then
+    adb shell pm revoke com.ichi2.anki.debug android.permission.READ_EXTERNAL_STORAGE
+    adb shell pm revoke com.ichi2.anki.debug android.permission.WRITE_EXTERNAL_STORAGE
+    adb shell am compat enable FORCE_ENABLE_SCOPED_STORAGE com.ichi2.anki.debug  > /dev/null
+    adb shell am compat enable DEFAULT_SCOPED_STORAGE com.ichi2.anki.debug > /dev/null
+    if [ $? == '0' ]; then
+        echo "scoped storage enabled: storage access disabled"
+    else
+        echo "something went wrong: edit script to display errors"
+    fi
+elif  [ "$1" = "" ]; then
+    echo "First argument missing."
+    help
+else
+    echo "unknown argument: '$1'. Valid values: 'limited', 'full'"
+    help
+fi
+
+
+# future extension: have an argument trigger the 'permission revoked' state by changing 'deckPath'
+# while storage is 'limited'


### PR DESCRIPTION
A script to enable/disable scoped storage without the need to uninstall/upgrade from `targetSdkVersion 29`

Makes testing of the disable/enable routine quicker

Issue #5304
Cherry-picked from https://github.com/ankidroid/Anki-Android/pull/13396
