### PR TITLE
build(ci): reduce PR stale timeout to 2 weeks

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -20,11 +20,11 @@ jobs:
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         stale-issue-message: 'Hello 👋, this issue has been opened for more than 3 months with no activity on it. If the issue is still here, please keep in mind that we need community support and help to fix it! Just comment something like _still searching for solutions_ and if you found one, please open a pull request! You have 7 days until this gets closed automatically'
-        stale-pr-message: 'Hello 👋, this PR has had no activity for more than 3 weeks and needs a reply from the author. If you think this is a mistake please comment and ping a maintainer to get this merged ASAP! Thanks for contributing! You have 7 days until this gets closed automatically'
+        stale-pr-message: 'Hello 👋, this PR has had no activity for more than 2 weeks and needs a reply from the author. If you think this is a mistake please comment and ping a maintainer to get this merged ASAP! Thanks for contributing! You have 7 days until this gets closed automatically'
         exempt-issue-labels: 'Keep Open'
         exempt-pr-labels: 'Keep Open'
         close-issue-reason: 'not_planned'
         days-before-issue-stale: 90
-        days-before-pr-stale: 21
+        days-before-pr-stale: 14
         only-pr-labels: 'Needs Author Reply'
 


### PR DESCRIPTION
As agreed in Discord - we don't want the PR queue to get stale as the number of conflicts adds to the workload

I've committed to keeping things moving and fixing up stale PRs to a reasonable extent.

If 2 weeks is too short, then I'm happy to raise it back.