### PR TITLE
Fixed hardware keyboard search bug.

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -676,6 +676,7 @@ open class DeckPicker :
         mFloatingActionMenu.closeFloatingActionMenu()
         menuInflater.inflate(R.menu.deck_picker, menu)
         setupSearchIcon(menu.findItem(R.id.deck_picker_action_filter))
+        mToolbarSearchView = menu.findItem(R.id.deck_picker_action_filter).actionView as SearchView
         // redraw menu synchronously to avoid flicker
         updateMenuFromState(menu)
         // ...then launch a task to possibly update the visible icons.


### PR DESCRIPTION
## Purpose / Description
Fixes the bug mentioned in #13210 

## Fixes
Fixes  #13210

## Approach
mToolbarSearchView was used to check if the SearchView is in focus but mToolbarSearchView was never initialized so it always returned null

## How Has This Been Tested?
Physical Device (Android 13) & Tests 

## Learning (optional, can help others)
https://developer.android.com/reference/kotlin/androidx/compose/ui/focus/FocusState

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented on your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [x] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
