### PR TITLE
Fix leech snackbar overlapping answer buttons

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/BackendUndo.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/BackendUndo.kt
@@ -16,7 +16,6 @@
 
 package com.ichi2.anki
 
-import android.view.View
 import androidx.fragment.app.FragmentActivity
 import com.ichi2.anki.CollectionManager.TR
 import com.ichi2.anki.snackbar.showSnackbar
@@ -25,8 +24,7 @@ import com.ichi2.libanki.undoableOp
 import com.ichi2.utils.BlocksSchemaUpgrade
 import net.ankiweb.rsdroid.BackendException
 
-/** @param anchorView The view to display the snackbar above */
-suspend fun FragmentActivity.backendUndoAndShowPopup(anchorView: View? = null): Boolean {
+suspend fun FragmentActivity.backendUndoAndShowPopup(): Boolean {
     return try {
         val changes = withProgress() {
             undoableOp {
@@ -34,11 +32,7 @@ suspend fun FragmentActivity.backendUndoAndShowPopup(anchorView: View? = null): 
             }
         }
 
-        showSnackbar(TR.undoActionUndone(changes.operation)) {
-            // A snackbar may obscure vital elements (e.g: the answer buttons on the Reviewer)
-            // `anchorView` stops this
-            anchorView?.let { setAnchorView(anchorView) }
-        }
+        showSnackbar(TR.undoActionUndone(changes.operation))
 
         true
     } catch (exc: BackendException) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/snackbar/Snackbars.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/snackbar/Snackbars.kt
@@ -32,6 +32,17 @@ import timber.log.Timber
 typealias SnackbarBuilder = Snackbar.() -> Unit
 
 /**
+ * An activity/fragment can implement this interface to specify a
+ * default configuration for snackbars shown in the activity/fragment.
+ */
+interface BaseSnackbarBuilderProvider {
+    /**
+     * The SnackbarBuilder that will be run to provide a base configuration for snackbars shown.
+     */
+    val baseSnackbarBuilder: SnackbarBuilder
+}
+
+/**
  * Show a snackbar.
  *
  * You can create snackbars by calling `showSnackbar` on either an activity or a view.
@@ -98,7 +109,11 @@ fun Activity.showSnackbar(
     val view: View? = findViewById(R.id.root_layout)
 
     if (view != null) {
-        view.showSnackbar(text, duration, snackbarBuilder)
+        val baseSnackbarBuilder = (this as? BaseSnackbarBuilderProvider)?.baseSnackbarBuilder
+        view.showSnackbar(text, duration) {
+            baseSnackbarBuilder?.invoke(this)
+            snackbarBuilder?.invoke(this)
+        }
     } else {
         val errorMessage = "While trying to show a snackbar, " +
             "could not find a view with id root_layout in $this"
@@ -222,7 +237,11 @@ fun Fragment.showSnackbar(
     duration: Int = Snackbar.LENGTH_LONG,
     snackbarBuilder: SnackbarBuilder? = null
 ) {
-    requireActivity().showSnackbar(text, duration, snackbarBuilder)
+    val baseSnackbarBuilder = (this as? BaseSnackbarBuilderProvider)?.baseSnackbarBuilder
+    requireActivity().showSnackbar(text, duration) {
+        baseSnackbarBuilder?.invoke(this)
+        snackbarBuilder?.invoke(this)
+    }
 }
 
 /**

--- a/AnkiDroid/src/main/java/com/ichi2/anki/snackbar/Snackbars.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/snackbar/Snackbars.kt
@@ -33,7 +33,7 @@ typealias SnackbarBuilder = Snackbar.() -> Unit
 
 /**
  * An activity/fragment can implement this interface to specify a
- * default configuration for snackbars shown in the activity/fragment.
+ * base configuration for snackbars shown in the activity/fragment.
  */
 interface BaseSnackbarBuilderProvider {
     /**


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
The snackbar that show when a card becomes a leech would overlap with the answer buttons.

This PR fixes the issue by showing the snackbar above the answer buttons.

## Fixes
Fixes #12606

## Approach
Use a variation of the approach suggested by @oakkitten in the issue.

`showSnackbar` is an extension function, so we can't override it, but we can make an interface that an Activity can implement to specify default configuration for a snackbar and `showSnackbar` can take this configuration into account.

Instead of specifying an anchor view as originally suggested, I've opted to use a `SnackbarBuilder` instead so that we can have more flexibility without really increasing the complexity.

I've also removed code for explicitly setting the snackbar above the answer buttons, since a regular `showSnackbar` will do the job now.

## How Has This Been Tested?

Tested leech, undo, bury, and suspend snackbars on both the old and new backends in emulator.

Screenshot of leech snackbar being fixed:
<img width="367" alt="Screenshot 2023-03-05 at 2 35 45 PM" src="https://user-images.githubusercontent.com/5134058/222993445-fff88920-1edd-44e1-8823-218798e48e40.png">

## Learning (optional, can help others)
_Describe the research stage_

_Links to blog posts, patterns, libraries or addons used to solve this problem_

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
