### PR TITLE
Refactor: Extract & generify 'import'

### DIFF
--- a/.idea/dictionaries/davidallison.xml
+++ b/.idea/dictionaries/davidallison.xml
@@ -52,6 +52,7 @@
       <w>freqs</w>
       <w>furigana</w>
       <w>gamepad</w>
+      <w>generifies</w>
       <w>glosbe</w>
       <w>helloworld</w>
       <w>ifnull</w>

--- a/AnkiDroid/src/main/java/com/ichi2/anki/BackendBackups.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/BackendBackups.kt
@@ -32,7 +32,7 @@ fun DeckPicker.performBackupInBackground() {
     }
 }
 
-fun DeckPicker.importColpkg(colpkgPath: String) {
+fun <Activity> Activity.importColpkg(colpkgPath: String) where Activity : AnkiActivity, Activity : ImportColpkgListener {
     launchCatchingTask {
         withProgress(
             extractProgress = {
@@ -44,8 +44,7 @@ fun DeckPicker.importColpkg(colpkgPath: String) {
             CollectionManager.importColpkg(colpkgPath)
         }
 
-        invalidateOptionsMenu()
-        updateDeckList()
+        onImportColpkg(colpkgPath)
     }
 }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/BackendImporting.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/BackendImporting.kt
@@ -36,7 +36,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import net.ankiweb.rsdroid.Translations
 
-fun DeckPicker.importApkgs(apkgPaths: List<String>) {
+fun AnkiActivity.importApkgs(apkgPaths: List<String>) {
     launchCatchingTask {
         for (apkgPath in apkgPaths) {
             val report = withProgress(

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -164,7 +164,8 @@ open class DeckPicker :
     MediaCheckDialogListener,
     OnRequestPermissionsResultCallback,
     CustomStudyListener,
-    ChangeManager.Subscriber {
+    ChangeManager.Subscriber,
+    ImportColpkgListener {
     // Short animation duration from system
     private var mShortAnimDuration = 0
     private var mBackButtonPressedToExit = false
@@ -2522,6 +2523,11 @@ open class DeckPicker :
     // Scoped Storage migration
     private fun setMigrationWasLastPostponedAtToNow() {
         migrationWasLastPostponedAt = TimeManager.time.intTime()
+    }
+
+    override fun onImportColpkg(colpkgPath: String?) {
+        invalidateOptionsMenu()
+        updateDeckList()
     }
 }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Import.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Import.kt
@@ -39,6 +39,10 @@ import timber.log.Timber
 // BackendBackups/BackendImporting - new backend for importing
 // importReplaceListener - old backend listener for importing
 
+fun interface ImportColpkgListener {
+    fun onImportColpkg(colpkgPath: String?)
+}
+
 fun DeckPicker.onSelectedPackageToImport(data: Intent) {
     val importResult = ImportUtils.handleFileImport(this, data)
     if (!importResult.isSuccess) {
@@ -76,7 +80,7 @@ private class ImportReplaceListener(deckPicker: DeckPicker) : TaskListenerWithCo
         }
         val res = context.resources
         if (result!!.succeeded()) {
-            context.updateDeckList()
+            context.onImportColpkg(colpkgPath = null)
         } else {
             context.showSimpleMessageDialog(res.getString(R.string.import_log_no_apkg), reload = true)
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Import.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Import.kt
@@ -18,7 +18,10 @@ package com.ichi2.anki
 
 import android.content.Intent
 import com.google.android.material.snackbar.Snackbar
+import com.ichi2.anki.dialogs.AsyncDialogFragment
+import com.ichi2.anki.dialogs.ImportDialog
 import com.ichi2.anki.dialogs.ImportFileSelectionFragment
+import com.ichi2.anki.dialogs.ImportFileSelectionFragment.ImportOptions
 import com.ichi2.anki.pages.CsvImporter
 import com.ichi2.anki.servicelayer.ScopedStorageService
 import com.ichi2.anki.snackbar.showSnackbar
@@ -55,6 +58,15 @@ fun DeckPicker.onSelectedCsvForImport(data: Intent) {
     startActivity(CsvImporter.getIntent(this, path))
 }
 
+fun DeckPicker.showImportDialog(id: Int, messageList: ArrayList<String>) {
+    Timber.d("showImportDialog() delegating to ImportDialog")
+    if (messageList.isEmpty()) {
+        messageList.add("")
+    }
+    val newFragment: AsyncDialogFragment = ImportDialog.newInstance(id, messageList)
+    showAsyncDialogFragment(newFragment)
+}
+
 fun DeckPicker.showImportDialog() {
     if (ScopedStorageService.userMigrationIsInProgress(this)) {
         showSnackbar(
@@ -63,7 +75,12 @@ fun DeckPicker.showImportDialog() {
         )
         return
     }
-    showDialogFragment(ImportFileSelectionFragment.createInstance(this))
+    val options = ImportOptions(
+        importApkg = true,
+        importColpkg = true,
+        importTextFile = true
+    )
+    showDialogFragment(ImportFileSelectionFragment.createInstance(this, options))
 }
 
 /* Legacy Backend */

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Import.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Import.kt
@@ -1,0 +1,171 @@
+/*
+ *  Copyright (c) 2023 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki
+
+import android.content.Intent
+import com.google.android.material.snackbar.Snackbar
+import com.ichi2.anki.dialogs.ImportFileSelectionFragment
+import com.ichi2.anki.pages.CsvImporter
+import com.ichi2.anki.servicelayer.ScopedStorageService
+import com.ichi2.anki.snackbar.showSnackbar
+import com.ichi2.async.TaskListenerWithContext
+import com.ichi2.libanki.importer.AnkiPackageImporter
+import com.ichi2.themes.StyledProgressDialog
+import com.ichi2.utils.Computation
+import com.ichi2.utils.ImportUtils
+import timber.log.Timber
+
+// see also:
+// ImportFileSelectionFragment - selects 'APKG/COLPKG/CSV' and opens a file picker
+// onSelectedPackageToImport/onSelectedCsvForImport
+// importUtils - copying selected file into local cache
+// ImportDialog - confirmation screen after file copied to cache
+//    * ImportDialogListener - DeckPicker implementation of handler for the confirmation screen
+//    * DeckPicker.importAdd/importReplace - called from confirmation screen
+// BackendBackups/BackendImporting - new backend for importing
+// importReplaceListener - old backend listener for importing
+
+fun DeckPicker.onSelectedPackageToImport(data: Intent) {
+    val importResult = ImportUtils.handleFileImport(this, data)
+    if (!importResult.isSuccess) {
+        ImportUtils.showImportUnsuccessfulDialog(this, importResult.humanReadableMessage, false)
+    }
+}
+
+fun DeckPicker.onSelectedCsvForImport(data: Intent) {
+    val path = ImportUtils.getFileCachedCopy(this, data) ?: return
+    startActivity(CsvImporter.getIntent(this, path))
+}
+
+fun DeckPicker.showImportDialog() {
+    if (ScopedStorageService.userMigrationIsInProgress(this)) {
+        showSnackbar(
+            R.string.functionality_disabled_during_storage_migration,
+            Snackbar.LENGTH_SHORT
+        )
+        return
+    }
+    showDialogFragment(ImportFileSelectionFragment.createInstance(this))
+}
+
+/* Legacy Backend */
+
+fun DeckPicker.importReplaceListener(): TaskListenerWithContext<DeckPicker, String, Computation<*>?> {
+    return ImportReplaceListener(this)
+}
+
+private class ImportReplaceListener(deckPicker: DeckPicker) : TaskListenerWithContext<DeckPicker, String, Computation<*>?>(deckPicker) {
+    override fun actualOnPostExecute(context: DeckPicker, result: Computation<*>?) {
+        Timber.i("Import: Replace Task Completed")
+        if (context.mProgressDialog != null && context.mProgressDialog!!.isShowing) {
+            context.mProgressDialog!!.dismiss()
+        }
+        val res = context.resources
+        if (result!!.succeeded()) {
+            context.updateDeckList()
+        } else {
+            context.showSimpleMessageDialog(res.getString(R.string.import_log_no_apkg), reload = true)
+        }
+    }
+
+    override fun actualOnPreExecute(context: DeckPicker) {
+        if (context.mProgressDialog == null || !context.mProgressDialog!!.isShowing) {
+            context.mProgressDialog = StyledProgressDialog.show(
+                context,
+                context.resources.getString(R.string.import_title),
+                context.resources.getString(R.string.import_replacing),
+                false
+            )
+        }
+    }
+
+    /**
+     * @param value A message
+     */
+    override fun actualOnProgressUpdate(context: DeckPicker, value: String) {
+        @Suppress("Deprecation")
+        context.mProgressDialog!!.setMessage(value)
+    }
+}
+
+fun DeckPicker.importAddListener(): TaskListenerWithContext<DeckPicker, String, ImporterData?> =
+    ImportAddListener(this)
+
+private class ImportAddListener(deckPicker: DeckPicker) : TaskListenerWithContext<DeckPicker, String, ImporterData?>(deckPicker) {
+    override fun actualOnPostExecute(context: DeckPicker, result: ImporterData?) {
+        if (context.mProgressDialog != null && context.mProgressDialog!!.isShowing) {
+            context.mProgressDialog!!.dismiss()
+        }
+        // If result.errFlag and result are both set, we are signalling
+        // some files were imported successfully & some errors occurred.
+        // If result.impList is null & result.errList is set
+        // we are signalling all the files which were selected threw error
+        if (result!!.impList == null && result.errList != null) {
+            Timber.w("Import: Add Failed: %s", result.errList)
+            context.showSimpleMessageDialog(result.errList)
+        } else {
+            Timber.i("Import: Add succeeded")
+
+            var fileCount = 0
+            var totalCardCount = 0
+
+            var errorMsg = ""
+
+            for (data in result.impList!!) {
+                // Check if mLog is not null or empty
+                // If mLog is not null or empty that indicates an error has occurred.
+                if (data.log.isEmpty()) {
+                    fileCount += 1
+                    totalCardCount += data.cardCount
+                } else { errorMsg += data.fileName + "\n" + data.log[0] + "\n" }
+            }
+
+            var dialogMsg = context.resources.getQuantityString(R.plurals.import_complete_message, fileCount, fileCount, totalCardCount)
+            if (result.errList != null) {
+                errorMsg += result.errList
+            }
+            if (errorMsg.isNotEmpty()) {
+                dialogMsg += "\n\n" + context.resources.getString(R.string.import_stats_error, errorMsg)
+            }
+
+            context.showSimpleMessageDialog(dialogMsg)
+            context.updateDeckList()
+        }
+    }
+
+    override fun actualOnPreExecute(context: DeckPicker) {
+        if (context.mProgressDialog == null || !context.mProgressDialog!!.isShowing) {
+            context.mProgressDialog = StyledProgressDialog.show(
+                context,
+                context.resources.getString(R.string.import_title),
+                null,
+                false
+            )
+        }
+    }
+
+    override fun actualOnProgressUpdate(context: DeckPicker, value: String) {
+        @Suppress("Deprecation")
+        context.mProgressDialog!!.setMessage(value)
+    }
+}
+
+/**
+ * @param impList: List of packages to import
+ * @param errList: a string describing the errors. Null if no error.
+ */
+data class ImporterData(val impList: List<AnkiPackageImporter>?, val errList: String?)


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
For the final 'functional' PR of scoped storage, we allow a colpkg 'import' from the Deck Picker to allow restoring from a backup.

This refactoring helps get this over the finish line

## Approach
* Extract & generify methods
* Add `ImportOptions` class to allow limiting the dialog options (we can hide: [apkg, colpkg, csv] from the import selection dialog)

## How Has This Been Tested?
Tested in #13396

## Learning
I'm pretty backlogged with PRs, prioritising this one will help keep velocity, but there will be multiple PRs with different implementations of this for now.


## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
