### PR TITLE
test: mark flaky test

### DIFF
--- a/AnkiDroid/src/test/java/com/ichi2/anki/ReviewerNoParamTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/ReviewerNoParamTest.kt
@@ -165,7 +165,7 @@ class ReviewerNoParamTest : RobolectricTest() {
     }
 
     @Test
-    @Flaky(OS.LINUX, "hasDrawerSwipeConflicts was false")
+    @Flaky(OS.ALL, "hasDrawerSwipeConflicts was false")
     @RunInBackground
     fun defaultDrawerConflictIsTrueIfGesturesEnabled() {
         enableGestureSetting()


### PR DESCRIPTION
defaultDrawerConflictIsTrueIfGesturesEnabled

flaked on macOS

```
ReviewerNoParamTest > defaultDrawerConflictIsTrueIfGesturesEnabled FAILED
    java.lang.AssertionError:
    Expected: <true>
         but: was <false>
        at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:20)
        at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:6)
        at com.ichi2.anki.ReviewerNoParamTest.defaultDrawerConflictIsTrueIfGesturesEnabled(ReviewerNoParamTest.kt:175)
```

https://github.com/ankidroid/Anki-Android/actions/runs/4349857503/jobs/7599985781