### PR TITLE
Set kotlin related task in lint-rules module to use JVM 11

### DIFF
--- a/lint-rules/build.gradle
+++ b/lint-rules/build.gradle
@@ -5,8 +5,15 @@ repositories {
     mavenCentral()
 }
 
-kotlin {
-    jvmToolchain(11)
+tasks.withType(JavaCompile).configureEach {
+    sourceCompatibility = JavaVersion.VERSION_11
+    targetCompatibility = JavaVersion.VERSION_11
+}
+
+tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
+    kotlinOptions {
+        jvmTarget = JavaVersion.VERSION_11 // starting with AGP 7.4.0 we need to target JVM 11 bytecode
+    }
 }
 
 dependencies {


### PR DESCRIPTION
## Purpose / Description

If the developer doesn't have JDK 11 set on the computer the compilation in lint-rules will fail with the mentioned no toolchain found error. It should download missing toolchains but I think in newer versions of Gradle we have to setup this manually(I haven't tested it however). This PR should fix this by manually setting the compatibility to JVM 11. Later, when issues related to jvmToolchain are fixed, we can look again into using this property.

Note that, for running gradle tasks from the terminal, I had to configure the JavaCompile as well because it would fail with an error related to compileJava and compileKotlin tasks using different jvm targets(for example JDK 17 being installed(and compileJava using it) and the kotlin compile task was configured against 11).


## Fixes
Fixes #13414 
Fixes #13340 

## How Has This Been Tested?

I tested it on my computer with a fresh installation of just JDK 17 and Android Studio. This replicated the issue and the fix solved it.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
