### PR TITLE
use endpoint for custom sync server

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sync/BackendSync.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sync/BackendSync.kt
@@ -22,10 +22,14 @@ import anki.sync.SyncStatusResponse
 import anki.sync.syncLoginRequest
 import com.ichi2.libanki.CollectionV16
 
-fun CollectionV16.syncLogin(username: String, password: String): SyncAuth {
+fun CollectionV16.syncLogin(username: String, password: String, endpoint: String?): SyncAuth {
     val req = syncLoginRequest {
         this.username = username
         this.password = password
+        // default endpoint used here, if it is null
+        if (endpoint != null) {
+            this.endpoint = endpoint
+        }
     }
     return backend.syncLogin(req)
 }


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
_Describe the problem or feature and motivation_

## Fixes
Fixes #13420 

## Approach
During login, only username and password passed, but it needs to pass endpoint also.

## How Has This Been Tested?

1. Run syncserver using Anki desktop
```
Anki> $env:SYNC_USER2="user: pass"
Anki> .\anki-console.bat --syncserver
```
2. Connect both Ank Desktop and AnkiDroid to same network in sync prefs
3. Login using `user: pass` on AnkiDroid
4. Then sync
5. The files are synchronised with desktop
6. Logout, turn of custom sync and Login to ankiweb.net
7. Then sync
8. The files are synchronised with web

## Learning (optional, can help others)


_Links to blog posts, patterns, libraries or addons used to solve this problem_

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
