### PR TITLE
Add automatic reminder to migrate storage (if migration is available)

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/BackupPromptDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/BackupPromptDialog.kt
@@ -140,10 +140,11 @@ class BackupPromptDialog private constructor(private val windowContext: Context)
     companion object {
         private const val ONE_DAY_IN_MS = 1000 * 60 * 60 * 24
 
-        suspend fun showIfAvailable(deckPicker: DeckPicker) {
+        /** @return Whether the dialog was shown */
+        suspend fun showIfAvailable(deckPicker: DeckPicker): Boolean {
             val backupPrompt = BackupPromptDialog(deckPicker)
             if (!backupPrompt.shouldShowDialog()) {
-                return
+                return false
             }
 
             val isLoggedIn = isLoggedIn()
@@ -157,6 +158,7 @@ class BackupPromptDialog private constructor(private val windowContext: Context)
                 }
                 materialDialog.show()
             }
+            return true
         }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/utils/AlertDialogFacade.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/AlertDialogFacade.kt
@@ -20,9 +20,12 @@ package com.ichi2.utils
 
 import android.content.DialogInterface
 import android.content.DialogInterface.OnClickListener
+import android.view.View
+import android.widget.CheckBox
 import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
 import androidx.appcompat.app.AlertDialog
+import com.ichi2.anki.R
 import com.ichi2.themes.Themes
 
 /** Wraps [DialogInterface.OnClickListener] as we don't need the `which` parameter */
@@ -123,4 +126,34 @@ fun AlertDialog.Builder.cancelable(cancelable: Boolean): AlertDialog.Builder {
 inline fun AlertDialog.Builder.show(block: AlertDialog.Builder.() -> Unit): AlertDialog.Builder = apply {
     this.block()
     this.show()
+}
+
+/**
+ * Adds a checkbox to the dialog, whilst continuing to display the value of [message]
+ * @param stringRes The string resource to display for the checkbox label.
+ * @param text The literal string to display for the checkbox label.
+ * @param isCheckedDefault Whether or not the checkbox is initially checked.
+ * @param onToggle A listener invoked when the checkbox is checked or unchecked.
+ */
+fun AlertDialog.Builder.checkBoxPrompt(
+    @StringRes stringRes: Int? = null,
+    text: CharSequence? = null,
+    isCheckedDefault: Boolean = false,
+    onToggle: (checked: Boolean) -> Unit
+): AlertDialog.Builder {
+    if (stringRes == null && text == null) {
+        throw IllegalArgumentException("either `stringRes` or `text` must be set")
+    }
+    val checkBoxView = View.inflate(this.context, R.layout.alert_dialog_checkbox, null)
+    val checkBox = checkBoxView.findViewById<CheckBox>(R.id.checkbox)
+
+    val checkBoxLabel = if (stringRes != null) context.getString(stringRes) else text
+    checkBox.text = checkBoxLabel
+    checkBox.isChecked = isCheckedDefault
+
+    checkBox.setOnCheckedChangeListener { _, isChecked ->
+        onToggle(isChecked)
+    }
+
+    return this.setView(checkBoxView)
 }

--- a/AnkiDroid/src/main/java/com/ichi2/utils/AlertDialogFacade.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/AlertDialogFacade.kt
@@ -38,7 +38,7 @@ fun DialogInterfaceListener.toClickListener(): OnClickListener {
  */
 fun AlertDialog.Builder.title(@StringRes stringRes: Int? = null, text: String? = null): AlertDialog.Builder {
     if (stringRes == null && text == null) {
-        throw IllegalArgumentException("either `stringRes` or `title` must be set")
+        throw IllegalArgumentException("either `stringRes` or `text` must be set")
     }
     return if (stringRes != null) {
         setTitle(stringRes)
@@ -49,7 +49,7 @@ fun AlertDialog.Builder.title(@StringRes stringRes: Int? = null, text: String? =
 
 fun AlertDialog.Builder.message(@StringRes stringRes: Int? = null, text: CharSequence? = null): AlertDialog.Builder {
     if (stringRes == null && text == null) {
-        throw IllegalArgumentException("either `stringRes` or `title` must be set")
+        throw IllegalArgumentException("either `stringRes` or `text` must be set")
     }
     return if (stringRes != null) {
         setMessage(stringRes)
@@ -73,7 +73,7 @@ fun AlertDialog.Builder.positiveButton(
     click: DialogInterfaceListener? = null
 ): AlertDialog.Builder {
     if (stringRes == null && text == null) {
-        throw IllegalArgumentException("either `stringRes` or `title` must be set")
+        throw IllegalArgumentException("either `stringRes` or `text` must be set")
     }
     return if (stringRes != null) {
         this.setPositiveButton(stringRes, click?.toClickListener())
@@ -88,7 +88,7 @@ fun AlertDialog.Builder.neutralButton(
     click: DialogInterfaceListener? = null
 ): AlertDialog.Builder {
     if (stringRes == null && text == null) {
-        throw IllegalArgumentException("either `stringRes` or `title` must be set")
+        throw IllegalArgumentException("either `stringRes` or `text` must be set")
     }
     return if (stringRes != null) {
         this.setNeutralButton(stringRes, click?.toClickListener())
@@ -103,7 +103,7 @@ fun AlertDialog.Builder.negativeButton(
     click: DialogInterfaceListener? = null
 ): AlertDialog.Builder {
     if (stringRes == null && text == null) {
-        throw IllegalArgumentException("either `stringRes` or `title` must be set")
+        throw IllegalArgumentException("either `stringRes` or `text` must be set")
     }
     return if (stringRes != null) {
         this.setNegativeButton(stringRes, click?.toClickListener())

--- a/AnkiDroid/src/main/res/layout/alert_dialog_checkbox.xml
+++ b/AnkiDroid/src/main/res/layout/alert_dialog_checkbox.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~  Copyright (c) 2023 David Allison <davidallisongithub@gmail.com>
+  ~
+  ~  This program is free software; you can redistribute it and/or modify it under
+  ~  the terms of the GNU General Public License as published by the Free Software
+  ~  Foundation; either version 3 of the License, or (at your option) any later
+  ~  version.
+  ~
+  ~  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+  ~  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+  ~  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+  ~
+  ~  You should have received a copy of the GNU General Public License along with
+  ~  this program.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+
+<!-- source: https://stackoverflow.com/a/9763836/ -->
+
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content" >
+
+    <CheckBox
+        android:id="@+id/checkbox"
+        style="?android:checkboxStyle"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        android:layout_marginHorizontal="18dp" />
+
+</FrameLayout>


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
If a user doesn't migrate:
* Storage is slow
* They permanently lose access to their collection on uninstall

If the user does migrate:
* Storage is fast
* Data is deleted on uninstall (unless a user opts out)

We have a subset of users who are safe to migrate (syncing)
and want them to migrate ASAP so they get the speed benefits
while syncing

Display the dialog from `showDialogThatOffersToMigrateStorage`

Add a 'do not show again' checkbox if the user dismisses the dialog twice

## Fixes
Related: #5304

## Approach
Same usage as with `BackupPromptDialog`: bcb9d69bdde1d4b4682855f53a82c81d0e9ac975
* Two improvements to `AlertDialogFacade`, these can be extracted if this review is likely to take long

## Review Goals

* this will appear the second time an upgraded, syncing user views the DeckPicker. Is this too soon?

## How Has This Been Tested?
API 29 emulator, with one manual fixup to ensure the correct dialog message is shown (due to running before #13261 is in)

![Screenshot 2023-03-08 at 23 33 33](https://user-images.githubusercontent.com/62114487/223879000-cc6d1469-3cd1-48b7-9535-3b04620eedc4.png)
![Screenshot 2023-03-08 at 23 41 53](https://user-images.githubusercontent.com/62114487/223879002-b4e3ce23-78d0-40af-aace-6d0828d832ee.png)


## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
