### PR TITLE
fixed NPE for csum by fixing the check

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Media.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Media.kt
@@ -777,7 +777,7 @@ create table meta (dirMod int, lastUsn int); insert into meta values (0, 0);"""
                         val csum = cur.getString(1)
                         fnames.add(fname)
                         val normName = Utils.nfcNormalized(fname)
-                        if (csum.isNotEmpty()) {
+                        if (!csum.isNullOrEmpty()) {
                             try {
                                 col.log("+media zip $fname")
                                 val file = File(dir(), fname)


### PR DESCRIPTION
## Pull Request template
The Logcat for the issue 
```
 java.io.FileNotFoundException: /storage/emulated/0/Android/data/com.ichi2.anki.debug/files/AnkiDroid42/collection.media/sound drone.ogg: open failed: ENOENT (No such file or directory)
                                                                                                    	at libcore.io.IoBridge.open(IoBridge.java:574)
                                                                                                    	at java.io.FileInputStream.<init>(FileInputStream.java:160)
                                                                                                    	at com.ichi2.libanki.Media.mediaChangesZip(Media.kt:784)
                                                                                                    	at com.ichi2.libanki.sync.MediaSyncer.sync(MediaSyncer.kt:172)
                                                                                                    	at com.ichi2.async.Connection.doInBackgroundSync(Connection.kt:379)
                                                                                                    	at com.ichi2.async.Connection.doOneInBackground(Connection.kt:127)
                                                                                                    	at com.ichi2.async.Connection.doInBackground(Connection.kt:121)
                                                                                                    	at com.ichi2.async.Connection.doInBackground(Connection.kt:51)
                                                                                                    
```

## Purpose / Description
csum null error due to improper check introduced in [here](https://github.com/ankidroid/Anki-Android/pull/13039)

## Fixes
Fixes #13429

## How Has This Been Tested?
Tested on OnePlus Nord CE


## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
