### PR TITLE
wrapped the gestures content in scroll view

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/preferences/ControlPreference.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/preferences/ControlPreference.kt
@@ -19,6 +19,7 @@ package com.ichi2.preferences
 import android.annotation.SuppressLint
 import android.content.Context
 import android.util.AttributeSet
+import android.widget.ScrollView
 import androidx.appcompat.app.AlertDialog
 import androidx.preference.ListPreference
 import com.afollestad.materialdialogs.MaterialDialog
@@ -114,7 +115,11 @@ class ControlPreference : ListPreference {
                         }
                     }
                     negativeButton(R.string.dialog_cancel) { dismiss() }
-                    customView(view = gesturePicker)
+                    customView(
+                        view = ScrollView(context).apply {
+                            addView(gesturePicker)
+                        }
+                    )
 
                     gesturePicker.onGestureChanged { gesture ->
                         showToastIfBindingIsUsed(fromGesture(gesture))


### PR DESCRIPTION


## Pull Request template

## Purpose / Description
Wrapped the material dialog content for the gestures setting in scroll view to allow full access of the content

## Fixes
Fixes #13432


## How Has This Been Tested?
tested on one plus nord ce
![WhatsApp Image 2023-03-14 at 03 38 38](https://user-images.githubusercontent.com/48384865/224844697-8b7318ca-05b5-457c-9393-3d891bfbfa11.jpg)

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
