### PR TITLE
Fix newly created deck not showing when changing card's deck in CardBrowser

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -1746,7 +1746,7 @@ open class CardBrowser :
     /** Returns the decks which are valid targets for "Change Deck"  */
     @get:VisibleForTesting
     val validDecksForChangeDeck: List<Deck>
-        get() = deckSpinnerSelection!!.dropDownDecks
+        get() = deckSpinnerSelection!!.computeDropDownDecks()
             .filterNot { d -> Decks.isDynamic(d) }
 
     @RustCleanup("this isn't how Desktop Anki does it")

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckSpinnerSelection.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckSpinnerSelection.kt
@@ -132,7 +132,7 @@ class DeckSpinnerSelection(
     /**
      * @return All decks, except maybe default if it should be hidden.
      */
-    private fun computeDropDownDecks(): List<Deck> {
+    fun computeDropDownDecks(): List<Deck> {
         val sortedDecks = collection.decks.allSorted().toMutableList()
         if (shouldHideDefaultDeck()) {
             sortedDecks.removeIf { x: Deck -> x.getLong("id") == Consts.DEFAULT_DECK_ID }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.kt
@@ -243,6 +243,17 @@ class CardBrowserTest : RobolectricTest() {
         }
     }
 
+    @Test // see #13391
+    fun newlyCreatedDeckIsShownAsOptionInBrowser() = runTest {
+        val deckOneId = addDeck("one")
+        val browser = browserWithNoNewCards
+        assertEquals(1, browser.validDecksForChangeDeck.size)
+        assertEquals(deckOneId, browser.validDecksForChangeDeck.first().id)
+        val deckTwoId = addDeck("two")
+        assertEquals(2, browser.validDecksForChangeDeck.size)
+        assertArrayEquals(longArrayOf(deckOneId, deckTwoId), browser.validDecksForChangeDeck.map { it.id }.toLongArray())
+    }
+
     @Test
     fun flagsAreShownInBigDecksTest() = runTest {
         val numberOfNotes = 75


### PR DESCRIPTION
## Pull Request template

The CardBrowser based its list of decks used for changing a card's deck on the DeckSpinnerSelection.dropDownDecks property. That property isn't updated unless the deck selection dialog is used(or the activity recreated) so CardBrowser wasn't seeing immediately the changes to the available decks. The fix connects CardBrowser to the method that DeckSpinnerSelection actually uses to update its list of decks.

## Fixes
Fixes #13391 

## How Has This Been Tested?

Ran the tests and also manually verified the expected behavior.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
