### PR TITLE
Show keyboard in onResume state of Reviewer.kt

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
@@ -26,11 +26,7 @@ import android.content.Intent
 import android.content.SharedPreferences
 import android.content.pm.PackageManager
 import android.content.res.ColorStateList
-import android.os.Build
-import android.os.Bundle
-import android.os.Handler
-import android.os.Message
-import android.os.Parcelable
+import android.os.*
 import android.text.SpannableString
 import android.text.style.UnderlineSpan
 import android.view.*
@@ -189,6 +185,7 @@ open class Reviewer :
     override fun onResume() {
         answerTimer.resume()
         super.onResume()
+        answerField!!.focusWithKeyboard()
     }
 
     @NeedsTest("is hidden if flag is on app bar")

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
@@ -185,7 +185,9 @@ open class Reviewer :
     override fun onResume() {
         answerTimer.resume()
         super.onResume()
-        answerField!!.focusWithKeyboard()
+        if (answerField != null) {
+            answerField!!.focusWithKeyboard()
+        }
     }
 
     @NeedsTest("is hidden if flag is on app bar")

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
@@ -26,7 +26,11 @@ import android.content.Intent
 import android.content.SharedPreferences
 import android.content.pm.PackageManager
 import android.content.res.ColorStateList
-import android.os.*
+import android.os.Build
+import android.os.Bundle
+import android.os.Handler
+import android.os.Message
+import android.os.Parcelable
 import android.text.SpannableString
 import android.text.style.UnderlineSpan
 import android.view.*


### PR DESCRIPTION
## Pull Request template

## Purpose / Description

## Fixes
Fixes #13450

## Approach

This can be achieved by adding answerField!!.focusWithKeyboard() in onResume()

## How Has This Been Tested?

Tested on Emulator

https://user-images.githubusercontent.com/65113071/226091366-19107112-12fa-419c-9760-8833937aba62.mp4


## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
