### PR TITLE
Fix AnswerTimer.resetTimerUI() not seting color correctly

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/AnswerTimer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/AnswerTimer.kt
@@ -18,12 +18,12 @@ package com.ichi2.anki.reviewer
 
 import android.content.Context
 import android.os.SystemClock
-import android.util.TypedValue
 import android.view.View
 import android.widget.Chronometer
 import androidx.annotation.VisibleForTesting
 import com.ichi2.anki.R
 import com.ichi2.libanki.Card
+import com.ichi2.themes.Themes.getColorFromAttr
 
 /**
  * Responsible for pause/resume of the card timer and the UI element displaying the amount of time to answer a card
@@ -74,21 +74,18 @@ class AnswerTimer(private val cardTimer: Chronometer) {
     }
 
     private fun resetTimerUI(newCard: Card) {
-        val typedValue = TypedValue()
         // Set normal timer color
-        getTheme().resolveAttribute(android.R.attr.textColor, typedValue, true)
-        cardTimer.setTextColor(typedValue.data)
+        cardTimer.setTextColor(getColorFromAttr(context, android.R.attr.textColor))
 
         cardTimer.base = elapsedRealTime
         cardTimer.start()
 
         // Stop and highlight the timer if it reaches the time limit.
-        getTheme().resolveAttribute(R.attr.maxTimerColor, typedValue, true)
         limit = newCard.timeLimit()
         cardTimer.setOnChronometerTickListener { chronometer: Chronometer ->
             val elapsed: Long = elapsedRealTime - chronometer.base
             if (elapsed >= limit) {
-                chronometer.setTextColor(typedValue.data)
+                chronometer.setTextColor(getColorFromAttr(context, R.attr.maxTimerColor))
                 chronometer.stop()
             }
         }


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
This fixes AnswerTimer not showing during reviews regardless of deck options.

## Fixes
Fixes #13456

## Approach
Since #13029 `android:textColor` is a `selector`. The code in `AnswerTimer.resetTimerUI()` was not ready for that, and it resulted in the AnswerTimer being invisible regardless of settings. This PR sets the color correctly and updates adjacent code for consistency.

## How Has This Been Tested?
Trivially, by reviewing any deck.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
