### PR TITLE
Increase snackbar maximum lines

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/snackbar/Snackbars.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/snackbar/Snackbars.kt
@@ -179,7 +179,7 @@ fun View.showSnackbar(
     snackbarBuilder: SnackbarBuilder? = null
 ) {
     val snackbar = Snackbar.make(this, text, duration)
-    snackbar.setMaxLines(2)
+    snackbar.setMaxLines(4)
     snackbar.behavior = SwipeDismissBehaviorFix()
 
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
Text overflow in some snackbars.

 For example,

- English
 `You may resume using AnkiDroid.`
  `Storage migration will continue in the background.`
  <img src="https://user-images.githubusercontent.com/10436072/226562930-8ea5c5e4-4b92-42a5-87ea-099b74222ede.png" width="320px">
- German
  `Du kannst jetzt AnkiDroid weiterverwenden.`
  `Die Speichermigration wird im Hintergrund fortfahren.`
  <img src="https://user-images.githubusercontent.com/10436072/226562406-2b2f6003-8ec0-4381-afff-a4928cac9be4.png" width="320px">

## Fixes
Fixes #13468

## Approach

- Increase the maximum lines of snackbar from 2 to 4 on Snackbars.kt (not just on the above example's snackbar part on Deckpicker.kt, considering other unfound or future cases)

## How Has This Been Tested?
Checked on a physical device (Android 11)
- English
  <img src="https://user-images.githubusercontent.com/10436072/226567753-b11d8cee-40a6-46a3-9b13-ca79619bf467.png" width="320px">

- German
  <img src="https://user-images.githubusercontent.com/10436072/226568174-058ad678-06a8-473b-96d6-e00a711b2a67.png" width="320px">

## Note

- German in 3 lines
  <img src="https://user-images.githubusercontent.com/10436072/226580228-23c4183e-2ac8-479b-9892-89d688068494.png" width="320px">


## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
