### PR TITLE
recreate DeckPicker activity on Deleting collection from app settings

### DIFF
--- a/AnkiDroid/src/main/res/values/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values/10-preferences.xml
@@ -435,7 +435,12 @@ this formatter is used if the bind only applies to both the question and the ans
     <string name="dialog__delete_collection__title" comment="Confirmation dialog title"
         >Delete collection</string>
     <string name="dialog__delete_collection__message"
-        >Are you sure you want to delete your collection, media, and backups?</string>
+        comment="“Close the window” here refers to the activity that the user is currently seeing.
+       When the collection is deleted, we exit the process, which closes the activity without animation.
+        On some devices the entire settings app may be closed.
+        User might not realize that this activity comes directly from AnkiDroid,
+        so it might be wise to avoid words such as “AnkiDroid or “app”."
+        >Are you sure you want to delete your collection, media, and backups?\n\nNote: this action will close the window.</string>
     <string name="progress__deleting_collection"
         >Deleting collection…</string>
 


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
Used shared pref to recreate the deck picker activity as soon as the collections are cleared using app settings
This Activity actually needed a recreation on clearing the collection as if not it was frozen until we visit the other activity and come back to it. Refresh or InvalidateOptionMenu would not work here 

## Fixes
Fixes #13477

## Approach
Used Shared Prefs

## How Has This Been Tested?
Tested on Oneplus Nord CE

_Links to blog posts, patterns, libraries or addons used to solve this problem_

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
