### PR TITLE
Fix startActivityForResult deprecation on NavigationDrawerActivity

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidJsAPI.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidJsAPI.kt
@@ -388,7 +388,7 @@ open class AnkiDroidJsAPI(private val activity: AbstractFlashcardViewer) {
         val currentCardId: CardId = currentCard.id
         intent.putExtra("currentCard", currentCardId)
         intent.putExtra("search_query", query)
-        activity.startActivityForResultWithAnimation(intent, NavigationDrawerActivity.REQUEST_BROWSE_CARDS, ActivityTransitionAnimation.Direction.START)
+        activity.startActivityWithAnimation(intent, ActivityTransitionAnimation.Direction.START)
     }
 
     @JavascriptInterface

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NavigationDrawerActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NavigationDrawerActivity.kt
@@ -329,7 +329,7 @@ abstract class NavigationDrawerActivity :
         if (currentCardId != null) {
             intent.putExtra("currentCard", currentCardId)
         }
-        startActivityForResultWithAnimation(intent, REQUEST_BROWSE_CARDS, START)
+        startActivityWithAnimation(intent, START)
     }
 
     // Override this to specify a specific card id
@@ -401,7 +401,6 @@ abstract class NavigationDrawerActivity :
     companion object {
         // Intent request codes
         const val REQUEST_PREFERENCES_UPDATE = 100
-        const val REQUEST_BROWSE_CARDS = 101
         const val FULL_SCREEN_NAVIGATION_DRAWER = "gestureFullScreenNavigationDrawer"
 
         const val EXTRA_STARTED_WITH_SHORTCUT = "com.ichi2.anki.StartedWithShortcut"

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NavigationDrawerActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NavigationDrawerActivity.kt
@@ -295,7 +295,7 @@ abstract class NavigationDrawerActivity :
                     } else {
                         com.ichi2.anki.pages.Statistics.getIntent(this)
                     }
-                    startActivityForResultWithAnimation(intent, REQUEST_STATISTICS, START)
+                    startActivityWithAnimation(intent, START)
                 }
                 R.id.nav_settings -> {
                     Timber.i("Navigating to settings")
@@ -402,7 +402,6 @@ abstract class NavigationDrawerActivity :
         // Intent request codes
         const val REQUEST_PREFERENCES_UPDATE = 100
         const val REQUEST_BROWSE_CARDS = 101
-        const val REQUEST_STATISTICS = 102
         const val FULL_SCREEN_NAVIGATION_DRAWER = "gestureFullScreenNavigationDrawer"
 
         const val EXTRA_STARTED_WITH_SHORTCUT = "com.ichi2.anki.StartedWithShortcut"

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckPickerContextMenu.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckPickerContextMenu.kt
@@ -151,7 +151,7 @@ class DeckPickerContextMenu(private val collection: Collection) : AnalyticsDialo
             DeckPickerContextMenuOption.BROWSE_CARDS -> {
                 collection.decks.select(deckId)
                 val intent = Intent(activity, CardBrowser::class.java)
-                (activity as DeckPicker).startActivityForResultWithAnimation(intent, NavigationDrawerActivity.REQUEST_BROWSE_CARDS, ActivityTransitionAnimation.Direction.START)
+                (activity as DeckPicker).startActivityWithAnimation(intent, ActivityTransitionAnimation.Direction.START)
             }
             DeckPickerContextMenuOption.ADD_CARD -> {
                 Timber.i("Add selected")


### PR DESCRIPTION
## Fixes
Related #8602

## Approach
change the calls to startActivity because the results were never used

## How Has This Been Tested?

I didn't think is was necessary

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
