### PR TITLE
Correct Snackbar when changing deck

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -59,10 +59,7 @@ import com.ichi2.anki.export.ExportType
 import com.ichi2.anki.receiver.SdCardReceiver
 import com.ichi2.anki.servicelayer.CardService.selectedNoteIds
 import com.ichi2.anki.servicelayer.NoteService.isMarked
-import com.ichi2.anki.servicelayer.SchedulerService.NextCard
-import com.ichi2.anki.servicelayer.SchedulerService.RepositionCards
-import com.ichi2.anki.servicelayer.SchedulerService.RescheduleCards
-import com.ichi2.anki.servicelayer.SchedulerService.ResetCards
+import com.ichi2.anki.servicelayer.SchedulerService.*
 import com.ichi2.anki.servicelayer.Undo
 import com.ichi2.anki.servicelayer.avgIntervalOfNote
 import com.ichi2.anki.servicelayer.totalLapsesOfNote
@@ -90,12 +87,8 @@ import net.ankiweb.rsdroid.BackendFactory
 import net.ankiweb.rsdroid.RustCleanup
 import org.json.JSONObject
 import timber.log.Timber
-import java.lang.Exception
-import java.lang.IllegalStateException
-import java.lang.StringBuilder
 import java.util.*
 import java.util.function.Consumer
-import kotlin.collections.ArrayList
 import kotlin.math.abs
 import kotlin.math.ceil
 import kotlin.math.max
@@ -447,6 +440,9 @@ open class CardBrowser :
     // TODO: This function can be simplified a lot
     @VisibleForTesting
     fun moveSelectedCardsToDeck(did: DeckId) {
+        mSearchTerms = ""
+        mSearchView!!.setQuery("", false)
+        mSearchView!!.clearFocus()
         val selectedDeck = col.decks.get(did)
         // TODO: Currently try-catch is at every level which isn't required, simplify that
         try {


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
`no of cards shown` snackbar is showing instead of `move to deck` snackbar

## Fixes
Fixes #12880 

## Approach
set search query to null

## How Has This Been Tested?
Tested on Emulator
[move.webm](https://user-images.githubusercontent.com/65113071/227429117-076f6912-107a-4170-b75a-6f9e46da2377.webm)


## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
