### PR TITLE
fix: Disable search preview when there are no cards

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -1026,6 +1026,7 @@ open class CardBrowser :
 
     private fun updatePreviewMenuItem() {
         mPreviewItem?.isVisible = cardCount > 0
+        mSearchItem?.isVisible = cardCount != 0
     }
 
     /** Returns the number of cards that are visible on the screen  */


### PR DESCRIPTION
## Purpose / Description
Disable search preview when there are no cards .

## Fixes
Fixes #13489 

## Approach
Modify visibility of `mSearchItem`

## How Has This Been Tested?



https://user-images.githubusercontent.com/76740999/227446522-97c5214e-6f7e-44a9-9cd9-22d6543ce38a.mp4



_Links to blog posts, patterns, libraries or addons used to solve this problem_

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
