### PR TITLE
changed cursor color so that it is easy to edit text in search bar

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -93,7 +93,6 @@ import net.ankiweb.rsdroid.BackendFactory
 import net.ankiweb.rsdroid.RustCleanup
 import org.json.JSONObject
 import timber.log.Timber
-import java.lang.Exception
 import java.lang.IllegalStateException
 import java.lang.StringBuilder
 import java.util.*
@@ -943,16 +942,23 @@ open class CardBrowser :
                 }
             })
             mSearchView = mSearchItem!!.actionView as CardBrowserSearchView
-            mSearchView!!.findViewById<EditText>(androidx.appcompat.R.id.search_src_text)?.let {
-                // Simplify the code once we have min SDK > 29
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-                    it.textCursorDrawable = AppCompatResources.getDrawable(applicationContext, R.drawable.cursor)
-                } else {
-                    val field = TextView::class.java.getDeclaredField("mCursorDrawableRes")
-                    field.isAccessible = true
-                    field.set(it, R.drawable.cursor)
+
+            try {
+                mSearchView!!.findViewById<EditText>(androidx.appcompat.R.id.search_src_text)?.let {
+                    // Simplify the code once we have min SDK > 29
+                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                        it.textCursorDrawable =
+                            AppCompatResources.getDrawable(applicationContext, R.drawable.cursor)
+                    } else {
+                        val field = TextView::class.java.getDeclaredField("mCursorDrawableRes")
+                        field.isAccessible = true
+                        field.set(it, R.drawable.cursor)
+                    }
                 }
+            } catch (e: Exception) {
+                Timber.e("SearchBar custom view error : $e")
             }
+
             mSearchView!!.setOnQueryTextListener(object : SearchView.OnQueryTextListener {
                 override fun onQueryTextChange(newText: String): Boolean {
                     if (mSearchView!!.shouldIgnoreValueChange()) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -18,8 +18,10 @@
 
 package com.ichi2.anki
 
+import android.annotation.SuppressLint
 import android.content.*
 import android.graphics.Typeface
+import android.os.Build
 import android.os.Bundle
 import android.os.SystemClock
 import android.text.TextUtils
@@ -31,6 +33,7 @@ import androidx.activity.result.ActivityResult
 import androidx.activity.result.contract.ActivityResultContracts.StartActivityForResult
 import androidx.annotation.CheckResult
 import androidx.annotation.VisibleForTesting
+import androidx.appcompat.content.res.AppCompatResources
 import androidx.appcompat.widget.SearchView
 import androidx.core.content.edit
 import anki.collection.OpChanges
@@ -908,6 +911,7 @@ open class CardBrowser :
         selectNavigationItem(R.id.nav_browser)
     }
 
+    @SuppressLint("DiscouragedPrivateApi")
     @KotlinCleanup("Add a few variables to get rid of the !!")
     override fun onCreateOptionsMenu(menu: Menu): Boolean {
         Timber.d("onCreateOptionsMenu()")
@@ -939,6 +943,16 @@ open class CardBrowser :
                 }
             })
             mSearchView = mSearchItem!!.actionView as CardBrowserSearchView
+            mSearchView!!.findViewById<EditText>(androidx.appcompat.R.id.search_src_text)?.let {
+                // Simplify the code once we have min SDK > 29
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                    it.textCursorDrawable = AppCompatResources.getDrawable(applicationContext, R.drawable.cursor)
+                } else {
+                    val field = TextView::class.java.getDeclaredField("mCursorDrawableRes")
+                    field.isAccessible = true
+                    field.set(it, R.drawable.cursor)
+                }
+            }
             mSearchView!!.setOnQueryTextListener(object : SearchView.OnQueryTextListener {
                 override fun onQueryTextChange(newText: String): Boolean {
                     if (mSearchView!!.shouldIgnoreValueChange()) {

--- a/AnkiDroid/src/main/res/drawable/cursor.xml
+++ b/AnkiDroid/src/main/res/drawable/cursor.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <size android:width="1dp" />
+    <solid android:color="#FFFFFF" /> <!-- Replace #FFFFFF with the white color of your choice -->
+</shape>

--- a/AnkiDroid/src/main/res/drawable/cursor.xml
+++ b/AnkiDroid/src/main/res/drawable/cursor.xml
@@ -2,5 +2,5 @@
 <shape xmlns:android="http://schemas.android.com/apk/res/android"
     android:shape="rectangle">
     <size android:width="1dp" />
-    <solid android:color="#FFFFFF" /> <!-- Replace #FFFFFF with the white color of your choice -->
+    <solid android:color="#FFFFFF" /> 
 </shape>


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
Add color to the cursor in the search bar

## Fixes
Fixes #13502

## Approach
used `textCursorDrawable`  to change the color of the cursor We need to use a different approach for API<29 as it method is not available there I have tested it thoroughly and it works fine  

## How Has This Been Tested?
Tested on OnePlus Nord CE
![Screenshot_19](https://user-images.githubusercontent.com/48384865/227797820-fd62e190-50a8-47e6-985c-5e313794820a.jpg)



_Links to blog posts, patterns, libraries or addons used to solve this problem_

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
