### PR TITLE
NF: rename Folder to Directory

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CollectionHelper.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CollectionHelper.kt
@@ -23,7 +23,7 @@ import android.text.format.Formatter
 import androidx.annotation.CheckResult
 import androidx.annotation.VisibleForTesting
 import androidx.core.content.edit
-import com.ichi2.anki.AnkiDroidFolder.DeleteOnUninstall
+import com.ichi2.anki.AnkiDroidDirectory.DeleteOnUninstall
 import com.ichi2.anki.exception.StorageAccessException
 import com.ichi2.anki.preferences.Preferences
 import com.ichi2.libanki.Collection
@@ -38,8 +38,6 @@ import net.ankiweb.rsdroid.BackendFactory
 import timber.log.Timber
 import java.io.File
 import java.io.IOException
-import java.lang.Exception
-import kotlin.Throws
 
 /**
  * Singleton which opens, stores, and closes the reference to the Collection.
@@ -462,7 +460,7 @@ open class CollectionHelper {
         // TODO Tracked in https://github.com/ankidroid/Anki-Android/issues/5304
         @CheckResult
         fun getDefaultAnkiDroidDirectory(context: Context): String {
-            val legacyStorage = StartupStoragePermissionManager.selectAnkiDroidFolder(context) != DeleteOnUninstall
+            val legacyStorage = StartupStoragePermissionManager.selectAnkiDroidDirectory(context) != DeleteOnUninstall
             return if (!legacyStorage) {
                 File(getAppSpecificExternalAnkiDroidDirectory(context), "AnkiDroid").absolutePath
             } else {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/BackupPromptDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/BackupPromptDialog.kt
@@ -39,7 +39,7 @@ import timber.log.Timber
  * If dismissed, it will not appear for a period of time (~2 weeks): [calculateNextTimeToShowDialog]
  * After 2 dismissals, the user may hide the dialog permanently.
  *
- * This exists to inform the user their data is at risk when in a scoped folder.
+ * This exists to inform the user their data is at risk when in a scoped directory.
  *
  * See [shouldShowDialog] for the criteria to display the dialog
  */
@@ -199,7 +199,7 @@ class BackupPromptDialog private constructor(private val windowContext: Context)
         }
 
         // The user may have upgraded, in which it's unsafe to uninstall as Android
-        // will permanently revoke access to the legacy folder
+        // will permanently revoke access to the legacy directory
         // The collection won't be lost, but it will be inaccessible.
         return userIsPreservingLegacyStorage(this.windowContext)
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/introduction/SetupCollectionFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/introduction/SetupCollectionFragment.kt
@@ -54,7 +54,7 @@ import com.ichi2.anki.introduction.SetupCollectionFragment.CollectionSetupOption
  * This exists for two reasons:
  * 1) Ensuring that a user does not create two profiles: one for Anki Desktop and one for AnkiDroid
  * 2) Adds a screen that allows for 'advanced' setup.
- * for example: selecting a 'safe' folder using scoped storage, which would not have been deleted
+ * for example: selecting a 'safe' directory using scoped storage, which would not have been deleted
  * if the app is uninstalled.
  */
 class SetupCollectionFragment : Fragment() {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/jsaddons/TgzPackageExtract.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/jsaddons/TgzPackageExtract.kt
@@ -124,7 +124,7 @@ class TgzPackageExtract(private val context: Context) {
      * @throws IOException
      */
     @Throws(Exception::class)
-    fun extractTarGzipToAddonFolder(tarballFile: File, addonsPackageDir: AddonsPackageDir) {
+    fun extractTarGzipToAddonDirectory(tarballFile: File, addonsPackageDir: AddonsPackageDir) {
         require(isGzip(tarballFile)) { context.getString(R.string.not_valid_js_addon, tarballFile.absolutePath) }
 
         try {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/model/RelativeFilePath.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/model/RelativeFilePath.kt
@@ -22,8 +22,8 @@ import java.nio.file.Path
 
 /**
  * A relative path, with the final component representing the filename.
- * During a recursive copy of a folder `source` to `destination`, this relative file path `relative`
- * can be used both on top of source and destination folder to get the path of `source/relative`
+ * During a recursive copy of a directory `source` to `destination`, this relative file path `relative`
+ * can be used both on top of source and destination directory to get the path of `source/relative`
  * and `destination/relative`.
  * It can also be used to move `source/relative` to `source/conflict/relative` in case of conflict.
  */
@@ -61,7 +61,7 @@ class RelativeFilePath private constructor(
     companion object {
 
         /**
-         * Return the relative path from Folder [baseDir] to file [file]. If [file]
+         * Return the relative path from Directory [baseDir] to file [file]. If [file]
          * is contained in [baseDir], return `null`.
          * Similar to [Path.relativize], but available in all APIs.
          */
@@ -71,7 +71,7 @@ class RelativeFilePath private constructor(
             fromCanonicalFiles(baseDir.canonicalFile, file.canonicalFile)
 
         /**
-         * Return the relative path from Folder [baseDir] to file [file]. If [file]
+         * Return the relative path from Directory [baseDir] to file [file]. If [file]
          * is contained in [baseDir], return `null`.
          * Assumes that [file] is actually a file and [baseDir] a directory, hence distinct.
          * Similar to [Path.relativize], but available in all APIs.

--- a/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/ScopedStorageService.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/ScopedStorageService.kt
@@ -63,8 +63,8 @@ fun AnkiDroidDirectory.getRelativeFilePath(file: DiskFile): RelativeFilePath? =
  * This storage directory is accessible without permissions after scoped storage changes,
  * and is much faster to access
  *
- * When uninstalling: A user will be asked if they want to delete this folder
- * A folder here may be modifiable via USB. In AnkiDroid's case, all collection folders should
+ * When uninstalling: A user will be asked if they want to delete this directory
+ * A directory here may be modifiable via USB. In AnkiDroid's case, all collection directorys should
  * be modifiable
  *
  * @see [isLegacyStorage]
@@ -116,7 +116,7 @@ object ScopedStorageService {
     const val PREF_MIGRATION_DESTINATION = "migrationDestinationPath"
 
     /**
-     * The maximum allowed number of 'AnkiDroid' folders
+     * The maximum allowed number of 'AnkiDroid' directorys
      *
      * Exists as un unreachable bound through normal activity.
      */
@@ -138,11 +138,11 @@ object ScopedStorageService {
         // of the current collection path
         val bestRootDestination = getBestDefaultRootDirectory(context, File(collectionPath))
 
-        // append a folder name to the root destination.
+        // append a directory name to the root destination.
         // If the root destination was /storage/emulated/0/Android/com.ichi2.anki/files
-        // we add a subfolder name to allow for more than one AnkiDroid data directory to be migrated.
+        // we add a subdirectory name to allow for more than one AnkiDroid data directory to be migrated.
         // This is useful as:
-        // * Multiple installations of AnkiDroid go to different folders
+        // * Multiple installations of AnkiDroid go to different directorys
         // * It will allow us to add profiles without changing directories again
         val bestProfileDirectory = (1..MAX_ANKIDROID_DIRECTORIES).asSequence()
             .map { File(bestRootDestination, "AnkiDroid$it") }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/scopedstorage/MigrateEssentialFiles.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/scopedstorage/MigrateEssentialFiles.kt
@@ -96,7 +96,7 @@ internal constructor(
 
         val destinationPath = destinationDirectory.path
 
-        ensureFolderIsEmpty(destinationPath)
+        ensureDirectoryIsEmpty(destinationPath)
 
         // ensure the current collection is the one in sourcePath
         ensurePathIsCurrentCollectionPath(sourceDirectory)
@@ -136,7 +136,7 @@ internal constructor(
 
         // updatePreferences() opened the collection in the new location, which will have created
         // a -wal file if the new backend code is active. Close it again, so that tests don't
-        // fail due to the presence of a -wal file in the destination folder.
+        // fail due to the presence of a -wal file in the destination directory.
         if (!BackendFactory.defaultLegacySchema) {
             closeCollection()
         }
@@ -146,7 +146,7 @@ internal constructor(
      * Ensures that [directory] is empty
      * @throws IllegalStateException if [directory] is not empty
      */
-    private fun ensureFolderIsEmpty(directory: AnkiDroidDirectory) {
+    private fun ensureDirectoryIsEmpty(directory: AnkiDroidDirectory) {
         val listFiles = directory.listFiles()
 
         if (listFiles.any()) {
@@ -553,7 +553,7 @@ internal constructor(
 
             val destinationDirectory = Directory.createInstance(destination)!!
             // ensure destination is under scoped storage
-            val destinationAnkiDroidDirectory = ScopedAnkiDroidDirectory.createInstance(destinationDirectory, context) ?: throw IllegalStateException("Destination folder was not under scoped storage '$destinationDirectory'")
+            val destinationAnkiDroidDirectory = ScopedAnkiDroidDirectory.createInstance(destinationDirectory, context) ?: throw IllegalStateException("Destination directory was not under scoped storage '$destinationDirectory'")
 
             val originalAlgo = MigrateEssentialFiles(
                 context,

--- a/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/scopedstorage/MoveConflictedFile.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/scopedstorage/MoveConflictedFile.kt
@@ -30,7 +30,7 @@ import java.io.File
 /**
  * Moves a file from [sourceFile] to [proposedDestinationFile].
  *
- * Ensures that the folder underneath [proposedDestinationFile] exists, and renames the destination file.
+ * Ensures that the directory underneath [proposedDestinationFile] exists, and renames the destination file.
  * if the file at [proposedDestinationFile] exists and has a distinct content, it will increment the filename, attempting to find a filename which is not in use.
  * if the file at [proposedDestinationFile] exists and has the same content, [sourceFile] is deleted and move is assumed to be successful.
  *
@@ -49,8 +49,8 @@ class MoveConflictedFile private constructor(
 ) : Operation() {
 
     override fun execute(context: MigrationContext): List<Operation> {
-        // create the "conflict" folder if it didn't exist, and the relative path to the file
-        // example: "AnkiDroid/conflict/collection.media/subfolder"
+        // create the "conflict" directory if it didn't exist, and the relative path to the file
+        // example: "AnkiDroid/conflict/collection.media/subdirectory"
         createDirectory(proposedDestinationFile.parentFile!!)
 
         // wrap the context so we can handle internal file conflict exceptions, and set the correct
@@ -83,7 +83,7 @@ class MoveConflictedFile private constructor(
         MoveFile(sourceFile, potentialDestinationFile).execute(wrappedContext)
     }
 
-    private fun createDirectory(folder: File) = CompatHelper.compat.createDirectories(folder)
+    private fun createDirectory(directory: File) = CompatHelper.compat.createDirectories(directory)
 
     companion object {
         const val CONFLICT_DIRECTORY = "conflict"

--- a/AnkiDroid/src/main/java/com/ichi2/anki/services/MigrationService.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/services/MigrationService.kt
@@ -248,9 +248,9 @@ class MigrationService : Service() {
             val ignoredFiles = MigrateEssentialFiles.iterateEssentialFiles(task.source) +
                 File(task.source.directory, MoveConflictedFile.CONFLICT_DIRECTORY)
             val ignoredSpace = ignoredFiles.sumOf { FileUtil.getSize(it) }
-            val folderSize = FileUtil.DirectoryContentInformation.fromDirectory(task.source.directory).totalBytes
-            val remainingSpaceToMigrate = folderSize - ignoredSpace
-            Timber.d("folder size: %d, safe: %d, remaining: %d", folderSize, ignoredSpace, remainingSpaceToMigrate)
+            val directorySize = FileUtil.DirectoryContentInformation.fromDirectory(task.source.directory).totalBytes
+            val remainingSpaceToMigrate = directorySize - ignoredSpace
+            Timber.d("directory size: %d, safe: %d, remaining: %d", directorySize, ignoredSpace, remainingSpaceToMigrate)
             return remainingSpaceToMigrate
         } catch (e: Exception) {
             Timber.w(e, "Failed to get directory size")

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/managespace/FileUtils.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/managespace/FileUtils.kt
@@ -142,9 +142,9 @@ fun File.isInsideDirectoriesRemovedWithTheApp(context: Context): Boolean {
 }
 
 /*
- * Retrieves folders such as /storage/emulated/0/Android/data/com.ichi2.anki.
- * User can put files into these folders, but there seems to be no API to fetch them.
- * Since this folder is usually a parent of folders such as `externalCacheDir`,
+ * Retrieves directorys such as /storage/emulated/0/Android/data/com.ichi2.anki.
+ * User can put files into these directorys, but there seems to be no API to fetch them.
+ * Since this directory is usually a parent of directorys such as `externalCacheDir`,
  * and ends in package name, attempting to determine it by other API methods seems reasonable.
  */
 private val Context.externalDirs: Set<File> get() =

--- a/AnkiDroid/src/test/java/com/ichi2/anki/InitialActivityTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/InitialActivityTest.kt
@@ -22,7 +22,7 @@ import android.os.Build
 import androidx.core.content.edit
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.ichi2.anki.AnkiDroidFolder.*
+import com.ichi2.anki.AnkiDroidDirectory.*
 import com.ichi2.anki.servicelayer.PreferenceUpgradeService
 import com.ichi2.testutils.EmptyApplication
 import org.hamcrest.CoreMatchers.equalTo
@@ -116,11 +116,11 @@ class InitialActivityTest : RobolectricTest() {
 
         // force a safe startup before Q
         assertThat(
-            (selectAnkiDroidFolder(false) as PublicFolder).requiredPermissions.asIterable(),
+            (selectAnkiDroidDirectory(false) as PublicDirectory).requiredPermissions.asIterable(),
             contains(*expectedPermissions)
         )
         assertThat(
-            (selectAnkiDroidFolder(true) as PublicFolder).requiredPermissions.asIterable(),
+            (selectAnkiDroidDirectory(true) as PublicDirectory).requiredPermissions.asIterable(),
             contains(*expectedPermissions)
         )
     }
@@ -129,12 +129,12 @@ class InitialActivityTest : RobolectricTest() {
     @Test
     fun startupQ() {
         assertThat(
-            selectAnkiDroidFolder(false),
-            instanceOf(PublicFolder::class.java)
+            selectAnkiDroidDirectory(false),
+            instanceOf(PublicDirectory::class.java)
         )
         assertThat(
-            selectAnkiDroidFolder(true),
-            instanceOf(PublicFolder::class.java)
+            selectAnkiDroidDirectory(true),
+            instanceOf(PublicDirectory::class.java)
         )
     }
 
@@ -144,11 +144,11 @@ class InitialActivityTest : RobolectricTest() {
     fun startupAfterQWithManageExternalStorage() {
         val expectedPermissions = arrayOf(android.Manifest.permission.MANAGE_EXTERNAL_STORAGE)
 
-        selectAnkiDroidFolder(
+        selectAnkiDroidDirectory(
             canManageExternalStorage = true
         ).let {
             assertThat(
-                (it as PublicFolder).requiredPermissions.asIterable(),
+                (it as PublicDirectory).requiredPermissions.asIterable(),
                 contains(*expectedPermissions)
             )
         }
@@ -158,7 +158,7 @@ class InitialActivityTest : RobolectricTest() {
     @Test
     fun startupAfterQWithoutManageExternalStorage() {
         assertThat(
-            selectAnkiDroidFolder(canManageExternalStorage = false),
+            selectAnkiDroidDirectory(canManageExternalStorage = false),
             instanceOf(DeleteOnUninstall::class.java)
         )
     }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/jsaddons/AddonModelTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/jsaddons/AddonModelTest.kt
@@ -53,7 +53,7 @@ class AddonModelTest : RobolectricTest() {
     override fun setUp() {
         super.setUp()
 
-        // for mapping json from assets folder
+        // for mapping json from assets directory
         mapper = AnkiSerialization.objectMapper
 
         validNpmPackageJson = FileOperation.getFileResource("valid-ankidroid-js-addon-test.json")

--- a/AnkiDroid/src/test/java/com/ichi2/anki/jsaddons/TgzPackageExtractTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/jsaddons/TgzPackageExtractTest.kt
@@ -71,7 +71,7 @@ class TgzPackageExtractTest : RobolectricTest() {
     }
 
     /**
-     * Test if extracted file exists in the output folder.
+     * Test if extracted file exists in the output directory.
      * The current test will extract in .tgz in following structure
      * tempAddonDir
      * - package
@@ -84,11 +84,11 @@ class TgzPackageExtractTest : RobolectricTest() {
      */
     @Test
     @Throws(IOException::class, ArchiveException::class)
-    fun extractTarGzipToAddonFolderTest() {
-        // extract file to tempAddonFolder, the function first unGzip .tgz to .tar then unTar(extract) .tar file
-        addonPackage.extractTarGzipToAddonFolder(File(tarballPath), addonDir)
+    fun extractTarGzipToAddonDirectoryTest() {
+        // extract file to tempAddonDirectory, the function first unGzip .tgz to .tar then unTar(extract) .tar file
+        addonPackage.extractTarGzipToAddonDirectory(File(tarballPath), addonDir)
 
-        // test if package folder exists
+        // test if package directory exists
         val packagePath = File(addonDir, "package")
         assertThat(packagePath, anExistingDirectory())
 
@@ -106,7 +106,7 @@ class TgzPackageExtractTest : RobolectricTest() {
     }
 
     /**
-     * Test if .tar file unTar successfully to temp folder
+     * Test if .tar file unTar successfully to temp directory
      *
      * @throws IOException
      * @throws ArchiveException
@@ -117,10 +117,10 @@ class TgzPackageExtractTest : RobolectricTest() {
         // first unGzip .tgz file to .tar
         val unGzipFile = addonPackage.unGzip(File(tarballPath), addonDir)
 
-        // unTar .tar file to temp folder, it is same as extract of files to tempAddonDir
+        // unTar .tar file to temp directory, it is same as extract of files to tempAddonDir
         addonPackage.unTar(unGzipFile, addonDir)
 
-        // test if package folder exists
+        // test if package directory exists
         val packagePath = File(addonDir, "package")
         assertThat(packagePath, anExistingDirectory())
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/ScopedStorageAnkiDroidTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/ScopedStorageAnkiDroidTest.kt
@@ -51,7 +51,7 @@ class ScopedStorageAnkiDroidTest : RobolectricTest() {
         val from = migratedFrom.listFiles()!!.associateBy { it.name }.toMutableMap()
         val to = migratedTo.listFiles()!!.associateBy { it.name }.toMutableMap()
 
-        assertThat("target folder name should be set", migratedTo.name, equalTo("AnkiDroid1"))
+        assertThat("target directory name should be set", migratedTo.name, equalTo("AnkiDroid1"))
         assertThat("target should be under scoped storage", ScopedStorageService.isLegacyStorage(migratedTo.absolutePath, targetContext), equalTo(false))
         assertThat("bare files should be moved", to.keys, equalTo(from.keys))
     }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/MigrateEssentialFilesTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/MigrateEssentialFilesTest.kt
@@ -231,13 +231,13 @@ class MigrateEssentialFilesTest : RobolectricTest() {
      * This is only the initial stage which does not delete data
      */
     private fun executeAlgorithmSuccessfully(
-        ankiDroidFolder: String,
+        ankiDroidDirectory: String,
         optionalDestinationPath: File? = null,
         stubbing: (KStubbing<MigrateEssentialFiles>.(MigrateEssentialFiles) -> Unit)? = null
     ): File {
         val destinationPath = optionalDestinationPath ?: getMigrationDestinationPath()
 
-        var algo = getAlgorithm(ankiDroidFolder, destinationPath)
+        var algo = getAlgorithm(ankiDroidDirectory, destinationPath)
 
         if (stubbing != null) {
             algo = spy(algo, stubbing)

--- a/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/MockExecutor.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/MockExecutor.kt
@@ -22,7 +22,7 @@ import com.ichi2.anki.servicelayer.scopedstorage.migrateuserdata.MigrateUserData
 /**
  * Functionality:
  *
- * * Execution of recursive tasks (folder copying etc..)
+ * * Execution of recursive tasks (directory copying etc..)
  *
  * This is a mock as it's not tested, but will eventually be moved to a real class with a slightly different API
  *

--- a/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/MoveConflictedFileTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/MoveConflictedFileTest.kt
@@ -82,7 +82,7 @@ class MoveConflictedFileTest : Test21And26(), OperationTest {
 
         assertThat("provided 'sourceFile' parameter is unchanged", operation.sourceFile.file, equalTo(params.sourceFile))
 
-        // this is "path", but with a "conflict" subfolder.
+        // this is "path", but with a "conflict" subdirectory.
         assertThat("'conflict' is prepended to the path", operation.proposedDestinationFile, equalTo(params.intendedDestinationFilePath))
     }
 
@@ -222,7 +222,7 @@ class MoveConflictedFileTest : Test21And26(), OperationTest {
      *
      * [createOperation] returns the operation to move this source file to [destinationTopLevel]
      *
-     * @param directoryComponents components to the folder holding the source file ["collection.media"]
+     * @param directoryComponents components to the directory holding the source file ["collection.media"]
      * @param sourceFileName The name of the source file: "file.ext"
      * @param content The content of the source file
      */

--- a/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/ScopedStorageMigrationIntegrationTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/ScopedStorageMigrationIntegrationTest.kt
@@ -131,7 +131,7 @@ class ScopedStorageMigrationIntegrationTest : RobolectricTest() {
 
         val result = underTest.execTask()
 
-        assertThat("migrating empty folder should succeed", result, equalTo(true))
+        assertThat("migrating empty directory should succeed", result, equalTo(true))
     }
 
     /**
@@ -148,7 +148,7 @@ class ScopedStorageMigrationIntegrationTest : RobolectricTest() {
 
         assertThat("all files should be in the destination", underTest.migratedFilesCount, equalTo(underTest.filesToMigrateCount))
         assertThat("one file is conflicted", underTest.conflictedFilesCount, equalTo(1))
-        assertThat("expect to have conflict/maybeConflicted.log in source (file & folder)", underTest.sourceFilesCount, equalTo(2))
+        assertThat("expect to have conflict/maybeConflicted.log in source (file & directory)", underTest.sourceFilesCount, equalTo(2))
         assertThat(underTest.conflictedFilePaths.single(), anyOf(endsWith("/conflict/maybeConflicted.log"), endsWith("\\conflict\\maybeConflicted.log")))
 
         assertThat("even with a conflict, the operation should succeed", result, equalTo(true))

--- a/AnkiDroid/src/test/java/com/ichi2/misc/LintReleaseFileTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/misc/LintReleaseFileTest.kt
@@ -30,7 +30,7 @@ class LintReleaseFileTest {
 
     @Test
     fun failsWithMultipleDeclarations() {
-        // this runs in the AnkiDroid module folder so we need go up one level
+        // this runs in the AnkiDroid module directory so we need go up one level
         val lintReleaseFile = File("../lint-release.xml")
         assertTrue(lintReleaseFile.exists(), "lint-release.xml was not found")
         val parser = SAXParserFactory.newInstance().newSAXParser()

--- a/AnkiDroid/src/test/java/com/ichi2/testutils/BackendEmulatingOpenConflict.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/testutils/BackendEmulatingOpenConflict.kt
@@ -29,7 +29,7 @@ class BackendEmulatingOpenConflict(context: Context) : Backend(context) {
     @Suppress("UNUSED_PARAMETER")
     override fun openCollection(
         collectionPath: String,
-        mediaFolderPath: String,
+        mediaDirectoryPath: String,
         mediaDbPath: String,
         forceSchema11: Boolean
     ) {


### PR DESCRIPTION
As @oakkitten noted on
https://github.com/ankidroid/Anki-Android/pull/13261/files#r1133275020 we usually use `directory`, unless API (be it anki's backend or android one) require to use Folder.

So renaming it everywhere possible for the sake of the consistency
