### PR TITLE
NF: rename DeleteOnUninstall

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CollectionHelper.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CollectionHelper.kt
@@ -23,7 +23,7 @@ import android.text.format.Formatter
 import androidx.annotation.CheckResult
 import androidx.annotation.VisibleForTesting
 import androidx.core.content.edit
-import com.ichi2.anki.AnkiDroidFolder.DeleteOnUninstall
+import com.ichi2.anki.AnkiDroidFolder.AppPrivateFolder
 import com.ichi2.anki.exception.StorageAccessException
 import com.ichi2.anki.preferences.Preferences
 import com.ichi2.libanki.Collection
@@ -462,7 +462,7 @@ open class CollectionHelper {
         // TODO Tracked in https://github.com/ankidroid/Anki-Android/issues/5304
         @CheckResult
         fun getDefaultAnkiDroidDirectory(context: Context): String {
-            val legacyStorage = StartupStoragePermissionManager.selectAnkiDroidFolder(context) != DeleteOnUninstall
+            val legacyStorage = StartupStoragePermissionManager.selectAnkiDroidFolder(context) != AppPrivateFolder
             return if (!legacyStorage) {
                 File(getAppSpecificExternalAnkiDroidDirectory(context), "AnkiDroid").absolutePath
             } else {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/InitialActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/InitialActivity.kt
@@ -143,7 +143,7 @@ sealed interface AnkiDroidFolder {
      * No permission dialog is required.
      * Google will not allow [android.Manifest.permission.MANAGE_EXTERNAL_STORAGE], so this is default on the Play Store.
      */
-    object DeleteOnUninstall : AnkiDroidFolder
+    object AppPrivateFolder : AnkiDroidFolder
 }
 
 /**
@@ -157,7 +157,7 @@ internal fun selectAnkiDroidFolder(canManageExternalStorage: Boolean): AnkiDroid
         // match AnkiDroid behaviour before scoped storage - force the use of ~/AnkiDroid,
         // since it's fast & safe up to & including 'Q'
         // If a user upgrades their OS from Android 10 to 11 then storage speed is severely reduced
-        // and a user should use one of the below options to provide aster speeds
+        // and a user should use one of the below options to provide faster speeds
         return AnkiDroidFolder.PublicFolder(
             arrayOf(
                 Manifest.permission.READ_EXTERNAL_STORAGE,
@@ -170,7 +170,7 @@ internal fun selectAnkiDroidFolder(canManageExternalStorage: Boolean): AnkiDroid
     return if (canManageExternalStorage) {
         AnkiDroidFolder.PublicFolder(arrayOf(Manifest.permission.MANAGE_EXTERNAL_STORAGE))
     } else {
-        return AnkiDroidFolder.DeleteOnUninstall
+        return AnkiDroidFolder.AppPrivateFolder
     }
 }
 
@@ -189,13 +189,13 @@ internal fun selectAnkiDroidFolder(canManageExternalStorage: Boolean): AnkiDroid
 @NeedsTest("Existing User: Changes Deck")
 class StartupStoragePermissionManager private constructor(
     private val deckPicker: DeckPicker,
-    uninstallPolicy: AnkiDroidFolder,
+    ankidroidFolder: AnkiDroidFolder,
     useCallbackIfActivityRecreated: Boolean
 ) {
     private var timesRequested: Int = 0
-    private val requiredPermissions = when (uninstallPolicy) {
-        is AnkiDroidFolder.DeleteOnUninstall -> noPermissionDialogRequired
-        is AnkiDroidFolder.PublicFolder -> uninstallPolicy.requiredPermissions
+    private val requiredPermissions = when (ankidroidFolder) {
+        is AnkiDroidFolder.AppPrivateFolder -> noPermissionDialogRequired
+        is AnkiDroidFolder.PublicFolder -> ankidroidFolder.requiredPermissions
     }
 
     /**

--- a/AnkiDroid/src/test/java/com/ichi2/anki/InitialActivityTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/InitialActivityTest.kt
@@ -159,7 +159,7 @@ class InitialActivityTest : RobolectricTest() {
     fun startupAfterQWithoutManageExternalStorage() {
         assertThat(
             selectAnkiDroidFolder(canManageExternalStorage = false),
-            instanceOf(DeleteOnUninstall::class.java)
+            instanceOf(AppPrivateFolder::class.java)
         )
     }
 


### PR DESCRIPTION
As noted in
https://github.com/ankidroid/Anki-Android/pull/13261/files#r1133165143 , "DeleteOnUninstall", while true, is not a description of a kind of folder. Renaming it make it easier to grasp.