### PR TITLE
build: 'full' build with no manifest restrictions

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -152,6 +152,10 @@ android {
         amazon {
             dimension "appStore"
         }
+        // A 'full' build has no restrictions on storage/camera. Distributed on GitHub/F-Droid
+        full {
+            dimension "appStore"
+        }
     }
 
     /**


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
A default build ('play') is not allowed `MANAGE_EXTERNAL_STORAGE`

We want a build with this permission so we can distribute it.

`amazon` removes the camera permission, so it is not appropriate

So add a new flavor: 'full' which has BOTH camera & storage permissions.

This may optionally be used by developers. TBC if we want this as the default as it's not representative of a real user experience.

## Fixes
- Related: #13431 
  - needs a follow up to `release.sh` and `parallel-package-release.sh`
  - needs an update to the F-Droid release script to use 'full' as the default

## Approach
* add a 'full' dimension

## How Has This Been Tested?

API 33 Emulator

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
