### PR TITLE
Use "full" flavor on parallel builds

### DIFF
--- a/tools/parallel-package-release.sh
+++ b/tools/parallel-package-release.sh
@@ -33,7 +33,7 @@ BUILDNAMES='A B C D E'
 for BUILD in $BUILDNAMES; do
     LCBUILD=`tr '[:upper:]' '[:lower:]' <<< $BUILD`
     ./gradlew --stop
-    if ! ./gradlew assemblePlayRelease -PcustomSuffix="$LCBUILD" -PcustomName="AnkiDroid.$BUILD" -Duniversal-apk=true
+    if ! ./gradlew assembleFullRelease -PcustomSuffix="$LCBUILD" -PcustomName="AnkiDroid.$BUILD" -Duniversal-apk=true
     then
       echo "Unable to build parallel target $BUILD"
       exit 1

--- a/tools/parallel-package-release.sh
+++ b/tools/parallel-package-release.sh
@@ -38,7 +38,7 @@ for BUILD in $BUILDNAMES; do
       echo "Unable to build parallel target $BUILD"
       exit 1
     fi
-    cp AnkiDroid/build/outputs/apk/play/release/AnkiDroid-play-universal-release.apk ./AnkiDroid-$TAG.parallel.$BUILD.apk
+    cp AnkiDroid/build/outputs/apk/full/release/AnkiDroid-full-universal-release.apk ./AnkiDroid-$TAG.parallel.$BUILD.apk
 done
 git reset --hard
 git clean -f

--- a/tools/release.sh
+++ b/tools/release.sh
@@ -129,17 +129,17 @@ fi  #API30
 
 # Now build the universal release also
 ./gradlew --stop
-echo "Running 'assemblePlayRelease' target with universal APK flag"
-if ! ./gradlew assemblePlayRelease -Duniversal-apk=true
+echo "Running 'assembleFullRelease' target with universal APK flag"
+if ! ./gradlew assembleFullRelease -Duniversal-apk=true
 then
-  echo "unable to build universal APK for play release"
+  echo "unable to build universal APK for full release"
   exit 1
 fi
 
 # Copy universal APK to cwd
 ABIS='universal arm64-v8a x86 x86_64 armeabi-v7a'
 for ABI in $ABIS; do
-  cp AnkiDroid/build/outputs/apk/play/release/AnkiDroid-play-"$ABI"-release.apk AnkiDroid-"$VERSION"-"$ABI".apk
+  cp AnkiDroid/build/outputs/apk/full/release/AnkiDroid-full-"$ABI"-release.apk AnkiDroid-"$VERSION"-"$ABI".apk
 done
 
 # Push to Github Releases.


### PR DESCRIPTION
## Fixes
Fixes #13431

## Approach
Change the assemble type on the script

## How Has This Been Tested?

Runned `./gradlew assembleFullRelease` to check if the command was okay. Didn't run the script because of the credentials.

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
