### PR TITLE
Use snackbar instead of toast on note editor

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
@@ -51,6 +51,7 @@ import androidx.core.content.res.ResourcesCompat
 import androidx.core.text.HtmlCompat
 import com.afollestad.materialdialogs.MaterialDialog
 import com.afollestad.materialdialogs.customview.customView
+import com.google.android.material.snackbar.Snackbar
 import com.ichi2.anim.ActivityTransitionAnimation
 import com.ichi2.anim.ActivityTransitionAnimation.Direction.*
 import com.ichi2.anki.dialogs.ConfirmationDialog
@@ -657,14 +658,9 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
             changed = true
             sourceText = null
             refreshNoteData(FieldChangeType.refreshWithStickyFields(shouldReplaceNewlines()))
-            UIUtils.showThemedToast(
-                this,
-                resources.getQuantityString(
-                    R.plurals.factadder_cards_added,
-                    noOfAddedCards,
-                    noOfAddedCards
-                ),
-                true
+            showSnackbar(
+                resources.getQuantityString(R.plurals.factadder_cards_added, noOfAddedCards, noOfAddedCards),
+                Snackbar.LENGTH_SHORT
             )
         } else {
             displayErrorSavingNote()


### PR DESCRIPTION
## Fixes
#13411

## How Has This Been Tested?

Added a note and saw the snackbar

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
