### PR TITLE
Don't finish activity after requesting all files access permission

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/utils/Permissions.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/Permissions.kt
@@ -49,7 +49,7 @@ object Permissions {
     }
 
     @RequiresApi(Build.VERSION_CODES.R)
-    private fun isExternalStorageManager(): Boolean {
+    fun isExternalStorageManager(): Boolean {
         // BUG: Environment.isExternalStorageManager() crashes under robolectric
         // https://github.com/robolectric/robolectric/issues/7300
         if (isRobolectric) {


### PR DESCRIPTION
## Purpose / Description
Finishing the activity is bad UX and unnecessary

## Fixes
Fixes #13463

## How Has This Been Tested?

SDK 33 emulator

https://user-images.githubusercontent.com/69634269/228090454-ebf8ee92-f096-4dc6-9c59-6fb0801df4d8.mp4

# Learning

Couldn't get to use https://developer.android.com/reference/androidx/activity/result/contract/ActivityResultContracts.RequestPermission

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
