### PR TITLE
temporarily disable publish of alpha to google

### DIFF
--- a/tools/release.sh
+++ b/tools/release.sh
@@ -114,17 +114,17 @@ fi
 
 # Build signed APK using Gradle and publish to Play
 # Configuration for pushing to Play specified in build.gradle 'play' task
-echo "Running 'publishPlayReleaseApk' gradle target"
-if ! ./gradlew publishPlayReleaseApk
-then
+#echo "Running 'publishPlayReleaseApk' gradle target"
+#if ! ./gradlew publishPlayReleaseApk
+#then
   # APK contains problems
   # Normally we want to abort the release but right now we know google will reject us until
   # we have targetSdkVersion 30, so ignore.
 #  git checkout -- $GRADLEFILE # Revert version change  #API30
 #  exit 1  #API30
 #else  #API30
-  echo "Google has rejected the APK upload. Likely because targetSdkVersion < 30. Continuing..."  #API30
-fi  #API30
+#  echo "Google has rejected the APK upload. Likely because targetSdkVersion < 30. Continuing..."  #API30
+#fi  #API30
 #fi  #API30
 
 # Now build the universal release also


### PR DESCRIPTION
## Pull Request template

## Purpose / Description

Temporarily disable the attempt to publish an alpha to google - now that we are API30+ google would probably accept it, but we would like at least one more github-only alpha before that happens

## Approach

Simply commenting out the google play store related lines. This will be (should be?) simple to revert and has `API30` near it in comments as well, for future adventurers in case I meet an untimely demise and don't handle it myself ;-)

## How Has This Been Tested?

It has not. Running the workflow will test it. There could be problems. I stand ready with mop and bucket to janitor the problems away

## Learning (optional, can help others)

I have learned nothing from this PR. Sometimes PRs are like that.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
