### PR TITLE
Github Action To Compare App Size

### DIFF
--- a/.github/workflows/comapre_app_size.yml
+++ b/.github/workflows/comapre_app_size.yml
@@ -14,9 +14,9 @@ jobs:
         with:
           java-version: '11.x'
       - name: Checkout main branch
-          uses: actions/checkout@v2
-          with:
-            ref: main
+        uses: actions/checkout@v2
+        with:
+          ref: main
       - name: Grant execute permission to gradlew
         run: chmod +x gradlew
       - name: Build base app

--- a/.github/workflows/comapre_app_size.yml
+++ b/.github/workflows/comapre_app_size.yml
@@ -37,9 +37,9 @@ jobs:
         uses: microsoft/android-app-size-diff@v1.0.5
         with:
           baseAppPath: base.apk
-          baseAppLabel: 'Base App'
+          baseAppLabel: Base App
           targetAppPath: target.apk
-          targetAppLabel: 'Target App'
+          targetAppLabel: Target App
           summaryOutputPath: summary.md
       - name: Print Summary
         run: cat summary.md

--- a/.github/workflows/comapre_app_size.yml
+++ b/.github/workflows/comapre_app_size.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set up JDK
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v1
         with:
           java-version: '11.x'
       - name: Grant execute permission to gradlew

--- a/.github/workflows/comapre_app_size.yml
+++ b/.github/workflows/comapre_app_size.yml
@@ -40,6 +40,8 @@ jobs:
           baseAppLabel: Base App
           targetAppPath: target.apk
           targetAppLabel: Target App
+          metrics: apkSize, installSize, arscFile, nativeLibs, dexFiles
+          thresholds: 10, 10, 10, 10, 10
           summaryOutputPath: summary.md
       - name: Print Summary
         run: cat summary.md

--- a/.github/workflows/comapre_app_size.yml
+++ b/.github/workflows/comapre_app_size.yml
@@ -34,12 +34,12 @@ jobs:
           ./gradlew assemblePlayDebug -DenableSeparateBuildPerCPUArchitecture=false
           mv AnkiDroid/build/outputs/apk/play/debug/AnkiDroid-play-debug.apk target.apk
       - name: App Size Comparison
-        uses: microsoft/android-app-size-diff@v1
+        uses: microsoft/android-app-size-diff@v1.0.5
         with:
           baseAppPath: base.apk
           baseAppLabel: 'Base App'
           targetAppPath: target.apk
           targetAppLabel: 'Target App'
           summaryOutputPath: summary.md
-      - name: Clean Up
-        run: rm base.apk target.apk
+      - name: Print Summary
+        run: cat summary.md

--- a/.github/workflows/comapre_app_size.yml
+++ b/.github/workflows/comapre_app_size.yml
@@ -30,9 +30,9 @@ jobs:
           ref: ${{ github.event.pull_request.head.ref }}
       - name: Build target app
         shell: bash
-          run: |
-            ./gradlew assemblePlayDebug -DenableSeparateBuildPerCPUArchitecture=false
-            mv AnkiDroid/build/outputs/apk/play/debug/AnkiDroid-play-debug.apk target.apk
+        run: |
+          ./gradlew assemblePlayDebug -DenableSeparateBuildPerCPUArchitecture=false
+          mv AnkiDroid/build/outputs/apk/play/debug/AnkiDroid-play-debug.apk target.apk
       - name: App Size Comparison
         uses: microsoft/android-app-size-diff@v1
         with:

--- a/.github/workflows/comapre_app_size.yml
+++ b/.github/workflows/comapre_app_size.yml
@@ -1,0 +1,45 @@
+name: Compare App Size
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  compare-app-size:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up JDK
+        uses: actions/setup-java@v2
+        with:
+          java-version: '11.x'
+      - name: Grant execute permission to gradlew
+        run: chmod +x gradlew
+      - name: Checkout main branch
+        uses: actions/checkout@v2
+        with:
+          ref: main
+      - name: Build base app
+        shell: bash
+        run: |
+          ./gradlew assemblePlayDebug -DenableSeparateBuildPerCPUArchitecture=false
+          mv AnkiDroid/build/outputs/apk/play/debug/AnkiDroid-play-debug.apk base.apk
+      - name: Checkout pull request branch
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+      - name: Build target app
+        shell: bash
+          run: |
+            ./gradlew assemblePlayDebug -DenableSeparateBuildPerCPUArchitecture=false
+            mv AnkiDroid/build/outputs/apk/play/debug/AnkiDroid-play-debug.apk target.apk
+      - name: App Size Comparison
+        uses: microsoft/android-app-size-diff@v1
+        with:
+          baseAppPath: base.apk
+          baseAppLabel: 'Base App'
+          targetAppPath: target.apk
+          targetAppLabel: 'Target App'
+          summaryOutputPath: summary.md
+      - name: Clean Up
+        run: rm base.apk target.apk

--- a/.github/workflows/comapre_app_size.yml
+++ b/.github/workflows/comapre_app_size.yml
@@ -13,12 +13,12 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: '11.x'
+      - name: Checkout main branch
+          uses: actions/checkout@v2
+          with:
+            ref: main
       - name: Grant execute permission to gradlew
         run: chmod +x gradlew
-      - name: Checkout main branch
-        uses: actions/checkout@v2
-        with:
-          ref: main
       - name: Build base app
         shell: bash
         run: |

--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -167,7 +167,7 @@ android {
      * Upload all the APKs to the Play Store and people will download
      * the correct one based on the CPU architecture of their device.
      */
-    def enableSeparateBuildPerCPUArchitecture = true
+    def enableSeparateBuildPerCPUArchitecture = (System.getProperty("enableSeparateBuildPerCPUArchitecture") ?: "true").toBoolean()
 
     splits {
         abi {


### PR DESCRIPTION
## Pull Request

## Purpose / Description
- It is important to monitor the app size while development as it has been found number of downloads of app is inversely proportional to app size. Mobile are devices with limited storage and connectivity to internet so we should try to keep the app size under control as much as possible.
- Also added the ability to just generate one universal apk or specific apk using `DenableSeparateBuildPerCPUArchitecture` if value provided to `false` just generates the universal apk and for `true` and value not provided generates specific apks

## Approach
- Added a github action that builds the apk for the main branch and apk for current feature branch and then compares the change in size using the following [github action](https://github.com/marketplace/actions/android-app-size-difference)

## Checklist

- [ ] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas
- [ ] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
