### PR TITLE
Replace MaterialDialog with AlertDialog

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.kt
@@ -37,7 +37,6 @@ import androidx.fragment.app.FragmentActivity
 import androidx.lifecycle.Lifecycle
 import androidx.viewpager2.adapter.FragmentStateAdapter
 import androidx.viewpager2.widget.ViewPager2
-import com.afollestad.materialdialogs.MaterialDialog
 import com.google.android.material.bottomnavigation.BottomNavigationView
 import com.google.android.material.tabs.TabLayout
 import com.google.android.material.tabs.TabLayoutMediator
@@ -200,17 +199,12 @@ open class CardTemplateEditor : AnkiActivity(), DeckSelectionListener {
         return tempModel != null && tempModel!!.model.toString() != oldModel.toString()
     }
 
-    @VisibleForTesting
-    fun showDiscardChangesDialog(): MaterialDialog {
-        val discardDialog = DiscardChangesDialog.showDialog(this) {
-            Timber.i("TemplateEditor:: OK button pressed to confirm discard changes")
-            // Clear the edited model from any cache files, and clear it from this objects memory to discard changes
-            TemporaryModel.clearTempModelFiles()
-            tempModel = null
-            finishWithAnimation(END)
-        }
-        discardDialog.show()
-        return discardDialog
+    private fun showDiscardChangesDialog() = DiscardChangesDialog.showDialog(this) {
+        Timber.i("TemplateEditor:: OK button pressed to confirm discard changes")
+        // Clear the edited model from any cache files, and clear it from this objects memory to discard changes
+        TemporaryModel.clearTempModelFiles()
+        tempModel = null
+        finishWithAnimation(END)
     }
 
     /** When a deck is selected via Deck Override  */

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DiscardChangesDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DiscardChangesDialog.kt
@@ -16,19 +16,22 @@
 package com.ichi2.anki.dialogs
 
 import android.content.Context
-import com.afollestad.materialdialogs.MaterialDialog
+import androidx.appcompat.app.AlertDialog
 import com.ichi2.anki.R
+import com.ichi2.utils.message
+import com.ichi2.utils.negativeButton
+import com.ichi2.utils.positiveButton
+import com.ichi2.utils.show
 
 class DiscardChangesDialog {
     companion object {
-        fun showDialog(context: Context?, positiveMethod: () -> Unit): MaterialDialog {
-            return MaterialDialog(context!!).show {
-                message(R.string.discard_unsaved_changes)
-                positiveButton(R.string.dialog_ok) {
-                    positiveMethod()
-                }
-                negativeButton(R.string.dialog_cancel)
-            }
+        fun showDialog(
+            context: Context,
+            positiveMethod: () -> Unit
+        ) = AlertDialog.Builder(context).show {
+            message(R.string.discard_unsaved_changes)
+            positiveButton(R.string.dialog_ok) { positiveMethod() }
+            negativeButton(R.string.dialog_cancel)
         }
     }
 }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/CardTemplateEditorTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/CardTemplateEditorTest.kt
@@ -17,6 +17,7 @@
 package com.ichi2.anki
 
 import android.app.Activity
+import android.content.DialogInterface
 import android.content.Intent
 import android.os.Bundle
 import android.widget.EditText
@@ -78,15 +79,15 @@ class CardTemplateEditorTest : RobolectricTest() {
         // Make sure we get a confirmation dialog if we hit the back button
         assertTrue("Unable to click?", shadowTestEditor.clickMenuItem(android.R.id.home))
         advanceRobolectricLooperWithSleep()
-        assertEquals("Wrong dialog shown?", getDialogText(true), getResourceString(R.string.discard_unsaved_changes))
-        clickDialogButton(WhichButton.NEGATIVE, true)
+        assertEquals("Wrong dialog shown?", getAlertDialogText(true), getResourceString(R.string.discard_unsaved_changes))
+        clickAlertDialogButton(DialogInterface.BUTTON_NEGATIVE, false)
         advanceRobolectricLooperWithSleep()
         assertTrue("model change not preserved despite canceling back button?", testEditor.modelHasChanged())
 
         // Make sure we things are cleared out after a cancel
         assertTrue("Unable to click?", shadowTestEditor.clickMenuItem(android.R.id.home))
-        assertEquals("Wrong dialog shown?", getDialogText(true), getResourceString(R.string.discard_unsaved_changes))
-        clickDialogButton(WhichButton.POSITIVE, true)
+        assertEquals("Wrong dialog shown?", getAlertDialogText(true), getResourceString(R.string.discard_unsaved_changes))
+        clickAlertDialogButton(DialogInterface.BUTTON_POSITIVE, false)
         advanceRobolectricLooperWithSleep()
         assertFalse("model change not cleared despite discarding changes?", testEditor.modelHasChanged())
 
@@ -141,8 +142,8 @@ class CardTemplateEditorTest : RobolectricTest() {
         val shadowTestEditor = shadowOf(testEditor)
         assertTrue("Unable to click?", shadowTestEditor.clickMenuItem(R.id.action_delete))
         advanceRobolectricLooperWithSleep()
-        assertEquals("Wrong dialog shown?", "Delete the “Card 1” card type, and its 0 cards?", getDialogText(true))
-        clickDialogButton(WhichButton.POSITIVE, true)
+        assertEquals("Wrong dialog shown?", "Delete the “Card 1” card type, and its 0 cards?", getMaterialDialogText(true))
+        clickMaterialDialogButton(WhichButton.POSITIVE, true)
         advanceRobolectricLooperWithSleep()
         assertTrue("Model should have changed", testEditor.modelHasChanged())
         assertEquals("Model should have 1 template now", 1, testEditor.tempModel?.templateCount)
@@ -153,7 +154,7 @@ class CardTemplateEditorTest : RobolectricTest() {
         assertEquals(
             "Did not show dialog about deleting only card?",
             getResourceString(R.string.card_template_editor_cant_delete),
-            getDialogText(true)
+            getMaterialDialogText(true)
         )
         assertEquals("Change already in database?", collectionBasicModelOriginal.toString().trim { it <= ' ' }, getCurrentDatabaseModelCopy(modelName).toString().trim { it <= ' ' })
 
@@ -248,8 +249,8 @@ class CardTemplateEditorTest : RobolectricTest() {
         val shadowTestEditor = shadowOf(testEditor)
         assertTrue("Unable to click?", shadowTestEditor.clickMenuItem(R.id.action_delete))
         advanceRobolectricLooperWithSleep()
-        assertEquals("Wrong dialog shown?", "Delete the “Card 1” card type, and its 0 cards?", getDialogText(true))
-        clickDialogButton(WhichButton.NEGATIVE, true)
+        assertEquals("Wrong dialog shown?", "Delete the “Card 1” card type, and its 0 cards?", getMaterialDialogText(true))
+        clickMaterialDialogButton(WhichButton.NEGATIVE, true)
         advanceRobolectricLooperWithSleep()
         assertFalse("Model should not have changed", testEditor.modelHasChanged())
 
@@ -270,9 +271,9 @@ class CardTemplateEditorTest : RobolectricTest() {
         assertEquals(
             "Did not show dialog about deleting only card?",
             getResourceString(R.string.card_template_editor_would_delete_note),
-            getDialogText(true)
+            getMaterialDialogText(true)
         )
-        clickDialogButton(WhichButton.POSITIVE, true)
+        clickMaterialDialogButton(WhichButton.POSITIVE, true)
         advanceRobolectricLooperWithSleep()
         assertNull("Can delete used template?", col.models.getCardIdsForModel(collectionBasicModelOriginal.getLong("id"), intArrayOf(0)))
         assertEquals("Change already in database?", collectionBasicModelOriginal.toString().trim { it <= ' ' }, getCurrentDatabaseModelCopy(modelName).toString().trim { it <= ' ' })
@@ -340,9 +341,9 @@ class CardTemplateEditorTest : RobolectricTest() {
         assertEquals(
             "Did not show dialog about deleting template and it's card?",
             getQuantityString(R.plurals.card_template_editor_confirm_delete, 1, 1, "Card 1"),
-            getDialogText(true)
+            getMaterialDialogText(true)
         )
-        clickDialogButton(WhichButton.NEGATIVE, true)
+        clickMaterialDialogButton(WhichButton.NEGATIVE, true)
         advanceRobolectricLooperWithSleep()
         assertNotNull("Cannot delete template?", col.models.getCardIdsForModel(collectionBasicModelOriginal.getLong("id"), intArrayOf(0)))
         assertNotNull("Cannot delete template?", col.models.getCardIdsForModel(collectionBasicModelOriginal.getLong("id"), intArrayOf(1)))
@@ -394,9 +395,9 @@ class CardTemplateEditorTest : RobolectricTest() {
         assertEquals(
             "Did not show dialog about deleting template and it's card?",
             getQuantityString(R.plurals.card_template_editor_confirm_delete, 1, 1, "Card 1"),
-            getDialogText(true)
+            getMaterialDialogText(true)
         )
-        clickDialogButton(WhichButton.POSITIVE, true)
+        clickMaterialDialogButton(WhichButton.POSITIVE, true)
         advanceRobolectricLooperWithSleep()
         advanceRobolectricLooperWithSleep()
         testEditor.viewPager.currentItem = 0
@@ -405,9 +406,9 @@ class CardTemplateEditorTest : RobolectricTest() {
         assertEquals(
             "Did not show dialog about deleting template and it's card?",
             getQuantityString(R.plurals.card_template_editor_confirm_delete, 1, 1, "Card 2"),
-            getDialogText(true)
+            getMaterialDialogText(true)
         )
-        clickDialogButton(WhichButton.POSITIVE, true)
+        clickMaterialDialogButton(WhichButton.POSITIVE, true)
         advanceRobolectricLooperWithSleep()
 
         // - assert can delete any 1 or 2 Card templates but not all
@@ -467,9 +468,9 @@ class CardTemplateEditorTest : RobolectricTest() {
         assertEquals(
             "Did not show dialog about deleting template and it's card?",
             getQuantityString(R.plurals.card_template_editor_confirm_delete, 1, 1, "Card 2"),
-            getDialogText(true)
+            getMaterialDialogText(true)
         )
-        clickDialogButton(WhichButton.POSITIVE, true)
+        clickMaterialDialogButton(WhichButton.POSITIVE, true)
         advanceRobolectricLooperWithSleep()
         assertTrue("Model should have changed", testEditor.modelHasChanged())
         assertNotNull("Cannot delete template?", col.models.getCardIdsForModel(collectionBasicModelOriginal.getLong("id"), intArrayOf(0)))
@@ -493,9 +494,9 @@ class CardTemplateEditorTest : RobolectricTest() {
         assertEquals(
             "Did not show dialog about deleting template and it's card?",
             getQuantityString(R.plurals.card_template_editor_confirm_delete, 0, 0, "Card 2"),
-            getDialogText(true)
+            getMaterialDialogText(true)
         )
-        clickDialogButton(WhichButton.POSITIVE, true)
+        clickMaterialDialogButton(WhichButton.POSITIVE, true)
         advanceRobolectricLooperWithSleep()
         assertTrue("Model should have changed", testEditor.modelHasChanged())
         assertNotNull("Cannot delete template?", col.models.getCardIdsForModel(collectionBasicModelOriginal.getLong("id"), intArrayOf(0)))
@@ -599,9 +600,9 @@ class CardTemplateEditorTest : RobolectricTest() {
         assertEquals(
             "Did not show dialog about adding template and it's card?",
             getQuantityString(R.plurals.card_template_editor_confirm_add, numAffectedCards, numAffectedCards),
-            getDialogText(true)
+            getMaterialDialogText(true)
         )
-        clickDialogButton(WhichButton.POSITIVE, true)
+        clickMaterialDialogButton(WhichButton.POSITIVE, true)
     }
 
     private fun getModelCardCount(model: Model): Int {

--- a/AnkiDroid/src/test/java/com/ichi2/anki/RobolectricTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/RobolectricTest.kt
@@ -207,7 +207,6 @@ open class RobolectricTest : CollectionGetter, AndroidTest {
      */
     protected fun clickAlertDialogButton(button: Int, @Suppress("SameParameterValue") checkDismissed: Boolean) {
         val dialog = ShadowDialog.getLatestDialog() as AlertDialog
-        Assert.assertTrue("Invalid button provided", ALERT_DIALOG_BUTTONS.contains(button))
 
         dialog.getButton(button).performClick()
         // Need to run UI thread tasks to actually run the onClickHandler
@@ -240,19 +239,19 @@ open class RobolectricTest : CollectionGetter, AndroidTest {
      * TODO: Rename to getDialogText when all MaterialDialogs are changed to AlertDialogs
      */
     protected fun getAlertDialogText(@Suppress("SameParameterValue") checkDismissed: Boolean): String? {
-        val dialog = ShadowDialog.getLatestDialog()
-        dialog as AlertDialog
+        val dialog = ShadowDialog.getLatestDialog() as AlertDialog
         if (checkDismissed && Shadows.shadowOf(dialog).hasBeenDismissed()) {
             Timber.e("The latest dialog has already been dismissed.")
             return null
         }
-        return dialog.findViewById<TextView>(android.R.id.message)?.text?.toString()
+        val messageViewWithinDialog = dialog.findViewById<TextView>(android.R.id.message)
+        Assert.assertFalse(messageViewWithinDialog == null)
+
+        return messageViewWithinDialog?.text?.toString()
     }
 
     // Robolectric needs a manual advance with the new PAUSED looper mode
     companion object {
-        val ALERT_DIALOG_BUTTONS = listOf(BUTTON_NEGATIVE, BUTTON_NEUTRAL, BUTTON_POSITIVE)
-
         private var mBackground = true
 
         // Robolectric needs a manual advance with the new PAUSED looper mode

--- a/AnkiDroid/src/test/java/com/ichi2/anki/RobolectricTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/RobolectricTest.kt
@@ -194,7 +194,6 @@ open class RobolectricTest : CollectionGetter, AndroidTest {
         mBackground = true
     }
 
-    @Deprecated("Use clickAlertDialogButton below")
     protected fun clickMaterialDialogButton(button: WhichButton?, @Suppress("SameParameterValue") checkDismissed: Boolean) {
         val dialog = ShadowDialog.getLatestDialog() as MaterialDialog
         dialog.getActionButton(button!!).performClick()
@@ -224,7 +223,6 @@ open class RobolectricTest : CollectionGetter, AndroidTest {
      *
      * @param checkDismissed true if you want to check for dismissed, will return null even if dialog exists but has been dismissed
      */
-    @Deprecated("Use getAlertDialogText below")
     protected fun getMaterialDialogText(@Suppress("SameParameterValue") checkDismissed: Boolean): String? {
         val dialog: MaterialDialog = ShadowDialog.getLatestDialog() as MaterialDialog
         if (checkDismissed && Shadows.shadowOf(dialog).hasBeenDismissed()) {

--- a/AnkiDroid/src/test/java/com/ichi2/anki/RobolectricTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/RobolectricTest.kt
@@ -17,12 +17,14 @@
 package com.ichi2.anki
 
 import android.content.Context
+import android.content.DialogInterface.*
 import android.content.Intent
 import android.content.SharedPreferences
 import android.os.Looper
 import android.widget.TextView
 import androidx.annotation.CallSuper
 import androidx.annotation.CheckResult
+import androidx.appcompat.app.AlertDialog
 import androidx.core.content.edit
 import androidx.fragment.app.DialogFragment
 import androidx.sqlite.db.SupportSQLiteOpenHelper
@@ -42,10 +44,7 @@ import com.ichi2.libanki.backend.exception.DeckRenameException
 import com.ichi2.libanki.sched.Sched
 import com.ichi2.libanki.sched.SchedV2
 import com.ichi2.libanki.utils.TimeManager
-import com.ichi2.testutils.AndroidTest
-import com.ichi2.testutils.IgnoreFlakyTestsInCIRule
-import com.ichi2.testutils.MockTime
-import com.ichi2.testutils.TaskSchedulerRule
+import com.ichi2.testutils.*
 import com.ichi2.utils.Computation
 import com.ichi2.utils.InMemorySQLiteOpenHelperFactory
 import kotlinx.coroutines.runBlocking
@@ -62,6 +61,7 @@ import org.robolectric.Shadows
 import org.robolectric.android.controller.ActivityController
 import org.robolectric.shadows.ShadowDialog
 import org.robolectric.shadows.ShadowLog
+import org.robolectric.shadows.ShadowLooper
 import org.robolectric.shadows.ShadowMediaPlayer
 import timber.log.Timber
 import java.util.concurrent.locks.ReentrantLock
@@ -194,9 +194,26 @@ open class RobolectricTest : CollectionGetter, AndroidTest {
         mBackground = true
     }
 
-    protected fun clickDialogButton(button: WhichButton?, @Suppress("SameParameterValue") checkDismissed: Boolean) {
+    @Deprecated("Use clickAlertDialogButton below")
+    protected fun clickMaterialDialogButton(button: WhichButton?, @Suppress("SameParameterValue") checkDismissed: Boolean) {
         val dialog = ShadowDialog.getLatestDialog() as MaterialDialog
         dialog.getActionButton(button!!).performClick()
+        if (checkDismissed) {
+            Assert.assertTrue("Dialog not dismissed?", Shadows.shadowOf(dialog).hasBeenDismissed())
+        }
+    }
+
+    /**
+     * Click on a dialog button for an AlertDialog dialog box. Replaces the above helper.
+     */
+    protected fun clickAlertDialogButton(button: Int, @Suppress("SameParameterValue") checkDismissed: Boolean) {
+        val dialog = ShadowDialog.getLatestDialog() as AlertDialog
+        Assert.assertTrue("Invalid button provided", ALERT_DIALOG_BUTTONS.contains(button))
+
+        dialog.getButton(button).performClick()
+        // Need to run UI thread tasks to actually run the onClickHandler
+        ShadowLooper.runUiThreadTasks()
+
         if (checkDismissed) {
             Assert.assertTrue("Dialog not dismissed?", Shadows.shadowOf(dialog).hasBeenDismissed())
         }
@@ -207,7 +224,8 @@ open class RobolectricTest : CollectionGetter, AndroidTest {
      *
      * @param checkDismissed true if you want to check for dismissed, will return null even if dialog exists but has been dismissed
      */
-    protected fun getDialogText(@Suppress("SameParameterValue") checkDismissed: Boolean): String? {
+    @Deprecated("Use getAlertDialogText below")
+    protected fun getMaterialDialogText(@Suppress("SameParameterValue") checkDismissed: Boolean): String? {
         val dialog: MaterialDialog = ShadowDialog.getLatestDialog() as MaterialDialog
         if (checkDismissed && Shadows.shadowOf(dialog).hasBeenDismissed()) {
             Timber.e("The latest dialog has already been dismissed.")
@@ -216,8 +234,27 @@ open class RobolectricTest : CollectionGetter, AndroidTest {
         return dialog.view.contentLayout.findViewById<TextView>(R.id.md_text_message).text.toString()
     }
 
+    /**
+     * Get the current dialog text for AlertDialogs (which are replacing MaterialDialogs). Will return null if no dialog visible
+     * *or* if you check for dismissed and it has been dismissed
+     *
+     * @param checkDismissed true if you want to check for dismissed, will return null even if dialog exists but has been dismissed
+     * TODO: Rename to getDialogText when all MaterialDialogs are changed to AlertDialogs
+     */
+    protected fun getAlertDialogText(@Suppress("SameParameterValue") checkDismissed: Boolean): String? {
+        val dialog = ShadowDialog.getLatestDialog()
+        dialog as AlertDialog
+        if (checkDismissed && Shadows.shadowOf(dialog).hasBeenDismissed()) {
+            Timber.e("The latest dialog has already been dismissed.")
+            return null
+        }
+        return dialog.findViewById<TextView>(android.R.id.message)?.text?.toString()
+    }
+
     // Robolectric needs a manual advance with the new PAUSED looper mode
     companion object {
+        val ALERT_DIALOG_BUTTONS = listOf(BUTTON_NEGATIVE, BUTTON_NEUTRAL, BUTTON_POSITIVE)
+
         private var mBackground = true
 
         // Robolectric needs a manual advance with the new PAUSED looper mode


### PR DESCRIPTION
## Purpose / Description
Based on https://github.com/ankidroid/Anki-Android/issues/13315, we would like to replace all instances of `MaterialDialog` with `AlertDialog`.

I started with `CardTemplateEditor` and realize that that would mean changing `DiscardChangesDialog` which was also used in 2 other locations (`NoteEditor` and `CardTemplateBrowserAppearanceEditor`). I made the change, along with some Robolectric tests (`CardTemplateEditorTest`) that required some changes in how we access underlying Robolectric `ShadowDialog`s.

Apologies that this PR became a bit involved, but hopefully should read fairly straightforwardly.

## Fixes
Fixes https://github.com/ankidroid/Anki-Android/issues/13315

## Approach
I started with a simple replace, and then modified and cleaned up things as I went along. 
* There was a situation where a method that was marked as `@VisibleForTesting` was not actually being tested, so I removed that
* In the case of `DiscardChangesDialog` I removed the return value for `showDialog` which wasn't being used anywhere
* I also made `context` a non-nullable parameter to the `showDialog` function, as it was always called with a valid `this` as a context.

## How Has This Been Tested?
So far, this has been tested in the simulator, with unit tests. I am currently working on getting it tested on my real device (I am new to Android development, I am mostly a backend Kotlin developer).

## Learning (optional, can help others)
We have a lot of code that can be written a more idiomatically in Kotlin, this presents a good way to start getting familiar with the codebase.

Note that I found this blogpost useful:
https://bterczynski.medium.com/testing-dialogs-in-robolectric-b7118f965ff3, as it described why the `performClick` call in the Robolectric tests was not having any impact.

Note: I will add screenshots as I finish up testing.  I wanted to get this PR up for review while I do that.

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
