### PR TITLE
fix crash due to `lateint var` not initialized

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/permissions/PermissionManager.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/permissions/PermissionManager.kt
@@ -116,7 +116,8 @@ class PermissionManager private constructor(
         if (permissions.requiresPermissionDialog) {
             this.launchPermissionDialog()
         } else {
-            callback.invoke(PermissionsRequestResults.allGranted(permissions))
+            launchPermissionDialog()
+            // callback.invoke(PermissionsRequestResults.allGranted(permissions))
         }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/permissions/PermissionManager.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/permissions/PermissionManager.kt
@@ -114,10 +114,9 @@ class PermissionManager private constructor(
     fun launchDialogOrExecuteCallbackNow() {
         val permissions = checkPermissions()
         if (permissions.requiresPermissionDialog) {
-            this.launchPermissionDialog()
+            this.callback.invoke(PermissionsRequestResults.allGranted(permissions))
         } else {
-            launchPermissionDialog()
-            // callback.invoke(PermissionsRequestResults.allGranted(permissions))
+            this.launchPermissionDialog()
         }
     }
 


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
Fixing callback dialog issue that caused crash

## Fixes
Fixes #13527

## Approach
_How does this change address the problem?_

## How Has This Been Tested?
Tested on one plus Nord ce


## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
