### PR TITLE
fixes the horizontal logged in UI

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/MyAccount.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/MyAccount.kt
@@ -217,6 +217,9 @@ open class MyAccount : AnkiActivity() {
         mLoggedIntoMyAccountView = layoutInflater.inflate(R.layout.my_account_logged_in, null)
         mUsernameLoggedIn = mLoggedIntoMyAccountView.findViewById(R.id.username_logged_in)
         val logoutButton = mLoggedIntoMyAccountView.findViewById<Button>(R.id.logout_button)
+        mLoggedIntoMyAccountView.let {
+            mAnkidroidLogo = it.findViewById(R.id.ankidroid_logo)
+        }
         logoutButton.setOnClickListener { logout() }
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             mPassword.setAutoFillListener {


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
1. When the user was logged in and switched to the horizontal mode they could not access the Logout button 
2. The email and password section had a yellow tint that came when the user clicked autofill (autofill in our case is not necessary)

## Fixes
Fixes #13549
I have made the AnkiDroid logo for the logged-in screen consistent to that to login screen i.e. the AnkiDroid logo is not visible in horizontal mode
And the marked the edit text fields as not important for autofill 

## Approach
_How does this change address the problem?_

## How Has This Been Tested?
![loggedIN](https://user-images.githubusercontent.com/48384865/229287315-b3c8c0dd-96f2-45a0-a079-49b06a66e991.jpg)


## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
