### PR TITLE
release: include universal build for each flavor in github releases

### DIFF
--- a/tools/release.sh
+++ b/tools/release.sh
@@ -112,7 +112,8 @@ if [ "$KSTOREPWD" == "" ]; then
   export KEYPWD
 fi
 
-# Build signed APK using Gradle and publish to Play
+# Build signed APK using Gradle and publish to Play.
+# Do this before building universal of the play flavor so the universal is not uploaded to Play Store
 # Configuration for pushing to Play specified in build.gradle 'play' task
 #echo "Running 'publishPlayReleaseApk' gradle target"
 #if ! ./gradlew publishPlayReleaseApk
@@ -127,19 +128,25 @@ fi
 #fi  #API30
 #fi  #API30
 
-# Now build the universal release also
+# Now build the full set of release APKs for all flavors, with universals
 ./gradlew --stop
-echo "Running 'assembleFullRelease' target with universal APK flag"
-if ! ./gradlew assembleFullRelease -Duniversal-apk=true
+echo "Running assembleNNNRelease target for all flavors with universal APK flag"
+if ! ./gradlew assembleFullRelease assemblePlayRelease assembleAmazonRelease -Duniversal-apk=true
 then
-  echo "unable to build universal APK for full release"
+  echo "unable to build universal APKs all flavors"
   exit 1
 fi
 
-# Copy universal APK to cwd
-ABIS='universal arm64-v8a x86 x86_64 armeabi-v7a'
+# Copy full ABI APKs to cwd
+ABIS='arm64-v8a x86 x86_64 armeabi-v7a'
 for ABI in $ABIS; do
   cp AnkiDroid/build/outputs/apk/full/release/AnkiDroid-full-"$ABI"-release.apk AnkiDroid-"$VERSION"-"$ABI".apk
+done
+
+# Copy universal APKs for all flavors to cwd
+FLAVORS='full amazon play'
+for ABI in $ABIS; do
+  cp AnkiDroid/build/outputs/apk/"$FLAVOR"/release/AnkiDroid-"$FLAVOR"-universal-release.apk AnkiDroid-"$VERSION"-"$FLAVOR"-universal.apk
 done
 
 # Push to Github Releases.
@@ -155,24 +162,23 @@ else
 fi
 
 echo "Creating new Github release"
-github-release release --tag v"$VERSION" --name "AnkiDroid $VERSION" --description "**For regular users:**<br/><br/>Install the main APK below, trying the 'universal' build first for new installs. If it refuses to install and run correctly or you have previously installed from the Play Store, you must pick the APK that matches CPU instruction set for your device.<br/><br/>This will be arm64-v8a for most phones from the last few years but [here is a guide to help you choose](https://www.howtogeek.com/339665/how-to-find-your-android-devices-info-for-correct-apk-downloads/)<br/><br/><br/>**For testers and multiple profiles users:**<br/><br/>The builds with letter codes below (A, B, etc) are universal parallel builds. They will install side-by-side with the main APK for testing, or to connect to a different AnkiWeb account in combination with changing the storage directory in preferences" $PRE_RELEASE
+github-release release --tag v"$VERSION" --name "AnkiDroid $VERSION" --description "**For regular users:**<br/><br/>Install the main APK below, trying the 'full-universal' build first for new installs. If it refuses to install and run correctly or you have previously installed from the Play Store, you must pick the APK that matches CPU instruction set for your device.<br/><br/>This will be arm64-v8a for most phones from the last few years but [here is a guide to help you choose](https://www.howtogeek.com/339665/how-to-find-your-android-devices-info-for-correct-apk-downloads/)<br/><br/><br/>**For testers and multiple profiles users:**<br/><br/>The builds with 'full', 'play' or 'amazon' are useful for testing our builds for different app stores.\n\nThe builds with letter codes below (A, B, etc) are universal parallel builds. They will install side-by-side with the main APK for testing, or to connect to a different AnkiWeb account in combination with changing the storage directory in preferences" $PRE_RELEASE
 
 echo "Sleeping 30s to make sure the release exists, see issue 11746"
 sleep 30
 
 for ABI in $ABIS; do
-  echo "Adding APK for $ABI to Github release"
+  echo "Adding full APK for $ABI to Github release"
   github-release upload --tag v"$VERSION" --name AnkiDroid-"$VERSION"-"$ABI".apk --file AnkiDroid-"$VERSION"-"$ABI".apk
+done
+# Copy flavor universal APKs to cwd
+for FLAVOR in $FLAVORS; do
+  echo "Adding universal APK for $FLAVOR to Github release"
+  github-release upload --tag v"$VERSION" --name AnkiDroid-"$VERSION"-"$FLAVOR"-universal.apk --file AnkiDroid-"$VERSION"-"$FLAVOR"-universal.apk
 done
 
 if [ "$PUBLIC" = "public" ]; then
   ./gradlew --stop
-  echo "Running 'assembleAmazonRelease' gradle target with universal APK flag"
-  if ! ./gradlew assembleAmazonRelease  -Duniversal-apk=true
-  then
-    echo "Unable to build amazon release"
-    exit 1
-  fi
   echo "Running 'publishToAmazonAppStore' gradle target"
   if ! ./gradlew publishToAmazonAppStore
   then


### PR DESCRIPTION

## Pull Request template

## Purpose / Description

this should help storage migration testing as a play build will now be available despite a general policy of "full builds on github releases"

## Fixes

This is related to a great comment from @Arthur-Milchior here https://github.com/ankidroid/Anki-Android/pull/13514#issuecomment-1487792345

## Approach

- generate universal APKs for *all* flavors
- split the APK copy step into ABI and FLAVOR chunks so we copy universals for all flavors
- split the APK github release push into ABI and FLAVOR chunks so we upload universals for all flavors
- updated related comments / release copy

## How Has This Been Tested?

I'm going to test the build but not the uploads locally but there is really no way to test this well other than to run the script and burn an alpha version number 🙈 

## Learning (optional, can help others)

🤷 

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
