### PR TITLE
finishActivityWithFade(this) is written twice in CardBrowser.kt

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -1014,7 +1014,6 @@ open class CardBrowser :
         deckPicker.flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
         startActivityWithAnimation(deckPicker, ActivityTransitionAnimation.Direction.FADE)
         finishActivityWithFade(this)
-        finishActivityWithFade(this)
         this.setResult(RESULT_CANCELED)
     }
 


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
`finishActivityWithFade(this)` is written twice in CardBrowser.kt. I don't think writing twice is worth it 

## How Has This Been Tested?
Tested on Emulator working fine

## Checklist
_Please, go through these checks before submitting the PR._

- [ ] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas
- [ ] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
