### PR TITLE
Replaced toast with Snackbar in MultimediaEditFieldActivity

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/activity/MultimediaEditFieldActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/activity/MultimediaEditFieldActivity.kt
@@ -294,12 +294,12 @@ class MultimediaEditFieldActivity : AnkiActivity(), OnRequestPermissionsResultCa
                 recreateEditingUIUsingCachedRequest()
                 return
             }
-            showSnackbar((R.string.multimedia_editor_audio_permission_refused), Snackbar.LENGTH_SHORT)
+            showSnackbar(R.string.multimedia_editor_audio_permission_refused, Snackbar.LENGTH_SHORT)
             UIRecreationHandler.onRequiredPermissionDenied(mCurrentChangeRequest!!, this)
         }
         if (requestCode == REQUEST_CAMERA_PERMISSION && permissions.size == 1) {
             if (grantResults[0] != PackageManager.PERMISSION_GRANTED) {
-                showSnackbar((R.string.multimedia_editor_camera_permission_refused), Snackbar.LENGTH_SHORT)
+                showSnackbar(R.string.multimedia_editor_camera_permission_refused, Snackbar.LENGTH_SHORT)
             }
 
             // We check permissions to set visibility on the camera button, just recreate

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/activity/MultimediaEditFieldActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/activity/MultimediaEditFieldActivity.kt
@@ -295,14 +295,16 @@ class MultimediaEditFieldActivity : AnkiActivity(), OnRequestPermissionsResultCa
                 recreateEditingUIUsingCachedRequest()
                 return
             }
-            showSnackbar(resources.getString(R.string.multimedia_editor_audio_permission_refused),
+            showSnackbar(
+                resources.getString(R.string.multimedia_editor_audio_permission_refused),
                 Snackbar.LENGTH_SHORT
             )
             UIRecreationHandler.onRequiredPermissionDenied(mCurrentChangeRequest!!, this)
         }
         if (requestCode == REQUEST_CAMERA_PERMISSION && permissions.size == 1) {
             if (grantResults[0] != PackageManager.PERMISSION_GRANTED) {
-                showSnackbar(resources.getString(R.string.multimedia_editor_camera_permission_refused),
+                showSnackbar(
+                    resources.getString(R.string.multimedia_editor_camera_permission_refused),
                     Snackbar.LENGTH_SHORT
                 )
             }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/activity/MultimediaEditFieldActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/activity/MultimediaEditFieldActivity.kt
@@ -81,7 +81,7 @@ class MultimediaEditFieldActivity : AnkiActivity(), OnRequestPermissionsResultCa
         val intent = this.intent
         val extras = getFieldFromIntent(intent)
         if (extras == null) {
-            showSnackbar(getString(R.string.multimedia_editor_failed))
+            showSnackbar(R.string.multimedia_editor_failed)
             finishCancel()
             return
         }
@@ -294,18 +294,12 @@ class MultimediaEditFieldActivity : AnkiActivity(), OnRequestPermissionsResultCa
                 recreateEditingUIUsingCachedRequest()
                 return
             }
-            showSnackbar(
-                resources.getString(R.string.multimedia_editor_audio_permission_refused),
-                Snackbar.LENGTH_SHORT
-            )
+            showSnackbar((R.string.multimedia_editor_audio_permission_refused), Snackbar.LENGTH_SHORT)
             UIRecreationHandler.onRequiredPermissionDenied(mCurrentChangeRequest!!, this)
         }
         if (requestCode == REQUEST_CAMERA_PERMISSION && permissions.size == 1) {
             if (grantResults[0] != PackageManager.PERMISSION_GRANTED) {
-                showSnackbar(
-                    resources.getString(R.string.multimedia_editor_camera_permission_refused),
-                    Snackbar.LENGTH_SHORT
-                )
+                showSnackbar((R.string.multimedia_editor_camera_permission_refused), Snackbar.LENGTH_SHORT)
             }
 
             // We check permissions to set visibility on the camera button, just recreate
@@ -315,7 +309,7 @@ class MultimediaEditFieldActivity : AnkiActivity(), OnRequestPermissionsResultCa
 
     private fun cancelActivityWithAssertionFailure(logMessage: String) {
         Timber.e(logMessage)
-        showSnackbar(getString(R.string.mutimedia_editor_assertion_failed))
+        showSnackbar(R.string.mutimedia_editor_assertion_failed)
         finishCancel()
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/activity/MultimediaEditFieldActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/activity/MultimediaEditFieldActivity.kt
@@ -29,11 +29,13 @@ import android.widget.LinearLayout
 import androidx.annotation.VisibleForTesting
 import androidx.core.app.ActivityCompat
 import androidx.core.app.ActivityCompat.OnRequestPermissionsResultCallback
+import com.google.android.material.snackbar.Snackbar
 import com.ichi2.anki.AnkiActivity
 import com.ichi2.anki.R
 import com.ichi2.anki.UIUtils
 import com.ichi2.anki.multimediacard.IMultimediaEditableNote
 import com.ichi2.anki.multimediacard.fields.*
+import com.ichi2.anki.snackbar.showSnackbar
 import com.ichi2.compat.CompatHelper.Companion.getSerializableCompat
 import com.ichi2.utils.KotlinCleanup
 import com.ichi2.utils.Permissions
@@ -293,19 +295,15 @@ class MultimediaEditFieldActivity : AnkiActivity(), OnRequestPermissionsResultCa
                 recreateEditingUIUsingCachedRequest()
                 return
             }
-            UIUtils.showThemedToast(
-                this,
-                resources.getString(R.string.multimedia_editor_audio_permission_refused),
-                true
+            showSnackbar(resources.getString(R.string.multimedia_editor_audio_permission_refused),
+                Snackbar.LENGTH_SHORT
             )
             UIRecreationHandler.onRequiredPermissionDenied(mCurrentChangeRequest!!, this)
         }
         if (requestCode == REQUEST_CAMERA_PERMISSION && permissions.size == 1) {
             if (grantResults[0] != PackageManager.PERMISSION_GRANTED) {
-                UIUtils.showThemedToast(
-                    this,
-                    resources.getString(R.string.multimedia_editor_camera_permission_refused),
-                    true
+                showSnackbar(resources.getString(R.string.multimedia_editor_camera_permission_refused),
+                    Snackbar.LENGTH_SHORT
                 )
             }
 
@@ -316,7 +314,7 @@ class MultimediaEditFieldActivity : AnkiActivity(), OnRequestPermissionsResultCa
 
     private fun cancelActivityWithAssertionFailure(logMessage: String) {
         Timber.e(logMessage)
-        UIUtils.showThemedToast(this, getString(R.string.mutimedia_editor_assertion_failed), false)
+        showSnackbar(getString(R.string.mutimedia_editor_assertion_failed), Snackbar.LENGTH_SHORT)
         finishCancel()
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/activity/MultimediaEditFieldActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/activity/MultimediaEditFieldActivity.kt
@@ -32,7 +32,6 @@ import androidx.core.app.ActivityCompat.OnRequestPermissionsResultCallback
 import com.google.android.material.snackbar.Snackbar
 import com.ichi2.anki.AnkiActivity
 import com.ichi2.anki.R
-import com.ichi2.anki.UIUtils
 import com.ichi2.anki.multimediacard.IMultimediaEditableNote
 import com.ichi2.anki.multimediacard.fields.*
 import com.ichi2.anki.snackbar.showSnackbar
@@ -82,7 +81,7 @@ class MultimediaEditFieldActivity : AnkiActivity(), OnRequestPermissionsResultCa
         val intent = this.intent
         val extras = getFieldFromIntent(intent)
         if (extras == null) {
-            UIUtils.showThemedToast(this, getString(R.string.multimedia_editor_failed), false)
+            showSnackbar(getString(R.string.multimedia_editor_failed), Snackbar.LENGTH_SHORT)
             finishCancel()
             return
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/activity/MultimediaEditFieldActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/activity/MultimediaEditFieldActivity.kt
@@ -81,7 +81,7 @@ class MultimediaEditFieldActivity : AnkiActivity(), OnRequestPermissionsResultCa
         val intent = this.intent
         val extras = getFieldFromIntent(intent)
         if (extras == null) {
-            showSnackbar(getString(R.string.multimedia_editor_failed), Snackbar.LENGTH_SHORT)
+            showSnackbar(getString(R.string.multimedia_editor_failed))
             finishCancel()
             return
         }
@@ -315,7 +315,7 @@ class MultimediaEditFieldActivity : AnkiActivity(), OnRequestPermissionsResultCa
 
     private fun cancelActivityWithAssertionFailure(logMessage: String) {
         Timber.e(logMessage)
-        showSnackbar(getString(R.string.mutimedia_editor_assertion_failed), Snackbar.LENGTH_SHORT)
+        showSnackbar(getString(R.string.mutimedia_editor_assertion_failed))
         finishCancel()
     }
 


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
Replaced toast with Snackbar in MultimediaEditFieldActivity 

## Fixes
Related to #13411

## How Has This Been Tested?
Tested on Realme 6

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration (SDK version(s), emulator or physical, etc)

## Learning (optional, can help others)
_Describe the research stage_

_Links to blog posts, patterns, libraries or addons used to solve this problem_

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [ ] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
