### PR TITLE
Make all colors available to the JS API consumers

### DIFF
--- a/AnkiDroid/src/main/assets/scripts/card.js
+++ b/AnkiDroid/src/main/assets/scripts/card.js
@@ -137,6 +137,15 @@ function ankiToggleFlag(flag) {
             case 4:
                 window.location.href = "signal:flag_blue";
                 break;
+            case 5:
+                window.location.href = "signal:flag_pink";
+                break;
+            case 6:
+                window.location.href = "signal:flag_turquoise";
+                break;
+            case 7:
+                window.location.href = "signal:flag_purple";
+                break;
             default:
                 console.log("No Flag Found");
                 break;

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
@@ -2370,6 +2370,18 @@ abstract class AbstractFlashcardViewer :
                         executeCommand(ViewerCommand.TOGGLE_FLAG_BLUE)
                         true
                     }
+                    "pink" -> {
+                        executeCommand(ViewerCommand.TOGGLE_FLAG_PINK)
+                        true
+                    }
+                    "turquoise" -> {
+                        executeCommand(ViewerCommand.TOGGLE_FLAG_TURQUOISE)
+                        true
+                    }
+                    "purple" -> {
+                        executeCommand(ViewerCommand.TOGGLE_FLAG_PURPLE)
+                        true
+                    }
                     else -> {
                         Timber.d("No such Flag found.")
                         true


### PR DESCRIPTION
## Purpose / Description

Adds the rest of the declared colors to the js `ankiToggleFlag()` method and makes AbstractFlashcardViewer to use them.

## Fixes
Fixes #13526 

## How Has This Been Tested?

Ran the tests, used the target js function in a card.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
