### PR TITLE
build(deps): bump jacoco to 0.8.9

### DIFF
--- a/AnkiDroid/jacoco.gradle
+++ b/AnkiDroid/jacoco.gradle
@@ -3,13 +3,13 @@ import groovy.transform.Memoized
 apply plugin: 'jacoco'
 
 jacoco {
-    toolVersion = "0.8.8"
+    toolVersion = "0.8.9"
 
 }
 
 android {
     testCoverage {
-        jacocoVersion '0.8.8'
+        jacocoVersion '0.8.9'
     }
 }
 


### PR DESCRIPTION

Jacoco 0.8.9 is out, let's use it.

Passes full suite of tests locally