### PR TITLE
Fix release process for full flavor builds

### DIFF
--- a/tools/release.sh
+++ b/tools/release.sh
@@ -100,10 +100,6 @@ git add $GRADLEFILE $CHANGELOG
 git commit -m "Bumped version to $VERSION"
 git tag v"$VERSION"
 
-# Push both commits and tag
-git push
-git push --tags
-
 # Read the key passwords if needed
 if [ "$KSTOREPWD" == "" ]; then
   read -rsp "Enter keystore password: " KSTOREPWD; echo
@@ -123,6 +119,10 @@ for UCFLAVOR in $UCFLAVORS; do
     exit 1
   fi
 done
+
+# Push both commits and tag before any of the builds leave the machine
+git push
+git push --tags
 
 # Build signed APK using Gradle and publish to Play.
 # Do this before building universal of the play flavor so the universal is not uploaded to Play Store

--- a/tools/release.sh
+++ b/tools/release.sh
@@ -145,7 +145,7 @@ done
 
 # Copy universal APKs for all flavors to cwd
 FLAVORS='full amazon play'
-for ABI in $ABIS; do
+for FLAVOR in $FLAVORS; do
   cp AnkiDroid/build/outputs/apk/"$FLAVOR"/release/AnkiDroid-"$FLAVOR"-universal-release.apk AnkiDroid-"$VERSION"-"$FLAVOR"-universal.apk
 done
 

--- a/tools/release.sh
+++ b/tools/release.sh
@@ -112,10 +112,23 @@ if [ "$KSTOREPWD" == "" ]; then
   export KEYPWD
 fi
 
+# Build the full set of release APKs for all flavors, with universals
+UCFLAVORS='Full Amazon Play'
+for UCFLAVOR in $UCFLAVORS; do
+  ./gradlew --stop
+  echo Running assemble"$UCFLAVOR"Release target with universal APK flag
+  if ! ./gradlew assemble"$UCFLAVOR"Release -Duniversal-apk=true
+  then
+    echo "unable to build release APKs for flavor $UCFLAVOR"
+    exit 1
+  fi
+done
+
 # Build signed APK using Gradle and publish to Play.
 # Do this before building universal of the play flavor so the universal is not uploaded to Play Store
 # Configuration for pushing to Play specified in build.gradle 'play' task
 #echo "Running 'publishPlayReleaseApk' gradle target"
+#./gradlew --stop
 #if ! ./gradlew publishPlayReleaseApk
 #then
   # APK contains problems
@@ -127,15 +140,6 @@ fi
 #  echo "Google has rejected the APK upload. Likely because targetSdkVersion < 30. Continuing..."  #API30
 #fi  #API30
 #fi  #API30
-
-# Now build the full set of release APKs for all flavors, with universals
-./gradlew --stop
-echo "Running assembleNNNRelease target for all flavors with universal APK flag"
-if ! ./gradlew assembleFullRelease assemblePlayRelease assembleAmazonRelease -Duniversal-apk=true
-then
-  echo "unable to build universal APKs all flavors"
-  exit 1
-fi
 
 # Copy full ABI APKs to cwd
 ABIS='arm64-v8a x86 x86_64 armeabi-v7a'


### PR DESCRIPTION
## Pull Request template

## Purpose / Description

Unfortunately the release process just broke and I was able to reproduce it locally (out of memory)

## Fixes

https://github.com/ankidroid/Anki-Android/actions/runs/4633209039/jobs/8198171270#step:10:230

> ERROR:R8: java.lang.OutOfMemoryError: Java heap space

## Approach

I was also able to get it to work locally if I built one flavor at a time, so I'm going to go with that

In the process I added a change that will hopefully burn fewer unreleased version numbers in the future and fixed a copy-pasta error in my last work on the release script

## How Has This Been Tested?

Local execution of the related commands from `./tools/release.sh`

## Learning (optional, can help others)

Java+Kotlin is obscenely RAM hungry. Something to continuously learn.

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
