### PR TITLE
fix: Show snackbar instead of toast

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiActivity.kt
@@ -35,7 +35,6 @@ import com.ichi2.anim.ActivityTransitionAnimation
 import com.ichi2.anim.ActivityTransitionAnimation.Direction
 import com.ichi2.anim.ActivityTransitionAnimation.Direction.*
 import com.ichi2.anki.CollectionManager.withCol
-import com.ichi2.anki.UIUtils.showThemedToast
 import com.ichi2.anki.analytics.UsageAnalytics
 import com.ichi2.anki.dialogs.AsyncDialogFragment
 import com.ichi2.anki.dialogs.DialogHandler
@@ -392,17 +391,12 @@ open class AnkiActivity : AppCompatActivity, SimpleMessageDialogListener, Collec
         }
     }
 
-    @KotlinCleanup("toast -> snackbar")
     open fun openUrl(url: Uri) {
         // DEFECT: We might want a custom view for the toast, given i8n may make the text too long for some OSes to
         // display the toast
         if (!AdaptionUtil.hasWebBrowser(this)) {
             @KotlinCleanup("check RTL with concat")
-            showThemedToast(
-                this,
-                resources.getString(R.string.no_browser_notification) + url,
-                false
-            )
+            showSnackbar(resources.getString(R.string.no_browser_notification) + url)
             return
         }
         val toolbarColor = Themes.getColorFromAttr(this, R.attr.colorPrimary)


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
fix: Show snackbar instead of toast

## Fixes
Fixes _Link to the issues._

## Approach
Show snackbar instead of toast

## How Has This Been Tested?


## Before

![WhatsApp Image 2023-04-08 at 2 18 10 PM](https://user-images.githubusercontent.com/76740999/230712875-13fec5ef-2ef3-4cfb-978d-e51a78267de9.jpeg)

## After


![WhatsApp Image 2023-04-08 at 2 21 31 PM](https://user-images.githubusercontent.com/76740999/230712877-dd3d18e7-adb4-4ef6-be18-dfffab246056.jpeg)



## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
