### PR TITLE
Deprecate methods in AlertDialogFacade

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -92,6 +92,7 @@ import com.ichi2.anki.services.MigrationService
 import com.ichi2.anki.services.ServiceConnection
 import com.ichi2.anki.snackbar.showSnackbar
 import com.ichi2.anki.stats.AnkiStatsTaskHandler
+import com.ichi2.anki.ui.dialogs.tools.setCheckBoxPrompt
 import com.ichi2.anki.web.HostNumFactory
 import com.ichi2.anki.widgets.DeckAdapter
 import com.ichi2.annotations.NeedsTest
@@ -2569,7 +2570,7 @@ open class DeckPicker :
             }
         // allow the user to dismiss the automatic dialog after it's been seen twice
         if (shownAutomatically && timesStorageMigrationPostponed > 1) {
-            dialog.checkBoxPrompt(R.string.button_do_not_show_again) { checked ->
+            dialog.setCheckBoxPrompt(R.string.button_do_not_show_again) { checked ->
                 Timber.d("Don't show again checked: %b", checked)
                 userCheckedDoNotShowAgain = checked
             }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/dialogs/tools/Dialogs.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/dialogs/tools/Dialogs.kt
@@ -1,0 +1,84 @@
+/*
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.ui.dialogs.tools
+
+import android.content.Context
+import android.view.View
+import android.widget.CheckBox
+import androidx.annotation.StringRes
+import androidx.appcompat.app.AlertDialog
+import androidx.fragment.app.DialogFragment
+import androidx.fragment.app.Fragment
+import com.ichi2.anki.R
+
+/**
+ * Configure, create and show a dialog.
+ *
+ *     showAlertDialog {
+ *         setTitle(title)
+ *         setMessage(message)
+ *     }
+ *
+ * Note that this dialog may disappear if the activity is recreated,
+ * for example, when the device is rotated, or when it goes into battery saver mode.
+ * For more important dialogs, consider using [DialogFragment] instead.
+ */
+fun Context.showAlertDialog(block: AlertDialog.Builder.() -> Unit) {
+    AlertDialog.Builder(this)
+        .apply(block)
+        .show()
+}
+
+/**
+ * Configure, create and show a dialog.
+ * The fragment must be attached to the context.
+ *
+ *     showAlertDialog {
+ *         setTitle(title)
+ *         setMessage(message)
+ *     }
+ *
+ * Note that this dialog may disappear if the fragment is recreated,
+ * for example, when the device is rotated, or when it goes into battery saver mode.
+ * For more important dialogs, consider using [DialogFragment] instead.
+ */
+fun Fragment.showAlertDialog(block: AlertDialog.Builder.() -> Unit) {
+    AlertDialog.Builder(requireContext())
+        .apply(block)
+        .show()
+}
+
+/**
+ * Add a checkbox with a title to the dialog.
+ * If the dialog has a message, it is retained.
+ *
+ * @param stringResId the resource ID of the string to be shown for the checkbox label
+ * @param isChecked whether or not the checkbox is initially checked
+ * @param onCheckedChangeListener a listener invoked when the checkbox is checked or unchecked
+ */
+fun AlertDialog.Builder.setCheckBoxPrompt(
+    @StringRes stringResId: Int,
+    isChecked: Boolean = false,
+    onCheckedChangeListener: (checked: Boolean) -> Unit
+) = apply {
+    val checkBoxLayout = View.inflate(this.context, R.layout.alert_dialog_checkbox, null)
+    val checkBox = checkBoxLayout.findViewById<CheckBox>(R.id.checkbox)
+
+    checkBox.setText(stringResId)
+    checkBox.isChecked = isChecked
+    checkBox.setOnCheckedChangeListener { _, isChecked -> onCheckedChangeListener(isChecked) }
+
+    setView(checkBoxLayout)
+}

--- a/AnkiDroid/src/main/java/com/ichi2/utils/AlertDialogFacade.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/AlertDialogFacade.kt
@@ -20,12 +20,9 @@ package com.ichi2.utils
 
 import android.content.DialogInterface
 import android.content.DialogInterface.OnClickListener
-import android.view.View
-import android.widget.CheckBox
 import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
 import androidx.appcompat.app.AlertDialog
-import com.ichi2.anki.R
 import com.ichi2.themes.Themes
 
 /** Wraps [DialogInterface.OnClickListener] as we don't need the `which` parameter */
@@ -39,6 +36,7 @@ fun DialogInterfaceListener.toClickListener(): OnClickListener {
  * Allows easier transformations from [MaterialDialog] to [AlertDialog].
  * Inline this file when material dialog is removed
  */
+@Deprecated("This method is deprecated as it is not type-safe. Use setTitle() instead.", ReplaceWith("setTitle(stringRes ?: text)"))
 fun AlertDialog.Builder.title(@StringRes stringRes: Int? = null, text: String? = null): AlertDialog.Builder {
     if (stringRes == null && text == null) {
         throw IllegalArgumentException("either `stringRes` or `text` must be set")
@@ -50,6 +48,7 @@ fun AlertDialog.Builder.title(@StringRes stringRes: Int? = null, text: String? =
     }
 }
 
+@Deprecated("This method is deprecated as it is not type-safe. Use setMessage() instead.", ReplaceWith("setMessage(stringRes ?: text)"))
 fun AlertDialog.Builder.message(@StringRes stringRes: Int? = null, text: CharSequence? = null): AlertDialog.Builder {
     if (stringRes == null && text == null) {
         throw IllegalArgumentException("either `stringRes` or `text` must be set")
@@ -64,12 +63,14 @@ fun AlertDialog.Builder.message(@StringRes stringRes: Int? = null, text: CharSeq
 /**
  * Shows an icon to the left of the dialog title.
  */
+@Deprecated("This method is deprecated as it is redundant. Use setIconAttribute() instead.", ReplaceWith("setIconAttribute(res)"))
 fun AlertDialog.Builder.iconAttr(
     @DrawableRes res: Int
 ) = apply {
     return this.setIcon(Themes.getResFromAttr(this.context, res))
 }
 
+@Deprecated("This method is deprecated as it is redundant. Use setPositiveButton() instead.", ReplaceWith("setPositiveButton(stringRes ?: text, click)"))
 fun AlertDialog.Builder.positiveButton(
     @StringRes stringRes: Int? = null,
     text: CharSequence? = null,
@@ -85,6 +86,7 @@ fun AlertDialog.Builder.positiveButton(
     }
 }
 
+@Deprecated("This method is deprecated as it is redundant. Use setNeutralButton() instead.", ReplaceWith("setNeutralButton(stringRes ?: text, click)"))
 fun AlertDialog.Builder.neutralButton(
     @StringRes stringRes: Int? = null,
     text: CharSequence? = null,
@@ -100,6 +102,7 @@ fun AlertDialog.Builder.neutralButton(
     }
 }
 
+@Deprecated("This method is deprecated as it is redundant. Use setNegativeButton() instead.", ReplaceWith("setNegativeButton(stringRes ?: text, click)"))
 fun AlertDialog.Builder.negativeButton(
     @StringRes stringRes: Int? = null,
     text: CharSequence? = null,
@@ -115,6 +118,7 @@ fun AlertDialog.Builder.negativeButton(
     }
 }
 
+@Deprecated("This method is deprecated as it is redundant. Use setCancelable() instead.", ReplaceWith("setCancelable(cancelable)"))
 fun AlertDialog.Builder.cancelable(cancelable: Boolean): AlertDialog.Builder {
     return this.setCancelable(cancelable)
 }
@@ -123,37 +127,8 @@ fun AlertDialog.Builder.cancelable(cancelable: Boolean): AlertDialog.Builder {
  * Executes the provided block, then creates an [AlertDialog] with the arguments supplied
  * and immediately displays the dialog
  */
+@Deprecated("This method is deprecated. Use showAlertDialog { ... } instead.")
 inline fun AlertDialog.Builder.show(block: AlertDialog.Builder.() -> Unit): AlertDialog.Builder = apply {
     this.block()
     this.show()
-}
-
-/**
- * Adds a checkbox to the dialog, whilst continuing to display the value of [message]
- * @param stringRes The string resource to display for the checkbox label.
- * @param text The literal string to display for the checkbox label.
- * @param isCheckedDefault Whether or not the checkbox is initially checked.
- * @param onToggle A listener invoked when the checkbox is checked or unchecked.
- */
-fun AlertDialog.Builder.checkBoxPrompt(
-    @StringRes stringRes: Int? = null,
-    text: CharSequence? = null,
-    isCheckedDefault: Boolean = false,
-    onToggle: (checked: Boolean) -> Unit
-): AlertDialog.Builder {
-    if (stringRes == null && text == null) {
-        throw IllegalArgumentException("either `stringRes` or `text` must be set")
-    }
-    val checkBoxView = View.inflate(this.context, R.layout.alert_dialog_checkbox, null)
-    val checkBox = checkBoxView.findViewById<CheckBox>(R.id.checkbox)
-
-    val checkBoxLabel = if (stringRes != null) context.getString(stringRes) else text
-    checkBox.text = checkBoxLabel
-    checkBox.isChecked = isCheckedDefault
-
-    checkBox.setOnCheckedChangeListener { _, isChecked ->
-        onToggle(isChecked)
-    }
-
-    return this.setView(checkBoxView)
 }


### PR DESCRIPTION
## Purpose / Description

`AlertDialog.Builder` `methods are well-known. Using a home-brew API that adds little to none functionality to the original ones is not very helpful. Also, some of the APIs are not type-safe, throwing an exception if neither of the string resource id nor text is provided.

## Approach

Methods are deprecated in favor of regular `AlertDialog.Builder` methods. Additionally,
* function AlertDialog.Builder.show is deprecated in favor of `showAlertDialog`. This function, placed in 
  `com.ichi2.anki.ui.dialogs.tools`, parallels the existing `showSnackbar`.
* function `checkBoxPrompt`, being used in one place only, is refactored into a more type-safe `setCheckBoxPrompt` in the same package.

**NOTE**: I didn't find a way to make proper `ReplaceWith` for many cases. E.g. I opted for `"setMessage(stringRes ?: text)"` for `message()`; the former only accepts a single argument but the latter accepts two. The resulting code needs some adjustments, e.g.

    positiveButton(R.string.dialog_cancel) { onCancel() }

is converted to

    setPositiveButton(R.string.dialog_cancel ?: null) { onCancel() }

which has to be manually changed into

    setPositiveButton(R.string.dialog_cancel) { _, _ -> onCancel() }

I don't know if there's a better way.

The tests fail because warnings are reported as errors, not sure what's the procedure to deal with this.

## How Has This Been Tested?

Tested in AS (deprecation warning) and on device (behavior of `setCheckBoxPrompt`).

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
