### PR TITLE
Add Override to Always Display Answer Button in Card Preview

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplatePreviewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplatePreviewer.kt
@@ -18,6 +18,7 @@ package com.ichi2.anki
 
 import android.os.Bundle
 import android.view.View
+import android.widget.LinearLayout
 import com.ichi2.anim.ActivityTransitionAnimation
 import com.ichi2.anki.UIUtils.showThemedToast
 import com.ichi2.anki.cardviewer.PreviewLayout
@@ -140,6 +141,7 @@ open class CardTemplatePreviewer : AbstractFlashcardViewer() {
         super.initLayout()
         topBarLayout!!.visibility = View.GONE
         findViewById<View>(R.id.answer_options_layout).visibility = View.GONE
+        findViewById<LinearLayout>(R.id.bottom_area_layout).visibility = View.VISIBLE
         previewLayout = createAndDisplay(this, mToggleAnswerHandler)
         previewLayout!!.setOnPreviousCard { onPreviousTemplate() }
         previewLayout!!.setOnNextCard { onNextTemplate() }


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
If `Answer buttons position` is set to `None`, there is no way to flip the card. This PR makes it so the answer buttons will display in the card editor preview regardless.

## Fixes
Resolves #12045

## Approach
This PR makes it so the answer buttons will display in the card editor preview regardless.

## How Has This Been Tested?

I set  `Answer buttons position` to `None`, went to the card browser, and previewed and was able to verify the display answer button still showed. I also checked that the display answer button did not show in regular reviewing as expected.

## Learning (optional, can help others)
_Describe the research stage_

_Links to blog posts, patterns, libraries or addons used to solve this problem_

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas
 - Not sure if this requires a comment.
- [x] You have performed a self-review of your own code
 - Not sure if it would be better to import `android.widget.*` as I saw in another file.
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
