### PR TITLE
fix: Can't open "Third Party Apps"

### DIFF
--- a/AnkiDroid/src/main/AndroidManifest.xml
+++ b/AnkiDroid/src/main/AndroidManifest.xml
@@ -65,6 +65,11 @@
         <intent>
             <action android:name="android.intent.action.TTS_SERVICE" />
         </intent>
+        <intent>
+            <action android:name="android.intent.action.VIEW" />
+            <category android:name="android.intent.category.BROWSABLE" />
+            <data android:scheme="https" />
+        </intent>
     </queries>
 
     <!--


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
"Third Party Apps" says we don't have a browser

Cause

https://github.com/ankidroid/Anki-Android/blob/490493792b45f73ecaa7267a5fa1548e1b36fab6/AnkiDroid/src/main/java/com/ichi2/utils/AdaptionUtil.kt#L75-L77

Broken in 56a195bf466c57e5a848e6ba8796a529816d5cab

## Fixes
- Fixes #13567
- Fixes #13571

## Approach
State that we want the ability to query apps which handle HTTPS URLs

## How Has This Been Tested?
API 33 emulator

## Learning (optional, can help others)

API 30: `queryIntentActivitiesCompat` requires `<queries>` to stop app enumeration.

https://developer.android.com/about/versions/11/privacy/package-visibility
https://developer.android.com/training/package-visibility/use-cases#open-urls


## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
