### PR TITLE
Crash fix due to `EditTextPreference` search field in CustomStudyDeck

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/ui/AppCompatPreferenceActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/ui/AppCompatPreferenceActivity.kt
@@ -25,17 +25,19 @@ import android.preference.PreferenceActivity
 import android.view.*
 import androidx.annotation.LayoutRes
 import androidx.appcompat.app.ActionBar
+import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatDelegate
 import androidx.appcompat.widget.Toolbar
 import com.ichi2.anki.CollectionHelper
+import com.ichi2.anki.R
 import com.ichi2.anki.receiver.SdCardReceiver
 import com.ichi2.libanki.Collection
 import com.ichi2.libanki.Deck
-import com.ichi2.utils.HashUtil
-import com.ichi2.utils.KotlinCleanup
+import com.ichi2.utils.*
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.MainScope
 import kotlinx.coroutines.cancel
+import net.ankiweb.rsdroid.BackendException
 import timber.log.Timber
 import java.util.*
 
@@ -295,7 +297,7 @@ abstract class AppCompatPreferenceActivity<PreferenceHack : AppCompatPreferenceA
     @Deprecated("Deprecated in Java")
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
         if (item.itemId == android.R.id.home) {
-            closeWithResult()
+            tryCloseWithResult()
             return true
         }
         return false
@@ -304,10 +306,25 @@ abstract class AppCompatPreferenceActivity<PreferenceHack : AppCompatPreferenceA
     override fun onKeyDown(keyCode: Int, event: KeyEvent): Boolean {
         if (keyCode == KeyEvent.KEYCODE_BACK && event.repeatCount == 0) {
             Timber.i("DeckOptions - onBackPressed()")
-            closeWithResult()
+            tryCloseWithResult()
             return true
         }
         return super.onKeyDown(keyCode, event)
+    }
+
+    private fun tryCloseWithResult() {
+        try {
+            closeWithResult()
+        } catch (e: BackendException) {
+            Timber.e(e, "Backend exception while trying to finish an AppCompatPreferenceActivity")
+            AlertDialog.Builder(this).show {
+                title(text = resources.getString(R.string.pref__widget_text__error))
+                message(text = e.message)
+                positiveButton(R.string.dialog_ok) { dialogInterface ->
+                    dialogInterface.dismiss()
+                }
+            }
+        }
     }
 
     override fun getSharedPreferences(name: String, mode: Int): SharedPreferences {


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
I am allowing the user to only see the search text for the deck and properties they selected which I think is the right thing to do as the text if altered and not matched with the required one causes an issue as I said on Discord 
There is another but that would require to creation of two new fields one for the deck and one for the property, deck field would be fine but the property field would be a mess as there are lists and limits or even text which are accepted as properties.


## Fixes
Fixes #13581


## How Has This Been Tested?

Tested on oneplus nord ce
![Screenshot_35](https://user-images.githubusercontent.com/48384865/230796923-db019c0c-57fa-4e77-b923-d13ce6cae15a.jpg)



## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
