### PR TITLE
fix: Changed title and action names of cancel share deck download dialog

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/SharedDecksDownloadFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/SharedDecksDownloadFragment.kt
@@ -432,7 +432,7 @@ class SharedDecksDownloadFragment : Fragment() {
     fun showCancelConfirmationDialog() {
         mDownloadCancelConfirmationDialog = context?.let {
             MaterialDialog(it).show {
-                title(R.string.confirm_cancel)
+                title(R.string.cancel_download_question_title)
                 positiveButton(R.string.dialog_yes) {
                     mDownloadManager.remove(mDownloadId)
                     unregisterReceiver()

--- a/AnkiDroid/src/main/java/com/ichi2/anki/SharedDecksDownloadFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/SharedDecksDownloadFragment.kt
@@ -432,14 +432,14 @@ class SharedDecksDownloadFragment : Fragment() {
     fun showCancelConfirmationDialog() {
         mDownloadCancelConfirmationDialog = context?.let {
             MaterialDialog(it).show {
-                title(R.string.cancel_download_question_title)
-                positiveButton(R.string.dialog_cancel) {
+                title(R.string.confirm_cancel)
+                positiveButton(R.string.dialog_yes) {
                     mDownloadManager.remove(mDownloadId)
                     unregisterReceiver()
                     isDownloadInProgress = false
                     activity?.onBackPressed()
                 }
-                negativeButton(R.string.dialog_continue) {
+                negativeButton(R.string.dialog_no) {
                     dismiss()
                 }
             }

--- a/AnkiDroid/src/main/res/values/02-strings.xml
+++ b/AnkiDroid/src/main/res/values/02-strings.xml
@@ -374,7 +374,7 @@
     <string name="download_deck">Download deck</string>
     <string name="try_again">Try Again</string>
     <string name="cancel_download">Cancel download</string>
-    <string name="cancel_download_question_title">Cancel download?</string>
+    <string name="cancel_download_question_title">Do you want to cancel download?</string>
     <string name="downloading_file">Downloading %s</string>
     <string name="import_deck">Import Deck</string>
     <string name="something_wrong">Something went wrong, please try again</string>

--- a/AnkiDroid/src/main/res/values/02-strings.xml
+++ b/AnkiDroid/src/main/res/values/02-strings.xml
@@ -374,7 +374,7 @@
     <string name="download_deck">Download deck</string>
     <string name="try_again">Try Again</string>
     <string name="cancel_download">Cancel download</string>
-    <string name="cancel_download_question_title">Do you want to cancel download?</string>
+    <string name="cancel_download_question_title">Cancel download?</string>
     <string name="downloading_file">Downloading %s</string>
     <string name="import_deck">Import Deck</string>
     <string name="something_wrong">Something went wrong, please try again</string>


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
Changed title and action names of cancel share deck download dialog

## Fixes
Fixes #13386

## Approach
Changed title and action names of cancel share deck download dialog

## How Has This Been Tested?



![sss](https://user-images.githubusercontent.com/76740999/230833932-78cafc22-c56c-4cb0-bb6c-eb94a66b6c4f.png)




## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
