### PR TITLE
Added keyboard shortcut (Ctrl+F) to search in the card browser

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -2693,6 +2693,15 @@ open class CardBrowser :
         }
     }
 
+    // For Keyboard shortcut
+    override fun onKeyUp(keyCode: Int, event: KeyEvent?): Boolean {
+        Timber.d("onKeyUp(): mSearchItem expand through External Keyboard")
+        if ((event?.isCtrlPressed == true) && (keyCode == KeyEvent.KEYCODE_F)) {
+            mSearchItem?.expandActionView()
+        }
+        return super.onKeyUp(keyCode, event)
+    }
+
     companion object {
         var cardBrowserCard: Card? = null
 


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
Added Ctrl+F shortcut to open search view when an external keyboard is attached to the device specified in the case of tablets.

## Fixes
It was a feature request  #13566.

## Approach
I used the function `fun onKeyUp(keyCode: Int, event: KeyEvent?)`.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration (SDK version(s), emulator or physical, etc)

## Learning (optional, can help others)
https://developer.android.com/develop/ui/views/touch-and-input/keyboard-input/commands

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented on your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
