### PR TITLE
Fix startActivityForResult deprecation on DeckPicker.kt

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -815,7 +815,7 @@ open class DeckPicker :
                     ModelBrowser::class.java
                 }
                 val noteTypeBrowser = Intent(this, manageNoteTypesTarget)
-                startActivityForResultWithAnimation(noteTypeBrowser, 0, START)
+                startActivityWithAnimation(noteTypeBrowser, START)
                 return true
             }
             R.id.action_restore_backup -> {
@@ -1115,7 +1115,7 @@ open class DeckPicker :
     fun addNote() {
         val intent = Intent(this@DeckPicker, NoteEditor::class.java)
         intent.putExtra(NoteEditor.EXTRA_CALLER, NoteEditor.CALLER_DECKPICKER)
-        startActivityForResultWithAnimation(intent, ADD_NOTE, START)
+        startActivityWithAnimation(intent, START)
     }
 
     private fun showStartupScreensAndDialogs(preferences: SharedPreferences, skip: Int) {
@@ -1245,7 +1245,7 @@ open class DeckPicker :
                 val infoIntent = Intent(this, Info::class.java)
                 infoIntent.putExtra(Info.TYPE_EXTRA, Info.TYPE_NEW_VERSION)
                 if (skip != 0) {
-                    startActivityForResultWithAnimation(infoIntent, SHOW_INFO_NEW_VERSION, START)
+                    startActivityWithAnimation(infoIntent, START)
                 } else {
                     startActivityForResultWithoutAnimation(infoIntent, SHOW_INFO_NEW_VERSION)
                 }
@@ -1549,7 +1549,7 @@ open class DeckPicker :
     override fun loginToSyncServer() {
         val myAccount = Intent(this, MyAccount::class.java)
         myAccount.putExtra("notLoggedIn", true)
-        startActivityForResultWithAnimation(myAccount, LOG_IN_FOR_SYNC, FADE)
+        startActivityWithAnimation(myAccount, FADE)
     }
 
     // Callback to import a file -- adding it to existing collection
@@ -1637,7 +1637,7 @@ open class DeckPicker :
             val intent = Intent()
             intent.putExtra("withDeckOptions", withDeckOptions)
             intent.setClass(this, StudyOptionsActivity::class.java)
-            startActivityForResultWithAnimation(intent, SHOW_STUDYOPTIONS, START)
+            startActivityWithAnimation(intent, START)
         }
     }
 
@@ -2137,7 +2137,7 @@ open class DeckPicker :
 
     private fun openReviewer() {
         val reviewer = Intent(this, Reviewer::class.java)
-        startActivityForResultWithAnimation(reviewer, REQUEST_REVIEW, START)
+        startActivityWithAnimation(reviewer, START)
     }
 
     override fun onCreateCustomStudySession() {
@@ -2366,7 +2366,6 @@ open class DeckPicker :
         private const val LOG_IN_FOR_SYNC = 6
         private const val SHOW_INFO_NEW_VERSION = 9
         const val SHOW_STUDYOPTIONS = 11
-        private const val ADD_NOTE = 12
         const val PICK_APKG_FILE = 13
         const val PICK_CSV_FILE = 14
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -514,7 +514,7 @@ open class DeckPicker :
                     showDatabaseErrorDialog(DatabaseErrorDialogType.DIALOG_STORAGE_UNAVAILABLE_AFTER_UNINSTALL)
                 } else {
                     val i = AdvancedSettingsFragment.getSubscreenIntent(this)
-                    startActivityForResultWithoutAnimation(i, REQUEST_PATH_UPDATE)
+                    startActivityWithoutAnimation(i)
                     showThemedToast(this, R.string.directory_inaccessible, false)
                 }
             }
@@ -1247,7 +1247,7 @@ open class DeckPicker :
                 if (skip != 0) {
                     startActivityWithAnimation(infoIntent, START)
                 } else {
-                    startActivityForResultWithoutAnimation(infoIntent, SHOW_INFO_NEW_VERSION)
+                    startActivityWithoutAnimation(infoIntent)
                 }
             } else {
                 Timber.i("Dev Build - not showing 'new features'")


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
Fix startActivityForResult deprecation on DeckPicker.kt

## Fixes
Related to #8602 

## How Has This Been Tested?
Tested on Realme 6

## Learning (optional, can help others)
_Describe the research stage_

_Links to blog posts, patterns, libraries or addons used to solve this problem_

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [ ] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
