### PR TITLE
Fixes some startActivityForResult deprecation

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
@@ -981,11 +981,7 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
         intent.putExtra(EXTRA_DID, deckId)
         // mutate event with additional properties
         intentEnricher.accept(intent)
-        startActivityForResultWithAnimation(
-            intent,
-            REQUEST_ADD,
-            START
-        )
+        startActivityWithAnimation(intent, START)
     }
 
     // ----------------------------------------------------------------------------
@@ -1125,11 +1121,7 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
             intent.putExtra("ordId", mCurrentEditedCard!!.ord)
             Timber.d("showCardTemplateEditor() with ord %s", mCurrentEditedCard!!.ord)
         }
-        startActivityForResultWithAnimation(
-            intent,
-            REQUEST_TEMPLATE_EDIT,
-            START
-        )
+        startActivityWithAnimation(intent, START)
     }
 
     @Suppress("deprecation") // onActivityResult
@@ -1505,7 +1497,7 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
         val field = note!!.getField(index)!!
         val editCard = Intent(this@NoteEditor, MultimediaEditFieldActivity::class.java)
         editCard.putExtra(MultimediaEditFieldActivity.EXTRA_MULTIMEDIA_EDIT_FIELD_ACTIVITY, MultimediaEditFieldActivityExtra(index, field, note))
-        startActivityForResultWithoutAnimation(editCard, REQUEST_MULTIMEDIA_EDIT)
+        startActivityWithoutAnimation(editCard)
     }
 
     private fun initFieldEditText(editText: FieldEditText?, index: Int, enabled: Boolean) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicImageFieldController.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicImageFieldController.kt
@@ -157,14 +157,14 @@ class BasicImageFieldController : FieldControllerBase(), IFieldController {
             setOnClickListener {
                 val i = Intent(Intent.ACTION_PICK)
                 i.setDataAndType(MediaStore.Images.Media.EXTERNAL_CONTENT_URI, "image/*")
-                mActivity.startActivityForResultWithoutAnimation(i, ACTIVITY_SELECT_IMAGE)
+                mActivity.startActivityWithoutAnimation(i)
             }
         }
 
         val btnDraw = Button(mActivity).apply {
             text = gtxt(R.string.drawing)
             setOnClickListener {
-                mActivity.startActivityForResultWithoutAnimation(Intent(mActivity, DrawingActivity::class.java), ACTIVITY_DRAWING)
+                mActivity.startActivityWithoutAnimation(Intent(mActivity, DrawingActivity::class.java))
             }
         }
 
@@ -270,7 +270,7 @@ class BasicImageFieldController : FieldControllerBase(), IFieldController {
                 return toReturn
             }
             try {
-                mActivity.startActivityForResultWithoutAnimation(cameraIntent, ACTIVITY_TAKE_PICTURE)
+                mActivity.startActivityWithoutAnimation(cameraIntent)
             } catch (e: Exception) {
                 Timber.w(e, "Unable to take picture")
                 showSomethingWentWrong()


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
Fixes some startActivityForResult deprecation on NoteEditor.kt & BasicImageFieldController.kt

## Fixes
Related to #8602 

## How Has This Been Tested?
Tested on Realme 6

## Learning (optional, can help others)
_Describe the research stage_

_Links to blog posts, patterns, libraries or addons used to solve this problem_

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [ ] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
