### PR TITLE
Display dialog for API>=33

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/InitialActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/InitialActivity.kt
@@ -17,6 +17,7 @@
 package com.ichi2.anki
 
 import android.Manifest
+import android.app.AlertDialog
 import android.content.Context
 import android.content.SharedPreferences
 import android.os.Build
@@ -204,6 +205,16 @@ class StartupStoragePermissionManager private constructor(
      */
     private fun onPermissionPermanentlyDenied() {
         // User denied access to file storage  so show error toast and display "App Info"
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            var dialog = AlertDialog.Builder(deckPicker)
+                .setTitle(R.string.storage_access)
+                .setMessage(R.string.storage_access_permission)
+                .setPositiveButton(R.string.dialog_ok) { _, _ ->
+                    deckPicker.finishActivityAndShowAppPermissionManagementScreen()
+                }
+            dialog.show()
+            return
+        }
         UIUtils.showThemedToast(deckPicker, R.string.startup_no_storage_permission, false)
         // note: this may not be defined on some Phones. In which case we still have a toast
         deckPicker.finishActivityAndShowAppPermissionManagementScreen()

--- a/AnkiDroid/src/main/res/values/03-dialogs.xml
+++ b/AnkiDroid/src/main/res/values/03-dialogs.xml
@@ -35,6 +35,8 @@
     <string name="tts_no_tts">Don’t speak</string>
     <string name="unused_strings">\n\nUnused files:\n</string>
 
+    <string name="storage_access">Storage Access</string>
+    <string name="storage_access_permission">>Ankidroid requires storage access permission to function properly. This permission allows the app to access and modify files in the general storage area of your device, which allows AnkiDroid to store and access your collection</string>
     <string name="preview_title" comment="Title of the window allowing to preview card(s)">Preview</string>
     <string name="reposition_card_dialog_title">Reposition new card</string>
     <string name="reposition_card_dialog_message">Start position:</string>


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
At an unknown API level, "Allow management of all files" is no longer available in the app permissions screen.

## Fixes
Fixed #13520

## Approach
Added a dialog box signifying the need of storage permission

Note - I couldn't find a prior string that was relevant, so I had to build a new one for the dialogue box's message.

![image](https://user-images.githubusercontent.com/72886809/229314587-7cb78eb3-e3cd-41ad-8e64-e9a9dcfdc4d1.png)

_Links to blog posts, patterns, libraries or addons used to solve this problem_

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
