### PR TITLE
Showing snackbar instead of toast for "Initializing TTS" in ReadText.kt

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/ReadText.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ReadText.kt
@@ -16,6 +16,7 @@
 package com.ichi2.anki
 
 import android.annotation.SuppressLint
+import android.app.Activity
 import android.content.Context
 import android.net.Uri
 import android.os.Bundle
@@ -286,8 +287,10 @@ object ReadText {
                 Timber.w("TTS not successfully initialized")
             }
         }
-        // Show toast that it's getting initialized, as it can take a while before the sound plays the first time
-        showThemedToast(context, context.getString(R.string.initializing_tts), false)
+        // Show snackbar that it's getting initialized, as it can take a while before the sound plays the first time
+        if (context is Activity) { // verification needed to make test pass, as tests use an ApplicationContext
+            context.showSnackbar(context.getString(R.string.initializing_tts))
+        }
     }
 
     private fun openTtsHelpUrl(helpUrl: Uri) {


### PR DESCRIPTION
## Pull Request template
This is my first contribution to AnkiDroid!

## Purpose / Description
Used a Snackbar instead of Toast

## Fixes
Related #13411 

## How Has This Been Tested?
Along with making sure all tests still pass, I tested the functionnality on an emulator.

## Learning (optional, can help others)
Because the toast to change was in an object class and not an activity or fragment, I had to cast the context in the initializeTts() to Activity, while being careful to not break the unit test. Indeed, in the unit test the cast would not work as it uses an ApplicationContext and not an Activity. 

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)


During testing, I saw that the snackbar shows after some time, just before the list of available languages is displayed. Any input on whether this is to be expected/how can it be fixed ? From my research, unlike toast which only needs a Context, the snackbar needs the Activity context, so I am not sure if there would be any other way of achieving desired results.