### PR TITLE
Use shebang in set_scoped_storage

### DIFF
--- a/tools/storage/set_scoped_storage.sh
+++ b/tools/storage/set_scoped_storage.sh
@@ -1,4 +1,4 @@
-#/bin/bash
+#!/bin/bash
 # enable/disable scoped storage: ./set_scoped_storage.sh [limited/full]
 
 


### PR DESCRIPTION
Otherwise, bash is not used. Instead, I get
> ./tools/storage/set_scoped_storage.sh: 5: Syntax error: "(" unexpected

because `function` is not basic shell I guess.