### PR TITLE
ensure scripts prints escaped character

### DIFF
--- a/tools/storage/set_scoped_storage.sh
+++ b/tools/storage/set_scoped_storage.sh
@@ -3,9 +3,9 @@
 
 
 function help() {
-    echo "\nPossible arguments:"
-    echo "limited\t\tEquivalent to a fresh install. /AnkiDroid/ is inaccessible"
-    echo "full\t\tEquivalent to an upgrade from targetSdkVersion 29 to 30. /AnkiDroid/ is accessible\n"
+    echo -e "\nPossible arguments:"
+    echo -e "limited\t\tEquivalent to a fresh install. /AnkiDroid/ is inaccessible"
+    echo -e "full\t\tEquivalent to an upgrade from targetSdkVersion 29 to 30. /AnkiDroid/ is accessible\n"
 }
 
 # This should be run when a single AOSP emulator is open.

--- a/tools/translation-rates.sh
+++ b/tools/translation-rates.sh
@@ -20,10 +20,10 @@ grep -v " 0" > tmp-list.txt
 echo "By country:"
 cat tmp-list.txt |  sort
 
-echo "\nBy rate approved (implies 100% translated):"
+echo -e "\nBy rate approved (implies 100% translated):"
 cat tmp-list.txt | grep approved | sed -e "s/\(.*\) \([0-9]*\)%/\2% \1/g" | sort -nr
 
-echo "\nBy rate translated:"
+echo -e "\nBy rate translated:"
 cat tmp-list.txt | grep translated | sed -e "s/\(.*\) \([0-9]*\)%/\2% \1/g" | sort -nr
 
 rm -f tmp-translations-page.html tmp-list.txt


### PR DESCRIPTION
On my desktop, running `./tools/storage/set_scopde_storage.sh` led to

> Alienware% ./tools/storage/set_scoped_storage.sh
> First argument missing.
> \nPossible arguments:
> limited\t\tEquivalent to a fresh install. /AnkiDroid/ is inaccessible
> full\t\tEquivalent to an upgrade from targetSdkVersion 29 to 30. /AnkiDroid/ is accessible\n

Adding `-e` ensures the characters are printed as expected.
