### PR TITLE
revert jacoco from 0.8.9 to 0.8.8 - macOS runner cannot find it

### DIFF
--- a/AnkiDroid/jacoco.gradle
+++ b/AnkiDroid/jacoco.gradle
@@ -3,13 +3,13 @@ import groovy.transform.Memoized
 apply plugin: 'jacoco'
 
 jacoco {
-    toolVersion = "0.8.9"
+    toolVersion = "0.8.8"
 
 }
 
 android {
     testCoverage {
-        jacocoVersion '0.8.9'
+        jacocoVersion '0.8.8'
     }
 }
 


### PR DESCRIPTION
## Pull Request template

## Purpose / Description

has caused spurious errors from other runners as well and from individual contributors. Feels like the global maven central CDN is not in sync but that is also not in our control, so revert

## Fixes
https://github.com/ankidroid/Anki-Android/actions/workflows/tests_unit.yml?query=is%3Afailure

## Approach
Investigate as much as I can locally, I never 404 for the pom.xml from repo1.maven.org but if the runner 404s sometimes and contributors do, there is not much I can do about the artifact resolution.

## How Has This Been Tested?

CI will have to pass.

## Learning (optional, can help others)

The internet is not reliable.

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
