### PR TITLE
Fix: storage migration shown on < API 30 & Amazon Builds

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -85,6 +85,7 @@ import com.ichi2.anki.preferences.AdvancedSettingsFragment
 import com.ichi2.anki.receiver.SdCardReceiver
 import com.ichi2.anki.servicelayer.*
 import com.ichi2.anki.servicelayer.SchedulerService.NextCard
+import com.ichi2.anki.servicelayer.ScopedStorageService.collectionWillBeMadeInaccessibleAfterUninstall
 import com.ichi2.anki.servicelayer.ScopedStorageService.isLegacyStorage
 import com.ichi2.anki.servicelayer.ScopedStorageService.userMigrationIsInProgress
 import com.ichi2.anki.servicelayer.scopedstorage.migrateuserdata.toMB
@@ -725,10 +726,11 @@ open class DeckPicker :
     }
 
     private fun shouldOfferToUpgrade(context: Context): Boolean {
+        // ALLOW_UNSAFE_MIGRATION skips ensuring that the user is backed up to AnkiWeb
         if (!BuildConfig.ALLOW_UNSAFE_MIGRATION && !isLoggedIn()) {
             return false
         }
-        return isLegacyStorage(context) && !userMigrationIsInProgress(context) && !Permissions.allFileAccessPermissionGranted(context)
+        return !userMigrationIsInProgress(context) && collectionWillBeMadeInaccessibleAfterUninstall(context)
     }
 
     private fun fetchSyncStatus(col: Collection): SyncIconState {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -510,7 +510,7 @@ open class DeckPicker :
             }
             DIRECTORY_NOT_ACCESSIBLE -> {
                 Timber.i("AnkiDroid directory inaccessible")
-                if (ScopedStorageService.collectionInaccessibleAfterUninstall(this)) {
+                if (ScopedStorageService.collectionWasMadeInaccessibleAfterUninstall(this)) {
                     showDatabaseErrorDialog(DatabaseErrorDialogType.DIALOG_STORAGE_UNAVAILABLE_AFTER_UNINSTALL)
                 } else {
                     val i = AdvancedSettingsFragment.getSubscreenIntent(this)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/ScopedStorageService.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/ScopedStorageService.kt
@@ -308,16 +308,24 @@ object ScopedStorageService {
     }
 
     /**
-     * @return whether the user's current collection is now inaccessible due to a 'reinstall'
+     * Whether the user's current collection is now inaccessible due to a 'reinstall'
+     *
+     * @return `false` if:
+     * * ⚠️ The directory will be **removed** on uninstall
+     *    * The user installed with a newer Android version, and is more likely to expect this behavior.
+     * * The collection is currently accessible
+     * * the user is on Android Q or below and Android will not revoke permissions
+     * * The user has the potential to grant [android.Manifest.permission.MANAGE_EXTERNAL_STORAGE]
      * @see android.R.attr.preserveLegacyExternalStorage
      * @see android.R.attr.requestLegacyExternalStorage
      */
-    fun collectionInaccessibleAfterUninstall(context: Context): Boolean {
+    fun collectionWasMadeInaccessibleAfterUninstall(context: Context): Boolean {
         // If we're < Q then `requestLegacyExternalStorage` was not introduced
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
             return false
         }
 
+        // the user may not have MANAGE_EXTERNAL_STORAGE, but they could obtain it
         if (Permissions.canManageExternalStorage(context)) {
             return false
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/ScopedStorageService.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/ScopedStorageService.kt
@@ -289,7 +289,7 @@ object ScopedStorageService {
             return Status.COMPLETED
         }
 
-        if (Permissions.allFileAccessPermissionGranted(context)) {
+        if (!collectionWillBeMadeInaccessibleAfterUninstall(context)) {
             return Status.NOT_NEEDED
         }
 
@@ -312,20 +312,59 @@ object ScopedStorageService {
      *
      * @return `false` if:
      * * ⚠️ The directory will be **removed** on uninstall
-     *    * The user installed with a newer Android version, and is more likely to expect this behavior.
+     *    * The user installed with Android 11+, and is more likely to expect this behavior
+     *    * Note: The directory data may not be removed if the user taps "Keep data" when uninstalling
      * * The collection is currently accessible
-     * * the user is on Android Q or below and Android will not revoke permissions
+     * * the user is on Android 9 or below and Android will not revoke permissions
      * * The user has the potential to grant [android.Manifest.permission.MANAGE_EXTERNAL_STORAGE]
      * @see android.R.attr.preserveLegacyExternalStorage
      * @see android.R.attr.requestLegacyExternalStorage
      */
     fun collectionWasMadeInaccessibleAfterUninstall(context: Context): Boolean {
         // If we're < Q then `requestLegacyExternalStorage` was not introduced
+        // We do not check for == Q here, instead relying on `isExternalStorageLegacy`
+        // requestLegacyExternalStorage is a strong assumption, but we need to handle the case that
+        // this assumption breaks down
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
             return false
         }
 
-        // the user may not have MANAGE_EXTERNAL_STORAGE, but they could obtain it
+        // the user could obtain MANAGE_EXTERNAL_STORAGE
+        if (Permissions.canManageExternalStorage(context)) {
+            return false
+        }
+
+        val collectionPath = File(CollectionHelper.getCollectionPath(context))
+        if (collectionPath.isInsideDirectoriesRemovedWithTheApp(context)) {
+            return false
+        }
+
+        return !Environment.isExternalStorageLegacy()
+    }
+
+    /**
+     * Whether the user's current collection will be inaccessible after uninstalling the app
+     *
+     * @return `false` if:
+     * * ⚠️ The directory will be **removed** on uninstall
+     *    * The user installed with Android 11+, and is more likely to expect this behavior
+     *    * Note: The directory data may not be removed if the user taps "Keep data" when uninstalling
+     * * The collection is now inaccessible
+     * * the user is on Android Q or below and Android **should** not revoke permissions
+     * * The user has the potential to grant [android.Manifest.permission.MANAGE_EXTERNAL_STORAGE]
+     * Returns `true` > Android 10 and the user has no way to access the collection on uninstall
+     * except for using another build of `com.ichi2.anki` or manually copying files
+     * @see android.R.attr.preserveLegacyExternalStorage
+     * @see android.R.attr.requestLegacyExternalStorage
+     */
+    fun collectionWillBeMadeInaccessibleAfterUninstall(context: Context): Boolean {
+        // If we're < Q then `requestLegacyExternalStorage` was not introduced
+        // If we're == Q then `preserveLegacyExternalStorage` is expected to be in place
+        if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.Q) {
+            return false
+        }
+
+        // the user could obtain MANAGE_EXTERNAL_STORAGE
         if (Permissions.canManageExternalStorage(context)) {
             return false
         }

--- a/AnkiDroid/src/main/java/com/ichi2/utils/Permissions.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/Permissions.kt
@@ -140,14 +140,4 @@ object Permissions {
         return Build.VERSION.SDK_INT >= Build.VERSION_CODES.R &&
             context.arePermissionsDefinedInAnkiDroidManifest(MANAGE_EXTERNAL_STORAGE)
     }
-
-    /**
-     * Whether 'all files access' (permission: [MANAGE_EXTERNAL_STORAGE]) is granted on a device on Android 11 or later
-     */
-    fun allFileAccessPermissionGranted(context: Context): Boolean {
-        if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.Q) {
-            return false
-        }
-        return hasPermission(context, MANAGE_EXTERNAL_STORAGE)
-    }
 }


### PR DESCRIPTION
## Pull Request template


## Fixes
- Fixes #13612
- Fixes #13620

## Approach
We were using the condition `allFileAccessPermissionGranted` 

But this returns false before API 30  Instead define and use `collectionWillBeMadeInaccessibleAfterUninstall` which takes this condition into account  

## How Has This Been Tested?
* Unit Tests
* Tested on API 27 emulator

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
