### PR TITLE
Move file consider destinations which are prefix of the source

### DIFF
--- a/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/MoveFileTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/MoveFileTest.kt
@@ -80,7 +80,7 @@ class MoveFileTest(private val attemptRename: Boolean) : RobolectricTest(), Oper
         assertThat("destination file should exist", destinationFile.exists(), equalTo(true))
 
         assertThat("content should be copied", getContent(destinationFile), equalTo("hello-world"))
-        assertProgressReported(size)
+        assertThat(executionContext.progress, equalTo(listOf(size, 0L)))
     }
 
     @Test

--- a/AnkiDroid/src/test/java/com/ichi2/utils/FileUtilTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/utils/FileUtilTest.kt
@@ -15,6 +15,7 @@
  */
 package com.ichi2.utils
 
+import com.ichi2.utils.FileUtil.isPrefix
 import org.acra.util.IOUtils.writeStringToFile
 import org.hamcrest.CoreMatchers
 import org.hamcrest.MatcherAssert.assertThat
@@ -176,5 +177,36 @@ class FileUtilTest {
         }
 
         assertThat("Should return file lengths", sizeFromDir(temporaryRootDir), equalTo(expectedLength))
+    }
+
+    @Test
+    fun filePrefixTest() {
+        val temporaryRootDir = temporaryDirectory.newFolder("tempRootDir")
+        val prefixFile = File(temporaryRootDir, "prefix")
+        writeStringToFile(prefixFile, "Hello ")
+        val fullFile = File(temporaryRootDir, "full")
+        writeStringToFile(fullFile, "Hello World")
+        assertEquals(FileUtil.FilePrefix.STRICT_PREFIX, isPrefix(prefixFile, fullFile))
+        assertEquals(FileUtil.FilePrefix.STRICT_SUFFIX, isPrefix(fullFile, prefixFile))
+    }
+
+    @Test
+    fun fileNotPrefixTest() {
+        val temporaryRootDir = temporaryDirectory.newFolder("tempRootDir")
+        val prefixFile = File(temporaryRootDir, "prefix")
+        writeStringToFile(prefixFile, "Hi World")
+        val fullFile = File(temporaryRootDir, "full")
+        writeStringToFile(fullFile, "Hello World")
+        assertEquals(FileUtil.FilePrefix.NOT_PREFIX, isPrefix(prefixFile, fullFile))
+    }
+
+    @Test
+    fun fileEqualTest() {
+        val temporaryRootDir = temporaryDirectory.newFolder("tempRootDir")
+        val prefixFile = File(temporaryRootDir, "prefix")
+        writeStringToFile(prefixFile, "Hello World")
+        val fullFile = File(temporaryRootDir, "full")
+        writeStringToFile(fullFile, "Hello World")
+        assertEquals(FileUtil.FilePrefix.EQUAL, isPrefix(prefixFile, fullFile))
     }
 }


### PR DESCRIPTION
I added a method to detect prefix of files.

As I found the code quite confusing to read, I rewrote it to split in three cases:
* source does not exists
* destination exists
* move can occur as expected

Fixed: #13170