### PR TITLE
Replace MaterialDialog with AlertDialog in SharedDecksDownloadFragment class

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/SharedDecksDownloadFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/SharedDecksDownloadFragment.kt
@@ -34,7 +34,6 @@ import android.widget.TextView
 import androidx.appcompat.app.AlertDialog
 import androidx.core.content.FileProvider
 import androidx.fragment.app.Fragment
-import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.ichi2.anki.SharedDecksActivity.Companion.DOWNLOAD_FILE
 import com.ichi2.compat.CompatHelper.Companion.getSerializableCompat
 import com.ichi2.utils.*
@@ -433,7 +432,7 @@ class SharedDecksDownloadFragment : Fragment() {
     @Suppress("DEPRECATION")
     fun showCancelConfirmationDialog() {
         mDownloadCancelConfirmationDialog = context?.let {
-            MaterialAlertDialogBuilder(it).show {
+            AlertDialog.Builder(it).show {
                 title(R.string.cancel_download_question_title)
                 positiveButton(R.string.dialog_yes) {
                     mDownloadManager.remove(mDownloadId)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/SharedDecksDownloadFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/SharedDecksDownloadFragment.kt
@@ -31,11 +31,12 @@ import android.webkit.URLUtil
 import android.widget.Button
 import android.widget.ProgressBar
 import android.widget.TextView
+import androidx.appcompat.app.AlertDialog
 import androidx.core.content.FileProvider
 import androidx.fragment.app.Fragment
-import com.afollestad.materialdialogs.MaterialDialog
 import com.ichi2.anki.SharedDecksActivity.Companion.DOWNLOAD_FILE
 import com.ichi2.compat.CompatHelper.Companion.getSerializableCompat
+import com.ichi2.utils.*
 import com.ichi2.utils.FileUtil
 import com.ichi2.utils.ImportUtils
 import timber.log.Timber
@@ -77,7 +78,7 @@ class SharedDecksDownloadFragment : Fragment() {
 
     var isDownloadInProgress = false
 
-    private var mDownloadCancelConfirmationDialog: MaterialDialog? = null
+    private var mDownloadCancelConfirmationDialog: AlertDialog? = null
 
     companion object {
         const val DOWNLOAD_PROGRESS_CHECK_DELAY = 100L
@@ -431,7 +432,7 @@ class SharedDecksDownloadFragment : Fragment() {
     @Suppress("deprecation") // onBackPressed
     fun showCancelConfirmationDialog() {
         mDownloadCancelConfirmationDialog = context?.let {
-            MaterialDialog(it).show {
+            AlertDialog.Builder(it).show {
                 title(R.string.cancel_download_question_title)
                 positiveButton(R.string.dialog_yes) {
                     mDownloadManager.remove(mDownloadId)
@@ -440,9 +441,9 @@ class SharedDecksDownloadFragment : Fragment() {
                     activity?.onBackPressed()
                 }
                 negativeButton(R.string.dialog_no) {
-                    dismiss()
+                    removeCancelConfirmationDialog()
                 }
-            }
+            }.create()
         }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/SharedDecksDownloadFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/SharedDecksDownloadFragment.kt
@@ -34,6 +34,7 @@ import android.widget.TextView
 import androidx.appcompat.app.AlertDialog
 import androidx.core.content.FileProvider
 import androidx.fragment.app.Fragment
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.ichi2.anki.SharedDecksActivity.Companion.DOWNLOAD_FILE
 import com.ichi2.compat.CompatHelper.Companion.getSerializableCompat
 import com.ichi2.utils.*
@@ -432,7 +433,7 @@ class SharedDecksDownloadFragment : Fragment() {
     @Suppress("deprecation") // onBackPressed
     fun showCancelConfirmationDialog() {
         mDownloadCancelConfirmationDialog = context?.let {
-            AlertDialog.Builder(it).show {
+            MaterialAlertDialogBuilder(it).show {
                 title(R.string.cancel_download_question_title)
                 positiveButton(R.string.dialog_yes) {
                     mDownloadManager.remove(mDownloadId)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/SharedDecksDownloadFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/SharedDecksDownloadFragment.kt
@@ -430,6 +430,7 @@ class SharedDecksDownloadFragment : Fragment() {
         removeCancelConfirmationDialog()
     }
 
+    @Suppress("DEPRECATION")
     fun showCancelConfirmationDialog() {
         mDownloadCancelConfirmationDialog = context?.let {
             MaterialAlertDialogBuilder(it).show {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/SharedDecksDownloadFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/SharedDecksDownloadFragment.kt
@@ -432,18 +432,18 @@ class SharedDecksDownloadFragment : Fragment() {
     @Suppress("DEPRECATION")
     fun showCancelConfirmationDialog() {
         mDownloadCancelConfirmationDialog = context?.let {
-            AlertDialog.Builder(it)
-                .title(R.string.cancel_download_question_title)
-                .positiveButton(R.string.dialog_yes) {
+            AlertDialog.Builder(it).show {
+                title(R.string.cancel_download_question_title)
+                positiveButton(R.string.dialog_yes) {
                     mDownloadManager.remove(mDownloadId)
                     unregisterReceiver()
                     isDownloadInProgress = false
                     activity?.onBackPressed()
                 }
-                .negativeButton(R.string.dialog_no) {
+                negativeButton(R.string.dialog_no) {
                     removeCancelConfirmationDialog()
                 }
-                .show()
+            }.create()
         }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/SharedDecksDownloadFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/SharedDecksDownloadFragment.kt
@@ -432,18 +432,18 @@ class SharedDecksDownloadFragment : Fragment() {
     @Suppress("DEPRECATION")
     fun showCancelConfirmationDialog() {
         mDownloadCancelConfirmationDialog = context?.let {
-            AlertDialog.Builder(it).show {
-                title(R.string.cancel_download_question_title)
-                positiveButton(R.string.dialog_yes) {
+            AlertDialog.Builder(it)
+                .title(R.string.cancel_download_question_title)
+                .positiveButton(R.string.dialog_yes) {
                     mDownloadManager.remove(mDownloadId)
                     unregisterReceiver()
                     isDownloadInProgress = false
                     activity?.onBackPressed()
                 }
-                negativeButton(R.string.dialog_no) {
+                .negativeButton(R.string.dialog_no) {
                     removeCancelConfirmationDialog()
                 }
-            }.create()
+                .show()
         }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/SharedDecksDownloadFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/SharedDecksDownloadFragment.kt
@@ -430,7 +430,6 @@ class SharedDecksDownloadFragment : Fragment() {
         removeCancelConfirmationDialog()
     }
 
-    @Suppress("deprecation") // onBackPressed
     fun showCancelConfirmationDialog() {
         mDownloadCancelConfirmationDialog = context?.let {
             MaterialAlertDialogBuilder(it).show {


### PR DESCRIPTION
## Purpose / Description
Deprecate MaterialDialog and use AlertDialog instead https://github.com/ankidroid/Anki-Android/issues/13315

## Fixes
Replaced MaterialDialog with AlertDialog in the function showCancelConfirmationDialog()

- [ ] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
