### PR TITLE
remove obvious comment

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.kt
@@ -1548,7 +1548,6 @@ open class Collection(
                 )
             }
         )
-        // for each model
         for (m in models.all()) {
             executeIntegrityTask.accept(
                 FunctionalInterfaces.FunctionThrowable { callback: Runnable ->


### PR DESCRIPTION
This PR removes an obvious comment (i.e. comment that restates what the code does in an obvious manner). It is already clear from the code in the following line that the loop is going over each model.