### PR TITLE
Fix "Access denied" errors after upgrading from 2.15.6

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/InitialActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/InitialActivity.kt
@@ -283,7 +283,7 @@ class StartupStoragePermissionManager private constructor(
         fun selectAnkiDroidFolder(context: Context): AnkiDroidFolder {
             return selectAnkiDroidFolder(
                 canManageExternalStorage = Permissions.canManageExternalStorage(context),
-                hasLegacyStoragePermissions = isLegacyStorage(context)
+                hasLegacyStoragePermissions = isLegacyStorage(context, false) == true
             )
         }
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/InitialActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/InitialActivity.kt
@@ -283,7 +283,7 @@ class StartupStoragePermissionManager private constructor(
         fun selectAnkiDroidFolder(context: Context): AnkiDroidFolder {
             return selectAnkiDroidFolder(
                 canManageExternalStorage = Permissions.canManageExternalStorage(context),
-                hasLegacyStoragePermissions = isLegacyStorage(context, false) == true
+                hasLegacyStoragePermissions = isLegacyStorage(context, setCollectionPath = false) == true
             )
         }
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/InitialActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/InitialActivity.kt
@@ -27,6 +27,7 @@ import com.ichi2.anki.permissions.PermissionsRequestResults
 import com.ichi2.anki.permissions.finishActivityAndShowAppPermissionManagementScreen
 import com.ichi2.anki.servicelayer.PreferenceUpgradeService
 import com.ichi2.anki.servicelayer.PreferenceUpgradeService.setPreferencesUpToDate
+import com.ichi2.anki.servicelayer.ScopedStorageService.isLegacyStorage
 import com.ichi2.annotations.NeedsTest
 import com.ichi2.utils.Permissions
 import com.ichi2.utils.VersionUtils.pkgVersionName
@@ -152,8 +153,8 @@ sealed interface AnkiDroidFolder {
  * When impossible, we use the app-private directory.
  * See https://github.com/ankidroid/Anki-Android/issues/5304 for more context.
  */
-internal fun selectAnkiDroidFolder(canManageExternalStorage: Boolean): AnkiDroidFolder {
-    if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.Q) {
+internal fun selectAnkiDroidFolder(canManageExternalStorage: Boolean, hasLegacyStoragePermissions: Boolean): AnkiDroidFolder {
+    if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.Q || hasLegacyStoragePermissions) {
         // match AnkiDroid behaviour before scoped storage - force the use of ~/AnkiDroid,
         // since it's fast & safe up to & including 'Q'
         // If a user upgrades their OS from Android 10 to 11 then storage speed is severely reduced
@@ -281,7 +282,8 @@ class StartupStoragePermissionManager private constructor(
 
         fun selectAnkiDroidFolder(context: Context): AnkiDroidFolder {
             return selectAnkiDroidFolder(
-                canManageExternalStorage = Permissions.canManageExternalStorage(context)
+                canManageExternalStorage = Permissions.canManageExternalStorage(context),
+                hasLegacyStoragePermissions = isLegacyStorage(context)
             )
         }
     }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/InitialActivityTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/InitialActivityTest.kt
@@ -116,11 +116,11 @@ class InitialActivityTest : RobolectricTest() {
 
         // force a safe startup before Q
         assertThat(
-            (selectAnkiDroidFolder(false) as PublicFolder).requiredPermissions.asIterable(),
+            (selectAnkiDroidFolder(false, hasLegacyStoragePermissions = false) as PublicFolder).requiredPermissions.asIterable(),
             contains(*expectedPermissions)
         )
         assertThat(
-            (selectAnkiDroidFolder(true) as PublicFolder).requiredPermissions.asIterable(),
+            (selectAnkiDroidFolder(true, hasLegacyStoragePermissions = false) as PublicFolder).requiredPermissions.asIterable(),
             contains(*expectedPermissions)
         )
     }
@@ -129,11 +129,11 @@ class InitialActivityTest : RobolectricTest() {
     @Test
     fun startupQ() {
         assertThat(
-            selectAnkiDroidFolder(false),
+            selectAnkiDroidFolder(false, hasLegacyStoragePermissions = false),
             instanceOf(PublicFolder::class.java)
         )
         assertThat(
-            selectAnkiDroidFolder(true),
+            selectAnkiDroidFolder(true, hasLegacyStoragePermissions = false),
             instanceOf(PublicFolder::class.java)
         )
     }
@@ -145,7 +145,8 @@ class InitialActivityTest : RobolectricTest() {
         val expectedPermissions = arrayOf(android.Manifest.permission.MANAGE_EXTERNAL_STORAGE)
 
         selectAnkiDroidFolder(
-            canManageExternalStorage = true
+            canManageExternalStorage = true,
+            hasLegacyStoragePermissions = false
         ).let {
             assertThat(
                 (it as PublicFolder).requiredPermissions.asIterable(),
@@ -158,7 +159,7 @@ class InitialActivityTest : RobolectricTest() {
     @Test
     fun startupAfterQWithoutManageExternalStorage() {
         assertThat(
-            selectAnkiDroidFolder(canManageExternalStorage = false),
+            selectAnkiDroidFolder(canManageExternalStorage = false, hasLegacyStoragePermissions = false),
             instanceOf(AppPrivateFolder::class.java)
         )
     }


### PR DESCRIPTION
selectAnkiDroidFolder() didn't handle the case of the user keeping the legacy storage permissions on an Android 11+ device

## Fixes
Fixes #13598 

## Approach
Check if the user has the legacy storage permissions on selectAnkiDroidFolder(). I'd refactor the method a little bit more, but got some problems fixing the tests if I refactored, perhaps because of a problem between mockkito and JUnit, and didn't think that it was worth the time

## How Has This Been Tested?

On a SDK 33 emulator
1. Build and install Ankidroid 2.15.6 (ensure that its applicationId is com.ichi2.anki.debug if you are using a debug version, or use com.ichi2.anki as your applicationId on the 3rd step)
2. Open the app and give the storage permission
3. Build and install this PR (`play` flavor)
4. Tested if the access denied errors persist:
    - Start a migration
    - Add a image or drawing on the note editor

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
