### PR TITLE
Showing warning on FixedEditText instead of Toast

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/ModelFieldEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ModelFieldEditor.kt
@@ -85,6 +85,7 @@ class ModelFieldEditor : AnkiActivity(), LocaleSelectionDialogHandler {
             subtitle = intent.getStringExtra("title")
         }
         startLoadingCollection()
+        // It provides methods to handle events before and after the text is modified
         textWatcher = object : TextWatcher {
             override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) {}
 
@@ -176,6 +177,7 @@ class ModelFieldEditor : AnkiActivity(), LocaleSelectionDialogHandler {
             MaterialDialog(this).show {
                 customView(view = _fieldNameInput, horizontalPadding = true)
                 title(R.string.model_field_editor_add)
+                // TODO :- This functionality must be extracted
                 _fieldNameInput.doOnTextChanged { text, _, _, _ ->
                     val fieldName = text.toString().trim()
                     if (fieldName.isEmpty()) {
@@ -218,7 +220,6 @@ class ModelFieldEditor : AnkiActivity(), LocaleSelectionDialogHandler {
                     this.dismiss()
                 }
             }
-                .noAutoDismiss()
                 .displayKeyboard(_fieldNameInput)
         }
     }
@@ -317,6 +318,7 @@ class ModelFieldEditor : AnkiActivity(), LocaleSelectionDialogHandler {
             MaterialDialog(this).show {
                 customView(view = _fieldNameInput, horizontalPadding = true)
                 title(R.string.model_field_editor_rename)
+                // TODO :- This functionality must be extracted
                 _fieldNameInput.doOnTextChanged { text, _, _, _ ->
                     val fieldName = text.toString().trim()
                     if (mFieldsLabels.any { fieldName == it }) {
@@ -358,7 +360,6 @@ class ModelFieldEditor : AnkiActivity(), LocaleSelectionDialogHandler {
                 }
                 displayKeyboard(_fieldNameInput)
             }
-                .noAutoDismiss()
         }
     }
 


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
It's better to show a warning on FixedEditText rather than Toast 

## Fixes
Fixes #13631

## Approach
Implementing a warning message on FixedEditText when user didn't enter anything in FixedEditText or the value is duplicate

## How Has This Been Tested?

Tested on Physical Device (Realme 9)

https://user-images.githubusercontent.com/65113071/233145117-79d5e4a0-1e05-429a-a026-87531f170ee9.mp4



## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
