### PR TITLE
Find Key Shortcut for Card Browser

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -769,6 +769,13 @@ open class CardBrowser :
                 launchCatchingTask { deleteSelectedNote() }
                 return true
             }
+            KeyEvent.KEYCODE_F -> {
+                if(event.isCtrlPressed){
+                    Timber.i("Ctrl+F - Find notes")
+                    mSearchItem?.expandActionView()
+                    return true
+                }
+            }
         }
         return super.onKeyDown(keyCode, event)
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -770,7 +770,7 @@ open class CardBrowser :
                 return true
             }
             KeyEvent.KEYCODE_F -> {
-                if(event.isCtrlPressed){
+                if (event.isCtrlPressed) {
                     Timber.i("Ctrl+F - Find notes")
                     mSearchItem?.expandActionView()
                     return true


### PR DESCRIPTION
## Purpose / Description
Added Ctrl+F shortcut to open search view when an external keyboard is attached to the device specified in the case of tablets.

## Fixes
- Fixes #13566.

## Approach
I used the function `fun onKeyDown(keyCode: Int, event: KeyEvent)`.

## How Has This Been Tested?
I have tested it on my physical device for searching the card and it was working fine. On pressing Ctrl+F the `mSearchItem?.expandActionView()` is triggered and then we can search for the cards. 

## Learning (optional, can help others)
https://developer.android.com/develop/ui/views/touch-and-input/keyboard-input/commands

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
