### PR TITLE
horizontalPadding to FixedEditText and showing warning instead of Toast 

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/ModelFieldEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ModelFieldEditor.kt
@@ -336,7 +336,7 @@ class ModelFieldEditor : AnkiActivity(), LocaleSelectionDialogHandler {
         fieldNameInput?.let { _fieldNameInput ->
             _fieldNameInput.setRawInputType(InputType.TYPE_CLASS_NUMBER)
             MaterialDialog(this).show {
-                customView(view = _fieldNameInput, scrollable = true)
+                customView(view = _fieldNameInput, horizontalPadding = true)
                 title(text = String.format(resources.getString(R.string.model_field_editor_reposition), 1, mFieldsLabels.size))
                 positiveButton(R.string.dialog_ok) {
                     val newPosition = _fieldNameInput.text.toString()
@@ -344,11 +344,11 @@ class ModelFieldEditor : AnkiActivity(), LocaleSelectionDialogHandler {
                         newPosition.toInt()
                     } catch (n: NumberFormatException) {
                         Timber.w(n)
-                        showThemedToast(this@ModelFieldEditor, resources.getString(R.string.toast_out_of_range), true)
+                        _fieldNameInput.error = resources.getString(R.string.toast_out_of_range)
                         return@positiveButton
                     }
                     if (pos < 1 || pos > mFieldsLabels.size) {
-                        showThemedToast(this@ModelFieldEditor, resources.getString(R.string.toast_out_of_range), true)
+                        _fieldNameInput.error = resources.getString(R.string.toast_out_of_range)
                     } else {
                         // Input is valid, now attempt to modify
                         try {
@@ -371,10 +371,14 @@ class ModelFieldEditor : AnkiActivity(), LocaleSelectionDialogHandler {
                             c.setConfirm(confirm)
                             this@ModelFieldEditor.showDialogFragment(c)
                         }
+                        this.dismiss()
                     }
                 }
-                negativeButton(R.string.dialog_cancel)
+                negativeButton(R.string.dialog_cancel) {
+                    this.dismiss()
+                }
             }
+                .noAutoDismiss()
                 .displayKeyboard(_fieldNameInput)
         }
     }


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
It's better to have a horizontal padding and show a warning on FixedEditText rather than Toast

## Fixes
Related #13639 

## Approach
Implementing a warning message on FixedEditText when user didn't enter anything in FixedEditText or the value is invalid
Adding horizontalPadding to FixedEditText

## How Has This Been Tested?

Tested on Physical Device (Realme 9)

https://user-images.githubusercontent.com/65113071/233353502-a0e6ab95-8e81-41f9-977a-86aa9fc084a7.mp4


## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
