### PR TITLE
build: update `targetSdkVersion` to 31

### DIFF
--- a/.github/workflows/tests_emulator.yml
+++ b/.github/workflows/tests_emulator.yml
@@ -47,7 +47,7 @@ jobs:
       matrix:
         # Refactor to make these dynamic with a low/high bracket only on schedule, not push
         # For now this is the latest supported API. Previously API 29 was fastest.
-        api-level: [30]
+        api-level: [31]
         arch: [x86_64]
         target: [google_apis]
         first-boot-delay: [600]

--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -63,7 +63,7 @@ android {
         versionName="2.16alpha97"
         minSdkVersion 21
         //noinspection OldTargetApi - also performed in api/build.fradle
-        targetSdkVersion 30 // change .tests_emulator.yml
+        targetSdkVersion 31 // change .tests_emulator.yml
         testApplicationId "com.ichi2.anki.tests"
         vectorDrawables.useSupportLibrary = true
         testInstrumentationRunner 'com.ichi2.testutils.NewCollectionPathTestRunner'

--- a/api/build.gradle
+++ b/api/build.gradle
@@ -19,7 +19,7 @@ android {
     defaultConfig {
         minSdkVersion 16
         //noinspection OldTargetApi
-        targetSdkVersion 30
+        targetSdkVersion 31
         buildConfigField "String", "READ_WRITE_PERMISSION", '"com.ichi2.anki.permission.READ_WRITE_DATABASE"'
         buildConfigField "String", "AUTHORITY", '"com.ichi2.anki.flashcards"'
     }


### PR DESCRIPTION
## Purpose / Description
Standard SDK update. 

## How Has This Been Tested?
Ran unit tests, ran lint. Using CI for emulator tests.

## Learning

`OldTargetApi` is still valid - disabled in `lint-release.xml`

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
