### PR TITLE
fix: Add cancel button to add note type dialog

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/ModelBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ModelBrowser.kt
@@ -47,6 +47,7 @@ import com.ichi2.libanki.utils.TimeManager
 import com.ichi2.ui.FixedEditText
 import com.ichi2.utils.KotlinCleanup
 import com.ichi2.utils.displayKeyboard
+import com.ichi2.utils.negativeButton
 import com.ichi2.widget.WidgetStatus.update
 import kotlinx.coroutines.Job
 import timber.log.Timber
@@ -294,6 +295,7 @@ class ModelBrowser : AnkiActivity() {
         MaterialDialog(this).show {
             title(R.string.model_browser_add)
             positiveButton(R.string.dialog_ok)
+            negativeButton(R.string.dialog_cancel)
             listItemsSingleChoice(items = infos.map { it.label }) { _, index, _ ->
                 MaterialDialog(this@ModelBrowser).show {
                     title(R.string.model_browser_add)


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
Add cancel button to add note type dialog

## Fixes
Fixes #13647

## Approach
 Used negativeButton(R.string.dialog_cancel)

## How Has This Been Tested?

![a3](https://user-images.githubusercontent.com/76740999/233708128-af0957fd-baea-4ca6-91dc-45c9253a75f4.png)



## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
