### PR TITLE
Fix: `StorageAccessException` shown after reinstall (API 30, non-Play Store build)

### DIFF
--- a/AnkiDroid/src/test/java/com/ichi2/anki/InitialActivityTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/InitialActivityTest.kt
@@ -141,10 +141,34 @@ class InitialActivityTest : RobolectricTest() {
     @SuppressLint("InlinedApi")
     @Config(sdk = [R_OR_AFTER])
     @Test
-    fun startupAfterQWithManageExternalStorage() {
+    fun `Android 11 - After upgrade from AnkiDroid 2 15 (with MANAGE_EXTERNAL_STORAGE)`() {
+        // after an upgrade, all we need is READ/WRITE. Once we reinstall, we need MANAGE_EXTERNAL_STORAGE
+        val expectedPermissions = arrayOf(
+            android.Manifest.permission.READ_EXTERNAL_STORAGE,
+            android.Manifest.permission.WRITE_EXTERNAL_STORAGE
+        )
+
+        selectAnkiDroidFolder(
+            canManageExternalStorage = true,
+            currentFolderIsAccessibleAndLegacy = true
+        ).let {
+            assertThat(
+                (it as PublicFolder).requiredPermissions.asIterable(),
+                contains(*expectedPermissions)
+            )
+        }
+    }
+
+    @SuppressLint("InlinedApi")
+    @Config(sdk = [R_OR_AFTER])
+    @Test
+    fun `Android 11 - After reinstall (with MANAGE_EXTERNAL_STORAGE)`() {
         val expectedPermissions = arrayOf(android.Manifest.permission.MANAGE_EXTERNAL_STORAGE)
 
-        selectAnkiDroidFolder(canManageExternalStorage = true).let {
+        selectAnkiDroidFolder(
+            canManageExternalStorage = true,
+            currentFolderIsAccessibleAndLegacy = false
+        ).let {
             assertThat(
                 (it as PublicFolder).requiredPermissions.asIterable(),
                 contains(*expectedPermissions)
@@ -161,13 +185,16 @@ class InitialActivityTest : RobolectricTest() {
         )
     }
 
+    /**
+     * Helper for [com.ichi2.anki.selectAnkiDroidFolder], making `currentFolderIsAccessibleAndLegacy` optional
+     */
     private fun selectAnkiDroidFolder(
         canManageExternalStorage: Boolean,
-        hasLegacyStoragePermissions: Boolean = false
+        currentFolderIsAccessibleAndLegacy: Boolean = false
     ): AnkiDroidFolder {
-        return selectAnkiDroidFolder(
+        return com.ichi2.anki.selectAnkiDroidFolder(
             canManageExternalStorage = canManageExternalStorage,
-            hasLegacyStoragePermissions = hasLegacyStoragePermissions
+            currentFolderIsAccessibleAndLegacy = currentFolderIsAccessibleAndLegacy
         )
     }
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/InitialActivityTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/InitialActivityTest.kt
@@ -116,11 +116,11 @@ class InitialActivityTest : RobolectricTest() {
 
         // force a safe startup before Q
         assertThat(
-            (selectAnkiDroidFolder(false, hasLegacyStoragePermissions = false) as PublicFolder).requiredPermissions.asIterable(),
+            (selectAnkiDroidFolder(false) as PublicFolder).requiredPermissions.asIterable(),
             contains(*expectedPermissions)
         )
         assertThat(
-            (selectAnkiDroidFolder(true, hasLegacyStoragePermissions = false) as PublicFolder).requiredPermissions.asIterable(),
+            (selectAnkiDroidFolder(true) as PublicFolder).requiredPermissions.asIterable(),
             contains(*expectedPermissions)
         )
     }
@@ -129,11 +129,11 @@ class InitialActivityTest : RobolectricTest() {
     @Test
     fun startupQ() {
         assertThat(
-            selectAnkiDroidFolder(false, hasLegacyStoragePermissions = false),
+            selectAnkiDroidFolder(false),
             instanceOf(PublicFolder::class.java)
         )
         assertThat(
-            selectAnkiDroidFolder(true, hasLegacyStoragePermissions = false),
+            selectAnkiDroidFolder(true),
             instanceOf(PublicFolder::class.java)
         )
     }
@@ -144,10 +144,7 @@ class InitialActivityTest : RobolectricTest() {
     fun startupAfterQWithManageExternalStorage() {
         val expectedPermissions = arrayOf(android.Manifest.permission.MANAGE_EXTERNAL_STORAGE)
 
-        selectAnkiDroidFolder(
-            canManageExternalStorage = true,
-            hasLegacyStoragePermissions = false
-        ).let {
+        selectAnkiDroidFolder(canManageExternalStorage = true).let {
             assertThat(
                 (it as PublicFolder).requiredPermissions.asIterable(),
                 contains(*expectedPermissions)
@@ -159,8 +156,18 @@ class InitialActivityTest : RobolectricTest() {
     @Test
     fun startupAfterQWithoutManageExternalStorage() {
         assertThat(
-            selectAnkiDroidFolder(canManageExternalStorage = false, hasLegacyStoragePermissions = false),
+            selectAnkiDroidFolder(canManageExternalStorage = false),
             instanceOf(AppPrivateFolder::class.java)
+        )
+    }
+
+    private fun selectAnkiDroidFolder(
+        canManageExternalStorage: Boolean,
+        hasLegacyStoragePermissions: Boolean = false
+    ): AnkiDroidFolder {
+        return selectAnkiDroidFolder(
+            canManageExternalStorage = canManageExternalStorage,
+            hasLegacyStoragePermissions = hasLegacyStoragePermissions
         )
     }
 


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
Scenario:
* The user can request 'MANAGE_EXTERNAL_STORAGE' (non-Play build)
* The collection path is `/storage/emulated/0/AnkiDroid`
* The user is on API 30
* The user reinstalled & kept data

Expected Result:
* We require 'MANAGE_EXTERNAL_STORAGE' to continue to access data

Previously:
1. We requested READ/WRITE_EXTERNAL_STORAGE
2. When accepted: 'StorageAccessException': User no longer had access to legacy storage.

## Approach
This splits `hasLegacyStoragePermissions` into two concepts:

1. Do we have a legacy collection
2. Does Android allow us to use legacy folders

Previously we only checked for (1) whereas we needed both

## How Has This Been Tested?
Unit tests + on API 30 emulators (`[amazon/Play]Debug` split)

## Learning

This builds on PR #13630: (ce0b0dc9ff6cfad16060e90e5e2f7316a8d478b0). Designed to fix https://github.com/ankidroid/Anki-Android/issues/13598

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
