### PR TITLE
fix: Storage Migration not being offered

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/ScopedStorageService.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/ScopedStorageService.kt
@@ -289,12 +289,12 @@ object ScopedStorageService {
             return Status.COMPLETED
         }
 
-        if (!collectionWillBeMadeInaccessibleAfterUninstall(context)) {
-            return Status.NOT_NEEDED
-        }
-
         if (userMigrationIsInProgress(context)) {
             return Status.IN_PROGRESS
+        }
+
+        if (!collectionWillBeMadeInaccessibleAfterUninstall(context)) {
+            return Status.NOT_NEEDED
         }
 
         return Status.NEEDS_MIGRATION

--- a/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/ScopedStorageService.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/ScopedStorageService.kt
@@ -374,6 +374,6 @@ object ScopedStorageService {
             return false
         }
 
-        return !Environment.isExternalStorageLegacy()
+        return Environment.isExternalStorageLegacy()
     }
 }


### PR DESCRIPTION
## Pull Request template

## Purpose / Description

Fixes issues I introduced: 
- 9fdfbe0b12e343738208a4df0763896aafeb53bd - 
   - moved from a 'permission' check to a 'file' check. This should have had lower priority than reporting the migration was in progress
   - Implementation of `collectionWillBeMadeInaccessibleAfterUninstall` didn't match spec

## How Has This Been Tested?
API 30 emulator: Storage migration now works

## Learning
Regression tests would have caught these

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
