### PR TITLE
fix: MigrationService: Progress is incorrect after service restart

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CollectionHelper.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CollectionHelper.kt
@@ -29,7 +29,7 @@ import com.ichi2.anki.preferences.Preferences
 import com.ichi2.libanki.Collection
 import com.ichi2.libanki.Storage
 import com.ichi2.libanki.exception.UnknownDatabaseVersionException
-import com.ichi2.preferences.PreferenceExtensions
+import com.ichi2.preferences.getOrSetString
 import com.ichi2.utils.FileUtil
 import com.ichi2.utils.KotlinCleanup
 import net.ankiweb.rsdroid.BackendException.BackendDbException.BackendDbFileTooNewException
@@ -551,10 +551,7 @@ open class CollectionHelper {
             } else if (ankiDroidDirectoryOverride != null) {
                 ankiDroidDirectoryOverride!!
             } else {
-                PreferenceExtensions.getOrSetString(
-                    preferences,
-                    PREF_COLLECTION_PATH
-                ) { getDefaultAnkiDroidDirectory(context) }
+                preferences.getOrSetString(PREF_COLLECTION_PATH) { getDefaultAnkiDroidDirectory(context) }
             }
         }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/ScopedStorageService.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/ScopedStorageService.kt
@@ -31,6 +31,7 @@ import com.ichi2.anki.servicelayer.ScopedStorageService.isLegacyStorage
 import com.ichi2.anki.servicelayer.scopedstorage.MigrateEssentialFiles
 import com.ichi2.anki.servicelayer.scopedstorage.migrateuserdata.MigrateUserData
 import com.ichi2.anki.servicelayer.scopedstorage.migrateuserdata.UserDataMigrationPreferences
+import com.ichi2.anki.services.MigrationService
 import com.ichi2.anki.ui.windows.managespace.isInsideDirectoriesRemovedWithTheApp
 import com.ichi2.utils.FileUtil.getParentsAndSelfRecursive
 import com.ichi2.utils.FileUtil.isDescendantOf
@@ -100,6 +101,13 @@ object ScopedStorageService {
      * @see UserDataMigrationPreferences
      */
     const val PREF_MIGRATION_SOURCE = "migrationSourcePath"
+
+    /**
+     * Preference listing the total number of bytes that [MigrationService] expects to transfer.
+     *
+     * @see [MigrationService.getTotalTransferSize]
+     */
+    const val PREF_MIGRATION_TOTAL_TO_TRANSFER: String = "migrationServiceTotalBytes"
 
     /**
      * Preference listing the [AnkiDroidDirectory] where a scoped storage migration is migrating to.

--- a/AnkiDroid/src/main/java/com/ichi2/preferences/PreferenceExtensions.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/preferences/PreferenceExtensions.kt
@@ -40,3 +40,14 @@ object PreferenceExtensions {
         return supplied
     }
 }
+
+@CheckResult // A "set" API should be used if the result is not required.
+fun SharedPreferences.getOrSetLong(key: String, supplier: Supplier<Long>): Long {
+    if (contains(key)) {
+        // the default is never returned
+        return getLong(key, -1337L)
+    }
+    val supplied = supplier.get()
+    edit { putLong(key, supplied) }
+    return supplied
+}

--- a/AnkiDroid/src/main/java/com/ichi2/preferences/PreferenceExtensions.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/preferences/PreferenceExtensions.kt
@@ -20,25 +20,22 @@ import androidx.annotation.CheckResult
 import androidx.core.content.edit
 import java.util.function.Supplier
 
-/** Extension methods over the SharedPreferences class  */
-object PreferenceExtensions {
-    /**
-     * Returns the string value specified by the key, or sets key to the result of the lambda and returns it.
-     *
-     * This is not designed to be used when bulk editing preferences.
-     *
-     * Defect #5828 - This is potentially not thread safe and could cause another preference commit to fail.
-     */
-    @CheckResult // Not truly an error as this has a side effect, but you should use a "set" API for perf.
-    fun getOrSetString(target: SharedPreferences, key: String, supplier: Supplier<String>): String {
-        if (target.contains(key)) {
-            // the default Is never returned. The value might be able be optimised, but the Android API should be better.
-            return target.getString(key, "")!!
-        }
-        val supplied = supplier.get()
-        target.edit { putString(key, supplied) }
-        return supplied
+/**
+ * Returns the string value specified by the key, or sets key to the result of the lambda and returns it.
+ *
+ * This is not designed to be used when bulk editing preferences.
+ *
+ * Defect #5828 - This is potentially not thread safe and could cause another preference commit to fail.
+ */
+@CheckResult // A "set" API should be used if the result is not required.
+fun SharedPreferences.getOrSetString(key: String, supplier: Supplier<String>): String {
+    if (contains(key)) {
+        // the default Is never returned. The value might be able be optimised, but the Android API should be better.
+        return getString(key, "")!!
     }
+    val supplied = supplier.get()
+    this.edit { putString(key, supplied) }
+    return supplied
 }
 
 @CheckResult // A "set" API should be used if the result is not required.

--- a/AnkiDroid/src/test/java/com/ichi2/preferences/PreferenceExtensionsTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/preferences/PreferenceExtensionsTest.kt
@@ -16,7 +16,6 @@
 package com.ichi2.preferences
 
 import android.content.SharedPreferences
-import com.ichi2.preferences.PreferenceExtensions.getOrSetString
 import com.ichi2.testutils.AnkiAssert.assertDoesNotThrow
 import org.junit.Assert.assertEquals
 import org.junit.Before
@@ -37,7 +36,7 @@ class PreferenceExtensionsTest {
     @Mock
     private val mMockEditor: SharedPreferences.Editor? = null
     private fun getOrSetString(key: String, supplier: Supplier<String>): String {
-        return getOrSetString(mockPreferences, key, supplier)
+        return mockPreferences.getOrSetString(key, supplier)
     }
 
     @Before


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
After restarting the phone, Storage Migration Progress should be preserved


## Fixes
Fixes #13634

## Approach
* Save a variable to Shared Preferences
* Restore & use it while converting

## How Has This Been Tested?
* API 30 emulator, with commit rebased on https://github.com/ankidroid/Anki-Android/pull/13657
  * Loaded AnKing. Started a migration. Turned off the emulated phone. Progress (total + files copied) were restored when emulated phone was turned on

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
