### PR TITLE
fix: StackOverflowException in androidTest

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CollectionHelper.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CollectionHelper.kt
@@ -544,8 +544,9 @@ open class CollectionHelper {
             return if (AnkiDroidApp.INSTRUMENTATION_TESTING) {
                 // create an "androidTest" directory inside the current collection directory which contains the test data
                 // "/AnkiDroid/androidTest" would be a new collection path
+                val currentCollectionDirectory = preferences.getOrSetString(PREF_COLLECTION_PATH) { getDefaultAnkiDroidDirectory(context) }
                 File(
-                    getDefaultAnkiDroidDirectory(context),
+                    currentCollectionDirectory,
                     "androidTest"
                 ).absolutePath
             } else if (ankiDroidDirectoryOverride != null) {


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
`getDefaultAnkiDroidDirectory` caused recursion. This recursion is normally gated on the existence of PREF_COLLECTION_PATH But we didn't take this into account when in INSTRUMENTATION_TEST mode

## Fixes
- Fixes #13644

## Approach
Only get the AnkiDroid directory when the default doesn't exist


## How Has This Been Tested?

Tested by rebasing onto d88ad6251c7358359e0dcca36c10f08ff543c4db and running tests on `playDebug` (API 32 emulator)

⚠️ Tests now fail due to an alternate setup issue (I suspect this is due to the emulator lacking permissions to access storage).

```
java.lang.NullPointerException
at com.ichi2.anki.TestUtils.isScreenSw600dp(TestUtils.kt:78)
at com.ichi2.anki.DeckPickerTest.checkIfStudyOptionsIsDisplayedOnTablet(DeckPickerTest.kt:91)
```

## Learning
This is fixed incidentally  by https://github.com/ankidroid/Anki-Android/commit/6dcf23fd10f2eb5d5e8333da895af8d4725f9397, but the underlying cause wasn't handled

⚠️ Something may be up with our emulator tests, we may find this when running the 'full suite'

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
