### PR TITLE
BackupPrompt: Fix TODOs/conditionally skip confirmation dialog

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/ScopedStorageService.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/ScopedStorageService.kt
@@ -334,8 +334,7 @@ object ScopedStorageService {
             return false
         }
 
-        val collectionPath = File(CollectionHelper.getCollectionPath(context))
-        if (collectionPath.isInsideDirectoriesRemovedWithTheApp(context)) {
+        if (userIsPromptedToDeleteCollectionOnUninstall(context)) {
             return false
         }
 
@@ -369,11 +368,14 @@ object ScopedStorageService {
             return false
         }
 
-        val collectionPath = File(CollectionHelper.getCollectionPath(context))
-        if (collectionPath.isInsideDirectoriesRemovedWithTheApp(context)) {
+        if (userIsPromptedToDeleteCollectionOnUninstall(context)) {
             return false
         }
 
         return Environment.isExternalStorageLegacy()
+    }
+
+    fun userIsPromptedToDeleteCollectionOnUninstall(context: Context): Boolean {
+        return File(CollectionHelper.getCollectionPath(context)).isInsideDirectoriesRemovedWithTheApp(context)
     }
 }


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
Fixes a TODO I left in the code. Feels over-documented for an ancillary feature.

## Fixes
Fixes #13663 

## Approach
This PR skips the 'Are you sure?' warning to dismiss the dialog if the user is syncing and their collection is safe

This is primarily documentation, the previous code has one minor bug in that a user could be preserving legacy storage AND not syncing AND had the ability to `MANAGE_EXTERNAL_STORAGE` then the 'backup' dialog was shown when it was not necessary

Mostly making use of newer documented methods in `ScopedStorageService`

Fixes #13663

## How Has This Been Tested?
⚠️ Untested - was for a backup dialog. Unit tests still pass, but this says little


## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
