### PR TITLE
chore: Improve aggregate exception message

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/exceptions/AggregateException.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/exceptions/AggregateException.kt
@@ -16,6 +16,8 @@
 
 package com.ichi2.exceptions
 
+import com.ichi2.anki.AnkiDroidApp
+import com.ichi2.anki.R
 import java.lang.Exception
 import java.lang.RuntimeException
 
@@ -25,6 +27,19 @@ import java.lang.RuntimeException
  * the successful completion of an operation
  */
 class AggregateException(message: String, val exceptions: List<Exception>) : RuntimeException(message) {
+
+    override val message: String
+        get() = "${exceptions.size} errors, the last being: '${exceptions.last().message}' [${super.message}]"
+
+    override fun getLocalizedMessage(): String {
+        return AnkiDroidApp.instance.resources.getQuantityString(
+            R.plurals.aggregate_exception_user_facing_message,
+            exceptions.size,
+            super.message,
+            exceptions.size,
+            exceptions.last().localizedMessage
+        )
+    }
 
     override fun toString(): String {
         return "$message\n ${exceptions.joinToString(separator = "\n") { it.stackTraceToString() }}"

--- a/AnkiDroid/src/main/res/values/02-strings.xml
+++ b/AnkiDroid/src/main/res/values/02-strings.xml
@@ -457,4 +457,12 @@
 
     <string name="media_sync_required_title">Media Sync Required</string>
     <string name="media_sync_unavailable_message">Media sync is disabled in the settings. Please sync and backup any media which hasn\'t been synced before continuing</string>
+
+    <plurals name="aggregate_exception_user_facing_message" comment="This is a summary of a collection of errors (to show a user) The first parameter is the message of the collection of errors
+     The second parameter is the number of errors the collection contains (2 or more)
+     The third parameter is the error message of the 'final' error of the collection.
+     Defined as a plural: Lithuanian defines the form of a count noun by the final digits of the number">
+        <item quantity="one">%2$d error: \'%3$s\' [%1$s]</item>
+        <item quantity="other">%2$d errors, the last being: \'%3$s\' [%1$s]</item>
+    </plurals>
 </resources>

--- a/AnkiDroid/src/test/java/com/ichi2/exceptions/AggregateExceptionAndroidTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/exceptions/AggregateExceptionAndroidTest.kt
@@ -1,0 +1,62 @@
+/*
+ *  Copyright (c) 2023 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.exceptions
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.ichi2.testutils.testExceptionWithStackTrace
+import org.hamcrest.MatcherAssert
+import org.hamcrest.Matchers
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class AggregateExceptionAndroidTest {
+
+    @Test
+    fun aggregateExceptionFriendlyErrorMessage() {
+        val first = testExceptionWithStackTrace("[aa]")
+        val second = testExceptionWithStackTrace("[bb]")
+        val result = AggregateException.raise(
+            "10 consecutive exceptions without progress",
+            listOf(first, second)
+        )
+
+        val asAggregateException = result as AggregateException
+
+        val systemErrorMessage = asAggregateException.message
+        val friendlyErrorMessage = asAggregateException.getUserFriendlyErrorText().toString()
+
+        MatcherAssert.assertThat(
+            systemErrorMessage,
+            Matchers.equalTo("2 errors, the last being: '[bb]' [10 consecutive exceptions without progress]")
+        )
+        MatcherAssert.assertThat(
+            friendlyErrorMessage,
+            Matchers.equalTo("2 errors, the last being: '[bb]' [10 consecutive exceptions without progress]")
+        )
+    }
+
+    /**
+     * Copied from pending PR (#13651)
+     * TODO: use the actual code when it's live
+     */
+    private fun Exception.getUserFriendlyErrorText(): CharSequence =
+        localizedMessage
+            ?: message
+            ?: this::class.simpleName
+            ?: "Unknown error"
+}

--- a/AnkiDroid/src/test/java/com/ichi2/exceptions/AggregateExceptionTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/exceptions/AggregateExceptionTest.kt
@@ -46,13 +46,13 @@ class AggregateExceptionTest {
     fun aggregateExceptionContainsAllExceptions() {
         val first = TestException("a")
         val second = TestException("b")
-        val result = AggregateException.raise("message", listOf(first, second))
+        val result = AggregateException.raise("[message]", listOf(first, second))
 
         assertThat(result, instanceOf(AggregateException::class.java))
 
         val asAggregateException = result as AggregateException
 
-        assertThat(asAggregateException.message, equalTo("message"))
+        assertThat(asAggregateException.message, containsString("[message]"))
         assertThat(asAggregateException.exceptions[0], equalTo(first))
         assertThat(asAggregateException.exceptions[1], equalTo(second))
     }

--- a/AnkiDroid/src/test/java/com/ichi2/exceptions/AggregateExceptionTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/exceptions/AggregateExceptionTest.kt
@@ -17,7 +17,9 @@
 package com.ichi2.exceptions
 
 import com.ichi2.testutils.TestException
+import com.ichi2.testutils.testExceptionWithStackTrace
 import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.containsString
 import org.hamcrest.Matchers.equalTo
 import org.hamcrest.Matchers.instanceOf
 import org.junit.Test
@@ -53,5 +55,21 @@ class AggregateExceptionTest {
         assertThat(asAggregateException.message, equalTo("message"))
         assertThat(asAggregateException.exceptions[0], equalTo(first))
         assertThat(asAggregateException.exceptions[1], equalTo(second))
+    }
+
+    @Test
+    fun aggregateExceptionStackTrace() {
+        val first = testExceptionWithStackTrace("[aa]")
+        val second = testExceptionWithStackTrace("[bb]")
+        val result = AggregateException.raise("message", listOf(first, second))
+
+        val asAggregateException = result as AggregateException
+
+        val stackTrace = asAggregateException.stackTraceToString()
+
+        assertThat(stackTrace, containsString("[aa]"))
+        assertThat(stackTrace, containsString("[bb]"))
+        assertThat(stackTrace, containsString("message"))
+        assertThat(stackTrace, containsString("testExceptionWithStackTrace"))
     }
 }

--- a/AnkiDroid/src/test/java/com/ichi2/testutils/TestException.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/testutils/TestException.kt
@@ -21,3 +21,11 @@ package com.ichi2.testutils
  * Ensures that an actual exception is not mistaken for an exception we want to catch
  */
 class TestException(message: String) : RuntimeException(message)
+
+fun testExceptionWithStackTrace(message: String): TestException {
+    try {
+        throw TestException(message)
+    } catch (e: TestException) {
+        return e
+    }
+}


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
3 requests were made in #13667

* One was tested already: `providedExceptionReturnedIfSingletonListProvided`
* One was implemented and untested. I added a test `aggregateExceptionStackTrace`
* One was not implemented, I implemented it `aggregateExceptionFriendlyErrorMessage`

## Fixes
Fixes #13667

## Approach
Define a string and a few methods

## How Has This Been Tested?
Unit test only


## Learning (optional, can help others)
Reminder about Lithuanian, as one reason we need `one` and `other`, even though `1` is not a possible value to the  parameter

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
