### PR TITLE
docs: Android Tests: fail if 'All files' is needed and not granted

### DIFF
--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/DeckPickerTest.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/DeckPickerTest.kt
@@ -35,6 +35,7 @@ import com.ichi2.anki.testutil.GrantStoragePermission.storagePermission
 import com.ichi2.anki.testutil.ThreadUtils.sleep
 import com.ichi2.anki.testutil.grantPermissions
 import com.ichi2.anki.testutil.notificationPermission
+import com.ichi2.anki.utils.EnsureAllFilesAccessRule
 import org.hamcrest.Matchers.instanceOf
 import org.junit.Assume.assumeFalse
 import org.junit.Assume.assumeTrue
@@ -49,6 +50,9 @@ class DeckPickerTest {
 
     @get:Rule
     val mRuntimePermissionRule = grantPermissions(storagePermission, notificationPermission)
+
+    @get:Rule
+    val ensureAllFilesAccessRule = EnsureAllFilesAccessRule()
 
     @Ignore("This test appears to be flaky everywhere")
     @Test

--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/InstrumentedTest.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/InstrumentedTest.kt
@@ -21,7 +21,9 @@ import android.content.Context
 import android.os.Build
 import androidx.test.platform.app.InstrumentationRegistry
 import com.ichi2.anki.CollectionHelper
+import com.ichi2.anki.utils.EnsureAllFilesAccessRule
 import com.ichi2.libanki.Collection
+import org.junit.Rule
 import java.io.File
 import java.io.IOException
 
@@ -32,6 +34,9 @@ abstract class InstrumentedTest {
     @get:Throws(IOException::class)
     protected val emptyCol: Collection
         get() = Shared.getEmptyCol(testContext)
+
+    @get:Rule
+    val ensureAllFilesAccessRule = EnsureAllFilesAccessRule()
 
     /**
      * @return A File object pointing to a directory in which temporary test files can be placed. The directory is

--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/testutil/GrantPermissions.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/testutil/GrantPermissions.kt
@@ -19,6 +19,7 @@ package com.ichi2.anki.testutil
 import android.os.Build
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.rule.GrantPermissionRule
+import com.ichi2.anki.utils.ensureAllFilesAccess
 import org.junit.rules.TestRule
 
 object GrantStoragePermission {
@@ -48,5 +49,6 @@ val notificationPermission = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TI
 /** Grants permissions, given some may be invalid */
 fun grantPermissions(vararg permissions: String?): TestRule {
     val validPermissions = permissions.filterNotNull().toTypedArray()
+    ensureAllFilesAccess()
     return GrantPermissionRule.grant(*validPermissions)
 }

--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/utils/GrantAllFilesAccessRule.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/utils/GrantAllFilesAccessRule.kt
@@ -1,0 +1,48 @@
+/*
+ *  Copyright (c) 2023 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.utils
+
+import android.os.Build
+import android.os.Environment
+import androidx.test.platform.app.InstrumentationRegistry
+import com.ichi2.utils.Permissions
+import org.junit.rules.TestRule
+import org.junit.runner.Description
+import org.junit.runners.model.Statement
+
+class EnsureAllFilesAccessRule : TestRule {
+    override fun apply(base: Statement, description: Description): Statement {
+        ensureAllFilesAccess()
+        return base
+    }
+}
+
+fun ensureAllFilesAccess() {
+    // PERF: Could be sped up - only need to calculate this once.
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R &&
+        Permissions.canManageExternalStorage(InstrumentationRegistry.getInstrumentation().targetContext) &&
+        !Environment.isExternalStorageManager() &&
+        !Environment.isExternalStorageLegacy()
+    ) {
+        // TODO: https://stackoverflow.com/q/75102412 to grant access, but see if we can remove dependency
+        throw IllegalStateException(
+            "'All Files' access is required on your emulator/device. " +
+                "Please grant it manually or change Build Variant to 'playDebug' in Android Studio " +
+                "(Build -> Select Build Variant)"
+        )
+    }
+}


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
We previously had 'unknown' failures

## Fixes
Fixes #13677

## Approach
Throw an 'obvious' exception instead

## How Has This Been Tested?
My API 32 emulator now fails tests with 'obvious' errors (`amazonDebug`), it passes with `playDebug`

## Learning
The code to grant 'All Files' access in instrumented tests is linked, but needs some quality work (removing a dependency + looking into deprecated methods)

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
