### PR TITLE
build: revert emulator to API 30

### DIFF
--- a/.github/workflows/tests_emulator.yml
+++ b/.github/workflows/tests_emulator.yml
@@ -47,7 +47,8 @@ jobs:
       matrix:
         # Refactor to make these dynamic with a low/high bracket only on schedule, not push
         # For now this is the latest supported API. Previously API 29 was fastest.
-        api-level: [31]
+        # #13695: This was reverted to API 30, 31 was unstable. This should be fixed
+        api-level: [30]
         arch: [x86_64]
         target: [google_apis]
         first-boot-delay: [600]


### PR DESCRIPTION
API 31 was unstable in CI.

Related: #13695
