### PR TITLE
fix: "Failed to load deck '<DeckId>' error when selecting any deck if on SchedV1

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -1730,7 +1730,7 @@ open class DeckPicker :
         if (col.decks.selected() != did) {
             col.clearUndo()
         }
-        if (col.get_config_int("schedVer") == 1) {
+        if (col.get_config_int("schedVer", 1) == 1) {
             promptUserToUpdateScheduler()
             return
         }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.kt
@@ -51,6 +51,7 @@ import com.ichi2.libanki.sched.SchedV2
 import com.ichi2.libanki.sched.SchedV3
 import com.ichi2.libanki.template.ParsedNode
 import com.ichi2.libanki.template.TemplateError
+import com.ichi2.libanki.utils.NotInLibAnki
 import com.ichi2.libanki.utils.Time
 import com.ichi2.libanki.utils.TimeManager
 import com.ichi2.upgrade.upgradeJSONIfNecessary
@@ -2562,4 +2563,15 @@ open class Collection(
 
         private const val SQLITE_WINDOW_SIZE_KB = 2048
     }
+}
+
+/**
+ * @throws JSONException object can't be cast
+ */
+@NotInLibAnki
+fun Collection.get_config_int(key: String, defaultValue: Int): Int {
+    if (has_config_not_null(key)) {
+        return get_config_int(key)
+    }
+    return defaultValue
 }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/utils/NotInLibAnki.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/utils/NotInLibAnki.kt
@@ -1,0 +1,29 @@
+/*
+ *  Copyright (c) 2023 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.libanki.utils
+
+@Target(
+    AnnotationTarget.CLASS,
+    AnnotationTarget.FUNCTION,
+    AnnotationTarget.VALUE_PARAMETER,
+    AnnotationTarget.EXPRESSION,
+    AnnotationTarget.FIELD,
+    AnnotationTarget.PROPERTY,
+    AnnotationTarget.LOCAL_VARIABLE
+)
+@Retention(AnnotationRetention.SOURCE)
+annotation class NotInLibAnki


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
A user saw 'Failed to load deck '<DeckId'> when selecting a deck.

## Cause
If the user was using the V1 scheduler then `schedVer` is not set

`get_config_int` threw an exception if this was the case.

## Fixes
- Fixes #13003
- Fixes #13692

## Approach
* Default to V1 if `schedVer` is not found

## How Has This Been Tested?
I was provided with a test collection. 

It now shows:
![Screenshot 2023-04-24 at 23 09 31](https://user-images.githubusercontent.com/62114487/234127379-9e69dea3-7561-4523-8a70-6162924bc9d8.png)

## Learning
The issue and fix was obvious once config was obtained (posted to #13003)

I love 'Past David'

https://github.com/ankidroid/Anki-Android/blob/a06e727f6094541b763e2dc18a300edb3e17fd26/AnkiDroid/src/test/java/com/ichi2/libanki/sched/SchedUpgradeTest.kt#L49-L51

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
