### PR TITLE
fix: storage permission checks on 'full' builds & broken Dialog

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -506,7 +506,7 @@ open class CardBrowser :
         mExportingDelegate = ActivityExportingDelegate(this) { col }
         super.onCreate(savedInstanceState)
         Timber.d("onCreate()")
-        if (wasLoadedFromExternalTextActionItem() && !hasStorageAccessPermission(this)) {
+        if (wasLoadedFromExternalTextActionItem() && !hasStorageAccessPermission(this) && !Permissions.isExternalStorageManagerCompat()) {
             Timber.w("'Card Browser' Action item pressed before storage permissions granted.")
             showThemedToast(this, getString(R.string.intent_handler_failed_no_storage_permission), false)
             displayDeckPickerForPermissionsDialog()

--- a/AnkiDroid/src/main/java/com/ichi2/anki/IntentHandler.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/IntentHandler.kt
@@ -29,12 +29,14 @@ import com.ichi2.anki.dialogs.DialogHandler.Companion.storeMessage
 import com.ichi2.anki.dialogs.DialogHandlerMessage
 import com.ichi2.anki.servicelayer.ScopedStorageService
 import com.ichi2.anki.services.ReminderService
+import com.ichi2.annotations.NeedsTest
 import com.ichi2.themes.Themes.disableXiaomiForceDarkMode
 import com.ichi2.utils.FileUtil
 import com.ichi2.utils.ImportUtils.handleFileImport
 import com.ichi2.utils.ImportUtils.isInvalidViewIntent
 import com.ichi2.utils.ImportUtils.showImportUnsuccessfulDialog
 import com.ichi2.utils.NetworkUtils
+import com.ichi2.utils.Permissions
 import com.ichi2.utils.Permissions.hasStorageAccessPermission
 import com.ichi2.utils.copyToClipboard
 import com.ichi2.utils.trimToLength
@@ -100,8 +102,9 @@ class IntentHandler : Activity() {
      * has been granted (as long as AnkiDroid targeted API < 30, requested legacy storage, and has not been uninstalled since)
      *
      */
+    @NeedsTest("clicking a file in 'Files' to import")
     private fun performActionIfStorageAccessible(runnable: Runnable, reloadIntent: Intent, action: String?) {
-        if (!ScopedStorageService.isLegacyStorage(this) || hasStorageAccessPermission(this)) {
+        if (!ScopedStorageService.isLegacyStorage(this) || hasStorageAccessPermission(this) || Permissions.isExternalStorageManagerCompat()) {
             Timber.i("User has storage permissions. Running intent: %s", action)
             runnable.run()
         } else {

--- a/AnkiDroid/src/main/java/com/ichi2/utils/Permissions.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/Permissions.kt
@@ -59,6 +59,18 @@ object Permissions {
     }
 
     /**
+     * On < Android 11, returns false.
+     * On >= Android 11, returns [isExternalStorageManager]
+     */
+    fun isExternalStorageManagerCompat(): Boolean {
+        return if (Build.VERSION.SDK_INT < Build.VERSION_CODES.R) {
+            return false
+        } else {
+            isExternalStorageManager()
+        }
+    }
+
+    /**
      * Check if we have write access permission to the external storage
      * @param context
      * @return


### PR DESCRIPTION
## Purpose / Description
1. `full` build: Previously imports via clicking a deck in 'Files' failed with `intent_handler_failed_no_storage_permission`: "Missing required storage permission. Please grant storage permission then retry your action"

## Fixes
- Fixes (probably) #13699
   -  Notified `criticalAY` of this. Almost certain that it'll be fixed

## Approach
1. Define & use isExternalStorageManagerCompat

## How Has This Been Tested?
* A deck can be tapped on from 'files' and is imported
* ⚠️ The Dialog on tapping an `.anki2` looks funky
   * Logged as #13704

## Learning (optional, can help others)
We need more testing + videos from new contributors testing their changes

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
