### PR TITLE
chore: remove 'MEDIA_CODEC_LIST' from crash reports

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CrashReportService.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CrashReportService.kt
@@ -109,7 +109,7 @@ object CrashReportService {
                 ReportField.INSTALLATION_ID,
                 ReportField.ENVIRONMENT,
                 ReportField.SHARED_PREFERENCES,
-                ReportField.MEDIA_CODEC_LIST,
+                // ReportField.MEDIA_CODEC_LIST,
                 ReportField.THREAD_DETAILS
             )
             .withLogcatArguments(*logcatArgs)


### PR DESCRIPTION
I've never used the information, and it makes navigation of the crash log more difficult than it should be

I'll face the consequences if I'm incorrect here.

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
