### PR TITLE
fix: NullPointerException on `isLegacyStorage()` call

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CollectionHelper.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CollectionHelper.kt
@@ -507,8 +507,8 @@ open class CollectionHelper {
          * @return Returns an array of [File]s reflecting the directories that AnkiDroid can access without storage permissions
          * @see android.content.Context.getExternalFilesDirs
          */
-        fun getAppSpecificExternalDirectories(context: Context): Array<File> {
-            return context.getExternalFilesDirs(null)
+        fun getAppSpecificExternalDirectories(context: Context): List<File> {
+            return context.getExternalFilesDirs(null).filterNotNull()
         }
 
         /**

--- a/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/ScopedStorageAndroidTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/ScopedStorageAndroidTest.kt
@@ -122,7 +122,7 @@ class ScopedStorageAndroidTest {
      */
     private fun runTestWithTwoExternalDirectories(externalDirectories: Array<File>, test: (Array<File>) -> Unit) {
         mockkObject(CollectionHelper) {
-            every { CollectionHelper.getAppSpecificExternalDirectories(any()) } returns externalDirectories
+            every { CollectionHelper.getAppSpecificExternalDirectories(any()) } returns externalDirectories.toList()
             test(externalDirectories)
         }
     }


### PR DESCRIPTION
The documentation on `getExternalFilesDirs` states:

> Some individual paths may be {@code null} if that
> shared storage is not currently available

## Pull Request template

## Purpose / Description
A crash was reported

## Fixes
- Fixes #13705

## Approach
* Remove the null elements from the list

## How Has This Been Tested?
Untested (sans unit tests). Fix was obvious

## Learning
Android APIs need better nullability annotations.

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
