### PR TITLE
fix: not being open to open the login screen from settings on a parallel build

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -125,7 +125,8 @@ android {
 
             // syntax: assembleRelease -PcustomSuffix="suffix" -PcustomName="New name"
             if (project.hasProperty("customSuffix")) {
-                applicationIdSuffix project.property("customSuffix")
+                // the suffix needs a '.' at the start
+                applicationIdSuffix project.property("customSuffix").replaceFirst(/^\.*/, ".")
                 resValue "string", "applicationId", "${defaultConfig.applicationId}${applicationIdSuffix}"
             } else {
                 resValue "string", "applicationId", defaultConfig.applicationId


### PR DESCRIPTION
## Fixes
Fixes #13583

## How Has This Been Tested?

- Build a parallel build
- Settings > Sync > AnkiWeb Account
- see if is able to login

## Learning (optional, can help others)
This is actually my fault. The "applicationIdSuffix" command adds an initial dot to the suffix, but its value keeps without it.

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
