### PR TITLE
fix: crash if exporting deck name containing "'"

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/export/ActivityExportingDelegate.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/export/ActivityExportingDelegate.kt
@@ -38,6 +38,7 @@ import com.ichi2.anki.dialogs.ExportDialog.ExportDialogListener
 import com.ichi2.anki.dialogs.ExportDialogParams
 import com.ichi2.anki.servicelayer.ScopedStorageService
 import com.ichi2.anki.snackbar.showSnackbar
+import com.ichi2.annotations.NeedsTest
 import com.ichi2.compat.CompatHelper
 import com.ichi2.libanki.AnkiPackageExporter
 import com.ichi2.libanki.Collection
@@ -98,6 +99,7 @@ class ActivityExportingDelegate(private val activity: AnkiActivity, private val 
         }
     }
 
+    @NeedsTest("exporting deck with name containing apostrophe")
     override fun exportColAsApkgOrColpkg(path: String?, includeSched: Boolean, includeMedia: Boolean) {
         val exportPath = getExportFileName(path, "All Decks", includeSched)
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/AnkiPackageExporter.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/AnkiPackageExporter.kt
@@ -143,7 +143,7 @@ open class AnkiExporter(col: Collection, did: DeckId?, val includeSched: Boolean
         // flexible
         dst.close()
         Timber.d("Attach DB")
-        col.db.database.execSQL("ATTACH '$path' AS DST_DB")
+        col.db.database.execSQL("ATTACH ? AS DST_DB", arrayOf(path))
         // copy cards, noting used nids (as unique set)
         Timber.d("Copy cards")
         col.db.database


### PR DESCRIPTION
## Purpose / Description
Fixes an error when exporting a deck

## Fixes
Fixes #13717

## Approach
Prepared Statements

## How Has This Been Tested?
Tested on API 30 Emulator. 

* Exported
* Deleted Deck
* Imported
* Card was imported

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
