### PR TITLE
Use `toList` first on `mAllTags`  for collections tag

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/tags/TagsList.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/tags/TagsList.kt
@@ -20,8 +20,6 @@ import com.ichi2.utils.TagsUtil.getTagAncestors
 import com.ichi2.utils.TagsUtil.getTagRoot
 import com.ichi2.utils.UniqueArrayList
 import com.ichi2.utils.UniqueArrayList.Companion.from
-import org.apache.commons.collections4.CollectionUtils.addAll
-import org.slf4j.MDC.clear
 import java.util.*
 
 /**

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/tags/TagsList.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/tags/TagsList.kt
@@ -284,7 +284,7 @@ class TagsList constructor(
      * A tag priors to another one if its root tag is checked or indeterminate while the other one's is not
      */
     fun sort() {
-        val sortedTags = sortedWith { lhs: String?, rhs: String? ->
+        val sortedList = mAllTags.toList().sortedWith { lhs: String?, rhs: String? ->
             val lhsRoot = getTagRoot(lhs!!)
             val rhsRoot = getTagRoot(rhs!!)
             val lhsChecked = isChecked(lhsRoot) || isIndeterminate(lhsRoot)
@@ -295,8 +295,8 @@ class TagsList constructor(
                 compareTag(lhs, rhs)
             }
         }
-        clear()
-        addAll(sortedTags)
+        mAllTags.clear()
+        mAllTags.addAll(sortedList)
     }
 
     /**

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/tags/TagsList.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/tags/TagsList.kt
@@ -20,6 +20,8 @@ import com.ichi2.utils.TagsUtil.getTagAncestors
 import com.ichi2.utils.TagsUtil.getTagRoot
 import com.ichi2.utils.UniqueArrayList
 import com.ichi2.utils.UniqueArrayList.Companion.from
+import org.apache.commons.collections4.CollectionUtils.addAll
+import org.slf4j.MDC.clear
 import java.util.*
 
 /**
@@ -282,7 +284,7 @@ class TagsList constructor(
      * A tag priors to another one if its root tag is checked or indeterminate while the other one's is not
      */
     fun sort() {
-        mAllTags.sortWith { lhs: String?, rhs: String? ->
+        val sortedTags = sortedWith { lhs: String?, rhs: String? ->
             val lhsRoot = getTagRoot(lhs!!)
             val rhsRoot = getTagRoot(rhs!!)
             val lhsChecked = isChecked(lhsRoot) || isIndeterminate(lhsRoot)
@@ -293,6 +295,8 @@ class TagsList constructor(
                 compareTag(lhs, rhs)
             }
         }
+        clear()
+        addAll(sortedTags)
     }
 
     /**


### PR DESCRIPTION

## Pull Request template

## Purpose / Description
Use `toList` first on `mAllTags` then sort it to avoid crashing then use clear and add the tags to the collection


## Fixes
Fixes #12471

## Approach


## How Has This Been Tested?
Tested on API24/31/27


_Links to blog posts, patterns, libraries or addons used to solve this problem_

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
