### PR TITLE
fix: crash importing decks on SDK 24 and below

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -296,7 +296,8 @@ dependencies {
     implementation 'androidx.webkit:webkit:1.6.1'
     // Note: the design support library can be quite buggy, so test everything thoroughly before updating it
     implementation 'com.google.android.material:material:1.8.0'
-    implementation 'com.fasterxml.jackson.core:jackson-databind:2.15.0'
+    // noinspection GradleDependency jackson-databind 2.13 requires SDK 24+: https://github.com/FasterXML/jackson-databind#compatibility
+    implementation 'com.fasterxml.jackson.core:jackson-databind:2.12.0'
     implementation 'com.vanniktech:android-image-cropper:4.5.0'
     implementation 'org.nanohttpd:nanohttpd:2.3.1'
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/importer/AnkiPackageImporter.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/importer/AnkiPackageImporter.kt
@@ -24,6 +24,7 @@ import com.ichi2.anki.CollectionHelper
 import com.ichi2.anki.CrashReportService
 import com.ichi2.anki.R
 import com.ichi2.anki.exception.ImportExportException
+import com.ichi2.annotations.NeedsTest
 import com.ichi2.libanki.Collection
 import com.ichi2.libanki.Storage
 import com.ichi2.libanki.Utils
@@ -43,6 +44,7 @@ class AnkiPackageImporter(col: Collection?, file: String?) : Anki2Importer(col!!
     private var mNameToNum: MutableMap<String, String>? = null
 
     @Throws(ImportExportException::class)
+    @NeedsTest("test this on our lowest SDK")
     override fun run() {
         publishProgress(0, 0, 0)
         val tempDir = File(File(mCol.path).parent, "tmpzip")


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
Deck imports crashed on low SDK versions

## Fixes
- Fixes #13729

## Approach
jackson-databind incompatibility: Downgrade dependency

## How Has This Been Tested?
* Tested on SDK 21 and SDK 24. No longer crashes

## Learning (optional, can help others)
 https://github.com/FasterXML/jackson-databind#compatibility

> Android
> 2.13: Android SDK 24+
> 2.14: Android SDK 26+

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
