### PR TITLE
fix: moving to note type with fewer sticky fields

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
@@ -1432,9 +1432,15 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
         }
     }
 
+    @NeedsTest("13719: moving from a note type with more fields to one with fewer fields")
     private fun saveToggleStickyMap() {
         for ((key) in mToggleStickyText) {
-            mToggleStickyText[key] = mEditFields!![key]!!.fieldText
+            // handle fields for different note type with different size
+            if (key < mEditFields!!.size) {
+                mToggleStickyText[key] = mEditFields!![key]?.fieldText
+            } else {
+                mToggleStickyText.remove(key)
+            }
         }
     }
 


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
`IndexOutOfBoundsException` when moving from 'Basic (optional reversed card)' to 'Basic (and reversed card)' after setting 'Toggle Sticky' for all fields

## Fixes
- Fixes #13719 

## Approach
This is due to 'toggle sticky' being present on this additional field

Quick fix to stop a crash. Needs more thought and testing

## How Has This Been Tested?
Tested manually on API 31 emulator. No longer crashes

## Learning (optional, can help others)
Need more automated testing

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
