### PR TITLE
fix: nullability issues in FileUtils

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/managespace/FileUtils.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/managespace/FileUtils.kt
@@ -134,10 +134,10 @@ private suspend fun Context.getUserDataAndCacheSizeUsingGetPackageSizeInfo(): Lo
 fun File.isInsideDirectoriesRemovedWithTheApp(context: Context): Boolean {
     infix fun File.isInsideOf(parent: File) = this.canonicalFile.startsWith(parent.canonicalFile)
 
-    return context.getExternalFilesDirs(null).any { this isInsideOf it } ||
-        context.externalCacheDirs.any { this isInsideOf it } ||
-        context.externalMediaDirs.any { this isInsideOf it } ||
-        context.obbDirs.any { this isInsideOf it } ||
+    return context.getExternalFilesDirs(null).filterNotNull().any { this isInsideOf it } ||
+        context.externalCacheDirs.filterNotNull().any { this isInsideOf it } ||
+        context.externalMediaDirs.filterNotNull().any { this isInsideOf it } ||
+        context.obbDirs.filterNotNull().any { this isInsideOf it } ||
         context.externalDirs.any { this isInsideOf it }
 }
 
@@ -149,6 +149,7 @@ fun File.isInsideDirectoriesRemovedWithTheApp(context: Context): Boolean {
  */
 private val Context.externalDirs: Set<File> get() =
     (getExternalFilesDirs(null) + externalCacheDirs)
+        .filterNotNull()
         .mapNotNullTo(mutableSetOf()) { externalFilesOrCacheDir ->
             externalFilesOrCacheDir.parentFile?.let { parentDir ->
                 if (parentDir.name == packageName) parentDir else null


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
Uses a number of methods which are documented to maybe return `null`, and we have a crash here saying `java.lang.NullPointerException: it must not be null`

## Fixes
- Fixes #13734

## How Has This Been Tested?
⚠️ Untested

## Learning 
* Probably the first user that we've lost due to the storage migration, given the comment in ACRA :/

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
