### PR TITLE
Fix SharedDecksDownloadFragment being leaked when app is sent to background

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/SharedDecksDownloadFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/SharedDecksDownloadFragment.kt
@@ -80,7 +80,7 @@ class SharedDecksDownloadFragment : Fragment() {
     private var mDownloadCancelConfirmationDialog: MaterialDialog? = null
 
     companion object {
-        const val DOWNLOAD_PROGRESS_CHECK_DELAY = 100L
+        const val DOWNLOAD_PROGRESS_CHECK_DELAY = 1000L
 
         const val DOWNLOAD_STARTED_PROGRESS_PERCENTAGE = "0"
         const val DOWNLOAD_COMPLETED_PROGRESS_PERCENTAGE = "100"
@@ -293,9 +293,13 @@ class SharedDecksDownloadFragment : Fragment() {
     private val mDownloadProgressChecker: Runnable by lazy {
         object : Runnable {
             override fun run() {
+                if (!isVisible) {
+                    stopDownloadProgressChecker()
+                    return
+                }
                 checkDownloadProgress()
 
-                // Keep checking download progress at intervals of 0.1 second.
+                // Keep checking download progress at intervals of 1 second.
                 mHandler.postDelayed(this, DOWNLOAD_PROGRESS_CHECK_DELAY)
             }
         }


### PR DESCRIPTION
## Purpose / Description

The current code schedules a Runnable to update the download progress and because it didn't properly handle the fragment's lifecycle it kept a reference to the old fragment when sent to the background. This PR also increases the DownloadManager query rate from 100ms to each second.

## Fixes
Fixes #13687 

## How Has This Been Tested?

Ran the tests and then manually checked if the exception still occurs.z

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
