### PR TITLE
Resolve TODO regarding migration transferring more bytes than initially calculated

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/services/MigrationService.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/services/MigrationService.kt
@@ -52,6 +52,20 @@ import kotlin.properties.ReadOnlyProperty
  * A foreground service responsible for migrating the collection
  * from a public directory to an app-private directory.
  *
+ * Notes on behavior:
+ *
+ *   * As the app can be killed at any time, to make sure that the service shows consistent
+ *     progress after it is restarted, we save the initial size of data to be transferred.
+ *     When resuming migration, we can calculate transferred size
+ *     by subtracting the size of remaining data from the stored value.
+ *
+ *   * We are not rate-limiting publication of the notifications in the code,
+ *     as the files do not seem to be transferred so fast as to cause any problems.
+ *     The system performs its own rate-limiting, dropping updates if they are published too quickly.
+ *     An exception is is made for "completed progress notifications". See:
+ *     https://android.googlesource.com/platform/frameworks/base/+/refs/heads/master/services/core/java/com/android/server/notification/NotificationManagerService.java
+ *     https://android.googlesource.com/platform/frameworks/base/+/refs/heads/master/services/core/java/com/android/server/notification/RateEstimator.java
+ *
  * TODO BEFORE-RELEASE Decide if this needs a wake lock.
  *   Copying files might take a long time.
  *   The user might decide to not use the phone for a while to let the migration run,


### PR DESCRIPTION
## Purpose / Description
> TODO BEFORE-RELEASE! Between this call and the subsequent migration the contents of the folder can change. This can lead to inconsistent readings in the UI.

## Approach
Simply coerce transferred size into 0 .. estimated transfer size. Add a note about this to the doc. Plus a few more notes. The result is that the progress might appear stuck near the end. Alternatively we could be updating the total size, or only coercing the ratio into 0f .. 1f, or not doing anything.

**Note**: if extra media files are added to the source while migration is ongoing, the migration will fail with `com.ichi2.anki.servicelayer.scopedstorage.migrateuserdata.MigrateUserData.DirectoryNotEmptyException` ("directory was not empty").

## How Has This Been Tested?

Tested on my device

## Checklist

- [ ] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
