### PR TITLE
Resolve TODOs regarding ongoing migration button title

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -39,6 +39,7 @@ import android.widget.*
 import androidx.annotation.VisibleForTesting
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.widget.SearchView
+import androidx.appcompat.widget.TooltipCompat
 import androidx.core.app.ActivityCompat.OnRequestPermissionsResultCallback
 import androidx.core.content.ContextCompat
 import androidx.core.content.edit
@@ -614,11 +615,6 @@ open class DeckPicker :
      * TODO Investigate whether we can stop recreating the menu,
      *   relying instead on modifying it directly and/or using [onPrepareOptionsMenu].
      *   Note an issue with the latter: https://github.com/ankidroid/Anki-Android/issues/7755
-     *
-     * TODO BEFORE-RELEASE Add tooltip text to the image button.
-     *   Menu items normally have titles that are shown on long tap.
-     *   As this menu item delegates the UI to the action view, it is up to that to handle presses.
-     *   When we decide on the text, use `TooltipCompat.setTooltipText` on the button to set it.
      */
     private fun setupMigrationProgressMenuItem(menu: Menu, migrationInProgress: Boolean) {
         val migrationProgressMenuItem = menu.findItem(R.id.action_migration_progress)
@@ -652,8 +648,10 @@ open class DeckPicker :
                     .findViewById<CircularProgressIndicator>(R.id.progress_indicator)
                     .apply { max = Int.MAX_VALUE }
 
-                actionView.findViewById<ImageButton>(R.id.button)
-                    .setOnClickListener { warnNoSyncDuringMigration() }
+                actionView.findViewById<ImageButton>(R.id.button).also { button ->
+                    button.setOnClickListener { warnNoSyncDuringMigration() }
+                    TooltipCompat.setTooltipText(button, getText(R.string.show_migration_progress))
+                }
 
                 migrationProgressPublishingJob = lifecycleScope.launch {
                     withBoundTo<MigrationService> { service ->

--- a/AnkiDroid/src/main/res/menu/deck_picker.xml
+++ b/AnkiDroid/src/main/res/menu/deck_picker.xml
@@ -8,10 +8,10 @@
             android:title="@string/search_decks"
             ankidroid:actionViewClass="androidx.appcompat.widget.SearchView"
             ankidroid:showAsAction="always|collapseActionView"/>
-        <!--        TODO: add a title for this action-->
         <item
             android:id="@+id/action_migration_progress"
             android:visible="false"
+            android:title="@string/show_migration_progress"
             ankidroid:actionLayout="@layout/migration_progress_menu_layout"
             ankidroid:showAsAction="always" />
         <!--

--- a/AnkiDroid/src/main/res/values/02-strings.xml
+++ b/AnkiDroid/src/main/res/values/02-strings.xml
@@ -316,7 +316,10 @@
     <!-- Deck Picker -->
     <string name="deck_picker_failed_deck_load">Failed to load deck ‘%s’</string>
     <string name="search_decks">Search decks</string>
-
+    <string name="show_migration_progress"
+        comment="Title for a button in deck picker's toolbar that shows ongoing migration progress.
+        Usually shown as a tooltip. The button opens a dialog with a more detailed progress information."
+        >Show migration progress</string>
 
     <string name="ankidroid_init_failed_webview_title">Fatal Error</string>
     <string name="ankidroid_init_failed_webview">AnkiDroid relies on the System WebView which is unavailable. This can happen if the system is installing updates. Please try again in a few minutes.\n\n%s</string>


### PR DESCRIPTION
## Purpose / Description
> TODO: add a title for this action

> TODO BEFORE-RELEASE Add tooltip text to the image button. Menu items normally have titles that are shown on long tap. As this menu item delegates the UI to the action view, it is up to that to handle presses. When we decide on the text, use `TooltipCompat.setTooltipText` on the button to set it.

Supersedes #13531 

## Approach
Do what the TODOs say

## How Has This Been Tested?
Tested on my device
<img width=300 src=https://user-images.githubusercontent.com/1710718/235180612-85a2a4bd-9a50-4a1d-9de2-b249b896150d.png>

## Checklist
- [ ] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
