### PR TITLE
Setting the namespace via a source

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -26,6 +26,8 @@ idea {
 
 def homePath = System.properties['user.home']
 android {
+    namespace "com.ichi2.anki"
+
     compileSdkVersion 33 // change api compileSdkVersion at the same time
 
     defaultConfig {


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
`package="com.ichi2.anki" found in source AndroidManifest.xml: /home/runner/work/Anki-Android/Anki-Android/AnkiDroid/build/intermediates/merged_manifest/playRelease/AndroidManifest.xml. Setting the namespace via a source AndroidManifest.xml's package attribute is deprecated`

## Fixes
Fixes #13682 

## How Has This Been Tested?
Using the namespace code snippet as suggested by google [here](https://developer.android.com/build/configure-app-module#set-namespace)

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
