### PR TITLE
Set noVerticalPadding to false in CustomStudyDialog.kt

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/customstudy/CustomStudyDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/customstudy/CustomStudyDialog.kt
@@ -199,7 +199,7 @@ class CustomStudyDialog(private val collection: Collection, private val customSt
         val jumpToReviewer = requireArguments().getBoolean("jumpToReviewer")
         // Set material dialog parameters
         val dialog = MaterialDialog(requireActivity())
-            .customView(view = v, scrollable = true, noVerticalPadding = true, horizontalPadding = true)
+            .customView(view = v, scrollable = true, noVerticalPadding = false, horizontalPadding = true)
             .positiveButton(R.string.dialog_ok) {
                 // Get the value selected by user
                 val n: Int = try {


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
There is no vertical padding in some CustomStudyDialog

## Fixes
Fixes #13763

## Approach
Set noVerticalPadding to false

## How Has This Been Tested?

Tested on Emulator (Pixel 5 API 29)
![vertical](https://user-images.githubusercontent.com/65113071/235340737-a6ad4d24-cd99-42b2-ae42-ab31698a3d08.png)


## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
