### PR TITLE
SearchBox is appearing when clicking on the search icon

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/PreferencesSearchView.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/PreferencesSearchView.kt
@@ -37,4 +37,9 @@ class PreferencesSearchView : SearchPreferenceActionView {
     override fun onActionViewCollapsed() {
         cancelSearch()
     }
+
+    override fun onActionViewExpanded() {
+        isIconified = false
+        super.onActionViewExpanded()
+    }
 }


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
SearchBox failed to appear when clicked for atleast second time. It's become inconvenient for the user to click two times on search icon

## Fixes
Fixes #13771

## Approach
set isIconified to false in onActionViewExpanded()

## How Has This Been Tested?

Tested on Physical Device (Realme 9)

https://user-images.githubusercontent.com/65113071/235350907-ec4d032c-efbb-41ac-b242-60ea8b323843.mp4



## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
