### PR TITLE
Used AutoFocusEditTextPreference instead of EditTextPreference

### DIFF
--- a/AnkiDroid/src/main/res/xml/cram_deck_options.xml
+++ b/AnkiDroid/src/main/res/xml/cram_deck_options.xml
@@ -19,7 +19,7 @@
     xmlns:app="http://arbitrary.app.namespace/com.ichi2.anki" >
 
     <PreferenceCategory android:title="@string/deck_conf_cram_filter" >
-        <EditTextPreference
+        <com.ichi2.preferences.AutoFocusEditTextPreference
             android:key="@string/filtered_deck_search_key"
             android:title="@string/deck_conf_cram_search" />
 


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
The keyboard is not showing automatically
## Fixes
Fixes #13775

## Approach
Replaced EditTextPreference with AutoFocusEditTextPreference

## How Has This Been Tested?

Tested on Emulator (Pixel 5 API 29)

https://user-images.githubusercontent.com/65113071/235426272-75ae47ff-e142-45cb-888a-c45737ec9829.mp4




## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
