### PR TITLE
style: log template preview dummy card error as d not e

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplatePreviewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplatePreviewer.kt
@@ -354,7 +354,8 @@ open class CardTemplatePreviewer : AbstractFlashcardViewer() {
             val template = col.findTemplates(n)[index]
             return col.getNewLinkedCard(PreviewerCard(col, n), n, template, 1, 0L, false)
         } catch (e: Exception) {
-            Timber.e(e, "getDummyCard() unable to create card")
+            // Calling code handles null return, so we can log this for developer's interest but move on
+            Timber.d(e, "getDummyCard() unable to create card")
         }
         return null
     }


### PR DESCRIPTION
## Pull Request template

## Purpose / Description

this was causing noise in the logs which may be a source of confusion in our pre-launch reports on play store

## Approach

Analyze logcat from play store auto-test runs pre-launch in combination with stack trace and captured video of the test session

It appears there is no problem with the app continuing and calling code for `getDummyCard` has to handle null returns anyway, so reducing log noise:

- should be okay technically / from correctness perspective
- may fix pre-launch report spurious errors flagged for IndexOutOfBoundsException

## How Has This Been Tested?

The exception was logged but caused no problems, it was tested in the auto-test lab and I have the logcat + video of session where the exception was thrown and it was fine

## Learning (optional, can help others)

We need to always enforce correct log levels, apparently we are sometimes lax

- error is only for things that almost completely blow up the app, and the app probably needs to restart
- warning is for things that almost completely blow up the app but we think we can safely continue after perhaps reinitializing things
- info is for things truly interesting
- debug is for things that are only interesting to developers while developing + testing
- verbose/trace - rarely used

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
