### PR TITLE
Resolve NeedsTests annotations in LoginActivity.kt

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/LoginActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/LoginActivity.kt
@@ -23,7 +23,6 @@ import android.view.View
 import android.view.View.GONE
 import androidx.lifecycle.Lifecycle
 import com.ichi2.anki.UIUtils.showThemedToast
-import com.ichi2.annotations.NeedsTest
 import timber.log.Timber
 
 /**
@@ -43,7 +42,7 @@ import timber.log.Timber
  *
  * TODO: Move this to a fragment
  */
-@NeedsTest("check result codes based on login result")
+
 class LoginActivity : MyAccount() {
 
     override fun onCreate(savedInstanceState: Bundle?) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/LoginActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/LoginActivity.kt
@@ -42,7 +42,6 @@ import timber.log.Timber
  *
  * TODO: Move this to a fragment
  */
-
 class LoginActivity : MyAccount() {
 
     override fun onCreate(savedInstanceState: Bundle?) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/LoginActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/LoginActivity.kt
@@ -44,7 +44,6 @@ import timber.log.Timber
  * TODO: Move this to a fragment
  */
 @NeedsTest("check result codes based on login result")
-@NeedsTest("activity is closed if started when logged in")
 class LoginActivity : MyAccount() {
 
     override fun onCreate(savedInstanceState: Bundle?) {

--- a/AnkiDroid/src/test/java/com/ichi2/anki/LoginActivityTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/LoginActivityTest.kt
@@ -1,0 +1,25 @@
+package com.ichi2.anki
+
+import androidx.lifecycle.Lifecycle
+import androidx.test.core.app.ActivityScenario.launch
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.ichi2.anki.MyAccount.Companion.STATE_LOGGED_IN
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class LoginActivityTest : RobolectricTest() {
+    @Test
+    fun activityIsClosedIfStartedWhenLoggedIn() {
+        val scenario = launch(LoginActivity::class.java)
+
+        scenario.moveToState(Lifecycle.State.CREATED)
+
+        scenario.onActivity { activity ->
+            run {
+                activity.switchToState(STATE_LOGGED_IN)
+                assert(activity.isFinishing)
+            }
+        }
+    }
+}

--- a/AnkiDroid/src/test/java/com/ichi2/anki/LoginActivityTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/LoginActivityTest.kt
@@ -1,6 +1,23 @@
+/*
+ *  Copyright (c) 2023 Tomasz Garbus <tomasz.garbus1@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package com.ichi2.anki
 
 import android.app.Activity
+import androidx.core.content.edit
 import androidx.lifecycle.Lifecycle
 import androidx.test.core.app.ActivityScenario.launchActivityForResult
 import androidx.test.ext.junit.runners.AndroidJUnit4
@@ -13,24 +30,20 @@ class LoginActivityTest : RobolectricTest() {
     @Test
     fun activityIsClosedIfStartedWhenLoggedIn() {
         // Effectively mocks isLoggedIn() to return true.
-        AnkiDroidApp.getSharedPrefs(AnkiDroidApp.instance).edit()
-            .putString(SyncPreferences.HKEY, "anything not null")
-            .apply()
+        getPreferences().edit { putString(SyncPreferences.HKEY, "anything not null") }
 
-        val scenario = launchActivityForResult(LoginActivity::class.java)
-
-        // When the user is logged in, we expect the activity to call finish() from onCreate().
-        // Since this is expected behaviour, we also expect the result to be "OK".
-        assertEquals(Activity.RESULT_OK, scenario.result.resultCode)
-        assertEquals(Lifecycle.State.DESTROYED, scenario.state)
+        launchActivityForResult(LoginActivity::class.java).use { scenario ->
+            // When the user is logged in, we expect the activity to call finish() from onCreate().
+            // Since this is expected behaviour, we also expect the result to be "OK".
+            assertEquals(Activity.RESULT_OK, scenario.result.resultCode)
+            assertEquals(Lifecycle.State.DESTROYED, scenario.state)
+        }
     }
 
     @Test
     fun activityIsNotFinishedOnStartupIfNotLoggedIn() {
         // Effectively mocks isLoggedIn() to return false.
-        AnkiDroidApp.getSharedPrefs(AnkiDroidApp.instance).edit()
-            .putString(SyncPreferences.HKEY, "")
-            .apply()
+        getPreferences().edit { putString(SyncPreferences.HKEY, "") }
 
         val scenario = launchActivityForResult(LoginActivity::class.java)
 


### PR DESCRIPTION
This is my first contribution, so I'm looking forward to getting some feedback before getting deeper into the codebase!

This is a clone of https://github.com/ankidroid/Anki-Android/pull/13759 (see also comment history there) because I wanted to move these changes off of my main branch.

Tests flow as follows:
* mock isLoggedIn() (we have mockk mockStatic I think) to return true
* start LoginActivity
* assert that the Lifecycle state of LoginActivity is finished/destroyed(as there's no reason to show this activity when the user is logged in). Also test the Activity result codes.