### PR TITLE
Fix ConcurrentModificationException in NoteEditor.saveToggleStickyMap()

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
@@ -1434,7 +1434,7 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
 
     @NeedsTest("13719: moving from a note type with more fields to one with fewer fields")
     private fun saveToggleStickyMap() {
-        for ((key) in mToggleStickyText) {
+        for ((key) in mToggleStickyText.toMap()) {
             // handle fields for different note type with different size
             if (key < mEditFields!!.size) {
                 mToggleStickyText[key] = mEditFields!![key]?.fieldText


### PR DESCRIPTION
## Purpose / Description
A map(mToggleStickyText) was being iterated on and changed at the same time which trigger the ConcurrentModificationException. I made a copy of the original map and used that to iterate over the content.

## Fixes

Fixes #13784 

## How Has This Been Tested?

Ran the tests and then manually verified the scenario where I was previously able to replicate the issue.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
