### PR TITLE
Moved cursor to end in NumberRangePreferenceCompat

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/preferences/NumberRangePreferenceCompat.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/preferences/NumberRangePreferenceCompat.kt
@@ -164,8 +164,6 @@ constructor(
          * on the current value of the [.mMax] field.
          */
         override fun onBindDialogView(view: View) {
-            super.onBindDialogView(view)
-
             editText = view.findViewById(android.R.id.edit)!!
 
             // Only allow integer input
@@ -173,6 +171,8 @@ constructor(
 
             // Clone the existing filters so we don't override them, then append our one at the end.
             editText.filters = arrayOf(*editText.filters, InputFilter.LengthFilter(numberRangePreference.maxDigits))
+
+            super.onBindDialogView(view)
         }
 
         @NeedsTest("value is set to preference previous value if text is blank")


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
It's become inconvenient for the user to relocate the cursor to end every time

## Fixes
Fixes #13799

## Approach
called `setFocusAndOpenKeyboard()` function which is already there in AndroidUiUtils

## How Has This Been Tested?

Tested on Emulator (Pixel 5 API 29)

https://user-images.githubusercontent.com/65113071/236374491-d1ae3dce-4821-4abd-952c-687f86d5c8b8.mp4




## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
