### PR TITLE
manual revert: "Use fragments resources on AsyncDialogFragment"

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -320,10 +320,6 @@ open class DeckPicker :
         super.onCreate(savedInstanceState)
 
         startupStoragePermissionManager = StartupStoragePermissionManager.register(this, useCallbackIfActivityRecreated = false)
-
-        asyncMessageContent = resources.getString(R.string.import_interrupted)
-        asyncMessageTitle = resources.getString(R.string.import_title)
-
         // handle the first load: display the app introduction
         if (!hasShownAppIntro()) {
             val appIntro = Intent(this, IntroductionActivity::class.java)
@@ -2373,12 +2369,6 @@ open class DeckPicker :
     companion object {
 
         private const val ONE_DAY_IN_SECONDS: Int = 60 * 60 * 24
-
-        /** Import Error variable so to access the resource directory without
-         * causing a crash
-         */
-        lateinit var asyncMessageContent: String
-        lateinit var asyncMessageTitle: String
 
         /**
          * Result codes from other activities

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/AsyncDialogFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/AsyncDialogFragment.kt
@@ -15,7 +15,10 @@
  ****************************************************************************************/
 package com.ichi2.anki.dialogs
 
+import android.content.res.Resources
+import com.ichi2.anki.AnkiDroidApp
 import com.ichi2.anki.analytics.AnalyticsDialogFragment
+import timber.log.Timber
 
 abstract class AsyncDialogFragment : AnalyticsDialogFragment() {
     /* provide methods for text to show in notification bar when the DialogFragment
@@ -25,4 +28,13 @@ abstract class AsyncDialogFragment : AnalyticsDialogFragment() {
     abstract val notificationMessage: String?
     abstract val notificationTitle: String
     open val dialogHandlerMessage: DialogHandlerMessage? get() = null
+
+    protected fun res(): Resources {
+        return try {
+            AnkiDroidApp.appResources
+        } catch (e: Exception) {
+            Timber.w(e, "AnkiDroidApp.getAppResources failure. Returning Fragment resources as fallback.")
+            resources
+        }
+    }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DatabaseErrorDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DatabaseErrorDialog.kt
@@ -56,7 +56,7 @@ class DatabaseErrorDialog : AsyncDialogFragment() {
     @SuppressLint("CheckResult")
     override fun onCreateDialog(savedInstanceState: Bundle?): MaterialDialog {
         super.onCreate(savedInstanceState)
-        val res = resources
+        val res = res()
         val dialog = MaterialDialog(requireActivity())
         val isLoggedIn = isLoggedIn()
         dialog.cancelable(true)
@@ -464,20 +464,20 @@ class DatabaseErrorDialog : AsyncDialogFragment() {
             DIALOG_LOAD_FAILED -> if (databaseCorruptFlag) {
                 // The sqlite database has been corrupted (DatabaseErrorHandler.onCorrupt() was called)
                 // Show a specific message appropriate for the situation
-                resources.getString(R.string.corrupt_db_message, resources.getString(R.string.repair_deck))
+                res().getString(R.string.corrupt_db_message, res().getString(R.string.repair_deck))
             } else {
                 // Generic message shown when a libanki task failed
-                resources.getString(R.string.access_collection_failed_message, resources.getString(R.string.link_help))
+                res().getString(R.string.access_collection_failed_message, res().getString(R.string.link_help))
             }
-            DIALOG_DB_ERROR -> resources.getString(R.string.answering_error_message)
-            DIALOG_DISK_FULL -> resources.getString(R.string.storage_full_message)
-            DIALOG_REPAIR_COLLECTION -> resources.getString(R.string.repair_deck_dialog, BackupManager.BROKEN_COLLECTIONS_SUFFIX)
-            DIALOG_RESTORE_BACKUP -> resources.getString(R.string.backup_restore_no_backups)
-            DIALOG_NEW_COLLECTION -> resources.getString(R.string.backup_del_collection_question)
-            DIALOG_CONFIRM_DATABASE_CHECK -> resources.getString(R.string.check_db_warning)
-            DIALOG_CONFIRM_RESTORE_BACKUP -> resources.getString(R.string.restore_backup)
-            DIALOG_FULL_SYNC_FROM_SERVER -> resources.getString(R.string.backup_full_sync_from_server_question)
-            DIALOG_DB_LOCKED -> resources.getString(R.string.database_locked_summary)
+            DIALOG_DB_ERROR -> res().getString(R.string.answering_error_message)
+            DIALOG_DISK_FULL -> res().getString(R.string.storage_full_message)
+            DIALOG_REPAIR_COLLECTION -> res().getString(R.string.repair_deck_dialog, BackupManager.BROKEN_COLLECTIONS_SUFFIX)
+            DIALOG_RESTORE_BACKUP -> res().getString(R.string.backup_restore_no_backups)
+            DIALOG_NEW_COLLECTION -> res().getString(R.string.backup_del_collection_question)
+            DIALOG_CONFIRM_DATABASE_CHECK -> res().getString(R.string.check_db_warning)
+            DIALOG_CONFIRM_RESTORE_BACKUP -> res().getString(R.string.restore_backup)
+            DIALOG_FULL_SYNC_FROM_SERVER -> res().getString(R.string.backup_full_sync_from_server_question)
+            DIALOG_DB_LOCKED -> res().getString(R.string.database_locked_summary)
             INCOMPATIBLE_DB_VERSION -> {
                 var databaseVersion = -1
                 try {
@@ -490,34 +490,34 @@ class DatabaseErrorDialog : AsyncDialogFragment() {
                 } else {
                     Consts.BACKEND_SCHEMA_VERSION
                 }
-                resources.getString(
+                res().getString(
                     R.string.incompatible_database_version_summary,
                     schemaVersion,
                     databaseVersion
                 )
             }
-            DIALOG_STORAGE_UNAVAILABLE_AFTER_UNINSTALL -> getString(R.string.directory_inaccessible_after_uninstall_summary, CollectionHelper.getCurrentAnkiDroidDirectory(requireContext()))
+            DIALOG_STORAGE_UNAVAILABLE_AFTER_UNINSTALL -> res().getString(R.string.directory_inaccessible_after_uninstall_summary, CollectionHelper.getCurrentAnkiDroidDirectory(requireContext()))
             else -> requireArguments().getString("dialogMessage")
         }
     private val title: String
         get() = when (requireDialogType()) {
-            DIALOG_LOAD_FAILED -> resources.getString(R.string.open_collection_failed_title)
-            DIALOG_ERROR_HANDLING -> resources.getString(R.string.error_handling_title)
-            DIALOG_REPAIR_COLLECTION -> resources.getString(R.string.dialog_positive_repair)
-            DIALOG_RESTORE_BACKUP -> resources.getString(R.string.backup_restore)
-            DIALOG_NEW_COLLECTION -> resources.getString(R.string.backup_new_collection)
-            DIALOG_CONFIRM_DATABASE_CHECK -> resources.getString(R.string.check_db_title)
-            DIALOG_CONFIRM_RESTORE_BACKUP -> resources.getString(R.string.restore_backup_title)
-            DIALOG_FULL_SYNC_FROM_SERVER -> resources.getString(R.string.backup_full_sync_from_server)
-            DIALOG_DB_LOCKED -> resources.getString(R.string.database_locked_title)
-            INCOMPATIBLE_DB_VERSION -> resources.getString(R.string.incompatible_database_version_title)
-            DIALOG_DB_ERROR -> resources.getString(R.string.answering_error_title)
-            DIALOG_DISK_FULL -> resources.getString(R.string.storage_full_title)
-            DIALOG_STORAGE_UNAVAILABLE_AFTER_UNINSTALL -> resources.getString(R.string.directory_inaccessible_after_uninstall)
+            DIALOG_LOAD_FAILED -> res().getString(R.string.open_collection_failed_title)
+            DIALOG_ERROR_HANDLING -> res().getString(R.string.error_handling_title)
+            DIALOG_REPAIR_COLLECTION -> res().getString(R.string.dialog_positive_repair)
+            DIALOG_RESTORE_BACKUP -> res().getString(R.string.backup_restore)
+            DIALOG_NEW_COLLECTION -> res().getString(R.string.backup_new_collection)
+            DIALOG_CONFIRM_DATABASE_CHECK -> res().getString(R.string.check_db_title)
+            DIALOG_CONFIRM_RESTORE_BACKUP -> res().getString(R.string.restore_backup_title)
+            DIALOG_FULL_SYNC_FROM_SERVER -> res().getString(R.string.backup_full_sync_from_server)
+            DIALOG_DB_LOCKED -> res().getString(R.string.database_locked_title)
+            INCOMPATIBLE_DB_VERSION -> res().getString(R.string.incompatible_database_version_title)
+            DIALOG_DB_ERROR -> res().getString(R.string.answering_error_title)
+            DIALOG_DISK_FULL -> res().getString(R.string.storage_full_title)
+            DIALOG_STORAGE_UNAVAILABLE_AFTER_UNINSTALL -> res().getString(R.string.directory_inaccessible_after_uninstall)
         }
 
     override val notificationMessage: String? get() = message
-    override val notificationTitle: String get() = resources.getString(R.string.answering_error_title)
+    override val notificationTitle: String get() = res().getString(R.string.answering_error_title)
 
     override val dialogHandlerMessage
         get() = ShowDatabaseErrorDialog(requireDialogType())

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ExportCompleteDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ExportCompleteDialog.kt
@@ -59,8 +59,8 @@ class ExportCompleteDialog(private val listener: ExportCompleteDialogListener) :
     }
 
     override val notificationTitle: String
-        get() = resources.getString(R.string.export_success_title)
+        get() = res().getString(R.string.export_success_title)
 
     override val notificationMessage: String
-        get() = resources.getString(R.string.export_success_message)
+        get() = res().getString(R.string.export_success_message)
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ImportDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ImportDialog.kt
@@ -42,7 +42,7 @@ class ImportDialog : AsyncDialogFragment() {
             DIALOG_IMPORT_ADD_CONFIRM -> {
                 dialog.show {
                     title(R.string.import_title)
-                    message(text = resources.getQuantityString(R.plurals.import_files_message_add_confirm, dialogMessageList.size, displayFileName))
+                    message(text = res().getQuantityString(R.plurals.import_files_message_add_confirm, dialogMessageList.size, displayFileName))
                     positiveButton(R.string.import_message_add) {
                         (activity as ImportDialogListener).importAdd(dialogMessageList)
                         dismissAllDialogFragments()
@@ -53,7 +53,7 @@ class ImportDialog : AsyncDialogFragment() {
             DIALOG_IMPORT_REPLACE_CONFIRM -> {
                 dialog.show {
                     title(R.string.import_title)
-                    message(text = resources.getString(R.string.import_message_replace_confirm, displayFileName))
+                    message(text = res().getString(R.string.import_message_replace_confirm, displayFileName))
                     positiveButton(R.string.dialog_positive_replace) {
                         (activity as ImportDialogListener).importReplace(dialogMessageList)
                         dismissAllDialogFragments()
@@ -78,12 +78,12 @@ class ImportDialog : AsyncDialogFragment() {
 
     override val notificationMessage: String
         get() {
-            return resources.getString(R.string.import_interrupted)
+            return res().getString(R.string.import_interrupted)
         }
 
     override val notificationTitle: String
         get() {
-            return resources.getString(R.string.import_title)
+            return res().getString(R.string.import_title)
         }
 
     fun dismissAllDialogFragments() {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ImportDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ImportDialog.kt
@@ -18,8 +18,6 @@ package com.ichi2.anki.dialogs
 
 import android.os.Bundle
 import com.afollestad.materialdialogs.MaterialDialog
-import com.ichi2.anki.DeckPicker.Companion.asyncMessageContent
-import com.ichi2.anki.DeckPicker.Companion.asyncMessageTitle
 import com.ichi2.anki.R
 import timber.log.Timber
 import java.net.URLDecoder
@@ -80,12 +78,12 @@ class ImportDialog : AsyncDialogFragment() {
 
     override val notificationMessage: String
         get() {
-            return asyncMessageContent
+            return resources.getString(R.string.import_interrupted)
         }
 
     override val notificationTitle: String
         get() {
-            return asyncMessageTitle
+            return resources.getString(R.string.import_title)
         }
 
     fun dismissAllDialogFragments() {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/MediaCheckDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/MediaCheckDialog.kt
@@ -52,28 +52,28 @@ class MediaCheckDialog : AsyncDialogFragment() {
                 // Generate report
                 val report = StringBuilder()
                 if (invalid!!.isNotEmpty()) {
-                    report.append(String.format(resources.getString(R.string.check_media_invalid), invalid.size))
+                    report.append(String.format(res().getString(R.string.check_media_invalid), invalid.size))
                 }
                 if (unused!!.isNotEmpty()) {
                     if (report.isNotEmpty()) {
                         report.append("\n")
                     }
-                    report.append(String.format(resources.getString(R.string.check_media_unused), unused.size))
+                    report.append(String.format(res().getString(R.string.check_media_unused), unused.size))
                 }
                 if (nohave!!.isNotEmpty()) {
                     if (report.isNotEmpty()) {
                         report.append("\n")
                     }
-                    report.append(String.format(resources.getString(R.string.check_media_nohave), nohave.size))
+                    report.append(String.format(res().getString(R.string.check_media_nohave), nohave.size))
                 }
                 if (report.isEmpty()) {
-                    report.append(resources.getString(R.string.check_media_no_unused_missing))
+                    report.append(res().getString(R.string.check_media_no_unused_missing))
                 }
 
                 // We also prefix the report with a message about the media db being rebuilt, since
                 // we do a full media scan and update the db on each media check on AnkiDroid.
                 val reportStr = """
-                    |${resources.getString(R.string.check_media_db_updated)}
+                    |${res().getString(R.string.check_media_db_updated)}
                     
                     |$report
                 """.trimMargin().trimIndent()
@@ -116,18 +116,18 @@ class MediaCheckDialog : AsyncDialogFragment() {
     override val notificationMessage: String
         get() {
             return when (requireArguments().getInt("dialogType")) {
-                DIALOG_CONFIRM_MEDIA_CHECK -> resources.getString(R.string.check_media_warning)
-                DIALOG_MEDIA_CHECK_RESULTS -> resources.getString(R.string.check_media_acknowledge)
-                else -> resources.getString(R.string.app_name)
+                DIALOG_CONFIRM_MEDIA_CHECK -> res().getString(R.string.check_media_warning)
+                DIALOG_MEDIA_CHECK_RESULTS -> res().getString(R.string.check_media_acknowledge)
+                else -> res().getString(R.string.app_name)
             }
         }
 
     override val notificationTitle: String
         get() {
             return if (requireArguments().getInt("dialogType") == DIALOG_CONFIRM_MEDIA_CHECK) {
-                resources.getString(R.string.check_media_title)
+                res().getString(R.string.check_media_title)
             } else {
-                resources.getString(R.string.app_name)
+                res().getString(R.string.app_name)
             }
         }
 


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
- Multiple crashes, see: https://github.com/ankidroid/Anki-Android/issues/13795

## Fixes
- Fixes #13795
- Reopens #12448

## Approach
* Automated revert of https://github.com/ankidroid/Anki-Android/commit/385afba7a5242dd3195554845a1e9e764697cd7c
* Then manual revert of https://github.com/ankidroid/Anki-Android/commit/6ea36860a8e9fddadff0bf484746248fd843eb53

## How Has This Been Tested?
⚠️ Untested (besides unit tests)

## Learning (optional, can help others)
We need more tests here

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)