### PR TITLE
Improve Diagnostics for issue 13807 (files not equal: `.nomedia`)

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/scopedstorage/FileUtils.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/scopedstorage/FileUtils.kt
@@ -1,0 +1,108 @@
+/*
+ *  Copyright (c) 2023 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * ----
+ * (https://commons.apache.org/proper/commons-io/javadocs/api-2.4/org/apache/commons/io/FileUtils.html#contentEquals(java.io.File,%20java.io.File))
+ * * CHANGES: Convert code to Kotlin, make `File` parameters non-null
+ *
+ * This file incorporates code under the following license
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ichi2.anki.servicelayer.scopedstorage
+
+import android.os.Build
+import androidx.annotation.RequiresApi
+import org.apache.commons.io.IOUtils
+import java.io.File
+import java.io.IOException
+import java.nio.file.Files
+
+/**
+ * Tests whether the contents of two files are equal.
+ *
+ *
+ * This method checks to see if the two files are different lengths or if they point to the same file, before
+ * resorting to byte-by-byte comparison of the contents.
+ *
+ *
+ *
+ * Code origin: Avalon
+ *
+ *
+ * @param file1 the first file
+ * @param file2 the second file
+ * @return true if the content of the files are equal or they both don't exist, false otherwise
+ * @throws IllegalArgumentException when an input is not a file.
+ * @throws IOException If an I/O error occurs.
+ * @see org.apache.commons.io.file.PathUtils.fileContentEquals
+ */
+@RequiresApi(Build.VERSION_CODES.O)
+@Throws(IOException::class)
+internal fun contentEquals(file1: File, file2: File): Boolean {
+    val file1Exists = file1.exists()
+    if (file1Exists != file2.exists()) {
+        return false
+    }
+    if (!file1Exists) {
+        // two not existing files are equal
+        return true
+    }
+    requireFile(file1, "file1")
+    requireFile(file2, "file2")
+    if (file1.length() != file2.length()) {
+        // lengths differ, cannot be equal
+        return false
+    }
+    if (file1.canonicalFile == file2.canonicalFile) {
+        // same file
+        return true
+    }
+    Files.newInputStream(file1.toPath()).use { input1 ->
+        Files.newInputStream(file2.toPath()).use { input2 ->
+            return IOUtils.contentEquals(
+                input1,
+                input2
+            )
+        }
+    }
+}
+
+/**
+ * Requires that the given `File` is a file.
+ *
+ * @param file The `File` to check.
+ * @param name The parameter name to use in the exception message.
+ * @return the given file.
+ * @throws NullPointerException if the given `File` is `null`.
+ * @throws IllegalArgumentException if the given `File` does not exist or is not a directory.
+ */
+private fun requireFile(file: File, name: String): File {
+    require(file.isFile) { "Parameter '$name' is not a file: $file" }
+    return file
+}

--- a/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/scopedstorage/FileUtils.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/scopedstorage/FileUtils.kt
@@ -15,7 +15,11 @@
  *
  * ----
  * (https://commons.apache.org/proper/commons-io/javadocs/api-2.4/org/apache/commons/io/FileUtils.html#contentEquals(java.io.File,%20java.io.File))
- * * CHANGES: Convert code to Kotlin, make `File` parameters non-null
+ * **CHANGES**
+ * * Auto convert code to Kotlin, make `File` parameters non-null.
+ * * Change `contentEquals` to `throwIfContentUnequal`, extract variables and throw
+ * IllegalStateException if file contents are not equal.
+ * * inline `requireFile`
  *
  * This file incorporates code under the following license
  *
@@ -46,63 +50,48 @@ import java.nio.file.Files
 /**
  * Tests whether the contents of two files are equal.
  *
- *
  * This method checks to see if the two files are different lengths or if they point to the same file, before
  * resorting to byte-by-byte comparison of the contents.
  *
- *
- *
  * Code origin: Avalon
- *
  *
  * @param file1 the first file
  * @param file2 the second file
- * @return true if the content of the files are equal or they both don't exist, false otherwise
+ * @throws IllegalStateException if the two files were unequal
  * @throws IllegalArgumentException when an input is not a file.
  * @throws IOException If an I/O error occurs.
  * @see org.apache.commons.io.file.PathUtils.fileContentEquals
  */
 @RequiresApi(Build.VERSION_CODES.O)
 @Throws(IOException::class)
-internal fun contentEquals(file1: File, file2: File): Boolean {
+internal fun throwIfContentUnequal(file1: File, file2: File) {
     val file1Exists = file1.exists()
-    if (file1Exists != file2.exists()) {
-        return false
+    val file2Exists = file2.exists()
+    if (file1Exists != file2Exists) {
+        throw IllegalStateException("Only one file existed. file1: $file1Exists; file2: $file2Exists")
     }
     if (!file1Exists) {
         // two not existing files are equal
-        return true
+        return
     }
-    requireFile(file1, "file1")
-    requireFile(file2, "file2")
-    if (file1.length() != file2.length()) {
+    require(file1.isFile) { "Parameter 'file1' is not a file: $file1" }
+    require(file2.isFile) { "Parameter 'file2' is not a file: $file2" }
+
+    val file1Length = file1.length()
+    val file2Length = file2.length()
+    if (file1Length != file2Length) {
         // lengths differ, cannot be equal
-        return false
+        throw IllegalStateException("File lengths differed. file1: $file1Length; file2: $file2Length")
     }
     if (file1.canonicalFile == file2.canonicalFile) {
         // same file
-        return true
+        return
     }
     Files.newInputStream(file1.toPath()).use { input1 ->
         Files.newInputStream(file2.toPath()).use { input2 ->
-            return IOUtils.contentEquals(
-                input1,
-                input2
-            )
+            if (!IOUtils.contentEquals(input1, input2)) {
+                throw IllegalStateException("files had same lengths ($file1Length), but different content")
+            }
         }
     }
-}
-
-/**
- * Requires that the given `File` is a file.
- *
- * @param file The `File` to check.
- * @param name The parameter name to use in the exception message.
- * @return the given file.
- * @throws NullPointerException if the given `File` is `null`.
- * @throws IllegalArgumentException if the given `File` does not exist or is not a directory.
- */
-private fun requireFile(file: File, name: String): File {
-    require(file.isFile) { "Parameter '$name' is not a file: $file" }
-    return file
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/scopedstorage/MigrateEssentialFiles.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/scopedstorage/MigrateEssentialFiles.kt
@@ -169,9 +169,7 @@ internal constructor(
     private fun throwIfEssentialFilesAreMutated(sourceDirectory: AnkiDroidDirectory, destinationDirectory: ScopedAnkiDroidDirectory) {
         // TODO: For Arthur to improve
         for ((source, destination) in iterateEssentialFiles(sourceDirectory).zip(iterateEssentialFiles(destinationDirectory.path))) {
-            if (!contentEquals(source, destination)) {
-                throw IllegalStateException("files not equal: $source, $destination")
-            }
+            throwIfContentUnequal(source, destination)
         }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/scopedstorage/MigrateEssentialFiles.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/scopedstorage/MigrateEssentialFiles.kt
@@ -16,6 +16,7 @@
 
 package com.ichi2.anki.servicelayer.scopedstorage
 
+import android.annotation.SuppressLint
 import android.content.Context
 import androidx.annotation.VisibleForTesting
 import androidx.core.content.edit
@@ -39,7 +40,6 @@ import com.ichi2.libanki.Storage
 import com.ichi2.libanki.Utils
 import kotlinx.coroutines.runBlocking
 import net.ankiweb.rsdroid.BackendFactory
-import org.apache.commons.io.FileUtils
 import timber.log.Timber
 import java.io.Closeable
 import java.io.File
@@ -164,11 +164,12 @@ internal constructor(
         }
     }
 
+    @SuppressLint("NewApi") // contentEquals is API 26, we're guaranteed to be above this if performing a migration
     @NeedsTest("untested, needs documentation")
     private fun throwIfEssentialFilesAreMutated(sourceDirectory: AnkiDroidDirectory, destinationDirectory: ScopedAnkiDroidDirectory) {
         // TODO: For Arthur to improve
         for ((source, destination) in iterateEssentialFiles(sourceDirectory).zip(iterateEssentialFiles(destinationDirectory.path))) {
-            if (!FileUtils.contentEquals(source, destination)) {
+            if (!contentEquals(source, destination)) {
                 throw IllegalStateException("files not equal: $source, $destination")
             }
         }


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
* The error message: `files not equal` was not sufficient
* I can't reproduce the issue, but we can do better with diagnostics

## Fixes
- Related: #13807 

## Approach
* Take `org.apache.commons.io.FileUtils.contentEquals`, vendor and modify the code to improve the error message

## How Has This Been Tested?
⚠️ Untested

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
