### PR TITLE
Fix new backend language not being changed into the system language

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/GeneralSettingsFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/GeneralSettingsFragment.kt
@@ -87,12 +87,12 @@ class GeneralSettingsFragment : SettingsFragment() {
         val systemLocale = getSystemLocale()
         requirePreference<ListPreference>(R.string.pref_language_key).apply {
             entries = arrayOf(getStringByLocale(R.string.language_system, systemLocale), *sortedLanguages.keys.toTypedArray())
-            entryValues = arrayOf(LanguageUtil.DEFAULT_LANGUAGE_TAG, *sortedLanguages.values.toTypedArray())
+            entryValues = arrayOf(LanguageUtil.SYSTEM_LANGUAGE_TAG, *sortedLanguages.values.toTypedArray())
             setOnPreferenceChangeListener { selectedLanguage ->
                 LanguageUtil.setDefaultBackendLanguages(selectedLanguage as String)
                 runBlocking { CollectionManager.discardBackend() }
 
-                val localeCode = if (selectedLanguage != LanguageUtil.DEFAULT_LANGUAGE_TAG) {
+                val localeCode = if (selectedLanguage != LanguageUtil.SYSTEM_LANGUAGE_TAG) {
                     selectedLanguage
                 } else {
                     null

--- a/AnkiDroid/src/main/java/com/ichi2/utils/LanguageUtil.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/LanguageUtil.kt
@@ -212,17 +212,17 @@ object LanguageUtil {
         } else {
             Locale.forLanguageTag(languageTag)
         }
-        BackendFactory.defaultLanguages = listOf(localeToBackendCode(locale))
+        BackendFactory.defaultLanguages = listOf(languageTagToBackendCode(locale.language))
     }
 
-    private fun localeToBackendCode(locale: Locale): String {
-        return when (locale.language) {
-            Locale("heb").language -> "he"
-            Locale("ind").language -> "id"
-            Locale("tgl").language -> "tl"
-            Locale("hi").language -> "hi-IN"
-            Locale("yue").language -> "zh-HK"
-            else -> locale.toLanguageTag()
+    private fun languageTagToBackendCode(languageTag: String): String {
+        return when (languageTag) {
+            "heb" -> "he"
+            "ind" -> "id"
+            "tgl" -> "tl"
+            "hi" -> "hi-IN"
+            "yue" -> "zh-HK"
+            else -> languageTag
         }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/utils/LanguageUtil.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/LanguageUtil.kt
@@ -22,6 +22,7 @@ import androidx.annotation.StringRes
 import androidx.appcompat.app.AppCompatDelegate
 import androidx.core.os.ConfigurationCompat
 import androidx.fragment.app.Fragment
+import com.ichi2.anki.AnkiDroidApp
 import net.ankiweb.rsdroid.BackendFactory
 import java.text.DateFormat
 import java.util.*
@@ -206,13 +207,16 @@ object LanguageUtil {
     fun getSystemLocale(): Locale = getLocaleCompat(Resources.getSystem())!!
 
     /** If locale is not provided, the current locale will be used. */
-    fun setDefaultBackendLanguages(languageTag: String = SYSTEM_LANGUAGE_TAG) {
-        val locale = if (languageTag == SYSTEM_LANGUAGE_TAG) {
-            Locale.getDefault()
+    fun setDefaultBackendLanguages(languageTag: String? = null) {
+        val langCode = languageTag ?: AnkiDroidApp.getSharedPrefs(AnkiDroidApp.instance)
+            .getString("language", SYSTEM_LANGUAGE_TAG)!!
+
+        val localeLanguage = if (langCode == SYSTEM_LANGUAGE_TAG) {
+            getSystemLocale().language
         } else {
-            Locale.forLanguageTag(languageTag)
+            langCode
         }
-        BackendFactory.defaultLanguages = listOf(languageTagToBackendCode(locale.language))
+        BackendFactory.defaultLanguages = listOf(languageTagToBackendCode(localeLanguage))
     }
 
     private fun languageTagToBackendCode(languageTag: String): String {

--- a/AnkiDroid/src/main/java/com/ichi2/utils/LanguageUtil.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/LanguageUtil.kt
@@ -30,8 +30,7 @@ import java.util.*
  * Utility call for proving language related functionality.
  */
 object LanguageUtil {
-    /** locale value of the currently selected locale of the app */
-    const val DEFAULT_LANGUAGE_TAG = ""
+    const val SYSTEM_LANGUAGE_TAG = ""
 
     /** A list of all languages supported by AnkiDroid
      * Please modify LanguageUtilsTest if changing
@@ -207,8 +206,8 @@ object LanguageUtil {
     fun getSystemLocale(): Locale = getLocaleCompat(Resources.getSystem())!!
 
     /** If locale is not provided, the current locale will be used. */
-    fun setDefaultBackendLanguages(languageTag: String = DEFAULT_LANGUAGE_TAG) {
-        val locale = if (languageTag == DEFAULT_LANGUAGE_TAG) {
+    fun setDefaultBackendLanguages(languageTag: String = SYSTEM_LANGUAGE_TAG) {
+        val locale = if (languageTag == SYSTEM_LANGUAGE_TAG) {
             Locale.getDefault()
         } else {
             Locale.forLanguageTag(languageTag)


### PR DESCRIPTION
Changing to another language then back to the system language didn't work for the new backend unless the user restarts the app

## Fixes
Fixes #13813 (I can't reproduce the exact reproduced issue, but fixed https://github.com/ankidroid/Anki-Android/issues/13813#issuecomment-1537457393 while at it)

## Approach
Use `getSystemLocale()` instead of `Locale.getDefault()`

## How Has This Been Tested?

On a SDK **29** emulator:
1. Enable the new backend
2. Change language to any other than the system language
3. Check if the statistics screen use the new language
4. Change app language to "System language"
5. Check if the statistics screen use the system language

Note that there is a known issue of the Android methods returning the app's language instead of system's on SDK 33 specifically. As we are using an alpha appcompat version, I don't think there is nothing currently actionable about it. Currently fixable by restarting the app

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
