### PR TITLE
fix: 'hasSubdecks' [new backend] & refactor DeckAdapter & fix IndexOutOfBoundsException

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -264,9 +264,9 @@ open class DeckPicker :
     private val mDeckExpanderClickListener = View.OnClickListener { view: View ->
         launchCatchingTask { toggleDeckExpand(view.tag as Long) }
     }
-    private val mDeckClickListener = View.OnClickListener { v: View -> launchCatchingTask { onDeckClick(v, DeckSelectionType.DEFAULT) } }
-    private val mCountsClickListener = View.OnClickListener { v: View -> launchCatchingTask { onDeckClick(v, DeckSelectionType.SHOW_STUDY_OPTIONS) } }
-    private suspend fun onDeckClick(v: View, selectionType: DeckSelectionType) {
+    private val mDeckClickListener = View.OnClickListener { v: View -> onDeckClick(v, DeckSelectionType.DEFAULT) }
+    private val mCountsClickListener = View.OnClickListener { v: View -> onDeckClick(v, DeckSelectionType.SHOW_STUDY_OPTIONS) }
+    private fun onDeckClick(v: View, selectionType: DeckSelectionType) {
         val deckId = v.tag as Long
         Timber.i("DeckPicker:: Selected deck with id %d", deckId)
         var collectionIsOpen = false
@@ -1075,7 +1075,7 @@ open class DeckPicker :
             }
             KeyEvent.KEYCODE_SLASH, KeyEvent.KEYCODE_S -> {
                 Timber.i("Study from keypress")
-                launchCatchingTask { handleDeckSelection(col.decks.selected(), DeckSelectionType.SKIP_STUDY_OPTIONS) }
+                handleDeckSelection(col.decks.selected(), DeckSelectionType.SKIP_STUDY_OPTIONS)
             }
             else -> {}
         }
@@ -1719,7 +1719,7 @@ open class DeckPicker :
         }
     }
 
-    private suspend fun handleDeckSelection(did: DeckId, selectionType: DeckSelectionType) {
+    private fun handleDeckSelection(did: DeckId, selectionType: DeckSelectionType) {
         // Clear the undo history when selecting a new deck
         if (col.decks.selected() != did) {
             col.clearUndo()
@@ -1814,7 +1814,7 @@ open class DeckPicker :
      *
      * @param did The deck ID of the deck to select.
      */
-    private suspend fun scrollDecklistToDeck(did: DeckId) {
+    private fun scrollDecklistToDeck(did: DeckId) {
         val position = mDeckListAdapter.findDeckPosition(did)
         mRecyclerViewLayoutManager.scrollToPositionWithOffset(position, recyclerView.height / 2)
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/widgets/DeckAdapter.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/widgets/DeckAdapter.kt
@@ -46,6 +46,7 @@ import java.util.*
 
 @KotlinCleanup("lots to do")
 @RustCleanup("Lots of bad code: should not be using suspend functions inside an adapter")
+@RustCleanup("Differs from legacy backend: Create deck 'One', create deck 'One::two'. 'One::two' was not expanded")
 class DeckAdapter(private val layoutInflater: LayoutInflater, context: Context) : RecyclerView.Adapter<DeckAdapter.ViewHolder>(), Filterable {
     private val mDeckList: MutableList<TreeNode<AbstractDeckTreeNode>>
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/TreeNode.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/TreeNode.kt
@@ -24,4 +24,26 @@ data class TreeNode<T : Any>(val value: T) {
     fun hasChildren(): Boolean = children.any()
     val children: MutableList<TreeNode<T>> = mutableListOf()
     override fun toString(): String = "$value, $children"
+
+    /**
+     * Flattens the tree to a list and provides a child -> parent association.
+     * @return A sequence of pairs. `first` is a node in the tree. `second` is the node's parent
+     * in the tree, or `null` if the node is a root.
+     */
+    private fun flattenWithParent(parent: T? = null): Sequence<Pair<T, T?>> = sequence {
+        val currentNode = this@TreeNode
+        yield(Pair(currentNode.value, parent))
+        for (child in currentNode.children) {
+            yieldAll(child.flattenWithParent(parent = currentNode.value))
+        }
+    }
+
+    fun associateNodeWithParent(): Map<T, T?> = flattenWithParent().toMap()
+}
+
+// https://stackoverflow.com/a/6831626
+fun <T : Any> List<TreeNode<T>>.associateNodeWithParent(): Map<T, T?> {
+    return this.map { it.associateNodeWithParent() }
+        .flatMap { map -> map.entries }
+        .associate(Map.Entry<T, T?>::toPair)
 }


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
Noticed while trying to reproduce another issue
* `hasSubdecks` adds padding to the `DeckAdapter`'s ViewHolder
* It was set if a single deck exists in the new backend. This shouldn't happen

## Fixes
- Fixes #13794

## Approach
* Understand the code
* Fix 'hasSubdecks'
* Realise code can be simplified further

I then saw an opportunity to perform cleanup for 70151c563e92029956fe0c8ee19de075347db599 which added a number of unnecessary `suspend` calls to the code. This handles most of the cleanup

Since `processNodes` was simplified, I then made it pure, and finally made `m[Current]DeckList` immutable lists, which should resolve #13794

## How Has This Been Tested?
Briefly, manually on an API33 emulator

Tested against Arthur's collection on an API 33 emulator

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
