### PR TITLE
NF: improve colorFromAttr

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiActivity.kt
@@ -18,6 +18,7 @@ import android.view.*
 import android.view.animation.Animation
 import android.widget.ProgressBar
 import androidx.activity.result.ActivityResultLauncher
+import androidx.annotation.ColorInt
 import androidx.annotation.LayoutRes
 import androidx.annotation.StringRes
 import androidx.appcompat.app.ActionBar
@@ -405,8 +406,14 @@ open class AnkiActivity : AppCompatActivity, SimpleMessageDialogListener, Collec
             )
             return
         }
-        val toolbarColor = Themes.getColorFromAttr(this, R.attr.colorPrimary)
-        val navBarColor = Themes.getColorFromAttr(this, R.attr.customTabNavBarColor)
+        @ColorInt
+        val colors = Themes.getColorFromAttr(this, intArrayOf(R.attr.colorPrimary, R.attr.customTabNavBarColor))
+
+        @ColorInt
+        val toolbarColor = colors[0]
+
+        @ColorInt
+        val navBarColor = colors[1]
         val colorSchemeParams = CustomTabColorSchemeParams.Builder()
             .setToolbarColor(toolbarColor)
             .setNavigationBarColor(navBarColor)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -90,12 +90,8 @@ import net.ankiweb.rsdroid.BackendFactory
 import net.ankiweb.rsdroid.RustCleanup
 import org.json.JSONObject
 import timber.log.Timber
-import java.lang.Exception
-import java.lang.IllegalStateException
-import java.lang.StringBuilder
 import java.util.*
 import java.util.function.Consumer
-import kotlin.collections.ArrayList
 import kotlin.math.abs
 import kotlin.math.ceil
 import kotlin.math.max

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
@@ -37,6 +37,7 @@ import android.view.ViewGroup.MarginLayoutParams
 import android.widget.*
 import android.widget.AdapterView.OnItemSelectedListener
 import androidx.annotation.CheckResult
+import androidx.annotation.ColorInt
 import androidx.annotation.RequiresApi
 import androidx.annotation.StringRes
 import androidx.annotation.VisibleForTesting
@@ -256,13 +257,16 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
                 modifyCurrentSelection(formatter, currentFocus)
             }
             // Sets the background and icon color of toolbar respectively.
-            setBackgroundColor(
-                Themes.getColorFromAttr(
-                    this@NoteEditor,
-                    R.attr.toolbarBackgroundColor
-                )
-            )
-            setIconColor(Themes.getColorFromAttr(this@NoteEditor, R.attr.toolbarIconColor))
+            @ColorInt
+            val colors = Themes.getColorFromAttr(this@NoteEditor, intArrayOf(R.attr.toolbarBackgroundColor, R.attr.toolbarIconColor))
+
+            @ColorInt
+            val backgroundColor = colors[0]
+
+            @ColorInt
+            val iconColor = colors[1]
+            setBackgroundColor(backgroundColor)
+            setIconColor(iconColor)
         }
         val mainView = findViewById<View>(android.R.id.content)
         // Enable toolbar

--- a/AnkiDroid/src/main/java/com/ichi2/anki/stats/AnkiStatsTaskHandler.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/stats/AnkiStatsTaskHandler.kt
@@ -103,8 +103,7 @@ class AnkiStatsTaskHandler private constructor(
                             Timber.w(it)
                         }
                         progressBar.visibility = View.GONE
-                        val backgroundColor = getColorFromAttr(webView.context, R.attr.colorBackground)
-                        webView.setBackgroundColor(backgroundColor)
+                        webView.setBackgroundColor(getColorFromAttr(webView.context, R.attr.colorBackground))
                         webView.visibility = View.VISIBLE
                         webView.invalidate()
                     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/stats/ChartBuilder.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/stats/ChartBuilder.kt
@@ -91,10 +91,8 @@ class ChartBuilder(private val chartView: ChartView, private val collectionData:
         val plotSheet = PlotSheet(mFirstElement - 0.5, mLastElement + 0.5, 0.0, mMaxCards * Y_AXIS_STRETCH_FACTOR)
         plotSheet.setFrameThickness(frameThickness * 0.66f, frameThickness * 0.66f, frameThickness.toFloat(), frameThickness * 0.9f)
         plotSheet.setFontSize(textSize)
-        val backgroundColor = getColorFromAttr(chartView.context, R.attr.colorBackground)
-        plotSheet.setBackgroundColor(ColorWrap(backgroundColor))
-        val textColor = getColorFromAttr(chartView.context, R.attr.textColor)
-        plotSheet.textColor = ColorWrap(textColor)
+        plotSheet.setBackgroundColor(ColorWrap(getColorFromAttr(chartView.context, R.attr.colorBackground)))
+        plotSheet.textColor = ColorWrap(getColorFromAttr(chartView.context, R.attr.textColor))
         plotSheet.setIsBackwards(mBackwards)
         if (chartType == ChartType.CARDS_TYPES) {
             return createPieChart(plotSheet)

--- a/AnkiDroid/src/main/java/com/ichi2/themes/Themes.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/themes/Themes.kt
@@ -103,14 +103,19 @@ object Themes {
         return attrs
     }
 
-    @JvmStatic // tests failed when removing, maybe try later
+    /**
+     * @see [getColorFromAttr], but for a single value.
+     */
     @ColorInt
-    fun getColorFromAttr(context: Context?, colorAttr: Int): Int {
+    fun getColorFromAttr(context: Context, colorAttr: Int): Int {
         val attrs = intArrayOf(colorAttr)
-        return getColorFromAttr(context!!, attrs)[0]
+        return getColorFromAttr(context, attrs)[0]
     }
 
-    @JvmStatic // tests failed when removing, maybe try later
+    /**
+     * @param attrs [ColorRes] of colors to get. This array should not be used after calling this function.
+     * @return An array with the [ColorInt] corresponding to the ColorRes in [attrs]; or of white if the value is not set.
+     */
     @ColorInt
     fun getColorFromAttr(context: Context, attrs: IntArray): IntArray {
         val ta = context.obtainStyledAttributes(attrs)
@@ -125,9 +130,7 @@ object Themes {
      * @return required color depending on the theme from the given attribute
      */
     @ColorInt
-    fun Fragment.getColorFromAttr(@AttrRes attribute: Int): Int {
-        return getColorFromAttr(requireContext(), attribute)
-    }
+    fun Fragment.getColorFromAttr(@AttrRes attribute: Int) = getColorFromAttr(requireContext(), attribute)
 
     /**
      * @return if current selected theme is `Follow system`

--- a/AnkiDroid/src/main/java/com/ichi2/utils/MenuUtils.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/MenuUtils.kt
@@ -18,6 +18,7 @@ import android.content.Context
 import android.graphics.drawable.Drawable
 import android.view.Menu
 import android.view.MenuItem
+import androidx.annotation.ColorInt
 import androidx.appcompat.graphics.drawable.DrawableWrapperCompat
 import androidx.appcompat.view.menu.MenuBuilder
 import androidx.appcompat.view.menu.MenuItemImpl
@@ -65,6 +66,7 @@ fun Context.increaseHorizontalPaddingOfOverflowMenuIcons(menu: Menu) {
  * Has no effect for items that have no icon.
  */
 fun Context.tintOverflowMenuIcons(menu: Menu, skipIf: ((MenuItem) -> Boolean)? = null) {
+    @ColorInt
     val iconColor = Themes.getColorFromAttr(this, R.attr.overflowAndPopupMenuIconColor)
 
     menu.forEachOverflowItemRecursive { item ->


### PR DESCRIPTION
Found this why investigating (admittedly unrelated) bug in DeckAdapter using colors

Tests pass locally, so JVMStatic can be removed.

Use a single request for multiple colors when possible.

Add documentation.
