### PR TITLE
Clean deck adapter and may be fix a crash

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -390,13 +390,15 @@ open class DeckPicker :
         }
 
         // create and set an adapter for the RecyclerView
-        mDeckListAdapter = DeckAdapter(layoutInflater, this).apply {
-            setDeckClickListener(mDeckClickListener)
-            setCountsClickListener(mCountsClickListener)
-            setDeckExpanderClickListener(mDeckExpanderClickListener)
-            setDeckLongClickListener(mDeckLongClickListener)
-            enablePartialTransparencyForBackground(hasDeckPickerBackground)
-        }
+        mDeckListAdapter = DeckAdapter(
+            layoutInflater,
+            this,
+            hasDeckPickerBackground,
+            mDeckClickListener,
+            mDeckExpanderClickListener,
+            mDeckLongClickListener,
+            mCountsClickListener
+        )
         recyclerView.adapter = mDeckListAdapter
 
         mPullToSyncWrapper = findViewById<SwipeRefreshLayout?>(R.id.pull_to_sync_wrapper).apply {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/widgets/DeckAdapter.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/widgets/DeckAdapter.kt
@@ -333,11 +333,11 @@ class DeckAdapter(
             null
         }
     override fun getFilter(): Filter {
-        return DeckFilter()
+        return DeckFilter(mDeckList)
     }
 
     @VisibleForTesting
-    inner class DeckFilter(deckList: List<TreeNode<AbstractDeckTreeNode>> = mDeckList) : TypedFilter<TreeNode<AbstractDeckTreeNode>>(deckList) {
+    inner class DeckFilter(deckList: List<TreeNode<AbstractDeckTreeNode>>) : TypedFilter<TreeNode<AbstractDeckTreeNode>>(deckList) {
         override fun filterResults(constraint: CharSequence, items: List<TreeNode<AbstractDeckTreeNode>>): List<TreeNode<AbstractDeckTreeNode>> {
             val filterPattern = constraint.toString().lowercase(Locale.getDefault()).trim { it <= ' ' }
             return items.mapNotNull { t: TreeNode<AbstractDeckTreeNode> -> filterDeckInternal(filterPattern, t) }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/widgets/DeckAdapter.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/widgets/DeckAdapter.kt
@@ -112,12 +112,12 @@ class DeckAdapter(
     /**
      * The button showing a deck is collapsed and offering to expand it.
      */
-    private val mExpandImage: Drawable?
+    private val mExpandImage: Drawable
 
     /**
      * The button showing a deck is expanded, and offer to collapse it.
      */
-    private val mCollapseImage: Drawable?
+    private val mCollapseImage: Drawable
     private var currentDeckId: DeckId = 0
 
     // Totals accumulated as each deck is processed. Their value should be ignored until [mNumbersComputed] is true.
@@ -447,10 +447,10 @@ class DeckAdapter(
         mRowCurrentDrawable = ta.getResourceId(4, 0)
         mDeckNameDefaultColor = ta.getColor(5, ContextCompat.getColor(context, R.color.black))
         mDeckNameDynColor = ta.getColor(6, ContextCompat.getColor(context, R.color.material_blue_A700))
-        mExpandImage = ta.getDrawable(7)
-        mExpandImage!!.isAutoMirrored = true
-        mCollapseImage = ta.getDrawable(8)
-        mCollapseImage!!.isAutoMirrored = true
+        mExpandImage = ta.getDrawable(7)!!
+        mExpandImage.isAutoMirrored = true
+        mCollapseImage = ta.getDrawable(8)!!
+        mCollapseImage.isAutoMirrored = true
         ta.recycle()
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/widgets/DeckAdapter.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/widgets/DeckAdapter.kt
@@ -64,28 +64,72 @@ class DeckAdapter(
     private val deckLongClickListener: OnLongClickListener,
     private val countsClickListener: View.OnClickListener
 ) : RecyclerView.Adapter<DeckAdapter.ViewHolder>(), Filterable {
+    /**
+     * A list of decks. Contains at least all decks that should be displayed while search is empty.
+     * It may also contain collapsed decks.
+     */
     private var mDeckList: List<TreeNode<AbstractDeckTreeNode>> = ArrayList()
 
-    /** A subset of mDeckList (currently displayed)  */
+    /** The subset of mDeckList that should be displayed as a result of current search.
+     * It contains decks that match this search and their parents. */
     private var mCurrentDeckList: List<TreeNode<AbstractDeckTreeNode>> = ArrayList()
+
+    /**
+     *  color used to display the number of cards if it is 0 in the trailing column of deck picker.
+     */
     private val mZeroCountColor: Int
+
+    /**
+     * Color used for the number of new cards to review today.
+     */
     private val mNewCountColor: Int
+
+    /**
+     * Color used for the number of cards in learning to see today.
+     */
     private val mLearnCountColor: Int
+
+    /**
+     * Color used for the number of card in review mode to see today.
+     */
     private val mReviewCountColor: Int
+
+    /**
+     * Color for the background of the currently selected deck.
+     */
     private val mRowCurrentDrawable: Int
+
+    /**
+     * Color for the text of the standard decks (not dynamic).
+     */
     private val mDeckNameDefaultColor: Int
+
+    /**
+     * Color for the text of dynamic decks.
+     */
     private val mDeckNameDynColor: Int
+
+    /**
+     * The button showing a deck is collapsed and offering to expand it.
+     */
     private val mExpandImage: Drawable?
+
+    /**
+     * The button showing a deck is expanded, and offer to collapse it.
+     */
     private val mCollapseImage: Drawable?
     private var currentDeckId: DeckId = 0
 
-    // Totals accumulated as each deck is processed
+    // Totals accumulated as each deck is processed. Their value should be ignored until [mNumbersComputed] is true.
     private var mNew = 0
     private var mLrn = 0
     private var mRev = 0
     private var mNumbersComputed = false
 
     // Flags
+    /**
+     * Whether any deck of the collection has a subdeck.
+     */
     private var mHasSubdecks = false
 
     private var deckIdToParentMap = mapOf<DeckId, DeckId?>()

--- a/AnkiDroid/src/main/java/com/ichi2/anki/widgets/DeckAdapter.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/widgets/DeckAdapter.kt
@@ -145,7 +145,7 @@ class DeckAdapter(
 
     fun getNodeByDid(did: DeckId): TreeNode<AbstractDeckTreeNode> {
         val pos = findDeckPosition(did)
-        return deckList[pos]
+        return mCurrentDeckList[pos]
     }
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
@@ -332,9 +332,6 @@ class DeckAdapter(
         } else {
             null
         }
-    private val deckList: List<TreeNode<AbstractDeckTreeNode>>
-        get() = mCurrentDeckList
-
     override fun getFilter(): Filter {
         return DeckFilter()
     }


### PR DESCRIPTION
Each commit except the last one consist in cleaning part of the code, so that I could understand what it is doing.

Last commit ensure that the deck adapter see all its values updated simultaneously, and just before the adapter is notified, instead of seeing a list cleared long before the notification. 

Hopefully fix #13794 except that I don't know how to reproduce it