### PR TITLE
fix: make lint run in CI/gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ import org.gradle.internal.jvm.Jvm
 buildscript {
     // The version for the Kotlin plugin and dependencies
     ext.kotlin_version = '1.8.21'
-    ext.lint_version = '31.0.1'
+    ext.lint_version = '30.4.2' // 31.0.1 stopped running lint checks in CI
     ext.acra_version = '5.9.7'
     ext.ankidroid_backend_version = '0.1.21-anki2.1.61'
     ext.hamcrest_version = '2.2'


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
lint was updated in 8e4b6d17a5b2765ce2f27f35be86ef6360a54dfd

But this stopped lint checks running via 'gradlew'
https://github.com/ankidroid/Anki-Android/issues/13786#issuecomment-1534189784

## Fixes
Fixes #13786

## Approach
reverts lint to `30.4.2`

## How Has This Been Tested?
* Deleted a copyright header in a test. Lint now fails (previously: passed)

tested with `/gradlew lintFullRelease`

## Learning (optional, can help others)

Many thanks to lukstbit for the investigation https://github.com/ankidroid/Anki-Android/issues/13786#issuecomment-1534189784

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
