### PR TITLE
CardBrowser is not getting bold

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -297,7 +297,8 @@ dependencies {
     implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
     implementation 'androidx.webkit:webkit:1.6.1'
     // Note: the design support library can be quite buggy, so test everything thoroughly before updating it
-    implementation 'com.google.android.material:material:1.8.0'
+    // Changing the version from 1.8.0 to 1.7.0 because the item in navigation drawer is getting bold unnecessarily
+    implementation 'com.google.android.material:material:1.7.0'
     // noinspection GradleDependency jackson-databind 2.13 requires SDK 24+: https://github.com/FasterXML/jackson-databind#compatibility
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.12.0'
     implementation 'com.vanniktech:android-image-cropper:4.5.0'


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
This issue was introduced due to #13198

## Fixes
Fixes #13818
Fixes #13375 

## Approach
Changed `com.google.android.material:material` to 1.7.0

## How Has This Been Tested?

Physical Device

https://github.com/ankidroid/Anki-Android/assets/65113071/81b9c3b2-fb72-4dc4-8498-41a6896ebe95





## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
