### PR TITLE
DiscardChangesDialog is closed in one click in NoteEditor

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
@@ -1046,7 +1046,6 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
             Timber.i("NoteEditor:: OK button pressed to confirm discard changes")
             closeNoteEditor()
         }
-            .show()
     }
 
     private fun closeNoteEditor(intent: Intent = Intent()) {


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
The DiscardChangesDialog is showing again when clicking on `cancel` button

## Fixes
Fixes #13834 

## Approach
The `show()` function in Dialog is called twice. So, I removed one `show()` function

## How Has This Been Tested?

Tested on Pixel API 21

https://github.com/ankidroid/Anki-Android/assets/65113071/72ade13f-1410-4a7a-9d01-99170189e9ef



## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
