### PR TITLE
VideoPlayer is showing in Reviewer Screen

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Sound.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Sound.kt
@@ -391,11 +391,12 @@ open class SoundPlayerImpl : SoundPlayer {
     ) {
         Timber.d("Playing %s", soundPath)
         val soundUri = Uri.parse(soundPath)
+        val soundUriPath = soundUri.path.toString()
         mCurrentAudioUri = soundUri
 
         val context = AnkiDroidApp.instance.applicationContext
 
-        val isVideo = isVideo(soundPath)
+        val isVideo = isVideo(soundUriPath)
         if (isVideo && !hasVideoSurface && playVideoExternallyCallback?.invoke(soundPath, completionListener) == true) {
             return
         }


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
This bug was introduced between alpha94 and alpha95. Because the parameter passed in `CompatHelper.compat.hasVideoThumbnail()` this function is `soundPath`, but we need to pass `soundUriPath`. Therefore the method returns false instead of true

## Fixes
Fixes #13837 

## Approach
Changed soundPath to soundUriPath

## How Has This Been Tested?

Tested on Emulator ( Pixel 5 API 33 )

https://github.com/ankidroid/Anki-Android/assets/65113071/0ea4a0be-e3ee-46cb-ba42-7d81976d4da5


## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
