### PR TITLE
Moved cursor to end in TagsDialog

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/tags/TagsDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/tags/TagsDialog.kt
@@ -269,6 +269,7 @@ class TagsDialog : AnalyticsDialogFragment {
             // utilize the addTagFilter to append '::' properly by appending a space to prefixTag
             inputET.setText("$prefixTag ")
         }
+        inputET.setSelection(inputET.text.length)
         addTagDialog.show()
     }
 


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
The cursor is at start of input text. The user has to move the cursor to end manually.

## Fixes
Fixes #13841

## Approach
called `setFocusandOpenKeyboard()` method

## How Has This Been Tested?

Tested on Emulator ( Pixel 5 API 33 )
![tag2](https://github.com/ankidroid/Anki-Android/assets/119813120/0feacd70-7744-4a02-9ce0-a142d6c7df9c)


## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
