### PR TITLE
Adding develepor options to add fake media

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/DevOptionsFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/DevOptionsFragment.kt
@@ -83,13 +83,13 @@ class DevOptionsFragment : SettingsFragment() {
             true
         }
 
-        val sizePreference = requirePreference<IncrementerNumberRangePreferenceCompat>(getString(R.string.pref_fill_collection_size_file))
-        val numberOfFilePreference = requirePreference<IncrementerNumberRangePreferenceCompat>(getString(R.string.pref_fill_collection_number_file))
+        val sizePreference = requirePreference<IncrementerNumberRangePreferenceCompat>(getString(R.string.pref_fill_collection_size_file_key))
+        val numberOfFilePreference = requirePreference<IncrementerNumberRangePreferenceCompat>(getString(R.string.pref_fill_collection_number_file_key))
 
         /*
          * Create fake media section
          */
-        requirePreference<Preference>(R.string.pref_fill_collection).setOnPreferenceClickListener {
+        requirePreference<Preference>(R.string.pref_fill_collection_key).setOnPreferenceClickListener {
             val sizeOfFiles = sizePreference.getValue()
             val numberOfFiles = numberOfFilePreference.getValue()
             AlertDialog.Builder(requireContext()).show {
@@ -122,7 +122,7 @@ class DevOptionsFragment : SettingsFragment() {
                         UIUtils.showThemedToast(requireContext(), "$i files added.", true)
                     }
                 }
-                UIUtils.showThemedToast(requireContext(), "%i files added successfully", false)
+                UIUtils.showThemedToast(requireContext(), "$numberOfFiles files added successfully", false)
             }
         }
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/DevOptionsFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/DevOptionsFragment.kt
@@ -22,8 +22,10 @@ import androidx.preference.SwitchPreference
 import com.ichi2.anki.*
 import com.ichi2.anki.analytics.UsageAnalytics
 import com.ichi2.anki.snackbar.showSnackbar
+import com.ichi2.preferences.IncrementerNumberRangePreferenceCompat
 import com.ichi2.utils.show
 import timber.log.Timber
+import java.io.File
 
 /**
  * Fragment exclusive to DEBUG builds which can be used
@@ -77,6 +79,46 @@ class DevOptionsFragment : SettingsFragment() {
         requirePreference<Preference>(R.string.pref_reset_onboarding_key).setOnPreferenceClickListener {
             OnboardingUtils.reset(requireContext())
             true
+        }
+
+        val sizePreference = requirePreference<IncrementerNumberRangePreferenceCompat>(getString(R.string.pref_fill_collection_size_file))
+        val numberOfFilePreference = requirePreference<IncrementerNumberRangePreferenceCompat>(getString(R.string.pref_fill_collection_number_file))
+
+        /*
+         * Debugging section
+         */
+        requirePreference<Preference>(R.string.pref_fill_collection).setOnPreferenceClickListener {
+            val sizeOfFiles = sizePreference.getValue()
+            val numberOfFiles = numberOfFilePreference.getValue()
+            AlertDialog.Builder(requireContext()).show {
+                setTitle("Warning!")
+                setMessage("You'll add $numberOfFilePreference files with no meaningful content, potentially overriding existing files. Do not do it on a collection you care about.")
+                setPositiveButton("OK") { _, _ ->
+                    generateFiles(sizeOfFiles, numberOfFiles)
+                }
+                setNegativeButton(R.string.dialog_cancel) { _, _ -> }
+            }
+            true
+        }
+    }
+
+    private fun generateFiles(size: Int, numberOfFiles: Int) {
+        launchCatchingTask {
+            withProgress("Generating $numberOfFiles files of size $size bytes") {
+                // Add 10.000 small files
+                val suffix = ".$size"
+                for (i in 1..numberOfFiles) {
+                    val f = File.createTempFile("00$i", suffix)
+                    f.appendBytes(ByteArray(size))
+
+                    CollectionManager.withCol {
+                        media.addFile(f)
+                    }
+                    if (i % 1000 == 0) {
+                        showSnackbar("$i files added.")
+                    }
+                }
+            }
         }
     }
 

--- a/AnkiDroid/src/main/res/values/preferences.xml
+++ b/AnkiDroid/src/main/res/values/preferences.xml
@@ -135,9 +135,9 @@
     <string name="pref_rust_backend_key">useRustBackend</string>
     <string name="dev_options_enabled_by_user_key">devOptionsEnabledByUser</string>
     <!-- Developer options > Create fake media -->
-    <string name="pref_fill_collection">fillCollection</string>
-    <string name="pref_fill_collection_number_file">fillCollectionNumberFile</string>
-    <string name="pref_fill_collection_size_file">fillCollectionSizeFile</string>
+    <string name="pref_fill_collection_key">fillCollection</string>
+    <string name="pref_fill_collection_number_file_key">fillCollectionNumberFile</string>
+    <string name="pref_fill_collection_size_file_key">fillCollectionSizeFile</string>
     <!-- Messages displayed after the user enabled developer options, and warned remaining messages will be in English -->
     <string name="dev_options_enabled_msg">Enabled developer options</string>
     <!-- About -->

--- a/AnkiDroid/src/main/res/values/preferences.xml
+++ b/AnkiDroid/src/main/res/values/preferences.xml
@@ -113,9 +113,6 @@
     <string name="card_browser_external_context_menu_key">card_browser_enable_external_context_menu</string>
     <string name="anki_card_external_context_menu_key">anki_card_enable_external_context_menu</string>
     <string name="pref_reset_languages_key">resetLanguages</string>
-    <string name="pref_fill_collection">fillCollection</string>
-    <string name="pref_fill_collection_number_file">fillCollectionNumberFile</string>
-    <string name="pref_fill_collection_size_file">fillCollectionSizeFile</string>
     <string name="enable_v3_sched_key">v3sched</string>
     <!-- Advanced statistics -->
     <string name="pref_advanced_statistics_screen_key">advancedStatisticsScreen</string>
@@ -137,6 +134,10 @@
     <string name="pref_reset_onboarding_key">resetOnboarding</string>
     <string name="pref_rust_backend_key">useRustBackend</string>
     <string name="dev_options_enabled_by_user_key">devOptionsEnabledByUser</string>
+    <!-- Developer options > Create fake media -->
+    <string name="pref_fill_collection">fillCollection</string>
+    <string name="pref_fill_collection_number_file">fillCollectionNumberFile</string>
+    <string name="pref_fill_collection_size_file">fillCollectionSizeFile</string>
     <!-- Messages displayed after the user enabled developer options, and warned remaining messages will be in English -->
     <string name="dev_options_enabled_msg">Enabled developer options</string>
     <!-- About -->

--- a/AnkiDroid/src/main/res/values/preferences.xml
+++ b/AnkiDroid/src/main/res/values/preferences.xml
@@ -113,6 +113,9 @@
     <string name="card_browser_external_context_menu_key">card_browser_enable_external_context_menu</string>
     <string name="anki_card_external_context_menu_key">anki_card_enable_external_context_menu</string>
     <string name="pref_reset_languages_key">resetLanguages</string>
+    <string name="pref_fill_collection">fillCollection</string>
+    <string name="pref_fill_collection_number_file">fillCollectionNumberFile</string>
+    <string name="pref_fill_collection_size_file">fillCollectionSizeFile</string>
     <string name="enable_v3_sched_key">v3sched</string>
     <!-- Advanced statistics -->
     <string name="pref_advanced_statistics_screen_key">advancedStatisticsScreen</string>

--- a/AnkiDroid/src/main/res/xml/preferences_dev_options.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_dev_options.xml
@@ -19,6 +19,8 @@
 ~ at developers, who are assumed to speak English.
 -->
 <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://arbitrary.app.namespace/com.ichi2.anki"
+    xmlns:app1="http://schemas.android.com/apk/res-auto"
     android:title="@string/pref_cat_dev_options"
     android:key="@string/pref_dev_options_screen_key">
     <SwitchPreference
@@ -51,4 +53,28 @@
         android:title="@string/reset_onboarding"
         android:summary="@string/reset_onboarding_desc"
         android:key="@string/pref_reset_onboarding_key"/>
+    <PreferenceCategory
+        android:title="Create medias"
+        >
+        <com.ichi2.preferences.IncrementerNumberRangePreferenceCompat
+            android:key="@string/pref_fill_collection_number_file"
+            android:title="Number of files to generate"
+            android:persistent="false"
+            app1:useSimpleSummaryProvider="true"
+            android:defaultValue="20"
+            app:min="1"
+            />
+        <com.ichi2.preferences.IncrementerNumberRangePreferenceCompat
+            android:key="@string/pref_fill_collection_size_file"
+            android:title="Size of the files to generate (in byte)"
+            app1:useSimpleSummaryProvider="true"
+            android:persistent="false"
+            android:defaultValue="1000000"
+            app:min="1"
+            />
+        <Preference
+            android:key="@string/pref_fill_collection"
+            android:title="Create the media"
+            />
+    </PreferenceCategory>
 </PreferenceScreen>

--- a/AnkiDroid/src/main/res/xml/preferences_dev_options.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_dev_options.xml
@@ -57,21 +57,21 @@
         android:title="Create fake media"
         >
         <com.ichi2.preferences.IncrementerNumberRangePreferenceCompat
-            android:key="@string/pref_fill_collection_number_file"
+            android:key="@string/pref_fill_collection_number_file_key"
             android:title="Number of files to generate"
             app1:useSimpleSummaryProvider="true"
             android:defaultValue="20"
             app:min="1"
             />
         <com.ichi2.preferences.IncrementerNumberRangePreferenceCompat
-            android:key="@string/pref_fill_collection_size_file"
+            android:key="@string/pref_fill_collection_size_file_key"
             android:title="Size of the files to generate (in byte)"
             app1:useSimpleSummaryProvider="true"
             android:defaultValue="1000000"
             app:min="1"
             />
         <Preference
-            android:key="@string/pref_fill_collection"
+            android:key="@string/pref_fill_collection_key"
             android:title="Create files"
             />
     </PreferenceCategory>

--- a/AnkiDroid/src/main/res/xml/preferences_dev_options.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_dev_options.xml
@@ -54,12 +54,11 @@
         android:summary="@string/reset_onboarding_desc"
         android:key="@string/pref_reset_onboarding_key"/>
     <PreferenceCategory
-        android:title="Create medias"
+        android:title="Create fake media"
         >
         <com.ichi2.preferences.IncrementerNumberRangePreferenceCompat
             android:key="@string/pref_fill_collection_number_file"
             android:title="Number of files to generate"
-            android:persistent="false"
             app1:useSimpleSummaryProvider="true"
             android:defaultValue="20"
             app:min="1"
@@ -68,13 +67,12 @@
             android:key="@string/pref_fill_collection_size_file"
             android:title="Size of the files to generate (in byte)"
             app1:useSimpleSummaryProvider="true"
-            android:persistent="false"
             android:defaultValue="1000000"
             app:min="1"
             />
         <Preference
             android:key="@string/pref_fill_collection"
-            android:title="Create the media"
+            android:title="Create files"
             />
     </PreferenceCategory>
 </PreferenceScreen>


### PR DESCRIPTION
This will add to manually test migration of media.

![2023-05-16-010442_401x701_scrot](https://github.com/ankidroid/Anki-Android/assets/357361/b2c79752-6bc4-4c5d-8c90-54a33dbda73e)


Bug: #13480 from @oakkitten 