### PR TITLE
Add International Phonetic Alphabet as a note field language hint option

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/LocaleSelectionDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/LocaleSelectionDialog.kt
@@ -69,7 +69,7 @@ class LocaleSelectionDialog : AnalyticsDialogFragment() {
         val activity: Activity = requireActivity()
         val tagsDialogView = LayoutInflater.from(activity)
             .inflate(R.layout.locale_selection_dialog, activity.findViewById(R.id.root_layout), false)
-        val adapter = LocaleListAdapter(Locale.getAvailableLocales())
+        val adapter = LocaleListAdapter(Locale.getAvailableLocales() + IPALanguage)
         setupRecyclerView(activity, tagsDialogView, adapter)
         inflateMenu(tagsDialogView, adapter)
 
@@ -173,6 +173,15 @@ class LocaleSelectionDialog : AnalyticsDialogFragment() {
     }
 
     companion object {
+        /**
+         * Language identifier for International Phonetic Alphabet. This isn't available from [Locale.getAvailableLocales], but
+         * GBoard seems to understand this as a language code.
+         *
+         * See issue #13883
+         * See https://en.wikipedia.org/wiki/International_Phonetic_Alphabet#IETF_language_tags
+         */
+        private val IPALanguage = Locale.Builder().setLanguageTag("und-fonipa").build()
+
         /**
          * @param handler Marker interface to enforce the convention the caller implementing LocaleSelectionDialogHandler
          */


### PR DESCRIPTION
## Purpose / Description

Although not available from `Locale.getAvailableLocales()`(the source we use for building the list of languages) "und-fonipa" seems to register as a language code for IPA(will appear as "_IPA Phonetics_" in the dialog). GBoard will use it when set as a language hint.

See https://en.wikipedia.org/wiki/International_Phonetic_Alphabet#IETF_language_tags 

## Fixes
Fixes #13883

## How Has This Been Tested?

Ran the tests and verified that the new language is being used as a language hint and that it does influence the keyboard(GBoard).

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
