### PR TITLE
JS module loading for older Androids (fixes #9311)

### DIFF
--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/utils/AssetHelperTest.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/utils/AssetHelperTest.kt
@@ -13,15 +13,23 @@
  You should have received a copy of the GNU General Public License along with
  this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package com.ichi2.utils
+package com.ichi2.anki.utils
 
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.ichi2.utils.AssetHelper
 import org.hamcrest.CoreMatchers.equalTo
 import org.hamcrest.MatcherAssert.assertThat
 import org.junit.Test
+import org.junit.runner.RunWith
 
+@RunWith(AndroidJUnit4::class)
 class AssetHelperTest {
     @Test
     fun guessMimeTypeTest() {
+        assertThat(AssetHelper.guessMimeType("test.js"), equalTo("text/javascript"))
+        assertThat(AssetHelper.guessMimeType("test.mjs"), equalTo("text/javascript"))
+        assertThat(AssetHelper.guessMimeType("test.json"), equalTo("application/json"))
+        assertThat(AssetHelper.guessMimeType("test.css"), equalTo("text/css"))
         assertThat(AssetHelper.guessMimeType("test.txt"), equalTo("text/plain"))
         assertThat(AssetHelper.guessMimeType("test.png"), equalTo("image/png"))
         assertThat(AssetHelper.guessMimeType("test.zip"), equalTo("application/zip"))

--- a/AnkiDroid/src/main/java/com/ichi2/utils/AssetHelper.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/AssetHelper.kt
@@ -35,12 +35,12 @@
  */
 package com.ichi2.utils
 
-import java.net.URLConnection
+import android.webkit.MimeTypeMap
 
 /** Clone of RestrictedApi functionality  */
 object AssetHelper {
     /**
-     * Use [URLConnection.guessContentTypeFromName] to guess MIME type or return the
+     * Use [MimeTypeMap.getMimeTypeFromExtension] to guess MIME type or return the
      * "text/plain" if it can't guess.
      *
      * Copy of [androidx.webkit.internal.AssetHelper.guessMimeType]
@@ -49,7 +49,12 @@ object AssetHelper {
      * @return MIME type guessed from file extension or "text/plain".
      */
     fun guessMimeType(path: String?): String {
-        val mimeType = URLConnection.guessContentTypeFromName(path)
-        return mimeType ?: "text/plain"
+        val extension = MimeTypeMap.getFileExtensionFromUrl(path)
+        return when (extension) {
+            "js" -> "text/javascript"
+            "mjs" -> "text/javascript"
+            "json" -> "application/json"
+            else -> MimeTypeMap.getSingleton().getMimeTypeFromExtension(extension) ?: "text/plain"
+        }
     }
 }


### PR DESCRIPTION
## Purpose / Description
JS modules must have `text/javascript` MIME, otherwise they won't load: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Modules.

## Fixes
Fixes #9311.

## Approach
`guessMimeType()` works on Android 10+. MIME type must be set explicitly on older Androids.

## How Has This Been Tested?

Android 8.0 and 13.0 in emulator.

Android 8 on Samsung T585.

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
