### PR TITLE
Make AnkiDroid MathJax typesetting awaitable

### DIFF
--- a/AnkiDroid/src/main/assets/scripts/card.js
+++ b/AnkiDroid/src/main/assets/scripts/card.js
@@ -239,9 +239,9 @@ var onPageFinished = function () {
                    no reflowing because the content only shows after MathJax has rendered. */
 
                 if (card.classList.contains("mathjax-needs-to-render")) {
-                    return MathJax.startup.promise
+                    return (MathJax.startup.promise = MathJax.startup.promise
                         .then(() => MathJax.typesetPromise([card]))
-                        .then(() => card.classList.remove("mathjax-needs-to-render"));
+                        .then(() => card.classList.remove("mathjax-needs-to-render")));
                 }
             }
         })


### PR DESCRIPTION
## Purpose / Description

`MathJax.startup.promise` must be reassigned to make downstream code await not only MathJax's initial typesetting, but AnkiDroid typesetting as well. See e.g. the following block in [MathJax's documentation](https://docs.mathjax.org/en/latest/web/typeset.html)
```js
function typeset(code) {
  MathJax.startup.promise = MathJax.startup.promise
    .then(() => MathJax.typesetPromise(code()))
    .catch((err) => console.log('Typeset failed: ' + err.message));
  return MathJax.startup.promise;
}
```

## How Has This Been Tested?

https://github.com/nihil-admirari/modern-cloze-overlapper on Android 8 on Samsung T585.

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
