### PR TITLE
using `activity.packageName` to fix the authority issue while exporting collection

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/export/ActivityExportingDelegate.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/export/ActivityExportingDelegate.kt
@@ -180,9 +180,11 @@ class ActivityExportingDelegate(private val activity: AnkiActivity, private val 
             showThemedToast(activity, activity.resources.getString(R.string.apk_share_error), false)
             return
         }
+        val authority = "${activity.packageName}.apkgfileprovider"
+
         // Get a URI for the file to be shared via the FileProvider API
         val uri: Uri = try {
-            FileProvider.getUriForFile(activity, "com.ichi2.anki.apkgfileprovider", attachment)
+            FileProvider.getUriForFile(activity, authority, attachment)
         } catch (e: IllegalArgumentException) {
             Timber.e("Could not generate a valid URI for the apkg file")
             showThemedToast(activity, activity.resources.getString(R.string.apk_share_error), false)


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
` android:authorities="${applicationId}.apkgfileprovider"
`
This change gets the authority for debug version with `.debug` before the apkgfileprovider which caused an exception in the codebase. So using 
`val authority = "${activity.packageName}.apkgfileprovider"`
fixes the mismatch in the code


## How Has This Been Tested?
tested on google emulator


## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
