### PR TITLE
IntegerDialog is showing keyboard automatically

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/IntegerDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/IntegerDialog.kt
@@ -20,6 +20,7 @@ import android.annotation.SuppressLint
 import android.os.Bundle
 import android.text.InputType
 import com.afollestad.materialdialogs.MaterialDialog
+import com.afollestad.materialdialogs.callbacks.onShow
 import com.afollestad.materialdialogs.input.getInputField
 import com.afollestad.materialdialogs.input.input
 import com.ichi2.anki.R
@@ -57,7 +58,9 @@ open class IntegerDialog : AnalyticsDialogFragment() {
                 maxLength = requireArguments().getInt("digits")
             ) { _: MaterialDialog?, text: CharSequence -> mConsumer!!.accept(text.toString().toInt()) }
             contentNullable(requireArguments().getString("content"))
-            displayKeyboard(getInputField())
+            onShow {
+                displayKeyboard(getInputField())
+            }
         }
 
         return show


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
keyboard is not shown when IntegerDialog is visible

## Fixes
Fixes #13895

## Approach
Now  `dispalykeyboard()` is called after IntegerDialog is shown

## How Has This Been Tested?
Tested on emulator (Pixel 5 API 33)

https://github.com/ankidroid/Anki-Android/assets/119813120/983022f9-6e82-4427-ac49-4da0219217f5


## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
