### PR TITLE
Fix background image distort for DeckPicker

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -376,7 +376,7 @@ open class DeckPicker :
 
         var hasDeckPickerBackground = false
         try {
-            hasDeckPickerBackground = applyDeckPickerBackground(view)
+            hasDeckPickerBackground = applyDeckPickerBackground()
         } catch (e: OutOfMemoryError) { // 6608 - OOM should be catchable here.
             Timber.w(e, "Failed to apply background - OOM")
             showThemedToast(this, getString(R.string.background_image_too_large), false)
@@ -558,23 +558,24 @@ open class DeckPicker :
 
     // throws doesn't seem to be checked by the compiler - consider it to be documentation
     @Throws(OutOfMemoryError::class)
-    private fun applyDeckPickerBackground(view: View): Boolean {
+    private fun applyDeckPickerBackground(): Boolean {
+        val backgroundView = findViewById<ImageView>(R.id.background)
         // Allow the user to clear data and get back to a good state if they provide an invalid background.
         if (!getSharedPrefs(this).getBoolean("deckPickerBackground", false)) {
             Timber.d("No DeckPicker background preference")
-            view.setBackgroundResource(0)
+            backgroundView.setBackgroundResource(0)
             return false
         }
         val currentAnkiDroidDirectory = CollectionHelper.getCurrentAnkiDroidDirectory(this)
         val imgFile = File(currentAnkiDroidDirectory, "DeckPickerBackground.png")
         return if (!imgFile.exists()) {
             Timber.d("No DeckPicker background image")
-            view.setBackgroundResource(0)
+            backgroundView.setBackgroundResource(0)
             false
         } else {
             Timber.i("Applying background")
             val drawable = Drawable.createFromPath(imgFile.absolutePath)
-            view.background = drawable
+            backgroundView.setImageDrawable(drawable)
             true
         }
     }

--- a/AnkiDroid/src/main/res/layout/deck_picker.xml
+++ b/AnkiDroid/src/main/res/layout/deck_picker.xml
@@ -5,7 +5,11 @@
     android:id="@+id/root_layout"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
-
+    <ImageView
+        android:id="@+id/background"
+        android:scaleType="centerCrop"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"/>
     <LinearLayout
         android:id="@+id/deckpicker_view"
         android:layout_width="match_parent"

--- a/AnkiDroid/src/main/res/layout/homescreen.xml
+++ b/AnkiDroid/src/main/res/layout/homescreen.xml
@@ -2,6 +2,10 @@
 <androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
-
+    <ImageView
+        android:id="@+id/background"
+        android:scaleType="centerCrop"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"/>
     <include layout="@layout/deck_picker" />
 </androidx.coordinatorlayout.widget.CoordinatorLayout>


### PR DESCRIPTION
## Purpose / Description

Setting the image as background didn't offer the same customization features as when used in an ImageView(which has the option to apply a scaleType. See images below for a phone:

<img src="https://github.com/ankidroid/Anki-Android/assets/52494258/e52dfc55-9a08-4b35-9091-d387044e6756" width=360px height=720px />
<img src="https://github.com/ankidroid/Anki-Android/assets/52494258/b9a5f357-faaf-4172-bc5f-7cca81c55592" width=720px height=360px />

Note that on xlarge screen(has dedicated layout) like tablets(landscape) the background isn't currently applied full screen but I think it's good as it is now:

<img src="https://github.com/ankidroid/Anki-Android/assets/52494258/f448fa20-b25f-487c-88fd-8deac6ca7602" width=520px height=840px/>

![background_landscape_tablet](https://github.com/ankidroid/Anki-Android/assets/52494258/4c3c4ae0-069a-476c-b72b-09e7d6c61122)



## Fixes
Fixes #13907

## How Has This Been Tested?

Ran tests and manually verified the image.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
