### PR TITLE
Revert "orientation lock for gesture picker dialog"

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/preferences/ControlPreference.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/preferences/ControlPreference.kt
@@ -17,14 +17,11 @@
 package com.ichi2.preferences
 
 import android.annotation.SuppressLint
-import android.app.Activity
 import android.content.Context
-import android.content.pm.ActivityInfo
 import android.util.AttributeSet
 import androidx.appcompat.app.AlertDialog
 import androidx.preference.ListPreference
 import com.afollestad.materialdialogs.MaterialDialog
-import com.afollestad.materialdialogs.callbacks.onDismiss
 import com.afollestad.materialdialogs.customview.customView
 import com.ichi2.anki.AnkiDroidApp
 import com.ichi2.anki.R
@@ -101,8 +98,6 @@ class ControlPreference : ListPreference {
         when (val index: Int = (newValue as String).toInt()) {
             ADD_GESTURE_INDEX -> {
                 val actionName = title
-                // TODO : Discuss if we want to move this to a fragment to allow horizontal orientation
-                (context as Activity).requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_NOSENSOR
                 MaterialDialog(context).show {
                     title(text = actionName.toString())
 
@@ -126,8 +121,6 @@ class ControlPreference : ListPreference {
                     }
 
                     noAutoDismiss()
-                }.onDismiss {
-                    (context as Activity).requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_SENSOR
                 }
             }
             ADD_KEY_INDEX -> {


### PR DESCRIPTION
This reverts commit 165c74ee6d91359e31cd0452216695a5552cbafd.

It was supposed to partially fix #13432, but it didn't.

Demo:
Build of 94328239e6bd3cb0b0dfefff719944d4abfbcfbd. Tested on my phone (Samsung, Android 13) and on an API 29 emulator

https://github.com/ankidroid/Anki-Android/assets/69634269/92ed5741-9baa-4479-b7fe-9bce90f8bc00

