### PR TITLE
immediate dialog after selecting note type

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/ModelBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ModelBrowser.kt
@@ -293,8 +293,8 @@ class ModelBrowser : AnkiActivity() {
         //   that you are cloning. I suggest reworking the strings so this is less confusing.
         MaterialDialog(this).show {
             title(R.string.model_browser_add)
-            positiveButton(R.string.dialog_ok)
-            listItemsSingleChoice(items = infos.map { it.label }) { _, index, _ ->
+            listItemsSingleChoice(items = infos.map { it.label }, waitForPositiveButton = false) { dialog, index, _ ->
+                dialog.dismiss()
                 MaterialDialog(this@ModelBrowser).show {
                     title(R.string.model_browser_add)
                     positiveButton(R.string.dialog_ok)


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
While adding a note type from manage note types, I am supposed to choose the note type, and after choosing I again need to press the Ok button and then it opens a new dialog for naming the note type
Obviously, if I chose note type, I meant to add note type.

## Fixes
Fixes #13914

## Approach
1. Remove the positive button
2. set `waitForPositiveButton = false` in `listItemSingleChoice() `so that I do not wait for the OK button to be clicked

## How Has This Been Tested?

Tested on Physical Device ( Realme 9 )

https://github.com/ankidroid/Anki-Android/assets/65113071/967f444e-a74a-4a7f-838a-de246d9ea6f2



## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
