### PR TITLE
fix: update menu (with sync icon) after syncing

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/Sync.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Sync.kt
@@ -760,6 +760,7 @@ fun DeckPicker.createSyncListener(isFetchingMedia: Boolean) = object : Connectio
             // Mark sync as completed - then refresh the sync icon
             SyncStatus.markSyncCompleted()
             invalidateOptionsMenu()
+            updateMenuState()
             updateDeckList()
             WidgetStatus.update(this@createSyncListener)
             if (fragmented) {


### PR DESCRIPTION
Don't have Android Studio set up yet on my computer. **Have not tested or even compiled**. However I figured I'd get the ball rolling on this bug with a proposed solution (from my reading of the code).

## Pull Request template

## Purpose / Description
Fixes #13528

## Fixes
Fixes #13528

## Approach
```kotlin
            SyncStatus.markSyncCompleted()
            invalidateOptionsMenu()
            updateDeckList()
            WidgetStatus.update(this@createSyncListener)
```
In https://github.com/ankidroid/Anki-Android/blob/6c5c663917ef9f92ccb3d8dd83796a86a9a2ee6f/AnkiDroid/src/main/java/com/ichi2/anki/Sync.kt#L760

Does this need a call to `updateMenuState()`? 

```kotlin
            SyncStatus.markSyncCompleted()
            invalidateOptionsMenu()
            updateMenuState()
            updateDeckList()
            WidgetStatus.update(this@createSyncListener)
```

I did a bunch of digging and the only relevant place `SyncStatus.getSyncStatus` seems to get called is in `fetchSyncStatus` which is subsequently only called in `updateMenuState`. 

## How Has This Been Tested?

**It has not been tested.** DO NOT MERGE UNTIL TESTED.

## Learning (optional, can help others)
I did a bunch of code searching.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas
- [ ] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
