### PR TITLE
unit test for custom preferences buttons

### DIFF
--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/CustomButtonsSettingsFragmentTest.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/CustomButtonsSettingsFragmentTest.kt
@@ -1,0 +1,120 @@
+/*
+ *  Copyright (c) 2023 Ashish Yadav <mailtoashish693@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki
+
+import android.content.Context
+import androidx.preference.ListPreference
+import androidx.preference.PreferenceCategory
+import androidx.preference.PreferenceManager
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.afollestad.materialdialogs.utils.MDUtil.getStringArray
+import org.junit.Assert
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class CustomButtonsSettingsFragmentTest {
+    private lateinit var preferenceManager: PreferenceManager
+
+    @Before
+    fun setup() {
+        preferenceManager = PreferenceManager(ApplicationProvider.getApplicationContext())
+    }
+
+    @Test
+    fun customButtonPreferences_checkKeyValuesAndAttributes() {
+        val preferenceScreen = preferenceManager.inflateFromResource(
+            ApplicationProvider.getApplicationContext(),
+            R.xml.preferences_custom_buttons,
+            null
+        )
+
+        val deckConfGeneralCategory =
+            preferenceScreen.findPreference<PreferenceCategory>(getString(R.string.deck_conf_general))
+        val menuDismissNoteCategory =
+            preferenceScreen.findPreference<PreferenceCategory>(getString(R.string.menu_dismiss_note))
+        val prefCatWhiteboardCategory =
+            preferenceScreen.findPreference<PreferenceCategory>(getString(R.string.pref_cat_whiteboard))
+
+        Assert.assertEquals(getString(R.string.deck_conf_general), deckConfGeneralCategory?.title)
+        Assert.assertEquals(getString(R.string.menu_dismiss_note), menuDismissNoteCategory?.title)
+        Assert.assertEquals(
+            getString(R.string.pref_cat_whiteboard),
+            prefCatWhiteboardCategory?.title
+        )
+
+        Assert.assertEquals(12, deckConfGeneralCategory?.preferenceCount)
+        Assert.assertEquals(3, menuDismissNoteCategory?.preferenceCount)
+        Assert.assertEquals(6, prefCatWhiteboardCategory?.preferenceCount)
+
+        // PreferenceCategory: deckConfGeneralCategory
+        val undoPreference =
+            deckConfGeneralCategory?.findPreference<ListPreference>(getString(R.string.custom_button_undo_key))
+        Assert.assertEquals(getString(R.string.undo), undoPreference?.title)
+        Assert.assertArrayEquals(
+            getStringArray(R.array.custom_button_labels),
+            undoPreference?.entries
+        )
+
+        Assert.assertArrayEquals(
+            getStringArray(R.array.custom_button_values),
+            undoPreference?.entryValues
+        )
+        Assert.assertEquals("2", undoPreference?.value)
+
+        // PreferenceCategory: menuDismissNoteCategory
+        val buryPreference =
+            menuDismissNoteCategory?.findPreference<ListPreference>(getString(R.string.custom_button_bury_key))
+        Assert.assertEquals(getString(R.string.menu_bury), buryPreference?.title)
+        Assert.assertArrayEquals(
+            getStringArray(R.array.custom_button_labels),
+            buryPreference?.entries
+        )
+        Assert.assertArrayEquals(
+            getStringArray(R.array.custom_button_values),
+            buryPreference?.entryValues
+        )
+        buryPreference?.value = "3"
+        Assert.assertEquals("3", buryPreference?.value)
+
+        // PreferenceCategory: prefCatWhiteboardCategory
+        val enableWhiteboardPreference =
+            prefCatWhiteboardCategory?.findPreference<ListPreference>(getString(R.string.custom_button_enable_whiteboard_key))
+        Assert.assertEquals(getString(R.string.enable_whiteboard), enableWhiteboardPreference?.title)
+        Assert.assertArrayEquals(
+            getStringArray(R.array.custom_button_labels),
+            enableWhiteboardPreference?.entries
+        )
+
+        Assert.assertArrayEquals(
+            getStringArray(R.array.custom_button_values),
+            enableWhiteboardPreference?.entryValues
+        )
+        enableWhiteboardPreference?.value = "0"
+        Assert.assertEquals("0", enableWhiteboardPreference?.value)
+    }
+
+    private fun getStringArray(resId: Int): Array<String> {
+        return ApplicationProvider.getApplicationContext<Context>().getStringArray(resId)
+    }
+
+    private fun getString(resId: Int): String {
+        return ApplicationProvider.getApplicationContext<Context>().getString(resId)
+    }
+}

--- a/AnkiDroid/src/main/res/xml/preferences_custom_buttons.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_custom_buttons.xml
@@ -23,166 +23,171 @@ MenuItem.SHOW_AS_ACTION_ALWAYS  = 2
 MENU_DISABLED = 3
 
 Ensure to add the custom icons to Preferences.java's reset functionality
-TODO: Add a unit test
 -->
 <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    android:title="@string/custom_buttons"
-    android:key="@string/pref_app_bar_buttons_screen_key">
+    android:key="@string/pref_app_bar_buttons_screen_key"
+    android:title="@string/custom_buttons">
     <Preference
         android:key="@string/reset_custom_buttons_key"
         android:title="@string/reset_custom_buttons" />
-    <PreferenceCategory android:title="@string/deck_conf_general" >
+    <PreferenceCategory
+        android:key="@string/deck_conf_general"
+        android:title="@string/deck_conf_general">
         <ListPreference
             android:defaultValue="2"
             android:entries="@array/custom_button_labels"
             android:entryValues="@array/custom_button_values"
             android:key="@string/custom_button_undo_key"
             android:title="@string/undo"
-            app:useSimpleSummaryProvider="true"/>
+            app:useSimpleSummaryProvider="true" />
         <ListPreference
             android:defaultValue="0"
             android:entries="@array/custom_button_labels"
             android:entryValues="@array/custom_button_values"
             android:key="@string/custom_button_schedule_card_key"
             android:title="@string/card_editor_reschedule_card"
-            app:useSimpleSummaryProvider="true"/>
+            app:useSimpleSummaryProvider="true" />
         <ListPreference
             android:defaultValue="2"
             android:entries="@array/custom_button_labels"
             android:entryValues="@array/custom_button_values"
             android:key="@string/custom_button_flag_key"
             android:title="@string/menu_flag"
-            app:useSimpleSummaryProvider="true"/>
+            app:useSimpleSummaryProvider="true" />
         <ListPreference
             android:defaultValue="1"
             android:entries="@array/custom_button_labels"
             android:entryValues="@array/custom_button_values"
             android:key="@string/custom_button_edit_card_key"
             android:title="@string/cardeditor_title_edit_card"
-            app:useSimpleSummaryProvider="true"/>
+            app:useSimpleSummaryProvider="true" />
         <ListPreference
             android:defaultValue="0"
             android:entries="@array/custom_button_labels"
             android:entryValues="@array/custom_button_values"
             android:key="@string/custom_button_tags_key"
             android:title="@string/menu_edit_tags"
-            app:useSimpleSummaryProvider="true"/>
+            app:useSimpleSummaryProvider="true" />
         <ListPreference
             android:defaultValue="3"
             android:entries="@array/custom_button_labels"
             android:entryValues="@array/custom_button_values"
             android:key="@string/custom_button_add_card_key"
             android:title="@string/menu_add_note"
-            app:useSimpleSummaryProvider="true"/>
+            app:useSimpleSummaryProvider="true" />
         <ListPreference
             android:defaultValue="1"
             android:entries="@array/custom_button_labels"
             android:entryValues="@array/custom_button_values"
             android:key="@string/custom_button_replay_key"
             android:title="@string/replay_audio"
-            app:useSimpleSummaryProvider="true"/>
+            app:useSimpleSummaryProvider="true" />
         <ListPreference
             android:defaultValue="3"
             android:entries="@array/custom_button_labels"
             android:entryValues="@array/custom_button_values"
             android:key="@string/custom_button_card_info_key"
             android:title="@string/card_info_title"
-            app:useSimpleSummaryProvider="true"/>
+            app:useSimpleSummaryProvider="true" />
         <ListPreference
             android:defaultValue="0"
             android:entries="@array/custom_button_labels"
             android:entryValues="@array/custom_button_values"
             android:key="@string/custom_button_select_tts_key"
             android:title="@string/select_tts"
-            app:useSimpleSummaryProvider="true"/>
+            app:useSimpleSummaryProvider="true" />
         <ListPreference
             android:defaultValue="0"
             android:entries="@array/custom_button_labels"
             android:entryValues="@array/custom_button_values"
             android:key="@string/custom_button_deck_options_key"
             android:title="@string/menu__deck_options"
-            app:useSimpleSummaryProvider="true"/>
+            app:useSimpleSummaryProvider="true" />
         <ListPreference
             android:defaultValue="1"
             android:entries="@array/custom_button_labels"
             android:entryValues="@array/custom_button_values"
             android:key="@string/custom_button_mark_card_key"
             android:title="@string/menu_mark_note"
-            app:useSimpleSummaryProvider="true"/>
+            app:useSimpleSummaryProvider="true" />
         <ListPreference
             android:defaultValue="0"
             android:entries="@array/custom_button_labels"
             android:entryValues="@array/custom_button_values"
             android:key="@string/custom_button_toggle_mic_toolbar_key"
             android:title="@string/menu_toggle_mic_tool_bar"
-            app:useSimpleSummaryProvider="true"/>
+            app:useSimpleSummaryProvider="true" />
     </PreferenceCategory>
-    <PreferenceCategory android:title="@string/menu_dismiss_note" >
+    <PreferenceCategory
+        android:key="@string/menu_dismiss_note"
+        android:title="@string/menu_dismiss_note">
         <ListPreference
             android:defaultValue="0"
             android:entries="@array/custom_button_labels"
             android:entryValues="@array/custom_button_values"
             android:key="@string/custom_button_bury_key"
             android:title="@string/menu_bury"
-            app:useSimpleSummaryProvider="true"/>
+            app:useSimpleSummaryProvider="true" />
         <ListPreference
             android:defaultValue="0"
             android:entries="@array/custom_button_labels"
             android:entryValues="@array/custom_button_values"
             android:key="@string/custom_button_suspend_key"
             android:title="@string/menu_suspend"
-            app:useSimpleSummaryProvider="true"/>
+            app:useSimpleSummaryProvider="true" />
         <ListPreference
             android:defaultValue="0"
             android:entries="@array/custom_button_labels"
             android:entryValues="@array/custom_button_values"
             android:key="@string/custom_button_delete_key"
             android:title="@string/menu_delete_note"
-            app:useSimpleSummaryProvider="true"/>
+            app:useSimpleSummaryProvider="true" />
     </PreferenceCategory>
-    <PreferenceCategory android:title="@string/pref_cat_whiteboard" >
+    <PreferenceCategory
+        android:key="@string/pref_cat_whiteboard"
+        android:title="@string/pref_cat_whiteboard">
         <ListPreference
             android:defaultValue="0"
             android:entries="@array/custom_button_labels"
             android:entryValues="@array/custom_button_values"
             android:key="@string/custom_button_enable_whiteboard_key"
             android:title="@string/enable_whiteboard"
-            app:useSimpleSummaryProvider="true"/>
+            app:useSimpleSummaryProvider="true" />
         <ListPreference
             android:defaultValue="1"
             android:entries="@array/custom_button_labels"
             android:entryValues="@array/custom_button_values"
             android:key="@string/custom_button_toggle_stylus_key"
             android:title="@string/enable_stylus"
-            app:useSimpleSummaryProvider="true"/>
+            app:useSimpleSummaryProvider="true" />
         <ListPreference
             android:defaultValue="0"
             android:entries="@array/custom_button_labels"
             android:entryValues="@array/custom_button_values"
             android:key="@string/custom_button_save_whiteboard_key"
             android:title="@string/save_whiteboard"
-            app:useSimpleSummaryProvider="true"/>
+            app:useSimpleSummaryProvider="true" />
         <ListPreference
             android:defaultValue="1"
             android:entries="@array/custom_button_labels"
             android:entryValues="@array/custom_button_values"
             android:key="@string/custom_button_whiteboard_pen_color_key"
             android:title="@string/title_whiteboard_pen_color"
-            app:useSimpleSummaryProvider="true"/>
+            app:useSimpleSummaryProvider="true" />
         <ListPreference
             android:defaultValue="2"
             android:entries="@array/custom_button_labels"
             android:entryValues="@array/custom_button_values"
             android:key="@string/custom_button_show_hide_whiteboard_key"
             android:title="@string/hide_whiteboard"
-            app:useSimpleSummaryProvider="true"/>
+            app:useSimpleSummaryProvider="true" />
         <ListPreference
             android:defaultValue="1"
             android:entries="@array/custom_button_labels"
             android:entryValues="@array/custom_button_values"
             android:key="@string/custom_button_clear_whiteboard_key"
             android:title="@string/clear_whiteboard"
-            app:useSimpleSummaryProvider="true"/>
+            app:useSimpleSummaryProvider="true" />
     </PreferenceCategory>
 </PreferenceScreen>


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
Created a unit test for custom button preference screen


## Approach
Testing the title for each preference category whether it is being set up properly or not.
then using the assertion to test the number of preferences in each category to test that nothing is being missed out and everything is in place
Finally picking one preference from each category for a value/setting it or the default value


## How Has This Been Tested?
Ran the test locally and it passed 


## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
