### PR TITLE
ellipsize the deck name if lengthy

### DIFF
--- a/AnkiDroid/src/main/res/layout/deck_item.xml
+++ b/AnkiDroid/src/main/res/layout/deck_item.xml
@@ -56,6 +56,7 @@
             android:background="@color/transparent"
             android:gravity="start|center_vertical"
             android:maxLines="2"
+            android:ellipsize="end"
             android:textColor="?android:textColorPrimary"
             android:textSize="20sp"
             android:textStyle="bold"


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
The deck name is shown in only 2 lines and if its lengthy then there is no hint that it is continued or not.


## Fixes
Minor change for better UI

## Approach
_How does this change address the problem?_

## How Has This Been Tested?
![Screenshot_96](https://github.com/ankidroid/Anki-Android/assets/48384865/43013f87-45f7-4c71-a705-e84df3c7a5e1)


## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
