### PR TITLE
Fix parent config not being applied on child decks in deck options

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckOptionsActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckOptionsActivity.kt
@@ -317,7 +317,7 @@ class DeckOptionsActivity :
                                             for (childDid in children.values) {
                                                 val child = col.decks.get(childDid)
                                                 if (child.isDyn) continue
-                                                changeDeckConfiguration(deck, mOptions, col)
+                                                changeDeckConfiguration(child, mOptions, col)
                                             }
                                         }
                                     } finally {


### PR DESCRIPTION
## Purpose / Description

The code iterated over the child decks to set the new configuration from the parent but it used the parent deck as the target so child decks kept their current deck configuration.

## Fixes
Fixes #13933 

## How Has This Been Tested?

Manually verified that the parent deck configuration will be applied on child decks when requested.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
