### PR TITLE
Remove `col` from class Card

### DIFF
--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/ContentProviderTest.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/ContentProviderTest.kt
@@ -981,13 +981,13 @@ class ContentProviderTest : InstrumentedTest() {
             col.reset()
             nextCard = sched.card
             waitToFinish()
-            if (nextCard != null && nextCard.note().id == noteID && nextCard.ord == cardOrd) break
+            if (nextCard != null && nextCard.nid == noteID && nextCard.ord == cardOrd) break
             waitToFinish()
         }
         assertNotNull("Check that there actually is a next scheduled card", nextCard)
         assertEquals(
             "Check that received card and actual card have same note id",
-            nextCard!!.note().id,
+            nextCard!!.nid,
             noteID
         )
         assertEquals(
@@ -1035,7 +1035,7 @@ class ContentProviderTest : InstrumentedTest() {
             for (i in 0..9) { // minimizing fails, when sched.reset() randomly chooses between multiple cards
                 col.reset()
                 nextCard = sched.card
-                if (nextCard != null && nextCard.note().id == noteID && nextCard.ord == cardOrd) break
+                if (nextCard != null && nextCard.nid == noteID && nextCard.ord == cardOrd) break
                 try {
                     Thread.sleep(500)
                 } catch (e: Exception) {
@@ -1045,7 +1045,7 @@ class ContentProviderTest : InstrumentedTest() {
             assertNotNull("Check that there actually is a next scheduled card", nextCard)
             assertEquals(
                 "Check that received card and actual card have same note id",
-                nextCard!!.note().id,
+                nextCard!!.nid,
                 noteID
             )
             assertEquals(
@@ -1096,7 +1096,7 @@ class ContentProviderTest : InstrumentedTest() {
         assertEquals("card is initial new", Consts.CARD_TYPE_NEW, card.queue)
         val cr = contentResolver
         val reviewInfoUri = FlashCardsContract.ReviewInfo.CONTENT_URI
-        val noteId = card.note().id
+        val noteId = card.nid
         val cardOrd = card.ord
         val earlyGraduatingEase =
             if (schedVersion == 1) AbstractFlashcardViewer.EASE_3 else AbstractFlashcardViewer.EASE_4
@@ -1116,7 +1116,7 @@ class ContentProviderTest : InstrumentedTest() {
         col.reset()
         val newCard = col.sched.card
         if (newCard != null) {
-            if (newCard.note().id == card.note().id && newCard.ord == card.ord) {
+            if (newCard.nid == card.nid && newCard.ord == card.ord) {
                 fail("Next scheduled card has not changed")
             }
         }
@@ -1150,7 +1150,7 @@ class ContentProviderTest : InstrumentedTest() {
         // -----------------------
         val cr = contentResolver
         val reviewInfoUri = FlashCardsContract.ReviewInfo.CONTENT_URI
-        val noteId = card.note().id
+        val noteId = card.nid
         val cardOrd = card.ord
         val bury = 1
         val values = ContentValues().apply {
@@ -1200,7 +1200,7 @@ class ContentProviderTest : InstrumentedTest() {
         // --------------------------
         val cr = contentResolver
         val reviewInfoUri = FlashCardsContract.ReviewInfo.CONTENT_URI
-        val noteId = card.note().id
+        val noteId = card.nid
         val cardOrd = card.ord
 
         @KotlinCleanup("rename, while valid suspend is a kotlin soft keyword")

--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/ContentProviderTest.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/ContentProviderTest.kt
@@ -1340,7 +1340,7 @@ class ContentProviderTest : InstrumentedTest() {
             )
             for (c in newNote.cards()) {
                 c.did = did
-                c.flush()
+                c.flush(col)
             }
             return Uri.withAppendedPath(
                 FlashCardsContract.Note.CONTENT_URI,

--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/ContentProviderTest.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/ContentProviderTest.kt
@@ -1233,7 +1233,7 @@ class ContentProviderTest : InstrumentedTest() {
         // ----------------------
         val col = col
         val card = getFirstCardFromScheduler(col)
-        val note = card!!.note()
+        val note = card!!.note(col)
         val noteId = note.id
 
         // make sure the tag is what we expect initially

--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/libanki/ImportTest.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/libanki/ImportTest.kt
@@ -188,7 +188,7 @@ class ImportTest : InstrumentedTest() {
         assertEquals(1, testCol.noteCount().toLong())
         // the front template should contain the text added in the 2nd package
         val tcid = testCol.findCards("")[0]
-        val tnote = testCol.getCard(tcid).note()
+        val tnote = testCol.getCard(tcid).note(testCol)
         assertTrue(
             testCol.findTemplates(tnote)[0].getString("qfmt").contains("Changed Front Template")
         )

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
@@ -888,7 +888,7 @@ abstract class AbstractFlashcardViewer :
             message(
                 text = resources.getString(
                     R.string.delete_note_message,
-                    Utils.stripHTML(currentCard!!.q(true))
+                    Utils.stripHTML(currentCard!!.q(col, true))
                 )
             )
             positiveButton(R.string.dialog_positive_delete) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
@@ -1370,7 +1370,7 @@ abstract class AbstractFlashcardViewer :
         setInterface()
         typeAnswer!!.input = ""
         typeAnswer!!.updateInfo(currentCard!!, resources)
-        if (!currentCard!!.isEmpty() && typeAnswer!!.validForEditText()) {
+        if (!currentCard!!.isEmpty(col) && typeAnswer!!.validForEditText()) {
             // Show text entry based on if the user wants to write the answer
             answerField!!.visibility = View.VISIBLE
             answerField!!.applyLanguageHint(typeAnswer!!.languageHint)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
@@ -906,7 +906,7 @@ abstract class AbstractFlashcardViewer :
     /** Consumers should use [.showDeleteNoteDialog]   */
     private fun deleteNoteWithoutConfirmation() {
         dismiss(DeleteNote(currentCard!!)) {
-            showSnackbarWithUndoButtonText(TR.browsingCardsDeleted(currentCard!!.note().numberOfCards()))
+            showSnackbarWithUndoButtonText(TR.browsingCardsDeleted(currentCard!!.note(col).numberOfCards()))
         }
     }
 
@@ -1369,7 +1369,7 @@ abstract class AbstractFlashcardViewer :
         mBackButtonPressedToReturn = false
         setInterface()
         typeAnswer!!.input = ""
-        typeAnswer!!.updateInfo(currentCard!!, resources)
+        typeAnswer!!.updateInfo(col, currentCard!!, resources)
         if (!currentCard!!.isEmpty(col) && typeAnswer!!.validForEditText()) {
             // Show text entry based on if the user wants to write the answer
             answerField!!.visibility = View.VISIBLE
@@ -1403,7 +1403,7 @@ abstract class AbstractFlashcardViewer :
 
         // TODO needs testing: changing a card's model without flipping it back to the front
         //  (such as editing a card, then editing the card template)
-        typeAnswer!!.updateInfo(currentCard!!, resources)
+        typeAnswer!!.updateInfo(col, currentCard!!, resources)
 
         // Explicitly hide the soft keyboard. It *should* be hiding itself automatically,
         // but sometimes failed to do so (e.g. if an OnKeyListener is attached).
@@ -1676,14 +1676,14 @@ abstract class AbstractFlashcardViewer :
 
     internal fun suspendNote(): Boolean {
         return dismiss(SuspendNote(currentCard!!)) {
-            val noteSuspended = resources.getQuantityString(R.plurals.note_suspended, currentCard!!.note().numberOfCards(), currentCard!!.note().numberOfCards())
+            val noteSuspended = resources.getQuantityString(R.plurals.note_suspended, currentCard!!.note(col).numberOfCards(), currentCard!!.note(col).numberOfCards())
             showSnackbarWithUndoButtonText(noteSuspended)
         }
     }
 
     internal fun buryNote(): Boolean {
         return dismiss(BuryNote(currentCard!!)) {
-            showSnackbarWithUndoButtonText(TR.studyingCardsBuried(currentCard!!.note().numberOfCards()))
+            showSnackbarWithUndoButtonText(TR.studyingCardsBuried(currentCard!!.note(col).numberOfCards()))
         }
     }
 
@@ -2127,7 +2127,7 @@ abstract class AbstractFlashcardViewer :
     }
 
     protected open fun shouldDisplayMark(): Boolean {
-        return isMarked(currentCard!!.note())
+        return isMarked(currentCard!!.note(col))
     }
 
     protected fun <TResult : Computation<NextCard<*>>?> nextCardHandler(): TaskListenerBuilder<Unit, TResult> {
@@ -2583,15 +2583,15 @@ abstract class AbstractFlashcardViewer :
 
     internal fun showTagsDialog() {
         val tags = ArrayList(col.tags.all())
-        val selTags = ArrayList(currentCard!!.note().tags)
+        val selTags = ArrayList(currentCard!!.note(col).tags)
         val dialog = mTagsDialogFactory!!.newTagsDialog().withArguments(TagsDialog.DialogType.EDIT_TAGS, selTags, tags)
         showDialogFragment(dialog)
     }
 
     override fun onSelectedTags(selectedTags: List<String>, indeterminateTags: List<String>, option: Int) {
-        if (currentCard!!.note().tags != selectedTags) {
+        if (currentCard!!.note(col).tags != selectedTags) {
             val tagString = selectedTags.joinToString(" ")
-            val note = currentCard!!.note()
+            val note = currentCard!!.note(col)
             note.setTagsFromStr(tagString)
             note.flush()
             // Reload current card to reflect tag changes

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
@@ -1370,7 +1370,7 @@ abstract class AbstractFlashcardViewer :
         setInterface()
         typeAnswer!!.input = ""
         typeAnswer!!.updateInfo(currentCard!!, resources)
-        if (!currentCard!!.isEmpty && typeAnswer!!.validForEditText()) {
+        if (!currentCard!!.isEmpty() && typeAnswer!!.validForEditText()) {
             // Show text entry based on if the user wants to write the answer
             answerField!!.visibility = View.VISIBLE
             answerField!!.applyLanguageHint(typeAnswer!!.languageHint)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
@@ -877,7 +877,7 @@ abstract class AbstractFlashcardViewer :
     }
 
     fun generateQuestionSoundList() {
-        val tags = Sound.extractTagsFromLegacyContent(currentCard!!.qSimple())
+        val tags = Sound.extractTagsFromLegacyContent(currentCard!!.qSimple(col))
         mSoundPlayer.addSounds(tags, SingleSoundSide.QUESTION)
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
@@ -963,7 +963,7 @@ abstract class AbstractFlashcardViewer :
                 Timber.i("Answering card %d", oldCard.id)
                 col.sched.answerCard(oldCard, ease)
                 Timber.i("Obtaining next card")
-                sched.card?.apply { render_output(reload = true) }
+                sched.card?.apply { render_output(col, reload = true) }
             }
             // TODO: this handling code is unnecessarily complex, and would be easier to follow
             //  if written imperatively
@@ -1377,7 +1377,7 @@ abstract class AbstractFlashcardViewer :
         } else {
             answerField!!.visibility = View.GONE
         }
-        val content = mHtmlGenerator!!.generateHtml(currentCard!!, reload, Side.FRONT)
+        val content = mHtmlGenerator!!.generateHtml(col, currentCard!!, reload, Side.FRONT)
         updateCard(content)
         hideEaseButtons()
         automaticAnswer.onDisplayQuestion()
@@ -1419,7 +1419,7 @@ abstract class AbstractFlashcardViewer :
             typeAnswer!!.input = answerField!!.text.toString()
         }
         mIsSelecting = false
-        val answerContent = mHtmlGenerator!!.generateHtml(currentCard!!, false, Side.BACK)
+        val answerContent = mHtmlGenerator!!.generateHtml(col, currentCard!!, false, Side.BACK)
         updateCard(answerContent)
         displayAnswerBottomBar()
         automaticAnswer.onDisplayAnswer()

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
@@ -1535,10 +1535,10 @@ abstract class AbstractFlashcardViewer :
                 // If the question is displayed or if the question should be replayed, read the question
                 if (mTtsInitialized) {
                     if (!displayAnswer || doAudioReplay && replayQuestion) {
-                        readCardTts(SingleSoundSide.QUESTION)
+                        readCardTts(col, SingleSoundSide.QUESTION)
                     }
                     if (displayAnswer) {
-                        readCardTts(SingleSoundSide.ANSWER)
+                        readCardTts(col, SingleSoundSide.ANSWER)
                     }
                 } else {
                     mReplayOnTtsInit = true
@@ -1547,8 +1547,8 @@ abstract class AbstractFlashcardViewer :
         }
     }
 
-    private fun readCardTts(side: SingleSoundSide) {
-        val tags = legacyGetTtsTags(currentCard!!, side, this)
+    private fun readCardTts(col: Collection, side: SingleSoundSide) {
+        val tags = legacyGetTtsTags(col, currentCard!!, side, this)
         mTTS.readCardText(tags, currentCard!!, side.toSoundSide())
     }
 
@@ -1596,7 +1596,7 @@ abstract class AbstractFlashcardViewer :
      */
     protected fun showSelectTtsDialogue() {
         if (mTtsInitialized) {
-            mTTS.selectTts(this, currentCard!!, if (displayAnswer) SoundSide.ANSWER else SoundSide.QUESTION)
+            mTTS.selectTts(col, this, currentCard!!, if (displayAnswer) SoundSide.ANSWER else SoundSide.QUESTION)
         }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
@@ -1549,7 +1549,7 @@ abstract class AbstractFlashcardViewer :
 
     private fun readCardTts(col: Collection, side: SingleSoundSide) {
         val tags = legacyGetTtsTags(col, currentCard!!, side, this)
-        mTTS.readCardText(tags, currentCard!!, side.toSoundSide())
+        mTTS.readCardText(col, tags, currentCard!!, side.toSoundSide())
     }
 
     private fun playSounds(questionAndAnswer: SoundSide) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidJsAPI.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidJsAPI.kt
@@ -478,7 +478,7 @@ open class AnkiDroidJsAPI(private val activity: AbstractFlashcardViewer) {
         for (s in cards) {
             val jsonObject = JSONObject()
             val fieldsData = s.card.note(col).fields
-            val fieldsName = s.card.model().fieldsNames
+            val fieldsName = s.card.model(col).fieldsNames
 
             val noteId = s.card.nid
             val cardId = s.card.id

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidJsAPI.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidJsAPI.kt
@@ -476,7 +476,7 @@ open class AnkiDroidJsAPI(private val activity: AbstractFlashcardViewer) {
             val fieldsData = s.card.note().fields
             val fieldsName = s.card.model().fieldsNames
 
-            val noteId = s.card.note().id
+            val noteId = s.card.nid
             val cardId = s.card.id
             jsonObject.put("cardId", cardId)
             jsonObject.put("noteId", noteId)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidJsAPI.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidJsAPI.kt
@@ -30,6 +30,7 @@ import com.ichi2.anki.snackbar.setMaxLines
 import com.ichi2.anki.snackbar.showSnackbar
 import com.ichi2.libanki.Card
 import com.ichi2.libanki.CardId
+import com.ichi2.libanki.Collection
 import com.ichi2.libanki.Consts.CARD_QUEUE
 import com.ichi2.libanki.Consts.CARD_TYPE
 import com.ichi2.libanki.Decks
@@ -43,6 +44,9 @@ import timber.log.Timber
 open class AnkiDroidJsAPI(private val activity: AbstractFlashcardViewer) {
     private val currentCard: Card
         get() = activity.currentCard!!
+
+    private val col: Collection
+        get() = activity.col
 
     /**
      Javascript Interface class for calling Java function from AnkiDroid WebView
@@ -208,7 +212,7 @@ open class AnkiDroidJsAPI(private val activity: AbstractFlashcardViewer) {
 
     @JavascriptInterface
     fun ankiGetCardMark(): Boolean {
-        return currentCard.note().hasTag("marked")
+        return currentCard.note(col).hasTag("marked")
     }
 
     @JavascriptInterface
@@ -473,7 +477,7 @@ open class AnkiDroidJsAPI(private val activity: AbstractFlashcardViewer) {
         val searchResult: MutableList<String> = ArrayList()
         for (s in cards) {
             val jsonObject = JSONObject()
-            val fieldsData = s.card.note().fields
+            val fieldsData = s.card.note(col).fields
             val fieldsName = s.card.model().fieldsNames
 
             val noteId = s.card.nid

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -2428,7 +2428,7 @@ open class CardBrowser :
         }
 
         private fun queryAvgIntervalForNotes(): String {
-            val avgInterval = card.avgIntervalOfNote()
+            val avgInterval = card.avgIntervalOfNote(col)
 
             return if (avgInterval == null) {
                 "" // upstream does not display interval for notes with new or learning cards

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -2464,10 +2464,11 @@ open class CardBrowser :
                 return
             }
             // render question and answer
-            val qa = card.render_output(reload = true, browser = true)
+            val qa = card.render_output(col, reload = true, browser = true)
             // Render full question / answer if the bafmt (i.e. "browser appearance") setting forced blank result
             if (qa.question_text.isEmpty() || qa.answer_text.isEmpty()) {
                 val (question_text, answer_text) = card.render_output(
+                    col,
                     reload = true,
                     browser = false
                 )

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -2379,7 +2379,7 @@ open class CardBrowser :
                 Column.SFLD -> card.note(col).sFld
                 Column.DECK -> col.decks.name(card.did)
                 Column.TAGS -> card.note(col).stringTags()
-                Column.CARD -> if (inCardMode) card.template().optString("name") else "${card.note(col).numberOfCards()}"
+                Column.CARD -> if (inCardMode) card.template(col).optString("name") else "${card.note(col).numberOfCards()}"
                 Column.DUE -> card.dueString(col)
                 Column.EASE -> if (inCardMode) getEaseForCards() else getAvgEaseForNotes()
                 Column.CHANGED -> LanguageUtil.getShortDateFormatFromS(if (inCardMode) card.mod else card.note(col).mod)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -2383,7 +2383,7 @@ open class CardBrowser :
                 Column.DECK -> col.decks.name(card.did)
                 Column.TAGS -> card.note().stringTags()
                 Column.CARD -> if (inCardMode) card.template().optString("name") else "${card.note().numberOfCards()}"
-                Column.DUE -> card.dueString
+                Column.DUE -> card.dueString()
                 Column.EASE -> if (inCardMode) getEaseForCards() else getAvgEaseForNotes()
                 Column.CHANGED -> LanguageUtil.getShortDateFormatFromS(if (inCardMode) card.mod else card.note().mod)
                 Column.CREATED -> LanguageUtil.getShortDateFormatFromMs(card.nid)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -2409,7 +2409,7 @@ open class CardBrowser :
         }
 
         private fun getAvgEaseForNotes(): String {
-            val avgEase = card.avgEaseOfNote()
+            val avgEase = card.avgEaseOfNote(col)
 
             return if (avgEase == null) {
                 AnkiDroidApp.instance.getString(R.string.card_browser_interval_new_card)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -2379,7 +2379,7 @@ open class CardBrowser :
                 Column.DECK -> col.decks.name(card.did)
                 Column.TAGS -> card.note(col).stringTags()
                 Column.CARD -> if (inCardMode) card.template().optString("name") else "${card.note(col).numberOfCards()}"
-                Column.DUE -> card.dueString()
+                Column.DUE -> card.dueString(col)
                 Column.EASE -> if (inCardMode) getEaseForCards() else getAvgEaseForNotes()
                 Column.CHANGED -> LanguageUtil.getShortDateFormatFromS(if (inCardMode) card.mod else card.note(col).mod)
                 Column.CREATED -> LanguageUtil.getShortDateFormatFromMs(card.nid)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -2386,7 +2386,7 @@ open class CardBrowser :
                 Column.CREATED -> LanguageUtil.getShortDateFormatFromMs(card.nid)
                 Column.EDITED -> LanguageUtil.getShortDateFormatFromS(card.note(col).mod)
                 Column.INTERVAL -> if (inCardMode) queryIntervalForCards() else queryAvgIntervalForNotes()
-                Column.LAPSES -> (if (inCardMode) card.lapses else card.totalLapsesOfNote()).toString()
+                Column.LAPSES -> (if (inCardMode) card.lapses else card.totalLapsesOfNote(col)).toString()
                 Column.NOTE_TYPE -> card.model(col).optString("name")
                 Column.REVIEWS -> if (inCardMode) card.reps.toString() else card.totalReviewsForNote().toString()
                 Column.QUESTION -> {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -2386,7 +2386,7 @@ open class CardBrowser :
                 Column.EDITED -> LanguageUtil.getShortDateFormatFromS(card.note(col).mod)
                 Column.INTERVAL -> if (inCardMode) queryIntervalForCards() else queryAvgIntervalForNotes()
                 Column.LAPSES -> (if (inCardMode) card.lapses else card.totalLapsesOfNote()).toString()
-                Column.NOTE_TYPE -> card.model().optString("name")
+                Column.NOTE_TYPE -> card.model(col).optString("name")
                 Column.REVIEWS -> if (inCardMode) card.reps.toString() else card.totalReviewsForNote().toString()
                 Column.QUESTION -> {
                     updateSearchItemQA()

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -2386,7 +2386,7 @@ open class CardBrowser :
                 Column.DUE -> card.dueString
                 Column.EASE -> if (inCardMode) getEaseForCards() else getAvgEaseForNotes()
                 Column.CHANGED -> LanguageUtil.getShortDateFormatFromS(if (inCardMode) card.mod else card.note().mod)
-                Column.CREATED -> LanguageUtil.getShortDateFormatFromMs(card.note().id)
+                Column.CREATED -> LanguageUtil.getShortDateFormatFromMs(card.nid)
                 Column.EDITED -> LanguageUtil.getShortDateFormatFromS(card.note().mod)
                 Column.INTERVAL -> if (inCardMode) queryIntervalForCards() else queryAvgIntervalForNotes()
                 Column.LAPSES -> (if (inCardMode) card.lapses else card.totalLapsesOfNote()).toString()

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -826,7 +826,7 @@ open class CardBrowser :
 
             // reload cards because they'll be passed back to caller
             for (c in cards) {
-                c.load()
+                c.load(col)
             }
         }
         // pass cards back so more actions can be performed by the caller

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -2388,7 +2388,7 @@ open class CardBrowser :
                 Column.INTERVAL -> if (inCardMode) queryIntervalForCards() else queryAvgIntervalForNotes()
                 Column.LAPSES -> (if (inCardMode) card.lapses else card.totalLapsesOfNote(col)).toString()
                 Column.NOTE_TYPE -> card.model(col).optString("name")
-                Column.REVIEWS -> if (inCardMode) card.reps.toString() else card.totalReviewsForNote().toString()
+                Column.REVIEWS -> if (inCardMode) card.reps.toString() else card.totalReviewsForNote(col).toString()
                 Column.QUESTION -> {
                     updateSearchItemQA()
                     mQa!!.first

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardInfo.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardInfo.kt
@@ -328,7 +328,7 @@ class CardInfo : AnkiActivity() {
                 if (c.type < Consts.CARD_TYPE_REV) {
                     easeInPercent = null
                 }
-                val due = c.dueString()
+                val due = c.dueString(collection)
                 val entries: MutableList<RevLogEntry> = ArrayList(collection.db.queryScalar("select count() from revlog where cid = ?", c.id))
                 collection.db.query(
                     "select " +

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardInfo.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardInfo.kt
@@ -317,7 +317,7 @@ class CardInfo : AnkiActivity() {
                 val lapses = c.lapses
                 val reviews = c.reps
                 val model = collection.models.get(c.note(collection).mid)
-                val cardType = getCardType(c, model)
+                val cardType = getCardType(collection, c, model)
                 val noteType = model!!.getString("name")
                 val deckName = collection.decks.get(c.did).getString("name")
                 val noteId = c.nid
@@ -356,9 +356,9 @@ class CardInfo : AnkiActivity() {
                 return CardInfoModel(addedDate, firstReview, latestReview, due, interval, easeInPercent, reviews, lapses, averageTime, totalTime, cardType, noteType, deckName, noteId, entries)
             }
 
-            protected fun getCardType(c: Card, model: Model?): String? {
+            protected fun getCardType(col: Collection, c: Card, model: Model?): String? {
                 return try {
-                    val ord = if (c.model().isCloze) {
+                    val ord = if (c.model(col).isCloze) {
                         0
                     } else {
                         c.ord

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardInfo.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardInfo.kt
@@ -316,7 +316,7 @@ class CardInfo : AnkiActivity() {
                 var easeInPercent: Double? = c.factor / 1000.0
                 val lapses = c.lapses
                 val reviews = c.reps
-                val model = collection.models.get(c.note().mid)
+                val model = collection.models.get(c.note(collection).mid)
                 val cardType = getCardType(c, model)
                 val noteType = model!!.getString("name")
                 val deckName = collection.decks.get(c.did).getString("name")

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardInfo.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardInfo.kt
@@ -328,7 +328,7 @@ class CardInfo : AnkiActivity() {
                 if (c.type < Consts.CARD_TYPE_REV) {
                     easeInPercent = null
                 }
-                val due = c.dueString
+                val due = c.dueString()
                 val entries: MutableList<RevLogEntry> = ArrayList(collection.db.queryScalar("select count() from revlog where cid = ?", c.id))
                 collection.db.query(
                     "select " +

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplatePreviewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplatePreviewer.kt
@@ -367,10 +367,12 @@ open class CardTemplatePreviewer : AbstractFlashcardViewer() {
             mNote = null
         }
 
-        /* if we have an unsaved note saved, use it instead of a collection lookup */ override fun note(
+        /* if we have an unsaved note saved, use it instead of a collection lookup */
+        override fun note(
+            col: Collection,
             reload: Boolean
         ): Note {
-            return mNote ?: super.note(reload)
+            return mNote ?: super.note(col, reload)
         }
 
         /** if we have an unsaved note saved, use it instead of a collection lookup  */

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplatePreviewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplatePreviewer.kt
@@ -379,12 +379,11 @@ open class CardTemplatePreviewer : AbstractFlashcardViewer() {
         }
 
         /** if we have an unsaved note, never return empty  */
-        override val isEmpty: Boolean
-            get() = if (mNote != null) {
-                false
-            } else {
-                super.isEmpty
-            }
+        override fun isEmpty() = if (mNote != null) {
+            false
+        } else {
+            super.isEmpty()
+        }
 
         /** Override the method that fetches the model so we can render unsaved models  */
         override fun model(): Model {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplatePreviewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplatePreviewer.kt
@@ -381,10 +381,10 @@ open class CardTemplatePreviewer : AbstractFlashcardViewer() {
         }
 
         /** if we have an unsaved note, never return empty  */
-        override fun isEmpty() = if (mNote != null) {
+        override fun isEmpty(col: Collection) = if (mNote != null) {
             false
         } else {
-            super.isEmpty()
+            super.isEmpty(col)
         }
 
         /** Override the method that fetches the model so we can render unsaved models  */

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplatePreviewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplatePreviewer.kt
@@ -388,8 +388,8 @@ open class CardTemplatePreviewer : AbstractFlashcardViewer() {
         }
 
         /** Override the method that fetches the model so we can render unsaved models  */
-        override fun model(): Model {
-            return mEditedModel ?: super.model()
+        override fun model(col: Collection): Model {
+            return mEditedModel ?: super.model(col)
         }
 
         override fun render_output(col: Collection, reload: Boolean, browser: Boolean): TemplateRenderOutput {
@@ -397,7 +397,7 @@ open class CardTemplatePreviewer : AbstractFlashcardViewer() {
                 render_output = if (BackendFactory.defaultLegacySchema) {
                     col.render_output_legacy(this, reload, browser)
                 } else {
-                    val index = if (model().isCloze) {
+                    val index = if (model(col).isCloze) {
                         0
                     } else {
                         ord
@@ -405,8 +405,8 @@ open class CardTemplatePreviewer : AbstractFlashcardViewer() {
                     val context = TemplateManager.TemplateRenderContext.from_card_layout(
                         note(col),
                         this,
-                        model(),
-                        model().getJSONArray("tmpls")[index] as JSONObject,
+                        model(col),
+                        model(col).getJSONArray("tmpls")[index] as JSONObject,
                         fill_empty = false
                     )
                     context.render()

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplatePreviewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplatePreviewer.kt
@@ -390,7 +390,7 @@ open class CardTemplatePreviewer : AbstractFlashcardViewer() {
             return mEditedModel ?: super.model()
         }
 
-        override fun render_output(reload: Boolean, browser: Boolean): TemplateRenderOutput {
+        override fun render_output(col: Collection, reload: Boolean, browser: Boolean): TemplateRenderOutput {
             if (render_output == null || reload) {
                 render_output = if (BackendFactory.defaultLegacySchema) {
                     col.render_output_legacy(this, reload, browser)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplatePreviewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplatePreviewer.kt
@@ -232,7 +232,7 @@ open class CardTemplatePreviewer : AbstractFlashcardViewer() {
             // loading from the note editor
             val toPreview = setCurrentCardFromNoteEditorBundle(col)
             if (toPreview != null) {
-                mTemplateCount = col.findTemplates(toPreview.note()).size
+                mTemplateCount = col.findTemplates(toPreview.note(col)).size
                 if (mTemplateCount >= 2) {
                     previewLayout!!.showNavigationButtons()
                 }
@@ -280,7 +280,7 @@ open class CardTemplatePreviewer : AbstractFlashcardViewer() {
             currentCard!!.oDid = currentCard!!.did
         }
         currentCard!!.did = newDid
-        val currentNote = currentCard!!.note()
+        val currentNote = currentCard!!.note(col)
         val tagsList = mNoteEditorBundle!!.getStringArrayList("tags")
         NoteUtils.setTags(currentNote, tagsList)
         return currentCard
@@ -376,8 +376,8 @@ open class CardTemplatePreviewer : AbstractFlashcardViewer() {
         }
 
         /** if we have an unsaved note saved, use it instead of a collection lookup  */
-        override fun note(): Note {
-            return mNote ?: super.note()
+        override fun note(col: Collection): Note {
+            return mNote ?: super.note(col)
         }
 
         /** if we have an unsaved note, never return empty  */
@@ -403,7 +403,7 @@ open class CardTemplatePreviewer : AbstractFlashcardViewer() {
                         ord
                     }
                     val context = TemplateManager.TemplateRenderContext.from_card_layout(
-                        note(),
+                        note(col),
                         this,
                         model(),
                         model().getJSONArray("tmpls")[index] as JSONObject,

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardUtils.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardUtils.kt
@@ -3,9 +3,9 @@ package com.ichi2.anki
 
 import com.ichi2.anki.servicelayer.NoteService.isMarked
 import com.ichi2.libanki.Card
+import com.ichi2.libanki.Collection
 import com.ichi2.libanki.Note
 import com.ichi2.utils.HashUtil.HashSetInit
-import java.util.*
 
 /**
  * Utilities for working on multiple cards
@@ -14,10 +14,10 @@ object CardUtils {
     /**
      * @return List of corresponding notes without duplicates, even if the input list has multiple cards of the same note.
      */
-    fun getNotes(cards: Collection<Card>): Set<Note> {
+    fun getNotes(col: Collection, cards: kotlin.collections.Collection<Card>): Set<Note> {
         val notes: MutableSet<Note> = HashSetInit(cards.size)
         for (card in cards) {
-            notes.add(card.note())
+            notes.add(card.note(col))
         }
         return notes
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
@@ -758,7 +758,7 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
                 }
                 col.setDeck(longArrayOf(mCurrentEditedCard!!.id), deckId)
                 // refresh the card object to reflect the database changes from above
-                mCurrentEditedCard!!.load()
+                mCurrentEditedCard!!.load(col)
                 // also reload the note object
                 mEditorNote = mCurrentEditedCard!!.note()
                 // then set the card ID to the new deck

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
@@ -1885,7 +1885,7 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
         for (i in 0 until tmpls.length()) {
             var name = tmpls.getJSONObject(i).optString("name")
             // If more than one card, and we have an existing card, underline existing card
-            if (!addNote && tmpls.length() > 1 && model === mEditorNote!!.model() && mCurrentEditedCard != null && mCurrentEditedCard!!.template()
+            if (!addNote && tmpls.length() > 1 && model === mEditorNote!!.model() && mCurrentEditedCard != null && mCurrentEditedCard!!.template(col)
                 .optString("name") == name
             ) {
                 name = "<u>$name</u>"

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
@@ -319,7 +319,7 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
                     finishWithoutAnimation()
                     return
                 }
-                mEditorNote = mCurrentEditedCard!!.note()
+                mEditorNote = mCurrentEditedCard!!.note(col)
                 addNote = false
             }
             CALLER_STUDYOPTIONS, CALLER_DECKPICKER, CALLER_REVIEWER_ADD, CALLER_CARDBROWSER_ADD, CALLER_NOTEEDITOR ->
@@ -331,7 +331,7 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
                     finishWithoutAnimation()
                     return
                 }
-                mEditorNote = mCurrentEditedCard!!.note()
+                mEditorNote = mCurrentEditedCard!!.note(col)
                 addNote = false
             }
             CALLER_NOTEEDITOR_INTENT_ADD -> {
@@ -760,7 +760,7 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
                 // refresh the card object to reflect the database changes from above
                 mCurrentEditedCard!!.load(col)
                 // also reload the note object
-                mEditorNote = mCurrentEditedCard!!.note()
+                mEditorNote = mCurrentEditedCard!!.note(col)
                 // then set the card ID to the new deck
                 mCurrentEditedCard!!.did = deckId
                 modified = true

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
@@ -1121,8 +1121,8 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
         )
         // Also pass the note id and ord if not adding new note
         if (!addNote && mCurrentEditedCard != null) {
-            intent.putExtra("noteId", mCurrentEditedCard!!.note().id)
-            Timber.d("showCardTemplateEditor() with note %s", mCurrentEditedCard!!.note().id)
+            intent.putExtra("noteId", mCurrentEditedCard!!.nid)
+            Timber.d("showCardTemplateEditor() with note %s", mCurrentEditedCard!!.nid)
             intent.putExtra("ordId", mCurrentEditedCard!!.ord)
             Timber.d("showCardTemplateEditor() with ord %s", mCurrentEditedCard!!.ord)
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
@@ -605,7 +605,7 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
         // changed note type?
         if (!addNote && mCurrentEditedCard != null) {
             val newModel: JSONObject? = currentlySelectedModel
-            val oldModel: JSONObject = mCurrentEditedCard!!.model()
+            val oldModel: JSONObject = mCurrentEditedCard!!.model(col)
             if (newModel != oldModel) {
                 return true
             }
@@ -724,7 +724,7 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
         } else {
             // Check whether note type has been changed
             val newModel = currentlySelectedModel
-            val oldModel = if (mCurrentEditedCard == null) null else mCurrentEditedCard!!.model()
+            val oldModel = if (mCurrentEditedCard == null) null else mCurrentEditedCard!!.model(col)
             if (newModel != oldModel) {
                 mReloadRequired = true
                 if (mModelChangeCardMap!!.size < mEditorNote!!.numberOfCards() || mModelChangeCardMap!!.containsValue(
@@ -1983,7 +1983,7 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
     private inner class EditNoteTypeListener : OnItemSelectedListener {
         override fun onItemSelected(parent: AdapterView<*>?, view: View?, pos: Int, id: Long) {
             // Get the current model
-            val noteModelId = mCurrentEditedCard!!.model().getLong("id")
+            val noteModelId = mCurrentEditedCard!!.model(col).getLong("id")
             // Get new model
             val newModel = col.models.get(mAllModelIds!![pos])
             if (newModel == null) {
@@ -2027,7 +2027,7 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
                 updateFieldsFromStickyText()
             } else {
                 populateEditFields(FieldChangeType.refresh(shouldReplaceNewlines()), false)
-                updateCards(mCurrentEditedCard!!.model())
+                updateCards(mCurrentEditedCard!!.model(col))
                 findViewById<View>(R.id.CardEditorTagButton).isEnabled = true
                 // ((LinearLayout) findViewById(R.id.CardEditorCardsButton)).setEnabled(false);
                 mDeckSpinnerSelection!!.setEnabledActionBarSpinner(true)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
@@ -184,7 +184,11 @@ open class Reviewer :
     }
 
     override fun onResume() {
-        answerTimer.resume()
+        launchCatchingTask {
+            withCol {
+                answerTimer.resume(col)
+            }
+        }
         super.onResume()
         if (answerField != null) {
             answerField!!.focusWithKeyboard()
@@ -1138,7 +1142,7 @@ open class Reviewer :
 
     override fun displayCardQuestion() {
         // show timer, if activated in the deck's preferences
-        answerTimer.setupForCard(currentCard!!)
+        answerTimer.setupForCard(col, currentCard!!)
         delayedHide(100)
         super.displayCardQuestion()
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
@@ -264,7 +264,7 @@ open class Reviewer :
         launchCatchingTask {
             card.setUserFlag(flag)
             if (BackendFactory.defaultLegacySchema) {
-                card.flush()
+                card.flush(col)
                 /* Following code would allow to update value of {{cardFlag}}.
                Anki does not update this value when a flag is changed, so
                currently this code would do something that anki itself

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
@@ -244,7 +244,7 @@ open class Reviewer :
             return
         }
         launchCatchingTask {
-            toggleMark(card.note())
+            toggleMark(card.note(col))
             refreshActionBar()
             onMarkChanged()
         }
@@ -732,7 +732,7 @@ open class Reviewer :
         mActionButtons.setCustomButtonsStatus(menu)
         var alpha = if (super.controlBlocked !== ReviewerUi.ControlBlock.SLOW) Themes.ALPHA_ICON_ENABLED_LIGHT else Themes.ALPHA_ICON_DISABLED_LIGHT
         val markCardIcon = menu.findItem(R.id.action_mark_card)
-        if (currentCard != null && isMarked(currentCard!!.note())) {
+        if (currentCard != null && isMarked(currentCard!!.note(col))) {
             markCardIcon.setTitle(R.string.menu_unmark_note).setIcon(R.drawable.ic_star_white)
         } else {
             markCardIcon.setTitle(R.string.menu_mark_note).setIcon(R.drawable.ic_star_border_white)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/CardAppearance.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/CardAppearance.kt
@@ -19,6 +19,7 @@ import android.content.SharedPreferences
 import androidx.annotation.CheckResult
 import com.ichi2.anki.reviewer.ReviewerCustomFonts
 import com.ichi2.libanki.Card
+import com.ichi2.libanki.Collection
 import com.ichi2.themes.Theme
 import com.ichi2.themes.Themes.currentTheme
 
@@ -91,8 +92,8 @@ class CardAppearance(private val customFonts: ReviewerCustomFonts, private val c
         /**
          * hasUserDefinedNightMode finds out if the user has included class .night_mode in card's stylesheet
          */
-        fun hasUserDefinedNightMode(card: Card): Boolean {
-            return card.css().contains(nightModeClassRegex)
+        fun hasUserDefinedNightMode(col: Collection, card: Card): Boolean {
+            return card.css(col).contains(nightModeClassRegex)
         }
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/CardHtml.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/CardHtml.kt
@@ -186,8 +186,8 @@ class CardHtml(
         /**
          * @return the answer part of this card's template as entered by user, without any parsing
          */
-        private fun getAnswerFormat(card: Card): String {
-            val model = card.model()
+        private fun getAnswerFormat(col: Collection, card: Card): String {
+            val model = card.model(col)
             val template: JSONObject = if (model.isStd) {
                 model.getJSONArray("tmpls").getJSONObject(card.ord)
             } else {
@@ -204,7 +204,7 @@ class CardHtml(
          * @return The content stripped of audio due to {{FrontSide}} inclusion.
          */
         fun removeFrontSideAudio(col: Collection, card: Card, answerContent: String): String {
-            val answerFormat = getAnswerFormat(card)
+            val answerFormat = getAnswerFormat(col, card)
             var newAnswerContent = answerContent
             if (answerFormat.contains("{{FrontSide}}")) { // possible audio removal necessary
                 val frontSideFormat = card.render_output(col, false).question_text

--- a/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/CardHtml.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/CardHtml.kt
@@ -217,10 +217,10 @@ class CardHtml(
             return newAnswerContent
         }
 
-        fun legacyGetTtsTags(card: Card, cardSide: SingleSoundSide, context: Context): List<TTSTag> {
+        fun legacyGetTtsTags(col: Collection, card: Card, cardSide: SingleSoundSide, context: Context): List<TTSTag> {
             val cardSideContent: String = when (cardSide) {
                 QUESTION -> card.q(true)
-                ANSWER -> card.pureAnswer()
+                ANSWER -> card.pureAnswer(col)
             }
             return TtsParser.getTextsToRead(cardSideContent, context.getString(R.string.reviewer_tts_cloze_spoken_replacement))
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/CardHtml.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/CardHtml.kt
@@ -135,7 +135,7 @@ class CardHtml(
         fun createInstance(col: Collection, card: Card, reload: Boolean, side: Side, context: HtmlGenerator): CardHtml {
             val content = displayString(col, card, reload, side, context)
 
-            val nightModeInversion = currentTheme.isNightMode && !hasUserDefinedNightMode(card)
+            val nightModeInversion = currentTheme.isNightMode && !hasUserDefinedNightMode(col, card)
 
             val renderOutput = card.render_output(col)
             val questionAv = renderOutput.question_av_tags

--- a/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/CardHtml.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/CardHtml.kt
@@ -157,7 +157,7 @@ class CardHtml(
          * TODO: This is no longer entirely true as more post-processing occurs
          */
         private fun displayString(card: Card, reload: Boolean, side: Side, context: HtmlGenerator): String {
-            if (side == Side.FRONT && card.isEmpty) {
+            if (side == Side.FRONT && card.isEmpty()) {
                 return context.resources.getString(R.string.empty_card_warning)
             }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/CardHtml.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/CardHtml.kt
@@ -219,7 +219,7 @@ class CardHtml(
         fun legacyGetTtsTags(card: Card, cardSide: SingleSoundSide, context: Context): List<TTSTag> {
             val cardSideContent: String = when (cardSide) {
                 QUESTION -> card.q(true)
-                ANSWER -> card.pureAnswer
+                ANSWER -> card.pureAnswer()
             }
             return TtsParser.getTextsToRead(cardSideContent, context.getString(R.string.reviewer_tts_cloze_spoken_replacement))
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/CardHtml.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/CardHtml.kt
@@ -162,7 +162,7 @@ class CardHtml(
                 return context.resources.getString(R.string.empty_card_warning)
             }
 
-            var content: String = if (side == Side.FRONT) card.q(reload) else card.a()
+            var content: String = if (side == Side.FRONT) card.q(col, reload) else card.a()
             content = Media.escapeImages(content)
             content = context.filterTypeAnswer(content, side)
             Timber.v("question: '%s'", content)
@@ -219,7 +219,7 @@ class CardHtml(
 
         fun legacyGetTtsTags(col: Collection, card: Card, cardSide: SingleSoundSide, context: Context): List<TTSTag> {
             val cardSideContent: String = when (cardSide) {
-                QUESTION -> card.q(true)
+                QUESTION -> card.q(col, true)
                 ANSWER -> card.pureAnswer(col)
             }
             return TtsParser.getTextsToRead(cardSideContent, context.getString(R.string.reviewer_tts_cloze_spoken_replacement))

--- a/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/CardHtml.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/CardHtml.kt
@@ -133,7 +133,7 @@ class CardHtml(
 
     companion object {
         fun createInstance(col: Collection, card: Card, reload: Boolean, side: Side, context: HtmlGenerator): CardHtml {
-            val content = displayString(card, reload, side, context)
+            val content = displayString(col, card, reload, side, context)
 
             val nightModeInversion = currentTheme.isNightMode && !hasUserDefinedNightMode(card)
 
@@ -157,8 +157,8 @@ class CardHtml(
          * Or warning if required
          * TODO: This is no longer entirely true as more post-processing occurs
          */
-        private fun displayString(card: Card, reload: Boolean, side: Side, context: HtmlGenerator): String {
-            if (side == Side.FRONT && card.isEmpty()) {
+        private fun displayString(col: Collection, card: Card, reload: Boolean, side: Side, context: HtmlGenerator): String {
+            if (side == Side.FRONT && card.isEmpty(col)) {
                 return context.resources.getString(R.string.empty_card_warning)
             }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/CardHtml.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/CardHtml.kt
@@ -146,7 +146,7 @@ class CardHtml(
                 if (!BackendFactory.defaultLegacySchema) answerAv.filterIsInstance(SoundOrVideoTag::class.java) else null
 
             // legacy (slow) function to return the answer without the front side
-            fun getAnswerWithoutFrontSideLegacy(): String = removeFrontSideAudio(col, card, card.a())
+            fun getAnswerWithoutFrontSideLegacy(): String = removeFrontSideAudio(col, card, card.a(col))
 
             return CardHtml(content, card.ord, nightModeInversion, context, side, ::getAnswerWithoutFrontSideLegacy, questionSound, answerSound)
         }
@@ -162,7 +162,7 @@ class CardHtml(
                 return context.resources.getString(R.string.empty_card_warning)
             }
 
-            var content: String = if (side == Side.FRONT) card.q(col, reload) else card.a()
+            var content: String = if (side == Side.FRONT) card.q(col, reload) else card.a(col)
             content = Media.escapeImages(content)
             content = context.filterTypeAnswer(content, side)
             Timber.v("question: '%s'", content)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/HtmlGenerator.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/HtmlGenerator.kt
@@ -22,6 +22,7 @@ import androidx.annotation.CheckResult
 import com.ichi2.anki.AnkiDroidApp
 import com.ichi2.anki.reviewer.ReviewerCustomFonts
 import com.ichi2.libanki.Card
+import com.ichi2.libanki.Collection
 import com.ichi2.libanki.Sound
 import com.ichi2.libanki.Utils
 import timber.log.Timber
@@ -36,8 +37,8 @@ class HtmlGenerator(
 ) {
 
     @CheckResult
-    fun generateHtml(card: Card, reload: Boolean, side: Side): CardHtml {
-        return CardHtml.createInstance(card, reload, side, this)
+    fun generateHtml(col: Collection, card: Card, reload: Boolean, side: Side): CardHtml {
+        return CardHtml.createInstance(col, card, reload, side, this)
     }
 
     fun filterTypeAnswer(content: String, side: Side): String {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/TTS.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/TTS.kt
@@ -43,8 +43,8 @@ class TTS {
      * @param card The card to check the type of before determining the ordinal.
      * @return The card ordinal. If it's a Cloze card, returns 0.
      */
-    private fun getOrdUsingCardType(card: Card): Int {
-        return if (card.model().isCloze) {
+    private fun getOrdUsingCardType(col: Collection, card: Card): Int {
+        return if (card.model(col).isCloze) {
             0
         } else {
             card.ord
@@ -57,8 +57,8 @@ class TTS {
      * @param card     The card to play TTS for
      * @param cardSide The side of the current card to play TTS for
      */
-    fun readCardText(ttsTags: List<TTSTag>, card: Card, cardSide: SoundSide) {
-        ReadText.readCardSide(ttsTags, cardSide, CardUtils.getDeckIdForCard(card), getOrdUsingCardType(card))
+    fun readCardText(col: Collection, ttsTags: List<TTSTag>, card: Card, cardSide: SoundSide) {
+        ReadText.readCardSide(ttsTags, cardSide, CardUtils.getDeckIdForCard(card), getOrdUsingCardType(col, card))
     }
 
     /**
@@ -73,7 +73,7 @@ class TTS {
         ReadText.selectTts(
             getTextForTts(context, textToRead),
             CardUtils.getDeckIdForCard(card),
-            getOrdUsingCardType(card),
+            getOrdUsingCardType(col, card),
             qa
         )
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/TTS.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/TTS.kt
@@ -68,7 +68,7 @@ class TTS {
      * @param qa   The card question or card answer
      */
     fun selectTts(col: Collection, context: Context, card: Card, qa: SoundSide) {
-        val textToRead = if (qa == SoundSide.QUESTION) card.q(true) else card.pureAnswer(col)
+        val textToRead = if (qa == SoundSide.QUESTION) card.q(col, true) else card.pureAnswer(col)
         // get the text from the card
         ReadText.selectTts(
             getTextForTts(context, textToRead),

--- a/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/TTS.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/TTS.kt
@@ -23,6 +23,7 @@ import com.ichi2.anki.CardUtils
 import com.ichi2.anki.R
 import com.ichi2.anki.ReadText
 import com.ichi2.libanki.Card
+import com.ichi2.libanki.Collection
 import com.ichi2.libanki.Sound.SoundSide
 import com.ichi2.libanki.TTSTag
 import com.ichi2.libanki.Utils
@@ -66,8 +67,8 @@ class TTS {
      * @param card The card to read text from
      * @param qa   The card question or card answer
      */
-    fun selectTts(context: Context, card: Card, qa: SoundSide) {
-        val textToRead = if (qa == SoundSide.QUESTION) card.q(true) else card.pureAnswer()
+    fun selectTts(col: Collection, context: Context, card: Card, qa: SoundSide) {
+        val textToRead = if (qa == SoundSide.QUESTION) card.q(true) else card.pureAnswer(col)
         // get the text from the card
         ReadText.selectTts(
             getTextForTts(context, textToRead),

--- a/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/TTS.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/TTS.kt
@@ -67,7 +67,7 @@ class TTS {
      * @param qa   The card question or card answer
      */
     fun selectTts(context: Context, card: Card, qa: SoundSide) {
-        val textToRead = if (qa == SoundSide.QUESTION) card.q(true) else card.pureAnswer
+        val textToRead = if (qa == SoundSide.QUESTION) card.q(true) else card.pureAnswer()
         // get the text from the card
         ReadText.selectTts(
             getTextForTts(context, textToRead),

--- a/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/TypeAnswer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/TypeAnswer.kt
@@ -100,7 +100,7 @@ class TypeAnswer(
             fldTag = fldTag.split(":").toTypedArray()[1]
         }
         // loop through fields for a match
-        val flds: JSONArray = card.model().getJSONArray("flds")
+        val flds: JSONArray = card.model(col).getJSONArray("flds")
         for (fld in flds.jsonObjectIterable()) {
             val name = fld.getString("name")
             if (name == fldTag) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/TypeAnswer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/TypeAnswer.kt
@@ -86,7 +86,7 @@ class TypeAnswer(
      */
     fun updateInfo(col: Collection, card: Card, res: Resources) {
         correct = null
-        val q = card.q(false)
+        val q = card.q(col, false)
         val m = PATTERN.matcher(q)
         var clozeIdx = 0
         if (!m.find()) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/TypeAnswer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/TypeAnswer.kt
@@ -23,6 +23,7 @@ import com.ichi2.anki.R
 import com.ichi2.anki.servicelayer.LanguageHint
 import com.ichi2.anki.servicelayer.LanguageHintService
 import com.ichi2.libanki.Card
+import com.ichi2.libanki.Collection
 import com.ichi2.libanki.Sound
 import com.ichi2.libanki.Utils
 import com.ichi2.utils.DiffEngine
@@ -83,7 +84,7 @@ class TypeAnswer(
      * Extract type answer/cloze text and font/size
      * @param card The next card to display
      */
-    fun updateInfo(card: Card, res: Resources) {
+    fun updateInfo(col: Collection, card: Card, res: Resources) {
         correct = null
         val q = card.q(false)
         val m = PATTERN.matcher(q)
@@ -103,7 +104,7 @@ class TypeAnswer(
         for (fld in flds.jsonObjectIterable()) {
             val name = fld.getString("name")
             if (name == fldTag) {
-                correct = card.note().getItem(name)
+                correct = card.note(col).getItem(name)
                 if (clozeIdx != 0) {
                     // narrow to cloze
                     correct = contentForCloze(correct!!, clozeIdx)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/provider/CardContentProvider.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/provider/CardContentProvider.kt
@@ -467,7 +467,7 @@ class CardContentProvider : ContentProvider() {
                     Timber.d("CardContentProvider: Moving card to other deck...")
                     col.decks.flush()
                     currentCard.did = did
-                    currentCard.flush()
+                    currentCard.flush(col)
                     col.save()
                     updated++
                 } else {
@@ -752,7 +752,7 @@ class CardContentProvider : ContentProvider() {
                 col.addNote(newNote, allowEmpty)
                 for (card: Card in newNote.cards()) {
                     card.did = deckId
-                    card.flush()
+                    card.flush(col)
                 }
                 result++
             }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/provider/CardContentProvider.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/provider/CardContentProvider.kt
@@ -1076,7 +1076,7 @@ class CardContentProvider : ContentProvider() {
                 FlashCardsContract.Card.QUESTION -> rb.add(question)
                 FlashCardsContract.Card.ANSWER -> rb.add(answer)
                 FlashCardsContract.Card.QUESTION_SIMPLE -> rb.add(currentCard.qSimple())
-                FlashCardsContract.Card.ANSWER_SIMPLE -> rb.add(currentCard.render_output(false).answer_text)
+                FlashCardsContract.Card.ANSWER_SIMPLE -> rb.add(currentCard.render_output(col, false).answer_text)
                 FlashCardsContract.Card.ANSWER_PURE -> rb.add(currentCard.pureAnswer())
                 else -> throw UnsupportedOperationException("Queue \"$column\" is unknown")
             }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/provider/CardContentProvider.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/provider/CardContentProvider.kt
@@ -1065,7 +1065,7 @@ class CardContentProvider : ContentProvider() {
             throw IllegalArgumentException("Card is using an invalid template", je)
         }
         val question = currentCard.q(col)
-        val answer = currentCard.a()
+        val answer = currentCard.a(col)
         val rb = rv.newRow()
         for (column in columns) {
             when (column) {
@@ -1091,7 +1091,7 @@ class CardContentProvider : ContentProvider() {
                 FlashCardsContract.ReviewInfo.CARD_ORD -> rb.add(currentCard.ord)
                 FlashCardsContract.ReviewInfo.BUTTON_COUNT -> rb.add(buttonCount)
                 FlashCardsContract.ReviewInfo.NEXT_REVIEW_TIMES -> rb.add(nextReviewTimesJson.toString())
-                FlashCardsContract.ReviewInfo.MEDIA_FILES -> rb.add(JSONArray(col.media.filesInStr(currentCard.note(col).mid, currentCard.q(col) + currentCard.a())))
+                FlashCardsContract.ReviewInfo.MEDIA_FILES -> rb.add(JSONArray(col.media.filesInStr(currentCard.note(col).mid, currentCard.q(col) + currentCard.a(col))))
                 else -> throw UnsupportedOperationException("Queue \"$column\" is unknown")
             }
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/provider/CardContentProvider.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/provider/CardContentProvider.kt
@@ -1069,7 +1069,7 @@ class CardContentProvider : ContentProvider() {
         val rb = rv.newRow()
         for (column in columns) {
             when (column) {
-                FlashCardsContract.Card.NOTE_ID -> rb.add(currentCard.note().id)
+                FlashCardsContract.Card.NOTE_ID -> rb.add(currentCard.nid)
                 FlashCardsContract.Card.CARD_ORD -> rb.add(currentCard.ord)
                 FlashCardsContract.Card.CARD_NAME -> rb.add(cardName)
                 FlashCardsContract.Card.DECK_ID -> rb.add(currentCard.did)
@@ -1087,7 +1087,7 @@ class CardContentProvider : ContentProvider() {
         val rb = rv.newRow()
         for (column in columns) {
             when (column) {
-                FlashCardsContract.Card.NOTE_ID -> rb.add(currentCard.note().id)
+                FlashCardsContract.Card.NOTE_ID -> rb.add(currentCard.nid)
                 FlashCardsContract.ReviewInfo.CARD_ORD -> rb.add(currentCard.ord)
                 FlashCardsContract.ReviewInfo.BUTTON_COUNT -> rb.add(buttonCount)
                 FlashCardsContract.ReviewInfo.NEXT_REVIEW_TIMES -> rb.add(nextReviewTimesJson.toString())

--- a/AnkiDroid/src/main/java/com/ichi2/anki/provider/CardContentProvider.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/provider/CardContentProvider.kt
@@ -1091,7 +1091,7 @@ class CardContentProvider : ContentProvider() {
                 FlashCardsContract.ReviewInfo.CARD_ORD -> rb.add(currentCard.ord)
                 FlashCardsContract.ReviewInfo.BUTTON_COUNT -> rb.add(buttonCount)
                 FlashCardsContract.ReviewInfo.NEXT_REVIEW_TIMES -> rb.add(nextReviewTimesJson.toString())
-                FlashCardsContract.ReviewInfo.MEDIA_FILES -> rb.add(JSONArray(col.media.filesInStr(currentCard.note().mid, currentCard.q() + currentCard.a())))
+                FlashCardsContract.ReviewInfo.MEDIA_FILES -> rb.add(JSONArray(col.media.filesInStr(currentCard.note(col).mid, currentCard.q() + currentCard.a())))
                 else -> throw UnsupportedOperationException("Queue \"$column\" is unknown")
             }
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/provider/CardContentProvider.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/provider/CardContentProvider.kt
@@ -1064,7 +1064,7 @@ class CardContentProvider : ContentProvider() {
         } catch (je: JSONException) {
             throw IllegalArgumentException("Card is using an invalid template", je)
         }
-        val question = currentCard.q()
+        val question = currentCard.q(col)
         val answer = currentCard.a()
         val rb = rv.newRow()
         for (column in columns) {
@@ -1091,7 +1091,7 @@ class CardContentProvider : ContentProvider() {
                 FlashCardsContract.ReviewInfo.CARD_ORD -> rb.add(currentCard.ord)
                 FlashCardsContract.ReviewInfo.BUTTON_COUNT -> rb.add(buttonCount)
                 FlashCardsContract.ReviewInfo.NEXT_REVIEW_TIMES -> rb.add(nextReviewTimesJson.toString())
-                FlashCardsContract.ReviewInfo.MEDIA_FILES -> rb.add(JSONArray(col.media.filesInStr(currentCard.note(col).mid, currentCard.q() + currentCard.a())))
+                FlashCardsContract.ReviewInfo.MEDIA_FILES -> rb.add(JSONArray(col.media.filesInStr(currentCard.note(col).mid, currentCard.q(col) + currentCard.a())))
                 else -> throw UnsupportedOperationException("Queue \"$column\" is unknown")
             }
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/provider/CardContentProvider.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/provider/CardContentProvider.kt
@@ -1077,7 +1077,7 @@ class CardContentProvider : ContentProvider() {
                 FlashCardsContract.Card.ANSWER -> rb.add(answer)
                 FlashCardsContract.Card.QUESTION_SIMPLE -> rb.add(currentCard.qSimple(col))
                 FlashCardsContract.Card.ANSWER_SIMPLE -> rb.add(currentCard.render_output(col, false).answer_text)
-                FlashCardsContract.Card.ANSWER_PURE -> rb.add(currentCard.pureAnswer())
+                FlashCardsContract.Card.ANSWER_PURE -> rb.add(currentCard.pureAnswer(col))
                 else -> throw UnsupportedOperationException("Queue \"$column\" is unknown")
             }
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/provider/CardContentProvider.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/provider/CardContentProvider.kt
@@ -1075,7 +1075,7 @@ class CardContentProvider : ContentProvider() {
                 FlashCardsContract.Card.DECK_ID -> rb.add(currentCard.did)
                 FlashCardsContract.Card.QUESTION -> rb.add(question)
                 FlashCardsContract.Card.ANSWER -> rb.add(answer)
-                FlashCardsContract.Card.QUESTION_SIMPLE -> rb.add(currentCard.qSimple())
+                FlashCardsContract.Card.QUESTION_SIMPLE -> rb.add(currentCard.qSimple(col))
                 FlashCardsContract.Card.ANSWER_SIMPLE -> rb.add(currentCard.render_output(col, false).answer_text)
                 FlashCardsContract.Card.ANSWER_PURE -> rb.add(currentCard.pureAnswer())
                 else -> throw UnsupportedOperationException("Queue \"$column\" is unknown")

--- a/AnkiDroid/src/main/java/com/ichi2/anki/provider/CardContentProvider.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/provider/CardContentProvider.kt
@@ -1077,7 +1077,7 @@ class CardContentProvider : ContentProvider() {
                 FlashCardsContract.Card.ANSWER -> rb.add(answer)
                 FlashCardsContract.Card.QUESTION_SIMPLE -> rb.add(currentCard.qSimple())
                 FlashCardsContract.Card.ANSWER_SIMPLE -> rb.add(currentCard.render_output(false).answer_text)
-                FlashCardsContract.Card.ANSWER_PURE -> rb.add(currentCard.pureAnswer)
+                FlashCardsContract.Card.ANSWER_PURE -> rb.add(currentCard.pureAnswer())
                 else -> throw UnsupportedOperationException("Queue \"$column\" is unknown")
             }
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/provider/CardContentProvider.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/provider/CardContentProvider.kt
@@ -1060,7 +1060,7 @@ class CardContentProvider : ContentProvider() {
 
     private fun addCardToCursor(currentCard: Card, rv: MatrixCursor, @Suppress("UNUSED_PARAMETER") col: Collection, columns: Array<String>) {
         val cardName: String = try {
-            currentCard.template().getString("name")
+            currentCard.template(col).getString("name")
         } catch (je: JSONException) {
             throw IllegalArgumentException("Card is using an invalid template", je)
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/AnswerTimer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/AnswerTimer.kt
@@ -23,6 +23,7 @@ import android.widget.Chronometer
 import androidx.annotation.VisibleForTesting
 import com.ichi2.anki.R
 import com.ichi2.libanki.Card
+import com.ichi2.libanki.Collection
 import com.ichi2.themes.Themes.getColorFromAttr
 
 /**
@@ -56,7 +57,7 @@ class AnswerTimer(private val cardTimer: Chronometer) {
      *
      * This may also change the limit, based on [Card.timeLimit]
      */
-    fun setupForCard(newCard: Card) {
+    fun setupForCard(col: Collection, newCard: Card) {
         currentCard = newCard
         showTimer = newCard.showTimer()
         if (showTimer && cardTimer.visibility == View.INVISIBLE) {
@@ -69,11 +70,11 @@ class AnswerTimer(private val cardTimer: Chronometer) {
         if (!showTimer) {
             cardTimer.stop()
         } else {
-            resetTimerUI(newCard)
+            resetTimerUI(col, newCard)
         }
     }
 
-    private fun resetTimerUI(newCard: Card) {
+    private fun resetTimerUI(col: Collection, newCard: Card) {
         // Set normal timer color
         cardTimer.setTextColor(getColorFromAttr(context, android.R.attr.textColor))
 
@@ -81,7 +82,7 @@ class AnswerTimer(private val cardTimer: Chronometer) {
         cardTimer.start()
 
         // Stop and highlight the timer if it reaches the time limit.
-        limit = newCard.timeLimit()
+        limit = newCard.timeLimit(col)
         cardTimer.setOnChronometerTickListener { chronometer: Chronometer ->
             val elapsed: Long = elapsedRealTime - chronometer.base
             if (elapsed >= limit) {
@@ -102,7 +103,7 @@ class AnswerTimer(private val cardTimer: Chronometer) {
         currentCard.stopTimer()
     }
 
-    fun resume() {
+    fun resume(col: Collection) {
         if (!this::currentCard.isInitialized) {
             return
         }
@@ -117,7 +118,7 @@ class AnswerTimer(private val cardTimer: Chronometer) {
         // timeTaken() seconds ago.
         cardTimer.base = elapsedRealTime - currentCard.timeTaken()
         // Don't start the timer if we have already reached the time limit or it will tick over
-        if (elapsedRealTime - cardTimer.base < currentCard.timeLimit()) {
+        if (elapsedRealTime - cardTimer.base < currentCard.timeLimit(col)) {
             cardTimer.start()
         }
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/AnswerTimer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/AnswerTimer.kt
@@ -115,8 +115,8 @@ class AnswerTimer(private val cardTimer: Chronometer) {
             return
         }
         // Then update and resume the UI timer. Set the base time as if the timer had started
-        // timeTaken() seconds ago.
-        cardTimer.base = elapsedRealTime - currentCard.timeTaken()
+        // timeTaken(col) seconds ago.
+        cardTimer.base = elapsedRealTime - currentCard.timeTaken(col)
         // Don't start the timer if we have already reached the time limit or it will tick over
         if (elapsedRealTime - cardTimer.base < currentCard.timeLimit(col)) {
             cardTimer.start()

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/AnswerTimer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/AnswerTimer.kt
@@ -59,7 +59,7 @@ class AnswerTimer(private val cardTimer: Chronometer) {
      */
     fun setupForCard(col: Collection, newCard: Card) {
         currentCard = newCard
-        showTimer = newCard.showTimer()
+        showTimer = newCard.showTimer(col)
         if (showTimer && cardTimer.visibility == View.INVISIBLE) {
             cardTimer.visibility = View.VISIBLE
         } else if (!showTimer && cardTimer.visibility != View.INVISIBLE) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/CardService.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/CardService.kt
@@ -27,6 +27,7 @@ object CardService {
      */
     fun selectedNoteIds(selectedCardIds: List<Long>, col: com.ichi2.libanki.Collection) =
         CardUtils.getNotes(
+            col,
             selectedCardIds.map { col.getCard(it) }
         ).map { it.id }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/NoteService.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/NoteService.kt
@@ -240,7 +240,7 @@ object NoteService {
     }
 }
 
-fun Card.totalLapsesOfNote() = NoteService.totalLapses(note(col))
+fun Card.totalLapsesOfNote(col: com.ichi2.libanki.Collection) = NoteService.totalLapses(note(col))
 
 fun Card.totalReviewsForNote() = NoteService.totalReviews(note(col))
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/NoteService.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/NoteService.kt
@@ -26,7 +26,12 @@ import com.ichi2.anki.CollectionManager.withCol
 import com.ichi2.anki.CrashReportService
 import com.ichi2.anki.FieldEditText
 import com.ichi2.anki.multimediacard.IMultimediaEditableNote
-import com.ichi2.anki.multimediacard.fields.*
+import com.ichi2.anki.multimediacard.fields.AudioRecordingField
+import com.ichi2.anki.multimediacard.fields.EFieldType
+import com.ichi2.anki.multimediacard.fields.IField
+import com.ichi2.anki.multimediacard.fields.ImageField
+import com.ichi2.anki.multimediacard.fields.MediaClipField
+import com.ichi2.anki.multimediacard.fields.TextField
 import com.ichi2.anki.multimediacard.impl.MultimediaEditableNote
 import com.ichi2.libanki.Card
 import com.ichi2.libanki.Consts
@@ -235,8 +240,8 @@ object NoteService {
     }
 }
 
-fun Card.totalLapsesOfNote() = NoteService.totalLapses(note())
+fun Card.totalLapsesOfNote() = NoteService.totalLapses(note(col))
 
-fun Card.totalReviewsForNote() = NoteService.totalReviews(note())
+fun Card.totalReviewsForNote() = NoteService.totalReviews(note(col))
 
-fun Card.avgIntervalOfNote() = NoteService.avgInterval(note())
+fun Card.avgIntervalOfNote() = NoteService.avgInterval(note(col))

--- a/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/NoteService.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/NoteService.kt
@@ -244,4 +244,4 @@ fun Card.totalLapsesOfNote(col: com.ichi2.libanki.Collection) = NoteService.tota
 
 fun Card.totalReviewsForNote(col: com.ichi2.libanki.Collection) = NoteService.totalReviews(note(col))
 
-fun Card.avgIntervalOfNote() = NoteService.avgInterval(note(col))
+fun Card.avgIntervalOfNote(col: com.ichi2.libanki.Collection) = NoteService.avgInterval(note(col))

--- a/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/NoteService.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/NoteService.kt
@@ -242,6 +242,6 @@ object NoteService {
 
 fun Card.totalLapsesOfNote(col: com.ichi2.libanki.Collection) = NoteService.totalLapses(note(col))
 
-fun Card.totalReviewsForNote() = NoteService.totalReviews(note(col))
+fun Card.totalReviewsForNote(col: com.ichi2.libanki.Collection) = NoteService.totalReviews(note(col))
 
 fun Card.avgIntervalOfNote() = NoteService.avgInterval(note(col))

--- a/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/SchedulerService.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/SchedulerService.kt
@@ -20,14 +20,18 @@ import androidx.annotation.StringRes
 import com.ichi2.anki.CrashReportService
 import com.ichi2.anki.R
 import com.ichi2.anki.servicelayer.SchedulerService.NextCard
-import com.ichi2.libanki.*
+import com.ichi2.libanki.Card
+import com.ichi2.libanki.Collection
+import com.ichi2.libanki.Consts
+import com.ichi2.libanki.Note
+import com.ichi2.libanki.UndoAction
 import com.ichi2.libanki.UndoAction.Companion.revertCardToProvidedState
 import com.ichi2.libanki.UndoAction.UndoNameId
+import com.ichi2.libanki.Utils
 import com.ichi2.utils.Computation
 import timber.log.Timber
-import java.util.*
+import java.util.Optional
 import java.util.concurrent.CancellationException
-import kotlin.collections.ArrayList
 import com.ichi2.libanki.Collection as AnkiCollection
 
 typealias NextCardAnd<T> = Computation<NextCard<T>>
@@ -56,15 +60,15 @@ class SchedulerService {
 
     class GetCard : ActionAndNextCard() {
         override fun execute(): ComputeResult {
-            return getCard(this)
+            return getCard(col, this)
         }
 
         companion object {
-            fun getCard(getCard: ActionAndNextCard): ComputeResult {
+            fun getCard(col: Collection, getCard: ActionAndNextCard): ComputeResult {
                 val sched = getCard.col.sched
                 Timber.i("Obtaining card")
                 val newCard = sched.card
-                newCard?.render_output(true)
+                newCard?.render_output(col, true)
                 return Computation.ok(NextCard.withNoResult(newCard))
             }
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/SchedulerService.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/SchedulerService.kt
@@ -87,7 +87,7 @@ class SchedulerService {
                 // collect undo information
                 col.markUndo(UndoAction.revertNoteToProvidedState(R.string.menu_bury_note, card))
                 // then bury
-                col.sched.buryNote(card.note().id)
+                col.sched.buryNote(card.nid)
             }
         }
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/SchedulerService.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/SchedulerService.kt
@@ -89,7 +89,7 @@ class SchedulerService {
         override fun execute(): ComputeResult {
             return computeThenGetNextCardInTransaction {
                 // collect undo information
-                col.markUndo(UndoAction.revertNoteToProvidedState(R.string.menu_bury_note, card))
+                col.markUndo(UndoAction.revertNoteToProvidedState(col, R.string.menu_bury_note, card))
                 // then bury
                 col.sched.buryNote(card.nid)
             }
@@ -99,7 +99,7 @@ class SchedulerService {
     class DeleteNote(val card: Card) : ActionAndNextCard() {
         override fun execute(): ComputeResult {
             return computeThenGetNextCardInTransaction {
-                val note: Note = card.note()
+                val note: Note = card.note(col)
                 // collect undo information
                 val allCs = note.cards()
                 col.markUndo(UndoDeleteNote(note, allCs, card))
@@ -129,12 +129,12 @@ class SchedulerService {
         override fun execute(): ComputeResult {
             return computeThenGetNextCardInTransaction {
                 // collect undo information
-                val cards = card.note().cards()
+                val cards = card.note(col).cards()
                 val cids = LongArray(cards.size)
                 for (i in cards.indices) {
                     cids[i] = cards[i].id
                 }
-                col.markUndo(UndoAction.revertNoteToProvidedState(R.string.menu_suspend_note, card))
+                col.markUndo(UndoAction.revertNoteToProvidedState(col, R.string.menu_suspend_note, card))
                 // suspend note
                 col.sched.suspendCards(cids)
             }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/SchedulerService.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/SchedulerService.kt
@@ -185,7 +185,7 @@ class SchedulerService {
             note.flush(note.mod, false)
             ids.add(note.id)
             for (c in allCs) {
-                c.flush(false)
+                c.flush(col, false)
                 ids.add(c.id)
             }
             col.db.execute("DELETE FROM graves WHERE oid IN " + Utils.ids2str(ids))
@@ -201,7 +201,7 @@ class SchedulerService {
         override fun undo(col: AnkiCollection): Card? {
             Timber.i("Undoing action of type %s on %d cards", javaClass, cardsCopied.size)
             for (card in cardsCopied) {
-                card.flush(false)
+                card.flush(col, false)
             }
             // /* card schedule change undone, reset and get
             // new card */

--- a/AnkiDroid/src/main/java/com/ichi2/async/CollectionOperations.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/async/CollectionOperations.kt
@@ -54,7 +54,7 @@ fun updateCard(
             // TODO: undo integration
             editNote.flush()
             // flush card too, in case, did has been changed
-            editCard.flush()
+            editCard.flush(col)
         }
     } else {
         // TODO: the proper way to do this would be to call this in undoableOp() in a coroutine
@@ -415,7 +415,7 @@ fun changeDeckMulti(
             val note = card.note(col)
             note.flush()
             // flush card too, in case, did has been changed
-            card.flush()
+            card.flush(col)
         }
         val changeDeckMulti: UndoAction = UndoChangeDeckMulti(cards, originalDids)
         // mark undo for all at once

--- a/AnkiDroid/src/main/java/com/ichi2/async/CollectionOperations.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/async/CollectionOperations.kt
@@ -48,7 +48,7 @@ fun updateCard(
 ): Card {
     Timber.d("doInBackgroundUpdateNote")
     // Save the note
-    val editNote = editCard.note()
+    val editNote = editCard.note(col)
     if (BackendFactory.defaultLegacySchema) {
         col.db.executeInTransaction {
             // TODO: undo integration
@@ -238,14 +238,14 @@ suspend fun renderBrowserQA(
  * Goes through selected cards and checks selected and marked attribute
  * @return If there are unselected cards, if there are unmarked cards
  */
-suspend fun checkCardSelection(checkedCards: Set<CardBrowser.CardCache>): Pair<Boolean, Boolean> = withContext(Dispatchers.IO) {
+suspend fun checkCardSelection(col: Collection, checkedCards: Set<CardBrowser.CardCache>): Pair<Boolean, Boolean> = withContext(Dispatchers.IO) {
     var hasUnsuspended = false
     var hasUnmarked = false
     for (c in checkedCards) {
         ensureActive() // check if job is not cancelled
         val card = c.card
         hasUnsuspended = hasUnsuspended || card.queue != Consts.QUEUE_TYPE_SUSPENDED
-        hasUnmarked = hasUnmarked || !NoteService.isMarked(card.note())
+        hasUnmarked = hasUnmarked || !NoteService.isMarked(card.note(col))
         if (hasUnsuspended && hasUnmarked) break
     }
     Pair(hasUnsuspended, hasUnmarked)
@@ -313,7 +313,7 @@ fun deleteMultipleNotes(
         val sched = col.sched
         // list of all ids to pass to remNotes method.
         // Need Set (-> unique) so we don't pass duplicates to col.remNotes()
-        val notes = CardUtils.getNotes(listOf(*cards))
+        val notes = CardUtils.getNotes(col, listOf(*cards))
         val allCards = CardUtils.getAllCards(notes)
         // delete note
         val uniqueNoteIds = LongArray(notes.size)
@@ -412,7 +412,7 @@ fun changeDeckMulti(
             originalDids[i] = card.did
             // then set the card ID to the new deck
             card.did = newDid
-            val note = card.note()
+            val note = card.note(col)
             note.flush()
             // flush card too, in case, did has been changed
             card.flush()

--- a/AnkiDroid/src/main/java/com/ichi2/async/CollectionOperations.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/async/CollectionOperations.kt
@@ -65,7 +65,7 @@ fun updateCard(
         if (col.decks.active().contains(editCard.did) || !canAccessScheduler) {
             editCard.apply {
                 load(col)
-                q(true) // reload qa-cache
+                q(col, true) // reload qa-cache
             }
         } else {
             col.sched.card!! // check: are there deleted too?

--- a/AnkiDroid/src/main/java/com/ichi2/async/CollectionOperations.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/async/CollectionOperations.kt
@@ -64,7 +64,7 @@ fun updateCard(
     return if (isFromReviewer) {
         if (col.decks.active().contains(editCard.did) || !canAccessScheduler) {
             editCard.apply {
-                load()
+                load(col)
                 q(true) // reload qa-cache
             }
         } else {
@@ -361,7 +361,7 @@ fun suspendCardMulti(col: Collection, cardIds: List<Long>): Array<Card> {
 
         // reload cards because they'll be passed back to caller
         for (c in cards) {
-            c.load()
+            c.load(col)
         }
         sched.deferReset()
         // pass cards back so more actions can be performed by the caller
@@ -407,7 +407,7 @@ fun changeDeckMulti(
         val originalDids = LongArray(cards.size)
         for (i in cards.indices) {
             val card = cards[i]
-            card.load()
+            card.load(col)
             // save original did for undo
             originalDids[i] = card.did
             // then set the card ID to the new deck

--- a/AnkiDroid/src/main/java/com/ichi2/async/UndoActions.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/async/UndoActions.kt
@@ -94,7 +94,7 @@ class UndoChangeDeckMulti(private val cards: Array<Card>, private val originalDi
         // move cards to original deck
         for (i in cards.indices) {
             val card = cards[i]
-            card.load()
+            card.load(col)
             card.did = originalDids[i]
             val note = card.note()
             note.flush()

--- a/AnkiDroid/src/main/java/com/ichi2/async/UndoActions.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/async/UndoActions.kt
@@ -96,7 +96,7 @@ class UndoChangeDeckMulti(private val cards: Array<Card>, private val originalDi
             val card = cards[i]
             card.load(col)
             card.did = originalDids[i]
-            val note = card.note()
+            val note = card.note(col)
             note.flush()
             card.flush()
         }

--- a/AnkiDroid/src/main/java/com/ichi2/async/UndoActions.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/async/UndoActions.kt
@@ -27,7 +27,6 @@ import com.ichi2.libanki.Note
 import com.ichi2.libanki.UndoAction
 import com.ichi2.libanki.Utils
 import timber.log.Timber
-import java.util.ArrayList
 
 /** @param hasUnsuspended  whether there were any unsuspended card (in which card the action was "Suspend",
  * otherwise the action was "Unsuspend")
@@ -78,7 +77,7 @@ class UndoDeleteNoteMulti(private val notesArr: Array<Note>, private val allCard
             ids.add(n.id)
         }
         for (c in allCards) {
-            c.flush(false)
+            c.flush(col, false)
             ids.add(c.id)
         }
         col.db.execute("DELETE FROM graves WHERE oid IN " + Utils.ids2str(ids))
@@ -98,7 +97,7 @@ class UndoChangeDeckMulti(private val cards: Array<Card>, private val originalDi
             card.did = originalDids[i]
             val note = card.note(col)
             note.flush()
-            card.flush()
+            card.flush(col)
         }
         return null // don't fetch new card
     }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Card.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Card.kt
@@ -232,7 +232,7 @@ open class Card : Cloneable {
         return render_output(col, reload, browser).question_and_style()
     }
 
-    fun a(): String {
+    fun a(col: Collection): String {
         return render_output(col).answer_and_style()
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Card.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Card.kt
@@ -143,10 +143,10 @@ open class Card : Cloneable {
         render_output = null
         note = null
         this.id = id
-        load()
+        load(col)
     }
 
-    fun load() {
+    fun load(col: Collection) {
         col.db.query("SELECT * FROM cards WHERE id = ?", this.id).use { cursor ->
             if (!cursor.moveToFirst()) {
                 throw WrongId(this.id, "card")

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Card.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Card.kt
@@ -292,7 +292,7 @@ open class Card : Cloneable {
     /**
      * Time limit for answering in milliseconds.
      */
-    fun timeLimit(): Int {
+    fun timeLimit(col: Collection): Int {
         val conf = col.decks.confForDid(if (!isInDynamicDeck) did else oDid)
         return conf.getInt("maxTaken") * 1000
     }
@@ -303,7 +303,7 @@ open class Card : Cloneable {
     fun timeTaken(): Int {
         // Indeed an int. Difference between two big numbers is still small.
         val total = (TimeManager.time.intTimeMS() - timerStarted).toInt()
-        return Math.min(total, timeLimit())
+        return Math.min(total, timeLimit(col))
     }
 
     open fun isEmpty() = try {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Card.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Card.kt
@@ -241,7 +241,7 @@ open class Card : Cloneable {
         return "<style>${render_output(col).css}</style>"
     }
 
-    fun questionAvTags(): List<AvTag> {
+    fun questionAvTags(col: Collection): List<AvTag> {
         return render_output(col).question_av_tags
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Card.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Card.kt
@@ -306,7 +306,7 @@ open class Card : Cloneable {
         return Math.min(total, timeLimit(col))
     }
 
-    open fun isEmpty() = try {
+    open fun isEmpty(col: Collection) = try {
         Models.emptyCard(model(), ord, note().fields)
     } catch (er: TemplateError) {
         Timber.w("Card is empty because the card's template has an error: %s.", er.message(col.context))

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Card.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Card.kt
@@ -429,7 +429,7 @@ open class Card : Cloneable {
     }
 
     // not in Anki.
-    fun dueString(): String {
+    fun dueString(col: Collection): String {
         var t = nextDue(col)
         if (queue < 0) {
             t = "($t)"

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Card.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Card.kt
@@ -325,17 +325,16 @@ open class Card : Cloneable {
     /*
      * Returns the answer with anything before the <hr id=answer> tag removed
      */
-    val pureAnswer: String
-        get() {
-            val s = render_output(false).answer_text
-            for (target in arrayOf("<hr id=answer>", "<hr id=\"answer\">")) {
-                val pos = s.indexOf(target)
-                if (pos == -1) continue
-                return s.substring(pos + target.length).trim { it <= ' ' }
-            }
-            // neither found
-            return s
+    fun pureAnswer(): String {
+        val s = render_output(false).answer_text
+        for (target in arrayOf("<hr id=answer>", "<hr id=\"answer\">")) {
+            val pos = s.indexOf(target)
+            if (pos == -1) continue
+            return s.substring(pos + target.length).trim { it <= ' ' }
         }
+        // neither found
+        return s
+    }
 
     /**
      * Save the currently elapsed reviewing time so it can be restored on resume.

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Card.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Card.kt
@@ -261,10 +261,10 @@ open class Card : Cloneable {
     }
 
     open fun note(): Note {
-        return note(false)
+        return note(col, false)
     }
 
-    open fun note(reload: Boolean): Note {
+    open fun note(col: Collection, reload: Boolean): Note {
         if (note == null || reload) {
             note = col.getNote(nid)
         }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Card.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Card.kt
@@ -174,7 +174,7 @@ open class Card : Cloneable {
         note = null
     }
 
-    fun flush(changeModUsn: Boolean = true) {
+    fun flush(col: Collection, changeModUsn: Boolean = true) {
         if (changeModUsn) {
             mod = TimeManager.time.intTime()
             usn = col.usn()

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Card.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Card.kt
@@ -228,7 +228,7 @@ open class Card : Cloneable {
         col.log(this)
     }
 
-    fun q(reload: Boolean = false, browser: Boolean = false): String {
+    fun q(col: Collection, reload: Boolean = false, browser: Boolean = false): String {
         return render_output(col, reload, browser).question_and_style()
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Card.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Card.kt
@@ -300,7 +300,7 @@ open class Card : Cloneable {
     /*
      * Time taken to answer card, in integer MS.
      */
-    fun timeTaken(): Int {
+    fun timeTaken(col: Collection): Int {
         // Indeed an int. Difference between two big numbers is still small.
         val total = (TimeManager.time.intTimeMS() - timerStarted).toInt()
         return Math.min(total, timeLimit(col))
@@ -351,8 +351,8 @@ open class Card : Cloneable {
      *
      * Unlike the desktop client, AnkiDroid must pause and resume the process in the middle of
      * reviewing. This method is required to keep track of the actual amount of time spent in
-     * the reviewer and *must* be called on resume before any calls to timeTaken() take place
-     * or the result of timeTaken() will be wrong.
+     * the reviewer and *must* be called on resume before any calls to timeTaken(col) take place
+     * or the result of timeTaken(col) will be wrong.
      */
     fun resumeTimer() {
         timerStarted = TimeManager.time.intTimeMS() - elapsedTime

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Card.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Card.kt
@@ -306,13 +306,12 @@ open class Card : Cloneable {
         return Math.min(total, timeLimit())
     }
 
-    open val isEmpty: Boolean
-        get() = try {
-            Models.emptyCard(model(), ord, note().fields)
-        } catch (er: TemplateError) {
-            Timber.w("Card is empty because the card's template has an error: %s.", er.message(col.context))
-            true
-        }
+    open fun isEmpty() = try {
+        Models.emptyCard(model(), ord, note().fields)
+    } catch (er: TemplateError) {
+        Timber.w("Card is empty because the card's template has an error: %s.", er.message(col.context))
+        true
+    }
 
     /*
      * ***********************************************************

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Card.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Card.kt
@@ -260,7 +260,7 @@ open class Card : Cloneable {
         return render_output!!
     }
 
-    open fun note(): Note {
+    open fun note(col: Collection): Note {
         return note(col, false)
     }
 
@@ -273,7 +273,7 @@ open class Card : Cloneable {
 
     // not in upstream
     open fun model(): Model {
-        return note().model()
+        return note(col).model()
     }
 
     fun template(): JSONObject {
@@ -307,7 +307,7 @@ open class Card : Cloneable {
     }
 
     open fun isEmpty(col: Collection) = try {
-        Models.emptyCard(model(), ord, note().fields)
+        Models.emptyCard(model(), ord, note(col).fields)
     } catch (er: TemplateError) {
         Timber.w("Card is empty because the card's template has an error: %s.", er.message(col.context))
         true
@@ -458,7 +458,7 @@ open class Card : Cloneable {
         return LanguageUtil.getShortDateFormatFromS(date)
     } // In Anki Desktop, a card with oDue <> 0 && oDid == 0 is not marked as dynamic.
 
-    fun avgEaseOfNote() = avgEase(note())
+    fun avgEaseOfNote() = avgEase(note(col))
 
     /** Non libAnki  */
     val isInDynamicDeck: Boolean

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Card.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Card.kt
@@ -430,14 +430,13 @@ open class Card : Cloneable {
     }
 
     // not in Anki.
-    val dueString: String
-        get() {
-            var t = nextDue()
-            if (queue < 0) {
-                t = "($t)"
-            }
-            return t
+    fun dueString(): String {
+        var t = nextDue()
+        if (queue < 0) {
+            t = "($t)"
         }
+        return t
+    }
 
     // as in Anki aqt/browser.py
     @VisibleForTesting

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Card.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Card.kt
@@ -229,33 +229,33 @@ open class Card : Cloneable {
     }
 
     fun q(reload: Boolean = false, browser: Boolean = false): String {
-        return render_output(reload, browser).question_and_style()
+        return render_output(col, reload, browser).question_and_style()
     }
 
     fun a(): String {
-        return render_output().answer_and_style()
+        return render_output(col).answer_and_style()
     }
 
     @RustCleanup("legacy")
     fun css(): String {
-        return "<style>${render_output().css}</style>"
+        return "<style>${render_output(col).css}</style>"
     }
 
     fun questionAvTags(): List<AvTag> {
-        return render_output().question_av_tags
+        return render_output(col).question_av_tags
     }
 
     fun answerAvTags(): List<AvTag> {
-        return render_output().answer_av_tags
+        return render_output(col).answer_av_tags
     }
 
     /**
      * @throws net.ankiweb.rsdroid.exceptions.BackendInvalidInputException: If the card does not exist
      */
     @RustCleanup("move col.render_output back to Card once the java collection is removed")
-    open fun render_output(reload: Boolean = false, browser: Boolean = false): TemplateRenderOutput {
+    open fun render_output(col: Collection, reload: Boolean = false, browser: Boolean = false): TemplateRenderOutput {
         if (render_output == null || reload) {
-            render_output = col.render_output(this, reload, browser)
+            render_output = col.render_output(col, this, reload, browser)
         }
         return render_output!!
     }
@@ -319,14 +319,14 @@ open class Card : Cloneable {
      * ***********************************************************
      */
     fun qSimple(): String {
-        return render_output(false).question_text
+        return render_output(col, false).question_text
     }
 
     /*
      * Returns the answer with anything before the <hr id=answer> tag removed
      */
     fun pureAnswer(): String {
-        val s = render_output(false).answer_text
+        val s = render_output(col, false).answer_text
         for (target in arrayOf("<hr id=answer>", "<hr id=\"answer\">")) {
             val pos = s.indexOf(target)
             if (pos == -1) continue
@@ -557,7 +557,7 @@ open class Card : Cloneable {
         }
 
         fun loadQA(reload: Boolean, browser: Boolean) {
-            card.render_output(reload, browser)
+            card.render_output(col, reload, browser)
         }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Card.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Card.kt
@@ -507,15 +507,15 @@ open class Card : Cloneable {
         }
 
         /** Copy of cache. Useful to create a copy of a subclass without loosing card if it is loaded.  */
-        protected constructor(cache: Cache) {
-            col = cache.col
+        protected constructor(col: Collection, cache: Cache) {
+            this.col = col
             this.id = cache.id
             mCard = cache.mCard
         }
 
         /** Copy of cache. Useful to create a copy of a subclass without loosing card if it is loaded.  */
-        constructor(card: Card) {
-            col = card.col
+        constructor(col: Collection, card: Card) {
+            this.col = col
             this.id = card.id
             mCard = card
         }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Card.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Card.kt
@@ -272,16 +272,16 @@ open class Card : Cloneable {
     }
 
     // not in upstream
-    open fun model(): Model {
+    open fun model(col: Collection): Model {
         return note(col).model()
     }
 
     fun template(): JSONObject {
-        val m = model()
+        val m = model(col)
         return if (m.isStd) {
             m.getJSONArray("tmpls").getJSONObject(ord)
         } else {
-            model().getJSONArray("tmpls").getJSONObject(0)
+            model(col).getJSONArray("tmpls").getJSONObject(0)
         }
     }
 
@@ -307,7 +307,7 @@ open class Card : Cloneable {
     }
 
     open fun isEmpty(col: Collection) = try {
-        Models.emptyCard(model(), ord, note(col).fields)
+        Models.emptyCard(model(col), ord, note(col).fields)
     } catch (er: TemplateError) {
         Timber.w("Card is empty because the card's template has an error: %s.", er.message(col.context))
         true

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Card.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Card.kt
@@ -458,7 +458,7 @@ open class Card : Cloneable {
         return LanguageUtil.getShortDateFormatFromS(date)
     } // In Anki Desktop, a card with oDue <> 0 && oDid == 0 is not marked as dynamic.
 
-    fun avgEaseOfNote() = avgEase(note(col))
+    fun avgEaseOfNote(col: Collection) = avgEase(note(col))
 
     /** Non libAnki  */
     val isInDynamicDeck: Boolean

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Card.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Card.kt
@@ -276,7 +276,7 @@ open class Card : Cloneable {
         return note(col).model()
     }
 
-    fun template(): JSONObject {
+    fun template(col: Collection): JSONObject {
         val m = model(col)
         return if (m.isStd) {
             m.getJSONArray("tmpls").getJSONObject(ord)

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Card.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Card.kt
@@ -245,7 +245,7 @@ open class Card : Cloneable {
         return render_output(col).question_av_tags
     }
 
-    fun answerAvTags(): List<AvTag> {
+    fun answerAvTags(col: Collection): List<AvTag> {
         return render_output(col).answer_av_tags
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Card.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Card.kt
@@ -237,7 +237,7 @@ open class Card : Cloneable {
     }
 
     @RustCleanup("legacy")
-    fun css(): String {
+    fun css(col: Collection): String {
         return "<style>${render_output(col).css}</style>"
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Card.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Card.kt
@@ -430,7 +430,7 @@ open class Card : Cloneable {
 
     // not in Anki.
     fun dueString(): String {
-        var t = nextDue()
+        var t = nextDue(col)
         if (queue < 0) {
             t = "($t)"
         }
@@ -439,7 +439,7 @@ open class Card : Cloneable {
 
     // as in Anki aqt/browser.py
     @VisibleForTesting
-    fun nextDue(): String {
+    fun nextDue(col: Collection): String {
         val date: Long
         val due = due
         date = if (isInDynamicDeck) {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Card.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Card.kt
@@ -325,7 +325,7 @@ open class Card : Cloneable {
     /*
      * Returns the answer with anything before the <hr id=answer> tag removed
      */
-    fun pureAnswer(): String {
+    fun pureAnswer(col: Collection): String {
         val s = render_output(col, false).answer_text
         for (target in arrayOf("<hr id=answer>", "<hr id=\"answer\">")) {
             val pos = s.indexOf(target)

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Card.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Card.kt
@@ -318,7 +318,7 @@ open class Card : Cloneable {
      * The methods below are not in LibAnki.
      * ***********************************************************
      */
-    fun qSimple(): String {
+    fun qSimple(col: Collection): String {
         return render_output(col, false).question_text
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Card.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Card.kt
@@ -367,7 +367,7 @@ open class Card : Cloneable {
         return ++reps
     }
 
-    fun showTimer(): Boolean {
+    fun showTimer(col: Collection): Boolean {
         val options = col.decks.confForDid(if (!isInDynamicDeck) did else oDid)
         return DeckConfig.parseTimerOpt(options, true)
     }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Card.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Card.kt
@@ -205,7 +205,7 @@ open class Card : Cloneable {
         col.log(this)
     }
 
-    fun flushSched() {
+    fun flushSched(col: Collection) {
         mod = TimeManager.time.intTime()
         usn = col.usn()
         assert(due < "4294967296".toLong())

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Card.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Card.kt
@@ -65,9 +65,6 @@ import java.util.concurrent.CancellationException
  * - lrn queue: integer timestamp
  */
 open class Card : Cloneable {
-    // Needed for tests
-    var col: Collection
-
     /**
      * Time in MS when timer was started
      */
@@ -117,12 +114,11 @@ open class Card : Cloneable {
     var lastIvl = 0
 
     constructor(col: Collection) {
-        this.col = col
         timerStarted = 0L
         render_output = null
         note = null
         // to flush, set nid, ord, and due
-        this.id = TimeManager.time.timestampID(this.col.db, "cards")
+        this.id = TimeManager.time.timestampID(col.db, "cards")
         did = 1
         this.type = Consts.CARD_TYPE_NEW
         queue = Consts.QUEUE_TYPE_NEW
@@ -138,7 +134,6 @@ open class Card : Cloneable {
     }
 
     constructor(col: Collection, id: Long) {
-        this.col = col
         timerStarted = 0L
         render_output = null
         note = null

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.kt
@@ -927,7 +927,7 @@ open class Collection(
         }
         card.due = _dueForDid(card.did, due).toLong()
         if (flush) {
-            card.flush()
+            card.flush(col)
         }
         return card
     }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.kt
@@ -1435,7 +1435,7 @@ open class Collection(
     }
 
     fun markReview(card: Card) {
-        val wasLeech = card.note().hasTag("leech")
+        val wasLeech = card.note(col).hasTag("leech")
         val clonedCard = card.clone()
         markUndo(UndoReview(wasLeech, clonedCard))
     }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.kt
@@ -1384,7 +1384,7 @@ open class Collection(
     fun render_output_legacy(c: Card, reload: Boolean, browser: Boolean): TemplateRenderOutput {
         val f = c.note(col, reload)
         val m = c.model(col)
-        val t = c.template()
+        val t = c.template(col)
         val did: DeckId = if (c.isInDynamicDeck) {
             c.oDid
         } else {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.kt
@@ -1376,7 +1376,7 @@ open class Collection(
         _loadScheduler()
     }
 
-    open fun render_output(c: Card, reload: Boolean, browser: Boolean): TemplateRenderOutput? {
+    open fun render_output(col: Collection, c: Card, reload: Boolean, browser: Boolean): TemplateRenderOutput? {
         return render_output_legacy(c, reload, browser)
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.kt
@@ -1382,7 +1382,7 @@ open class Collection(
 
     @RustCleanup("Hack for Card Template Previewer, needs review")
     fun render_output_legacy(c: Card, reload: Boolean, browser: Boolean): TemplateRenderOutput {
-        val f = c.note(reload)
+        val f = c.note(col, reload)
         val m = c.model()
         val t = c.template()
         val did: DeckId = if (c.isInDynamicDeck) {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.kt
@@ -1383,7 +1383,7 @@ open class Collection(
     @RustCleanup("Hack for Card Template Previewer, needs review")
     fun render_output_legacy(c: Card, reload: Boolean, browser: Boolean): TemplateRenderOutput {
         val f = c.note(col, reload)
-        val m = c.model()
+        val m = c.model(col)
         val t = c.template()
         val did: DeckId = if (c.isInDynamicDeck) {
             c.oDid
@@ -1421,7 +1421,7 @@ open class Collection(
             answer_text = qa["a"]!!,
             question_av_tags = listOf(),
             answer_av_tags = listOf(),
-            css = c.model().getString("css")
+            css = c.model(col).getString("css")
         )
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/CollectionV16.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/CollectionV16.kt
@@ -137,7 +137,7 @@ class CollectionV16(
         reload: Boolean,
         browser: Boolean
     ): TemplateManager.TemplateRenderContext.TemplateRenderOutput {
-        return TemplateManager.TemplateRenderContext.from_existing_card(c, browser).render()
+        return TemplateManager.TemplateRenderContext.from_existing_card(col, c, browser).render()
     }
 
     override fun findCards(

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/CollectionV16.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/CollectionV16.kt
@@ -132,6 +132,7 @@ class CollectionV16(
     }
 
     override fun render_output(
+        col: Collection,
         c: Card,
         reload: Boolean,
         browser: Boolean

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/SoundKt.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/SoundKt.kt
@@ -80,7 +80,7 @@ suspend fun getAvTag(card: Card, url: String): AvTag? {
         val questionSide = values[1] == "q"
         val index = values[2].toInt()
         val tags = withCol {
-            if (questionSide) { card.questionAvTags() } else { card.answerAvTags() }
+            if (questionSide) { card.questionAvTags() } else { card.answerAvTags(col) }
         }
         if (index < tags.size) {
             tags[index]

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/SoundKt.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/SoundKt.kt
@@ -80,7 +80,7 @@ suspend fun getAvTag(card: Card, url: String): AvTag? {
         val questionSide = values[1] == "q"
         val index = values[2].toInt()
         val tags = withCol {
-            if (questionSide) { card.questionAvTags() } else { card.answerAvTags(col) }
+            if (questionSide) { card.questionAvTags(col) } else { card.answerAvTags(col) }
         }
         if (index < tags.size) {
             tags[index]

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/TemplateManager.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/TemplateManager.kt
@@ -186,7 +186,7 @@ class TemplateManager {
 
         /**
          * Returns the card being rendered.
-         * Be careful not to call .q() or .a() on the card, or you'll create an
+         * Be careful not to call .q() or .a(col) on the card, or you'll create an
          * infinite loop.
          */
         fun card() = _card

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/TemplateManager.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/TemplateManager.kt
@@ -136,8 +136,8 @@ class TemplateManager {
         private var extra_state: HashMap<str, Any> = Dict()
 
         companion object {
-            fun from_existing_card(card: Card, browser: bool): TemplateRenderContext {
-                return TemplateRenderContext(card.col, card, card.note(), browser)
+            fun from_existing_card(col: Collection, card: Card, browser: bool): TemplateRenderContext {
+                return TemplateRenderContext(card.col, card, card.note(col), browser)
             }
 
             fun from_card_layout(

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/TemplateManager.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/TemplateManager.kt
@@ -195,13 +195,13 @@ class TemplateManager {
         fun note_type() = _note_type
 
         @RustCleanup("legacy")
-        fun qfmt(): str {
-            return templates_for_card(card(), _browser).first
+        fun qfmt(col: Collection): str {
+            return templates_for_card(col, card(), _browser).first
         }
 
         @RustCleanup("legacy")
-        fun afmt(): str {
-            return templates_for_card(card(), _browser).second
+        fun afmt(col: Collection): str {
+            return templates_for_card(col, card(), _browser).second
         }
 
         fun render(): TemplateRenderOutput {
@@ -279,8 +279,8 @@ class TemplateManager {
         }
 
         @RustCleanup("legacy")
-        fun templates_for_card(card: Card, browser: bool): Pair<str, str> {
-            val template = card.template()
+        fun templates_for_card(col: Collection, card: Card, browser: bool): Pair<str, str> {
+            val template = card.template(col)
             var a: String? = null
             var q: String? = null
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/TemplateManager.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/TemplateManager.kt
@@ -137,7 +137,7 @@ class TemplateManager {
 
         companion object {
             fun from_existing_card(col: Collection, card: Card, browser: bool): TemplateRenderContext {
-                return TemplateRenderContext(card.col, card, card.note(col), browser)
+                return TemplateRenderContext(col, card, card.note(col), browser)
             }
 
             fun from_card_layout(

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/TextCardExporter.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/TextCardExporter.kt
@@ -38,7 +38,7 @@ class TextCardExporter(col: Collection, did: DeckId?, includeHTML: Boolean) : Ex
         val out = StringBuilder()
         for (cid in ids) {
             val c = col.getCard(cid)
-            out.append(esc(c.q()))
+            out.append(esc(c.q(col)))
             out.append("\t")
             out.append(esc(c.a()))
             out.append("\n")

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/TextCardExporter.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/TextCardExporter.kt
@@ -40,7 +40,7 @@ class TextCardExporter(col: Collection, did: DeckId?, includeHTML: Boolean) : Ex
             val c = col.getCard(cid)
             out.append(esc(c.q(col)))
             out.append("\t")
-            out.append(esc(c.a()))
+            out.append(esc(c.a(col)))
             out.append("\n")
         }
         BufferedWriter(

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/UndoAction.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/UndoAction.kt
@@ -57,11 +57,12 @@ abstract class UndoAction
          * @return An UndoAction which, if executed, put back the `card` in the state given here
          */
         fun revertNoteToProvidedState(
+            col: Collection,
             @StringRes @UndoNameId
             undoNameId: Int,
             card: Card
         ): UndoAction {
-            return revertToProvidedState(undoNameId, card, card.note().cards())
+            return revertToProvidedState(undoNameId, card, card.note(col).cards())
         }
 
         /**

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/UndoAction.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/UndoAction.kt
@@ -96,7 +96,7 @@ abstract class UndoAction
                 override fun undo(col: Collection): Card {
                     Timber.i("Undo: %d", undoNameId)
                     for (cc in cards) {
-                        cc.flush(false)
+                        cc.flush(col, false)
                     }
                     return card
                 }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Sched.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Sched.kt
@@ -948,7 +948,7 @@ class Sched(col: Collection) : SchedV2(col) {
         // if over threshold or every half threshold reps after that
         if (card.lapses >= lf && (card.lapses - lf) % Math.max(lf / 2, 1) == 0) {
             // add a leech tag
-            val n = card.note()
+            val n = card.note(col)
             n.addTag("leech")
             n.flush()
             // handle

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Sched.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Sched.kt
@@ -94,7 +94,7 @@ class Sched(col: Collection) : SchedV2(col) {
         _updateStats(card, "time", card.timeTaken().toLong())
         card.mod = time.intTime()
         card.usn = col.usn()
-        card.flushSched()
+        card.flushSched(col)
     }
 
     override fun counts(card: Card): Counts {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Sched.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Sched.kt
@@ -91,7 +91,7 @@ class Sched(col: Collection) : SchedV2(col) {
         } else {
             throw RuntimeException("Invalid queue")
         }
-        _updateStats(card, "time", card.timeTaken().toLong())
+        _updateStats(card, "time", card.timeTaken(col).toLong())
         card.mod = time.intTime()
         card.usn = col.usn()
         card.flushSched(col)

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.kt
@@ -2676,7 +2676,7 @@ end)  """
         }
         Timber.i("Undo Review of card %d, leech: %b", card.id, wasLeech)
         // write old data
-        card.flush(false)
+        card.flush(col, false)
         val conf = _cardConf(card)
         val previewing = conf.isDyn && !conf.getBoolean("resched")
         if (!previewing) {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.kt
@@ -244,7 +244,7 @@ open class SchedV2(col: Collection) : AbstractSched(col) {
         _updateStats(card, "time", card.timeTaken().toLong())
         card.mod = time.intTime()
         card.usn = col.usn()
-        card.flushSched()
+        card.flushSched(col)
     }
 
     fun _answerCard(card: Card, @BUTTON_TYPE ease: Int) {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.kt
@@ -241,7 +241,7 @@ open class SchedV2(col: Collection) : AbstractSched(col) {
 
         _answerCard(card, ease)
 
-        _updateStats(card, "time", card.timeTaken().toLong())
+        _updateStats(card, "time", card.timeTaken(col).toLong())
         card.mod = time.intTime()
         card.usn = col.usn()
         card.flushSched(col)
@@ -1392,7 +1392,7 @@ open class SchedV2(col: Collection) : AbstractSched(col) {
     ) {
         val lastIvl = -_delayForGrade(conf, lastLeft)
         val ivl = if (leaving) card.ivl else -_delayForGrade(conf, card.left)
-        log(card.id, col.usn(), ease, ivl, lastIvl, card.factor, card.timeTaken(), type)
+        log(card.id, col.usn(), ease, ivl, lastIvl, card.factor, card.timeTaken(col), type)
     }
 
     protected fun log(
@@ -1680,7 +1680,7 @@ open class SchedV2(col: Collection) : AbstractSched(col) {
             if (delay != 0) -delay else card.ivl,
             card.lastIvl,
             card.factor,
-            card.timeTaken(),
+            card.timeTaken(col),
             type
         )
     }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.kt
@@ -1945,7 +1945,7 @@ open class SchedV2(col: Collection) : AbstractSched(col) {
         // if over threshold or every half threshold reps after that
         if (card.lapses >= lf && (card.lapses - lf) % Math.max(lf / 2, 1) == 0) {
             // add a leech tag
-            val n = card.note()
+            val n = card.note(col)
             n.addTag("leech")
             n.flush()
             // handle
@@ -2670,9 +2670,9 @@ end)  """
 
     override fun undoReview(card: Card, wasLeech: Boolean) {
         // remove leech tag if it didn't have it before
-        if (!wasLeech && card.note().hasTag("leech")) {
-            card.note().delTag("leech")
-            card.note().flush()
+        if (!wasLeech && card.note(col).hasTag("leech")) {
+            card.note(col).delTag("leech")
+            card.note(col).flush()
         }
         Timber.i("Undo Review of card %d, leech: %b", card.id, wasLeech)
         // write old data

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV3.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV3.kt
@@ -87,7 +87,7 @@ class SchedV3(col: CollectionV16) : AbstractSched(col) {
             newState = stateFromEase(states, ease)
             rating = ratingFromEase(ease)
             answeredAtMillis = time.intTimeMS()
-            millisecondsTaken = card.timeTaken()
+            millisecondsTaken = card.timeTaken(col)
         }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV3.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV3.kt
@@ -17,7 +17,11 @@
 package com.ichi2.libanki.sched
 
 import android.app.Activity
-import anki.scheduler.*
+import anki.scheduler.CardAnswer
+import anki.scheduler.QueuedCards
+import anki.scheduler.SchedulingState
+import anki.scheduler.SchedulingStates
+import anki.scheduler.cardAnswer
 import com.ichi2.async.CancelListener
 import com.ichi2.libanki.Card
 import com.ichi2.libanki.CollectionV16
@@ -73,7 +77,7 @@ class SchedV3(col: CollectionV16) : AbstractSched(col) {
             activityForLeechNotification?.get()?.let { leech(card, it) }
         }
         // tests assume the card was mutated
-        card.load()
+        card.load(col)
     }
 
     fun buildAnswer(card: Card, states: SchedulingStates, ease: Int): CardAnswer {

--- a/AnkiDroid/src/test/java/com/ichi2/anki/AbstractFlashcardViewerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/AbstractFlashcardViewerTest.kt
@@ -111,7 +111,7 @@ class AbstractFlashcardViewerTest : RobolectricTest() {
 
         AbstractFlashcardViewer.editorCard = viewer.currentCard
 
-        val note = viewer.currentCard!!.note()
+        val note = viewer.currentCard!!.note(col)
         note.setField(1, "David")
 
         viewer.saveEditedCard()
@@ -138,7 +138,7 @@ class AbstractFlashcardViewerTest : RobolectricTest() {
 
         AbstractFlashcardViewer.editorCard = viewer.currentCard
 
-        val note = viewer.currentCard!!.note()
+        val note = viewer.currentCard!!.note(col)
         note.setField(1, "David")
 
         viewer.saveEditedCard()

--- a/AnkiDroid/src/test/java/com/ichi2/anki/AnkiDroidJsAPITest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/AnkiDroidJsAPITest.kt
@@ -133,7 +133,7 @@ class AnkiDroidJsAPITest : RobolectricTest() {
 
         // Card Mark
         assertThat(javaScriptFunction.ankiGetCardMark(), equalTo(false))
-        reviewer.currentCard!!.note().addTag("marked")
+        reviewer.currentCard!!.note(col).addTag("marked")
         assertThat(javaScriptFunction.ankiGetCardMark(), equalTo(true))
     }
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.kt
@@ -462,7 +462,7 @@ class CardBrowserTest : RobolectricTest() {
             due = 5
             queue = Consts.QUEUE_TYPE_REV
             type = Consts.CARD_TYPE_REV
-            flush()
+            flush(col)
         }
 
         val b = browserWithNoNewCards
@@ -552,7 +552,7 @@ class CardBrowserTest : RobolectricTest() {
         col.decks.select(deck)
         val c2 = addNoteUsingBasicModel("New", "world").firstCard()
         c2.did = deck
-        c2.flush()
+        c2.flush(col)
 
         val cardBrowser = browserWithNoNewCards
         cardBrowser.searchCards("world or hello")
@@ -609,7 +609,7 @@ class CardBrowserTest : RobolectricTest() {
         col.decks.select(deck)
         val c2 = addNoteUsingBasicModel("Front", "Back").firstCard()
         c2.did = deck
-        c2.flush()
+        c2.flush(col)
 
         val cardBrowser = browserWithNoNewCards
         cardBrowser.searchCards("Hello")
@@ -643,7 +643,7 @@ class CardBrowserTest : RobolectricTest() {
     private fun flagCardForNote(n: Note, flag: Int) {
         val c = n.firstCard()
         c.setUserFlag(flag)
-        c.flush()
+        c.flush(col)
     }
 
     private fun selectDefaultDeck() {

--- a/AnkiDroid/src/test/java/com/ichi2/anki/CardTemplatePreviewerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/CardTemplatePreviewerTest.kt
@@ -92,7 +92,7 @@ class CardTemplatePreviewerTest : RobolectricTest() {
         val previewerController = Robolectric.buildActivity(TestCardTemplatePreviewer::class.java, intent).create().start().resume().visible()
         saveControllerForCleanup(previewerController)
         val testCardTemplatePreviewer = previewerController.get()
-        val arr = testCardTemplatePreviewer.getDummyCard(collectionBasicModelOriginal, 0)!!.note().fields
+        val arr = testCardTemplatePreviewer.getDummyCard(collectionBasicModelOriginal, 0)!!.note(col).fields
         assertThat(arr[0], equalTo("(" + fields[0] + ")"))
         assertThat(arr[1], equalTo("(" + fields[1] + ")"))
     }
@@ -113,7 +113,7 @@ class CardTemplatePreviewerTest : RobolectricTest() {
         val previewerController = Robolectric.buildActivity(TestCardTemplatePreviewer::class.java, intent).create().start().resume().visible()
         saveControllerForCleanup(previewerController)
         val testCardTemplatePreviewer = previewerController.get()
-        val arr = testCardTemplatePreviewer.getDummyCard(collectionBasicModelOriginal, 0)!!.note().fields
+        val arr = testCardTemplatePreviewer.getDummyCard(collectionBasicModelOriginal, 0)!!.note(col).fields
         assertThat(arr[0], equalTo(testCardTemplatePreviewer.getString(R.string.cloze_sample_text, "c1")))
         assertThat(arr[1], equalTo("(" + fields[1] + ")"))
     }
@@ -134,7 +134,7 @@ class CardTemplatePreviewerTest : RobolectricTest() {
         val previewerController = Robolectric.buildActivity(TestCardTemplatePreviewer::class.java, intent).create().start().resume().visible()
         saveControllerForCleanup(previewerController)
         val testCardTemplatePreviewer = previewerController.get()
-        val arr = testCardTemplatePreviewer.getDummyCard(collectionBasicModelOriginal, 0)!!.note().fields
+        val arr = testCardTemplatePreviewer.getDummyCard(collectionBasicModelOriginal, 0)!!.note(col).fields
         assertThat(arr[0], equalTo("(" + fields[0] + ")"))
         assertThat(arr[1], equalTo(testCardTemplatePreviewer.getString(R.string.basic_answer_sample_text)))
     }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/CardTemplatePreviewerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/CardTemplatePreviewerTest.kt
@@ -53,7 +53,7 @@ class CardTemplatePreviewerTest : RobolectricTest() {
         Assert.assertTrue(
             "model change did not show up?",
             testCardTemplatePreviewer.getDummyCard(collectionBasicModelOriginal, 0)!!.q(col).contains("PREVIEWER_TEST") &&
-            testCardTemplatePreviewer.getDummyCard(collectionBasicModelOriginal, 0)!!.a().contains("PREVIEWER_TEST")
+                testCardTemplatePreviewer.getDummyCard(collectionBasicModelOriginal, 0)!!.a(col).contains("PREVIEWER_TEST")
         )
 
         // Take it through a destroy/re-create lifecycle in order to test instance state persistence
@@ -66,7 +66,7 @@ class CardTemplatePreviewerTest : RobolectricTest() {
         Assert.assertTrue(
             "model change not preserved in lifecycle??",
             testCardTemplatePreviewer.getDummyCard(collectionBasicModelOriginal, 0)!!.q(col).contains("PREVIEWER_TEST") &&
-                testCardTemplatePreviewer.getDummyCard(collectionBasicModelOriginal, 0)!!.a().contains("PREVIEWER_TEST")
+                testCardTemplatePreviewer.getDummyCard(collectionBasicModelOriginal, 0)!!.a(col).contains("PREVIEWER_TEST")
         )
 
         // Make sure we can click

--- a/AnkiDroid/src/test/java/com/ichi2/anki/CardTemplatePreviewerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/CardTemplatePreviewerTest.kt
@@ -52,8 +52,8 @@ class CardTemplatePreviewerTest : RobolectricTest() {
         var testCardTemplatePreviewer = previewerController.get()
         Assert.assertTrue(
             "model change did not show up?",
-            testCardTemplatePreviewer.getDummyCard(collectionBasicModelOriginal, 0)!!.q().contains("PREVIEWER_TEST") &&
-                testCardTemplatePreviewer.getDummyCard(collectionBasicModelOriginal, 0)!!.a().contains("PREVIEWER_TEST")
+            testCardTemplatePreviewer.getDummyCard(collectionBasicModelOriginal, 0)!!.q(col).contains("PREVIEWER_TEST") &&
+            testCardTemplatePreviewer.getDummyCard(collectionBasicModelOriginal, 0)!!.a().contains("PREVIEWER_TEST")
         )
 
         // Take it through a destroy/re-create lifecycle in order to test instance state persistence
@@ -65,7 +65,7 @@ class CardTemplatePreviewerTest : RobolectricTest() {
         testCardTemplatePreviewer = previewerController.get()
         Assert.assertTrue(
             "model change not preserved in lifecycle??",
-            testCardTemplatePreviewer.getDummyCard(collectionBasicModelOriginal, 0)!!.q().contains("PREVIEWER_TEST") &&
+            testCardTemplatePreviewer.getDummyCard(collectionBasicModelOriginal, 0)!!.q(col).contains("PREVIEWER_TEST") &&
                 testCardTemplatePreviewer.getDummyCard(collectionBasicModelOriginal, 0)!!.a().contains("PREVIEWER_TEST")
         )
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/PreviewerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/PreviewerTest.kt
@@ -58,7 +58,7 @@ class PreviewerTest : RobolectricTest() {
 
         assertThat("Initial content assumption", previewer.cardContent, not(containsString("Hi")))
 
-        cardToPreview.note().setField(0, "Hi")
+        cardToPreview.note(col).setField(0, "Hi")
 
         previewer.saveEditedCard()
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/PreviewerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/PreviewerTest.kt
@@ -140,7 +140,7 @@ class PreviewerTest : RobolectricTest() {
     private fun setDeck(name: String?, card: Card) {
         val did = addDeck(name)
         card.did = did
-        card.flush()
+        card.flush(col)
     }
 
     private fun getPreviewerPreviewingList(arr: LongArray, c: Array<Card?>): Previewer {

--- a/AnkiDroid/src/test/java/com/ichi2/anki/ReviewerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/ReviewerTest.kt
@@ -375,7 +375,7 @@ class ReviewerTest : RobolectricTest() {
         reviewCard.queue = Consts.QUEUE_TYPE_REV
         reviewCard.type = Consts.CARD_TYPE_REV
         reviewCard.due = 0
-        reviewCard.flush()
+        reviewCard.flush(col)
     }
 
     private class ReviewerForMenuItems : Reviewer() {

--- a/AnkiDroid/src/test/java/com/ichi2/anki/RobolectricTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/RobolectricTest.kt
@@ -562,7 +562,7 @@ open class RobolectricTest : CollectionGetter, AndroidTest {
     }
 
     fun equalFirstField(expected: Card, obtained: Card) {
-        MatcherAssert.assertThat(obtained.note().fields[0], Matchers.equalTo(expected.note().fields[0]))
+        MatcherAssert.assertThat(obtained.note(col).fields[0], Matchers.equalTo(expected.note(col).fields[0]))
     }
 
     @CheckResult

--- a/AnkiDroid/src/test/java/com/ichi2/anki/cardviewer/CardAppearanceTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/cardviewer/CardAppearanceTest.kt
@@ -18,6 +18,7 @@ package com.ichi2.anki.cardviewer
 
 import com.ichi2.anki.cardviewer.CardAppearance.Companion.hasUserDefinedNightMode
 import com.ichi2.libanki.Card
+import com.ichi2.libanki.Collection
 import com.ichi2.testutils.assertFalse
 import org.junit.Test
 import org.mockito.Mockito
@@ -30,13 +31,14 @@ class CardAppearanceTest {
     @Test
     fun hasUserDefinedNightModeTest() {
         val mockCard = Mockito.mock(Card::class.java)
-        doReturn(".night_mode {}").whenever(mockCard).css()
-        assertTrue("CSS should have a night mode class", hasUserDefinedNightMode(mockCard))
+        val col: Collection = Mockito.mock()
+        doReturn(".night_mode {}").whenever(mockCard).css(col)
+        assertTrue("CSS should have a night mode class", hasUserDefinedNightMode(col, mockCard))
 
-        doReturn(".nightMode{}").whenever(mockCard).css()
-        assertTrue("CSS should have a night mode class", hasUserDefinedNightMode(mockCard))
+        doReturn(".nightMode{}").whenever(mockCard).css(col)
+        assertTrue("CSS should have a night mode class", hasUserDefinedNightMode(col, mockCard))
 
-        doReturn(".night_mode_old {}").whenever(mockCard).css()
-        assertFalse("CSS should not have a night mode class", hasUserDefinedNightMode(mockCard))
+        doReturn(".night_mode_old {}").whenever(mockCard).css(col)
+        assertFalse("CSS should not have a night mode class", hasUserDefinedNightMode(col, mockCard))
     }
 }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/reviewer/AnswerTimerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/reviewer/AnswerTimerTest.kt
@@ -50,7 +50,7 @@ class AnswerTimerTest {
         val timer = getTimer()
 
         val card: Card = mock {
-            on { showTimer() } doReturn false
+            on { showTimer(any()) } doReturn false
         }
 
         timer.setupForCard(col, card)
@@ -69,7 +69,7 @@ class AnswerTimerTest {
         val timer = getTimer()
 
         val card: Card = mock {
-            on { showTimer() } doReturn true
+            on { showTimer(any()) } doReturn true
             on { timeLimit(any()) } doReturn 12
         }
 
@@ -95,11 +95,11 @@ class AnswerTimerTest {
         val timer = getTimer()
 
         val timerCard: Card = mock {
-            on { showTimer() } doReturn true
+            on { showTimer(any()) } doReturn true
         }
 
         val nonTimerCard: Card = mock {
-            on { showTimer() } doReturn false
+            on { showTimer(any()) } doReturn false
         }
 
         timer.setupForCard(col, timerCard)
@@ -129,7 +129,7 @@ class AnswerTimerTest {
         val timer = getTimer()
 
         val timerCard: Card = mock {
-            on { showTimer() } doReturn true
+            on { showTimer(any()) } doReturn true
             on { timeLimit(any()) } doReturn 1000
         }
 
@@ -147,7 +147,7 @@ class AnswerTimerTest {
         val timer = getTimer()
 
         val timerCard: Card = mock {
-            on { showTimer() } doReturn true
+            on { showTimer(any()) } doReturn true
             on { timeLimit(any()) } doReturn 1000
             on { timeTaken(any()) } doReturn 1001
         }
@@ -169,7 +169,7 @@ class AnswerTimerTest {
         val timer = getTimer()
 
         val nonTimerCard: Card = mock {
-            on { showTimer() } doReturn false
+            on { showTimer(any()) } doReturn false
         }
 
         timer.setupForCard(col, nonTimerCard)

--- a/AnkiDroid/src/test/java/com/ichi2/anki/reviewer/AnswerTimerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/reviewer/AnswerTimerTest.kt
@@ -149,7 +149,7 @@ class AnswerTimerTest {
         val timerCard: Card = mock {
             on { showTimer() } doReturn true
             on { timeLimit(any()) } doReturn 1000
-            on { timeTaken() } doReturn 1001
+            on { timeTaken(any()) } doReturn 1001
         }
 
         timer.setupForCard(col, timerCard)

--- a/AnkiDroid/src/test/java/com/ichi2/anki/reviewer/AnswerTimerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/reviewer/AnswerTimerTest.kt
@@ -22,6 +22,7 @@ import android.widget.Chronometer
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.ichi2.libanki.Card
+import com.ichi2.libanki.Collection
 import com.ichi2.testutils.EmptyApplication
 import org.hamcrest.CoreMatchers.equalTo
 import org.hamcrest.MatcherAssert.assertThat
@@ -37,6 +38,7 @@ import org.robolectric.annotation.Config
 @Config(application = EmptyApplication::class)
 class AnswerTimerTest {
     lateinit var chronometer: Chronometer
+    val col: Collection = mock()
 
     @Before
     fun init() {
@@ -51,7 +53,7 @@ class AnswerTimerTest {
             on { showTimer() } doReturn false
         }
 
-        timer.setupForCard(card)
+        timer.setupForCard(col, card)
 
         assertThat("timer should not be enabled", timer.showTimer, equalTo(false))
 
@@ -68,13 +70,13 @@ class AnswerTimerTest {
 
         val card: Card = mock {
             on { showTimer() } doReturn true
-            on { timeLimit() } doReturn 12
+            on { timeLimit(any()) } doReturn 12
         }
 
         Mockito.mockStatic(SystemClock::class.java).use { mocked ->
             mocked.`when`<Long> { SystemClock.elapsedRealtime() }.doReturn(13)
 
-            timer.setupForCard(card)
+            timer.setupForCard(col, card)
         }
 
         assertThat("timer should be enabled", timer.showTimer, equalTo(true))
@@ -100,16 +102,16 @@ class AnswerTimerTest {
             on { showTimer() } doReturn false
         }
 
-        timer.setupForCard(timerCard)
+        timer.setupForCard(col, timerCard)
         assertThat("timer should be enabled", timer.showTimer, equalTo(true))
         assertThat("chronometer should be visible", chronometer.visibility, equalTo(View.VISIBLE))
 
-        timer.setupForCard(nonTimerCard)
+        timer.setupForCard(col, nonTimerCard)
 
         assertThat("timer should not be enabled", timer.showTimer, equalTo(false))
         assertThat("chronometer should not be visible", chronometer.visibility, equalTo(View.INVISIBLE))
 
-        timer.setupForCard(timerCard)
+        timer.setupForCard(col, timerCard)
         assertThat("timer should be enabled", timer.showTimer, equalTo(true))
         assertThat("chronometer should be visible", chronometer.visibility, equalTo(View.VISIBLE))
     }
@@ -119,7 +121,7 @@ class AnswerTimerTest {
         val timer = getTimer()
         // before we call setupForCard
         timer.pause()
-        timer.resume()
+        timer.resume(col)
     }
 
     @Test
@@ -128,15 +130,15 @@ class AnswerTimerTest {
 
         val timerCard: Card = mock {
             on { showTimer() } doReturn true
-            on { timeLimit() } doReturn 1000
+            on { timeLimit(any()) } doReturn 1000
         }
 
-        timer.setupForCard(timerCard)
+        timer.setupForCard(col, timerCard)
 
         reset(chronometer)
         timer.pause()
         verify(chronometer).stop()
-        timer.resume()
+        timer.resume(col)
         verify(chronometer).start()
     }
 
@@ -146,16 +148,16 @@ class AnswerTimerTest {
 
         val timerCard: Card = mock {
             on { showTimer() } doReturn true
-            on { timeLimit() } doReturn 1000
+            on { timeLimit(any()) } doReturn 1000
             on { timeTaken() } doReturn 1001
         }
 
-        timer.setupForCard(timerCard)
+        timer.setupForCard(col, timerCard)
 
         reset(chronometer)
         timer.pause()
         verify(chronometer).stop()
-        timer.resume()
+        timer.resume(col)
         verify(chronometer, never()).start()
     }
 
@@ -170,12 +172,12 @@ class AnswerTimerTest {
             on { showTimer() } doReturn false
         }
 
-        timer.setupForCard(nonTimerCard)
+        timer.setupForCard(col, nonTimerCard)
 
         timer.pause()
         verify(nonTimerCard).stopTimer()
         verify(nonTimerCard, never()).resumeTimer()
-        timer.resume()
+        timer.resume(col)
         verify(nonTimerCard).resumeTimer()
 
         verify(chronometer, never()).start()

--- a/AnkiDroid/src/test/java/com/ichi2/anki/services/NoteServiceTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/services/NoteServiceTest.kt
@@ -250,7 +250,7 @@ class NoteServiceTest : RobolectricTest() {
             card.apply {
                 type = Consts.CARD_TYPE_REV
                 factor = 3000 / (i + 1)
-                flush()
+                flush(col)
             }
         }
         // avg ease = (3000/10 + 1500/10 + 100/10 + 750/10) / 4 = [156.25] = 156
@@ -259,7 +259,7 @@ class NoteServiceTest : RobolectricTest() {
         // test case: one card is new
         note.cards()[2].apply {
             type = Consts.CARD_TYPE_NEW
-            flush()
+            flush(col)
         }
         // avg ease = (3000/10 + 1500/10 + 750/10) / 3 = [175] = 175
         assertEquals(175, NoteService.avgEase(note))
@@ -267,7 +267,7 @@ class NoteServiceTest : RobolectricTest() {
         // test case: all cards are new
         for (card in note.cards()) {
             card.type = Consts.CARD_TYPE_NEW
-            card.flush()
+            card.flush(col)
         }
         // no cards are rev, so avg ease cannot be calculated
         assertEquals(null, NoteService.avgEase(note))
@@ -285,7 +285,7 @@ class NoteServiceTest : RobolectricTest() {
             card.apply {
                 type = reviewOrRelearningList.shuffled().first()
                 ivl = 3000 / (i + 1)
-                flush()
+                flush(col)
             }
         }
 
@@ -295,7 +295,7 @@ class NoteServiceTest : RobolectricTest() {
         // case: one card is new or learning
         note.cards()[2].apply {
             type = newOrLearningList.shuffled().first()
-            flush()
+            flush(col)
         }
 
         // avg interval = (3000 + 1500 + 750) / 3 = [1750] = 1750
@@ -304,7 +304,7 @@ class NoteServiceTest : RobolectricTest() {
         // case: all cards are new or learning
         for (card in note.cards()) {
             card.type = newOrLearningList.shuffled().first()
-            card.flush()
+            card.flush(col)
         }
 
         // no cards are rev or relearning, so avg interval cannot be calculated

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/CardTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/CardTest.kt
@@ -134,7 +134,7 @@ class CardTest : RobolectricTest() {
         // model default
         val c = note.cards()[1]
         c.did = newId
-        c.flush()
+        c.flush(col)
         note.setItem("Text", "{{c4::four}}")
         note.flush()
         assertEquals(newId, note.cards()[3].did)

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/CardTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/CardTest.kt
@@ -259,82 +259,82 @@ class CardTest : RobolectricTest() {
         c.due = 27L
         c.queue = Consts.QUEUE_TYPE_MANUALLY_BURIED
         assertEquals("27", c.nextDue())
-        assertEquals("(27)", c.dueString)
+        assertEquals("(27)", c.dueString())
         c.queue = Consts.QUEUE_TYPE_SIBLING_BURIED
         assertEquals("27", c.nextDue())
-        assertEquals("(27)", c.dueString)
+        assertEquals("(27)", c.dueString())
         c.queue = Consts.QUEUE_TYPE_SUSPENDED
         assertEquals("27", c.nextDue())
-        assertEquals("(27)", c.dueString)
+        assertEquals("(27)", c.dueString())
         c.queue = Consts.QUEUE_TYPE_NEW
         c.due = 27L
         assertEquals("27", c.nextDue())
-        assertEquals("27", c.dueString)
+        assertEquals("27", c.dueString())
         c.queue = Consts.QUEUE_TYPE_PREVIEW
         assertEquals("27", c.nextDue())
-        assertEquals("27", c.dueString)
+        assertEquals("27", c.dueString())
         c.type = Consts.CARD_TYPE_LRN
         c.due = id
         c.queue = Consts.QUEUE_TYPE_MANUALLY_BURIED
         assertEquals("", c.nextDue())
-        assertEquals("()", c.dueString)
+        assertEquals("()", c.dueString())
         c.queue = Consts.QUEUE_TYPE_SIBLING_BURIED
         assertEquals("", c.nextDue())
-        assertEquals("()", c.dueString)
+        assertEquals("()", c.dueString())
         c.queue = Consts.QUEUE_TYPE_SUSPENDED
         assertEquals("", c.nextDue())
-        assertEquals("()", c.dueString)
+        assertEquals("()", c.dueString())
         c.queue = Consts.QUEUE_TYPE_LRN
         assertEquals("3/19/21", c.nextDue())
-        assertEquals("3/19/21", c.dueString)
+        assertEquals("3/19/21", c.dueString())
         c.queue = Consts.QUEUE_TYPE_PREVIEW
         assertEquals("", c.nextDue())
-        assertEquals("", c.dueString)
+        assertEquals("", c.dueString())
         c.type = Consts.CARD_TYPE_REV
         c.due = 20
         //  Since tests run the 7th of august, in 20 days we are the 27th of august 2020
         c.queue = Consts.QUEUE_TYPE_MANUALLY_BURIED
         assertEquals("8/27/20", c.nextDue())
-        assertEquals("(8/27/20)", c.dueString)
+        assertEquals("(8/27/20)", c.dueString())
         c.queue = Consts.QUEUE_TYPE_SIBLING_BURIED
         assertEquals("8/27/20", c.nextDue())
-        assertEquals("(8/27/20)", c.dueString)
+        assertEquals("(8/27/20)", c.dueString())
         c.queue = Consts.QUEUE_TYPE_SUSPENDED
         assertEquals("8/27/20", c.nextDue())
-        assertEquals("(8/27/20)", c.dueString)
+        assertEquals("(8/27/20)", c.dueString())
         c.queue = Consts.QUEUE_TYPE_REV
         assertEquals("8/27/20", c.nextDue())
-        assertEquals("8/27/20", c.dueString)
+        assertEquals("8/27/20", c.dueString())
         c.queue = Consts.QUEUE_TYPE_PREVIEW
         assertEquals("", c.nextDue())
-        assertEquals("", c.dueString)
+        assertEquals("", c.dueString())
         c.type = Consts.CARD_TYPE_RELEARNING
         c.due = id
         c.queue = Consts.QUEUE_TYPE_MANUALLY_BURIED
         assertEquals("", c.nextDue())
-        assertEquals("()", c.dueString)
+        assertEquals("()", c.dueString())
         c.queue = Consts.QUEUE_TYPE_SIBLING_BURIED
         assertEquals("", c.nextDue())
-        assertEquals("()", c.dueString)
+        assertEquals("()", c.dueString())
         c.queue = Consts.QUEUE_TYPE_SUSPENDED
         assertEquals("", c.nextDue())
-        assertEquals("()", c.dueString)
+        assertEquals("()", c.dueString())
         c.queue = Consts.QUEUE_TYPE_LRN
         c.due = id
         assertEquals("3/19/21", c.nextDue())
-        assertEquals("3/19/21", c.dueString)
+        assertEquals("3/19/21", c.dueString())
         c.queue = Consts.QUEUE_TYPE_PREVIEW
         assertEquals("", c.nextDue())
-        assertEquals("", c.dueString)
+        assertEquals("", c.dueString())
 
         // Dynamic deck
         val dyn = decks.newDyn("dyn")
         c.oDid = c.did
         c.did = dyn
         assertEquals("(filtered)", c.nextDue())
-        assertEquals("(filtered)", c.dueString)
+        assertEquals("(filtered)", c.dueString())
         c.queue = Consts.QUEUE_TYPE_SIBLING_BURIED
         assertEquals("(filtered)", c.nextDue())
-        assertEquals("((filtered))", c.dueString)
+        assertEquals("((filtered))", c.dueString())
     }
 }

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/CardTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/CardTest.kt
@@ -259,82 +259,82 @@ class CardTest : RobolectricTest() {
         c.due = 27L
         c.queue = Consts.QUEUE_TYPE_MANUALLY_BURIED
         assertEquals("27", c.nextDue(col))
-        assertEquals("(27)", c.dueString())
+        assertEquals("(27)", c.dueString(col))
         c.queue = Consts.QUEUE_TYPE_SIBLING_BURIED
         assertEquals("27", c.nextDue(col))
-        assertEquals("(27)", c.dueString())
+        assertEquals("(27)", c.dueString(col))
         c.queue = Consts.QUEUE_TYPE_SUSPENDED
         assertEquals("27", c.nextDue(col))
-        assertEquals("(27)", c.dueString())
+        assertEquals("(27)", c.dueString(col))
         c.queue = Consts.QUEUE_TYPE_NEW
         c.due = 27L
         assertEquals("27", c.nextDue(col))
-        assertEquals("27", c.dueString())
+        assertEquals("27", c.dueString(col))
         c.queue = Consts.QUEUE_TYPE_PREVIEW
         assertEquals("27", c.nextDue(col))
-        assertEquals("27", c.dueString())
+        assertEquals("27", c.dueString(col))
         c.type = Consts.CARD_TYPE_LRN
         c.due = id
         c.queue = Consts.QUEUE_TYPE_MANUALLY_BURIED
         assertEquals("", c.nextDue(col))
-        assertEquals("()", c.dueString())
+        assertEquals("()", c.dueString(col))
         c.queue = Consts.QUEUE_TYPE_SIBLING_BURIED
         assertEquals("", c.nextDue(col))
-        assertEquals("()", c.dueString())
+        assertEquals("()", c.dueString(col))
         c.queue = Consts.QUEUE_TYPE_SUSPENDED
         assertEquals("", c.nextDue(col))
-        assertEquals("()", c.dueString())
+        assertEquals("()", c.dueString(col))
         c.queue = Consts.QUEUE_TYPE_LRN
         assertEquals("3/19/21", c.nextDue(col))
-        assertEquals("3/19/21", c.dueString())
+        assertEquals("3/19/21", c.dueString(col))
         c.queue = Consts.QUEUE_TYPE_PREVIEW
         assertEquals("", c.nextDue(col))
-        assertEquals("", c.dueString())
+        assertEquals("", c.dueString(col))
         c.type = Consts.CARD_TYPE_REV
         c.due = 20
         //  Since tests run the 7th of august, in 20 days we are the 27th of august 2020
         c.queue = Consts.QUEUE_TYPE_MANUALLY_BURIED
         assertEquals("8/27/20", c.nextDue(col))
-        assertEquals("(8/27/20)", c.dueString())
+        assertEquals("(8/27/20)", c.dueString(col))
         c.queue = Consts.QUEUE_TYPE_SIBLING_BURIED
         assertEquals("8/27/20", c.nextDue(col))
-        assertEquals("(8/27/20)", c.dueString())
+        assertEquals("(8/27/20)", c.dueString(col))
         c.queue = Consts.QUEUE_TYPE_SUSPENDED
         assertEquals("8/27/20", c.nextDue(col))
-        assertEquals("(8/27/20)", c.dueString())
+        assertEquals("(8/27/20)", c.dueString(col))
         c.queue = Consts.QUEUE_TYPE_REV
         assertEquals("8/27/20", c.nextDue(col))
-        assertEquals("8/27/20", c.dueString())
+        assertEquals("8/27/20", c.dueString(col))
         c.queue = Consts.QUEUE_TYPE_PREVIEW
         assertEquals("", c.nextDue(col))
-        assertEquals("", c.dueString())
+        assertEquals("", c.dueString(col))
         c.type = Consts.CARD_TYPE_RELEARNING
         c.due = id
         c.queue = Consts.QUEUE_TYPE_MANUALLY_BURIED
         assertEquals("", c.nextDue(col))
-        assertEquals("()", c.dueString())
+        assertEquals("()", c.dueString(col))
         c.queue = Consts.QUEUE_TYPE_SIBLING_BURIED
         assertEquals("", c.nextDue(col))
-        assertEquals("()", c.dueString())
+        assertEquals("()", c.dueString(col))
         c.queue = Consts.QUEUE_TYPE_SUSPENDED
         assertEquals("", c.nextDue(col))
-        assertEquals("()", c.dueString())
+        assertEquals("()", c.dueString(col))
         c.queue = Consts.QUEUE_TYPE_LRN
         c.due = id
         assertEquals("3/19/21", c.nextDue(col))
-        assertEquals("3/19/21", c.dueString())
+        assertEquals("3/19/21", c.dueString(col))
         c.queue = Consts.QUEUE_TYPE_PREVIEW
         assertEquals("", c.nextDue(col))
-        assertEquals("", c.dueString())
+        assertEquals("", c.dueString(col))
 
         // Dynamic deck
         val dyn = decks.newDyn("dyn")
         c.oDid = c.did
         c.did = dyn
         assertEquals("(filtered)", c.nextDue(col))
-        assertEquals("(filtered)", c.dueString())
+        assertEquals("(filtered)", c.dueString(col))
         c.queue = Consts.QUEUE_TYPE_SIBLING_BURIED
         assertEquals("(filtered)", c.nextDue(col))
-        assertEquals("((filtered))", c.dueString())
+        assertEquals("((filtered))", c.dueString(col))
     }
 }

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/CardTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/CardTest.kt
@@ -258,83 +258,83 @@ class CardTest : RobolectricTest() {
         c.type = Consts.CARD_TYPE_NEW
         c.due = 27L
         c.queue = Consts.QUEUE_TYPE_MANUALLY_BURIED
-        assertEquals("27", c.nextDue())
+        assertEquals("27", c.nextDue(col))
         assertEquals("(27)", c.dueString())
         c.queue = Consts.QUEUE_TYPE_SIBLING_BURIED
-        assertEquals("27", c.nextDue())
+        assertEquals("27", c.nextDue(col))
         assertEquals("(27)", c.dueString())
         c.queue = Consts.QUEUE_TYPE_SUSPENDED
-        assertEquals("27", c.nextDue())
+        assertEquals("27", c.nextDue(col))
         assertEquals("(27)", c.dueString())
         c.queue = Consts.QUEUE_TYPE_NEW
         c.due = 27L
-        assertEquals("27", c.nextDue())
+        assertEquals("27", c.nextDue(col))
         assertEquals("27", c.dueString())
         c.queue = Consts.QUEUE_TYPE_PREVIEW
-        assertEquals("27", c.nextDue())
+        assertEquals("27", c.nextDue(col))
         assertEquals("27", c.dueString())
         c.type = Consts.CARD_TYPE_LRN
         c.due = id
         c.queue = Consts.QUEUE_TYPE_MANUALLY_BURIED
-        assertEquals("", c.nextDue())
+        assertEquals("", c.nextDue(col))
         assertEquals("()", c.dueString())
         c.queue = Consts.QUEUE_TYPE_SIBLING_BURIED
-        assertEquals("", c.nextDue())
+        assertEquals("", c.nextDue(col))
         assertEquals("()", c.dueString())
         c.queue = Consts.QUEUE_TYPE_SUSPENDED
-        assertEquals("", c.nextDue())
+        assertEquals("", c.nextDue(col))
         assertEquals("()", c.dueString())
         c.queue = Consts.QUEUE_TYPE_LRN
-        assertEquals("3/19/21", c.nextDue())
+        assertEquals("3/19/21", c.nextDue(col))
         assertEquals("3/19/21", c.dueString())
         c.queue = Consts.QUEUE_TYPE_PREVIEW
-        assertEquals("", c.nextDue())
+        assertEquals("", c.nextDue(col))
         assertEquals("", c.dueString())
         c.type = Consts.CARD_TYPE_REV
         c.due = 20
         //  Since tests run the 7th of august, in 20 days we are the 27th of august 2020
         c.queue = Consts.QUEUE_TYPE_MANUALLY_BURIED
-        assertEquals("8/27/20", c.nextDue())
+        assertEquals("8/27/20", c.nextDue(col))
         assertEquals("(8/27/20)", c.dueString())
         c.queue = Consts.QUEUE_TYPE_SIBLING_BURIED
-        assertEquals("8/27/20", c.nextDue())
+        assertEquals("8/27/20", c.nextDue(col))
         assertEquals("(8/27/20)", c.dueString())
         c.queue = Consts.QUEUE_TYPE_SUSPENDED
-        assertEquals("8/27/20", c.nextDue())
+        assertEquals("8/27/20", c.nextDue(col))
         assertEquals("(8/27/20)", c.dueString())
         c.queue = Consts.QUEUE_TYPE_REV
-        assertEquals("8/27/20", c.nextDue())
+        assertEquals("8/27/20", c.nextDue(col))
         assertEquals("8/27/20", c.dueString())
         c.queue = Consts.QUEUE_TYPE_PREVIEW
-        assertEquals("", c.nextDue())
+        assertEquals("", c.nextDue(col))
         assertEquals("", c.dueString())
         c.type = Consts.CARD_TYPE_RELEARNING
         c.due = id
         c.queue = Consts.QUEUE_TYPE_MANUALLY_BURIED
-        assertEquals("", c.nextDue())
+        assertEquals("", c.nextDue(col))
         assertEquals("()", c.dueString())
         c.queue = Consts.QUEUE_TYPE_SIBLING_BURIED
-        assertEquals("", c.nextDue())
+        assertEquals("", c.nextDue(col))
         assertEquals("()", c.dueString())
         c.queue = Consts.QUEUE_TYPE_SUSPENDED
-        assertEquals("", c.nextDue())
+        assertEquals("", c.nextDue(col))
         assertEquals("()", c.dueString())
         c.queue = Consts.QUEUE_TYPE_LRN
         c.due = id
-        assertEquals("3/19/21", c.nextDue())
+        assertEquals("3/19/21", c.nextDue(col))
         assertEquals("3/19/21", c.dueString())
         c.queue = Consts.QUEUE_TYPE_PREVIEW
-        assertEquals("", c.nextDue())
+        assertEquals("", c.nextDue(col))
         assertEquals("", c.dueString())
 
         // Dynamic deck
         val dyn = decks.newDyn("dyn")
         c.oDid = c.did
         c.did = dyn
-        assertEquals("(filtered)", c.nextDue())
+        assertEquals("(filtered)", c.nextDue(col))
         assertEquals("(filtered)", c.dueString())
         c.queue = Consts.QUEUE_TYPE_SIBLING_BURIED
-        assertEquals("(filtered)", c.nextDue())
+        assertEquals("(filtered)", c.nextDue(col))
         assertEquals("((filtered))", c.dueString())
     }
 }

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/CardTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/CardTest.kt
@@ -35,7 +35,7 @@ import kotlin.test.assertNotNull
 class CardTest : RobolectricTest() {
 
     @Test
-    fun `pureAnswer() handled quoted html element`() {
+    fun `pureAnswer(col) handled quoted html element`() {
         // <hr id="answer"> is also used
         val modelName = addNonClozeModel("Test", arrayOf("One", "Two"), "{{One}}", "{{One}}<hr id=\"answer\">{{Two}}")
         val note = col.newNote(col.models.byName(modelName)!!)
@@ -44,7 +44,7 @@ class CardTest : RobolectricTest() {
         col.addNote(note)
         val card = note.cards()[0]
 
-        assertThat(card.pureAnswer(), equalTo("2"))
+        assertThat(card.pureAnswer(col), equalTo("2"))
     }
 
     /******************

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/CardTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/CardTest.kt
@@ -35,7 +35,7 @@ import kotlin.test.assertNotNull
 class CardTest : RobolectricTest() {
 
     @Test
-    fun `pureAnswer handled quoted html element`() {
+    fun `pureAnswer() handled quoted html element`() {
         // <hr id="answer"> is also used
         val modelName = addNonClozeModel("Test", arrayOf("One", "Two"), "{{One}}", "{{One}}<hr id=\"answer\">{{Two}}")
         val note = col.newNote(col.models.byName(modelName)!!)
@@ -44,7 +44,7 @@ class CardTest : RobolectricTest() {
         col.addNote(note)
         val card = note.cards()[0]
 
-        assertThat(card.pureAnswer, equalTo("2"))
+        assertThat(card.pureAnswer(), equalTo("2"))
     }
 
     /******************

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/CardTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/CardTest.kt
@@ -76,7 +76,7 @@ class CardTest : RobolectricTest() {
         col.addNote(note)
         val c = note.cards()[0]
         col.models.current()!!.getLong("id")
-        assertEquals(0, c.template().getInt("ord"))
+        assertEquals(0, c.template(col).getInt("ord"))
     }
 
     @Test

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/ClozeTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/ClozeTest.kt
@@ -35,24 +35,24 @@ class ClozeTest : RobolectricTest() {
         f = d.newNote(d.models.byName("Cloze")!!)
         f.setItem("Text", "hello {{c1::world}}")
         assertEquals(1, d.addNote(f))
-        assertThat(f.firstCard().q(), containsString("hello <span class=cloze>[...]</span>"))
-        assertThat(f.firstCard().a(), containsString("hello <span class=cloze>world</span>"))
+        assertThat(f.firstCard().q(col), containsString("hello <span class=cloze>[...]</span>"))
+        assertThat(f.firstCard().a(col), containsString("hello <span class=cloze>world</span>"))
         // and with a comment
         f = d.newNote(d.models.byName("Cloze")!!)
         f.setItem("Text", "hello {{c1::world::typical}}")
         assertEquals(1, d.addNote(f))
-        assertThat(f.firstCard().q(), containsString("<span class=cloze>[typical]</span>"))
-        assertThat(f.firstCard().a(), containsString("<span class=cloze>world</span>"))
+        assertThat(f.firstCard().q(col), containsString("<span class=cloze>[typical]</span>"))
+        assertThat(f.firstCard().a(col), containsString("<span class=cloze>world</span>"))
         // and with two clozes
         f = d.newNote(d.models.byName("Cloze")!!)
         f.setItem("Text", "hello {{c1::world}} {{c2::bar}}")
         assertEquals(2, d.addNote(f))
         val c1 = f.firstCard()
         val c2 = f.cards()[1]
-        assertThat(c1.q(), containsString("<span class=cloze>[...]</span> bar"))
-        assertThat(c1.a(), containsString("<span class=cloze>world</span> bar"))
-        assertThat(c2.q(), containsString("world <span class=cloze>[...]</span>"))
-        assertThat(c2.a(), containsString("world <span class=cloze>bar</span>"))
+        assertThat(c1.q(col), containsString("<span class=cloze>[...]</span> bar"))
+        assertThat(c1.a(col), containsString("<span class=cloze>world</span> bar"))
+        assertThat(c2.q(col), containsString("world <span class=cloze>[...]</span>"))
+        assertThat(c2.a(col), containsString("world <span class=cloze>bar</span>"))
         // if there are multiple answers for a single cloze, they are given in a
         // list
         f = d.newNote(d.models.byName("Cloze")!!)
@@ -79,8 +79,8 @@ class ClozeTest : RobolectricTest() {
         f.flush()
         if (!BackendFactory.defaultLegacySchema) { f.id = 0 }
         assertEquals(1, d.addNote(f))
-        assertThat(f.firstCard().q(), containsString("Cloze with <span class=cloze>[...]</span>"))
-        assertThat(f.firstCard().a(), containsString("Cloze with <span class=cloze>multi-line\nstring</span>"))
+        assertThat(f.firstCard().q(col), containsString("Cloze with <span class=cloze>[...]</span>"))
+        assertThat(f.firstCard().a(col), containsString("Cloze with <span class=cloze>multi-line\nstring</span>"))
         // try a multiline cloze in p tag
         f.setItem(
             "Text",
@@ -92,8 +92,8 @@ class ClozeTest : RobolectricTest() {
         f.flush()
         if (!BackendFactory.defaultLegacySchema) { f.id = 0 }
         assertEquals(1, d.addNote(f))
-        assertThat(f.firstCard().q(), containsString("<p>Cloze in html tag with <span class=cloze>[...]</span>"))
-        assertThat(f.firstCard().a(), containsString("<p>Cloze in html tag with <span class=cloze>multi-line\nstring</span>"))
+        assertThat(f.firstCard().q(col), containsString("<p>Cloze in html tag with <span class=cloze>[...]</span>"))
+        assertThat(f.firstCard().a(col), containsString("<p>Cloze in html tag with <span class=cloze>multi-line\nstring</span>"))
 
         // make sure multiline cloze things aren't too greedy
         f.setItem(
@@ -108,7 +108,7 @@ class ClozeTest : RobolectricTest() {
         if (!BackendFactory.defaultLegacySchema) { f.id = 0 }
         assertEquals(1, d.addNote(f))
         assertThat(
-            f.firstCard().q(),
+            f.firstCard().q(col),
             containsString(
                 """
     <p>Cloze in html tag with <span class=cloze>[...]</span> and then {{c2:another

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/ClozeTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/ClozeTest.kt
@@ -30,7 +30,7 @@ class ClozeTest : RobolectricTest() {
         f.setItem("Text", "nothing")
         assertThat(d.addNote(f), greaterThan(0))
         val card = f.cards()[0]
-        assertTrue(card.isEmpty())
+        assertTrue(card.isEmpty(col))
         // try with one cloze
         f = d.newNote(d.models.byName("Cloze")!!)
         f.setItem("Text", "hello {{c1::world}}")

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/ClozeTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/ClozeTest.kt
@@ -58,7 +58,7 @@ class ClozeTest : RobolectricTest() {
         f = d.newNote(d.models.byName("Cloze")!!)
         f.setItem("Text", "a {{c1::b}} {{c1::c}}")
         assertEquals(1, d.addNote(f))
-        assertThat(f.firstCard().a(), containsString("<span class=cloze>b</span> <span class=cloze>c</span>"))
+        assertThat(f.firstCard().a(col), containsString("<span class=cloze>b</span> <span class=cloze>c</span>"))
         // if we add another cloze, a card should be generated
         val cnt = d.cardCount()
         f.setItem("Text", "{{c2::hello}} {{c1::foo}}")
@@ -117,7 +117,7 @@ class ClozeTest : RobolectricTest() {
             )
         )
         assertThat(
-            f.firstCard().a(),
+            f.firstCard().a(col),
             containsString(
                 """
     <p>Cloze in html tag with <span class=cloze>multi-line

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/ClozeTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/ClozeTest.kt
@@ -30,7 +30,7 @@ class ClozeTest : RobolectricTest() {
         f.setItem("Text", "nothing")
         assertThat(d.addNote(f), greaterThan(0))
         val card = f.cards()[0]
-        assertTrue(card.isEmpty)
+        assertTrue(card.isEmpty())
         // try with one cloze
         f = d.newNote(d.models.byName("Cloze")!!)
         f.setItem("Text", "hello {{c1::world}}")

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/CollectionTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/CollectionTest.kt
@@ -37,7 +37,7 @@ class CollectionTest : RobolectricTest() {
         val did = addDeck("Testing")
         for (c in n.cards()) {
             c.did = did
-            c.flush()
+            c.flush(col)
         }
         assertThat("two cloze notes should be generated", n.numberOfCards(), equalTo(2))
 

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/CollectionTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/CollectionTest.kt
@@ -119,7 +119,7 @@ class CollectionTest : RobolectricTest() {
         assertEquals(4, col.cardCount())
         // check q/a generation
         val c0 = note.cards()[0]
-        assertThat(c0.q(), Matchers.containsString("three"))
+        assertThat(c0.q(col), Matchers.containsString("three"))
         // it should not be a duplicate
         assertEquals(note.dupeOrEmpty(), Note.DupeOrEmpty.CORRECT)
         // now let's make a duplicate
@@ -193,16 +193,16 @@ class CollectionTest : RobolectricTest() {
         n.setItem("Front", "foo[abc]")
         col.addNote(n)
         val c = n.cards()[0]
-        assertTrue(c.q().endsWith("abc"))
+        assertTrue(c.q(col).endsWith("abc"))
         // and should avoid sound
         n.setItem("Front", "foo[sound:abc.mp3]")
         n.flush()
-        val question = c.q(true)
+        val question = c.q(col, true)
         assertThat("Question «$question» does not contains «anki:play».", question, Matchers.containsString("anki:play"))
         // it shouldn't throw an error while people are editing
         m.getJSONArray("tmpls").getJSONObject(0).put("qfmt", "{{kana:}}")
         mm.save(m)
-        c.q(true)
+        c.q(col, true)
     }
 
     @Test

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/FinderTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/FinderTest.kt
@@ -184,17 +184,17 @@ class FinderTest : RobolectricTest() {
         c.queue = QUEUE_TYPE_REV
         c.type = CARD_TYPE_REV
         assertEquals(0, col.findCards("is:review").size)
-        c.flush()
+        c.flush(col)
         AnkiAssert.assertEqualsArrayList(arrayOf(c.id), col.findCards("is:review"))
         assertEquals(0, col.findCards("is:due").size)
         c.due = 0
         c.queue = QUEUE_TYPE_REV
-        c.flush()
+        c.flush(col)
         AnkiAssert.assertEqualsArrayList(arrayOf(c.id), col.findCards("is:due"))
         assertEquals(4, col.findCards("-is:due").size)
         c.queue = QUEUE_TYPE_SUSPENDED
         // ensure this card gets a later mod time
-        c.flush()
+        c.flush(col)
         col.db.execute("update cards set mod = mod + 1 where id = ?", c.id)
         AnkiAssert.assertEqualsArrayList(arrayOf(c.id), col.findCards("is:suspended"))
         // nids

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/FlagTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/FlagTest.kt
@@ -44,7 +44,7 @@ class FlagTest : RobolectricTest() {
         assertEquals(0, col.findCards("flag:1").size)
         // set flag 2
         col.setUserFlag(2, listOf(c.id))
-        c.load()
+        c.load(col)
         assertEquals(2, c.userFlag())
         // assertEquals(origBits, c.flags & origBits);TODO: create direct access to real flag value
         assertEquals(0, col.findCards("flag:0").size)
@@ -52,11 +52,11 @@ class FlagTest : RobolectricTest() {
         assertEquals(0, col.findCards("flag:3").size)
         // change to 3
         col.setUserFlag(3, listOf(c.id))
-        c.load()
+        c.load(col)
         assertEquals(3, c.userFlag())
         // unset
         col.setUserFlag(0, listOf(c.id))
-        c.load()
+        c.load(col)
         assertEquals(0, c.userFlag())
 
         // should work with Cards method as well

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/FlagTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/FlagTest.kt
@@ -37,7 +37,7 @@ class FlagTest : RobolectricTest() {
         // make sure higher bits are preserved
         val origBits = 0b101 shl 3
         c.setFlag(origBits)
-        c.flush()
+        c.flush(col)
         // no flags to start with
         assertEquals(0, c.userFlag())
         assertEquals(1, col.findCards("flag:0").size)

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/ImportingTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/ImportingTest.kt
@@ -129,7 +129,7 @@ class ImportingTest : RobolectricTest() {
       // the front template should contain the text added in the 2nd package
       tlong cid = dst.findCards("")[0]  // only 1 note in collection
       tNote note = dst.getCard(tcid).note();
-      assertThat(tnote.cards().get(0).template().getString("qfmt"), containsString("Changed Front Template"));
+      assertThat(tnote.cards().get(0).template(col).getString("qfmt"), containsString("Changed Front Template"));
       }
 
       @Test

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/MathJaxClozeTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/MathJaxClozeTest.kt
@@ -69,7 +69,7 @@ class MathJaxClozeTest : RobolectricTest() {
             val cards = note.cards()
             val c2 = cards[0]
             val q = c2.q(col)
-            val a = c2.a()
+            val a = c2.a(col)
             assertThat(q, containsString("\\(1 \\div 2 =\\)"))
             assertThat(a, containsString("\\(1 \\div 2 =\\)"))
             assertThat(a, containsString("<span ${clozeClass()}>\\(\\frac{1}{2}\\)</span>"))
@@ -100,7 +100,7 @@ class MathJaxClozeTest : RobolectricTest() {
         val cards = note.cards()
         val c2 = cards[0]
         val q = c2.q(col)
-        val a = c2.a()
+        val a = c2.a(col)
         assertThat(q, endsWith("</style>the \\((\\)<span ${clozeClass()}${clozeData("&#x5C;&#x28;x&#x5C;&#x29;")}>[...]</span>\\()\\) is \\(y\\) but not <span ${clozeClass()}${clozeData("&#x5C;&#x28;z&#x5C;&#x29;")}>[...]</span> or \\(\\lambda\\)"))
         assertThat(a, endsWith("</style>the \\((\\)<span ${clozeClass()}>\\(x\\)</span>\\()\\) is \\(y\\) but not <span ${clozeClass()}>\\(z\\)</span> or \\(\\lambda\\)<br>\n"))
     }

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/MathJaxClozeTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/MathJaxClozeTest.kt
@@ -47,11 +47,11 @@ class MathJaxClozeTest : RobolectricTest() {
 
         val cards = note.cards()
 
-        assertThat(cards[0].q(), containsString(clozeClass()))
-        assertThat(cards[1].q(), containsString(clozeClass()))
-        assertThat(cards[2].q(), not(containsString(clozeClass())))
-        assertThat(cards[3].q(), containsString(clozeClass()))
-        assertThat(cards[4].q(), containsString(clozeClass()))
+        assertThat(cards[0].q(col), containsString(clozeClass()))
+        assertThat(cards[1].q(col), containsString(clozeClass()))
+        assertThat(cards[2].q(col), not(containsString(clozeClass())))
+        assertThat(cards[3].q(col), containsString(clozeClass()))
+        assertThat(cards[4].q(col), containsString(clozeClass()))
     }
 
     @Test
@@ -68,7 +68,7 @@ class MathJaxClozeTest : RobolectricTest() {
 
             val cards = note.cards()
             val c2 = cards[0]
-            val q = c2.q()
+            val q = c2.q(col)
             val a = c2.a()
             assertThat(q, containsString("\\(1 \\div 2 =\\)"))
             assertThat(a, containsString("\\(1 \\div 2 =\\)"))
@@ -80,7 +80,7 @@ class MathJaxClozeTest : RobolectricTest() {
             c.addNote(note)
             val cards = note.cards()
             val c2 = cards[0]
-            val q = c2.q()
+            val q = c2.q(col)
             assertThat(q, containsString("\\(a\\) <span ${clozeClass()}${clozeData("b")}>[...]</span> \\[ [...] \\]"))
         }
     }
@@ -99,7 +99,7 @@ class MathJaxClozeTest : RobolectricTest() {
 
         val cards = note.cards()
         val c2 = cards[0]
-        val q = c2.q()
+        val q = c2.q(col)
         val a = c2.a()
         assertThat(q, endsWith("</style>the \\((\\)<span ${clozeClass()}${clozeData("&#x5C;&#x28;x&#x5C;&#x29;")}>[...]</span>\\()\\) is \\(y\\) but not <span ${clozeClass()}${clozeData("&#x5C;&#x28;z&#x5C;&#x29;")}>[...]</span> or \\(\\lambda\\)"))
         assertThat(a, endsWith("</style>the \\((\\)<span ${clozeClass()}>\\(x\\)</span>\\()\\) is \\(y\\) but not <span ${clozeClass()}>\\(z\\)</span> or \\(\\lambda\\)<br>\n"))

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/ModelTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/ModelTest.kt
@@ -272,7 +272,7 @@ class ModelTest : RobolectricTest() {
         assertEquals(0, c.ord)
         assertEquals(1, c2.ord)
         // switch templates
-        col.models.moveTemplate(m, c.template(), 1)
+        col.models.moveTemplate(m, c.template(col), 1)
         c.load(col)
         c2.load(col)
         assertEquals(1, c.ord)

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/ModelTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/ModelTest.kt
@@ -273,8 +273,8 @@ class ModelTest : RobolectricTest() {
         assertEquals(1, c2.ord)
         // switch templates
         col.models.moveTemplate(m, c.template(), 1)
-        c.load()
-        c2.load()
+        c.load(col)
+        c2.load(col)
         assertEquals(1, c.ord)
         assertEquals(0, c2.ord)
         // removing a template should delete its cards
@@ -612,8 +612,8 @@ class ModelTest : RobolectricTest() {
         assertEquals(1, c1.ord)
         col.models.change(basic, note.id, basic, noOp, map)
         note.load()
-        c0.load()
-        c1.load()
+        c0.load(col)
+        c1.load(col)
         assertThat(c0.q(), containsString("note"))
         assertThat(c1.q(), containsString("b123"))
         assertEquals(1, c0.ord)
@@ -630,7 +630,7 @@ class ModelTest : RobolectricTest() {
         // }
         col.models.change(basic, note.id, basic, noOp, map)
         note.load()
-        c0.load()
+        c0.load(col)
         // the card was deleted
         // but we have two cards, as a new one was generated
         assertEquals(2, note.numberOfCards())

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/ModelTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/ModelTest.kt
@@ -67,7 +67,7 @@ class ModelTest : RobolectricTest() {
         note.setItem("Front", "helloworld")
         col.addNote(note)
         val card = note.firstCard()
-        val q = card.q()
+        val q = card.q(col)
         assertThat(
             "field should be at the end of the template - empty string for front",
             q,
@@ -98,7 +98,7 @@ class ModelTest : RobolectricTest() {
         note.setItem("FrontSide2", "2")
         col.addNote(note)
         val card = note.firstCard()
-        val q = card.q()
+        val q = card.q(col)
         assertThat(
             "FrontSide should be an empty string, even though it was set",
             q,
@@ -283,7 +283,7 @@ class ModelTest : RobolectricTest() {
         // and should have updated the other cards' ordinals
         c = note.cards()[0]
         assertEquals(0, c.ord)
-        assertEquals("1", stripHTML(c.q()))
+        assertEquals("1", stripHTML(c.q(col)))
         // it shouldn't be possible to orphan notes by removing templates
         t = Models.newTemplate("template name")
         t.put("qfmt", "{{Front}}1")
@@ -347,7 +347,7 @@ class ModelTest : RobolectricTest() {
         val note = col.newNote()
         note.setItem("Front", "hello<b>world")
         col.addNote(note)
-        assertThat(note.cards()[0].q(), containsString("helloworld"))
+        assertThat(note.cards()[0].q(col), containsString("helloworld"))
     }
 
     @Test
@@ -389,7 +389,7 @@ class ModelTest : RobolectricTest() {
         }
 
         assertThat(
-            note.cards()[0].q(),
+            note.cards()[0].q(col),
             containsString("hello <span ${clozeClass()}${clozeData("world")}>[...]</span>")
         )
         assertThat(
@@ -407,7 +407,7 @@ class ModelTest : RobolectricTest() {
         clearId(note)
         assertEquals(1, col.addNote(note, Models.AllowEmpty.FALSE))
         assertThat(
-            note.cards()[0].q(),
+            note.cards()[0].q(col),
             containsString("<span ${clozeClass()}${clozeData("world")}>[typical]</span>")
         )
         assertThat(
@@ -423,7 +423,7 @@ class ModelTest : RobolectricTest() {
         val c1 = cards[0]
         val c2 = cards[1]
         assertThat(
-            c1.q(),
+            c1.q(col),
             containsString("<span ${clozeClass()}${clozeData("world")}>[...]</span> bar")
         )
         assertThat(
@@ -431,7 +431,7 @@ class ModelTest : RobolectricTest() {
             containsString("<span ${clozeClass()}>world</span> bar")
         )
         assertThat(
-            c2.q(),
+            c2.q(col),
             containsString("world <span ${clozeClass()}${clozeData("bar")}>[...]</span>")
         )
         assertThat(
@@ -504,20 +504,20 @@ class ModelTest : RobolectricTest() {
         )
         assertNotEquals(0, col.addNote(note))
         assertEquals(5, note.numberOfCards())
-        assertThat(note.cards()[0].q(), containsString(clozeClass()))
-        assertThat(note.cards()[1].q(), containsString(clozeClass()))
+        assertThat(note.cards()[0].q(col), containsString(clozeClass()))
+        assertThat(note.cards()[1].q(col), containsString(clozeClass()))
         assertThat(
-            note.cards()[2].q(),
+            note.cards()[2].q(col),
             not(containsString(clozeClass()))
         )
-        assertThat(note.cards()[3].q(), containsString(clozeClass()))
-        assertThat(note.cards()[4].q(), containsString(clozeClass()))
+        assertThat(note.cards()[3].q(col), containsString(clozeClass()))
+        assertThat(note.cards()[4].q(col), containsString(clozeClass()))
 
         note = col.newNote()
         note.setItem("Text", "\\(a\\) {{c1::b}} \\[ {{c1::c}} \\]")
         assertNotEquals(0, col.addNote(note))
         assertEquals(1, note.numberOfCards())
-        val question = note.cards()[0].q()
+        val question = note.cards()[0].q(col)
         if (!BackendFactory.defaultLegacySchema) {
             // below needs updating to support latest backend output
             return
@@ -539,7 +539,7 @@ class ModelTest : RobolectricTest() {
         note.setItem("Text", "hello {{c1::world}}")
         col.addNote(note)
         assertThat(
-            note.cards()[0].q(),
+            note.cards()[0].q(col),
             containsString("[[type:cloze:Text]]")
         )
     }
@@ -567,7 +567,7 @@ class ModelTest : RobolectricTest() {
         val a2 = "<i>chained</i>"
         note.setItem("Text", "This {{c1::$q1::$a1}} demonstrates {{c1::$q2::$a2}} clozes.")
         assertEquals(1, col.addNote(note))
-        note.cards()[0].q()
+        note.cards()[0].q(col)
         /* TODO: chained modifier
         assertThat("Question «"+question+"» does not contain the expected string", question, containsString("This <span class=cloze>[sentence]</span> demonstrates <span class=cloze>[chained]</span> clozes.")
                    );
@@ -606,16 +606,16 @@ class ModelTest : RobolectricTest() {
         // switch cards
         val c0 = note.cards()[0]
         val c1 = note.cards()[1]
-        assertThat(c0.q(), containsString("b123"))
-        assertThat(c1.q(), containsString("note"))
+        assertThat(c0.q(col), containsString("b123"))
+        assertThat(c1.q(col), containsString("note"))
         assertEquals(0, c0.ord)
         assertEquals(1, c1.ord)
         col.models.change(basic, note.id, basic, noOp, map)
         note.load()
         c0.load(col)
         c1.load(col)
-        assertThat(c0.q(), containsString("note"))
-        assertThat(c1.q(), containsString("b123"))
+        assertThat(c0.q(col), containsString("note"))
+        assertThat(c1.q(col), containsString("b123"))
         assertEquals(1, c0.ord)
         assertEquals(0, c1.ord)
         // .cards() returns cards in order

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/ModelTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/ModelTest.kt
@@ -393,7 +393,7 @@ class ModelTest : RobolectricTest() {
             containsString("hello <span ${clozeClass()}${clozeData("world")}>[...]</span>")
         )
         assertThat(
-            note.cards()[0].a(),
+            note.cards()[0].a(col),
             containsString("hello <span ${clozeClass()}>world</span>")
         )
         // and with a comment
@@ -411,7 +411,7 @@ class ModelTest : RobolectricTest() {
             containsString("<span ${clozeClass()}${clozeData("world")}>[typical]</span>")
         )
         assertThat(
-            note.cards()[0].a(),
+            note.cards()[0].a(col),
             containsString("<span ${clozeClass()}>world</span>")
         )
         // and with 2 clozes
@@ -427,7 +427,7 @@ class ModelTest : RobolectricTest() {
             containsString("<span ${clozeClass()}${clozeData("world")}>[...]</span> bar")
         )
         assertThat(
-            c1.a(),
+            c1.a(col),
             containsString("<span ${clozeClass()}>world</span> bar")
         )
         assertThat(
@@ -435,7 +435,7 @@ class ModelTest : RobolectricTest() {
             containsString("world <span ${clozeClass()}${clozeData("bar")}>[...]</span>")
         )
         assertThat(
-            c2.a(),
+            c2.a(col),
             containsString("world <span ${clozeClass()}>bar</span>")
         )
         // if there are multiple answers for a single cloze, they are given in a
@@ -450,7 +450,7 @@ class ModelTest : RobolectricTest() {
         clearId(note)
         assertEquals(1, col.addNote(note, Models.AllowEmpty.FALSE))
         assertThat(
-            note.cards()[0].a(),
+            note.cards()[0].a(col),
             containsString("<span ${clozeClass()}>b</span> <span ${clozeClass()}>c</span>")
         )
         // if we add another cloze, a card should be generated
@@ -571,7 +571,7 @@ class ModelTest : RobolectricTest() {
         /* TODO: chained modifier
         assertThat("Question «"+question+"» does not contain the expected string", question, containsString("This <span class=cloze>[sentence]</span> demonstrates <span class=cloze>[chained]</span> clozes.")
                    );
-        assertThat(note.cards().get(0).a(), containsString("This <span class=cloze>phrase</span> demonstrates <span class=cloze>en chaine</span> clozes."
+        assertThat(note.cards().get(0).a(col), containsString("This <span class=cloze>phrase</span> demonstrates <span class=cloze>en chaine</span> clozes."
                                                     ));
 
          */

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/UndoTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/UndoTest.kt
@@ -109,7 +109,7 @@ class UndoTest : RobolectricTest() {
             undo()
             reset()
             assertEquals(Counts(1, 0, 0), sched.counts())
-            c.load()
+            c.load(col)
             assertEquals(QUEUE_TYPE_NEW, c.queue)
             assertNotEquals(1001, c.left)
             assertNull(undoType())

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/sched/AbstractSchedTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/sched/AbstractSchedTest.kt
@@ -479,7 +479,7 @@ mw.col.sched.extendLimits(1, 0)
             cards[i]!!.queue = Consts.QUEUE_TYPE_LRN
             cards[i]!!.type = Consts.CARD_TYPE_LRN
             cards[i]!!.due = time.intTime() - 20 * 60 + i
-            cards[i]!!.flush()
+            cards[i]!!.flush(col)
         }
         col.reset()
         // Regression test success non deterministically without the sleep

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/sched/AbstractSchedTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/sched/AbstractSchedTest.kt
@@ -106,7 +106,7 @@ class AbstractSchedTest : RobolectricTest() {
         sched.answerCard(card, sched.goodNewButton)
         sched.card
         nonTaskUndo(col)
-        card.load()
+        card.load(col)
         assertThat(sched.newCount(), `is`(9))
         assertThat(sched.counts(card).new, `is`(10))
     }

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/sched/SchedTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/sched/SchedTest.kt
@@ -382,17 +382,17 @@ class SchedTest : RobolectricTest() {
         col.reset()
         // should get '1' first
         var c = card!!
-        assertTrue(c.q().endsWith("1"))
+        assertTrue(c.q(col).endsWith("1"))
         // pass it so it's due in 10 minutes
         col.sched.answerCard(c, BUTTON_TWO)
         // get the other card
         c = card!!
-        assertTrue(c.q().endsWith("2"))
+        assertTrue(c.q(col).endsWith("2"))
         // fail it so it's due in 1 minute
         col.sched.answerCard(c, BUTTON_ONE)
         // we shouldn't get the same card again
         c = card!!
-        assertFalse(c.q().endsWith("2"))
+        assertFalse(c.q(col).endsWith("2"))
     }
 
     @Test

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/sched/SchedTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/sched/SchedTest.kt
@@ -1295,7 +1295,7 @@ class SchedTest : RobolectricTest() {
         assertEquals(Counts(3, 0, 0), col.sched.counts())
         for (i in arrayOf("one", "three", "two")) {
             val c = card!!
-            assertEquals(c.note().getItem("Front"), i)
+            assertEquals(c.note(col).getItem("Front"), i)
             col.sched.answerCard(c, BUTTON_TWO)
         }
     }

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/sched/SchedTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/sched/SchedTest.kt
@@ -361,7 +361,7 @@ class SchedTest : RobolectricTest() {
         c.oDue = 321
         c.flush()
         (col.sched as Sched).removeLrn()
-        c.load()
+        c.load(col)
         assertEquals(QUEUE_TYPE_REV, c.queue)
         assertEquals(321, c.due)
     }
@@ -754,7 +754,7 @@ class SchedTest : RobolectricTest() {
         assertEquals(CARD_TYPE_REV, c.type)
         col.sched.suspendCards(longArrayOf(c.id))
         col.sched.unsuspendCards(longArrayOf(c.id))
-        c.load()
+        c.load(col)
         assertEquals(QUEUE_TYPE_REV, c.queue)
         assertEquals(CARD_TYPE_REV, c.type)
         assertEquals(1, c.due)
@@ -763,11 +763,11 @@ class SchedTest : RobolectricTest() {
         c.flush()
         addDynamicDeck("tmp")
         col.sched.rebuildDyn()
-        c.load()
+        c.load(col)
         assertNotEquals(1, c.due)
         assertNotEquals(1, c.did)
         col.sched.suspendCards(longArrayOf(c.id))
-        c.load()
+        c.load(col)
         assertEquals(1, c.due)
         assertEquals(1, c.did)
     }
@@ -857,7 +857,7 @@ class SchedTest : RobolectricTest() {
         // delete the deck, returning the card mid-study
         col.decks.rem(col.decks.selected())
         assertEquals(1, col.sched.deckDueTree().size.toLong())
-        c.load()
+        c.load(col)
         assertEquals(1, c.ivl)
         assertEquals((col.sched.today + 1).toLong(), c.due)
         // make it due
@@ -873,7 +873,7 @@ class SchedTest : RobolectricTest() {
         col.sched.rebuildDyn(did)
         col.reset()
         assertEquals(Counts(0, 0, 1), col.sched.counts())
-        c.load()
+        c.load(col)
         assertEquals(4, col.sched.answerButtons(c).toLong())
         // add a sibling so we can test minSpace, etc
         val c2 = c.clone()
@@ -910,7 +910,7 @@ class SchedTest : RobolectricTest() {
         assertNotEquals(c.due, oldDue)
         // if we terminate cramming prematurely it should be set back to new
         col.sched.emptyDyn(did)
-        c.load()
+        c.load(col)
         assertEquals(QUEUE_TYPE_NEW, c.queue)
         assertEquals(CARD_TYPE_NEW, c.type)
         assertEquals(oldDue, c.due)
@@ -967,7 +967,7 @@ class SchedTest : RobolectricTest() {
         c = card!!
         col.sched.answerCard(c, BUTTON_ONE)
         col.sched.emptyDyn(did)
-        c.load()
+        c.load(col)
         assertEquals(100, c.ivl)
         assertEquals((col.sched.today + 25).toLong(), c.due)
         // fail+grad early
@@ -979,7 +979,7 @@ class SchedTest : RobolectricTest() {
         col.sched.answerCard(c, BUTTON_ONE)
         col.sched.answerCard(c, BUTTON_THREE)
         col.sched.emptyDyn(did)
-        c.load()
+        c.load(col)
         assertEquals(100, c.ivl)
         assertEquals((col.sched.today + 25).toLong(), c.due)
         // due cards - pass
@@ -991,7 +991,7 @@ class SchedTest : RobolectricTest() {
         c = card!!
         col.sched.answerCard(c, BUTTON_THREE)
         col.sched.emptyDyn(did)
-        c.load()
+        c.load(col)
         assertEquals(100, c.ivl)
         assertEquals(-25, c.due)
         // fail
@@ -1003,7 +1003,7 @@ class SchedTest : RobolectricTest() {
         c = card!!
         col.sched.answerCard(c, BUTTON_ONE)
         col.sched.emptyDyn(did)
-        c.load()
+        c.load(col)
         assertEquals(100, c.ivl)
         assertEquals(-25, c.due)
         // fail with normal grad
@@ -1015,7 +1015,7 @@ class SchedTest : RobolectricTest() {
         c = card!!
         col.sched.answerCard(c, BUTTON_ONE)
         col.sched.answerCard(c, BUTTON_THREE)
-        c.load()
+        c.load(col)
         assertEquals(100, c.ivl)
         assertEquals(-25, c.due)
         // lapsed card pulled into cram
@@ -1374,13 +1374,13 @@ class SchedTest : RobolectricTest() {
         col.addNote(note)
         val c = note.cards()[0]
         col.sched.reschedCards(listOf(c.id), 0, 0)
-        c.load()
+        c.load(col)
         assertEquals(col.sched.today.toLong(), c.due)
         assertEquals(1, c.ivl)
         assertEquals(CARD_TYPE_REV, c.type)
         assertEquals(QUEUE_TYPE_REV, c.queue)
         col.sched.reschedCards(listOf(c.id), 1, 1)
-        c.load()
+        c.load(col)
         assertEquals((col.sched.today + 1).toLong(), c.due)
         assertEquals(+1, c.ivl)
     }

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/sched/SchedTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/sched/SchedTest.kt
@@ -120,7 +120,7 @@ class SchedTest : RobolectricTest() {
         val n = addNoteUsingBasicModel("Hello", "World")
         val c = n.firstCard()
         c.queue = QUEUE_TYPE_SIBLING_BURIED
-        c.flush()
+        c.flush(col)
         return c
     }
 
@@ -359,7 +359,7 @@ class SchedTest : RobolectricTest() {
         c.type = CARD_TYPE_REV
         c.queue = QUEUE_TYPE_LRN
         c.oDue = 321
-        c.flush()
+        c.flush(col)
         (col.sched as Sched).removeLrn()
         c.load(col)
         assertEquals(QUEUE_TYPE_REV, c.queue)
@@ -423,7 +423,7 @@ class SchedTest : RobolectricTest() {
         assertNull(card)
         // for testing, move it back a day
         c.due = c.due - 1
-        c.flush()
+        c.flush(col)
         col.reset()
         assertEquals(Counts(0, 1, 0), col.sched.counts())
         c = card!!
@@ -438,7 +438,7 @@ class SchedTest : RobolectricTest() {
         col.sched.answerCard(c, BUTTON_TWO)
         // simulate the passing of another two days
         c.due = c.due - 2
-        c.flush()
+        c.flush(col)
         col.reset()
         // the last pass should graduate it into a review card
         assertEquals(SECONDS_PER_DAY, col.sched.nextIvl(c, BUTTON_TWO))
@@ -448,7 +448,7 @@ class SchedTest : RobolectricTest() {
         // if the lapse step is tomorrow, failing it should handle the counts
         // correctly
         c.due = 0
-        c.flush()
+        c.flush(col)
         col.reset()
         assertEquals(Counts(0, 0, 1), col.sched.counts())
         conf = col.sched._cardConf(c)
@@ -479,7 +479,7 @@ class SchedTest : RobolectricTest() {
             lapses = 1
             ivl = 100
             startTimer()
-            flush()
+            flush(col)
         }
         // save it for later use as well
         val cardcopy = c.clone()
@@ -510,7 +510,7 @@ class SchedTest : RobolectricTest() {
         // try again with an ease of 2 instead
         // //////////////////////////////////////////////////////////////////////////////////////////////////
         c = cardcopy.clone()
-        c.flush()
+        c.flush(col)
         col.sched.answerCard(c, BUTTON_TWO)
         assertEquals(QUEUE_TYPE_REV, c.queue)
         // the new interval should be (100 + 8/4) * 1.2 = 122
@@ -524,7 +524,7 @@ class SchedTest : RobolectricTest() {
         // ease 3
         // //////////////////////////////////////////////////////////////////////////////////////////////////
         c = cardcopy.clone()
-        c.flush()
+        c.flush(col)
         col.sched.answerCard(c, BUTTON_THREE)
         // the new interval should be (100 + 8/2) * 2.5 = 260
         assertTrue(checkRevIvl(c, 260))
@@ -534,7 +534,7 @@ class SchedTest : RobolectricTest() {
         // ease 4
         // //////////////////////////////////////////////////////////////////////////////////////////////////
         c = cardcopy.clone()
-        c.flush()
+        c.flush(col)
         col.sched.answerCard(c, BUTTON_FOUR)
         // the new interval should be (100 + 8) * 2.5 * 1.3 = 351
         assertTrue(checkRevIvl(c, 351))
@@ -558,7 +558,7 @@ class SchedTest : RobolectricTest() {
         c.setReps(1)
         c.ivl = 1
         c.startTimer()
-        c.flush()
+        c.flush(col)
         col.reset()
         // Upstream, there is no space in 2d
         assertEquals("2 d", without_unicode_isolation(col.sched.nextIvlStr(targetContext, c, BUTTON_TWO)))
@@ -585,7 +585,7 @@ class SchedTest : RobolectricTest() {
           c.setFactor(STARTING_FACTOR);
           c.setLeft(2002);
           c.setIvl(0);
-          c.flush();
+          c.flush(col);
           // checkpoint
           col.save();
           col.getSched().reset();
@@ -743,7 +743,7 @@ class SchedTest : RobolectricTest() {
             ivl = 100
             type = CARD_TYPE_REV
             queue = QUEUE_TYPE_REV
-            flush()
+            flush(col)
         }
 
         col.reset()
@@ -760,7 +760,7 @@ class SchedTest : RobolectricTest() {
         assertEquals(1, c.due)
         // should cope with cards in cram decks
         c.due = 1
-        c.flush()
+        c.flush(col)
         addDynamicDeck("tmp")
         col.sched.rebuildDyn()
         c.load(col)
@@ -788,7 +788,7 @@ class SchedTest : RobolectricTest() {
             mod = 1
             factor = STARTING_FACTOR
             startTimer()
-            flush()
+            flush(col)
         }
         col.reset()
         assertEquals(Counts(0, 0, 0), col.sched.counts())
@@ -865,7 +865,7 @@ class SchedTest : RobolectricTest() {
         assertEquals(Counts(0, 0, 0), col.sched.counts())
         c.due = -5
         c.ivl = 100
-        c.flush()
+        c.flush(col)
         col.reset()
         assertEquals(Counts(0, 0, 1), col.sched.counts())
         // cram again
@@ -881,7 +881,7 @@ class SchedTest : RobolectricTest() {
             id = 0
             ord = 1
             due = 325
-            flush()
+            flush(col)
         }
 
         // should be able to answer it
@@ -947,7 +947,7 @@ class SchedTest : RobolectricTest() {
             type = CARD_TYPE_REV
             due = (col.sched.today + 25).toLong()
             factor = STARTING_FACTOR
-            flush()
+            flush(col)
         }
         val cardcopy = c.clone()
         col.sched.rebuildDyn(did)
@@ -961,7 +961,7 @@ class SchedTest : RobolectricTest() {
         assertEquals((col.sched.today + 25).toLong(), c.due)
         // check failure too
         c = cardcopy
-        c.flush()
+        c.flush(col)
         col.sched.rebuildDyn(did)
         col.reset()
         c = card!!
@@ -972,7 +972,7 @@ class SchedTest : RobolectricTest() {
         assertEquals((col.sched.today + 25).toLong(), c.due)
         // fail+grad early
         c = cardcopy
-        c.flush()
+        c.flush(col)
         col.sched.rebuildDyn(did)
         col.reset()
         c = card!!
@@ -985,7 +985,7 @@ class SchedTest : RobolectricTest() {
         // due cards - pass
         c = cardcopy
         c.due = -25
-        c.flush()
+        c.flush(col)
         col.sched.rebuildDyn(did)
         col.reset()
         c = card!!
@@ -997,7 +997,7 @@ class SchedTest : RobolectricTest() {
         // fail
         c = cardcopy
         c.due = -25
-        c.flush()
+        c.flush(col)
         col.sched.rebuildDyn(did)
         col.reset()
         c = card!!
@@ -1009,7 +1009,7 @@ class SchedTest : RobolectricTest() {
         // fail with normal grad
         c = cardcopy
         c.due = -25
-        c.flush()
+        c.flush(col)
         col.sched.rebuildDyn(did)
         col.reset()
         c = card!!
@@ -1150,7 +1150,7 @@ class SchedTest : RobolectricTest() {
             type = CARD_TYPE_REV
             queue = QUEUE_TYPE_REV
             due = col.sched.today.toLong()
-            flush()
+            flush(col)
         }
 
         col.reset()
@@ -1173,7 +1173,7 @@ class SchedTest : RobolectricTest() {
                 type = CARD_TYPE_REV
                 queue = QUEUE_TYPE_REV
                 due = 0
-                flush()
+                flush(col)
             }
         }
         // fail the first one
@@ -1237,7 +1237,7 @@ class SchedTest : RobolectricTest() {
         val c = note.cards()[0]
         c.queue = QUEUE_TYPE_REV
         c.due = 0
-        c.flush()
+        c.flush(col)
         // add one more with a new deck
         note = col.newNote()
         note.setItem("Front", "two")
@@ -1266,7 +1266,7 @@ class SchedTest : RobolectricTest() {
         assertEquals(0, value.newCount.toLong())
         // code should not fail if a card has an invalid deck
         c.did = 12345
-        c.flush()
+        c.flush(col)
         col.sched.deckDueTree()
     }
 
@@ -1356,7 +1356,7 @@ class SchedTest : RobolectricTest() {
             type = CARD_TYPE_REV
             ivl = 100
             due = 0
-            flush()
+            flush(col)
         }
         col.reset()
         assertEquals(Counts(0, 0, 1), col.sched.counts())
@@ -1402,7 +1402,7 @@ class SchedTest : RobolectricTest() {
             lapses = 1
             ivl = 100
             startTimer()
-            flush()
+            flush(col)
         }
         col.reset()
         col.sched.answerCard(c, BUTTON_ONE)
@@ -1427,7 +1427,7 @@ class SchedTest : RobolectricTest() {
             setReps(3)
             lapses = 1
             startTimer()
-            flush()
+            flush(col)
         }
 
         val conf = col.sched._cardConf(c)

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/sched/SchedV2Test.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/sched/SchedV2Test.kt
@@ -605,17 +605,17 @@ open class SchedV2Test : RobolectricTest() {
         col.reset()
         // should get '1' first
         var c = card!!
-        Assert.assertTrue(c.q().endsWith("1"))
+        Assert.assertTrue(c.q(col).endsWith("1"))
         // pass it so it's due in 10 minutes
         col.sched.answerCard(c, BUTTON_THREE)
         // get the other card
         c = card!!
-        Assert.assertTrue(c.q().endsWith("2"))
+        Assert.assertTrue(c.q(col).endsWith("2"))
         // fail it so it's due in 1 minute
         col.sched.answerCard(c, BUTTON_ONE)
         // we shouldn't get the same card again
         c = card!!
-        Assert.assertFalse(c.q().endsWith("2"))
+        Assert.assertFalse(c.q(col).endsWith("2"))
     }
 
     @Test

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/sched/SchedV2Test.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/sched/SchedV2Test.kt
@@ -1610,7 +1610,7 @@ open class SchedV2Test : RobolectricTest() {
         Assert.assertEquals(Counts(3, 0, 0), col.sched.counts())
         for (i in arrayOf("one", "three", "two")) {
             val c = card!!
-            Assert.assertEquals(i, c.note().getItem("Front"))
+            Assert.assertEquals(i, c.note(col).getItem("Front"))
             col.sched.answerCard(c, BUTTON_THREE)
         }
     }

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/sched/SchedV2Test.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/sched/SchedV2Test.kt
@@ -760,7 +760,7 @@ open class SchedV2Test : RobolectricTest() {
         col.getSched().answerCard(c, BUTTON_ONE);
         assertTrue(hooked);
         assertEquals(QUEUE_TYPE_SUSPENDED, c.getQueue());
-        c.load();
+        c.load(col);
         assertEquals(QUEUE_TYPE_SUSPENDED, c.getQueue());
         */
     }
@@ -1048,20 +1048,20 @@ open class SchedV2Test : RobolectricTest() {
         val c2 = note.cards()[0]
         // burying
         col.sched.buryCards(longArrayOf(c.id), true)
-        c.load()
+        c.load(col)
         Assert.assertEquals(QUEUE_TYPE_MANUALLY_BURIED, c.queue)
         col.sched.buryCards(longArrayOf(c2.id), false)
-        c2.load()
+        c2.load(col)
         Assert.assertEquals(QUEUE_TYPE_SIBLING_BURIED, c2.queue)
         col.reset()
         assertNull(card)
         col.sched.unburyCardsForDeck(BaseSched.UnburyType.MANUAL)
-        c.load()
+        c.load(col)
         Assert.assertEquals(QUEUE_TYPE_NEW, c.queue)
-        c2.load()
+        c2.load(col)
         Assert.assertEquals(QUEUE_TYPE_SIBLING_BURIED, c2.queue)
         col.sched.unburyCardsForDeck(BaseSched.UnburyType.SIBLINGS)
-        c2.load()
+        c2.load(col)
         Assert.assertEquals(QUEUE_TYPE_NEW, c2.queue)
         col.sched.buryCards(longArrayOf(c.id, c2.id))
         col.sched.unburyCardsForDeck(BaseSched.UnburyType.ALL)
@@ -1105,7 +1105,7 @@ open class SchedV2Test : RobolectricTest() {
         Assert.assertEquals(CARD_TYPE_RELEARNING, c.type)
         col.sched.suspendCards(longArrayOf(c.id))
         col.sched.unsuspendCards(longArrayOf(c.id))
-        c.load()
+        c.load(col)
         Assert.assertEquals(QUEUE_TYPE_LRN, c.queue)
         Assert.assertEquals(CARD_TYPE_RELEARNING, c.type)
         Assert.assertEquals(due, c.due)
@@ -1114,11 +1114,11 @@ open class SchedV2Test : RobolectricTest() {
         c.flush()
         addDynamicDeck("tmp")
         col.sched.rebuildDyn()
-        c.load()
+        c.load(col)
         Assert.assertNotEquals(1, c.due)
         Assert.assertNotEquals(1, c.did)
         col.sched.suspendCards(longArrayOf(c.id))
-        c.load()
+        c.load(col)
         Assert.assertNotEquals(1, c.due)
         Assert.assertNotEquals(1, c.did)
         Assert.assertEquals(1, c.oDue)
@@ -1229,7 +1229,7 @@ open class SchedV2Test : RobolectricTest() {
         col.reset()
 
         // card should still be in learning state
-        c.load()
+        c.load(col)
         Assert.assertEquals(CARD_TYPE_LRN, c.queue)
         Assert.assertEquals(QUEUE_TYPE_LRN, c.type)
         Assert.assertEquals(2, c.left % 1000)
@@ -1244,7 +1244,7 @@ open class SchedV2Test : RobolectricTest() {
 
         // emptying the deck preserves learning state
         col.sched.emptyDyn(did)
-        c.load()
+        c.load(col)
         Assert.assertEquals(CARD_TYPE_LRN, c.queue)
         Assert.assertEquals(QUEUE_TYPE_LRN, c.type)
         Assert.assertEquals(1, c.left % 1000)
@@ -1306,7 +1306,7 @@ open class SchedV2Test : RobolectricTest() {
 
         // emptying the filtered deck should restore card
         col.sched.emptyDyn(did)
-        c.load()
+        c.load(col)
         Assert.assertEquals(QUEUE_TYPE_NEW, c.queue)
         Assert.assertEquals(0, c.reps)
         Assert.assertEquals(CARD_TYPE_NEW, c.type)
@@ -1688,13 +1688,13 @@ open class SchedV2Test : RobolectricTest() {
         col.addNote(note)
         val c = note.cards()[0]
         col.sched.reschedCards(listOf(c.id), 0, 0)
-        c.load()
+        c.load(col)
         Assert.assertEquals(col.sched.today.toLong(), c.due)
         Assert.assertEquals(1, c.ivl)
         Assert.assertEquals(QUEUE_TYPE_REV, c.type)
         Assert.assertEquals(CARD_TYPE_REV, c.queue)
         col.sched.reschedCards(listOf(c.id), 1, 1)
-        c.load()
+        c.load(col)
         Assert.assertEquals((col.sched.today + 1).toLong(), c.due)
         Assert.assertEquals(+1, c.ivl)
     }
@@ -1769,7 +1769,7 @@ open class SchedV2Test : RobolectricTest() {
 
         // the move to v2 should reset it to new
         col.changeSchedulerVer(2)
-        c.load()
+        c.load(col)
         Assert.assertEquals(QUEUE_TYPE_NEW, c.queue)
         Assert.assertEquals(CARD_TYPE_NEW, c.type)
 
@@ -1778,19 +1778,19 @@ open class SchedV2Test : RobolectricTest() {
         c = card!!
         col.sched.answerCard(c, BUTTON_ONE)
         col.sched.buryCards(longArrayOf(c.id))
-        c.load()
+        c.load(col)
         Assert.assertEquals(QUEUE_TYPE_MANUALLY_BURIED, c.queue)
 
         // revert to version 1
         col.changeSchedulerVer(1)
 
         // card should have moved queues
-        c.load()
+        c.load(col)
         Assert.assertEquals(QUEUE_TYPE_SIBLING_BURIED, c.queue)
 
         // and it should be new again when unburied
         col.sched.unburyCards()
-        c.load()
+        c.load(col)
         Assert.assertEquals(CARD_TYPE_NEW, c.queue)
         Assert.assertEquals(QUEUE_TYPE_NEW, c.type)
 
@@ -1798,7 +1798,7 @@ open class SchedV2Test : RobolectricTest() {
         col.changeSchedulerVer(2)
         // card with 100 day interval, answering again
         col.sched.reschedCards(listOf(c.id), 100, 100)
-        c.load()
+        c.load(col)
         c.due = 0
         c.flush()
         val conf = col.sched._cardConf(c)
@@ -1807,11 +1807,11 @@ open class SchedV2Test : RobolectricTest() {
         col.reset()
         c = card!!
         col.sched.answerCard(c, BUTTON_ONE)
-        c.load()
+        c.load(col)
         Assert.assertEquals(50, c.ivl)
         // due should be correctly set when removed from learning early
         col.changeSchedulerVer(1)
-        c.load()
+        c.load(col)
         Assert.assertEquals(QUEUE_TYPE_REV, c.queue)
         Assert.assertEquals(CARD_TYPE_REV, c.type)
         Assert.assertEquals(50, c.due)
@@ -1840,7 +1840,7 @@ open class SchedV2Test : RobolectricTest() {
         col.sched.rebuildDyn(did)
         col.sched.emptyDyn(did)
         col.reset()
-        c.load()
+        c.load(col)
         Assert.assertEquals(-5, c.due)
     }
 

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/sched/SchedV2Test.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/sched/SchedV2Test.kt
@@ -122,7 +122,7 @@ open class SchedV2Test : RobolectricTest() {
             oDid = homeDeckId
             did = dynId
         }
-        c.flush()
+        c.flush(col)
         val v2 = SchedV2(col)
         val schedCard = v2.card!!
         MatcherAssert.assertThat(schedCard, Matchers.notNullValue())
@@ -520,7 +520,7 @@ open class SchedV2Test : RobolectricTest() {
         // or normal removal
         c.type = CARD_TYPE_NEW
         c.queue = QUEUE_TYPE_LRN
-        c.flush()
+        c.flush(col)
         col.sched.answerCard(c, BUTTON_FOUR)
         Assert.assertEquals(CARD_TYPE_REV, c.type)
         Assert.assertEquals(QUEUE_TYPE_REV, c.queue)
@@ -545,7 +545,7 @@ open class SchedV2Test : RobolectricTest() {
             queue = QUEUE_TYPE_REV
             type = CARD_TYPE_REV
         }
-        c.flush()
+        c.flush(col)
 
         // fail the card
         col.reset()
@@ -576,7 +576,7 @@ open class SchedV2Test : RobolectricTest() {
             queue = QUEUE_TYPE_REV
             type = CARD_TYPE_REV
         }
-        c.flush()
+        c.flush(col)
         val conf = col.decks.confForDid(1)
         conf.getJSONObject("lapse").put("delays", JSONArray(doubleArrayOf()))
         col.decks.save(conf)
@@ -646,7 +646,7 @@ open class SchedV2Test : RobolectricTest() {
         assertNull(card)
         // for testing, move it back a day
         c.due = c.due - 1
-        c.flush()
+        c.flush(col)
         col.reset()
         Assert.assertEquals(Counts(0, 1, 0), col.sched.counts())
         c = card!!
@@ -661,7 +661,7 @@ open class SchedV2Test : RobolectricTest() {
         col.sched.answerCard(c, BUTTON_THREE)
         // simulate the passing of another two days
         c.due = c.due - 2
-        c.flush()
+        c.flush(col)
         col.reset()
         // the last pass should graduate it into a review card
         Assert.assertEquals(Stats.SECONDS_PER_DAY, col.sched.nextIvl(c, BUTTON_THREE))
@@ -671,7 +671,7 @@ open class SchedV2Test : RobolectricTest() {
         // if the lapse step is tomorrow, failing it should handle the counts
         // correctly
         c.due = 0
-        c.flush()
+        c.flush(col)
         col.reset()
         Assert.assertEquals(Counts(0, 0, 1), col.sched.counts())
         conf = col.sched._cardConf(c)
@@ -703,13 +703,13 @@ open class SchedV2Test : RobolectricTest() {
             ivl = 100
         }
         c.startTimer()
-        c.flush()
+        c.flush(col)
         // save it for later use as well
         val cardcopy = c.clone()
         // try with an ease of 2
         // //////////////////////////////////////////////////////////////////////////////////////////////////
         c = cardcopy.clone()
-        c.flush()
+        c.flush(col)
         col.reset()
         col.sched.answerCard(c, BUTTON_TWO)
         Assert.assertEquals(QUEUE_TYPE_REV, c.queue)
@@ -724,7 +724,7 @@ open class SchedV2Test : RobolectricTest() {
         // ease 3
         // //////////////////////////////////////////////////////////////////////////////////////////////////
         c = cardcopy.clone()
-        c.flush()
+        c.flush(col)
         col.sched.answerCard(c, BUTTON_THREE)
         // the new interval should be (100 + 8/2) * 2.5 = 260
         Assert.assertTrue(AnkiAssert.checkRevIvl(c, 260))
@@ -734,7 +734,7 @@ open class SchedV2Test : RobolectricTest() {
         // ease 4
         // //////////////////////////////////////////////////////////////////////////////////////////////////
         c = cardcopy.clone()
-        c.flush()
+        c.flush(col)
         col.sched.answerCard(c, BUTTON_FOUR)
         // the new interval should be (100 + 8) * 2.5 * 1.3 = 351
         Assert.assertTrue(AnkiAssert.checkRevIvl(c, 351))
@@ -748,7 +748,7 @@ open class SchedV2Test : RobolectricTest() {
         col.decks.save(conf)
         c = cardcopy.clone()
         c.lapses = 7
-        c.flush()
+        c.flush(col)
         /* todo hook
         // steup hook
         hooked = new [] {};
@@ -797,7 +797,7 @@ open class SchedV2Test : RobolectricTest() {
             c.queue = QUEUE_TYPE_REV
             c.type = CARD_TYPE_REV
             c.due = 0
-            c.flush()
+            c.flush(col)
         }
         var parentIndex = 0
         if (defaultLegacySchema) {
@@ -839,7 +839,7 @@ open class SchedV2Test : RobolectricTest() {
         c.setReps(1)
         c.ivl = 1
         c.startTimer()
-        c.flush()
+        c.flush(col)
         col.reset()
         // Upstream, there is no space in 2d
         Assert.assertEquals(
@@ -896,7 +896,7 @@ open class SchedV2Test : RobolectricTest() {
            c.setFactor(STARTING_FACTOR);
            c.setLeft(2002);
            c.setIvl(0);
-           c.flush();
+           c.flush(col);
            // checkpoint
            col.save();
            col.getSched().reset();
@@ -999,7 +999,7 @@ open class SchedV2Test : RobolectricTest() {
         c.type = CARD_TYPE_RELEARNING
         c.ivl = 100
         c.factor = STARTING_FACTOR
-        c.flush()
+        c.flush(col)
         Assert.assertEquals(60, col.sched.nextIvl(c, BUTTON_ONE))
         Assert.assertEquals(100 * Stats.SECONDS_PER_DAY, col.sched.nextIvl(c, BUTTON_THREE))
         Assert.assertEquals(101 * Stats.SECONDS_PER_DAY, col.sched.nextIvl(c, BUTTON_FOUR))
@@ -1009,7 +1009,7 @@ open class SchedV2Test : RobolectricTest() {
         c.queue = QUEUE_TYPE_REV
         c.ivl = 100
         c.factor = STARTING_FACTOR
-        c.flush()
+        c.flush(col)
         // failing it should put it at 60s
         Assert.assertEquals(60, col.sched.nextIvl(c, BUTTON_ONE))
         // or 1 day if relearn is false
@@ -1092,7 +1092,7 @@ open class SchedV2Test : RobolectricTest() {
         c.ivl = 100
         c.type = CARD_TYPE_REV
         c.queue = QUEUE_TYPE_REV
-        c.flush()
+        c.flush(col)
         col.reset()
         c = card!!
         col.sched.answerCard(c, BUTTON_ONE)
@@ -1111,7 +1111,7 @@ open class SchedV2Test : RobolectricTest() {
         Assert.assertEquals(due, c.due)
         // should cope with cards in cram decks
         c.due = 1
-        c.flush()
+        c.flush(col)
         addDynamicDeck("tmp")
         col.sched.rebuildDyn()
         c.load(col)
@@ -1142,7 +1142,7 @@ open class SchedV2Test : RobolectricTest() {
         }
 
         c.startTimer()
-        c.flush()
+        c.flush(col)
         col.reset()
         Assert.assertEquals(Counts(0, 0, 0), col.sched.counts())
         // create a dynamic deck and refresh it
@@ -1193,7 +1193,7 @@ open class SchedV2Test : RobolectricTest() {
         // due in 75 days, so it's been waiting 25 days
         c.ivl = 100
         c.due = (col.sched.today + 75).toLong()
-        c.flush()
+        c.flush(col)
         col.sched.rebuildDyn(did)
         col.reset()
         c = card!!
@@ -1467,7 +1467,7 @@ open class SchedV2Test : RobolectricTest() {
         c.type = CARD_TYPE_REV
         c.queue = QUEUE_TYPE_REV
         c.due = col.sched.today.toLong()
-        c.flush()
+        c.flush(col)
         col.reset()
         Assert.assertEquals(Counts(0, 0, 1), col.sched.counts())
         col.sched.answerCard(card!!, BUTTON_ONE)
@@ -1487,7 +1487,7 @@ open class SchedV2Test : RobolectricTest() {
             c.type = CARD_TYPE_REV
             c.queue = QUEUE_TYPE_REV
             c.due = 0
-            c.flush()
+            c.flush(col)
         }
         // fail the first one
         col.reset()
@@ -1498,7 +1498,7 @@ open class SchedV2Test : RobolectricTest() {
         Assert.assertEquals(QUEUE_TYPE_REV, c2.queue)
         // if the failed card becomes due, it should show first
         c.due = time.intTime() - 1
-        c.flush()
+        c.flush(col)
         col.reset()
         c = card!!
         Assert.assertEquals(QUEUE_TYPE_LRN, c.queue)
@@ -1539,7 +1539,7 @@ open class SchedV2Test : RobolectricTest() {
         val c = note.cards()[0]
         c.queue = QUEUE_TYPE_REV
         c.due = 0
-        c.flush()
+        c.flush(col)
         // add one more with a new deck
         note = col.newNote()
         note.setItem("Front", "two")
@@ -1566,7 +1566,7 @@ open class SchedV2Test : RobolectricTest() {
         Assert.assertEquals(0, value.newCount.toLong())
         // code should not fail if a card has an invalid deck
         c.did = 12345
-        c.flush()
+        c.flush(col)
         col.sched.deckDueTree()
     }
 
@@ -1671,7 +1671,7 @@ open class SchedV2Test : RobolectricTest() {
         c.type = CARD_TYPE_REV
         c.ivl = 100
         c.due = 0
-        c.flush()
+        c.flush(col)
         col.reset()
         Assert.assertEquals(Counts(0, 0, 1), col.sched.counts())
         col.sched.forgetCards(listOf(c.id))
@@ -1716,7 +1716,7 @@ open class SchedV2Test : RobolectricTest() {
         c.lapses = 1
         c.ivl = 100
         c.startTimer()
-        c.flush()
+        c.flush(col)
         col.reset()
         col.sched.answerCard(c, BUTTON_ONE)
         col.sched._cardConf(c).getJSONObject("lapse").put("delays", JSONArray(doubleArrayOf()))
@@ -1740,7 +1740,7 @@ open class SchedV2Test : RobolectricTest() {
         c.setReps(3)
         c.lapses = 1
         c.startTimer()
-        c.flush()
+        c.flush(col)
         val conf = col.sched._cardConf(c)
         conf.getJSONObject("lapse").put("mult", 0.5)
         col.decks.save(conf)
@@ -1800,7 +1800,7 @@ open class SchedV2Test : RobolectricTest() {
         col.sched.reschedCards(listOf(c.id), 100, 100)
         c.load(col)
         c.due = 0
-        c.flush()
+        c.flush(col)
         val conf = col.sched._cardConf(c)
         conf.getJSONObject("lapse").put("mult", 0.5)
         col.decks.save(conf)
@@ -1833,7 +1833,7 @@ open class SchedV2Test : RobolectricTest() {
         c.due = -5
         c.queue = QUEUE_TYPE_REV
         c.ivl = 5
-        c.flush()
+        c.flush(col)
 
         // into and out of filtered deck
         val did = addDynamicDeck("Cram")

--- a/api/src/main/java/com/ichi2/anki/FlashCardsContract.kt
+++ b/api/src/main/java/com/ichi2/anki/FlashCardsContract.kt
@@ -725,7 +725,7 @@ public object FlashCardsContract {
      *      ContentResolver cr = getContentResolver();
      *      Uri reviewInfoUri = FlashCardsContract.ReviewInfo.CONTENT_URI;
      *      ContentValues values = new ContentValues();
-     *      long noteId = card.note().getId();
+     *      long noteId = card.note(col).getId();
      *      int cardOrd = card.getOrd();
      *
      *      values.put(FlashCardsContract.ReviewInfo.NOTE_ID, noteId);


### PR DESCRIPTION
This remove `val col` from `Card`. This ensure that we explicitely know what requires the collection to be open, and will help cleaning more code and remove crash bug caused by access to a closed collection.

This was part of #13936 .