### PR TITLE
Remove sched

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
@@ -54,6 +54,7 @@ import com.ichi2.anki.AnkiDroidJsAPIConstants.SET_CARD_DUE
 import com.ichi2.anki.AnkiDroidJsAPIConstants.ankiJsErrorCodeDefault
 import com.ichi2.anki.AnkiDroidJsAPIConstants.ankiJsErrorCodeSetDue
 import com.ichi2.anki.CollectionManager.withCol
+import com.ichi2.anki.CollectionManager.withOpenColOrNull
 import com.ichi2.anki.Whiteboard.Companion.createInstance
 import com.ichi2.anki.Whiteboard.OnPaintColorChangeListener
 import com.ichi2.anki.cardviewer.Gesture
@@ -359,7 +360,7 @@ open class Reviewer :
         GetCard().runWithHandler(answerCardHandler(false))
         disableDrawerSwipeOnConflicts()
         // Add a weak reference to current activity so that scheduler can talk to to Activity
-        sched!!.setContext(WeakReference(this))
+        col.sched.setContext(WeakReference(this))
 
         // Set full screen/immersive mode if needed
         if (mPrefFullscreenReview) {
@@ -1035,7 +1036,7 @@ open class Reviewer :
 
         // Show next review time
         if (shouldShowNextReviewTime()) {
-            fun nextIvlStr(button: Int) = sched!!.nextIvlStr(this, currentCard!!, button)
+            fun nextIvlStr(button: Int) = col.sched.nextIvlStr(this, currentCard!!, button)
 
             easeButton1!!.nextTime = nextIvlStr(Consts.BUTTON_ONE)
             easeButton2!!.nextTime = nextIvlStr(Consts.BUTTON_TWO)
@@ -1049,7 +1050,7 @@ open class Reviewer :
     }
 
     val buttonCount: Int
-        get() = sched!!.answerButtons(currentCard!!)
+        get() = col.sched.answerButtons(currentCard!!)
 
     override fun automaticShowQuestion(action: AutomaticAnswerAction) {
         // explicitly do not call super
@@ -1097,10 +1098,10 @@ open class Reviewer :
         if (currentCard == null) return
         super.updateActionBar()
         val actionBar = supportActionBar
-        val counts = sched!!.counts(currentCard!!)
+        val counts = col.sched.counts(currentCard!!)
         if (actionBar != null) {
             if (mPrefShowETA) {
-                mEta = sched!!.eta(counts, false)
+                mEta = col.sched.eta(counts, false)
                 actionBar.subtitle = Utils.remainingTime(this, (mEta * 60).toLong())
             }
         }
@@ -1113,7 +1114,7 @@ open class Reviewer :
         // if this code is run as a card is being answered, currentCard may be non-null but
         // the queues may be empty - we can't call countIdx() in such a case
         if (counts.count() != 0) {
-            when (sched!!.countIdx(currentCard!!)) {
+            when (col.sched.countIdx(currentCard!!)) {
                 Counts.Queue.NEW -> mNewCount!!.setSpan(UnderlineSpan(), 0, mNewCount!!.length, 0)
                 Counts.Queue.LRN -> mLrnCount!!.setSpan(UnderlineSpan(), 0, mLrnCount!!.length, 0)
                 Counts.Queue.REV -> mRevCount!!.setSpan(UnderlineSpan(), 0, mRevCount!!.length, 0)
@@ -1176,8 +1177,12 @@ open class Reviewer :
 
     override fun onStop() {
         super.onStop()
-        if (!isFinishing && colIsOpen() && sched != null) {
-            update(this)
+        if (!isFinishing) {
+            launchCatchingTask {
+                withOpenColOrNull {
+                    update(context)
+                }
+            }
         }
         saveCollectionInBackground()
     }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/CardQueue.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/CardQueue.kt
@@ -18,13 +18,10 @@ package com.ichi2.libanki.sched
 
 import com.ichi2.libanki.Card
 import com.ichi2.libanki.CardId
-import com.ichi2.libanki.Collection
-import com.ichi2.utils.KotlinCleanup
 import java.util.*
 
 abstract class CardQueue<T : Card.Cache?>( // We need to store mSched and not queue, because during initialization of sched, when CardQueues are initialized
     // sched.getCol is null.
-    private val sched: AbstractSched?
 ) {
     protected val queue = LinkedList<T>()
     fun loadFirstCard() {
@@ -41,7 +38,7 @@ abstract class CardQueue<T : Card.Cache?>( // We need to store mSched and not qu
 
     fun remove(cid: CardId): Boolean {
         // CardCache and LrnCache with the same id will be considered as equal so it's a valid implementation.
-        return queue.remove(col?.let { Card.Cache(it, cid) })
+        return queue.removeIf { it?.id == cid }
     }
 
     fun add(elt: T) {
@@ -66,8 +63,4 @@ abstract class CardQueue<T : Card.Cache?>( // We need to store mSched and not qu
     fun listIterator(): MutableListIterator<T> {
         return queue.listIterator()
     }
-
-    @KotlinCleanup("make non-null")
-    protected val col: Collection?
-        get() = sched!!.col
 }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/LrnCardQueue.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/LrnCardQueue.kt
@@ -17,8 +17,9 @@
 package com.ichi2.libanki.sched
 
 import com.ichi2.libanki.CardId
+import com.ichi2.libanki.Collection
 
-class LrnCardQueue(sched: AbstractSched) : CardQueue<LrnCard>(sched) {
+class LrnCardQueue : CardQueue<LrnCard>() {
     /**
      * Whether the queue already contains its current expected value.
      * If it's not the case, then we won't add cards reviewed immediately and wait for a filling to occur.
@@ -26,8 +27,8 @@ class LrnCardQueue(sched: AbstractSched) : CardQueue<LrnCard>(sched) {
     var isFilled = false
         private set
 
-    fun add(due: Long, cid: CardId) {
-        add(LrnCard(col!!, due, cid))
+    fun add(col: Collection, due: Long, cid: CardId) {
+        add(LrnCard(col, due, cid))
     }
 
     fun sort() {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Sched.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Sched.kt
@@ -332,7 +332,7 @@ class Sched(col: Collection) : SchedV2(col) {
             mReportLimit
         ).use { cur ->
             while (cur.moveToNext()) {
-                mLrnQueue.add(cur.getLong(0), cur.getLong(1))
+                mLrnQueue.add(col, cur.getLong(0), cur.getLong(1))
             }
             // as it arrives sorted by did first, we need to sort it
             mLrnQueue.sort()
@@ -680,7 +680,7 @@ class Sched(col: Collection) : SchedV2(col) {
                      * queue is not empty if it should not be empty (important for the conditional belows), but the
                      * front of the queue contains distinct card.
                      */
-                    mRevQueue.add(cid)
+                    mRevQueue.add(col, cid)
                 }
                 if (!mRevQueue.isEmpty) {
                     // ordering

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.kt
@@ -77,10 +77,10 @@ open class SchedV2(col: Collection) : AbstractSched(col) {
     private var mNewCardModulus = 0
 
     // Queues
-    protected val mNewQueue = SimpleCardQueue(this)
-    protected val mLrnQueue = LrnCardQueue(this)
-    protected val mLrnDayQueue = SimpleCardQueue(this)
-    protected val mRevQueue = SimpleCardQueue(this)
+    protected val mNewQueue = SimpleCardQueue()
+    protected val mLrnQueue = LrnCardQueue()
+    protected val mLrnDayQueue = SimpleCardQueue()
+    protected val mRevQueue = SimpleCardQueue()
     private var mNewDids = LinkedList<Long>()
     protected var mLrnDids = LinkedList<Long>()
 
@@ -819,7 +819,7 @@ open class SchedV2(col: Collection) : AbstractSched(col) {
                     lim
                 )
                 ) {
-                    mNewQueue.add(cid)
+                    mNewQueue.add(col, cid)
                 }
                 if (!mNewQueue.isEmpty) {
                     // Note: libanki reverses mNewQueue and returns the last element in _getNewCard().
@@ -1042,7 +1042,7 @@ open class SchedV2(col: Collection) : AbstractSched(col) {
             ).use { cur ->
                 mLrnQueue.setFilled()
                 while (cur.moveToNext()) {
-                    mLrnQueue.add(cur.getLong(0), cur.getLong(1))
+                    mLrnQueue.add(col, cur.getLong(0), cur.getLong(1))
                 }
                 // as it arrives sorted by did first, we need to sort it
                 mLrnQueue.sort()
@@ -1109,7 +1109,7 @@ open class SchedV2(col: Collection) : AbstractSched(col) {
                 mQueueLimit
             )
             ) {
-                mLrnDayQueue.add(cid)
+                mLrnDayQueue.add(col, cid)
             }
             if (!mLrnDayQueue.isEmpty) {
                 // order
@@ -1578,7 +1578,7 @@ open class SchedV2(col: Collection) : AbstractSched(col) {
                 lim
             ).use { cur ->
                 while (cur.moveToNext()) {
-                    mRevQueue.add(cur.getLong(0))
+                    mRevQueue.add(col, cur.getLong(0))
                 }
             }
             if (!mRevQueue.isEmpty) {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SimpleCardQueue.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SimpleCardQueue.kt
@@ -17,11 +17,10 @@
 package com.ichi2.libanki.sched
 
 import com.ichi2.libanki.Card
-import com.ichi2.utils.KotlinCleanup
+import com.ichi2.libanki.Collection
 
-@KotlinCleanup("Make sched non-null ")
-class SimpleCardQueue(sched: AbstractSched?) : CardQueue<Card.Cache?>(sched) {
-    fun add(id: Long) {
-        add(col?.let { Card.Cache(it, id) })
+class SimpleCardQueue : CardQueue<Card.Cache?>() {
+    fun add(col: Collection, id: Long) {
+        add(Card.Cache(col, id))
     }
 }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/AnkiDroidJsAPITest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/AnkiDroidJsAPITest.kt
@@ -259,7 +259,7 @@ class AnkiDroidJsAPITest : RobolectricTest() {
         reviewer.webView!!.evaluateJavascript(jsScript) { s -> assertThat(s, equalTo(true)) }
 
         // count number of notes
-        assertThat(reviewer.sched!!.cardCount(), equalTo(4))
+        assertThat(reviewer.col.sched.cardCount(), equalTo(4))
 
         // ----------
         // Bury Note
@@ -269,7 +269,7 @@ class AnkiDroidJsAPITest : RobolectricTest() {
         reviewer.webView!!.evaluateJavascript(jsScript) { s -> assertThat(s, equalTo(true)) }
 
         // count number of notes
-        assertThat(reviewer.sched!!.cardCount(), equalTo(3))
+        assertThat(reviewer.col.sched.cardCount(), equalTo(3))
 
         // -------------
         // Suspend Card
@@ -279,7 +279,7 @@ class AnkiDroidJsAPITest : RobolectricTest() {
         reviewer.webView!!.evaluateJavascript(jsScript) { s -> assertThat(s, equalTo(true)) }
 
         // count number of notes
-        assertThat(reviewer.sched!!.cardCount(), equalTo(2))
+        assertThat(reviewer.col.sched.cardCount(), equalTo(2))
 
         // -------------
         // Suspend Note
@@ -289,7 +289,7 @@ class AnkiDroidJsAPITest : RobolectricTest() {
         reviewer.webView!!.evaluateJavascript(jsScript) { s -> assertThat(s, equalTo(true)) }
 
         // count number of notes
-        assertThat(reviewer.sched!!.cardCount(), equalTo(1))
+        assertThat(reviewer.col.sched.cardCount(), equalTo(1))
     }
 
     private fun createTestScript(apiName: String): String {

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/sched/AbstractSchedTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/sched/AbstractSchedTest.kt
@@ -114,8 +114,7 @@ class AbstractSchedTest : RobolectricTest() {
     @Test
     fun testCardQueue() {
         val col = col
-        val sched = col.sched as SchedV2
-        val queue = SimpleCardQueue(sched)
+        val queue = SimpleCardQueue()
         assertThat(queue.size(), `is`(0))
         val nbCard = 6
         val cids = LongArray(nbCard)
@@ -124,7 +123,7 @@ class AbstractSchedTest : RobolectricTest() {
             val card = note.firstCard()
             val cid = card.id
             cids[i] = cid
-            queue.add(cid)
+            queue.add(col, cid)
         }
         assertThat(queue.size(), `is`(nbCard))
         assertEquals(cids[0], queue.removeFirstCard().id)


### PR DESCRIPTION
I remove members of type Schedulers in classes outside of test (except Collection).
This will ensure that all access to a scheduler is through `col` and ultimately in `withCol`.

As discussed in #13936

search of those members was done with regexp `\bva[rl].*:.*Sched`