### PR TITLE
Disable keep screen on while disabling automatic show answer

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
@@ -1275,7 +1275,7 @@ abstract class AbstractFlashcardViewer :
         if (mGesturesEnabled) {
             mGestureProcessor.init(preferences)
         }
-        if (preferences.getBoolean("keepScreenOn", false)) {
+        if (preferences.getBoolean("timeoutAnswer", false) || preferences.getBoolean("keepScreenOn", false)) {
             this.window.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
         }
         return preferences

--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/ReviewingSettingsFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/ReviewingSettingsFragment.kt
@@ -72,13 +72,6 @@ class ReviewingSettingsFragment : SettingsFragment() {
                 launchCatchingTask { setDayOffset(requireContext(), newValue as Int) }
             }
         }
-        // Automatic display answer
-        requirePreference<SwitchPreference>(R.string.timeout_answer_preference).setOnPreferenceChangeListener { newValue ->
-            // Enable `Keep screen on` along with the automatic display answer preference
-            if (newValue == true) {
-                requirePreference<SwitchPreference>(R.string.keep_screen_on_preference).isChecked = true
-            }
-        }
 
         /**
          * Timeout answer


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
Diable `keep screen on` when disabling `automatic display answer`

## Fixes
Fixes #13951

## Approach
set isChecked to false when disabling "automatic display answer"

## How Has This Been Tested?
Tested on Emulator

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
