### PR TITLE
fix: Cursor color being the same of the app bar on the light theme

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/AdvancedSettingsFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/AdvancedSettingsFragment.kt
@@ -132,7 +132,7 @@ class AdvancedSettingsFragment : SettingsFragment() {
         }
 
         // Enable API
-        requirePreference<SwitchPreference>(R.string.enable_api_key).setOnPreferenceChangeListener { newValue ->
+        requirePreference<SwitchPreferenceCompat>(R.string.enable_api_key).setOnPreferenceChangeListener { newValue ->
             val providerName = ComponentName(requireContext(), CardContentProvider::class.java.name)
             val state = if (newValue == true) {
                 Timber.i("AnkiDroid ContentProvider enabled by user")
@@ -149,10 +149,10 @@ class AdvancedSettingsFragment : SettingsFragment() {
          */
 
         @RustCleanup("move this to Reviewing > Scheduling once the new backend is the default")
-        val v3schedPref = requirePreference<SwitchPreference>(R.string.enable_v3_sched_key)
+        val v3schedPref = requirePreference<SwitchPreferenceCompat>(R.string.enable_v3_sched_key)
 
         // Use V16 backend
-        requirePreference<SwitchPreference>(R.string.pref_rust_backend_key).apply {
+        requirePreference<SwitchPreferenceCompat>(R.string.pref_rust_backend_key).apply {
             if (!BuildConfig.LEGACY_SCHEMA) {
                 title = "New schema already enabled on local.properties"
                 isEnabled = false
@@ -214,14 +214,14 @@ class AdvancedSettingsFragment : SettingsFragment() {
          * on this same condition at [Preferences.configureSearchBar] */
         // Disable the emoji/kana buttons to scroll preference if those keys don't exist
         if (!CompatHelper.hasKanaAndEmojiKeys()) {
-            val emojiScrolling = findPreference<SwitchPreference>("scrolling_buttons")
+            val emojiScrolling = findPreference<SwitchPreferenceCompat>("scrolling_buttons")
             if (emojiScrolling != null) {
                 preferenceScreen.removePreference(emojiScrolling)
             }
         }
         // Disable the double scroll preference if no scrolling keys
         if (!CompatHelper.hasScrollKeys() && !CompatHelper.hasKanaAndEmojiKeys()) {
-            val doubleScrolling = findPreference<SwitchPreference>("double_scrolling")
+            val doubleScrolling = findPreference<SwitchPreferenceCompat>("double_scrolling")
             if (doubleScrolling != null) {
                 preferenceScreen.removePreference(doubleScrolling)
             }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/AppearanceSettingsFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/AppearanceSettingsFragment.kt
@@ -20,7 +20,7 @@ import android.provider.MediaStore
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.preference.ListPreference
 import androidx.preference.Preference
-import androidx.preference.SwitchPreference
+import androidx.preference.SwitchPreferenceCompat
 import com.ichi2.anki.*
 import com.ichi2.anki.CollectionManager.withCol
 import com.ichi2.anki.snackbar.showSnackbar
@@ -35,7 +35,7 @@ import java.io.FileInputStream
 import java.io.FileOutputStream
 
 class AppearanceSettingsFragment : SettingsFragment() {
-    private var mBackgroundImage: SwitchPreference? = null
+    private var mBackgroundImage: SwitchPreferenceCompat? = null
     override val preferenceResource: Int
         get() = R.xml.preferences_appearance
     override val analyticsScreenNameConstant: String
@@ -43,7 +43,7 @@ class AppearanceSettingsFragment : SettingsFragment() {
 
     override fun initSubscreen() {
         // Configure background
-        mBackgroundImage = requirePreference<SwitchPreference>("deckPickerBackground")
+        mBackgroundImage = requirePreference<SwitchPreferenceCompat>("deckPickerBackground")
         mBackgroundImage!!.onPreferenceClickListener = Preference.OnPreferenceClickListener {
             if (mBackgroundImage!!.isChecked) {
                 try {
@@ -133,7 +133,7 @@ class AppearanceSettingsFragment : SettingsFragment() {
         // Show estimate time
         // Represents the collection pref "estTime": i.e.
         // whether the buttons should indicate the duration of the interval if we click on them.
-        requirePreference<SwitchPreference>(R.string.show_estimates_preference).apply {
+        requirePreference<SwitchPreferenceCompat>(R.string.show_estimates_preference).apply {
             launchCatchingTask { isChecked = withCol { get_config_boolean("estTimes") } }
             setOnPreferenceChangeListener { newETA ->
                 launchCatchingTask { withCol { set_config("estTimes", newETA) } }
@@ -142,7 +142,7 @@ class AppearanceSettingsFragment : SettingsFragment() {
         // Show progress
         // Represents the collection pref "dueCounts": i.e.
         // whether the remaining number of cards should be shown.
-        requirePreference<SwitchPreference>(R.string.show_progress_preference).apply {
+        requirePreference<SwitchPreferenceCompat>(R.string.show_progress_preference).apply {
             launchCatchingTask { isChecked = withCol { get_config_boolean("dueCounts") } }
             setOnPreferenceChangeListener { newDueCountsValue ->
                 launchCatchingTask { withCol { set_config("dueCounts", newDueCountsValue) } }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/DevOptionsFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/DevOptionsFragment.kt
@@ -18,7 +18,7 @@ package com.ichi2.anki.preferences
 import android.content.Context
 import androidx.appcompat.app.AlertDialog
 import androidx.preference.Preference
-import androidx.preference.SwitchPreference
+import androidx.preference.SwitchPreferenceCompat
 import com.ichi2.anki.*
 import com.ichi2.anki.analytics.UsageAnalytics
 import com.ichi2.anki.snackbar.showSnackbar
@@ -40,7 +40,7 @@ class DevOptionsFragment : SettingsFragment() {
         get() = "prefs.dev_options"
 
     override fun initSubscreen() {
-        val enableDevOptionsPref = requirePreference<SwitchPreference>(R.string.dev_options_enabled_by_user_key)
+        val enableDevOptionsPref = requirePreference<SwitchPreferenceCompat>(R.string.dev_options_enabled_by_user_key)
         /**
          * If it is a DEBUG build, hide the preference to disable developer options
          * If it is a RELEASE build, configure the preference to disable dev options

--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/GeneralSettingsFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/GeneralSettingsFragment.kt
@@ -18,7 +18,7 @@ package com.ichi2.anki.preferences
 import androidx.appcompat.app.AppCompatDelegate
 import androidx.core.os.LocaleListCompat
 import androidx.preference.ListPreference
-import androidx.preference.SwitchPreference
+import androidx.preference.SwitchPreferenceCompat
 import com.ichi2.anki.*
 import com.ichi2.anki.CollectionManager.withCol
 import com.ichi2.anki.contextmenu.AnkiCardContextMenu
@@ -54,7 +54,7 @@ class GeneralSettingsFragment : SettingsFragment() {
         // Paste PNG
         // Represents in the collection's pref "pastePNG" , i.e.
         // whether to convert clipboard uri to png format or not.
-        requirePreference<SwitchPreference>(R.string.paste_png_key).apply {
+        requirePreference<SwitchPreferenceCompat>(R.string.paste_png_key).apply {
             launchCatchingTask { isChecked = withCol { get_config("pastePNG", false)!! } }
             setOnPreferenceChangeListener { newValue ->
                 launchCatchingTask { withCol { set_config("pastePNG", newValue) } }
@@ -65,7 +65,7 @@ class GeneralSettingsFragment : SettingsFragment() {
             CrashReportService.onPreferenceChanged(requireContext(), newValue as String)
         }
         // Anki card context menu
-        requirePreference<SwitchPreference>(R.string.anki_card_external_context_menu_key).apply {
+        requirePreference<SwitchPreferenceCompat>(R.string.anki_card_external_context_menu_key).apply {
             title = getString(R.string.card_browser_enable_external_context_menu, getString(R.string.context_menu_anki_card_label))
             summary = getString(R.string.card_browser_enable_external_context_menu_summary, getString(R.string.context_menu_anki_card_label))
             setOnPreferenceChangeListener { newValue ->
@@ -73,7 +73,7 @@ class GeneralSettingsFragment : SettingsFragment() {
             }
         }
         // Card browser context menu
-        requirePreference<SwitchPreference>(R.string.card_browser_external_context_menu_key).apply {
+        requirePreference<SwitchPreferenceCompat>(R.string.card_browser_external_context_menu_key).apply {
             title = getString(R.string.card_browser_enable_external_context_menu, getString(R.string.card_browser_context_menu))
             summary = getString(R.string.card_browser_enable_external_context_menu_summary, getString(R.string.card_browser_context_menu))
             setOnPreferenceChangeListener { newValue ->

--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/NotificationsSettingsFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/NotificationsSettingsFragment.kt
@@ -19,7 +19,7 @@ import android.app.AlarmManager
 import android.content.Context.ALARM_SERVICE
 import android.content.Intent
 import androidx.preference.ListPreference
-import androidx.preference.SwitchPreference
+import androidx.preference.SwitchPreferenceCompat
 import com.ichi2.anki.R
 import com.ichi2.anki.services.BootService.Companion.scheduleNotification
 import com.ichi2.anki.services.NotificationService
@@ -40,8 +40,8 @@ class NotificationsSettingsFragment : SettingsFragment() {
         if (AdaptionUtil.isXiaomiRestrictedLearningDevice) {
             /** These preferences should be searchable or not based
              * on this same condition at [Preferences.configureSearchBar] */
-            preferenceScreen.removePreference(requirePreference<SwitchPreference>(R.string.pref_notifications_vibrate_key))
-            preferenceScreen.removePreference(requirePreference<SwitchPreference>(R.string.pref_notifications_blink_key))
+            preferenceScreen.removePreference(requirePreference<SwitchPreferenceCompat>(R.string.pref_notifications_vibrate_key))
+            preferenceScreen.removePreference(requirePreference<SwitchPreferenceCompat>(R.string.pref_notifications_blink_key))
         }
         // Minimum cards due
         // The number of cards that should be due today in a deck to justify adding a notification.

--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/ReviewingSettingsFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/ReviewingSettingsFragment.kt
@@ -16,7 +16,7 @@
 package com.ichi2.anki.preferences
 
 import androidx.preference.ListPreference
-import androidx.preference.SwitchPreference
+import androidx.preference.SwitchPreferenceCompat
 import com.ichi2.anki.CollectionManager.withCol
 import com.ichi2.anki.R
 import com.ichi2.anki.launchCatchingTask
@@ -88,7 +88,7 @@ class ReviewingSettingsFragment : SettingsFragment() {
             }
         }
         // New timezone handling
-        requirePreference<SwitchPreference>(R.string.new_timezone_handling_preference).apply {
+        requirePreference<SwitchPreferenceCompat>(R.string.new_timezone_handling_preference).apply {
             launchCatchingTask {
                 isChecked = withCol { sched._new_timezone_enabled() }
                 isEnabled = withCol { schedVer() > 1 }

--- a/AnkiDroid/src/main/res/color/slider_active_track_color.xml
+++ b/AnkiDroid/src/main/res/color/slider_active_track_color.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <selector xmlns:android="http://schemas.android.com/apk/res/android" >
-  <item android:color="?attr/colorControlActivated" android:state_enabled="true"/>
+  <item android:color="?attr/widgetColorActivated" android:state_enabled="true"/>
   <item android:alpha="0.32" android:color="?attr/colorOnSurface"/>
 </selector>

--- a/AnkiDroid/src/main/res/color/slider_halo_color.xml
+++ b/AnkiDroid/src/main/res/color/slider_halo_color.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <selector xmlns:android="http://schemas.android.com/apk/res/android" >
-  <item android:alpha="0.24" android:color="?attr/colorControlActivated" android:state_enabled="true"/>
+  <item android:alpha="0.24" android:color="?attr/widgetColorActivated" android:state_enabled="true"/>
   <item android:color="@android:color/transparent"/>
 </selector>

--- a/AnkiDroid/src/main/res/color/slider_thumb_color.xml
+++ b/AnkiDroid/src/main/res/color/slider_thumb_color.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <selector xmlns:android="http://schemas.android.com/apk/res/android" >
-  <item android:color="?attr/colorControlActivated" android:state_enabled="true"/>
+  <item android:color="?attr/widgetColorActivated" android:state_enabled="true"/>
   <item android:alpha="0.38" android:color="?attr/colorOnSurface"/>
 </selector>

--- a/AnkiDroid/src/main/res/color/switch_thumb_tint.xml
+++ b/AnkiDroid/src/main/res/color/switch_thumb_tint.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android" >
+    <item android:color="?attr/widgetColorActivated" android:state_checked="true" />
+    <item android:color="#ececec"/>
+</selector>

--- a/AnkiDroid/src/main/res/color/switch_track_tint.xml
+++ b/AnkiDroid/src/main/res/color/switch_track_tint.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android" >
+    <item android:alpha="0.38" android:color="?attr/widgetColorActivated" android:state_checked="true" />
+    <item android:alpha="0.36" android:color="?attr/colorOnSurface" />
+</selector>

--- a/AnkiDroid/src/main/res/values/attrs.xml
+++ b/AnkiDroid/src/main/res/values/attrs.xml
@@ -56,6 +56,7 @@
         <attr name="displayValue" format="boolean"/>
     </declare-styleable>
 
+    <attr name="widgetColorActivated" format="color"/>
     <!-- App buttons -->
     <attr name="largeButtonBackgroundColor" format="color"/>
     <attr name="largeButtonBackgroundColorFocused" format="color"/>

--- a/AnkiDroid/src/main/res/values/theme_black.xml
+++ b/AnkiDroid/src/main/res/values/theme_black.xml
@@ -15,7 +15,6 @@
         <item name="android:textColorSecondary">@color/text_color_secondary_dark</item>
         <item name="android:colorBackground">@color/theme_black_primary</item>
         <item name="android:windowBackground">@color/theme_black_primary</item>
-        <item name="colorControlActivated">?attr/colorAccent</item>
         <item name="preferenceCategoryTitleTextColor">?attr/colorAccent</item>
         <!-- App buttons -->
         <item name="largeButtonBackgroundColor">#303030</item>

--- a/AnkiDroid/src/main/res/values/theme_dark.xml
+++ b/AnkiDroid/src/main/res/values/theme_dark.xml
@@ -14,11 +14,15 @@
         <item name="colorPrimary">@color/theme_dark_primary</item>
         <item name="colorPrimaryDark">@color/theme_dark_primary_dark</item>
         <item name="colorAccent">@color/material_blue_400</item>
+        <item name="colorOnSurface">@color/white</item>
         <item name="android:textColor">@color/text_color_dark</item>
         <item name="android:textColorSecondary">@color/text_color_secondary_dark</item>
         <item name="android:colorBackground">@color/material_theme_grey</item>
         <item name="android:windowBackground">@color/material_theme_grey</item>
-        <item name="colorControlActivated">?attr/colorAccent</item>
+        <!-- Widget colors -->
+        <item name="widgetColorActivated">?attr/colorAccent</item>
+        <item name="trackTint">@color/switch_track_tint</item>
+        <item name="thumbTint">@color/switch_thumb_tint</item>
         <item name="preferenceCategoryTitleTextColor">?attr/colorAccent</item>
         <!-- Navigation drawer -->
         <item name="navDrawerItemColor">@color/drawer_item_text_dark</item>

--- a/AnkiDroid/src/main/res/values/theme_light.xml
+++ b/AnkiDroid/src/main/res/values/theme_light.xml
@@ -32,8 +32,12 @@ APIs. It's visible when there aren't enough decks to fill the screen.
         <item name="android:textColorSecondary">@color/text_color_secondary_light</item>
         <item name="android:colorBackground">@android:color/white</item>
         <item name="android:windowBackground">@android:color/white</item>
-        <item name="colorControlActivated">?attr/colorPrimary</item>
         <item name="preferenceCategoryTitleTextColor">@color/material_light_blue_800</item>
+        <item name="colorOnSurface">@color/black</item>
+        <!-- Widget colors -->
+        <item name="widgetColorActivated">?attr/colorPrimary</item>
+        <item name="trackTint">@color/switch_track_tint</item>
+        <item name="thumbTint">@color/switch_thumb_tint</item>
         <!-- Navigation drawer theme -->
         <item name="navDrawerItemColor">@color/drawer_item_text_light</item>
         <item name="navDrawerItemBackgroundColor">@drawable/drawer_item_background_light</item>

--- a/AnkiDroid/src/main/res/values/theme_plain.xml
+++ b/AnkiDroid/src/main/res/values/theme_plain.xml
@@ -13,8 +13,9 @@
         <item name="colorAccent">@color/theme_plain_accent</item>
         <item name="android:textColor">@color/text_color_light</item>
         <item name="android:textColorSecondary">@color/text_color_secondary_light</item>
-        <item name="colorControlActivated">?attr/colorAccent</item>
         <item name="preferenceCategoryTitleTextColor">?attr/colorAccent</item>
+        <!-- Widget colors -->
+        <item name="widgetColorActivated">?attr/colorAccent</item>
         <!-- App buttons -->
         <item name="largeButtonBackgroundColor">#607D8B</item>
         <item name="largeButtonBackgroundColorFocused">#587180</item>

--- a/AnkiDroid/src/main/res/xml/preferences_accessibility.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_accessibility.xml
@@ -42,7 +42,7 @@
         android:valueTo="200"
         android:stepSize="10"
         app:displayFormat="@string/pref_summary_percentage"/>
-    <SwitchPreference
+    <SwitchPreferenceCompat
         android:key="@string/show_large_answer_buttons_preference"
         android:defaultValue="false"
         android:summary="@string/show_large_answer_buttons_summ"

--- a/AnkiDroid/src/main/res/xml/preferences_advanced.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_advanced.xml
@@ -39,7 +39,7 @@
             app1:useSimpleSummaryProvider="true"
             app:min="0"
             app:max="99" />
-        <SwitchPreference
+        <SwitchPreferenceCompat
             android:defaultValue="false"
             android:key="@string/tts_key"
             android:summary="@string/tts_summ"
@@ -48,17 +48,17 @@
             android:summary="@string/reset_languages_summ"
             android:title="@string/reset_languages"
             android:key="@string/pref_reset_languages_key" />
-        <SwitchPreference
+        <SwitchPreferenceCompat
             android:defaultValue="false"
             android:key="@string/convert_fen_text_key"
             android:summary="@string/convert_fen_text_summ"
             android:title="@string/convert_fen_text" />
-        <SwitchPreference
+        <SwitchPreferenceCompat
             android:defaultValue="false"
             android:key="@string/more_scrolling_buttons_key"
             android:summary="@string/more_scrolling_buttons_summ"
             android:title="@string/more_scrolling_buttons" />
-        <SwitchPreference
+        <SwitchPreferenceCompat
             android:defaultValue="false"
             android:key="@string/double_scrolling_gap_key"
             android:summary="@string/double_scrolling_gap_summ"
@@ -80,29 +80,29 @@
         <PreferenceCategory
             android:key="@string/pref_cat_workarounds_key"
             android:title="@string/pref_cat_workarounds" >
-            <SwitchPreference
+            <SwitchPreferenceCompat
                 android:defaultValue="false"
                 android:key="@string/disable_hardware_render_key"
                 android:summary="@string/software_render_summ"
                 android:title="@string/software_render" />
-            <SwitchPreference
+            <SwitchPreferenceCompat
                 android:defaultValue="false"
                 android:key="@string/safe_display_key"
                 android:summary="@string/safe_display_summ"
                 android:title="@string/safe_display" />
-            <SwitchPreference
+            <SwitchPreferenceCompat
                 android:defaultValue="false"
                 android:key="@string/use_input_tag_key"
                 android:disableDependentsState="true"
                 android:summary="@string/use_input_tag_summ"
                 android:title="@string/use_input_tag" />
             <!-- Workaround for #5533 -->
-            <SwitchPreference
+            <SwitchPreferenceCompat
                 android:defaultValue="false"
                 android:key="@string/disable_single_field_edit_key"
                 android:summary="@string/disable_extended_text_ui_summ"
                 android:title="@string/disable_extended_text_ui" />
-            <SwitchPreference
+            <SwitchPreferenceCompat
                 android:defaultValue="true"
                 android:key="@string/note_editor_newline_replace_key"
                 android:summary="@string/note_editor_replace_newlines_summ"
@@ -110,7 +110,7 @@
                 />
             <!-- #7896 - Workaround for old webviews which could not render some characters in a <code> block
             due to problems with the default monospace font handling -->
-            <SwitchPreference
+            <SwitchPreferenceCompat
                 android:defaultValue="false"
                 android:key="@string/no_code_formatting_key"
                 android:summary="@string/no_code_formatting_summ"
@@ -120,7 +120,7 @@
                 UseInputTag: has had `disableDependentsState` set, so this is disabled
                 if useInputTag is true
              -->
-            <SwitchPreference
+            <SwitchPreferenceCompat
                 android:defaultValue="true"
                 android:key="@string/type_in_answer_focus_key"
                 android:summary="@string/type_in_answer_focus_summ"
@@ -129,7 +129,7 @@
             <!-- #9639 - allow all files in media selection dialog - .opus is application/octet-stream
             in older versions of Android (fixed between API 26 and API 30)
              We don't want to allow this by default, but we want an override -->
-            <SwitchPreference
+            <SwitchPreferenceCompat
                 android:defaultValue="false"
                 android:key="@string/media_import_allow_all_files_key"
                 android:summary="@string/media_import_allow_all_files_summ"
@@ -138,7 +138,7 @@
         <PreferenceCategory
             android:key="@string/pref_cat_plugins_key"
             android:title="@string/pref_cat_plugins" >
-            <SwitchPreference
+            <SwitchPreferenceCompat
                 android:defaultValue="true"
                 android:key="@string/enable_api_key"
                 android:summary="@string/enable_api_summary"
@@ -151,12 +151,12 @@
         </PreferenceCategory>
         <PreferenceCategory
             android:title="@string/pref_cat_experimental">
-            <SwitchPreference
+            <SwitchPreferenceCompat
                 android:key="@string/pref_rust_backend_key"
                 android:title="@string/use_rust_backend_title"
                 android:summary="@string/use_rust_backend_summary"
                 android:defaultValue="false"/>
-            <SwitchPreference
+            <SwitchPreferenceCompat
                 android:key="@string/enable_v3_sched_key"
                 android:dependency="@string/pref_rust_backend_key"
                 android:title="@string/enable_v3_sched_title"

--- a/AnkiDroid/src/main/res/xml/preferences_advanced_statistics.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_advanced_statistics.xml
@@ -8,7 +8,7 @@
     android:title="@string/advanced_statistics_title"
     android:key="@string/pref_advanced_statistics_screen_key">
 
-    <SwitchPreference
+    <SwitchPreferenceCompat
         android:defaultValue="false"
         android:key="@string/pref_advanced_statistics_enabled_key"
         android:summary="@string/enable_advanced_statistics_summ"

--- a/AnkiDroid/src/main/res/xml/preferences_appearance.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_appearance.xml
@@ -57,7 +57,7 @@
             search:ignore="true"/>
     </PreferenceCategory>
     <PreferenceCategory android:title="@string/background_image_title" >
-        <SwitchPreference
+        <SwitchPreferenceCompat
             android:checked="false"
             android:defaultValue="0"
             android:key="@string/pref_deck_picker_background_key"
@@ -78,12 +78,12 @@
             android:entryValues="@array/full_screen_mode_values"
             android:title="@string/fullscreen_review"
             app:useSimpleSummaryProvider="true"/>
-        <SwitchPreference
+        <SwitchPreferenceCompat
             android:defaultValue="false"
             android:key="@string/center_vertically_preference"
             android:summary="@string/vertical_centering_summ"
             android:title="@string/vertical_centering" />
-        <SwitchPreference
+        <SwitchPreferenceCompat
             android:key="@string/show_estimates_preference"
             android:summary="@string/show_estimates_summ"
             android:title="@string/show_estimates" />
@@ -94,16 +94,16 @@
             android:key="@string/answer_buttons_position_preference"
             android:title="@string/answer_buttons_position"
             app:useSimpleSummaryProvider="true"/>
-        <SwitchPreference
+        <SwitchPreferenceCompat
             android:key="@string/show_topbar_preference"
             android:defaultValue="true"
             android:summary="@string/show_top_bar_summ"
             android:title="@string/show_top_bar" />
-        <SwitchPreference
+        <SwitchPreferenceCompat
             android:key="@string/show_progress_preference"
             android:summary="@string/show_progress_summ"
             android:title="@string/show_progress" />
-        <SwitchPreference
+        <SwitchPreferenceCompat
             android:key="@string/show_eta_preference"
             android:defaultValue="true"
             android:summary="@string/show_eta_summ"
@@ -130,7 +130,7 @@
             app:useSimpleSummaryProvider="true"/>
     </PreferenceCategory>
     <PreferenceCategory android:title="@string/card_browser">
-        <SwitchPreference
+        <SwitchPreferenceCompat
             android:checked="false"
             android:defaultValue="false"
             android:key="@string/pref_display_filenames_in_browser_key"

--- a/AnkiDroid/src/main/res/xml/preferences_controls.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_controls.xml
@@ -22,19 +22,19 @@
     android:title="@string/pref_cat_controls"
     android:key="@string/pref_controls_screen_key">
 
-    <SwitchPreference
+    <SwitchPreferenceCompat
         android:defaultValue="false"
         android:disableDependentsState="false"
         android:key="@string/gestures_preference"
         android:summary="@string/gestures_summ"
         android:title="@string/gestures" />
-    <SwitchPreference
+    <SwitchPreferenceCompat
         android:defaultValue="false"
         android:dependency="@string/gestures_preference"
         android:key="@string/gestures_corner_touch_preference"
         android:summary="@string/gestures_corner_touch_summary"
         android:title="@string/gestures_corner_touch" />
-    <SwitchPreference
+    <SwitchPreferenceCompat
         android:defaultValue="false"
         android:dependency="@string/gestures_preference"
         android:disableDependentsState="false"

--- a/AnkiDroid/src/main/res/xml/preferences_dev_options.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_dev_options.xml
@@ -23,11 +23,11 @@
     xmlns:app1="http://schemas.android.com/apk/res-auto"
     android:title="@string/pref_cat_dev_options"
     android:key="@string/pref_dev_options_screen_key">
-    <SwitchPreference
+    <SwitchPreferenceCompat
         android:title="@string/dev_options_enabled_pref"
         android:key="@string/dev_options_enabled_by_user_key"
         android:defaultValue="true"/>
-    <SwitchPreference
+    <SwitchPreferenceCompat
         android:defaultValue="false"
         android:key="@string/html_javascript_debugging_key"
         android:summary="@string/html_javascript_debugging_summ"
@@ -44,7 +44,7 @@
         android:title="Lock Database"
         android:summary="Touch here to lock the database (all threads block in-process, exception if using second process)"
         android:key="@string/pref_lock_database_key"/>
-    <SwitchPreference
+    <SwitchPreferenceCompat
         android:title="@string/show_onboarding"
         android:summary="@string/show_onboarding_desc"
         android:key="@string/pref_show_onboarding_key"

--- a/AnkiDroid/src/main/res/xml/preferences_general.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_general.xml
@@ -39,13 +39,13 @@
             android:key="@string/error_reporting_mode_key"
             android:title="@string/error_reporting_choice"
             app:useSimpleSummaryProvider="true"/>
-        <SwitchPreference
-            android:defaultValue="false"
+        <SwitchPreferenceCompat
+            android:defaultValue="true"
             android:key="@string/analytics_opt_in_key"
             android:summary="@string/analytics_summ"
             android:title="@string/analytics_title" />
-        <SwitchPreference
-            android:defaultValue="false"
+        <SwitchPreferenceCompat
+            android:defaultValue="true"
             android:title="@string/paste_as_png"
             android:summary="@string/paste_as_png_summary"
             android:maxLength="41"
@@ -57,7 +57,7 @@
                 android:key="@string/deck_for_new_cards_key"
                 android:title="@string/use_current"
                 app:useSimpleSummaryProvider="true"/>
-            <SwitchPreference
+            <SwitchPreferenceCompat
                 android:defaultValue="false"
                 android:key="@string/exit_via_double_tap_back_key"
                 android:summary="@string/exit_via_double_tap_back_summ"
@@ -66,13 +66,13 @@
         <!-- Title and summary are variable, handled in string:
             card_browser_enable_external_context_menu -->
         <PreferenceCategory android:title="@string/pref_cat_system_wide">
-            <SwitchPreference
+            <SwitchPreferenceCompat
                 android:id="@+id/anki_card_external_context_menu"
                 android:defaultValue="true"
                 android:key="@string/anki_card_external_context_menu_key"
                 tools:title="‘Anki Card’ Menu"
                 tools:summary="Enables the ‘Anki Card’ context menu globally"/>
-            <SwitchPreference
+            <SwitchPreferenceCompat
                 android:id="@+id/card_browser_external_context_menu"
                 android:defaultValue="false"
                 android:key="@string/card_browser_external_context_menu_key"

--- a/AnkiDroid/src/main/res/xml/preferences_notifications.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_notifications.xml
@@ -25,11 +25,11 @@
         android:key="@string/pref_notifications_minimum_cards_due_key"
         android:title="@string/notification_pref_title"
         app:useSimpleSummaryProvider="true"/>
-    <SwitchPreference
+    <SwitchPreferenceCompat
         android:defaultValue="false"
         android:key="@string/pref_notifications_vibrate_key"
         android:title="@string/notification_minimum_cards_due_vibrate" />
-    <SwitchPreference
+    <SwitchPreferenceCompat
         android:defaultValue="false"
         android:key="@string/pref_notifications_blink_key"
         android:title="@string/notification_minimum_cards_due_blink" />

--- a/AnkiDroid/src/main/res/xml/preferences_reviewing.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_reviewing.xml
@@ -54,7 +54,7 @@
             app1:summaryFormat="@string/pref_summary_minutes"/>
     </PreferenceCategory>
     <PreferenceCategory android:title="@string/timeout_answer_text" >
-        <SwitchPreference
+        <SwitchPreferenceCompat
             android:defaultValue="false"
             android:disableDependentsState="false"
             android:key="@string/timeout_answer_preference"
@@ -86,12 +86,12 @@
             app1:displayFormat="@string/pref_summary_seconds"/>
     </PreferenceCategory>
     <PreferenceCategory android:title="@string/pref_cat_advanced">
-        <SwitchPreference
+        <SwitchPreferenceCompat
             android:defaultValue="false"
             android:key="@string/keep_screen_on_preference"
             android:summary="@string/pref_keep_screen_on_summ"
             android:title="@string/pref_keep_screen_on" />
-        <SwitchPreference
+        <SwitchPreferenceCompat
             android:key="@string/new_timezone_handling_preference"
             android:title="@string/new_timezone"
             android:defaultValue="false" />

--- a/AnkiDroid/src/main/res/xml/preferences_sync.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_sync.xml
@@ -36,17 +36,17 @@
         android:key="@string/sync_fetch_media_key"
         android:title="@string/sync_fetch_missing_media"
         app:useSimpleSummaryProvider="true"/>
-    <SwitchPreference
+    <SwitchPreferenceCompat
         android:defaultValue="false"
         android:key="@string/automatic_sync_choice_key"
         android:summary="@string/automatic_sync_choice_summ"
         android:title="@string/automatic_sync_choice" />
-    <SwitchPreference
+    <SwitchPreferenceCompat
         android:defaultValue="true"
         android:key="@string/sync_status_badge_key"
         android:summary="@string/sync_status_badge_summ"
         android:title="@string/sync_status_badge" />
-    <SwitchPreference
+    <SwitchPreferenceCompat
         android:defaultValue="false"
         android:key="@string/metered_sync_key"
         android:title="@string/metered_sync_title"


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
Changing colorControlActivated value originally had the purpose of tinting the preferences switches (49a880bca6bc422bcebbaf32555042f32e1e648c)

Since this caused the problem of the text selector being the same color of the app bar on the light theme (#12337), using a more specific color selector should be preferred

## Fixes
Fixes #12337 and closes #13503

## Approach
On the commits

## How Has This Been Tested?

API 25 emulator

https://github.com/ankidroid/Anki-Android/assets/69634269/cb4ac0ad-5dc9-4032-bfdc-c44da1ed2e7c


## Learning (optional, can help others)

Appcompat has a lot of attributes. Try searching deep if you haven't found an attribute to change something

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
