### PR TITLE
Update androidx fragments library to 1.6.0

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -289,6 +289,7 @@ dependencies {
     implementation "androidx.core:core-ktx:1.10.1"
     implementation 'androidx.exifinterface:exifinterface:1.3.6'
     implementation "androidx.fragment:fragment-ktx:$fragments_version"
+    debugImplementation("androidx.fragment:fragment-testing-manifest:$fragments_version")
     implementation "androidx.preference:preference-ktx:1.2.0"
     implementation 'androidx.recyclerview:recyclerview:1.3.0'
     implementation 'androidx.sqlite:sqlite-framework:2.3.1'
@@ -376,12 +377,7 @@ dependencies {
     testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:$coroutines_version"
     testImplementation "io.mockk:mockk:1.13.5"
     testImplementation 'org.apache.commons:commons-exec:1.3' // obtaining the OS
-
-    // debugImplementation required vs testImplementation: https://issuetracker.google.com/issues/128612536
-    debugImplementation("androidx.fragment:fragment-testing:$fragments_version") {
-        // exclude transitive androidx.test:core dep: https://github.com/android/android-test/issues/1587
-        exclude group: 'androidx.test', module: 'core'
-    }
+    testImplementation("androidx.fragment:fragment-testing:$fragments_version")
 
     // May need a resolution strategy for support libs to our versions
     androidTestImplementation "androidx.test.espresso:espresso-core:$espresso_version"
@@ -393,6 +389,7 @@ dependencies {
     androidTestImplementation "androidx.test:rules:$androidx_test_version"
     androidTestImplementation "org.jetbrains.kotlin:kotlin-test:$kotlin_version"
     androidTestImplementation "org.jetbrains.kotlin:kotlin-test-junit:$kotlin_version"
+    androidTestImplementation("androidx.fragment:fragment-testing:$fragments_version")
 }
 
 android {

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ buildscript {
     ext.hamcrest_version = '2.2'
     ext.junit_version = '5.9.3'
     ext.coroutines_version = '1.6.4'
-    ext.fragments_version = "1.5.7"
+    ext.fragments_version = "1.6.0"
     ext.espresso_version = '3.5.1'
     ext.androidx_test_version = '1.5.0'
     ext.androidx_test_junit_version = '1.1.5'


### PR DESCRIPTION
## Purpose / Description

Update the fragments library to the new stable version using the new artifacts, see the [release page](https://developer.android.com/jetpack/androidx/releases/fragment#1.6.0) for more info.

## Fixes
Fixes #12904 

## How Has This Been Tested?

Ran the  tests, both unit and instrumented.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
