### PR TITLE
fix: use snackbar with sync error on new backend

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/Sync.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Sync.kt
@@ -174,19 +174,19 @@ fun DeckPicker.handleNewSync(
 fun MyAccount.handleNewLogin(username: String, password: String) {
     val endpoint = getEndpoint(this)
     launchCatchingTask {
-        val auth = try {
-            withProgress({}, onCancel = ::cancelSync) {
+        try {
+            val auth = withProgress({}, onCancel = ::cancelSync) {
                 withCol {
                     newBackend.syncLogin(username, password, endpoint)
                 }
             }
+            updateLogin(baseContext, username, auth.hkey)
+            finishWithAnimation(ActivityTransitionAnimation.Direction.FADE)
         } catch (exc: BackendSyncException.BackendSyncAuthFailedException) {
             // auth failed; clear out login details
             updateLogin(baseContext, "", "")
-            throw exc
+            exc.localizedMessage?.let { showSnackbar(it) }
         }
-        updateLogin(baseContext, username, auth.hkey)
-        finishWithAnimation(ActivityTransitionAnimation.Direction.FADE)
     }
 }
 


### PR DESCRIPTION
## Purpose / Description
With the new backend, a dialog was shown instead of a snackbar like the old backend does

## Fixes
Fixes #13966 

## Approach
_How does this change address the problem?_

## How Has This Been Tested?

on a pixel 6 emulator Android 13 I tried an invalid and a valid login with the new backend enabled

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
