### PR TITLE
Migrate CardBrowserOrderDialog to AlertDialog

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -34,7 +34,6 @@ import androidx.annotation.VisibleForTesting
 import androidx.appcompat.widget.SearchView
 import androidx.core.content.edit
 import anki.collection.OpChanges
-import com.afollestad.materialdialogs.list.SingleChoiceListener
 import com.google.android.material.snackbar.Snackbar
 import com.ichi2.anim.ActivityTransitionAnimation
 import com.ichi2.anki.AnkiFont.Companion.getTypeface
@@ -45,7 +44,7 @@ import com.ichi2.anki.UIUtils.showThemedToast
 import com.ichi2.anki.dialogs.*
 import com.ichi2.anki.dialogs.CardBrowserMySearchesDialog.Companion.newInstance
 import com.ichi2.anki.dialogs.CardBrowserMySearchesDialog.MySearchesDialogListener
-import com.ichi2.anki.dialogs.CardBrowserOrderDialog.Companion.newInstance
+import com.ichi2.anki.dialogs.CardBrowserOrderDialog
 import com.ichi2.anki.dialogs.DeckSelectionDialog.Companion.newInstance
 import com.ichi2.anki.dialogs.DeckSelectionDialog.DeckSelectionListener
 import com.ichi2.anki.dialogs.DeckSelectionDialog.SelectableDeck
@@ -255,7 +254,11 @@ open class CardBrowser :
      * Broadcast that informs us when the sd card is about to be unmounted
      */
     private var mUnmountReceiver: BroadcastReceiver? = null
-    private val orderSingleChoiceDialogListener: SingleChoiceListener = { _, index: Int, _ -> changeCardOrder(index) }
+    private val orderSingleChoiceDialogListener: DialogInterface.OnClickListener =
+        DialogInterface.OnClickListener { dialog: DialogInterface, which: Int ->
+            dialog.dismiss()
+            changeCardOrder(which)
+        }
 
     init {
         ChangeManager.subscribe(this)
@@ -1159,7 +1162,7 @@ open class CardBrowser :
                 return true
             }
             R.id.action_sort_by_size -> {
-                showDialogFragment(newInstance(mOrder, mOrderAsc, orderSingleChoiceDialogListener))
+                showDialogFragment(CardBrowserOrderDialog.newInstance(mOrder, mOrderAsc, orderSingleChoiceDialogListener))
                 return true
             }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/CardBrowserOrderDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/CardBrowserOrderDialog.kt
@@ -16,22 +16,18 @@
 
 package com.ichi2.anki.dialogs
 
-import android.annotation.SuppressLint
 import android.app.Dialog
+import android.content.DialogInterface
 import android.os.Bundle
-import com.afollestad.materialdialogs.MaterialDialog
-import com.afollestad.materialdialogs.list.SingleChoiceListener
-import com.afollestad.materialdialogs.list.listItemsSingleChoice
+import androidx.appcompat.app.AlertDialog
 import com.ichi2.anki.CardBrowser
 import com.ichi2.anki.R
 import com.ichi2.anki.analytics.AnalyticsDialogFragment
 
 class CardBrowserOrderDialog : AnalyticsDialogFragment() {
-    @SuppressLint("CheckResult")
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
         super.onCreate(savedInstanceState)
-        val res = resources
-        val items = res.getStringArray(R.array.card_browser_order_labels)
+        val items = resources.getStringArray(R.array.card_browser_order_labels)
         // Set sort order arrow
         for (i in items.indices) {
             if (i != CardBrowser.CARD_ORDER_NONE && i == requireArguments().getInt("order")) {
@@ -43,24 +39,19 @@ class CardBrowserOrderDialog : AnalyticsDialogFragment() {
             }
         }
 
-        return MaterialDialog(requireActivity()).show {
-            title(R.string.card_browser_change_display_order_title)
-            message(R.string.card_browser_change_display_order_reverse)
-            listItemsSingleChoice(
-                items = items.toList(),
-                initialSelection = requireArguments().getInt("order"),
-                selection = orderSingleChoiceDialogListener
-            )
-        }
+        return AlertDialog.Builder(requireContext())
+            .setTitle(R.string.card_browser_change_display_order_title)
+            .setSingleChoiceItems(items, requireArguments().getInt("order"), orderSingleChoiceDialogListener)
+            .create()
     }
 
     companion object {
-        private var orderSingleChoiceDialogListener: SingleChoiceListener = null
+        private var orderSingleChoiceDialogListener: DialogInterface.OnClickListener? = null
 
         fun newInstance(
             order: Int,
             isOrderAsc: Boolean,
-            orderSingleChoiceDialogListener: SingleChoiceListener
+            orderSingleChoiceDialogListener: DialogInterface.OnClickListener
         ): CardBrowserOrderDialog {
             val f = CardBrowserOrderDialog()
             val args = Bundle()

--- a/AnkiDroid/src/main/res/values/07-cardbrowser.xml
+++ b/AnkiDroid/src/main/res/values/07-cardbrowser.xml
@@ -51,7 +51,6 @@
     <string name="card_browser_list_my_searches_remove_content">Delete “%1$s”?</string>
     <string name="card_browser_change_display_order">Change display order</string>
     <string name="card_browser_change_display_order_title">Choose display order</string>
-    <string name="card_browser_change_display_order_reverse">Select a field twice to reverse</string>
     <string name="card_details_due" comment="Date at which a card will be due to review again.">Due</string>
     <string name="card_details_tags">Tags</string>
     <string-array name="card_browser_order_labels">


### PR DESCRIPTION
## Fixes
#13315

## Approach
AlertDialog can't have both a message and items, so I removed the message

## How Has This Been Tested?

[pr (2).webm](https://github.com/ankidroid/Anki-Android/assets/65715921/2debfe7c-6d3d-4fdf-95e9-fbd39f8e233a)

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
