### PR TITLE
checking for null result to avoid class cast exception

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/utils/TypedFilter.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/TypedFilter.kt
@@ -49,7 +49,7 @@ abstract class TypedFilter<T>(private val getCurrentItems: (() -> List<T>)) : Fi
     @Suppress("UNCHECKED_CAST")
     override fun publishResults(constraint: CharSequence?, results: FilterResults?) {
         // this is only ever called from performFiltering so we can guarantee the value can be cast to List<T>
-        if (results != null && results.values is List<*>) {
+        if (results?.values != null && results.values is List<*>) {
             val list = results.values as List<T>
             publishResults(constraint, list)
         }

--- a/AnkiDroid/src/main/java/com/ichi2/utils/TypedFilter.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/TypedFilter.kt
@@ -48,6 +48,7 @@ abstract class TypedFilter<T>(private val getCurrentItems: (() -> List<T>)) : Fi
 
     @Suppress("UNCHECKED_CAST")
     override fun publishResults(constraint: CharSequence?, results: FilterResults?) {
+        // this is only ever called from performFiltering so we can guarantee the value can be cast to List<T>
         if (results != null && results.values is List<*>) {
             val list = results.values as List<T>
             publishResults(constraint, list)

--- a/AnkiDroid/src/main/java/com/ichi2/utils/TypedFilter.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/TypedFilter.kt
@@ -48,9 +48,10 @@ abstract class TypedFilter<T>(private val getCurrentItems: (() -> List<T>)) : Fi
 
     @Suppress("UNCHECKED_CAST")
     override fun publishResults(constraint: CharSequence?, results: FilterResults?) {
-        // this is only ever called from performFiltering so we can guarantee the value can be cast to List<T>
-        val list = results!!.values as List<T>
-        publishResults(constraint, list)
+        if (results != null && results.values is List<*>) {
+            val list = results.values as List<T>
+            publishResults(constraint, list)
+        }
     }
 
     /**

--- a/AnkiDroid/src/main/java/com/ichi2/utils/TypedFilter.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/TypedFilter.kt
@@ -49,7 +49,7 @@ abstract class TypedFilter<T>(private val getCurrentItems: (() -> List<T>)) : Fi
     @Suppress("UNCHECKED_CAST")
     override fun publishResults(constraint: CharSequence?, results: FilterResults?) {
         // this is only ever called from performFiltering so we can guarantee the value can be cast to List<T>
-        if (results?.values != null && results.values is List<*>) {
+        if (results?.values != null) {
             val list = results.values as List<T>
             publishResults(constraint, list)
         }


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
The results parameter is declared as nullable (FilterResults?), but we are force unwrapping it (!!) without checking for null. If results is null, a NullPointerException will be thrown.


## Fixes
Fixes  #13974

## Approach
To fix this issue, we should perform a null check before accessing the values property. 

## How Has This Been Tested?

NPE would be avoided by the check hence avoiding the crash

## Learning (optional, can help others)
_Describe the research stage_

_Links to blog posts, patterns, libraries or addons used to solve this problem_

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
