### PR TITLE
Clean some Runnable

### DIFF
--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/libanki/HttpTest.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/libanki/HttpTest.kt
@@ -51,14 +51,13 @@ class HttpTest {
 
         // We have to carefully run things on the main thread here or the threading protections in BaseAsyncTask throw
         // The first one is just to run the static initializer, really
-        val onlineRunnable = Runnable {
+        InstrumentationRegistry.getInstrumentation().runOnMainSync {
             try {
                 Class.forName("com.ichi2.async.Connection")
             } catch (e: Exception) {
                 Assert.fail("Unable to load Connection class: " + e.message)
             }
         }
-        InstrumentationRegistry.getInstrumentation().runOnMainSync(onlineRunnable)
 
         // If we are not online this test is not nearly as interesting
         // TODO simulate offline programmatically - currently exercised by manually toggling an emulator offline pre-test
@@ -75,7 +74,7 @@ class HttpTest {
             return
         }
 
-        val r = Runnable {
+        InstrumentationRegistry.getInstrumentation().runOnMainSync {
             val conn = Connection.login(testListener, invalidPayload)
             try {
                 // This forces us to synchronously wait for the AsyncTask to do it's work
@@ -84,7 +83,6 @@ class HttpTest {
                 Assert.fail("Caught exception while trying to login: " + e.message)
             }
         }
-        InstrumentationRegistry.getInstrumentation().runOnMainSync(r)
         Assert.assertFalse(
             "Successful login despite invalid credentials",
             testListener.getPayload()!!.success

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
@@ -972,7 +972,7 @@ abstract class AbstractFlashcardViewer :
             // TODO: this handling code is unnecessarily complex, and would be easier to follow
             //  if written imperatively
             val handler = answerCardHandler(true)
-            handler.before?.run()
+            handler.before?.let { it() }
             handler.after?.accept(Computation.ok(NextCard.withNoResult(newCard)))
         }
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
@@ -1184,11 +1184,11 @@ abstract class AbstractFlashcardViewer :
                 }
             }
         }
-        val after = Runnable { flipCardLayout!!.visibility = View.GONE }
+        val after = { flipCardLayout!!.visibility = View.GONE }
 
         // hide "Show Answer" button
         if (animationDisabled()) {
-            after.run()
+            after()
         } else {
             flipCardLayout!!.alpha = 1f
             flipCardLayout!!.animate().alpha(0f).setDuration(shortAnimDuration.toLong()).withEndAction(after)
@@ -1196,12 +1196,12 @@ abstract class AbstractFlashcardViewer :
     }
 
     protected open fun hideEaseButtons() {
-        val after = Runnable { actualHideEaseButtons() }
+        val after = { actualHideEaseButtons() }
         val easeButtonsVisible = easeButtonsLayout!!.visibility == View.VISIBLE
         flipCardLayout!!.isClickable = true
         flipCardLayout!!.visibility = View.VISIBLE
         if (animationDisabled() || !easeButtonsVisible) {
-            after.run()
+            after()
         } else {
             flipCardLayout!!.alpha = 0f
             flipCardLayout!!.animate().alpha(1f).setDuration(shortAnimDuration.toLong()).withEndAction(after)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
@@ -1935,8 +1935,8 @@ abstract class AbstractFlashcardViewer :
         }
 
         private val mScrollHandler = newHandler()
-        private val mScrollXRunnable = Runnable { mIsXScrolling = false }
-        private val mScrollYRunnable = Runnable { mIsYScrolling = false }
+        private val mScrollXRunnable = { mIsXScrolling = false }
+        private val mScrollYRunnable = { mIsYScrolling = false }
     }
 
     internal open inner class MyGestureDetector : SimpleOnGestureListener() {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -1444,11 +1444,10 @@ open class CardBrowser :
         val title = getString(R.string.reset_card_dialog_title)
         val message = getString(R.string.reset_card_dialog_message)
         dialog.setArgs(title, message)
-        val confirm = Runnable {
+        dialog.setConfirm {
             Timber.i("CardBrowser:: ResetProgress button pressed")
             resetProgressNoConfirm(selectedCardIds)
         }
-        dialog.setConfirm(confirm)
         showDialogFragment(dialog)
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.kt
@@ -748,9 +748,7 @@ open class CardTemplateEditor : AnkiActivity(), DeckSelectionListener {
             )
             d.setArgs(msg)
 
-            val deleteCard = Runnable { deleteTemplate(tmpl, model) }
-            val confirm = Runnable { executeWithSyncCheck(deleteCard) }
-            d.setConfirm(confirm)
+            d.setConfirm { executeWithSyncCheck { deleteTemplate(tmpl, model) } }
             mTemplateEditor.showDialogFragment(d)
         }
 
@@ -770,9 +768,7 @@ open class CardTemplateEditor : AnkiActivity(), DeckSelectionListener {
             )
             d.setArgs(msg)
 
-            val addCard = Runnable { addNewTemplate(model) }
-            val confirm = Runnable { executeWithSyncCheck(addCard) }
-            d.setConfirm(confirm)
+            d.setConfirm { executeWithSyncCheck { addNewTemplate(model) } }
             mTemplateEditor.showDialogFragment(d)
         }
 
@@ -788,14 +784,12 @@ open class CardTemplateEditor : AnkiActivity(), DeckSelectionListener {
                 e.log()
                 val d = ConfirmationDialog()
                 d.setArgs(resources.getString(R.string.full_sync_confirmation))
-                val confirm = Runnable {
+                d.setConfirm {
                     mTemplateEditor.col.modSchemaNoCheck()
                     schemaChangingAction.run()
                     mTemplateEditor.dismissAllDialogFragments()
                 }
-                val cancel = Runnable { mTemplateEditor.dismissAllDialogFragments() }
-                d.setConfirm(confirm)
-                d.setCancel(cancel)
+                d.setCancel { mTemplateEditor.dismissAllDialogFragments() }
                 mTemplateEditor.showDialogFragment(d)
             }
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -2822,11 +2822,10 @@ class ForceFullSyncDialog(val message: String?) : DialogHandlerMessage(
     override fun handleAsyncMessage(deckPicker: DeckPicker) {
         // Confirmation dialog for forcing full sync
         val dialog = ConfirmationDialog()
-        val confirm = Runnable {
+        dialog.setConfirm {
             // Bypass the check once the user confirms
             CollectionHelper.instance.getCol(AnkiDroidApp.instance)!!.modSchemaNoCheck()
         }
-        dialog.setConfirm(confirm)
         dialog.setArgs(message)
         deckPicker.showDialogFragment(dialog)
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -130,7 +130,6 @@ import net.ankiweb.rsdroid.RustCleanup
 import org.json.JSONException
 import timber.log.Timber
 import java.io.File
-import java.lang.Runnable
 import java.lang.ref.WeakReference
 import kotlin.math.roundToLong
 import kotlin.system.measureTimeMillis
@@ -2533,7 +2532,7 @@ open class DeckPicker :
         }
 
         // Animation utility methods used by renderPage() method
-        fun fadeIn(view: View?, duration: Int, translation: Float = 0f, startAction: Runnable? = Runnable { view!!.visibility = View.VISIBLE }): ViewPropertyAnimator {
+        fun fadeIn(view: View?, duration: Int, translation: Float = 0f, startAction: (() -> Unit)? = { view!!.visibility = View.VISIBLE }): ViewPropertyAnimator {
             view!!.alpha = 0f
             view.translationY = translation
             return view.animate()
@@ -2543,7 +2542,7 @@ open class DeckPicker :
                 .withStartAction(startAction)
         }
 
-        fun fadeOut(view: View?, duration: Int, translation: Float = 0f, endAction: Runnable? = Runnable { view!!.visibility = View.GONE }): ViewPropertyAnimator {
+        fun fadeOut(view: View?, duration: Int, translation: Float = 0f, endAction: (() -> Unit)? = { view!!.visibility = View.GONE }): ViewPropertyAnimator {
             view!!.alpha = 1f
             view.translationY = 0f
             return view.animate()

--- a/AnkiDroid/src/main/java/com/ichi2/anki/IntentHandler.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/IntentHandler.kt
@@ -70,9 +70,9 @@ class IntentHandler : Activity() {
         // as this requires nothing
         val runIfStoragePermissions = Consumer { runnable: Runnable -> performActionIfStorageAccessible(runnable, reloadIntent, action) }
         when (getLaunchType(intent)) {
-            LaunchType.FILE_IMPORT -> runIfStoragePermissions.accept(Runnable { handleFileImport(intent, reloadIntent, action) })
-            LaunchType.SYNC -> runIfStoragePermissions.accept(Runnable { handleSyncIntent(reloadIntent, action) })
-            LaunchType.REVIEW -> runIfStoragePermissions.accept(Runnable { handleReviewIntent(intent) })
+            LaunchType.FILE_IMPORT -> runIfStoragePermissions.accept { handleFileImport(intent, reloadIntent, action) }
+            LaunchType.SYNC -> runIfStoragePermissions.accept { handleSyncIntent(reloadIntent, action) }
+            LaunchType.REVIEW -> runIfStoragePermissions.accept { handleReviewIntent(intent) }
             LaunchType.DEFAULT_START_APP_IF_NEW -> {
                 Timber.d("onCreate() performing default action")
                 launchDeckPickerIfNoOtherTasks(reloadIntent)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ModelFieldEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ModelFieldEditor.kt
@@ -228,7 +228,7 @@ class ModelFieldEditor : AnkiActivity(), LocaleSelectionDialogHandler {
      * Creates a dialog to delete the currently selected field
      */
     private fun deleteFieldDialog() {
-        val confirm = Runnable {
+        val confirm: () -> Unit = {
             collection.modSchemaNoCheck()
             deleteField()
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ModelFieldEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ModelFieldEditor.kt
@@ -181,7 +181,7 @@ class ModelFieldEditor : AnkiActivity(), LocaleSelectionDialogHandler {
                         // Create dialogue to for schema change
                         val c = ConfirmationDialog()
                         c.setArgs(resources.getString(R.string.full_sync_confirmation))
-                        val confirm = Runnable {
+                        c.setConfirm {
                             try {
                                 addField(fieldName, false)
                             } catch (e1: ConfirmModSchemaException) {
@@ -189,7 +189,6 @@ class ModelFieldEditor : AnkiActivity(), LocaleSelectionDialogHandler {
                                 // This should never be thrown
                             }
                         }
-                        c.setConfirm(confirm)
                         this@ModelFieldEditor.showDialogFragment(c)
                     }
                     collection.models.update(mModel)
@@ -307,7 +306,7 @@ class ModelFieldEditor : AnkiActivity(), LocaleSelectionDialogHandler {
                         // Handler mod schema confirmation
                         val c = ConfirmationDialog()
                         c.setArgs(resources.getString(R.string.full_sync_confirmation))
-                        val confirm = Runnable {
+                        c.setConfirm {
                             collection.modSchemaNoCheck()
                             try {
                                 renameField()
@@ -316,7 +315,6 @@ class ModelFieldEditor : AnkiActivity(), LocaleSelectionDialogHandler {
                                 // This should never be thrown
                             }
                         }
-                        c.setConfirm(confirm)
                         this@ModelFieldEditor.showDialogFragment(c)
                     }
                 }
@@ -360,7 +358,7 @@ class ModelFieldEditor : AnkiActivity(), LocaleSelectionDialogHandler {
                             // Handle mod schema confirmation
                             val c = ConfirmationDialog()
                             c.setArgs(resources.getString(R.string.full_sync_confirmation))
-                            val confirm = Runnable {
+                            c.setConfirm {
                                 try {
                                     collection.modSchemaNoCheck()
                                     repositionField(pos - 1)
@@ -368,7 +366,6 @@ class ModelFieldEditor : AnkiActivity(), LocaleSelectionDialogHandler {
                                     throw RuntimeException(e1)
                                 }
                             }
-                            c.setConfirm(confirm)
                             this@ModelFieldEditor.showDialogFragment(c)
                         }
                     }
@@ -427,11 +424,10 @@ class ModelFieldEditor : AnkiActivity(), LocaleSelectionDialogHandler {
             // Handler mMod schema confirmation
             val c = ConfirmationDialog()
             c.setArgs(resources.getString(R.string.full_sync_confirmation))
-            val confirm = Runnable {
+            c.setConfirm {
                 collection.modSchemaNoCheck()
                 launchCatchingTask { changeSortField(mModel, currentPos) }
             }
-            c.setConfirm(confirm)
             this@ModelFieldEditor.showDialogFragment(c)
         }
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NavigationDrawerActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NavigationDrawerActivity.kt
@@ -72,7 +72,7 @@ abstract class NavigationDrawerActivity :
     /**
      * runnable that will be executed after the drawer has been closed.
      */
-    private var mPendingRunnable: Runnable? = null
+    private var mPendingRunnable: (() -> Unit)? = null
 
     override fun setContentView(@LayoutRes layoutResID: Int) {
         val preferences = AnkiDroidApp.getSharedPrefs(baseContext)
@@ -274,7 +274,7 @@ abstract class NavigationDrawerActivity :
          * This runnable will be executed in onDrawerClosed(...)
          * to make the animation more fluid on older devices.
          */
-        mPendingRunnable = Runnable {
+        mPendingRunnable = {
             // Take action if a different item selected
             when (item.itemId) {
                 R.id.nav_decks -> {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
@@ -1706,7 +1706,7 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
 
             val clozeDrawable = ResourcesCompat.getDrawable(resources, R.drawable.ic_cloze_black_24dp, null)
             clozeDrawable!!.setTint(Themes.getColorFromAttr(this@NoteEditor, R.attr.toolbarIconColor))
-            val clozeButton = toolbar.insertItem(0, clozeDrawable, Runnable { toolbar.onFormat(clozeFormatter) })
+            val clozeButton = toolbar.insertItem(0, clozeDrawable) { toolbar.onFormat(clozeFormatter) }
             clozeButton.contentDescription = resources.getString(R.string.insert_cloze)
             TooltipCompat.setTooltipText(clozeButton, resources.getString(R.string.insert_cloze))
         }
@@ -1734,7 +1734,7 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
         // Sets the add custom tag icon color.
         val drawable = ResourcesCompat.getDrawable(resources, R.drawable.ic_add_toolbar_icon, null)
         drawable!!.setTint(Themes.getColorFromAttr(this@NoteEditor, R.attr.toolbarIconColor))
-        val addButton = toolbar.insertItem(0, drawable, Runnable { displayAddToolbarDialog() })
+        val addButton = toolbar.insertItem(0, drawable) { displayAddToolbarDialog() }
         addButton.contentDescription = resources.getString(R.string.add_toolbar_item)
         TooltipCompat.setTooltipText(addButton, resources.getString(R.string.add_toolbar_item))
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
@@ -734,11 +734,10 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
                     // If cards will be lost via the new mapping then show a confirmation dialog before proceeding with the change
                     val dialog = ConfirmationDialog()
                     dialog.setArgs(res.getString(R.string.confirm_map_cards_to_nothing))
-                    val confirm = Runnable {
+                    dialog.setConfirm {
                         // Bypass the check once the user confirms
                         changeNoteTypeWithErrorHandling(oldModel, newModel)
                     }
-                    dialog.setConfirm(confirm)
                     showDialogFragment(dialog)
                 } else {
                     // Otherwise go straight to changing note type
@@ -795,7 +794,7 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
             // Libanki has determined we should ask the user to confirm first
             val dialog = ConfirmationDialog()
             dialog.setArgs(res.getString(R.string.full_sync_confirmation))
-            val confirm = Runnable {
+            dialog.setConfirm {
                 // Bypass the check once the user confirms
                 col.modSchemaNoCheck()
                 try {
@@ -805,7 +804,6 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
                     throw RuntimeException(e2)
                 }
             }
-            dialog.setConfirm(confirm)
             showDialogFragment(dialog)
         }
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
@@ -682,12 +682,11 @@ open class Reviewer :
         val title = resources.getString(R.string.reset_card_dialog_title)
         val message = resources.getString(R.string.reset_card_dialog_message)
         dialog.setArgs(title, message)
-        val confirm = Runnable {
+        dialog.setConfirm {
             Timber.i("NoteEditor:: ResetProgress button pressed")
             val cardIds = listOf(currentCard!!.id)
             ResetCards(cardIds).runWithHandler(scheduleCollectionTaskHandler(R.plurals.reset_cards_dialog_acknowledge))
         }
-        dialog.setConfirm(confirm)
         showDialogFragment(dialog)
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsFragment.kt
@@ -682,9 +682,8 @@ class StudyOptionsFragment : Fragment(), Toolbar.OnMenuItemClickListener {
                         " AND queue = " + Consts.QUEUE_TYPE_NEW
                     val fullNewCount = col.db.queryScalar(query)
                     if (fullNewCount > 0) {
-                        val setNewTotalText = Runnable { textNewTotal.text = fullNewCount.toString() }
                         if (!Thread.currentThread().isInterrupted) {
-                            textNewTotal.post(setNewTotalText)
+                            textNewTotal.post { textNewTotal.text = fullNewCount.toString() }
                         }
                     }
                 }.apply {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ConfirmationDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ConfirmationDialog.kt
@@ -26,8 +26,8 @@ import com.ichi2.anki.R
  * Create a new instance, call setArgs(...), setConfirm(), and setCancel() then show it via the fragment manager as usual.
  */
 class ConfirmationDialog : DialogFragment() {
-    private var mConfirm = Runnable {} // Do nothing by default
-    private var mCancel = Runnable {} // Do nothing by default
+    private var mConfirm = {} // Do nothing by default
+    private var mCancel = {} // Do nothing by default
     fun setArgs(message: String?) {
         setArgs("", message)
     }
@@ -39,11 +39,11 @@ class ConfirmationDialog : DialogFragment() {
         arguments = args
     }
 
-    fun setConfirm(confirm: Runnable) {
+    fun setConfirm(confirm: () -> Unit) {
         mConfirm = confirm
     }
 
-    fun setCancel(cancel: Runnable) {
+    fun setCancel(cancel: () -> Unit) {
         mCancel = cancel
     }
 
@@ -55,10 +55,10 @@ class ConfirmationDialog : DialogFragment() {
             title(text = (if ("" == title) res.getString(R.string.app_name) else title)!!)
             message(text = requireArguments().getString("message")!!)
             positiveButton(R.string.dialog_ok) {
-                mConfirm.run()
+                mConfirm()
             }
             negativeButton(R.string.dialog_cancel) {
-                mCancel.run()
+                mCancel()
             }
         }
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/noteeditor/Toolbar.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/noteeditor/Toolbar.kt
@@ -142,7 +142,7 @@ class Toolbar : FrameLayout {
         return super.onKeyUp(keyCode, event)
     }
 
-    fun insertItem(@IdRes id: Int, @DrawableRes drawable: Int, runnable: Runnable): AppCompatImageButton {
+    fun insertItem(@IdRes id: Int, @DrawableRes drawable: Int, runnable: () -> Unit): AppCompatImageButton {
         // we use the light theme here to ensure the tint is black on both
         // A null theme can be passed after colorControlNormal is defined (API 25)
         val themeContext: Context = ContextThemeWrapper(context, R.style.Theme_Light_Compat)
@@ -151,10 +151,10 @@ class Toolbar : FrameLayout {
     }
 
     fun insertItem(id: Int, drawable: Drawable?, formatter: TextFormatter): View {
-        return insertItem(id, drawable, Runnable { onFormat(formatter) })
+        return insertItem(id, drawable) { onFormat(formatter) }
     }
 
-    fun insertItem(@IdRes id: Int, drawable: Drawable?, runnable: Runnable): AppCompatImageButton {
+    fun insertItem(@IdRes id: Int, drawable: Drawable?, runnable: () -> Unit): AppCompatImageButton {
         val context = context
         val button = AppCompatImageButton(context)
         button.id = id
@@ -187,7 +187,7 @@ class Toolbar : FrameLayout {
             addViewToToolbar(button)
         }
         mCustomButtons.add(button)
-        button.setOnClickListener { runnable.run() }
+        button.setOnClickListener { runnable() }
 
         // Hack - items are truncated from the scrollview
         val v = findViewById<View>(R.id.toolbar_layout)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/AsyncLayerAdapter.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/AsyncLayerAdapter.kt
@@ -53,7 +53,7 @@ fun <TProgress, TResult> TaskListenerBuilder<TProgress, TResult?>.toListener(): 
         }
 
         override fun onCancelled() {
-            onCancelled?.run()
+            onCancelled?.let { it() }
         }
     }
 }
@@ -67,13 +67,13 @@ class TaskListenerBuilder<TProgress, TResult> constructor() {
         before = { listener.onPreExecute() }
         after = Consumer<TResult> { x -> listener.onPostExecute(x) }
         onProgressUpdate = Consumer<TProgress> { x -> listener.onProgressUpdate(x) }
-        onCancelled = Runnable { listener.onCancelled() }
+        onCancelled = { listener.onCancelled() }
     }
 
     var before: (() -> Unit)? = null
     var after: Consumer<TResult>? = null
     var onProgressUpdate: Consumer<TProgress>? = null
-    var onCancelled: Runnable? = null
+    var onCancelled: (() -> Unit)? = null
 
     fun before(before: () -> Unit): TaskListenerBuilder<TProgress, TResult> {
         this.before = before
@@ -141,17 +141,17 @@ class TaskListenerBuilder<TProgress, TResult> constructor() {
         return this
     }
 
-    fun onCancelled(onCancelled: Runnable): TaskListenerBuilder<TProgress, TResult> {
+    fun onCancelled(onCancelled: () -> Unit): TaskListenerBuilder<TProgress, TResult> {
         this.onCancelled = onCancelled
         return this
     }
 
-    fun alsoOoCancelled(onCancelled: Runnable): TaskListenerBuilder<TProgress, TResult> {
+    fun alsoOoCancelled(onCancelled: () -> Unit): TaskListenerBuilder<TProgress, TResult> {
         val previousMethod = this.onCancelled
         if (previousMethod == null) {
             this.onCancelled = onCancelled
         } else {
-            this.onCancelled = Runnable { previousMethod.run(); onCancelled.run() }
+            this.onCancelled = { previousMethod(); onCancelled() }
         }
         return this
     }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.kt
@@ -1495,7 +1495,7 @@ open class Collection(
         val currentTask = intArrayOf(1)
         // a few fixes are in all-models loops, the rest are one-offs
         val totalTasks = models.all().size * 4 + 27
-        val notifyProgress = Runnable { fixIntegrityProgress(progressCallback, currentTask[0]++, totalTasks) }
+        val notifyProgress = { fixIntegrityProgress(progressCallback, currentTask[0]++, totalTasks) }
         val executeIntegrityTask = Consumer { function: FunctionalInterfaces.FunctionThrowable<Runnable, List<String?>?> ->
             // DEFECT: notifyProgress will lag if an exception is thrown.
             try {
@@ -1517,7 +1517,7 @@ open class Collection(
         try {
             db.database.beginTransaction()
             save()
-            notifyProgress.run()
+            notifyProgress()
             if (!db.database.isDatabaseIntegrityOk) {
                 return result.markAsFailed()
             }


### PR DESCRIPTION
Many `Runnable` where there from Java. Using trailing lambda makes code shorter, and that lead to replacing some types by  `() -> Unit`.
The ones that remains are used by Java libraries expecting `Runnable`