### PR TITLE
Fix gestures selection in landscape mode

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/preferences/ControlPreference.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/preferences/ControlPreference.kt
@@ -17,14 +17,11 @@
 package com.ichi2.preferences
 
 import android.annotation.SuppressLint
-import android.app.Activity
 import android.content.Context
-import android.content.pm.ActivityInfo
 import android.util.AttributeSet
 import androidx.appcompat.app.AlertDialog
 import androidx.preference.ListPreference
 import com.afollestad.materialdialogs.MaterialDialog
-import com.afollestad.materialdialogs.callbacks.onDismiss
 import com.afollestad.materialdialogs.customview.customView
 import com.ichi2.anki.AnkiDroidApp
 import com.ichi2.anki.R
@@ -101,8 +98,6 @@ class ControlPreference : ListPreference {
         when (val index: Int = (newValue as String).toInt()) {
             ADD_GESTURE_INDEX -> {
                 val actionName = title
-                // TODO : Discuss if we want to move this to a fragment to allow horizontal orientation
-                (context as Activity).requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_NOSENSOR
                 MaterialDialog(context).show {
                     title(text = actionName.toString())
 
@@ -126,8 +121,6 @@ class ControlPreference : ListPreference {
                     }
 
                     noAutoDismiss()
-                }.onDismiss {
-                    (context as Activity).requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_SENSOR
                 }
             }
             ADD_KEY_INDEX -> {

--- a/AnkiDroid/src/main/java/com/ichi2/ui/GestureDisplay.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/ui/GestureDisplay.kt
@@ -84,13 +84,6 @@ constructor(context: Context, attributeSet: AttributeSet? = null, defStyleAttr: 
     @SuppressLint("ClickableViewAccessibility")
     override fun onTouchEvent(event: MotionEvent): Boolean = mDetector.onTouchEvent(event) || super.onTouchEvent(event)
 
-    /** Ensures that this View is square (height = width) */
-    override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {
-        super.onMeasure(widthMeasureSpec, widthMeasureSpec)
-        val width = measuredWidth
-        setMeasuredDimension(width, width)
-    }
-
     fun getGesture() = mGesture
 
     /** Updates the UI from a new gesture

--- a/AnkiDroid/src/main/res/layout/gesture_display.xml
+++ b/AnkiDroid/src/main/res/layout/gesture_display.xml
@@ -22,7 +22,6 @@
     tools:layout_width="400dp">
 
 
-
     <ImageView
         android:id="@+id/top_left"
         style="@style/binding_gesture_tap_button"
@@ -80,7 +79,8 @@
     <ImageView
         android:id="@+id/bottom_center"
         style="@style/binding_gesture_tap_button"
-        app:layout_constraintBottom_toBottomOf="@+id/bottom_left"
+        android:layout_marginBottom="16dp"
+        app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent" />
 
@@ -88,7 +88,8 @@
         android:id="@+id/bottom_right"
         style="@style/binding_gesture_tap_button"
         android:layout_marginEnd="16dp"
-        app:layout_constraintBottom_toBottomOf="@+id/bottom_center"
+        android:layout_marginBottom="16dp"
+        app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent" />
 
     <ImageView

--- a/AnkiDroid/src/main/res/layout/gesture_picker.xml
+++ b/AnkiDroid/src/main/res/layout/gesture_picker.xml
@@ -21,17 +21,18 @@
     tools:layout_height="500dp"
     tools:layout_width="400dp"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content">
+    android:layout_height="match_parent">
 
     <com.ichi2.ui.GestureDisplay
         android:id="@+id/gestureDisplay"
-        android:layout_width="match_parent"
+        android:layout_width="0dp"
         android:layout_height="0dp"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
-        tools:layout_height="400dp"
-        tools:layout_width="400dp" />
+        app:layout_constraintBottom_toTopOf="@id/spinner_gesture"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintDimensionRatio="1:1"
+        tools:parentTag="androidx.constraintlayout.widget.ConstraintLayout"/>
 
     <Spinner
         android:id="@+id/spinner_gesture"
@@ -42,6 +43,6 @@
         android:spinnerMode="dropdown"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/gestureDisplay"/>
+        app:layout_constraintBottom_toBottomOf="parent"/>
 
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
## Fixes
Fixes #13432

## Approach
Properly use the ConstraintLayout attributes to be more responsive.

This fix is more helpful for tablets which are commonly used in landscape mode. The dialog don't look very good in phones because of the lack of vertical space, but probably the best way to gain some vertical space is doing a whole custom fragment

## How Has This Been Tested?

[device-2023-06-11-153833.webm](https://github.com/ankidroid/Anki-Android/assets/69634269/eefa00e4-eb29-4a1c-b30c-35e2b7fcc597)

On a Nexus 9 tablet emulator:
![image](https://github.com/ankidroid/Anki-Android/assets/69634269/b59a930a-5315-43d8-b97f-d51bffd00757)

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
