### PR TITLE
Replace MaterialDialog with Alertdialog for ModelFieldEditor.kt 

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/ModelFieldEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ModelFieldEditor.kt
@@ -173,7 +173,7 @@ class ModelFieldEditor : AnkiActivity(), LocaleSelectionDialogHandler {
         fieldNameInput?.let { _fieldNameInput ->
             _fieldNameInput.isSingleLine = true
             AlertDialog.Builder(this).show {
-                customView(_fieldNameInput, marginLeft = 64, marginRight = 64, marginTop = 32)
+                customView(view = _fieldNameInput, paddingLeft = 64, paddingRight = 64, paddingTop = 32)
                 title(R.string.model_field_editor_add)
                 positiveButton(R.string.dialog_ok) {
                     // Name is valid, now field is added
@@ -296,7 +296,7 @@ class ModelFieldEditor : AnkiActivity(), LocaleSelectionDialogHandler {
             _fieldNameInput.setText(mFieldsLabels[currentPos])
             _fieldNameInput.setSelection(_fieldNameInput.text!!.length)
             AlertDialog.Builder(this).show {
-                customView(_fieldNameInput, marginLeft = 64, marginRight = 64, marginTop = 32)
+                customView(view = _fieldNameInput, paddingLeft = 64, paddingRight = 64, paddingTop = 32)
                 title(R.string.model_field_editor_rename)
                 positiveButton(R.string.rename) {
                     if (uniqueName(_fieldNameInput) == null) {
@@ -339,7 +339,7 @@ class ModelFieldEditor : AnkiActivity(), LocaleSelectionDialogHandler {
         fieldNameInput?.let { _fieldNameInput ->
             _fieldNameInput.setRawInputType(InputType.TYPE_CLASS_NUMBER)
             AlertDialog.Builder(this).show {
-                customView(_fieldNameInput)
+                customView(view = _fieldNameInput, paddingLeft = 64, paddingRight = 64, paddingTop = 32)
                 title(text = String.format(resources.getString(R.string.model_field_editor_reposition), 1, mFieldsLabels.size))
                 positiveButton(R.string.dialog_ok) {
                     val newPosition = _fieldNameInput.text.toString()

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ModelFieldEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ModelFieldEditor.kt
@@ -27,10 +27,9 @@ import android.widget.EditText
 import android.widget.ListView
 import androidx.annotation.RequiresApi
 import androidx.annotation.VisibleForTesting
+import androidx.appcompat.app.AlertDialog
 import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.FragmentManager
-import com.afollestad.materialdialogs.MaterialDialog
-import com.afollestad.materialdialogs.customview.customView
 import com.google.android.material.snackbar.Snackbar
 import com.ichi2.anim.ActivityTransitionAnimation
 import com.ichi2.anki.CollectionManager.withCol
@@ -46,7 +45,11 @@ import com.ichi2.anki.snackbar.showSnackbar
 import com.ichi2.libanki.Collection
 import com.ichi2.libanki.Model
 import com.ichi2.ui.FixedEditText
-import com.ichi2.utils.displayKeyboard
+import com.ichi2.utils.customView
+import com.ichi2.utils.negativeButton
+import com.ichi2.utils.positiveButton
+import com.ichi2.utils.show
+import com.ichi2.utils.title
 import com.ichi2.utils.toStringList
 import com.ichi2.widget.WidgetStatus
 import org.json.JSONArray
@@ -164,11 +167,13 @@ class ModelFieldEditor : AnkiActivity(), LocaleSelectionDialogHandler {
     * Creates a dialog to create a field
     */
     private fun addFieldDialog() {
-        fieldNameInput = FixedEditText(this)
+        fieldNameInput = FixedEditText(this).apply {
+            focusWithKeyboard()
+        }
         fieldNameInput?.let { _fieldNameInput ->
             _fieldNameInput.isSingleLine = true
-            MaterialDialog(this).show {
-                customView(view = _fieldNameInput, horizontalPadding = true)
+            AlertDialog.Builder(this).show {
+                customView(_fieldNameInput, marginLeft = 64, marginRight = 64, marginTop = 32)
                 title(R.string.model_field_editor_add)
                 positiveButton(R.string.dialog_ok) {
                     // Name is valid, now field is added
@@ -197,7 +202,6 @@ class ModelFieldEditor : AnkiActivity(), LocaleSelectionDialogHandler {
                 }
                 negativeButton(R.string.dialog_cancel)
             }
-                .displayKeyboard(_fieldNameInput)
         }
     }
 
@@ -286,13 +290,13 @@ class ModelFieldEditor : AnkiActivity(), LocaleSelectionDialogHandler {
      * Processing time is constant
      */
     private fun renameFieldDialog() {
-        fieldNameInput = FixedEditText(this)
+        fieldNameInput = FixedEditText(this).apply { focusWithKeyboard() }
         fieldNameInput?.let { _fieldNameInput ->
             _fieldNameInput.isSingleLine = true
             _fieldNameInput.setText(mFieldsLabels[currentPos])
             _fieldNameInput.setSelection(_fieldNameInput.text!!.length)
-            MaterialDialog(this).show {
-                customView(view = _fieldNameInput, horizontalPadding = true)
+            AlertDialog.Builder(this).show {
+                customView(_fieldNameInput, marginLeft = 64, marginRight = 64, marginTop = 32)
                 title(R.string.model_field_editor_rename)
                 positiveButton(R.string.rename) {
                     if (uniqueName(_fieldNameInput) == null) {
@@ -321,7 +325,6 @@ class ModelFieldEditor : AnkiActivity(), LocaleSelectionDialogHandler {
                     }
                 }
                 negativeButton(R.string.dialog_cancel)
-                displayKeyboard(_fieldNameInput)
             }
         }
     }
@@ -332,11 +335,11 @@ class ModelFieldEditor : AnkiActivity(), LocaleSelectionDialogHandler {
      * Processing time is scales with number of items
      */
     private fun repositionFieldDialog() {
-        fieldNameInput = FixedEditText(this)
+        fieldNameInput = FixedEditText(this).apply { focusWithKeyboard() }
         fieldNameInput?.let { _fieldNameInput ->
             _fieldNameInput.setRawInputType(InputType.TYPE_CLASS_NUMBER)
-            MaterialDialog(this).show {
-                customView(view = _fieldNameInput, horizontalPadding = true)
+            AlertDialog.Builder(this).show {
+                customView(_fieldNameInput)
                 title(text = String.format(resources.getString(R.string.model_field_editor_reposition), 1, mFieldsLabels.size))
                 positiveButton(R.string.dialog_ok) {
                     val newPosition = _fieldNameInput.text.toString()
@@ -371,15 +374,10 @@ class ModelFieldEditor : AnkiActivity(), LocaleSelectionDialogHandler {
                             c.setConfirm(confirm)
                             this@ModelFieldEditor.showDialogFragment(c)
                         }
-                        this.dismiss()
                     }
                 }
-                negativeButton(R.string.dialog_cancel) {
-                    this.dismiss()
-                }
+                negativeButton(R.string.dialog_cancel)
             }
-                .noAutoDismiss()
-                .displayKeyboard(_fieldNameInput)
         }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/utils/AlertDialogFacade.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/AlertDialogFacade.kt
@@ -160,30 +160,22 @@ fun AlertDialog.Builder.checkBoxPrompt(
 }
 
 fun AlertDialog.Builder.customView(
-    editText: View,
-    marginTop: Int = 0,
-    marginBottom: Int = 0,
-    marginLeft: Int = 0,
-    marginRight: Int = 0
+    view: View,
+    paddingTop: Int = 0,
+    paddingBottom: Int = 0,
+    paddingLeft: Int = 0,
+    paddingRight: Int = 0
 ): AlertDialog.Builder {
     val container = FrameLayout(context)
-    container.addView(editText)
+
     val containerParams = FrameLayout.LayoutParams(
         FrameLayout.LayoutParams.MATCH_PARENT,
         FrameLayout.LayoutParams.WRAP_CONTENT
     )
 
-    containerParams.topMargin = marginTop
-    containerParams.leftMargin = marginLeft
-    containerParams.rightMargin = marginRight
-    containerParams.bottomMargin = marginBottom
-
-    container.layoutParams = containerParams
-
-    val superContainer = FrameLayout(context)
-    superContainer.addView(container)
-
-    setView(superContainer)
+    container.setPadding(paddingLeft, paddingTop, paddingRight, paddingBottom)
+    container.addView(view, containerParams)
+    setView(container)
 
     return this
 }

--- a/AnkiDroid/src/main/java/com/ichi2/utils/AlertDialogFacade.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/AlertDialogFacade.kt
@@ -22,6 +22,7 @@ import android.content.DialogInterface
 import android.content.DialogInterface.OnClickListener
 import android.view.View
 import android.widget.CheckBox
+import android.widget.FrameLayout
 import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
 import androidx.appcompat.app.AlertDialog
@@ -156,4 +157,33 @@ fun AlertDialog.Builder.checkBoxPrompt(
     }
 
     return this.setView(checkBoxView)
+}
+
+fun AlertDialog.Builder.customView(
+    editText: View,
+    marginTop: Int = 0,
+    marginBottom: Int = 0,
+    marginLeft: Int = 0,
+    marginRight: Int = 0
+): AlertDialog.Builder {
+    val container = FrameLayout(context)
+    container.addView(editText)
+    val containerParams = FrameLayout.LayoutParams(
+        FrameLayout.LayoutParams.MATCH_PARENT,
+        FrameLayout.LayoutParams.WRAP_CONTENT
+    )
+
+    containerParams.topMargin = marginTop
+    containerParams.leftMargin = marginLeft
+    containerParams.rightMargin = marginRight
+    containerParams.bottomMargin = marginBottom
+
+    container.layoutParams = containerParams
+
+    val superContainer = FrameLayout(context)
+    superContainer.addView(container)
+
+    setView(superContainer)
+
+    return this
 }


### PR DESCRIPTION
## Fixes
Related to [#13315](https://github.com/ankidroid/Anki-Android/issues/13315)

## Approach
I tried following previous pull requests related to this issue as much as possible. When I noticed that no other previous pull request adapting a Material dialog that had an EditText inside, I added a new "customView" function to the Alert dialog facade to achieve a similar UI Design. 

## How Has This Been Tested?
Tested all the modified dialogs by inputting, canceling or making changes.

## Learning (optional, can help others)
While trying to work on this problem, I noticed that there was no alternative to the customView function from the materialDialog library in the AlertDialog library. While trying to inflate an EditText it was actually hard to find a solution to add a margin to the InputField to make it look like its materialDialog version (I wanted to avoid making an xml file). I found a solution thanks to this [Post](https://stackoverflow.com/questions/27774414/add-bigger-margin-to-edittext-in-android-alertdialog).

Here are screenshots of the before and after :
<img src="https://github.com/ankidroid/Anki-Android/assets/46049558/dcfafc7a-adac-476e-a486-935f52bfb42e"  width="250" height="500" /> --> <img src="https://github.com/ankidroid/Anki-Android/assets/46049558/08076959-1bc0-4249-b948-0248422c4b13"  width="250" height="500" />

