### PR TITLE
checking for bitmap size to avoid `illegalArgumentException`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,4 +58,3 @@ tools/crowdin_key.txt
 # Testing / quality remnants
 AnkiDroid/ACRA-INSTALLATION
 .codacy.json
-*.log

--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,4 @@ tools/crowdin_key.txt
 # Testing / quality remnants
 AnkiDroid/ACRA-INSTALLATION
 .codacy.json
+*.log

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Whiteboard.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Whiteboard.kt
@@ -223,7 +223,6 @@ class Whiteboard(activity: AnkiActivity, handleMultiTouch: Boolean, inverted: Bo
      */
     override fun onSizeChanged(w: Int, h: Int, oldw: Int, oldh: Int) {
         super.onSizeChanged(w, h, oldw, oldh)
-        Timber.w("Whiteboard::onSizeChanged width:$w height:$h")
         // createScaledBitmap requires a width and height > 0; #13972
         if (w <= 0 || h <= 0) {
             Timber.w("Width or height <= 0: w: $w h: $h Bitmap couldn't be created with the new size")

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Whiteboard.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Whiteboard.kt
@@ -224,7 +224,11 @@ class Whiteboard(activity: AnkiActivity, handleMultiTouch: Boolean, inverted: Bo
     override fun onSizeChanged(w: Int, h: Int, oldw: Int, oldh: Int) {
         super.onSizeChanged(w, h, oldw, oldh)
         Timber.w("Whiteboard::onSizeChanged width:$w height:$h")
-        if (w == 0 || h == 0) return
+        // createScaledBitmap requires a width and height > 0; #13972
+        if (w <= 0 || h <= 0) {
+            Timber.w("Width or height <= 0: w: $w h: $h Bitmap couldn't be created with the new size")
+            return
+        }
         val scaledBitmap: Bitmap = Bitmap.createScaledBitmap(mBitmap, w, h, true)
         mBitmap = scaledBitmap
         mCanvas = Canvas(mBitmap)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Whiteboard.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Whiteboard.kt
@@ -214,7 +214,12 @@ class Whiteboard(activity: AnkiActivity, handleMultiTouch: Boolean, inverted: Bo
         // To fix issue #1336, just make the whiteboard big and square.
         val p = displayDimensions
         val bitmapSize = max(p.x, p.y)
-        createBitmap(bitmapSize, bitmapSize)
+        if (bitmapSize > 0) {
+            createBitmap(bitmapSize, bitmapSize)
+        } else {
+            // Handles the case where bitmapSize is 0 or negative.
+            Timber.e("Bitmap size less than zero")
+        }
     }
 
     /**

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Whiteboard.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Whiteboard.kt
@@ -223,25 +223,10 @@ class Whiteboard(activity: AnkiActivity, handleMultiTouch: Boolean, inverted: Bo
      */
     override fun onSizeChanged(w: Int, h: Int, oldw: Int, oldh: Int) {
         super.onSizeChanged(w, h, oldw, oldh)
-        if (w > 0 && h > 0) {
-            val scaledBitmap: Bitmap? = try {
-                Bitmap.createScaledBitmap(mBitmap, w, h, true)
-            } catch (e: IllegalArgumentException) {
-                Timber.e("Bitmap size less than zero")
-                null
-            }
-            if (scaledBitmap != null) {
-                mBitmap.recycle()
-                mBitmap = scaledBitmap
-                mCanvas = Canvas(mBitmap)
-            } else {
-                val validWidth = 500
-                val validHeight = 500
-                mBitmap.recycle()
-                mBitmap = Bitmap.createBitmap(validWidth, validHeight, Bitmap.Config.ARGB_8888)
-                mCanvas = Canvas(mBitmap)
-            }
-        }
+        if (w == 0 && h == 0) return
+        val scaledBitmap: Bitmap = Bitmap.createScaledBitmap(mBitmap, w, h, true)
+        mBitmap = scaledBitmap
+        mCanvas = Canvas(mBitmap)
     }
 
     private fun drawStart(x: Float, y: Float) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Whiteboard.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Whiteboard.kt
@@ -223,6 +223,7 @@ class Whiteboard(activity: AnkiActivity, handleMultiTouch: Boolean, inverted: Bo
      */
     override fun onSizeChanged(w: Int, h: Int, oldw: Int, oldh: Int) {
         super.onSizeChanged(w, h, oldw, oldh)
+        Timber.w("Whiteboard::onSizeChanged width:$w height:$h")
         if (w == 0 || h == 0) return
         val scaledBitmap: Bitmap = Bitmap.createScaledBitmap(mBitmap, w, h, true)
         mBitmap = scaledBitmap

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Whiteboard.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Whiteboard.kt
@@ -223,7 +223,7 @@ class Whiteboard(activity: AnkiActivity, handleMultiTouch: Boolean, inverted: Bo
      */
     override fun onSizeChanged(w: Int, h: Int, oldw: Int, oldh: Int) {
         super.onSizeChanged(w, h, oldw, oldh)
-        if (w == 0 && h == 0) return
+        if (w == 0 || h == 0) return
         val scaledBitmap: Bitmap = Bitmap.createScaledBitmap(mBitmap, w, h, true)
         mBitmap = scaledBitmap
         mCanvas = Canvas(mBitmap)


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
Bitmap size check to avoid the condition where bitmap size <0

## Fixes
Fixes #13972

## Approach
_How does this change address the problem?_

## How Has This Been Tested?
 condition is suffice to avoid the exception but I would like to have an opinion if we should have a default bitmap size i.e `500x500` in case this case arises. @BrayanDSO 


## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

