### PR TITLE
Moved cursor to end in IncrementerNumberRangePreferenceCompat

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/preferences/IncrementerNumberRangePreferenceCompat.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/preferences/IncrementerNumberRangePreferenceCompat.kt
@@ -113,6 +113,7 @@ class IncrementerNumberRangePreferenceCompat : NumberRangePreferenceCompat, Dial
             // Make sure value is within range
             mLastValidEntry = numberRangePreference.getValidatedRangeFromInt(value)
             editText.setText(mLastValidEntry.toString())
+            editText.setSelection(editText.text.length)
         }
     }
 


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
The cursor should be at the end while increment or decrement integers

## Fixes
Related #13954 

## Approach
set cursor to the end

## How Has This Been Tested?
Tested on Emulator

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
