### PR TITLE
Dependency updates 20230621

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,3 +20,7 @@ updates:
   - dependency-name: org.apache.commons:commons-compress
     versions:
     - ">= 1.12, < 1.23"
+    # We cannot update this one until minimum API24. Ignore range should slide with known versions so we stay informed.
+  - dependency-name: com.fasterxml.jackson.core:jackson-databind
+    versions:
+      - ">= 2.13.5, < 2.16"

--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -340,7 +340,7 @@ dependencies {
     // noinspection GradleDependency - commons-compress 1.12 - later versions use `File.toPath`; API26 can remove?
     implementation 'org.apache.commons:commons-compress:1.12' // #6419 - handle >2GB apkg files
     implementation 'org.apache.commons:commons-collections4:4.4' // SetUniqueList
-    implementation 'commons-io:commons-io:2.11.0' // FileUtils.contentEquals
+    implementation 'commons-io:commons-io:2.13.0' // FileUtils.contentEquals
     implementation 'net.mikehardy:google-analytics-java7:2.0.13'
     implementation 'com.squareup.okhttp3:okhttp:4.11.0'
     implementation 'com.arcao:slf4j-timber:3.1'

--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -301,7 +301,7 @@ dependencies {
     // Changing the version from 1.8.0 to 1.7.0 because the item in navigation drawer is getting bold unnecessarily
     implementation 'com.google.android.material:material:1.7.0'
     // noinspection GradleDependency jackson-databind 2.13 requires SDK 24+: https://github.com/FasterXML/jackson-databind#compatibility
-    implementation 'com.fasterxml.jackson.core:jackson-databind:2.15.0'
+    implementation 'com.fasterxml.jackson.core:jackson-databind:2.13.5'
     implementation 'com.vanniktech:android-image-cropper:4.5.0'
     implementation 'org.nanohttpd:nanohttpd:2.3.1'
 

--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -358,7 +358,7 @@ dependencies {
     // Cannot use debugImplementation since classes need to be imported in AnkiDroidApp
     // and there's no no-op version for release build. Usage has been disabled for release
     // build via AnkiDroidApp.
-    implementation 'com.squareup.leakcanary:leakcanary-android:2.10'
+    implementation 'com.squareup.leakcanary:leakcanary-android:2.11'
 
     api project(":api")
 

--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -307,7 +307,7 @@ dependencies {
 
     // Backend libraries
 
-    implementation 'com.google.protobuf:protobuf-kotlin:3.23.0' // This is required when loading from a file
+    implementation 'com.google.protobuf:protobuf-kotlin:3.23.3' // This is required when loading from a file
 
     Properties localProperties = new Properties()
     if (project.rootProject.file('local.properties').exists()) {

--- a/AnkiDroid/src/test/java/com/ichi2/anki/RobolectricTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/RobolectricTest.kt
@@ -68,6 +68,7 @@ import java.util.concurrent.locks.ReentrantLock
 import kotlin.concurrent.withLock
 import kotlin.coroutines.CoroutineContext
 import kotlin.coroutines.EmptyCoroutineContext
+import kotlin.time.Duration.Companion.milliseconds
 
 open class RobolectricTest : CollectionGetter, AndroidTest {
 
@@ -641,7 +642,7 @@ open class RobolectricTest : CollectionGetter, AndroidTest {
         dispatchTimeoutMs: Long = 60_000L,
         testBody: suspend TestScope.() -> Unit
     ) {
-        kotlinx.coroutines.test.runTest(context, dispatchTimeoutMs) {
+        runTest(context, dispatchTimeoutMs.milliseconds) {
             CollectionManager.setTestDispatcher(UnconfinedTestDispatcher(testScheduler))
             testBody()
         }

--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ buildscript {
     ext.espresso_version = '3.5.1'
     ext.androidx_test_version = '1.5.0'
     ext.androidx_test_junit_version = '1.1.5'
-    ext.robolectric_version = '4.10.2'
+    ext.robolectric_version = '4.10.3'
 
     repositories {
         google()

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ buildscript {
     ext.ankidroid_backend_version = '0.1.21-anki2.1.61'
     ext.hamcrest_version = '2.2'
     ext.junit_version = '5.9.3'
-    ext.coroutines_version = '1.6.4'
+    ext.coroutines_version = '1.7.1'
     ext.fragments_version = "1.6.0"
     ext.espresso_version = '3.5.1'
     ext.androidx_test_version = '1.5.0'


### PR DESCRIPTION
## Pull Request template

## Purpose / Description

Staying up to date in general on dependencies, but also very importantly this fixes API < 24 failures on main right now by reverting an incorrect update to jackson-databind

## Fixes
API < 24 as mentioned in description

## Approach
revert the databind change and alter dependabot config to stop prompting for it with a note we need API>=24

## How Has This Been Tested?

Locally with `./gradlew jacocoTesstReport` against an API24 emulator, CI will check API30

