### PR TITLE
fix build related to vanished transitive dependency of amazon publish plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,15 +22,25 @@ buildscript {
         maven {
             url "https://plugins.gradle.org/m2/"
         }
+        maven { url 'https://jitpack.io' }
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:7.4.2'
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
-        classpath "app.brant:amazonappstorepublisher:0.1.0"
+        classpath "com.github.BrantApps.gradle-amazon-app-store-publisher:amazonappstorepublisher:master-SNAPSHOT"
 
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "org.jlleitschuh.gradle:ktlint-gradle:11.4.1"
+    }
+    configurations.all {
+        resolutionStrategy.eachDependency { details ->
+            if (details.requested.group == 'org.jetbrains.kotlinx'
+                    && details.requested.name.contains('kotlinx-serialization-runtime')
+                    && details.requested.version.contains('0.11.0')) {
+                details.useVersion "0.14.0"
+            }
+        }
     }
 }
 


### PR DESCRIPTION

## Pull Request template

## Purpose / Description

Update the amazon publish plugin to current master, and override one of it's dependencies to one that has not vanished off the face of the internet

## Fixes

Fixes the build which is currently broken on main

## Approach
Carefully override the one group/artifact/version combo that vanished to one that exists, and add the maven repository required to find a current master build of the plugin

## How Has This Been Tested?


I have not tried to publish to amazon (no one has in forever...) but the build works for me locally with these fixes applied

## Learning (optional, can help others)

Entropy and chaos.

It's always entropy and chaos.

Things work fine, and then something unrelated happens and things break.
