### PR TITLE
Fix the reversal of correct/incorrect closing tag in the error message of the card template preview

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/template/TemplateError.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/template/TemplateError.kt
@@ -34,7 +34,7 @@ abstract class TemplateError : NoSuchElementException() {
         }
     }
 
-    class WrongConditionalClosed(val expected: String, val found: String) : TemplateError() {
+    class WrongConditionalClosed(val found: String, val expected: String) : TemplateError() {
         override fun message(context: Context): String {
             return context.getString(R.string.wrong_tag_closed, found, expected)
         }


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
On (the back side of) card templates in the current backend, if you input an incorrect closing tag, for example, "{{#Tags}}blah{{/**Ta**}}", its preview says 
`Found '{/Tags}}', but expected '{{/Ta}}'`.
<img src="https://github.com/ankidroid/Anki-Android/assets/10436072/ba29eb91-5c00-4b13-9487-9b8610de1495" width="200px"> <img src="https://github.com/ankidroid/Anki-Android/assets/10436072/95eb7106-f531-4a73-9562-5c88205dcb34" width="200px">



This commit will fix the inappropriate reversal.
In other words, by this commit the preview will say 
`Found '{/Ta}}', but expected '{{/Tags}}'` 
as in Anki Desktop and in the advanced "new backend".

**In Anki Desktop**
<img src="https://github.com/ankidroid/Anki-Android/assets/10436072/378783ad-3514-4ca9-b3f8-83581662f503" width="400px">


**In the new backend**
<img src="https://github.com/ankidroid/Anki-Android/assets/10436072/b592576c-f14f-41d3-9802-c6ed9efa7fc0" width="300px">


## Approach

Swap the first parameter and the second parameter of `WrongConditionalClosed()`
https://github.com/ankidroid/Anki-Android/blob/c1dcf40a2f41decf926ce944573daf450f62558f/AnkiDroid/src/main/java/com/ichi2/libanki/template/TemplateError.kt#L37-L41


**Relevant part 1**
https://github.com/ankidroid/Anki-Android/blob/c1dcf40a2f41decf926ce944573daf450f62558f/AnkiDroid/src/main/res/values/01-core.xml#L213


**Relevant part 2**
https://github.com/ankidroid/Anki-Android/blob/c1dcf40a2f41decf926ce944573daf450f62558f/AnkiDroid/src/main/java/com/ichi2/libanki/template/ParsedNode.kt#L159-L162



## How Has This Been Tested?
Checked on a physical device (Android 11)
<img src="https://github.com/ankidroid/Anki-Android/assets/10436072/a0746747-245b-4688-a026-b307bc6a25ea" width="320px"> 

## Note
Yes, it is a fix for short period of time until the "new backend" becomes default...

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
