### PR TITLE
Move essential file migration into the service

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CoroutineHelpers.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CoroutineHelpers.kt
@@ -245,6 +245,7 @@ suspend fun <T> Fragment.withProgress(@StringRes messageId: Int, block: suspend 
 suspend fun <T> withProgressDialog(
     context: Activity,
     onCancel: (() -> Unit)?,
+    delayMillis: Long = 600,
     op: suspend (android.app.ProgressDialog) -> T
 ): T = coroutineScope {
     val dialog = android.app.ProgressDialog(context).apply {
@@ -257,7 +258,7 @@ suspend fun <T> withProgressDialog(
     context.window.setFlags(WindowManager.LayoutParams.FLAG_NOT_TOUCHABLE, WindowManager.LayoutParams.FLAG_NOT_TOUCHABLE)
     // reveal the dialog after 600ms
     val dialogJob = launch {
-        delay(600)
+        delay(delayMillis)
         dialog.show()
     }
     try {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -962,6 +962,7 @@ open class DeckPicker :
 
     override fun onResume() {
         Timber.d("onResume()")
+        mActivityPaused = false
         // stop onResume() processing the message.
         // we need to process the message after `loadDeckCounts` is added in refreshState
         // As `loadDeckCounts` is cancelled in `migrate()`
@@ -972,7 +973,6 @@ open class DeckPicker :
     }
 
     fun refreshState() {
-        mActivityPaused = false
         // Due to the App Introduction, this may be called before permission has been granted.
         if (mSyncOnResume && hasStorageAccessPermission(this)) {
             Timber.i("Performing Sync on Resume")

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/dialogs/ActivityAgnosticDialogs.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/dialogs/ActivityAgnosticDialogs.kt
@@ -21,13 +21,16 @@ import android.app.Application
 import android.app.Dialog
 import android.os.Bundle
 import androidx.appcompat.app.AlertDialog
+import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.edit
 import androidx.core.os.bundleOf
 import androidx.core.text.parseAsHtml
 import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.FragmentActivity
 import androidx.preference.PreferenceManager.getDefaultSharedPreferences
+import com.ichi2.anki.AnkiDroidApp
 import com.ichi2.anki.R
+import com.ichi2.anki.ui.dialogs.ActivityAgnosticDialogs.Companion.MIGRATION_FAILED_DIALOG_ERROR_TEXT_KEY
 import com.ichi2.anki.utils.getUserFriendlyErrorText
 import com.ichi2.utils.copyToClipboardAndShowConfirmation
 import makeLinksClickable
@@ -96,6 +99,8 @@ class MigrationFailedDialogFragment : DialogFragment() {
         private const val STACKTRACE_KEY = "stacktrace"
         private const val CHANGES_ROLLED_BACK_KEY = "changes rolled back"
 
+        const val TAG = "MigrationFailedDialogFragment"
+
         fun show(activity: FragmentActivity, errorText: CharSequence, stacktrace: String, changesRolledBack: Boolean) {
             MigrationFailedDialogFragment()
                 .apply {
@@ -105,7 +110,7 @@ class MigrationFailedDialogFragment : DialogFragment() {
                         CHANGES_ROLLED_BACK_KEY to changesRolledBack
                     )
                 }
-                .show(activity.supportFragmentManager, "MigrationFailedDialogFragment")
+                .show(activity.supportFragmentManager, TAG)
         }
     }
 }
@@ -184,7 +189,7 @@ class ActivityAgnosticDialogs private constructor(private val application: Appli
     companion object {
         private const val MIGRATION_SUCCEEDED_DIALOG_PENDING_KEY = "migration succeeded dialog pending"
 
-        private const val MIGRATION_FAILED_DIALOG_ERROR_TEXT_KEY = "migration failed dialog error text"
+        const val MIGRATION_FAILED_DIALOG_ERROR_TEXT_KEY = "migration failed dialog error text"
         private const val MIGRATION_FAILED_DIALOG_STACKTRACE_KEY = "migration failed dialog stacktrace"
         private const val MIGRATION_FAILED_DIALOG_CHANGES_ROLLED_BACK_KEY = "migration failed dialog changes rolled back"
 
@@ -192,6 +197,11 @@ class ActivityAgnosticDialogs private constructor(private val application: Appli
             .apply { registerCallbacks() }
     }
 }
+
+fun storageMigrationFailedDialogIsShownOrPending(activity: AppCompatActivity) =
+    activity.supportFragmentManager.findFragmentByTag(MigrationFailedDialogFragment.TAG) != null ||
+        AnkiDroidApp.getSharedPrefs(activity)
+        .getString(MIGRATION_FAILED_DIALOG_ERROR_TEXT_KEY, null) != null
 
 interface DefaultActivityLifecycleCallbacks : Application.ActivityLifecycleCallbacks {
     override fun onActivityCreated(activity: Activity, savedInstanceState: Bundle?) {}

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/dialogs/ActivityAgnosticDialogs.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/dialogs/ActivityAgnosticDialogs.kt
@@ -60,12 +60,18 @@ class MigrationSucceededDialogFragment : DialogFragment() {
 //   and also add instructions to fix the issue in case of easily fixable problems,
 //   such as running out of disk space.
 class MigrationFailedDialogFragment : DialogFragment() {
+    @Suppress("MoveVariableDeclarationIntoWhen") // changesRolledBack
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
         val errorText = arguments?.getString(ERROR_TEXT_KEY) ?: ""
         val stacktrace = arguments?.getString(STACKTRACE_KEY) ?: ""
+        val changesRolledBack = arguments?.getBoolean(CHANGES_ROLLED_BACK_KEY) ?: false
 
+        val messageTemplateId = when (changesRolledBack) {
+            true -> R.string.migration__failed__changes_rolled_back__message
+            false -> R.string.migration__failed__changes_not_rolled_back__message
+        }
         val helpUrl = getString(R.string.link_migration_failed_dialog_learn_more_en)
-        val message = getString(R.string.migration__failed__message, errorText, helpUrl).parseAsHtml()
+        val message = getString(messageTemplateId, errorText, helpUrl).parseAsHtml()
 
         return AlertDialog.Builder(requireContext())
             .setTitle(R.string.migration__failed__title)
@@ -88,10 +94,17 @@ class MigrationFailedDialogFragment : DialogFragment() {
     companion object {
         private const val ERROR_TEXT_KEY = "error text"
         private const val STACKTRACE_KEY = "stacktrace"
+        private const val CHANGES_ROLLED_BACK_KEY = "changes rolled back"
 
-        fun show(activity: FragmentActivity, errorText: CharSequence, stacktrace: String) {
+        fun show(activity: FragmentActivity, errorText: CharSequence, stacktrace: String, changesRolledBack: Boolean) {
             MigrationFailedDialogFragment()
-                .apply { arguments = bundleOf(ERROR_TEXT_KEY to errorText, STACKTRACE_KEY to stacktrace) }
+                .apply {
+                    arguments = bundleOf(
+                        ERROR_TEXT_KEY to errorText,
+                        STACKTRACE_KEY to stacktrace,
+                        CHANGES_ROLLED_BACK_KEY to changesRolledBack
+                    )
+                }
                 .show(activity.supportFragmentManager, "MigrationFailedDialogFragment")
         }
     }
@@ -112,18 +125,20 @@ class ActivityAgnosticDialogs private constructor(private val application: Appli
         }
     }
 
-    fun showOrScheduleStorageMigrationFailedDialog(e: Exception) {
+    fun showOrScheduleStorageMigrationFailedDialog(exception: Exception, changesRolledBack: Boolean) {
         val currentlyStartedFragmentActivity = this.currentlyStartedFragmentActivity
         val context = currentlyStartedFragmentActivity ?: application
-        val errorText = context.getUserFriendlyErrorText(e)
-        val stacktrace = e.stackTraceToString()
+        val errorText = context.getUserFriendlyErrorText(exception)
+        val stacktrace = exception.stackTraceToString()
 
         if (currentlyStartedFragmentActivity != null) {
-            MigrationFailedDialogFragment.show(currentlyStartedFragmentActivity, errorText, stacktrace)
+            MigrationFailedDialogFragment
+                .show(currentlyStartedFragmentActivity, errorText, stacktrace, changesRolledBack)
         } else {
             preferences.edit {
-                putString(MIGRATION_FAILED_DIALOG_ERROR_TEXT_KEY, errorText.toString())
-                putString(MIGRATION_FAILED_STACKTRACE_KEY, stacktrace)
+                putString(MIGRATION_FAILED_DIALOG_ERROR_TEXT_KEY, errorText)
+                putString(MIGRATION_FAILED_DIALOG_STACKTRACE_KEY, stacktrace)
+                putBoolean(MIGRATION_FAILED_DIALOG_CHANGES_ROLLED_BACK_KEY, changesRolledBack)
             }
         }
     }
@@ -152,12 +167,14 @@ class ActivityAgnosticDialogs private constructor(private val application: Appli
                 }
 
                 val errorText = preferences.getString(MIGRATION_FAILED_DIALOG_ERROR_TEXT_KEY, null)
-                val stacktrace = preferences.getString(MIGRATION_FAILED_STACKTRACE_KEY, null)
+                val stacktrace = preferences.getString(MIGRATION_FAILED_DIALOG_STACKTRACE_KEY, null)
+                val changesRolledBack = preferences.getBoolean(MIGRATION_FAILED_DIALOG_CHANGES_ROLLED_BACK_KEY, false)
                 if (errorText != null && stacktrace != null) {
-                    MigrationFailedDialogFragment.show(activity, errorText, stacktrace)
+                    MigrationFailedDialogFragment.show(activity, errorText, stacktrace, changesRolledBack)
                     preferences.edit {
                         remove(MIGRATION_FAILED_DIALOG_ERROR_TEXT_KEY)
-                        remove(MIGRATION_FAILED_STACKTRACE_KEY)
+                        remove(MIGRATION_FAILED_DIALOG_STACKTRACE_KEY)
+                        remove(MIGRATION_FAILED_DIALOG_CHANGES_ROLLED_BACK_KEY)
                     }
                 }
             }
@@ -168,7 +185,8 @@ class ActivityAgnosticDialogs private constructor(private val application: Appli
         private const val MIGRATION_SUCCEEDED_DIALOG_PENDING_KEY = "migration succeeded dialog pending"
 
         private const val MIGRATION_FAILED_DIALOG_ERROR_TEXT_KEY = "migration failed dialog error text"
-        private const val MIGRATION_FAILED_STACKTRACE_KEY = "migration failed dialog stacktrace"
+        private const val MIGRATION_FAILED_DIALOG_STACKTRACE_KEY = "migration failed dialog stacktrace"
+        private const val MIGRATION_FAILED_DIALOG_CHANGES_ROLLED_BACK_KEY = "migration failed dialog changes rolled back"
 
         fun register(application: Application) = ActivityAgnosticDialogs(application)
             .apply { registerCallbacks() }

--- a/AnkiDroid/src/main/res/values/01-core.xml
+++ b/AnkiDroid/src/main/res/values/01-core.xml
@@ -246,11 +246,29 @@
         >Multiple consecutive errors without progress, most recent: %s</string>
 
     <!-- Scoped storage migration -->
-    <string name="migration__migrating_data">Migrating data</string>
-    <string name="migration__calculating_transfer_size">Calculating transfer size…</string>
-    <string name="migration__transferred_x_of_y"
-        comment="The placeholders will be replaced with short localized byte amounts,
-        e.g. Transferred 10 kB of 5.2 MB">Transferred %1$s of %2$s</string>
+    <string name="migration__migrating_database_files"
+        comment="Notification title that is shown when copying essential database files.
+        As this is shown on the same line as the notification message, prefer shorter text."
+        >Migrating database files</string>
+    <string name="migration__copying"
+        comment="Notification message that is shown when copying essential database files.
+        As this is shown on the same line as the notification title, prefer shorter text."
+        >Copying…</string>
+
+    <string name="migration__migrating_media"
+        comment="Notification title that is shown when migrating media files.
+        As this is shown on the same line as the notification message, prefer shorter text."
+        >Migrating media</string>
+    <string name="migration__calculating_transfer_size"
+        comment="Notification message that is shown when calculating the total size of media files to move.
+        As this is shown on the same line as the notification title, prefer shorter text."
+        >Calculating transfer size…</string>
+    <string name="migration__moved_x_of_y"
+        comment="Notification message that is shown when moving media files.
+        As this is shown on the same line as the notification title, prefer shorter text.
+        The placeholders will be replaced with short localized byte amounts,
+        e.g. Moved 10 kB of 5.2 MB"
+        >Moved %1$s of %2$s</string>
 
     <string name="migration_successful_message"
         comment="A title for a dialog, or a short message shown in a notification,
@@ -267,12 +285,29 @@
     <string name="migration__failed__title"
         comment="A title for a dialog, or a short message shown in a notification,
         when storage migration fails">Migration failed</string>
-    <string name="migration__failed__message"
-        comment="A more detailed message shown when storage migration fails"><![CDATA[
-        Storage migration is paused after failing with the error: %1$s.
+    <string name="migration__failed__changes_rolled_back__message"
+        comment="A more detailed message shown when storage migration fails, with the changes rolled back"><![CDATA[
+        Copying database files failed with the error: %1$s.
+        <br><br>
+        The changes were reverted.
         <br><br>
         Please try re-running the migration.
-        To resolve the problem, you may need to free up some disk space, or-reconnect the missing media.
+        To resolve the problem, you may need to free up some disk space,
+        or reconnect the removable storage that holds your collection.
+        <br><br>
+        <a href="%2$s">Learn more and get help</a>
+    ]]></string>
+    <string name="migration__failed__changes_not_rolled_back__message"
+        comment="A more detailed message shown when storage migration fails, with the changes not rolled back"><![CDATA[
+        Moving media files is paused after having failed with the error: %1$s.
+        <br><br>
+        The changes were <i>not</i> reverted.
+        While no data should’ve been lost,
+        the media files might be split between the old and the new folder.
+        <br><br>
+        Please try re-running the migration.
+        To resolve the problem, you may need to free up some disk space,
+        or reconnect the removable storage that holds your collection.
         <br><br>
         <a href="%2$s">Learn more and get help</a>
     ]]></string>


### PR DESCRIPTION
#### Purpose / Description / Approach
See commit messages (no, really). Note the new TODO. Note string changes in the notification.

Below are the new error dialog shown when there's an error while migrating essential files, and the altered media migration error dialog.

<img width=300 src=https://github.com/ankidroid/Anki-Android/assets/1710718/b6f184a1-d686-4730-98d1-ce01fc7a1753> <img width=300 src=https://github.com/ankidroid/Anki-Android/assets/1710718/4897ccd3-7c60-4e83-9046-1f270b6fc93b>

A demo with a few activity recreations. Note that at the end of the video there's a rogue dialog offering to resume migration under the migration dialog, that's a result of the problem described in the TODO.

https://github.com/ankidroid/Anki-Android/assets/1710718/7ef4ca82-bad5-4c3d-ae25-c44fcfbae0fc

Thanks to @snowtimeglass for help with strings.

#### Fixes
Fixes #13970, hopefully fixes #13868 and closes #13918 as obsolete

#### How Has This Been Tested?
Tested on my device

#### Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
