### PR TITLE
Fix card browser add icon appearing dark

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/utils/MenuUtils.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/MenuUtils.kt
@@ -45,6 +45,8 @@ fun Context.increaseHorizontalPaddingOfOverflowMenuIcons(menu: Menu) {
     val extraPadding = convertDpToPixel(5f, this).toInt()
 
     class Wrapper(drawable: Drawable) : DrawableWrapperCompat(drawable) {
+        override fun mutate() = drawable!!.mutate() // DrawableWrapperCompat fails to delegate this
+
         override fun getIntrinsicWidth() = super.getIntrinsicWidth() + extraPadding * 2
 
         override fun setBounds(left: Int, top: Int, right: Int, bottom: Int) {
@@ -60,7 +62,7 @@ fun Context.increaseHorizontalPaddingOfOverflowMenuIcons(menu: Menu) {
 }
 
 /**
- * Recursively tints the icons of the items of the given overflow or popup menu
+ * Recursively mutates and tints the icons of the items of the given overflow or popup menu
  * with the color [R.attr.overflowAndPopupMenuIconColor] that is specified in the theme.
  * Has no effect for items that have no icon.
  */
@@ -69,7 +71,7 @@ fun Context.tintOverflowMenuIcons(menu: Menu, skipIf: ((MenuItem) -> Boolean)? =
 
     menu.forEachOverflowItemRecursive { item ->
         if (skipIf == null || !skipIf(item)) {
-            item.icon?.setTint(iconColor)
+            item.icon?.mutate()?.setTint(iconColor)
         }
     }
 }


### PR DESCRIPTION
Please test on device before approving.

As per the documentation,

> By default, all drawables instances loaded from the same resource
share a common state; if you modify the state of one instance, all the other instances will receive the same modification.

In reviewer, tint is applied to the icons of overflow menu items. Previously, the icons were not mutated, which lead to these icons appearing dark when used in other activities.

#### Fixes
Fixes #13921, closes #13925

#### Approach
Mutate icons

#### How Has This Been Tested?

Tested on my device

#### Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
