### PR TITLE
Replaced MaterialDialog with AlertDialog in ImportDialog.

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ImportDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ImportDialog.kt
@@ -17,8 +17,10 @@
 package com.ichi2.anki.dialogs
 
 import android.os.Bundle
-import com.afollestad.materialdialogs.MaterialDialog
+import androidx.appcompat.app.AlertDialog
 import com.ichi2.anki.R
+import com.ichi2.utils.negativeButton
+import com.ichi2.utils.positiveButton
 import timber.log.Timber
 import java.net.URLDecoder
 
@@ -29,37 +31,35 @@ class ImportDialog : AsyncDialogFragment() {
         fun dismissAllDialogFragments()
     }
 
-    override fun onCreateDialog(savedInstanceState: Bundle?): MaterialDialog {
+    override fun onCreateDialog(savedInstanceState: Bundle?): AlertDialog {
         super.onCreate(savedInstanceState)
         val type = requireArguments().getInt("dialogType")
-        val dialog = MaterialDialog(requireActivity())
-        dialog.cancelable(true)
+        val dialog = AlertDialog.Builder(requireActivity())
+        dialog.setCancelable(true)
         val dialogMessageList = requireArguments().getStringArrayList("dialogMessage")!!
         // Iterate over dialog message list & create display filename
         val displayFileName = dialogMessageList.joinToString("\n") { filenameFromPath(convertToDisplayName(it)) }
 
         return when (type) {
             DIALOG_IMPORT_ADD_CONFIRM -> {
-                dialog.show {
-                    title(R.string.import_title)
-                    message(text = res().getQuantityString(R.plurals.import_files_message_add_confirm, dialogMessageList.size, displayFileName))
-                    positiveButton(R.string.import_message_add) {
+                dialog.setTitle(R.string.import_title)
+                    .setMessage(res().getQuantityString(R.plurals.import_files_message_add_confirm, dialogMessageList.size, displayFileName))
+                    .positiveButton(R.string.import_message_add) {
                         (activity as ImportDialogListener).importAdd(dialogMessageList)
                         dismissAllDialogFragments()
                     }
-                    negativeButton(R.string.dialog_cancel)
-                }
+                    .negativeButton(R.string.dialog_cancel)
+                    .create()
             }
             DIALOG_IMPORT_REPLACE_CONFIRM -> {
-                dialog.show {
-                    title(R.string.import_title)
-                    message(text = res().getString(R.string.import_message_replace_confirm, displayFileName))
-                    positiveButton(R.string.dialog_positive_replace) {
+                dialog.setTitle(R.string.import_title)
+                    .setMessage(res().getString(R.string.import_message_replace_confirm, displayFileName))
+                    .positiveButton(R.string.dialog_positive_replace) {
                         (activity as ImportDialogListener).importReplace(dialogMessageList)
                         dismissAllDialogFragments()
                     }
-                    negativeButton(R.string.dialog_cancel)
-                }
+                    .negativeButton(R.string.dialog_cancel)
+                    .create()
             }
             else -> null!!
         }


### PR DESCRIPTION
## Purpose / Description
Replaced MaterialDialog with AlertDialog as mentioned here https://github.com/ankidroid/Anki-Android/issues/13315

## Fixes
https://github.com/ankidroid/Anki-Android/issues/13315

## How Has This Been Tested?
Tested on Physical Device running Android 13.

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented on your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [x] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

## Screenshots:
Before             |  After
:-------------------------:|:-------------------------:
![image](https://github.com/ankidroid/Anki-Android/assets/46300244/9692320f-e97b-4e33-b09d-686251e634e7) | ![image](https://github.com/ankidroid/Anki-Android/assets/46300244/28868908-85ce-42a5-9379-e30c26f56319)
![image](https://github.com/ankidroid/Anki-Android/assets/46300244/42f2b355-433b-4ace-af60-bb24671a65fa) | ![image](https://github.com/ankidroid/Anki-Android/assets/46300244/f799499d-64b2-45b8-9d30-c14c72e1e136)

## Video:
### Single import:
https://github.com/ankidroid/Anki-Android/assets/46300244/dffdb9e4-b0f9-4bb4-9cef-9da318986999

### Multiple import:
https://github.com/ankidroid/Anki-Android/assets/46300244/f650ccf1-c149-45a1-8e6a-59f30eeb2852
