### PR TITLE
fix: Open changelog's link to development commits in an external browser

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/Info.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Info.kt
@@ -130,18 +130,19 @@ class Info : AnkiActivity() {
                     ): Boolean {
                         // Excludes the url that are opened inside the changelog.html
                         // and redirect the user to the browser
-                        if (request?.url.toString() in arrayListOf(CHANGE_LOG_URL, GITHUB_COMMITS)) {
+                        val url = request?.url?.toString() ?: return false
+                        if (url in arrayListOf(CHANGE_LOG_URL, GITHUB_COMMITS)) {
                             return false
                         }
                         if (!AdaptionUtil.hasWebBrowser(this@Info)) {
                             // snackbar can't be used here as it's a webview and lack coordinator layout
                             UIUtils.showThemedToast(
                                 this@Info,
-                                resources.getString(R.string.no_browser_notification) + request?.url.toString(),
+                                resources.getString(R.string.no_browser_notification) + url,
                                 false
                             )
                         } else {
-                            Intent(Intent.ACTION_VIEW, Uri.parse(request?.url.toString())).apply {
+                            Intent(Intent.ACTION_VIEW, Uri.parse(url)).apply {
                                 startActivity(this)
                             }
                         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Info.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Info.kt
@@ -41,8 +41,6 @@ import timber.log.Timber
 
 private const val CHANGE_LOG_URL = "https://docs.ankidroid.org/changelog.html"
 
-private const val GITHUB_COMMITS = "https://github.com/ankidroid/Anki-Android/commits/main"
-
 /**
  * Shows an about box, which is a small HTML page.
  */
@@ -131,7 +129,7 @@ class Info : AnkiActivity() {
                         // Excludes the url that are opened inside the changelog.html
                         // and redirect the user to the browser
                         val url = request?.url?.toString() ?: return false
-                        if (url in arrayListOf(CHANGE_LOG_URL, GITHUB_COMMITS)) {
+                        if (url == CHANGE_LOG_URL) {
                             return false
                         }
                         if (!AdaptionUtil.hasWebBrowser(this@Info)) {
@@ -142,9 +140,7 @@ class Info : AnkiActivity() {
                                 false
                             )
                         } else {
-                            Intent(Intent.ACTION_VIEW, Uri.parse(url)).apply {
-                                startActivity(this)
-                            }
+                            startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(url)))
                         }
                         return true
                     }


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
If you tapped the link for the development version commits in the changelog, instead of opening it in an external browser, it would open it inside the changelog webview, which had the problem of the links being red and didn't offer the full power of a real browser.

![image](https://github.com/ankidroid/Anki-Android/assets/69634269/fb2add86-a61f-4ce3-9c86-625bf2e2ff0c)

## Approach
Excludes the commits link from the links to be opened inside the changelog webview

## How Has This Been Tested?

API 25 emulator

[device-2023-06-26-182023.webm](https://github.com/ankidroid/Anki-Android/assets/69634269/aa773755-4e52-46d6-92fd-f325dfe09447)


## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [X] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
