### PR TITLE
Set translate icon tint color to blue

### DIFF
--- a/AnkiDroid/src/main/res/drawable/ic_language_black_24dp.xml
+++ b/AnkiDroid/src/main/res/drawable/ic_language_black_24dp.xml
@@ -19,7 +19,7 @@
     android:height="24dp"
     android:viewportWidth="24"
     android:viewportHeight="24"
-    android:tint="?attr/iconColor">
+    android:tint="@android:color/holo_blue_dark">
   <path
       android:fillColor="@android:color/white"
       android:pathData="M12.87,15.07l-2.54,-2.51 0.03,-0.03c1.74,-1.94 2.98,-4.17 3.71,-6.53L17,6L17,4h-7L10,2L8,2v2L1,4v1.99h11.17C11.5,7.92 10.44,9.75 9,11.35 8.07,10.32 7.3,9.19 6.69,8h-2c0.73,1.63 1.73,3.17 2.98,4.56l-5.09,5.02L4,19l5,-5 3.11,3.11 0.76,-2.04zM18.5,10h-2L12,22h2l1.12,-3h4.75L21,22h2l-4.5,-12zM15.88,17l1.62,-4.33L19.12,17h-3.24z"/>


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
Translate icon tint color is not in blue color

## Fixes
Fixes #14040

## Approach
set tint color to holo blue dark 

## How Has This Been Tested?
Tested on Physical Device (Realme 9)

**Light**

![light](https://github.com/ankidroid/Anki-Android/assets/65113071/8d997be6-67b0-4127-9137-6bece14c4dce)

**Black**

![black](https://github.com/ankidroid/Anki-Android/assets/65113071/558a30fb-ed61-4e3f-8674-1cfa187d817d)

**Plain**

![plain](https://github.com/ankidroid/Anki-Android/assets/65113071/7026fdde-f21e-4f0d-b0fd-e779aa30abfe)

**Dark**

![dark](https://github.com/ankidroid/Anki-Android/assets/65113071/106f3c75-7368-47b5-ab50-98bc9ae2a8bd)



## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
