### PR TITLE
Fix empty front card

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
@@ -767,6 +767,10 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
             }
             // now load any changes to the fields from the form
             for (f in mEditFields!!) {
+                if (getCurrentFieldText(0).isEmpty()) {
+                    displayErrorSavingNote()
+                    return
+                }
                 modified = modified or updateField(f)
             }
             // added tag?

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
@@ -765,12 +765,13 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
                 mCurrentEditedCard!!.did = deckId
                 modified = true
             }
+            // Check if the front of the card is not empty
+            if (getCurrentFieldText(0).isEmpty()) {
+                displayErrorSavingNote()
+                return
+            }
             // now load any changes to the fields from the form
             for (f in mEditFields!!) {
-                if (getCurrentFieldText(0).isEmpty()) {
-                    displayErrorSavingNote()
-                    return
-                }
                 modified = modified or updateField(f)
             }
             // added tag?


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
In this commit, I fix the issue that allowed modifying the field 'front' of a card to an empty value. When adding a card, the user can't leave the 'front' field empty. By resolving this problem, I have ensured a more consistent user experience.

## Fixes
Fixes #14043 

## Approach
When editing a card, it was possible to leave the "Front" field empty, which is not expected behavior according to the app, as this is blocked when adding a new card.

## How Has This Been Tested?
Tested Pixel 3a API 33 (Emulador) and Motorola Moto G7 (Real device)

The fix has been tested by following these steps:
1. Opened the Anki app.
2. Navigated to the Card Browser screen.
3. Selected an existing card and clicked on "Edit Note".
4. Modified the "Front" field to be empty.
5. Pressed the save button.
6. Verified that an SnackBar with an error message (the same as when try to add with Front empty) was displayed and the card was not saved with an empty "Front" field.
![edit_fix](https://github.com/ankidroid/Anki-Android/assets/69876102/7c97fadd-938b-4638-884d-1f7de890aeb1)


## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [x] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
