### PR TITLE
build(deps): gradle wrapper update PRs should target dependency-updates branch

### DIFF
--- a/.github/workflows/update-gradle-wrapper.yml
+++ b/.github/workflows/update-gradle-wrapper.yml
@@ -16,3 +16,5 @@ jobs:
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           set-distribution-checksum: false
+          base-branch: dependency-updates
+          target-branch: dependency-updates


### PR DESCRIPTION
## Pull Request template

## Purpose / Description

the gradle wrapper update action was targeting our default branch but I like to stage all these things through the dependency-updates branch to reduce noise on main branch

## Approach
Use the available configuration items `base-branch` and `target-branch`: https://github.com/gradle-update/update-gradle-wrapper-action#base-branch

## How Has This Been Tested?

Can't really test it, but when gradle releases version >8.1.1 we shall see...
