### PR TITLE
Dependency updates 20230628

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -51,12 +51,12 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: "temurin"
-          java-version: "11" # ubuntu-latest is about to default to 11, force it everywhere
+          java-version: "17" # newer libraries require 17 now, force it everywhere
 
-      - name: Verify JDK11
-        # Default JDK varies depending on different runner flavors, make sure we are on 11
-        # Run a check that exits with error unless it is 11 version to future-proof against unexpected upgrades
-        run: java -fullversion 2>&1 | grep '11.0'
+      - name: Verify JDK17
+        # Default JDK varies depending on different runner flavors, make sure we are on 17
+        # Run a check that exits with error unless it is 17 version to future-proof against unexpected upgrades
+        run: java -fullversion 2>&1 | grep '17.0'
         shell: bash
 
       - name: Setup Gradle

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,12 +21,12 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: "temurin"
-          java-version: "11" # ubuntu-latest is about to default to 11, force it everywhere
+          java-version: "17" # newer libraries require 17 now, force it everywhere
 
-      - name: Verify JDK11
-        # Default JDK varies depending on different runner flavors, make sure we are on 11
-        # Run a check that exits with error unless it is 11 version to future-proof against unexpected upgrades
-        run: java -fullversion 2>&1 | grep '11.0'
+      - name: Verify JDK17
+        # Default JDK varies depending on different runner flavors, make sure we are on 17
+        # Run a check that exits with error unless it is 17 version to future-proof against unexpected upgrades
+        run: java -fullversion 2>&1 | grep '17.0'
         shell: bash
 
       - name: Install Release Utilities

--- a/.github/workflows/tests_emulator.yml
+++ b/.github/workflows/tests_emulator.yml
@@ -63,7 +63,13 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: "temurin"
-          java-version: "11" # ubuntu-latest is about to default to 11, force it everywhere
+          java-version: "17" # newer libraries require 17 now, force it everywhere
+
+      - name: Verify JDK17
+        # Default JDK varies depending on different runner flavors, make sure we are on 17
+        # Run a check that exits with error unless it is 17 version to future-proof against unexpected upgrades
+        run: java -fullversion 2>&1 | grep '17.0'
+        shell: bash
 
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v2

--- a/.github/workflows/tests_unit.yml
+++ b/.github/workflows/tests_unit.yml
@@ -69,12 +69,12 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: "temurin"
-          java-version: "11" # ubuntu-latest is about to default to 11, force it everywhere
+          java-version: "17" # newer libraries require 17 now, force it everywhere
 
-      - name: Verify JDK11
-        # Default JDK varies depending on different runner flavors, make sure we are on 11
-        # Run a check that exits with error unless it is 11 version to future-proof against unexpected upgrades
-        run: java -fullversion 2>&1 | grep '11.0'
+      - name: Verify JDK17
+        # Default JDK varies depending on different runner flavors, make sure we are on 17
+        # Run a check that exits with error unless it is 17 version to future-proof against unexpected upgrades
+        run: java -fullversion 2>&1 | grep '17.0'
         shell: bash
 
       - name: Setup Gradle

--- a/.github/workflows/update-gradle-wrapper.yml
+++ b/.github/workflows/update-gradle-wrapper.yml
@@ -16,3 +16,5 @@ jobs:
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           set-distribution-checksum: false
+          base-branch: dependency-updates
+          target-branch: dependency-updates

--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -213,12 +213,12 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_11
+        targetCompatibility JavaVersion.VERSION_11
         coreLibraryDesugaringEnabled true
     }
     kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_1_8
+        jvmTarget = JavaVersion.VERSION_11
     }
     ndkVersion "22.0.7026061"
 }

--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -364,7 +364,7 @@ dependencies {
 
     testImplementation "org.junit.vintage:junit-vintage-engine:$junit_version"
     testImplementation 'org.mockito:mockito-inline:5.2.0'
-    testImplementation "org.mockito.kotlin:mockito-kotlin:4.1.0"
+    testImplementation "org.mockito.kotlin:mockito-kotlin:5.0.0"
     testImplementation "org.hamcrest:hamcrest:$hamcrest_version"
     testImplementation 'net.lachlanmckee:timber-junit-rule:1.0.1'
     // robolectricDownloader.gradle *may* need a new SDK jar entry if they release one or if we change targetSdk. Instructions in that gradle file.

--- a/build.gradle
+++ b/build.gradle
@@ -116,12 +116,16 @@ subprojects {
 ext {
 
     jvmVersion = Jvm.current().javaVersion.majorVersion
-    if (jvmVersion != "11" && jvmVersion != "17" && jvmVersion != "18") {
+    if (jvmVersion != "17" && jvmVersion != "18") {
         println "\n\n\n"
         println "**************************************************************************************************************"
         println "\n\n\n"
-        println "ERROR: AnkiDroid builds with JVM version 11, 17 or 18."
+        println "ERROR: AnkiDroid builds with JVM version 17 or 18."
         println "  Incompatible major version detected: '" + jvmVersion + "'"
+        println "\n\n\n"
+        println "  If you receive this error because you want to use a newer JDK, we may accept PRs to support new versions."
+        println "  Edit the main build.gradle file, find this message in the file, and add support for the new version."
+        println "  Please make sure the `jacocoTestReport` target works on an emulator with our minSdkVersion (currently 21)."
         println "\n\n\n"
         println "**************************************************************************************************************"
         println "\n\n\n"

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ import org.gradle.internal.jvm.Jvm
 buildscript {
     // The version for the Kotlin plugin and dependencies
     ext.kotlin_version = '1.8.22'
-    ext.lint_version = '30.4.2' // 31.0.1 stopped running lint checks in CI
+    ext.lint_version = '31.0.2' // 31.0.1 stopped running lint checks in CI
     ext.acra_version = '5.10.1'
     ext.ankidroid_backend_version = '0.1.21-anki2.1.61'
     ext.hamcrest_version = '2.2'

--- a/build.gradle
+++ b/build.gradle
@@ -31,7 +31,7 @@ buildscript {
         classpath "com.github.BrantApps.gradle-amazon-app-store-publisher:amazonappstorepublisher:master-SNAPSHOT"
 
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-        classpath "org.jlleitschuh.gradle:ktlint-gradle:11.4.1"
+        classpath "org.jlleitschuh.gradle:ktlint-gradle:11.4.2"
     }
     configurations.all {
         resolutionStrategy.eachDependency { details ->


### PR DESCRIPTION
## Pull Request template

## Purpose / Description

Non-trivial dependency updates - important changes:

- JDK11 is dropped, minimum supported JDK for AnkiDroid is now JDK17
- compilation source/target JVM level is bumped from 8 to 11

These are required to keep up with transitive dependencies and I would like to get them in before we branch 2.16 off for release / support fixes, as straddling the JDK toolchain version is painful

## Approach

Carefully work through dependency update PRs, they all have related commits with explanations

## How Has This Been Tested?

Carefully test on API21 emulator while checking that JVM11 source/target and JDK17-compiled artifacts work correctly. They all seem to work

## Learning (optional, can help others)
I rarely learn much from dependency updates, except that staying up to date takes effort

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
