### PR TITLE
Replaced MaterialDialog with AlertDialog in DeckPickerContextMenu

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckPickerContextMenu.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckPickerContextMenu.kt
@@ -19,9 +19,8 @@ import android.app.Dialog
 import android.content.Intent
 import android.os.Bundle
 import androidx.annotation.StringRes
+import androidx.appcompat.app.AlertDialog
 import androidx.fragment.app.Fragment
-import com.afollestad.materialdialogs.MaterialDialog
-import com.afollestad.materialdialogs.list.listItems
 import com.ichi2.anim.ActivityTransitionAnimation
 import com.ichi2.anki.CardBrowser
 import com.ichi2.anki.DeckPicker
@@ -34,6 +33,7 @@ import com.ichi2.libanki.DeckId
 import com.ichi2.utils.BundleUtils.requireLong
 import com.ichi2.utils.ExtendedFragmentFactory
 import com.ichi2.utils.FragmentFactoryUtils
+import com.ichi2.utils.cancelable
 import timber.log.Timber
 import java.util.function.Supplier
 
@@ -52,14 +52,14 @@ class DeckPickerContextMenu(private val collection: Collection) : AnalyticsDialo
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
         super.onCreate(savedInstanceState)
         val title = collection.decks.name(deckId)
-        return MaterialDialog(requireActivity())
-            .title(text = title)
-            .cancelable(true)
-            .noAutoDismiss()
-            .listItems(items = contextMenuOptions.map { resources.getString(it.optionName) }) {
-                    _: MaterialDialog, index: Int, _: CharSequence ->
-                handleActionOnLongClick(contextMenuOptions[index])
+        return AlertDialog.Builder(requireContext())
+            .setTitle(title)
+            .setItems(contextMenuOptions.map { resources.getString(it.optionName) }.toTypedArray()) {
+                    _, i ->
+                handleActionOnLongClick(contextMenuOptions[i])
             }
+            .cancelable(true)
+            .create()
     }
 
     /**


### PR DESCRIPTION
## Purpose / Description
Replaced MaterialDialog with AlertDialog as mentioned here https://github.com/ankidroid/Anki-Android/issues/13315

## Fixes
https://github.com/ankidroid/Anki-Android/issues/13315

## How Has This Been Tested?
Tested on Physical Device running Android 13.

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented on your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [x] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

## Screenshots:
Before             |  After
:-------------------------:|:-------------------------:
![image](https://github.com/ankidroid/Anki-Android/assets/46300244/0384588e-8950-41c0-a575-dc7d9910b12f) | ![image](https://github.com/ankidroid/Anki-Android/assets/46300244/db850f12-a1c0-435d-ab44-9715fd8652f8)

