### PR TITLE
fix: avoid concurrent change exception when removing card from queue

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/CardQueue.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/CardQueue.kt
@@ -40,8 +40,9 @@ abstract class CardQueue<T : Card.Cache>(
         return queue.remove()!!.card
     }
 
-    fun remove(cid: CardId) =
-        queue.removeIf { card -> card.id == cid }
+    fun remove(cid: CardId): Boolean {
+        return queue.remove(Card.Cache(col, cid))
+    }
 
     fun add(elt: T) {
         queue.add(elt)


### PR DESCRIPTION
Fundamentally reverts https://github.com/ankidroid/Anki-Android/commit/614b31434e987523ae3220f409fc1b5721f8b0eb#diff-dc3d0158a31e3414efd9b630b24220cbdb75

## Fixes
Fixes #14066 

## How Has This Been Tested?

Hasn't

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
