### PR TITLE
fix: handle TagsArrayAdapter::checkBoxState null values

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/tags/TagsArrayAdapter.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/tags/TagsArrayAdapter.kt
@@ -86,10 +86,10 @@ class TagsArrayAdapter(private val tags: TagsList, private val resources: Resour
          * Get or set the checkbox state of the currently bound ViewHolder.
          * [vh] must be nonnull.
          */
-        private var checkBoxState: CheckBoxTriStates.State
-            get() = vh!!.mCheckBoxView.state
+        private var checkBoxState: CheckBoxTriStates.State?
+            get() = vh?.mCheckBoxView?.state
             set(state) {
-                vh!!.mCheckBoxView.state = state
+                state?.let { vh?.mCheckBoxView?.state = it }
             }
 
         /**
@@ -135,8 +135,8 @@ class TagsArrayAdapter(private val tags: TagsList, private val resources: Resour
         fun updateCheckBoxCycleStyle(tags: TagsList) {
             val realSubtreeCnt = subtreeCheckedCnt - if (tags.isChecked(tag)) 1 else 0
             val hasDescendantChecked = realSubtreeCnt > 0
-            vh!!.mCheckBoxView.cycleIndeterminateToChecked = hasDescendantChecked
-            vh!!.mCheckBoxView.cycleCheckedToIndeterminate = hasDescendantChecked
+            vh?.mCheckBoxView?.cycleIndeterminateToChecked = hasDescendantChecked
+            vh?.mCheckBoxView?.cycleCheckedToIndeterminate = hasDescendantChecked
         }
 
         /**


### PR DESCRIPTION
theoretically, it should avoid #14068.

I'm not sure if there is a chance to generate a misbehavior here instead of crashing, but since I can't reproduce it, I can't tell.

For now, not crashing is better than crashing

## Fixes
Fixes #14068

## How Has This Been Tested?

hasn't

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
