### PR TITLE
fix: make bqfmt and bafmt not crash if not found

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.kt
@@ -1391,8 +1391,8 @@ open class Collection(
             c.did
         }
         val qa: HashMap<String, String> = if (browser) {
-            val bqfmt = t.getString("bqfmt")
-            val bafmt = t.getString("bafmt")
+            val bqfmt = t.optString("bqfmt")
+            val bafmt = t.optString("bafmt")
             _renderQA(
                 cid = c.id,
                 model = m,


### PR DESCRIPTION
optString fallbacks to "" if the string wasn't found, which is the default bqfmt and bafmt value if the user hasn't set one

## Pull Request template

## Purpose / Description
_Describe the problem or feature and motivation_

## Fixes
Fixes #14073

## How Has This Been Tested?

Hasn't

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
