### PR TITLE
Improve `discardCard`

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
@@ -76,6 +76,7 @@ import com.ichi2.annotations.NeedsTest
 import com.ichi2.libanki.*
 import com.ichi2.libanki.Collection
 import com.ichi2.libanki.sched.Counts
+import com.ichi2.libanki.sched.SchedV2
 import com.ichi2.libanki.utils.TimeManager
 import com.ichi2.themes.Themes
 import com.ichi2.themes.Themes.currentTheme
@@ -1624,6 +1625,13 @@ open class Reviewer :
         }
     }
 
+    override fun onBackPressed() {
+        val sched = sched
+        if (!isDrawerOpen && sched is SchedV2) {
+            sched.discardCurrentCard()
+        }
+        super.onBackPressed()
+    }
     companion object {
         private const val ADD_NOTE = 12
         private const val REQUEST_AUDIO_PERMISSION = 0

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
@@ -1626,12 +1626,22 @@ open class Reviewer :
     }
 
     override fun onBackPressed() {
-        val sched = sched
-        if (!isDrawerOpen && sched is SchedV2) {
-            sched.discardCurrentCard()
+        if (isDrawerOpen) {
+            super.onBackPressed()
+        } else {
+            currentCard = null
+            launchCatchingTask {
+                withCol {
+                    val sched = sched
+                    if (sched is SchedV2) {
+                        sched.discardCurrentCard()
+                    }
+                }
+                super.onBackPressed()
+            }
         }
-        super.onBackPressed()
     }
+
     companion object {
         private const val ADD_NOTE = 12
         private const val REQUEST_AUDIO_PERMISSION = 0


### PR DESCRIPTION
This is part of the work of #14084 to remove Sched from AbstractFlashCard.

It moves `discardCurrentCard` to an async call, which ensure that the reviewer is not closed before the discard is done.
Other FlashCard class don't actually need to discard, so they can close synchronously.

Thanks again to @lukstbit for catching this issue