### PR TITLE
Remove animation of DeckPicker FAB when selecting menu item

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -832,8 +832,6 @@ open class DeckPicker :
     }
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
-        mFloatingActionMenu.closeFloatingActionMenu(applyRiseAndShrinkAnimation = true)
-
         if (drawerToggle.onOptionsItemSelected(item)) {
             return true
         }


### PR DESCRIPTION
## Purpose / Description

Whenever a menu item was selected in the DeckPicker the FAB was closed with an animation.

## Fixes

Fixes #14093 

## How Has This Been Tested?

Manually verified the application.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
