### PR TITLE
nf: Undeprecate AnkiDroidApp.getSharedPrefs

### DIFF
--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/ACRATest.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/ACRATest.kt
@@ -27,6 +27,7 @@ import com.ichi2.anki.CrashReportService
 import com.ichi2.anki.CrashReportService.FEEDBACK_REPORT_ALWAYS
 import com.ichi2.anki.CrashReportService.FEEDBACK_REPORT_ASK
 import com.ichi2.anki.R
+import com.ichi2.anki.preferences.sharedPrefs
 import com.ichi2.anki.testutil.GrantStoragePermission
 import org.acra.ACRA
 import org.acra.builder.ReportBuilder
@@ -276,5 +277,5 @@ class ACRATest : InstrumentedTest() {
     }
 
     private val sharedPrefs: SharedPreferences
-        get() = AnkiDroidApp.getSharedPrefs(testContext)
+        get() = testContext.sharedPrefs()
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
@@ -63,6 +63,7 @@ import com.ichi2.anki.cardviewer.TypeAnswer.Companion.createInstance
 import com.ichi2.anki.dialogs.tags.TagsDialog
 import com.ichi2.anki.dialogs.tags.TagsDialogFactory
 import com.ichi2.anki.dialogs.tags.TagsDialogListener
+import com.ichi2.anki.preferences.sharedPrefs
 import com.ichi2.anki.receiver.SdCardReceiver
 import com.ichi2.anki.reviewer.*
 import com.ichi2.anki.reviewer.AutomaticAnswer.AutomaticallyAnswered
@@ -969,16 +970,37 @@ abstract class AbstractFlashcardViewer :
         topBarLayout = findViewById(R.id.top_bar)
         mCardFrame = findViewById(R.id.flashcard)
         mCardFrameParent = mCardFrame!!.parent as ViewGroup
-        mTouchLayer = findViewById<FrameLayout>(R.id.touch_layer).apply { setOnTouchListener(mGestureListener) }
+        mTouchLayer =
+            findViewById<FrameLayout>(R.id.touch_layer).apply { setOnTouchListener(mGestureListener) }
         mCardFrame!!.removeAllViews()
 
         // Initialize swipe
         gestureDetector = GestureDetector(this, mGestureDetectorImpl)
         easeButtonsLayout = findViewById(R.id.ease_buttons)
-        easeButton1 = EaseButton(EASE_1, findViewById(R.id.flashcard_layout_ease1), findViewById(R.id.ease1), findViewById(R.id.nextTime1)).apply { setListeners(mEaseHandler) }
-        easeButton2 = EaseButton(EASE_2, findViewById(R.id.flashcard_layout_ease2), findViewById(R.id.ease2), findViewById(R.id.nextTime2)).apply { setListeners(mEaseHandler) }
-        easeButton3 = EaseButton(EASE_3, findViewById(R.id.flashcard_layout_ease3), findViewById(R.id.ease3), findViewById(R.id.nextTime3)).apply { setListeners(mEaseHandler) }
-        easeButton4 = EaseButton(EASE_4, findViewById(R.id.flashcard_layout_ease4), findViewById(R.id.ease4), findViewById(R.id.nextTime4)).apply { setListeners(mEaseHandler) }
+        easeButton1 = EaseButton(
+            EASE_1,
+            findViewById(R.id.flashcard_layout_ease1),
+            findViewById(R.id.ease1),
+            findViewById(R.id.nextTime1)
+        ).apply { setListeners(mEaseHandler) }
+        easeButton2 = EaseButton(
+            EASE_2,
+            findViewById(R.id.flashcard_layout_ease2),
+            findViewById(R.id.ease2),
+            findViewById(R.id.nextTime2)
+        ).apply { setListeners(mEaseHandler) }
+        easeButton3 = EaseButton(
+            EASE_3,
+            findViewById(R.id.flashcard_layout_ease3),
+            findViewById(R.id.ease3),
+            findViewById(R.id.nextTime3)
+        ).apply { setListeners(mEaseHandler) }
+        easeButton4 = EaseButton(
+            EASE_4,
+            findViewById(R.id.flashcard_layout_ease4),
+            findViewById(R.id.ease4),
+            findViewById(R.id.nextTime4)
+        ).apply { setListeners(mEaseHandler) }
         if (!mShowNextReviewTime) {
             easeButton1!!.hideNextReviewTime()
             easeButton2!!.hideNextReviewTime()
@@ -986,7 +1008,9 @@ abstract class AbstractFlashcardViewer :
             easeButton4!!.hideNextReviewTime()
         }
         val flipCard = findViewById<Button>(R.id.flip_card)
-        flipCardLayout = findViewById<LinearLayout>(R.id.flashcard_layout_flip).apply { setOnClickListener(mFlipCardListener) }
+        flipCardLayout = findViewById<LinearLayout>(R.id.flashcard_layout_flip).apply {
+            setOnClickListener(mFlipCardListener)
+        }
         if (animationEnabled()) {
             flipCard.setBackgroundResource(getResFromAttr(this, R.attr.hardButtonRippleRef))
         }
@@ -1008,7 +1032,7 @@ abstract class AbstractFlashcardViewer :
         initControls()
 
         // Position answer buttons
-        val answerButtonsPosition = AnkiDroidApp.getSharedPrefs(this).getString(
+        val answerButtonsPosition = this.sharedPrefs().getString(
             getString(R.string.answer_buttons_position_preference),
             "bottom"
         )
@@ -1016,7 +1040,8 @@ abstract class AbstractFlashcardViewer :
         val answerArea = findViewById<LinearLayout>(R.id.bottom_area_layout)
         val answerAreaParams = answerArea.layoutParams as RelativeLayout.LayoutParams
         val whiteboardContainer = findViewById<FrameLayout>(R.id.whiteboard)
-        val whiteboardContainerParams = whiteboardContainer.layoutParams as RelativeLayout.LayoutParams
+        val whiteboardContainerParams =
+            whiteboardContainer.layoutParams as RelativeLayout.LayoutParams
         val flashcardContainerParams = mCardFrame!!.layoutParams as RelativeLayout.LayoutParams
         val touchLayerContainerParams = mTouchLayer!!.layoutParams as RelativeLayout.LayoutParams
         when (answerButtonsPosition) {
@@ -1028,6 +1053,7 @@ abstract class AbstractFlashcardViewer :
                 answerArea.removeView(answerField)
                 answerArea.addView(answerField, 1)
             }
+
             "bottom",
             "none" -> {
                 whiteboardContainerParams.addRule(RelativeLayout.ABOVE, R.id.bottom_area_layout)
@@ -1038,6 +1064,7 @@ abstract class AbstractFlashcardViewer :
                 touchLayerContainerParams.addRule(RelativeLayout.BELOW, R.id.mic_tool_bar_layer)
                 answerAreaParams.addRule(RelativeLayout.ALIGN_PARENT_BOTTOM)
             }
+
             else -> Timber.w("Unknown answerButtonsPosition: %s", answerButtonsPosition)
         }
         answerArea.visibility = if (answerButtonsPosition == "none") View.GONE else View.VISIBLE
@@ -1245,7 +1272,7 @@ abstract class AbstractFlashcardViewer :
     }
 
     protected open fun restorePreferences(): SharedPreferences {
-        val preferences = AnkiDroidApp.getSharedPrefs(baseContext)
+        val preferences = baseContext.sharedPrefs()
         typeAnswer = createInstance(preferences)
         // mDeckFilename = preferences.getString("deckFilename", "");
         fullscreenMode = fromPreference(preferences)
@@ -1255,13 +1282,18 @@ abstract class AbstractFlashcardViewer :
         mDoubleScrolling = preferences.getBoolean("double_scrolling", false)
         prefShowTopbar = preferences.getBoolean("showTopbar", true)
         mLargeAnswerButtons = preferences.getBoolean("showLargeAnswerButtons", false)
-        mDoubleTapTimeInterval = preferences.getInt(DOUBLE_TAP_TIME_INTERVAL, DEFAULT_DOUBLE_TAP_TIME_INTERVAL)
+        mDoubleTapTimeInterval =
+            preferences.getInt(DOUBLE_TAP_TIME_INTERVAL, DEFAULT_DOUBLE_TAP_TIME_INTERVAL)
         mExitViaDoubleTapBack = preferences.getBoolean("exitViaDoubleTapBack", false)
         mGesturesEnabled = preferences.getBoolean(GestureProcessor.PREF_KEY, false)
         if (mGesturesEnabled) {
             mGestureProcessor.init(preferences)
         }
-        if (preferences.getBoolean("timeoutAnswer", false) || preferences.getBoolean("keepScreenOn", false)) {
+        if (preferences.getBoolean("timeoutAnswer", false) || preferences.getBoolean(
+                "keepScreenOn",
+                false
+            )
+        ) {
             this.window.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
         }
         return preferences
@@ -1271,7 +1303,7 @@ abstract class AbstractFlashcardViewer :
         // These are preferences we pull out of the collection instead of SharedPreferences
         try {
             mShowNextReviewTime = col.get_config_boolean("estTimes")
-            val preferences = AnkiDroidApp.getSharedPrefs(baseContext)
+            val preferences = baseContext.sharedPrefs()
             automaticAnswer = AutomaticAnswer.createInstance(this, preferences, col)
         } catch (ex: Exception) {
             Timber.w(ex)
@@ -1289,7 +1321,7 @@ abstract class AbstractFlashcardViewer :
     protected open fun recreateWebView() {
         if (webView == null) {
             webView = createWebView()
-            initializeDebugging(AnkiDroidApp.getSharedPrefs(this))
+            initializeDebugging(this.sharedPrefs())
             mCardFrame!!.addView(webView)
             mGestureDetectorImpl.onWebViewCreated(webView!!)
         }
@@ -1472,7 +1504,7 @@ abstract class AbstractFlashcardViewer :
         }
         cardContent = content.getTemplateHtml()
         Timber.d("base url = %s", mBaseUrl)
-        if (AnkiDroidApp.getSharedPrefs(this).getBoolean("html_javascript_debugging", false)) {
+        if (this.sharedPrefs().getBoolean("html_javascript_debugging", false)) {
             try {
                 FileOutputStream(
                     File(

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiActivity.kt
@@ -44,6 +44,7 @@ import com.ichi2.anki.dialogs.SimpleMessageDialog
 import com.ichi2.anki.dialogs.SimpleMessageDialog.SimpleMessageDialogListener
 import com.ichi2.anki.preferences.Preferences
 import com.ichi2.anki.preferences.Preferences.Companion.MINIMUM_CARDS_DUE_FOR_NOTIFICATION
+import com.ichi2.anki.preferences.sharedPrefs
 import com.ichi2.anki.snackbar.showSnackbar
 import com.ichi2.anki.workarounds.AppLoadedFromBackupWorkaround.showedActivityFailedScreen
 import com.ichi2.async.CollectionLoader
@@ -149,7 +150,7 @@ open class AnkiActivity : AppCompatActivity, SimpleMessageDialogListener, Collec
      * @see .animationEnabled
      */
     fun animationDisabled(): Boolean {
-        val preferences = AnkiDroidApp.getSharedPrefs(this)
+        val preferences = this.sharedPrefs()
         return preferences.getBoolean("safeDisplay", false)
     }
 
@@ -493,7 +494,7 @@ open class AnkiActivity : AppCompatActivity, SimpleMessageDialogListener, Collec
         message: String?,
         channel: Channel
     ) {
-        val prefs = AnkiDroidApp.getSharedPrefs(this)
+        val prefs = this.sharedPrefs()
         // Show a notification unless all notifications have been totally disabled
         if (prefs.getString(MINIMUM_CARDS_DUE_FOR_NOTIFICATION, "0")!!
             .toInt() <= Preferences.PENDING_NOTIFICATIONS_ONLY

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.kt
@@ -33,6 +33,7 @@ import android.webkit.CookieManager
 import androidx.annotation.VisibleForTesting
 import androidx.core.content.edit
 import androidx.lifecycle.MutableLiveData
+import androidx.preference.PreferenceManager
 import com.ichi2.anki.CrashReportService.sendExceptionReport
 import com.ichi2.anki.UIUtils.showThemedToast
 import com.ichi2.anki.analytics.UsageAnalytics
@@ -342,9 +343,8 @@ open class AnkiDroidApp : Application() {
          * @param context Context to get preferences for.
          * @return A SharedPreferences object for this instance of the app.
          */
-        @Suppress("deprecation") // TODO Tracked in https://github.com/ankidroid/Anki-Android/issues/5019
         fun getSharedPrefs(context: Context?): SharedPreferences {
-            return android.preference.PreferenceManager.getDefaultSharedPreferences(context)
+            return PreferenceManager.getDefaultSharedPreferences(context!!)
         }
 
         val cacheStorageDirectory: String

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.kt
@@ -343,8 +343,8 @@ open class AnkiDroidApp : Application() {
          * @param context Context to get preferences for.
          * @return A SharedPreferences object for this instance of the app.
          */
-        fun getSharedPrefs(context: Context?): SharedPreferences {
-            return PreferenceManager.getDefaultSharedPreferences(context!!)
+        fun getSharedPrefs(context: Context): SharedPreferences {
+            return PreferenceManager.getDefaultSharedPreferences(context)
         }
 
         val cacheStorageDirectory: String

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.kt
@@ -33,13 +33,13 @@ import android.webkit.CookieManager
 import androidx.annotation.VisibleForTesting
 import androidx.core.content.edit
 import androidx.lifecycle.MutableLiveData
-import androidx.preference.PreferenceManager
 import com.ichi2.anki.CrashReportService.sendExceptionReport
 import com.ichi2.anki.UIUtils.showThemedToast
 import com.ichi2.anki.analytics.UsageAnalytics
 import com.ichi2.anki.contextmenu.AnkiCardContextMenu
 import com.ichi2.anki.contextmenu.CardBrowserContextMenu
 import com.ichi2.anki.exception.StorageAccessException
+import com.ichi2.anki.preferences.sharedPrefs
 import com.ichi2.anki.services.BootService
 import com.ichi2.anki.services.NotificationService
 import com.ichi2.anki.ui.dialogs.ActivityAgnosticDialogs
@@ -344,7 +344,7 @@ open class AnkiDroidApp : Application() {
          * @return A SharedPreferences object for this instance of the app.
          */
         fun getSharedPrefs(context: Context): SharedPreferences {
-            return PreferenceManager.getDefaultSharedPreferences(context)
+            return context.sharedPrefs()
         }
 
         val cacheStorageDirectory: String

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.kt
@@ -22,7 +22,6 @@ import android.app.Activity
 import android.app.Application
 import android.content.Context
 import android.content.Intent
-import android.content.SharedPreferences
 import android.content.res.Resources
 import android.net.Uri
 import android.os.Bundle
@@ -95,7 +94,7 @@ open class AnkiDroidApp : Application() {
         instance = this
 
         // Get preferences
-        val preferences = getSharedPrefs(this)
+        val preferences = this.sharedPrefs()
 
         // TODO remove the following if-block once AnkiDroid uses the new schema by default
         if (BuildConfig.LEGACY_SCHEMA) {
@@ -187,13 +186,33 @@ open class AnkiDroidApp : Application() {
         mNotifications.observeForever { NotificationService.triggerNotificationFor(this) }
 
         registerActivityLifecycleCallbacks(object : ActivityLifecycleCallbacks {
-            override fun onActivityCreated(activity: Activity, savedInstanceState: Bundle?) { Timber.i("${activity::class.simpleName}::onCreate") }
-            override fun onActivityStarted(activity: Activity) { Timber.i("${activity::class.simpleName}::onStart") }
-            override fun onActivityResumed(activity: Activity) { Timber.i("${activity::class.simpleName}::onResume") }
-            override fun onActivityPaused(activity: Activity) { Timber.i("${activity::class.simpleName}::onPause") }
-            override fun onActivityStopped(activity: Activity) { Timber.i("${activity::class.simpleName}::onStop") }
-            override fun onActivitySaveInstanceState(activity: Activity, outState: Bundle) { Timber.i("${activity::class.simpleName}::onSaveInstanceState") }
-            override fun onActivityDestroyed(activity: Activity) { Timber.i("${activity::class.simpleName}::onDestroy") }
+            override fun onActivityCreated(activity: Activity, savedInstanceState: Bundle?) {
+                Timber.i("${activity::class.simpleName}::onCreate")
+            }
+
+            override fun onActivityStarted(activity: Activity) {
+                Timber.i("${activity::class.simpleName}::onStart")
+            }
+
+            override fun onActivityResumed(activity: Activity) {
+                Timber.i("${activity::class.simpleName}::onResume")
+            }
+
+            override fun onActivityPaused(activity: Activity) {
+                Timber.i("${activity::class.simpleName}::onPause")
+            }
+
+            override fun onActivityStopped(activity: Activity) {
+                Timber.i("${activity::class.simpleName}::onStop")
+            }
+
+            override fun onActivitySaveInstanceState(activity: Activity, outState: Bundle) {
+                Timber.i("${activity::class.simpleName}::onSaveInstanceState")
+            }
+
+            override fun onActivityDestroyed(activity: Activity) {
+                Timber.i("${activity::class.simpleName}::onDestroy")
+            }
         })
 
         activityAgnosticDialogs = ActivityAgnosticDialogs.register(this)
@@ -335,16 +354,6 @@ open class AnkiDroidApp : Application() {
                 isAccessible = true
                 set(field, value)
             }
-        }
-
-        /**
-         * Convenience method for accessing Shared preferences
-         *
-         * @param context Context to get preferences for.
-         * @return A SharedPreferences object for this instance of the app.
-         */
-        fun getSharedPrefs(context: Context): SharedPreferences {
-            return context.sharedPrefs()
         }
 
         val cacheStorageDirectory: String

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiFont.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiFont.kt
@@ -3,6 +3,7 @@ package com.ichi2.anki
 
 import android.content.Context
 import android.graphics.Typeface
+import com.ichi2.anki.preferences.sharedPrefs
 import com.ichi2.libanki.Utils
 import timber.log.Timber
 import java.io.File
@@ -101,7 +102,7 @@ class AnkiFont private constructor(val name: String, private val family: String,
             val createdFont = AnkiFont(name, family, attributes, path)
 
             // determine if override font or default font
-            val preferences = AnkiDroidApp.getSharedPrefs(ctx)
+            val preferences = ctx.sharedPrefs()
             val defaultFont = preferences.getString("defaultFont", "")
             val overrideFont = "1" == preferences.getString("overrideFontBehavior", "0")
             if (defaultFont.equals(name, ignoreCase = true)) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/BackupManager.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/BackupManager.kt
@@ -20,6 +20,7 @@ import android.content.SharedPreferences
 import android.text.format.DateFormat
 import androidx.annotation.VisibleForTesting
 import androidx.core.content.edit
+import com.ichi2.anki.preferences.sharedPrefs
 import com.ichi2.compat.CompatHelper
 import com.ichi2.libanki.Collection
 import com.ichi2.libanki.Utils
@@ -57,7 +58,7 @@ open class BackupManager {
      */
     @Suppress("PMD.NPathComplexity")
     fun performBackupInBackground(colPath: String, interval: Int, time: Time): Boolean {
-        val prefs = AnkiDroidApp.getSharedPrefs(AnkiDroidApp.instance.baseContext)
+        val prefs = AnkiDroidApp.instance.baseContext.sharedPrefs()
         if (hasDisabledBackups(prefs)) {
             Timber.w("backups are disabled")
             return false
@@ -154,11 +155,14 @@ open class BackupManager {
             CompatHelper.compat.copyFile(colPath, zos)
             zos.close()
             // Delete old backup files if needed
-            val prefs = AnkiDroidApp.getSharedPrefs(AnkiDroidApp.instance.baseContext)
+            val prefs = AnkiDroidApp.instance.baseContext.sharedPrefs()
             deleteColBackups(colPath, prefs.getInt("backupMax", 8))
             // set timestamp of file in order to avoid creating a new backup unless its changed
             if (!backupFile.setLastModified(colFile.lastModified())) {
-                Timber.w("performBackupInBackground() setLastModified() failed on file %s", backupFile.name)
+                Timber.w(
+                    "performBackupInBackground() setLastModified() failed on file %s",
+                    backupFile.name
+                )
                 return false
             }
             Timber.i("Backup created successfully")

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CollectionHelper.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CollectionHelper.kt
@@ -26,6 +26,7 @@ import androidx.core.content.edit
 import com.ichi2.anki.AnkiDroidFolder.AppPrivateFolder
 import com.ichi2.anki.exception.StorageAccessException
 import com.ichi2.anki.preferences.Preferences
+import com.ichi2.anki.preferences.sharedPrefs
 import com.ichi2.libanki.Collection
 import com.ichi2.libanki.Storage
 import com.ichi2.libanki.exception.UnknownDatabaseVersionException
@@ -497,11 +498,13 @@ open class CollectionHelper {
          * @return the absolute path to the AnkiDroid directory.
          */
         fun getCurrentAnkiDroidDirectory(context: Context): String {
-            val preferences = AnkiDroidApp.getSharedPrefs(context)
+            val preferences = context.sharedPrefs()
             return if (AnkiDroidApp.INSTRUMENTATION_TESTING) {
                 // create an "androidTest" directory inside the current collection directory which contains the test data
                 // "/AnkiDroid/androidTest" would be a new collection path
-                val currentCollectionDirectory = preferences.getOrSetString(PREF_COLLECTION_PATH) { getDefaultAnkiDroidDirectory(context) }
+                val currentCollectionDirectory = preferences.getOrSetString(PREF_COLLECTION_PATH) {
+                    getDefaultAnkiDroidDirectory(context)
+                }
                 File(
                     currentCollectionDirectory,
                     "androidTest"
@@ -509,7 +512,11 @@ open class CollectionHelper {
             } else if (ankiDroidDirectoryOverride != null) {
                 ankiDroidDirectoryOverride!!
             } else {
-                preferences.getOrSetString(PREF_COLLECTION_PATH) { getDefaultAnkiDroidDirectory(context) }
+                preferences.getOrSetString(PREF_COLLECTION_PATH) {
+                    getDefaultAnkiDroidDirectory(
+                        context
+                    )
+                }
             }
         }
 
@@ -519,7 +526,7 @@ open class CollectionHelper {
          * this will represent a change from `/AnkiDroid` to `/Android/data/...`
          */
         fun resetAnkiDroidDirectory(context: Context) {
-            val preferences = AnkiDroidApp.getSharedPrefs(context)
+            val preferences = context.sharedPrefs()
             val directory = getDefaultAnkiDroidDirectory(context)
             Timber.d("resetting AnkiDroid directory to %s", directory)
             preferences.edit { putString(PREF_COLLECTION_PATH, directory) }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CrashReportService.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CrashReportService.kt
@@ -28,6 +28,7 @@ import com.ichi2.anki.analytics.UsageAnalytics
 import com.ichi2.anki.analytics.UsageAnalytics.sendAnalyticsException
 import com.ichi2.anki.exception.ManuallyReportedException
 import com.ichi2.anki.exception.UserSubmittedException
+import com.ichi2.anki.preferences.sharedPrefs
 import com.ichi2.libanki.utils.TimeManager
 import com.ichi2.utils.WebViewDebugging.setDataDirectorySuffix
 import org.acra.ACRA
@@ -168,9 +169,9 @@ object CrashReportService {
 
         // Setup logging and crash reporting
         if (BuildConfig.DEBUG) {
-            setDebugACRAConfig(AnkiDroidApp.getSharedPrefs(mApplication))
+            setDebugACRAConfig(mApplication.sharedPrefs())
         } else {
-            setProductionACRAConfig(AnkiDroidApp.getSharedPrefs(mApplication))
+            setProductionACRAConfig(mApplication.sharedPrefs())
         }
         if (ACRA.isACRASenderServiceProcess() && android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.P) {
             try {
@@ -186,7 +187,7 @@ object CrashReportService {
      * @param value value of FEEDBACK_REPORT_KEY preference
      */
     fun setAcraReportingMode(value: String) {
-        AnkiDroidApp.getSharedPrefs(mApplication).edit {
+        mApplication.sharedPrefs().edit {
             // Set the ACRA disable value
             if (value == FEEDBACK_REPORT_NEVER) {
                 putBoolean(ACRA.PREF_DISABLE_ACRA, true)
@@ -267,7 +268,8 @@ object CrashReportService {
     fun sendExceptionReport(e: Throwable, origin: String?, additionalInfo: String?, onlyIfSilent: Boolean) {
         sendAnalyticsException(e, false)
         AnkiDroidApp.sentExceptionReportHack = true
-        val reportMode = AnkiDroidApp.getSharedPrefs(mApplication.applicationContext).getString(FEEDBACK_REPORT_KEY, FEEDBACK_REPORT_ASK)
+        val reportMode = mApplication.applicationContext.sharedPrefs()
+            .getString(FEEDBACK_REPORT_KEY, FEEDBACK_REPORT_ASK)
         if (onlyIfSilent) {
             if (FEEDBACK_REPORT_ALWAYS != reportMode) {
                 Timber.i("sendExceptionReport - onlyIfSilent true, but ACRA is not 'always accept'. Skipping report send.")
@@ -286,12 +288,12 @@ object CrashReportService {
     }
 
     fun isAcraEnabled(context: Context, defaultValue: Boolean): Boolean {
-        if (!AnkiDroidApp.getSharedPrefs(context).contains(ACRA.PREF_DISABLE_ACRA)) {
+        if (!context.sharedPrefs().contains(ACRA.PREF_DISABLE_ACRA)) {
             // we shouldn't use defaultValue below, as it would be inverted which complicated understanding.
             Timber.w("No default value for '%s'", ACRA.PREF_DISABLE_ACRA)
             return defaultValue
         }
-        return !AnkiDroidApp.getSharedPrefs(context).getBoolean(ACRA.PREF_DISABLE_ACRA, true)
+        return !context.sharedPrefs().getBoolean(ACRA.PREF_DISABLE_ACRA, true)
     }
 
     /**
@@ -320,7 +322,7 @@ object CrashReportService {
      *  submitted
      */
     fun sendReport(ankiActivity: AnkiActivity): Boolean {
-        val preferences = AnkiDroidApp.getSharedPrefs(ankiActivity)
+        val preferences = ankiActivity.sharedPrefs()
         val reportMode = preferences.getString(FEEDBACK_REPORT_KEY, "")
         return if (FEEDBACK_REPORT_NEVER == reportMode) {
             preferences.edit { putBoolean(ACRA.PREF_DISABLE_ACRA, false) }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/FieldEditText.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/FieldEditText.kt
@@ -36,6 +36,7 @@ import androidx.core.view.OnReceiveContentListener
 import androidx.core.view.ViewCompat
 import androidx.core.view.inputmethod.EditorInfoCompat
 import androidx.core.view.inputmethod.InputConnectionCompat
+import com.ichi2.anki.preferences.sharedPrefs
 import com.ichi2.anki.servicelayer.NoteService
 import com.ichi2.themes.Themes.getColorFromAttr
 import com.ichi2.ui.FixedEditText
@@ -72,7 +73,7 @@ class FieldEditText : FixedEditText, NoteService.NoteField {
     }
 
     private fun shouldDisableExtendedTextUi(): Boolean {
-        return AnkiDroidApp.getSharedPrefs(this.context).getBoolean("disableExtendedTextUi", false)
+        return this.context.sharedPrefs().getBoolean("disableExtendedTextUi", false)
     }
 
     @KotlinCleanup("Simplify")

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Import.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Import.kt
@@ -24,6 +24,7 @@ import com.ichi2.anki.dialogs.ImportDialog
 import com.ichi2.anki.dialogs.ImportFileSelectionFragment
 import com.ichi2.anki.dialogs.ImportFileSelectionFragment.ImportOptions
 import com.ichi2.anki.pages.CsvImporter
+import com.ichi2.anki.preferences.sharedPrefs
 import com.ichi2.anki.servicelayer.ScopedStorageService
 import com.ichi2.anki.snackbar.showSnackbar
 import com.ichi2.async.TaskListenerWithContext
@@ -91,7 +92,7 @@ fun DeckPicker.showImportDialog(options: ImportOptions) {
 class DatabaseRestorationListener(val deckPicker: DeckPicker, val newAnkiDroidDirectory: String) : ImportColpkgListener {
     override fun onImportColpkg(colpkgPath: String?) {
         Timber.i("Database restoration correct")
-        AnkiDroidApp.getSharedPrefs(deckPicker).edit {
+        deckPicker.sharedPrefs().edit {
             putString("deckPath", newAnkiDroidDirectory)
         }
         deckPicker.dismissAllDialogFragments()

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Info.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Info.kt
@@ -30,6 +30,7 @@ import android.webkit.WebViewClient
 import android.widget.Button
 import androidx.appcompat.widget.ThemeUtils
 import com.ichi2.anim.ActivityTransitionAnimation
+import com.ichi2.anki.preferences.sharedPrefs
 import com.ichi2.utils.AdaptionUtil
 import com.ichi2.utils.IntentUtil.canOpenIntent
 import com.ichi2.utils.IntentUtil.tryOpenIntent
@@ -57,7 +58,7 @@ class Info : AnkiActivity() {
         val type = intent.getIntExtra(TYPE_EXTRA, TYPE_NEW_VERSION)
         // If the page crashes, we do not want to display it again (#7135 maybe)
         if (type == TYPE_NEW_VERSION) {
-            val prefs = AnkiDroidApp.getSharedPrefs(this.baseContext)
+            val prefs = this.baseContext.sharedPrefs()
             InitialActivity.setUpgradedToLatestVersion(prefs)
         }
         setContentView(R.layout.info)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/InitialActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/InitialActivity.kt
@@ -68,7 +68,7 @@ object InitialActivity {
 
     /** @return Whether any preferences were upgraded
      */
-    fun upgradePreferences(context: Context?, previousVersionCode: Long): Boolean {
+    fun upgradePreferences(context: Context, previousVersionCode: Long): Boolean {
         return PreferenceUpgradeService.upgradePreferences(context, previousVersionCode)
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/IntentHandler.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/IntentHandler.kt
@@ -27,6 +27,7 @@ import androidx.core.content.FileProvider
 import com.ichi2.anki.UIUtils.showThemedToast
 import com.ichi2.anki.dialogs.DialogHandler.Companion.storeMessage
 import com.ichi2.anki.dialogs.DialogHandlerMessage
+import com.ichi2.anki.preferences.sharedPrefs
 import com.ichi2.anki.servicelayer.ScopedStorageService
 import com.ichi2.anki.services.ReminderService
 import com.ichi2.annotations.NeedsTest
@@ -229,7 +230,7 @@ class IntentHandler : Activity() {
             analyticName = "DoSyncDialog"
         ) {
             override fun handleAsyncMessage(deckPicker: DeckPicker) {
-                val preferences = AnkiDroidApp.getSharedPrefs(deckPicker)
+                val preferences = deckPicker.sharedPrefs()
                 val res = deckPicker.resources
                 val hkey = preferences.getString("hkey", "")
                 val millisecondsSinceLastSync = millisecondsSinceLastSync(preferences)
@@ -239,13 +240,22 @@ class IntentHandler : Activity() {
                 } else {
                     val err = res.getString(R.string.sync_error)
                     if (limited) {
-                        val remainingTimeInSeconds = max((INTENT_SYNC_MIN_INTERVAL - millisecondsSinceLastSync) / 1000, 1)
+                        val remainingTimeInSeconds =
+                            max((INTENT_SYNC_MIN_INTERVAL - millisecondsSinceLastSync) / 1000, 1)
                         // getQuantityString needs an int
                         val remaining = min(Int.MAX_VALUE.toLong(), remainingTimeInSeconds).toInt()
-                        val message = res.getQuantityString(R.plurals.sync_automatic_sync_needs_more_time, remaining, remaining)
+                        val message = res.getQuantityString(
+                            R.plurals.sync_automatic_sync_needs_more_time,
+                            remaining,
+                            remaining
+                        )
                         deckPicker.showSimpleNotification(err, message, Channel.SYNC)
                     } else {
-                        deckPicker.showSimpleNotification(err, res.getString(R.string.youre_offline), Channel.SYNC)
+                        deckPicker.showSimpleNotification(
+                            err,
+                            res.getString(R.string.youre_offline),
+                            Channel.SYNC
+                        )
                     }
                 }
                 deckPicker.finishWithoutAnimation()

--- a/AnkiDroid/src/main/java/com/ichi2/anki/IntroductionActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/IntroductionActivity.kt
@@ -30,6 +30,7 @@ import com.ichi2.anki.InitialActivity.StartupFailure
 import com.ichi2.anki.introduction.SetupCollectionFragment
 import com.ichi2.anki.introduction.SetupCollectionFragment.*
 import com.ichi2.anki.introduction.SetupCollectionFragment.Companion.handleCollectionSetupOption
+import com.ichi2.anki.preferences.sharedPrefs
 import com.ichi2.anki.workarounds.AppLoadedFromBackupWorkaround.showedActivityFailedScreen
 import com.ichi2.annotations.NeedsTest
 import com.ichi2.themes.Themes
@@ -95,7 +96,7 @@ class IntroductionActivity : AppIntro() {
     }
 
     private fun startDeckPicker(result: Int = RESULT_START_NEW) {
-        AnkiDroidApp.getSharedPrefs(this).edit { putBoolean(INTRODUCTION_SLIDES_SHOWN, true) }
+        this.sharedPrefs().edit { putBoolean(INTRODUCTION_SLIDES_SHOWN, true) }
         val deckPicker = Intent(this, DeckPicker::class.java)
         deckPicker.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_NEW_TASK)
         if (result == RESULT_SYNC_PROFILE) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/MyAccount.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/MyAccount.kt
@@ -29,6 +29,7 @@ import androidx.appcompat.widget.Toolbar
 import androidx.core.content.edit
 import com.google.android.material.textfield.TextInputLayout
 import com.ichi2.anim.ActivityTransitionAnimation
+import com.ichi2.anki.preferences.sharedPrefs
 import com.ichi2.anki.snackbar.showSnackbar
 import com.ichi2.anki.web.HostNumFactory.getInstance
 import com.ichi2.async.Connection
@@ -59,11 +60,12 @@ open class MyAccount : AnkiActivity() {
     open fun switchToState(newState: Int) {
         when (newState) {
             STATE_LOGGED_IN -> {
-                val username = AnkiDroidApp.getSharedPrefs(baseContext).getString("username", "")
+                val username = baseContext.sharedPrefs().getString("username", "")
                 mUsernameLoggedIn.text = username
                 toolbar = mLoggedIntoMyAccountView.findViewById(R.id.toolbar)
                 if (toolbar != null) {
-                    toolbar!!.title = getString(R.string.sync_account) // This can be cleaned up if all three main layouts are guaranteed to share the same toolbar object
+                    toolbar!!.title =
+                        getString(R.string.sync_account) // This can be cleaned up if all three main layouts are guaranteed to share the same toolbar object
                     setSupportActionBar(toolbar)
                 }
                 setContentView(mLoggedIntoMyAccountView)
@@ -127,7 +129,7 @@ open class MyAccount : AnkiActivity() {
     }
 
     private fun saveUserInformation(username: String, hkey: String) {
-        val preferences = AnkiDroidApp.getSharedPrefs(baseContext)
+        val preferences = baseContext.sharedPrefs()
         preferences.edit {
             putString("username", username)
             putString("hkey", hkey)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
@@ -68,6 +68,7 @@ import com.ichi2.anki.noteeditor.FieldState.FieldChangeType
 import com.ichi2.anki.noteeditor.Toolbar
 import com.ichi2.anki.noteeditor.Toolbar.TextFormatListener
 import com.ichi2.anki.noteeditor.Toolbar.TextWrapper
+import com.ichi2.anki.preferences.sharedPrefs
 import com.ichi2.anki.receiver.SdCardReceiver
 import com.ichi2.anki.servicelayer.LanguageHintService
 import com.ichi2.anki.servicelayer.NoteService
@@ -866,9 +867,9 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
         menu.findItem(R.id.action_show_toolbar).isChecked =
             !shouldHideToolbar()
         menu.findItem(R.id.action_capitalize).isChecked =
-            AnkiDroidApp.getSharedPrefs(this).getBoolean(PREF_NOTE_EDITOR_CAPITALIZE, true)
+            this.sharedPrefs().getBoolean(PREF_NOTE_EDITOR_CAPITALIZE, true)
         menu.findItem(R.id.action_scroll_toolbar).isChecked =
-            AnkiDroidApp.getSharedPrefs(this).getBoolean(PREF_NOTE_EDITOR_SCROLL_TOOLBAR, true)
+            this.sharedPrefs().getBoolean(PREF_NOTE_EDITOR_SCROLL_TOOLBAR, true)
         return super.onCreateOptionsMenu(menu)
     }
 
@@ -909,7 +910,7 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
             }
             R.id.action_show_toolbar -> {
                 item.isChecked = !item.isChecked
-                AnkiDroidApp.getSharedPrefs(this).edit {
+                this.sharedPrefs().edit {
                     putBoolean(PREF_NOTE_EDITOR_SHOW_TOOLBAR, item.isChecked)
                 }
                 updateToolbar()
@@ -922,7 +923,7 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
             }
             R.id.action_scroll_toolbar -> {
                 item.isChecked = !item.isChecked
-                AnkiDroidApp.getSharedPrefs(this).edit {
+                this.sharedPrefs().edit {
                     putBoolean(PREF_NOTE_EDITOR_SCROLL_TOOLBAR, item.isChecked)
                 }
                 updateToolbar()
@@ -932,7 +933,7 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
     }
 
     private fun toggleCapitalize(value: Boolean) {
-        AnkiDroidApp.getSharedPrefs(this).edit {
+        this.sharedPrefs().edit {
             putBoolean(PREF_NOTE_EDITOR_CAPITALIZE, value)
         }
         for (f in mEditFields!!) {
@@ -945,7 +946,7 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
             return
         }
         Timber.i("Setting font size to %d", fontSizeSp)
-        AnkiDroidApp.getSharedPrefs(this).edit { putInt(PREF_NOTE_EDITOR_FONT_SIZE, fontSizeSp) }
+        this.sharedPrefs().edit { putInt(PREF_NOTE_EDITOR_FONT_SIZE, fontSizeSp) }
         for (f in mEditFields!!) {
             f!!.textSize = fontSizeSp.toFloat()
         }
@@ -1256,7 +1257,7 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
 
         // Use custom font if selected from preferences
         var customTypeface: Typeface? = null
-        val preferences = AnkiDroidApp.getSharedPrefs(baseContext)
+        val preferences = baseContext.sharedPrefs()
         val customFont = preferences.getString("browserEditorFont", "")
         if ("" != customFont) {
             customTypeface = AnkiFont.getTypeface(this, customFont!!)
@@ -1293,7 +1294,7 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
             editLineView.setHintLocale(getHintLocaleForField(editLineView.name))
             initFieldEditText(newEditText, i, !editModelMode)
             mEditFields!!.add(newEditText)
-            val prefs = AnkiDroidApp.getSharedPrefs(this)
+            val prefs = this.sharedPrefs()
             if (prefs.getInt(PREF_NOTE_EDITOR_FONT_SIZE, -1) > 0) {
                 newEditText.textSize = prefs.getInt(PREF_NOTE_EDITOR_FONT_SIZE, -1).toFloat()
             }
@@ -1747,13 +1748,13 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
 
     private val toolbarButtons: ArrayList<CustomToolbarButton>
         get() {
-            val set = AnkiDroidApp.getSharedPrefs(this)
+            val set = this.sharedPrefs()
                 .getStringSet(PREF_NOTE_EDITOR_CUSTOM_BUTTONS, HashUtil.HashSetInit(0))
             return CustomToolbarButton.fromStringSet(set!!)
         }
 
     private fun saveToolbarButtons(buttons: ArrayList<CustomToolbarButton>) {
-        AnkiDroidApp.getSharedPrefs(this).edit {
+        this.sharedPrefs().edit {
             putStringSet(PREF_NOTE_EDITOR_CUSTOM_BUTTONS, CustomToolbarButton.toStringSet(buttons))
         }
     }
@@ -2221,12 +2222,12 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
         private const val PREF_NOTE_EDITOR_CUSTOM_BUTTONS = "note_editor_custom_buttons"
 
         private fun shouldReplaceNewlines(): Boolean {
-            return AnkiDroidApp.getSharedPrefs(AnkiDroidApp.instance)
+            return AnkiDroidApp.instance.sharedPrefs()
                 .getBoolean(PREF_NOTE_EDITOR_NEWLINE_REPLACE, true)
         }
 
         private fun shouldHideToolbar(): Boolean {
-            return !AnkiDroidApp.getSharedPrefs(AnkiDroidApp.instance)
+            return !AnkiDroidApp.instance.sharedPrefs()
                 .getBoolean(PREF_NOTE_EDITOR_SHOW_TOOLBAR, true)
         }
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/OnboardingUtils.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/OnboardingUtils.kt
@@ -21,6 +21,7 @@ import android.content.Context
 import androidx.annotation.VisibleForTesting
 import androidx.core.content.edit
 import com.ichi2.anki.IntroductionActivity.Companion.INTRODUCTION_SLIDES_SHOWN
+import com.ichi2.anki.preferences.sharedPrefs
 import timber.log.Timber
 import java.util.*
 
@@ -53,7 +54,7 @@ class OnboardingUtils {
          */
         fun isVisited(featureIdentifier: OnboardingFlag, context: Context): Boolean {
             // Return if onboarding is not enabled.
-            if (!AnkiDroidApp.getSharedPrefs(context).getBoolean(SHOW_ONBOARDING, false)) {
+            if (!context.sharedPrefs().getBoolean(SHOW_ONBOARDING, false)) {
                 return true
             }
 
@@ -73,14 +74,19 @@ class OnboardingUtils {
             // Set the bit at the index defined for a feature once the tutorial for that feature is seen by the user.
             visitedFeatures.set(featureIdentifier.getOnboardingEnumValue())
 
-            AnkiDroidApp.getSharedPrefs(context).edit { putLong(featureIdentifier.getFeatureConstant(), visitedFeatures.toLongArray()[0]) }
+            context.sharedPrefs().edit {
+                putLong(
+                    featureIdentifier.getFeatureConstant(),
+                    visitedFeatures.toLongArray()[0]
+                )
+            }
         }
 
         /**
          * Returns a BitSet where the set bits indicate the visited screens.
          */
         private fun getAllVisited(context: Context, featureConstant: String): BitSet {
-            val currentValue = AnkiDroidApp.getSharedPrefs(context).getLong(featureConstant, 0)
+            val currentValue = context.sharedPrefs().getLong(featureConstant, 0)
             return BitSet.valueOf(longArrayOf(currentValue))
         }
 
@@ -90,7 +96,7 @@ class OnboardingUtils {
         }
 
         private fun reset(context: Context, featureConstants: Collection<String>) {
-            AnkiDroidApp.getSharedPrefs(context).edit {
+            context.sharedPrefs().edit {
                 featureConstants.forEach {
                     this@edit.putLong(it, 0)
                 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
@@ -60,6 +60,7 @@ import com.ichi2.anki.dialogs.RescheduleDialog.Companion.rescheduleSingleCard
 import com.ichi2.anki.multimediacard.AudioView
 import com.ichi2.anki.multimediacard.AudioView.Companion.createRecorderInstance
 import com.ichi2.anki.multimediacard.AudioView.Companion.generateTempAudioFile
+import com.ichi2.anki.preferences.sharedPrefs
 import com.ichi2.anki.reviewer.*
 import com.ichi2.anki.reviewer.AnswerButtons.Companion.getBackgroundColors
 import com.ichi2.anki.reviewer.AnswerButtons.Companion.getTextColors
@@ -997,7 +998,7 @@ open class Reviewer :
     }
 
     private fun updateWhiteboardEditorPosition() {
-        mAnswerButtonsPosition = AnkiDroidApp.getSharedPrefs(this)
+        mAnswerButtonsPosition = this.sharedPrefs()
             .getString("answerButtonPosition", "bottom")
         val layoutParams: RelativeLayout.LayoutParams
         when (mAnswerButtonsPosition) {
@@ -1007,6 +1008,7 @@ open class Reviewer :
                 layoutParams.addRule(RelativeLayout.ALIGN_PARENT_BOTTOM)
                 mColorPalette.layoutParams = layoutParams
             }
+
             "bottom" -> {
                 layoutParams = mColorPalette.layoutParams as RelativeLayout.LayoutParams
                 layoutParams.removeRule(RelativeLayout.ALIGN_PARENT_BOTTOM)
@@ -1246,7 +1248,7 @@ open class Reviewer :
                 or View.SYSTEM_UI_FLAG_IMMERSIVE
             )
         // Show / hide the Action bar together with the status bar
-        val prefs = AnkiDroidApp.getSharedPrefs(a)
+        val prefs = a.sharedPrefs()
         val fullscreenMode = fromPreference(prefs)
         a.window.statusBarColor = getColorFromAttr(a, android.R.attr.colorPrimary)
         val decorView = a.window.decorView

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Statistics.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Statistics.kt
@@ -40,6 +40,7 @@ import com.google.android.material.tabs.TabLayoutMediator
 import com.ichi2.anim.ActivityTransitionAnimation
 import com.ichi2.anki.dialogs.DeckSelectionDialog.DeckSelectionListener
 import com.ichi2.anki.dialogs.DeckSelectionDialog.SelectableDeck
+import com.ichi2.anki.preferences.sharedPrefs
 import com.ichi2.anki.stats.AnkiStatsTaskHandler
 import com.ichi2.anki.stats.AnkiStatsTaskHandler.Companion.getInstance
 import com.ichi2.anki.stats.ChartView
@@ -108,7 +109,7 @@ class Statistics : NavigationDrawerActivity(), DeckSelectionListener, SubtitleLi
         // Prepare options menu only after loading everything
         invalidateOptionsMenu()
         //        StatisticFragment.updateAllFragments();
-        when (val defaultDeck = AnkiDroidApp.getSharedPrefs(this).getString("stats_default_deck", "current")) {
+        when (val defaultDeck = this.sharedPrefs().getString("stats_default_deck", "current")) {
             "current" -> mStatsDeckId = col.decks.selected()
             "all" -> mStatsDeckId = Stats.ALL_DECKS_ID
             else -> Timber.w("Unknown defaultDeck: %s", defaultDeck)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Whiteboard.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Whiteboard.kt
@@ -33,6 +33,7 @@ import androidx.annotation.VisibleForTesting
 import androidx.core.content.ContextCompat
 import androidx.core.content.edit
 import com.ichi2.anki.dialogs.WhiteBoardWidthDialog
+import com.ichi2.anki.preferences.sharedPrefs
 import com.ichi2.compat.CompatHelper
 import com.ichi2.libanki.utils.Time
 import com.ichi2.libanki.utils.TimeUtils
@@ -77,7 +78,7 @@ class Whiteboard(activity: AnkiActivity, handleMultiTouch: Boolean, inverted: Bo
     private val mHandleMultiTouch: Boolean = handleMultiTouch
     private var mOnPaintColorChangeListener: OnPaintColorChangeListener? = null
     val currentStrokeWidth: Int
-        get() = AnkiDroidApp.getSharedPrefs(mAnkiActivity).getInt("whiteBoardStrokeWidth", 6)
+        get() = mAnkiActivity.sharedPrefs().getInt("whiteBoardStrokeWidth", 6)
 
     override fun onDraw(canvas: Canvas) {
         super.onDraw(canvas)
@@ -378,7 +379,7 @@ class Whiteboard(activity: AnkiActivity, handleMultiTouch: Boolean, inverted: Bo
 
     private fun saveStrokeWidth(wbStrokeWidth: Int) {
         mPaint.strokeWidth = wbStrokeWidth.toFloat()
-        AnkiDroidApp.getSharedPrefs(mAnkiActivity).edit {
+        mAnkiActivity.sharedPrefs().edit {
             putInt("whiteBoardStrokeWidth", wbStrokeWidth)
         }
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/analytics/AnkiDroidCrashReportDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/analytics/AnkiDroidCrashReportDialog.kt
@@ -24,9 +24,9 @@ import android.view.View
 import android.widget.CheckBox
 import android.widget.EditText
 import androidx.core.content.edit
-import com.ichi2.anki.AnkiDroidApp
 import com.ichi2.anki.CrashReportService
 import com.ichi2.anki.R
+import com.ichi2.anki.preferences.sharedPrefs
 import org.acra.dialog.CrashReportDialog
 import org.acra.dialog.CrashReportDialogHelper
 
@@ -59,7 +59,7 @@ class AnkiDroidCrashReportDialog : CrashReportDialog(), DialogInterface.OnClickL
      * Build the custom view used by the dialog
      */
     override fun buildCustomView(savedInstanceState: Bundle?): View {
-        val preferences = AnkiDroidApp.getSharedPrefs(this)
+        val preferences = this.sharedPrefs()
         val inflater = layoutInflater
 
         @SuppressLint("InflateParams")
@@ -82,11 +82,16 @@ class AnkiDroidCrashReportDialog : CrashReportDialog(), DialogInterface.OnClickL
         if (which == DialogInterface.BUTTON_POSITIVE) {
             // Next time don't tick the auto-report checkbox by default
             val autoReport = mAlwaysReportCheckBox!!.isChecked
-            val preferences = AnkiDroidApp.getSharedPrefs(this)
+            val preferences = this.sharedPrefs()
             preferences.edit { putBoolean("autoreportCheckboxValue", autoReport) }
             // Set the autoreport value to true if ticked
             if (autoReport) {
-                preferences.edit { putString(CrashReportService.FEEDBACK_REPORT_KEY, CrashReportService.FEEDBACK_REPORT_ALWAYS) }
+                preferences.edit {
+                    putString(
+                        CrashReportService.FEEDBACK_REPORT_KEY,
+                        CrashReportService.FEEDBACK_REPORT_ALWAYS
+                    )
+                }
                 CrashReportService.setAcraReportingMode(CrashReportService.FEEDBACK_REPORT_ALWAYS)
             }
             // Send the crash report

--- a/AnkiDroid/src/main/java/com/ichi2/anki/analytics/UsageAnalytics.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/analytics/UsageAnalytics.kt
@@ -29,6 +29,7 @@ import com.brsanthu.googleanalytics.request.DefaultRequest
 import com.ichi2.anki.AnkiDroidApp
 import com.ichi2.anki.BuildConfig
 import com.ichi2.anki.R
+import com.ichi2.anki.preferences.sharedPrefs
 import com.ichi2.utils.DisplayUtils
 import com.ichi2.utils.KotlinCleanup
 import com.ichi2.utils.WebViewDebugging.hasSetDataDirectory
@@ -80,7 +81,7 @@ object UsageAnalytics {
                 .build()
         }
         installDefaultExceptionHandler()
-        val userPrefs = AnkiDroidApp.getSharedPrefs(context)
+        val userPrefs = context.sharedPrefs()
         optIn = userPrefs.getBoolean(ANALYTICS_OPTIN_KEY, false)
         userPrefs.registerOnSharedPreferenceChangeListener { sharedPreferences: SharedPreferences, key: String? ->
             if (key == ANALYTICS_OPTIN_KEY) {
@@ -289,12 +290,12 @@ object UsageAnalytics {
     // A listener on this preference handles the rest
     var isEnabled: Boolean
         get() {
-            val userPrefs = AnkiDroidApp.getSharedPrefs(AnkiDroidApp.instance)
+            val userPrefs = AnkiDroidApp.instance.sharedPrefs()
             return userPrefs.getBoolean(ANALYTICS_OPTIN_KEY, false)
         }
         set(value) {
             // A listener on this preference handles the rest
-            AnkiDroidApp.getSharedPrefs(AnkiDroidApp.instance).edit {
+            AnkiDroidApp.instance.sharedPrefs().edit {
                 putBoolean(ANALYTICS_OPTIN_KEY, value)
             }
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/HtmlGenerator.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/HtmlGenerator.kt
@@ -19,7 +19,7 @@ package com.ichi2.anki.cardviewer
 import android.content.Context
 import android.content.res.Resources
 import androidx.annotation.CheckResult
-import com.ichi2.anki.AnkiDroidApp
+import com.ichi2.anki.preferences.sharedPrefs
 import com.ichi2.anki.reviewer.ReviewerCustomFonts
 import com.ichi2.libanki.Card
 import com.ichi2.libanki.Sound
@@ -52,12 +52,22 @@ class HtmlGenerator(
     }
 
     companion object {
-        fun createInstance(context: Context, typeAnswer: TypeAnswer, baseUrl: String): HtmlGenerator {
-            val preferences = AnkiDroidApp.getSharedPrefs(context)
+        fun createInstance(
+            context: Context,
+            typeAnswer: TypeAnswer,
+            baseUrl: String
+        ): HtmlGenerator {
+            val preferences = context.sharedPrefs()
             val cardAppearance = CardAppearance.create(ReviewerCustomFonts(context), preferences)
             val cardHtmlTemplate = loadCardTemplate(context)
 
-            return HtmlGenerator(typeAnswer, cardAppearance, cardHtmlTemplate, context.resources, baseUrl)
+            return HtmlGenerator(
+                typeAnswer,
+                cardAppearance,
+                cardHtmlTemplate,
+                context.resources,
+                baseUrl
+            )
         }
 
         /**

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/BackupPromptDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/BackupPromptDialog.kt
@@ -27,6 +27,7 @@ import com.afollestad.materialdialogs.actions.setActionButtonEnabled
 import com.afollestad.materialdialogs.checkbox.checkBoxPrompt
 import com.ichi2.anki.*
 import com.ichi2.anki.CollectionManager.withCol
+import com.ichi2.anki.preferences.sharedPrefs
 import com.ichi2.anki.servicelayer.ScopedStorageService.collectionWillBeMadeInaccessibleAfterUninstall
 import com.ichi2.anki.servicelayer.ScopedStorageService.userIsPromptedToDeleteCollectionOnUninstall
 import com.ichi2.compat.CompatHelper.Companion.getPackageInfoCompat
@@ -60,13 +61,14 @@ class BackupPromptDialog private constructor(private val windowContext: Context)
     private var userCheckedDoNotShowAgain = false
 
     private var timesDialogDismissed: Int
-        get() = AnkiDroidApp.getSharedPrefs(windowContext).getInt("backupPromptDismissedCount", 0)
-        set(value) = AnkiDroidApp.getSharedPrefs(windowContext).edit { putInt("backupPromptDismissedCount", value) }
+        get() = windowContext.sharedPrefs().getInt("backupPromptDismissedCount", 0)
+        set(value) = windowContext.sharedPrefs()
+            .edit { putInt("backupPromptDismissedCount", value) }
 
     private var dialogPermanentlyDismissed: Boolean
-        get() = AnkiDroidApp.getSharedPrefs(windowContext).getBoolean("backupPromptDisabled", false)
+        get() = windowContext.sharedPrefs().getBoolean("backupPromptDisabled", false)
         set(disablePermanently) {
-            AnkiDroidApp.getSharedPrefs(windowContext).edit {
+            windowContext.sharedPrefs().edit {
                 putBoolean("backupPromptDisabled", disablePermanently)
                 if (disablePermanently) {
                     remove("backupPromptDismissedCount")
@@ -76,8 +78,11 @@ class BackupPromptDialog private constructor(private val windowContext: Context)
         }
 
     private var nextTimeToShowDialog: Long
-        get() = AnkiDroidApp.getSharedPrefs(windowContext).getLong("timeToShowBackupDialog", 0)
-        set(value) { AnkiDroidApp.getSharedPrefs(windowContext).edit { putLong("timeToShowBackupDialog", value) } }
+        get() = windowContext.sharedPrefs().getLong("timeToShowBackupDialog", 0)
+        set(value) {
+            windowContext.sharedPrefs()
+                .edit { putLong("timeToShowBackupDialog", value) }
+        }
 
     private fun onDismiss() {
         Timber.i("BackupPromptDialog dismissed")
@@ -233,7 +238,7 @@ class BackupPromptDialog private constructor(private val windowContext: Context)
                 return false
             }
             // Show dialog to sync if user hasn't synced in a while
-            val preferences = AnkiDroidApp.getSharedPrefs(windowContext)
+            val preferences = windowContext.sharedPrefs()
             return millisecondsSinceLastSync(preferences) >= ONE_DAY_IN_MS * 7
         }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/customstudy/CustomStudyDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/customstudy/CustomStudyDialog.kt
@@ -43,6 +43,7 @@ import com.ichi2.anki.dialogs.customstudy.CustomStudyDialog.ContextMenuConfigura
 import com.ichi2.anki.dialogs.customstudy.CustomStudyDialog.ContextMenuOption.*
 import com.ichi2.anki.dialogs.tags.TagsDialog
 import com.ichi2.anki.dialogs.tags.TagsDialogListener
+import com.ichi2.anki.preferences.sharedPrefs
 import com.ichi2.libanki.Collection
 import com.ichi2.libanki.Consts
 import com.ichi2.libanki.Consts.DYN_PRIORITY
@@ -211,7 +212,7 @@ class CustomStudyDialog(private val collection: Collection, private val customSt
                 }
                 when (contextMenuOption) {
                     STUDY_NEW -> {
-                        AnkiDroidApp.getSharedPrefs(requireActivity()).edit { putInt("extendNew", n) }
+                        requireActivity().sharedPrefs().edit { putInt("extendNew", n) }
                         val deck = collection.decks.get(did)
                         deck.put("extendNew", n)
                         collection.decks.save(deck)
@@ -219,7 +220,7 @@ class CustomStudyDialog(private val collection: Collection, private val customSt
                         onLimitsExtended(jumpToReviewer)
                     }
                     STUDY_REV -> {
-                        AnkiDroidApp.getSharedPrefs(requireActivity()).edit { putInt("extendRev", n) }
+                        requireActivity().sharedPrefs().edit { putInt("extendRev", n) }
                         val deck = collection.decks.get(did)
                         deck.put("extendRev", n)
                         collection.decks.save(deck)
@@ -415,7 +416,7 @@ class CustomStudyDialog(private val collection: Collection, private val customSt
         }
     private val defaultValue: String
         get() {
-            val prefs = AnkiDroidApp.getSharedPrefs(requireActivity())
+            val prefs = requireActivity().sharedPrefs()
             return when (ContextMenuOption.fromInt(requireArguments().getInt("id"))) {
                 STUDY_NEW -> prefs.getInt("extendNew", 10).toString()
                 STUDY_REV -> prefs.getInt("extendRev", 50).toString()

--- a/AnkiDroid/src/main/java/com/ichi2/anki/export/ActivityExportingDelegate.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/export/ActivityExportingDelegate.kt
@@ -36,6 +36,7 @@ import com.ichi2.anki.UIUtils.showThemedToast
 import com.ichi2.anki.dialogs.ExportDialog.ExportDialogListener
 import com.ichi2.anki.dialogs.ExportDialogParams
 import com.ichi2.anki.dialogs.ExportReadyDialog.ExportReadyDialogListener
+import com.ichi2.anki.preferences.sharedPrefs
 import com.ichi2.anki.servicelayer.ScopedStorageService
 import com.ichi2.anki.snackbar.showSnackbar
 import com.ichi2.annotations.NeedsTest
@@ -305,14 +306,14 @@ class ActivityExportingDelegate(private val activity: AnkiActivity, private val 
      */
     private fun saveSuccessfulCollectionExportIfRelevant() {
         if (::mExportFileName.isInitialized && !mExportFileName.endsWith(".colpkg")) return
-        AnkiDroidApp.getSharedPrefs(activity).edit {
+        activity.sharedPrefs().edit {
             putLong(
                 LAST_SUCCESSFUL_EXPORT_AT_SECOND_KEY,
                 TimeManager.time.intTime()
             )
         }
         val col = collectionSupplier.get()
-        AnkiDroidApp.getSharedPrefs(activity).edit {
+        activity.sharedPrefs().edit {
             putLong(
                 LAST_SUCCESSFUL_EXPORT_AT_MOD_KEY,
                 col.mod

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicMediaClipFieldController.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicMediaClipFieldController.kt
@@ -29,6 +29,7 @@ import com.ichi2.anki.AnkiDroidApp
 import com.ichi2.anki.CrashReportService
 import com.ichi2.anki.R
 import com.ichi2.anki.UIUtils.showThemedToast
+import com.ichi2.anki.preferences.sharedPrefs
 import com.ichi2.compat.CompatHelper
 import com.ichi2.ui.FixedTextView
 import com.ichi2.utils.ExceptionUtil.executeSafe
@@ -79,7 +80,8 @@ class BasicMediaClipFieldController : FieldControllerBase(), IFieldController {
     }
 
     private fun openChooserPrompt(initialMimeType: String, extraMimeTypes: Array<String>, @StringRes prompt: Int, resultCode: Int) {
-        val allowAllFiles = AnkiDroidApp.getSharedPrefs(this.mActivity).getBoolean("mediaImportAllowAllFiles", false)
+        val allowAllFiles =
+            this.mActivity.sharedPrefs().getBoolean("mediaImportAllowAllFiles", false)
         val i = Intent()
         i.type = if (allowAllFiles) "*/*" else initialMimeType
         if (!allowAllFiles && extraMimeTypes.any()) {
@@ -91,7 +93,10 @@ class BasicMediaClipFieldController : FieldControllerBase(), IFieldController {
         // Only get openable files, to avoid virtual files issues with Android 7+
         i.addCategory(Intent.CATEGORY_OPENABLE)
         val chooserPrompt = mActivity.resources.getString(prompt)
-        mActivity.startActivityForResultWithoutAnimation(Intent.createChooser(i, chooserPrompt), resultCode)
+        mActivity.startActivityForResultWithoutAnimation(
+            Intent.createChooser(i, chooserPrompt),
+            resultCode
+        )
     }
 
     @KotlinCleanup("make data non-null")

--- a/AnkiDroid/src/main/java/com/ichi2/anki/noteeditor/Toolbar.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/noteeditor/Toolbar.kt
@@ -41,6 +41,7 @@ import com.ichi2.anki.AnkiDroidApp
 import com.ichi2.anki.NoteEditor
 import com.ichi2.anki.R
 import com.ichi2.anki.UIUtils.convertDpToPixel
+import com.ichi2.anki.preferences.sharedPrefs
 import com.ichi2.compat.CompatHelper
 import com.ichi2.libanki.Utils
 import com.ichi2.utils.ViewGroupUtils
@@ -179,7 +180,7 @@ class Toolbar : FrameLayout {
         val twoDp = ceil((2 / context.resources.displayMetrics.density).toDouble()).toInt()
         button.setPadding(twoDp, twoDp, twoDp, twoDp)
         // end apply style
-        val shouldScroll = AnkiDroidApp.getSharedPrefs(AnkiDroidApp.instance)
+        val shouldScroll = AnkiDroidApp.instance.sharedPrefs()
             .getBoolean(NoteEditor.PREF_NOTE_EDITOR_SCROLL_TOOLBAR, true)
         if (shouldScroll) {
             mToolbar.addView(button, mToolbar.childCount)
@@ -194,7 +195,8 @@ class Toolbar : FrameLayout {
         val expectedWidth = getVisibleItemCount(mToolbar) * convertDpToPixel(48F, context)
         val width = screenWidth
         val p = LayoutParams(v.layoutParams)
-        p.gravity = Gravity.CENTER_VERTICAL or if (expectedWidth > width) Gravity.START else Gravity.CENTER_HORIZONTAL
+        p.gravity =
+            Gravity.CENTER_VERTICAL or if (expectedWidth > width) Gravity.START else Gravity.CENTER_HORIZONTAL
         v.layoutParams = p
         return button
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/AdvancedSettingsFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/AdvancedSettingsFragment.kt
@@ -113,7 +113,9 @@ class AdvancedSettingsFragment : SettingsFragment() {
                 isEnabled = false
             }
             setSummaryProvider {
-                if (AnkiDroidApp.getSharedPrefs(requireContext()).getBoolean("advanced_statistics_enabled", false)) {
+                if (requireContext().sharedPrefs()
+                    .getBoolean("advanced_statistics_enabled", false)
+                ) {
                     getString(R.string.enabled)
                 } else {
                     getString(R.string.disabled)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/CustomButtonsSettingsFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/CustomButtonsSettingsFragment.kt
@@ -22,7 +22,6 @@ import androidx.appcompat.app.AlertDialog
 import androidx.core.content.edit
 import androidx.preference.Preference
 import androidx.preference.PreferenceCategory
-import com.ichi2.anki.AnkiDroidApp
 import com.ichi2.anki.R
 import com.ichi2.utils.*
 
@@ -40,7 +39,7 @@ class CustomButtonsSettingsFragment : SettingsFragment() {
                 title(R.string.reset_settings_to_default)
                 positiveButton(R.string.reset) {
                     // Reset the settings to default
-                    AnkiDroidApp.getSharedPrefs(requireContext()).edit {
+                    requireContext().sharedPrefs().edit {
                         remove("customButtonUndo")
                         remove("customButtonScheduleCard")
                         remove("customButtonEditCard")

--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/DevOptionsFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/DevOptionsFragment.kt
@@ -155,7 +155,7 @@ class DevOptionsFragment : SettingsFragment() {
          * or if the user has enabled it with the secret on [com.ichi2.anki.preferences.AboutFragment]
          */
         fun isEnabled(context: Context): Boolean {
-            return BuildConfig.DEBUG || AnkiDroidApp.getSharedPrefs(context)
+            return BuildConfig.DEBUG || context.sharedPrefs()
                 .getBoolean(context.getString(R.string.dev_options_enabled_by_user_key), false)
         }
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/PreferenceUtils.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/PreferenceUtils.kt
@@ -15,9 +15,12 @@
  */
 package com.ichi2.anki.preferences
 
+import android.content.Context
+import android.content.SharedPreferences
 import androidx.annotation.StringRes
 import androidx.preference.Preference
 import androidx.preference.PreferenceFragmentCompat
+import androidx.preference.PreferenceManager
 
 /**
  * Sets the callback to be invoked when this preference is changed by the user
@@ -49,4 +52,9 @@ inline fun <reified T : Preference> PreferenceFragmentCompat.requirePreference(k
 inline fun <reified T : Preference> PreferenceFragmentCompat.requirePreference(@StringRes resId: Int): T {
     val key = getString(resId)
     return requirePreference(key)
+}
+
+/** shorthand method to get the default [SharedPreferences] instance */
+fun Context.sharedPrefs(): SharedPreferences {
+    return PreferenceManager.getDefaultSharedPreferences(this)
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/Preferences.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/Preferences.kt
@@ -251,11 +251,12 @@ class Preferences :
      */
     fun setDevOptionsEnabled(isEnabled: Boolean) {
         // Update the "devOptionsEnabledByUser" pref value
-        AnkiDroidApp.getSharedPrefs(this).edit {
+        this.sharedPrefs().edit {
             putBoolean(getString(R.string.dev_options_enabled_by_user_key), isEnabled)
         }
         // Show/hide the header
-        val headerFragment = supportFragmentManager.findFragmentByTag(HeaderFragment::class.java.name)
+        val headerFragment =
+            supportFragmentManager.findFragmentByTag(HeaderFragment::class.java.name)
         if (headerFragment is HeaderFragment) {
             headerFragment.setDevOptionsVisibility(isEnabled)
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/SyncSettingsFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/SyncSettingsFragment.kt
@@ -18,7 +18,6 @@ package com.ichi2.anki.preferences
 import androidx.appcompat.app.AlertDialog
 import androidx.preference.Preference
 import com.google.android.material.snackbar.Snackbar
-import com.ichi2.anki.AnkiDroidApp
 import com.ichi2.anki.CollectionManager.withCol
 import com.ichi2.anki.R
 import com.ichi2.anki.customSyncBase
@@ -59,7 +58,7 @@ class SyncSettingsFragment : SettingsFragment() {
         }
         // Custom sync server
         requirePreference<Preference>(R.string.custom_sync_server_key).setSummaryProvider {
-            val preferences = AnkiDroidApp.getSharedPrefs(requireContext())
+            val preferences = requireContext().sharedPrefs()
             val url = customSyncBase(preferences)
 
             if (url == null) {
@@ -77,7 +76,7 @@ class SyncSettingsFragment : SettingsFragment() {
     }
 
     private fun updateForceFullSyncEnabledState() {
-        val isLoggedIn = Preferences.hasAnkiWebAccount(AnkiDroidApp.getSharedPrefs(requireContext()))
+        val isLoggedIn = Preferences.hasAnkiWebAccount(requireContext().sharedPrefs())
         requirePreference<Preference>(R.string.force_full_sync_key).isEnabled = isLoggedIn
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/PeripheralKeymap.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/PeripheralKeymap.kt
@@ -20,6 +20,7 @@ import android.content.SharedPreferences
 import android.view.KeyEvent
 import com.ichi2.anki.AnkiDroidApp
 import com.ichi2.anki.cardviewer.ViewerCommand
+import com.ichi2.anki.preferences.sharedPrefs
 import com.ichi2.anki.reviewer.Binding.Companion.key
 import com.ichi2.anki.reviewer.CardSide.Companion.fromAnswer
 import com.ichi2.anki.reviewer.MappableBinding.Companion.fromPreference
@@ -31,7 +32,7 @@ class PeripheralKeymap(reviewerUi: ReviewerUi, commandProcessor: ViewerCommand.C
     private val mKeyMap: KeyMap
     private var mHasSetup = false
     fun setup() {
-        val preferences = AnkiDroidApp.getSharedPrefs(AnkiDroidApp.instance)
+        val preferences = AnkiDroidApp.instance.sharedPrefs()
         setup(preferences)
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/ReviewerCustomFonts.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/ReviewerCustomFonts.kt
@@ -17,8 +17,8 @@
 package com.ichi2.anki.reviewer
 
 import android.content.Context
-import com.ichi2.anki.AnkiDroidApp
 import com.ichi2.anki.AnkiFont
+import com.ichi2.anki.preferences.sharedPrefs
 import com.ichi2.libanki.Utils
 import com.ichi2.utils.HashUtil.HashMapInit
 
@@ -38,7 +38,7 @@ class ReviewerCustomFonts(context: Context) {
      */
     private fun getDefaultFontStyle(context: Context, customFontsMap: Map<String?, AnkiFont>): String? {
         if (mDefaultFontStyle == null) {
-            val preferences = AnkiDroidApp.getSharedPrefs(context)
+            val preferences = context.sharedPrefs()
             val defaultFont = customFontsMap[preferences.getString("defaultFont", null)]
             mDefaultFontStyle = if (defaultFont != null) {
                 """BODY { ${defaultFont.getCSS(false)} }
@@ -57,7 +57,7 @@ class ReviewerCustomFonts(context: Context) {
      */
     private fun getOverrideFontStyle(context: Context, customFontsMap: Map<String?, AnkiFont>): String? {
         if (mOverrideFontStyle == null) {
-            val preferences = AnkiDroidApp.getSharedPrefs(context)
+            val preferences = context.sharedPrefs()
             val defaultFont = customFontsMap[preferences.getString("defaultFont", null)]
             val overrideFont = "1" == preferences.getString("overrideFontBehavior", "0")
             mOverrideFontStyle = if (defaultFont != null && overrideFont) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/PreferenceUpgradeService.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/PreferenceUpgradeService.kt
@@ -41,7 +41,7 @@ private typealias VersionIdentifier = Int
 private typealias LegacyVersionIdentifier = Long
 
 object PreferenceUpgradeService {
-    fun upgradePreferences(context: Context?, previousVersionCode: LegacyVersionIdentifier): Boolean =
+    fun upgradePreferences(context: Context, previousVersionCode: LegacyVersionIdentifier): Boolean =
         upgradePreferences(AnkiDroidApp.getSharedPrefs(context), previousVersionCode)
 
     /** @return Whether any preferences were upgraded */

--- a/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/PreferenceUpgradeService.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/PreferenceUpgradeService.kt
@@ -22,10 +22,10 @@ import androidx.annotation.VisibleForTesting
 import androidx.appcompat.app.AppCompatDelegate
 import androidx.core.content.edit
 import androidx.core.os.LocaleListCompat
-import com.ichi2.anki.AnkiDroidApp
 import com.ichi2.anki.cardviewer.Gesture
 import com.ichi2.anki.cardviewer.ViewerCommand
 import com.ichi2.anki.noteeditor.CustomToolbarButton
+import com.ichi2.anki.preferences.sharedPrefs
 import com.ichi2.anki.reviewer.Binding
 import com.ichi2.anki.reviewer.Binding.Companion.keyCode
 import com.ichi2.anki.reviewer.CardSide
@@ -42,7 +42,7 @@ private typealias LegacyVersionIdentifier = Long
 
 object PreferenceUpgradeService {
     fun upgradePreferences(context: Context, previousVersionCode: LegacyVersionIdentifier): Boolean =
-        upgradePreferences(AnkiDroidApp.getSharedPrefs(context), previousVersionCode)
+        upgradePreferences(context.sharedPrefs(), previousVersionCode)
 
     /** @return Whether any preferences were upgraded */
     internal fun upgradePreferences(preferences: SharedPreferences, previousVersionCode: LegacyVersionIdentifier): Boolean {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/ScopedStorageService.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/ScopedStorageService.kt
@@ -22,10 +22,10 @@ import android.content.SharedPreferences
 import android.os.Build
 import android.os.Environment
 import androidx.annotation.VisibleForTesting
-import com.ichi2.anki.AnkiDroidApp
 import com.ichi2.anki.CollectionHelper
 import com.ichi2.anki.CollectionManager
 import com.ichi2.anki.model.Directory
+import com.ichi2.anki.preferences.sharedPrefs
 import com.ichi2.anki.servicelayer.ScopedStorageService.isLegacyStorage
 import com.ichi2.anki.servicelayer.scopedstorage.MigrateEssentialFiles
 import com.ichi2.anki.servicelayer.scopedstorage.migrateuserdata.MigrateUserData
@@ -203,7 +203,7 @@ object ScopedStorageService {
      * It is a logic bug if only one is set
      */
     fun mediaMigrationIsInProgress(context: Context): Boolean =
-        mediaMigrationIsInProgress(AnkiDroidApp.getSharedPrefs(context))
+        mediaMigrationIsInProgress(context.sharedPrefs())
 
     /**
      * Whether a user data scoped storage migration is taking place
@@ -288,7 +288,7 @@ object ScopedStorageService {
      * if `isLegacyStorage` is called when obtaining the collection path
      */
     fun isLegacyStorage(context: Context, setCollectionPath: Boolean): Boolean? {
-        if (!setCollectionPath && !AnkiDroidApp.getSharedPrefs(context)
+        if (!setCollectionPath && !context.sharedPrefs()
             .contains(CollectionHelper.PREF_COLLECTION_PATH)
         ) {
             return null

--- a/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/scopedstorage/MigrateEssentialFiles.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/scopedstorage/MigrateEssentialFiles.kt
@@ -20,10 +20,10 @@ import android.annotation.SuppressLint
 import android.content.Context
 import androidx.annotation.VisibleForTesting
 import androidx.core.content.edit
-import com.ichi2.anki.AnkiDroidApp
 import com.ichi2.anki.CollectionHelper
 import com.ichi2.anki.CrashReportService
 import com.ichi2.anki.model.Directory
+import com.ichi2.anki.preferences.sharedPrefs
 import com.ichi2.anki.servicelayer.*
 import com.ichi2.anki.servicelayer.ScopedStorageService.PREF_MIGRATION_DESTINATION
 import com.ichi2.anki.servicelayer.ScopedStorageService.PREF_MIGRATION_SOURCE
@@ -153,23 +153,33 @@ internal constructor(
      * Any error in opening the collection are thrown, and the preference change is reverted.
      */
     fun updateCollectionPath() {
-        val prefs = AnkiDroidApp.getSharedPrefs(context)
+        val prefs = context.sharedPrefs()
 
         // keep the old values in case we need to restore them
-        oldPrefValues = listOf(PREF_MIGRATION_SOURCE, PREF_MIGRATION_DESTINATION, CollectionHelper.PREF_COLLECTION_PATH)
+        oldPrefValues = listOf(
+            PREF_MIGRATION_SOURCE,
+            PREF_MIGRATION_DESTINATION,
+            CollectionHelper.PREF_COLLECTION_PATH
+        )
             .associateWith { prefs.getString(it, null) }
 
         prefs.edit {
             // specify that a migration is in progress
             putString(PREF_MIGRATION_SOURCE, folders.unscopedSourceDirectory.directory.absolutePath)
-            putString(PREF_MIGRATION_DESTINATION, folders.scopedDestinationDirectory.directory.absolutePath)
-            putString(CollectionHelper.PREF_COLLECTION_PATH, folders.scopedDestinationDirectory.directory.absolutePath)
+            putString(
+                PREF_MIGRATION_DESTINATION,
+                folders.scopedDestinationDirectory.directory.absolutePath
+            )
+            putString(
+                CollectionHelper.PREF_COLLECTION_PATH,
+                folders.scopedDestinationDirectory.directory.absolutePath
+            )
         }
     }
 
     /** Can be called if collection fails to open after migration completes. */
     fun restoreOldCollectionPath() {
-        val prefs = AnkiDroidApp.getSharedPrefs(context)
+        val prefs = context.sharedPrefs()
         prefs.edit {
             oldPrefValues?.forEach {
                 putString(it.key, it.value)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/services/BootService.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/services/BootService.kt
@@ -8,6 +8,7 @@ import android.content.Intent
 import com.ichi2.anki.*
 import com.ichi2.anki.UIUtils.showThemedToast
 import com.ichi2.anki.preferences.Preferences
+import com.ichi2.anki.preferences.sharedPrefs
 import com.ichi2.compat.CompatHelper
 import com.ichi2.libanki.Collection
 import com.ichi2.libanki.utils.Time
@@ -108,9 +109,13 @@ class BootService : BroadcastReceiver() {
 
         fun scheduleNotification(time: Time, context: Context) {
             val alarmManager = context.getSystemService(Context.ALARM_SERVICE) as AlarmManager
-            val sp = AnkiDroidApp.getSharedPrefs(context)
+            val sp = context.sharedPrefs()
             // Don't schedule a notification if the due reminders setting is not enabled
-            if (sp.getString(Preferences.MINIMUM_CARDS_DUE_FOR_NOTIFICATION, Integer.toString(Preferences.PENDING_NOTIFICATIONS_ONLY))!!.toInt() >= Preferences.PENDING_NOTIFICATIONS_ONLY) {
+            if (sp.getString(
+                    Preferences.MINIMUM_CARDS_DUE_FOR_NOTIFICATION,
+                    Integer.toString(Preferences.PENDING_NOTIFICATIONS_ONLY)
+                )!!.toInt() >= Preferences.PENDING_NOTIFICATIONS_ONLY
+            ) {
                 return
             }
             val calendar = time.calendar()
@@ -119,7 +124,12 @@ class BootService : BroadcastReceiver() {
                 set(Calendar.MINUTE, 0)
                 set(Calendar.SECOND, 0)
             }
-            val notificationIntent = CompatHelper.compat.getImmutableBroadcastIntent(context, 0, Intent(context, NotificationService::class.java), 0)
+            val notificationIntent = CompatHelper.compat.getImmutableBroadcastIntent(
+                context,
+                0,
+                Intent(context, NotificationService::class.java),
+                0
+            )
             alarmManager.setRepeating(
                 AlarmManager.RTC_WAKEUP,
                 calendar.timeInMillis,
@@ -136,12 +146,12 @@ class BootService : BroadcastReceiver() {
                 val col = CollectionHelper.instance.getCol(context)!!
                 when (col.schedVer()) {
                     1 -> {
-                        val sp = AnkiDroidApp.getSharedPrefs(context)
+                        val sp = context.sharedPrefs()
                         sp.getInt("dayOffset", defValue)
                     }
                     2 -> col.get_config("rollover", defValue)!!
                     else -> {
-                        val sp = AnkiDroidApp.getSharedPrefs(context)
+                        val sp = context.sharedPrefs()
                         sp.getInt("dayOffset", defValue)
                     }
                 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/services/BootService.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/services/BootService.kt
@@ -129,7 +129,7 @@ class BootService : BroadcastReceiver() {
         }
 
         /** Returns the hour of day when rollover to the next day occurs  */
-        protected fun getRolloverHourOfDay(context: Context?): Int {
+        protected fun getRolloverHourOfDay(context: Context): Int {
             // TODO; We might want to use the BootService retry code here when called from preferences.
             val defValue = 4
             return try {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/services/MigrationService.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/services/MigrationService.kt
@@ -30,6 +30,7 @@ import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
 import com.ichi2.anki.*
+import com.ichi2.anki.preferences.sharedPrefs
 import com.ichi2.anki.servicelayer.ScopedStorageService
 import com.ichi2.anki.servicelayer.ScopedStorageService.PREF_MIGRATION_DESTINATION
 import com.ichi2.anki.servicelayer.ScopedStorageService.PREF_MIGRATION_SOURCE
@@ -108,10 +109,13 @@ class MigrationService : ServiceWithALifecycleScope(), ServiceWithASimpleBinder<
             if (serviceIsRunning) return
             serviceIsRunning = true
 
-            AnkiDroidApp.getSharedPrefs(context).edit { remove(PREF_MIGRATION_ERROR_TEXT) }
+            context.sharedPrefs().edit { remove(PREF_MIGRATION_ERROR_TEXT) }
             flowOfProgress.tryEmit(null)
 
-            ContextCompat.startForegroundService(context, Intent(context, MigrationService::class.java))
+            ContextCompat.startForegroundService(
+                context,
+                Intent(context, MigrationService::class.java)
+            )
         }
 
         val flowOfProgress: MutableStateFlow<Progress?> = MutableStateFlow(null)
@@ -136,7 +140,7 @@ class MigrationService : ServiceWithALifecycleScope(), ServiceWithASimpleBinder<
         data class Failed(val exception: Exception, val changesRolledBack: Boolean) : Done
     }
 
-    private val preferences get() = AnkiDroidApp.getSharedPrefs(this)
+    private val preferences get() = this.sharedPrefs()
 
     private lateinit var migrateUserDataTask: MigrateUserData
 
@@ -224,6 +228,7 @@ class MigrationService : ServiceWithALifecycleScope(), ServiceWithASimpleBinder<
                             is Progress.Succeeded ->
                                 AnkiDroidApp.instance.activityAgnosticDialogs
                                     .showOrScheduleStorageMigrationSucceededDialog()
+
                             is Progress.Failed ->
                                 AnkiDroidApp.instance.activityAgnosticDialogs
                                     .showOrScheduleStorageMigrationFailedDialog(
@@ -242,9 +247,15 @@ class MigrationService : ServiceWithALifecycleScope(), ServiceWithASimpleBinder<
         val ignoredFiles = MigrateEssentialFiles.iterateEssentialFiles(task.source) +
             File(task.source.directory, MoveConflictedFile.CONFLICT_DIRECTORY)
         val ignoredSpace = ignoredFiles.sumOf { FileUtil.getSize(it) }
-        val folderSize = FileUtil.DirectoryContentInformation.fromDirectory(task.source.directory).totalBytes
+        val folderSize =
+            FileUtil.DirectoryContentInformation.fromDirectory(task.source.directory).totalBytes
         val remainingSpaceToMigrate = folderSize - ignoredSpace
-        Timber.d("folder size: %d, safe: %d, remaining: %d", folderSize, ignoredSpace, remainingSpaceToMigrate)
+        Timber.d(
+            "folder size: %d, safe: %d, remaining: %d",
+            folderSize,
+            ignoredSpace,
+            remainingSpaceToMigrate
+        )
         return remainingSpaceToMigrate
     }
 
@@ -408,7 +419,7 @@ sealed interface MediaMigrationState {
 // TODO Consider refactoring ScopedStorageService to remove its methods used here,
 //   inlining them, and use this method throughout the app for media migration state.
 fun Context.getMediaMigrationState(): MediaMigrationState {
-    val preferences = AnkiDroidApp.getSharedPrefs(this)
+    val preferences = this.sharedPrefs()
 
     fun migrationIsOngoing() = ScopedStorageService.mediaMigrationIsInProgress(preferences)
     fun collectionIsInAppPrivateDirectory() = !ScopedStorageService.isLegacyStorage(this)
@@ -420,6 +431,7 @@ fun Context.getMediaMigrationState(): MediaMigrationState {
         when {
             errorText.isNullOrBlank() ->
                 MediaMigrationState.Ongoing.NotPaused
+
             else ->
                 MediaMigrationState.Ongoing.PausedDueToError(errorText)
         }
@@ -427,8 +439,10 @@ fun Context.getMediaMigrationState(): MediaMigrationState {
         when {
             collectionIsInAppPrivateDirectory() ->
                 MediaMigrationState.NotOngoing.NotNeeded.CollectionIsInAppPrivateFolder
+
             collectionWillRemainAccessibleAfterReinstall() ->
                 MediaMigrationState.NotOngoing.NotNeeded.CollectionIsInPublicFolderButWillRemainAccessible
+
             else ->
                 MediaMigrationState.NotOngoing.Needed
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/services/NotificationService.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/services/NotificationService.kt
@@ -22,11 +22,11 @@ import android.content.Intent
 import android.graphics.Color
 import androidx.core.app.NotificationCompat
 import androidx.core.content.ContextCompat
-import com.ichi2.anki.AnkiDroidApp
 import com.ichi2.anki.Channel
 import com.ichi2.anki.DeckPicker
 import com.ichi2.anki.R
 import com.ichi2.anki.preferences.Preferences
+import com.ichi2.anki.preferences.sharedPrefs
 import com.ichi2.compat.CompatHelper
 import com.ichi2.widget.WidgetStatus
 import timber.log.Timber
@@ -39,14 +39,22 @@ class NotificationService : BroadcastReceiver() {
 
         fun triggerNotificationFor(context: Context) {
             Timber.i("NotificationService: OnStartCommand")
-            val manager = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
-            val preferences = AnkiDroidApp.getSharedPrefs(context)
-            val minCardsDue = preferences.getString(Preferences.MINIMUM_CARDS_DUE_FOR_NOTIFICATION, Integer.toString(Preferences.PENDING_NOTIFICATIONS_ONLY))!!.toInt()
+            val manager =
+                context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+            val preferences = context.sharedPrefs()
+            val minCardsDue = preferences.getString(
+                Preferences.MINIMUM_CARDS_DUE_FOR_NOTIFICATION,
+                Integer.toString(Preferences.PENDING_NOTIFICATIONS_ONLY)
+            )!!.toInt()
             val dueCardsCount = WidgetStatus.fetchDue(context)
             if (dueCardsCount >= minCardsDue) {
                 // Build basic notification
                 val cardsDueText = context.resources
-                    .getQuantityString(R.plurals.widget_minimum_cards_due_notification_ticker_text, dueCardsCount, dueCardsCount)
+                    .getQuantityString(
+                        R.plurals.widget_minimum_cards_due_notification_ticker_text,
+                        dueCardsCount,
+                        dueCardsCount
+                    )
                 // This generates a log warning "Use of stream types is deprecated..."
                 // The NotificationCompat code uses setSound() no matter what we do and triggers it.
                 val builder = NotificationCompat.Builder(
@@ -67,7 +75,8 @@ class NotificationService : BroadcastReceiver() {
                 }
                 // Creates an explicit intent for an Activity in your app
                 val resultIntent = Intent(context, DeckPicker::class.java)
-                resultIntent.flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
+                resultIntent.flags =
+                    Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
                 val resultPendingIntent = CompatHelper.compat.getImmutableActivityIntent(
                     context,
                     0,

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/dialogs/ActivityAgnosticDialogs.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/dialogs/ActivityAgnosticDialogs.kt
@@ -28,8 +28,8 @@ import androidx.core.text.parseAsHtml
 import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.FragmentActivity
 import androidx.preference.PreferenceManager.getDefaultSharedPreferences
-import com.ichi2.anki.AnkiDroidApp
 import com.ichi2.anki.R
+import com.ichi2.anki.preferences.sharedPrefs
 import com.ichi2.anki.ui.dialogs.ActivityAgnosticDialogs.Companion.MIGRATION_FAILED_DIALOG_ERROR_TEXT_KEY
 import com.ichi2.anki.utils.getUserFriendlyErrorText
 import com.ichi2.utils.copyToClipboardAndShowConfirmation
@@ -200,7 +200,7 @@ class ActivityAgnosticDialogs private constructor(private val application: Appli
 
 fun storageMigrationFailedDialogIsShownOrPending(activity: AppCompatActivity) =
     activity.supportFragmentManager.findFragmentByTag(MigrationFailedDialogFragment.TAG) != null ||
-        AnkiDroidApp.getSharedPrefs(activity)
+        activity.sharedPrefs()
         .getString(MIGRATION_FAILED_DIALOG_ERROR_TEXT_KEY, null) != null
 
 interface DefaultActivityLifecycleCallbacks : Application.ActivityLifecycleCallbacks {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/web/HostNumFactory.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/web/HostNumFactory.kt
@@ -21,7 +21,7 @@ import com.ichi2.anki.AnkiDroidApp
 import com.ichi2.libanki.sync.HostNum
 
 object HostNumFactory {
-    fun getInstance(context: Context?): HostNum {
+    fun getInstance(context: Context): HostNum {
         return PreferenceBackedHostNum.fromPreferences(AnkiDroidApp.getSharedPrefs(context))
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/web/HostNumFactory.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/web/HostNumFactory.kt
@@ -17,11 +17,11 @@
 package com.ichi2.anki.web
 
 import android.content.Context
-import com.ichi2.anki.AnkiDroidApp
+import com.ichi2.anki.preferences.sharedPrefs
 import com.ichi2.libanki.sync.HostNum
 
 object HostNumFactory {
     fun getInstance(context: Context): HostNum {
-        return PreferenceBackedHostNum.fromPreferences(AnkiDroidApp.getSharedPrefs(context))
+        return PreferenceBackedHostNum.fromPreferences(context.sharedPrefs())
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/stats/AdvancedStatistics.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/stats/AdvancedStatistics.kt
@@ -17,9 +17,9 @@ package com.ichi2.libanki.stats
 
 import android.content.Context
 import android.database.Cursor
-import com.ichi2.anki.AnkiDroidApp.Companion.getSharedPrefs
 import com.ichi2.anki.CollectionHelper
 import com.ichi2.anki.R
+import com.ichi2.anki.preferences.sharedPrefs
 import com.ichi2.anki.stats.StatsMetaInfo
 import com.ichi2.libanki.Collection
 import com.ichi2.libanki.Consts
@@ -117,7 +117,7 @@ class AdvancedStatistics {
         context: Context,
         dids: String
     ): StatsMetaInfo {
-        if (!getSharedPrefs(context).getBoolean("advanced_statistics_enabled", false)) {
+        if (!context.sharedPrefs().getBoolean("advanced_statistics_enabled", false)) {
             return metaInfo
         }
         // To indicate that we calculated the statistics so that Stats.java knows that it shouldn't display the standard Forecast chart.
@@ -858,7 +858,7 @@ class AdvancedStatistics {
         }
 
         init {
-            val prefs = getSharedPrefs(context)
+            val prefs = context.sharedPrefs()
             mCol = CollectionHelper.instance.getCol(context)!!
             computeNDays = prefs.getInt("advanced_forecast_stats_compute_n_days", 0)
             val computePrecision = prefs.getInt("advanced_forecast_stats_compute_precision", 90)

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/stats/AdvancedStatistics.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/stats/AdvancedStatistics.kt
@@ -114,7 +114,7 @@ class AdvancedStatistics {
     fun calculateDueAsMetaInfo(
         metaInfo: StatsMetaInfo,
         type: AxisType,
-        context: Context?,
+        context: Context,
         dids: String
     ): StatsMetaInfo {
         if (!getSharedPrefs(context).getBoolean("advanced_statistics_enabled", false)) {
@@ -817,7 +817,7 @@ class AdvancedStatistics {
     /**
      * Stores global settings.
      */
-    private class Settings(context: Context?) {
+    private class Settings(context: Context) {
         val computeNDays: Int
         val computeMaxError: Double
         val simulateNIterations: Int

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/stats/Stats.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/stats/Stats.kt
@@ -349,7 +349,7 @@ from cards where did in ${_limit()} and queue = ${Consts.QUEUE_TYPE_REV}"""
         return answerButtonsOverview
     }
 
-    fun calculateDue(context: Context?, type: AxisType): Boolean {
+    fun calculateDue(context: Context, type: AxisType): Boolean {
         // Not in libanki
         var metaInfo = StatsMetaInfo()
         metaInfo = AdvancedStatistics().calculateDueAsMetaInfo(metaInfo, type, context, _limit())

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sync/HttpSyncer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sync/HttpSyncer.kt
@@ -23,6 +23,7 @@ import android.content.SharedPreferences
 import android.net.Uri
 import com.ichi2.anki.AnkiDroidApp
 import com.ichi2.anki.exception.UnknownHttpResponseException
+import com.ichi2.anki.preferences.sharedPrefs
 import com.ichi2.anki.web.CustomSyncServer
 import com.ichi2.anki.web.HttpFetcher
 import com.ichi2.async.Connection
@@ -137,9 +138,17 @@ open class HttpSyncer(
             postVars["c"] = if (comp != 0) 1 else 0
             for ((key, value) in postVars) {
                 buf.write(bdry + "\r\n")
-                buf.write(String.format(Locale.US, "Content-Disposition: form-data; name=\"%s\"\r\n\r\n%s\r\n", key, value))
+                buf.write(
+                    String.format(
+                        Locale.US,
+                        "Content-Disposition: form-data; name=\"%s\"\r\n\r\n%s\r\n",
+                        key,
+                        value
+                    )
+                )
             }
-            tmpFileBuffer = File.createTempFile("syncer", ".tmp", File(AnkiDroidApp.cacheStorageDirectory))
+            tmpFileBuffer =
+                File.createTempFile("syncer", ".tmp", File(AnkiDroidApp.cacheStorageDirectory))
             val fos = FileOutputStream(tmpFileBuffer)
             var bos = BufferedOutputStream(fos)
             val tgt: GZIPOutputStream
@@ -278,10 +287,15 @@ open class HttpSyncer(
     fun stream2String(stream: InputStream?, maxSize: Int): String {
         val rd: BufferedReader
         return try {
-            rd = BufferedReader(InputStreamReader(stream, "UTF-8"), if (maxSize == -1) 4096 else min(4096, maxSize))
+            rd = BufferedReader(
+                InputStreamReader(stream, "UTF-8"),
+                if (maxSize == -1) 4096 else min(4096, maxSize)
+            )
             var line: String
             val sb = StringBuilder()
-            while (rd.readLine().also { line = it } != null && (maxSize == -1 || sb.length < maxSize)) {
+            while (rd.readLine()
+                .also { line = it } != null && (maxSize == -1 || sb.length < maxSize)
+            ) {
                 sb.append(line)
                 bytesReceived.addAndGet(line.length.toLong())
                 publishProgress()
@@ -305,11 +319,12 @@ open class HttpSyncer(
         }
     }
 
-    val preferences: SharedPreferences get() = AnkiDroidApp.getSharedPrefs(AnkiDroidApp.instance)
+    val preferences: SharedPreferences get() = AnkiDroidApp.instance.sharedPrefs()
 
     open fun getDefaultSyncUrl() = "https://sync${hostNum ?: ""}.ankiweb.net/sync/"
 
-    open fun getCustomSyncUrlOrNull() = CustomSyncServer.getCollectionSyncUrlIfSetAndEnabledOrNull(preferences)
+    open fun getCustomSyncUrlOrNull() =
+        CustomSyncServer.getCollectionSyncUrlIfSetAndEnabledOrNull(preferences)
 
     fun syncURL() = getCustomSyncUrlOrNull() ?: getDefaultSyncUrl()
 
@@ -318,7 +333,8 @@ open class HttpSyncer(
 
     companion object {
         private const val BOUNDARY = "Anki-sync-boundary"
-        private val ANKI_POST_TYPE: MediaType = ("multipart/form-data; boundary=$BOUNDARY").toMediaType()
+        private val ANKI_POST_TYPE: MediaType =
+            ("multipart/form-data; boundary=$BOUNDARY").toMediaType()
         const val ANKIWEB_STATUS_OK = "OK"
         fun getInputStream(string: String): ByteArrayInputStream? {
             return try {
@@ -336,7 +352,8 @@ open class HttpSyncer(
         @KotlinCleanup("move to constructor")
         this.con = con
         @KotlinCleanup("combined declaration and initialization")
-        postVars = HashMapInit(0) // New map is created each time it is filled. No need to allocate room
+        postVars =
+            HashMapInit(0) // New map is created each time it is filled. No need to allocate room
         @KotlinCleanup("move to constructor")
         mHostNum = hostNum
     }

--- a/AnkiDroid/src/main/java/com/ichi2/preferences/ControlPreference.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/preferences/ControlPreference.kt
@@ -23,7 +23,6 @@ import androidx.appcompat.app.AlertDialog
 import androidx.preference.ListPreference
 import com.afollestad.materialdialogs.MaterialDialog
 import com.afollestad.materialdialogs.customview.customView
-import com.ichi2.anki.AnkiDroidApp
 import com.ichi2.anki.R
 import com.ichi2.anki.UIUtils
 import com.ichi2.anki.cardviewer.GestureProcessor
@@ -32,6 +31,7 @@ import com.ichi2.anki.dialogs.CardSideSelectionDialog
 import com.ichi2.anki.dialogs.GestureSelectionDialogUtils
 import com.ichi2.anki.dialogs.GestureSelectionDialogUtils.onGestureChanged
 import com.ichi2.anki.dialogs.KeySelectionDialogUtils
+import com.ichi2.anki.preferences.sharedPrefs
 import com.ichi2.anki.reviewer.CardSide
 import com.ichi2.anki.reviewer.MappableBinding
 import com.ichi2.anki.reviewer.MappableBinding.Companion.fromGesture
@@ -70,7 +70,7 @@ class ControlPreference : ListPreference {
         entryTitles.add(context.getString(R.string.binding_add_key))
         entryIndices.add(ADD_KEY_INDEX)
         // Put "Add gesture" option if gestures are enabled
-        if (AnkiDroidApp.getSharedPrefs(context).getBoolean(GestureProcessor.PREF_KEY, false)) {
+        if (context.sharedPrefs().getBoolean(GestureProcessor.PREF_KEY, false)) {
             entryTitles.add(context.getString(R.string.binding_add_gesture))
             entryIndices.add(ADD_GESTURE_INDEX)
         }
@@ -183,7 +183,7 @@ class ControlPreference : ListPreference {
 
     /** @return command where the binding is mapped excluding the current command */
     private fun getCommandWithBindingExceptThis(binding: MappableBinding): ViewerCommand? {
-        return MappableBinding.allMappings(AnkiDroidApp.getSharedPrefs(context))
+        return MappableBinding.allMappings(context.sharedPrefs())
             // filter to the commands which have a binding matching this one except this
             .firstOrNull { x -> x.second.any { cmdBinding -> cmdBinding == binding } && x.first.preferenceKey != key }?.first
     }

--- a/AnkiDroid/src/main/java/com/ichi2/preferences/CustomDialogPreference.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/preferences/CustomDialogPreference.kt
@@ -20,24 +20,26 @@ import android.content.Context
 import android.content.DialogInterface
 import android.util.AttributeSet
 import androidx.core.content.edit
-import com.ichi2.anki.AnkiDroidApp
 import com.ichi2.anki.R
+import com.ichi2.anki.preferences.sharedPrefs
 
 // TODO Tracked in https://github.com/ankidroid/Anki-Android/issues/5019 see implementation at ResetLanguageDialogPreference
 @Suppress("Deprecation", "Unused")
 class CustomDialogPreference(private val context_: Context, attrs: AttributeSet?) : android.preference.DialogPreference(context_, attrs), DialogInterface.OnClickListener {
     override fun onClick(dialog: DialogInterface, which: Int) {
         if (which == DialogInterface.BUTTON_POSITIVE) {
-            AnkiDroidApp.getSharedPrefs(context_).edit(commit = true) {
+            context_.sharedPrefs().edit(commit = true) {
                 when (title) {
                     context_.resources.getString(R.string.deck_conf_reset) -> {
                         // Deck Options :: Restore Defaults for Options Group
                         putBoolean("confReset", true)
                     }
+
                     context_.resources.getString(R.string.dialog_positive_remove) -> {
                         // Deck Options :: Remove Options Group
                         putBoolean("confRemove", true)
                     }
+
                     context_.resources.getString(R.string.deck_conf_set_subdecks) -> {
                         // Deck Options :: Set Options Group for all Sub-decks
                         putBoolean("confSetSubdecks", true)

--- a/AnkiDroid/src/main/java/com/ichi2/themes/Themes.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/themes/Themes.kt
@@ -27,6 +27,7 @@ import androidx.core.content.ContextCompat
 import androidx.fragment.app.Fragment
 import com.ichi2.anki.AnkiDroidApp
 import com.ichi2.anki.R
+import com.ichi2.anki.preferences.sharedPrefs
 import com.ichi2.ui.AppCompatPreferenceActivity
 import timber.log.Timber
 
@@ -65,9 +66,9 @@ object Themes {
         // after the time when the theme should be set
         // TODO (#5019): always use the context as the parameter for getSharedPrefs
         val prefs = if (context is AppCompatPreferenceActivity<*>) {
-            AnkiDroidApp.getSharedPrefs(AnkiDroidApp.instance)
+            AnkiDroidApp.instance.sharedPrefs()
         } else {
-            AnkiDroidApp.getSharedPrefs(context)
+            context.sharedPrefs()
         }
 
         currentTheme = if (themeFollowsSystem(prefs)) {

--- a/AnkiDroid/src/main/java/com/ichi2/ui/OnGestureListener.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/ui/OnGestureListener.kt
@@ -18,8 +18,8 @@ package com.ichi2.ui
 import android.view.GestureDetector
 import android.view.MotionEvent
 import android.view.View
-import com.ichi2.anki.AnkiDroidApp
 import com.ichi2.anki.cardviewer.Gesture
+import com.ichi2.anki.preferences.sharedPrefs
 import com.ichi2.anki.reviewer.GestureMapper
 import java.util.function.Consumer
 
@@ -73,7 +73,7 @@ class OnGestureListener(
     companion object {
         fun createInstance(view: View, consumer: Consumer<Gesture>): OnGestureListener {
             val gestureMapper = GestureMapper()
-            gestureMapper.init(AnkiDroidApp.getSharedPrefs(view.context))
+            gestureMapper.init(view.context.sharedPrefs())
             return OnGestureListener(view, gestureMapper, consumer)
         }
     }

--- a/AnkiDroid/src/main/java/com/ichi2/utils/LanguageUtil.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/LanguageUtil.kt
@@ -23,6 +23,7 @@ import androidx.appcompat.app.AppCompatDelegate
 import androidx.core.os.ConfigurationCompat
 import androidx.fragment.app.Fragment
 import com.ichi2.anki.AnkiDroidApp
+import com.ichi2.anki.preferences.sharedPrefs
 import net.ankiweb.rsdroid.BackendFactory
 import java.text.DateFormat
 import java.util.*
@@ -208,7 +209,7 @@ object LanguageUtil {
 
     /** If locale is not provided, the current locale will be used. */
     fun setDefaultBackendLanguages(languageTag: String? = null) {
-        val langCode = languageTag ?: AnkiDroidApp.getSharedPrefs(AnkiDroidApp.instance)
+        val langCode = languageTag ?: AnkiDroidApp.instance.sharedPrefs()
             .getString("language", SYSTEM_LANGUAGE_TAG)!!
 
         val localeLanguage = if (langCode == SYSTEM_LANGUAGE_TAG) {

--- a/AnkiDroid/src/main/java/com/ichi2/utils/SyncStatus.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/SyncStatus.kt
@@ -22,6 +22,7 @@ import anki.sync.SyncAuth
 import anki.sync.SyncStatusResponse
 import com.ichi2.anki.AnkiDroidApp
 import com.ichi2.anki.SyncPreferences
+import com.ichi2.anki.preferences.sharedPrefs
 import com.ichi2.libanki.Collection
 import net.ankiweb.rsdroid.BackendFactory
 
@@ -43,7 +44,7 @@ enum class SyncStatus {
             if (!BackendFactory.defaultLegacySchema) {
                 val output = col.newBackend.backend.syncStatus(auth)
                 if (output.hasNewEndpoint()) {
-                    AnkiDroidApp.getSharedPrefs(context).edit {
+                    context.sharedPrefs().edit {
                         putString(SyncPreferences.CURRENT_SYNC_URI, output.newEndpoint)
                     }
                 }
@@ -70,13 +71,13 @@ enum class SyncStatus {
 
         private val isDisabled: Boolean
             get() {
-                val preferences = AnkiDroidApp.getSharedPrefs(AnkiDroidApp.instance)
+                val preferences = AnkiDroidApp.instance.sharedPrefs()
                 return !preferences.getBoolean("showSyncStatusBadge", true)
             }
 
         /** Whether data has been changed - to be converted to Rust  */
         fun hasDatabaseChanges(): Boolean {
-            return AnkiDroidApp.getSharedPrefs(AnkiDroidApp.instance).getBoolean("changesSinceLastSync", false)
+            return AnkiDroidApp.instance.sharedPrefs().getBoolean("changesSinceLastSync", false)
         }
 
         /** To be converted to Rust  */
@@ -85,14 +86,14 @@ enum class SyncStatus {
                 return
             }
             sMarkedInMemory = true
-            AnkiDroidApp.getSharedPrefs(AnkiDroidApp.instance).edit { putBoolean("changesSinceLastSync", true) }
+            AnkiDroidApp.instance.sharedPrefs().edit { putBoolean("changesSinceLastSync", true) }
         }
 
         /** To be converted to Rust  */
         @KotlinCleanup("Convert these to @RustCleanup")
         fun markSyncCompleted() {
             sMarkedInMemory = false
-            AnkiDroidApp.getSharedPrefs(AnkiDroidApp.instance).edit { putBoolean("changesSinceLastSync", false) }
+            AnkiDroidApp.instance.sharedPrefs().edit { putBoolean("changesSinceLastSync", false) }
         }
 
         fun ignoreDatabaseModification(runnable: Runnable) {

--- a/AnkiDroid/src/main/java/com/ichi2/utils/ViewGroupUtils.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/ViewGroupUtils.kt
@@ -20,7 +20,7 @@ import android.R
 import android.app.Activity
 import android.view.View
 import android.view.ViewGroup
-import com.ichi2.anki.AnkiDroidApp
+import com.ichi2.anki.preferences.sharedPrefs
 import timber.log.Timber
 import java.util.ArrayList
 
@@ -47,7 +47,7 @@ object ViewGroupUtils {
     }
 
     fun setRenderWorkaround(activity: Activity) {
-        if (AnkiDroidApp.getSharedPrefs(activity).getBoolean("softwareRender", false)) {
+        if (activity.sharedPrefs().getBoolean("softwareRender", false)) {
             Timber.i("ViewGroupUtils::setRenderWorkaround - software render requested, altering Views...")
             setContentViewLayerTypeSoftware(activity)
         } else {

--- a/AnkiDroid/src/main/java/com/ichi2/widget/AnkiDroidWidgetSmall.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/widget/AnkiDroidWidgetSmall.kt
@@ -29,6 +29,7 @@ import com.ichi2.anki.AnkiDroidApp
 import com.ichi2.anki.IntentHandler
 import com.ichi2.anki.R
 import com.ichi2.anki.analytics.UsageAnalytics
+import com.ichi2.anki.preferences.sharedPrefs
 import com.ichi2.compat.CompatHelper
 import com.ichi2.utils.KotlinCleanup
 import timber.log.Timber
@@ -43,7 +44,7 @@ class AnkiDroidWidgetSmall : AppWidgetProvider() {
     override fun onEnabled(context: Context) {
         super.onEnabled(context)
         Timber.d("SmallWidget: Widget enabled")
-        val preferences = AnkiDroidApp.getSharedPrefs(context)
+        val preferences = context.sharedPrefs()
         preferences.edit(commit = true) { putBoolean("widgetSmallEnabled", true) }
         UsageAnalytics.sendAnalyticsEvent(this.javaClass.simpleName, "enabled")
     }
@@ -51,7 +52,7 @@ class AnkiDroidWidgetSmall : AppWidgetProvider() {
     override fun onDisabled(context: Context) {
         super.onDisabled(context)
         Timber.d("SmallWidget: Widget disabled")
-        val preferences = AnkiDroidApp.getSharedPrefs(context)
+        val preferences = context.sharedPrefs()
         preferences.edit(commit = true) { putBoolean("widgetSmallEnabled", false) }
         UsageAnalytics.sendAnalyticsEvent(this.javaClass.simpleName, "disabled")
     }

--- a/AnkiDroid/src/main/java/com/ichi2/widget/WidgetStatus.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/widget/WidgetStatus.kt
@@ -19,6 +19,7 @@ import com.ichi2.anki.AnkiDroidApp
 import com.ichi2.anki.CollectionHelper
 import com.ichi2.anki.MetaDB
 import com.ichi2.anki.preferences.Preferences
+import com.ichi2.anki.preferences.sharedPrefs
 import com.ichi2.async.BaseAsyncTask
 import com.ichi2.libanki.sched.Counts
 import com.ichi2.utils.KotlinCleanup
@@ -42,10 +43,13 @@ object WidgetStatus {
      */
     @Suppress("deprecation") // #7108: AsyncTask
     fun update(context: Context) {
-        val preferences = AnkiDroidApp.getSharedPrefs(context)
+        val preferences = context.sharedPrefs()
         sSmallWidgetEnabled = preferences.getBoolean("widgetSmallEnabled", false)
-        val notificationEnabled = preferences.getString(Preferences.MINIMUM_CARDS_DUE_FOR_NOTIFICATION, "1000001")!!.toInt() < 1000000
-        val canExecuteTask = sUpdateDeckStatusAsyncTask == null || sUpdateDeckStatusAsyncTask!!.status == android.os.AsyncTask.Status.FINISHED
+        val notificationEnabled =
+            preferences.getString(Preferences.MINIMUM_CARDS_DUE_FOR_NOTIFICATION, "1000001")!!
+                .toInt() < 1000000
+        val canExecuteTask =
+            sUpdateDeckStatusAsyncTask == null || sUpdateDeckStatusAsyncTask!!.status == android.os.AsyncTask.Status.FINISHED
         if ((sSmallWidgetEnabled || notificationEnabled) && canExecuteTask) {
             Timber.d("WidgetStatus.update(): updating")
             sUpdateDeckStatusAsyncTask = UpdateDeckStatusAsyncTask()

--- a/AnkiDroid/src/main/java/com/ichi2/widget/WidgetStatus.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/widget/WidgetStatus.kt
@@ -41,7 +41,7 @@ object WidgetStatus {
      *             https://developer.android.com/guide/topics/appwidgets/#MetaData
      */
     @Suppress("deprecation") // #7108: AsyncTask
-    fun update(context: Context?) {
+    fun update(context: Context) {
         val preferences = AnkiDroidApp.getSharedPrefs(context)
         sSmallWidgetEnabled = preferences.getBoolean("widgetSmallEnabled", false)
         val notificationEnabled = preferences.getString(Preferences.MINIMUM_CARDS_DUE_FOR_NOTIFICATION, "1000001")!!.toInt() < 1000000

--- a/AnkiDroid/src/test/java/com/ichi2/anki/AbstractFlashcardViewerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/AbstractFlashcardViewerTest.kt
@@ -18,6 +18,7 @@ import com.ichi2.anki.AbstractFlashcardViewer.WebViewSignalParserUtils.SIGNAL_NO
 import com.ichi2.anki.AbstractFlashcardViewer.WebViewSignalParserUtils.TYPE_FOCUS
 import com.ichi2.anki.AbstractFlashcardViewer.WebViewSignalParserUtils.getSignalFromUrl
 import com.ichi2.anki.cardviewer.ViewerCommand
+import com.ichi2.anki.preferences.sharedPrefs
 import com.ichi2.anki.reviewer.AutomaticAnswer
 import com.ichi2.anki.reviewer.AutomaticAnswerAction
 import com.ichi2.anki.reviewer.AutomaticAnswerSettings
@@ -58,7 +59,8 @@ class AbstractFlashcardViewerTest : RobolectricTest() {
 
         override val elapsedRealTime: Long
             get() {
-                mLastTime += AnkiDroidApp.getSharedPrefs(baseContext).getInt(DOUBLE_TAP_TIME_INTERVAL, DEFAULT_DOUBLE_TAP_TIME_INTERVAL)
+                mLastTime += baseContext.sharedPrefs()
+                    .getInt(DOUBLE_TAP_TIME_INTERVAL, DEFAULT_DOUBLE_TAP_TIME_INTERVAL)
                 return mLastTime.toLong()
             }
         val hintLocale: String?

--- a/AnkiDroid/src/test/java/com/ichi2/anki/DeckPickerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/DeckPickerTest.kt
@@ -10,6 +10,7 @@ import androidx.fragment.app.DialogFragment
 import androidx.test.core.app.ActivityScenario
 import com.ichi2.anki.dialogs.DatabaseErrorDialog.DatabaseErrorDialogType
 import com.ichi2.anki.dialogs.DeckPickerConfirmDeleteDeckDialog
+import com.ichi2.anki.preferences.sharedPrefs
 import com.ichi2.annotations.NeedsTest
 import com.ichi2.libanki.Storage
 import com.ichi2.libanki.exception.UnknownDatabaseVersionException
@@ -275,7 +276,7 @@ class DeckPickerTest : RobolectricTest() {
             grantWritePermissions()
             BackupManagerTestUtilities.setupSpaceForBackup(targetContext)
             // We don't show it if the user is new.
-            AnkiDroidApp.getSharedPrefs(targetContext).edit().putString("lastVersion", "0.1")
+            targetContext.sharedPrefs().edit().putString("lastVersion", "0.1")
                 .apply()
             val d = super.startActivityNormallyOpenCollectionWithIntent(
                 DeckPickerEx::class.java,
@@ -522,7 +523,7 @@ class DeckPickerTest : RobolectricTest() {
         val collectionDirectory = p.parent
 
         // set collection path
-        AnkiDroidApp.getSharedPrefs(targetContext).edit {
+        targetContext.sharedPrefs().edit {
             putString(CollectionHelper.PREF_COLLECTION_PATH, collectionDirectory)
         }
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/InitialActivityTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/InitialActivityTest.kt
@@ -17,12 +17,14 @@
 package com.ichi2.anki
 
 import android.annotation.SuppressLint
+import android.content.Context
 import android.content.SharedPreferences
 import android.os.Build
 import androidx.core.content.edit
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.ichi2.anki.AnkiDroidFolder.*
+import com.ichi2.anki.preferences.sharedPrefs
 import com.ichi2.anki.servicelayer.PreferenceUpgradeService
 import com.ichi2.testutils.EmptyApplication
 import org.hamcrest.CoreMatchers.equalTo
@@ -42,10 +44,12 @@ import org.robolectric.annotation.Config
 class InitialActivityTest : RobolectricTest() {
 
     private lateinit var mSharedPreferences: SharedPreferences
+    private val appContext: Context
+        get() = ApplicationProvider.getApplicationContext()
 
     @Before
     fun before() {
-        mSharedPreferences = AnkiDroidApp.getSharedPrefs(ApplicationProvider.getApplicationContext())
+        mSharedPreferences = appContext.sharedPrefs()
     }
 
     @Test
@@ -99,11 +103,18 @@ class InitialActivityTest : RobolectricTest() {
 
     @Test
     fun perform_setup_integration_test() {
-        val sharedPrefs = AnkiDroidApp.getSharedPrefs(ApplicationProvider.getApplicationContext())
-        val initialSetupResult = InitialActivity.performSetupFromFreshInstallOrClearedPreferences(AnkiDroidApp.getSharedPrefs(ApplicationProvider.getApplicationContext()))
+        val sharedPrefs = appContext.sharedPrefs()
+        val initialSetupResult = InitialActivity.performSetupFromFreshInstallOrClearedPreferences(
+            appContext.sharedPrefs()
+        )
         assertThat(initialSetupResult, equalTo(true))
-        val secondResult = InitialActivity.performSetupFromFreshInstallOrClearedPreferences(sharedPrefs)
-        assertThat("should not perform initial setup if setup has already occurred", secondResult, equalTo(false))
+        val secondResult =
+            InitialActivity.performSetupFromFreshInstallOrClearedPreferences(sharedPrefs)
+        assertThat(
+            "should not perform initial setup if setup has already occurred",
+            secondResult,
+            equalTo(false)
+        )
     }
 
     @Config(sdk = [BEFORE_Q])

--- a/AnkiDroid/src/test/java/com/ichi2/anki/OnboardingFlagTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/OnboardingFlagTest.kt
@@ -21,6 +21,7 @@ package com.ichi2.anki
 import androidx.core.content.edit
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.ichi2.anki.OnboardingUtils.Companion.SHOW_ONBOARDING
+import com.ichi2.anki.preferences.sharedPrefs
 import org.junit.After
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -38,7 +39,7 @@ class OnboardingFlagTest : RobolectricTest() {
 
     @Before
     fun setShowOnboardingPreference() {
-        AnkiDroidApp.getSharedPrefs(targetContext).edit { putBoolean(SHOW_ONBOARDING, true) }
+        targetContext.sharedPrefs().edit { putBoolean(SHOW_ONBOARDING, true) }
     }
 
     @After

--- a/AnkiDroid/src/test/java/com/ichi2/anki/ReviewerNoParamTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/ReviewerNoParamTest.kt
@@ -27,6 +27,7 @@ import com.ichi2.anki.cardviewer.Gesture.SWIPE_UP
 import com.ichi2.anki.cardviewer.GestureProcessor
 import com.ichi2.anki.cardviewer.ViewerCommand
 import com.ichi2.anki.model.WhiteboardPenColor
+import com.ichi2.anki.preferences.sharedPrefs
 import com.ichi2.anki.reviewer.FullScreenMode
 import com.ichi2.anki.reviewer.FullScreenMode.Companion.setPreference
 import com.ichi2.anki.reviewer.MappableBinding
@@ -259,7 +260,7 @@ class ReviewerNoParamTest : RobolectricTest() {
     private val gestureProcessor: GestureProcessor
         get() {
             val gestureProcessor = GestureProcessor(null)
-            gestureProcessor.init(AnkiDroidApp.getSharedPrefs(targetContext))
+            gestureProcessor.init(targetContext.sharedPrefs())
             return gestureProcessor
         }
 
@@ -276,13 +277,13 @@ class ReviewerNoParamTest : RobolectricTest() {
     }
 
     private fun setGestureSetting(value: Boolean) {
-        AnkiDroidApp.getSharedPrefs(targetContext).edit {
+        targetContext.sharedPrefs().edit {
             putBoolean(GestureProcessor.PREF_KEY, value)
         }
     }
 
     private fun disableGestures(vararg gestures: Gesture) {
-        val prefs = AnkiDroidApp.getSharedPrefs(targetContext)
+        val prefs = targetContext.sharedPrefs()
         for (command in ViewerCommand.values()) {
             for (mappableBinding in MappableBinding.fromPreference(prefs, command)) {
                 if (mappableBinding.binding.gesture in gestures) {
@@ -294,12 +295,12 @@ class ReviewerNoParamTest : RobolectricTest() {
 
     /** Enables a gesture (without changing the overall setting of whether gestures are allowed)  */
     private fun enableGesture(gesture: Gesture) {
-        val prefs = AnkiDroidApp.getSharedPrefs(targetContext)
+        val prefs = targetContext.sharedPrefs()
         ViewerCommand.FLIP_OR_ANSWER_EASE1.addBinding(prefs, MappableBinding.fromGesture(gesture))
     }
 
     private fun startReviewerFullScreen(): ReviewerExt {
-        val sharedPrefs = AnkiDroidApp.getSharedPrefs(targetContext)
+        val sharedPrefs = targetContext.sharedPrefs()
         setPreference(sharedPrefs, FullScreenMode.BUTTONS_ONLY)
         return ReviewerTest.startReviewer(this, ReviewerExt::class.java)
     }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/ReviewerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/ReviewerTest.kt
@@ -23,6 +23,7 @@ import com.ichi2.anki.AbstractFlashcardViewer.Companion.RESULT_DEFAULT
 import com.ichi2.anki.cardviewer.ViewerCommand
 import com.ichi2.anki.exception.ConfirmModSchemaException
 import com.ichi2.anki.preferences.PreferenceUtils
+import com.ichi2.anki.preferences.sharedPrefs
 import com.ichi2.anki.reviewer.ActionButtonStatus
 import com.ichi2.libanki.Card
 import com.ichi2.libanki.Consts
@@ -271,7 +272,7 @@ class ReviewerTest : RobolectricTest() {
     private fun disableAllReviewerAppBarButtons() {
         val keys = PreferenceUtils.getAllCustomButtonKeys(targetContext)
 
-        val preferences = AnkiDroidApp.getSharedPrefs(targetContext)
+        val preferences = targetContext.sharedPrefs()
 
         preferences.edit {
             for (k in keys) {

--- a/AnkiDroid/src/test/java/com/ichi2/anki/RobolectricTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/RobolectricTest.kt
@@ -36,6 +36,7 @@ import com.afollestad.materialdialogs.actions.getActionButton
 import com.ichi2.anki.dialogs.DialogHandler
 import com.ichi2.anki.dialogs.utils.FragmentTestActivity
 import com.ichi2.anki.exception.ConfirmModSchemaException
+import com.ichi2.anki.preferences.sharedPrefs
 import com.ichi2.async.*
 import com.ichi2.compat.customtabs.CustomTabActivityHelper
 import com.ichi2.libanki.*
@@ -337,7 +338,7 @@ open class RobolectricTest : CollectionGetter, AndroidTest {
      * @see [editPreferences] for editing
      */
     fun getPreferences(): SharedPreferences {
-        return AnkiDroidApp.getSharedPrefs(targetContext)
+        return targetContext.sharedPrefs()
     }
 
     protected fun getResourceString(res: Int): String {

--- a/AnkiDroid/src/test/java/com/ichi2/anki/TestCardTemplatePreviewer.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/TestCardTemplatePreviewer.kt
@@ -16,13 +16,17 @@
 package com.ichi2.anki
 
 import android.view.View
+import com.ichi2.anki.preferences.sharedPrefs
 
 class TestCardTemplatePreviewer : CardTemplatePreviewer() {
     var showingAnswer = false
         private set
 
     fun disableDoubleClickPrevention() {
-        lastClickTime = (AnkiDroidApp.getSharedPrefs(baseContext).getInt(DOUBLE_TAP_TIME_INTERVAL, DEFAULT_DOUBLE_TAP_TIME_INTERVAL) * -2).toLong()
+        lastClickTime = (
+            baseContext.sharedPrefs()
+                .getInt(DOUBLE_TAP_TIME_INTERVAL, DEFAULT_DOUBLE_TAP_TIME_INTERVAL) * -2
+            ).toLong()
     }
 
     override fun displayCardAnswer() {

--- a/AnkiDroid/src/test/java/com/ichi2/anki/jsaddons/AddonModelTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/jsaddons/AddonModelTest.kt
@@ -20,10 +20,10 @@ import android.content.SharedPreferences
 import android.os.Looper.getMainLooper
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.ichi2.anki.AnkiDroidApp
 import com.ichi2.anki.AnkiSerialization
 import com.ichi2.anki.RobolectricTest
 import com.ichi2.anki.jsaddons.AddonsConst.REVIEWER_ADDON
+import com.ichi2.anki.preferences.sharedPrefs
 import com.ichi2.utils.FileOperation
 import junit.framework.TestCase.*
 import org.hamcrest.MatcherAssert.assertThat
@@ -46,7 +46,7 @@ class AddonModelTest : RobolectricTest() {
 
     @Before
     fun before() {
-        mPrefs = AnkiDroidApp.getSharedPrefs(targetContext)
+        mPrefs = targetContext.sharedPrefs()
     }
 
     @Before

--- a/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/ScopedStorageAnkiDroidTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/ScopedStorageAnkiDroidTest.kt
@@ -17,10 +17,10 @@
 package com.ichi2.anki.servicelayer
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.ichi2.anki.AnkiDroidApp
 import com.ichi2.anki.CollectionHelper
 import com.ichi2.anki.CollectionManager
 import com.ichi2.anki.RobolectricTest
+import com.ichi2.anki.preferences.sharedPrefs
 import com.ichi2.anki.servicelayer.scopedstorage.MigrateEssentialFiles
 import com.ichi2.anki.servicelayer.scopedstorage.migrateEssentialFilesForTest
 import com.ichi2.anki.servicelayer.scopedstorage.setLegacyStorage
@@ -115,7 +115,8 @@ class ScopedStorageAnkiDroidTest : RobolectricTest() {
     }
 
     private fun getBestRootDirectory(): File {
-        val collectionPath = AnkiDroidApp.getSharedPrefs(targetContext).getString(CollectionHelper.PREF_COLLECTION_PATH, null)!!
+        val collectionPath =
+            targetContext.sharedPrefs().getString(CollectionHelper.PREF_COLLECTION_PATH, null)!!
 
         // Get the scoped storage directory to migrate to. This is based on the location
         // of the current collection path

--- a/AnkiDroid/src/test/java/com/ichi2/anki/servicemodel/PreferenceUpgradeServiceTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/servicemodel/PreferenceUpgradeServiceTest.kt
@@ -19,9 +19,9 @@ package com.ichi2.anki.servicemodel
 import android.content.SharedPreferences
 import androidx.core.content.edit
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.ichi2.anki.AnkiDroidApp
 import com.ichi2.anki.RobolectricTest
 import com.ichi2.anki.noteeditor.CustomToolbarButton
+import com.ichi2.anki.preferences.sharedPrefs
 import com.ichi2.anki.servicelayer.PreferenceUpgradeService
 import com.ichi2.anki.servicelayer.PreferenceUpgradeService.PreferenceUpgrade
 import com.ichi2.anki.servicelayer.RemovedPreferences
@@ -46,7 +46,7 @@ class PreferenceUpgradeServiceTest : RobolectricTest() {
     @Before
     override fun setUp() {
         super.setUp()
-        mPrefs = AnkiDroidApp.getSharedPrefs(targetContext)
+        mPrefs = targetContext.sharedPrefs()
     }
 
     @Test

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/sync/HttpSyncerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/sync/HttpSyncerTest.kt
@@ -20,6 +20,7 @@ import androidx.core.content.edit
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.ichi2.anki.AnkiDroidApp
 import com.ichi2.anki.SyncPreferences
+import com.ichi2.anki.preferences.sharedPrefs
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
 import org.junit.Ignore
@@ -94,14 +95,14 @@ class HttpSyncerTest {
     }
 
     private fun setCustomServerWithNoUrl() {
-        val userPreferences = AnkiDroidApp.getSharedPrefs(AnkiDroidApp.instance)
+        val userPreferences = AnkiDroidApp.instance.sharedPrefs()
         userPreferences.edit {
             putBoolean(SyncPreferences.CUSTOM_SYNC_ENABLED, true)
         }
     }
 
     private fun setCustomServer(s: String) {
-        val userPreferences = AnkiDroidApp.getSharedPrefs(AnkiDroidApp.instance)
+        val userPreferences = AnkiDroidApp.instance.sharedPrefs()
         userPreferences.edit {
             putBoolean(SyncPreferences.CUSTOM_SYNC_ENABLED, true)
             putString(SyncPreferences.CUSTOM_SYNC_URI, s)

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/sync/RemoteMediaServerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/sync/RemoteMediaServerTest.kt
@@ -20,6 +20,7 @@ import androidx.core.content.edit
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.ichi2.anki.AnkiDroidApp
 import com.ichi2.anki.SyncPreferences
+import com.ichi2.anki.preferences.sharedPrefs
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
 import org.junit.Ignore
@@ -93,14 +94,14 @@ class RemoteMediaServerTest {
     }
 
     private fun setCustomServerWithNoUrl() {
-        AnkiDroidApp.getSharedPrefs(AnkiDroidApp.instance)
+        AnkiDroidApp.instance.sharedPrefs()
             .edit {
                 putBoolean(SyncPreferences.CUSTOM_SYNC_ENABLED, true)
             }
     }
 
     private fun setCustomMediaServer(s: String) {
-        AnkiDroidApp.getSharedPrefs(AnkiDroidApp.instance)
+        AnkiDroidApp.instance.sharedPrefs()
             .edit {
                 putBoolean(SyncPreferences.CUSTOM_SYNC_ENABLED, true)
                 putString(SyncPreferences.CUSTOM_SYNC_URI, s)

--- a/AnkiDroid/src/test/java/com/ichi2/testutils/AndroidTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/testutils/AndroidTest.kt
@@ -20,7 +20,7 @@ import android.content.Context
 import android.content.SharedPreferences
 import androidx.core.content.edit
 import androidx.test.core.app.ApplicationProvider
-import com.ichi2.anki.AnkiDroidApp
+import com.ichi2.anki.preferences.sharedPrefs
 
 /** Marker interface for classes annotated with `@RunWith(AndroidJUnit4.class)` */
 interface AndroidTest
@@ -42,7 +42,7 @@ val AndroidTest.targetContext: Context
  * Returns an instance of [SharedPreferences] using the test context
  * @see [editPreferences] for editing
  */
-fun AndroidTest.getSharedPrefs(): SharedPreferences = AnkiDroidApp.getSharedPrefs(targetContext)
+fun AndroidTest.getSharedPrefs(): SharedPreferences = targetContext.sharedPrefs()
 
 fun AndroidTest.getString(res: Int): String = targetContext.getString(res)
 


### PR DESCRIPTION
The androidx version of the method is equal to the android one, so this is actually a non-functional change

## How Has This Been Tested?

Open the app and change some prefs

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
