### PR TITLE
Highlighted Correct Deck

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -277,6 +277,7 @@ open class DeckPicker :
                 // Calling notifyDataSetChanged() will update the color of the selected deck.
                 // This interferes with the ripple effect, so we don't do it if lollipop and not tablet view
                 mDeckListAdapter.notifyDataSetChanged()
+                updateDeckList()
             }
         } catch (e: Exception) {
             // Maybe later don't report if collectionIsOpen is false?


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
Highlighting wrong deck in tablet

## Fixes
Fixes #14057

## Approach
updated DeckList when it is in tablet mode.

## How Has This Been Tested?

Tested on Tablet Emulator ( Pixel C API 33 )
[highlight.webm](https://github.com/ankidroid/Anki-Android/assets/65113071/b59126be-d15f-45eb-aaa3-cd1d7e7f4f72)

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
