### PR TITLE
Replace "Bluetooth" with "Gamepad" in Settings

### DIFF
--- a/AnkiDroid/src/main/res/values/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values/10-preferences.xml
@@ -219,8 +219,8 @@
         ]]></string>
     <string name="custom_sync_server_base_url_title" maxLength="41">Sync url</string>
     <!-- Key Bindings -->
-    <string name="keyboard">Keyboard</string>
-    <string name="bluetooth">Bluetooth</string>
+    <string name="gamepad" comment="One of the items in the \'Controls\' summary">Gamepad</string>
+    <string name="keyboard" comment="One of the items in the \'Controls\' summary">Keyboard</string>
     <string name="controls_main_category" maxLength="41">Command mapping</string>
 
 

--- a/AnkiDroid/src/main/res/values/constants.xml
+++ b/AnkiDroid/src/main/res/values/constants.xml
@@ -303,8 +303,8 @@
 
     <string-array name="controls_summary_entries">
         <item>@string/pref_cat_gestures</item>
+        <item>@string/gamepad</item>
         <item>@string/keyboard</item>
-        <item>@string/bluetooth</item>
     </string-array>
 
     <string-array name="advanced_summary_entries">


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
The `Bluetooth` in the summary of "Controls" of the settings is not clear on meaning and role there. 

This commit will replace it with `Gamepad`.

Incidentally, it will place the new string before `Keyboard`, according to the order of the command mapping lists.

## Fixes
Fixes #14109

## How Has This Been Tested?
Checked on a physical device (Android 11)
![image](https://github.com/ankidroid/Anki-Android/assets/10436072/22bde735-a395-479e-88a8-a8bc6ce74296)
Before | After
--- | ---
![image](https://github.com/ankidroid/Anki-Android/assets/10436072/8efb7053-1250-4dc6-97eb-6a97b8ad6b0f)|![image](https://github.com/ankidroid/Anki-Android/assets/10436072/c3a84a4d-747a-487a-8af3-b702e57afc49)|



## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
