### PR TITLE
Use wake lock while migrating storage

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/utils/AndroidUtils.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/utils/AndroidUtils.kt
@@ -1,0 +1,44 @@
+/*
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.utils
+
+import android.os.PowerManager
+import androidx.core.content.ContextCompat
+import com.ichi2.anki.AnkiDroidApp
+
+/**
+ * Acquire a wake lock and release it after running [block].
+ *
+ * @param levelAndFlags Combination of wake lock level and flag values defining
+ *   the requested behavior of the WakeLock
+ * @param tag Your class name (or other tag) for debugging purposes
+ * @return The return value of `block`
+ *
+ * @see android.os.PowerManager.newWakeLock
+ */
+inline fun <T> withWakeLock(levelAndFlags: Int, tag: String, block: () -> T): T {
+    val context = AnkiDroidApp.instance
+    val wakeLock = ContextCompat
+        .getSystemService(context, PowerManager::class.java)!!
+        .newWakeLock(levelAndFlags, context.packageName + ":" + tag)
+
+    wakeLock.acquire()
+
+    return try {
+        block()
+    } finally {
+        wakeLock.release()
+    }
+}

--- a/AnkiDroid/src/main/java/com/ichi2/async/Connection.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/async/Connection.kt
@@ -586,7 +586,7 @@ class Connection : BaseAsyncTask<Connection.Payload, Any, Connection.Payload>() 
         val pm = context.getSystemService(Context.POWER_SERVICE) as PowerManager
         mWakeLock = pm.newWakeLock(
             PowerManager.PARTIAL_WAKE_LOCK,
-            AnkiDroidApp.appResources.getString(R.string.app_name) + ":Connection"
+            AnkiDroidApp.instance.packageName + ":Connection"
         )
     }
 }


### PR DESCRIPTION
### Purpose / Description
Prevent storage migration from pausing when screen is off/device is sleeping. Fixes #13728

### Approach
Use a wake lock unconditionally. **NOTE: I haven't added any warnings to the user as I couldn't come up with text I liked.**

### How Has This Been Tested?

Now the code runs on my device/emu and I see the wake lock in the wake lock log:

```
07-09 10:37:09.755 - 10183 - ACQ com.ichi2.anki.debug:MigrationService (partial,on-after-release)
07-09 10:37:10.776 - 10183 - REL com.ichi2.anki.debug:MigrationService
```

But I couldn't verify that it fixes the issue because I could reproduce the issue. Somehow no matter what I tried I couldn't get the device to stop copying files. Real device, emulator, force idle in adb. Verified that there were no other wake locks. ¯\\\_(ツ)_/¯

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
