### PR TITLE
fix: always sync media before a migration

### DIFF
--- a/AnkiDroid/src/main/res/values/02-strings.xml
+++ b/AnkiDroid/src/main/res/values/02-strings.xml
@@ -460,8 +460,6 @@
         and AnkiDroid was minimised when the sync completed"
         >Tap to start storage migration</string>
 
-    <string name="media_sync_required_title">Media Sync Required</string>
-    <string name="media_sync_unavailable_message">Media sync is disabled in the settings. Please sync and backup any media which hasn\'t been synced before continuing</string>
     <string name="remember_sync_metered_checkbox_msg">Don\'t ask again (this warning can be re-enabled from Sync Settings)</string>
 
 </resources>


### PR DESCRIPTION
## Purpose / Description
Previous UX flow was odd, with a dialog warning to sync media that offered a migrate option regardless of it instead of a syncing option

## Approach
Migrate the media regardless of the `Fetch media` preference value since we are already forcing the user to sync in order to keep their data safe, so it makes sense to sync all of it

## How Has This Been Tested?

Android 13: do a migration and see if media is synced with `Fetch media` set to `None`


## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
