### PR TITLE
fix: Simplify 'Dont ask again string' in metered connection dialog

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -1629,7 +1629,7 @@ open class DeckPicker :
                 message(R.string.metered_sync_warning)
                 positiveButton(R.string.dialog_continue) { doSync() }
                 negativeButton(R.string.dialog_cancel)
-                checkBoxPrompt(R.string.remember_sync_metered_checkbox_msg) { isCheckboxChecked ->
+                checkBoxPrompt(R.string.button_do_not_show_again) { isCheckboxChecked ->
                     preferences.edit {
                         putBoolean(
                             getString(R.string.metered_sync_key),

--- a/AnkiDroid/src/main/res/values/02-strings.xml
+++ b/AnkiDroid/src/main/res/values/02-strings.xml
@@ -462,6 +462,5 @@
 
     <string name="media_sync_required_title">Media Sync Required</string>
     <string name="media_sync_unavailable_message">Media sync is disabled in the settings. Please sync and backup any media which hasn\'t been synced before continuing</string>
-    <string name="remember_sync_metered_checkbox_msg">Don\'t ask again (this warning can be re-enabled from Sync Settings)</string>
 
 </resources>


### PR DESCRIPTION
## Purpose / Description
Simplify 'Dont ask again string' in metered connection dialog.

## Fixes
Fixes #14091 

## Approach
Resused string and removed unused string.

## How Has This Been Tested?

![anki](https://github.com/ankidroid/Anki-Android/assets/76740999/555629b6-c7ef-4269-8ff2-75f63d6e50a5)


## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
