### PR TITLE
Switch to use dokka for generating documentation in api module

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'maven-publish'
     id 'com.android.library'
     id 'kotlin-android'
+    id "org.jetbrains.dokka"
 }
 
 group = "com.ichi2.anki"
@@ -64,23 +65,13 @@ task androidSourcesJar(type: Jar) {
     from android.sourceSets.main.java.srcDirs
 }
 
-task androidJavadocs(type: Javadoc) {
-    source = android.sourceSets.main.java.srcDirs
-    classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
-    android.libraryVariants.all { variant ->
-        if (variant.name == 'release') {
-            owner.classpath += variant.javaCompileProvider.get().classpath
-        }
+task dokkaJavadocJar(type: Jar, dependsOn: dokkaJavadoc) {
+    from(dokkaJavadoc)
+    archiveClassifier.set("javadoc")
+    doLast {
+        println("API javadocs output directory: ${dokkaJavadoc.outputDirectory.get()}")
+        println("API javadocs jar output directory: ${destinationDirectory.get()}")
     }
-    exclude '**/R.html', '**/R.*.html', '**/index.html'
-    if (JavaVersion.current().isJava9Compatible()) {
-        options.addBooleanOption('html5', true)
-    }
-}
-
-task androidJavadocsJar(type: Jar, dependsOn: androidJavadocs) {
-    archiveClassifier.set('javadoc')
-    from androidJavadocs.destinationDir
 }
 
 publishing {
@@ -90,7 +81,7 @@ publishing {
 
             artifact("$buildDir/outputs/aar/${project.getName()}-release.aar")
             artifact androidSourcesJar
-            artifact androidJavadocsJar
+            artifact dokkaJavadocJar
 
             versionMapping {
                 usage('java-api') {

--- a/api/src/main/java/com/ichi2/anki/FlashCardsContract.kt
+++ b/api/src/main/java/com/ichi2/anki/FlashCardsContract.kt
@@ -13,7 +13,7 @@ import com.ichi2.anki.api.BuildConfig
  * The contract between AnkiDroid and applications. Contains definitions for the supported URIs and
  * columns.
  *
- * ######
+ *
  * ### Overview
  *
  *

--- a/build.gradle
+++ b/build.gradle
@@ -17,6 +17,7 @@ buildscript {
     ext.androidx_test_junit_version = '1.1.5'
     ext.robolectric_version = '4.10.3'
     ext.android_gradle_plugin = "8.0.2"
+    ext.dokka_version = "1.9.0" // not the same with kotlin version!
 
     configurations.all {
         resolutionStrategy.eachDependency { details ->
@@ -37,6 +38,7 @@ plugins {
     id 'org.jetbrains.kotlin.plugin.parcelize' version "$kotlin_version" apply false
     id 'org.jetbrains.kotlin.plugin.serialization' version "$kotlin_version" apply false
     id 'org.jlleitschuh.gradle.ktlint' version '11.5.1' apply false
+    id 'org.jetbrains.dokka' version "$dokka_version" apply false
 }
 
 Properties localProperties = new Properties()


### PR DESCRIPTION
## Purpose / Description

At the moment the `androidJavadocs` task in api module fails complaining about an invalid file `/FlashcardContract.kt`(and the others as well), probably because we switched to kotlin. In order to fix this I removed the previous gradle tasks that created the javadocs and switched to using kotlin's documentation engine [dokka](https://kotlinlang.org/docs/dokka-introduction.html).

Dokka can output in various formats including javadocs(in alpha state but I didn't see any issues) but also kotlin's own style of documentation. The added tasks are taken straight from the [documentation](https://kotlinlang.org/docs/dokka-gradle.html#build-javadoc-jar). 

If agreed I can also add the changes/switch to create documentation in kotlin's style(see for example the [documentation for coroutines](https://kotlinlang.org/api/kotlinx.coroutines/kotlinx-coroutines-core/kotlinx.coroutines/-coroutine-scope/)).

## How Has This Been Tested?

Ran the tasks and verified that the documentation is generated.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
