### PR TITLE
fix: remove camera permission

### DIFF
--- a/AnkiDroid/src/main/AndroidManifest.xml
+++ b/AnkiDroid/src/main/AndroidManifest.xml
@@ -37,7 +37,6 @@
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
     <uses-permission android:name="android.permission.WAKE_LOCK"/>
-    <uses-permission android:name="android.permission.CAMERA" />
     <uses-permission android:name="android.permission.GET_PACKAGE_SIZE" android:maxSdkVersion="25" />
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/activity/MultimediaEditFieldActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/activity/MultimediaEditFieldActivity.kt
@@ -37,7 +37,6 @@ import com.ichi2.anki.multimediacard.fields.*
 import com.ichi2.compat.CompatHelper.Companion.getSerializableCompat
 import com.ichi2.utils.KotlinCleanup
 import com.ichi2.utils.Permissions
-import com.ichi2.utils.Permissions.arePermissionsDefinedInAnkiDroidManifest
 import timber.log.Timber
 import java.io.File
 import java.text.DecimalFormat
@@ -105,19 +104,6 @@ class MultimediaEditFieldActivity : AnkiActivity(), OnRequestPermissionsResultCa
                 this,
                 arrayOf(Manifest.permission.RECORD_AUDIO),
                 REQUEST_AUDIO_PERMISSION
-            )
-            return true
-        }
-
-        // Request permission to use the camera if image field
-        if (field is ImageField && this.arePermissionsDefinedInAnkiDroidManifest(Manifest.permission.CAMERA) &&
-            !Permissions.canUseCamera(this)
-        ) {
-            Timber.d("Requesting Camera Permissions")
-            ActivityCompat.requestPermissions(
-                this,
-                arrayOf(Manifest.permission.CAMERA),
-                REQUEST_CAMERA_PERMISSION
             )
             return true
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicImageFieldController.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicImageFieldController.kt
@@ -19,7 +19,6 @@
  ****************************************************************************************/
 package com.ichi2.anki.multimediacard.fields
 
-import android.Manifest
 import android.annotation.SuppressLint
 import android.app.Activity
 import android.content.ClipData
@@ -64,7 +63,6 @@ import com.ichi2.compat.CompatHelper
 import com.ichi2.compat.CompatHelper.Companion.getParcelableCompat
 import com.ichi2.ui.FixedEditText
 import com.ichi2.utils.*
-import com.ichi2.utils.Permissions.arePermissionsDefinedInAnkiDroidManifest
 import timber.log.Timber
 import java.io.File
 import java.io.FileNotFoundException
@@ -186,7 +184,7 @@ class BasicImageFieldController : FieldControllerBase(), IFieldController {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
             layout.addView(btnDraw, ViewGroup.LayoutParams.MATCH_PARENT)
         }
-        if (context.arePermissionsDefinedInAnkiDroidManifest(Manifest.permission.CAMERA)) {
+        if (canUseCamera(context)) {
             layout.addView(btnCamera, ViewGroup.LayoutParams.MATCH_PARENT)
         }
         layout.addView(mCropButton, ViewGroup.LayoutParams.MATCH_PARENT)
@@ -222,12 +220,7 @@ class BasicImageFieldController : FieldControllerBase(), IFieldController {
 
     @SuppressLint("UnsupportedChromeOsCameraSystemFeature")
     private fun canUseCamera(context: Context): Boolean {
-        if (!Permissions.canUseCamera(context)) {
-            return false
-        }
-
         val pm = context.packageManager
-
         if (!pm.hasSystemFeature(PackageManager.FEATURE_CAMERA) && !pm.hasSystemFeature(PackageManager.FEATURE_CAMERA_FRONT)) {
             return false
         }

--- a/AnkiDroid/src/main/java/com/ichi2/utils/Permissions.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/Permissions.kt
@@ -31,10 +31,6 @@ import timber.log.Timber
 import java.lang.Exception
 
 object Permissions {
-    fun canUseCamera(context: Context): Boolean {
-        return hasPermission(context, Manifest.permission.CAMERA)
-    }
-
     fun canRecordAudio(context: Context): Boolean {
         return hasPermission(context, Manifest.permission.RECORD_AUDIO)
     }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/multimediacard/activity/MultimediaEditFieldActivityTestBase.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/multimediacard/activity/MultimediaEditFieldActivityTestBase.kt
@@ -33,12 +33,6 @@ import org.robolectric.Shadows
 import org.robolectric.android.controller.ActivityController
 
 abstract class MultimediaEditFieldActivityTestBase : RobolectricTest() {
-    protected fun grantCameraPermission() {
-        val application = ApplicationProvider.getApplicationContext<Application>()
-        val app = Shadows.shadowOf(application)
-        app.grantPermissions(Manifest.permission.CAMERA)
-    }
-
     protected fun grantRecordAudioPermission() {
         val application = ApplicationProvider.getApplicationContext<Application>()
         val app = Shadows.shadowOf(application)

--- a/AnkiDroid/src/test/java/com/ichi2/anki/multimediacard/fields/BasicImageFieldControllerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/multimediacard/fields/BasicImageFieldControllerTest.kt
@@ -46,7 +46,6 @@ open class BasicImageFieldControllerTest : MultimediaEditFieldActivityTestBase()
 
     @Test
     fun constructionWithDataSucceeds() {
-        grantCameraPermission()
         val controller = getControllerForField(imageFieldWithData(), emptyNote, 0)
         assertThat("construction of image field with data should succeed", controller, instanceOf(BasicImageFieldController::class.java))
     }
@@ -123,7 +122,6 @@ open class BasicImageFieldControllerTest : MultimediaEditFieldActivityTestBase()
     @get:CheckResult
     protected val validControllerNoImage: BasicImageFieldController
         get() {
-            grantCameraPermission()
             return getControllerForField(emptyImageField(), emptyNote, 0) as BasicImageFieldController
         }
 


### PR DESCRIPTION
if only the image taken by the camera app is necessary, there is no need for the permission

## Purpose / Description
thought about removing it after seeing the play console message about less than 1% of the similar apps having the permission

## Approach
simply remove the permission. The current code didn't need it

## How Has This Been Tested?

In a SDK 23 and a 33 emulators, in a Android 29 phone
1. Press the FAB >> Add
2. Tap the attachment clip icon > `Select image` > `Camera`
3. Take a picture
4. See if it is added to a card

## Learning 

https://stackoverflow.com/questions/32462725/capture-image-without-permission-with-android-6-0

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
