### PR TITLE
fix: Use <i> instead of <em>

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/noteeditor/Toolbar.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/noteeditor/Toolbar.kt
@@ -100,7 +100,7 @@ class Toolbar : FrameLayout {
             findViewById<View>(id).setOnClickListener { onFormat(TextWrapper(prefix, suffix)) }
 
         setupButtonWrappingText(R.id.note_editor_toolbar_button_bold, "<b>", "</b>")
-        setupButtonWrappingText(R.id.note_editor_toolbar_button_italic, "<em>", "</em>")
+        setupButtonWrappingText(R.id.note_editor_toolbar_button_italic, "<i>", "</i>")
         setupButtonWrappingText(R.id.note_editor_toolbar_button_underline, "<u>", "</u>")
         setupButtonWrappingText(R.id.note_editor_toolbar_button_insert_mathjax, "\\(", "\\)")
         setupButtonWrappingText(R.id.note_editor_toolbar_button_horizontal_rule, "<hr>", "")


### PR DESCRIPTION
## Purpose / Description
This was reported in https://github.com/ankidroid/Anki-Android/issues/14150. Here's a fix for it if it's determined that this is something that should be changed.

The purpose is to provide consistency across the Anki desktop and mobile versions. The desktop version uses `<i>` to make text italic, whereas AnkiDroid uses `<em>`.

## Fixes
Fixes #14150

## Approach
The note editor toolbar has a helper function that attaches an `onClickListener` to the toolbar buttons with the strings the text should be wrapped in. This just updates the prefix/suffix text from `<em>...</em>` to `<i>...</i>`.

## How Has This Been Tested?

I edited a note and confirmed that highlighted text was wrapped in `<i>...</i>`.
<img src=https://github.com/ankidroid/Anki-Android/assets/2564517/8a45ce53-04e9-41da-bda8-da00453e9439 width=300/>

## Learning (optional, can help others)
Searched for usages of `<em>` in the app :smile: 

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [x] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
  - There are some issues reported regarding the editable `TextView`s having an `android:contentDescription` attribute, but they're unrelated to my changes.