### PR TITLE
Fix crash in BasicImageFieldController due to uninitialized properties

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicImageFieldController.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicImageFieldController.kt
@@ -599,8 +599,8 @@ class BasicImageFieldController : FieldControllerBase(), IFieldController {
     // ensure the previous preview is not visible
     private fun hideImagePreview() {
         BitmapUtil.freeImageView(mImagePreview)
-        mCropButton.visibility = View.INVISIBLE
-        mImageFileSize.visibility = View.INVISIBLE
+        if (::mCropButton.isInitialized) mCropButton.visibility = View.INVISIBLE
+        if (::mImageFileSize.isInitialized) mImageFileSize.visibility = View.INVISIBLE
     }
 
     override fun onDestroy() {


### PR DESCRIPTION
## Purpose / Description
Small PR to fix a bug until that part of the code is refactored. See issue on acra: https://ankidroid.org/acra/app/1/bug/61331/report/745e50d4-67c2-45ac-87bf-48ba22a3ba53 :

```
java.lang.RuntimeException: Unable to destroy activity {com.ichi2.anki/com.ichi2.anki.multimediacard.activity.MultimediaEditFieldActivity}: kotlin.UninitializedPropertyAccessException: lateinit property mCropButton has not been initialized
	at android.app.ActivityThread.performDestroyActivity(ActivityThread.java:5427)
	at android.app.ActivityThread.handleDestroyActivity(ActivityThread.java:5460)
	at android.app.servertransaction.DestroyActivityItem.execute(DestroyActivityItem.java:47)
	at android.app.servertransaction.ActivityTransactionItem.execute(ActivityTransactionItem.java:45)
	at android.app.servertransaction.TransactionExecutor.executeLifecycleState(TransactionExecutor.java:176)
	at android.app.servertransaction.TransactionExecutor.execute(TransactionExecutor.java:97)
	at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2247)
	at android.os.Handler.dispatchMessage(Handler.java:106)
	at android.os.Looper.loopOnce(Looper.java:201)
	at android.os.Looper.loop(Looper.java:288)
	at android.app.ActivityThread.main(ActivityThread.java:7881)
	at java.lang.reflect.Method.invoke(Native Method)
	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:568)
	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1045)
Caused by: kotlin.UninitializedPropertyAccessException: lateinit property mCropButton has not been initialized
	at com.ichi2.anki.multimediacard.fields.BasicImageFieldController.hideImagePreview(SourceFile:23)
	at com.ichi2.anki.multimediacard.fields.BasicImageFieldController.onDestroy(Unknown Source:0)
	at com.ichi2.anki.multimediacard.activity.MultimediaEditFieldActivity.onDestroy(SourceFile:8)
	at android.app.Activity.performDestroy(Activity.java:8315)
	at android.app.Instrumentation.callActivityOnDestroy(Instrumentation.java:1364)
	at android.app.ActivityThread.performDestroyActivity(ActivityThread.java:5414)
	... 13 more
```

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
