### PR TITLE
fix: error at advanced settings

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/AdvancedSettingsFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/AdvancedSettingsFragment.kt
@@ -182,15 +182,17 @@ class AdvancedSettingsFragment : SettingsFragment() {
 
         // v3 scheduler
         v3schedPref.apply {
-            launchCatchingTask { withCol { isChecked = v3Enabled } }
+            launchCatchingTask {
+                withCol { isChecked = v3Enabled }
+                setOnPreferenceChangeListener { newValue: Any ->
+                    Timber.d("v3 scheduler set to $newValue")
+                    launchCatchingTask { withCol { v3Enabled = newValue as Boolean } }
+                }
+            }
             // if new backend was enabled on local.properties, remove the pref dependency
             if (!BuildConfig.LEGACY_SCHEMA) {
                 dependency = null
                 isEnabled = true
-            }
-            setOnPreferenceChangeListener { newValue: Any ->
-                Timber.d("v3 scheduler set to $newValue")
-                launchCatchingTask { withCol { v3Enabled = newValue as Boolean } }
             }
         }
     }


### PR DESCRIPTION
My guess is that the issue ocurred because the isChecked task were computed after or while the changeListener was set, so I'm setting the change listener only after the value is configured

## Purpose / Description
found another occurrence in ACRA

## Fixes
Fixes #13216 

## How Has This Been Tested?

I couldn't reproduce the issue, so I only opened the Advanced settings to see if I got an error message (emulator 33)

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
