### PR TITLE
Search text is in normal instead hint text

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -1801,11 +1801,6 @@ open class CardBrowser :
     private fun filterByTags(selectedTags: List<String>, option: Int) {
         // TODO: Duplication between here and CustomStudyDialog:onSelectedTags
         mSearchView!!.setQuery("", false)
-        val tags = selectedTags.toString()
-        mSearchView!!.queryHint = resources.getString(
-            R.string.CardEditorTags,
-            tags.substring(1, tags.length - 1)
-        )
 
         val sb = StringBuilder()
         sb.append(
@@ -1821,7 +1816,7 @@ open class CardBrowser :
             sb.append("($tagsConcat)") // Only if we added anything to the tag list
         }
         mSearchTerms = sb.toString()
-        searchCards()
+        searchWithFilterQuery(mSearchTerms)
     }
 
     /** Updates search terms to only show cards with selected flag.  */


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
Search text is in hint text instead of normal text while filtering by tags

## Fixes
Fixes #14175 

## Approach
use searchWithFilterQuery function in filterByTags function

## How Has This Been Tested?
Tested on Emulator ( Pixel 5 API 33 )

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
