### PR TITLE
Fix crash when exporting a deck with a name containing a path separator

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/export/ActivityExportingDelegate.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/export/ActivityExportingDelegate.kt
@@ -121,7 +121,8 @@ class ActivityExportingDelegate(private val activity: AnkiActivity, private val 
     }
 
     override fun exportDeckAsApkg(path: String?, did: DeckId, includeSched: Boolean, includeMedia: Boolean) {
-        val deckName = collectionSupplier.get().decks.name(did).run { replace("/", "_") }
+        // files can't have `/` in their names
+        val deckName = collectionSupplier.get().decks.name(did).replace("/", "_")
         val exportPath = getExportFileName(path, deckName, includeSched)
 
         if (BackendFactory.defaultLegacySchema) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/export/ActivityExportingDelegate.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/export/ActivityExportingDelegate.kt
@@ -121,7 +121,7 @@ class ActivityExportingDelegate(private val activity: AnkiActivity, private val 
     }
 
     override fun exportDeckAsApkg(path: String?, did: DeckId, includeSched: Boolean, includeMedia: Boolean) {
-        val deckName = collectionSupplier.get().decks.name(did)
+        val deckName = collectionSupplier.get().decks.name(did).run { replace("/", "_") }
         val exportPath = getExportFileName(path, deckName, includeSched)
 
         if (BackendFactory.defaultLegacySchema) {


### PR DESCRIPTION
## Purpose / Description

A fix for one of the issues on acra where the individual export of a deck(from the deck context menu) that has a name containing a unix path separator crashes(example deck name: `Deck1 2023/8/6`). The fix replaces the path separators with underscores.

Acra issue: https://ankidroid.org/acra/app/1/bug/63092/report/95b05d5d-1109-44f3-9eda-7ed3a6811ca4

## How Has This Been Tested?

Manually exported a deck with a path separator in its name.

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
