### PR TITLE
Fix importing a shared deck by providing a dedicated download path

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/IntentHandler.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/IntentHandler.kt
@@ -136,6 +136,22 @@ class IntentHandler : Activity() {
     private fun handleFileImport(intent: Intent, reloadIntent: Intent, action: String?) {
         Timber.i("Handling file import")
         val importResult = handleFileImport(this, intent)
+        // attempt to delete the downloaded deck if it is a shared deck download import
+        if (intent.hasExtra(SharedDecksDownloadFragment.EXTRA_IS_SHARED_DOWNLOAD)) {
+            try {
+                val sharedDeckUri = intent.data
+                if (sharedDeckUri != null) {
+                    // TODO move the file deletion on a background thread
+                    contentResolver.delete(intent.data!!, null, null)
+                    Timber.i("onCreate: downloaded shared deck deleted")
+                } else {
+                    Timber.i("onCreate: downloaded a shared deck but uri was null when trying to delete its file")
+                }
+            } catch (e: Exception) {
+                Timber.w(e, "onCreate: failed to delete downloaded shared deck")
+            }
+        }
+
         // Start DeckPicker if we correctly processed ACTION_VIEW
         if (importResult.isSuccess) {
             try {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/SharedDecksActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/SharedDecksActivity.kt
@@ -102,7 +102,7 @@ class SharedDecksActivity : AnkiActivity() {
             sharedDecksDownloadFragment.arguments = bundleOf(DOWNLOAD_FILE to DownloadFile(url, userAgent, contentDisposition, mimetype))
 
             supportFragmentManager.commit {
-                add(R.id.shared_decks_fragment_container, sharedDecksDownloadFragment, SHARED_DECKS_DOWNLOAD_FRAGMENT)
+                add(R.id.shared_decks_fragment_container, sharedDecksDownloadFragment, SHARED_DECKS_DOWNLOAD_FRAGMENT).addToBackStack(null)
             }
         }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/SharedDecksDownloadFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/SharedDecksDownloadFragment.kt
@@ -35,8 +35,8 @@ import androidx.core.content.FileProvider
 import androidx.fragment.app.Fragment
 import com.afollestad.materialdialogs.MaterialDialog
 import com.ichi2.anki.SharedDecksActivity.Companion.DOWNLOAD_FILE
+import com.ichi2.anki.snackbar.showSnackbar
 import com.ichi2.compat.CompatHelper.Companion.getSerializableCompat
-import com.ichi2.utils.FileUtil
 import com.ichi2.utils.ImportUtils
 import timber.log.Timber
 import java.io.File
@@ -84,6 +84,17 @@ class SharedDecksDownloadFragment : Fragment() {
 
         const val DOWNLOAD_STARTED_PROGRESS_PERCENTAGE = "0"
         const val DOWNLOAD_COMPLETED_PROGRESS_PERCENTAGE = "100"
+
+        const val EXTRA_IS_SHARED_DOWNLOAD = "extra_is_shared_download"
+
+        /**
+         * The folder on the app's external storage([Context.getExternalFilesDir]) where downloaded
+         * decks will be temporarily stored before importing.
+         *
+         * Note: when changing this constant make sure to also change the associated entry in filepaths.xml
+         * so our FileProvider can actually serve the file!
+         */
+        const val SHARED_DECKS_DOWNLOAD_FOLDER = "shared_decks"
     }
 
     override fun onCreateView(
@@ -135,6 +146,17 @@ class SharedDecksDownloadFragment : Fragment() {
      * the download progress checker.
      */
     private fun downloadFile(fileToBeDownloaded: DownloadFile) {
+        val externalFilesFolder = requireContext().getExternalFilesDir(null)
+        if (externalFilesFolder == null) {
+            showSnackbar(R.string.external_storage_unavailable)
+            parentFragmentManager.popBackStack()
+            return
+        }
+        // ensure the "shared_decks" folder exists
+        val decksDownloadFolder = File(externalFilesFolder, SHARED_DECKS_DOWNLOAD_FOLDER)
+        if (!decksDownloadFolder.exists()) {
+            decksDownloadFolder.mkdirs()
+        }
         // Register broadcast receiver for download completion.
         Timber.d("Registering broadcast receiver for download completion")
         activity?.registerReceiver(mOnComplete, IntentFilter(DownloadManager.ACTION_DOWNLOAD_COMPLETE))
@@ -169,7 +191,11 @@ class SharedDecksDownloadFragment : Fragment() {
         request.setTitle(currentFileName)
 
         request.setNotificationVisibility(DownloadManager.Request.VISIBILITY_VISIBLE_NOTIFY_COMPLETED)
-        request.setDestinationInExternalFilesDir(context, FileUtil.getDownloadDirectory(), currentFileName)
+        request.setDestinationInExternalFilesDir(
+            context,
+            null,
+            "$SHARED_DECKS_DOWNLOAD_FOLDER/$currentFileName"
+        )
 
         return request
     }
@@ -389,15 +415,17 @@ class SharedDecksDownloadFragment : Fragment() {
         fileIntent.action = Intent.ACTION_VIEW
 
         val fileUri = context?.let {
+            val sharedDecksPath = File(it.getExternalFilesDir(null), SHARED_DECKS_DOWNLOAD_FOLDER)
             FileProvider.getUriForFile(
                 it,
                 it.applicationContext?.packageName + ".apkgfileprovider",
-                File(it.getExternalFilesDir(FileUtil.getDownloadDirectory()), mFileName.toString())
+                File(sharedDecksPath, mFileName.toString())
             )
         }
         Timber.d("File URI -> $fileUri")
         fileIntent.setDataAndType(fileUri, mimeType)
         fileIntent.flags = Intent.FLAG_ACTIVITY_NEW_TASK
+        fileIntent.putExtra(EXTRA_IS_SHARED_DOWNLOAD, true)
         try {
             context?.startActivity(fileIntent)
         } catch (e: ActivityNotFoundException) {

--- a/AnkiDroid/src/main/res/layout/activity_shared_decks.xml
+++ b/AnkiDroid/src/main/res/layout/activity_shared_decks.xml
@@ -1,10 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.coordinatorlayout.widget.CoordinatorLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/root_layout"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     tools:context=".SharedDecksActivity">
+<androidx.constraintlayout.widget.ConstraintLayout
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
     
     <androidx.appcompat.widget.Toolbar
         android:id="@+id/webview_toolbar"
@@ -37,3 +42,4 @@
         app:layout_constraintBottom_toBottomOf="parent" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/AnkiDroid/src/main/res/values/02-strings.xml
+++ b/AnkiDroid/src/main/res/values/02-strings.xml
@@ -386,6 +386,7 @@
     <string name="deck_download_progress_message">You can use other apps while the download is running</string>
     <string name="check_network">Please check your network connection</string>
     <string name="search_using_deck_name">Search using deck name</string>
+    <string name="external_storage_unavailable">Download aborted, the external storage is not available</string>
     <string name="home">Home</string>
 
     <!-- Reviewer actions 

--- a/AnkiDroid/src/main/res/xml/filepaths.xml
+++ b/AnkiDroid/src/main/res/xml/filepaths.xml
@@ -3,5 +3,6 @@
     <external-cache-path path="export/" name="export-directory" />
     <cache-path path="/" name="cache-directory" />
     <external-path path="." name="photos" />
+    <external-files-path name="shared_decks" path="shared_decks" />
     <external-cache-path name="temp-photos" path="temp-photos" />
 </paths>


### PR DESCRIPTION
## Purpose / Description

Attempts to fix some reported issues related to FileNotFoundExceptions when importing shared decks(for example https://ankidroid.org/acra/app/1/bug/63087/report/cca29061-dec2-416f-bbf1-a0e5bb864aa2 ). See commit message for extra info.

See documentation for [FileProvider](https://developer.android.com/reference/androidx/core/content/FileProvider), especially the section **Specifying Available Files**. Notice the mappings between the paths in filepaths.xml and the specific system directories the documentation specifies.

## How Has This Been Tested?

Manually imported a shared deck, however I don't know how relevant is this as I wasn't able to replicate the crashes from acra.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
