### PR TITLE
Fix attribute not found in vector drawable of Reviewer menu item

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
@@ -798,7 +798,7 @@ open class Reviewer :
             }
             val whiteboardIcon = ContextCompat.getDrawable(this, R.drawable.ic_gesture_white)!!.mutate()
             val stylusIcon = ContextCompat.getDrawable(this, R.drawable.ic_gesture_stylus)!!.mutate()
-            val whiteboardColorPaletteIcon = VectorDrawableCompat.create(resources, R.drawable.ic_color_lens_white_24dp, null)!!.mutate()
+            val whiteboardColorPaletteIcon = VectorDrawableCompat.create(resources, R.drawable.ic_color_lens_white_24dp, this.theme)!!.mutate()
             if (mShowWhiteboard) {
                 whiteboardIcon.alpha = Themes.ALPHA_ICON_ENABLED_LIGHT
                 hideWhiteboardIcon.icon = whiteboardIcon


### PR DESCRIPTION
## Purpose / Description

One of the whiteboard menu item(that appears after the whiteboard is enabled by the user) used a theme attribute(`?attr/iconColor`) in its vector drawable(`ic_color_lens_white_24dp`). This vector drawable was inflated through `VectorDrawableCompat.create()` without passing a theme so the custom theme attribute couldn't be resolved. See stacktrace below:
```
java.lang.UnsupportedOperationException: Failed to resolve attribute at index 1: TypedValue{t=0x2/d=0x7f04026b a=-1}
   at androidx.core.content.res.TypedArrayUtils.getNamedColorStateList(TypedArrayUtils.java:172)
   at androidx.vectordrawable.graphics.drawable.VectorDrawableCompat.updateStateFromTypedArray(VectorDrawableCompat.java:765)
   at androidx.vectordrawable.graphics.drawable.VectorDrawableCompat.inflate(VectorDrawableCompat.java:719)
   at androidx.vectordrawable.graphics.drawable.VectorDrawableCompat.createFromXmlInner(VectorDrawableCompat.java:682)
   at androidx.vectordrawable.graphics.drawable.VectorDrawableCompat.create(VectorDrawableCompat.java:664)
   at com.ichi2.anki.Reviewer.onCreateOptionsMenu(Reviewer.kt:801)
   at android.app.Activity.onCreatePanelMenu(Activity.java:2846)
   at androidx.activity.ComponentActivity.onCreatePanelMenu(ComponentActivity.java:542)
   at androidx.appcompat.view.WindowCallbackWrapper.onCreatePanelMenu(WindowCallbackWrapper.java:95)
   at androidx.appcompat.app.AppCompatDelegateImpl$AppCompatWindowCallback.onCreatePanelMenu(AppCompatDelegateImpl.java:3444)
   at androidx.appcompat.app.ToolbarActionBar.populateOptionsMenu(ToolbarActionBar.java:458)
   at androidx.appcompat.app.ToolbarActionBar$1.run(ToolbarActionBar.java:58)
   at android.os.Handler.handleCallback(Handler.java:739)
   at android.os.Handler.dispatchMessage(Handler.java:95)
   at android.os.Looper.loop(Looper.java:148)
   at android.app.ActivityThread.main(ActivityThread.java:5417)
   at java.lang.reflect.Method.invoke(Native Method)
   at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:726)
   at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:616)
```

Note: I also looked through other usages of `VectorDrawableCompat.create` and all use a valid theme.

## Fixes
Fixes #14199 

## How Has This Been Tested?

Manually ran the reviewer and used the whiteboard.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
