### PR TITLE
Make the zero counts dimmer in black and dark themes

### DIFF
--- a/AnkiDroid/src/main/res/values/theme_black.xml
+++ b/AnkiDroid/src/main/res/values/theme_black.xml
@@ -45,7 +45,7 @@
         <item name="newCountColor">@color/material_blue_700</item>
         <item name="learnCountColor">@color/material_red_400</item>
         <item name="reviewCountColor">@color/material_green_400</item>
-        <item name="zeroCountColor">#808080</item>
+        <item name="zeroCountColor">#202020</item>
         <!-- Reviewer colors -->
         <item name="topBarColor">@color/theme_black_primary</item>
         <item name="maxTimerColor">@color/material_red_300</item>

--- a/AnkiDroid/src/main/res/values/theme_dark.xml
+++ b/AnkiDroid/src/main/res/values/theme_dark.xml
@@ -60,7 +60,7 @@
         <item name="newCountColor">@color/material_indigo_200</item>
         <item name="learnCountColor">@color/material_red_200</item>
         <item name="reviewCountColor">@color/material_green_200</item>
-        <item name="zeroCountColor">#808080</item>
+        <item name="zeroCountColor">#404040</item>
         <!-- Reviewer colors -->
         <item name="topBarColor">@color/theme_dark_primary_light</item>
         <item name="maxTimerColor">@color/material_red_300</item>


### PR DESCRIPTION


## Pull Request template

## Purpose / Description

The previous PR #12971 made the color of the zero counts in the main screen brighter, in order to make it more visible. However, as a result of this, the contrast between the light gray and the other count colors (blue, red, green) becomes a bit too minimal to differentiate easily at a glance.

This commit will re-adjust the color of the zero. It will make the color dimmer. The aim of the dimmed zero is to not call attention, so it doesn't so matter if it can't be easily seen.



## Fixes
Fixes #13889

## Approach

* Black theme: revert to the color used in 2.15.6
* Dark theme: adjust the color to be a bit lighter than the background, as in the black theme

## How Has This Been Tested?
Checked on a physical device (Android 11)
![Screenshot_2023-08-08-19-39-26-95_7b5228b5a93c00ecba98ecb0735c59e2](https://github.com/ankidroid/Anki-Android/assets/10436072/a6ef8e3b-5747-4cb9-871e-e7e1db03beb6)
![Screenshot_2023-08-08-19-38-52-81_7b5228b5a93c00ecba98ecb0735c59e2](https://github.com/ankidroid/Anki-Android/assets/10436072/c5da7860-0f36-4650-9fb1-b75b249cdff1)


## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
