### PR TITLE
chore: remove chess notation support

### DIFF
--- a/AnkiDroid/src/main/assets/card_template.html
+++ b/AnkiDroid/src/main/assets/card_template.html
@@ -4,7 +4,6 @@
         <title>AnkiDroid Flashcard</title>
         <meta charset="utf-8">
         <link rel="stylesheet" type="text/css" href="file:///android_asset/flashcard.css">
-        <link rel="stylesheet" type="text/css" href="file:///android_asset/chess.css">
         <link rel="stylesheet" type="text/css" href="file:///android_asset/mathjax/mathjax.css">
         <style>
         ::style::


### PR DESCRIPTION
## Purpose / Description
this completes 99799ca280837fa09e6c4895118d6f6d928186b4 by removing a reference to the deleted `chess.css`

Removed in: https://github.com/ankidroid/Anki-Android/commit/99799ca280837fa09e6c4895118d6f6d928186b4#diff-58bcd503b1404ef531943f5842219768f82d271f6ce8f0da93a7860e48aa9639

## Fixes
* Fixes #14092

## Approach
Removes a missed reference

## How Has This Been Tested?

Untested

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
