### PR TITLE
fix: double tap when answering a card using keyboard

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
@@ -659,11 +659,20 @@ abstract class AbstractFlashcardViewer :
     }
 
     override fun onKeyDown(keyCode: Int, event: KeyEvent): Boolean {
-        return if (processCardFunction { cardWebView: WebView? -> processHardwareButtonScroll(keyCode, cardWebView) }) {
-            true
-        } else {
-            super.onKeyDown(keyCode, event)
+        if (processCardFunction { cardWebView: WebView? -> processHardwareButtonScroll(keyCode, cardWebView) }) {
+            return true
         }
+
+        // Subclasses other than 'Reviewer' have not been setup with Gestures/KeyPresses
+        // so hardcode this functionality for now.
+        // This is in onKeyDown to match the gesture processor in the Reviewer
+        if (!displayAnswer && !answerFieldIsFocused()) {
+            if (keyCode == KeyEvent.KEYCODE_SPACE || keyCode == KeyEvent.KEYCODE_ENTER || keyCode == KeyEvent.KEYCODE_NUMPAD_ENTER) {
+                displayCardAnswer()
+                return true
+            }
+        }
+        return super.onKeyDown(keyCode, event)
     }
 
     public override val currentCardId: CardId? get() = currentCard?.id
@@ -698,19 +707,6 @@ abstract class AbstractFlashcardViewer :
             return true
         }
         return false
-    }
-
-    override fun onKeyUp(keyCode: Int, event: KeyEvent): Boolean {
-        if (answerFieldIsFocused()) {
-            return super.onKeyUp(keyCode, event)
-        }
-        if (!displayAnswer) {
-            if (keyCode == KeyEvent.KEYCODE_SPACE || keyCode == KeyEvent.KEYCODE_ENTER || keyCode == KeyEvent.KEYCODE_NUMPAD_ENTER) {
-                displayCardAnswer()
-                return true
-            }
-        }
-        return super.onKeyUp(keyCode, event)
     }
 
     protected open fun answerFieldIsFocused(): Boolean {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
@@ -1110,7 +1110,7 @@ abstract class AbstractFlashcardViewer :
     }
 
     /** If a card is displaying the question, flip it, otherwise answer it  */
-    private fun flipOrAnswerCard(cardOrdinal: Int) {
+    internal open fun flipOrAnswerCard(cardOrdinal: Int) {
         if (!displayAnswer) {
             displayCardAnswer()
             return

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NavigationDrawerActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NavigationDrawerActivity.kt
@@ -26,6 +26,7 @@ import android.view.MenuItem
 import android.view.View
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.annotation.LayoutRes
+import androidx.annotation.VisibleForTesting
 import androidx.appcompat.app.ActionBarDrawerToggle
 import androidx.appcompat.widget.Toolbar
 import androidx.coordinatorlayout.widget.CoordinatorLayout
@@ -369,7 +370,8 @@ abstract class NavigationDrawerActivity :
         mNavButtonGoesBack = false
     }
 
-    val isDrawerOpen: Boolean
+    @VisibleForTesting
+    open val isDrawerOpen: Boolean
         get() = mDrawerLayout.isDrawerOpen(GravityCompat.START)
 
     /**

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/PeripheralKeymap.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/PeripheralKeymap.kt
@@ -57,7 +57,7 @@ class PeripheralKeymap(reviewerUi: ReviewerUi, commandProcessor: ViewerCommand.C
         return if (!mHasSetup || event.repeatCount > 0) {
             false
         } else {
-            mKeyMap.onKeyUp(keyCode, event)
+            mKeyMap.onKeyDown(keyCode, event)
         }
     }
 
@@ -70,7 +70,7 @@ class PeripheralKeymap(reviewerUi: ReviewerUi, commandProcessor: ViewerCommand.C
         val mBindingMap = HashMap<MappableBinding, ViewerCommand>()
 
         @Suppress("UNUSED_PARAMETER")
-        fun onKeyUp(keyCode: Int, event: KeyEvent?): Boolean {
+        fun onKeyDown(keyCode: Int, event: KeyEvent?): Boolean {
             var ret = false
             val bindings = key(event!!)
             val side = fromAnswer(reviewerUI.isDisplayingAnswer)

--- a/AnkiDroid/src/test/java/com/ichi2/anki/ReviewerKeyboardInputTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/ReviewerKeyboardInputTest.kt
@@ -36,7 +36,6 @@ import com.ichi2.utils.Computation
 import kotlinx.coroutines.Job
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
-import org.junit.Ignore
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.ArgumentMatchers
@@ -213,7 +212,6 @@ class ReviewerKeyboardInputTest : RobolectricTest() {
     }
 
     @Test
-    @Ignore("Issue 14214")
     fun defaultKeyboardInputsFlipAndAnswersCard() {
         // Issue 14214
         val underTest = KeyboardInputTestReviewer.displayingQuestion()


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
When a user had a bluetooth/physical keyboard, and pressed 'space' when the card was in the 'answer' state AND gestures were enabled, a 'double tap' would occur:

* The gesture processor would process the command on `onKeyDown`
  * Answer the card   
* Code in `AbstractFlashvardViewer.onKeyUp` would execute 
  * Flip the card 

## Fixes
* Fixes #14214

## Approach
* Refactor for tests
* Move the code to handle for 'space' etc.. to `onKeyDown`
  * If the command processor is used, `super.onKeyDown` isn't called.

## How Has This Been Tested?
* Unit Tested
* Tested on my S21 (Android 13)

## Learning
* Getting back into AnkiDroid, things feel really sluggish from an DevEx/Android Studio perspective, I'll see what we can do going forwards

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
