### PR TITLE
fix: unexpected reviewer highlights with keyboard

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
@@ -536,6 +536,11 @@ abstract class AbstractFlashcardViewer :
         restorePreferences()
         mTagsDialogFactory = TagsDialogFactory(this).attachToActivity<TagsDialogFactory>(this)
         super.onCreate(savedInstanceState)
+
+        // Issue 14142: The reviewer had a focus highlight after answering using a keyboard.
+        // This theme removes the highlight, but there is likely a better way.
+        this.setTheme(R.style.ThemeOverlay_DisableKeyboardHighlight)
+
         setContentView(getContentViewAttr(fullscreenMode))
 
         // Make ACTION_PROCESS_TEXT for in-app searching possible on > Android 4.0

--- a/AnkiDroid/src/main/res/values/disable-fullscreen-keyboard-highlight.xml
+++ b/AnkiDroid/src/main/res/values/disable-fullscreen-keyboard-highlight.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~  Copyright (c) 2023 David Allison <davidallisongithub@gmail.com>
+  ~
+  ~  This program is free software; you can redistribute it and/or modify it under
+  ~  the terms of the GNU General Public License as published by the Free Software
+  ~  Foundation; either version 3 of the License, or (at your option) any later
+  ~  version.
+  ~
+  ~  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+  ~  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+  ~  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+  ~
+  ~  You should have received a copy of the GNU General Public License along with
+  ~  this program.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+
+<resources>
+    <style name="ThemeOverlay.DisableKeyboardHighlight" parent="">
+        <item name="android:colorControlHighlight">@color/transparent</item>
+    </style>
+</resources>


### PR DESCRIPTION


## Pull Request template

## Purpose / Description
The Reviewer window was fully highlighted if using the keyboard to answer a card using 'space'

## Fixes
* Fixes #14142

## Approach
We use `android:colorControlHighlight` to remove this


## How Has This Been Tested?
Briefly tested on my S21 and I saw no UI regressions (Standard reviewer configuration)
⚠️ This is high risk for UI regressions

Also tested in dark mode

## Learning (optional, can help others)
Learning for others: themes are additive

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
