### PR TITLE
fix: use supported JDK with "Update Gradle Wrapper"

### DIFF
--- a/.github/workflows/update-gradle-wrapper.yml
+++ b/.github/workflows/update-gradle-wrapper.yml
@@ -1,6 +1,7 @@
 name: Update Gradle Wrapper
 
 on:
+  workflow_dispatch:
   schedule:
     - cron: "0 0 * * *"
 

--- a/.github/workflows/update-gradle-wrapper.yml
+++ b/.github/workflows/update-gradle-wrapper.yml
@@ -11,6 +11,12 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - name: Configure JDK
+        uses: actions/setup-java@v3
+        with:
+          distribution: "temurin"
+          java-version: "17" # newer libraries require 17 now, force it everywhere
+
       - name: Update Gradle Wrapper
         uses: gradle-update/update-gradle-wrapper-action@v1
         with:


### PR DESCRIPTION
## Pull Request template

## Purpose / Description

Run fails with

```
  ERROR: AnkiDroid builds with JVM version 17 or 18.
    Incompatible major version detected: '11'
```

## Fixes
* Fixes #14232

## Approach
* update the CI script
* Realise I can't run the script, so update the script again

## How Has This Been Tested?
* ⚠️ I tried to test, but couldn't reproduce our failure due to my repo setup. ⚠️ Untested ⚠️
  * https://github.com/david-allison/Anki-Android/actions/workflows/update-gradle-wrapper.yml

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
