### PR TITLE
fix: 'Sync required' indicator doesn't go away

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/ui/BadgeDrawableBuilder.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/ui/BadgeDrawableBuilder.kt
@@ -70,7 +70,7 @@ class BadgeDrawableBuilder(private val context: Context) {
             }
             val icon = menuItem.icon
             if (icon is BadgeDrawable) {
-                menuItem.icon = icon.current
+                menuItem.icon = icon.drawable
                 Timber.d("Badge removed")
             }
         }


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
After a sync on the legacy schema, the badge did not go away

## Fixes
Fixes #14225

## Approach
* Added logs and the call was made correctly
* Added `removeBadge` after the calls to add a badge, and the badge still appeared
* Fixed
* Tested

## How Has This Been Tested?
* API 24 emulator
* S21 (Android 13)

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
