### PR TITLE
Enable third-party cookies in the webview

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
@@ -1106,6 +1106,9 @@ abstract class AbstractFlashcardViewer :
         // enable dom storage so that sessionStorage & localStorage can be used in webview
         webView.settings.domStorageEnabled = true
 
+        // enable third party cookies so that cookies can be used in webview
+        CookieManager.getInstance().setAcceptThirdPartyCookies(webView, true)
+
         return webView
     }
 


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
The desktop version of Anki allows third-party cookies by default. However, this is not the case for Ankidroid.

This PR enables third-party cookies in the webview

This will allow you to login from within an iframe. If the website allows cross-site cookies.

## Fixes
None.

## Approach
https://developer.android.com/reference/android/webkit/CookieManager#setAcceptThirdPartyCookies(android.webkit.WebView,%20boolean)

## How Has This Been Tested?
Device: Emulator(Pixel_3A_API_33)

Login test(cross-site): Python flask(https://github.com/app-generator/sample-flask-auth-session) + nginx(https connection)

modified `config.py`
```python
    # Allow cross-site cookie
    SESSION_COOKIE_SAMESITE = 'None'
    SESSION_COOKIE_SECURE = True
```

## Learning (optional, can help others)
![image](https://github.com/ankidroid/Anki-Android/assets/7389524/fa7ce3a7-2681-4970-8d19-2e6a3654f7f8)

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
