### PR TITLE
feature : minimal screen touch time to reveal answer

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/analytics/UsageAnalytics.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/analytics/UsageAnalytics.kt
@@ -534,6 +534,7 @@ object UsageAnalytics {
         "answerButtonSize",
         "showLargeAnswerButtons",
         "relativeCardBrowserFontSize",
+        "showCardAnswerButtonTime",
         // Advanced
         "deckPath", // AnkiDroid directory
         "backupMax", // Max number of backups

--- a/AnkiDroid/src/main/res/values/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values/10-preferences.xml
@@ -144,6 +144,8 @@
     <string name="pref_backup_max" maxLength="41">Max number of backups</string>
     <string name="pref_double_tap_time_interval" maxLength="41">Double tap time interval (milliseconds)</string>
     <string name="pref_double_tap_time_interval_summary">A second tap of the answer buttons will be ignored if this time has not elapsed. This prevents accidental double taps</string>
+    <string name="pref_show_answer_long_press" maxLength="41">Show answer long-press time (ms)</string>
+    <string name="pref_show_answer_long_press_summary">Minimum long-press time before the show answer button will register a touch. May reduce the chance of accidental extra button presses. Default is 0ms</string>
     <string name="show_estimates" maxLength="41">Show button time</string>
     <string name="show_estimates_summ">Show next review time on answer buttons</string>
     <string name="show_large_answer_buttons" maxLength="41">Show large answer buttons</string>

--- a/AnkiDroid/src/main/res/values/preferences.xml
+++ b/AnkiDroid/src/main/res/values/preferences.xml
@@ -119,6 +119,7 @@
     <string name="image_zoom_preference">imageZoom</string>
     <string name="answer_button_size_preference">answerButtonSize</string>
     <string name="show_large_answer_buttons_preference">showLargeAnswerButtons</string>
+    <string name="pref_card_minimal_click_time">showCardAnswerButtonTime</string>
     <!-- Custom sync server -->
     <string name="pref_custom_sync_server_screen_key">customSyncServerScreen</string>
     <string name="custom_sync_server_collection_url_key">syncBaseUrl</string>

--- a/AnkiDroid/src/main/res/xml/preferences_accessibility.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_accessibility.xml
@@ -55,4 +55,11 @@
         android:valueTo="200"
         android:stepSize="10"
         app:displayFormat="@string/pref_summary_percentage"/>
+    <com.ichi2.preferences.NumberRangePreferenceCompat
+        android:defaultValue="0"
+        android:key="@string/pref_card_minimal_click_time"
+        android:summary="@string/pref_show_answer_long_press_summary"
+        android:title="@string/pref_show_answer_long_press"
+        app:min="0"
+        android:max="2000" />
 </PreferenceScreen>


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
The user can define the minimum touch time for the show answer button as to avoid accidental touches and revealing the answer, this would allow the button to be clickable only after the certain time
min time : 0
max time : 2 s


## Fixes
Fixes #14229 

## How Has This Been Tested?
Tested on google emualtor 
![Screenshot_119](https://github.com/ankidroid/Anki-Android/assets/48384865/25b4efe3-5ab8-455d-b2ce-f30c6f6efa45)
![Screenshot_118](https://github.com/ankidroid/Anki-Android/assets/48384865/8e3c6c03-a5a1-48d6-a580-90d9ee650d3a)

https://github.com/ankidroid/Anki-Android/assets/48384865/fa7e1eae-2769-49b5-bde9-5779040f3c24


## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
