### PR TITLE
fix: resolution of 'add_shortcut' launcher icon

### DIFF
--- a/AnkiDroid/src/main/res/drawable/add_shortcut.xml
+++ b/AnkiDroid/src/main/res/drawable/add_shortcut.xml
@@ -14,13 +14,12 @@
   ~ limitations under the License.
  -->
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="24dp"
-    android:height="24dp"
-    android:viewportWidth="960"
-    android:viewportHeight="960"
+    android:width="96dp"
+    android:height="96dp"
+    android:viewportHeight="24"
+    android:viewportWidth="24"
     android:tint="@android:color/holo_blue_dark">
     <path
         android:fillColor="#FFFFFF"
-        android:pathData="M445.93,764.07L445.93,514.07L195.93,514.07L195.93,445.93L445.93,445.93L445.93,195.93L514.07,195.93L514.07,445.93L764.07,445.93L764.07,514.07L514.07,514.07L514.07,764.07L445.93,764.07Z"/>
+        android:pathData="M19,13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z" />
 </vector>
-


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
* Icon was added in (#14136)

When creating a shortcut in the launcher, the icon resolution was low

## Fixes
* Fixes #14246

## Approach
* New => Vector Asset
  * Replace the existing drawable
* Fixed the tints + property ordering to match the existing
* This didn't work, upped size to 96x96dp
* Worked

## How Has This Been Tested?
S21 using OneUI

Before
<img src="https://github.com/ankidroid/Anki-Android/assets/62114487/30f60df8-5c6b-4fb1-8359-b5832fd95409"  height="300">

After
<img src="https://github.com/ankidroid/Anki-Android/assets/62114487/a71a8ee4-3cfc-4d73-821c-05e8952ef451"  height="300">



## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
