### PR TITLE
build: update `targetSdkVersion` to 32

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -69,8 +69,11 @@ android {
         versionCode=21603300
         versionName="2.16.3"
         minSdkVersion 21
-        //noinspection OldTargetApi - also performed in api/build.fradle
-        targetSdkVersion 31 // change .tests_emulator.yml
+        // change api/build.gradle
+        // change robolectricDownloader.gradle
+        // After #13695: change .tests_emulator.yml
+        // noinspection OldTargetApi
+        targetSdkVersion 32
         testApplicationId "com.ichi2.anki.tests"
         vectorDrawables.useSupportLibrary = true
         testInstrumentationRunner 'com.ichi2.testutils.NewCollectionPathTestRunner'

--- a/AnkiDroid/robolectricDownloader.gradle
+++ b/AnkiDroid/robolectricDownloader.gradle
@@ -24,8 +24,8 @@ def robolectricAndroidSdkVersions = [
 //        [androidVersion: "9", frameworkSdkBuildVersion: "4913185-2"],
         [androidVersion: "10", frameworkSdkBuildVersion:  "5803371"],
 //        [androidVersion: "11", frameworkSdkBuildVersion:  "6757853"],
-        [androidVersion: "12", frameworkSdkBuildVersion:  "7732740"],
-//        [androidVersion: "12.1", frameworkSdkBuildVersion:  "8229987"],
+//        [androidVersion: "12", frameworkSdkBuildVersion:  "7732740"],
+        [androidVersion: "12.1", frameworkSdkBuildVersion:  "8229987"],
 //        [androidVersion: "13", frameworkSdkBuildVersion:  "9030017"],
 ]
 

--- a/api/build.gradle
+++ b/api/build.gradle
@@ -23,7 +23,7 @@ android {
     defaultConfig {
         minSdkVersion 16
         //noinspection OldTargetApi
-        targetSdkVersion 31
+        targetSdkVersion 32
         buildConfigField "String", "READ_WRITE_PERMISSION", '"com.ichi2.anki.permission.READ_WRITE_DATABASE"'
         buildConfigField "String", "AUTHORITY", '"com.ichi2.anki.flashcards"'
     }


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
Android 12L (API level 32) is a minor release that makes Android 12 even better on large screens.

There are no breaking changes. Since we have removed support for TVs, this is primarily relevant for foldable phones and Chromebooks

Changes: https://developer.android.com/about/versions/12/12L/summary


## Fixes
* Partially: #14129

## Approach
update `targetSdkVersion` to 32

## How Has This Been Tested?
* Unit Tests

Since Google has imposed a hard deadline in a couple of weeks, only tested on:
* Large Desktop API 32

![Screenshot 2023-08-18 at 20 07 33](https://github.com/ankidroid/Anki-Android/assets/62114487/620ba88a-0f20-4a2a-ac33-19ae2e518524)

 
## Learning (optional, can help others)
Never used a Desktop Emulator before. Easy process

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
