### PR TITLE
build: bump to API33

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -73,7 +73,7 @@ android {
         // change robolectricDownloader.gradle
         // After #13695: change .tests_emulator.yml
         // noinspection OldTargetApi
-        targetSdkVersion 32
+        targetSdkVersion 33
         testApplicationId "com.ichi2.anki.tests"
         vectorDrawables.useSupportLibrary = true
         testInstrumentationRunner 'com.ichi2.testutils.NewCollectionPathTestRunner'

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -254,7 +254,7 @@ open class DeckPicker :
     // used for check media
     private val checkMediaStoragePermissionCheck = PermissionManager.register(
         this,
-        arrayOf(Manifest.permission.READ_EXTERNAL_STORAGE, Manifest.permission.WRITE_EXTERNAL_STORAGE),
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) arrayOf(Manifest.permission.READ_EXTERNAL_STORAGE, Manifest.permission.WRITE_EXTERNAL_STORAGE) else emptyArray(),
         useCallbackIfActivityRecreated = true,
         callback = callbackHandlingStoragePermissionsCheckForCheckMedia(WeakReference(this))
     )

--- a/AnkiDroid/src/test/resources/robolectric.properties
+++ b/AnkiDroid/src/test/resources/robolectric.properties
@@ -1,0 +1,4 @@
+# Android 13 triggers robolectric issue: https://github.com/robolectric/robolectric/issues/8215
+# Temporarily lock to sdk32 until that issue is resolved, then remove this file so
+# that robolectric once again uses targetSdkVersion from AnkiDroid/build.gradle (33 currently)
+sdk=32


### PR DESCRIPTION
## Pull Request template

## Purpose / Description

Use API33 as our target, to comply with Play Store guidelines

## Fixes
* Fixes #14129 
* Fixes #14120

## Approach
- bumps the targetSdkVersion
- temporarily clamps robolectric to API32 until they fix an upstream issue (as noted in separate commit)

## How Has This Been Tested?

I tested these things, as indicated in related issue:

- system follows theme with light and dark in system, and app-specific them in AnkiDroid prefs with light and dark both checked
  - changelog loading (followed theme)
  - Anki manual, Github FAQ (followed theme)
  - AnkiDroid manual (did not follow theme, because there is no theming on AnkiDroid.org - this is actually correct app behavior...)
- acquisition of audio, image, video without specifying new API33 granular permissions, both when directly creating them during card creation and when using the picker to choose existing ones

Everything worked for me

## Learning (optional, can help others)

Sometimes it is easy !?! 


## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
