### PR TITLE
fix: requesting no permissions succeeds 

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/permissions/PermissionManager.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/permissions/PermissionManager.kt
@@ -64,7 +64,7 @@ class PermissionManager private constructor(
                     return@registerForActivityResult
                 }
             }
-            callback.invoke(results)
+            callback.invoke(PermissionsRequestRawResults(results, requestedPermissions = true))
         }
     private val activityRef = WeakReference(activity)
 
@@ -116,7 +116,7 @@ class PermissionManager private constructor(
         if (permissions.requiresPermissionDialog) {
             this.launchPermissionDialog()
         } else {
-            callback.invoke(permissions.toPermissionsRequestRawResult()!!)
+            callback.invoke(permissions.toPermissionsRequestRawResult(requestedPermissions = permissions.permissions.any())!!)
         }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/permissions/PermissionsCheckResult.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/permissions/PermissionsCheckResult.kt
@@ -24,12 +24,13 @@ open class PermissionsCheckResult(val permissions: Map<String, Boolean>) {
     val requiresPermissionDialog: Boolean = permissions.any { !it.value }
 
     /**
+     * @param requestedPermissions Whether any permissions were requested
      * @return A [PermissionsRequestRawResults], or `null` if a permissions dialog is required.
      */
-    fun toPermissionsRequestRawResult(): PermissionsRequestRawResults? {
+    fun toPermissionsRequestRawResult(requestedPermissions: Boolean): PermissionsRequestRawResults? {
         if (requiresPermissionDialog) {
             return null
         }
-        return permissions
+        return PermissionsRequestRawResults(permissions, requestedPermissions)
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/permissions/PermissionsCheckResult.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/permissions/PermissionsCheckResult.kt
@@ -21,7 +21,6 @@ package com.ichi2.anki.permissions
  * @param permissions A map, containing an entry for each required permission, associating to it whether it's already granted
  */
 open class PermissionsCheckResult(val permissions: Map<String, Boolean>) {
-    val allGranted = permissions.all { it.value }
     val requiresPermissionDialog: Boolean = permissions.any { !it.value }
 
     /**

--- a/AnkiDroid/src/main/java/com/ichi2/anki/permissions/PermissionsRequestResults.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/permissions/PermissionsRequestResults.kt
@@ -27,17 +27,17 @@ import com.ichi2.anki.permissions.PermissionsRequestResults.PermissionRequestRes
  * Data to build a [PermissionsRequestResults], when there is no [Activity] to create it
  * Maps from a permission to whether it was granted
  */
-typealias PermissionsRequestRawResults = Map<String, Boolean>
+data class PermissionsRequestRawResults(val permissions: Map<String, Boolean>, val requestedPermissions: Boolean)
 
 /**
  * The result of requesting permissions
  * After we perform a request, starting at API M, we can know if a permission is temporarily or permanently denied.
  */
-class PermissionsRequestResults(permissions: Map<String, PermissionRequestResult>) {
+class PermissionsRequestResults(permissions: Map<String, PermissionRequestResult>, requestedPermissions: Boolean) {
     // If the permissions request interaction with the user is interrupted.
     // then we get an empty results array
     // https://developer.android.com/reference/androidx/core/app/ActivityCompat.OnRequestPermissionsResultCallback
-    val cancelled = !permissions.any()
+    val cancelled = requestedPermissions && !permissions.any()
 
     val allGranted = !cancelled && permissions.all { it.value == GRANTED }
 
@@ -51,8 +51,8 @@ class PermissionsRequestResults(permissions: Map<String, PermissionRequestResult
 
     companion object {
         fun from(activity: Activity, rawResults: PermissionsRequestRawResults): PermissionsRequestResults {
-            val permissions = rawResults.mapValues { toPermissionRequestResult(activity, it.key, it.value) }
-            return PermissionsRequestResults(permissions)
+            val permissions = rawResults.permissions.mapValues { toPermissionRequestResult(activity, it.key, it.value) }
+            return PermissionsRequestResults(permissions, rawResults.requestedPermissions)
         }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/permissions/PermissionsRequestResults.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/permissions/PermissionsRequestResults.kt
@@ -50,13 +50,6 @@ class PermissionsRequestResults(permissions: Map<String, PermissionRequestResult
     val hasTemporarilyDeniedPermissions = permissions.any { it.value == TEMPORARILY_DENIED }
 
     companion object {
-        fun allGranted(checkResult: PermissionsCheckResult): PermissionsRequestResults {
-            if (!checkResult.allGranted) {
-                throw IllegalStateException("allGranted called when permissions were not all granted")
-            }
-            return PermissionsRequestResults(checkResult.permissions.mapValues { GRANTED })
-        }
-
         fun from(activity: Activity, rawResults: PermissionsRequestRawResults): PermissionsRequestResults {
             val permissions = rawResults.mapValues { toPermissionRequestResult(activity, it.key, it.value) }
             return PermissionsRequestResults(permissions)


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
While testing #14259, it wasn't feasible to test by passing an empty collection of permissions to PermissionManager.

I did this change to allow testing, the test worked, and we'll want this in so we can unblock #14259

This is a quick fix, as the code will go away very soon in Brayan's permission dialog change.

## Approach
* Remove dead code so I don't need to refactor it
* Add a differentiating flag

## How Has This Been Tested?
S21, Android 13 on top of my patch for #14259

## Learning (optional, can help others)
Closing the permission dialog also returns an empty set of results

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
