### PR TITLE
Use FragmentLifecycleCallbacks to log fragments lifecycles

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.kt
@@ -28,9 +28,13 @@ import android.os.Bundle
 import android.os.Environment
 import android.system.Os
 import android.util.Log
+import android.view.View
 import android.webkit.CookieManager
 import androidx.annotation.VisibleForTesting
 import androidx.core.content.edit
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.FragmentActivity
+import androidx.fragment.app.FragmentManager
 import androidx.lifecycle.MutableLiveData
 import com.ichi2.anki.CrashReportService.sendExceptionReport
 import com.ichi2.anki.UIUtils.showThemedToast
@@ -188,6 +192,12 @@ open class AnkiDroidApp : Application() {
         registerActivityLifecycleCallbacks(object : ActivityLifecycleCallbacks {
             override fun onActivityCreated(activity: Activity, savedInstanceState: Bundle?) {
                 Timber.i("${activity::class.simpleName}::onCreate")
+                (activity as? FragmentActivity)
+                    ?.supportFragmentManager
+                    ?.registerFragmentLifecycleCallbacks(
+                        FragmentLifecycleLogger(activity),
+                        true
+                    )
             }
 
             override fun onActivityStarted(activity: Activity) {
@@ -420,6 +430,71 @@ open class AnkiDroidApp : Application() {
                 return
             }
             super.log(priority, tag, message, t)
+        }
+    }
+
+    private class FragmentLifecycleLogger(
+        private val activity: Activity
+    ) : FragmentManager.FragmentLifecycleCallbacks() {
+        override fun onFragmentAttached(
+            fm: FragmentManager,
+            f: Fragment,
+            context: Context
+        ) {
+            Timber.i("${activity::class.simpleName}::${f::class.simpleName}::onAttach")
+        }
+
+        override fun onFragmentCreated(
+            fm: FragmentManager,
+            f: Fragment,
+            savedInstanceState: Bundle?
+        ) {
+            Timber.i("${activity::class.simpleName}::${f::class.simpleName}::onCreate")
+        }
+
+        override fun onFragmentViewCreated(
+            fm: FragmentManager,
+            f: Fragment,
+            v: View,
+            savedInstanceState: Bundle?
+        ) {
+            Timber.i("${activity::class.simpleName}::${f::class.simpleName}::onViewCreated")
+        }
+
+        override fun onFragmentStarted(fm: FragmentManager, f: Fragment) {
+            Timber.i("${activity::class.simpleName}::${f::class.simpleName}::onStart")
+        }
+
+        override fun onFragmentResumed(fm: FragmentManager, f: Fragment) {
+            Timber.i("${activity::class.simpleName}::${f::class.simpleName}::onResume")
+        }
+
+        override fun onFragmentPaused(fm: FragmentManager, f: Fragment) {
+            Timber.i("${activity::class.simpleName}::${f::class.simpleName}::onPause")
+        }
+
+        override fun onFragmentStopped(fm: FragmentManager, f: Fragment) {
+            Timber.i("${activity::class.simpleName}::${f::class.simpleName}::onStop")
+        }
+
+        override fun onFragmentSaveInstanceState(
+            fm: FragmentManager,
+            f: Fragment,
+            outState: Bundle
+        ) {
+            Timber.i("${activity::class.simpleName}::${f::class.simpleName}::onSaveInstanceState")
+        }
+
+        override fun onFragmentViewDestroyed(fm: FragmentManager, f: Fragment) {
+            Timber.i("${activity::class.simpleName}::${f::class.simpleName}::onViewDestroyed")
+        }
+
+        override fun onFragmentDestroyed(fm: FragmentManager, f: Fragment) {
+            Timber.i("${activity::class.simpleName}::${f::class.simpleName}::onDestroy")
+        }
+
+        override fun onFragmentDetached(fm: FragmentManager, f: Fragment) {
+            Timber.i("${activity::class.simpleName}::${f::class.simpleName}::onDetach")
         }
     }
 }


### PR DESCRIPTION
## Purpose / Description

While looking at fixing the bugs related to importing decks I noticed that it could be helpful to see lifecycle information for fragments like we implemented for the activities we use. This can be done through [FragmentLifecycleCallbacks](https://developer.android.com/reference/androidx/fragment/app/FragmentManager.FragmentLifecycleCallbacks).
The format I used is: _"activity_name"::"fragment_name"::"lifeycle_method_name"_ in order to group the fragments under an activity name.

Open for changes on what lifecycle methods to log and the actual logcat text to use.

## How Has This Been Tested?

Checked logcat for fragment lifecycle related events.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
