### PR TITLE
fix: restore scroll position after editing card 

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -190,6 +190,7 @@ open class CardBrowser :
         if (data != null &&
             (data.getBooleanExtra("reloadRequired", false) || data.getBooleanExtra("noteChanged", false))
         ) {
+            Timber.d("Reloading Card Browser due to activity result")
             // if reloadRequired or noteChanged flag was sent from note editor then reload card list
             searchCards()
             mShouldRestoreScroll = true
@@ -1676,7 +1677,9 @@ open class CardBrowser :
         val query = searchText!!
         val order = if (mOrder == CARD_ORDER_NONE) NoOrdering() else UseCollectionOrdering()
         launchCatchingTask {
+            Timber.d("performing search")
             val cards = withProgress { searchForCards(query, order, inCardsMode) }
+            Timber.d("Search returned %d cards", cards.size)
             // Render the first few items
             for (i in 0 until Math.min(numCardsToRender(), cards.size)) {
                 cards[i].load(false, mColumn1Index, mColumn2Index)
@@ -1710,6 +1713,7 @@ open class CardBrowser :
             mShouldRestoreScroll = false
             val newPosition = newPositionOfSelectedCard
             if (newPosition != CARD_NOT_AVAILABLE) {
+                Timber.d("Restoring scroll position after search")
                 autoScrollTo(newPosition)
             }
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -90,11 +90,11 @@ import net.ankiweb.rsdroid.BackendFactory
 import net.ankiweb.rsdroid.RustCleanup
 import org.json.JSONObject
 import timber.log.Timber
-import java.lang.Exception
 import java.lang.IllegalStateException
 import java.lang.StringBuilder
 import java.util.*
 import java.util.function.Consumer
+import kotlin.Exception
 import kotlin.collections.ArrayList
 import kotlin.math.abs
 import kotlin.math.ceil
@@ -192,8 +192,8 @@ open class CardBrowser :
         ) {
             Timber.d("Reloading Card Browser due to activity result")
             // if reloadRequired or noteChanged flag was sent from note editor then reload card list
-            searchCards()
             mShouldRestoreScroll = true
+            searchCards()
             // in use by reviewer?
             if (reviewerCardId == mCurrentCardId) {
                 mReloadRequired = true
@@ -1694,6 +1694,7 @@ open class CardBrowser :
         updateList()
         /*check whether mSearchView is initialized as it is lateinit property.*/
         if (mSearchView == null || mSearchView!!.isIconified) {
+            restoreScrollPositionIfRequested()
             return
         }
         if (hasSelectedAllDecks()) {
@@ -1709,15 +1710,25 @@ open class CardBrowser :
                 setAction(R.string.card_browser_search_all_decks) { searchAllDecks() }
             }
         }
-        if (mShouldRestoreScroll) {
-            mShouldRestoreScroll = false
-            val newPosition = newPositionOfSelectedCard
-            if (newPosition != CARD_NOT_AVAILABLE) {
-                Timber.d("Restoring scroll position after search")
-                autoScrollTo(newPosition)
-            }
-        }
+        restoreScrollPositionIfRequested()
         updatePreviewMenuItem()
+    }
+
+    /**
+     * Restores the scroll position of the browser when requested (for example after editing a card)
+     */
+    @NeedsTest("Issue 14220: Ensure this is called if mSearchView == null. Use Espresso to test")
+    private fun restoreScrollPositionIfRequested() {
+        if (!mShouldRestoreScroll) {
+            Timber.d("Not restoring search position")
+            return
+        }
+        mShouldRestoreScroll = false
+        val newPosition = newPositionOfSelectedCard
+        if (newPosition != CARD_NOT_AVAILABLE) {
+            Timber.d("Restoring scroll position after search")
+            autoScrollTo(newPosition)
+        }
     }
 
     @VisibleForTesting


### PR DESCRIPTION
## Pull Request template

## Fixes
* Fixes #14220

## Approach
* Reset the scroll position in a case where it previously wasn't handled

## How Has This Been Tested?
* API 33 emulator

## Learning
I spent too much time trying to red/greed this test via Robolectric. Should have left it to Espresso

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
