### PR TITLE
lint: fixes to allow acra_version bump

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/ModelBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ModelBrowser.kt
@@ -63,7 +63,7 @@ class ModelBrowser : AnkiActivity() {
     private var mModelListPosition = 0
 
     // Used exclusively to display model name
-    private var mModels: ArrayList<Model>? = null
+    private var mModels: MutableList<Model>? = null
     private var mCardCounts: ArrayList<Int>? = null
     private var mModelIds: ArrayList<Long>? = null
     private var mModelDisplayList: ArrayList<DisplayPair>? = null

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/tags/TagsArrayAdapter.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/tags/TagsArrayAdapter.kt
@@ -190,7 +190,7 @@ class TagsArrayAdapter(private val tags: TagsList, private val resources: Resour
      * A subset of all tags in [tags] satisfying the user's search.
      * @see getFilter
      */
-    private val mFilteredList: ArrayList<String>
+    private val mFilteredList: MutableList<String>
 
     /**
      * The root node of the tag tree.

--- a/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.kt
@@ -39,7 +39,6 @@ import com.ichi2.ui.FixedTextView
 import net.ankiweb.rsdroid.RustCleanup
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.*
-import org.junit.Assert.*
 import org.junit.Ignore
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -49,8 +48,12 @@ import org.robolectric.annotation.Config
 import timber.log.Timber
 import java.util.Locale
 import java.util.Random
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
+import kotlin.test.fail
+import kotlin.test.junit5.JUnit5Asserter
 
 @RunWith(AndroidJUnit4::class)
 class CardBrowserTest : RobolectricTest() {
@@ -252,7 +255,7 @@ class CardBrowserTest : RobolectricTest() {
         assertEquals(deckOneId, browser.validDecksForChangeDeck.first().id)
         val deckTwoId = addDeck("two")
         assertEquals(2, browser.validDecksForChangeDeck.size)
-        assertArrayEquals(longArrayOf(deckOneId, deckTwoId), browser.validDecksForChangeDeck.map { it.id }.toLongArray())
+        assertEquals(longArrayOf(deckOneId, deckTwoId), browser.validDecksForChangeDeck.map { it.id }.toLongArray())
     }
 
     @Test
@@ -591,7 +594,7 @@ class CardBrowserTest : RobolectricTest() {
         col.save()
         val updatedMod = col.db.queryScalar("select mod from col")
         assertThat("Card Browser has the new sortType field", col.get_config_string("sortType"), equalTo("cardEase"))
-        assertNotEquals("Modification time must change", 0, updatedMod)
+        JUnit5Asserter.assertNotEquals("Modification time must change", 0, updatedMod)
     }
 
     @Test


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
* #14144 
Caused a number of lint warnings/errors to appear

## Approach
Fix the errors:
* kotlin.collections.forEach
* use Kotlin `assertNotNull` assertions

## How Has This Been Tested?
`./gradlew lint` on the above branch now passes

## Learning (optional, can help others)
From the PR, it introduces a newer version of Kotlin: `The binary version of its metadata is 1.9.0, expected version is 1.7.1.`

The linked probably shouldn't be merged, until this is resolved

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
