### PR TITLE
fix: 'rebuild' did not update the deck UI 

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -2288,13 +2288,16 @@ open class DeckPicker :
         }
     }
 
-    suspend fun rebuildFiltered(did: DeckId) {
-        withProgress(resources.getString(R.string.rebuild_filtered_deck)) {
-            withCol {
-                Timber.d("rebuildFiltered: doInBackground - RebuildCram")
-                decks.select(did)
-                sched.rebuildDyn(decks.selected())
-                updateValuesFromDeck(this, true)
+    @NeedsTest("14285: regression test to ensure UI is updated after this call")
+    fun rebuildFiltered(did: DeckId) {
+        launchCatchingTask {
+            withProgress(resources.getString(R.string.rebuild_filtered_deck)) {
+                withCol {
+                    Timber.d("rebuildFiltered: doInBackground - RebuildCram")
+                    decks.select(did)
+                    sched.rebuildDyn(decks.selected())
+                    updateValuesFromDeck(this, true)
+                }
             }
             updateDeckList()
             if (fragmented) loadStudyOptionsFragment(false)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -1993,6 +1993,7 @@ open class DeckPicker :
             // actually happens
             performBackupInBackground()
         }
+        Timber.d("updateDeckList: quick: %b", quick)
         if (quick) {
             launchCatchingTask {
                 withProgress {
@@ -2049,6 +2050,7 @@ open class DeckPicker :
         if (dueTree == null) {
             // mDueTree may be set back to null when the activity restart.
             // We may need to recompute it.
+            Timber.d("renderPage: recomputing dueTree")
             updateDeckList()
             return
         }
@@ -2091,6 +2093,7 @@ open class DeckPicker :
             if (mToolbarSearchView != null) {
                 mDeckListAdapter.filter.filter(currentFilter)
             }
+            Timber.d("Not rendering deck list as there are no cards")
             // We're done here
             return
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckPickerContextMenu.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckPickerContextMenu.kt
@@ -28,7 +28,6 @@ import com.ichi2.anki.DeckPicker
 import com.ichi2.anki.R
 import com.ichi2.anki.analytics.AnalyticsDialogFragment
 import com.ichi2.anki.dialogs.customstudy.CustomStudyDialog
-import com.ichi2.anki.launchCatchingTask
 import com.ichi2.libanki.Collection
 import com.ichi2.libanki.DeckId
 import com.ichi2.utils.BundleUtils.requireLong
@@ -139,7 +138,7 @@ class DeckPickerContextMenu(private val collection: Collection) : AnalyticsDialo
             }
             DeckPickerContextMenuOption.CUSTOM_STUDY_REBUILD -> {
                 Timber.i("Rebuild deck selected")
-                launchCatchingTask { activity.rebuildFiltered(deckId) }
+                activity.rebuildFiltered(deckId)
                 activity.dismissAllDialogFragments()
             }
             DeckPickerContextMenuOption.CUSTOM_STUDY_EMPTY -> {


### PR DESCRIPTION
## Fixes
* Fixes #14285 

## Approach
⚠️ For reviewers: I don't understand /why/ this one worked. Possibly the context of `launchCatchingTask` being the activity rather than the Fragment?
* add logs to diagnose
  * determine  `updateDeckList` isn't called
  * move `updateDeckList` outside `withProgress` to match `emptyFiltered` (no effect)
  * move `launchCatchingTask` inside the method `rebuildFiltered`
* outcome of the above: rewrite `rebuildFiltered` to be the same as `emptyFiltered` 


## How Has This Been Tested?
Android 13 emulator

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
