### PR TITLE
Add digital eraser support in the Whiteboard

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/Whiteboard.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Whiteboard.kt
@@ -110,12 +110,12 @@ class Whiteboard(activity: AnkiActivity, handleMultiTouch: Boolean, inverted: Bo
     private fun handleDrawEvent(event: MotionEvent): Boolean {
         val x = event.x
         val y = event.y
-        if (event.getToolType(event.actionIndex) != MotionEvent.TOOL_TYPE_STYLUS && toggleStylus) {
-            return false
-        }
         if (event.getToolType(event.actionIndex) == MotionEvent.TOOL_TYPE_ERASER) {
             stylusErase(event)
             return true
+        }
+        if (event.getToolType(event.actionIndex) != MotionEvent.TOOL_TYPE_STYLUS && toggleStylus) {
+            return false
         }
         return when (event.actionMasked) {
             MotionEvent.ACTION_DOWN -> {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Whiteboard.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Whiteboard.kt
@@ -113,7 +113,8 @@ class Whiteboard(activity: AnkiActivity, handleMultiTouch: Boolean, inverted: Bo
         if (event.getToolType(event.actionIndex) != MotionEvent.TOOL_TYPE_STYLUS && toggleStylus) {
             return false
         }
-        if (stylusErase(event)) {
+        if (event.getToolType(event.actionIndex) == MotionEvent.TOOL_TYPE_ERASER) {
+            stylusErase(event)
             return true
         }
         return when (event.actionMasked) {
@@ -147,6 +148,12 @@ class Whiteboard(activity: AnkiActivity, handleMultiTouch: Boolean, inverted: Bo
                 }
                 false
             }
+            211, 213 -> {
+                if (event.buttonState == MotionEvent.BUTTON_STYLUS_PRIMARY) {
+                    stylusErase(event)
+                }
+                true
+            }
             else -> false
         }
     }
@@ -171,13 +178,8 @@ class Whiteboard(activity: AnkiActivity, handleMultiTouch: Boolean, inverted: Bo
     /**
      * Erase with stylus pen.(By using the eraser button on the stylus pen or by using the digital eraser)
      */
-    private fun stylusErase(event: MotionEvent): Boolean {
-        if ((
-            (event.actionMasked in intArrayOf(211, 213) && event.buttonState == MotionEvent.BUTTON_STYLUS_PRIMARY) ||
-                (event.getToolType(event.actionIndex) == MotionEvent.TOOL_TYPE_ERASER)
-            ) &&
-            !undoEmpty()
-        ) {
+    private fun stylusErase(event: MotionEvent) {
+        if (!undoEmpty()) {
             val didErase = mUndo.erase(event.x.toInt(), event.y.toInt())
             if (didErase) {
                 mUndo.apply()
@@ -185,9 +187,7 @@ class Whiteboard(activity: AnkiActivity, handleMultiTouch: Boolean, inverted: Bo
                     mAnkiActivity.invalidateOptionsMenu()
                 }
             }
-            return true
         }
-        return false
     }
 
     /**


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
I bought the `STAEDTLER Noris digital jumbo stylus pen` for my Galaxy Tab S7+.

It has a soft digital eraser at the end of the stylus. However, Ankidroid doesn't support digital eraser yet.

So I decided to make it support this feature.

## Fixes
None.

## Approach
https://developer.android.com/reference/android/view/MotionEvent#TOOL_TYPE_ERASER

## How Has This Been Tested?
Stylus Pen: STAEDTLER Noris digital jumbo (https://www.staedtler.com/intl/en/discover/noris-digital-jumbo-tradition-meets-innovation/)
Device: Samsung Galaxy Tab S7+(SM-T970)

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
