### PR TITLE
Whiteboard in Preview of Card browser

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/Previewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Previewer.kt
@@ -33,6 +33,7 @@ import androidx.annotation.CheckResult
 import androidx.annotation.VisibleForTesting
 import androidx.appcompat.view.menu.MenuBuilder
 import androidx.core.content.ContextCompat
+import androidx.core.view.MenuItemCompat
 import com.google.android.material.snackbar.Snackbar
 import com.ichi2.anki.cardviewer.Gesture
 import com.ichi2.anki.cardviewer.PreviewLayout
@@ -303,11 +304,23 @@ class Previewer : AbstractFlashcardViewer() {
         menuInflater.inflate(R.menu.previewer, menu)
 
         displayIcons(menu)
+        val whiteboardEditItem = menu.findItem(R.id.action_edit)
+        MenuItemCompat.setIconTintList(
+            whiteboardEditItem,
+            ContextCompat.getColorStateList(
+                this,
+                R.color.white
+            )
+        )
         val toggleWhiteboardIcon = menu.findItem(R.id.action_toggle_whiteboard)
+        val toggleWhiteboardAlphaIcon = ContextCompat.getDrawable(this, R.drawable.ic_gesture_white)!!.mutate()
         val toggleStylusIcon = menu.findItem(R.id.action_toggle_stylus)
         if (prefWhiteboard) {
             // Configure the whiteboard related items in the action bar
             toggleWhiteboardIcon.setTitle(R.string.disable_whiteboard)
+            toggleWhiteboardAlphaIcon.alpha = Themes.ALPHA_ICON_ENABLED_LIGHT
+            toggleWhiteboardIcon.icon = toggleWhiteboardAlphaIcon
+
             // Always allow "Disable Whiteboard", even if "Enable Whiteboard" is disabled
             toggleWhiteboardIcon.isVisible = true
             val whiteboardIcon = ContextCompat.getDrawable(this, R.drawable.ic_gesture_white)!!.mutate()
@@ -327,6 +340,8 @@ class Previewer : AbstractFlashcardViewer() {
             toggleStylusIcon.icon = stylusIcon
         } else {
             toggleWhiteboardIcon.setTitle(R.string.enable_whiteboard)
+            toggleWhiteboardAlphaIcon.alpha = Themes.ALPHA_ICON_DISABLED_LIGHT
+            toggleWhiteboardIcon.icon = toggleWhiteboardAlphaIcon
         }
 
         increaseHorizontalPaddingOfOverflowMenuIcons(menu)

--- a/AnkiDroid/src/main/res/menu/previewer.xml
+++ b/AnkiDroid/src/main/res/menu/previewer.xml
@@ -18,6 +18,23 @@
 <menu xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:ankidroid="http://schemas.android.com/apk/res-auto" >
     <item
+        android:id="@+id/action_clear_whiteboard"
+        android:title="@string/clear_whiteboard"
+        android:icon="@drawable/ic_clear_white"
+        android:visible="false"
+        ankidroid:showAsAction="always"/>
+    <item
+        android:id="@+id/action_toggle_stylus"
+        android:title="@string/enable_stylus"
+        android:icon="@drawable/ic_gesture_stylus"
+        android:visible="false"
+        ankidroid:showAsAction="never"/>
+    <item
+        android:id="@+id/action_toggle_whiteboard"
+        android:title="@string/enable_whiteboard"
+        android:icon="@drawable/ic_gesture_white"
+        ankidroid:showAsAction="ifRoom"/>
+    <item
         android:id="@+id/action_edit"
         android:icon="@drawable/ic_mode_edit_white"
         android:title="@string/cardeditor_title_edit_card"


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
Added whiteboard functionality to the preview screen in Card browser.

[Available whiteboard menu]
- Toggle whiteboard
- Toggle stylus writing
- Clear whiteboard

![whiteboard01](https://github.com/ankidroid/Anki-Android/assets/7389524/db0207df-db20-420e-a6fa-e8c88a550adf)
![whiteboard02](https://github.com/ankidroid/Anki-Android/assets/7389524/250d4d3c-5980-4ddf-87be-4e6883ead318)
![whiteboard03](https://github.com/ankidroid/Anki-Android/assets/7389524/c98a7b87-002b-470e-8d16-8293b567797d)

It based on Reviewer.kt code, but still has many memory leaks. I need help to fix it.
![leaks](https://github.com/ankidroid/Anki-Android/assets/7389524/8cbc90e8-a1d1-4e61-b3db-5bd58743fb9d)

## Fixes
* Fixes #14322

## Approach
Ported Whiteboard functionality based on Reviewer.kt code.

## How Has This Been Tested?
Device: Emulator(Pixel_3A_API_33)

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
