### PR TITLE
dev: add git commit hash to debug info

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -25,6 +25,14 @@ idea {
 }
 
 def homePath = System.properties['user.home']
+/**
+ * @return the current git hash
+ * @example edf739d95bad7b370a6ed4398d46723f8219b3cd
+ */
+static def gitCommitHash() {
+    "git rev-parse HEAD".execute().text.trim()
+}
+
 android {
     namespace "com.ichi2.anki"
 
@@ -43,6 +51,7 @@ android {
         buildConfigField "String", "BACKEND_VERSION", "\"$ankidroid_backend_version\""
         buildConfigField "Boolean", "ENABLE_LEAK_CANARY", "false"
         buildConfigField "Boolean", "ALLOW_UNSAFE_MIGRATION", "false"
+        buildConfigField "String", "GIT_COMMIT_HASH", "\"${gitCommitHash()}\""
         resValue "string", "app_name", "AnkiDroid"
 
         // The version number is of the form:

--- a/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/DebugInfoService.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/DebugInfoService.kt
@@ -42,7 +42,7 @@ object DebugInfoService {
         val webviewUserAgent = getWebviewUserAgent(info)
         val newSchema = !BackendFactory.defaultLegacySchema
         return """
-               AnkiDroid Version = $pkgVersionName
+               AnkiDroid Version = $pkgVersionName (${BuildConfig.GIT_COMMIT_HASH})
                
                Android Version = ${Build.VERSION.RELEASE}
                


### PR DESCRIPTION
## Purpose / Description
While I have a development build on my Android emulator, sometimes
I encounter a bug, this makes the build much more visible to help
with diagnostics

## Approach
Define the hash in `BuildConfig`

## How Has This Been Tested?

API 33 emulator, displays:

`AnkiDroid Version = 2.16.3-debug (edf739d95bad7b370a6ed4398d46723f8219b3cd)`

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
