### PR TITLE
audio recording: hide 'contents' label if empty

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicAudioRecordingFieldController.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicAudioRecordingFieldController.kt
@@ -29,6 +29,7 @@ import com.ichi2.anki.multimediacard.AudioView
 import com.ichi2.anki.multimediacard.AudioView.Companion.createRecorderInstance
 import com.ichi2.anki.multimediacard.AudioView.Companion.generateTempAudioFile
 import com.ichi2.anki.multimediacard.AudioView.OnRecordingFinishEventListener
+import com.ichi2.annotations.NeedsTest
 import com.ichi2.ui.FixedTextView
 import com.ichi2.utils.UiUtil.makeBold
 import java.io.File
@@ -41,6 +42,7 @@ class BasicAudioRecordingFieldController : FieldControllerBase(), IFieldControll
     private var mTempAudioPath: String? = null
     private var mAudioView: AudioView? = null
 
+    @NeedsTest("'Field Contents' label should be invisible if there's no fields with contents")
     override fun createUI(context: Context, layout: LinearLayout) {
         val origAudioPath = mField.audioPath
         var bExist = false
@@ -87,6 +89,7 @@ class BasicAudioRecordingFieldController : FieldControllerBase(), IFieldControll
             label.text = makeBold(this.getString(R.string.audio_recording_field_list))
             label.gravity = Gravity.CENTER_HORIZONTAL
             previewLayout.addView(label)
+            var hasTextContents = false
             for (i in 0 until mNote.initialFieldCount) {
                 val field = mNote.getInitialField(i)
                 val textView = FixedTextView(this)
@@ -94,7 +97,9 @@ class BasicAudioRecordingFieldController : FieldControllerBase(), IFieldControll
                 textView.textSize = 16f
                 textView.setPadding(16, 0, 16, 24)
                 previewLayout.addView(textView)
+                hasTextContents = hasTextContents or !field?.text.isNullOrBlank()
             }
+            label.visibility = if (hasTextContents) View.VISIBLE else View.GONE
         }
     }
 


### PR DESCRIPTION
## Purpose / Description
'Field Contents' was designed to make it easier to read the content of a note while recording audio

But sometimes a user will want an audio-only note
In this case: the note's fields are all empty, and showing the 'Field Contents' heading doesn't make sense

## Approach
Hide the label if there's no content

## How Has This Been Tested?
API 33: hidden if no text, displayed if text

**Before**

<img width="382" alt="field_before" src="https://github.com/ankidroid/Anki-Android/assets/62114487/71cd30ba-2eba-4c2b-8594-cc177684f059">

**After**
<img width="384" alt="field_after" src="https://github.com/ankidroid/Anki-Android/assets/62114487/200bab24-1ab7-4df3-8684-accc5e12b631">


## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
