### PR TITLE
Tests for inverse animation

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
@@ -839,7 +839,6 @@ abstract class AbstractFlashcardViewer :
         finishWithoutAnimation()
     }
 
-    @NeedsTest("Starting animation from swipe is inverse to the finishing one")
     protected open fun editCard(fromGesture: Gesture? = null) {
         if (currentCard == null) {
             // This should never occurs. It means the review button was pressed while there is no more card in the reviewer.

--- a/AnkiDroid/src/test/java/com/ichi2/anki/AbstractFlashcardViewerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/AbstractFlashcardViewerTest.kt
@@ -2,12 +2,15 @@
 
 package com.ichi2.anki
 
+import android.app.Application
+import android.content.Context
 import android.content.Intent
 import android.os.Build
 import android.webkit.RenderProcessGoneDetail
 import androidx.annotation.CheckResult
 import androidx.annotation.RequiresApi
 import androidx.core.content.IntentCompat
+import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.ichi2.anim.ActivityTransitionAnimation
 import com.ichi2.anki.AbstractFlashcardViewer.WebViewSignalParserUtils.ANSWER_ORDINAL_1
@@ -39,6 +42,7 @@ import org.junit.jupiter.params.provider.MethodSource
 import org.junit.runner.RunWith
 import org.mockito.Mockito.*
 import org.robolectric.Robolectric
+import org.robolectric.Shadows
 import org.robolectric.android.controller.ActivityController
 import org.robolectric.shadows.ShadowToast
 import java.util.*
@@ -49,18 +53,10 @@ import com.ichi2.anim.ActivityTransitionAnimation.Direction as Direction
 @RunWith(AndroidJUnit4::class)
 class AbstractFlashcardViewerTest : RobolectricTest() {
     class NonAbstractFlashcardViewer : AbstractFlashcardViewer() {
-        lateinit var editCardIntent: Intent
         var answered: Int? = null
         private var mLastTime = 0
         override fun performReload() {
             // intentionally blank
-        }
-
-        @Deprecated("")
-        @Suppress("DEPRECATION")
-        override fun startActivityForResult(intent: Intent, requestCode: Int) {
-            editCardIntent = intent
-            super.startActivityForResult(intent, requestCode)
         }
 
         val typedInput get() = super.typedInputText
@@ -177,9 +173,10 @@ class AbstractFlashcardViewerTest : RobolectricTest() {
                 ActivityTransitionAnimation.getInverseTransition(expectedAnimation)
 
             viewer.executeCommand(ViewerCommand.EDIT, gesture)
+            val actual = Shadows.shadowOf(ApplicationProvider.getApplicationContext<Context>() as Application).nextStartedActivity
 
             val actualInverseAnimation = IntentCompat.getParcelableExtra(
-                viewer.editCardIntent,
+                actual,
                 FINISH_ANIMATION_EXTRA,
                 Direction::class.java
             )


### PR DESCRIPTION
Hello :) I have been an Android developer for the last three years and have been using ankidroid for the last five years, I decided this would be a good project to attempt to contribute to for improving my Android skills. 

## Purpose / Description
Adds tests for checking the animations in the AbstractCardViewer are correctly inverted when added the intent.

## Fixes
https://github.com/ankidroid/Anki-Android/issues/13283

## Approach
By overriding the test implementations onActivityStarted I can assign a value to a new top level intent and check, by extracting the parcelable animation, that the intent has correctly been assigned the correct inverse animation value when going through the editCard flow.

This loops it for 3 separate cases:

```
val gestures = listOf(Gesture.SWIPE_LEFT, Gesture.SWIPE_UP, Gesture.LONG_TAP)
```

## How Has This Been Tested?

This applies no changes to the logic of the non-test code (as per testing standards) but I have tested that this doesn't break any preexisting tests by running them on my machine, and the new test passes.

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [X] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [X] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
