### PR TITLE
Fix note editor deck selection related issues

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckSpinnerSelection.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckSpinnerSelection.kt
@@ -88,6 +88,7 @@ class DeckSpinnerSelection(
         for (d in dropDownDecks) {
             val currentName = d.name
             deckNames.add(currentName)
+            mAllDeckIds.add(d.id)
         }
         val noteDeckAdapter: ArrayAdapter<String?> = object : ArrayAdapter<String?>(context, R.layout.multiline_spinner_item, deckNames as List<String?>) {
             override fun getDropDownView(position: Int, convertView: View?, parent: ViewGroup): View {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckSpinnerSelection.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckSpinnerSelection.kt
@@ -110,10 +110,10 @@ class DeckSpinnerSelection(
     }
 
     /**
-     * @return All decks, except maybe default if it should be hidden.
+     * @return All decks.
      */
     fun computeDropDownDecks(includeFiltered: Boolean): List<DeckNameId> {
-        return collection.decks.allNamesAndIds(skipEmptyDefault = true, includeFiltered = includeFiltered)
+        return collection.decks.allNamesAndIds(includeFiltered = includeFiltered)
     }
 
     fun setSpinnerListener() {

--- a/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.kt
@@ -39,7 +39,6 @@ import com.ichi2.testutils.withNoWritePermission
 import com.ichi2.ui.FixedTextView
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.*
-import org.junit.Assert.assertArrayEquals
 import org.junit.Ignore
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -251,11 +250,12 @@ class CardBrowserTest : RobolectricTest() {
     fun newlyCreatedDeckIsShownAsOptionInBrowser() = runTest {
         val deckOneId = addDeck("one")
         val browser = browserWithNoNewCards
-        assertEquals(1, browser.validDecksForChangeDeck.size)
-        assertEquals(deckOneId, browser.validDecksForChangeDeck.first().id)
+        assertEquals(2, browser.validDecksForChangeDeck.size) // 1 added + default deck
+        assertEquals(1, browser.validDecksForChangeDeck.count { it.id == deckOneId })
         val deckTwoId = addDeck("two")
-        assertEquals(2, browser.validDecksForChangeDeck.size)
-        assertArrayEquals(longArrayOf(deckOneId, deckTwoId), browser.validDecksForChangeDeck.map { it.id }.toLongArray())
+        assertEquals(3, browser.validDecksForChangeDeck.size) // 2 added + default deck
+        assertEquals(1, browser.validDecksForChangeDeck.count { it.id == deckOneId })
+        assertEquals(1, browser.validDecksForChangeDeck.count { it.id == deckTwoId })
     }
 
     @Test


### PR DESCRIPTION
## Purpose / Description
When initializing DeckSpinnerSelection in NoteEditor the available deck ids weren't added to the `mAllDeckIds` list and later the selection was not registered.

I also fixed another regression from #14171. Reproduction:

_Click deck spinner in NoteEditor -> note that the default(empty) deck is being shown -> try to select it -> the first deck is chosen instead_

This was happening because there was a mismatch between what decks were shown in `DeckSelectionDialog`(was including the empty default deck) and the list of decks that were used to handle the deck selection(didn't include the empty default deck selection).

Note: with the changes from the second commit CardBrowser will also show the default deck.

## Fixes
Fixes #14354 

## How Has This Been Tested?

Manually verified the deck selection UI.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
