### PR TITLE
Remove answer recommended commands

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
@@ -841,10 +841,6 @@ abstract class AbstractFlashcardViewer :
         }
     }
 
-    private fun getRecommendedEase(easy: Boolean): Int {
-        return if (easy) EASE_4 else EASE_3
-    }
-
     open fun answerCard(@BUTTON_TYPE ease: Int) {
         launchCatchingTask {
             if (mInAnswer) {
@@ -1656,14 +1652,6 @@ abstract class AbstractFlashcardViewer :
                 }
                 ViewerCommand.FLIP_OR_ANSWER_EASE4 -> {
                     flipOrAnswerCard(EASE_4)
-                    true
-                }
-                ViewerCommand.FLIP_OR_ANSWER_RECOMMENDED -> {
-                    flipOrAnswerCard(getRecommendedEase(false))
-                    true
-                }
-                ViewerCommand.FLIP_OR_ANSWER_BETTER_THAN_RECOMMENDED -> {
-                    flipOrAnswerCard(getRecommendedEase(true))
                     true
                 }
                 ViewerCommand.EXIT -> {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/analytics/UsageAnalytics.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/analytics/UsageAnalytics.kt
@@ -496,8 +496,6 @@ object UsageAnalytics {
         "binding_FLIP_OR_ANSWER_EASE2",
         "binding_FLIP_OR_ANSWER_EASE3",
         "binding_FLIP_OR_ANSWER_EASE4",
-        "binding_FLIP_OR_ANSWER_RECOMMENDED",
-        "binding_FLIP_OR_ANSWER_BETTER_THAN_RECOMMENDED",
         "binding_UNDO",
         "binding_EDIT",
         "binding_MARK",

--- a/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/ViewerCommand.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/ViewerCommand.kt
@@ -39,8 +39,6 @@ enum class ViewerCommand(val resourceId: Int) {
     FLIP_OR_ANSWER_EASE2(R.string.gesture_answer_2),
     FLIP_OR_ANSWER_EASE3(R.string.gesture_answer_3),
     FLIP_OR_ANSWER_EASE4(R.string.gesture_answer_4),
-    FLIP_OR_ANSWER_RECOMMENDED(R.string.gesture_answer_green),
-    FLIP_OR_ANSWER_BETTER_THAN_RECOMMENDED(R.string.gesture_answer_better_recommended),
     UNDO(R.string.undo),
     EDIT(R.string.cardeditor_title_edit_card),
     MARK(R.string.menu_mark_note),
@@ -138,18 +136,16 @@ enum class ViewerCommand(val resourceId: Int) {
                 FLIP_OR_ANSWER_EASE3 -> from(
                     keyCode(KeyEvent.KEYCODE_BUTTON_B, CardSide.BOTH),
                     keyCode(KeyEvent.KEYCODE_3, CardSide.ANSWER),
-                    keyCode(KeyEvent.KEYCODE_NUMPAD_3, CardSide.ANSWER)
+                    keyCode(KeyEvent.KEYCODE_NUMPAD_3, CardSide.ANSWER),
+                    keyCode(KeyEvent.KEYCODE_DPAD_CENTER, CardSide.BOTH),
+                    keyCode(KeyEvent.KEYCODE_SPACE, CardSide.ANSWER),
+                    keyCode(KeyEvent.KEYCODE_ENTER, CardSide.ANSWER),
+                    keyCode(KeyEvent.KEYCODE_NUMPAD_ENTER, CardSide.ANSWER)
                 )
                 FLIP_OR_ANSWER_EASE4 -> from(
                     keyCode(KeyEvent.KEYCODE_BUTTON_A, CardSide.BOTH),
                     keyCode(KeyEvent.KEYCODE_4, CardSide.ANSWER),
                     keyCode(KeyEvent.KEYCODE_NUMPAD_4, CardSide.ANSWER)
-                )
-                FLIP_OR_ANSWER_RECOMMENDED -> from(
-                    keyCode(KeyEvent.KEYCODE_DPAD_CENTER, CardSide.BOTH),
-                    keyCode(KeyEvent.KEYCODE_SPACE, CardSide.ANSWER),
-                    keyCode(KeyEvent.KEYCODE_ENTER, CardSide.ANSWER),
-                    keyCode(KeyEvent.KEYCODE_NUMPAD_ENTER, CardSide.ANSWER)
                 )
                 EDIT -> from(keyCode(KeyEvent.KEYCODE_E, CardSide.BOTH))
                 MARK -> from(unicode('*', CardSide.BOTH))

--- a/AnkiDroid/src/main/res/values/11-arrays.xml
+++ b/AnkiDroid/src/main/res/values/11-arrays.xml
@@ -73,8 +73,6 @@
     <string name="gesture_answer_2">Answer button 2</string>
     <string name="gesture_answer_3">Answer button 3</string>
     <string name="gesture_answer_4">Answer button 4</string>
-    <string name="gesture_answer_green">Answer recommended (green)</string>
-    <string name="gesture_answer_better_recommended">Answer better than recommended</string>
     <string name="gesture_play">Play media</string>
     <string name="gesture_abort_learning">Abort learning</string>
     <string name="gesture_flag_red">Toggle Red Flag</string>

--- a/AnkiDroid/src/test/java/com/ichi2/anki/AbstractFlashcardViewerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/AbstractFlashcardViewerTest.kt
@@ -161,11 +161,11 @@ class AbstractFlashcardViewerTest : RobolectricTest() {
         val viewer: NonAbstractFlashcardViewer = getViewer(true)
 
         assertThat("Displaying question", viewer.isDisplayingAnswer, equalTo(false))
-        viewer.executeCommand(ViewerCommand.FLIP_OR_ANSWER_BETTER_THAN_RECOMMENDED)
+        viewer.executeCommand(ViewerCommand.FLIP_OR_ANSWER_EASE4)
 
         assertThat("Displaying answer", viewer.isDisplayingAnswer, equalTo(true))
 
-        viewer.executeCommand(ViewerCommand.FLIP_OR_ANSWER_BETTER_THAN_RECOMMENDED)
+        viewer.executeCommand(ViewerCommand.FLIP_OR_ANSWER_EASE4)
 
         assertThat(viewer.answered, notNullValue())
     }
@@ -222,14 +222,14 @@ class AbstractFlashcardViewerTest : RobolectricTest() {
     @Test
     fun shortcutShowsToastOnFinish() = runTest {
         val viewer: NonAbstractFlashcardViewer = getViewer(true, true)
-        viewer.executeCommand(ViewerCommand.FLIP_OR_ANSWER_BETTER_THAN_RECOMMENDED)
-        viewer.executeCommand(ViewerCommand.FLIP_OR_ANSWER_BETTER_THAN_RECOMMENDED)
+        viewer.executeCommand(ViewerCommand.FLIP_OR_ANSWER_EASE4)
+        viewer.executeCommand(ViewerCommand.FLIP_OR_ANSWER_EASE4)
         assertEquals(getResourceString(R.string.studyoptions_congrats_finished), ShadowToast.getTextOfLatestToast())
     }
 
     private fun showNextCard(viewer: NonAbstractFlashcardViewer) {
-        viewer.executeCommand(ViewerCommand.FLIP_OR_ANSWER_BETTER_THAN_RECOMMENDED)
-        viewer.executeCommand(ViewerCommand.FLIP_OR_ANSWER_BETTER_THAN_RECOMMENDED)
+        viewer.executeCommand(ViewerCommand.FLIP_OR_ANSWER_EASE4)
+        viewer.executeCommand(ViewerCommand.FLIP_OR_ANSWER_EASE4)
     }
 
     @get:CheckResult

--- a/AnkiDroid/src/test/java/com/ichi2/anki/cardviewer/ViewerCommandTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/cardviewer/ViewerCommandTest.kt
@@ -32,7 +32,6 @@ class ViewerCommandTest {
         assertEquals(
             "binding_SHOW_ANSWER, binding_FLIP_OR_ANSWER_EASE1, " +
                 "binding_FLIP_OR_ANSWER_EASE2, binding_FLIP_OR_ANSWER_EASE3, binding_FLIP_OR_ANSWER_EASE4, " +
-                "binding_FLIP_OR_ANSWER_RECOMMENDED, binding_FLIP_OR_ANSWER_BETTER_THAN_RECOMMENDED, " +
                 "binding_UNDO, binding_EDIT, binding_MARK, binding_BURY_CARD, " +
                 "binding_SUSPEND_CARD, binding_DELETE, binding_PLAY_MEDIA, " +
                 "binding_EXIT, binding_BURY_NOTE, binding_SUSPEND_NOTE, binding_TOGGLE_FLAG_RED, " +


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
_Describe the problem or feature and motivation_

## Fixes
Fixes #14265

## Approach
I did what #14625 asked

> Remove the Answer recommended (green) and Answer better than recomended commands
Move their default commands to Answer button 3 and Answer button 4 respectively
Upgrade their preference assigned commands to Answer button 3 and Answer button 4 respectively

## How Has This Been Tested?

I increased the app version manually and ran the app to see if the commands were moved in the emulator

## Learning (optional, can help others)
_Describe the research stage_

_Links to blog posts, patterns, libraries or addons used to solve this problem_

## Checklist
_Please, go through these checks before submitting the PR._

- [ ] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas
- [ ] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
