### PR TITLE
Stop using finishWithoutAnimation() and launchForResultWIthoutAnimation()

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
@@ -749,7 +749,7 @@ abstract class AbstractFlashcardViewer :
             mUnmountReceiver = object : BroadcastReceiver() {
                 override fun onReceive(context: Context, intent: Intent) {
                     if (intent.action == SdCardReceiver.MEDIA_EJECT) {
-                        finishWithoutAnimation()
+                        finish()
                     }
                 }
             }
@@ -767,7 +767,7 @@ abstract class AbstractFlashcardViewer :
 
     private fun finishNoStorageAvailable() {
         this@AbstractFlashcardViewer.setResult(DeckPicker.RESULT_MEDIA_EJECTED)
-        finishWithoutAnimation()
+        finish()
     }
 
     @NeedsTest("Starting animation from swipe is inverse to the finishing one")

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiActivity.kt
@@ -122,7 +122,7 @@ open class AnkiActivity : AppCompatActivity, SimpleMessageDialogListener {
     }
 
     protected open fun onActionBarBackPressed(): Boolean {
-        finishWithoutAnimation()
+        finish()
         return true
     }
 
@@ -267,12 +267,6 @@ open class AnkiActivity : AppCompatActivity, SimpleMessageDialogListener {
 
     override fun finish() {
         finishWithAnimation(DEFAULT)
-    }
-
-    fun finishWithoutAnimation() {
-        Timber.i("finishWithoutAnimation")
-        super.finish()
-        disableActivityAnimation()
     }
 
     fun finishWithAnimation(animation: Direction) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiActivity.kt
@@ -248,14 +248,6 @@ open class AnkiActivity : AppCompatActivity, SimpleMessageDialogListener {
         }
     }
 
-    fun launchActivityForResultWithoutAnimation(
-        intent: Intent,
-        launcher: ActivityResultLauncher<Intent?>
-    ) {
-        disableIntentAnimation(intent)
-        launchActivityForResult(intent, launcher, NONE)
-    }
-
     fun launchActivityForResultWithAnimation(
         intent: Intent,
         launcher: ActivityResultLauncher<Intent?>,

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -1309,7 +1309,7 @@ open class CardBrowser :
     }
 
     protected fun onPreview() {
-        launchActivityForResultWithoutAnimation(previewIntent, onPreviewCardsActivityResult)
+        onPreviewCardsActivityResult.launch(previewIntent)
     } // Preview all cards, starting from the one that is currently selected
 
     // Multiple cards have been explicitly selected, so preview only those cards

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -2321,7 +2321,7 @@ open class CardBrowser :
             mUnmountReceiver = object : BroadcastReceiver() {
                 override fun onReceive(context: Context, intent: Intent) {
                     if (intent.action == SdCardReceiver.MEDIA_EJECT) {
-                        finishWithoutAnimation()
+                        finish()
                     }
                 }
             }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.kt
@@ -106,7 +106,7 @@ open class CardTemplateEditor : AnkiActivity(), DeckSelectionListener {
             mModelId = intent.getLongExtra(EDITOR_MODEL_ID, NOT_FOUND_NOTE_TYPE)
             if (mModelId == NOT_FOUND_NOTE_TYPE) {
                 Timber.e("CardTemplateEditor :: no model ID was provided")
-                finishWithoutAnimation()
+                finish()
                 return
             }
             // get id for currently edited note (optional)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -940,7 +940,7 @@ open class DeckPicker :
             }
         } else if (requestCode == REQUEST_PATH_UPDATE) {
             // The collection path was inaccessible on startup so just close the activity and let user restart
-            finishWithoutAnimation()
+            finish()
         } else if (requestCode == PICK_APKG_FILE && resultCode == RESULT_OK) {
             onSelectedPackageToImport(data!!)
         } else if (requestCode == PICK_CSV_FILE && resultCode == RESULT_OK) {
@@ -1395,7 +1395,7 @@ open class DeckPicker :
 
     fun onSdCardNotMounted() {
         showThemedToast(this, resources.getString(R.string.sd_card_not_mounted), false)
-        finishWithoutAnimation()
+        finish()
     }
 
     // Callback method to submit error report
@@ -1481,7 +1481,7 @@ open class DeckPicker :
     fun exit() {
         Timber.i("exit()")
         CollectionHelper.instance.closeCollection("DeckPicker:exit()")
-        finishWithoutAnimation()
+        finish()
     }
 
     open fun handleDbError() {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Info.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Info.kt
@@ -146,7 +146,7 @@ class Info : AnkiActivity() {
                     }
                 }
             }
-            else -> finishWithoutAnimation()
+            else -> finish()
         }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/IntentHandler.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/IntentHandler.kt
@@ -274,7 +274,7 @@ class IntentHandler : Activity() {
                         )
                     }
                 }
-                deckPicker.finishWithoutAnimation()
+                deckPicker.finish()
             }
 
             override fun toMessage(): Message = emptyMessage(this.what)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ModelFieldEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ModelFieldEditor.kt
@@ -119,7 +119,7 @@ class ModelFieldEditor : AnkiActivity(), LocaleSelectionDialogHandler {
         val collectionModel = collection.notetypes.get(noteTypeID)
         if (collectionModel == null) {
             showThemedToast(this, R.string.field_editor_model_not_available, true)
-            finishWithoutAnimation()
+            finish()
             return
         }
         mNotetype = collectionModel

--- a/AnkiDroid/src/main/java/com/ichi2/anki/MyAccount.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/MyAccount.kt
@@ -76,7 +76,7 @@ open class MyAccount : AnkiActivity() {
         }
         super.onCreate(savedInstanceState)
         if (isUserATestClient) {
-            finishWithoutAnimation()
+            finish()
             return
         }
         mayOpenUrl(Uri.parse(resources.getString(R.string.register_url)))

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NavigationDrawerActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NavigationDrawerActivity.kt
@@ -249,7 +249,7 @@ abstract class NavigationDrawerActivity :
             if (this is Reviewer && preferences.getBoolean("tts", false)) {
                 // Workaround to kick user back to StudyOptions after opening settings from Reviewer
                 // because onDestroy() of old Activity interferes with TTS in new Activity
-                finishWithoutAnimation()
+                finish()
             } else {
                 ActivityCompat.recreate(this)
             }
@@ -376,7 +376,7 @@ abstract class NavigationDrawerActivity :
         val stackBuilder = TaskStackBuilder.create(activity)
         stackBuilder.addNextIntentWithParentStack(intent)
         stackBuilder.startActivities(Bundle())
-        activity.finishWithoutAnimation()
+        activity.finish()
     }
 
     fun toggleDrawer() {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
@@ -309,13 +309,13 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
         when (caller) {
             CALLER_NO_CALLER -> {
                 Timber.e("no caller could be identified, closing")
-                finishWithoutAnimation()
+                finish()
                 return
             }
             CALLER_REVIEWER_EDIT -> {
                 mCurrentEditedCard = AbstractFlashcardViewer.editorCard
                 if (mCurrentEditedCard == null) {
-                    finishWithoutAnimation()
+                    finish()
                     return
                 }
                 mEditorNote = mCurrentEditedCard!!.note()
@@ -327,7 +327,7 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
             CALLER_CARDBROWSER_EDIT -> {
                 mCurrentEditedCard = CardBrowser.cardBrowserCard
                 if (mCurrentEditedCard == null) {
-                    finishWithoutAnimation()
+                    finish()
                     return
                 }
                 mEditorNote = mCurrentEditedCard!!.note()
@@ -336,11 +336,11 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
             CALLER_NOTEEDITOR_INTENT_ADD -> {
                 fetchIntentInformation(intent)
                 if (sourceText == null) {
-                    finishWithoutAnimation()
+                    finish()
                     return
                 }
                 if ("Aedict Notepad" == sourceText!![0] && addFromAedict(sourceText!![1])) {
-                    finishWithoutAnimation()
+                    finish()
                     return
                 }
                 addNote = true
@@ -998,7 +998,7 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
             mUnmountReceiver = object : BroadcastReceiver() {
                 override fun onReceive(context: Context, intent: Intent) {
                     if (intent.action != null && intent.action == SdCardReceiver.MEDIA_EJECT) {
-                        finishWithoutAnimation()
+                        finish()
                     }
                 }
             }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Previewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Previewer.kt
@@ -67,7 +67,7 @@ class Previewer : AbstractFlashcardViewer() {
         }
         if (mCardList.isEmpty() || mIndex < 0 || mIndex > mCardList.size - 1) {
             Timber.e("Previewer started with empty card list or invalid index")
-            finishWithoutAnimation()
+            finish()
             return
         }
         showBackIcon()
@@ -216,7 +216,7 @@ class Previewer : AbstractFlashcardViewer() {
         mReloadRequired = true
         val newCardList = getColUnsafe.filterToValidCards(mCardList)
         if (newCardList.isEmpty()) {
-            finishWithoutAnimation()
+            finish()
             return
         }
         mIndex = getNextIndex(newCardList)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/OnRenderProcessGoneDelegate.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/OnRenderProcessGoneDelegate.kt
@@ -66,7 +66,7 @@ open class OnRenderProcessGoneDelegate(val target: AbstractFlashcardViewer) {
                 !canRecoverFromWebViewRendererCrash() -> {
                     Timber.e("Unrecoverable WebView Render crash")
                     if (!activityIsMinimised()) displayFatalError(detail)
-                    target.finishWithoutAnimation()
+                    target.finish()
                     return true
                 }
                 !activityIsMinimised() -> {
@@ -167,5 +167,5 @@ open class OnRenderProcessGoneDelegate(val target: AbstractFlashcardViewer) {
         // Revisit webViewCrashedOnCard() if changing this. Logic currently assumes we have a card.
         target.currentCard != null
 
-    protected fun onCloseRenderLoopDialog() = target.finishWithoutAnimation()
+    protected fun onCloseRenderLoopDialog() = target.finish()
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckPickerBackupNoSpaceLeftDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckPickerBackupNoSpaceLeftDialog.kt
@@ -33,10 +33,10 @@ class DeckPickerBackupNoSpaceLeftDialog : AnalyticsDialogFragment() {
             title(R.string.storage_almost_full_title)
             message(text = res.getString(R.string.storage_warning, space / 1024 / 1024))
             positiveButton(R.string.dialog_ok) {
-                (activity as DeckPicker).finishWithoutAnimation()
+                (activity as DeckPicker).finish()
             }
             cancelable(true)
-            setOnCancelListener { (activity as DeckPicker).finishWithoutAnimation() }
+            setOnCancelListener { (activity as DeckPicker).finish() }
         }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/activity/MultimediaEditFieldActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/activity/MultimediaEditFieldActivity.kt
@@ -93,7 +93,7 @@ class MultimediaEditFieldActivity : AnkiActivity(), OnRequestPermissionsResultCa
         Timber.d("Completing activity via finishCancel()")
         val resultData = Intent()
         setResult(RESULT_CANCELED, resultData)
-        finishWithoutAnimation()
+        finish()
     }
 
     private fun hasPerformedPermissionRequestForField(field: IField): Boolean {
@@ -324,7 +324,7 @@ class MultimediaEditFieldActivity : AnkiActivity(), OnRequestPermissionsResultCa
             putExtra(EXTRA_RESULT_FIELD_INDEX, mFieldIndex)
         }
         setResult(RESULT_OK, resultData)
-        finishWithoutAnimation()
+        finish()
     }
 
     override fun onDestroy() {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/permissions/PermissionManager.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/permissions/PermissionManager.kt
@@ -145,7 +145,7 @@ class PermissionManager private constructor(
  * We finish the activity as setting permissions terminates the app
  */
 fun AnkiActivity.finishActivityAndShowAppPermissionManagementScreen() {
-    this.finishWithoutAnimation()
+    this.finish()
     showAppPermissionManagementScreen()
 }
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/cardviewer/OnRenderProcessGoneDelegateTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/cardviewer/OnRenderProcessGoneDelegateTest.kt
@@ -63,7 +63,7 @@ class OnRenderProcessGoneDelegateTest {
         )
             .displayCardQuestion()
         assertThat(delegate.displayedDialog, equalTo(true))
-        verify(mock, times(1).description("After the dialog, the screen should be closed")).finishWithoutAnimation()
+        verify(mock, times(1).description("After the dialog, the screen should be closed")).finish()
     }
 
     @Test
@@ -108,7 +108,7 @@ class OnRenderProcessGoneDelegateTest {
         verify(mock, never()).recreateWebViewFrame()
 
         assertThat("A toast should be displayed", delegate.displayedToast, equalTo(true))
-        verify(mock, times(1).description("screen should be closed")).finishWithoutAnimation()
+        verify(mock, times(1).description("screen should be closed")).finish()
     }
 
     @Test
@@ -123,7 +123,7 @@ class OnRenderProcessGoneDelegateTest {
         verify(mock, never()).recreateWebViewFrame()
 
         assertThat("A toast should not be displayed as the screen is minimised", delegate.displayedToast, equalTo(false))
-        verify(mock, times(1).description("screen should be closed")).finishWithoutAnimation()
+        verify(mock, times(1).description("screen should be closed")).finish()
     }
 
     private fun callOnRenderProcessGone(delegate: OnRenderProcessGoneDelegateImpl) {
@@ -151,7 +151,7 @@ class OnRenderProcessGoneDelegateTest {
         doNothing().whenever(mock).destroyWebViewFrame()
         doNothing().whenever(mock).recreateWebViewFrame()
         doNothing().whenever(mock).displayCardQuestion()
-        doNothing().whenever(mock).finishWithoutAnimation()
+        doNothing().whenever(mock).finish()
         return mock
     }
 


### PR DESCRIPTION
Historically, finishWithoutAnimation() was mostly used as a replacement for finish(), since it was deprecated by previous AnkiDroid devs in favor of using finishWithoutAnimation() and finishWithAnimation().

The issue was that it was common to see contributors, especially new ones (including myself), using finishWithoutAnimation() because only because finish() wasn't available and finishWithAnimation() was harder to use

Since there is no reason for wanting for a screen to finish without animation, which is unnatural, and now that finish() is undeprecated, it should be the default way of closing a screen.

There is no concern about devices with animation, since the behavior will be the same with finish()

Same for `launchForResultWIthoutAnimation()`. `startActivityForResultWithoutAnimation` will be removed anyway later because it is a deprecated method

This is part of the initiative of making the app's UI/UX better and more consistent

## Approach
- Replace `finishWithoutAnimation()` with `finish()`
- Remove launchForResultWIthoutAnimation()

## How Has This Been Tested?

33 emulator: opened the app and opened/closed some screens

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
