### PR TITLE
Update downloaded robolectric versions

### DIFF
--- a/AnkiDroid/robolectricDownloader.gradle
+++ b/AnkiDroid/robolectricDownloader.gradle
@@ -14,19 +14,19 @@ import java.nio.file.Files
 // This list will need to be updated for new Android SDK versions that come out.
 // Only the versions currently used in AnkiDroid Robolectric tests are active, the rest are commented out
 def robolectricAndroidSdkVersions = [
-        [androidVersion: "5.0.2_r3", frameworkSdkBuildVersion: "r0"],
-        [androidVersion: "5.1.1_r9", frameworkSdkBuildVersion: "r2"],
+//        [androidVersion: "5.0.2_r3", frameworkSdkBuildVersion: "r0"],
+//        [androidVersion: "5.1.1_r9", frameworkSdkBuildVersion: "r2"],
 //        [androidVersion: "6.0.1_r3", frameworkSdkBuildVersion: "r1"],
 //        [androidVersion: "7.0.0_r1", frameworkSdkBuildVersion: "r1"],
 //        [androidVersion: "7.1.0_r7", frameworkSdkBuildVersion: "r1"],
 //        [androidVersion: "8.0.0_r4", frameworkSdkBuildVersion: "r1"],
 //        [androidVersion: "8.1.0", frameworkSdkBuildVersion: "4611349"],
-//        [androidVersion: "9", frameworkSdkBuildVersion: "4913185-2"],
+        [androidVersion: "9", frameworkSdkBuildVersion: "4913185-2"],
         [androidVersion: "10", frameworkSdkBuildVersion:  "5803371"],
-//        [androidVersion: "11", frameworkSdkBuildVersion:  "6757853"],
+        [androidVersion: "11", frameworkSdkBuildVersion:  "6757853"],
 //        [androidVersion: "12", frameworkSdkBuildVersion:  "7732740"],
         [androidVersion: "12.1", frameworkSdkBuildVersion:  "8229987"],
-//        [androidVersion: "13", frameworkSdkBuildVersion:  "9030017"],
+        [androidVersion: "13", frameworkSdkBuildVersion:  "9030017"],
 ]
 
 // Base, public task - will be displayed in ./gradlew robolectricDownloader:tasks

--- a/AnkiDroid/robolectricDownloader.gradle
+++ b/AnkiDroid/robolectricDownloader.gradle
@@ -14,7 +14,7 @@ import java.nio.file.Files
 // This list will need to be updated for new Android SDK versions that come out.
 
 // Only the versions currently used in AnkiDroid Robolectric tests are active, the rest are commented out
-// To update these versions:
+// To update these versions, open a terminal in the Anki-Android directory and perform the following steps:
 //   1. Run `rm -r ~/.m2` to delete the .m2 directory in your home directory.
 //   2. Run `./gradlew jacocoUnitTestReport` to run all unit tests.
 //   3. Run `find ~/.m2 -type d -name '*-robolectric-*'`.

--- a/AnkiDroid/robolectricDownloader.gradle
+++ b/AnkiDroid/robolectricDownloader.gradle
@@ -1,5 +1,5 @@
 /**
- * Downloads all android-all dependencies and copies them to the mavenLocal() repository
+ * Downloads all android-all-instrumented dependencies and copies them to the mavenLocal() repository
  *
  * Once applied to your gradle project, can be executed with ./gradlew robolectricSdkDownload
  */
@@ -41,15 +41,15 @@ task robolectricSdkDownload {
 
 // Generate the configuration and actual copy tasks.
 robolectricAndroidSdkVersions.forEach { robolectricSdkVersion ->
-    def version = "${robolectricSdkVersion['androidVersion']}-robolectric-${robolectricSdkVersion['frameworkSdkBuildVersion']}"
+    def version = "${robolectricSdkVersion['androidVersion']}-robolectric-${robolectricSdkVersion['frameworkSdkBuildVersion']}-i4"
 
     // Creating a configuration with a dependency allows Gradle to manage the actual resolution of
     // the jar file
     def sdkConfig = configurations.create(version)
-    dependencies.add(version, "org.robolectric:android-all:${version}")
+    dependencies.add(version, "org.robolectric:android-all-instrumented:${version}")
 
     def mavenLocalFile = new File(this.repositories.mavenLocal().url)
-    def mavenRobolectric = new File(mavenLocalFile, "org/robolectric/android-all/${version}")
+    def mavenRobolectric = new File(mavenLocalFile, "org/robolectric/android-all-instrumented/${version}")
     // Copying all files downloaded for the created configuration into maven local.
     task "robolectricSdkDownload-${version}"(type: Copy) {
         from sdkConfig
@@ -57,7 +57,7 @@ robolectricAndroidSdkVersions.forEach { robolectricSdkVersion ->
 
         doLast {
             ArtifactResolutionResult result = dependencies.createArtifactResolutionQuery()
-                .forModule("org.robolectric", "android-all", version)
+                .forModule("org.robolectric", "android-all-instrumented", version)
                 .withArtifacts(MavenModule, MavenPomArtifact)
                 .execute()
 

--- a/AnkiDroid/robolectricDownloader.gradle
+++ b/AnkiDroid/robolectricDownloader.gradle
@@ -12,7 +12,13 @@ import java.nio.file.Files
 
 // List from: https://github.com/robolectric/robolectric/blob/master/robolectric/src/main/java/org/robolectric/plugins/DefaultSdkProvider.java
 // This list will need to be updated for new Android SDK versions that come out.
+
 // Only the versions currently used in AnkiDroid Robolectric tests are active, the rest are commented out
+// To update these versions:
+//   1. Run `rm -r ~/.m2` to delete the .m2 directory in your home directory.
+//   2. Run `./gradlew jacocoUnitTestReport` to run all unit tests.
+//   3. Run `find ~/.m2 -type d -name '*-robolectric-*'`.
+//   4. Update the lines below to match the output from `find`.
 def robolectricAndroidSdkVersions = [
 //        [androidVersion: "6.0.1_r3", frameworkSdkBuildVersion: "r1"],
 //        [androidVersion: "7.0.0_r1", frameworkSdkBuildVersion: "r1"],

--- a/AnkiDroid/robolectricDownloader.gradle
+++ b/AnkiDroid/robolectricDownloader.gradle
@@ -14,8 +14,6 @@ import java.nio.file.Files
 // This list will need to be updated for new Android SDK versions that come out.
 // Only the versions currently used in AnkiDroid Robolectric tests are active, the rest are commented out
 def robolectricAndroidSdkVersions = [
-//        [androidVersion: "5.0.2_r3", frameworkSdkBuildVersion: "r0"],
-//        [androidVersion: "5.1.1_r9", frameworkSdkBuildVersion: "r2"],
 //        [androidVersion: "6.0.1_r3", frameworkSdkBuildVersion: "r1"],
 //        [androidVersion: "7.0.0_r1", frameworkSdkBuildVersion: "r1"],
 //        [androidVersion: "7.1.0_r7", frameworkSdkBuildVersion: "r1"],


### PR DESCRIPTION
## Purpose / Description
The problem is explained on #14350. The minimum SDK version was updated to 23 in #14171, which means these versions need to be updated, as they are tied into the SDK versions.

## Fixes
Fixes #14350.

## Approach
I followed the steps suggested on #14350. The resulting folders that were downloaded to my local filesystem when running the unit tests were:
- ~/.m2/repository/org/robolectric/android-all-instrumented/10-robolectric-5803371-i4
- ~/.m2/repository/org/robolectric/android-all-instrumented/11-robolectric-6757853-i4
- ~/.m2/repository/org/robolectric/android-all-instrumented/12.1-robolectric-8229987-i4
- ~/.m2/repository/org/robolectric/android-all-instrumented/13-robolectric-9030017-i4
- ~/.m2/repository/org/robolectric/android-all-instrumented/9-robolectric-4913185-2-i4

Therefore I updated the uncommented lines to match these versions. I removed the first two in the list, as they are now older than the minimum SDK version of 23. I also updated the artifacts being downloaded to match (apparently this was changed in [Robolectric 4.6](https://github.com/robolectric/robolectric/releases/tag/robolectric-4.6)?).

## How Has This Been Tested?
I ran through the steps listed on the comment I wrote to confirm that they make sense. I also checked that running `./gradlew robolectricSdkDownload` downloaded exactly the same files.

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
