### PR TITLE
build(deps): bump acra_version from 5.11.1 to 5.11.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     // If changing this, make sure to update org.jetbrains.kotlin.plugin.serialization version too
     ext.kotlin_version = '1.9.10'
     ext.lint_version = '31.1.1'
-    ext.acra_version = '5.11.1'
+    ext.acra_version = '5.11.2'
     ext.ankidroid_backend_version = '0.1.25-anki2.1.66'
     ext.hamcrest_version = '2.2'
     ext.junit_version = '5.10.0'


### PR DESCRIPTION
Bumps `acra_version` from 5.11.1 to 5.11.2.

Fixes #14348 

This is a startup crash that is unavoidable if it hits people so merging it here for a 2.17alpha2 release, plus going to cherry-pick the corresponding change to release-2.16 branch
