### PR TITLE
Show type answer field in reviewer when answer buttons are hidden

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
@@ -43,6 +43,7 @@ import androidx.annotation.IdRes
 import androidx.annotation.VisibleForTesting
 import androidx.appcompat.app.AlertDialog
 import androidx.core.net.toFile
+import androidx.core.view.children
 import androidx.core.view.isVisible
 import androidx.webkit.WebViewAssetLoader
 import anki.collection.OpChanges
@@ -953,6 +954,14 @@ abstract class AbstractFlashcardViewer :
             else -> Timber.w("Unknown answerButtonsPosition: %s", answerButtonsPosition)
         }
         answerArea.visibility = if (answerButtonsPosition == "none") View.GONE else View.VISIBLE
+        // workaround for #14419, iterate over the bottom area children and manually enable the
+        // answer field while still hiding the other children
+        if (answerButtonsPosition == "none") {
+            answerArea.visibility = View.VISIBLE
+            answerArea.children.forEach {
+                it.visibility = if (it.id == R.id.answer_field) View.VISIBLE else View.GONE
+            }
+        }
         answerArea.layoutParams = answerAreaParams
         whiteboardContainer.layoutParams = whiteboardContainerParams
         mCardFrame!!.layoutParams = flashcardContainerParams


### PR DESCRIPTION
## Purpose / Description
The type answer input field was hidden because the view is placed in the `reviewer_answer_buttons` layout which will be hidden if the user sets the "Answer buttons position" to "none" in settings. Ideally that layout would be refactored to exclude the type answer field which doesn't really belong there. 

## Fixes

Fixes #14419 

## How Has This Been Tested?

Ran the tests, manually verified the UI in various scenarios.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
