### PR TITLE
Removes unnecessary API <= 23 checks

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/provider/CardContentProvider.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/provider/CardContentProvider.kt
@@ -27,7 +27,6 @@ import android.net.Uri
 import android.webkit.MimeTypeMap
 import com.ichi2.anki.*
 import com.ichi2.anki.exception.ConfirmModSchemaException
-import com.ichi2.compat.CompatHelper.Companion.isMarshmallow
 import com.ichi2.libanki.*
 import com.ichi2.libanki.Collection
 import com.ichi2.libanki.Consts.BUTTON_TYPE
@@ -175,13 +174,13 @@ class CardContentProvider : ContentProvider() {
 
     /** Only enforce permissions for queries and inserts on Android M and above, or if its a 'rogue client'  */
     private fun shouldEnforceQueryOrInsertSecurity(): Boolean {
-        return isMarshmallow || knownRogueClient()
+        return knownRogueClient()
     }
 
     /** Enforce permissions for all updates on Android M and above. Otherwise block depending on URI and client app  */
     private fun shouldEnforceUpdateSecurity(uri: Uri): Boolean {
         val whitelist = listOf(NOTES_ID_CARDS_ORD, MODELS_ID, MODELS_ID_TEMPLATES_ID, SCHEDULE, DECK_SELECTED)
-        return isMarshmallow || !whitelist.contains(sUriMatcher.match(uri)) || knownRogueClient()
+        return !whitelist.contains(sUriMatcher.match(uri)) || knownRogueClient()
     }
 
     override fun query(uri: Uri, projection: Array<String>?, selection: String?, selectionArgs: Array<String>?, order: String?): Cursor? {

--- a/AnkiDroid/src/main/java/com/ichi2/compat/CompatHelper.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/CompatHelper.kt
@@ -56,10 +56,6 @@ class CompatHelper private constructor() {
         val sdkVersion: Int
             get() = Build.VERSION.SDK_INT
 
-        /** Determine if the device is running API level 23 or higher.  */
-        val isMarshmallow: Boolean
-            get() = sdkVersion >= Build.VERSION_CODES.M
-
         /**
          * Main public method to get the compatibility class
          */

--- a/api/src/main/java/com/ichi2/anki/api/AddContentApi.kt
+++ b/api/src/main/java/com/ichi2/anki/api/AddContentApi.kt
@@ -273,7 +273,7 @@ public class AddContentApi(context: Context) {
      * @throws SecurityException if READ_WRITE_PERMISSION not granted (e.g. due to install order bug)
      */
     public fun previewNewNote(mid: Long, flds: Array<String>): Map<String, Map<String, String>>? {
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M && !hasReadWritePermission()) {
+        if (!hasReadWritePermission()) {
             // avoid situation where addNote will pass, but deleteNote will fail
             throw SecurityException("previewNewNote requires full read-write-permission")
         }


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
Since Anki-Android now has minSdkVersion= 23, so checking whether API <= 23 is unnecessary.

## Fixes
Fixes #14338

## Approach
This removes any unnecessary checks for API level 23.

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
