### PR TITLE
fix: Removes custom fonts setting

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/AppearanceSettingsFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/AppearanceSettingsFragment.kt
@@ -25,7 +25,6 @@ import androidx.preference.SwitchPreferenceCompat
 import com.ichi2.anki.*
 import com.ichi2.anki.CollectionManager.withCol
 import com.ichi2.anki.snackbar.showSnackbar
-import com.ichi2.libanki.Utils
 import com.ichi2.themes.Theme
 import com.ichi2.themes.Themes
 import com.ichi2.themes.Themes.systemIsInNightMode
@@ -120,17 +119,6 @@ class AppearanceSettingsFragment : SettingsFragment() {
             }
         }
 
-        // Default font
-        requirePreference<ListPreference>(R.string.pref_default_font_key).apply {
-            entries = getCustomFonts("System default")
-            entryValues = getCustomFonts("")
-        }
-        // Browser and Note editor font
-        requirePreference<ListPreference>(R.string.pref_browser_and_editor_font_key).apply {
-            entries = getCustomFonts("System default")
-            entryValues = getCustomFonts("", useFullPath = true)
-        }
-
         // Show estimate time
         // Represents the collection pref "estTime": i.e.
         // whether the buttons should indicate the duration of the interval if we click on them.
@@ -149,27 +137,6 @@ class AppearanceSettingsFragment : SettingsFragment() {
                 launchCatchingTask { withCol { config.set("dueCounts", newDueCountsValue) } }
             }
         }
-    }
-
-    /** Returns a list of the names of the installed custom fonts */
-    private fun getCustomFonts(defaultValue: String, useFullPath: Boolean = false): Array<String?> {
-        val fonts = Utils.getCustomFonts(requireContext())
-        val count = fonts.size
-        Timber.d("There are %d custom fonts", count)
-        val names = arrayOfNulls<String>(count + 1)
-        names[0] = defaultValue
-        if (useFullPath) {
-            for (index in 1 until count + 1) {
-                names[index] = fonts[index - 1].path
-                Timber.d("Adding custom font: %s", names[index])
-            }
-        } else {
-            for (index in 1 until count + 1) {
-                names[index] = fonts[index - 1].name
-                Timber.d("Adding custom font: %s", names[index])
-            }
-        }
-        return names
     }
 
     private val mBackgroundImageResultLauncher = registerForActivityResult(ActivityResultContracts.GetContent()) { selectedImage ->

--- a/AnkiDroid/src/main/res/values/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values/10-preferences.xml
@@ -37,7 +37,6 @@
     <string name="pref_cat_whiteboard" maxLength="41">Whiteboard</string>
     <string name="pref_cat_appearance" maxLength="41">Appearance</string>
     <string name="pref_cat_themes" maxLength="41">Themes</string>
-    <string name="pref_cat_fonts" maxLength="41">Fonts</string>
     <string name="pref_cat_gestures" maxLength="41">Gestures</string>
     <string name="pref_cat_controls" maxLength="41">Controls</string>
     <string name="pref_cat_advanced" maxLength="41">Advanced</string>
@@ -115,8 +114,6 @@
     <string name="app_theme" maxLength="41">Theme</string>
     <string name="day_theme" maxLength="41">Day theme</string>
     <string name="night_theme" maxLength="41">Night theme</string>
-    <string name="default_font" maxLength="41">Default font</string>
-    <string name="override_font" maxLength="41">Default font applicability</string>
     <string name="language" maxLength="41">Language</string>
     <string name="language_system">System language</string>
     <string name="notification_pref" maxLength="41">Notifications</string>
@@ -219,7 +216,6 @@
     <!-- Deck configurations -->
     <string name="deck_conf_general" maxLength="41" comment="Label of the submenu for the general options of new deck">General</string>
     <string name="deck_conf_reminders" maxLength="41">Reminders</string>
-    <string name="pref_browser_editor_font" maxLength="41">Browser and editor font</string>
     <string name="deck_conf_cram_filter" maxLength="41">Filter</string>
     <string name="deck_conf_cram_search" maxLength="41">Search</string>
     <string name="deck_conf_cram_limit" maxLength="41">Limit to</string>

--- a/AnkiDroid/src/main/res/values/11-arrays.xml
+++ b/AnkiDroid/src/main/res/values/11-arrays.xml
@@ -44,10 +44,6 @@
     <string name="add_to_deck_use_current_deck">Use current deck</string>
     <string name="add_to_deck_decide_by_note_type">Decide by note type</string>
 
-    <!-- override_font_labels -->
-    <string name="override_font_if_missing">When no font specified on flashcards</string>
-    <string name="override_font_always" comment="Option to always override font">Always</string>
-
     <!-- theme labels -->
     <string name="theme_follow_system">Follow system</string>
 

--- a/AnkiDroid/src/main/res/values/constants.xml
+++ b/AnkiDroid/src/main/res/values/constants.xml
@@ -85,10 +85,6 @@
         <item>@string/add_to_deck_use_current_deck</item>
         <item>@string/add_to_deck_decide_by_note_type</item>
     </string-array>
-    <string-array name="override_font_labels">
-        <item>@string/override_font_if_missing</item>
-        <item>@string/override_font_always</item>
-    </string-array>
     <string-array name="day_theme_labels">
         <item>@string/day_theme_light</item>
         <item>@string/day_theme_plain</item>
@@ -183,10 +179,6 @@
         <item>3</item>
         <item>4</item>
     </string-array>
-    <string-array name="override_font_values">
-        <item>0</item>
-        <item>1</item>
-    </string-array>
     <string-array name="full_screen_mode_values">
         <item>0</item>
         <item>1</item>
@@ -263,7 +255,6 @@
 
     <string-array name="appearance_summary_entries">
         <item>@string/pref_cat_themes</item>
-        <item>@string/pref_cat_fonts</item>
         <item>@string/pref_cat_reviewer</item>
     </string-array>
 

--- a/AnkiDroid/src/main/res/values/preferences.xml
+++ b/AnkiDroid/src/main/res/values/preferences.xml
@@ -38,9 +38,6 @@
     <string name="fullscreen_mode_preference">fullscreenMode</string>
     <string name="center_vertically_preference">centerVertically</string>
     <string name="show_estimates_preference">showEstimates</string>
-    <string name="pref_default_font_key">defaultFont</string>
-    <string name="pref_font_applicability_key">overrideFontBehavior</string>
-    <string name="pref_browser_and_editor_font_key">browserEditorFont</string>
     <string name="pref_display_filenames_in_browser_key">card_browser_show_media_filenames</string>
     <string name="show_topbar_preference">showTopbar</string>
     <string name="show_progress_preference">showProgress</string>

--- a/AnkiDroid/src/main/res/xml/preferences_appearance.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_appearance.xml
@@ -110,26 +110,6 @@
             android:summary="@string/show_eta_summ"
             android:title="@string/show_eta" />
     </PreferenceCategory>
-    <PreferenceCategory android:title="@string/pref_cat_fonts" >
-        <ListPreference
-            android:defaultValue="@string/empty_string"
-            android:key="@string/pref_default_font_key"
-            android:shouldDisableView="true"
-            android:title="@string/default_font"
-            app:useSimpleSummaryProvider="true"/>
-        <ListPreference
-            android:defaultValue="0"
-            android:key="@string/pref_font_applicability_key"
-            android:entries="@array/override_font_labels"
-            android:entryValues="@array/override_font_values"
-            android:title="@string/override_font"
-            app:useSimpleSummaryProvider="true"/>
-        <ListPreference
-            android:defaultValue="@string/empty_string"
-            android:key="@string/pref_browser_and_editor_font_key"
-            android:title="@string/pref_browser_editor_font"
-            app:useSimpleSummaryProvider="true"/>
-    </PreferenceCategory>
     <PreferenceCategory android:title="@string/card_browser">
         <SwitchPreferenceCompat
             android:checked="false"


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
AnkiDroid directory is not accessible by common means in Android 10+ devices with the play store version, because of scoped storage. This means that the user cannot add a custom font to use it.

## Fixes
Fixes #14343

## Approach
This removes the custom font settings from the appearance section as it is no longer required.

## How Has This Been Tested?
| Before | After |
|--|--|
|<img src="https://github.com/ankidroid/Anki-Android/assets/84731134/dfb70e0f-8922-4bf3-a5bd-854bede5047c" width="300">| <img src="https://github.com/ankidroid/Anki-Android/assets/84731134/ecc1882c-23c0-4615-b02b-67128a56afae" width="300">|


## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [x] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
