### PR TITLE
fix: don't invalidate card if device doesn't have a browser

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
@@ -91,7 +91,6 @@ import com.ichi2.themes.Themes
 import com.ichi2.themes.Themes.getResFromAttr
 import com.ichi2.ui.FixedEditText
 import com.ichi2.utils.*
-import com.ichi2.utils.AdaptionUtil.hasWebBrowser
 import com.ichi2.utils.AssetHelper.guessMimeType
 import com.ichi2.utils.ClipboardUtil.getText
 import com.ichi2.utils.HandlerUtils.executeFunctionWithDelay
@@ -2182,13 +2181,6 @@ abstract class AbstractFlashcardViewer :
             val result = loader!!.shouldInterceptRequest(url)
             if (result != null) {
                 return result
-            }
-            if (!hasWebBrowser(baseContext)) {
-                val scheme = url.scheme!!.trim { it <= ' ' }
-                if ("http".equals(scheme, ignoreCase = true) || "https".equals(scheme, ignoreCase = true)) {
-                    val response = resources.getString(R.string.no_outgoing_link_in_cardbrowser)
-                    return WebResourceResponse("text/html", "utf-8", ByteArrayInputStream(response.toByteArray()))
-                }
             }
             if (url.toString().startsWith("file://")) {
                 if (isLoadedFromProtocolRelativeUrl(request.url.toString())) {

--- a/AnkiDroid/src/main/res/values/02-strings.xml
+++ b/AnkiDroid/src/main/res/values/02-strings.xml
@@ -217,7 +217,6 @@
     <string name="multimedia_editor_image_compression_failed"><![CDATA[Camera images may be large. You may wish to compress & resize images in the media directory]]></string>
     <string name="no_browser_notification">No browser found，please visit web page by pc or mobile: </string>
     <string name="web_page_error">Error loading page: %s</string>
-    <string name="no_outgoing_link_in_cardbrowser">External page link in card is not supported.</string>
     <!-- The name of the deck which corrupt cards will be moved to -->
     <!-- Deckpicker Background -->
     <string name="background_image_title">Background</string>


### PR DESCRIPTION
after we started using a internal server for serving the reviewer html, the whole card is replaced by `External page link in card is not supported.` if there isn't a browser installed

The original reason for checking browser was to adapt to educational devices that don't have a browser (efc9cec05884826a875cdfb446102b9a5c6d8e91), but the check isn't necessary in pratical terms, since there is already a message if the user taps a link without having a browser, i.e. `The system does not have an app installed that can perform this action.`

## Fixes
Fixes #14462 

## Approach
Remove the check

## How Has This Been Tested?

Android 33 emulator:
1. Don't have a browser installed in the device
2. Open a card and see if it renders normally

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
