### PR TITLE
Detect invalid capital letters

### DIFF
--- a/lint-rules/src/test/java/com/ichi2/anki/lint/rules/InvalidStringFormatDetectorTest.kt
+++ b/lint-rules/src/test/java/com/ichi2/anki/lint/rules/InvalidStringFormatDetectorTest.kt
@@ -54,6 +54,66 @@ class InvalidStringFormatDetectorTest {
         |</resources>
     """.trimMargin()
 
+    @Language("XML")
+    private val invalidCapitalization = """<resources>
+        |<string name="testString">%D</string>
+        |<string name="testString2">%1D</string>
+        |<string name="testString3">%9D</string>
+        |<string name="testString4">%-9D</string>
+        |<string name="testString5">%1${'$'}D</string>
+        |<string name="testString6">%F</string>
+        |<string name="testString7">%1F</string>
+        |<string name="testString8">%9F</string>
+        |<string name="testString9">%-9F</string>
+        |<string name="testString10">%1${'$'}F</string>
+        |<string name="testString11">%N</string>
+        |<string name="testString12">%O</string>
+        |<string name="testString13">%G</string>
+        |<string name="testString14">%C</string>
+        |<string name="testString15">%D %1D %9D %-9D %1${'$'}D %F %1F %9F %-9F %1${'$'}F %N %O %G %C</string>
+        |<string name="testString16">% %D</string>
+        |<string name="testString17">%D%</string>
+        |<string name="testString18">%D%%</string>
+        |<plurals name="pluralTestString1">
+            <item quantity="other">%2${'$'}D</item>
+        </plurals>
+        |</resources>
+    """.trimMargin()
+
+    @Language("XML")
+    private val validCapitalization = """<resources>
+        |<string name="testString">%d</string>
+        |<string name="testString2">%1d</string>
+        |<string name="testString3">%9d</string>
+        |<string name="testString4">%-9d</string>
+        |<string name="testString5">%1${'$'}d</string>
+        |<string name="testString6">%f</string>
+        |<string name="testString7">%1f</string>
+        |<string name="testString8">%9f</string>
+        |<string name="testString9">%-9f</string>
+        |<string name="testString10">%1${'$'}f</string>
+        |<string name="testString11">%n</string>
+        |<string name="testString12">%o</string>
+        |<string name="testString13">%g</string>
+        |<string name="testString14">%c</string>
+        |<string name="testString15">%d %1d %9d %-9d %1${'$'}d %f %1f %9f %-9f %1${'$'}f %n %o %g %c</string>
+        |<string name="testString16">% %d</string>
+        |<string name="testString16">%%D</string>
+        |<string name="testString17">% D</string>
+        |<string name="testString18">%d%</string>
+        |<string name="testString19">%d%%</string>
+        |<string name="testString20">%abcd</string>
+        |<string name="testString21">%S %X %T %E %H %B %A</string>
+        |<string name="testString22">%S %1S %9S %-9S %1${'$'}S</string>
+        |<string name="testString23">%1{'$'}d\nDatabase version</string>
+        |<string name="testString24">%abcD</string>
+        |<string name="testString25">%abcDefg</string>
+        |<plurals name="pluralTestString1">
+            <item quantity="other">Hello hello %2${'$'}d hello hello</item>
+        </plurals>
+        |</resources>
+    """.trimMargin()
+
     @Test
     fun error_if_string_format_invalid() {
         TestLintTask.lint()
@@ -72,6 +132,29 @@ class InvalidStringFormatDetectorTest {
             .allowMissingSdk()
             .allowCompilationErrors()
             .files(TestFiles.xml("res/values/string.xml", valid))
+            .issues(InvalidStringFormatDetector.ISSUE)
+            .run()
+            .expectClean()
+    }
+
+    @Test
+    fun error_if_capitalization_invalid() {
+        TestLintTask.lint()
+            .allowMissingSdk()
+            .allowCompilationErrors()
+            .allowDuplicates()
+            .files(TestFiles.xml("res/values/string.xml", invalidCapitalization))
+            .issues(InvalidStringFormatDetector.ISSUE)
+            .run()
+            .expectErrorCount(19)
+    }
+
+    @Test
+    fun no_error_if_capitalization_valid() {
+        TestLintTask.lint()
+            .allowMissingSdk()
+            .allowCompilationErrors()
+            .files(TestFiles.xml("res/values/string.xml", validCapitalization))
             .issues(InvalidStringFormatDetector.ISSUE)
             .run()
             .expectClean()


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
See below

## Fixes
[Fixes _Link to the issues._](https://github.com/ankidroid/Anki-Android/issues/14079)

## Approach

This addresses the problem of detecting formatting specifiers being capitalized accidently, leading to crashes.
Eg. $1%D instead of $1%d

./gradlew lint
Running the above command should run the detection

## How Has This Been Tested?

Added tests to InvalidStringFormatDetectorTest
You can run the tests as you normally would

## Learning (optional, can help others)

https://www.developer.com/java/java-string-format-method/
Provides a chart of the Format Specifiers

I used the following regex:
(?<!%)%[^%a-zA-Z]*[DFNOGC].*

(?<!%)% => should match %, but does not match if there's another % immediately to the left
[^%a-zA-Z]* => should match any characters (zero or more) that are not %, alphabetical or whitespace
[DFNOGC] => should match any of the capital characters that cause the errors
.* => can match any non whitespace characters (zero or more) following the format specifier

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [N/A] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [N/A] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
