### PR TITLE
 "lose current input" even when there is no input solved (#13821) 

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
@@ -612,10 +612,15 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
             return true
         }
         // changed fields?
-        return if (isFieldEdited) {
-            true
+        if (isFieldEdited) {
+            for (value in mEditFields!!) {
+                if (value?.text.toString() != "") {
+                    return true
+                }
+            }
+            return false
         } else {
-            isTagsEdited
+            return isTagsEdited
         }
         // changed tags?
     }
@@ -2125,12 +2130,11 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
 
     private inner class EditFieldTextWatcher(private val index: Int) : TextWatcher {
         override fun afterTextChanged(arg0: Editable) {
-            isFieldEdited = mEditFields?.get(index)?.text.toString() != ""
+            isFieldEdited = true
             if (index == 0) {
                 setDuplicateFieldStyles()
             }
         }
-
         override fun beforeTextChanged(arg0: CharSequence, arg1: Int, arg2: Int, arg3: Int) {
             // do nothing
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
@@ -2125,7 +2125,7 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
 
     private inner class EditFieldTextWatcher(private val index: Int) : TextWatcher {
         override fun afterTextChanged(arg0: Editable) {
-            isFieldEdited = true
+            isFieldEdited = mEditFields?.get(index)?.text.toString() != ""
             if (index == 0) {
                 setDuplicateFieldStyles()
             }


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
After trying to add a card and write something in any of the text fields if the user erased the text written in those fields although not having anything written, the program would save the state when the text was written and would pop an alert box.

## Fixes
Fixes #13821 

```
 if (isFieldEdited) {
            for (value in mEditFields!!) {
                if (value?.text.toString() != "") {
                    return true
                }
            }
            return false
```
After modifying the text and before going back to the homepage, the program is going to check if there is anything written in any of the text fields of the card, in case that it is the alert box would pop  and in the other case it wouldn't

## Approach
Thanks to this change the program will save the state correctly without something unnecesary alert boxes

## How Has This Been Tested?
Do the same thing i wrote in the description and check that the alert box does not pop out.

## Learning (optional, can help others)


## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
