### PR TITLE
Handle the PR already existing when running the sync_translations workflow

### DIFF
--- a/.github/workflows/sync_translations.yml
+++ b/.github/workflows/sync_translations.yml
@@ -78,13 +78,20 @@ jobs:
               ("0" + now.getUTCDate()).slice(-2) + " " + 
               ("0" + now.getUTCHours()).slice(-2) + ":" +
               ("0" + now.getUTCMinutes()).slice(-2);
-              
-            github.rest.pulls.create({              
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              title: "Updated strings from Crowdin " + formattedDate,
-              head: "i18n_sync",
-              base: "main",
-              body: "Contains the newest strings changes from Crowdin.",
-              maintainer_can_modify: true
-            });
+            try {  
+              github.rest.pulls.create({              
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title: "Updated strings from Crowdin " + formattedDate,
+                head: "i18n_sync",
+                base: "main",
+                body: "Contains the newest strings changes from Crowdin.",
+                maintainer_can_modify: true
+              });
+            } catch(err) {
+              if (err.status === 422) {
+                console.log("A PR containing translations sync already exists!");
+              } else {
+                throw err;
+              }
+            }


### PR DESCRIPTION
## Fixes
Currently the `sync_translation` workflow will fail if it's run again while a PR with strings translations already exists([example](https://github.com/ankidroid/Anki-Android/actions/runs/6339312113)). This is a common scenario when there are incorrect strings that need to be reverted so the workflow shouldn't fail for this. This PR fixes this issue by try/catching the call to create the PR and logging a message when the PR is available(and the workflow will not be marked as failed).

The same fix is present in [`update_js_libs`](https://github.com/ankidroid/Anki-Android/blob/main/.github/workflows/update_js_libs.yml) workflow.

## How Has This Been Tested?

Hard to test these workflows changes but any issue will be obvious pretty soon.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
