### PR TITLE
Stop sound when card/note is buried or suspended

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
@@ -1610,6 +1610,7 @@ abstract class AbstractFlashcardViewer :
                     sched.buryCards(listOf(currentCard!!.id))
                 }
             }
+            mSoundPlayer.stopSounds()
             showSnackbar(R.string.card_buried, Reviewer.ACTION_SNACKBAR_TIME)
         }
         return true
@@ -1623,6 +1624,7 @@ abstract class AbstractFlashcardViewer :
                     sched.suspendCards(listOf(currentCard!!.id))
                 }
             }
+            mSoundPlayer.stopSounds()
             showSnackbar(TR.studyingCardSuspended(), Reviewer.ACTION_SNACKBAR_TIME)
         }
         return true
@@ -1638,6 +1640,7 @@ abstract class AbstractFlashcardViewer :
             }
             val count = changed.count
             val noteSuspended = resources.getQuantityString(R.plurals.note_suspended, count, count)
+            mSoundPlayer.stopSounds()
             showSnackbar(noteSuspended, Reviewer.ACTION_SNACKBAR_TIME)
         }
         return true
@@ -1651,6 +1654,7 @@ abstract class AbstractFlashcardViewer :
                     sched.buryNotes(listOf(currentCard!!.nid))
                 }
             }
+            mSoundPlayer.stopSounds()
             showSnackbar(TR.studyingCardsBuried(changed.count), Reviewer.ACTION_SNACKBAR_TIME)
         }
         return true


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
Stop playing sound file when the action of "bury" or "suspend" is done.

## Fixes
Fixes #14494

## Approach
Stop sound player before the feedback snackbar of the action is shown.

## How Has This Been Tested?
Checked in a physical device (Android 11) about the following actions.

- Bury
- Bury card
- Bury note
- Suspend
- Suspend card
- Suspend note

 Checked both cases when "Don't play automatically" is enabled and disabled.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] ~~UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)~~
- [ ] ~~UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)~~
