### PR TITLE
url loading from assets

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/Info.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Info.kt
@@ -98,6 +98,8 @@ class Info : AnkiActivity() {
         val anchorTextColor = anchorTextThemeColor.toRGBHex()
 
         mWebView!!.setBackgroundColor(backgroundColor)
+        mWebView!!.settings.allowFileAccess = true
+        mWebView!!.settings.allowContentAccess = true
         setRenderWorkaround(this)
         when (type) {
             TYPE_NEW_VERSION -> {
@@ -106,7 +108,7 @@ class Info : AnkiActivity() {
                     setOnClickListener { close() }
                 }
                 val background = backgroundColor.toRGBHex()
-                mWebView!!.loadUrl("/assets/changelog.html")
+                mWebView!!.loadUrl("/android_asset/changelog.html")
                 mWebView!!.settings.javaScriptEnabled = true
                 mWebView!!.webViewClient = object : WebViewClient() {
                     override fun onPageFinished(view: WebView, url: String) {


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
1. The url loading was not set to handle the local file correctly.
2. The access would be denied in case API>=30

## Fixes
Fixes #14499

https://developer.android.com/reference/kotlin/android/webkit/WebSettings#getallowcontentaccess

## How Has This Been Tested?
Tested on Google Emulator

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
