### PR TITLE
change KotlinCleanup.kt path, from '/utils' to '/annotations'

### DIFF
--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/NoteEditorTest.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/NoteEditorTest.kt
@@ -22,7 +22,7 @@ import android.os.Build
 import androidx.test.ext.junit.rules.ActivityScenarioRule
 import androidx.test.platform.app.InstrumentationRegistry
 import com.ichi2.anki.testutil.GrantStoragePermission
-import com.ichi2.utils.KotlinCleanup
+import com.ichi2.annotations.KotlinCleanup
 import org.hamcrest.Matchers
 import org.junit.Assume
 import org.junit.Before

--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/TestUtils.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/TestUtils.kt
@@ -24,7 +24,7 @@ import androidx.test.espresso.ViewAction
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.runner.lifecycle.ActivityLifecycleMonitorRegistry
 import androidx.test.runner.lifecycle.Stage
-import com.ichi2.utils.KotlinCleanup
+import com.ichi2.annotations.KotlinCleanup
 import org.hamcrest.Description
 import org.hamcrest.Matcher
 import org.hamcrest.TypeSafeMatcher

--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/ContentProviderTest.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/ContentProviderTest.kt
@@ -29,9 +29,9 @@ import com.ichi2.anki.FlashCardsContract
 import com.ichi2.anki.testutil.DatabaseUtils.cursorFillWindow
 import com.ichi2.anki.testutil.GrantStoragePermission.storagePermission
 import com.ichi2.anki.testutil.grantPermissions
+import com.ichi2.annotations.KotlinCleanup
 import com.ichi2.libanki.*
 import com.ichi2.libanki.exception.ConfirmModSchemaException
-import com.ichi2.utils.KotlinCleanup
 import org.hamcrest.MatcherAssert.*
 import org.hamcrest.Matchers.*
 import org.json.JSONObject

--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/NotificationChannelTest.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/NotificationChannelTest.kt
@@ -24,8 +24,8 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.ichi2.anki.AnkiDroidApp
 import com.ichi2.anki.Channel
 import com.ichi2.anki.testutil.GrantStoragePermission
+import com.ichi2.annotations.KotlinCleanup
 import com.ichi2.compat.CompatHelper.Companion.sdkVersion
-import com.ichi2.utils.KotlinCleanup
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.greaterThanOrEqualTo
 import org.junit.Before

--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/Shared.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/Shared.kt
@@ -16,9 +16,9 @@
 package com.ichi2.anki.tests
 
 import android.content.Context
+import com.ichi2.annotations.KotlinCleanup
 import com.ichi2.libanki.Collection
 import com.ichi2.libanki.Storage
-import com.ichi2.utils.KotlinCleanup
 import org.junit.Assert.assertTrue
 import java.io.File
 import java.io.IOException

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
@@ -76,6 +76,8 @@ import com.ichi2.anki.services.migrationServiceWhileStartedOrNull
 import com.ichi2.anki.snackbar.BaseSnackbarBuilderProvider
 import com.ichi2.anki.snackbar.SnackbarBuilder
 import com.ichi2.anki.snackbar.showSnackbar
+import com.ichi2.annotations.BlocksSchemaUpgrade
+import com.ichi2.annotations.KotlinCleanup
 import com.ichi2.annotations.NeedsTest
 import com.ichi2.compat.CompatHelper.Companion.compat
 import com.ichi2.compat.CompatHelper.Companion.resolveActivityCompat

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiActivity.kt
@@ -46,6 +46,7 @@ import com.ichi2.anki.preferences.Preferences.Companion.MINIMUM_CARDS_DUE_FOR_NO
 import com.ichi2.anki.preferences.sharedPrefs
 import com.ichi2.anki.snackbar.showSnackbar
 import com.ichi2.anki.workarounds.AppLoadedFromBackupWorkaround.showedActivityFailedScreen
+import com.ichi2.annotations.KotlinCleanup
 import com.ichi2.async.CollectionLoader
 import com.ichi2.compat.customtabs.CustomTabActivityHelper
 import com.ichi2.compat.customtabs.CustomTabsFallback
@@ -53,7 +54,6 @@ import com.ichi2.compat.customtabs.CustomTabsHelper
 import com.ichi2.libanki.Collection
 import com.ichi2.themes.Themes
 import com.ichi2.utils.AdaptionUtil
-import com.ichi2.utils.KotlinCleanup
 import timber.log.Timber
 
 @UiThread

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.kt
@@ -47,6 +47,7 @@ import com.ichi2.anki.preferences.sharedPrefs
 import com.ichi2.anki.services.BootService
 import com.ichi2.anki.services.NotificationService
 import com.ichi2.anki.ui.dialogs.ActivityAgnosticDialogs
+import com.ichi2.annotations.KotlinCleanup
 import com.ichi2.compat.CompatHelper
 import com.ichi2.utils.*
 import timber.log.Timber

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -65,6 +65,7 @@ import com.ichi2.anki.snackbar.showSnackbar
 import com.ichi2.anki.utils.SECONDS_PER_DAY
 import com.ichi2.anki.utils.roundedTimeSpanUnformatted
 import com.ichi2.anki.widgets.DeckDropDownAdapter.SubtitleListener
+import com.ichi2.annotations.KotlinCleanup
 import com.ichi2.annotations.NeedsTest
 import com.ichi2.async.*
 import com.ichi2.compat.Compat

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.kt
@@ -49,6 +49,7 @@ import com.ichi2.anki.dialogs.DiscardChangesDialog
 import com.ichi2.anki.dialogs.InsertFieldDialog
 import com.ichi2.anki.dialogs.InsertFieldDialog.Companion.REQUEST_FIELD_INSERT
 import com.ichi2.anki.snackbar.showSnackbar
+import com.ichi2.annotations.KotlinCleanup
 import com.ichi2.annotations.NeedsTest
 import com.ichi2.compat.CompatHelper.Companion.getSerializableCompat
 import com.ichi2.libanki.*
@@ -57,7 +58,6 @@ import com.ichi2.libanki.Notetypes.Companion.NOT_FOUND_NOTE_TYPE
 import com.ichi2.libanki.exception.ConfirmModSchemaException
 import com.ichi2.ui.FixedEditText
 import com.ichi2.ui.FixedTextView
-import com.ichi2.utils.KotlinCleanup
 import com.ichi2.utils.jsonObjectIterable
 import org.json.JSONArray
 import org.json.JSONException

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CollectionHelper.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CollectionHelper.kt
@@ -28,11 +28,11 @@ import com.ichi2.anki.exception.StorageAccessException
 import com.ichi2.anki.exception.UnknownDatabaseVersionException
 import com.ichi2.anki.preferences.Preferences
 import com.ichi2.anki.preferences.sharedPrefs
+import com.ichi2.annotations.KotlinCleanup
 import com.ichi2.libanki.Collection
 import com.ichi2.libanki.DB
 import com.ichi2.preferences.getOrSetString
 import com.ichi2.utils.FileUtil
-import com.ichi2.utils.KotlinCleanup
 import net.ankiweb.rsdroid.BackendException.BackendDbException.BackendDbFileTooNewException
 import net.ankiweb.rsdroid.BackendException.BackendDbException.BackendDbLockedException
 import timber.log.Timber

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -103,6 +103,7 @@ import com.ichi2.anki.ui.dialogs.storageMigrationFailedDialogIsShownOrPending
 import com.ichi2.anki.utils.SECONDS_PER_DAY
 import com.ichi2.anki.utils.timeQuantityTopDeckPicker
 import com.ichi2.anki.widgets.DeckAdapter
+import com.ichi2.annotations.KotlinCleanup
 import com.ichi2.annotations.NeedsTest
 import com.ichi2.async.*
 import com.ichi2.compat.CompatHelper.Companion.sdkVersion

--- a/AnkiDroid/src/main/java/com/ichi2/anki/FieldEditLine.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/FieldEditLine.kt
@@ -38,9 +38,9 @@ import androidx.core.os.ParcelCompat
 import androidx.core.view.ViewCompat
 import androidx.vectordrawable.graphics.drawable.VectorDrawableCompat
 import com.ichi2.anki.UIUtils.getDensityAdjustedValue
+import com.ichi2.annotations.KotlinCleanup
 import com.ichi2.ui.AnimationUtil.collapseView
 import com.ichi2.ui.AnimationUtil.expandView
-import com.ichi2.utils.KotlinCleanup
 import java.util.*
 
 class FieldEditLine : FrameLayout {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/FieldEditText.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/FieldEditText.kt
@@ -38,13 +38,13 @@ import androidx.core.view.inputmethod.EditorInfoCompat
 import androidx.core.view.inputmethod.InputConnectionCompat
 import com.ichi2.anki.preferences.sharedPrefs
 import com.ichi2.anki.servicelayer.NoteService
+import com.ichi2.annotations.KotlinCleanup
 import com.ichi2.themes.Themes.getColorFromAttr
 import com.ichi2.ui.FixedEditText
 import com.ichi2.utils.ClipboardUtil.IMAGE_MIME_TYPES
 import com.ichi2.utils.ClipboardUtil.getImageUri
 import com.ichi2.utils.ClipboardUtil.getPlainText
 import com.ichi2.utils.ClipboardUtil.hasImage
-import com.ichi2.utils.KotlinCleanup
 import kotlinx.parcelize.Parcelize
 import timber.log.Timber
 import java.util.*

--- a/AnkiDroid/src/main/java/com/ichi2/anki/MetaDB.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/MetaDB.kt
@@ -8,9 +8,9 @@ import android.database.sqlite.SQLiteException
 import androidx.annotation.WorkerThread
 import com.ichi2.anki.model.WhiteboardPenColor
 import com.ichi2.anki.model.WhiteboardPenColor.Companion.default
+import com.ichi2.annotations.KotlinCleanup
 import com.ichi2.libanki.DeckId
 import com.ichi2.libanki.Sound.SoundSide
-import com.ichi2.utils.KotlinCleanup
 import com.ichi2.widget.SmallWidgetStatus
 import timber.log.Timber
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/MyAccount.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/MyAccount.kt
@@ -28,9 +28,9 @@ import androidx.appcompat.widget.Toolbar
 import com.google.android.material.textfield.TextInputLayout
 import com.ichi2.anim.ActivityTransitionAnimation
 import com.ichi2.anki.preferences.sharedPrefs
+import com.ichi2.annotations.KotlinCleanup
 import com.ichi2.ui.TextInputEditField
 import com.ichi2.utils.AdaptionUtil.isUserATestClient
-import com.ichi2.utils.KotlinCleanup
 import timber.log.Timber
 
 /**

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NavigationDrawerActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NavigationDrawerActivity.kt
@@ -44,11 +44,11 @@ import com.ichi2.anki.dialogs.HelpDialog
 import com.ichi2.anki.preferences.Preferences
 import com.ichi2.anki.preferences.sharedPrefs
 import com.ichi2.anki.workarounds.FullDraggableContainerFix
+import com.ichi2.annotations.KotlinCleanup
 import com.ichi2.compat.CompatHelper
 import com.ichi2.libanki.CardId
 import com.ichi2.themes.Themes
 import com.ichi2.utils.HandlerUtils
-import com.ichi2.utils.KotlinCleanup
 import timber.log.Timber
 
 @KotlinCleanup("IDE-lint")

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
@@ -77,6 +77,7 @@ import com.ichi2.anki.snackbar.SnackbarBuilder
 import com.ichi2.anki.snackbar.showSnackbar
 import com.ichi2.anki.ui.setupNoteTypeSpinner
 import com.ichi2.anki.widgets.DeckDropDownAdapter.SubtitleListener
+import com.ichi2.annotations.KotlinCleanup
 import com.ichi2.annotations.NeedsTest
 import com.ichi2.compat.Compat
 import com.ichi2.libanki.*

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
@@ -74,6 +74,7 @@ import com.ichi2.anki.servicelayer.resetCards
 import com.ichi2.anki.snackbar.showSnackbar
 import com.ichi2.anki.utils.remainingTime
 import com.ichi2.anki.workarounds.FirefoxSnackbarWorkaround.handledLaunchFromWebBrowser
+import com.ichi2.annotations.KotlinCleanup
 import com.ichi2.annotations.NeedsTest
 import com.ichi2.libanki.*
 import com.ichi2.libanki.Collection

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Whiteboard.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Whiteboard.kt
@@ -34,11 +34,11 @@ import androidx.core.content.edit
 import com.ichi2.anki.dialogs.WhiteBoardWidthDialog
 import com.ichi2.anki.preferences.sharedPrefs
 import com.ichi2.anki.utils.getTimestamp
+import com.ichi2.annotations.KotlinCleanup
 import com.ichi2.compat.CompatHelper
 import com.ichi2.libanki.utils.Time
 import com.ichi2.themes.Themes.currentTheme
 import com.ichi2.utils.DisplayUtils.getDisplayDimensions
-import com.ichi2.utils.KotlinCleanup
 import com.mrudultora.colorpicker.ColorPickerPopUp
 import timber.log.Timber
 import java.io.FileNotFoundException

--- a/AnkiDroid/src/main/java/com/ichi2/anki/analytics/UsageAnalytics.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/analytics/UsageAnalytics.kt
@@ -30,8 +30,8 @@ import com.ichi2.anki.AnkiDroidApp
 import com.ichi2.anki.BuildConfig
 import com.ichi2.anki.R
 import com.ichi2.anki.preferences.sharedPrefs
+import com.ichi2.annotations.KotlinCleanup
 import com.ichi2.utils.DisplayUtils
-import com.ichi2.utils.KotlinCleanup
 import com.ichi2.utils.WebViewDebugging.hasSetDataDirectory
 import org.acra.ACRA
 import org.acra.util.Installation

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckSelectionDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckSelectionDialog.kt
@@ -41,11 +41,11 @@ import com.ichi2.anki.analytics.AnalyticsDialogFragment
 import com.ichi2.anki.dialogs.DeckSelectionDialog.DecksArrayAdapter.DecksFilter
 import com.ichi2.anki.dialogs.DeckSelectionDialog.SelectableDeck
 import com.ichi2.anki.launchCatchingTask
+import com.ichi2.annotations.KotlinCleanup
 import com.ichi2.annotations.NeedsTest
 import com.ichi2.libanki.*
 import com.ichi2.libanki.Collection
 import com.ichi2.utils.DeckNameComparator
-import com.ichi2.utils.KotlinCleanup
 import com.ichi2.utils.TypedFilter
 import kotlinx.parcelize.IgnoredOnParcel
 import kotlinx.parcelize.Parcelize

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/HelpDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/HelpDialog.kt
@@ -31,10 +31,10 @@ import com.ichi2.anki.UIUtils.showThemedToast
 import com.ichi2.anki.analytics.UsageAnalytics
 import com.ichi2.anki.dialogs.RecursivePictureMenu.Companion.createInstance
 import com.ichi2.anki.dialogs.RecursivePictureMenu.ItemHeader
+import com.ichi2.annotations.KotlinCleanup
 import com.ichi2.utils.AdaptionUtil.isUserATestClient
 import com.ichi2.utils.IntentUtil.canOpenIntent
 import com.ichi2.utils.IntentUtil.tryOpenIntent
-import com.ichi2.utils.KotlinCleanup
 import java.io.Serializable
 import java.util.*
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/customstudy/CustomStudyDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/customstudy/CustomStudyDialog.kt
@@ -44,6 +44,7 @@ import com.ichi2.anki.dialogs.customstudy.CustomStudyDialog.ContextMenuOption.*
 import com.ichi2.anki.dialogs.tags.TagsDialog
 import com.ichi2.anki.dialogs.tags.TagsDialogListener
 import com.ichi2.anki.preferences.sharedPrefs
+import com.ichi2.annotations.KotlinCleanup
 import com.ichi2.libanki.Collection
 import com.ichi2.libanki.Consts
 import com.ichi2.libanki.Consts.DYN_PRIORITY
@@ -51,7 +52,6 @@ import com.ichi2.libanki.Deck
 import com.ichi2.libanki.DeckId
 import com.ichi2.libanki.backend.exception.DeckRenameException
 import com.ichi2.utils.HashUtil.hashMapInit
-import com.ichi2.utils.KotlinCleanup
 import com.ichi2.utils.asLocalizedMessage
 import org.json.JSONArray
 import org.json.JSONObject

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/tags/TagsDialogListener.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/tags/TagsDialogListener.kt
@@ -18,7 +18,7 @@ package com.ichi2.anki.dialogs.tags
 import android.os.Bundle
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentManager
-import com.ichi2.utils.KotlinCleanup
+import com.ichi2.annotations.KotlinCleanup
 import java.util.ArrayList
 
 @KotlinCleanup("make selectedTags and indeterminateTags non-null")

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/activity/MultimediaEditFieldActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/activity/MultimediaEditFieldActivity.kt
@@ -34,8 +34,8 @@ import com.ichi2.anki.R
 import com.ichi2.anki.UIUtils
 import com.ichi2.anki.multimediacard.IMultimediaEditableNote
 import com.ichi2.anki.multimediacard.fields.*
+import com.ichi2.annotations.KotlinCleanup
 import com.ichi2.compat.CompatHelper.Companion.getSerializableCompat
-import com.ichi2.utils.KotlinCleanup
 import com.ichi2.utils.Permissions
 import timber.log.Timber
 import java.io.File

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/activity/PickStringDialogFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/activity/PickStringDialogFragment.kt
@@ -26,7 +26,7 @@ import android.content.DialogInterface
 import android.os.Bundle
 import android.widget.ArrayAdapter
 import androidx.fragment.app.DialogFragment
-import com.ichi2.utils.KotlinCleanup
+import com.ichi2.annotations.KotlinCleanup
 import java.util.*
 
 /**

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicImageFieldController.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicImageFieldController.kt
@@ -58,6 +58,7 @@ import com.ichi2.anki.DrawingActivity
 import com.ichi2.anki.R
 import com.ichi2.anki.UIUtils
 import com.ichi2.anki.multimediacard.activity.MultimediaEditFieldActivity
+import com.ichi2.annotations.KotlinCleanup
 import com.ichi2.annotations.NeedsTest
 import com.ichi2.ui.FixedEditText
 import com.ichi2.utils.*

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicMediaClipFieldController.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicMediaClipFieldController.kt
@@ -30,10 +30,10 @@ import com.ichi2.anki.CrashReportService
 import com.ichi2.anki.R
 import com.ichi2.anki.UIUtils.showThemedToast
 import com.ichi2.anki.preferences.sharedPrefs
+import com.ichi2.annotations.KotlinCleanup
 import com.ichi2.compat.CompatHelper
 import com.ichi2.ui.FixedTextView
 import com.ichi2.utils.ExceptionUtil.executeSafe
-import com.ichi2.utils.KotlinCleanup
 import timber.log.Timber
 import java.io.File
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/FieldBase.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/FieldBase.kt
@@ -19,7 +19,7 @@
 
 package com.ichi2.anki.multimediacard.fields
 
-import com.ichi2.utils.KotlinCleanup
+import com.ichi2.annotations.KotlinCleanup
 
 /**
  * Base for all field types.

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/FieldControllerBase.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/FieldControllerBase.kt
@@ -21,7 +21,7 @@ package com.ichi2.anki.multimediacard.fields
 import android.os.Bundle
 import com.ichi2.anki.multimediacard.IMultimediaEditableNote
 import com.ichi2.anki.multimediacard.activity.MultimediaEditFieldActivity
-import com.ichi2.utils.KotlinCleanup
+import com.ichi2.annotations.KotlinCleanup
 
 @KotlinCleanup("remove hungarian notation")
 @Suppress("VariableNamingDetector")

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/ImageField.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/ImageField.kt
@@ -21,8 +21,8 @@ package com.ichi2.anki.multimediacard.fields
 
 import androidx.annotation.CheckResult
 import androidx.annotation.VisibleForTesting
+import com.ichi2.annotations.KotlinCleanup
 import com.ichi2.libanki.Collection
-import com.ichi2.utils.KotlinCleanup
 import org.jsoup.Jsoup
 import timber.log.Timber
 import java.io.File

--- a/AnkiDroid/src/main/java/com/ichi2/anki/noteeditor/FieldState.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/noteeditor/FieldState.kt
@@ -23,9 +23,9 @@ import androidx.core.os.BundleCompat
 import com.ichi2.anki.FieldEditLine
 import com.ichi2.anki.NoteEditor
 import com.ichi2.anki.R
+import com.ichi2.annotations.KotlinCleanup
 import com.ichi2.libanki.NotetypeJson
 import com.ichi2.libanki.Notetypes
-import com.ichi2.utils.KotlinCleanup
 import com.ichi2.utils.MapUtil.getKeyByValue
 import org.json.JSONObject
 import java.util.*

--- a/AnkiDroid/src/main/java/com/ichi2/anki/provider/CardContentProvider.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/provider/CardContentProvider.kt
@@ -26,6 +26,7 @@ import android.database.sqlite.SQLiteQueryBuilder
 import android.net.Uri
 import android.webkit.MimeTypeMap
 import com.ichi2.anki.*
+import com.ichi2.annotations.KotlinCleanup
 import com.ichi2.libanki.*
 import com.ichi2.libanki.Collection
 import com.ichi2.libanki.Consts.BUTTON_TYPE
@@ -36,7 +37,6 @@ import com.ichi2.libanki.exception.EmptyMediaException
 import com.ichi2.libanki.sched.DeckNode
 import com.ichi2.libanki.utils.TimeManager
 import com.ichi2.utils.FileUtil.internalizeUri
-import com.ichi2.utils.KotlinCleanup
 import com.ichi2.utils.Permissions.arePermissionsDefinedInManifest
 import org.json.JSONArray
 import org.json.JSONException

--- a/AnkiDroid/src/main/java/com/ichi2/anki/web/HttpFetcher.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/web/HttpFetcher.kt
@@ -20,8 +20,8 @@
 
 package com.ichi2.anki.web
 import android.content.Context
+import com.ichi2.annotations.KotlinCleanup
 import com.ichi2.compat.CompatHelper
-import com.ichi2.utils.KotlinCleanup
 import com.ichi2.utils.VersionUtils.pkgVersionName
 import okhttp3.Interceptor
 import okhttp3.OkHttpClient

--- a/AnkiDroid/src/main/java/com/ichi2/anki/widgets/DeckAdapter.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/widgets/DeckAdapter.kt
@@ -27,10 +27,10 @@ import androidx.annotation.VisibleForTesting
 import androidx.recyclerview.widget.RecyclerView
 import com.ichi2.anki.CollectionManager.withCol
 import com.ichi2.anki.R
+import com.ichi2.annotations.KotlinCleanup
 import com.ichi2.libanki.DeckId
 import com.ichi2.libanki.sched.Counts
 import com.ichi2.libanki.sched.DeckNode
-import com.ichi2.utils.KotlinCleanup
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock

--- a/AnkiDroid/src/main/java/com/ichi2/annotations/KotlinCleanup.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/annotations/KotlinCleanup.kt
@@ -18,7 +18,7 @@
         "@RunWith(AndroidJUnit4::class) to speed up tests (if no other Android references)"
 )
 
-package com.ichi2.utils
+package com.ichi2.annotations
 
 /** Use when code can be changed after further conversion to Kotlin */
 @Target(

--- a/AnkiDroid/src/main/java/com/ichi2/compat/CompatV23.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/CompatV23.kt
@@ -33,7 +33,7 @@ import android.os.Vibrator
 import android.provider.MediaStore
 import android.view.View
 import androidx.appcompat.widget.TooltipCompat
-import com.ichi2.utils.KotlinCleanup
+import com.ichi2.annotations.KotlinCleanup
 import timber.log.Timber
 import java.io.File
 import java.io.FileInputStream

--- a/AnkiDroid/src/main/java/com/ichi2/compat/CompatV26.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/CompatV26.kt
@@ -26,7 +26,7 @@ import android.os.Vibrator
 import android.view.View
 import androidx.annotation.VisibleForTesting
 import com.ichi2.anki.NotificationChannels
-import com.ichi2.utils.KotlinCleanup
+import com.ichi2.annotations.KotlinCleanup
 import java.io.*
 import java.nio.file.*
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.kt
@@ -30,6 +30,7 @@ import anki.config.ConfigKey
 import anki.search.SearchNode
 import anki.sync.SyncAuth
 import anki.sync.SyncStatusResponse
+import com.ichi2.annotations.KotlinCleanup
 import com.ichi2.libanki.Utils.ids2str
 import com.ichi2.libanki.backend.model.toBackendNote
 import com.ichi2.libanki.backend.model.toProtoBuf

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/DB.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/DB.kt
@@ -29,8 +29,8 @@ import androidx.sqlite.db.SupportSQLiteDatabase
 import com.ichi2.anki.CollectionHelper
 import com.ichi2.anki.CrashReportService.sendExceptionReport
 import com.ichi2.anki.dialogs.DatabaseErrorDialog
+import com.ichi2.annotations.KotlinCleanup
 import com.ichi2.utils.DatabaseChangeDecorator
-import com.ichi2.utils.KotlinCleanup
 import net.ankiweb.rsdroid.Backend
 import net.ankiweb.rsdroid.database.AnkiSupportSQLiteDatabase
 import org.intellij.lang.annotations.Language

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.kt
@@ -29,10 +29,10 @@ import anki.collection.OpChangesWithCount
 import anki.collection.OpChangesWithId
 import anki.decks.FilteredDeckForUpdate
 import com.google.protobuf.kotlin.toByteStringUtf8
+import com.ichi2.annotations.KotlinCleanup
 import com.ichi2.libanki.backend.BackendUtils
 import com.ichi2.libanki.backend.exception.DeckRenameException
 import com.ichi2.libanki.utils.*
-import com.ichi2.utils.KotlinCleanup
 import com.ichi2.utils.jsonObjectIterable
 import net.ankiweb.rsdroid.RustCleanup
 import net.ankiweb.rsdroid.exceptions.BackendDeckIsFilteredException

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Media.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Media.kt
@@ -19,6 +19,7 @@ package com.ichi2.libanki
 
 import androidx.annotation.WorkerThread
 import com.google.protobuf.kotlin.toByteString
+import com.ichi2.annotations.KotlinCleanup
 import com.ichi2.libanki.exception.EmptyMediaException
 import com.ichi2.utils.*
 import timber.log.Timber

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Note.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Note.kt
@@ -18,8 +18,8 @@
 package com.ichi2.libanki
 
 import androidx.annotation.VisibleForTesting
+import com.ichi2.annotations.KotlinCleanup
 import com.ichi2.libanki.exception.WrongId
-import com.ichi2.utils.KotlinCleanup
 import net.ankiweb.rsdroid.RustCleanup
 import org.json.JSONObject
 import timber.log.Timber

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/NotetypeJson.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/NotetypeJson.kt
@@ -17,6 +17,7 @@
 package com.ichi2.libanki
 
 import androidx.annotation.CheckResult
+import com.ichi2.annotations.KotlinCleanup
 import com.ichi2.utils.*
 import org.json.JSONArray
 import org.json.JSONObject

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Notetypes.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Notetypes.kt
@@ -39,6 +39,7 @@ import anki.notetypes.NotetypeNameIdUseCount
 import anki.notetypes.StockNotetype
 import com.google.protobuf.ByteString
 import com.ichi2.anki.CrashReportService
+import com.ichi2.annotations.KotlinCleanup
 import com.ichi2.libanki.Consts.MODEL_CLOZE
 import com.ichi2.libanki.Utils.checksum
 import com.ichi2.libanki.backend.BackendUtils
@@ -47,7 +48,6 @@ import com.ichi2.libanki.exception.ConfirmModSchemaException
 import com.ichi2.libanki.utils.*
 import com.ichi2.utils.Assert
 import com.ichi2.utils.HashUtil
-import com.ichi2.utils.KotlinCleanup
 import com.ichi2.utils.jsonObjectIterable
 import net.ankiweb.rsdroid.RustCleanup
 import net.ankiweb.rsdroid.exceptions.BackendNotFoundException

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/SoundKt.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/SoundKt.kt
@@ -25,7 +25,7 @@
 package com.ichi2.libanki
 
 import com.ichi2.anki.CollectionManager.withCol
-import com.ichi2.utils.KotlinCleanup
+import com.ichi2.annotations.KotlinCleanup
 
 @KotlinCleanup("combine file with Sound.kt if done in libAnki")
 /**

--- a/AnkiDroid/src/main/java/com/ichi2/themes/HtmlColors.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/themes/HtmlColors.kt
@@ -16,8 +16,8 @@
 
 package com.ichi2.themes
 
+import com.ichi2.annotations.KotlinCleanup
 import com.ichi2.utils.HashUtil.hashMapInit
-import com.ichi2.utils.KotlinCleanup
 import timber.log.Timber
 import java.util.*
 import java.util.regex.Matcher

--- a/AnkiDroid/src/main/java/com/ichi2/ui/AppCompatPreferenceActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/ui/AppCompatPreferenceActivity.kt
@@ -31,6 +31,7 @@ import androidx.appcompat.widget.Toolbar
 import com.ichi2.anki.CollectionHelper
 import com.ichi2.anki.R
 import com.ichi2.anki.receiver.SdCardReceiver
+import com.ichi2.annotations.KotlinCleanup
 import com.ichi2.libanki.Collection
 import com.ichi2.libanki.Deck
 import com.ichi2.utils.*

--- a/AnkiDroid/src/main/java/com/ichi2/ui/CheckBoxTriStates.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/ui/CheckBoxTriStates.kt
@@ -22,7 +22,7 @@ import android.util.AttributeSet
 import android.widget.CompoundButton.OnCheckedChangeListener
 import androidx.appcompat.widget.AppCompatCheckBox
 import com.ichi2.anki.R
-import com.ichi2.utils.KotlinCleanup
+import com.ichi2.annotations.KotlinCleanup
 
 /**
  * Based on https://gist.github.com/kevin-barrientos/d75a5baa13a686367d45d17aaec7f030.

--- a/AnkiDroid/src/main/java/com/ichi2/utils/ExceptionUtil.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/ExceptionUtil.kt
@@ -20,6 +20,7 @@ import androidx.annotation.CheckResult
 import com.ichi2.anki.CrashReportService
 import com.ichi2.anki.R
 import com.ichi2.anki.UIUtils
+import com.ichi2.annotations.KotlinCleanup
 import com.ichi2.libanki.backend.exception.DeckRenameException
 import java.io.PrintWriter
 import java.io.StringWriter

--- a/AnkiDroid/src/main/java/com/ichi2/utils/HashUtil.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/HashUtil.kt
@@ -15,6 +15,7 @@
  ****************************************************************************************/
 package com.ichi2.utils
 
+import com.ichi2.annotations.KotlinCleanup
 import java.util.HashMap
 import java.util.HashSet
 

--- a/AnkiDroid/src/main/java/com/ichi2/utils/JSONArray.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/JSONArray.kt
@@ -41,6 +41,7 @@
  */
 package com.ichi2.utils
 
+import com.ichi2.annotations.KotlinCleanup
 import org.json.JSONArray
 import org.json.JSONObject
 

--- a/AnkiDroid/src/main/java/com/ichi2/utils/UniqueArrayList.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/UniqueArrayList.kt
@@ -16,6 +16,7 @@
 package com.ichi2.utils
 
 import androidx.annotation.RequiresApi
+import com.ichi2.annotations.KotlinCleanup
 import org.apache.commons.collections4.list.SetUniqueList
 import java.util.*
 

--- a/AnkiDroid/src/main/java/com/ichi2/widget/AnkiDroidWidgetSmall.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/widget/AnkiDroidWidgetSmall.kt
@@ -31,7 +31,7 @@ import com.ichi2.anki.IntentHandler
 import com.ichi2.anki.R
 import com.ichi2.anki.analytics.UsageAnalytics
 import com.ichi2.anki.preferences.sharedPrefs
-import com.ichi2.utils.KotlinCleanup
+import com.ichi2.annotations.KotlinCleanup
 import timber.log.Timber
 import kotlin.math.sqrt
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/ActivityStartupMetaTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/ActivityStartupMetaTest.kt
@@ -18,11 +18,11 @@ package com.ichi2.anki
 import android.content.pm.ActivityInfo
 import android.content.pm.PackageManager
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.ichi2.annotations.KotlinCleanup
 import com.ichi2.compat.CompatHelper.Companion.getPackageInfoCompat
 import com.ichi2.compat.PackageInfoFlagsCompat
 import com.ichi2.testutils.ActivityList
 import com.ichi2.testutils.ActivityList.ActivityLaunchParam
-import com.ichi2.utils.KotlinCleanup
 import org.hamcrest.MatcherAssert
 import org.hamcrest.Matchers
 import org.junit.Test

--- a/AnkiDroid/src/test/java/com/ichi2/anki/CardTemplatePreviewerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/CardTemplatePreviewerTest.kt
@@ -20,9 +20,9 @@ import android.os.Bundle
 import android.view.View
 import com.ichi2.anki.servicelayer.NoteService
 import com.ichi2.anki.servicelayer.NoteService.getFieldsAsBundleForPreview
+import com.ichi2.annotations.KotlinCleanup
 import com.ichi2.libanki.Card
 import com.ichi2.libanki.NotetypeJson
-import com.ichi2.utils.KotlinCleanup
 import com.ichi2.utils.stringIterable
 import org.hamcrest.CoreMatchers.*
 import org.hamcrest.MatcherAssert.assertThat

--- a/AnkiDroid/src/test/java/com/ichi2/anki/NoteEditorTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/NoteEditorTest.kt
@@ -26,6 +26,7 @@ import com.ichi2.anki.AbstractFlashcardViewer.Companion.editorCard
 import com.ichi2.anki.NoteEditorTest.FromScreen.DECK_LIST
 import com.ichi2.anki.NoteEditorTest.FromScreen.REVIEWER
 import com.ichi2.anki.multimediacard.activity.MultimediaEditFieldActivity
+import com.ichi2.annotations.KotlinCleanup
 import com.ichi2.compat.Compat.Companion.ACTION_PROCESS_TEXT
 import com.ichi2.compat.Compat.Companion.EXTRA_PROCESS_TEXT
 import com.ichi2.libanki.Consts
@@ -33,7 +34,6 @@ import com.ichi2.libanki.Decks.Companion.CURRENT_DECK
 import com.ichi2.libanki.Note
 import com.ichi2.libanki.NotetypeJson
 import com.ichi2.testutils.AnkiAssert.assertDoesNotThrow
-import com.ichi2.utils.KotlinCleanup
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.*

--- a/AnkiDroid/src/test/java/com/ichi2/anki/StudyOptionsFragmentTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/StudyOptionsFragmentTest.kt
@@ -17,7 +17,7 @@ package com.ichi2.anki
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.ichi2.anki.StudyOptionsFragment.Companion.formatDescription
-import com.ichi2.utils.KotlinCleanup
+import com.ichi2.annotations.KotlinCleanup
 import org.junit.Assert.assertEquals
 import org.junit.Test
 import org.junit.runner.RunWith

--- a/AnkiDroid/src/test/java/com/ichi2/anki/analytics/AnalyticsConstantsTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/analytics/AnalyticsConstantsTest.kt
@@ -12,7 +12,7 @@
  */
 package com.ichi2.anki.analytics
 
-import com.ichi2.utils.KotlinCleanup
+import com.ichi2.annotations.KotlinCleanup
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.*
 import org.junit.Assert

--- a/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/CustomStudyDialogTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/CustomStudyDialogTest.kt
@@ -26,12 +26,12 @@ import com.ichi2.anki.RobolectricTest
 import com.ichi2.anki.dialogs.customstudy.CustomStudyDialog
 import com.ichi2.anki.dialogs.customstudy.CustomStudyDialog.CustomStudyListener
 import com.ichi2.anki.dialogs.customstudy.CustomStudyDialogFactory
+import com.ichi2.annotations.KotlinCleanup
 import com.ichi2.libanki.Collection
 import com.ichi2.libanki.sched.Scheduler
 import com.ichi2.testutils.JsonUtils.toOrderedString
 import com.ichi2.testutils.ParametersUtils
 import com.ichi2.testutils.items
-import com.ichi2.utils.KotlinCleanup
 import org.hamcrest.CoreMatchers.notNullValue
 import org.hamcrest.MatcherAssert
 import org.hamcrest.Matchers

--- a/AnkiDroid/src/test/java/com/ichi2/anki/multimediacard/activity/MultimediaEditFieldActivityTestBase.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/multimediacard/activity/MultimediaEditFieldActivityTestBase.kt
@@ -25,7 +25,7 @@ import com.ichi2.anki.multimediacard.fields.IField
 import com.ichi2.anki.multimediacard.fields.IFieldController
 import com.ichi2.anki.multimediacard.fields.TextField
 import com.ichi2.anki.multimediacard.impl.MultimediaEditableNote
-import com.ichi2.utils.KotlinCleanup
+import com.ichi2.annotations.KotlinCleanup
 import org.mockito.Mockito.mock
 import org.mockito.kotlin.whenever
 import org.robolectric.Robolectric

--- a/AnkiDroid/src/test/java/com/ichi2/anki/services/NoteServiceTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/services/NoteServiceTest.kt
@@ -21,12 +21,12 @@ import com.ichi2.anki.multimediacard.IMultimediaEditableNote
 import com.ichi2.anki.multimediacard.fields.ImageField
 import com.ichi2.anki.multimediacard.fields.MediaClipField
 import com.ichi2.anki.servicelayer.NoteService
+import com.ichi2.annotations.KotlinCleanup
 import com.ichi2.libanki.Collection
 import com.ichi2.libanki.Consts
 import com.ichi2.libanki.Note
 import com.ichi2.libanki.NotetypeJson
 import com.ichi2.testutils.createTransientFile
-import com.ichi2.utils.KotlinCleanup
 import org.hamcrest.CoreMatchers.*
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.io.FileMatchers.*

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/AbstractSchedTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/AbstractSchedTest.kt
@@ -16,9 +16,9 @@
 package com.ichi2.libanki
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.ichi2.annotations.KotlinCleanup
 import com.ichi2.libanki.sched.Counts
 import com.ichi2.testutils.JvmTest
-import com.ichi2.utils.KotlinCleanup
 import org.hamcrest.MatcherAssert.*
 import org.hamcrest.Matchers.*
 import org.json.JSONArray

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/MathJaxClozeTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/MathJaxClozeTest.kt
@@ -3,9 +3,9 @@
 package com.ichi2.libanki
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.ichi2.annotations.KotlinCleanup
 import com.ichi2.libanki.template.MathJax
 import com.ichi2.testutils.JvmTest
-import com.ichi2.utils.KotlinCleanup
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.*
 import org.junit.Assert.*

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/ModelTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/ModelTest.kt
@@ -16,11 +16,11 @@
 package com.ichi2.libanki
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.ichi2.annotations.KotlinCleanup
 import com.ichi2.libanki.Consts.MODEL_CLOZE
 import com.ichi2.libanki.Utils.stripHTML
 import com.ichi2.libanki.exception.ConfirmModSchemaException
 import com.ichi2.testutils.JvmTest
-import com.ichi2.utils.KotlinCleanup
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.*
 import org.json.JSONObject

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/SchedulerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/SchedulerTest.kt
@@ -17,6 +17,7 @@ package com.ichi2.libanki
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.ichi2.anki.utils.SECONDS_PER_DAY
+import com.ichi2.annotations.KotlinCleanup
 import com.ichi2.libanki.Consts.BUTTON_FOUR
 import com.ichi2.libanki.Consts.BUTTON_ONE
 import com.ichi2.libanki.Consts.BUTTON_THREE
@@ -41,7 +42,6 @@ import com.ichi2.libanki.utils.TimeManager
 import com.ichi2.libanki.utils.TimeManager.time
 import com.ichi2.testutils.AnkiAssert
 import com.ichi2.testutils.JvmTest
-import com.ichi2.utils.KotlinCleanup
 import org.hamcrest.CoreMatchers.equalTo
 import org.hamcrest.MatcherAssert
 import org.hamcrest.Matchers

--- a/AnkiDroid/src/test/java/com/ichi2/testutils/CollectionDBCorruption.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/testutils/CollectionDBCorruption.kt
@@ -18,8 +18,8 @@ package com.ichi2.testutils
 
 import android.content.Context
 import com.ichi2.anki.CollectionHelper
+import com.ichi2.annotations.KotlinCleanup
 import com.ichi2.annotations.NeedsTest
-import com.ichi2.utils.KotlinCleanup
 import timber.log.Timber
 import java.io.File
 import java.io.RandomAccessFile

--- a/AnkiDroid/src/test/java/com/ichi2/testutils/MockTime.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/testutils/MockTime.kt
@@ -16,8 +16,8 @@
 package com.ichi2.testutils
 
 import android.annotation.SuppressLint
+import com.ichi2.annotations.KotlinCleanup
 import com.ichi2.libanki.utils.Time
-import com.ichi2.utils.KotlinCleanup
 import java.util.*
 
 /** @param [step] Number of milliseconds between each call.

--- a/AnkiDroid/src/test/java/com/ichi2/utils/UniqueArrayListTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/utils/UniqueArrayListTest.kt
@@ -15,6 +15,7 @@
  */
 package com.ichi2.utils
 
+import com.ichi2.annotations.KotlinCleanup
 import com.ichi2.utils.ListUtil.Companion.assertListEquals
 import org.hamcrest.CoreMatchers.instanceOf
 import org.hamcrest.CoreMatchers.not


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
_Describe the problem or feature and motivation_
I relocated the `KotlinCleanup.kt` file from `/utils` to `/annotations` because I believe this file functions as an annotation, and it's more appropriate to place it in the `/annotations` directory.


## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas
- [ ] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
