### PR TITLE
Enables Status Bar on App Intro

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/IntroductionActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/IntroductionActivity.kt
@@ -66,6 +66,8 @@ class IntroductionActivity : AppIntro() {
         }
         Themes.setTheme(this)
 
+        showStatusBar(true)
+
         setTransformer(AppIntroPageTransformerType.Zoom)
 
         addSlide(SetupCollectionFragment())


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
The status bar is automatically hidden and it makes the black bar remain In UI which looks really weird.

## Fixes
Fixes #14432

## Approach
This PR enables status bar on the intro page. It was previously disabled by default by the [App Intro](https://github.com/AppIntro/AppIntro) library.

## How Has This Been Tested?

<img src="https://github.com/ankidroid/Anki-Android/assets/84731134/2b5685ba-d24a-40e8-8d95-102b6125f794" width="300"/>

## Learning (optional, can help others)
[App Intro](https://github.com/AppIntro/AppIntro) library disables the status bar by default as mentioned [here](https://github.com/AppIntro/AppIntro/blob/db24d333e0c3e9c52bd763900552ef606461622e/appintro/src/main/java/com/github/appintro/AppIntroBase.kt#L389).

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [x] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
