### PR TITLE
Adds nothing to undo message

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/Undo.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Undo.kt
@@ -34,10 +34,11 @@ suspend fun FragmentActivity.undoAndShowSnackbar(duration: Int = Snackbar.LENGTH
                 undo()
             }
         }
-        if (changes.operation.isEmpty()) {
-            showSnackbar(TR.actionsNothingToUndo(), duration)
+        val message = if (changes.operation.isEmpty()) {
+            TR.actionsNothingToUndo()
         } else {
-            showSnackbar(TR.undoActionUndone(changes.operation), duration)
+            TR.undoActionUndone(changes.operation)
         }
+        showSnackbar(message, duration)
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Undo.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Undo.kt
@@ -34,6 +34,10 @@ suspend fun FragmentActivity.undoAndShowSnackbar(duration: Int = Snackbar.LENGTH
                 undo()
             }
         }
-        showSnackbar(TR.undoActionUndone(changes.operation), duration)
+        if (changes.operation.isEmpty()) {
+            showSnackbar(TR.actionsNothingToUndo(), duration)
+        } else {
+            showSnackbar(TR.undoActionUndone(changes.operation), duration)
+        }
     }
 }


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
An empty snackbar is shown even without anything to undo as described in the linked issue.

## Fixes
Fixes #14471

## Approach
This checks if the changes were empty, then shows a message accordingly.

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [x] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
