### PR TITLE
fix: don't crash when replacing controls

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/preferences/ControlPreference.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/preferences/ControlPreference.kt
@@ -197,15 +197,12 @@ class ControlPreference : ListPreference {
     }
 
     /**
-     * Remove binding from all control preferences
-     * in the parent PreferenceGroup of this [ControlPreference]
+     * Remove binding from all control preferences other than this one
      */
     private fun clearBinding(binding: MappableBinding) {
-        val preferenceGroup = parent
-            ?: return
-
         for (command in ViewerCommand.values()) {
-            val commandPreference = preferenceGroup.findPreference<ControlPreference>(command.preferenceKey)!!
+            val commandPreference = preferenceManager.findPreference<ControlPreference>(command.preferenceKey)
+                ?: continue
             val bindings = MappableBinding.fromPreferenceString(commandPreference.value)
             if (binding in bindings) {
                 bindings.remove(binding)


### PR DESCRIPTION
## Purpose / Description
Crash when replacing gestures that have the binding assigned to other preference
Reproduction steps:
1. Assign an already used key/gesture to a preference
2. Confirm → Crash

Cause: Now that the ControlPreferences aren't all in the same PreferenceGroup, it can't be used anymore

## Approach
Use PreferenceManager instead of PreferenceGroup and add a safeguard `continue` to avoid future crashes

## How Has This Been Tested?

Emulator 33, same reproduction steps

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
