### PR TITLE
fix: opens keyboard when focus is on input text box

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
@@ -1024,7 +1024,7 @@ abstract class AbstractFlashcardViewer :
         webView.settings.allowFileAccess = true
 
         // Problems with focus and input tags is the reason we keep the old type answer mechanism for old Androids.
-        webView.isFocusableInTouchMode = typeAnswer!!.useInputTag
+        webView.isFocusableInTouchMode = typeAnswer!!.autoFocus
         webView.isScrollbarFadingEnabled = true
         Timber.d("Focusable = %s, Focusable in touch mode = %s", webView.isFocusable, webView.isFocusableInTouchMode)
         webView.webViewClient = CardViewerWebClient(mAssetLoader, this)


### PR DESCRIPTION
## Purpose / Description
fix: opens keyboard when focus is on input text box in card view.

## Fixes
Fixes #14546 

## Approach
use `typeAnswer!!.autoFocus` in `isFocusableInTouchMode` in web view.

## How Has This Been Tested?

https://github.com/ankidroid/Anki-Android/assets/76740999/a25bfcc2-af6e-4d7a-baaa-956d80f83c3a



## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
