### PR TITLE
Update to android gradle plugin 8.1.2

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -32,6 +32,17 @@ static def gitCommitHash() {
     "git rev-parse HEAD".execute().text.trim()
 }
 
+/**
+ * Set this to true to create five separate APKs instead of one:
+ *   - 2 APKs that only work on ARM/ARM64 devices
+ *   - 2 APKs that only works on x86/x86_64 devices
+ *   - a universal APK that works on all devices
+ * The advantage is the size of most APKs is reduced by about 2.5MB.
+ * Upload all the APKs to the Play Store and people will download
+ * the correct one based on the CPU architecture of their device.
+ */
+def enableSeparateBuildPerCPUArchitecture = true
+
 android {
     namespace "com.ichi2.anki"
 
@@ -98,7 +109,7 @@ android {
             versionNameSuffix "-debug"
             debuggable true
             applicationIdSuffix ".debug"
-            splits.abi.universalApk = true // Build universal APK for debug always
+            enableSeparateBuildPerCPUArchitecture = false // Build one universal APK for debug always
             // Check Crash Reports page on developer wiki for info on ACRA testing
             // buildConfigField "String", "ACRA_URL", '"https://918f7f55-f238-436c-b34f-c8b5f1331fe5-bluemix.cloudant.com/acra-ankidroid/_design/acra-storage/_update/report"'
             if (project.rootProject.file('local.properties').exists()) {
@@ -171,17 +182,6 @@ android {
             dimension "appStore"
         }
     }
-
-    /**
-     * Set this to true to create five separate APKs instead of one:
-     *   - 2 APKs that only work on ARM/ARM64 devices
-     *   - 2 APKs that only works on x86/x86_64 devices
-     *   - a universal APK that works on all devices
-     * The advantage is the size of most APKs is reduced by about 2.5MB.
-     * Upload all the APKs to the Play Store and people will download
-     * the correct one based on the CPU architecture of their device.
-     */
-    def enableSeparateBuildPerCPUArchitecture = true
 
     splits {
         abi {

--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ buildscript {
     ext.androidx_test_version = '1.5.0'
     ext.androidx_test_junit_version = '1.1.5'
     ext.robolectric_version = '4.10.3'
-    ext.android_gradle_plugin = "8.0.2"
+    ext.android_gradle_plugin = "8.1.2"
     ext.dokka_version = "1.9.0" // not the same with kotlin version!
 
     configurations.all {

--- a/lint-release.xml
+++ b/lint-release.xml
@@ -162,6 +162,10 @@
 
     <issue id="MonochromeLauncherIcon" severity="fatal" />
 
+    <!-- this is temporary - needed to work with android gradle plugin 8.1 -->
+    <!-- ideally commits to fix this are completed, such as in https://github.com/ankidroid/Anki-Android/pull/14158 -->
+    <issue id="UnspecifiedRegisterReceiverFlag" severity="ignore" />
+
     <!-- this is new with AGP7.1+, does not appear to create value -->
     <issue id="IntentFilterUniqueDataAttributes" severity="ignore" />
 


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description

This will mostly supercede #14158 by avoiding all the issues associated with going to unreleased gradle versions (8.2+ betas and 8.3+ alphas)

It will unblock a stack of dependencies that are blocked waiting for AGP 8.1+

## Fixes
Related #14158

## Approach
I move the var we use to create ABI splits to a wider scope then disable it in debug builds so as not to tickle https://issuetracker.google.com/issues/302961829

I am leaving #14158 open though, as it contains a couple commits that will be useful when we go to android gradle plugin 8.2+ with regard to dynamically registered context receivers. Note that the commits don't work yet but they appear correct and close to working so it is work worth preserving

## How Has This Been Tested?

`./gradlew jacocoTestReport` locally (which was always enough to trigger (https://issuetracker.google.com/issues/302961829)

## Learning (optional, can help others)

Don't worry, you can just be sitting there with some working software minding your own business, and someone, somewhere, will update one of your dependencies and break all your stuff.

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
