### PR TITLE
Bump compileSdk to 34, handle new deprecations

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -46,7 +46,7 @@ def enableSeparateBuildPerCPUArchitecture = true
 android {
     namespace "com.ichi2.anki"
 
-    compileSdk 33 // change api compileSdkVersion at the same time
+    compileSdk 34 // change api compileSdk at the same time
 
     buildFeatures {
         buildConfig = true
@@ -87,11 +87,8 @@ android {
         versionCode=21700101
         versionName="2.17alpha1"
         minSdk 23
-        // change api/build.gradle
-        // change robolectricDownloader.gradle
         // After #13695: change .tests_emulator.yml
-        // noinspection OldTargetApi
-        targetSdk 33
+        targetSdk 33 // change api/build.gradle.kts and update ../robolectricDownloader.gradle at same time
         testApplicationId "com.ichi2.anki.tests"
         vectorDrawables.useSupportLibrary = true
         testInstrumentationRunner 'com.ichi2.testutils.NewCollectionPathTestRunner'

--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/NoteEditorTabOrderTest.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/NoteEditorTabOrderTest.kt
@@ -67,9 +67,12 @@ class NoteEditorTabOrderTest : NoteEditorTest() {
     }
 
     private fun sendKeyDownUp(activity: Activity, keyCode: Int) {
-        val inputConnection = BaseInputConnection(activity.currentFocus, true)
-        inputConnection.sendKeyEvent(KeyEvent(KeyEvent.ACTION_DOWN, keyCode))
-        inputConnection.sendKeyEvent(KeyEvent(KeyEvent.ACTION_UP, keyCode))
+        val focusedView = activity.currentFocus
+        if (focusedView != null) {
+            val inputConnection = BaseInputConnection(focusedView, true)
+            inputConnection.sendKeyEvent(KeyEvent(KeyEvent.ACTION_DOWN, keyCode))
+            inputConnection.sendKeyEvent(KeyEvent(KeyEvent.ACTION_UP, keyCode))
+        }
     }
 
     @Throws(Throwable::class)

--- a/AnkiDroid/src/main/java/com/ichi2/anim/ActivityTransitionAnimation.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anim/ActivityTransitionAnimation.kt
@@ -11,6 +11,7 @@ import com.ichi2.anki.R
 import kotlinx.parcelize.Parcelize
 
 object ActivityTransitionAnimation {
+    @Suppress("DEPRECATION", "deprecated in API34 for predictive back, must plumb through new open/close parameter")
     fun slide(activity: Activity, direction: Direction?) {
         when (direction) {
             Direction.START -> if (isRightToLeft(activity)) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
@@ -1907,20 +1907,20 @@ abstract class AbstractFlashcardViewer :
     }
 
     internal open inner class MyGestureDetector : SimpleOnGestureListener() {
-        override fun onFling(e1: MotionEvent, e2: MotionEvent, velocityX: Float, velocityY: Float): Boolean {
+        override fun onFling(e1: MotionEvent?, e2: MotionEvent, velocityX: Float, velocityY: Float): Boolean {
             Timber.d("onFling")
 
             // #5741 - A swipe from the top caused delayedHide to be triggered,
             // accepting a gesture and quickly disabling the status bar, which wasn't ideal.
             // it would be lovely to use e1.getEdgeFlags(), but alas, it doesn't work.
-            if (isTouchingEdge(e1)) {
+            if (e1 != null && isTouchingEdge(e1)) {
                 Timber.d("ignoring edge fling")
                 return false
             }
 
             // Go back to immersive mode if the user had temporarily exited it (and then execute swipe gesture)
             this@AbstractFlashcardViewer.onFling()
-            if (mGesturesEnabled) {
+            if (e1 != null && mGesturesEnabled) {
                 try {
                     val dy = e2.y - e1.y
                     val dx = e2.x - e1.x

--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/SettingsFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/SettingsFragment.kt
@@ -63,17 +63,19 @@ abstract class SettingsFragment :
         return super.onPreferenceTreeClick(preference)
     }
 
-    override fun onSharedPreferenceChanged(sharedPreferences: SharedPreferences?, key: String) {
+    override fun onSharedPreferenceChanged(sharedPreferences: SharedPreferences, key: String?) {
         if (key !in UsageAnalytics.preferencesWhoseChangesShouldBeReported) {
             return
         }
-        val valueToReport = getPreferenceReportableValue(sharedPreferences?.get(key))
-        UsageAnalytics.sendAnalyticsEvent(
-            category = UsageAnalytics.Category.SETTING,
-            action = UsageAnalytics.Actions.CHANGED_SETTING,
-            value = valueToReport,
-            label = key
-        )
+        if (key != null) {
+            val valueToReport = getPreferenceReportableValue(sharedPreferences.get(key))
+            UsageAnalytics.sendAnalyticsEvent(
+                category = UsageAnalytics.Category.SETTING,
+                action = UsageAnalytics.Actions.CHANGED_SETTING,
+                value = valueToReport,
+                label = key
+            )
+        }
     }
 
     override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {

--- a/AnkiDroid/src/main/java/com/ichi2/compat/CompatV29.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/CompatV29.kt
@@ -61,7 +61,9 @@ open class CompatV29 : CompatV26(), Compat {
         }
         val newImageUri = context.contentResolver.insert(imagesCollection, newImage)
         context.contentResolver.openOutputStream(newImageUri!!).use {
-            bitmap.compress(format, quality, it)
+            if (it != null) {
+                bitmap.compress(format, quality, it)
+            }
         }
         newImage.clear()
         newImage.put(MediaStore.Images.Media.IS_PENDING, 0)

--- a/AnkiDroid/src/main/java/com/ichi2/ui/OnGestureListener.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/ui/OnGestureListener.kt
@@ -46,20 +46,27 @@ class OnGestureListener(
         consumer.accept(Gesture.LONG_TAP)
     }
 
-    override fun onFling(e1: MotionEvent, e2: MotionEvent, velocityX: Float, velocityY: Float): Boolean {
-        val dx = e2.x - e1.x
-        val dy = e2.y - e1.y
-        val gesture = gestureMapper.gesture(
-            dx,
-            dy,
-            velocityX,
-            velocityY,
-            isSelecting = false,
-            isXScrolling = false,
-            isYScrolling = false
-        )
-        if (gesture != null) {
-            consumer.accept(gesture)
+    override fun onFling(
+        e1: MotionEvent?,
+        e2: MotionEvent,
+        velocityX: Float,
+        velocityY: Float
+    ): Boolean {
+        if (e1 != null) {
+            val dx = e2.x - e1.x
+            val dy = e2.y - e1.y
+            val gesture = gestureMapper.gesture(
+                dx,
+                dy,
+                velocityX,
+                velocityY,
+                isSelecting = false,
+                isXScrolling = false,
+                isYScrolling = false
+            )
+            if (gesture != null) {
+                consumer.accept(gesture)
+            }
         }
         return true
     }

--- a/AnkiDroid/src/main/java/com/ichi2/utils/ReflectionUtils.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/ReflectionUtils.kt
@@ -16,5 +16,5 @@
 package com.ichi2.utils
 
 inline fun <reified T> getInstanceFromClassName(javaClassName: String): T {
-    return Class.forName(javaClassName).newInstance() as T
+    return Class.forName(javaClassName).getDeclaredConstructor().newInstance() as T
 }

--- a/AnkiDroid/src/main/java/com/ichi2/utils/TextViewUtil.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/TextViewUtil.kt
@@ -16,10 +16,17 @@
 
 package com.ichi2.utils
 
+import android.os.Build
+import android.util.TypedValue
 import android.widget.TextView
 
 object TextViewUtil {
     fun getTextSizeSp(first: TextView): Float {
-        return first.textSize / first.resources.displayMetrics.scaledDensity
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+            TypedValue.deriveDimension(TypedValue.COMPLEX_UNIT_SP, first.textSize, first.resources.displayMetrics)
+        } else {
+            @Suppress("DEPRECATION", "remove this branch and collapse conditional when minSdkVersion is >= 34")
+            first.textSize / first.resources.displayMetrics.scaledDensity
+        }
     }
 }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/servicemodel/UpgradeGesturesToControlsTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/servicemodel/UpgradeGesturesToControlsTest.kt
@@ -51,7 +51,13 @@ class UpgradeGesturesToControlsTest(private val testData: TestData) : Robolectri
         super.setUp()
         prefs = super.getPreferences()
         instance = UpgradeGesturesToControls()
-        prefs.registerOnSharedPreferenceChangeListener { _, key -> run { Timber.i("added key $key"); changedKeys.add(key) } }
+        prefs.registerOnSharedPreferenceChangeListener { _, key ->
+            run {
+                Timber.i("added key $key"); if (key != null) {
+                    changedKeys.add(key)
+                }
+            }
+        }
     }
 
     @Test

--- a/AnkiDroid/src/test/java/com/ichi2/anki/servicemodel/UpgradeGesturesToControlsTestNoParam.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/servicemodel/UpgradeGesturesToControlsTestNoParam.kt
@@ -42,7 +42,13 @@ class UpgradeGesturesToControlsTestNoParam : RobolectricTest() {
         super.setUp()
         prefs = super.getPreferences()
         instance = UpgradeGesturesToControls()
-        prefs.registerOnSharedPreferenceChangeListener { _, key -> run { Timber.i("added key $key"); changedKeys.add(key) } }
+        prefs.registerOnSharedPreferenceChangeListener { _, key ->
+            run {
+                Timber.i("added key $key"); if (key != null) {
+                    changedKeys.add(key)
+                }
+            }
+        }
     }
 
     @Test

--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -13,7 +13,7 @@ version = "2.0.0"
 
 android {
     namespace = "com.ichi2.anki.api"
-    compileSdk = 33
+    compileSdk = 34
 
     buildFeatures {
         buildConfig = true


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description

Bump our compileSdk to 34 so we can process our growing stack of API34-dependent dependency bumps

## Fixes
Nothing fixed, but will unblock lots of dependency tag merges

## Approach
Most of the deprecations were quite straightforward, I split each class into a separate commit with description

There is one about transition animations that I did not handle as it will be very intrusive, that one will need a tracking issue

## How Has This Been Tested?

Lots of runs locally of `jacocoTestReport` target and lint targets

## Learning (optional, can help others)
Takes a lot of effort to fight bitrot

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
