### PR TITLE
wrap content tags and cards button's height

### DIFF
--- a/AnkiDroid/src/main/res/layout/note_editor.xml
+++ b/AnkiDroid/src/main/res/layout/note_editor.xml
@@ -88,7 +88,7 @@
                     <androidx.appcompat.widget.AppCompatButton
                         android:id="@+id/CardEditorTagButton"
                         android:layout_width="match_parent"
-                        android:layout_height="40dp"
+                        android:layout_height="wrap_content"
                         tools:text="Tags: AnkiDroid"
                         android:gravity="start|center_vertical"
                         android:paddingStart="15dip"
@@ -99,7 +99,7 @@
                     <androidx.appcompat.widget.AppCompatButton
                         android:id="@+id/CardEditorCardsButton"
                         android:layout_width="match_parent"
-                        android:layout_height="40dp"
+                        android:layout_height="wrap_content"
                         tools:text="Cards: Card 1"
                         android:gravity="start|center_vertical"
                         android:paddingStart="15dip"


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
I have removed the hardcoded height for the buttons as the text was not visible in case we selected too many tags, the text simply got underflowed. I am just fixing the issue but would like to get the code shifted to MaterialCardview and fixing the max heights and add scroll functionality to this portion.



## How Has This Been Tested?
Tested on oneplus nord ce

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
