### PR TITLE
fix: replace "ok" with "yes" in crop image dialog

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicImageFieldController.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicImageFieldController.kt
@@ -656,7 +656,7 @@ class BasicImageFieldController : FieldControllerBase(), IFieldController {
 
         AlertDialog.Builder(mActivity).show {
             message(text = content)
-            positiveButton(R.string.dialog_ok) {
+            positiveButton(R.string.dialog_yes) {
                 mViewModel = requestCrop(mViewModel)
             }
             negativeButton(R.string.dialog_no) {


### PR DESCRIPTION
## Purpose / Description
fix: replace "ok" with "yes" in crop image dialog to make it meaningful.

## Fixes
Fixes _Link to the issues._

## Approach
Replace strings.

## How Has This Been Tested?

![image](https://github.com/ankidroid/Anki-Android/assets/76740999/64077029-6df1-4334-a46f-9087cfdfe500)


## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
