### PR TITLE
Dependency updates 20231019

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,4 +19,4 @@ updates:
   # We cannot update this one until API26. Ignore range should slide with known versions so we stay informed.
   - dependency-name: org.apache.commons:commons-compress
     versions:
-    - ">= 1.12, < 1.23"
+    - ">= 1.12, < 1.25"

--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -327,7 +327,7 @@ dependencies {
 
     // Backend libraries
 
-    implementation 'com.google.protobuf:protobuf-kotlin-lite:3.24.2' // This is required when loading from a file
+    implementation 'com.google.protobuf:protobuf-kotlin-lite:3.24.3' // This is required when loading from a file
 
     Properties localProperties = new Properties()
     if (project.rootProject.file('local.properties').exists()) {

--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -354,7 +354,7 @@ dependencies {
     implementation 'org.apache.commons:commons-collections4:4.4' // SetUniqueList
     implementation 'commons-io:commons-io:2.14.0' // FileUtils.contentEquals
     implementation 'net.mikehardy:google-analytics-java7:2.0.13'
-    implementation 'com.squareup.okhttp3:okhttp:4.11.0'
+    implementation 'com.squareup.okhttp3:okhttp:4.12.0'
     implementation 'com.arcao:slf4j-timber:3.1'
     implementation 'com.jakewharton.timber:timber:5.0.1'
     implementation 'org.jsoup:jsoup:1.16.1'

--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -309,7 +309,7 @@ dependencies {
     implementation "androidx.fragment:fragment-ktx:$fragments_version"
     debugImplementation("androidx.fragment:fragment-testing-manifest:$fragments_version")
     implementation "androidx.preference:preference-ktx:1.2.1"
-    implementation 'androidx.recyclerview:recyclerview:1.3.1'
+    implementation 'androidx.recyclerview:recyclerview:1.3.2'
     implementation 'androidx.sqlite:sqlite-framework:2.3.1'
     implementation 'androidx.swiperefreshlayout:swiperefreshlayout:1.1.0'
     implementation 'androidx.viewpager2:viewpager2:1.0.0'

--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -352,7 +352,7 @@ dependencies {
     // noinspection GradleDependency - commons-compress 1.12 - later versions use `File.toPath`; API26 can remove?
     implementation 'org.apache.commons:commons-compress:1.12'
     implementation 'org.apache.commons:commons-collections4:4.4' // SetUniqueList
-    implementation 'commons-io:commons-io:2.13.0' // FileUtils.contentEquals
+    implementation 'commons-io:commons-io:2.14.0' // FileUtils.contentEquals
     implementation 'net.mikehardy:google-analytics-java7:2.0.13'
     implementation 'com.squareup.okhttp3:okhttp:4.11.0'
     implementation 'com.arcao:slf4j-timber:3.1'

--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -310,7 +310,7 @@ dependencies {
     debugImplementation("androidx.fragment:fragment-testing-manifest:$fragments_version")
     implementation "androidx.preference:preference-ktx:1.2.1"
     implementation 'androidx.recyclerview:recyclerview:1.3.2'
-    implementation 'androidx.sqlite:sqlite-framework:2.3.1'
+    implementation 'androidx.sqlite:sqlite-framework:2.4.0'
     implementation 'androidx.swiperefreshlayout:swiperefreshlayout:1.1.0'
     implementation 'androidx.viewpager2:viewpager2:1.0.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.4'

--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -32,6 +32,17 @@ static def gitCommitHash() {
     "git rev-parse HEAD".execute().text.trim()
 }
 
+/**
+ * Set this to true to create five separate APKs instead of one:
+ *   - 2 APKs that only work on ARM/ARM64 devices
+ *   - 2 APKs that only works on x86/x86_64 devices
+ *   - a universal APK that works on all devices
+ * The advantage is the size of most APKs is reduced by about 2.5MB.
+ * Upload all the APKs to the Play Store and people will download
+ * the correct one based on the CPU architecture of their device.
+ */
+def enableSeparateBuildPerCPUArchitecture = true
+
 android {
     namespace "com.ichi2.anki"
 
@@ -98,7 +109,7 @@ android {
             versionNameSuffix "-debug"
             debuggable true
             applicationIdSuffix ".debug"
-            splits.abi.universalApk = true // Build universal APK for debug always
+            enableSeparateBuildPerCPUArchitecture = false // Build one universal APK for debug always
             // Check Crash Reports page on developer wiki for info on ACRA testing
             // buildConfigField "String", "ACRA_URL", '"https://918f7f55-f238-436c-b34f-c8b5f1331fe5-bluemix.cloudant.com/acra-ankidroid/_design/acra-storage/_update/report"'
             if (project.rootProject.file('local.properties').exists()) {
@@ -171,17 +182,6 @@ android {
             dimension "appStore"
         }
     }
-
-    /**
-     * Set this to true to create five separate APKs instead of one:
-     *   - 2 APKs that only work on ARM/ARM64 devices
-     *   - 2 APKs that only works on x86/x86_64 devices
-     *   - a universal APK that works on all devices
-     * The advantage is the size of most APKs is reduced by about 2.5MB.
-     * Upload all the APKs to the Play Store and people will download
-     * the correct one based on the CPU architecture of their device.
-     */
-    def enableSeparateBuildPerCPUArchitecture = true
 
     splits {
         abi {

--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -388,7 +388,7 @@ dependencies {
     testImplementation "org.jetbrains.kotlin:kotlin-test:$kotlin_version"
     testImplementation "org.jetbrains.kotlin:kotlin-test-junit5:$kotlin_version"
     testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:$coroutines_version"
-    testImplementation "io.mockk:mockk:1.13.7"
+    testImplementation "io.mockk:mockk:1.13.8"
     testImplementation 'org.apache.commons:commons-exec:1.3' // obtaining the OS
     testImplementation("androidx.fragment:fragment-testing:$fragments_version")
 

--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -303,7 +303,7 @@ dependencies {
     implementation 'androidx.activity:activity-ktx:1.7.2'
     implementation 'androidx.annotation:annotation:1.7.0'
     implementation 'androidx.appcompat:appcompat:1.7.0-alpha02'
-    implementation 'androidx.browser:browser:1.5.0'
+    implementation 'androidx.browser:browser:1.6.0'
     implementation "androidx.core:core-ktx:1.10.1"
     implementation 'androidx.exifinterface:exifinterface:1.3.6'
     implementation "androidx.fragment:fragment-ktx:$fragments_version"

--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -300,7 +300,7 @@ dependencies {
     compileOnly "com.google.auto.service:auto-service-annotations:1.1.1"
     annotationProcessor "com.google.auto.service:auto-service:1.1.1"
 
-    implementation 'androidx.activity:activity-ktx:1.7.2'
+    implementation 'androidx.activity:activity-ktx:1.8.0'
     implementation 'androidx.annotation:annotation:1.7.0'
     implementation 'androidx.appcompat:appcompat:1.7.0-alpha02'
     implementation 'androidx.browser:browser:1.6.0'

--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -304,7 +304,7 @@ dependencies {
     implementation 'androidx.annotation:annotation:1.7.0'
     implementation 'androidx.appcompat:appcompat:1.7.0-alpha02'
     implementation 'androidx.browser:browser:1.6.0'
-    implementation "androidx.core:core-ktx:1.10.1"
+    implementation "androidx.core:core-ktx:1.12.0"
     implementation 'androidx.exifinterface:exifinterface:1.3.6'
     implementation "androidx.fragment:fragment-ktx:$fragments_version"
     debugImplementation("androidx.fragment:fragment-testing-manifest:$fragments_version")

--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -327,7 +327,7 @@ dependencies {
 
     // Backend libraries
 
-    implementation 'com.google.protobuf:protobuf-kotlin-lite:3.24.3' // This is required when loading from a file
+    implementation 'com.google.protobuf:protobuf-kotlin-lite:3.24.4' // This is required when loading from a file
 
     Properties localProperties = new Properties()
     if (project.rootProject.file('local.properties').exists()) {

--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -46,7 +46,7 @@ def enableSeparateBuildPerCPUArchitecture = true
 android {
     namespace "com.ichi2.anki"
 
-    compileSdk 33 // change api compileSdkVersion at the same time
+    compileSdk 34 // change api compileSdk at the same time
 
     buildFeatures {
         buildConfig = true
@@ -87,11 +87,8 @@ android {
         versionCode=21700101
         versionName="2.17alpha1"
         minSdk 23
-        // change api/build.gradle
-        // change robolectricDownloader.gradle
         // After #13695: change .tests_emulator.yml
-        // noinspection OldTargetApi
-        targetSdk 33
+        targetSdk 33 // change api/build.gradle.kts and update ../robolectricDownloader.gradle at same time
         testApplicationId "com.ichi2.anki.tests"
         vectorDrawables.useSupportLibrary = true
         testInstrumentationRunner 'com.ichi2.testutils.NewCollectionPathTestRunner'

--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -314,7 +314,7 @@ dependencies {
     implementation 'androidx.swiperefreshlayout:swiperefreshlayout:1.1.0'
     implementation 'androidx.viewpager2:viewpager2:1.0.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
-    implementation 'androidx.webkit:webkit:1.7.0'
+    implementation 'androidx.webkit:webkit:1.8.0'
     // Note: the design support library can be quite buggy, so test everything thoroughly before updating it
     // Changing the version from 1.8.0 to 1.7.0 because the item in navigation drawer is getting bold unnecessarily
     implementation 'com.google.android.material:material:1.7.0'

--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -302,7 +302,7 @@ dependencies {
 
     implementation 'androidx.activity:activity-ktx:1.8.0'
     implementation 'androidx.annotation:annotation:1.7.0'
-    implementation 'androidx.appcompat:appcompat:1.7.0-alpha02'
+    implementation 'androidx.appcompat:appcompat:1.7.0-alpha03'
     implementation 'androidx.browser:browser:1.6.0'
     implementation "androidx.core:core-ktx:1.12.0"
     implementation 'androidx.exifinterface:exifinterface:1.3.6'

--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -304,7 +304,7 @@ dependencies {
     annotationProcessor "com.google.auto.service:auto-service:1.1.1"
 
     implementation 'androidx.activity:activity-ktx:1.7.2'
-    implementation 'androidx.annotation:annotation:1.6.0'
+    implementation 'androidx.annotation:annotation:1.7.0'
     implementation 'androidx.appcompat:appcompat:1.7.0-alpha02'
     implementation 'androidx.browser:browser:1.5.0'
     implementation "androidx.core:core-ktx:1.10.1"

--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/NoteEditorTabOrderTest.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/NoteEditorTabOrderTest.kt
@@ -67,9 +67,12 @@ class NoteEditorTabOrderTest : NoteEditorTest() {
     }
 
     private fun sendKeyDownUp(activity: Activity, keyCode: Int) {
-        val inputConnection = BaseInputConnection(activity.currentFocus, true)
-        inputConnection.sendKeyEvent(KeyEvent(KeyEvent.ACTION_DOWN, keyCode))
-        inputConnection.sendKeyEvent(KeyEvent(KeyEvent.ACTION_UP, keyCode))
+        val focusedView = activity.currentFocus
+        if (focusedView != null) {
+            val inputConnection = BaseInputConnection(focusedView, true)
+            inputConnection.sendKeyEvent(KeyEvent(KeyEvent.ACTION_DOWN, keyCode))
+            inputConnection.sendKeyEvent(KeyEvent(KeyEvent.ACTION_UP, keyCode))
+        }
     }
 
     @Throws(Throwable::class)

--- a/AnkiDroid/src/main/java/com/ichi2/anim/ActivityTransitionAnimation.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anim/ActivityTransitionAnimation.kt
@@ -11,6 +11,7 @@ import com.ichi2.anki.R
 import kotlinx.parcelize.Parcelize
 
 object ActivityTransitionAnimation {
+    @Suppress("DEPRECATION", "deprecated in API34 for predictive back, must plumb through new open/close parameter")
     fun slide(activity: Activity, direction: Direction?) {
         when (direction) {
             Direction.START -> if (isRightToLeft(activity)) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
@@ -1907,20 +1907,20 @@ abstract class AbstractFlashcardViewer :
     }
 
     internal open inner class MyGestureDetector : SimpleOnGestureListener() {
-        override fun onFling(e1: MotionEvent, e2: MotionEvent, velocityX: Float, velocityY: Float): Boolean {
+        override fun onFling(e1: MotionEvent?, e2: MotionEvent, velocityX: Float, velocityY: Float): Boolean {
             Timber.d("onFling")
 
             // #5741 - A swipe from the top caused delayedHide to be triggered,
             // accepting a gesture and quickly disabling the status bar, which wasn't ideal.
             // it would be lovely to use e1.getEdgeFlags(), but alas, it doesn't work.
-            if (isTouchingEdge(e1)) {
+            if (e1 != null && isTouchingEdge(e1)) {
                 Timber.d("ignoring edge fling")
                 return false
             }
 
             // Go back to immersive mode if the user had temporarily exited it (and then execute swipe gesture)
             this@AbstractFlashcardViewer.onFling()
-            if (mGesturesEnabled) {
+            if (e1 != null && mGesturesEnabled) {
                 try {
                     val dy = e2.y - e1.y
                     val dx = e2.x - e1.x

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateBrowserAppearanceEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateBrowserAppearanceEditor.kt
@@ -81,8 +81,10 @@ class CardTemplateBrowserAppearanceEditor : AnkiActivity() {
         return super.onOptionsItemSelected(item)
     }
 
+    @Suppress("DEPRECATION", "Deprecated in API34+dependencies for predictive back feature")
     override fun onBackPressed() {
         Timber.i("Back Button Pressed")
+        super.onBackPressed()
         closeWithDiscardWarning()
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplatePreviewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplatePreviewer.kt
@@ -114,8 +114,10 @@ open class CardTemplatePreviewer : AbstractFlashcardViewer() {
         finishWithAnimation(ActivityTransitionAnimation.Direction.END)
     }
 
+    @Suppress("DEPRECATION", "Deprecated in API34+dependencies for predictive back feature")
     override fun onBackPressed() {
         Timber.i("CardTemplatePreviewer:: onBackPressed()")
+        super.onBackPressed()
         closeCardTemplatePreviewer()
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ModelFieldEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ModelFieldEditor.kt
@@ -469,7 +469,9 @@ class ModelFieldEditor : AnkiActivity(), LocaleSelectionDialogHandler {
         finishWithAnimation(ActivityTransitionAnimation.Direction.END)
     }
 
+    @Suppress("DEPRECATION", "Deprecated in API34+dependencies for predictive back feature")
     override fun onBackPressed() {
+        super.onBackPressed()
         closeActivity()
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
@@ -819,8 +819,10 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
         closeNoteEditor()
     }
 
+    @Suppress("DEPRECATION", "Deprecated in API34+dependencies for predictive back feature")
     override fun onBackPressed() {
         Timber.i("NoteEditor:: onBackPressed()")
+        super.onBackPressed()
         closeCardEditorWithCheck()
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/NotificationsSettingsFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/NotificationsSettingsFragment.kt
@@ -60,7 +60,9 @@ class NotificationsSettingsFragment : SettingsFragment() {
                         false
                     )
                     val alarmManager = requireActivity().getSystemService(ALARM_SERVICE) as AlarmManager
-                    alarmManager.cancel(intent)
+                    if (intent != null) {
+                        alarmManager.cancel(intent)
+                    }
                 }
                 true
             }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/SettingsFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/SettingsFragment.kt
@@ -63,17 +63,19 @@ abstract class SettingsFragment :
         return super.onPreferenceTreeClick(preference)
     }
 
-    override fun onSharedPreferenceChanged(sharedPreferences: SharedPreferences?, key: String) {
+    override fun onSharedPreferenceChanged(sharedPreferences: SharedPreferences, key: String?) {
         if (key !in UsageAnalytics.preferencesWhoseChangesShouldBeReported) {
             return
         }
-        val valueToReport = getPreferenceReportableValue(sharedPreferences?.get(key))
-        UsageAnalytics.sendAnalyticsEvent(
-            category = UsageAnalytics.Category.SETTING,
-            action = UsageAnalytics.Actions.CHANGED_SETTING,
-            value = valueToReport,
-            label = key
-        )
+        if (key != null) {
+            val valueToReport = getPreferenceReportableValue(sharedPreferences.get(key))
+            UsageAnalytics.sendAnalyticsEvent(
+                category = UsageAnalytics.Category.SETTING,
+                action = UsageAnalytics.Actions.CHANGED_SETTING,
+                value = valueToReport,
+                label = key
+            )
+        }
     }
 
     override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/services/BootService.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/services/BootService.kt
@@ -103,12 +103,14 @@ class BootService : BroadcastReceiver() {
                 0,
                 false
             )
-            alarmManager.setRepeating(
-                AlarmManager.RTC_WAKEUP,
-                calendar.timeInMillis,
-                AlarmManager.INTERVAL_DAY,
-                notificationIntent
-            )
+            if (notificationIntent != null) {
+                alarmManager.setRepeating(
+                    AlarmManager.RTC_WAKEUP,
+                    calendar.timeInMillis,
+                    AlarmManager.INTERVAL_DAY,
+                    notificationIntent
+                )
+            }
         }
 
         /** Returns the hour of day when rollover to the next day occurs  */

--- a/AnkiDroid/src/main/java/com/ichi2/anki/services/ReminderService.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/services/ReminderService.kt
@@ -48,7 +48,9 @@ class ReminderService : BroadcastReceiver() {
             0,
             false
         )
-        alarmManager.cancel(reminderIntent)
+        if (reminderIntent != null) {
+            alarmManager.cancel(reminderIntent)
+        }
     }
 
     override fun onReceive(context: Context, intent: Intent) {

--- a/AnkiDroid/src/main/java/com/ichi2/compat/CompatV29.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/CompatV29.kt
@@ -61,7 +61,9 @@ open class CompatV29 : CompatV26(), Compat {
         }
         val newImageUri = context.contentResolver.insert(imagesCollection, newImage)
         context.contentResolver.openOutputStream(newImageUri!!).use {
-            bitmap.compress(format, quality, it)
+            if (it != null) {
+                bitmap.compress(format, quality, it)
+            }
         }
         newImage.clear()
         newImage.put(MediaStore.Images.Media.IS_PENDING, 0)

--- a/AnkiDroid/src/main/java/com/ichi2/ui/OnGestureListener.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/ui/OnGestureListener.kt
@@ -46,20 +46,27 @@ class OnGestureListener(
         consumer.accept(Gesture.LONG_TAP)
     }
 
-    override fun onFling(e1: MotionEvent, e2: MotionEvent, velocityX: Float, velocityY: Float): Boolean {
-        val dx = e2.x - e1.x
-        val dy = e2.y - e1.y
-        val gesture = gestureMapper.gesture(
-            dx,
-            dy,
-            velocityX,
-            velocityY,
-            isSelecting = false,
-            isXScrolling = false,
-            isYScrolling = false
-        )
-        if (gesture != null) {
-            consumer.accept(gesture)
+    override fun onFling(
+        e1: MotionEvent?,
+        e2: MotionEvent,
+        velocityX: Float,
+        velocityY: Float
+    ): Boolean {
+        if (e1 != null) {
+            val dx = e2.x - e1.x
+            val dy = e2.y - e1.y
+            val gesture = gestureMapper.gesture(
+                dx,
+                dy,
+                velocityX,
+                velocityY,
+                isSelecting = false,
+                isXScrolling = false,
+                isYScrolling = false
+            )
+            if (gesture != null) {
+                consumer.accept(gesture)
+            }
         }
         return true
     }

--- a/AnkiDroid/src/main/java/com/ichi2/utils/ReflectionUtils.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/ReflectionUtils.kt
@@ -16,5 +16,5 @@
 package com.ichi2.utils
 
 inline fun <reified T> getInstanceFromClassName(javaClassName: String): T {
-    return Class.forName(javaClassName).newInstance() as T
+    return Class.forName(javaClassName).getDeclaredConstructor().newInstance() as T
 }

--- a/AnkiDroid/src/main/java/com/ichi2/utils/TextViewUtil.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/TextViewUtil.kt
@@ -16,10 +16,17 @@
 
 package com.ichi2.utils
 
+import android.os.Build
+import android.util.TypedValue
 import android.widget.TextView
 
 object TextViewUtil {
     fun getTextSizeSp(first: TextView): Float {
-        return first.textSize / first.resources.displayMetrics.scaledDensity
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+            TypedValue.deriveDimension(TypedValue.COMPLEX_UNIT_SP, first.textSize, first.resources.displayMetrics)
+        } else {
+            @Suppress("DEPRECATION", "remove this branch and collapse conditional when minSdkVersion is >= 34")
+            first.textSize / first.resources.displayMetrics.scaledDensity
+        }
     }
 }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/servicemodel/UpgradeGesturesToControlsTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/servicemodel/UpgradeGesturesToControlsTest.kt
@@ -51,7 +51,13 @@ class UpgradeGesturesToControlsTest(private val testData: TestData) : Robolectri
         super.setUp()
         prefs = super.getPreferences()
         instance = UpgradeGesturesToControls()
-        prefs.registerOnSharedPreferenceChangeListener { _, key -> run { Timber.i("added key $key"); changedKeys.add(key) } }
+        prefs.registerOnSharedPreferenceChangeListener { _, key ->
+            run {
+                Timber.i("added key $key"); if (key != null) {
+                    changedKeys.add(key)
+                }
+            }
+        }
     }
 
     @Test

--- a/AnkiDroid/src/test/java/com/ichi2/anki/servicemodel/UpgradeGesturesToControlsTestNoParam.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/servicemodel/UpgradeGesturesToControlsTestNoParam.kt
@@ -42,7 +42,13 @@ class UpgradeGesturesToControlsTestNoParam : RobolectricTest() {
         super.setUp()
         prefs = super.getPreferences()
         instance = UpgradeGesturesToControls()
-        prefs.registerOnSharedPreferenceChangeListener { _, key -> run { Timber.i("added key $key"); changedKeys.add(key) } }
+        prefs.registerOnSharedPreferenceChangeListener { _, key ->
+            run {
+                Timber.i("added key $key"); if (key != null) {
+                    changedKeys.add(key)
+                }
+            }
+        }
     }
 
     @Test

--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -59,7 +59,7 @@ android {
 apply(from = "../lint.gradle")
 
 dependencies {
-    implementation("androidx.annotation:annotation:1.6.0")
+    implementation("androidx.annotation:annotation:1.7.0")
     implementation("org.jetbrains.kotlin:kotlin-stdlib:${rootProject.extra["kotlin_version"]}")
 
     testImplementation("org.junit.jupiter:junit-jupiter:${rootProject.extra["junit_version"]}")

--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -13,7 +13,7 @@ version = "2.0.0"
 
 android {
     namespace = "com.ichi2.anki.api"
-    compileSdk = 33
+    compileSdk = 34
 
     buildFeatures {
         buildConfig = true

--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ buildscript {
     ext.androidx_test_version = '1.5.0'
     ext.androidx_test_junit_version = '1.1.5'
     ext.robolectric_version = '4.10.3'
-    ext.android_gradle_plugin = "8.0.2"
+    ext.android_gradle_plugin = "8.1.2"
     ext.dokka_version = "1.9.0" // not the same with kotlin version!
 
     configurations.all {

--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ buildscript {
     ext.androidx_test_junit_version = '1.1.5'
     ext.robolectric_version = '4.10.3'
     ext.android_gradle_plugin = "8.1.2"
-    ext.dokka_version = "1.9.0" // not the same with kotlin version!
+    ext.dokka_version = "1.9.10" // not the same with kotlin version!
 
     configurations.all {
         resolutionStrategy.eachDependency { details ->

--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,7 @@ plugins {
     id 'org.jetbrains.kotlin.android' version "$kotlin_version" apply false
     id 'org.jetbrains.kotlin.plugin.parcelize' version "$kotlin_version" apply false
     id 'org.jetbrains.kotlin.plugin.serialization' version "$kotlin_version" apply false
-    id 'org.jlleitschuh.gradle.ktlint' version '11.6.0' apply false
+    id 'org.jlleitschuh.gradle.ktlint' version '11.6.1' apply false
     id 'org.jetbrains.dokka' version "$dokka_version" apply false
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,7 @@ plugins {
     id 'org.jetbrains.kotlin.android' version "$kotlin_version" apply false
     id 'org.jetbrains.kotlin.plugin.parcelize' version "$kotlin_version" apply false
     id 'org.jetbrains.kotlin.plugin.serialization' version "$kotlin_version" apply false
-    id 'org.jlleitschuh.gradle.ktlint' version '11.5.1' apply false
+    id 'org.jlleitschuh.gradle.ktlint' version '11.6.0' apply false
     id 'org.jetbrains.dokka' version "$dokka_version" apply false
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/gradlew
+++ b/gradlew
@@ -145,7 +145,7 @@ if ! "$cygwin" && ! "$darwin" && ! "$nonstop" ; then
     case $MAX_FD in #(
       max*)
         # In POSIX sh, ulimit -H is undefined. That's why the result is checked to see if it worked.
-        # shellcheck disable=SC3045
+        # shellcheck disable=SC2039,SC3045
         MAX_FD=$( ulimit -H -n ) ||
             warn "Could not query maximum file descriptor limit"
     esac
@@ -153,7 +153,7 @@ if ! "$cygwin" && ! "$darwin" && ! "$nonstop" ; then
       '' | soft) :;; #(
       *)
         # In POSIX sh, ulimit -n is undefined. That's why the result is checked to see if it worked.
-        # shellcheck disable=SC3045
+        # shellcheck disable=SC2039,SC3045
         ulimit -n "$MAX_FD" ||
             warn "Could not set maximum file descriptor limit to $MAX_FD"
     esac
@@ -202,11 +202,11 @@ fi
 # Add default JVM options here. You can also use JAVA_OPTS and GRADLE_OPTS to pass JVM options to this script.
 DEFAULT_JVM_OPTS='"-Xmx64m" "-Xms64m"'
 
-# Collect all arguments for the java command;
-#   * $DEFAULT_JVM_OPTS, $JAVA_OPTS, and $GRADLE_OPTS can contain fragments of
-#     shell script including quotes and variable substitutions, so put them in
-#     double quotes to make sure that they get re-expanded; and
-#   * put everything else in single quotes, so that it's not re-expanded.
+# Collect all arguments for the java command:
+#   * DEFAULT_JVM_OPTS, JAVA_OPTS, JAVA_OPTS, and optsEnvironmentVar are not allowed to contain shell fragments,
+#     and any embedded shellness will be escaped.
+#   * For example: A user cannot expect ${Hostname} to be expanded, as it is an environment variable and will be
+#     treated as '${Hostname}' itself on the command line.
 
 set -- \
         "-Dorg.gradle.appname=$APP_BASE_NAME" \

--- a/lint-release.xml
+++ b/lint-release.xml
@@ -162,6 +162,10 @@
 
     <issue id="MonochromeLauncherIcon" severity="fatal" />
 
+    <!-- this is temporary - needed to work with android gradle plugin 8.1 -->
+    <!-- ideally commits to fix this are completed, such as in https://github.com/ankidroid/Anki-Android/pull/14158 -->
+    <issue id="UnspecifiedRegisterReceiverFlag" severity="ignore" />
+
     <!-- this is new with AGP7.1+, does not appear to create value -->
     <issue id="IntentFilterUniqueDataAttributes" severity="ignore" />
 


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description

Unwinding the stack of "needs API34" dependencies that had piled up

Squash merge, each of these was examined independently while rolling them up into dependency-updates branch, I'm pretty comfortable with them, going to merge when CI goes green

## Fixes
Fixes all of the API34 target stuff *except*:

1- predictive back needs better handling (it is "okay" now but some of the handling is just deprecation suppresison which is not great, there is a tracking issue)
2- dynamic context receivers being exported or not is *not* handled and we cannot update targetSdk to 34 until they are handled. This has preliminary work in #14557 and a cross-linked PR from that one - with some commits that get things close and some discussion on what's left

## Approach
Bumping to compileSdk 34 and handling the fallout dependency by dependency as there are new nullability changes, new deprecations etc.

## How Has This Been Tested?

Lots and lots of local `jacocoTestReport` and lint runs, some direct app interaction on API33 and API34 emulators in specific cases

## Learning (optional, can help others)
Meh, entropy

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
