### PR TITLE
Restore position of "Undo" in the toolbar menu of DeckPicker

### DIFF
--- a/AnkiDroid/src/main/res/menu/deck_picker.xml
+++ b/AnkiDroid/src/main/res/menu/deck_picker.xml
@@ -30,15 +30,15 @@
             android:title="@string/button_sync"
             ankidroid:showAsAction="always"/>
         <item
+            android:id="@+id/action_undo"
+            ankidroid:showAsAction="never"
+            android:visible="false"
+            tools:title="Undo X"/>
+        <item
             android:id="@+id/checks"
             android:title="@string/checks_action"
             ankidroid:showAsAction="never">
             <menu>
-                <item
-                    android:id="@+id/action_undo"
-                    ankidroid:showAsAction="never"
-                    android:visible="false"
-                    tools:title="Undo X"/>
                 <item
                     android:id="@+id/action_check_database"
                     android:menuCategory="secondary"


### PR DESCRIPTION
## Purpose / Description

I incorrectly added it to the "Checks" menu in #14463 so I reverted the change and now it appears again in the main toolbar menu.

## How Has This Been Tested?

Checked the undo functionality of DeckPicker.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
