### PR TITLE
fix: set icon colors to colorControlNormal

### DIFF
--- a/AnkiDroid/src/main/res/drawable/ic_backup_restore.xml
+++ b/AnkiDroid/src/main/res/drawable/ic_backup_restore.xml
@@ -3,8 +3,8 @@
     android:height="24dp"
     android:viewportWidth="24"
     android:viewportHeight="24"
-    android:tint="?attr/toolbarIconColor">
+    android:tint="?attr/colorControlNormal">
   <path
-      android:fillColor="?attr/colorControlNormal"
+      android:fillColor="@color/white"
       android:pathData="M14,12c0,-1.1 -0.9,-2 -2,-2s-2,0.9 -2,2 0.9,2 2,2 2,-0.9 2,-2zM12,3c-4.97,0 -9,4.03 -9,9L0,12l4,4 4,-4L5,12c0,-3.87 3.13,-7 7,-7s7,3.13 7,7 -3.13,7 -7,7c-1.51,0 -2.91,-0.49 -4.06,-1.3l-1.42,1.44C8.04,20.3 9.94,21 12,21c4.97,0 9,-4.03 9,-9s-4.03,-9 -9,-9z" />
 </vector>

--- a/AnkiDroid/src/main/res/drawable/ic_baseline_backup_24.xml
+++ b/AnkiDroid/src/main/res/drawable/ic_baseline_backup_24.xml
@@ -14,8 +14,8 @@
   ~  this program.  If not, see <http://www.gnu.org/licenses/>.
   -->
 
-<vector android:height="24dp" android:tint="?attr/toolbarIconColor"
+<vector android:height="24dp" android:tint="?attr/colorControlNormal"
     android:viewportHeight="24" android:viewportWidth="24"
     android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
-    <path android:fillColor="?attr/colorControlNormal" android:pathData="M19.35,10.04C18.67,6.59 15.64,4 12,4 9.11,4 6.6,5.64 5.35,8.04 2.34,8.36 0,10.91 0,14c0,3.31 2.69,6 6,6h13c2.76,0 5,-2.24 5,-5 0,-2.64 -2.05,-4.78 -4.65,-4.96zM14,13v4h-4v-4H7l5,-5 5,5h-3z"/>
+    <path android:fillColor="@color/white" android:pathData="M19.35,10.04C18.67,6.59 15.64,4 12,4 9.11,4 6.6,5.64 5.35,8.04 2.34,8.36 0,10.91 0,14c0,3.31 2.69,6 6,6h13c2.76,0 5,-2.24 5,-5 0,-2.64 -2.05,-4.78 -4.65,-4.96zM14,13v4h-4v-4H7l5,-5 5,5h-3z"/>
 </vector>


### PR DESCRIPTION
In order to be consistent with the other icons in the app

<!--- Please fill the necessary details below -->
## Purpose / Description
Backup icon color was different than the other ones in the preferences home page

## Approach
Set the icon colors to `colorControlNormal`, which is what we use for most icons and what most apps use too for their icons

## How Has This Been Tested?

See if the color was changed in the XML preview
![image](https://github.com/ankidroid/Anki-Android/assets/69634269/89d9eb57-973f-4a7e-921c-1db88bb83057)


## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
