### PR TITLE
Dependency updates 20231026 / unblock releases

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -354,7 +354,7 @@ dependencies {
     implementation 'com.squareup.okhttp3:okhttp:4.12.0'
     implementation 'com.arcao:slf4j-timber:3.1'
     implementation 'com.jakewharton.timber:timber:5.0.1'
-    implementation 'org.jsoup:jsoup:1.16.1'
+    implementation 'org.jsoup:jsoup:1.16.2'
     implementation "com.github.zafarkhaja:java-semver:0.9.0" // For AnkiDroid JS API Versioning
     implementation 'com.drakeet.drawer:drawer:1.0.3'
     implementation 'uk.co.samuelwall:material-tap-target-prompt:3.3.2'

--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -349,7 +349,7 @@ dependencies {
     // noinspection GradleDependency - commons-compress 1.12 - later versions use `File.toPath`; API26 can remove?
     implementation 'org.apache.commons:commons-compress:1.12'
     implementation 'org.apache.commons:commons-collections4:4.4' // SetUniqueList
-    implementation 'commons-io:commons-io:2.14.0' // FileUtils.contentEquals
+    implementation 'commons-io:commons-io:2.15.0' // FileUtils.contentEquals
     implementation 'net.mikehardy:google-analytics-java7:2.0.13'
     implementation 'com.squareup.okhttp3:okhttp:4.12.0'
     implementation 'com.arcao:slf4j-timber:3.1'

--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -32,17 +32,6 @@ static def gitCommitHash() {
     "git rev-parse HEAD".execute().text.trim()
 }
 
-/**
- * Set this to true to create five separate APKs instead of one:
- *   - 2 APKs that only work on ARM/ARM64 devices
- *   - 2 APKs that only works on x86/x86_64 devices
- *   - a universal APK that works on all devices
- * The advantage is the size of most APKs is reduced by about 2.5MB.
- * Upload all the APKs to the Play Store and people will download
- * the correct one based on the CPU architecture of their device.
- */
-def enableSeparateBuildPerCPUArchitecture = true
-
 android {
     namespace "com.ichi2.anki"
 
@@ -106,7 +95,7 @@ android {
             versionNameSuffix "-debug"
             debuggable true
             applicationIdSuffix ".debug"
-            enableSeparateBuildPerCPUArchitecture = false // Build one universal APK for debug always
+            splits.abi.universalApk = true // Build universal APK for debug always
             // Check Crash Reports page on developer wiki for info on ACRA testing
             // buildConfigField "String", "ACRA_URL", '"https://918f7f55-f238-436c-b34f-c8b5f1331fe5-bluemix.cloudant.com/acra-ankidroid/_design/acra-storage/_update/report"'
             if (project.rootProject.file('local.properties').exists()) {
@@ -179,6 +168,17 @@ android {
             dimension "appStore"
         }
     }
+
+    /**
+     * Set this to true to create five separate APKs instead of one:
+     *   - 2 APKs that only work on ARM/ARM64 devices
+     *   - 2 APKs that only works on x86/x86_64 devices
+     *   - a universal APK that works on all devices
+     * The advantage is the size of most APKs is reduced by about 2.5MB.
+     * Upload all the APKs to the Play Store and people will download
+     * the correct one based on the CPU architecture of their device.
+     */
+    def enableSeparateBuildPerCPUArchitecture = true
 
     splits {
         abi {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
@@ -1506,6 +1506,7 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
                         // we only want to decorate when we lose focus
                         return@OnFocusChangeListener
                     }
+                    @SuppressLint("CheckResult")
                     val currentFieldStrings = currentFieldStrings
                     if (currentFieldStrings.size != 2 || currentFieldStrings[1]!!.isNotEmpty()) {
                         // we only decorate on 2-field cards while second field is still empty

--- a/AnkiDroid/src/main/java/com/ichi2/anki/contextmenu/SystemContextMenu.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/contextmenu/SystemContextMenu.kt
@@ -15,6 +15,7 @@
  */
 package com.ichi2.anki.contextmenu
 
+import android.annotation.SuppressLint
 import android.content.ComponentName
 import android.content.Context
 import android.content.pm.PackageManager
@@ -35,6 +36,7 @@ abstract class SystemContextMenu(private val context: Context) {
     }
 
     fun ensureConsistentStateWithPreferenceStatus(preferenceStatus: Boolean) {
+        @SuppressLint("CheckResult")
         val actualStatus = systemMenuStatus
         if (actualStatus == null || actualStatus != preferenceStatus) {
             Timber.d("Modifying Context Menu Status: Preference was %b", preferenceStatus)

--- a/AnkiDroid/src/test/java/com/ichi2/anki/multimediacard/fields/BasicImageFieldControllerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/multimediacard/fields/BasicImageFieldControllerTest.kt
@@ -15,6 +15,7 @@
  */
 package com.ichi2.anki.multimediacard.fields
 
+import android.annotation.SuppressLint
 import android.app.Activity
 import android.content.Intent
 import androidx.activity.result.ActivityResultRegistry
@@ -40,6 +41,7 @@ import kotlin.test.fail
 open class BasicImageFieldControllerTest : MultimediaEditFieldActivityTestBase() {
     @Test
     fun constructionWithoutDataGivesNoError() {
+        @SuppressLint("CheckResult")
         val controller: IFieldController = validControllerNoImage
         assertThat("construction of image field without data should not give an error", controller, instanceOf(BasicImageFieldController::class.java))
     }
@@ -52,6 +54,7 @@ open class BasicImageFieldControllerTest : MultimediaEditFieldActivityTestBase()
 
     @Test
     fun nonExistingFileDoesNotDisplayPreview() {
+        @SuppressLint("CheckResult")
         val controller = validControllerNoImage
         assertThat(controller.isShowingPreview, equalTo(false))
         val f = mock(File::class.java)
@@ -66,6 +69,7 @@ open class BasicImageFieldControllerTest : MultimediaEditFieldActivityTestBase()
 
     @Test
     fun erroringFileDoesNotDisplayPreview() {
+        @SuppressLint("CheckResult")
         val controller = validControllerNoImage
         assertThat(controller.isShowingPreview, equalTo(false))
         val f = mock(File::class.java)
@@ -80,6 +84,7 @@ open class BasicImageFieldControllerTest : MultimediaEditFieldActivityTestBase()
 
     @Test
     fun fileSelectedOnSVG() {
+        @SuppressLint("CheckResult")
         val controller = validControllerNoImage
         val f = File("test.svg")
         controller.setImagePreview(f, 100)
@@ -96,6 +101,7 @@ open class BasicImageFieldControllerTest : MultimediaEditFieldActivityTestBase()
         // TODO: This started failing after API 30:
         //  showThemedToast threw an NPE. Diagnose the underlying issue.
 
+        @SuppressLint("CheckResult")
         val controller = validControllerNoImage
         controller.registryToUse = object : ActivityResultRegistry() {
             override fun <I, O> onLaunch(

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     // If changing this, make sure to update org.jetbrains.kotlin.plugin.serialization version too
     ext.kotlin_version = '1.9.10'
     ext.lint_version = '31.1.1'
-    ext.acra_version = '5.11.2'
+    ext.acra_version = '5.11.3'
     ext.ankidroid_backend_version = '0.1.26-anki23.10beta'
     ext.hamcrest_version = '2.2'
     ext.junit_version = '5.10.0'

--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ buildscript {
     ext.androidx_test_version = '1.5.0'
     ext.androidx_test_junit_version = '1.1.5'
     ext.robolectric_version = '4.10.3'
-    ext.android_gradle_plugin = "8.1.2"
+    ext.android_gradle_plugin = "8.2.0-rc01"
     ext.dokka_version = "1.9.10" // not the same with kotlin version!
 
     configurations.all {


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description

- 2 minor easy bumps
- 1 actual change where I pull in android gradle plugin 8.2.0-rc01 so we get ABI splits while resources are included again (which is our unit test configuration...). This reverted the change which broke release builds, so we should have release builds *and* have unit tests running

## Fixes
Fixes #14571 

## Approach
Check to see if recent updates to android gradle plugin as they approach 8.2.0 final release finally cherry-picked the fix for https://issuetracker.google.com/issues/302961829

They did!

- revert my busted release / no-abi-split patch
- bump to new android gradle plugin
- profit

## How Has This Been Tested?

`./gradlew jacocoUnitTestReport` has always been the reproducer for the android gradle plugin bug when my workaround patch was reverted, so I reverted my patch and sure enough it failed

Then I bumped to 8.2.0-rc01 and it worked, so that's that I think

## Learning (optional, can help others)
Sometimes other people fix entropy for you but not until you've bruised your toe bumping into the breakage

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
