### PR TITLE
build(deps): API module should have same targetApi as others

### DIFF
--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -21,8 +21,7 @@ android {
 
     defaultConfig {
         minSdk = 16
-        //noinspection OldTargetApi
-        targetSdk = 32
+        targetSdk = 33
         buildConfigField(
             "String",
             "READ_WRITE_PERMISSION",


### PR DESCRIPTION

Exactly what the title says :-) - api targetSdk had trailed other modules for no reason I could determine

This bumps it to match Ankidroid module