### PR TITLE
compat: Normalise locale to two letter code

### DIFF
--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/compat/CompatNormalizeTest.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/compat/CompatNormalizeTest.kt
@@ -1,0 +1,44 @@
+/*
+ *  Copyright (c) 2023 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.compat
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.ichi2.anki.tests.InstrumentedTest
+import com.ichi2.compat.CompatHelper
+import org.hamcrest.CoreMatchers.equalTo
+import org.hamcrest.MatcherAssert.*
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.util.Locale
+
+@RunWith(AndroidJUnit4::class)
+class CompatNormalizeTest : InstrumentedTest() {
+    @Test
+    fun normalize() {
+        fun assertEqual(l: Locale, str: String) {
+            val normalized = CompatHelper.compat.normalize(l)
+            assertThat(normalized.toLanguageTag(), equalTo(str))
+        }
+
+        assertEqual(Locale("en", "GB"), "en-GB")
+        assertEqual(Locale("es", "MX"), "es-MX")
+        assertEqual(Locale("spa", "MEX"), "es-MX")
+        assertEqual(Locale("fil", "PH"), "fil-PH")
+        // TBC
+        assertEqual(Locale("ar", ""), "ar")
+    }
+}

--- a/AnkiDroid/src/main/java/com/ichi2/compat/Compat.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/Compat.kt
@@ -32,6 +32,7 @@ import android.media.MediaRecorder
 import android.net.Uri
 import android.os.Bundle
 import android.view.View
+import androidx.annotation.CheckResult
 import java.io.*
 import java.util.*
 
@@ -198,6 +199,13 @@ interface Compat {
      */
     @Throws(IOException::class)
     fun contentOfDirectory(directory: File): FileStream
+
+    /**
+     * Converts a locale to a 'two letter' code (ISO-639-1 + ISO 3166-1 alpha-2)
+     * Locale("spa", "MEX", "001") => Locale("es", "MX", "001")
+     */
+    @CheckResult
+    fun normalize(locale: Locale): Locale
 
     companion object {
         /* Mock the Intent PROCESS_TEXT constants introduced in API 23. */

--- a/AnkiDroid/src/main/java/com/ichi2/compat/CompatHelper.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/CompatHelper.kt
@@ -45,6 +45,7 @@ class CompatHelper private constructor() {
         sdkVersion >= Build.VERSION_CODES.S -> CompatV31()
         sdkVersion >= Build.VERSION_CODES.Q -> CompatV29()
         sdkVersion >= Build.VERSION_CODES.O -> CompatV26()
+        sdkVersion >= Build.VERSION_CODES.N -> CompatV24()
         else -> CompatV23()
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/compat/CompatV24.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/CompatV24.kt
@@ -17,7 +17,25 @@
 package com.ichi2.compat
 
 import android.annotation.TargetApi
+import android.icu.util.ULocale
+import com.ichi2.utils.isRobolectric
+import timber.log.Timber
+import java.util.Locale
 
 /** Implementation of [Compat] for SDK level 24 and higher. Check [Compat]'s for more detail.  */
 @TargetApi(24)
-open class CompatV24 : CompatV23(), Compat
+open class CompatV24 : CompatV23(), Compat {
+    override fun normalize(locale: Locale): Locale {
+        // ULocale isn't currently handled by Robolectric
+        if (isRobolectric) {
+            return super.normalize(locale)
+        }
+        return try {
+            val uLocale = ULocale(locale.language, locale.country, locale.variant)
+            Locale(uLocale.language, uLocale.country, uLocale.variant)
+        } catch (e: Exception) {
+            Timber.w("Failed to normalize locale %s", locale, e)
+            locale
+        }
+    }
+}

--- a/AnkiDroid/src/main/java/com/ichi2/compat/CompatV24.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/CompatV24.kt
@@ -1,0 +1,23 @@
+/*
+ *  Copyright (c) 2023 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.compat
+
+import android.annotation.TargetApi
+
+/** Implementation of [Compat] for SDK level 24 and higher. Check [Compat]'s for more detail.  */
+@TargetApi(24)
+open class CompatV24 : CompatV23(), Compat

--- a/AnkiDroid/src/main/java/com/ichi2/compat/CompatV26.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/CompatV26.kt
@@ -32,7 +32,7 @@ import java.nio.file.*
 
 /** Implementation of [Compat] for SDK level 26 and higher. Check  [Compat]'s for more detail.  */
 @TargetApi(26)
-open class CompatV26 : CompatV23(), Compat {
+open class CompatV26 : CompatV24(), Compat {
     /**
      * In Oreo and higher, you must create a channel for all notifications.
      * This will create the channel if it doesn't exist, or if it exists it will update the name.


### PR DESCRIPTION
## Purpose / Description
We need this for TTS compatibility with Anki Desktop. We want `{{tts es_MX ...}}` to work (as used in Anki), but a `android.speech.tts.Voice` may have a locale which is serialised to `spa_MEX`.

## Fixes
* Related: #14358

## Approach
* `ULocale` on API 24+
* Match locales using `language` and `country` on API 23

## How Has This Been Tested?

Tested on API 23 and my Samsung S21 (Android 13)

## Learning (optional, can help others)
https://developer.android.com/reference/android/icu/util/ULocale

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
