### PR TITLE
feat: TTS Support ({{tts-voices}})

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
@@ -60,6 +60,7 @@ import com.ichi2.anki.cardviewer.HtmlGenerator.Companion.createInstance
 import com.ichi2.anki.cardviewer.SoundPlayer.CardSoundConfig
 import com.ichi2.anki.cardviewer.SoundPlayer.CardSoundConfig.Companion.create
 import com.ichi2.anki.cardviewer.TypeAnswer.Companion.createInstance
+import com.ichi2.anki.dialogs.TtsVoicesDialogFragment
 import com.ichi2.anki.dialogs.tags.TagsDialog
 import com.ichi2.anki.dialogs.tags.TagsDialogFactory
 import com.ichi2.anki.dialogs.tags.TagsDialogListener
@@ -2210,6 +2211,10 @@ abstract class AbstractFlashcardViewer :
                 launchCatchingTask {
                     controlSound(url)
                 }
+                return true
+            }
+            if (url.startsWith("tts-voices:")) {
+                showDialogFragment(TtsVoicesDialogFragment())
                 return true
             }
             if (url.startsWith("file") || url.startsWith("data:")) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
@@ -495,6 +495,7 @@ abstract class AbstractFlashcardViewer :
         mPreviousAnswerIndicator = PreviousAnswerIndicator(findViewById(R.id.chosen_answer))
         shortAnimDuration = resources.getInteger(android.R.integer.config_shortAnimTime)
         mGestureDetectorImpl = LinkDetectingGestureDetector()
+        TtsVoicesFieldFilter.ensureApplied()
     }
 
     protected open fun getContentViewAttr(fullscreenMode: FullScreenMode): Int {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AndroidTtsPlayer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AndroidTtsPlayer.kt
@@ -1,0 +1,142 @@
+/*
+ *  Copyright (c) 2023 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki
+
+import android.net.Uri
+import android.os.Bundle
+import android.speech.tts.TextToSpeech
+import android.speech.tts.TextToSpeech.ERROR
+import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.lifecycleScope
+import com.ichi2.anki.ReadText.errorToDeveloperString
+import com.ichi2.anki.snackbar.showSnackbar
+import com.ichi2.compat.UtteranceProgressListenerCompat
+import com.ichi2.libanki.AvTag
+import com.ichi2.libanki.TTSTag
+import com.ichi2.libanki.TtsPlayer
+import com.ichi2.libanki.TtsVoice
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.launch
+import timber.log.Timber
+
+class AndroidTtsPlayer(private val context: AnkiActivity, private val voices: List<TtsVoice>) : TtsPlayer(), DefaultLifecycleObserver {
+    private var tts: TextToSpeech? = null
+    private var createTtsJob: Job? = null
+
+    /** Flyweight pattern for an empty bundle */
+    private val bundleFlyweight = Bundle()
+
+    private val ttsCompletedChannel: Channel<String?> = Channel()
+    override fun onCreate(owner: LifecycleOwner) {
+        super.onCreate(owner)
+        createTtsJob = owner.lifecycleScope.launch {
+            tts = TtsVoices.createTts(context)?.apply {
+                setOnUtteranceProgressListener(object : UtteranceProgressListenerCompat() {
+                    override fun onStart(utteranceId: String?) {
+                    }
+
+                    override fun onDone(utteranceId: String?) {
+                        owner.lifecycleScope.launch {
+                            ttsCompletedChannel.send(utteranceId)
+                        }
+                    }
+
+                    override fun onError(utteranceId: String?, errorCode: Int) {
+                        // TODO: Copied from ReadText
+                        Timber.v("Android TTS failed: %s (%d). Check logcat for error. Indicates a problem with Android TTS engine.", errorToDeveloperString(errorCode), errorCode)
+                        val helpUrl = Uri.parse(context.getString(R.string.link_faq_tts))
+                        context.mayOpenUrl(helpUrl)
+                        // TODO: We can do better in this UI now we have a reason for failure
+                        context.showSnackbar(R.string.no_tts_available_message) {
+                            setAction(R.string.help) { ReadText.openTtsHelpUrl(helpUrl) }
+                        }
+                    }
+                })
+            }
+            // optimisation: avoid the overhead of waiting for a completed job
+            createTtsJob = null
+        }
+    }
+
+    override fun onDestroy(owner: LifecycleOwner) {
+        super.onDestroy(owner)
+        tts?.stop()
+        tts?.shutdown()
+    }
+
+    override fun get_available_voices(): List<TtsVoice> {
+        return this.voices
+    }
+
+    override suspend fun play(tag: AvTag) {
+        if (tag !is TTSTag) {
+            Timber.w("Expected TTS Tag, got %s", tag)
+            return
+        }
+        val match = voice_for_tag(tag)
+        if (match == null) {
+            Timber.w("could not find voice for %s", tag)
+            return
+        }
+
+        val voice = match.voice
+        if (voice !is AndroidTtsVoice) {
+            Timber.w("Invalid voice for %s", tag)
+            return
+        }
+
+        play(tag, voice)
+    }
+
+    private suspend fun play(tag: TTSTag, voice: AndroidTtsVoice) {
+        val tts = requireTts().also {
+            it.voice = voice.voice
+            if (it.setSpeechRate(tag.speed) == ERROR) {
+                return
+            }
+            // if it's already playing: stop it
+            it.stopPlaying()
+        }
+
+        Timber.d("tts text '%s' to be played for locale (%s)", tag.fieldText, tag.lang)
+        tts.speak(tag.fieldText, TextToSpeech.QUEUE_FLUSH, bundleFlyweight, "stringId")
+        ttsCompletedChannel.receive()
+        Timber.v("tts completed")
+    }
+
+    /** Blocks if necessary to provide a TextToSpeech instance */
+    private suspend fun requireTts(): TextToSpeech {
+        createTtsJob?.join()
+        return tts!!
+    }
+
+    companion object {
+        private fun TextToSpeech.stopPlaying() {
+            if (this.isSpeaking) {
+                Timber.d("tts engine appears to be busy... clearing queue")
+                this.stop()
+            }
+        }
+
+        suspend fun createInstance(context: AnkiActivity): AndroidTtsPlayer {
+            val voices = TtsVoices.allTtsVoices().toList()
+            return AndroidTtsPlayer(context, voices)
+        }
+    }
+}

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.kt
@@ -230,6 +230,8 @@ open class AnkiDroidApp : Application() {
 
         activityAgnosticDialogs = ActivityAgnosticDialogs.register(this)
         TtsVoices.launchBuildLocalesJob()
+        // enable {{tts-voices:}} field filter
+        TtsVoicesFieldFilter.ensureApplied()
     }
 
     /**

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ReadText.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ReadText.kt
@@ -69,7 +69,6 @@ object ReadText {
             if (textToSpeech!!.isSpeaking && queueMode == TextToSpeech.QUEUE_FLUSH) {
                 Timber.d("tts engine appears to be busy... clearing queue")
                 stopTts()
-                // sTextQueue.add(new String[] { text, loc });
             }
             Timber.d("tts text '%s' to be played for locale (%s)", text, loc)
             textToSpeech!!.speak(textToSpeak, queueMode, mTtsParams, "stringId")
@@ -260,20 +259,6 @@ object ReadText {
                         listener.onDone(questionAnswer)
                     }
 
-                    fun errorToDeveloperString(errorCode: Int): String {
-                        return when (errorCode) {
-                            TextToSpeech.ERROR -> "Generic failure"
-                            TextToSpeech.ERROR_SYNTHESIS -> "TTS engine failed to synthesize input"
-                            TextToSpeech.ERROR_INVALID_REQUEST -> "Invalid request"
-                            TextToSpeech.ERROR_NETWORK -> "Network connectivity problem"
-                            TextToSpeech.ERROR_NETWORK_TIMEOUT -> "Network timeout"
-                            TextToSpeech.ERROR_NOT_INSTALLED_YET -> "Unfinished download of the voice data"
-                            TextToSpeech.ERROR_OUTPUT -> "Output error (audio device or a file)"
-                            TextToSpeech.ERROR_SERVICE -> "TTS service"
-                            else -> "Unhandled Error [$errorCode]"
-                        }
-                    }
-
                     override fun onError(utteranceId: String?, errorCode: Int) {
                         Timber.v("Android TTS failed: %s (%d). Check logcat for error. Indicates a problem with Android TTS engine.", errorToDeveloperString(errorCode), errorCode)
                         val helpUrl = Uri.parse(context.getString(R.string.link_faq_tts))
@@ -304,7 +289,21 @@ object ReadText {
         showThemedToast(context, context.getString(R.string.initializing_tts), false)
     }
 
-    private fun openTtsHelpUrl(helpUrl: Uri) {
+    fun errorToDeveloperString(errorCode: Int): String {
+        return when (errorCode) {
+            TextToSpeech.ERROR -> "Generic failure"
+            TextToSpeech.ERROR_SYNTHESIS -> "TTS engine failed to synthesize input"
+            TextToSpeech.ERROR_INVALID_REQUEST -> "Invalid request"
+            TextToSpeech.ERROR_NETWORK -> "Network connectivity problem"
+            TextToSpeech.ERROR_NETWORK_TIMEOUT -> "Network timeout"
+            TextToSpeech.ERROR_NOT_INSTALLED_YET -> "Unfinished download of the voice data"
+            TextToSpeech.ERROR_OUTPUT -> "Output error (audio device or a file)"
+            TextToSpeech.ERROR_SERVICE -> "TTS service"
+            else -> "Unhandled Error [$errorCode]"
+        }
+    }
+
+    fun openTtsHelpUrl(helpUrl: Uri) {
         val activity = flashCardViewer.get() as AnkiActivity?
         activity!!.openUrl(helpUrl)
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/TtsVoices.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/TtsVoices.kt
@@ -26,6 +26,7 @@ import android.content.Context
 import android.speech.tts.TextToSpeech
 import android.speech.tts.Voice
 import com.ichi2.compat.CompatHelper
+import com.ichi2.libanki.TemplateManager
 import com.ichi2.libanki.TtsVoice
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -184,6 +185,32 @@ object TtsVoices {
                 }
             }
         }
+}
+
+/**
+ * `{{tts-voices:}}` A filter which lists all available TTS Voices for the current engine
+ */
+class TtsVoicesFieldFilter : TemplateManager.FieldFilter() {
+    // modified from libAnki: tts.py: on_tts_voices
+    override fun apply(
+        fieldText: String,
+        fieldName: String,
+        filterName: String,
+        ctx: TemplateManager.TemplateRenderContext
+    ): String {
+        if (filterName != "tts-voices") {
+            return fieldText
+        }
+        // This is not translated in Anki Desktop
+        return "<a href=\"tts-voices:\"/>Open TTS voices settings</a>"
+    }
+
+    companion object {
+        /** Enables the {{tts-voices}} filter */
+        fun ensureApplied() {
+            TemplateManager.fieldFilters.putIfAbsent("tts-voices", TtsVoicesFieldFilter())
+        }
+    }
 }
 
 /**

--- a/AnkiDroid/src/main/java/com/ichi2/anki/TtsVoices.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/TtsVoices.kt
@@ -81,6 +81,12 @@ object TtsVoices {
         return this.availableLocaleData
     }
 
+    suspend fun refresh() {
+        launchBuildLocalesJob()
+        buildLocalesJob?.join()
+        loadTtsVoicesData()
+    }
+
     /**
      * Returns the list of available locales for use in TTS
      *

--- a/AnkiDroid/src/main/java/com/ichi2/anki/TtsVoices.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/TtsVoices.kt
@@ -12,19 +12,29 @@
  *
  *  You should have received a copy of the GNU General Public License along with
  *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  This file incorporates code under the following license
+ *  https://github.com/ankitects/anki/blob/9600f033f745bfae4e00dd9fa43e44d3b30c22d2/qt/aqt/tts.py
+ *
+ *    Copyright: Ankitects Pty Ltd and contributors
+ *    License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
  */
 
 package com.ichi2.anki
 
+import android.content.Context
 import android.speech.tts.TextToSpeech
+import android.speech.tts.Voice
+import com.ichi2.compat.CompatHelper
+import com.ichi2.libanki.TtsVoice
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.suspendCancellableCoroutine
 import timber.log.Timber
 import java.util.Locale
 import kotlin.coroutines.resume
-import kotlin.coroutines.suspendCoroutine
 
 /**
  * Voices which an be used in TTS (Text to Speech)
@@ -40,6 +50,9 @@ object TtsVoices {
     // the new values
     /** An immutable list of locales available for TTS */
     private lateinit var availableLocaleData: List<Locale>
+
+    /** An immutable list of voices available for TTS */
+    private lateinit var availableVoices: Set<AndroidTtsVoice>
 
     /** A job which populates [availableLocaleData] */
     private var buildLocalesJob: Job? = null
@@ -86,6 +99,19 @@ object TtsVoices {
     }
 
     /**
+     * Returns the list of available voices for use in TTS
+     */
+    suspend fun allTtsVoices(): Set<AndroidTtsVoice> {
+        if (this::availableLocaleData.isInitialized) {
+            return this.availableVoices
+        }
+
+        launchBuildLocalesJob()
+        buildLocalesJob?.join()
+        return this.availableVoices
+    }
+
+    /**
      * Launches a [Job] to populate the list of available locales for use in TTS
      *
      * This is run in the background, without blocking the main thread
@@ -121,29 +147,16 @@ object TtsVoices {
         }
 
         // Samsung TextToSpeech engine returns locales with a displayName of "GBR,DEFAULT"/"GBR,f00"
-        // so use getAvailableLocales and check if they're available
+        // so normalize them before displaying them to users
         // sample of problematic data: language = "eng", region = "GBR", variant = "f00"
-        val availableTtsLocales = mutableListOf<Locale>()
         try {
-            val systemLocales = Locale.getAvailableLocales()
-            for (loc in systemLocales) {
-                try {
-                    val retCode = tts.isLanguageAvailable(loc)
-                    if (retCode >= TextToSpeech.LANG_COUNTRY_AVAILABLE) {
-                        availableTtsLocales.add(loc)
-                    } else {
-                        Timber.v(
-                            "%s not available (error code %d)",
-                            loc.displayName,
-                            retCode
-                        )
-                    }
-                } catch (e: IllegalArgumentException) {
-                    Timber.w(e, "Error checking if language %s available", loc.displayName)
-                }
-            }
+            // TODO: Handle multiple engines
+            val ttsEngine = tts.defaultEngine
+            availableVoices = tts.voices.map { it.toTtsVoice(ttsEngine) }.toSet()
+            availableLocaleData = tts.availableLanguages.map { CompatHelper.compat.normalize(it) }
+        } catch (e: Exception) {
+            availableLocaleData = emptyList()
         } finally {
-            availableLocaleData = availableTtsLocales
             tts.shutdown()
         }
     }
@@ -154,10 +167,14 @@ object TtsVoices {
      * @return a usable [TextToSpeech] instance, or `null` if the [TextToSpeech.OnInitListener]
      * returns [TextToSpeech.ERROR]
      */
-    private suspend fun createTts() =
-        suspendCoroutine { continuation ->
+    suspend fun createTts(context: Context = AnkiDroidApp.instance) =
+        suspendCancellableCoroutine { continuation ->
             var textToSpeech: TextToSpeech? = null
-            textToSpeech = TextToSpeech(AnkiDroidApp.instance) { status ->
+            continuation.invokeOnCancellation {
+                textToSpeech?.stop()
+                textToSpeech?.shutdown()
+            }
+            textToSpeech = TextToSpeech(context) { status ->
                 if (status == TextToSpeech.SUCCESS) {
                     continuation.resume(textToSpeech)
                 } else {
@@ -167,4 +184,54 @@ object TtsVoices {
                 }
             }
         }
+}
+
+/**
+ * Converts a [Voice] to a [TtsVoice] for use in libAnki
+ *
+ * @param engine The package name of the TTS Engine
+ */
+fun Voice.toTtsVoice(engine: String) = AndroidTtsVoice(this, engine)
+
+/**
+ * An instance of [TtsVoice] which allows access to the underlying [Voice] object
+ */
+// We include the engine name in the TTS 'name' to future-proof the feature of
+// allowing a user to switch between TTS providers on the same card
+// a name looks like: com.google.android.tts-cmn-cn-x-ccc-local
+// com.google.android.tts + cmn-cn-x-ccc-local
+class AndroidTtsVoice(val voice: Voice, val engine: String) : TtsVoice(name = "$engine-${voice.name}", lang = toAnkiTwoLetterCode(voice.locale)) {
+    override fun unavailable(): Boolean {
+        return voice.features.contains(TextToSpeech.Engine.KEY_FEATURE_NOT_INSTALLED)
+    }
+
+    /**
+     * The locale of the voice normalized to a human readable language/country, missing the variant
+     * Designed for [Locale.getDisplayName]
+     */
+    val normalizedLocale: Locale
+        // on Samsung phones, the variant (f001/DEFAULT) looks awful in the UI
+        // normalise: "en-GBR" is "English (GBR)". "en-GB" is "English (United Kingdom)"
+        // then remove the variant: We want English (United Kingdom), not (United Kingdom,DEFAULT)
+        get() = CompatHelper.compat.normalize(voice.locale).let { Locale(it.language, it.country) }
+
+    val isNetworkConnectionRequired
+        get() = voice.isNetworkConnectionRequired
+
+    companion object {
+        /**
+         * Returns an Anki-compatible 'two letter' code (ISO-639-1 + ISO 3166-1 [alpha-2 preferred])
+         * ```
+         * Locale("spa", "MEX", "001") => "es_MX"
+         * Locale("ar", "") => "ar"
+         * ```
+         *
+         * This differs from [Locale.toLanguageTag]:
+         * * [Locale.variant][Locale.getVariant] is not output
+         * * A "_" is used instead of a "-" to match Anki Desktop
+         */
+        fun toAnkiTwoLetterCode(locale: Locale): String = CompatHelper.compat.normalize(locale).run {
+            return if (country.isBlank()) language else "${language}_$country"
+        }
+    }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/TtsVoicesDialogFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/TtsVoicesDialogFragment.kt
@@ -202,6 +202,11 @@ class TtsVoicesDialogFragment : DialogFragment() {
         }
     }
 
+    override fun onResume() {
+        super.onResume()
+        viewModel.waitForRefresh()
+    }
+
     /**
      * Helper function to observe a flow while the current lifecycle is active
      */

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/TtsVoicesDialogFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/TtsVoicesDialogFragment.kt
@@ -1,0 +1,307 @@
+/*
+ *  Copyright (c) 2023 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.dialogs
+
+import android.app.AlertDialog
+import android.content.ActivityNotFoundException
+import android.content.Intent
+import android.content.res.ColorStateList
+import android.graphics.Color
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.Button
+import android.widget.EditText
+import android.widget.TextView
+import androidx.core.widget.doOnTextChanged
+import androidx.fragment.app.DialogFragment
+import androidx.fragment.app.viewModels
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.flowWithLifecycle
+import androidx.lifecycle.lifecycleScope
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
+import androidx.recyclerview.widget.RecyclerView
+import com.google.android.material.button.MaterialButton
+import com.google.android.material.chip.Chip
+import com.google.android.material.progressindicator.LinearProgressIndicator
+import com.ichi2.anki.AndroidTtsError
+import com.ichi2.anki.AndroidTtsVoice
+import com.ichi2.anki.AnkiActivity
+import com.ichi2.anki.R
+import com.ichi2.anki.UIUtils
+import com.ichi2.anki.dialogs.viewmodel.TtsVoicesViewModel
+import com.ichi2.anki.snackbar.showSnackbar
+import com.ichi2.libanki.TtsVoice
+import com.ichi2.themes.Themes
+import com.ichi2.utils.UiUtil.makeFullscreen
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.launch
+import timber.log.Timber
+
+/**
+ * A dialog which allows a user to preview Text to speech voices and copy them to the clipboard
+ * for use in a card template
+ *
+ * This may be opened after {{tts-voices:}} is placed a card template
+ *
+ * It provides the user the ability to filter voices by online/offline, and whether the voice
+ * is installed on the system
+ *
+ * We filter by online/offline to discourage data usage and reduce latency
+ * Although uninstalled voices can be used, and a TTS should install an uninstalled voice,
+ * in practice there are many bugs in the TTS Engines, so we want to explicitly inform a user
+ *
+ * As a future extension: this dialog should have a 'refresh' button/functionality to handle
+ * voice installs
+ *
+ * @see [TtsVoicesViewModel]
+ */
+class TtsVoicesDialogFragment : DialogFragment() {
+
+    private val viewModel: TtsVoicesViewModel by this.viewModels()
+
+    private lateinit var progressBar: LinearProgressIndicator
+    private lateinit var layout: View
+    private lateinit var spokenTextEditText: EditText
+    private lateinit var recyclerView: RecyclerView
+    private lateinit var internetRequiredChip: Chip
+
+    private lateinit var voicesAdapter: TtsVoiceAdapter
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        voicesAdapter = TtsVoiceAdapter()
+        Themes.setTheme(requireContext()) // (re)-enable selectableItemBackground on theme change
+
+        layout = inflater.inflate(R.layout.dialog_tts_voices, null).apply {
+            recyclerView = findViewById<RecyclerView>(R.id.files).apply {
+                this.adapter = voicesAdapter
+            }
+            spokenTextEditText = findViewById<EditText>(R.id.spoken_text).apply {
+                // setup the initial value from the UI
+                viewModel.setSpokenText(text.toString())
+                doOnTextChanged { text, _, _, _ -> viewModel.setSpokenText(text.toString()) }
+            }
+            findViewById<MaterialButton>(R.id.back_button).apply {
+                setOnClickListener {
+                    this@TtsVoicesDialogFragment.dismiss()
+                }
+            }
+            findViewById<Button>(R.id.options_buttons).apply {
+                setOnClickListener { openTtsSettings() }
+            }
+            internetRequiredChip = findViewById<Chip>(R.id.toggle_internet_required).apply {
+                setOnCheckedChangeListener { _, value ->
+                    viewModel.showInternetEnabled.value = value
+                    chipBackgroundColor = if (value) {
+                        // TODO: This should be RMaterial.attr.colorSecondaryContainer
+                        // but this shows as Purple after Themes.setTheme
+                        ColorStateList.valueOf(requireContext().getColor(R.color.text_input_background))
+                    } else {
+                        ColorStateList.valueOf(Color.TRANSPARENT)
+                    }
+                }
+                viewModel.showInternetEnabled.value = this.isChecked
+            }
+            findViewById<Chip>(R.id.only_show_uninstalled).apply {
+                setOnCheckedChangeListener { _, value ->
+                    viewModel.showNotInstalled.value = value
+                    chipBackgroundColor = if (value) {
+                        ColorStateList.valueOf(requireContext().getColor(R.color.text_input_background))
+                    } else {
+                        ColorStateList.valueOf(Color.TRANSPARENT)
+                    }
+                }
+                viewModel.showNotInstalled.value = this.isChecked
+            }
+            progressBar = findViewById(R.id.progress)
+        }
+
+        return layout
+    }
+
+    fun openTtsSettings() {
+        try {
+            requireContext().startActivity(
+                Intent("com.android.settings.TTS_SETTINGS").apply {
+                    flags = Intent.FLAG_ACTIVITY_NEW_TASK
+                }
+            )
+        } catch (e: ActivityNotFoundException) {
+            Timber.w(e)
+            UIUtils.showThemedToast(requireContext(), R.string.tts_voices_failed_opening_tts_system_settings, shortLength = true)
+        }
+    }
+
+    override fun onStart() {
+        super.onStart()
+
+        dialog?.makeFullscreen()
+
+        viewModel.availableVoicesFlow.observe {
+            if (it is TtsVoicesViewModel.VoiceLoadingState.Failure) {
+                progressBar.visibility = View.VISIBLE
+                AlertDialog.Builder(this.context)
+                    .setMessage(it.exception.localizedMessage)
+                    .setOnDismissListener { this@TtsVoicesDialogFragment.dismiss() }
+                    .show()
+            }
+
+            if (it is TtsVoicesViewModel.VoiceLoadingState.Success) {
+                Timber.v("loaded new voice collection")
+                voicesAdapter.submitList(it.voices)
+                progressBar.visibility = View.GONE
+            }
+        }
+
+        viewModel.showNotInstalled.observe { showInstalled ->
+            // if the user is showing installed, it shows ALL uninstalled voices
+            internetRequiredChip.isEnabled = !showInstalled
+        }
+
+        viewModel.uninstalledVoicePlayed.observe { voice ->
+            dialog?.window?.decorView?.showSnackbar(R.string.tts_voices_selected_voice_should_be_installed) {
+                setAction(R.string.tts_voices_use_selected_voice_without_install) { viewModel.copyToClipboard(voice) }
+            }
+        }
+
+        viewModel.ttsPlaybackErrorFlow.observe {
+            val string = if (it is AndroidTtsError) {
+                // TODO: Do we want a human readable string here as well - snackbar has limited room
+                // but developerString is currently not translated as it returns
+                // developerString: ERROR_NETWORK_TIMEOUT, so "Audio error (ERROR_NETWORK_TIMEOUT)"
+                requireContext().getString(R.string.tts_voices_playback_error, it.errorCode.developerString)
+            } else {
+                it.toString()
+            }
+            dialog?.window?.decorView?.showSnackbar(string) {
+                setAction(R.string.help) {
+                    // TODO: Should do this in ViewModel, but we need an Activity
+                    (requireActivity() as AnkiActivity).openUrl(R.string.link_faq_tts)
+                }
+            }
+        }
+    }
+
+    /**
+     * Helper function to observe a flow while the current lifecycle is active
+     */
+    private fun <T> Flow<T>.observe(exec: (T) -> Unit) {
+        lifecycleScope.launch {
+            this@observe
+                .flowWithLifecycle(lifecycle, Lifecycle.State.STARTED)
+                .collect(exec)
+        }
+    }
+
+    private class TtsVoiceDiffCallback : DiffUtil.ItemCallback<AndroidTtsVoice>() {
+        override fun areItemsTheSame(oldItem: AndroidTtsVoice, newItem: AndroidTtsVoice): Boolean =
+            oldItem.name == newItem.name
+
+        override fun areContentsTheSame(
+            oldItem: AndroidTtsVoice,
+            newItem: AndroidTtsVoice
+        ): Boolean = oldItem.unavailable() == newItem.unavailable()
+    }
+
+    // inner allows access to viewModel/openTtsSettings
+    inner class TtsVoiceAdapter() : ListAdapter<AndroidTtsVoice, TtsVoiceAdapter.TtsViewHolder>(TtsVoiceDiffCallback()) {
+        inner class TtsViewHolder(private val voiceView: View) : RecyclerView.ViewHolder(voiceView) {
+            private val textViewTop = voiceView.findViewById<TextView>(R.id.mtrl_list_item_secondary_text)
+            private val textViewBottom = voiceView.findViewById<TextView>(R.id.mtrl_list_item_text)
+            private val actionButton = voiceView.findViewById<MaterialButton>(R.id.action_button)
+            private val localOrOffline = voiceView.findViewById<MaterialButton>(R.id.local_or_network)
+
+            fun bind(voice: AndroidTtsVoice) {
+                textViewTop.text = voice.normalizedLocale.displayName
+                textViewBottom.text = voice.tryDisplayLocalizedName()
+
+                localOrOffline.setIconResource(if (voice.isNetworkConnectionRequired) R.drawable.baseline_wifi_24 else R.drawable.baseline_offline_pin_24)
+                if (voice.unavailable()) {
+                    actionButton.setOnClickListener { openTtsSettings() }
+                    actionButton.setIconResource(R.drawable.ic_file_download_white)
+                } else {
+                    actionButton.setIconResource(R.drawable.baseline_content_copy_24)
+                    actionButton.setOnClickListener { viewModel.copyToClipboard(voice) }
+                    voiceView.setOnClickListener { viewModel.playVoice(voice) }
+                }
+
+                voiceView.setOnClickListener { viewModel.playVoice(voice) }
+            }
+        }
+
+        override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): TtsViewHolder {
+            val v = LayoutInflater.from(parent.context).inflate(R.layout.dialog_tts_voices_voice, parent, false)
+            return TtsViewHolder(v)
+        }
+
+        override fun onBindViewHolder(holder: TtsViewHolder, position: Int) {
+            holder.bind(this.currentList[position])
+        }
+    }
+}
+
+fun TtsVoice.tryDisplayLocalizedName(): String {
+    if (this !is AndroidTtsVoice) {
+        return this.toString()
+    }
+
+    if (engine == "com.google.android.tts") {
+        return prettyPrintGoogle(this)
+    }
+    // exclude the engine when printing
+    return voice.name
+}
+
+/**
+ * Removes the prefix and suffix from a Google voice name, and provides the 'code' of the voice
+ *
+ * * sr => sr
+ * * cmn-cn-x-ccd-network => ccd
+ * * cmn-cn-x-ccc-local => ccc
+ * * zh-CN-language => zh CN
+ *
+ * We can remove the Locale prefix as we have better locale data in the voice
+ * We can remove the network/local suffix as this can be obtained from the TTS Engine
+ */
+fun prettyPrintGoogle(voice: AndroidTtsVoice): String {
+    val parts = voice.voice.name.split("-").toMutableList()
+
+    if (parts.last() == "language") {
+        return parts.dropLast(1).joinToString(" ")
+    }
+
+    if (parts.size == 1 && parts[0] == voice.lang) {
+        return voice.voice.name
+    }
+
+    when (parts.last()) {
+        "local", "network" -> parts.dropLast(1)
+        else -> {}
+    }
+
+    if (parts.size == 5 && parts[2] == "x") {
+        return parts[3]
+    }
+
+    return parts.joinToString(" ")
+}

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/viewmodel/TtsVoicesViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/viewmodel/TtsVoicesViewModel.kt
@@ -1,0 +1,193 @@
+/*
+ *  Copyright (c) 2023 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.dialogs.viewmodel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.ichi2.anki.AndroidTtsPlayer
+import com.ichi2.anki.AndroidTtsVoice
+import com.ichi2.anki.AnkiDroidApp
+import com.ichi2.anki.TtsVoices
+import com.ichi2.anki.dialogs.tryDisplayLocalizedName
+import com.ichi2.libanki.TTSTag
+import com.ichi2.libanki.TtsPlayer
+import com.ichi2.libanki.TtsVoice
+import com.ichi2.utils.copyToClipboard
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+
+/**
+ * @see [com.ichi2.anki.dialogs.TtsVoicesDialogFragment]
+ */
+class TtsVoicesViewModel : ViewModel() {
+    /**
+     * Whether we should show internet-enabled voices in the list.
+     *
+     * Internet-enabled voices are more 'risky' for users so we want to discourage them
+     * * Costs could be incurred if the user is on a metered connection
+     * * Additional latency before speech synthesis begins (typically)
+     */
+    val showInternetEnabled: MutableStateFlow<Boolean> = MutableStateFlow(false)
+
+    /** Whether we filter the list to only 'not installed' voices, or show installed + other filters */
+    val showNotInstalled: MutableStateFlow<Boolean> = MutableStateFlow(false)
+
+    /** The status of loading the list of voices to use */
+    private val ttsVoiceListStatus: MutableStateFlow<LoadVoiceStatus> =
+        MutableStateFlow(LoadVoiceStatus.Calculating)
+
+    /** The status of loading the TTS Engine to play previews */
+    private val ttsEngineStatus: MutableStateFlow<TtsEngineStatus> =
+        MutableStateFlow(TtsEngineStatus.Uninitialized)
+
+    /** The user-selected text which we will play via the TTS Engine */
+    private var textToSpeak: String = ""
+
+    /**
+     * Lists errors which are obtained from TTS Playback
+     *
+     * Typically: if a network voice is requested and a user is offline
+     */
+    val ttsPlaybackErrorFlow: MutableSharedFlow<TtsPlayer.TtsError> =
+        MutableSharedFlow()
+
+    /** When a voice is played which has not yet been installed */
+    val uninstalledVoicePlayed = MutableSharedFlow<TtsVoice>()
+
+    /** Combines individual filters into a single object */
+    private val filterFlow = showInternetEnabled.combine(showNotInstalled) { showInternetEnabled, showNotInstalled ->
+        return@combine Filters(showInternetEnabled, showNotInstalled)
+    }
+
+    /** The collection of either a [TtsEngineStatus] with voices, error, or 'loading'  */
+    val availableVoicesFlow = ttsEngineStatus.combine(ttsVoiceListStatus) { a, b ->
+        if (a is TtsEngineStatus.Error) {
+            return@combine VoiceLoadingState.Failure(a.exception)
+        }
+        if (b is LoadVoiceStatus.Error) {
+            return@combine VoiceLoadingState.Failure(b.exception)
+        }
+
+        if (a is TtsEngineStatus.Success && b is LoadVoiceStatus.Success) {
+            return@combine VoiceLoadingState.Success(b.voices)
+        }
+        return@combine VoiceLoadingState.Pending
+    }.combine(filterFlow) { state, filter ->
+        if (state is VoiceLoadingState.Success) {
+            // showNotInstalled filters the whole list
+            val voices = state.voices.filter { filter.showNotInstalled == it.unavailable() }
+            if (filter.showNotInstalled) {
+                return@combine VoiceLoadingState.Success(voices)
+            }
+
+            return@combine VoiceLoadingState.Success(voices.filter { filter.showInternetEnabled || !it.isNetworkConnectionRequired })
+        }
+        return@combine state
+    }
+
+    /** Filters which can be applied to the list of TTS Voices */
+    data class Filters(val showInternetEnabled: Boolean, val showNotInstalled: Boolean)
+
+    /** The state of loading the screen. When successful, voices are provided */
+    interface VoiceLoadingState {
+        data class Success(val voices: List<AndroidTtsVoice>) : VoiceLoadingState
+        data object Pending : VoiceLoadingState
+        data class Failure(val exception: Exception) : VoiceLoadingState
+    }
+
+    init {
+        viewModelScope.launch(Dispatchers.IO) {
+            ttsVoiceListStatus.emit(LoadVoiceStatus.Calculating)
+            try {
+                // sort by language display name:
+                // it's more intuitive to have 'Welsh' at the bottom rather than as 'cy'
+                val voices = TtsVoices.allTtsVoices()
+                    .sortedWith(
+                        compareBy<AndroidTtsVoice> { it.normalizedLocale.displayName }
+                            .thenBy { it.tryDisplayLocalizedName() }
+                    )
+
+                ttsVoiceListStatus.emit(LoadVoiceStatus.Success(voices))
+            } catch (e: Exception) {
+                ttsVoiceListStatus.emit(LoadVoiceStatus.Error(e))
+            }
+        }
+        viewModelScope.launch(Dispatchers.IO) {
+            ttsEngineStatus.emit(TtsEngineStatus.Loading)
+            val player =
+                AndroidTtsPlayer.createInstance(context = AnkiDroidApp.instance, viewModelScope)
+            ttsEngineStatus.emit(TtsEngineStatus.Success(player))
+        }
+        addCloseable {
+            val currentState = ttsEngineStatus.value
+            if (currentState !is TtsEngineStatus.Success) {
+                return@addCloseable
+            }
+            currentState.ttsPlayer.close()
+        }
+    }
+
+    fun setSpokenText(text: String) {
+        textToSpeak = text
+    }
+
+    fun playVoice(voice: TtsVoice) = viewModelScope.launch(Dispatchers.IO) {
+        if (voice.unavailable()) {
+            uninstalledVoicePlayed.emit(voice)
+        }
+        playTts(textToSpeak, voice)
+    }
+
+    fun copyToClipboard(voice: TtsVoice) {
+        // At least in API 33, we do not need to display a snackbar, as the Android OS already
+        // displays the copied text
+        AnkiDroidApp.instance.copyToClipboard(voice.toString())
+    }
+
+    private suspend fun playTts(textToSpeak: String, voice: TtsVoice) {
+        val currentState = ttsEngineStatus.value
+        if (currentState !is TtsEngineStatus.Success) {
+            return
+        }
+        currentState.ttsPlayer.play(textToSpeak, voice).error?.let {
+            withContext(Dispatchers.Main) {
+                ttsPlaybackErrorFlow.emit(it)
+            }
+        }
+    }
+
+    sealed interface LoadVoiceStatus {
+        data object Calculating : LoadVoiceStatus
+        class Success(val voices: List<AndroidTtsVoice>) : LoadVoiceStatus
+        class Error(val exception: Exception) : LoadVoiceStatus
+    }
+
+    sealed interface TtsEngineStatus {
+        data object Uninitialized : TtsEngineStatus
+        data object Loading : TtsEngineStatus
+        class Success(val ttsPlayer: TtsPlayer) : TtsEngineStatus
+        class Error(val exception: Exception) : TtsEngineStatus
+    }
+}
+
+suspend fun TtsPlayer.play(textToSpeak: String, voice: TtsVoice, speed: Float = 1.0f): TtsPlayer.TtsCompletionStatus {
+    return this.play(TTSTag(textToSpeak, voice.lang, listOf(voice.name), speed, listOf()))
+}

--- a/AnkiDroid/src/main/java/com/ichi2/compat/UtteranceProgressListenerCompat.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/UtteranceProgressListenerCompat.kt
@@ -1,0 +1,32 @@
+/*
+ *  Copyright (c) 2023 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.compat
+
+import android.speech.tts.UtteranceProgressListener
+import timber.log.Timber
+
+abstract class UtteranceProgressListenerCompat : UtteranceProgressListener() {
+
+    abstract override fun onError(utteranceId: String?, errorCode: Int)
+
+    @Suppress("DeprecatedCallableAddReplaceWith")
+    @Deprecated("")
+    override fun onError(utteranceId: String?) {
+        // required for UtteranceProgressListener, but also deprecated
+        Timber.e("onError(string) should not have been called")
+    }
+}

--- a/AnkiDroid/src/main/java/com/ichi2/utils/UiUtil.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/UiUtil.kt
@@ -15,10 +15,12 @@
  */
 package com.ichi2.utils
 
+import android.app.Dialog
 import android.graphics.Typeface
 import android.text.Spannable
 import android.text.SpannableStringBuilder
 import android.text.style.StyleSpan
+import android.view.ViewGroup
 import android.widget.Spinner
 
 object UiUtil {
@@ -34,5 +36,11 @@ object UiUtil {
             this.setSelection(position)
             return
         }
+    }
+    fun Dialog.makeFullscreen() {
+        window?.setLayout(
+            ViewGroup.LayoutParams.MATCH_PARENT,
+            ViewGroup.LayoutParams.MATCH_PARENT
+        )
     }
 }

--- a/AnkiDroid/src/main/res/color/mtrl_list_item_tint.xml
+++ b/AnkiDroid/src/main/res/color/mtrl_list_item_tint.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Copyright 2019 The Android Open Source Project
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  -->
+
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <item android:alpha="0.87" android:color="?attr/colorOnSurface"/>
+
+</selector>

--- a/AnkiDroid/src/main/res/color/text_input_background.xml
+++ b/AnkiDroid/src/main/res/color/text_input_background.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~  Copyright (c) 2023 David Allison <davidallisongithub@gmail.com>
+  ~
+  ~  This program is free software; you can redistribute it and/or modify it under
+  ~  the terms of the GNU General Public License as published by the Free Software
+  ~  Foundation; either version 3 of the License, or (at your option) any later
+  ~  version.
+  ~
+  ~  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+  ~  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+  ~  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+  ~
+  ~  You should have received a copy of the GNU General Public License along with
+  ~  this program.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:alpha="0.12" android:color="?attr/colorPrimary"/>
+</selector>

--- a/AnkiDroid/src/main/res/drawable/baseline_content_copy_24.xml
+++ b/AnkiDroid/src/main/res/drawable/baseline_content_copy_24.xml
@@ -1,0 +1,21 @@
+<!--
+  ~  Copyright (c) 2023 David Allison <davidallisongithub@gmail.com>
+  ~
+  ~  This program is free software; you can redistribute it and/or modify it under
+  ~  the terms of the GNU General Public License as published by the Free Software
+  ~  Foundation; either version 3 of the License, or (at your option) any later
+  ~  version.
+  ~
+  ~  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+  ~  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+  ~  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+  ~
+  ~  You should have received a copy of the GNU General Public License along with
+  ~  this program.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+
+<vector android:height="24dp" android:tint="?attr/colorControlNormal"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M16,1L4,1c-1.1,0 -2,0.9 -2,2v14h2L4,3h12L16,1zM19,5L8,5c-1.1,0 -2,0.9 -2,2v14c0,1.1 0.9,2 2,2h11c1.1,0 2,-0.9 2,-2L21,7c0,-1.1 -0.9,-2 -2,-2zM19,21L8,21L8,7h11v14z"/>
+</vector>

--- a/AnkiDroid/src/main/res/drawable/baseline_download_for_offline_24.xml
+++ b/AnkiDroid/src/main/res/drawable/baseline_download_for_offline_24.xml
@@ -1,0 +1,21 @@
+<!--
+  ~  Copyright (c) 2023 David Allison <davidallisongithub@gmail.com>
+  ~
+  ~  This program is free software; you can redistribute it and/or modify it under
+  ~  the terms of the GNU General Public License as published by the Free Software
+  ~  Foundation; either version 3 of the License, or (at your option) any later
+  ~  version.
+  ~
+  ~  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+  ~  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+  ~  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+  ~
+  ~  You should have received a copy of the GNU General Public License along with
+  ~  this program.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+
+<vector android:height="24dp" android:tint="?attr/colorControlNormal"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M12,2C6.49,2 2,6.49 2,12s4.49,10 10,10s10,-4.49 10,-10S17.51,2 12,2zM11,10V6h2v4h3l-4,4l-4,-4H11zM17,17H7v-2h10V17z"/>
+</vector>

--- a/AnkiDroid/src/main/res/drawable/baseline_offline_pin_24.xml
+++ b/AnkiDroid/src/main/res/drawable/baseline_offline_pin_24.xml
@@ -1,0 +1,21 @@
+<!--
+  ~  Copyright (c) 2023 David Allison <davidallisongithub@gmail.com>
+  ~
+  ~  This program is free software; you can redistribute it and/or modify it under
+  ~  the terms of the GNU General Public License as published by the Free Software
+  ~  Foundation; either version 3 of the License, or (at your option) any later
+  ~  version.
+  ~
+  ~  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+  ~  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+  ~  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+  ~
+  ~  You should have received a copy of the GNU General Public License along with
+  ~  this program.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+
+<vector android:height="24dp" android:tint="?attr/colorControlNormal"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M12,2C6.5,2 2,6.5 2,12s4.5,10 10,10s10,-4.5 10,-10S17.5,2 12,2zM17,18H7v-2h10V18zM10.3,14L7,10.7l1.4,-1.4l1.9,1.9l5.3,-5.3L17,7.3L10.3,14z"/>
+</vector>

--- a/AnkiDroid/src/main/res/drawable/baseline_wifi_24.xml
+++ b/AnkiDroid/src/main/res/drawable/baseline_wifi_24.xml
@@ -1,0 +1,21 @@
+<!--
+  ~  Copyright (c) 2023 David Allison <davidallisongithub@gmail.com>
+  ~
+  ~  This program is free software; you can redistribute it and/or modify it under
+  ~  the terms of the GNU General Public License as published by the Free Software
+  ~  Foundation; either version 3 of the License, or (at your option) any later
+  ~  version.
+  ~
+  ~  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+  ~  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+  ~  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+  ~
+  ~  You should have received a copy of the GNU General Public License along with
+  ~  this program.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+
+<vector android:height="24dp" android:tint="?attr/colorControlNormal"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M1,9l2,2c4.97,-4.97 13.03,-4.97 18,0l2,-2C16.93,2.93 7.08,2.93 1,9zM9,17l3,3 3,-3c-1.65,-1.66 -4.34,-1.66 -6,0zM5,13l2,2c2.76,-2.76 7.24,-2.76 10,0l2,-2C15.14,9.14 8.87,9.14 5,13z"/>
+</vector>

--- a/AnkiDroid/src/main/res/layout/dialog_tts_voices.xml
+++ b/AnkiDroid/src/main/res/layout/dialog_tts_voices.xml
@@ -1,0 +1,163 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+~ Copyright (c) 2023 David Allison <davidallisongithub@gmail.com>
+~
+~ This program is free software; you can redistribute it and/or modify it under
+~ the terms of the GNU General Public License as published by the Free Software
+~ Foundation; either version 3 of the License, or (at your option) any later
+~ version.
+~
+~ This program is distributed in the hope that it will be useful, but WITHOUT ANY
+~ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+~ PARTICULAR PURPOSE. See the GNU General Public License for more details.
+~
+~ You should have received a copy of the GNU General Public License along with
+~ this program.  If not, see <http://www.gnu.org/licenses/>.
+-->
+<androidx.constraintlayout.widget.ConstraintLayout
+    android:id="@+id/layout2"
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:clipToPadding="false"
+    android:gravity="center_vertical"
+    android:orientation="vertical"
+    android:padding="16dp"
+    >
+
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/back_button"
+        android:layout_width="48dp"
+        android:layout_height="48dp"
+        android:background="?attr/selectableItemBackground"
+        app:icon="@drawable/md_nav_back"
+        android:translationX="-16dp"
+        app:iconGravity="textStart"
+        app:iconPadding="0dp"
+        app:iconSize="24dp"
+        app:iconTint="?attr/colorControlNormal"
+        app:layout_constraintBottom_toTopOf="@+id/progress"
+        app:layout_constraintTop_toTopOf="parent" />
+
+
+    <com.google.android.material.progressindicator.LinearProgressIndicator
+        android:id="@+id/progress"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="-16dp"
+        android:layout_marginEnd="-16dp"
+        android:indeterminate="true"
+        android:paddingTop="8dp"
+        app:layout_constraintStart_toStartOf="@+id/textInputLayout2"
+        app:layout_constraintTop_toBottomOf="@+id/textInputLayout2" />
+
+
+    <com.google.android.material.textfield.TextInputLayout
+        android:id="@+id/textInputLayout2"
+        style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="-16dp"
+        android:layout_marginBottom="16dp"
+        android:layout_marginEnd="12dp"
+        app:boxBackgroundColor="@color/text_input_background"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toEndOf="@+id/back_button"
+        app:layout_constraintTop_toTopOf="parent"
+        app:shapeAppearanceOverlay="?attr/shapeAppearanceCornerLarge">
+
+        <com.google.android.material.textfield.TextInputEditText
+            android:id="@+id/spoken_text"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:drawableStart="@drawable/ic_action_mic"
+            android:drawablePadding="4dp"
+            android:inputType="text"
+            android:maxLines="1"
+            android:padding="8dp"
+            android:text="@string/tts_voices_default_text"
+            />
+    </com.google.android.material.textfield.TextInputLayout>
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/options_buttons"
+        android:layout_width="48dp"
+        android:layout_height="48dp"
+        android:background="?attr/selectableItemBackground"
+        app:icon="@drawable/ic_settings_black"
+
+        app:iconSize="24dp"
+        app:iconPadding="0dp"
+        app:iconGravity="textStart"
+
+        app:iconTint="?attr/colorControlNormal"
+        app:layout_constraintBottom_toBottomOf="@+id/chipGroup"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="@+id/only_show_uninstalled" />
+
+
+    <com.google.android.material.chip.ChipGroup
+        android:id="@+id/chipGroup"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:paddingTop="12dp"
+        app:layout_constraintStart_toStartOf="@+id/back_button"
+        app:layout_constraintTop_toBottomOf="@+id/textInputLayout2">
+
+        <com.google.android.material.chip.Chip
+            android:id="@+id/toggle_internet_required"
+            style="@style/Widget.Material3.Chip.Filter"
+            app:chipSurfaceColor="@android:color/transparent"
+            app:chipBackgroundColor="@android:color/transparent"
+
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/tts_voices_chip_filter_to_internet"
+            app:chipIcon="@drawable/baseline_wifi_24"
+            app:checkedIconEnabled="false"
+            app:chipIconVisible="true"
+            app:closeIconVisible="false" />
+
+        <com.google.android.material.chip.Chip
+            android:id="@+id/only_show_uninstalled"
+            style="@style/Widget.Material3.Chip.Filter"
+            app:chipSurfaceColor="@android:color/transparent"
+            app:chipBackgroundColor="@android:color/transparent"
+
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/tts_voices_chip_filter_to_installable_audio"
+            app:chipIcon="@drawable/baseline_download_for_offline_24"
+            app:chipIconVisible="true"
+            app:checkedIconEnabled="false"
+            app:closeIconVisible="false" />
+
+    </com.google.android.material.chip.ChipGroup>
+
+
+    <!--
+    HACK: Couldn't get relative positioning to work, so I used absolute
+    use a negative elevation so it doesn't take click events for elements at the top of the screen
+    -->
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/files"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:fastScrollEnabled="true"
+        android:focusable="true"
+        android:scrollbarAlwaysDrawVerticalTrack="true"
+        android:scrollbars="vertical"
+        android:paddingTop="116dp"
+        android:elevation="-2px"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+        tools:listitem="@layout/dialog_tts_voices_voice"
+        tools:visibility="gone"/>
+
+</androidx.constraintlayout.widget.ConstraintLayout>
+

--- a/AnkiDroid/src/main/res/layout/dialog_tts_voices_voice.xml
+++ b/AnkiDroid/src/main/res/layout/dialog_tts_voices_voice.xml
@@ -1,0 +1,120 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+~ Copyright (c) 2023 David Allison <davidallisongithub@gmail.com>
+~
+~ This program is free software; you can redistribute it and/or modify it under
+~ the terms of the GNU General Public License as published by the Free Software
+~ Foundation; either version 3 of the License, or (at your option) any later
+~ version.
+~
+~ This program is distributed in the hope that it will be useful, but WITHOUT ANY
+~ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+~ PARTICULAR PURPOSE. See the GNU General Public License for more details.
+~
+~ You should have received a copy of the GNU General Public License along with
+~ this program.  If not, see <http://www.gnu.org/licenses/>.
+~
+~
+~ This file incorporates code under the following license
+~ Copyright (C) 2019 The Android Open Source Project
+~
+~ Licensed under the Apache License, Version 2.0 (the "License");
+~ you may not use this file except in compliance with the License.
+~ You may obtain a copy of the License at
+~
+~      http://www.apache.org/licenses/LICENSE-2.0
+~
+~ Unless required by applicable law or agreed to in writing, software
+~ distributed under the License is distributed on an "AS IS" BASIS,
+~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+~ See the License for the specific language governing permissions and
+~ limitations under the License.
+
+~ https://github.com/material-components/material-components-android/blob/54d2c8b87f364ca9cb04cbd9b751efd490bbb56e/lib/java/com/google/android/material/lists/res/layout/material_list_item_two_line.xml#L30
+-->
+<androidx.constraintlayout.widget.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="horizontal"
+    android:clickable="true"
+    android:focusable="true"
+    android:background="?attr/selectableItemBackground"
+    android:minHeight="60dp"
+    >
+    <!-- TODO: use DividerItemDecoration or similar to add space instead of minHeight -->
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/local_or_network"
+        android:background="@color/transparent"
+        android:layout_width="36dp"
+        android:layout_height="48dp"
+
+        android:clickable="false"
+        android:focusable="false"
+
+        app:icon="@drawable/baseline_offline_pin_24"
+        app:iconTint="?attr/colorControlNormal"
+        app:iconSize="24dp"
+        app:iconGravity="start"
+        android:padding="0dp"
+
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"/>
+
+    <com.ichi2.ui.FixedTextView
+        android:id="@+id/mtrl_list_item_text"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:maxLines="1"
+        android:paddingEnd="16dp"
+        android:paddingStart="10dp"
+        android:paddingTop="2dp"
+        android:textAppearance="?attr/textAppearanceSubtitle1"
+        android:textColor="@color/mtrl_list_item_tint"
+        android:textSize="16dp"
+        android:textFontWeight="400"
+        app:layout_constraintEnd_toStartOf="@id/action_button"
+        app:layout_constraintStart_toEndOf="@id/local_or_network"
+        app:layout_constraintTop_toBottomOf="@+id/mtrl_list_item_secondary_text"
+        tools:text="mtrl_list_item_text" />
+
+    <com.ichi2.ui.FixedTextView
+        android:id="@+id/mtrl_list_item_secondary_text"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_below="@id/mtrl_list_item_text"
+        android:layout_gravity="center_vertical"
+        android:maxLines="2"
+        android:paddingEnd="16dp"
+        android:paddingStart="10dp"
+        android:textSize="12dp"
+        android:textFontWeight="500"
+        android:textAppearance="?attr/textAppearanceBody2"
+        app:layout_constraintEnd_toStartOf="@id/action_button"
+        app:layout_constraintStart_toEndOf="@id/local_or_network"
+        app:layout_constraintTop_toTopOf="@+id/local_or_network"
+        tools:text="mtrl_list_item_secondary_text" />
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/action_button"
+        android:layout_width="48dp"
+        android:layout_height="48dp"
+
+        app:icon="@drawable/baseline_download_for_offline_24"
+        app:iconSize="24dp"
+        app:iconPadding="0dp"
+        app:iconGravity="textStart"
+        app:iconTint="?attr/colorControlNormal"
+
+        android:background="?attr/selectableItemBackground"
+
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:shapeAppearance="?attr/shapeAppearanceCornerLarge" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/AnkiDroid/src/main/res/values/02-strings.xml
+++ b/AnkiDroid/src/main/res/values/02-strings.xml
@@ -398,4 +398,43 @@
 
     <string name="audio_saved">Recording saved</string>
 
+    <string name="tts_voices_default_text" comment="The default text to speak when selecting
+    Text to speech voices"
+        >
+        Tap a voice to listen
+    </string>
+
+    <string name="tts_voices_selected_voice_should_be_installed" comment="If a voice has been tapped, is installable
+but not installed, we want to inform the user that they should install it for the best experience
+There will also be an option to use it without downloading">Voice should be installed before use
+    </string>
+
+    <string name="tts_voices_use_selected_voice_without_install" comment="A user has been
+informed that a voice should be installed before use. This is text on a snackbar button which
+allows them to use the voice without installing it">Use anyway
+    </string>
+
+    <string name="tts_voices_playback_error" comment="an error occurred when playing a text to speech
+voice. The string is a technical error code such as 'ERROR_NOT_INSTALLED_YET' or ''">
+        Audio error (%s)
+    </string>
+
+    <!-- Chips should probably be in a separate file, due to the additional length req -->
+    <string name="tts_voices_chip_filter_to_internet" comment="
+    Filters a list of text to speech voices, to enable/disable voices which require the internet to
+    function.
+    This is on a chip control, so keep the text short, ideally one word">
+        Internet
+    </string>
+
+    <string name="tts_voices_chip_filter_to_installable_audio" comment="
+    Displays a list of Text to Speech voices which should be downloaded/installed before use
+    This is on a chip control, so keep the text short, ideally one word">
+        Install
+    </string>
+
+    <string name="tts_voices_failed_opening_tts_system_settings" comment="error message if
+opening the system text to speech settings fails">
+        Failed to open text to speech settings
+    </string>
 </resources>


### PR DESCRIPTION
## Purpose / Description
* Handles `{{tts-voices:}}`

## Fixes
* Partially #14358

## Approach
* I wanted `{{tts-voices:}}`, but since retrieving voices required a `suspend` function, it was better to open a new window rather than do as Anki does and list them on the Card
   * Also, Android has a LOT more voices: can be over 400 
* So make a dialog, and design it well, special thanks to emma on Dicord, along with the usual suspects
* Tap a voice to listen + change the spoken text
* Chips to filter online/uninstalled voices
  * Typically, we want to discourage online, and enforce installing uninstalled voices 
  * But since Android is terrible, give users an option to 'copy' if feasible
* Error dialog if a voice fails to play
  * + link to our manual section
* Refreshing the list every 2 seconds
  * Tapping an uninstalled voice should start a download  


## How Has This Been Tested?

https://github.com/ankidroid/Anki-Android/assets/62114487/b1cc2e2d-2889-4bb7-80c2-f0e2b31d0ef0



## Learning (optional, can help others)
* TTS Engines on my phone are terrible: it's been 5 hours and Chinese (Taiwan) wasn't downloaded
* setTheme is required for `?attr/selectableItemBackground`  to work

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
