### PR TITLE
Draft: Gradle lint

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -254,7 +254,8 @@ amazon {
 }
 
 // Install Git pre-commit hook for Ktlint
-task installGitHook(type: Copy) {
+def preBuild = tasks.named('preBuild');
+tasks.register('installGitHook', Copy) {
     from new File(rootProject.rootDir, 'pre-commit')
     into { new File(rootProject.rootDir, '.git/hooks') }
     fileMode 0755

--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -259,29 +259,7 @@ tasks.register('installGitHook', Copy) {
     from new File(rootProject.rootDir, 'pre-commit')
     into { new File(rootProject.rootDir, '.git/hooks') }
     fileMode 0755
-}
-tasks.getByPath(':AnkiDroid:preBuild').dependsOn installGitHook
-
-// Issue 11078 - some emulators run, but run zero tests, and still report success
-task assertNonzeroAndroidTests() {
-    doLast {
-        // androidTest currently creates one .xml file per emulator with aggregate results in this dir
-        File folder = file("./build/outputs/androidTest-results/connected/flavors/play")
-        File[] listOfFiles = folder.listFiles({ d, f -> f ==~ /.*.xml/ } as FilenameFilter)
-        for (File file : listOfFiles) {
-            // The aggregate results file currently contains a line with this pattern holding test count
-            String[] matches = file.readLines().findAll { it.contains('<testsuite') }
-            if (matches.length != 1) {
-                throw new GradleScriptException("Unable to determine count of tests executed for " + file.name + ". Regex pattern out of date?", null)
-            }
-            if (!(matches[0] ==~ /.* tests="\d+" .*/) || matches[0].contains('tests="0"')) {
-                throw new GradleScriptException("androidTest executed 0 tests for " + file.name + " - Probably a bug with the emulator. Try another image.", null)
-            }
-        }
-    }
-}
-afterEvaluate {
-    tasks.getByPath(':AnkiDroid:connectedPlayDebugAndroidTest').finalizedBy(assertNonzeroAndroidTests)
+    preBuild.get().dependsOn installGitHook
 }
 
 apply from: "./robolectricDownloader.gradle"

--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -156,7 +156,7 @@ android {
      * This is because we cannot use Camera Permissions in Amazon App Store (for FireTv etc...)
      * Therefore, different AndroidManifest for Camera Permissions is used in Amazon flavor.
      */
-    flavorDimensions "appStore"
+    flavorDimensions += ("appStore")
     productFlavors {
         play {
             dimension "appStore"

--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -190,10 +190,10 @@ android {
         }
     }
     // applicationVariants are e.g. debug, release
-    applicationVariants.all { variant ->
+    applicationVariants.configureEach { variant ->
         // We want the same version stream for all ABIs in debug but for release we can split them
         if (variant.buildType.name == 'release') {
-            variant.outputs.all { output ->
+            variant.outputs.configureEach { output ->
 
                 // For each separate APK per architecture, set a unique version code as described here:
                 // https://developer.android.com/studio/build/configure-apk-splits.html
@@ -288,7 +288,7 @@ apply from: "./jacoco.gradle"
 apply from: "../lint.gradle"
 
 dependencies {
-    configurations.all {
+    configurations.configureEach {
         resolutionStrategy {
             // Timber has this as a dependency but they are not up to date. We want to force our version.
             force 'org.jetbrains:annotations:24.1.0'

--- a/AnkiDroid/jacoco.gradle
+++ b/AnkiDroid/jacoco.gradle
@@ -104,12 +104,12 @@ task jacocoTestReport(type: JacocoReport, dependsOn: ['testPlayDebugUnitTest', '
         html.destination htmlOutDir
     }
 
-    def kotlinClasses = fileTree(dir: "$project.buildDir/tmp/kotlin-classes/playDebug", excludes: fileFilter)
+    def kotlinClasses = fileTree(dir: "$layout.buildDirectory/tmp/kotlin-classes/playDebug", excludes: fileFilter)
     def mainSrc = "$project.projectDir/src/main/java"
 
     sourceDirectories.from = files([mainSrc])
     classDirectories.from = files([kotlinClasses])
-    executionData.from = fileTree(dir: project.buildDir, includes: [
+    executionData.from = fileTree(dir: layout.buildDirectory, includes: [
             '**/*.exec',
             '**/*.ec'
     ])
@@ -128,12 +128,12 @@ task jacocoUnitTestReport(type: JacocoReport, dependsOn: ['testPlayDebugUnitTest
         html.destination htmlOutDir
     }
 
-    def kotlinClasses = fileTree(dir: "$project.buildDir/tmp/kotlin-classes/playDebug", excludes: fileFilter)
+    def kotlinClasses = fileTree(dir: "$layout.buildDirectory/tmp/kotlin-classes/playDebug", excludes: fileFilter)
     def mainSrc = "$project.projectDir/src/main/java"
 
     sourceDirectories.from = files([mainSrc])
     classDirectories.from = files([kotlinClasses])
-    executionData.from = fileTree(dir: project.buildDir, includes: [
+    executionData.from = fileTree(dir: layout.buildDirectory, includes: [
             '**/*.exec'
 
     ])
@@ -152,12 +152,12 @@ task jacocoAndroidTestReport(type: JacocoReport, dependsOn: ['connectedPlayDebug
         html.destination htmlOutDir
     }
 
-    def kotlinClasses = fileTree(dir: "$project.buildDir/tmp/kotlin-classes/playDebug", excludes: fileFilter)
+    def kotlinClasses = fileTree(dir: "$layout.buildDirectory/tmp/kotlin-classes/playDebug", excludes: fileFilter)
     def mainSrc = "$project.projectDir/src/main/java"
 
     sourceDirectories.from = files([mainSrc])
     classDirectories.from = files([kotlinClasses])
-    executionData.from = fileTree(dir: project.buildDir, includes: [
+    executionData.from = fileTree(dir: layout.buildDirectory, includes: [
             '**/*.ec'
     ])
 }

--- a/AnkiDroid/jacoco.gradle
+++ b/AnkiDroid/jacoco.gradle
@@ -163,4 +163,22 @@ tasks.register('jacocoAndroidTestReport', JacocoReport) {
     executionData.from = fileTree(dir: layout.buildDirectory, includes: [
             '**/*.ec'
     ])
+
+    // Issue 11078 - some emulators run, but run zero tests, and still report success
+    doLast {
+        // androidTest currently creates one .xml file per emulator with aggregate results in this dir
+        File folder = file("$layout.buildDirectory/outputs/androidTest-results/connected/flavors/play")
+        File[] listOfFiles = folder.listFiles({ d, f -> f ==~ /.*.xml/ } as FilenameFilter)
+        for (File file : listOfFiles) {
+            // The aggregate results file currently contains a line with this pattern holding test count
+            String[] matches = file.readLines().findAll { it.contains('<testsuite') }
+            if (matches.length != 1) {
+                throw new GradleScriptException("Unable to determine count of tests executed for " + file.name + ". Regex pattern out of date?", null)
+            }
+            if (!(matches[0] ==~ /.* tests="\d+" .*/) || matches[0].contains('tests="0"')) {
+                throw new GradleScriptException("androidTest executed 0 tests for " + file.name + " - Probably a bug with the emulator. Try another image.", null)
+            }
+        }
+    }
+
 }

--- a/AnkiDroid/jacoco.gradle
+++ b/AnkiDroid/jacoco.gradle
@@ -3,13 +3,13 @@ import groovy.transform.Memoized
 apply plugin: 'jacoco'
 
 jacoco {
-    toolVersion = "0.8.8"
+    toolVersion = "0.8.11"
 
 }
 
 android {
     testCoverage {
-        jacocoVersion '0.8.8'
+        jacocoVersion '0.8.11'
     }
 }
 

--- a/AnkiDroid/jacoco.gradle
+++ b/AnkiDroid/jacoco.gradle
@@ -54,7 +54,7 @@ def openReport(htmlOutDir) {
     }
 }
 
-tasks.withType(Test) {
+tasks.withType(Test).configureEach {
     jacoco.includeNoLocationClasses = true
     jacoco.excludes = ['jdk.internal.*']
 }

--- a/AnkiDroid/jacoco.gradle
+++ b/AnkiDroid/jacoco.gradle
@@ -92,7 +92,8 @@ def fileFilter = [
 ]
 
 // Our merge report task
-task jacocoTestReport(type: JacocoReport, dependsOn: ['testPlayDebugUnitTest', 'connectedPlayDebugAndroidTest']) {
+tasks.register('jacocoTestReport', JacocoReport) {
+    dependsOn('testPlayDebugUnitTest', 'connectedPlayDebugAndroidTest')
     def htmlOutDir = layout.buildDirectory.dir("reports/jacoco/$name/html").get().asFile
 
     doLast {
@@ -116,7 +117,8 @@ task jacocoTestReport(type: JacocoReport, dependsOn: ['testPlayDebugUnitTest', '
 }
 
 // A unit-test only report task
-task jacocoUnitTestReport(type: JacocoReport, dependsOn: ['testPlayDebugUnitTest']) {
+tasks.register('jacocoUnitTestReport', JacocoReport) {
+    dependsOn['testPlayDebugUnitTest']
     def htmlOutDir = layout.buildDirectory.dir("reports/jacoco/$name/html").get().asFile
 
     doLast {
@@ -140,7 +142,8 @@ task jacocoUnitTestReport(type: JacocoReport, dependsOn: ['testPlayDebugUnitTest
 }
 
 // A connected android tests only report task
-task jacocoAndroidTestReport(type: JacocoReport, dependsOn: ['connectedPlayDebugAndroidTest']) {
+tasks.register('jacocoAndroidTestReport', JacocoReport) {
+    dependsOn['connectedPlayDebugAndroidTest']
     def htmlOutDir = layout.buildDirectory.dir("reports/jacoco/$name/html").get().asFile
 
     doLast {

--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -15,13 +15,20 @@ android {
     namespace = "com.ichi2.anki.api"
     compileSdk = 34
 
+    @Suppress("UnstableApiUsage")
+    testOptions {
+        targetSdk = 33
+    }
+    lint {
+        targetSdk = 33
+    }
+
     buildFeatures {
         buildConfig = true
     }
 
     defaultConfig {
         minSdk = 16
-        targetSdk = 33
         buildConfigField(
             "String",
             "READ_WRITE_PERMISSION",

--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -98,7 +98,7 @@ publishing {
         create("mavenJava", MavenPublication::class) {
             artifactId = "api"
 
-            artifact("$buildDir/outputs/aar/${project.getName()}-release.aar")
+            artifact("$layout.buildDirectory/outputs/aar/${project.getName()}-release.aar")
             artifact(androidSourcesJar)
             artifact(dokkaJavadocJar)
 
@@ -142,16 +142,16 @@ publishing {
 
 val zipReleaseProvider = tasks.register("zipRelease", Zip::class) {
     from(layout.buildDirectory.dir("repos/releases"))
-    destinationDirectory = buildDir
-    archiveFileName = "$buildDir/release-${archiveVersion.get()}.zip"
+    destinationDirectory = layout.buildDirectory
+    archiveFileName = "$layout.buildDirectory/release-${archiveVersion.get()}.zip"
 }
 
 // Use this task to make a release you can send to someone
 // You may like `./gradlew :api:publishToMavenLocal for development
 val generateRelease: TaskProvider<Task> = tasks.register("generateRelease") {
     doLast {
-        println("Release $version can be found at $buildDir/repos/releases/")
-        println("Release $version zipped can be found $buildDir/release-$version.zip")
+        println("Release $version can be found at $layout.buildDirectory/repos/releases/")
+        println("Release $version zipped can be found $layout.buildDirectory/release-$version.zip")
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,6 @@
 import org.gradle.internal.jvm.Jvm
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompilerExecutionStrategy
 
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
@@ -19,7 +21,7 @@ buildscript {
     ext.android_gradle_plugin = "8.1.4"
     ext.dokka_version = "1.9.10" // not the same with kotlin version!
 
-    configurations.all {
+    configurations.configureEach {
         resolutionStrategy.eachDependency { details ->
             if (details.requested.group == 'org.jetbrains.kotlinx'
                     && details.requested.name.contains('kotlinx-serialization-runtime')
@@ -90,8 +92,8 @@ subprojects {
             result in a warning but we treat warnings as errors.
             (see https://youtrack.jetbrains.com/issue/KT-28777/Using-experimental-coroutines-api-causes-unresolved-dependency)
         */
-        tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
-            kotlinOptions {
+        tasks.withType(KotlinCompile).configureEach {
+            compilerOptions {
                 allWarningsAsErrors = fatalWarnings
                 def compilerArgs = ['-Xjvm-default=all']
                 if (project.name != "api") {
@@ -141,8 +143,8 @@ ext {
         // the CI machines don't have enough RAM to do that without going in to swap quite a bit
         // so for CI machines only - to improve reliability despite compilation speed hit, compile kotlin in process
         println "CI build detected: setting compiler execution strategy to IN_PROCESS"
-        tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
-            compilerExecutionStrategy.set(org.jetbrains.kotlin.gradle.tasks.KotlinCompilerExecutionStrategy.IN_PROCESS)
+        tasks.withType(KotlinCompile).configureEach {
+            compilerExecutionStrategy.set(KotlinCompilerExecutionStrategy.IN_PROCESS)
         }
     } else {
         // Use 50% of cores to account for SMT which doesn't help this workload

--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ buildscript {
     ext.androidx_test_version = '1.5.0'
     ext.androidx_test_junit_version = '1.1.5'
     ext.robolectric_version = '4.11.1'
-    ext.android_gradle_plugin = "8.1.4"
+    ext.android_gradle_plugin = "8.2.0-rc03"
     ext.dokka_version = "1.9.10" // not the same with kotlin version!
 
     configurations.configureEach {


### PR DESCRIPTION

De-linting gradle files

Note that this is *not* working yet. Specifically I cannot get jacocoTestReport target to correctly generate coverage data

Success criteria to un-draft and merge:

- verify generating an api module AAR works
- verify that coverage data is generated, including on multiple runs (that is: incremental compile - currently the report says no class files are specified on a clean run, and an incremental run breaks the build)
- verify that the ktlint git pre commit hook is installed correctly
- verify that the android "no unit tests ran" check works correctly in the case no unit tests run