### PR TITLE
fix(Card Browser): notes-only mode

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.kt
@@ -418,8 +418,24 @@ open class Collection(
 
     /** Return a list of card ids  */
     @RustCleanup("Remove in V16.") // Not in libAnki
-    fun findOneCardByNote(query: String): List<Long> {
-        return findNotes(query, SortOrder.NoOrdering())
+    fun findOneCardByNote(query: String): List<CardId> {
+        // This function shouldn't exist and CardBrowser should be modified to use Notes,
+        // so not much effort was expended here
+
+        val noteIds = findNotes(query, SortOrder.NoOrdering())
+        // select the card with the lowest `ord` to show
+        return db.queryLongList(
+            """
+SELECT c.id
+FROM (
+  SELECT nid, MIN(ord) AS ord
+  FROM cards
+  WHERE nid IN ${Utils.ids2str(noteIds)} 
+  GROUP BY nid
+) AS card_with_min_ord
+JOIN cards AS c ON card_with_min_ord.nid = c.nid AND card_with_min_ord.ord = c.ord;
+            """.trimMargin()
+        )
     }
 
     @RustCleanup("Calling code should handle returned OpChanges")

--- a/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.kt
@@ -629,6 +629,20 @@ class CardBrowserTest : RobolectricTest() {
         assertThat("Result should contain one card", cardBrowser.cardCount, equalTo(1))
     }
 
+    @Test
+    fun `'notes-only mode' returns one card from each note`() = runTest {
+        // #14623: The functionality was broken
+        addNoteUsingBasicAndReversedModel("Hello", "World")
+        addNoteUsingBasicAndReversedModel("Hello", "Anki")
+
+        browserWithNoNewCards.apply {
+            searchAllDecks()
+            assertThat("Result should contain 4 cards", cardCount, equalTo(4))
+            switchCardOrNote(newCardsMode = false)
+            assertThat("Result should contain 2 cards (one per note)", cardCount, equalTo(2))
+        }
+    }
+
     private fun assertUndoDoesNotContain(browser: CardBrowser, @StringRes resId: Int) {
         val shadowActivity = shadowOf(browser)
         val item = shadowActivity.optionsMenu.findItem(R.id.action_undo)


### PR DESCRIPTION


<!--- Please fill the necessary details below -->
## Purpose / Description
* #14623

## Fixes
* Fixes #14623

## Approach
Temporary fix to return the card with the lowest `ord`

quick fix: We should modify CardBrowser to allow the display of notes, rather than continue this pattern

## How Has This Been Tested?
Unit Test. Imported Arthur's collection and tried it on a subset of cards

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
