### PR TITLE
Fix: All decks show the same number of total cards and total new cards

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -266,21 +266,23 @@ open class DeckPicker :
         val deckId = v.tag as Long
         Timber.i("DeckPicker:: Selected deck with id %d", deckId)
         var collectionIsOpen = false
-        try {
-            collectionIsOpen = colIsOpenUnsafe()
-            handleDeckSelection(deckId, selectionType)
-            if (fragmented) {
-                // Calling notifyDataSetChanged() will update the color of the selected deck.
-                // This interferes with the ripple effect, so we don't do it if lollipop and not tablet view
-                mDeckListAdapter.notifyDataSetChanged()
-                updateDeckList()
+        launchCatchingTask {
+            try {
+                collectionIsOpen = colIsOpenUnsafe()
+                handleDeckSelection(deckId, selectionType)
+                if (fragmented) {
+                    // Calling notifyDataSetChanged() will update the color of the selected deck.
+                    // This interferes with the ripple effect, so we don't do it if lollipop and not tablet view
+                    mDeckListAdapter.notifyDataSetChanged()
+                    updateDeckList()
+                }
+            } catch (e: Exception) {
+                // Maybe later don't report if collectionIsOpen is false?
+                Timber.w(e)
+                val info = "$deckId colOpen:$collectionIsOpen"
+                CrashReportService.sendExceptionReport(e, "deckPicker::onDeckClick", info)
+                displayFailedToOpenDeck(deckId)
             }
-        } catch (e: Exception) {
-            // Maybe later don't report if collectionIsOpen is false?
-            Timber.w(e)
-            val info = "$deckId colOpen:$collectionIsOpen"
-            CrashReportService.sendExceptionReport(e, "deckPicker::onDeckClick", info)
-            displayFailedToOpenDeck(deckId)
         }
     }
 
@@ -1093,7 +1095,9 @@ open class DeckPicker :
             }
             KeyEvent.KEYCODE_SLASH, KeyEvent.KEYCODE_S -> {
                 Timber.i("Study from keypress")
-                handleDeckSelection(getColUnsafe.decks.selected(), DeckSelectionType.SKIP_STUDY_OPTIONS)
+                launchCatchingTask {
+                    handleDeckSelection(getColUnsafe.decks.selected(), DeckSelectionType.SKIP_STUDY_OPTIONS)
+                }
             }
             else -> {}
         }
@@ -1689,88 +1693,89 @@ open class DeckPicker :
         }
     }
 
-    private fun handleDeckSelection(did: DeckId, selectionType: DeckSelectionType) {
-        if ((getColUnsafe.config.get("schedVer") ?: 1L) == 1L) {
-            promptUserToUpdateScheduler()
-            return
-        }
-        // Select the deck
-        getColUnsafe.decks.select(did)
-        // Also forget the last deck used by the Browser
-        CardBrowser.clearLastDeckId()
-        // Reset the schedule so that we get the counts for the currently selected deck
-        mFocusedDeck = did
-        // Get some info about the deck to handle special cases
-        val deckDueTreeNode = mDeckListAdapter.getNodeByDid(did)
-        if (deckDueTreeNode.knownToHaveRep()) {
-            // If we don't yet have numbers, we trust the user that they knows what they opens, tries to open it.
-            // If there is nothing to review, it'll come back to deck picker.
-            openReviewerOrStudyOptions(selectionType)
-            return
-        }
-        // There are numbers
-        // Figure out what action to take
-        if (getColUnsafe.sched.hasCardsTodayAfterStudyAheadLimit()) {
-            // If there are cards due that can't be studied yet (due to the learn ahead limit) then go to study options
-            openStudyOptions(false)
-        } else if (getColUnsafe.sched.newDue() || getColUnsafe.sched.revDue()) {
-            // If there are no cards to review because of the daily study limit then give "Study more" option
+    @NeedsTest("14608: Ensure that the deck options refer to the selected deck")
+    private suspend fun handleDeckSelection(did: DeckId, selectionType: DeckSelectionType) {
+        fun showStudyMoreSnackbar(did: DeckId) =
             showSnackbar(R.string.studyoptions_limit_reached) {
                 addCallback(mSnackbarShowHideCallback)
                 setAction(R.string.study_more) {
                     val d = mCustomStudyDialogFactory.newCustomStudyDialog().withArguments(
                         CustomStudyDialog.ContextMenuConfiguration.LIMITS,
-                        getColUnsafe.decks.selected(),
+                        did,
                         true
                     )
                     showDialogFragment(d)
                 }
             }
 
-            // Check if we need to update the fragment or update the deck list. The same checks
-            // are required for all snackbars below.
+        fun showEmptyDeckSnackbar() = showSnackbar(R.string.empty_deck) {
+            addCallback(mSnackbarShowHideCallback)
+            setAction(R.string.menu_add) { addNote() }
+        }
+
+        fun showCustomStudySnackbar() = showSnackbar(R.string.studyoptions_empty_schedule) {
+            addCallback(mSnackbarShowHideCallback)
+            setAction(R.string.custom_study) {
+                val d = mCustomStudyDialogFactory.newCustomStudyDialog().withArguments(
+                    CustomStudyDialog.ContextMenuConfiguration.EMPTY_SCHEDULE,
+                    did,
+                    true
+                )
+                showDialogFragment(d)
+            }
+        }
+
+        /** Check if we need to update the fragment or update the deck list */
+        fun updateUi() {
             if (fragmented) {
                 // Tablets must always show the study options that corresponds to the current deck,
                 // regardless of whether the deck is currently reviewable or not.
-                openStudyOptions(false)
+                openStudyOptions(withDeckOptions = false)
             } else {
                 // On phones, we update the deck list to ensure the currently selected deck is
                 // highlighted correctly.
                 updateDeckList()
             }
-        } else if (getColUnsafe.decks.isDyn(did)) {
-            // Go to the study options screen if filtered deck with no cards to study
-            openStudyOptions(false)
-        } else if (deckDueTreeNode.children.isEmpty() && getColUnsafe.isEmptyDeck(did)) {
-            // If the deck is empty and has no children then show a message saying it's empty
-            showSnackbar(R.string.empty_deck) {
-                addCallback(mSnackbarShowHideCallback)
-                setAction(R.string.menu_add) { addNote() }
-            }
+        }
 
-            if (fragmented) {
-                openStudyOptions(false)
-            } else {
-                updateDeckList()
-            }
-        } else {
-            // Otherwise say there are no cards scheduled to study, and give option to do custom study
-            showSnackbar(R.string.studyoptions_empty_schedule) {
-                addCallback(mSnackbarShowHideCallback)
-                setAction(R.string.custom_study) {
-                    val d = mCustomStudyDialogFactory.newCustomStudyDialog().withArguments(
-                        CustomStudyDialog.ContextMenuConfiguration.EMPTY_SCHEDULE,
-                        getColUnsafe.decks.selected(),
-                        true
-                    )
-                    showDialogFragment(d)
-                }
-            }
+        if (withCol { ((config.get("schedVer") ?: 1L) == 1L) }) {
+            promptUserToUpdateScheduler()
+            return
+        }
 
-            if (fragmented) {
-                openStudyOptions(false)
-            } else {
-                updateDeckList()
+        withCol { decks.select(did) }
+        // Also forget the last deck used by the Browser
+        CardBrowser.clearLastDeckId()
+        mFocusedDeck = did
+        val deck = mDeckListAdapter.getNodeByDid(did)
+        if (deck.hasCardsReadyToStudy()) {
+            openReviewerOrStudyOptions(selectionType)
+            return
+        }
+
+        when (queryCompletedDeckCustomStudyAction(did)) {
+            CompletedDeckStatus.LEARN_AHEAD_LIMIT_REACHED -> {
+                // If there are cards due that can't be studied yet (due to the learn ahead limit) then go to study options
+                openStudyOptions(withDeckOptions = false)
+            }
+            CompletedDeckStatus.DAILY_STUDY_LIMIT_REACHED -> {
+                // If there are no cards to review because of the daily study limit then give "Study more" option
+                showStudyMoreSnackbar(did)
+                updateUi()
+            }
+            CompletedDeckStatus.DYNAMIC_DECK_NO_LIMITS_REACHED -> {
+                // Go to the study options screen if filtered deck with no cards to study
+                openStudyOptions(withDeckOptions = false)
+            }
+            CompletedDeckStatus.EMPTY_REGULAR_DECK -> {
+                // If the deck is empty (& has no children) then show a message saying it's empty
+                showEmptyDeckSnackbar()
+                updateUi()
+            }
+            CompletedDeckStatus.REGULAR_DECK_NO_MORE_CARDS_TODAY -> {
+                // Otherwise say there are no cards scheduled to study, and give option to do custom study
+                showCustomStudySnackbar()
+                updateUi()
             }
         }
     }
@@ -2413,6 +2418,41 @@ open class DeckPicker :
         if (migrateStorageAfterMediaSyncCompleted) {
             migrate()
         }
+    }
+
+    /**
+     * Returns how a user can 'custom study' a deck with no more pending cards
+     *
+     * @param did The id of a deck with no pending cards to review
+     */
+    private suspend fun queryCompletedDeckCustomStudyAction(
+        did: DeckId
+    ): CompletedDeckStatus = withCol {
+        when {
+            sched.hasCardsTodayAfterStudyAheadLimit() -> CompletedDeckStatus.LEARN_AHEAD_LIMIT_REACHED
+            sched.newDue() || sched.revDue() -> CompletedDeckStatus.LEARN_AHEAD_LIMIT_REACHED
+            decks.isDyn(did) -> CompletedDeckStatus.DYNAMIC_DECK_NO_LIMITS_REACHED
+            mDeckListAdapter.getNodeByDid(did).children.isEmpty() && isEmptyDeck(did) -> CompletedDeckStatus.EMPTY_REGULAR_DECK
+            else -> CompletedDeckStatus.REGULAR_DECK_NO_MORE_CARDS_TODAY
+        }
+    }
+
+    /** Status for a deck with no current cards to review */
+    enum class CompletedDeckStatus {
+        /** No cards for today, but there would be if the user waited */
+        LEARN_AHEAD_LIMIT_REACHED,
+
+        /** No cards for today, but either the 'new' or 'review' limit was reached */
+        DAILY_STUDY_LIMIT_REACHED,
+
+        /** No cards are available, but the deck was dynamic */
+        DYNAMIC_DECK_NO_LIMITS_REACHED,
+
+        /** The deck contained no cards and had no child decks */
+        EMPTY_REGULAR_DECK,
+
+        /** The user has completed their studying for today, and there are future reviews */
+        REGULAR_DECK_NO_MORE_CARDS_TODAY
     }
 }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -265,33 +265,15 @@ open class DeckPicker :
     private fun onDeckClick(v: View, selectionType: DeckSelectionType) {
         val deckId = v.tag as Long
         Timber.i("DeckPicker:: Selected deck with id %d", deckId)
-        var collectionIsOpen = false
         launchCatchingTask {
-            try {
-                collectionIsOpen = colIsOpenUnsafe()
-                handleDeckSelection(deckId, selectionType)
-                if (fragmented) {
-                    // Calling notifyDataSetChanged() will update the color of the selected deck.
-                    // This interferes with the ripple effect, so we don't do it if lollipop and not tablet view
-                    mDeckListAdapter.notifyDataSetChanged()
-                    updateDeckList()
-                }
-            } catch (e: Exception) {
-                // Maybe later don't report if collectionIsOpen is false?
-                Timber.w(e)
-                val info = "$deckId colOpen:$collectionIsOpen"
-                CrashReportService.sendExceptionReport(e, "deckPicker::onDeckClick", info)
-                displayFailedToOpenDeck(deckId)
+            handleDeckSelection(deckId, selectionType)
+            if (fragmented) {
+                // Calling notifyDataSetChanged() will update the color of the selected deck.
+                // This interferes with the ripple effect, so we don't do it if lollipop and not tablet view
+                mDeckListAdapter.notifyDataSetChanged()
+                updateDeckList()
             }
         }
-    }
-
-    private fun displayFailedToOpenDeck(deckId: DeckId) {
-        // #6208 - if the click is accepted before the sync completes, we get a failure.
-        // We use the Deck ID as the deck likely doesn't exist any more.
-        val message = getString(R.string.deck_picker_failed_deck_load, deckId.toString())
-        showThemedToast(this, message, false)
-        Timber.w(message)
     }
 
     private val mDeckLongClickListener = OnLongClickListener { v ->

--- a/AnkiDroid/src/main/java/com/ichi2/anki/widgets/DeckAdapter.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/widgets/DeckAdapter.kt
@@ -23,6 +23,7 @@ import android.view.View
 import android.view.View.OnLongClickListener
 import android.view.ViewGroup
 import android.widget.*
+import androidx.annotation.CheckResult
 import androidx.annotation.VisibleForTesting
 import androidx.recyclerview.widget.RecyclerView
 import com.ichi2.anki.CollectionManager.withCol
@@ -141,6 +142,7 @@ class DeckAdapter(private val layoutInflater: LayoutInflater, context: Context) 
         }
     }
 
+    @CheckResult
     fun getNodeByDid(did: DeckId): DeckNode {
         val pos = findDeckPosition(did)
         return deckList[pos]

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/DeckNode.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/DeckNode.kt
@@ -67,7 +67,7 @@ data class DeckNode(
         )
     }
 
-    fun knownToHaveRep(): Boolean {
+    fun hasCardsReadyToStudy(): Boolean {
         return revCount > 0 || newCount > 0 || lrnCount > 0
     }
 

--- a/AnkiDroid/src/main/res/values/02-strings.xml
+++ b/AnkiDroid/src/main/res/values/02-strings.xml
@@ -257,7 +257,6 @@
     <string name="card_viewer_media_relative_protocol">Card Content Error: Media update required</string>
 
     <!-- Deck Picker -->
-    <string name="deck_picker_failed_deck_load">Failed to load deck ‘%s’</string>
     <string name="search_decks">Search decks</string>
     <string name="show_migration_progress"
         comment="Title for a button in deck picker's toolbar that shows ongoing migration progress.


### PR DESCRIPTION
## Purpose / Description
* #14608

* Perform refactorings as I see them to move towards more `suspend` functionality

## Fixes
* Fixes #14608

## Approach
* extract `queryCompletedDeckCustomStudyAction`
* use `launchCatchingTask` to execute the functionality
* move `getColUnsafe.decks.select(did)` into a `withCol`
* move `getColUnsafe.config.get("schedVer")` into `withCol`
* replace usages of `getColUnsafe.deck.selected()` with `did`
* Further reactorings for readability:
  * extract snackbar methods to inner functions
  * remove duplicated `updateUi`  method

## How Has This Been Tested?
S21, Android 13 & ran unit tests

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
