### PR TITLE
cleanups: Kotlin Cleanup & mLongClickTestRunnable

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
@@ -77,7 +77,6 @@ import com.ichi2.anki.snackbar.BaseSnackbarBuilderProvider
 import com.ichi2.anki.snackbar.SnackbarBuilder
 import com.ichi2.anki.snackbar.showSnackbar
 import com.ichi2.annotations.NeedsTest
-import com.ichi2.compat.CompatHelper.Companion.compat
 import com.ichi2.compat.CompatHelper.Companion.resolveActivityCompat
 import com.ichi2.compat.ResolveInfoFlagsCompat
 import com.ichi2.libanki.*
@@ -257,11 +256,6 @@ abstract class AbstractFlashcardViewer :
     // LISTENERS
     // ----------------------------------------------------------------------------
     private val mLongClickHandler = newHandler()
-    private val mLongClickTestRunnable = Runnable {
-        Timber.i("AbstractFlashcardViewer:: onEmulatedLongClick")
-        compat.vibrate(AnkiDroidApp.instance.applicationContext, 50)
-        mLongClickHandler.postDelayed(mStartLongClickAction, 300)
-    }
     private val mStartLongClickAction = Runnable { mGestureProcessor.onLongTap() }
 
     // Handler for the "show answer" button
@@ -571,7 +565,6 @@ abstract class AbstractFlashcardViewer :
     override fun onPause() {
         super.onPause()
         automaticAnswer.disable()
-        mLongClickHandler.removeCallbacks(mLongClickTestRunnable)
         mLongClickHandler.removeCallbacks(mStartLongClickAction)
         if (this::mSoundPlayer.isInitialized) {
             mSoundPlayer.stopSounds()
@@ -1834,7 +1827,6 @@ abstract class AbstractFlashcardViewer :
     protected open fun closeReviewer(result: Int) {
         automaticAnswer.disable()
         mPreviousAnswerIndicator!!.stopAutomaticHide()
-        mLongClickHandler.removeCallbacks(mLongClickTestRunnable)
         mLongClickHandler.removeCallbacks(mStartLongClickAction)
         this@AbstractFlashcardViewer.setResult(result)
         finishWithAnimation(ActivityTransitionAnimation.Direction.END)
@@ -1940,7 +1932,6 @@ abstract class AbstractFlashcardViewer :
 
         override fun onSingleTapUp(e: MotionEvent): Boolean {
             if (mTouchStarted) {
-                mLongClickHandler.removeCallbacks(mLongClickTestRunnable)
                 mTouchStarted = false
             }
             return false

--- a/AnkiDroid/src/main/java/com/ichi2/compat/CompatV26.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/CompatV26.kt
@@ -26,7 +26,6 @@ import android.os.Vibrator
 import android.view.View
 import androidx.annotation.VisibleForTesting
 import com.ichi2.anki.NotificationChannels
-import com.ichi2.utils.KotlinCleanup
 import java.io.*
 import java.nio.file.*
 
@@ -44,11 +43,9 @@ open class CompatV26 : CompatV24(), Compat {
     override fun setTooltipTextByContentDescription(view: View) { /* Nothing to do API26+ */
     }
 
-    @Suppress("DEPRECATION")
-    @KotlinCleanup("when solving the deprecation of Context.VIBRATOR_SERVICE fix the SENSELESS_COMPARISON warning")
+    @Suppress("DEPRECATION") // VIBRATOR_SERVICE => VIBRATOR_MANAGER_SERVICE handled in CompatV31
     override fun vibrate(context: Context, durationMillis: Long) {
-        val vibratorManager = context.getSystemService(Context.VIBRATOR_SERVICE) as Vibrator
-        @Suppress("SENSELESS_COMPARISON")
+        val vibratorManager = context.getSystemService(Context.VIBRATOR_SERVICE) as? Vibrator
         if (vibratorManager != null) {
             val effect = VibrationEffect.createOneShot(durationMillis, VibrationEffect.DEFAULT_AMPLITUDE)
             vibratorManager.vibrate(effect)


### PR DESCRIPTION
## Purpose / Description
* I came across a confusing `KotlinCleanup` and want to ensure others don't spend time on it

Afterwards, I investigated a use of `vibrate` and found that it was never called

## How Has This Been Tested?
⚠️ Untested

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
