### PR TITLE
Fix app bar colors in deck info activity

### DIFF
--- a/AnkiDroid/src/main/res/layout/deck_picker_dialog.xml
+++ b/AnkiDroid/src/main/res/layout/deck_picker_dialog.xml
@@ -29,7 +29,7 @@
         android:minHeight="?attr/actionBarSize"
         android:layout_alignParentTop="true"
         android:theme="@style/ActionBarStyle"
-        android:background="?attr/colorPrimary"
+        android:background="?attr/appBarColor"
         app:popupTheme="@style/ActionBar.Popup"
         tools:title="@string/search_deck"
         tools:menu="@menu/deck_picker_dialog_menu">

--- a/AnkiDroid/src/main/res/layout/studyoptions_fragment.xml
+++ b/AnkiDroid/src/main/res/layout/studyoptions_fragment.xml
@@ -19,7 +19,7 @@
             android:minHeight="?attr/actionBarSize"
             android:theme="@style/ActionBarStyle"
             android:layout_alignParentTop="true"
-            android:background="?attr/colorPrimary"
+            android:background="?attr/appBarColor"
             app:popupTheme="@style/ActionBar.Popup"
             app:navigationContentDescription="@string/abc_action_bar_up_description"
             app:navigationIcon="?attr/homeAsUpIndicator"/>


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
Forgot about those screens in dark mode

## Fixes
Fixes #14642 
Also fixes the same issue in the deck picker layout

## Approach
use `appBarColor` instead of `colorPrimary`

## How Has This Been Tested?

saw the XML previews in Android studio
![image](https://github.com/ankidroid/Anki-Android/assets/69634269/cc3617d5-9800-4b2f-aa0a-54fce9264dbc)

![image](https://github.com/ankidroid/Anki-Android/assets/69634269/4d8b8fd7-1c2e-4ca5-a8e3-21f97bd3698f)

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [X] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
