### PR TITLE
feat: Add `Show play buttons on cards with audio` preference as in Anki Desktop

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
@@ -544,7 +544,7 @@ abstract class AbstractFlashcardViewer :
         registerExternalStorageListener()
         restoreCollectionPreferences(col)
         initLayout()
-        mHtmlGenerator = createInstance(this, typeAnswer!!)
+        mHtmlGenerator = createInstance(this, col, typeAnswer!!)
 
         // Initialize text-to-speech. This is an asynchronous operation.
         mTTS.initialize(this, ReadTextListener())

--- a/AnkiDroid/src/main/java/com/ichi2/anki/analytics/UsageAnalytics.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/analytics/UsageAnalytics.kt
@@ -487,6 +487,7 @@ object UsageAnalytics {
         "showTopbar", // Show top bar
         "showProgress", // Show remaining
         "showETA", // Show ETA
+        "showAudioPlayButtons", // Show play buttons on cards with audio (reversed in collection: HIDE_AUDIO_PLAY_BUTTONS)
         "card_browser_show_media_filenames", // Display filenames in card browser
         // Controls
         "gestures", // Enable gestures

--- a/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/HtmlGenerator.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/HtmlGenerator.kt
@@ -19,10 +19,13 @@ package com.ichi2.anki.cardviewer
 import android.content.Context
 import android.content.res.Resources
 import androidx.annotation.CheckResult
+import anki.config.ConfigKey
 import com.ichi2.anki.preferences.sharedPrefs
 import com.ichi2.anki.reviewer.ReviewerCustomFonts
 import com.ichi2.libanki.Card
+import com.ichi2.libanki.Collection
 import com.ichi2.libanki.Sound
+import com.ichi2.libanki.stripAvRefs
 import timber.log.Timber
 import java.io.BufferedReader
 import java.io.IOException
@@ -33,6 +36,7 @@ class HtmlGenerator(
     private val typeAnswer: TypeAnswer,
     val cardAppearance: CardAppearance,
     val cardTemplate: CardTemplate,
+    private val showAudioPlayButtons: Boolean,
     val resources: Resources
 ) {
 
@@ -49,22 +53,28 @@ class HtmlGenerator(
     }
 
     fun expandSounds(content: String): String {
-        return Sound.expandSounds(content)
+        return if (showAudioPlayButtons) {
+            Sound.expandSounds(content)
+        } else {
+            stripAvRefs(content)
+        }
     }
 
     companion object {
         fun createInstance(
             context: Context,
+            col: Collection,
             typeAnswer: TypeAnswer
         ): HtmlGenerator {
             val preferences = context.sharedPrefs()
             val cardAppearance = CardAppearance.create(ReviewerCustomFonts(), preferences)
             val cardHtmlTemplate = loadCardTemplate(context)
-
+            val showAudioPlayButtons = !col.config.getBool(ConfigKey.Bool.HIDE_AUDIO_PLAY_BUTTONS)
             return HtmlGenerator(
                 typeAnswer,
                 cardAppearance,
                 cardHtmlTemplate,
+                showAudioPlayButtons,
                 context.resources
             )
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/AppearanceSettingsFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/AppearanceSettingsFragment.kt
@@ -22,6 +22,7 @@ import androidx.core.app.ActivityCompat
 import androidx.preference.ListPreference
 import androidx.preference.Preference
 import androidx.preference.SwitchPreferenceCompat
+import anki.config.ConfigKey
 import com.ichi2.anki.*
 import com.ichi2.anki.CollectionManager.withCol
 import com.ichi2.anki.snackbar.showSnackbar
@@ -139,6 +140,16 @@ class AppearanceSettingsFragment : SettingsFragment() {
                 val newDueCountsValueBool = newDueCountsValue as? Boolean ?: return@setOnPreferenceChangeListener false
                 launchCatchingTask { withCol { config.set("dueCounts", newDueCountsValueBool) } }
                 true
+            }
+        }
+
+        // Show play buttons on cards with audio
+        // Note: Stored inverted in the collection as HIDE_AUDIO_PLAY_BUTTONS
+        requirePreference<SwitchPreferenceCompat>(R.string.show_audio_play_buttons_key).apply {
+            title = CollectionManager.TR.preferencesShowPlayButtonsOnCardsWith()
+            launchCatchingTask { isChecked = withCol { !config.getBool(ConfigKey.Bool.HIDE_AUDIO_PLAY_BUTTONS) } }
+            setOnPreferenceChangeListener { newValue ->
+                launchCatchingTask { withCol { config.setBool(ConfigKey.Bool.HIDE_AUDIO_PLAY_BUTTONS, !(newValue as Boolean)) } }
             }
         }
     }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/SoundKt.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/SoundKt.kt
@@ -58,7 +58,7 @@ open class AvTag
 val AV_REF_RE = Regex("\\[anki:(play:(.):(\\d+))]")
 val AV_PLAYLINK_RE = Regex("playsound:(.):(\\d+)")
 
-fun stripAvRefs(text: String) = AV_REF_RE.replace("", text)
+fun stripAvRefs(text: String) = AV_REF_RE.replace(text, "")
 
 fun addPlayIcons(content: String): String {
     return AV_REF_RE.replace(content) { match ->

--- a/AnkiDroid/src/main/res/values/preferences.xml
+++ b/AnkiDroid/src/main/res/values/preferences.xml
@@ -44,6 +44,7 @@
     <string name="show_topbar_preference">showTopbar</string>
     <string name="show_progress_preference">showProgress</string>
     <string name="show_eta_preference">showETA</string>
+    <string name="show_audio_play_buttons_key">showAudioPlayButtons</string>
     <string name="pref_card_browser_font_scale_key">relativeCardBrowserFontSize</string>
     <!-- App bar buttons -->
     <string name="pref_app_bar_buttons_screen_key">appBarButtonsScreen</string>

--- a/AnkiDroid/src/main/res/xml/preferences_appearance.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_appearance.xml
@@ -24,6 +24,7 @@
 <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:search="http://schemas.android.com/apk/com.bytehamster.lib.preferencesearch"
+    xmlns:tools="http://schemas.android.com/tools"
         android:title="@string/pref_cat_appearance"
         android:key="@string/pref_appearance_screen_key">
     <PreferenceCategory android:title="@string/pref_cat_themes" >
@@ -109,6 +110,11 @@
             android:defaultValue="true"
             android:summary="@string/show_eta_summ"
             android:title="@string/show_eta" />
+        <SwitchPreferenceCompat
+            android:key="@string/show_audio_play_buttons_key"
+            android:defaultValue="true"
+            tools:title="Show play buttons on cards with audio"
+            />
     </PreferenceCategory>
     <PreferenceCategory android:title="@string/card_browser">
         <SwitchPreferenceCompat

--- a/AnkiDroid/src/test/java/com/ichi2/anki/AbstractFlashcardViewerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/AbstractFlashcardViewerTest.kt
@@ -12,6 +12,7 @@ import androidx.annotation.RequiresApi
 import androidx.core.content.IntentCompat
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import anki.config.ConfigKey
 import com.ichi2.anim.ActivityTransitionAnimation
 import com.ichi2.anki.AbstractFlashcardViewer.WebViewSignalParserUtils.ANSWER_ORDINAL_1
 import com.ichi2.anki.AbstractFlashcardViewer.WebViewSignalParserUtils.ANSWER_ORDINAL_2
@@ -257,6 +258,51 @@ class AbstractFlashcardViewerTest : RobolectricTest() {
         viewer.executeCommand(ViewerCommand.FLIP_OR_ANSWER_EASE4)
         viewer.executeCommand(ViewerCommand.FLIP_OR_ANSWER_EASE4)
         assertEquals(getResourceString(R.string.studyoptions_congrats_finished), ShadowToast.getTextOfLatestToast())
+    }
+
+    @Test
+    fun `Show audio play buttons preference handling - sound`() = runTest {
+        addNoteUsingBasicTypedModel("SOUND [sound:android_audiorec.3gp]", "back")
+        getViewerContent().let { content ->
+            assertThat("show audio preference default value: enabled", content, containsString("playsound:q:0"))
+            assertThat("show audio preference default value: enabled", content, containsString("SOUND"))
+        }
+        setHidePlayAudioButtons(true)
+        getViewerContent().let { content ->
+            assertThat("show audio preference disabled", content, not(containsString("playsound:q:0")))
+            assertThat("show audio preference disabled", content, containsString("SOUND"))
+        }
+        setHidePlayAudioButtons(false)
+        getViewerContent().let { content ->
+            assertThat("show audio preference enabled explicitly", content, containsString("playsound:q:0"))
+            assertThat("show audio preference enabled explicitly", content, containsString("SOUND"))
+        }
+    }
+
+    @Test
+    fun `Show audio play buttons preference handling - tts`() = runTest {
+        addNoteUsingTextToSpeechNoteType("TTS", "BACK")
+        getViewerContent().let { content ->
+            assertThat("show audio preference default value: enabled", content, containsString("playsound:q:0"))
+            assertThat("show audio preference default value: enabled", content, containsString("TTS"))
+        }
+        setHidePlayAudioButtons(true)
+        getViewerContent().let { content ->
+            assertThat("show audio preference disabled", content, not(containsString("playsound:q:0")))
+            assertThat("show audio preference disabled", content, containsString("TTS"))
+        }
+        setHidePlayAudioButtons(false)
+        getViewerContent().let { content ->
+            assertThat("show audio preference enabled explicitly", content, containsString("playsound:q:0"))
+            assertThat("show audio preference enabled explicitly", content, containsString("TTS"))
+        }
+    }
+
+    private fun setHidePlayAudioButtons(value: Boolean) = col.config.setBool(ConfigKey.Bool.HIDE_AUDIO_PLAY_BUTTONS, value)
+
+    private fun getViewerContent(): String? {
+        // PERF: Optimise this to not create a new viewer each time
+        return getViewer(addCard = false).cardContent
     }
 
     private fun showNextCard(viewer: NonAbstractFlashcardViewer) {

--- a/AnkiDroid/src/test/java/com/ichi2/anki/RobolectricTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/RobolectricTest.kt
@@ -416,6 +416,13 @@ open class RobolectricTest : AndroidTest {
         return name
     }
 
+    /** Adds a note with Text to Speech functionality */
+    @Suppress("SameParameterValue")
+    protected fun addNoteUsingTextToSpeechNoteType(front: String, back: String) {
+        addNonClozeModel("TTS", arrayOf("Front", "Back"), "{{Front}}{{tts en_GB:Front}}", "{{tts en_GB:Front}}<br>{{Back}}")
+        addNoteUsingModelName("TTS", front, back)
+    }
+
     private fun addField(notetype: NotetypeJson, name: String) {
         val models = col.notetypes
         try {


### PR DESCRIPTION
## Purpose / Description
Functionality added in Anki Desktop. Also useful in AnkiDroid

## Fixes
* Fixes #14649

## Approach
* Add a Preference
* Check the value of the preference and render `[sound]` and TTS differently

## How Has This Been Tested?
Unit Tests 

<details>

<summary><b>Screenshot</b></summary>

![image](https://github.com/ankidroid/Anki-Android/assets/62114487/7d955ca5-813e-4da0-be77-4f1f79ca620a)

<!-- ![image](https://github.com/ankidroid/Anki-Android/assets/62114487/6bf64c03-c7ed-48b9-bb33-aa0d416e808c) -->

<!-- ![image](https://github.com/ankidroid/Anki-Android/assets/62114487/c748360d-7111-4239-9b1e-b7c06af48227) -->
</details>

Tested on my phone with TTS and sound

## Learning (optional, can help others)
https://github.com/search?q=repo%3Aankitects%2Fanki%20hide_audio_play_buttons&type=code

https://github.com/ankitects/anki/blob/e327195470824074465657f98bb0282c7c93a56e/qt/aqt/main.py#L587-L592

* Need to be more careful with testing, almost let the `stripAvRefs` bug through

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
