### PR TITLE
fix permission margin

### DIFF
--- a/AnkiDroid/src/main/res/layout/permission_item.xml
+++ b/AnkiDroid/src/main/res/layout/permission_item.xml
@@ -5,10 +5,9 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:minHeight="?attr/listPreferredItemHeight"
-    android:paddingStart="?attr/listPreferredItemPaddingStart"
     android:paddingTop="16dp"
-    android:paddingEnd="8dp"
-    android:paddingBottom="16dp"
+    android:paddingStart="?android:attr/listPreferredItemPaddingStart"
+    android:paddingEnd="?android:attr/listPreferredItemPaddingEnd"
     tools:context=".ui.windows.permissions.PermissionItem">
 
     <ImageView

--- a/AnkiDroid/src/main/res/layout/permission_item.xml
+++ b/AnkiDroid/src/main/res/layout/permission_item.xml
@@ -29,7 +29,7 @@
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         app:layout_constrainedWidth="true"
-        app:layout_constraintEnd_toEndOf="@+id/guideline_end"
+        app:layout_constraintEnd_toStartOf="@id/switch_widget"
         app:layout_constraintStart_toStartOf="@+id/guideline_front"
         app:layout_constraintTop_toTopOf="parent"
         tools:maxLines="1"
@@ -43,7 +43,7 @@
         android:layout_marginTop="2dp"
         android:textColor="?android:attr/textColorSecondary"
         app:layout_constrainedWidth="true"
-        app:layout_constraintEnd_toEndOf="@+id/guideline_end"
+        app:layout_constraintEnd_toStartOf="@id/switch_widget"
         app:layout_constraintStart_toStartOf="@+id/guideline_front"
         app:layout_constraintTop_toBottomOf="@id/title"
         tools:maxLines="3"
@@ -55,10 +55,9 @@
         android:layout_height="wrap_content"
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintStart_toStartOf="@id/guideline_end"
+        app:layout_constraintStart_toEndOf="@id/summary"
         app:layout_constraintEnd_toEndOf="parent"
-        android:layout_marginHorizontal="12dp"
-        />
+        android:paddingStart="16dp"/>
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guideline_front"
@@ -66,12 +65,4 @@
         android:layout_height="wrap_content"
         android:orientation="vertical"
         app:layout_constraintGuide_begin="56dp" />
-
-    <androidx.constraintlayout.widget.Guideline
-        android:id="@+id/guideline_end"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:orientation="vertical"
-        app:layout_constraintGuide_end="56dp" />
-
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/AnkiDroid/src/main/res/layout/permission_item.xml
+++ b/AnkiDroid/src/main/res/layout/permission_item.xml
@@ -14,7 +14,7 @@
         android:id="@+id/icon"
         android:layout_width="24dp"
         android:layout_height="24dp"
-        android:layout_marginTop="4dp"
+        android:layout_marginTop="20dp"
         android:layout_marginEnd="8dp"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toStartOf="@id/guideline_front"


### PR DESCRIPTION

## Fixes
Fixes #14653

## Approach
I used the same padding of preferences switches as asked

## How Has This Been Tested?

I could not reproduce the issue, but I trust what I did and looks okay in the preview see
![image](https://github.com/ankidroid/Anki-Android/assets/65715921/6dcedb43-2474-46a9-ba41-c290496e7ac9)


## Learning (optional, can help others)
_Describe the research stage_

_Links to blog posts, patterns, libraries or addons used to solve this problem_

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [x] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
