### PR TITLE
fix: only close the permissions screen by tapping the continue button

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/permissions/PermissionsActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/permissions/PermissionsActivity.kt
@@ -19,12 +19,14 @@ import android.content.Context
 import android.content.Intent
 import android.os.Bundle
 import android.os.Parcelable
+import androidx.activity.addCallback
 import androidx.appcompat.widget.AppCompatButton
 import androidx.core.content.IntentCompat
 import androidx.fragment.app.commit
 import com.ichi2.anki.AnkiActivity
 import com.ichi2.anki.PermissionSet
 import com.ichi2.anki.R
+import com.ichi2.annotations.NeedsTest
 
 /**
  * Screen responsible for getting permissions from the user.
@@ -55,12 +57,9 @@ class PermissionsActivity : AnkiActivity() {
         supportFragmentManager.commit {
             replace(R.id.fragment_container, permissionsFragment)
         }
-    }
-
-    @Suppress("DEPRECATION", "needs update to handle predictive back, see 14558")
-    override fun onBackPressed() {
-        super.onBackPressed()
         // only close the activity by tapping the continue button
+        @NeedsTest("activity can only be closed by tapping the continue button")
+        onBackPressedDispatcher.addCallback {}
     }
 
     fun setContinueButtonEnabled(isEnabled: Boolean) {


### PR DESCRIPTION
This was the initial behavior of #14130, but was changed by mistake when trying to deal with the onBackPressed deprecation

This fixes it and actually avoids the deprecation

## How Has This Been Tested?

Emulator 33:
1. New install with the `full` flavor
2. Press back in the permission screen → See that it doesn't go back to the reviewer

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
