### PR TITLE
Implemented predictive back navigation for some screens

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/Info.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Info.kt
@@ -27,6 +27,7 @@ import android.webkit.WebChromeClient
 import android.webkit.WebResourceRequest
 import android.webkit.WebView
 import android.webkit.WebViewClient
+import androidx.activity.OnBackPressedCallback
 import androidx.appcompat.widget.ThemeUtils
 import com.google.android.material.button.MaterialButton
 import com.ichi2.anim.ActivityTransitionAnimation
@@ -46,7 +47,7 @@ private const val CHANGE_LOG_URL = "https://docs.ankidroid.org/changelog.html"
  * Shows an about box, which is a small HTML page.
  */
 class Info : AnkiActivity() {
-    private var mWebView: WebView? = null
+    private lateinit var mWebView: WebView
 
     @SuppressLint("SetJavaScriptEnabled")
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -67,7 +68,7 @@ class Info : AnkiActivity() {
         findViewById<MaterialButton>(R.id.info_donate).setOnClickListener { openUrl(Uri.parse(getString(R.string.link_opencollective_donate))) }
         title = "$appName v$pkgVersionName"
         mWebView = findViewById(R.id.info)
-        mWebView!!.webChromeClient = object : WebChromeClient() {
+        mWebView.webChromeClient = object : WebChromeClient() {
             override fun onProgressChanged(view: WebView, progress: Int) {
                 // Hide the progress indicator when the page has finished loaded
                 if (progress == 100) {
@@ -88,7 +89,11 @@ class Info : AnkiActivity() {
                 visibility = View.GONE
             }
         }
-
+        val onBackPressedCallback = object : OnBackPressedCallback(false) {
+            override fun handleOnBackPressed() {
+                if (mWebView.canGoBack()) mWebView.goBack()
+            }
+        }
         // Apply Theme colors
         val typedArray = theme.obtainStyledAttributes(intArrayOf(android.R.attr.colorBackground, android.R.attr.textColor))
         val backgroundColor = typedArray.getColor(0, -1)
@@ -97,9 +102,9 @@ class Info : AnkiActivity() {
         val anchorTextThemeColor = ThemeUtils.getThemeAttrColor(this, android.R.attr.colorAccent)
         val anchorTextColor = anchorTextThemeColor.toRGBHex()
 
-        mWebView!!.setBackgroundColor(backgroundColor)
-        mWebView!!.settings.allowFileAccess = true
-        mWebView!!.settings.allowContentAccess = true
+        mWebView.setBackgroundColor(backgroundColor)
+        mWebView.settings.allowFileAccess = true
+        mWebView.settings.allowContentAccess = true
         setRenderWorkaround(this)
         when (type) {
             TYPE_NEW_VERSION -> {
@@ -108,14 +113,14 @@ class Info : AnkiActivity() {
                     setOnClickListener { close() }
                 }
                 val background = backgroundColor.toRGBHex()
-                mWebView!!.loadUrl("/android_asset/changelog.html")
-                mWebView!!.settings.javaScriptEnabled = true
-                mWebView!!.webViewClient = object : WebViewClient() {
+                mWebView.loadUrl("/android_asset/changelog.html")
+                mWebView.settings.javaScriptEnabled = true
+                mWebView.webViewClient = object : WebViewClient() {
                     override fun onPageFinished(view: WebView, url: String) {
                         /* The order of below javascript code must not change (this order works both in debug and release mode)
                                  *  or else it will break in any one mode.
                                  */
-                        mWebView!!.loadUrl(
+                        mWebView.loadUrl(
                             "javascript:document.body.style.setProperty(\"color\", \"" + textColor + "\");" +
                                 "x=document.getElementsByTagName(\"a\"); for(i=0;i<x.length;i++){x[i].style.color=\"" + anchorTextColor + "\";}" +
                                 "document.getElementsByTagName(\"h1\")[0].style.color=\"" + textColor + "\";" +
@@ -146,10 +151,20 @@ class Info : AnkiActivity() {
                         }
                         return true
                     }
+
+                    override fun doUpdateVisitedHistory(
+                        view: WebView?,
+                        url: String?,
+                        isReload: Boolean
+                    ) {
+                        super.doUpdateVisitedHistory(view, url, isReload)
+                        onBackPressedCallback.isEnabled = view != null && view.canGoBack()
+                    }
                 }
             }
             else -> finish()
         }
+        onBackPressedDispatcher.addCallback(this, onBackPressedCallback)
     }
 
     private fun close() {
@@ -168,15 +183,6 @@ class Info : AnkiActivity() {
 
     private fun finishWithAnimation() {
         finishWithAnimation(ActivityTransitionAnimation.Direction.START)
-    }
-
-    @Suppress("deprecation") // onBackPressed
-    override fun onBackPressed() {
-        if (mWebView!!.canGoBack()) {
-            mWebView!!.goBack()
-        } else {
-            super.onBackPressed()
-        }
     }
 
     companion object {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ModelFieldEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ModelFieldEditor.kt
@@ -454,10 +454,6 @@ class ModelFieldEditor : AnkiActivity(), LocaleSelectionDialogHandler {
     }
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean = when (item.itemId) {
-        android.R.id.home -> {
-            onBackPressed()
-            true
-        }
         R.id.action_add_new_model -> {
             addFieldDialog()
             true
@@ -467,12 +463,6 @@ class ModelFieldEditor : AnkiActivity(), LocaleSelectionDialogHandler {
 
     private fun closeActivity() {
         finishWithAnimation(ActivityTransitionAnimation.Direction.END)
-    }
-
-    @Suppress("DEPRECATION", "Deprecated in API34+dependencies for predictive back feature")
-    override fun onBackPressed() {
-        super.onBackPressed()
-        closeActivity()
     }
 
     fun handleAction(contextMenuAction: ModelEditorContextMenuAction) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Previewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Previewer.kt
@@ -75,6 +75,7 @@ class Previewer : AbstractFlashcardViewer() {
         disableDrawerSwipe()
         startLoadingCollection()
         initPreviewProgress()
+        setOkResult()
     }
 
     private fun initPreviewProgress() {
@@ -161,13 +162,8 @@ class Previewer : AbstractFlashcardViewer() {
         return super.onOptionsItemSelected(item)
     }
 
-    override fun onBackPressed() {
-        setResult(RESULT_OK, resultIntent)
-        super.onBackPressed()
-    }
-
     override fun onNavigationPressed() {
-        setResult(RESULT_OK, resultIntent)
+        setOkResult()
         super.onNavigationPressed()
     }
 
@@ -214,6 +210,7 @@ class Previewer : AbstractFlashcardViewer() {
 
     override fun performReload() {
         mReloadRequired = true
+        setOkResult()
         val newCardList = getColUnsafe.filterToValidCards(mCardList)
         if (newCardList.isEmpty()) {
             finish()
@@ -228,6 +225,7 @@ class Previewer : AbstractFlashcardViewer() {
     override fun onEditedNoteChanged() {
         super.onEditedNoteChanged()
         mNoteChanged = true
+        setOkResult()
     }
 
     @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
@@ -267,13 +265,15 @@ class Previewer : AbstractFlashcardViewer() {
         mProgressText.text = progress
     }
 
-    private val resultIntent: Intent
-        get() {
-            val intent = Intent()
-            intent.putExtra("reloadRequired", mReloadRequired)
-            intent.putExtra("noteChanged", mNoteChanged)
-            return intent
-        }
+    private fun setOkResult() {
+        setResult(
+            RESULT_OK,
+            Intent().apply {
+                putExtra("reloadRequired", mReloadRequired)
+                putExtra("noteChanged", mNoteChanged)
+            }
+        )
+    }
 
     companion object {
         @CheckResult


### PR DESCRIPTION
## Purpose / Description
Implemented predictive back navigation for Info.kt, ModelFieldEditor.kt and Previewer.kt. These are the simplest screens to change, with a note on Info.kt if we really need to handle the WebView.canGoBack() as we start an outside browser for any url.

Info.kt: 

https://github.com/ankidroid/Anki-Android/assets/52494258/ad45c1cd-8b45-4211-848d-f3b200926bdd

Previewer.kt:

https://github.com/ankidroid/Anki-Android/assets/52494258/4efe1dcb-633d-4f57-a7c2-9fab9ab8ede7

ModelFieldEditor.kt:

https://github.com/ankidroid/Anki-Android/assets/52494258/a3e0da17-dfd3-482c-afc9-e03efd08d8a8

## Fixes
Related to #14558 

## How Has This Been Tested?

Enabled the predictive back navigation and manually tested the changed screens

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)


