### PR TITLE
Allow first field to be empty in edit note

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
@@ -756,11 +756,6 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
                 mCurrentEditedCard!!.did = deckId
                 modified = true
             }
-            // Check if the front of the card is not empty
-            if (getCurrentFieldText(0).isEmpty()) {
-                displayErrorSavingNote()
-                return
-            }
             // now load any changes to the fields from the form
             for (f in mEditFields!!) {
                 modified = modified or updateField(f)


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
Making AnkiDroid consistent with Anki - allowing the first field to be empty in edit note

## Fixes
* Fixes #14664 

## Approach
Took off the condition 

## How Has This Been Tested?
Tested on OnePlus Nord CE

## Checklist
_Please, go through these checks before submitting the PR._

- [ ] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas
- [ ] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
