### PR TITLE
 docs(NoteEditor): NeedsTest - After a note is saved, 'first field must not be empty' does not apply

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
@@ -673,6 +673,7 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
     }
 
     @VisibleForTesting
+    @NeedsTest("14664: 'first field must not be empty' no longer applies after saving the note")
     suspend fun saveNote() {
         val res = resources
         if (mSelectedTags == null) {


### PR DESCRIPTION
After a note is saved, 'first field must not be empty' does not apply

* Issue #14664
* Follow up to review comment on #14665