### PR TITLE
refactor: Set preferences single line title statically

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/SettingsFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/SettingsFragment.kt
@@ -81,7 +81,6 @@ abstract class SettingsFragment :
     override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
         UsageAnalytics.sendAnalyticsScreenView(analyticsScreenNameConstant)
         addPreferencesFromResource(preferenceResource)
-        allPreferences().forEach { it.isSingleLineTitle = false }
         initSubscreen()
     }
 

--- a/AnkiDroid/src/main/res/values/styles.xml
+++ b/AnkiDroid/src/main/res/values/styles.xml
@@ -182,4 +182,8 @@
         <item name="labelStyle">@style/SliderLabelStyle</item>
         <item name="tickVisible">false</item>
     </style>
+
+    <style name="PreferenceThemeOverlay.AnkiDroid">
+        <item name="singleLineTitle">false</item>
+    </style>
 </resources>

--- a/AnkiDroid/src/main/res/values/theme_dark.xml
+++ b/AnkiDroid/src/main/res/values/theme_dark.xml
@@ -138,5 +138,6 @@
         <!-- Widget styles -->
         <item name="switchPreferenceCompatStyle">@style/Preference.SwitchPreferenceCompat.Material3</item>
         <item name="sliderStyle">@style/SliderStyle</item>
+        <item name="preferenceTheme">@style/PreferenceThemeOverlay.AnkiDroid</item>
     </style>
 </resources>

--- a/AnkiDroid/src/main/res/values/theme_light.xml
+++ b/AnkiDroid/src/main/res/values/theme_light.xml
@@ -148,5 +148,6 @@ APIs. It's visible when there aren't enough decks to fill the screen.
         <!-- Widget styles -->
         <item name="switchPreferenceCompatStyle">@style/Preference.SwitchPreferenceCompat.Material3</item>
         <item name="sliderStyle">@style/SliderStyle</item>
+        <item name="preferenceTheme">@style/PreferenceThemeOverlay.AnkiDroid</item>
     </style>
 </resources>


### PR DESCRIPTION
So IDE previews are more precise and fragments that don't inherit from SettingsFragment also use the same style

## How Has This Been Tested?

Use japanese as app language and see if the preferences at the `General` section don't ellipsize

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
