### PR TITLE
build(deps): adopt android gradle plugin 8.1.3 vs 8.2.0-rc series

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ buildscript {
     ext.androidx_test_version = '1.5.0'
     ext.androidx_test_junit_version = '1.1.5'
     ext.robolectric_version = '4.11.1'
-    ext.android_gradle_plugin = "8.2.0-rc01"
+    ext.android_gradle_plugin = "8.1.3"
     ext.dokka_version = "1.9.10" // not the same with kotlin version!
 
     configurations.all {


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description

This is a more comfortable development experience as it does not force developers to use the developer preview of android studio to sync correctly, and 8.1.3 (vs 8.1.2...) appears to have the upstream issue we had with split ABI and include resources in tests fixed




## How Has This Been Tested?

Local run of `./gradlew jacocoTestReport` which is always sufficient to trigger the previous "ABI split + tests include resources" compile failure in the past. Works now

## Learning (optional, can help others)

@lukstbit has an eagle eye for android gradle plugin releases 🧐 😆 

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
