### PR TITLE
NF: more timbers for getting data from http server

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/ReviewerServer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ReviewerServer.kt
@@ -74,7 +74,7 @@ class ReviewerServer(activity: FragmentActivity, val mediaDir: String) : AnkiSer
             }
         }
 
-        Timber.e("not found: $uri")
+        Timber.w("not found: $uri")
         return newFixedLengthResponse(Response.Status.NOT_FOUND, "text/plain", "")
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ReviewerServer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ReviewerServer.kt
@@ -50,6 +50,7 @@ class ReviewerServer(activity: FragmentActivity, val mediaDir: String) : AnkiSer
                         this.javaClass.classLoader!!.getResourceAsStream(uri.substring(1))
                 }
                 if (stream != null) {
+                    Timber.v("OK: $uri")
                     return newChunkedResponse(Response.Status.OK, mime, stream)
                 }
             }
@@ -59,6 +60,7 @@ class ReviewerServer(activity: FragmentActivity, val mediaDir: String) : AnkiSer
             if (file.exists()) {
                 val inputStream = FileInputStream(file)
                 val mimeType = AssetHelper.guessMimeType(uri)
+                Timber.v("OK: $uri")
                 return newChunkedResponse(Response.Status.OK, mimeType, inputStream)
                 // probably don't need this anymore
                 // resp.addHeader("Access-Control-Allow-Origin", "*")
@@ -72,7 +74,7 @@ class ReviewerServer(activity: FragmentActivity, val mediaDir: String) : AnkiSer
             }
         }
 
-        Timber.d("not found: $uri")
+        Timber.e("not found: $uri")
         return newFixedLengthResponse(Response.Status.NOT_FOUND, "text/plain", "")
     }
 


### PR DESCRIPTION
I believe that a value not found should be an error. Simply because that's what one may look for when debugging.

And also, it's important to state when the value is found. Otherwise, when looking at log, it's not clear that the silence mean the value was actually found without looking at the codebase.

In the bug I was trying to debug right now, I wanted to check whether it was a problem with unfound media, or an issue with a media that android does not render properly. This saved me time.