### PR TITLE
Replace Timber.e by Timber.v

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
@@ -1541,7 +1541,7 @@ abstract class AbstractFlashcardViewer :
             server?.reviewerHtml = content
             if (card != null) {
                 card.settings.mediaPlaybackRequiresUserGesture = !mCardSoundConfig!!.autoplay
-                Timber.e("*** set server %s content to %s", server, content)
+                Timber.v("*** set server %s content to %s", server, content)
                 card.loadUrl(server?.baseUrl() + "reviewer.html")
             }
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/NoteService.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/NoteService.kt
@@ -129,7 +129,7 @@ object NoteService {
                 if (inFile.exists() && inFile.length() > 0) {
                     val fname = col.media.addFile(inFile)
                     val outFile = File(col.media.dir, fname)
-                    Timber.e("%s %s", fname, outFile)
+                    Timber.v("""File "%s" should be copied to "%s""", fname, outFile)
                     if (field.hasTemporaryMedia && outFile.absolutePath != tmpMediaPath) {
                         // Delete original
                         inFile.delete()

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Media.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Media.kt
@@ -35,7 +35,7 @@ open class Media(private val col: Collection) {
     val dir = getCollectionMediaPath(col.path)
 
     init {
-        Timber.e("dir %s", dir)
+        Timber.v("dir %s", dir)
         val file = File(dir)
         if (!file.exists()) {
             file.mkdirs()
@@ -51,7 +51,7 @@ open class Media(private val col: Collection) {
         if (oFile == null || oFile.length() == 0L) {
             throw EmptyMediaException()
         }
-        Timber.e("dir now %s", dir)
+        Timber.v("dir now %s", dir)
         return col.backend.addMediaFile(oFile.name, oFile.readBytes().toByteString())
     }
 


### PR DESCRIPTION
In 7a65160e0e23e20080091a30abdd4c05fc610e06 multiple error were timbered on what seems to be the normal successful path. I remove them to have a verbose timber instead, so they do not clutter the error space when trying to debug an actual error.