### PR TITLE
Ensure media are detected correctly even with space in their name

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/utils/AssetHelper.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/AssetHelper.kt
@@ -35,10 +35,25 @@
  */
 package com.ichi2.utils
 
+import android.net.Uri
 import android.webkit.MimeTypeMap
+import java.io.File
+import java.util.Locale
 
 /** Clone of RestrictedApi functionality  */
 object AssetHelper {
+    /**
+     Returns the extension of [path].
+     It uses [MimeTypeMap.getFileExtensionFromURL], with the path transformed into a Uri.
+     */
+    fun getFileExtensionFromFilePath(path: String): String {
+        return MimeTypeMap.getFileExtensionFromUrl(
+            Uri.fromFile(File(path)).toString().lowercase(
+                Locale.ROOT
+            )
+        )
+    }
+
     /**
      * Use [MimeTypeMap.getMimeTypeFromExtension] to guess MIME type or return the
      * "text/plain" if it can't guess.
@@ -48,8 +63,8 @@ object AssetHelper {
      * @param path path of the file to guess its MIME type.
      * @return MIME type guessed from file extension or "text/plain".
      */
-    fun guessMimeType(path: String?): String {
-        return when (val extension = MimeTypeMap.getFileExtensionFromUrl(path)) {
+    fun guessMimeType(path: String): String {
+        return when (val extension = getFileExtensionFromFilePath(path)) {
             "js" -> "text/javascript"
             "mjs" -> "text/javascript"
             "json" -> "application/json"

--- a/AnkiDroid/src/main/java/com/ichi2/utils/ContentResolverUtil.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/ContentResolverUtil.kt
@@ -22,10 +22,6 @@ import android.provider.MediaStore
 import android.webkit.MimeTypeMap
 import androidx.annotation.CheckResult
 import timber.log.Timber
-import java.io.File
-import java.lang.Exception
-import java.lang.IllegalStateException
-import java.util.*
 
 object ContentResolverUtil {
     /** Obtains the filename from the url. Throws if all methods return exception  */
@@ -62,7 +58,7 @@ object ContentResolverUtil {
             // If scheme is a File
             // This will replace white spaces with %20 and also other special characters. This will avoid returning null values on file name with spaces and special characters.
             if (uri.path != null) {
-                extension = MimeTypeMap.getFileExtensionFromUrl(Uri.fromFile(File(uri.path as String)).toString().lowercase(Locale.ROOT))
+                extension = AssetHelper.getFileExtensionFromFilePath(uri.path as String)
             }
         }
         return if (extension == null) {

--- a/AnkiDroid/src/main/java/com/ichi2/utils/ImportUtils.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/ImportUtils.kt
@@ -23,7 +23,6 @@ import android.content.Intent
 import android.net.Uri
 import android.os.Message
 import android.provider.OpenableColumns
-import android.webkit.MimeTypeMap
 import androidx.annotation.CheckResult
 import androidx.appcompat.app.AlertDialog
 import androidx.core.os.bundleOf
@@ -41,7 +40,6 @@ import java.io.InputStream
 import java.net.URLDecoder
 import java.net.URLEncoder
 import java.util.*
-import kotlin.collections.ArrayList
 
 object ImportUtils {
     /* A filename should be shortened if over this threshold */
@@ -245,7 +243,7 @@ object ImportUtils {
         @CheckResult
         private fun getExtension(fileName: String): String {
             val file = Uri.fromFile(File(fileName))
-            return MimeTypeMap.getFileExtensionFromUrl(file.toString())
+            return AssetHelper.getFileExtensionFromFilePath(file.toString())
         }
 
         protected open fun getFileNameFromContentProvider(context: Context, data: Uri): String? {


### PR DESCRIPTION
I wanted to unit test it. But unit test failes when `Uri` is used. I can mock `Uri`, but this would remove most of the interest of the test. If I control that `Uri` returns what I expect, then I don't get any information from the test.

I corrected all uses of MimeTypeMap.getFileExtensionFromUrl even if I don't know of any bug at other places caused by incorrect extension identification.

Fixes #14696
