### PR TITLE
Test: Ensure media are detected correctly even with space in their name

### DIFF
--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/utils/AssetHelperTest.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/utils/AssetHelperTest.kt
@@ -33,5 +33,7 @@ class AssetHelperTest {
         assertThat(AssetHelper.guessMimeType("test.txt"), equalTo("text/plain"))
         assertThat(AssetHelper.guessMimeType("test.png"), equalTo("image/png"))
         assertThat(AssetHelper.guessMimeType("test.zip"), equalTo("application/zip"))
+        // #14696: path with space in it
+        assertThat(AssetHelper.guessMimeType("/Dominant seventh arpeggio-C-right-1-increasing_test.svg"), equalTo("image/svg+xml"))
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/utils/AssetHelper.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/AssetHelper.kt
@@ -44,7 +44,7 @@ import java.util.Locale
 object AssetHelper {
     /**
      Returns the extension of [path].
-     It uses [MimeTypeMap.getFileExtensionFromURL], with the path transformed into a Uri.
+     It uses [MimeTypeMap.getFileExtensionFromUrl], with the path transformed into a Uri.
      */
     fun getFileExtensionFromFilePath(path: String): String {
         return MimeTypeMap.getFileExtensionFromUrl(


### PR DESCRIPTION
## Purpose / Description
* #14700 wanted to add tests, but couldn't


## Approach

* Add a test for #14696

----

* Use the debugger to determine the bad input
* Check test fails before #14700
* Ensure test passes after #14700

## How Has This Been Tested?
API 33 and API 24 emulator


## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
