### PR TITLE
fix: handle plural strings in SliderPreference

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/utils/Resources.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/utils/Resources.kt
@@ -1,0 +1,39 @@
+/*
+ *  Copyright (c) 2023 Brayan Oliveira <brayandso.dev@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.ichi2.anki.utils
+
+import android.content.Context
+import android.content.res.Resources
+import androidx.annotation.PluralsRes
+import androidx.annotation.StringRes
+
+/**
+ * @param resId must be a [StringRes] or a [PluralsRes]
+ */
+fun Resources.getFormattedStringOrPlurals(resId: Int, quantity: Int): String {
+    return when (getResourceTypeName(resId)) {
+        "string" -> getString(resId, quantity)
+        "plurals" -> getQuantityString(resId, quantity, quantity)
+        else -> throw IllegalArgumentException("Provided resId is not a valid @StringRes or @PluralsRes")
+    }
+}
+
+/**
+ * @see [Resources.getFormattedStringOrPlurals]
+ */
+fun Context.getFormattedStringOrPlurals(resId: Int, quantity: Int): String {
+    return resources.getFormattedStringOrPlurals(resId, quantity)
+}

--- a/AnkiDroid/src/main/java/com/ichi2/preferences/SliderPreference.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/preferences/SliderPreference.kt
@@ -26,6 +26,7 @@ import androidx.preference.Preference
 import androidx.preference.PreferenceViewHolder
 import com.google.android.material.slider.Slider
 import com.ichi2.anki.R
+import com.ichi2.anki.utils.getFormattedStringOrPlurals
 
 /**
  * Similar to [androidx.preference.SeekBarPreference],
@@ -43,7 +44,7 @@ import com.ichi2.anki.R
  *       If not set, the `valueFrom` value is going to be used.
  *       It must be between `valueFrom` and `valueTo`
  * * app:summaryFormat (*optional*):
- *       Format string to be used as template to display the value in the preference summary.
+ *       Format `string` or `plurals` to be used as template to display the value in the preference summary.
  *       There must be ONLY ONE placeholder, which will be replaced by the preference value.
  * * app:displayValue (*optional*): whether to show the current preference value on a TextView
  *       by the end of the slider
@@ -57,7 +58,7 @@ class SliderPreference(context: Context, attrs: AttributeSet? = null) : Preferen
     private var valueTo: Int = 0
     private var stepSize: Float = 1F
 
-    private var summaryFormat: String? = null
+    private var summaryFormatResource: Int? = null
     private var displayValue: Boolean = false
     private var displayFormat: String? = null
 
@@ -70,7 +71,6 @@ class SliderPreference(context: Context, attrs: AttributeSet? = null) : Preferen
                 throw IllegalArgumentException("value $value should be between the min of $valueFrom and max of $valueTo")
             }
             field = value
-            summaryFormat?.let { summary = String.format(it, value) }
             persistInt(value)
             notifyChanged()
         }
@@ -85,7 +85,8 @@ class SliderPreference(context: Context, attrs: AttributeSet? = null) : Preferen
         }
 
         context.withStyledAttributes(attrs, R.styleable.CustomPreference) {
-            summaryFormat = getString(R.styleable.CustomPreference_summaryFormat)
+            summaryFormatResource = getResourceId(R.styleable.CustomPreference_summaryFormat, 0)
+                .takeIf { it != 0 }
         }
 
         context.withStyledAttributes(attrs, R.styleable.SliderPreference) {
@@ -125,8 +126,8 @@ class SliderPreference(context: Context, attrs: AttributeSet? = null) : Preferen
         )
 
         val summaryView = holder.findViewById(android.R.id.summary) as TextView
-        summaryFormat?.let {
-            summaryView.text = String.format(it, slider.value.toInt())
+        summaryFormatResource?.let {
+            summaryView.text = context.getFormattedStringOrPlurals(it, slider.value.toInt())
             summaryView.visibility = View.VISIBLE
         }
 

--- a/AnkiDroid/src/main/res/values/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values/10-preferences.xml
@@ -160,7 +160,10 @@
     <string name="time_limit" maxLength="41">Timebox time limit</string>
     <string name="new_timezone" maxLength="41">New timezone handling</string>
     <string name="day_offset_with_description" maxLength="41">Start of next day</string>
-    <string name="day_offset_summary">%s hours past midnight</string>
+    <plurals name="day_offset_summ" comment="%d is going to be replaced with the number of hours past midnight. It can be replaced if something else suits better the translation">
+        <item quantity="one">%d hour past midnight</item>
+        <item quantity="other">%d hours past midnight</item>
+    </plurals>
     <string name="pref_keep_screen_on" maxLength="41">Keep screen on</string>
     <string name="pref_keep_screen_on_summ">Disable screen timeout</string>
     <string name="enable_api_title" maxLength="41">Enable AnkiDroid API</string>

--- a/AnkiDroid/src/main/res/values/attrs.xml
+++ b/AnkiDroid/src/main/res/values/attrs.xml
@@ -31,7 +31,7 @@
         <!-- Whether the preference should automatically set its summary to the value saved for the
              preference, and update the summary when the value is changed. Defaults to false -->
         <attr name="useSimpleSummaryProvider" format="boolean"/>
-        <!-- Format string to be used as template to build the preference summary.
+        <!-- Format `string` or `plurals` to be used as template to build the preference summary.
              The placeholder is replaced by the preference value, and it must be only one placeholder.
              If the preference value is updated, the summary is automatically updated as well. -->
         <attr name="summaryFormat" format="string"/>

--- a/AnkiDroid/src/main/res/xml/preferences_reviewing.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_reviewing.xml
@@ -35,7 +35,7 @@
             android:valueTo="23"
             android:title="@string/day_offset_with_description"
             app1:persistent="false"
-            app1:summaryFormat="@string/day_offset_summary"/>
+            app1:summaryFormat="@plurals/day_offset_summ"/>
         <com.ichi2.preferences.NumberRangePreferenceCompat
             android:key="@string/learn_cutoff_preference"
             android:title="@string/learn_cutoff"


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
SliderPreference summaries didn't handle plurals

## Fixes
* Fixes #14572 
* Closes #14701

## Approach
Upgrade `summaryFormat` attribute to handle both `string` and `plurals` resources

## How Has This Been Tested?

Emulator 34

[Screen_recording_20231111_152907.webm](https://github.com/ankidroid/Anki-Android/assets/69634269/d37470f1-dbcd-4bd1-a56d-8e1b756d8ad5)


## Learning (optional, can help others)

getResourceTypeName can be used to differentiate resource types. Source: ChatGPT

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
