### PR TITLE
Handle android dialog cancellation when used as frontend for js dialogs

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/pages/PageChromeClient.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/pages/PageChromeClient.kt
@@ -20,6 +20,7 @@ import android.webkit.WebChromeClient
 import android.webkit.WebView
 import androidx.appcompat.app.AlertDialog
 import com.ichi2.anki.R
+import com.ichi2.utils.cancelable
 import com.ichi2.utils.message
 import com.ichi2.utils.negativeButton
 import com.ichi2.utils.positiveButton
@@ -35,6 +36,7 @@ open class PageChromeClient : WebChromeClient() {
         AlertDialog.Builder(view.context).show {
             message?.let { message(text = message) }
             positiveButton(R.string.dialog_ok) { result?.confirm() }
+            setOnCancelListener { result?.cancel() }
         }
         return true
     }
@@ -49,6 +51,7 @@ open class PageChromeClient : WebChromeClient() {
             message?.let { message(text = message) }
             positiveButton(R.string.dialog_ok) { result?.confirm() }
             negativeButton(R.string.dialog_cancel) { result?.cancel() }
+            cancelable(false)
         }
         return true
     }


### PR DESCRIPTION
## Purpose / Description

The affected deck option was showing an alert in js which was translated  by the backend supporting code into a native  AlertDialog. This dialog handled only the happy path to communicate with the underlying js code, if the user cancelled the dialog in any other way the js code would never receive the expected call so the app hanged.

Also fixed a(most likely) issue with the other type of js dialog, the confirm call. I could have used the same listener as above, but I opted instead to make the native dialog as not cancellable to enforce the user to make a clear choice when asked for confirmation.

## Fixes
* Fixes #14687 

## How Has This Been Tested?

Manually verified the affected deck option.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
