### PR TITLE
Fix NoteEditor discarding changes on BACK when editing

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
@@ -34,6 +34,7 @@ import android.view.View.OnFocusChangeListener
 import android.view.ViewGroup.MarginLayoutParams
 import android.widget.*
 import android.widget.AdapterView.OnItemSelectedListener
+import androidx.activity.addCallback
 import androidx.annotation.*
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.view.menu.MenuBuilder
@@ -273,6 +274,12 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
         enableToolbar(mainView)
         startLoadingCollection()
         mOnboarding.onCreate()
+        // TODO this callback doesn't handle predictive back navigation!
+        // see #14678, added to temporarily fix for a bug
+        onBackPressedDispatcher.addCallback(this) {
+            Timber.i("NoteEditor:: onBackPressed()")
+            closeCardEditorWithCheck()
+        }
     }
 
     override fun onSaveInstanceState(savedInstanceState: Bundle) {
@@ -814,13 +821,6 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
         mEditorNote!!.load()
         // close note editor
         closeNoteEditor()
-    }
-
-    @Suppress("DEPRECATION", "Deprecated in API34+dependencies for predictive back feature")
-    override fun onBackPressed() {
-        Timber.i("NoteEditor:: onBackPressed()")
-        super.onBackPressed()
-        closeCardEditorWithCheck()
     }
 
     override fun onDestroy() {

--- a/AnkiDroid/src/test/java/com/ichi2/anki/NoteEditorTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/NoteEditorTest.kt
@@ -184,7 +184,7 @@ class NoteEditorTest : RobolectricTest() {
         enableNullCollection()
         ActivityScenario.launchActivityForResult(NoteEditor::class.java).use { scenario ->
             scenario.onActivity { noteEditor: NoteEditor ->
-                noteEditor.onBackPressed()
+                noteEditor.onBackPressedDispatcher.onBackPressed()
                 assertThat("Pressing back should finish the activity", noteEditor.isFinishing)
             }
             val result = scenario.result


### PR DESCRIPTION
## Purpose / Description

The deprecated onBackPressed() did the correct checks when user hit BACK. It also called the super.onBackPressed() which closed the activity although it was suposed to show an AlertDialog asking the user for action about his changes. In the Logcat you can see the window token exception being thrown when a dialog is shown using a bad activity context.

I replaced it with a OnBackPressedCallback as this doesn't have the issue with the super call. Note that this callback doesn't handle the predictive back navigation as it is always on.

## Fixes
* Fixes #14678 

## How Has This Been Tested?

Manually checked the bug scenario also tried adding a note and hitting BACK. Ran the tests.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
