### PR TITLE
Add apk build date in About Fragment

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -50,6 +50,7 @@ android {
         buildConfigField "Boolean", "ENABLE_LEAK_CANARY", "false"
         buildConfigField "Boolean", "ALLOW_UNSAFE_MIGRATION", "false"
         buildConfigField "String", "GIT_COMMIT_HASH", "\"${gitCommitHash()}\""
+        buildConfigField "long", "BUILD_TIME", System.currentTimeMillis().toString()
         resValue "string", "app_name", "AnkiDroid"
 
         // The version number is of the form:

--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/AboutFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/AboutFragment.kt
@@ -18,6 +18,7 @@ package com.ichi2.anki.preferences
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
+import android.text.format.DateFormat
 import android.text.method.LinkMovementMethod
 import android.view.LayoutInflater
 import android.view.View
@@ -36,6 +37,9 @@ import com.ichi2.utils.IntentUtil
 import com.ichi2.utils.VersionUtils.pkgVersionName
 import com.ichi2.utils.copyToClipboard
 import com.ichi2.utils.show
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
 
 class AboutFragment : Fragment() {
     override fun onCreateView(
@@ -45,8 +49,14 @@ class AboutFragment : Fragment() {
     ): View? {
         val layoutView = inflater.inflate(R.layout.about_layout, container, false)
 
+        // Version date
+        val apkBuildDate = SimpleDateFormat(DateFormat.getBestDateTimePattern(Locale.getDefault(), "d MMM yyyy"))
+            .format(Date(BuildConfig.BUILD_TIME))
+        layoutView.findViewById<TextView>(R.id.about_build_date).text = apkBuildDate
+
         // Version text
-        layoutView.findViewById<TextView>(R.id.about_version).text = pkgVersionName
+        layoutView.findViewById<TextView>(R.id.about_version).text =
+            pkgVersionName
 
         // Logo secret
         layoutView.findViewById<ImageView>(R.id.about_app_logo)

--- a/AnkiDroid/src/main/res/layout/about_layout.xml
+++ b/AnkiDroid/src/main/res/layout/about_layout.xml
@@ -48,8 +48,15 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginTop="4dp"
-        android:layout_marginBottom="14dp"
         tools:text="2.x" />
+
+    <TextView
+        android:id="@+id/about_build_date"
+        style="?android:textAppearanceSmall"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="14dp"
+        tools:text="13 Apr 2023" />
 
     <TextView
         android:id="@+id/about_contributors_title"


### PR DESCRIPTION
## Purpose / Description
Add apk build date in About Fragment near version number

## Fixes
* Fixes #14691 

## How Has This Been Tested?
Manually tested on emulator Pixel 3a

<img src="https://github.com/ankidroid/Anki-Android/assets/40427461/59688944-41fc-4cb8-aa6c-50931d120138" width="300">


## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [x] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
