### PR TITLE
14692: Fix crash in Note Editor Preview when 'Read Text' is enabled

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Note.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Note.kt
@@ -330,34 +330,4 @@ class Note : Cloneable {
             return highestClozeId + 1
         }
     }
-
-    fun ephemeralCard(
-        col: Collection,
-        ord: Int = 0,
-        fillEmpty: Boolean = false
-    ): Card {
-        val card = Card(col, null)
-        card.ord = ord
-        card.did = 1
-
-        val nt = notetype
-        val templateIdx = if (nt.type == Consts.MODEL_CLOZE) {
-            0
-        } else {
-            ord
-        }
-        val template = nt.tmpls[templateIdx] as JSONObject
-        template.put("ord", card.ord)
-
-        val output = TemplateManager.TemplateRenderContext.fromCardLayout(
-            this,
-            card,
-            notetype = nt,
-            template = template,
-            fillEmpty = fillEmpty
-        ).render()
-        card.renderOutput = output
-        card.setNote(this)
-        return card
-    }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Note.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Note.kt
@@ -38,7 +38,7 @@ class Note : Cloneable {
     @get:VisibleForTesting
     var guId: String? = null
         private set
-    private lateinit var notetype: NotetypeJson
+    lateinit var notetype: NotetypeJson
 
     var mid: Long = 0
         private set


### PR DESCRIPTION
## Purpose / Description
* #14692

If the 'Read Text' option is enabled, then opening a card preview (from the note editor) caused a crash

`readCardTts` tried to access `card.q(reload = true)`, which failed as the card was a preview with unsaved text.

## Fixes
* Fixes #14692

## Approach
First I overrode the `readCardTts` function to no longer call `.q(reload = true)`, but then decided that it would be cleaner to subclass the `Card` class, as is done above for `PreviewerCard`

This was because there was additional AnkiDroid TTS Logic which didn't feel appropriate to replicate inside the previewer (selecting `pureAnswer`)

`Note.ephemeralCard` was only used once, so was an easy candidate to bring into the `EphemeralCard` class

After that, fix the class to handle `render_output` without crashing.

## How Has This Been Tested?
API 33 emulator: no more crashes. The question/answer text is read out, without any additional HTML

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
