### PR TITLE
tests: add - 'Read Text' + Note Editor Preview

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
@@ -1467,7 +1467,8 @@ abstract class AbstractFlashcardViewer :
         }
     }
 
-    private fun readCardTts(side: SingleSoundSide) {
+    @VisibleForTesting
+    fun readCardTts(side: SingleSoundSide) {
         val tags = legacyGetTtsTags(currentCard!!, side, this)
         mTTS.readCardText(tags, currentCard!!, side.toSoundSide())
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplatePreviewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplatePreviewer.kt
@@ -40,7 +40,6 @@ import java.io.IOException
  * buttons will be shown).
  */
 @NeedsTest("after switch to new schema as default, add test to confirm audio tags rendered")
-@NeedsTest("14692: 'Read Text' being enabled, and previewing a card from the note editor")
 open class CardTemplatePreviewer : AbstractFlashcardViewer() {
     private var mEditedModelFileName: String? = null
     private var mEditedNotetype: NotetypeJson? = null


### PR DESCRIPTION
~~⚠️ Blocked on https://github.com/ankidroid/Anki-Android/pull/14716, needs a rebase before merge~~

Follow up to fix a `@NeedsTest` added in:
* PR #14714
* Commit 170c2d1ee5a354b42395e8c0de4363a1e1fc367b

Not the best test, but it fails before and passes after

