### PR TITLE
Preferences: add plurals for learn ahead/timebox

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/preferences/NumberRangePreferenceCompat.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/preferences/NumberRangePreferenceCompat.kt
@@ -28,6 +28,7 @@ import androidx.preference.EditTextPreference
 import androidx.preference.EditTextPreferenceDialogFragmentCompat
 import com.ichi2.anki.AnkiDroidApp
 import com.ichi2.anki.R
+import com.ichi2.anki.utils.getFormattedStringOrPlurals
 import com.ichi2.annotations.NeedsTest
 import timber.log.Timber
 
@@ -53,12 +54,15 @@ constructor(
         defaultValue = attrs?.getAttributeValue("http://schemas.android.com/apk/res/android", "defaultValue")
 
         context.withStyledAttributes(attrs, R.styleable.CustomPreference) {
-            val summaryFormat = this.getString(R.styleable.CustomPreference_summaryFormat)
-            if (summaryFormat != null) {
-                setSummaryProvider {
-                    String.format(summaryFormat, text)
+            getResourceId(R.styleable.CustomPreference_summaryFormat, 0)
+                .takeIf { it != 0 }?.let { redId ->
+                    setSummaryProvider {
+                        if (text == null) {
+                            return@setSummaryProvider ""
+                        }
+                        context.getFormattedStringOrPlurals(redId, text!!.toInt())
+                    }
                 }
-            }
         }
     }
 

--- a/AnkiDroid/src/main/res/values/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values/10-preferences.xml
@@ -22,7 +22,10 @@
     <!-- generic strings -->
     <string name="disabled">Disabled</string>
     <string name="pref_summary_seconds">%s s</string>
-    <string name="pref_summary_minutes">%s min</string>
+    <plurals name="pref_summ_minutes">
+        <item quantity="one">%d min</item>
+        <item quantity="other">%d mins</item>
+    </plurals>
     <string comment="Percentage value of a preference. %s represents the number to be replaced. Use \%% to represent a single percent sign (%)"
         name="pref_summary_percentage">%s\%%</string>
     <string name="pref_search_no_results">No results</string>

--- a/AnkiDroid/src/main/res/xml/preferences_reviewing.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_reviewing.xml
@@ -41,13 +41,13 @@
             android:title="@string/learn_cutoff"
             app:max="999"
             app:min="0"
-            app1:summaryFormat="@string/pref_summary_minutes"/>
+            app1:summaryFormat="@plurals/pref_summ_minutes"/>
         <com.ichi2.preferences.NumberRangePreferenceCompat
             android:key="@string/time_limit_preference"
             android:title="@string/time_limit"
             app:max="9999"
             app:min="0"
-            app1:summaryFormat="@string/pref_summary_minutes"/>
+            app1:summaryFormat="@plurals/pref_summ_minutes"/>
     </PreferenceCategory>
     <PreferenceCategory android:title="@string/timeout_answer_text" >
         <SwitchPreferenceCompat


### PR DESCRIPTION
## Purpose / Description
* I was looking at the 'learn ahead' preference and two things bothered me:
   * (unfixed) 0 mins == disabled, but the user is not notified
   * (fixed) 1 min is shown as 1 mins

## Approach
Use a summaryProvider, similar to:
* 55ee1d7f333feb8ffc126fbdadd5c795a2762fc9 
* #14704
* #14572

## How Has This Been Tested?
API 33 emulator

<img width="347" alt="Screenshot 2023-11-14 at 12 33 22" src="https://github.com/ankidroid/Anki-Android/assets/62114487/5f71c447-ee4c-4b08-a40e-9b3796d0d19d">


## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
