### PR TITLE
fix: timebox showing immediately

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
@@ -93,6 +93,7 @@ import java.io.File
 import java.util.function.Consumer
 
 @KotlinCleanup("too many to count")
+@NeedsTest("#14709: Timebox shouldn't appear instantly when the Reviewer is opened")
 open class Reviewer :
     AbstractFlashcardViewer(),
     ReviewerUi {
@@ -294,7 +295,10 @@ open class Reviewer :
             toggleStylus = MetaDB.getWhiteboardStylusState(this, parentDid)
             whiteboard!!.toggleStylus = toggleStylus
         }
-        launchCatchingTask { updateCardAndRedraw() }
+        launchCatchingTask {
+            withCol { startTimebox() }
+            updateCardAndRedraw()
+        }
         disableDrawerSwipeOnConflicts()
 
         // Set full screen/immersive mode if needed


### PR DESCRIPTION
## Purpose / Description
* #14709 : https://github.com/ankidroid/Anki-Android/commit/67bb409f7a4c8f82d6d4bd745b507ac41c89c3fe removed a call to `startTimebox`

## Fixes 
* Fixes #14709
* Fixes #14614

## Approach
*  call `startTimebox`

## How Has This Been Tested?
API 33 emulator


## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
