### PR TITLE
chore: inline note.model() => note.notetype

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplatePreviewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplatePreviewer.kt
@@ -232,7 +232,7 @@ open class CardTemplatePreviewer : AbstractFlashcardViewer() {
             // loading from the note editor
             val toPreview = setCurrentCardFromNoteEditorBundle(col)
             if (toPreview != null) {
-                mTemplateCount = toPreview.note().model().templatesNames.size
+                mTemplateCount = toPreview.note().notetype.templatesNames.size
                 if (mTemplateCount >= 2) {
                     previewLayout!!.showNavigationButtons()
                 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
@@ -370,7 +370,7 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
         // Deck Selector
         val deckTextView = findViewById<TextView>(R.id.CardEditorDeckText)
         // If edit mode and more than one card template distinguish between "Deck" and "Card deck"
-        if (!addNote && mEditorNote!!.model().getJSONArray("tmpls").length() > 1) {
+        if (!addNote && mEditorNote!!.notetype.getJSONArray("tmpls").length() > 1) {
             deckTextView.setText(R.string.CardEditorCardDeck)
         }
         mDeckSpinnerSelection =
@@ -706,7 +706,7 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
                 updateField(f)
             }
             // Save deck to model
-            mEditorNote!!.model().put("did", deckId)
+            mEditorNote!!.notetype.put("did", deckId)
             // Save tags to model
             mEditorNote!!.setTagsFromStr(tagsAsString(mSelectedTags!!))
             val tags = JSONArray()
@@ -990,7 +990,7 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
         }
         previewer.putExtra(
             CardTemplateNotetype.INTENT_MODEL_FILENAME,
-            CardTemplateNotetype.saveTempModel(this, mEditorNote!!.model())
+            CardTemplateNotetype.saveTempModel(this, mEditorNote!!.notetype)
         )
 
         // Send the previewer all our current editing information
@@ -1190,7 +1190,7 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
                     Timber.d("onActivityResult() template edit return - current card exists")
                     // reload current card - the template ordinals are possibly different post-edit
                     mCurrentEditedCard = getColUnsafe.getCard(mCurrentEditedCard!!.id)
-                    updateCards(mEditorNote!!.model())
+                    updateCards(mEditorNote!!.notetype)
                 }
             }
         }
@@ -1220,14 +1220,14 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
      */
     @KotlinCleanup("fix the requireNoNulls")
     private fun getCurrentMultimediaEditableNote(col: Collection): MultimediaEditableNote {
-        val note = NoteService.createEmptyNote(mEditorNote!!.model())
+        val note = NoteService.createEmptyNote(mEditorNote!!.notetype)
         val fields = currentFieldStrings.requireNoNulls()
         NoteService.updateMultimediaNoteFromFields(col, fields, mEditorNote!!.mid, note!!)
         return note
     }
 
     val currentFields: JSONArray
-        get() = mEditorNote!!.model().getJSONArray("flds")
+        get() = mEditorNote!!.notetype.getJSONArray("flds")
 
     @get:CheckResult
     val currentFieldStrings: Array<String?>
@@ -1646,7 +1646,7 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
         setNoteTypePosition()
         setDid(note)
         updateTags()
-        updateCards(mEditorNote!!.model())
+        updateCards(mEditorNote!!.notetype)
         updateToolbar()
         populateEditFields(changeType, false)
         updateFieldsFromStickyText()
@@ -1681,7 +1681,7 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
             toolbar.visibility = View.VISIBLE
         }
         toolbar.clearCustomItems()
-        if (mEditorNote!!.model().isCloze) {
+        if (mEditorNote!!.notetype.isCloze) {
             addClozeButton(
                 drawableRes = R.drawable.ic_cloze_new_card,
                 description = TR.editingClozeDeletion(),
@@ -1836,7 +1836,7 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
 
     private fun setNoteTypePosition() {
         // Set current note type and deck positions in spinners
-        val position = mAllModelIds!!.indexOf(mEditorNote!!.model().getLong("id"))
+        val position = mAllModelIds!!.indexOf(mEditorNote!!.notetype.getLong("id"))
         // set selection without firing selectionChanged event
         mNoteTypeSpinner!!.setSelection(position, false)
     }
@@ -1861,7 +1861,7 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
         for (i in 0 until tmpls.length()) {
             var name = tmpls.getJSONObject(i).optString("name")
             // If more than one card, and we have an existing card, underline existing card
-            if (!addNote && tmpls.length() > 1 && model === mEditorNote!!.model() && mCurrentEditedCard != null && mCurrentEditedCard!!.template()
+            if (!addNote && tmpls.length() > 1 && model === mEditorNote!!.notetype && mCurrentEditedCard != null && mCurrentEditedCard!!.template()
                 .optString("name") == name
             ) {
                 name = "<u>$name</u>"
@@ -1872,7 +1872,7 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
             }
         }
         // Make cards list red if the number of cards is being reduced
-        if (!addNote && tmpls.length() < mEditorNote!!.model().getJSONArray("tmpls").length()) {
+        if (!addNote && tmpls.length() < mEditorNote!!.notetype.getJSONArray("tmpls").length()) {
             cardsList = StringBuilder("<font color='red'>$cardsList</font>")
         }
         mCardsButton!!.text = HtmlCompat.fromHtml(

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Card.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Card.kt
@@ -265,7 +265,7 @@ open class Card : Cloneable {
 
     // not in upstream
     open fun model(): NotetypeJson {
-        return note().model()
+        return note().notetype
     }
 
     fun template(): JSONObject {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.kt
@@ -526,7 +526,7 @@ JOIN cards AS c ON card_with_min_ord.nid = c.nid AND card_with_min_ord.ord = c.o
     /** allowEmpty is ignored in the new schema */
     @RustCleanup("Remove this in favour of addNote() above; call addNote() inside undoableOp()")
     fun addNote(note: Note): Int {
-        addNote(note, note.model().did)
+        addNote(note, note.notetype.did)
         return note.numberOfCards()
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Note.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Note.kt
@@ -140,11 +140,6 @@ class Note : Cloneable {
         )
     }
 
-    @KotlinCleanup("replace with variable")
-    fun model(): NotetypeJson {
-        return notetype
-    }
-
     /**
      * Dict interface
      * ***********************************************************

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/TemplateManager.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/TemplateManager.kt
@@ -127,7 +127,7 @@ class TemplateManager {
         private var _fill_empty: Boolean = fill_empty
 
 //      private var _fields: HashMap<String, String>? = null
-        private var _note_type: NotetypeJson = notetype ?: note.model()
+        private var _note_type: NotetypeJson = notetype ?: note.notetype
 
         companion object {
             fun fromExistingCard(card: Card, browser: Boolean): TemplateRenderContext {

--- a/AnkiDroid/src/test/java/com/ichi2/anki/NoteEditorTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/NoteEditorTest.kt
@@ -199,7 +199,7 @@ class NoteEditorTest : RobolectricTest() {
         val currentDid = addDeck("Basic::Test")
         col.config.set(CURRENT_DECK, currentDid)
         val n = super.addNoteUsingBasicModel("Test", "Note")
-        n.model().put("did", currentDid)
+        n.notetype.put("did", currentDid)
         val editor = getNoteEditorEditingExistingBasicNote("Test", "Note", DECK_LIST)
         col.config.set(CURRENT_DECK, Consts.DEFAULT_DECK_ID) // Change DID if going through default path
         val copyNoteIntent = getCopyNoteIntent(editor)

--- a/AnkiDroid/src/test/java/com/ichi2/anki/ReviewerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/ReviewerTest.kt
@@ -327,7 +327,7 @@ class ReviewerTest : RobolectricTest() {
 
         val newNote = col.newNote()
         newNote.setField(0, "Hello")
-        assertThat(newNote.model()["name"], equalTo("Three"))
+        assertThat(newNote.notetype["name"], equalTo("Three"))
 
         assertThat(col.addNote(newNote), equalTo(3))
     }

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/DecksTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/DecksTest.kt
@@ -39,7 +39,7 @@ class DecksTest : JvmTest() {
         val deck1 = addDeck("deck1")
         val note = col.newNote()
         note.setItem("Front", "1")
-        note.model().put("did", deck1)
+        note.notetype.put("did", deck1)
         col.addNote(note)
         val c = note.cards()[0]
         assertEquals(deck1, c.did)

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/ModelTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/ModelTest.kt
@@ -331,7 +331,7 @@ class NotetypeTest : JvmTest() {
         val col = col
         col.notetypes.setCurrent(col.notetypes.byName("Cloze")!!)
         var note = col.newNote()
-        assertEquals("Cloze", note.model().getString("name"))
+        assertEquals("Cloze", note.notetype.getString("name"))
         // a cloze model with no clozes is not empty
         note.setItem("Text", "nothing")
         assertEquals(1, col.addNote(note))

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/NoteWithColTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/NoteWithColTest.kt
@@ -31,6 +31,6 @@ class NoteWithColTest : JvmTest() {
     @Config(qualifiers = "en")
     fun newNoteTest() {
         val note = col.newNote()
-        assertThat(note.model()["name"], equalTo("Basic"))
+        assertThat(note.notetype["name"], equalTo("Basic"))
     }
 }

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/SchedulerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/SchedulerTest.kt
@@ -178,7 +178,7 @@ open class SchedulerTest : JvmTest() {
             val note = col.newNote()
             note.setItem("Front", i.toString())
             if (i > 4) {
-                note.model().put("did", deck2)
+                note.notetype.put("did", deck2)
             }
             col.addNote(note)
         }
@@ -1163,7 +1163,7 @@ open class SchedulerTest : JvmTest() {
         note = col.newNote()
         note.setItem("Front", "two")
         val default1 = addDeck("Default::1")
-        note.model().put("did", default1)
+        note.notetype.put("did", default1)
         col.addNote(note)
         // make it a review card
         val c = note.cards()[0]
@@ -1173,12 +1173,12 @@ open class SchedulerTest : JvmTest() {
         // add one more with a new deck
         note = col.newNote()
         note.setItem("Front", "two")
-        note.model().put("did", addDeck("foo::bar"))
+        note.notetype.put("did", addDeck("foo::bar"))
         col.addNote(note)
         // and one that's a sibling
         note = col.newNote()
         note.setItem("Front", "three")
-        note.model().put("did", addDeck("foo::baz"))
+        note.notetype.put("did", addDeck("foo::baz"))
         col.addNote(note)
         Assert.assertEquals(5, col.decks.allNamesAndIds().size.toLong())
         val tree = col.sched.deckDueTree().children[0]
@@ -1226,13 +1226,13 @@ open class SchedulerTest : JvmTest() {
         note = col.newNote()
         note.setItem("Front", "two")
         var default1 = addDeck("Default::2")
-        note.model().put("did", default1)
+        note.notetype.put("did", default1)
         col.addNote(note)
         // and another that's higher up
         note = col.newNote()
         note.setItem("Front", "three")
         default1 = addDeck("Default::1")
-        note.model().put("did", default1)
+        note.notetype.put("did", default1)
         col.addNote(note)
         // should get top level one first, then ::1, then ::2
         Assert.assertEquals(Counts(3, 0, 0), col.sched.counts())


### PR DESCRIPTION
Used the IDE inline functionality

Untested, unit tests should do