### PR TITLE
Match `Settings` and `Permissions screen` app bar and status bar colors 

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/Preferences.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/Preferences.kt
@@ -41,6 +41,7 @@ import com.ichi2.anki.CollectionManager.withCol
 import com.ichi2.anki.services.BootService.Companion.scheduleNotification
 import com.ichi2.libanki.Collection
 import com.ichi2.libanki.utils.TimeManager
+import com.ichi2.themes.setTransparentStatusBar
 import com.ichi2.utils.getInstanceFromClassName
 import timber.log.Timber
 import java.util.*
@@ -64,6 +65,7 @@ class Preferences :
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.preferences)
+        setTransparentStatusBar()
 
         enableToolbar().setDisplayHomeAsUpEnabled(true)
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/permissions/PermissionsActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/permissions/PermissionsActivity.kt
@@ -27,6 +27,7 @@ import com.ichi2.anki.AnkiActivity
 import com.ichi2.anki.PermissionSet
 import com.ichi2.anki.R
 import com.ichi2.annotations.NeedsTest
+import com.ichi2.themes.setTransparentStatusBar
 
 /**
  * Screen responsible for getting permissions from the user.
@@ -47,6 +48,7 @@ class PermissionsActivity : AnkiActivity() {
         }
         super.onCreate(savedInstanceState)
         setContentView(R.layout.permissions_activity)
+        setTransparentStatusBar()
 
         findViewById<AppCompatButton>(R.id.continue_button).setOnClickListener {
             finish()

--- a/AnkiDroid/src/main/java/com/ichi2/themes/Themes.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/themes/Themes.kt
@@ -21,9 +21,12 @@ package com.ichi2.themes
 import android.content.Context
 import android.content.SharedPreferences
 import android.content.res.Configuration
+import android.graphics.Color
 import androidx.annotation.AttrRes
 import androidx.annotation.ColorInt
+import androidx.core.view.WindowInsetsControllerCompat
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.FragmentActivity
 import com.google.android.material.color.MaterialColors
 import com.ichi2.anki.AnkiDroidApp
 import com.ichi2.anki.R
@@ -134,4 +137,10 @@ object Themes {
         return context.resources.configuration.uiMode and Configuration.UI_MODE_NIGHT_MASK ==
             Configuration.UI_MODE_NIGHT_YES
     }
+}
+
+fun FragmentActivity.setTransparentStatusBar() {
+    WindowInsetsControllerCompat(window, window.decorView).isAppearanceLightStatusBars =
+        !Themes.currentTheme.isNightMode
+    window.statusBarColor = Color.TRANSPARENT
 }

--- a/AnkiDroid/src/main/res/layout/preferences.xml
+++ b/AnkiDroid/src/main/res/layout/preferences.xml
@@ -21,13 +21,13 @@
     android:id="@+id/root_layout"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:fitsSystemWindows="true"
     tools:context=".preferences.Preferences">
 
     <com.google.android.material.appbar.AppBarLayout
         android:id="@+id/appbar"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:fitsSystemWindows="true">
+        android:layout_height="wrap_content">
 
         <com.google.android.material.appbar.CollapsingToolbarLayout
             android:id="@+id/collapsingToolbarLayout"
@@ -38,7 +38,7 @@
             app:toolbarId="@id/toolbar">
 
             <com.google.android.material.appbar.MaterialToolbar
-                android:id="@id/toolbar"
+                android:id="@+id/toolbar"
                 android:layout_width="match_parent"
                 android:layout_height="?attr/actionBarSize"
                 app:layout_collapseMode="pin"

--- a/AnkiDroid/src/main/res/values/theme_dark.xml
+++ b/AnkiDroid/src/main/res/values/theme_dark.xml
@@ -14,6 +14,7 @@
         <item name="colorPrimary">@color/material_blue_400</item>
         <item name="colorOnPrimary">@color/white</item>
         <item name="colorPrimaryDark">@color/theme_dark_primary_dark</item>
+        <item name="colorSurface">?android:colorBackground</item>
         <item name="colorAccent">@color/material_blue_400</item>
         <item name="colorOnSurface">@color/white</item>
         <item name="colorPrimaryContainer">@color/white</item> <!-- Switch thumb color when disabled and being pressed -->
@@ -131,9 +132,6 @@
 
         <!-- Introduction -->
         <item name="introductionLogoTransparent">#883d3d3d</item>
-
-        <!-- Browser Options Dialog-->
-        <item name="colorSurface">@color/theme_dark_primary</item>
 
         <!-- Widget styles -->
         <item name="switchPreferenceCompatStyle">@style/Preference.SwitchPreferenceCompat.Material3</item>


### PR DESCRIPTION
## Purpose / Description
The status bar color didn't match the app bar in the new settings layout and in the permissions activity

## Fixes
* Part of #13878 

## Approach
In the commits

## How Has This Been Tested?

### Emulator 24

![231115060920](https://github.com/ankidroid/Anki-Android/assets/69634269/2f8e8d4c-3f3d-450f-8af2-4c9a38e60425)

[Screen_recording_20231115_060947.webm](https://github.com/ankidroid/Anki-Android/assets/69634269/3752abf4-89f1-4df4-9aa8-d5ff3c7a4259)

### Emulator 33 resizable

![231115061704-Discord__#ankidroid-design__Anki_e_mais_3_páginas_](https://github.com/ankidroid/Anki-Android/assets/69634269/c358cd7b-7947-4765-a359-f4d7ad1585ad)

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [x] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
