### PR TITLE
add redo button and control

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
@@ -304,6 +304,10 @@ open class Reviewer :
         setRenderWorkaround(this)
     }
 
+    fun redo() {
+        launchCatchingTask { redoAndShowSnackbar(ACTION_SNACKBAR_TIME) }
+    }
+
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
         // 100ms was not enough on my device (Honor 9 Lite -  Android Pie)
         delayedHide(1000)
@@ -322,6 +326,10 @@ open class Reviewer :
                 } else {
                     undo()
                 }
+            }
+            R.id.action_redo -> {
+                Timber.i("Reviewer:: Redo button pressed")
+                redo()
             }
             R.id.action_reset_card_progress -> {
                 Timber.i("Reviewer:: Reset progress button pressed")
@@ -717,6 +725,17 @@ open class Reviewer :
                 // so in some languages such as Japanese, which have pre/post-positional particle with the object,
                 // we need to use the string for just "Undo" instead of the string for "Undo %s".
                 undoIcon.title = resources.getString(R.string.undo)
+            }
+            menu.findItem(R.id.action_redo)?.apply {
+                if (getColUnsafe.redoAvailable()) {
+                    title = getColUnsafe.redoLabel()
+                    iconAlpha = Themes.ALPHA_ICON_ENABLED_LIGHT
+                    isEnabled = true
+                } else {
+                    setTitle(R.string.redo)
+                    iconAlpha = Themes.ALPHA_ICON_DISABLED_LIGHT
+                    isEnabled = false
+                }
             }
         }
         if (undoEnabled) {
@@ -1142,6 +1161,10 @@ open class Reviewer :
             }
             ViewerCommand.MARK -> {
                 onMark(currentCard)
+                return true
+            }
+            ViewerCommand.REDO -> {
+                redo()
                 return true
             }
             ViewerCommand.ADD_NOTE -> {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Undo.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Undo.kt
@@ -21,6 +21,7 @@ import anki.collection.OpChangesAfterUndo
 import com.google.android.material.snackbar.Snackbar
 import com.ichi2.anki.CollectionManager.TR
 import com.ichi2.anki.snackbar.showSnackbar
+import com.ichi2.libanki.redo
 import com.ichi2.libanki.undo
 import com.ichi2.libanki.undoableOp
 
@@ -38,6 +39,24 @@ suspend fun FragmentActivity.undoAndShowSnackbar(duration: Int = Snackbar.LENGTH
             TR.actionsNothingToUndo()
         } else {
             TR.undoActionUndone(changes.operation)
+        }
+        showSnackbar(message, duration)
+    }
+}
+
+suspend fun FragmentActivity.redoAndShowSnackbar(duration: Int = Snackbar.LENGTH_SHORT) {
+    withProgress {
+        val changes = undoableOp {
+            if (redoAvailable()) {
+                redo()
+            } else {
+                OpChangesAfterUndo.getDefaultInstance()
+            }
+        }
+        val message = if (changes.operation.isEmpty()) {
+            TR.actionsNothingToRedo()
+        } else {
+            TR.undoActionRedone(changes.operation)
         }
         showSnackbar(message, duration)
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/analytics/UsageAnalytics.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/analytics/UsageAnalytics.kt
@@ -500,6 +500,7 @@ object UsageAnalytics {
         "binding_FLIP_OR_ANSWER_EASE3",
         "binding_FLIP_OR_ANSWER_EASE4",
         "binding_UNDO",
+        "binding_REDO",
         "binding_EDIT",
         "binding_MARK",
         "binding_BURY_CARD",
@@ -553,6 +554,7 @@ object UsageAnalytics {
         // App bar buttons
         "reset_custom_buttons",
         "customButtonUndo",
+        "customButtonRedo",
         "customButtonScheduleCard",
         "customButtonFlag",
         "customButtonEditCard",

--- a/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/ViewerCommand.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/ViewerCommand.kt
@@ -40,6 +40,7 @@ enum class ViewerCommand(val resourceId: Int) {
     FLIP_OR_ANSWER_EASE3(R.string.answer_good),
     FLIP_OR_ANSWER_EASE4(R.string.answer_easy),
     UNDO(R.string.undo),
+    REDO(R.string.redo),
     EDIT(R.string.cardeditor_title_edit_card),
     MARK(R.string.menu_mark_note),
     BURY_CARD(R.string.menu_bury_card),
@@ -157,6 +158,7 @@ enum class ViewerCommand(val resourceId: Int) {
                 REPLAY_VOICE -> from(keyCode(KeyEvent.KEYCODE_V, CardSide.BOTH))
                 RECORD_VOICE -> from(keyCode(KeyEvent.KEYCODE_V, CardSide.BOTH, shift()))
                 UNDO -> from(keyCode(KeyEvent.KEYCODE_Z, CardSide.BOTH))
+                REDO -> from(keyCode(KeyEvent.KEYCODE_Z, CardSide.BOTH, ModifierKeys(shift = true, ctrl = true, alt = false)))
                 TOGGLE_FLAG_RED -> from(keyCode(KeyEvent.KEYCODE_1, CardSide.BOTH, ctrl()), keyCode(KeyEvent.KEYCODE_NUMPAD_1, CardSide.BOTH, ctrl()))
                 TOGGLE_FLAG_ORANGE -> from(keyCode(KeyEvent.KEYCODE_2, CardSide.BOTH, ctrl()), keyCode(KeyEvent.KEYCODE_NUMPAD_2, CardSide.BOTH, ctrl()))
                 TOGGLE_FLAG_GREEN -> from(keyCode(KeyEvent.KEYCODE_3, CardSide.BOTH, ctrl()), keyCode(KeyEvent.KEYCODE_NUMPAD_3, CardSide.BOTH, ctrl()))

--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/CustomButtonsSettingsFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/CustomButtonsSettingsFragment.kt
@@ -39,26 +39,9 @@ class CustomButtonsSettingsFragment : SettingsFragment() {
                 positiveButton(R.string.reset) {
                     // Reset the settings to default
                     requireContext().sharedPrefs().edit {
-                        remove("customButtonUndo")
-                        remove("customButtonScheduleCard")
-                        remove("customButtonEditCard")
-                        remove("customButtonTags")
-                        remove("customButtonAddCard")
-                        remove("customButtonReplay")
-                        remove("customButtonCardInfo")
-                        remove("customButtonSelectTts")
-                        remove("customButtonDeckOptions")
-                        remove("customButtonMarkCard")
-                        remove("customButtonToggleMicToolBar")
-                        remove("customButtonBury")
-                        remove("customButtonSuspend")
-                        remove("customButtonFlag")
-                        remove("customButtonDelete")
-                        remove("customButtonEnableWhiteboard")
-                        remove("customButtonSaveWhiteboard")
-                        remove("customButtonWhiteboardPenColor")
-                        remove("customButtonClearWhiteboard")
-                        remove("customButtonShowHideWhiteboard")
+                        allKeys().forEach {
+                            remove(it)
+                        }
                     }
                     // #9263: refresh the screen to display the changes
                     refreshScreen()

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/ActionButtonStatus.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/ActionButtonStatus.kt
@@ -34,6 +34,7 @@ class ActionButtonStatus(private val reviewerUi: ReviewerUi) {
     fun setup(preferences: SharedPreferences) {
         // NOTE: the default values below should be in sync with preferences_custom_buttons.xml and reviewer.xml
         setupButton(preferences, R.id.action_undo, "customButtonUndo", SHOW_AS_ACTION_ALWAYS)
+        setupButton(preferences, R.id.action_redo, "customButtonRedo", SHOW_AS_ACTION_IF_ROOM)
         setupButton(preferences, R.id.action_schedule, "customButtonScheduleCard", SHOW_AS_ACTION_NEVER)
         setupButton(preferences, R.id.action_flag, "customButtonFlag", SHOW_AS_ACTION_ALWAYS)
         setupButton(preferences, R.id.action_tag, "customButtonTags", SHOW_AS_ACTION_NEVER)

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.kt
@@ -497,6 +497,15 @@ JOIN cards AS c ON card_with_min_ord.nid = c.nid AND card_with_min_ord.ord = c.o
         return status.undo != null
     }
 
+    fun redoLabel(): String? {
+        val action = undoStatus().redo
+        return action?.let { tr.undoRedoAction(it) }
+    }
+
+    fun redoAvailable(): Boolean {
+        return undoStatus().redo != null
+    }
+
     open fun onCreate() {
         sched.useNewTimezoneCode()
         config.set("schedVer", 2)

--- a/AnkiDroid/src/main/java/com/ichi2/ui/RtlCompliantActionProvider.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/ui/RtlCompliantActionProvider.kt
@@ -46,7 +46,6 @@ class RtlCompliantActionProvider(context: Context) : ActionProviderCompat(contex
             it.isAutoMirrored = true
             actionView.setImageDrawable(it)
         }
-        actionView.id = R.id.action_undo
         actionView.setOnClickListener {
             if (!forItem.isEnabled) {
                 return@setOnClickListener

--- a/AnkiDroid/src/main/res/drawable/ic_redo.xml
+++ b/AnkiDroid/src/main/res/drawable/ic_redo.xml
@@ -1,0 +1,5 @@
+<vector android:autoMirrored="true" android:height="24dp"
+    android:tint="?attr/colorControlNormal" android:viewportHeight="24"
+    android:viewportWidth="24" android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M18.4,10.6C16.55,8.99 14.15,8 11.5,8c-4.65,0 -8.58,3.03 -9.96,7.22L3.9,16c1.05,-3.19 4.05,-5.5 7.6,-5.5 1.95,0 3.73,0.72 5.12,1.88L13,16h9V7l-3.6,3.6z"/>
+</vector>

--- a/AnkiDroid/src/main/res/menu/reviewer.xml
+++ b/AnkiDroid/src/main/res/menu/reviewer.xml
@@ -10,6 +10,12 @@
         ankidroid:actionProviderClass="com.ichi2.ui.RtlCompliantActionProvider"
         ankidroid:showAsAction="always"/>
     <item
+        android:id="@+id/action_redo"
+        android:enabled="false"
+        android:icon="@drawable/ic_redo"
+        android:title="@string/redo"
+        ankidroid:showAsAction="always"/>
+    <item
         android:id="@+id/action_clear_whiteboard"
         android:title="@string/clear_whiteboard"
         android:icon="@drawable/ic_clear_white"

--- a/AnkiDroid/src/main/res/menu/reviewer.xml
+++ b/AnkiDroid/src/main/res/menu/reviewer.xml
@@ -14,6 +14,7 @@
         android:enabled="false"
         android:icon="@drawable/ic_redo"
         android:title="@string/redo"
+        ankidroid:actionProviderClass="com.ichi2.ui.RtlCompliantActionProvider"
         ankidroid:showAsAction="always"/>
     <item
         android:id="@+id/action_clear_whiteboard"

--- a/AnkiDroid/src/main/res/values/01-core.xml
+++ b/AnkiDroid/src/main/res/values/01-core.xml
@@ -65,6 +65,7 @@
     <string name="ease_button_easy">Easy</string>
     <string name="menu_import">Import</string>
     <string name="undo">Undo</string>
+    <string name="redo">Redo</string>
     <string name="undo_action_whiteboard_last_stroke" comment="One of the display patterns of 'Undo' item on the action menu in Reviewer. It is shown as the title of the item when the whiteboard (handwriting) feature is enabled and visible and has any strokes (handwritten lines)">Undo stroke</string>
     <string name="move_all_to_deck">Move all to deck</string>
     <string name="unbury">Unbury</string>

--- a/AnkiDroid/src/main/res/values/preferences.xml
+++ b/AnkiDroid/src/main/res/values/preferences.xml
@@ -51,6 +51,7 @@
     <string name="pref_app_bar_buttons_screen_key">appBarButtonsScreen</string>
     <string name="reset_custom_buttons_key">reset_custom_buttons</string>
     <string name="custom_button_undo_key">customButtonUndo</string>
+    <string name="custom_button_redo_key">customButtonRedo</string>
     <string name="custom_button_schedule_card_key">customButtonScheduleCard</string>
     <string name="custom_button_flag_key">customButtonFlag</string>
     <string name="custom_button_edit_card_key">customButtonEditCard</string>
@@ -83,6 +84,7 @@
     <string name="answer_good_command_key">binding_FLIP_OR_ANSWER_EASE3</string>
     <string name="answer_easy_command_key">binding_FLIP_OR_ANSWER_EASE4</string>
     <string name="undo_command_key">binding_UNDO</string>
+    <string name="redo_command_key">binding_REDO</string>
     <string name="edit_command_key">binding_EDIT</string>
     <string name="mark_command_key">binding_MARK</string>
     <string name="bury_card_command_key">binding_BURY_CARD</string>

--- a/AnkiDroid/src/main/res/xml/preferences_controls.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_controls.xml
@@ -237,6 +237,11 @@
             android:icon="@drawable/ic_undo_white"
             />
         <com.ichi2.preferences.ControlPreference
+            android:key="@string/redo_command_key"
+            android:title="@string/redo"
+            android:icon="@drawable/ic_redo"
+            />
+        <com.ichi2.preferences.ControlPreference
             android:key="@string/show_hint_command_key"
             android:title="@string/gesture_show_hint"
             />

--- a/AnkiDroid/src/main/res/xml/preferences_custom_buttons.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_custom_buttons.xml
@@ -41,6 +41,13 @@ TODO: Add a unit test
             android:title="@string/undo"
             app:useSimpleSummaryProvider="true"/>
         <ListPreference
+            android:defaultValue="1"
+            android:entries="@array/custom_button_labels"
+            android:entryValues="@array/custom_button_values"
+            android:key="@string/custom_button_redo_key"
+            android:title="@string/redo"
+            app:useSimpleSummaryProvider="true"/>
+        <ListPreference
             android:defaultValue="0"
             android:entries="@array/custom_button_labels"
             android:entryValues="@array/custom_button_values"

--- a/AnkiDroid/src/test/java/com/ichi2/anki/cardviewer/ViewerCommandTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/cardviewer/ViewerCommandTest.kt
@@ -32,7 +32,7 @@ class ViewerCommandTest {
         assertEquals(
             "binding_SHOW_ANSWER, binding_FLIP_OR_ANSWER_EASE1, " +
                 "binding_FLIP_OR_ANSWER_EASE2, binding_FLIP_OR_ANSWER_EASE3, binding_FLIP_OR_ANSWER_EASE4, " +
-                "binding_UNDO, binding_EDIT, binding_MARK, binding_BURY_CARD, " +
+                "binding_UNDO, binding_REDO, binding_EDIT, binding_MARK, binding_BURY_CARD, " +
                 "binding_SUSPEND_CARD, binding_DELETE, binding_PLAY_MEDIA, " +
                 "binding_EXIT, binding_BURY_NOTE, binding_SUSPEND_NOTE, binding_TOGGLE_FLAG_RED, " +
                 "binding_TOGGLE_FLAG_ORANGE, binding_TOGGLE_FLAG_GREEN, binding_TOGGLE_FLAG_BLUE, " +


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
Added option to redo card

## Fixes
* Fixes #14030 

## Approach
_How does this change address the problem?_

## How Has This Been Tested?

In emulator 34, I undid a card answered then tapped the redo button. I did that with the control with ctrl+shift+z too

![image](https://github.com/ankidroid/Anki-Android/assets/65715921/ef4cf88e-5690-4363-b960-b9a3b984d9bf)

![image](https://github.com/ankidroid/Anki-Android/assets/65715921/6a43ff66-b90c-496e-a745-c884f1e0daad)

## Learning (optional, can help others)
_Describe the research stage_

_Links to blog posts, patterns, libraries or addons used to solve this problem_

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
