### PR TITLE
feat: use material toolbar at manage space activity

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/managespace/ManageSpaceActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/managespace/ManageSpaceActivity.kt
@@ -20,6 +20,7 @@ package com.ichi2.anki.ui.windows.managespace
 import android.os.Bundle
 import com.ichi2.anki.AnkiActivity
 import com.ichi2.anki.R
+import com.ichi2.themes.setTransparentStatusBar
 
 class ManageSpaceActivity : AnkiActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -29,11 +30,8 @@ class ManageSpaceActivity : AnkiActivity() {
 
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_manage_space)
+        setTransparentStatusBar()
 
-        enableToolbar().apply {
-            setHomeButtonEnabled(true)
-            setDisplayHomeAsUpEnabled(true)
-            setTitle(R.string.pref__manage_space__screen_title)
-        }
+        enableToolbar().setDisplayHomeAsUpEnabled(true)
     }
 }

--- a/AnkiDroid/src/main/res/layout/activity_manage_space.xml
+++ b/AnkiDroid/src/main/res/layout/activity_manage_space.xml
@@ -1,18 +1,59 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~  This program is free software; you can redistribute it and/or modify it under
+  ~  the terms of the GNU General Public License as published by the Free Software
+  ~  Foundation; either version 3 of the License, or (at your option) any later
+  ~  version.
+  ~
+  ~  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+  ~  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+  ~  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+  ~
+  ~  You should have received a copy of the GNU General Public License along with
+  ~  this program.  If not, see <http://www.gnu.org/licenses/>.
+  -->
 <androidx.coordinatorlayout.widget.CoordinatorLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/root_layout"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    >
+    android:fitsSystemWindows="true"
+    tools:context=".ui.windows.managespace.ManageSpaceActivity">
 
-    <include layout="@layout/toolbar" />
+    <com.google.android.material.appbar.AppBarLayout
+        android:id="@+id/appbar"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+
+        <com.google.android.material.appbar.CollapsingToolbarLayout
+            android:id="@+id/collapsingToolbarLayout"
+            style="?collapsingToolbarLayoutMediumStyle"
+            android:layout_width="match_parent"
+            android:layout_height="?collapsingToolbarLayoutMediumSize"
+            app:layout_scrollFlags="scroll|exitUntilCollapsed|snap"
+            app:toolbarId="@id/toolbar"
+            app:title="@string/pref__manage_space__screen_title">
+
+            <com.google.android.material.appbar.MaterialToolbar
+                android:id="@+id/toolbar"
+                android:layout_width="match_parent"
+                android:layout_height="?attr/actionBarSize"
+                app:layout_collapseMode="pin"
+                app:navigationContentDescription="@string/abc_action_bar_up_description"
+                app:navigationIcon="?attr/homeAsUpIndicator"
+                />
+
+        </com.google.android.material.appbar.CollapsingToolbarLayout>
+
+    </com.google.android.material.appbar.AppBarLayout>
 
     <androidx.fragment.app.FragmentContainerView
         android:id="@+id/fragment_container"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:layout_marginTop="?attr/actionBarSize"
+        app:layout_behavior="com.google.android.material.appbar.AppBarLayout$ScrollingViewBehavior"
         android:name="com.ichi2.anki.ui.windows.managespace.ManageSpaceFragment"
         />
 


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
Making the app more beautiful

## Fixes
* Part of #13878 

## Approach
Similar to what I did at #14603. Note that I don't want every toolbar in the app to be collapsible, but this one made sense, since this is a screen that use `Preference`s just like the Settings' one. Plus also it looked good IMO.

## How Has This Been Tested?

Emulator 24

[manage.webm](https://github.com/ankidroid/Anki-Android/assets/69634269/3db03154-f105-410b-929b-7e75fff1b304)

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
