### PR TITLE
refactor: remove appIntro dependency

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -361,7 +361,6 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
     implementation "org.jetbrains.kotlin:kotlin-test:$kotlin_version"
     implementation 'com.github.ByteHamster:SearchPreference:2.4.0'
-    implementation 'com.github.AppIntro:AppIntro:6.3.1'
 
     // Cannot use debugImplementation since classes need to be imported in AnkiDroidApp
     // and there's no no-op version for release build. Usage has been disabled for release

--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/LayoutValidationTest.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/LayoutValidationTest.kt
@@ -101,7 +101,10 @@ class LayoutValidationTest : InstrumentedTest() {
             // with a specified fragment name, as these would currently fail the test, throwing:
             //   UnsupportedOperationException: FragmentContainerView must be within
             //   a FragmentActivity to use android:name="..."
-            val ignoredLayoutIds = listOf(com.ichi2.anki.R.layout.activity_manage_space)
+            val ignoredLayoutIds = listOf(
+                com.ichi2.anki.R.layout.activity_manage_space,
+                com.ichi2.anki.R.layout.introduction_activity
+            )
 
             return layout::class.java.fields
                 .map { arrayOf(it.getInt(layout), it.name) }

--- a/AnkiDroid/src/main/res/layout/introduction_activity.xml
+++ b/AnkiDroid/src/main/res/layout/introduction_activity.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.coordinatorlayout.widget.CoordinatorLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:id="@+id/root_layout">
+
+    <androidx.fragment.app.FragmentContainerView
+        android:id="@+id/fragment_container"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:name="com.ichi2.anki.introduction.SetupCollectionFragment"/>
+
+</androidx.coordinatorlayout.widget.CoordinatorLayout>


### PR DESCRIPTION
It didn't have any special use that we couldn't deal with ease without it

## How Has This Been Tested?

Emulator 24. Haven't tested CI because I'm leaving home right now

[intro.webm](https://github.com/ankidroid/Anki-Android/assets/69634269/607ba15d-d609-4b22-9eec-1b0c0931e271)

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
