### PR TITLE
build(deps): ignore commons-compress below 1.26

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,4 +19,4 @@ updates:
   # We cannot update this one until API26. Ignore range should slide with known versions so we stay informed.
   - dependency-name: org.apache.commons:commons-compress
     versions:
-    - ">= 1.12, < 1.25"
+    - ">= 1.12, < 1.26"


### PR DESCRIPTION
We are still not minSdkVersion >= API26 so we may not advance this dependency yet, we just notch this forward one version at a time so we continue to be aware of their releases, but ignore them for now

`File.toPath` is used in `TarArchiveEntry`

