### PR TITLE
Fix ExportReadyDialog not being restored from notification

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -184,7 +184,7 @@ open class DeckPicker :
     private lateinit var mRecyclerViewLayoutManager: LinearLayoutManager
     private lateinit var mDeckListAdapter: DeckAdapter
     private val mSnackbarShowHideCallback = Snackbar.Callback()
-    private lateinit var mExportingDelegate: ActivityExportingDelegate
+    lateinit var mExportingDelegate: ActivityExportingDelegate
     private lateinit var mNoDecksPlaceholder: LinearLayout
     lateinit var mPullToSyncWrapper: SwipeRefreshLayout
         private set

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DialogHandler.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DialogHandler.kt
@@ -116,6 +116,7 @@ abstract class DialogHandlerMessage protected constructor(val which: WhichDialog
                 WhichDialogHandler.MSG_SHOW_FORCE_FULL_SYNC_DIALOG -> ForceFullSyncDialog.fromMessage(message)
                 WhichDialogHandler.MSG_DO_SYNC -> IntentHandler.Companion.DoSync()
                 WhichDialogHandler.MSG_MIGRATE_ON_SYNC_SUCCESS -> MigrateStorageOnSyncSuccess.MigrateOnSyncSuccessHandler()
+                WhichDialogHandler.MSG_EXPORT_READY -> ExportReadyDialog.ExportReadyDialogMessage.fromMessage(message)
             }
         }
     }
@@ -131,7 +132,8 @@ abstract class DialogHandlerMessage protected constructor(val which: WhichDialog
         MSG_SHOW_DATABASE_ERROR_DIALOG(6),
         MSG_SHOW_FORCE_FULL_SYNC_DIALOG(7),
         MSG_DO_SYNC(8),
-        MSG_MIGRATE_ON_SYNC_SUCCESS(9)
+        MSG_MIGRATE_ON_SYNC_SUCCESS(9),
+        MSG_EXPORT_READY(10)
         ;
         companion object {
             fun fromInt(value: Int) = WhichDialogHandler.values().first { it.what == value }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ExportReadyDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ExportReadyDialog.kt
@@ -18,8 +18,11 @@ package com.ichi2.anki.dialogs
 
 import android.annotation.SuppressLint
 import android.os.Bundle
+import android.os.Message
 import androidx.appcompat.app.AlertDialog
+import androidx.core.os.BundleCompat
 import androidx.core.os.bundleOf
+import com.ichi2.anki.DeckPicker
 import com.ichi2.anki.R
 import com.ichi2.utils.*
 
@@ -52,4 +55,31 @@ class ExportReadyDialog(private val listener: ExportReadyDialogListener) : Async
         get() = res().getString(R.string.export_ready_title)
 
     override val notificationMessage: String? = null
+
+    override val dialogHandlerMessage: DialogHandlerMessage
+        get() = ExportReadyDialogMessage(exportPath)
+
+    /** Export ready dialog message*/
+    class ExportReadyDialogMessage(private val exportPath: String) : DialogHandlerMessage(
+        which = WhichDialogHandler.MSG_EXPORT_READY,
+        analyticName = "ExportReadyDialog"
+    ) {
+        override fun handleAsyncMessage(deckPicker: DeckPicker) {
+            deckPicker.showDialogFragment(
+                deckPicker.mExportingDelegate.mDialogsFactory.newExportReadyDialog().withArguments(exportPath)
+            )
+        }
+
+        override fun toMessage(): Message = Message.obtain().apply {
+            what = this@ExportReadyDialogMessage.what
+            data = bundleOf("exportPath" to exportPath)
+        }
+
+        companion object {
+            fun fromMessage(message: Message): ExportReadyDialogMessage {
+                val exportPath = BundleCompat.getParcelable(message.data, "exportPath", String::class.java)!!
+                return ExportReadyDialogMessage(exportPath)
+            }
+        }
+    }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/export/ActivityExportingDelegate.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/export/ActivityExportingDelegate.kt
@@ -58,7 +58,7 @@ import java.util.function.Supplier
  * @param collectionSupplier a predicate that supplies a collection instance
 */
 class ActivityExportingDelegate(private val activity: AnkiActivity, private val collectionSupplier: Supplier<Collection>) : ExportDialogListener, ExportReadyDialogListener {
-    private val mDialogsFactory: ExportDialogsFactory
+    val mDialogsFactory: ExportDialogsFactory
     private val mSaveFileLauncher: ActivityResultLauncher<Intent>
     private lateinit var mExportFileName: String
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/export/ExportDialogsFactory.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/export/ExportDialogsFactory.kt
@@ -23,7 +23,7 @@ import com.ichi2.anki.dialogs.ExportReadyDialog
 import com.ichi2.anki.dialogs.ExportReadyDialog.ExportReadyDialogListener
 import com.ichi2.utils.ExtendedFragmentFactory
 
-internal class ExportDialogsFactory(
+class ExportDialogsFactory(
     private val ExportReadyDialogListener: ExportReadyDialogListener,
     private val exportDialogListener: ExportDialogListener
 ) : ExtendedFragmentFactory() {


### PR DESCRIPTION
## Purpose / Description

The app has a system for restoring dialogs which appeared when the DeckPicker was not in focus, but it wasn't implemented for ExportReadyDialog. This fix copies the implementation of other dialogs that get restored. 

The code around DialogHandlerMessage needs to be refactored to handle the situation when the user doesn't enter the DeckPicker when a dialog is scheduled to be restored(like when using the widget)

Video with the fixed behavior:

https://github.com/ankidroid/Anki-Android/assets/52494258/85ef15c9-13bf-424c-86c3-ce2dd3bdbcd3




## Fixes
* Fixes #14734

## How Has This Been Tested?

Ran the tests, manually verified the bug scenario.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
