### PR TITLE
chore: remove ACTION_PROCESS_TEXT compat

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -68,7 +68,6 @@ import com.ichi2.anki.utils.roundedTimeSpanUnformatted
 import com.ichi2.anki.widgets.DeckDropDownAdapter.SubtitleListener
 import com.ichi2.annotations.NeedsTest
 import com.ichi2.async.*
-import com.ichi2.compat.Compat
 import com.ichi2.libanki.*
 import com.ichi2.libanki.SortOrder.NoOrdering
 import com.ichi2.libanki.SortOrder.UseCollectionOrdering
@@ -856,8 +855,8 @@ open class CardBrowser :
 
         // Maybe we were called from ACTION_PROCESS_TEXT.
         // In that case we already fill in the search.
-        if (Compat.ACTION_PROCESS_TEXT == intent.action) {
-            val search = intent.getCharSequenceExtra(Compat.EXTRA_PROCESS_TEXT)
+        if (Intent.ACTION_PROCESS_TEXT == intent.action) {
+            val search = intent.getCharSequenceExtra(Intent.EXTRA_PROCESS_TEXT)
             if (!search.isNullOrEmpty()) {
                 Timber.i("CardBrowser :: Called with search intent: %s", search.toString())
                 mSearchView!!.setQuery(search, true)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
@@ -80,7 +80,6 @@ import com.ichi2.anki.snackbar.showSnackbar
 import com.ichi2.anki.ui.setupNoteTypeSpinner
 import com.ichi2.anki.widgets.DeckDropDownAdapter.SubtitleListener
 import com.ichi2.annotations.NeedsTest
-import com.ichi2.compat.Compat
 import com.ichi2.libanki.*
 import com.ichi2.libanki.Collection
 import com.ichi2.libanki.Decks.Companion.CURRENT_DECK
@@ -247,7 +246,7 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
             caller = intent.getIntExtra(EXTRA_CALLER, CALLER_NO_CALLER)
             if (caller == CALLER_NO_CALLER) {
                 val action = intent.action
-                if (ACTION_CREATE_FLASHCARD == action || ACTION_CREATE_FLASHCARD_SEND == action || Compat.ACTION_PROCESS_TEXT == action) {
+                if (ACTION_CREATE_FLASHCARD == action || ACTION_CREATE_FLASHCARD_SEND == action || Intent.ACTION_PROCESS_TEXT == action) {
                     caller = CALLER_NOTEEDITOR_INTENT_ADD
                 }
             }
@@ -550,9 +549,9 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
     private fun fetchIntentInformation(intent: Intent) {
         val extras = intent.extras ?: return
         sourceText = arrayOfNulls(2)
-        if (Compat.ACTION_PROCESS_TEXT == intent.action) {
-            val stringExtra = intent.getStringExtra(Compat.EXTRA_PROCESS_TEXT)
-            Timber.d("Obtained %s from intent: %s", stringExtra, Compat.EXTRA_PROCESS_TEXT)
+        if (Intent.ACTION_PROCESS_TEXT == intent.action) {
+            val stringExtra = intent.getStringExtra(Intent.EXTRA_PROCESS_TEXT)
+            Timber.d("Obtained %s from intent: %s", stringExtra, Intent.EXTRA_PROCESS_TEXT)
             sourceText!![0] = stringExtra ?: ""
             sourceText!![1] = ""
         } else if (ACTION_CREATE_FLASHCARD == intent.action) {

--- a/AnkiDroid/src/main/java/com/ichi2/compat/Compat.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/Compat.kt
@@ -206,10 +206,4 @@ interface Compat {
      */
     @CheckResult
     fun normalize(locale: Locale): Locale
-
-    companion object {
-        /* Mock the Intent PROCESS_TEXT constants introduced in API 23. */
-        const val ACTION_PROCESS_TEXT = "android.intent.action.PROCESS_TEXT"
-        const val EXTRA_PROCESS_TEXT = "android.intent.extra.PROCESS_TEXT"
-    }
 }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/NoteEditorTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/NoteEditorTest.kt
@@ -26,8 +26,6 @@ import com.ichi2.anki.AbstractFlashcardViewer.Companion.editorCard
 import com.ichi2.anki.NoteEditorTest.FromScreen.DECK_LIST
 import com.ichi2.anki.NoteEditorTest.FromScreen.REVIEWER
 import com.ichi2.anki.multimediacard.activity.MultimediaEditFieldActivity
-import com.ichi2.compat.Compat.Companion.ACTION_PROCESS_TEXT
-import com.ichi2.compat.Compat.Companion.EXTRA_PROCESS_TEXT
 import com.ichi2.libanki.Consts
 import com.ichi2.libanki.Decks.Companion.CURRENT_DECK
 import com.ichi2.libanki.Note
@@ -238,8 +236,8 @@ class NoteEditorTest : RobolectricTest() {
     fun processTextIntentShouldCopyFirstField() {
         ensureCollectionLoadIsSynchronous()
 
-        val i = Intent(ACTION_PROCESS_TEXT)
-        i.putExtra(EXTRA_PROCESS_TEXT, "hello\nworld")
+        val i = Intent(Intent.ACTION_PROCESS_TEXT)
+        i.putExtra(Intent.EXTRA_PROCESS_TEXT, "hello\nworld")
         val editor = startActivityNormallyOpenCollectionWithIntent(NoteEditor::class.java, i)
         val actual = editor.currentFieldStrings.toList()
 


### PR DESCRIPTION
No longer necessary: we're API 23

* Replace the `const val` with a value-getter property
* Use the IDE to inline the value