### PR TITLE
8602 start activity for result new api

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -1147,7 +1147,7 @@ open class DeckPicker :
     fun addNote() {
         val intent = Intent(this@DeckPicker, NoteEditor::class.java)
         intent.putExtra(NoteEditor.EXTRA_CALLER, NoteEditor.CALLER_DECKPICKER)
-        startActivityForResultWithAnimation(intent, ADD_NOTE, START)
+        startActivityWithAnimation(intent, START)
     }
 
     private fun showStartupScreensAndDialogs(preferences: SharedPreferences, skip: Int) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -251,6 +251,12 @@ open class DeckPicker :
         showStartupScreensAndDialogs(baseContext.sharedPrefs(), 3)
     }
 
+    private val loginForSyncLauncher = registerForActivityResult(ActivityResultContracts.StartActivityForResult()) {
+        if (it.resultCode == RESULT_OK) {
+            mSyncOnResume = true
+        }
+    }
+
     private var migrateStorageAfterMediaSyncCompleted = false
 
     // stored for testing purposes
@@ -912,9 +918,7 @@ open class DeckPicker :
             handleDbError()
             return
         }
-        if (requestCode == LOG_IN_FOR_SYNC && resultCode == RESULT_OK) {
-            mSyncOnResume = true
-        } else if (requestCode == REQUEST_PATH_UPDATE) {
+        if (requestCode == REQUEST_PATH_UPDATE) {
             // The collection path was inaccessible on startup so just close the activity and let user restart
             finish()
         } else if (requestCode == PICK_APKG_FILE && resultCode == RESULT_OK) {
@@ -1555,7 +1559,7 @@ open class DeckPicker :
     override fun loginToSyncServer() {
         val myAccount = Intent(this, MyAccount::class.java)
         myAccount.putExtra("notLoggedIn", true)
-        startActivityForResultWithAnimation(myAccount, LOG_IN_FOR_SYNC, FADE)
+        launchActivityForResultWithAnimation(myAccount, loginForSyncLauncher, FADE)
     }
 
     // Callback to import a file -- adding it to existing collection

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -853,7 +853,7 @@ open class DeckPicker :
                 val manageNoteTypesTarget =
                     ManageNotetypes::class.java
                 val noteTypeBrowser = Intent(this, manageNoteTypesTarget)
-                startActivityForResultWithAnimation(noteTypeBrowser, 0, START)
+                startActivityWithAnimation(noteTypeBrowser, START)
                 return true
             }
             R.id.action_restore_backup -> {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -2149,7 +2149,6 @@ open class DeckPicker :
         private const val LOG_IN_FOR_SYNC = 6
         private const val SHOW_INFO_NEW_VERSION = 9
         const val SHOW_STUDYOPTIONS = 11
-        private const val ADD_NOTE = 12
         const val PICK_APKG_FILE = 13
         const val PICK_CSV_FILE = 14
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -1287,11 +1287,8 @@ open class DeckPicker :
                 Timber.i("Displaying new features")
                 val infoIntent = Intent(this, Info::class.java)
                 infoIntent.putExtra(Info.TYPE_EXTRA, Info.TYPE_NEW_VERSION)
-                if (skip != 0) {
-                    launchActivityForResultWithAnimation(infoIntent, showNewVersionInfoLauncher, START)
-                } else {
-                    startActivityForResultWithoutAnimation(infoIntent, SHOW_INFO_NEW_VERSION)
-                }
+                val transition = if (skip != 0) START else NONE
+                launchActivityForResultWithAnimation(infoIntent, showNewVersionInfoLauncher, transition)
             } else {
                 Timber.i("Dev Build - not showing 'new features'")
                 // Don't show new features dialog for development builds
@@ -2158,8 +2155,6 @@ open class DeckPicker :
         @VisibleForTesting
         const val REQUEST_STORAGE_PERMISSION = 0
         private const val REQUEST_PATH_UPDATE = 1
-        private const val LOG_IN_FOR_SYNC = 6
-        private const val SHOW_INFO_NEW_VERSION = 9
         const val PICK_APKG_FILE = 13
         const val PICK_CSV_FILE = 14
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -243,8 +243,8 @@ open class DeckPicker :
         ActivityCompat.recreate(this)
     }
 
-    private val reviewerScreenLauncher = registerForActivityResult(ActivityResultContracts.StartActivityForResult()) {
-        processReviewerScreenResult(it.resultCode)
+    private val reviewLauncher = registerForActivityResult(ActivityResultContracts.StartActivityForResult()) {
+        processReviewResults(it.resultCode)
     }
 
     private var migrateStorageAfterMediaSyncCompleted = false
@@ -912,18 +912,6 @@ open class DeckPicker :
             showStartupScreensAndDialogs(baseContext.sharedPrefs(), 3)
         } else if (requestCode == LOG_IN_FOR_SYNC && resultCode == RESULT_OK) {
             mSyncOnResume = true
-        } else if (requestCode == SHOW_STUDYOPTIONS) {
-            if (resultCode == AbstractFlashcardViewer.RESULT_NO_MORE_CARDS) {
-                // Show a message when reviewing has finished
-                if (getColUnsafe.sched.totalCount() == 0) {
-                    showSnackbar(R.string.studyoptions_congrats_finished)
-                } else {
-                    showSnackbar(R.string.studyoptions_no_cards_due)
-                }
-            } else if (resultCode == AbstractFlashcardViewer.RESULT_ABORT_AND_SYNC) {
-                Timber.i("Obtained Abort and Sync result")
-                sync()
-            }
         } else if (requestCode == REQUEST_PATH_UPDATE) {
             // The collection path was inaccessible on startup so just close the activity and let user restart
             finish()
@@ -934,7 +922,7 @@ open class DeckPicker :
         }
     }
 
-    private fun processReviewerScreenResult(resultCode: Int) {
+    private fun processReviewResults(resultCode: Int) {
         if (resultCode == AbstractFlashcardViewer.RESULT_NO_MORE_CARDS) {
             // Show a message when reviewing has finished
             if (getColUnsafe.sched.totalCount() == 0) {
@@ -1645,7 +1633,7 @@ open class DeckPicker :
             val intent = Intent()
             intent.putExtra("withDeckOptions", withDeckOptions)
             intent.setClass(this, StudyOptionsActivity::class.java)
-            startActivityForResultWithAnimation(intent, SHOW_STUDYOPTIONS, START)
+            launchActivityForResultWithAnimation(intent, reviewLauncher, START)
         }
     }
 
@@ -2059,7 +2047,7 @@ open class DeckPicker :
 
     private fun openReviewer() {
         val reviewer = Intent(this, Reviewer::class.java)
-        launchActivityForResultWithAnimation(reviewer, reviewerScreenLauncher, START)
+        launchActivityForResultWithAnimation(reviewer, reviewLauncher, START)
     }
 
     override fun onCreateCustomStudySession() {
@@ -2166,7 +2154,6 @@ open class DeckPicker :
         private const val REQUEST_PATH_UPDATE = 1
         private const val LOG_IN_FOR_SYNC = 6
         private const val SHOW_INFO_NEW_VERSION = 9
-        const val SHOW_STUDYOPTIONS = 11
         const val PICK_APKG_FILE = 13
         const val PICK_CSV_FILE = 14
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -247,6 +247,10 @@ open class DeckPicker :
         processReviewResults(it.resultCode)
     }
 
+    private val showNewVersionInfoLauncher = registerForActivityResult(ActivityResultContracts.StartActivityForResult()) {
+        showStartupScreensAndDialogs(baseContext.sharedPrefs(), 3)
+    }
+
     private var migrateStorageAfterMediaSyncCompleted = false
 
     // stored for testing purposes
@@ -908,9 +912,7 @@ open class DeckPicker :
             handleDbError()
             return
         }
-        if (requestCode == SHOW_INFO_NEW_VERSION) {
-            showStartupScreensAndDialogs(baseContext.sharedPrefs(), 3)
-        } else if (requestCode == LOG_IN_FOR_SYNC && resultCode == RESULT_OK) {
+        if (requestCode == LOG_IN_FOR_SYNC && resultCode == RESULT_OK) {
             mSyncOnResume = true
         } else if (requestCode == REQUEST_PATH_UPDATE) {
             // The collection path was inaccessible on startup so just close the activity and let user restart
@@ -1282,7 +1284,7 @@ open class DeckPicker :
                 val infoIntent = Intent(this, Info::class.java)
                 infoIntent.putExtra(Info.TYPE_EXTRA, Info.TYPE_NEW_VERSION)
                 if (skip != 0) {
-                    startActivityForResultWithAnimation(infoIntent, SHOW_INFO_NEW_VERSION, START)
+                    launchActivityForResultWithAnimation(infoIntent, showNewVersionInfoLauncher, START)
                 } else {
                     startActivityForResultWithoutAnimation(infoIntent, SHOW_INFO_NEW_VERSION)
                 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -257,6 +257,11 @@ open class DeckPicker :
         }
     }
 
+    private val requestPathUpdateLauncher = registerForActivityResult(ActivityResultContracts.StartActivityForResult()) {
+        // The collection path was inaccessible on startup so just close the activity and let user restart
+        finish()
+    }
+
     private var migrateStorageAfterMediaSyncCompleted = false
 
     // stored for testing purposes
@@ -515,7 +520,7 @@ open class DeckPicker :
                     showDatabaseErrorDialog(DatabaseErrorDialogType.DIALOG_STORAGE_UNAVAILABLE_AFTER_UNINSTALL)
                 } else {
                     val i = AdvancedSettingsFragment.getSubscreenIntent(this)
-                    startActivityForResultWithoutAnimation(i, REQUEST_PATH_UPDATE)
+                    launchActivityForResultWithAnimation(i, requestPathUpdateLauncher, NONE)
                     showThemedToast(this, R.string.directory_inaccessible, false)
                 }
             }
@@ -918,10 +923,7 @@ open class DeckPicker :
             handleDbError()
             return
         }
-        if (requestCode == REQUEST_PATH_UPDATE) {
-            // The collection path was inaccessible on startup so just close the activity and let user restart
-            finish()
-        } else if (requestCode == PICK_APKG_FILE && resultCode == RESULT_OK) {
+        if (requestCode == PICK_APKG_FILE && resultCode == RESULT_OK) {
             onSelectedPackageToImport(data!!)
         } else if (requestCode == PICK_CSV_FILE && resultCode == RESULT_OK) {
             onSelectedCsvForImport(data!!)
@@ -2154,7 +2156,6 @@ open class DeckPicker :
          */
         @VisibleForTesting
         const val REQUEST_STORAGE_PERMISSION = 0
-        private const val REQUEST_PATH_UPDATE = 1
         const val PICK_APKG_FILE = 13
         const val PICK_CSV_FILE = 14
 


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
`startActivityForResult` is deprecated. We want to replace these calls using the new Register  For Activity Result APIs. 

I removed all instances of `AnkiActivity.startActivityForResultWithAnimation`, and
`AnkiActivity.startActivityForResultWithoutAnimation` in DeckPicker.kt, and replaced them with calls to `AnkiActivity.launchActivityForResultWithAnimation`, which utilized the new API underneath. (The function name could be changed, because it does handle non-animations too)

## Fixes
Related: #8602 

## How Has This Been Tested?

I ran unit tests and I manually tested the functionality on an emulator.

## Learning (optional, can help others)
In `onActivityResult`, there is a specific result code check that's used for every launched activity result. In order to capture this for every new `ActivityResultLauncher` I created a `DeckPickerActivityResultCallback` inner class to pass to `registerForActivityResult`. The `DeckPickerActivityResultCallback` handles the shared result code checks, and it also takes a lambda to run after the common checks have been made.

I couldn't fully remove `onActivityResult`, because it still handles two request codes, PICK_APKG_FILE and PICK_CSV_FILE, that are coupled with `ImportFileSelectionFragment` class. `ImportFileSelectionFragment` would have to be updated to use the new API as well, but that would require some structural changes, so that seems like it was outside the scope of this one pull request. 

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
