### PR TITLE
Replace values() function with entries property

### DIFF
--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/dialogs/ModelEditorContextMenuTest.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/dialogs/ModelEditorContextMenuTest.kt
@@ -41,7 +41,7 @@ class ModelEditorContextMenuTest {
             themeResId = R.style.Theme_Light
         ) { MockModelEditorContextMenu(isAtLeastAtN = true) }
         onView(withText(testDialogTitle)).check(matches(isDisplayed()))
-        ModelEditorContextMenuAction.values().forEach {
+        ModelEditorContextMenuAction.entries.forEach {
             onView(withText(it.actionTextId)).check(matches(isDisplayed()))
         }
     }
@@ -59,7 +59,7 @@ class ModelEditorContextMenuTest {
             doesNotExist()
         )
         // make sure we aren't losing other items besides ModelEditorContextMenuAction.AddLanguageHint
-        ModelEditorContextMenuAction.values()
+        ModelEditorContextMenuAction.entries
             .filterNot { it == ModelEditorContextMenuAction.AddLanguageHint }.forEach {
                 onView(withText(it.actionTextId)).check(matches(isDisplayed()))
             }

--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/NotificationChannelTest.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/NotificationChannelTest.kt
@@ -72,7 +72,7 @@ class NotificationChannelTest : InstrumentedTest() {
         for (i in channels.indices) {
             Timber.d("Found channel with id %s", channels[i].id)
         }
-        var expectedChannels = Channel.values().size
+        var expectedChannels = Channel.entries.size
         // If we have channels but have *targeted* pre-26, there is a "miscellaneous" channel auto-defined
         if (mTargetAPI < 26) {
             expectedChannels += 1
@@ -89,7 +89,7 @@ class NotificationChannelTest : InstrumentedTest() {
             expectedChannels,
             greaterThanOrEqualTo(channels.size)
         )
-        for (channel in Channel.values()) {
+        for (channel in Channel.entries) {
             assertNotNull(
                 "There should be a reminder channel",
                 mManager!!.getNotificationChannel(channel.id)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NotificationChannels.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NotificationChannels.kt
@@ -44,7 +44,7 @@ object NotificationChannels {
     @TargetApi(26)
     fun setup(context: Context) {
         val res = context.resources
-        for (channel in Channel.values()) {
+        for (channel in Channel.entries) {
             val id = channel.id
             val name = channel.getName(res)
             val importance = channel.importance()

--- a/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/GestureProcessor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/GestureProcessor.kt
@@ -52,7 +52,7 @@ class GestureProcessor(private val processor: ViewerCommand.CommandProcessor?) {
         isEnabled = preferences.getBoolean(PREF_KEY, false)
 
         val associatedCommands = HashMap<Gesture, ViewerCommand>()
-        for (command in ViewerCommand.values()) {
+        for (command in ViewerCommand.entries) {
             for (mappableBinding in MappableBinding.fromPreference(preferences, command)) {
                 if (mappableBinding.binding.isGesture) {
                     associatedCommands[mappableBinding.binding.gesture!!] = command

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DialogHandler.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DialogHandler.kt
@@ -136,7 +136,7 @@ abstract class DialogHandlerMessage protected constructor(val which: WhichDialog
         MSG_EXPORT_READY(10)
         ;
         companion object {
-            fun fromInt(value: Int) = WhichDialogHandler.values().first { it.what == value }
+            fun fromInt(value: Int) = entries.first { it.what == value }
         }
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ModelEditorContextMenu.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ModelEditorContextMenu.kt
@@ -26,9 +26,9 @@ open class ModelEditorContextMenu : AnalyticsDialogFragment() {
         super.onCreate(savedInstanceState)
         // add only the actions which can be done at the current API level
         var availableItems = if (isAtLeastAtN()) {
-            ModelEditorContextMenuAction.values().toList()
+            ModelEditorContextMenuAction.entries.toList()
         } else {
-            ModelEditorContextMenuAction.values().filterNot { it == AddLanguageHint }
+            ModelEditorContextMenuAction.entries.filterNot { it == AddLanguageHint }
         }
         availableItems = availableItems.sortedBy { it.order }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/tags/TagsDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/tags/TagsDialog.kt
@@ -119,7 +119,7 @@ class TagsDialog : AnalyticsDialogFragment {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         resizeWhenSoftInputShown(requireActivity().window)
-        mType = DialogType.values()[requireArguments().getInt(DIALOG_TYPE_KEY)]
+        mType = DialogType.entries[requireArguments().getInt(DIALOG_TYPE_KEY)]
         mTags = TagsList(
             requireArguments().getStringArrayList(ALL_TAGS_KEY)!!,
             requireArguments().getStringArrayList(CHECKED_TAGS_KEY)!!,

--- a/AnkiDroid/src/main/java/com/ichi2/anki/notetype/ManageNotetypes.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/notetype/ManageNotetypes.kt
@@ -164,7 +164,7 @@ class ManageNotetypes : AnkiActivity() {
     private suspend fun addNewNotetype() {
         val optionsToDisplay = withProgress {
             withCol {
-                val standardNotetypesModels = StockNotetype.Kind.values()
+                val standardNotetypesModels = StockNotetype.Kind.entries
                     .filter { it != StockNotetype.Kind.UNRECOGNIZED }
                     .map {
                         val stockNotetype = from_json_bytes(getStockNotetypeLegacy(it))

--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/ControlsSettingsFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/ControlsSettingsFragment.kt
@@ -30,7 +30,7 @@ class ControlsSettingsFragment : SettingsFragment() {
     @NeedsTest("Keys and titles in the XML layout are the same of the ViewerCommands")
     override fun initSubscreen() {
         val commands = HashMap<String, ViewerCommand>()
-        ViewerCommand.values().forEach { commands[it.preferenceKey] = it }
+        ViewerCommand.entries.forEach { commands[it.preferenceKey] = it }
         // set defaultValue in the prefs creation.
         // if a preference is empty, it has a value like "1/"
         allPreferences()

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/MappableBinding.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/MappableBinding.kt
@@ -206,7 +206,7 @@ class MappableBinding(val binding: Binding, private val screen: Screen) {
 
         @CheckResult
         fun allMappings(prefs: SharedPreferences): MutableList<Pair<ViewerCommand, MutableList<MappableBinding>>> {
-            return ViewerCommand.values().map {
+            return ViewerCommand.entries.map {
                 Pair(it, fromPreference(prefs, it))
             }.toMutableList()
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/PeripheralKeymap.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/PeripheralKeymap.kt
@@ -37,7 +37,7 @@ class PeripheralKeymap(reviewerUi: ReviewerUi, commandProcessor: ViewerCommand.C
     }
 
     fun setup(preferences: SharedPreferences) {
-        for (command in ViewerCommand.values()) {
+        for (command in ViewerCommand.entries) {
             add(command, preferences)
         }
         mHasSetup = true

--- a/AnkiDroid/src/main/java/com/ichi2/preferences/ControlPreference.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/preferences/ControlPreference.kt
@@ -200,7 +200,7 @@ class ControlPreference : ListPreference {
      * Remove binding from all control preferences other than this one
      */
     private fun clearBinding(binding: MappableBinding) {
-        for (command in ViewerCommand.values()) {
+        for (command in ViewerCommand.entries) {
             val commandPreference = preferenceManager.findPreference<ControlPreference>(command.preferenceKey)
                 ?: continue
             val bindings = MappableBinding.fromPreferenceString(commandPreference.value)

--- a/AnkiDroid/src/main/java/com/ichi2/ui/CheckBoxTriStates.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/ui/CheckBoxTriStates.kt
@@ -179,7 +179,7 @@ class CheckBoxTriStates : AppCompatCheckBox {
 
         constructor(superState: Parcelable?) : super(superState) {}
         private constructor(source: Parcel) : super(source) {
-            state = State.values()[source.readInt()]
+            state = State.entries[source.readInt()]
             cycleCheckedToIndeterminate = source.readInt() != 0
             cycleIndeterminateToChecked = source.readInt() != 0
         }

--- a/AnkiDroid/src/main/java/com/ichi2/ui/GestureDisplay.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/ui/GestureDisplay.kt
@@ -72,7 +72,7 @@ constructor(context: Context, attributeSet: AttributeSet? = null, defStyleAttr: 
     }
 
     /** Lists all selectable gestures from this view (excludes null) */
-    fun availableValues(): List<Gesture> = Gesture.values().filter {
+    fun availableValues(): List<Gesture> = entries.filter {
         (mTapGestureMode == TapGestureMode.NINE_POINT || !NINE_POINT_TAP_GESTURES.contains(it))
     }
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/ReviewerNoParamTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/ReviewerNoParamTest.kt
@@ -284,7 +284,7 @@ class ReviewerNoParamTest : RobolectricTest() {
 
     private fun disableGestures(vararg gestures: Gesture) {
         val prefs = targetContext.sharedPrefs()
-        for (command in ViewerCommand.values()) {
+        for (command in ViewerCommand.entries) {
             for (mappableBinding in MappableBinding.fromPreference(prefs, command)) {
                 if (mappableBinding.binding.gesture in gestures) {
                     command.removeBinding(prefs, mappableBinding)

--- a/AnkiDroid/src/test/java/com/ichi2/anki/cardviewer/ViewerCommandTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/cardviewer/ViewerCommandTest.kt
@@ -24,7 +24,7 @@ class ViewerCommandTest {
 
     @Test
     fun preference_keys_are_not_changed() {
-        val names = Joiner.on(", ").join(ViewerCommand.values().map { x -> x.preferenceKey })
+        val names = Joiner.on(", ").join(ViewerCommand.entries.map { x -> x.preferenceKey })
 
         // NONE OF THESE SHOULD BE CHANGED OR A USER WILL LOSE THE ASSOCIATED PREFERENCES
         // Adds are acceptable

--- a/AnkiDroid/src/test/java/com/ichi2/anki/cardviewer/ViewerCommandTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/cardviewer/ViewerCommandTest.kt
@@ -16,7 +16,6 @@
 
 package com.ichi2.anki.cardviewer
 
-import com.google.common.base.Joiner
 import org.junit.Assert.assertEquals
 import org.junit.Test
 
@@ -24,7 +23,7 @@ class ViewerCommandTest {
 
     @Test
     fun preference_keys_are_not_changed() {
-        val names = Joiner.on(", ").join(ViewerCommand.entries.map { x -> x.preferenceKey })
+        val names = ViewerCommand.entries.joinToString(", ") { x -> x.preferenceKey }
 
         // NONE OF THESE SHOULD BE CHANGED OR A USER WILL LOSE THE ASSOCIATED PREFERENCES
         // Adds are acceptable

--- a/AnkiDroid/src/test/java/com/ichi2/anki/ui/windows/permissions/PermissionsActivityTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/ui/windows/permissions/PermissionsActivityTest.kt
@@ -32,7 +32,7 @@ class PermissionsActivityTest : RobolectricTest() {
     @Test
     fun `Each screen starts normally and has the same permissions of a PermissionSet`() {
         ActivityScenario.launch(PermissionsActivity::class.java).onActivity { activity ->
-            for (permissionSet in PermissionSet.values()) {
+            for (permissionSet in PermissionSet.entries) {
                 val fragment = permissionSet.permissionsFragment?.getDeclaredConstructor()?.newInstance() ?: continue
                 activity.supportFragmentManager.commitNow {
                     replace(R.id.fragment_container, fragment)


### PR DESCRIPTION
## Purpose / Description
- This uses a new language feature that was made stable in Kotlin 1.9. This was missed because of dependabot (which I don't like for precisely this reason).
  - See here for details: https://kotlinlang.org/docs/whatsnew19.html#stable-replacement-of-the-enum-class-values-function
- Also I replaced Joiner in ViewerCommandTest with Kotlin's joinToString.

This doesn't fix or change any approach to anything.

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [N/A] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [N/A] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [N/A] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
