### PR TITLE
Use ServiceCompat.stopForeground

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/services/MigrationService.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/services/MigrationService.kt
@@ -216,7 +216,9 @@ class MigrationService : ServiceWithALifecycleScope(), ServiceWithASimpleBinder<
 
                     if (progress is Progress.Done) {
                         ServiceCompat.stopForeground(
-                            this@MigrationService, ServiceCompat.STOP_FOREGROUND_DETACH)
+                            this@MigrationService,
+                            ServiceCompat.STOP_FOREGROUND_DETACH
+                        )
 
                         stopSelf()
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/services/MigrationService.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/services/MigrationService.kt
@@ -20,11 +20,11 @@ import android.app.Notification
 import android.content.Context
 import android.content.Intent
 import android.net.Uri
-import android.os.Build
 import android.os.PowerManager
 import android.text.format.Formatter
 import androidx.core.app.NotificationCompat
 import androidx.core.app.PendingIntentCompat
+import androidx.core.app.ServiceCompat
 import androidx.core.content.ContextCompat
 import androidx.core.content.edit
 import androidx.lifecycle.Lifecycle
@@ -215,12 +215,8 @@ class MigrationService : ServiceWithALifecycleScope(), ServiceWithASimpleBinder<
                     startForeground(2, makeMigrationProgressNotification(progress))
 
                     if (progress is Progress.Done) {
-                        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.N) {
-                            @Suppress("DEPRECATION")
-                            stopForeground(false)
-                        } else {
-                            stopForeground(STOP_FOREGROUND_DETACH)
-                        }
+                        ServiceCompat.stopForeground(
+                            this@MigrationService, ServiceCompat.STOP_FOREGROUND_DETACH)
 
                         stopSelf()
 


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
- Use ServiceCompat.stopForeground, which does the version checks internally. You can see it [here](https://androidx.tech/artifacts/core/core/1.12.0-source/androidx/core/app/ServiceCompat.java.html#:~:text=public%20static%20void-,stopForeground,-(%40NonNull%20Service). It just does the same thing, but it's nicer to look at.

## How Has This Been Tested?
I made this change in another well-used and well-tested app over two years ago, and no user issue has been opened that has to do with my change. Which makes sense, because functionality didn't change. It'll be the same here, too.

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [N/A] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [N/A] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [N/A] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
