### PR TITLE
Fix card not being suspended after first being buried

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -1724,7 +1724,7 @@ open class CardBrowser :
         }
         withProgress {
             undoableOp {
-                val wantSuspend = getCard(cardIds.first()).queue >= 0
+                val wantSuspend = getCard(cardIds.first()).queue != Consts.QUEUE_TYPE_SUSPENDED
                 if (wantSuspend) {
                     sched.suspendCards(cardIds).changes
                 } else {


### PR DESCRIPTION
## Purpose / Description

The old code was only suspending cards with QUEUE_TYPE_NEW, QUEUE_TYPE_LRN, QUEUE_TYPE_REV, QUEUE_TYPE_DAY_LEARN_RELEARN or QUEUE_TYPE_PREVIEW. The code was changed to suspend any cards that weren't already suspended, otherwise it will unsuspend previously suspended cards.

## Fixes
* Fixes #14751

## How Has This Been Tested?

Ran the tests, manually verified the bug scenario in the app.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
