### PR TITLE
tests: reduce log spam

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.kt
@@ -455,11 +455,10 @@ open class AnkiDroidApp : Application() {
     class RobolectricDebugTree : DebugTree() {
         override fun log(priority: Int, tag: String?, message: String, t: Throwable?) {
             // This is noisy in test environments
-            if (tag == "Backend\$checkMainThreadOp") {
-                return
-            }
-            if (tag == "Media" && priority == Log.VERBOSE && message.startsWith("dir")) {
-                return
+            when (tag) {
+                "Backend\$checkMainThreadOp" -> return
+                "Media" -> if (priority == Log.VERBOSE && message.startsWith("dir")) return
+                "CollectionManager" -> if (message.startsWith("blocked main thread")) return
             }
             super.log(priority, tag, message, t)
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.kt
@@ -458,6 +458,9 @@ open class AnkiDroidApp : Application() {
             if (tag == "Backend\$checkMainThreadOp") {
                 return
             }
+            if (tag == "Media" && priority == Log.VERBOSE && message.startsWith("dir")) {
+                return
+            }
             super.log(priority, tag, message, t)
         }
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CollectionManager.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CollectionManager.kt
@@ -59,6 +59,10 @@ object CollectionManager {
     @VisibleForTesting
     var emulateOpenFailure = false
 
+    /** A speed optimisation to remove the logging function of the collection */
+    @VisibleForTesting
+    var disableLogFile: Boolean = false
+
     /**
      * Execute the provided block on a serial background queue, to ensure
      * concurrent access does not happen.
@@ -227,7 +231,7 @@ object CollectionManager {
         if (collection == null || collection!!.dbClosed) {
             val path = collectionPathInValidFolder()
             collection =
-                collection(path, log = true, backend)
+                collection(path, log = !disableLogFile, backend)
         }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DialogHandler.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DialogHandler.kt
@@ -55,10 +55,9 @@ class DialogHandler(activity: AnkiActivity) : Handler(getDefaultLooper()) {
      * Read and handle Message which was stored via [storeMessage]
      */
     fun executeMessage() {
+        if (sStoredMessage == null) return
         Timber.d("Reading persistent message")
-        if (sStoredMessage != null) {
-            sendStoredMessage(sStoredMessage!!)
-        }
+        sendStoredMessage(sStoredMessage!!)
         sStoredMessage = null
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.kt
@@ -608,10 +608,10 @@ JOIN cards AS c ON card_with_min_ord.nid = c.nid AND card_with_min_ord.ord = c.o
     }
 
     private fun _openLog() {
-        Timber.i("Opening Collection Log")
         if (!debugLog) {
             return
         }
+        Timber.i("Opening Collection Log")
         try {
             val lpath = File(path.replaceFirst("\\.anki2$".toRegex(), ".log"))
             if (lpath.exists() && lpath.length() > 10 * 1024 * 1024) {
@@ -630,6 +630,7 @@ JOIN cards AS c ON card_with_min_ord.nid = c.nid AND card_with_min_ord.ord = c.o
     }
 
     private fun _closeLog() {
+        if (!debugLog) return
         Timber.i("Closing Collection Log")
         mLogHnd?.close()
         mLogHnd = null

--- a/AnkiDroid/src/test/java/com/ichi2/anki/RobolectricTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/RobolectricTest.kt
@@ -108,7 +108,8 @@ open class RobolectricTest : AndroidTest {
         // See the Android logging (from Timber)
         ShadowLog.stream = System.out
             // Filters for non-Timber sources. Prefer filtering in RobolectricDebugTree if possible
-            .filter("^(?!W/ShadowLegacyPath).*$") // W/ShadowLegacyPath: android.graphics.Path#op() not supported yet.
+            // LifecycleMonitor: not needed as we already use registerActivityLifecycleCallbacks for logs
+            .filter("^(?!(W/ShadowLegacyPath|D/LifecycleMonitor)).*$") // W/ShadowLegacyPath: android.graphics.Path#op() not supported yet.
 
         Storage.setUseInMemory(useInMemoryDatabase())
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/RobolectricTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/RobolectricTest.kt
@@ -101,8 +101,10 @@ open class RobolectricTest : AndroidTest {
 
         maybeSetupBackend()
 
-        // If you want to see the Android logging (from Timber), you need to set it up here
+        // See the Android logging (from Timber)
         ShadowLog.stream = System.out
+            // Filters for non-Timber sources. Prefer filtering in RobolectricDebugTree if possible
+            .filter("^(?!W/ShadowLegacyPath).*$") // W/ShadowLegacyPath: android.graphics.Path#op() not supported yet.
 
         Storage.setUseInMemory(useInMemoryDatabase())
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/RobolectricTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/RobolectricTest.kt
@@ -82,6 +82,8 @@ open class RobolectricTest : AndroidTest {
         return true
     }
 
+    open val disableCollectionLogFile = true
+
     @get:Rule
     val mTaskScheduler = TaskSchedulerRule()
 
@@ -101,6 +103,8 @@ open class RobolectricTest : AndroidTest {
 
         maybeSetupBackend()
 
+        // disable the collection log file for a speed boost & reduce log output
+        CollectionManager.disableLogFile = disableCollectionLogFile
         // See the Android logging (from Timber)
         ShadowLog.stream = System.out
             // Filters for non-Timber sources. Prefer filtering in RobolectricDebugTree if possible

--- a/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/ScopedStorageMigrationIntegrationTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/ScopedStorageMigrationIntegrationTest.kt
@@ -50,6 +50,9 @@ class ScopedStorageMigrationIntegrationTest : RobolectricTest() {
 
     override fun useInMemoryDatabase() = false
 
+    // we want collection.log to be tested
+    override val disableCollectionLogFile: Boolean = false
+
     @After
     override fun tearDown() {
         try {

--- a/AnkiDroid/src/test/java/com/ichi2/testutils/FilterLogStream.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/testutils/FilterLogStream.kt
@@ -1,0 +1,30 @@
+/*
+ *  Copyright (c) 2023 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.testutils
+
+import java.io.OutputStream
+import java.io.PrintStream
+import java.util.regex.Pattern
+
+class FilterLogStream(stream: OutputStream, private val pattern: Pattern) : PrintStream(stream) {
+    override fun println(x: String) {
+        if (!pattern.matcher(x).find()) return
+        super.println(x)
+    }
+}
+
+fun PrintStream.filter(regex: String): PrintStream = FilterLogStream(this, Pattern.compile(regex))


### PR DESCRIPTION
## Purpose / Description
I was a little frustrated with one repeated line of log spam in unit tests, then I cleaned up things a little more

## Approach
* Define a filter to remove `Log` calls
* Disable collection log
* Disable `LifecycleMonitor` as we already have: https://github.com/ankidroid/Anki-Android/blob/8cf3cc306e405c5a4f54ef58c9e80eed1d542f87/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.kt#L194-L203
*  Hide a few more lines using `RobolectricDebugTree`

## How Has This Been Tested?

```diff
SLF4J: Class path contains multiple SLF4J bindings.
SLF4J: Found binding in [jar:file:/Users/davidallison/.gradle/caches/transforms-3/e5c1eae594943ab3cbc66dbcbaedd199/transformed/slf4j-timber-3.1-runtime.jar!/org/slf4j/impl/StaticLoggerBinder.class]
SLF4J: Found binding in [jar:file:/Users/davidallison/.gradle/caches/transforms-3/05ba5ab9b8ca946a61743b2d39120441/transformed/slf4j-timber-3.1/jars/classes.jar!/org/slf4j/impl/StaticLoggerBinder.class]
SLF4J: See http://www.slf4j.org/codes.html#multiple_bindings for an explanation.
SLF4J: Actual binding is of type [com.arcao.slf4j.timber.TimberLoggerFactory]
D/Backend: Opening rust backend with lang=[en]
- V/Media: dir /var/folders/ym/nqynp93d4j74dpzw20sq4wq00000gn/T/robolectric-CardBrowserTest_browserIsNotInitiallyInMultiSelectModeWithNoCards17411554122174555331/external-files/AnkiDroid/collection.media
I/Collection: (Re)opening Database: /var/folders/ym/nqynp93d4j74dpzw20sq4wq00000gn/T/robolectric-CardBrowserTest_browserIsNotInitiallyInMultiSelectModeWithNoCards17411554122174555331/external-files/AnkiDroid/collection.anki2
- I/Collection: Opening Collection Log
- D/Collection: [1596783600] Storage.kt:collection() /var/folders/ym/nqynp93d4j74dpzw20sq4wq00000gn/T/robolectric-CardBrowserTest_browserIsNotInitiallyInMultiSelectModeWithNoCards17411554122174555331/external-files/AnkiDroid/collection.anki2, 2.17alpha5-debug
- W/CollectionManager: blocked main thread for 234ms:
- com.ichi2.anki.RobolectricTest.getCol(RobolectricTest.kt:330)
- D/LifecycleMonitor: Lifecycle status change: com.ichi2.anki.CardBrowser@513ff44a in: PRE_ON_CREATE
I/Themes: Setting theme to LIGHT
I/AnkiDroidApp$onCreate: CardBrowser::onCreate
Invalid ID 0x00000000.
D/AnkiActivity: AnkiActivity.startLoadingCollection()
D/AnkiActivity: Synchronously calling onCollectionLoaded
D/CardBrowser: onCollectionLoaded()
D/CardBrowser$searchCards: performing search
- D/LifecycleMonitor: Lifecycle status change: com.ichi2.anki.CardBrowser@513ff44a in: CREATED
I/AnkiDroidApp$onCreate: CardBrowser::onStart
- D/LifecycleMonitor: Lifecycle status change: com.ichi2.anki.CardBrowser@513ff44a in: STARTED
I/AnkiDroidApp$onCreate: CardBrowser::onResume
D/UsageAnalytics: sendAnalyticsScreenView(): CardBrowser
D/UsageAnalytics: getOptIn() status: false
- D/DialogHandler: Reading persistent message
- D/LifecycleMonitor: Lifecycle status change: com.ichi2.anki.CardBrowser@513ff44a in: RESUMED
- W/ShadowLegacyPath: android.graphics.Path#op() not supported yet.
- W/ShadowLegacyPath: android.graphics.Path#op() not supported yet.
- W/ShadowLegacyPath: android.graphics.Path#op() not supported yet.
- W/ShadowLegacyPath: android.graphics.Path#op() not supported yet.
- W/ShadowLegacyPath: android.graphics.Path#op() not supported yet.
- W/ShadowLegacyPath: android.graphics.Path#op() not supported yet.
- W/ShadowLegacyPath: android.graphics.Path#op() not supported yet.
- W/ShadowLegacyPath: android.graphics.Path#op() not supported yet.
- W/ShadowLegacyPath: android.graphics.Path#op() not supported yet.
D/CardBrowser$searchCards: Search returned 0 cards
I/CardBrowser: CardBrowser:: Completed searchCards() Successfully
D/CardBrowser: onSelectionChanged()
D/CardBrowser: Not restoring search position
D/CardBrowser: onCreateOptionsMenu()
D/CardBrowser: onSelectionChanged()
D/RobolectricTest: Calling destroy on controller com.ichi2.anki.CardBrowser@513ff44a
I/AnkiDroidApp$onCreate: CardBrowser::onDestroy
- D/LifecycleMonitor: Lifecycle status change: com.ichi2.anki.CardBrowser@513ff44a in: DESTROYED
I/CollectionHelper: closeCollection: RobolectricTest: End
- I/Collection: Closing Collection Log
I/Collection: Collection closed
```



## Learning (optional, can help others)
* I want to discuss `SLF4J` with @mikehardy 
* how to use the `diff` codeblock in GitHub (A + or - prefix on a line) signifies an addition/deletion

https://android.googlesource.com/platform/frameworks/testing/+/master/support/src/android/support/test/internal/runner/lifecycle/ActivityLifecycleMonitorImpl.java

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)