### PR TITLE
feat: allow printing or exporting stats

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/pages/Statistics.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/pages/Statistics.kt
@@ -17,13 +17,69 @@ package com.ichi2.anki.pages
 
 import android.content.Context
 import android.content.Intent
+import android.os.Bundle
+import android.print.PrintAttributes
+import android.print.PrintManager
+import android.view.Menu
+import android.view.MenuInflater
+import android.view.MenuItem
+import android.view.View
+import androidx.core.content.ContextCompat.getSystemService
+import androidx.core.view.MenuHost
+import androidx.core.view.MenuProvider
+import androidx.lifecycle.Lifecycle
+import com.ichi2.anki.CollectionManager
 import com.ichi2.anki.R
+import com.ichi2.anki.utils.getTimestamp
+import com.ichi2.libanki.utils.TimeManager
 
 class Statistics : PageFragment() {
     override val title = R.string.statistics
     override val pageName = "graphs"
     override var webViewClient = PageWebViewClient()
     override var webChromeClient = PageChromeClient()
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        requireActivity().invalidateOptionsMenu()
+        val menuHost: MenuHost = requireActivity()
+        menuHost.addMenuProvider(
+            object : MenuProvider {
+                override fun onCreateMenu(menu: Menu, menuInflater: MenuInflater) {
+                    menuInflater.inflate(R.menu.statistics, menu)
+                    val exportStats = menu.findItem(R.id.action_export_stats)
+                    exportStats?.title = CollectionManager.TR.statisticsSavePdf()
+                }
+
+                override fun onMenuItemSelected(menuItem: MenuItem): Boolean {
+                    return when (menuItem.itemId) {
+                        R.id.action_export_stats -> {
+                            exportWebViewContentAsPDF()
+                            true
+                        }
+                        else -> false
+                    }
+                }
+            },
+            viewLifecycleOwner,
+            Lifecycle.State.RESUMED
+        )
+    }
+
+    /**Prepares and initiates a printing task for the content(stats) displayed in the WebView.
+     * It uses the Android PrintManager service to create a print job, based on the content of the WebView.
+     * The resulting output is a PDF document. **/
+    fun exportWebViewContentAsPDF() {
+        val printManager = getSystemService(requireContext(), PrintManager::class.java)
+        val currentDateTime = getTimestamp(TimeManager.time)
+        val jobName = "${getString(R.string.app_name)}-stats-$currentDateTime"
+        val printAdapter = webView.createPrintDocumentAdapter(jobName)
+        printManager?.print(
+            jobName,
+            printAdapter,
+            PrintAttributes.Builder().build()
+        )
+    }
 
     companion object {
         fun getIntent(context: Context): Intent {

--- a/AnkiDroid/src/main/res/drawable/ic_export_file.xml
+++ b/AnkiDroid/src/main/res/drawable/ic_export_file.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:tint="?attr/colorControlNormal"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:fillColor="@color/white"
+      android:pathData="M20.92,15.62a1.15,1.15 0,0 0,-0.21 -0.33l-3,-3a1,1 0,0 0,-1.42 1.42l1.3,1.29H12a1,1 0,0 0,0 2h5.59l-1.3,1.29a1,1 0,0 0,0 1.42,1 1,0 0,0 1.42,0l3,-3a0.93,0.93 0,0 0,0.21 -0.33,1 1,0 0,0 0,-0.76ZM14,20H6a1,1 0,0 1,-1 -1V5a1,1 0,0 1,1 -1h5v3a3,3 0,0 0,3 3h4a1,1 0,0 0,0.92 -0.62,1 1,0 0,0 -0.21,-1.09l-6,-6a1.07,1.07 0,0 0,-0.28 -0.19h-0.09l-0.28,-0.1H6a3,3 0,0 0,-3 3v14a3,3 0,0 0,3 3h8a1,1 0,0 0,0 -2ZM13,5.41 L15.59,8H14a1,1 0,0 1,-1 -1Z"/>
+</vector>

--- a/AnkiDroid/src/main/res/menu/statistics.xml
+++ b/AnkiDroid/src/main/res/menu/statistics.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Copyright (c) 2023 Ashish Yadav <mailtoashish693@gmail.com>
+
+  This program is free software; you can redistribute it and/or modify it under
+  the terms of the GNU General Public License as published by the Free Software
+  Foundation; either version 3 of the License, or (at your option) any later
+  version.
+
+  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License along with
+  this program.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
+
+        <item
+            android:id="@+id/action_export_stats"
+            tools:title="Save PDF"
+            android:icon="@drawable/ic_export_file"
+            app:showAsAction="ifRoom"/>
+</menu>


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
Allow the stats web view to be exported as PDF or printed just like Anki

## Fixes
* Fixes #14689

## How Has This Been Tested?

Tested on google emulator 
![Screenshot 2023-11-20 001042](https://github.com/ankidroid/Anki-Android/assets/48384865/2b093a12-898e-4c90-b810-ce1a6111f1a9)
![Screenshot 2023-11-20 001054](https://github.com/ankidroid/Anki-Android/assets/48384865/c3b0b989-e14b-47a3-b2cd-621c4315e79d)

_Links to blog posts, patterns, libraries or addons used to solve this problem_

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
