### PR TITLE
Add implementation for "stopTimerOnAnswer" deck configuration option

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
@@ -139,6 +139,7 @@ open class Reviewer :
 
     // Preferences from the collection
     private var mShowRemainingCardCount = false
+    private var stopTimerOnAnswer = false
     private val mActionButtons = ActionButtons(this)
     private lateinit var mToolbar: Toolbar
 
@@ -1061,6 +1062,9 @@ open class Reviewer :
     @VisibleForTesting
     override fun displayCardAnswer() {
         delayedHide(100)
+        if (stopTimerOnAnswer) {
+            answerTimer.pause()
+        }
         super.displayCardAnswer()
     }
 
@@ -1196,6 +1200,7 @@ open class Reviewer :
     override fun restoreCollectionPreferences(col: Collection) {
         super.restoreCollectionPreferences(col)
         mShowRemainingCardCount = col.config.get("dueCounts") ?: true
+        stopTimerOnAnswer = col.decks.confForDid(col.decks.current().id).getBoolean("stopTimerOnAnswer")
     }
 
     override fun onSingleTap(): Boolean {


### PR DESCRIPTION
## Purpose / Description

This PR provides the implementation for the new `stopTimerOnAnswer` deck config option.

Note: from my testing it seems that if the user clicks show answer and then goes to the main screen and the app is destroyed while in background, when coming back the reviewer will show again the question so I didn't do anything to save the new property "stopTimerOnAnswer" and the timer will start running from the beginning.

## Fixes
* Fixes #14588 

## How Has This Been Tested?

Ran the tests, manually verified the timer behavior in Reviewer.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
