### PR TITLE
build(deps): bump backend to 0.1.29-anki23.10.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     ext.kotlin_version = '1.9.20'
     ext.lint_version = '31.1.1'
     ext.acra_version = '5.11.3'
-    ext.ankidroid_backend_version = '0.1.28-anki23.10.1'
+    ext.ankidroid_backend_version = '0.1.29-anki23.10.1'
     ext.hamcrest_version = '2.2'
     ext.junit_version = '5.10.1'
     ext.coroutines_version = '1.7.3'


### PR DESCRIPTION

Just heading towards a release, and I like to get all the possible things in there - so getting the backend bump in as well even though it is nominally dev-only