### PR TITLE
refactor: intents

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -54,6 +54,8 @@ import com.ichi2.anki.dialogs.tags.TagsDialogFactory
 import com.ichi2.anki.dialogs.tags.TagsDialogListener
 import com.ichi2.anki.export.ActivityExportingDelegate
 import com.ichi2.anki.export.ExportType
+import com.ichi2.anki.pages.CardInfo.Companion.toIntent
+import com.ichi2.anki.pages.CardInfoDestination
 import com.ichi2.anki.preferences.sharedPrefs
 import com.ichi2.anki.receiver.SdCardReceiver
 import com.ichi2.anki.servicelayer.CardService.selectedNoteIds
@@ -1182,7 +1184,7 @@ open class CardBrowser :
                 val selectedCardIds = selectedCardIds
                 if (selectedCardIds.isNotEmpty()) {
                     val cardId = selectedCardIds[0]
-                    val intent = com.ichi2.anki.pages.CardInfo.getIntent(this, cardId)
+                    val intent = CardInfoDestination(cardId).toIntent(this)
                     startActivityWithAnimation(intent, ActivityTransitionAnimation.Direction.FADE)
                 }
                 return true

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -38,6 +38,7 @@ import com.google.android.material.snackbar.Snackbar
 import com.ichi2.anim.ActivityTransitionAnimation
 import com.ichi2.anki.CollectionManager.TR
 import com.ichi2.anki.CollectionManager.withCol
+import com.ichi2.anki.Previewer.Companion.toIntent
 import com.ichi2.anki.UIUtils.showThemedToast
 import com.ichi2.anki.dialogs.*
 import com.ichi2.anki.dialogs.CardBrowserMySearchesDialog.Companion.newInstance
@@ -1323,7 +1324,7 @@ open class CardBrowser :
         }
 
     private fun getPreviewIntent(index: Int, selectedCardIds: LongArray): Intent {
-        return Previewer.getPreviewIntent(this@CardBrowser, index, selectedCardIds)
+        return PreviewDestination(index, selectedCardIds).toIntent(this)
     }
 
     private fun rescheduleSelectedCards() {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Previewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Previewer.kt
@@ -277,11 +277,12 @@ class Previewer : AbstractFlashcardViewer() {
 
     companion object {
         @CheckResult
-        fun getPreviewIntent(context: Context?, index: Int, cardList: LongArray?): Intent {
-            val intent = Intent(context, Previewer::class.java)
-            intent.putExtra("index", index)
-            intent.putExtra("cardList", cardList)
-            return intent
-        }
+        fun PreviewDestination.toIntent(context: Context) =
+            Intent(context, Previewer::class.java).apply {
+                putExtra("index", index)
+                putExtra("cardList", cardList)
+            }
     }
 }
+
+class PreviewDestination(val index: Int, val cardList: LongArray)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
@@ -60,6 +60,8 @@ import com.ichi2.anki.dialogs.ConfirmationDialog
 import com.ichi2.anki.dialogs.RescheduleDialog.Companion.rescheduleSingleCard
 import com.ichi2.anki.multimediacard.AudioView
 import com.ichi2.anki.multimediacard.AudioView.Companion.createRecorderInstance
+import com.ichi2.anki.pages.CardInfo.Companion.toIntent
+import com.ichi2.anki.pages.CardInfoDestination
 import com.ichi2.anki.preferences.sharedPrefs
 import com.ichi2.anki.reviewer.*
 import com.ichi2.anki.reviewer.AnswerButtons.Companion.getBackgroundColors
@@ -658,7 +660,7 @@ open class Reviewer :
             showSnackbar(getString(R.string.multimedia_editor_something_wrong), Snackbar.LENGTH_SHORT)
             return
         }
-        val intent = com.ichi2.anki.pages.CardInfo.getIntent(this, currentCard!!.id)
+        val intent = CardInfoDestination(currentCard!!.id).toIntent(this)
         val animation = getAnimationTransitionFromGesture(fromGesture)
         intent.putExtra(FINISH_ANIMATION_EXTRA, getInverseTransition(animation) as Parcelable)
         startActivityWithAnimation(intent, animation)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/pages/CardInfo.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/pages/CardInfo.kt
@@ -19,7 +19,9 @@ import android.content.Context
 import android.content.Intent
 import android.os.Bundle
 import android.webkit.WebView
+import androidx.core.os.bundleOf
 import com.ichi2.anki.R
+import com.ichi2.libanki.CardId
 
 class CardInfo : PageFragment() {
     override val title = R.string.card_info_title
@@ -47,11 +49,9 @@ class CardInfo : PageFragment() {
     companion object {
         private const val ARG_CARD_ID = "cardId"
 
-        fun getIntent(context: Context, cardId: Long): Intent {
-            val arguments = Bundle().apply {
-                putLong(ARG_CARD_ID, cardId)
-            }
-            return PagesActivity.getIntent(context, CardInfo::class, arguments)
-        }
+        fun CardInfoDestination.toIntent(context: Context): Intent =
+            PagesActivity.getIntent(context, CardInfo::class, bundleOf(ARG_CARD_ID to cardId))
     }
 }
+
+data class CardInfoDestination(val cardId: CardId)

--- a/AnkiDroid/src/test/java/com/ichi2/anki/PreviewerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/PreviewerTest.kt
@@ -18,6 +18,7 @@ package com.ichi2.anki
 import android.widget.SeekBar
 import android.widget.TextView
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.ichi2.anki.Previewer.Companion.toIntent
 import com.ichi2.libanki.Card
 import org.hamcrest.CoreMatchers.not
 import org.hamcrest.MatcherAssert.assertThat
@@ -143,17 +144,17 @@ class PreviewerTest : RobolectricTest() {
         card.flush()
     }
 
-    private fun getPreviewerPreviewingList(arr: LongArray, c: Array<Card?>): Previewer {
-        val previewIntent = Previewer.getPreviewIntent(targetContext, 0, arr)
+    private fun getPreviewerPreviewingList(cardIds: LongArray, c: Array<Card?>): Previewer {
+        val previewIntent = PreviewDestination(index = 0, cardIds).toIntent(targetContext)
         val previewer = super.startActivityNormallyOpenCollectionWithIntent(Previewer::class.java, previewIntent)
-        for (i in arr.indices) {
+        for (i in cardIds.indices) {
             AbstractFlashcardViewer.editorCard = c[i]
         }
         return previewer
     }
 
     private fun getPreviewerPreviewing(usableCard: Card): Previewer {
-        val previewIntent = Previewer.getPreviewIntent(targetContext, 0, longArrayOf(usableCard.id))
+        val previewIntent = PreviewDestination(index = 0, longArrayOf(usableCard.id)).toIntent(targetContext)
         val previewer = super.startActivityNormallyOpenCollectionWithIntent(Previewer::class.java, previewIntent)
         AbstractFlashcardViewer.editorCard = usableCard
         return previewer


### PR DESCRIPTION
## Purpose / Description
I've got a pending PR to convert the `CardBrowser` to a ViewModel style architecture.

This is going to be a squash merge job, but there are a number of 'obvious' commits which can be split out, these mean that fewer files are affected in the merge

## Approach
* We don't want the ViewModel to have knowledge of the `Context` class
* So build a context-agnostic helper class, and define an extension method in the activity which accepts a `Context`
* use `bundleOf` 

## How Has This Been Tested?
Unit tests only

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
